### PR TITLE
PWGHF: make HfTagSelTracks handle Run 3 data with unassigned tracks

### DIFF
--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -321,15 +321,18 @@ struct HfTagSelTracks {
 #endif
   )
   {
+    auto prevColId = -1;
     math_utils::Point3D<float> vtxXYZ;
     for (auto& track : tracks) {
-      // reset to origin
-      // FIXME: use some other definitely incorrect value?
-      vtxXYZ = {0, 0, 0};
-
       if (track.has_collision()) {
-        auto collision = track.collision();
-        vtxXYZ = {collision.posX(), collision.posY(), collision.posZ()};
+        if (track.collisionId() != prevColId) {
+          auto collision = track.collision();
+          vtxXYZ = {collision.posX(), collision.posY(), collision.posZ()};
+          prevColId = track.collisionId();
+        }
+      } else {
+        // reset vertex for unassigned track
+        vtxXYZ = {0, 0, 0};
       }
 
 #ifdef MY_DEBUG


### PR DESCRIPTION
This will make `HFSelTrack` compatible with `Tracks` table if there are unassigned tracks. These tracks will enter the selection histograms but will have invalid DCA (currently set to put them into overflow bin). 