### PR TITLE
Change bitmask provided by cutculator

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -111,6 +111,7 @@ class FemtoDreamCutculator
 
     /// If the input is sane, the selection bit is put together
     if (inputSane) {
+      int internal_index = 0;
       for (auto sel : selVec) {
         double signOffset;
         switch (sel.getSelectionType()) {
@@ -130,8 +131,12 @@ class FemtoDreamCutculator
         /// for upper and lower limit we have to substract/add an epsilon so that the cut is actually fulfilled
         if (sel.isSelected(input + signOffset * 1.e-6 * input)) {
           output |= 1UL << counter;
+          for (int i = internal_index; i > 0; i--) {
+            output &= ~(1UL << (counter - i));
+          }
         }
         ++counter;
+        ++internal_index;
       }
     } else {
       std::cout << "Choice " << in << " not recognized - repeating\n";

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -47,7 +47,7 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// Partition for particle 1
   Partition<aod::FemtoDreamParticles> partsOne = (aod::femtodreamparticle::partType == Track) &&
-                                                 //  (aod::femtodreamparticle::cut == ConfCutPartOne) && // not working, need for bit-mask
+                                                 ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne) && // not working, need for bit-mask
                                                  (aod::femtodreamparticle::pt > ConfPtMinPartOne) &&
                                                  (aod::femtodreamparticle::pt < ConfPtMaxPartOne) &&
                                                  (nabs(aod::femtodreamparticle::tempFitVar) < ConfDCAxyMaxPartOne) &&
@@ -70,7 +70,7 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// Partition for particle 2
   Partition<aod::FemtoDreamParticles> partsTwo = (aod::femtodreamparticle::partType == Track) &&
-                                                 //  (aod::femtodreamparticle::cut == ConfCutPartTwo) && // not working, need for bit-mask
+                                                 ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo) && // not working, need for bit-mask
                                                  (aod::femtodreamparticle::pt > ConfPtMinPartTwo) &&
                                                  (aod::femtodreamparticle::pt < ConfPtMaxPartTwo) &&
                                                  (nabs(aod::femtodreamparticle::tempFitVar) < ConfDCAxyMaxPartTwo) &&


### PR DESCRIPTION
Cutculator now provides a bitmask that is ready to use for track selections.
