### PR TITLE
ThreeBody Trigger

### DIFF
--- a/EventFiltering/CMakeLists.txt
+++ b/EventFiltering/CMakeLists.txt
@@ -37,3 +37,8 @@ o2physics_add_dpl_workflow(hf-filter
                            SOURCES PWGHF/HFFilter.cxx
                            PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::DetectorsVertexing
                            COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(cf-filter
+                            SOURCES PWGCF/CFFilter.cxx
+                            PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore 
+                            COMPONENT_NAME Analysis)

--- a/EventFiltering/CMakeLists.txt
+++ b/EventFiltering/CMakeLists.txt
@@ -38,7 +38,7 @@ o2physics_add_dpl_workflow(hf-filter
                            PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::DetectorsVertexing
                            COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(cf-filter
+o2physics_add_dpl_workflow(cf-threebodyfemto-filter
                             SOURCES PWGCF/CFFilter.cxx
-                            PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore 
+                            PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore 
                             COMPONENT_NAME Analysis)

--- a/EventFiltering/PWGCF/CFFilter.cxx
+++ b/EventFiltering/PWGCF/CFFilter.cxx
@@ -29,7 +29,6 @@
 #include "../../PWGCF/FemtoDream/FemtoDreamMath.h"
 #include "../../PWGCF/FemtoDream/FemtoDreamPairCleaner.h"
 
-
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
 
@@ -39,9 +38,9 @@
 namespace
 {
 
-static constexpr int nTriplets{4}; 
+static constexpr int nTriplets{4};
 
-enum CFTriggers { 
+enum CFTriggers {
   kPPP = 0,
   kPPL,
   kPLL,
@@ -55,8 +54,8 @@ static const std::vector<std::string> CfTriggerNames{"ppp", "ppL", "pLL", "LLL"}
 namespace o2::aod
 {
 using FullCollision = soa::Join<aod::Collisions,
-                                                      aod::EvSels,
-                                                      aod::Mults>::iterator;
+                                aod::EvSels,
+                                aod::Mults>::iterator;
 } // namespace o2::aod
 
 using namespace o2;
@@ -78,7 +77,7 @@ struct CFFilter {
     registry.add("fProcessedEvents", "CF - event filtered;;events", HistType::kTH1F, {{6, -0.5, 4.5}});
     std::array<std::string, 6> eventTitles = {"all", "rejected", "p-p-p", "p-p-L", "p-L-L", "L-L-L"};
     for (size_t iBin = 0; iBin < eventTitles.size(); iBin++) {
-     registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());
+      registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin + 1, eventTitles[iBin].data());
     }
     registry.add("fSameEvent", "CF - same event distribution;;events", HistType::kTH1F, {{8000, 0, 8}});
   }
@@ -87,38 +86,37 @@ struct CFFilter {
   float mMassLambda = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
 
   void process(aod::FullCollision const& col, o2::aod::FemtoDreamCollisions const& colsFemto,
-    o2::aod::FemtoDreamParticles& partsFemto)
+               o2::aod::FemtoDreamParticles& partsFemto)
   {
     registry.get<TH1>(HIST("fProcessedEvents"))->Fill(0);
-    bool keepEvent[nTriplets]{false}; 
-   
+    bool keepEvent[nTriplets]{false};
+
     // check if current collision was selected by femto skimmer
     auto collsInFemto = colsFemto.sliceBy(o2::aod::femtodreamcollision::collisionId, col.globalIndex());
-    if(collsInFemto.size()==0){
-      keepEvent[kPPL]=false;
-    }
-    else{
+    if (collsInFemto.size() == 0) {
+      keepEvent[kPPL] = false;
+    } else {
       auto collInFemto = collsInFemto.begin();
 
       //uint8_t trackTypeSel = o2::aod::femtodreamparticle::ParticleType::kTrack; Fix this to work instead of below hardcoded lines
       //uint V0TypeSel = o2::aod::femtodreamparticle::ParticleType::kV0; Fix this to work instead of below hardcoded lines
-      uint8_t Track = 0; // Track
-      uint8_t V0 = 1; // V0
+      uint8_t Track = 0;      // Track
+      uint8_t V0 = 1;         // V0
       uint8_t V0Daughter = 2; // V0
-      uint32_t trackMask =524288 ;
+      uint32_t trackMask = 524288;
       uint32_t V0Mask = 64;
       uint32_t testedBit0 = 0;
 
       //Obtain particle and antiparticle candidates of protons and lambda hyperons for current femto collision
-      Partition<o2::aod::FemtoDreamParticles> partsProton1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
-                                                            (o2::aod::femtodreamparticle::partType == Track)&& ((o2::aod::femtodreamparticle::cut&trackMask) == trackMask)  ;
-      Partition<o2::aod::FemtoDreamParticles> partsLambda1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
-                                                            (o2::aod::femtodreamparticle::partType == V0)&& ((o2::aod::femtodreamparticle::cut&V0Mask) == V0Mask) ;
-      Partition<o2::aod::FemtoDreamParticles> partsProton0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
-                                                            (o2::aod::femtodreamparticle::partType == Track)&& ((o2::aod::femtodreamparticle::cut&trackMask) == testedBit0)  ;
-      Partition<o2::aod::FemtoDreamParticles> partsLambda0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
-                                                            (o2::aod::femtodreamparticle::partType == V0)&& ((o2::aod::femtodreamparticle::cut&V0Mask) == testedBit0) ;
-      
+      Partition<o2::aod::FemtoDreamParticles> partsProton1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex()) &&
+                                                             (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & trackMask) == trackMask);
+      Partition<o2::aod::FemtoDreamParticles> partsLambda1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex()) &&
+                                                             (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & V0Mask) == V0Mask);
+      Partition<o2::aod::FemtoDreamParticles> partsProton0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex()) &&
+                                                             (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & trackMask) == testedBit0);
+      Partition<o2::aod::FemtoDreamParticles> partsLambda0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex()) &&
+                                                             (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & V0Mask) == testedBit0);
+
       partsProton1.bindTable(partsFemto);
       partsLambda1.bindTable(partsFemto);
       partsProton0.bindTable(partsFemto);
@@ -129,46 +127,48 @@ struct CFFilter {
       // Calculate Q3 and check if it is smaller than 0.6
       // If at collision has at least one triplet with Q3<0.6, the trigger value is set to true!
       // IMPORTANT: Include close pair rejection here
-      int lowQ3Triplets = 0; 
-      if(partsLambda0.size()>=1 && partsProton0.size()>=2){
-        for(auto& partLambda : partsLambda0){
+      int lowQ3Triplets = 0;
+      if (partsLambda0.size() >= 1 && partsProton0.size() >= 2) {
+        for (auto& partLambda : partsLambda0) {
           if (!pairCleanerTV.isCleanPair(partLambda, partLambda, partsFemto)) {
             continue;
           }
-          for (auto& [p1, p2] : combinations(partsProton0, partsProton0) ){
+          for (auto& [p1, p2] : combinations(partsProton0, partsProton0)) {
             auto Q3 = FemtoDreamMath::getQ3(p1, mMassProton, p2, mMassProton, partLambda, mMassLambda);
             registry.get<TH1>(HIST("fSameEvent"))->Fill(Q3);
-            if(Q3<1.5)  lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
-          }
-        }
-      }      
-      if(partsLambda1.size()>=1 && partsProton1.size()>=2){
-        for(auto& partLambda : partsLambda1){
-          if (!pairCleanerTV.isCleanPair(partLambda, partLambda, partsFemto)) {
-            continue;
-          }
-          for (auto& [p1, p2] : combinations(partsProton1, partsProton1) ){
-            auto Q3 = FemtoDreamMath::getQ3(p1, mMassProton, p2, mMassProton, partLambda, mMassLambda);
-            registry.get<TH1>(HIST("fSameEvent"))->Fill(Q3);
-            if(Q3<1.5)  lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
+            if (Q3 < 1.5)
+              lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
           }
         }
       }
-      if(lowQ3Triplets>0) keepEvent[kPPL]=true;
+      if (partsLambda1.size() >= 1 && partsProton1.size() >= 2) {
+        for (auto& partLambda : partsLambda1) {
+          if (!pairCleanerTV.isCleanPair(partLambda, partLambda, partsFemto)) {
+            continue;
+          }
+          for (auto& [p1, p2] : combinations(partsProton1, partsProton1)) {
+            auto Q3 = FemtoDreamMath::getQ3(p1, mMassProton, p2, mMassProton, partLambda, mMassLambda);
+            registry.get<TH1>(HIST("fSameEvent"))->Fill(Q3);
+            if (Q3 < 1.5)
+              lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
+          }
+        }
+      }
+      if (lowQ3Triplets > 0)
+        keepEvent[kPPL] = true;
     }
 
     tags(keepEvent[kPPP], keepEvent[kPPL], keepEvent[kPLL], keepEvent[kLLL]);
-    
-    if (!keepEvent[kPPP] && !keepEvent[kPPL] && !keepEvent[kPLL]&& !keepEvent[kLLL]) {
+
+    if (!keepEvent[kPPP] && !keepEvent[kPPL] && !keepEvent[kPLL] && !keepEvent[kLLL]) {
       registry.get<TH1>(HIST("fProcessedEvents"))->Fill(1);
     } else {
       for (int iTrigger{0}; iTrigger < nTriplets; iTrigger++) {
         if (keepEvent[iTrigger]) {
-          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger+1);
+          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger + 1);
         }
       }
     }
-
   }
 };
 

--- a/EventFiltering/PWGCF/CFFilter.cxx
+++ b/EventFiltering/PWGCF/CFFilter.cxx
@@ -1,0 +1,178 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CFFilter.cxx
+/// \brief Selection of events with triplets for femtoscopic studies
+///
+/// \author Laura Serksnyte, TU München, laura.serksnyte@cern.ch
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "../filterTables.h"
+
+#include "../../PWGCF/DataModel/FemtoDerived.h"
+#include "../../PWGCF/FemtoDream/FemtoDreamParticleHisto.h"
+#include "../../PWGCF/FemtoDream/FemtoDreamPairCleaner.h"
+#include "../../PWGCF/FemtoDream/FemtoDreamContainer.h"
+#include "../../PWGCF/FemtoDream/FemtoDreamMath.h"
+#include "../../PWGCF/FemtoDream/FemtoDreamPairCleaner.h"
+
+
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+
+#include <cmath>
+#include <string>
+
+namespace
+{
+
+static constexpr int nTriplets{4}; 
+
+enum CFTriggers { 
+  kPPP = 0,
+  kPPL,
+  kPLL,
+  kLLL
+};
+
+static const std::vector<std::string> CfTriggerNames{"ppp", "ppL", "pLL", "LLL"};
+
+} // namespace
+
+namespace o2::aod
+{
+using FullCollision = soa::Join<aod::Collisions,
+                                                      aod::EvSels,
+                                                      aod::Mults>::iterator;
+} // namespace o2::aod
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::analysis::femtoDream;
+
+struct CFFilter {
+
+  Produces<aod::CFFilters> tags;
+
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+
+  //FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kTrack> pairCleanerTT; Currently not used, will be needed later
+  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCleanerTV;
+
+  void init(o2::framework::InitContext&)
+  {
+    registry.add("fProcessedEvents", "CF - event filtered;;events", HistType::kTH1F, {{6, -0.5, 4.5}});
+    std::array<std::string, 6> eventTitles = {"all", "rejected", "p-p-p", "p-p-L", "p-L-L", "L-L-L"};
+    for (size_t iBin = 0; iBin < eventTitles.size(); iBin++) {
+     registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin+1, eventTitles[iBin].data());
+    }
+    registry.add("fSameEvent", "CF - same event distribution;;events", HistType::kTH1F, {{8000, 0, 8}});
+  }
+
+  float mMassProton = TDatabasePDG::Instance()->GetParticle(2212)->Mass();
+  float mMassLambda = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+
+  void process(aod::FullCollision const& col, o2::aod::FemtoDreamCollisions const& colsFemto,
+    o2::aod::FemtoDreamParticles& partsFemto)
+  {
+    registry.get<TH1>(HIST("fProcessedEvents"))->Fill(0);
+    bool keepEvent[nTriplets]{false}; 
+   
+    // check if current collision was selected by femto skimmer
+    auto collsInFemto = colsFemto.sliceBy(o2::aod::femtodreamcollision::collisionId, col.globalIndex());
+    if(collsInFemto.size()==0){
+      keepEvent[kPPL]=false;
+    }
+    else{
+      auto collInFemto = collsInFemto.begin();
+
+      //uint8_t trackTypeSel = o2::aod::femtodreamparticle::ParticleType::kTrack; Fix this to work instead of below hardcoded lines
+      //uint V0TypeSel = o2::aod::femtodreamparticle::ParticleType::kV0; Fix this to work instead of below hardcoded lines
+      uint8_t Track = 0; // Track
+      uint8_t V0 = 1; // V0
+      uint8_t V0Daughter = 2; // V0
+      uint32_t trackMask =524288 ;
+      uint32_t V0Mask = 64;
+      uint32_t testedBit0 = 0;
+
+      //Obtain particle and antiparticle candidates of protons and lambda hyperons for current femto collision
+      Partition<o2::aod::FemtoDreamParticles> partsProton1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
+                                                            (o2::aod::femtodreamparticle::partType == Track)&& ((o2::aod::femtodreamparticle::cut&trackMask) == trackMask)  ;
+      Partition<o2::aod::FemtoDreamParticles> partsLambda1 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
+                                                            (o2::aod::femtodreamparticle::partType == V0)&& ((o2::aod::femtodreamparticle::cut&V0Mask) == V0Mask) ;
+      Partition<o2::aod::FemtoDreamParticles> partsProton0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
+                                                            (o2::aod::femtodreamparticle::partType == Track)&& ((o2::aod::femtodreamparticle::cut&trackMask) == testedBit0)  ;
+      Partition<o2::aod::FemtoDreamParticles> partsLambda0 = (o2::aod::femtodreamparticle::femtoDreamCollisionId == collInFemto.globalIndex())&&
+                                                            (o2::aod::femtodreamparticle::partType == V0)&& ((o2::aod::femtodreamparticle::cut&V0Mask) == testedBit0) ;
+      
+      partsProton1.bindTable(partsFemto);
+      partsLambda1.bindTable(partsFemto);
+      partsProton0.bindTable(partsFemto);
+      partsLambda0.bindTable(partsFemto);
+
+      // This is the main trigger part for proton-proton-Lambda
+      // pairCleanerTV -> Test if lambda hyperons don't have a daughter which is as well used as primary proton
+      // Calculate Q3 and check if it is smaller than 0.6
+      // If at collision has at least one triplet with Q3<0.6, the trigger value is set to true!
+      // IMPORTANT: Include close pair rejection here
+      int lowQ3Triplets = 0; 
+      if(partsLambda0.size()>=1 && partsProton0.size()>=2){
+        for(auto& partLambda : partsLambda0){
+          if (!pairCleanerTV.isCleanPair(partLambda, partLambda, partsFemto)) {
+            continue;
+          }
+          for (auto& [p1, p2] : combinations(partsProton0, partsProton0) ){
+            auto Q3 = FemtoDreamMath::getQ3(p1, mMassProton, p2, mMassProton, partLambda, mMassLambda);
+            registry.get<TH1>(HIST("fSameEvent"))->Fill(Q3);
+            if(Q3<1.5)  lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
+          }
+        }
+      }      
+      if(partsLambda1.size()>=1 && partsProton1.size()>=2){
+        for(auto& partLambda : partsLambda1){
+          if (!pairCleanerTV.isCleanPair(partLambda, partLambda, partsFemto)) {
+            continue;
+          }
+          for (auto& [p1, p2] : combinations(partsProton1, partsProton1) ){
+            auto Q3 = FemtoDreamMath::getQ3(p1, mMassProton, p2, mMassProton, partLambda, mMassLambda);
+            registry.get<TH1>(HIST("fSameEvent"))->Fill(Q3);
+            if(Q3<1.5)  lowQ3Triplets++; // real value 0.6. We use 1.5 here for testing locally because of statistics
+          }
+        }
+      }
+      if(lowQ3Triplets>0) keepEvent[kPPL]=true;
+    }
+
+    tags(keepEvent[kPPP], keepEvent[kPPL], keepEvent[kPLL], keepEvent[kLLL]);
+    
+    if (!keepEvent[kPPP] && !keepEvent[kPPL] && !keepEvent[kPLL]&& !keepEvent[kLLL]) {
+      registry.get<TH1>(HIST("fProcessedEvents"))->Fill(1);
+    } else {
+      for (int iTrigger{0}; iTrigger < nTriplets; iTrigger++) {
+        if (keepEvent[iTrigger]) {
+          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger+1);
+        }
+      }
+    }
+
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
+{
+  return WorkflowSpec{adaptAnalysisTask<CFFilter>(cfg)};
+}

--- a/EventFiltering/PWGCF/CFFilter.cxx
+++ b/EventFiltering/PWGCF/CFFilter.cxx
@@ -57,7 +57,7 @@ static constexpr uint8_t Track = 0;      // Track
 static constexpr uint8_t V0 = 1;         // V0
 static constexpr uint8_t V0Daughter = 2; // V0  daughters
 static constexpr uint32_t kSignMinusMask = 1;
-static constexpr uint32_t kSignPlusMask = 1<<1;
+static constexpr uint32_t kSignPlusMask = 1 << 1;
 static constexpr uint32_t kValue0 = 0;
 
 } // namespace
@@ -79,11 +79,10 @@ struct CFFilter {
   Produces<aod::CFFilters> tags;
 
   //Obtain particle and antiparticle candidates of protons and lambda hyperons for current femto collision
-  Partition<o2::aod::FemtoDreamParticles> partsProton1 = (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & kSignPlusMask) >kValue0);
-  Partition<o2::aod::FemtoDreamParticles> partsLambda1 = (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & kSignPlusMask) >kValue0);
-  Partition<o2::aod::FemtoDreamParticles> partsProton0 = (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & kSignMinusMask)  >kValue0);
-  Partition<o2::aod::FemtoDreamParticles> partsLambda0 = (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & kSignMinusMask)  >kValue0);
-
+  Partition<o2::aod::FemtoDreamParticles> partsProton1 = (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & kSignPlusMask) > kValue0);
+  Partition<o2::aod::FemtoDreamParticles> partsLambda1 = (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & kSignPlusMask) > kValue0);
+  Partition<o2::aod::FemtoDreamParticles> partsProton0 = (o2::aod::femtodreamparticle::partType == Track) && ((o2::aod::femtodreamparticle::cut & kSignMinusMask) > kValue0);
+  Partition<o2::aod::FemtoDreamParticles> partsLambda0 = (o2::aod::femtodreamparticle::partType == V0) && ((o2::aod::femtodreamparticle::cut & kSignMinusMask) > kValue0);
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
@@ -92,7 +91,7 @@ struct CFFilter {
 
   void init(o2::framework::InitContext&)
   {
-    registry.add("fProcessedEvents", "CF - event filtered;;events", HistType::kTH1F, {{6, -0.5, 4.5}});
+    registry.add("fProcessedEvents", "CF - event filtered;;events", HistType::kTH1F, {{6, -0.5, 5.5}});
     std::array<std::string, 6> eventTitles = {"all", "rejected", "p-p-p", "p-p-L", "p-L-L", "L-L-L"};
     for (size_t iBin = 0; iBin < eventTitles.size(); iBin++) {
       registry.get<TH1>(HIST("fProcessedEvents"))->GetXaxis()->SetBinLabel(iBin + 1, eventTitles[iBin].data());
@@ -107,13 +106,13 @@ struct CFFilter {
   {
     registry.get<TH1>(HIST("fProcessedEvents"))->Fill(0);
     bool keepEvent[nTriplets]{false};
-    
+
     // This is the main trigger part for proton-proton-Lambda
     // pairCleanerTV -> Test if lambda hyperons don't have a daughter which is as well used as primary proton
     // Calculate Q3 and check if it is smaller than 0.6
     // If at collision has at least one triplet with Q3<0.6, the trigger value is set to true!
     // IMPORTANT: Include close pair rejection here
-    if(partsFemto.size()!=0){
+    if (partsFemto.size() != 0) {
       int lowQ3Triplets = 0;
       if (partsLambda0.size() >= 1 && partsProton0.size() >= 2) {
         for (auto& partLambda : partsLambda0) {
@@ -141,10 +140,9 @@ struct CFFilter {
           }
         }
       } // end if
-      if (lowQ3Triplets > 0) keepEvent[kPPL] = true;
+      if (lowQ3Triplets > 0)
+        keepEvent[kPPL] = true;
     }
-
-
 
     tags(keepEvent[kPPP], keepEvent[kPPL], keepEvent[kPLL], keepEvent[kLLL]);
 
@@ -153,7 +151,7 @@ struct CFFilter {
     } else {
       for (int iTrigger{0}; iTrigger < nTriplets; iTrigger++) {
         if (keepEvent[iTrigger]) {
-          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger + 1);
+          registry.get<TH1>(HIST("fProcessedEvents"))->Fill(iTrigger + 2);
         }
       }
     } // end else

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -60,7 +60,6 @@ DECLARE_SOA_TABLE(CFFilters, "AOD", "CF Filters", //!
                   filtering::PPP, filtering::PPL, filtering::PLL, filtering::LLL);
 using CfFilter = CFFilters::iterator;
 
-
 /// List of the available filters, the description of their tables and the name of the tasks
 constexpr int NumberOfFilters{4};
 constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "HeavyFlavourFilters", "CorrelationFilters"};

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -31,6 +31,12 @@ DECLARE_SOA_COLUMN(HfHighPt, hasHfHighPt, bool); //! high-pT charm hadron
 DECLARE_SOA_COLUMN(HfBeauty, hasHfBeauty, bool); //! beauty hadron
 DECLARE_SOA_COLUMN(HfFemto, hasHfFemto, bool);   //! charm-hadron - N pair
 
+// CF three body triggers
+DECLARE_SOA_COLUMN(PPP, hasPPP, bool); //! has p-p-p triplet
+DECLARE_SOA_COLUMN(PPL, hasPPL, bool); //! has p-p-L triplet
+DECLARE_SOA_COLUMN(PLL, hasPLL, bool); //! has p-L-L triplet
+DECLARE_SOA_COLUMN(LLL, hasLLL, bool); //! has L-L-L tripletD
+
 } // namespace filtering
 
 // nuclei
@@ -49,12 +55,18 @@ DECLARE_SOA_TABLE(HfFilters, "AOD", "HF Filters", //!
 
 using HfFilter = HfFilters::iterator;
 
+// correlations
+DECLARE_SOA_TABLE(CFFilters, "AOD", "CF Filters", //!
+                  filtering::PPP, filtering::PPL, filtering::PLL, filtering::LLL);
+using CfFilter = CFFilters::iterator;
+
+
 /// List of the available filters, the description of their tables and the name of the tasks
-constexpr int NumberOfFilters{3};
-constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "HeavyFlavourFilters"};
-constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "HFFilters"};
-constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-hf-filter"};
-constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, HfFilters> FiltersPack;
+constexpr int NumberOfFilters{4};
+constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "HeavyFlavourFilters", "CorrelationFilters"};
+constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "HFFilters", "CFFilters"};
+constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-hf-filter", "o2-analysis-cf-filter"};
+constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, HfFilters, CFFilters> FiltersPack;
 static_assert(o2::framework::pack_size(FiltersPack) == NumberOfFilters);
 
 template <typename T, typename C>

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -26,20 +26,20 @@
 namespace o2::aod
 {
 using FilteredFullCollisions = soa::Filtered<soa::Join<aod::Collisions,
-                                                      aod::EvSels,
-                                                      aod::Mults>>; 
-using FilteredFullCollision = FilteredFullCollisions::iterator; 
+                                                       aod::EvSels,
+                                                       aod::Mults>>;
+using FilteredFullCollision = FilteredFullCollisions::iterator;
 /// FemtoDreamCollision
 namespace femtodreamcollision
 {
-DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
-DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
-DECLARE_SOA_INDEX_COLUMN_FULL(Collision, collision, int, FilteredFullCollisions, "_0");       //! GlobalIndex  
+DECLARE_SOA_COLUMN(MultV0M, multV0M, float);                                            //! V0M multiplicity
+DECLARE_SOA_COLUMN(Sphericity, sphericity, float);                                      //! Sphericity of the event
+DECLARE_SOA_INDEX_COLUMN_FULL(Collision, collision, int, FilteredFullCollisions, "_0"); //! GlobalIndex
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",
                   o2::soa::Index<>,
-                  femtodreamcollision::CollisionId, 
+                  femtodreamcollision::CollisionId,
                   o2::aod::collision::PosZ,
                   femtodreamcollision::MultV0M,
                   femtodreamcollision::Sphericity);

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -16,7 +16,6 @@
 #include "MathUtils/Utils.h"
 #include "Framework/DataTypes.h"
 #include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/EventSelection.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/Expressions.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -25,21 +24,15 @@
 
 namespace o2::aod
 {
-using FilteredFullCollisions = soa::Filtered<soa::Join<aod::Collisions,
-                                                       aod::EvSels,
-                                                       aod::Mults>>;
-using FilteredFullCollision = FilteredFullCollisions::iterator;
 /// FemtoDreamCollision
 namespace femtodreamcollision
 {
 DECLARE_SOA_COLUMN(MultV0M, multV0M, float);                                            //! V0M multiplicity
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float);                                      //! Sphericity of the event
-DECLARE_SOA_INDEX_COLUMN_FULL(Collision, collision, int, FilteredFullCollisions, "_0"); //! GlobalIndex
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",
                   o2::soa::Index<>,
-                  femtodreamcollision::CollisionId,
                   o2::aod::collision::PosZ,
                   femtodreamcollision::MultV0M,
                   femtodreamcollision::Sphericity);

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -16,6 +16,7 @@
 #include "MathUtils/Utils.h"
 #include "Framework/DataTypes.h"
 #include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/EventSelection.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/Expressions.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -24,16 +25,21 @@
 
 namespace o2::aod
 {
-
+using FilteredFullCollisions = soa::Filtered<soa::Join<aod::Collisions,
+                                                      aod::EvSels,
+                                                      aod::Mults>>; 
+using FilteredFullCollision = FilteredFullCollisions::iterator; 
 /// FemtoDreamCollision
 namespace femtodreamcollision
 {
 DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
+DECLARE_SOA_INDEX_COLUMN_FULL(Collision, collision, int, FilteredFullCollisions, "_0");       //! GlobalIndex  
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",
                   o2::soa::Index<>,
+                  femtodreamcollision::CollisionId, 
                   o2::aod::collision::PosZ,
                   femtodreamcollision::MultV0M,
                   femtodreamcollision::Sphericity);

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -27,8 +27,8 @@ namespace o2::aod
 /// FemtoDreamCollision
 namespace femtodreamcollision
 {
-DECLARE_SOA_COLUMN(MultV0M, multV0M, float);                                            //! V0M multiplicity
-DECLARE_SOA_COLUMN(Sphericity, sphericity, float);                                      //! Sphericity of the event
+DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
+DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",

--- a/PWGCF/FemtoDream/FemtoDreamMath.h
+++ b/PWGCF/FemtoDream/FemtoDreamMath.h
@@ -11,7 +11,7 @@
 
 /// \file FemtoDreamMath.h
 /// \brief Definition of the FemtoDreamMath Container for math calculations of quantities related to pairs
-/// \author Valentina Mantovani Sarti, TU München, valentina.mantovani-sarti@tum.de
+/// \author Valentina Mantovani Sarti, TU München, valentina.mantovani-sarti@tum.de, Laura Serksnyte, TU München, laura.serksnyte@cern.ch
 
 #ifndef ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMMATH_H_
 #define ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMMATH_H_
@@ -58,6 +58,55 @@ class FemtoDreamMath
 
     const ROOT::Math::PxPyPzMVector trackRelK = PartOneCMS - PartTwoCMS;
     return 0.5 * trackRelK.P();
+  }
+    /// Compute the qij of a pair of particles
+  /// \tparam T type of tracks
+  /// \param vecparti Particle i PxPyPzMVector
+  /// \param vecpartj Particle j PxPyPzMVector
+  // The q12 components can be calculated as:
+  //             q^mu = (p1-p2)^mu /2 - ((p1-p2)*P/(2P^2))*P^mu
+  //             where P = p1+p2
+  // Reference: https://www.annualreviews.org/doi/pdf/10.1146/annurev.nucl.55.090704.151533
+  // In the following code the above written equation will be expressed as:
+  //             q = trackDifference/2 -  scaling * trackSum
+  // where scaling is a float number:
+  //             scaling = trackDifference*trackSum/(2*trackSum^2) = ((p1-p2)*P/(2P^2))
+  // We don't use the reduced vector - no division by 2
+  template <typename T>
+  static ROOT::Math::PxPyPzEVector getqij(const T& vecparti, const T& vecpartj)
+  {
+    ROOT::Math::PxPyPzEVector trackSum = vecparti + vecpartj;
+    ROOT::Math::PxPyPzEVector trackDifference = vecparti - vecpartj;
+    float scaling = trackDifference.Dot(trackSum)/trackSum.Dot(trackSum);
+    return  trackDifference -  scaling * trackSum;
+  }
+
+  /// Compute the Q3 of a triplet of particles
+  /// \tparam T type of tracks
+  /// \param part1 Particle 1
+  /// \param mass1 Mass of particle 1
+  /// \param part2 Particle 2
+  /// \param mass2 Mass of particle 2
+  /// \param part3 Particle 3
+  /// \param mass3 Mass of particle 3
+  template <typename T>
+  static float getQ3(const T& part1, const float mass1, const T& part2, const float mass2, const T& part3, const float mass3)
+  {
+    float E1 = sqrt(pow(part1.px(),2)+pow(part1.py(),2)+pow(part1.pz(),2)+pow(mass1,2));
+    float E2 = sqrt(pow(part2.px(),2)+pow(part2.py(),2)+pow(part2.pz(),2)+pow(mass2,2));
+    float E3 = sqrt(pow(part3.px(),2)+pow(part3.py(),2)+pow(part3.pz(),2)+pow(mass3,2));
+
+    const ROOT::Math::PxPyPzEVector vecpart1(part1.px(), part1.py(), part1.pz(), E1);
+    const ROOT::Math::PxPyPzEVector vecpart2(part2.px(), part2.py(), part2.pz(), E2);
+    const ROOT::Math::PxPyPzEVector vecpart3(part3.px(), part3.py(), part3.pz(), E3);
+
+    ROOT::Math::PxPyPzEVector q12 = getqij(vecpart1,vecpart2);
+    ROOT::Math::PxPyPzEVector q23 = getqij(vecpart2,vecpart3);
+    ROOT::Math::PxPyPzEVector q31 = getqij(vecpart3,vecpart1);
+
+    float Q32 = q12.M2()+q23.M2()+q31.M2();
+
+    return sqrt(-Q32);
   }
 
   /// Compute the transverse momentum of a pair of particles

--- a/PWGCF/FemtoDream/FemtoDreamMath.h
+++ b/PWGCF/FemtoDream/FemtoDreamMath.h
@@ -59,7 +59,7 @@ class FemtoDreamMath
     const ROOT::Math::PxPyPzMVector trackRelK = PartOneCMS - PartTwoCMS;
     return 0.5 * trackRelK.P();
   }
-    /// Compute the qij of a pair of particles
+  /// Compute the qij of a pair of particles
   /// \tparam T type of tracks
   /// \param vecparti Particle i PxPyPzMVector
   /// \param vecpartj Particle j PxPyPzMVector
@@ -77,8 +77,8 @@ class FemtoDreamMath
   {
     ROOT::Math::PxPyPzEVector trackSum = vecparti + vecpartj;
     ROOT::Math::PxPyPzEVector trackDifference = vecparti - vecpartj;
-    float scaling = trackDifference.Dot(trackSum)/trackSum.Dot(trackSum);
-    return  trackDifference -  scaling * trackSum;
+    float scaling = trackDifference.Dot(trackSum) / trackSum.Dot(trackSum);
+    return trackDifference - scaling * trackSum;
   }
 
   /// Compute the Q3 of a triplet of particles
@@ -92,19 +92,19 @@ class FemtoDreamMath
   template <typename T>
   static float getQ3(const T& part1, const float mass1, const T& part2, const float mass2, const T& part3, const float mass3)
   {
-    float E1 = sqrt(pow(part1.px(),2)+pow(part1.py(),2)+pow(part1.pz(),2)+pow(mass1,2));
-    float E2 = sqrt(pow(part2.px(),2)+pow(part2.py(),2)+pow(part2.pz(),2)+pow(mass2,2));
-    float E3 = sqrt(pow(part3.px(),2)+pow(part3.py(),2)+pow(part3.pz(),2)+pow(mass3,2));
+    float E1 = sqrt(pow(part1.px(), 2) + pow(part1.py(), 2) + pow(part1.pz(), 2) + pow(mass1, 2));
+    float E2 = sqrt(pow(part2.px(), 2) + pow(part2.py(), 2) + pow(part2.pz(), 2) + pow(mass2, 2));
+    float E3 = sqrt(pow(part3.px(), 2) + pow(part3.py(), 2) + pow(part3.pz(), 2) + pow(mass3, 2));
 
     const ROOT::Math::PxPyPzEVector vecpart1(part1.px(), part1.py(), part1.pz(), E1);
     const ROOT::Math::PxPyPzEVector vecpart2(part2.px(), part2.py(), part2.pz(), E2);
     const ROOT::Math::PxPyPzEVector vecpart3(part3.px(), part3.py(), part3.pz(), E3);
 
-    ROOT::Math::PxPyPzEVector q12 = getqij(vecpart1,vecpart2);
-    ROOT::Math::PxPyPzEVector q23 = getqij(vecpart2,vecpart3);
-    ROOT::Math::PxPyPzEVector q31 = getqij(vecpart3,vecpart1);
+    ROOT::Math::PxPyPzEVector q12 = getqij(vecpart1, vecpart2);
+    ROOT::Math::PxPyPzEVector q23 = getqij(vecpart2, vecpart3);
+    ROOT::Math::PxPyPzEVector q31 = getqij(vecpart3, vecpart1);
 
-    float Q32 = q12.M2()+q23.M2()+q31.M2();
+    float Q32 = q12.M2() + q23.M2() + q31.M2();
 
     return sqrt(-Q32);
   }

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -11,13 +11,14 @@
 
 /// \file FemtoDreamPairCleaner.h
 /// \brief FemtoDreamPairCleaner - Makes sure only proper candidates are paired
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de, Laura Serksnyte <laura.serksnyte@cern.ch>, TU München
 
 #ifndef ANALYSIS_TASKS_PWGCF_O2FEMTODREAM_INCLUDE_O2FEMTODREAM_FEMTODREAMPAIRCLEANER_H_
 #define ANALYSIS_TASKS_PWGCF_O2FEMTODREAM_INCLUDE_O2FEMTODREAM_FEMTODREAMPAIRCLEANER_H_
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "Framework/HistogramRegistry.h"
+
 
 using namespace o2::framework;
 
@@ -61,6 +62,13 @@ class FemtoDreamPairCleaner
     } else if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kV0) {
       /// Track-V0 combination
       // \todo to be implemented
+      uint64_t id1 = part2.indices()[0];
+      uint64_t id2 = part2.indices()[1];
+      auto daughter1 = particles.begin()+id1;
+      auto daughter2 = particles.begin()+id2;
+      if((*daughter1).indices()[0]<=0&&(*daughter1).indices()[1]<=0&&(*daughter2).indices()[0]<=0&&(*daughter2).indices()[1]<=0){
+        return true;
+      }
       return false;
     } else if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       /// Track-Cascade combination

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -19,7 +19,6 @@
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "Framework/HistogramRegistry.h"
 
-
 using namespace o2::framework;
 
 namespace o2::analysis::femtoDream
@@ -64,9 +63,9 @@ class FemtoDreamPairCleaner
       // \todo to be implemented
       uint64_t id1 = part2.indices()[0];
       uint64_t id2 = part2.indices()[1];
-      auto daughter1 = particles.begin()+id1;
-      auto daughter2 = particles.begin()+id2;
-      if((*daughter1).indices()[0]<=0&&(*daughter1).indices()[1]<=0&&(*daughter2).indices()[0]<=0&&(*daughter2).indices()[1]<=0){
+      auto daughter1 = particles.begin() + id1;
+      auto daughter2 = particles.begin() + id2;
+      if ((*daughter1).indices()[0] <= 0 && (*daughter1).indices()[1] <= 0 && (*daughter2).indices()[0] <= 0 && (*daughter2).indices()[1] <= 0) {
         return true;
       }
       return false;

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -32,7 +32,6 @@
 #include "Math/Vector4D.h"
 #include "TMath.h"
 
-
 using namespace o2;
 using namespace o2::analysis::femtoDream;
 using namespace o2::framework;
@@ -168,14 +167,14 @@ struct femtoDreamProducerTask {
     v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
   }
 
-  void process(soa::Join<aod::Collisions,aod::EvSels,aod::Mults>::iterator const& col,
+  void process(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& col,
                aod::FilteredFullTracks const& tracks,
                o2::aod::V0Datas const& fullV0s) /// \todo with FilteredFullV0s
-  {   
+  {
     /// First thing to do is to check whether the basic event selection criteria are fulfilled
     if (!colCuts.isSelected(col)) {
       // if it is a trigger run, store unselected collision as well
-      if(ConfIsTrigger){
+      if (ConfIsTrigger) {
         outputCollision(col.posZ(), col.multV0M(), colCuts.computeSphericity(col, tracks)); // globalIndexAO2D is required for the 3-body trigger
       }
       return;
@@ -185,7 +184,7 @@ struct femtoDreamProducerTask {
     const auto spher = colCuts.computeSphericity(col, tracks);
     colCuts.fillQA(col);
     // now the table is filled
-    outputCollision( vtxZ, mult, spher); // globalIndexAO2D is required for the 3-body trigger
+    outputCollision(vtxZ, mult, spher); // globalIndexAO2D is required for the 3-body trigger
 
     int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -32,6 +32,8 @@
 #include "Math/Vector4D.h"
 #include "TMath.h"
 
+
+
 using namespace o2;
 using namespace o2::analysis::femtoDream;
 using namespace o2::framework;
@@ -177,9 +179,10 @@ struct femtoDreamProducerTask {
     const auto vtxZ = col.posZ();
     const auto mult = col.multV0M();
     const auto spher = colCuts.computeSphericity(col, tracks);
+    const auto globalIndexAO2D = col.globalIndex(); // this is required for the 3-body trigger
     colCuts.fillQA(col);
     // now the table is filled
-    outputCollision(vtxZ, mult, spher);
+    outputCollision(globalIndexAO2D,vtxZ, mult, spher);// globalIndexAO2D is required for the 3-body trigger
 
     int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
@@ -221,6 +224,7 @@ struct femtoDreamProducerTask {
       }
       v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
       auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, v0, postrack, negtrack);
+
       if ((cutContainerV0.at(0) > 0) && (cutContainerV0.at(1) > 0) && (cutContainerV0.at(3) > 0)) {
         int postrackID = v0.posTrackId();
         int rowInPrimaryTrackTablePos = -1;

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -32,8 +32,6 @@
 #include "Math/Vector4D.h"
 #include "TMath.h"
 
-
-
 using namespace o2;
 using namespace o2::analysis::femtoDream;
 using namespace o2::framework;
@@ -182,7 +180,7 @@ struct femtoDreamProducerTask {
     const auto globalIndexAO2D = col.globalIndex(); // this is required for the 3-body trigger
     colCuts.fillQA(col);
     // now the table is filled
-    outputCollision(globalIndexAO2D,vtxZ, mult, spher);// globalIndexAO2D is required for the 3-body trigger
+    outputCollision(globalIndexAO2D, vtxZ, mult, spher); // globalIndexAO2D is required for the 3-body trigger
 
     int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -89,7 +89,7 @@ struct femtoDreamProducerTask {
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
 
-  Filter colFilter = (ConfIsTrigger == (uint8_t) false && nabs(aod::collision::posZ) < ConfEvtZvtx) || ConfIsTrigger == (uint8_t) true;
+  Filter colFilter = (ConfIsTrigger == (uint8_t) true) || (nabs(aod::collision::posZ) < ConfEvtZvtx);
 
   FemtoDreamTrackSelection trackCuts;
   Configurable<std::vector<float>> ConfTrkCharge{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kSign, "Track selection: ")};
@@ -181,7 +181,7 @@ struct femtoDreamProducerTask {
     // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
-        outputCollision(col.posZ(), col.multV0M(), colCuts.computeSphericity(col, tracks)); // globalIndexAO2D is required for the 3-body trigger
+        outputCollision(col.posZ(), col.multV0M(), colCuts.computeSphericity(col, tracks));
       }
       return;
     }


### PR DESCRIPTION
Dear experts,
this is the first version of 3-body trigger. As you will see, it is a bit slow, because there are sliceBy() and Partitions used for every collision. The current idea is to run femto skimming task and pipe the output to trigger. The CFFilter task currently takes as input aod::FullCollision const& col as well as the full FemtoDreamCollisions and FemtoDreamParticles tables. Then inside the code, I check, if the current collision is present in FemtoDreamCollision table -> if it is not, I set the trigger to false. Otherwise, the trigger is applied by forming triplets out of the particle candidates but for this, I have to use only the particles which are coming from specific collision thus inside the process task I apply the partitions. Please, let me know if there is a more efficient way to do this.
P.S. I as well had an idea to take as input only the FemtoDreamCollisions and FemtoDreamParticles. The FemtoDreamCollisions table has a column that stores the globalIndex from FullCollision table. If the skimming task is fed the collisions in order and there will be no parallelization on such level, one could then check the globalIndex and if for example the first collision in FemtoDreamCollisions has collisionID 5, one knows that the first 4 collisions from FullCollision table were rejected and one can update then the trigger table 4 times using trigger value false and then apply the trigger on current collision with collisionID 5. However, I am new to O2Physics and I don't know if this would be possible. Any advices will be greatly appreciated.
Cheers
Laura