### PR TITLE
Automatic cutculator configuration from json

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -80,6 +80,27 @@ class FemtoDreamCutculator
     }
   }
 
+  /// Retrieves automatically The selection passed to the function is retrieves from the dpl-config.json
+  /// \param prefix Prefix which is added to the name of the Configurable
+  void setTrackSelectionFromFile(const char* prefix)
+  {
+    for (const auto& sel : mConfigTree) {
+      std::string sel_name = sel.first;
+      femtoDreamTrackSelection::TrackSel obs;
+      if (sel_name.find(prefix) != std::string::npos) {
+        int index = FemtoDreamTrackSelection::findSelectionIndex(std::string_view(sel_name), prefix);
+        if (index >= 0) {
+          obs = femtoDreamTrackSelection::TrackSel(index);
+        } else {
+          continue;
+        }
+        if (obs == femtoDreamTrackSelection::TrackSel::kPIDnSigmaMax)
+          continue; // kPIDnSigmaMax is a special case
+        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs), prefix);
+      }
+    }
+  }
+
   /// This function investigates a given selection criterion. The available options are displayed in the terminal and the bit-wise container is put together according to the user input
   /// \tparam T1 Selection class under investigation
   /// \param T2  Selection type under investigation
@@ -171,9 +192,9 @@ class FemtoDreamCutculator
     if (in.compare("T") == 0) {
       output = iterateSelection(mTrackSel);
     } else if (in.compare("V") == 0) {
-      //output=  iterateSelection<nBins>(mV0Sel);
+      // output=  iterateSelection<nBins>(mV0Sel);
     } else if (in.compare("C") == 0) {
-      //output =  iterateSelection<nBins>(mCascadeSel);
+      // output =  iterateSelection<nBins>(mCascadeSel);
     } else {
       std::cout << "Option " << in << " not recognized - available options are (T/V/C) \n";
       analyseCuts();

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -143,6 +143,27 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
     return outString;
   }
 
+  /// Helper function to obtain the index of a given selection variable for consistent naming of the configurables
+  /// \param obs Track selection variable (together with prefix) got from file
+  /// \param prefix Additional prefix for the output of the configurable
+  static int findSelectionIndex(const std::string_view& obs, std::string_view prefix = "")
+  {
+    for (int index = 0; index < kNtrackSelection; index++) {
+      std::string_view cmp{static_cast<std::string>(prefix) + static_cast<std::string>(mSelectionNames[index])};
+      if (obs.compare(cmp) == 0)
+        return index;
+    }
+    LOGF(info, "Variable %s not found", obs);
+    return -1;
+  }
+
+  /// Helper function to obtain the type of a given selection variable for consistent naming of the configurables
+  /// \param iSel Track selection variable whose type is returned
+  static femtoDreamSelection::SelectionType getSelectionType(femtoDreamTrackSelection::TrackSel iSel)
+  {
+    return mSelectionTypes[iSel];
+  }
+
   /// Helper function to obtain the helper string of a given selection criterion for consistent description of the configurables
   /// \param iSel Track selection variable to be examined
   /// \param prefix Additional prefix for the output of the configurable
@@ -177,31 +198,46 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
   float dcaMin;
   float nSigmaPIDMax;
   std::vector<o2::track::PID> mPIDspecies; ///< All the particle species for which the n_sigma values need to be stored
-  static constexpr std::string_view mSelectionNames[12] = {"Sign",
-                                                           "PtMin",
-                                                           "PtMax",
-                                                           "EtaMax",
-                                                           "TPCnClsMin",
-                                                           "TPCfClsMin",
-                                                           "TPCcRowsMin",
-                                                           "TPCsClsMax",
-                                                           "DCAxyMax",
-                                                           "DCAzMax",
-                                                           "DCAMin",
-                                                           "PIDnSigmaMax"}; ///< Name of the different selections
-  static constexpr std::string_view mSelectionHelper[12] = {"Sign of the track",
-                                                            "Minimal pT (GeV/c)",
-                                                            "Maximal pT (GeV/c)",
-                                                            "Maximal eta",
-                                                            "Minimum number of TPC clusters",
-                                                            "Minimum fraction of crossed rows/findable clusters",
-                                                            "Minimum number of crossed TPC rows",
-                                                            "Maximal number of shared TPC cluster",
-                                                            "Maximal DCA_xy (cm)",
-                                                            "Maximal DCA_z (cm)",
-                                                            "Minimal DCA (cm)",
-                                                            "Maximal PID (nSigma)"}; ///< Helper information for the different selections
-};                                                                                   // namespace femtoDream
+  static constexpr int kNtrackSelection = 12;
+  static constexpr std::string_view mSelectionNames[kNtrackSelection] = {"Sign",
+                                                                         "PtMin",
+                                                                         "PtMax",
+                                                                         "EtaMax",
+                                                                         "TPCnClsMin",
+                                                                         "TPCfClsMin",
+                                                                         "TPCcRowsMin",
+                                                                         "TPCsClsMax",
+                                                                         "DCAxyMax",
+                                                                         "DCAzMax",
+                                                                         "DCAMin",
+                                                                         "PIDnSigmaMax"}; ///< Name of the different selections
+
+  static constexpr femtoDreamSelection::SelectionType mSelectionTypes[kNtrackSelection]{femtoDreamSelection::kEqual,
+                                                                                        femtoDreamSelection::kLowerLimit,
+                                                                                        femtoDreamSelection::kUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit,
+                                                                                        femtoDreamSelection::kLowerLimit,
+                                                                                        femtoDreamSelection::kLowerLimit,
+                                                                                        femtoDreamSelection::kLowerLimit,
+                                                                                        femtoDreamSelection::kUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit}; ///< Map to match a variable with its type
+
+  static constexpr std::string_view mSelectionHelper[kNtrackSelection] = {"Sign of the track",
+                                                                          "Minimal pT (GeV/c)",
+                                                                          "Maximal pT (GeV/c)",
+                                                                          "Maximal eta",
+                                                                          "Minimum number of TPC clusters",
+                                                                          "Minimum fraction of crossed rows/findable clusters",
+                                                                          "Minimum number of crossed TPC rows",
+                                                                          "Maximal number of shared TPC cluster",
+                                                                          "Maximal DCA_xy (cm)",
+                                                                          "Maximal DCA_z (cm)",
+                                                                          "Minimal DCA (cm)",
+                                                                          "Maximal PID (nSigma)"}; ///< Helper information for the different selections
+};                                                                                                 // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part, typename cutContainerType>
 void FemtoDreamTrackSelection::init(HistogramRegistry* registry, const std::string WhichDaugh)

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -26,16 +26,7 @@ int main(int argc, char* argv[])
 {
   FemtoDreamCutculator cut;
   cut.init(argv[1]);
-
-  cut.setTrackSelection(femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kpTMin, femtoDreamSelection::kLowerLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kpTMax, femtoDreamSelection::kUpperLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kTPCfClsMin, femtoDreamSelection::kLowerLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kTPCsClsMax, femtoDreamSelection::kUpperLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kDCAxyMax, femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
-  cut.setTrackSelection(femtoDreamTrackSelection::kDCAzMax, femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
+  cut.setTrackSelectionFromFile("ConfTrk");
 
   /// \todo factor out the pid here
   // cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit, "ConfTrk");

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -135,7 +135,7 @@ struct femtoDreamPairTaskTrackTrack {
     bool pidSelection = true;
     for (auto it : vec) {
       //\todo we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
-      //if (!((pidcut >> it.first) & it.second)) {
+      // if (!((pidcut >> it.first) & it.second)) {
       if (!((pidcut >> it) & 1)) {
         pidSelection = false;
       }
@@ -190,7 +190,7 @@ struct femtoDreamPairTaskTrackTrack {
         continue;
       }
 
-      ///close pair rejection
+      /// close pair rejection
       if (ConfIsCPR) {
         if (pairCloseRejection.isClosePair(p1, p2, parts)) {
           continue;


### PR DESCRIPTION
Previously, the selection variables were set manually in `fetmtoDreamCutCulator.cxx`. The method was potentially dangerous, in case the variable were not the same as in the producer task. Now the selection variables are directly read from the json file.