### PR TITLE
PWGHF: Adding the information about the prong ordering (Lc -> p K pi or Lc -> pi K p)

### DIFF
--- a/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
+++ b/DataModel/include/AnalysisDataModel/HFSecondaryVertex.h
@@ -508,6 +508,7 @@ DECLARE_SOA_COLUMN(FlagMCMatchRec, flagMCMatchRec, int8_t);         //! reconstr
 DECLARE_SOA_COLUMN(FlagMCMatchGen, flagMCMatchGen, int8_t);         //! generator level
 DECLARE_SOA_COLUMN(OriginMCRec, originMCRec, int8_t);               //! particle origin, reconstruction level
 DECLARE_SOA_COLUMN(OriginMCGen, originMCGen, int8_t);               //! particle origin, generator level
+DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t); //! swapping of the prongs order
 DECLARE_SOA_COLUMN(FlagMCDecayChanRec, flagMCDecayChanRec, int8_t); //! resonant decay channel flag, reconstruction level
 DECLARE_SOA_COLUMN(FlagMCDecayChanGen, flagMCDecayChanGen, int8_t); //! resonant decay channel flag, generator level
 
@@ -687,6 +688,7 @@ using HfCandProng3 = HfCandProng3Ext;
 DECLARE_SOA_TABLE(HfCandProng3MCRec, "AOD", "HFCANDP3MCREC", //!
                   hf_cand_prong3::FlagMCMatchRec,
                   hf_cand_prong3::OriginMCRec,
+                  hf_cand_prong3::IsCandidateSwapped,
                   hf_cand_prong3::FlagMCDecayChanRec);
 
 // table with results of generator level MC matching

--- a/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
+++ b/Tasks/PWGHF/HFCandidateCreator3Prong.cxx
@@ -160,6 +160,7 @@ struct HFCandidateCreator3ProngMC {
     int8_t sign = 0;
     int8_t flag = 0;
     int8_t origin = 0;
+    int8_t swapping = 0;
     int8_t channel = 0;
     std::vector<int> arrDaughIndex;
     std::array<int, 2> arrPDGDaugh;
@@ -172,6 +173,7 @@ struct HFCandidateCreator3ProngMC {
       //Printf("New rec. candidate");
       flag = 0;
       origin = 0;
+      swapping = 0;
       channel = 0;
       arrDaughIndex.clear();
       auto arrayDaughters = array{candidate.index0_as<aod::BigTracksMC>(), candidate.index1_as<aod::BigTracksMC>(), candidate.index2_as<aod::BigTracksMC>()};
@@ -191,17 +193,18 @@ struct HFCandidateCreator3ProngMC {
           flag = sign * (1 << DecayType::LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
+          swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
           RecoDecay::getDaughters(particlesMC, particlesMC.iteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.iteratorAt(arrDaughIndex[iProng]);
               arrPDGDaugh[iProng] = std::abs(daughI.pdgCode());
             }
-            if (arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) {
+            if ((arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) or (arrPDGDaugh[0] == arrPDGResonant1[1] && arrPDGDaugh[1] == arrPDGResonant1[0])) {
               channel = 1;
-            } else if (arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) {
+            } else if ((arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) or (arrPDGDaugh[0] == arrPDGResonant2[1] && arrPDGDaugh[1] == arrPDGResonant2[0])) {
               channel = 2;
-            } else if (arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) {
+            } else if ((arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) or (arrPDGDaugh[0] == arrPDGResonant3[1] && arrPDGDaugh[1] == arrPDGResonant3[0])) {
               channel = 3;
             }
           }
@@ -223,7 +226,7 @@ struct HFCandidateCreator3ProngMC {
         origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
       }
 
-      rowMCMatchRec(flag, origin, channel);
+      rowMCMatchRec(flag, origin, swapping, channel);
     }
 
     // Match generated particles.
@@ -253,11 +256,11 @@ struct HFCandidateCreator3ProngMC {
               auto daughJ = particlesMC.iteratorAt(arrDaughIndex[jProng]);
               arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
             }
-            if (arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) {
+            if ((arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) or (arrPDGDaugh[0] == arrPDGResonant1[1] && arrPDGDaugh[1] == arrPDGResonant1[0])) {
               channel = 1;
-            } else if (arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) {
+            } else if ((arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) or (arrPDGDaugh[0] == arrPDGResonant2[1] && arrPDGDaugh[1] == arrPDGResonant2[0])) {
               channel = 2;
-            } else if (arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) {
+            } else if ((arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) or (arrPDGDaugh[0] == arrPDGResonant3[1] && arrPDGDaugh[1] == arrPDGResonant3[0])) {
               channel = 3;
             }
           }

--- a/Tasks/PWGHF/HFTreeCreatorLcToPKPi.cxx
+++ b/Tasks/PWGHF/HFTreeCreatorLcToPKPi.cxx
@@ -76,6 +76,7 @@ DECLARE_SOA_COLUMN(CPA, cpa, float);
 DECLARE_SOA_COLUMN(CPAXY, cpaXY, float);
 DECLARE_SOA_COLUMN(Ct, ct, float);
 DECLARE_SOA_COLUMN(MCflag, mcflag, int8_t);
+DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t);
 // Events
 DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
@@ -151,7 +152,8 @@ DECLARE_SOA_TABLE(HfCandProng3Full, "AOD", "HFCANDP3Full",
                   full::Phi,
                   full::Y,
                   full::E,
-                  full::MCflag);
+                  full::MCflag,
+                  full::IsCandidateSwapped);
 
 DECLARE_SOA_TABLE(HfCandProng3FullEvents, "AOD", "HFCANDP3FullE",
                   collision::BCId,
@@ -282,7 +284,8 @@ struct CandidateTreeWriter {
             candidate.phi(),
             FunctionY,
             FunctionE,
-            candidate.flagMCMatchRec());
+            candidate.flagMCMatchRec(),
+            candidate.isCandidateSwapped());
         }
       };
 


### PR DESCRIPTION
The prong ordering information is needed to consider only the right signal candidate in the ML training when the PID is used.
@ginnocen @vkucera 