### PR TITLE
Revert "Try using team as code owner"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,6 @@
 # **DO NOT USE** @AliceO2Group/core for anything else. 
 * @AliceO2Group/core @jgrosseo @iarsene @ktf
 /ALICE3  @njacazio @ginnocen @vkucera
-/PWGHF  @AliceO2Group/O2Physics-PWGHF-code-owners
+/PWGHF  @ginnocen @vkucera
 /EventFiltering @mpuccio
 /PWGMM @aalkin


### PR DESCRIPTION
Reverts AliceO2Group/O2Physics#132 as it didnt work.