### PR TITLE
PWGHF: Use process switches instead of workflow options for Lc analysis chain

### DIFF
--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -150,9 +150,10 @@ struct HFCandidateCreator3ProngExpressions {
   void init(InitContext const&) {}
 
   /// Performs MC matching.
-  void processMC(aod::BigTracksMC const& /*tracks*/,
+  void processMC(aod::BigTracksMC const& tracks,
                  aod::McParticles const& particlesMC)
   {
+    rowCandidateProng3->bindExternalIndices(&tracks);
     int indexRec = -1;
     int8_t sign = 0;
     int8_t flag = 0;

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -143,18 +143,15 @@ struct HFCandidateCreator3Prong {
 
 /// Extends the base table with expression columns.
 struct HFCandidateCreator3ProngExpressions {
-  Spawns<aod::HfCandProng3Ext> rowCandidateProng3;
-  void init(InitContext const&) {}
-};
-
-/// Performs MC matching.
-struct HFCandidateCreator3ProngMC {
   Produces<aod::HfCandProng3MCRec> rowMCMatchRec;
   Produces<aod::HfCandProng3MCGen> rowMCMatchGen;
 
-  void process(aod::HfCandProng3 const& candidates,
-               aod::BigTracksMC const& tracks,
-               aod::McParticles const& particlesMC)
+  Spawns<aod::HfCandProng3Ext> rowCandidateProng3;
+  void init(InitContext const&) {}
+
+  /// Performs MC matching.
+  void processMC(aod::BigTracksMC const& /*tracks*/,
+                 aod::McParticles const& particlesMC)
   {
     int indexRec = -1;
     int8_t sign = 0;
@@ -169,7 +166,8 @@ struct HFCandidateCreator3ProngMC {
     std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus}; // Λc± → Λ(1520) π±
 
     // Match reconstructed candidates.
-    for (auto& candidate : candidates) {
+    // Spawned table can be used directly
+    for (auto& candidate : *rowCandidateProng3) {
       //Printf("New rec. candidate");
       flag = 0;
       origin = 0;
@@ -196,7 +194,7 @@ struct HFCandidateCreator3ProngMC {
           swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
           RecoDecay::getDaughters(particlesMC, particlesMC.iteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
-            for (auto iProng = 0; iProng < arrDaughIndex.size(); ++iProng) {
+            for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.iteratorAt(arrDaughIndex[iProng]);
               arrPDGDaugh[iProng] = std::abs(daughI.pdgCode());
             }
@@ -252,7 +250,7 @@ struct HFCandidateCreator3ProngMC {
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
           RecoDecay::getDaughters(particlesMC, particle, &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
-            for (auto jProng = 0; jProng < arrDaughIndex.size(); ++jProng) {
+            for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
               auto daughJ = particlesMC.iteratorAt(arrDaughIndex[jProng]);
               arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
             }
@@ -283,16 +281,13 @@ struct HFCandidateCreator3ProngMC {
       rowMCMatchGen(flag, origin, channel);
     }
   }
+
+  PROCESS_SWITCH(HFCandidateCreator3ProngExpressions, processMC, "Process MC", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  return WorkflowSpec{
     adaptAnalysisTask<HFCandidateCreator3Prong>(cfgc, TaskName{"hf-cand-creator-3prong"}),
     adaptAnalysisTask<HFCandidateCreator3ProngExpressions>(cfgc, TaskName{"hf-cand-creator-3prong-expressions"})};
-  const bool doMC = cfgc.options().get<bool>("doMC");
-  if (doMC) {
-    workflow.push_back(adaptAnalysisTask<HFCandidateCreator3ProngMC>(cfgc, TaskName{"hf-cand-creator-3prong-mc"}));
-  }
-  return workflow;
 }


### PR DESCRIPTION
* Updated 3-prong creator
* Updated Lc task

@vkucera Note how 3-prong creator was handled: since MC matching task needs the extended table, corresponding process function can be put directly into the extension task and it will have access to the extended table without subscribing. 

Note that this requires https://github.com/AliceO2Group/AliceO2/pull/7439 to work properly. 