### PR TITLE
Inclusion of CPR in Track-Track task, update of DetaDphiStar task

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
@@ -82,10 +82,10 @@ class FemtoDreamDetaDphiStar
       auto dphiAvg = AveragePhiStar(part1, part2, 0);
       histdetadpi[0][0]->Fill(deta, dphiAvg);
       if (pow(dphiAvg, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
-        return false;
+        return true;
       } else {
         histdetadpi[0][1]->Fill(deta, dphiAvg);
-        return true;
+        return false;
       }
 
     } else if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kV0) {
@@ -103,7 +103,7 @@ class FemtoDreamDetaDphiStar
         auto dphiAvg = AveragePhiStar(part1, *daughter, i);
         histdetadpi[i][0]->Fill(deta, dphiAvg);
         if (pow(dphiAvg, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
-          pass = false;
+          pass = true;
         } else {
           histdetadpi[i][1]->Fill(deta, dphiAvg);
         }


### PR DESCRIPTION
- the cut for Close Pair rejection has been added to the Track-Track task for both SE and ME
- added configurable for the value and sign of magnetic field (hard-coded at the moment)
- modification of boolean logic of isClosePair function 