### PR TITLE
Only auto-approve PRs if requested by PR author

### DIFF
--- a/.github/workflows/codeowner-self-approval.yml
+++ b/.github/workflows/codeowner-self-approval.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   approve:
     runs-on: ubuntu-latest
+    # Only run if the PR author enabled auto-merge, not someone else.
+    if: github.event.sender.login == github.event.pull_request.user.login
 
     steps:
       # Check out in order to get CODEOWNERS.


### PR DESCRIPTION
This prevents someone who is not the code owner, but has "Write" permissions on the repository from enabling auto-merge and thereby requesting auto-approval.