### PR TITLE
Add histogram in init for SameEvent causing error with recent histogr…

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -85,6 +85,7 @@ class FemtoDreamContainer
     mHistogramRegistry->add((folderName + "kstarPtPart2").c_str(), ("; " + femtoObs + "; #it{p} _{T} Particle 2 (GeV/#it{c})").c_str(), kTH2F, {femtoObsAxis, {375, 0., 7.5}});
     mHistogramRegistry->add((folderName + "MultPtPart1").c_str(), "; #it{p} _{T} Particle 1 (GeV/#it{c}); Multiplicity", kTH2F, {{375, 0., 7.5}, multAxis});
     mHistogramRegistry->add((folderName + "MultPtPart2").c_str(), "; #it{p} _{T} Particle 2 (GeV/#it{c}); Multiplicity", kTH2F, {{375, 0., 7.5}, multAxis});
+    mHistogramRegistry->add((folderName + "PtPart1PtPart2").c_str(), "; #it{p} _{T} Particle 1 (GeV/#it{c}); #it{p} _{T} Particle 2 (GeV/#it{c})", kTH2F, {{375, 0., 7.5}, {375, 0., 7.5}});
   }
 
   /// Set the PDG codes of the two particles involved


### PR DESCRIPTION
Connected to merged PR: https://github.com/AliceO2Group/O2Physics/pull/250
Missing histogram in the init of FemtoDreamContainer was not causing error during running on Friday 05.11.2021.
Error after running tonight tag.
Added histogram to init.