### PR TITLE
PWGMM: set switches in pseudorapidity task to true by default

### DIFF
--- a/PWGMM/Tasks/dndeta.h
+++ b/PWGMM/Tasks/dndeta.h
@@ -126,7 +126,7 @@ struct PseudorapidityDensity {
     }
   }
 
-  PROCESS_SWITCH(PseudorapidityDensity<TRACKTYPE>, processGen, "Process generator-level info", false);
+  PROCESS_SWITCH(PseudorapidityDensity<TRACKTYPE>, processGen, "Process generator-level info", true);
 
   void processMatching(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels>>::iterator const& collision, soa::Filtered<aod::Tracks> const& tracks, aod::McCollisions const&)
   {
@@ -138,7 +138,7 @@ struct PseudorapidityDensity {
     }
   }
 
-  PROCESS_SWITCH(PseudorapidityDensity<TRACKTYPE>, processMatching, "Process generator-level info matched to reco", false);
+  PROCESS_SWITCH(PseudorapidityDensity<TRACKTYPE>, processMatching, "Process generator-level info matched to reco", true);
 };
 } // namespace o2::pwgmm::multiplicity
 


### PR DESCRIPTION
Temporary workaround to be able to run on hyperloop.