### PR TITLE
CMake: Adding PWG name to executable name

### DIFF
--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -9,102 +9,102 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-o2physics_add_dpl_workflow(hf-track-index-skims-creator
+o2physics_add_dpl_workflow(track-index-skims-creator
                     SOURCES HFTrackIndexSkimsCreator.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-2prong
+o2physics_add_dpl_workflow(candidate-creator-2prong
                     SOURCES HFCandidateCreator2Prong.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-tree-creator-d0-tokpi
+o2physics_add_dpl_workflow(tree-creator-d0-tokpi
                     SOURCES HFTreeCreatorD0ToKPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-cascade
+o2physics_add_dpl_workflow(candidate-creator-cascade
                     SOURCES HFCandidateCreatorCascade.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-3prong
+o2physics_add_dpl_workflow(candidate-creator-3prong
                     SOURCES HFCandidateCreator3Prong.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-bplus
+o2physics_add_dpl_workflow(candidate-creator-bplus
                     SOURCES HFCandidateCreatorBPlus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-xicc
+o2physics_add_dpl_workflow(candidate-creator-xicc
                     SOURCES HFCandidateCreatorXicc.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-candidate-creator-x
+o2physics_add_dpl_workflow(candidate-creator-x
                     SOURCES HFCandidateCreatorX.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-tree-creator-lc-topkpi
+o2physics_add_dpl_workflow(tree-creator-lc-topkpi
                     SOURCES HFTreeCreatorLcToPKPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-tree-creator-x-tojpsipipi
+o2physics_add_dpl_workflow(tree-creator-x-tojpsipipi
                     SOURCES HFTreeCreatorXToJpsiPiPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-tree-creator-xicc-topkpipi
+o2physics_add_dpl_workflow(tree-creator-xicc-topkpipi
                     SOURCES HFTreeCreatorXiccToPKPiPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-d0-candidate-selector
+o2physics_add_dpl_workflow(d0-candidate-selector
                     SOURCES HFD0CandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-dplus-topikpi-candidate-selector
+o2physics_add_dpl_workflow(dplus-topikpi-candidate-selector
                     SOURCES HFDplusToPiKPiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-lc-candidate-selector
+o2physics_add_dpl_workflow(lc-candidate-selector
                     SOURCES HFLcCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-jpsi-candidate-selector
+o2physics_add_dpl_workflow(jpsi-candidate-selector
                     SOURCES HFJpsiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-xic-topkpi-candidate-selector
+o2physics_add_dpl_workflow(xic-topkpi-candidate-selector
                     SOURCES HFXicToPKPiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-xicc-topkpipi-candidate-selector
+o2physics_add_dpl_workflow(xicc-topkpipi-candidate-selector
                     SOURCES HFXiccToPKPiPiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-lc-tok0sp-candidate-selector
+o2physics_add_dpl_workflow(lc-tok0sp-candidate-selector
                     SOURCES HFLcK0sPCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-bplus-tod0pi-candidate-selector
+o2physics_add_dpl_workflow(bplus-tod0pi-candidate-selector
                     SOURCES HFBPlusToD0PiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-x-tojpsipipi-candidate-selector
+o2physics_add_dpl_workflow(x-tojpsipipi-candidate-selector
                     SOURCES HFXToJpsiPiPiCandidateSelector.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)

--- a/PWGHF/Tasks/CMakeLists.txt
+++ b/PWGHF/Tasks/CMakeLists.txt
@@ -14,72 +14,72 @@ o2physics_add_dpl_workflow(qa-rejection
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-d0
+o2physics_add_dpl_workflow(task-d0
                     SOURCES taskD0.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-dplus
+o2physics_add_dpl_workflow(task-dplus
                     SOURCES taskDPlus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-lc
+o2physics_add_dpl_workflow(task-lc
                     SOURCES taskLc.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-jpsi
+o2physics_add_dpl_workflow(task-jpsi
                     SOURCES taskJpsi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-bplus
+o2physics_add_dpl_workflow(task-bplus
                     SOURCES taskBPlus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-xic
+o2physics_add_dpl_workflow(task-xic
                     SOURCES taskXic.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-xicc
+o2physics_add_dpl_workflow(task-xicc
                     SOURCES taskXicc.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-x
+o2physics_add_dpl_workflow(task-x
                     SOURCES taskX.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-mc-validation
+o2physics_add_dpl_workflow(mc-validation
                     SOURCES HFMCValidation.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-lc-tok0sp
+o2physics_add_dpl_workflow(task-lc-tok0sp
                     SOURCES taskLcK0sP.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-correlator-d0d0bar
+o2physics_add_dpl_workflow(correlator-d0d0bar
                     SOURCES HFCorrelatorD0D0bar.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-correlator-dplusdminus
+o2physics_add_dpl_workflow(correlator-dplusdminus
                     SOURCES HFCorrelatorDplusDminus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-task-correlation-ddbar
+o2physics_add_dpl_workflow(task-correlation-ddbar
                     SOURCES taskCorrelationDDbar.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(hf-sel-optimisation
+o2physics_add_dpl_workflow(sel-optimisation
                     SOURCES HFSelOptimisation.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)

--- a/Tutorials/Skimming/CMakeLists.txt
+++ b/Tutorials/Skimming/CMakeLists.txt
@@ -13,63 +13,63 @@
 o2physics_add_dpl_workflow(tpcspectra-task-skim-reference
                     SOURCES spectraTPCReference.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(tpcspectra-task-skim-provider
                     SOURCES spectraTPCProvider.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(tpcspectra-task-skim-analyser
                     SOURCES spectraTPCAnalyser.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(nucleispectra-task-skim-reference
                     SOURCES spectraNucleiReference.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(nucleispectra-task-skim-provider
                     SOURCES spectraNucleiProvider.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(nucleispectra-task-skim-analyser
                     SOURCES spectraNucleiAnalyser.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 if(FastJet_FOUND)
 o2physics_add_dpl_workflow(jet-task-skim-provider
                     SOURCES jetProvider.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
                     O2Physics::PWGJECore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(jetspectra-task-skim-analyser
                     SOURCES jetSpectraAnalyser.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
                     O2Physics::PWGJECore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(jetspectra-task-skim-reference
                     SOURCES jetSpectraReference.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
                     O2Physics::PWGJECore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 endif()
 
 o2physics_add_dpl_workflow(upcspectra-task-skim-reference
                     SOURCES spectraUPCReference.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(upcspectra-task-skim-provider
                     SOURCES spectraUPCProvider.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)
 
 o2physics_add_dpl_workflow(upcspectra-task-skim-analyser
                     SOURCES spectraUPCAnalyser.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+                    COMPONENT_NAME AnalysisTutorial)

--- a/cmake/O2PhysicsAddExecutable.cmake
+++ b/cmake/O2PhysicsAddExecutable.cmake
@@ -41,7 +41,7 @@ include_guard()
 #
 # ${titi} will contain something like `O2Physicsexe-test-toto` (for the exact
 # naming see the o2physics_name_target function) and an executable named
-# o2physics-test-toto will be created upon build)
+# o2-test-toto will be created upon build)
 
 function(o2physics_add_executable baseTargetName)
 
@@ -67,7 +67,20 @@ function(o2physics_add_executable baseTargetName)
     string(TOLOWER ${A_COMPONENT_NAME} component)
     set(comp -${component})
   endif()
-  set(exeName o2${exeType}${comp}-${baseTargetName})
+
+  # Extract PWG name from folder path (if exists)
+  # First get a relative source directory
+  string(REPLACE ${PROJECT_SOURCE_DIR} "" RELATIVE_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
+  # Match PWG
+  string(REGEX MATCH "PWG[A-Z][A-Z]" PWG ${RELATIVE_LIST_DIR})
+  if(PWG)
+    string(REPLACE "PWG" "" PWGSUFFIX ${PWG})
+    string(TOLOWER ${PWGSUFFIX} pwg_lower)
+    set(pwg -${pwg_lower})
+  endif()
+
+  set(exeName o2${exeType}${comp}${pwg}-${baseTargetName})
+  message("exe ${exeName}")
 
   if(A_IS_TEST)
     set(isTest "IS_TEST")
@@ -83,7 +96,8 @@ function(o2physics_add_executable baseTargetName)
                         targetName
                         IS_EXE
                         ${isTest}
-                        ${isBench})
+                        ${isBench}
+                        PWG ${PWG})
 
   set(target ${targetName})
 

--- a/cmake/O2PhysicsAddExecutable.cmake
+++ b/cmake/O2PhysicsAddExecutable.cmake
@@ -96,7 +96,7 @@ function(o2physics_add_executable baseTargetName)
                         IS_EXE
                         ${isTest}
                         ${isBench}
-                        PWG ${PWG})
+                        PWG ${PWGSUFFIX})
 
   set(target ${targetName})
 

--- a/cmake/O2PhysicsAddExecutable.cmake
+++ b/cmake/O2PhysicsAddExecutable.cmake
@@ -80,7 +80,6 @@ function(o2physics_add_executable baseTargetName)
   endif()
 
   set(exeName o2${exeType}${comp}${pwg}-${baseTargetName})
-  message("exe ${exeName}")
 
   if(A_IS_TEST)
     set(isTest "IS_TEST")

--- a/cmake/O2PhysicsNameTarget.cmake
+++ b/cmake/O2PhysicsNameTarget.cmake
@@ -20,6 +20,7 @@ include_guard()
 # * IS_TEST: present to denote the target is a test executable
 # * IS_BENCH: present to denote the target is a benchmark executable
 # * IS_EXE: present to denote the target is an executable (and not a library)
+# * PWG (optional): PWG name to be appended to the target name
 #
 function(o2physics_name_target baseTargetName)
 
@@ -28,7 +29,7 @@ function(o2physics_name_target baseTargetName)
                         A
                         "IS_TEST;IS_BENCH;IS_EXE"
                         "NAME;COMPONENT_NAME"
-                        "")
+                        "PWG")
 
   if(A_UNPARSED_ARGUMENTS)
     message(
@@ -56,8 +57,14 @@ function(o2physics_name_target baseTargetName)
     set(comp -${component})
   endif()
 
+  # optional PWG name
+  if(A_PWG)
+    string(TOLOWER ${A_PWG} pwg_lower)
+    set(pwg -${pwg_lower})
+  endif()
+
   set(${A_NAME}
-      ${PROJECT_NAME}${targetType}${comp}-${baseTargetName}
+      ${PROJECT_NAME}${targetType}${comp}${pwg}-${baseTargetName}
       PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
This changes all executable names in the PWG folders such that they contain the pwg name. E.g.
o2-analysis-correlations --> o2-analysis-cf-correlations

Given that hf had done this manually, it is removed from their cmake files. So no change happens for the hf tasks.