### PR TITLE
PWGHF: Resolve the issue and remove unused histogram in Ξcc task

### DIFF
--- a/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -640,6 +640,7 @@ auto InvMassXToJpsiPiPi(const T& candidate)
 
 // 3-prong decay candidate table
 DECLARE_SOA_TABLE(HfCandProng3Base, "AOD", "HFCANDP3BASE", //!
+                  o2::soa::Index<>,
                   // general columns
                   HFCAND_COLUMNS,
                   // 3-prong specific columns

--- a/Tasks/PWGHF/HFCandidateCreatorXicc.cxx
+++ b/Tasks/PWGHF/HFCandidateCreatorXicc.cxx
@@ -177,7 +177,7 @@ struct HfCandidateCreatorXicc {
                          pvecpion[0], pvecpion[1], pvecpion[2],
                          impactParameter0.getY(), impactParameter1.getY(),
                          std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
-                         trackxic.getProngID(0).getRaw(), trackpion.globalIndex(),
+                         xicCand.globalIndex(), trackpion.globalIndex(),
                          hfFlag);
       } // if on selected Xicc
     }   // loop over candidates

--- a/Tasks/PWGHF/taskXicc.cxx
+++ b/Tasks/PWGHF/taskXicc.cxx
@@ -39,8 +39,7 @@ struct HfTaskXicc {
     "registry",
     {{"hptcand", "#Xi^{++}_{cc}-candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hptprong0", "#Xi^{++}_{cc}-candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-     {"hptprong1", "#Xi^{++}_{cc}-candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-     {"hptprong2", "#Xi^{++}_{cc}-candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}}}};
+     {"hptprong1", "#Xi^{++}_{cc}-candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}}}};
 
   Configurable<int> d_selectionFlagXicc{"d_selectionFlagXicc", 1, "Selection Flag for Xicc"};
   Configurable<double> cutYCandMax{"cutYCandMax", -1., "max. cand. rapidity"};


### PR DESCRIPTION
Resolve the issue related to get an index of Xic candidates.

- Replace the `trackxic.getProngID(0).getRaw()` to `trackxic.globalIndex()` to get a proper index of Xic candidates.
- Add `o2::soa::Index<>` in HfCandProng3Base 
- Remove unsed histogram