### PR TITLE
Change default ccdb path for PID

### DIFF
--- a/ALICE3/TableProducer/alice3-pidTOF.cxx
+++ b/ALICE3/TableProducer/alice3-pidTOF.cxx
@@ -89,8 +89,8 @@ struct ALICE3pidTOFTask {
   template <o2::track::PID::ID id>
   float nsigma(Trks::iterator track)
   {
-    // return (track.tofSignal() - tof::ExpTimes<Coll::iterator, Trks::iterator, id>::GetExpectedSignal(track.collision(), track)) / sigma<id>(track);
-    return (track.tofSignal() - track.collision().collisionTime() * 1000.f - tof::ExpTimes<Coll::iterator, Trks::iterator, id>::GetExpectedSignal(track.collision(), track)) / sigma<id>(track);
+    // return (track.tofSignal() - tof::ExpTimes< Trks::iterator, id>::GetExpectedSignal(track.collision(), track)) / sigma<id>(track);
+    return (track.tofSignal() - track.collision().collisionTime() * 1000.f - tof::ExpTimes<Trks::iterator, id>::GetExpectedSignal(track)) / sigma<id>(track);
   }
   void process(Coll const& collisions, Trks const& tracks)
   {

--- a/ALICE3/Tools/handleParamTOFResoALICE3.cxx
+++ b/ALICE3/Tools/handleParamTOFResoALICE3.cxx
@@ -28,7 +28,7 @@ namespace bpo = boost::program_options;
 bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv[], bpo::variables_map& vm)
 {
   options.add_options()(
-    "url,u", bpo::value<std::string>()->default_value("http://ccdb-test.cern.ch:8080"), "URL of the CCDB database")(
+    "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database")(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/ALICE3/PID/TOF"), "CCDB path for storage/retrieval")(
     "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity")(
     "stop,S", bpo::value<long>()->default_value(4108971600000), "Stop timestamp of object validity")(

--- a/Common/Core/PID/PIDTOF.h
+++ b/Common/Core/PID/PIDTOF.h
@@ -35,7 +35,7 @@ namespace o2::pid::tof
 static constexpr float kCSPEED = TMath::C() * 1.0e2f * 1.0e-12f; /// Speed of light in TOF units (cm/ps)
 
 /// \brief Class to handle the the TOF detector response for the TOF beta measurement
-template <typename Coll, typename Trck, o2::track::PID::ID id>
+template <typename Trck, o2::track::PID::ID id>
 class Beta
 {
  public:
@@ -46,29 +46,29 @@ class Beta
   static float GetBeta(const float length, const float tofSignal, const float collisionTime);
 
   /// Gets the beta for the track of interest
-  float GetBeta(const Coll& col, const Trck& trk) const { return GetBeta(trk.length(), trk.tofSignal(), col.collisionTime() * 1000.f); }
+  float GetBeta(const Trck& trk) const { return GetBeta(trk.length(), trk.tofSignal(), trk.collision().collisionTime() * 1000.f); }
 
   /// Computes the expected uncertainty on the beta measurement
   static float GetExpectedSigma(const float& length, const float& tofSignal, const float& collisionTime, const float& time_reso);
 
   /// Gets the expected uncertainty on the beta measurement of the track of interest
-  float GetExpectedSigma(const Coll& col, const Trck& trk) const { return GetExpectedSigma(trk.length(), trk.tofSignal(), col.collisionTime() * 1000.f, mExpectedResolution); }
+  float GetExpectedSigma(const Trck& trk) const { return GetExpectedSigma(trk.length(), trk.tofSignal(), trk.collision().collisionTime() * 1000.f, mExpectedResolution); }
 
   /// Gets the expected beta for a given mass hypothesis (no energy loss taken into account)
   static float GetExpectedSignal(const float& mom, const float& mass);
 
   /// Gets the expected beta given the particle index (no energy loss taken into account)
-  float GetExpectedSignal(const Coll& col, const Trck& trk) const { return GetExpectedSignal(trk.p(), o2::track::PID::getMass2Z(id)); }
+  float GetExpectedSignal(const Trck& trk) const { return GetExpectedSignal(trk.p(), o2::track::PID::getMass2Z(id)); }
 
   /// Gets the number of sigmas with respect the approximate beta (no energy loss taken into account)
-  float GetSeparation(const Coll& col, const Trck& trk) const { return (GetBeta(col, trk) - GetExpectedSignal(col, trk)) / GetExpectedSigma(col, trk); }
+  float GetSeparation(const Trck& trk) const { return (GetBeta(trk) - GetExpectedSignal(trk)) / GetExpectedSigma(trk); }
 
   float mExpectedResolution = 80; /// Expected time resolution
 };
 
 //_________________________________________________________________________
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float Beta<Coll, Trck, id>::GetBeta(const float length, const float tofSignal, const float collisionTime)
+template <typename Trck, o2::track::PID::ID id>
+float Beta<Trck, id>::GetBeta(const float length, const float tofSignal, const float collisionTime)
 {
   if (tofSignal <= 0) {
     return -999.f;
@@ -77,8 +77,8 @@ float Beta<Coll, Trck, id>::GetBeta(const float length, const float tofSignal, c
 }
 
 //_________________________________________________________________________
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float Beta<Coll, Trck, id>::GetExpectedSigma(const float& length, const float& tofSignal, const float& collisionTime, const float& time_reso)
+template <typename Trck, o2::track::PID::ID id>
+float Beta<Trck, id>::GetExpectedSigma(const float& length, const float& tofSignal, const float& collisionTime, const float& time_reso)
 {
   if (tofSignal <= 0) {
     return -999.f;
@@ -87,8 +87,8 @@ float Beta<Coll, Trck, id>::GetExpectedSigma(const float& length, const float& t
 }
 
 //_________________________________________________________________________
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float Beta<Coll, Trck, id>::GetExpectedSignal(const float& mom, const float& mass)
+template <typename Trck, o2::track::PID::ID id>
+float Beta<Trck, id>::GetExpectedSignal(const float& mom, const float& mass)
 {
   if (mom > 0) {
     return mom / TMath::Sqrt(mom * mom + mass * mass);
@@ -97,7 +97,7 @@ float Beta<Coll, Trck, id>::GetExpectedSignal(const float& mom, const float& mas
 }
 
 /// \brief Class to handle the the TOF detector response for the expected time
-template <typename Coll, typename Trck, o2::track::PID::ID id>
+template <typename Trck, o2::track::PID::ID id>
 class ExpTimes
 {
  public:
@@ -108,18 +108,18 @@ class ExpTimes
   static float ComputeExpectedTime(const float& tofExpMom, const float& length, const float& massZ);
 
   /// Gets the expected signal of the track of interest under the PID assumption
-  static float GetExpectedSignal(const Coll& col, const Trck& trk) { return ComputeExpectedTime(trk.tofExpMom() / kCSPEED, trk.length(), o2::track::PID::getMass2Z(id)); }
+  static float GetExpectedSignal(const Trck& trk) { return ComputeExpectedTime(trk.tofExpMom() / kCSPEED, trk.length(), o2::track::PID::getMass2Z(id)); }
 
   /// Gets the expected resolution of the measurement
-  float GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
+  float GetExpectedSigma(const DetectorResponse& response, const Trck& trk) const;
 
   /// Gets the number of sigmas with respect the expected time
-  float GetSeparation(const DetectorResponse& response, const Coll& col, const Trck& trk) const { return trk.tofSignal() > 0.f ? (trk.tofSignal() - col.collisionTime() * 1000.f - GetExpectedSignal(col, trk)) / GetExpectedSigma(response, col, trk) : -999.f; }
+  float GetSeparation(const DetectorResponse& response, const Trck& trk) const { return trk.tofSignal() > 0.f ? (trk.tofSignal() - trk.collision().collisionTime() * 1000.f - GetExpectedSignal(trk)) / GetExpectedSigma(response, trk) : -999.f; }
 };
 
 //_________________________________________________________________________
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ExpTimes<Coll, Trck, id>::ComputeExpectedTime(const float& tofExpMom, const float& length, const float& massZ)
+template <typename Trck, o2::track::PID::ID id>
+float ExpTimes<Trck, id>::ComputeExpectedTime(const float& tofExpMom, const float& length, const float& massZ)
 {
   if (tofExpMom <= 0.f) {
     return 0.f;
@@ -130,16 +130,15 @@ float ExpTimes<Coll, Trck, id>::ComputeExpectedTime(const float& tofExpMom, cons
 }
 
 //_________________________________________________________________________
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ExpTimes<Coll, Trck, id>::GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const
+template <typename Trck, o2::track::PID::ID id>
+float ExpTimes<Trck, id>::GetExpectedSigma(const DetectorResponse& response, const Trck& trk) const
 {
   if (!trk.hasTOF()) {
     return -999.f;
   }
-  const float x[7] = {trk.p(), trk.tofSignal(), col.collisionTimeRes() * 1000.f, o2::track::PID::getMass2Z(id), trk.length(), trk.sigma1Pt(), trk.pt()};
+  const float x[7] = {trk.p(), trk.tofSignal(), trk.collision().collisionTimeRes() * 1000.f, o2::track::PID::getMass2Z(id), trk.length(), trk.sigma1Pt(), trk.pt()};
   const float reso = response(response.kSigma, x);
   return reso >= 0.f ? reso : 0.f;
-  // return response(response.kSigma, const Coll& col, const Trck& trk, id);
 }
 
 } // namespace o2::pid::tof

--- a/Common/Core/PID/PIDTPC.h
+++ b/Common/Core/PID/PIDTPC.h
@@ -32,7 +32,7 @@ namespace o2::pid::tpc
 {
 
 /// \brief Class to handle the the TPC detector response
-template <typename Coll, typename Trck, o2::track::PID::ID id>
+template <typename Trck, o2::track::PID::ID id>
 class ELoss
 {
  public:
@@ -40,25 +40,25 @@ class ELoss
   ~ELoss() = default;
 
   /// Gets the expected signal of the measurement
-  float GetExpectedSignal(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
+  float GetExpectedSignal(const DetectorResponse& response, const Trck& trk) const;
 
   /// Gets the expected resolution of the measurement
-  float GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const;
+  float GetExpectedSigma(const DetectorResponse& response, const Trck& trk) const;
 
   /// Gets the number of sigmas with respect the expected value
-  float GetSeparation(const DetectorResponse& response, const Coll& col, const Trck& trk) const { return (trk.tpcSignal() - GetExpectedSignal(response, col, trk)) / GetExpectedSigma(response, col, trk); }
+  float GetSeparation(const DetectorResponse& response, const Trck& trk) const { return (trk.tpcSignal() - GetExpectedSignal(response, trk)) / GetExpectedSigma(response, trk); }
 };
 
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ELoss<Coll, Trck, id>::GetExpectedSignal(const DetectorResponse& response, const Coll& col, const Trck& trk) const
+template <typename Trck, o2::track::PID::ID id>
+float ELoss<Trck, id>::GetExpectedSignal(const DetectorResponse& response, const Trck& trk) const
 {
   const float x[2] = {trk.tpcInnerParam() / o2::track::PID::getMass(id), (float)o2::track::PID::getCharge(id)};
   const float bethe = response(DetectorResponse::kSignal, x);
   return bethe >= 0.f ? bethe : 0.f;
 }
 
-template <typename Coll, typename Trck, o2::track::PID::ID id>
-float ELoss<Coll, Trck, id>::GetExpectedSigma(const DetectorResponse& response, const Coll& col, const Trck& trk) const
+template <typename Trck, o2::track::PID::ID id>
+float ELoss<Trck, id>::GetExpectedSigma(const DetectorResponse& response, const Trck& trk) const
 {
   const float x[2] = {trk.tpcSignal(), (float)trk.tpcNClsFound()};
   const float reso = response(DetectorResponse::kSigma, x);

--- a/Common/TableProducer/PID/pidBayes.cxx
+++ b/Common/TableProducer/PID/pidBayes.cxx
@@ -80,7 +80,7 @@ struct bayesPid {
 
   std::array<bool, kNDet> enabledDet{false};
 
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathTOF{"ccdbPathTOF", "Analysis/PID/TOF", "Path of the TOF parametrization on the CCDB"};
   Configurable<std::string> ccdbPathTPC{"ccdbPathTPC", "Analysis/PID/TPC", "Path of the TPC parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
@@ -247,7 +247,7 @@ struct bayesPid {
   }
 
   template <o2::track::PID::ID pid>
-  using respTPC = tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using respTPC = tpc::ELoss<Trks::iterator, pid>;
 
   /// Computes PID probabilities for the TPC
   template <o2::track::PID::ID pid>
@@ -267,8 +267,8 @@ struct bayesPid {
     //   dedx = GetTPCsignalTunedOnData(track);
     // }
 
-    const float bethe = responseTPCPID.GetExpectedSignal(Response[kTPC], track.collision(), track);
-    const float sigma = responseTPCPID.GetExpectedSigma(Response[kTPC], track.collision(), track);
+    const float bethe = responseTPCPID.GetExpectedSignal(Response[kTPC], track);
+    const float sigma = responseTPCPID.GetExpectedSigma(Response[kTPC], track);
     LOG(INFO) << "For " << pid_constants::sNames[pid] << " computing bethe " << bethe << " and sigma " << sigma;
     // bethe = fTPCResponse.GetExpectedSignal(track, type, AliTPCPIDResponse::kdEdxDefault, fUseTPCEtaCorrection, fUseTPCMultiplicityCorrection, fUseTPCPileupCorrection);
     // sigma = fTPCResponse.GetExpectedSigma(track, type, AliTPCPIDResponse::kdEdxDefault, fUseTPCEtaCorrection, fUseTPCMultiplicityCorrection, fUseTPCPileupCorrection);
@@ -297,7 +297,7 @@ struct bayesPid {
 
   /// Response of the TOF detector
   template <o2::track::PID::ID pid>
-  using respTOF = tof::ExpTimes<Coll::iterator, Trks::iterator, pid>;
+  using respTOF = tof::ExpTimes<Trks::iterator, pid>;
 
   /// Compute PID probabilities for TOF
   template <o2::track::PID::ID pid>
@@ -359,10 +359,10 @@ struct bayesPid {
 
     const float meanCorrFactor = 0.07 / fTOFtail; // Correction factor on the mean because of the tail (should be ~ 0.1 with tail = 1.1)
 
-    const float nsigmas = responseTOFPID.GetSeparation(Response[kTOF], track.collision(), track) + meanCorrFactor;
+    const float nsigmas = responseTOFPID.GetSeparation(Response[kTOF], track) + meanCorrFactor;
 
-    const float expTime = responseTOFPID.GetExpectedSignal(track.collision(), track);
-    const float sig = responseTOFPID.GetExpectedSigma(Response[kTOF], track.collision(), track);
+    const float expTime = responseTOFPID.GetExpectedSignal(track);
+    const float sig = responseTOFPID.GetExpectedSigma(Response[kTOF], track);
 
     if (nsigmas < fTOFtail) {
       Probability[kTOF][pid] = exp(-0.5 * nsigmas * nsigmas) / sig;

--- a/Common/TableProducer/PID/pidTOF.cxx
+++ b/Common/TableProducer/PID/pidTOF.cxx
@@ -58,7 +58,7 @@ struct tofPid {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TOF", "Path of the TOF parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
   // Configuration flags to include and exclude particle hypotheses
@@ -125,7 +125,7 @@ struct tofPid {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = tof::ExpTimes<Colls::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = tof::ExpTimes<Trks::iterator, pid>;
   void process(Trks const& tracks, Colls const&)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -144,7 +144,7 @@ struct tofPid {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          const float separation = responsePID.GetSeparation(response, trk);
           aod::pidutils::packInTable<aod::pidtof_tiny::binned_nsigma_t,
                                      aod::pidtof_tiny::upper_bin,
                                      aod::pidtof_tiny::lower_bin>(separation, table,

--- a/Common/TableProducer/PID/pidTOFFull.cxx
+++ b/Common/TableProducer/PID/pidTOFFull.cxx
@@ -58,7 +58,7 @@ struct tofPidFull {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TOF", "Path of the TOF parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
   // Configuration flags to include and exclude particle hypotheses
@@ -125,7 +125,7 @@ struct tofPidFull {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = tof::ExpTimes<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = tof::ExpTimes<Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -144,8 +144,8 @@ struct tofPidFull {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
-                responsePID.GetSeparation(response, trk.collision(), trk));
+          table(responsePID.GetExpectedSigma(response, trk),
+                responsePID.GetSeparation(response, trk));
         }
       }
     };

--- a/Common/TableProducer/PID/pidTOFbeta.cxx
+++ b/Common/TableProducer/PID/pidTOFbeta.cxx
@@ -34,7 +34,7 @@ struct pidTOFTaskBeta {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
   using Colls = aod::Collisions;
   Produces<aod::pidTOFbeta> tablePIDBeta;
-  tof::Beta<Colls::iterator, Trks::iterator, PID::Electron> responseElectron;
+  tof::Beta<Trks::iterator, PID::Electron> responseElectron;
   Configurable<float> expreso{"tof-expreso", 80, "Expected resolution for the computation of the expected beta"};
 
   void init(o2::framework::InitContext&)
@@ -46,11 +46,11 @@ struct pidTOFTaskBeta {
   {
     tablePIDBeta.reserve(tracks.size());
     for (auto const& trk : tracks) {
-      tablePIDBeta(responseElectron.GetBeta(trk.collision(), trk),
-                   responseElectron.GetExpectedSigma(trk.collision(), trk),
-                   responseElectron.GetExpectedSignal(trk.collision(), trk),
-                   responseElectron.GetExpectedSigma(trk.collision(), trk),
-                   responseElectron.GetSeparation(trk.collision(), trk));
+      tablePIDBeta(responseElectron.GetBeta(trk),
+                   responseElectron.GetExpectedSigma(trk),
+                   responseElectron.GetExpectedSignal(trk),
+                   responseElectron.GetExpectedSigma(trk),
+                   responseElectron.GetSeparation(trk));
     }
   }
 };

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -59,7 +59,7 @@ struct tpcPid {
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> signalname{"param-signal", "BetheBloch", "Name of the parametrization for the expected signal, used in both file and CCDB mode"};
   Configurable<std::string> sigmaname{"param-sigma", "TPCReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC", "Path of the TPC parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
   // Configuration flags to include and exclude particle hypotheses
@@ -131,7 +131,7 @@ struct tpcPid {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = o2::pid::tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = o2::pid::tpc::ELoss<Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -150,7 +150,7 @@ struct tpcPid {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          const float separation = responsePID.GetSeparation(response, trk.collision(), trk);
+          const float separation = responsePID.GetSeparation(response, trk);
           aod::pidutils::packInTable<aod::pidtpc_tiny::binned_nsigma_t,
                                      aod::pidtpc_tiny::upper_bin,
                                      aod::pidtpc_tiny::lower_bin>(separation, table,

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -59,7 +59,7 @@ struct tpcPidFull {
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
   Configurable<std::string> signalname{"param-signal", "BetheBloch", "Name of the parametrization for the expected signal, used in both file and CCDB mode"};
   Configurable<std::string> sigmaname{"param-sigma", "TPCReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
-  Configurable<std::string> url{"ccdb-url", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC", "Path of the TPC parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
   // Configuration flags to include and exclude particle hypotheses
@@ -131,7 +131,7 @@ struct tpcPidFull {
   }
 
   template <o2::track::PID::ID pid>
-  using ResponseImplementation = o2::pid::tpc::ELoss<Coll::iterator, Trks::iterator, pid>;
+  using ResponseImplementation = o2::pid::tpc::ELoss<Trks::iterator, pid>;
   void process(Coll const& collisions, Trks const& tracks)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -150,8 +150,8 @@ struct tpcPidFull {
         // Prepare memory for enabled tables
         table.reserve(tracks.size());
         for (auto const& trk : tracks) { // Loop on Tracks
-          table(responsePID.GetExpectedSigma(response, trk.collision(), trk),
-                responsePID.GetSeparation(response, trk.collision(), trk));
+          table(responsePID.GetExpectedSigma(response, trk),
+                responsePID.GetSeparation(response, trk));
         }
       }
     };

--- a/Common/Tools/handleParamTOFReso.cxx
+++ b/Common/Tools/handleParamTOFReso.cxx
@@ -28,7 +28,7 @@ namespace bpo = boost::program_options;
 bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv[], bpo::variables_map& vm)
 {
   options.add_options()(
-    "url,u", bpo::value<std::string>()->default_value("http://ccdb-test.cern.ch:8080"), "URL of the CCDB database")(
+    "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database")(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TOF"), "CCDB path for storage/retrieval")(
     "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity")(
     "stop,S", bpo::value<long>()->default_value(4108971600000), "Stop timestamp of object validity")(

--- a/Common/Tools/handleParamTPCBetheBloch.cxx
+++ b/Common/Tools/handleParamTPCBetheBloch.cxx
@@ -29,7 +29,7 @@ namespace bpo = boost::program_options;
 bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv[], bpo::variables_map& vm)
 {
   options.add_options()(
-    "url,u", bpo::value<std::string>()->default_value("http://ccdb-test.cern.ch:8080"), "URL of the CCDB database")(
+    "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database")(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TPC"), "CCDB path for storage/retrieval")(
     "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity")(
     "stop,S", bpo::value<long>()->default_value(4108971600000), "Stop timestamp of object validity")(


### PR DESCRIPTION
- Move from http://ccdb-test.cern.ch:8080 to http://alice-ccdb.cern.ch

- Remove dependence of the collision in PID methods
  - Getting collision from track