### PR TITLE
PWGHF: Add (ALICE3) centrality selection in the Λc task

### DIFF
--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -45,7 +45,7 @@ struct TaskLc {
      {"hptprong0", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hptprong1", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
      {"hptprong2", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-     {"hcentrality", "centality; centrality percentile;  entries", {HistType::kTH1F, {{100, 0., 100.}}}}}};
+     {"hCentrality", "centrality;centrality percentile;entries", {HistType::kTH1F, {{100, 0., 100.}}}}}};
 
   Configurable<int> d_selectionFlagLc{"d_selectionFlagLc", 1, "Selection Flag for Lc"};
   Configurable<double> cutYCandMax{"cutYCandMax", -1., "max. cand. rapidity"};

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -70,11 +70,12 @@ struct TaskLc {
     registry.add("hdca2", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
   }
 
+  // FIXME: Add ALICE 2/3 switch!
   //void process(aod::HfCandProng3 const& candidates)
   void process(soa::Join<aod::Collisions, aod::Cents>::iterator const& collision, soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelLcCandidate>> const& candidates)
   {
     float centrality = collision.centV0M();
-    registry.fill(HIST("hcentrality"), centrality);
+    registry.fill(HIST("hCentrality"), centrality);
 
     for (auto& candidate : candidates) {
       if (!(candidate.hfflag() & 1 << DecayType::LcToPKPi)) {


### PR DESCRIPTION
Added (ALICE3) centrality as another dimension of the inv. mass histogram to be able to select offline for the desired centrality range.