### PR TITLE
Fix compiler warnings in `TriggerAliases.h` and `EventSelection.h`

### DIFF
--- a/Common/CCDB/TriggerAliases.cxx
+++ b/Common/CCDB/TriggerAliases.cxx
@@ -12,6 +12,20 @@
 #include "Common/CCDB/TriggerAliases.h"
 #include "Framework/Logger.h"
 
+const char* aliasLabels[kNaliases] = {
+  "kINT7",
+  "kEMC7",
+  "kINT7inMUON",
+  "kMuonSingleLowPt7",
+  "kMuonSingleHighPt7",
+  "kMuonUnlikeLowPt7",
+  "kMuonLikeLowPt7",
+  "kCUP8",
+  "kCUP9",
+  "kMUP10",
+  "kMUP11",
+  "kALL"};
+
 void TriggerAliases::AddClassIdToAlias(uint32_t aliasId, int classId)
 {
   if (classId < 0 || classId > 99) {

--- a/Common/CCDB/TriggerAliases.h
+++ b/Common/CCDB/TriggerAliases.h
@@ -33,19 +33,7 @@ enum triggerAliases {
   kNaliases
 };
 
-static const char* aliasLabels[kNaliases] = {
-  "kINT7",
-  "kEMC7",
-  "kINT7inMUON",
-  "kMuonSingleLowPt7",
-  "kMuonSingleHighPt7",
-  "kMuonUnlikeLowPt7",
-  "kMuonLikeLowPt7",
-  "kCUP8",
-  "kCUP9",
-  "kMUP10",
-  "kMUP11",
-  "kALL"};
+extern const char* aliasLabels[kNaliases];
 
 class TriggerAliases
 {

--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -72,33 +72,6 @@ enum EventSelectionFlags {
   kNsel
 };
 
-static const char* eventSelectionLabels[kNsel] = {
-  "kIsBBV0A",
-  "kIsBBV0C",
-  "kIsBBFDA",
-  "kIsBBFDC",
-  "kNoBGV0A",
-  "kNoBGV0C",
-  "kNoBGFDA",
-  "kNoBGFDC",
-  "kIsBBT0A",
-  "kIsBBT0C",
-  "kIsBBZNA",
-  "kIsBBZNC",
-  "kNoBGZNA",
-  "kNoBGZNC",
-  "kNoV0MOnVsOfPileup",
-  "kNoSPDOnVsOfPileup",
-  "kNoV0Casymmetry",
-  "kIsGoodTimeRange",
-  "kNoIncompleteDAQ",
-  "kNoTPCLaserWarmUp",
-  "kNoTPCHVdip",
-  "kNoPileupFromSPD",
-  "kNoV0PFPileup",
-  "kNoSPDClsVsTklBG",
-  "kNoV0C012vsTklBG"};
-
 // collision-joinable event selection decisions
 namespace evsel
 {

--- a/Common/Tasks/CMakeLists.txt
+++ b/Common/Tasks/CMakeLists.txt
@@ -21,7 +21,7 @@ o2physics_add_dpl_workflow(validation
 
 o2physics_add_dpl_workflow(event-selection-qa
                     SOURCES eventSelectionQa.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2::DetectorsBase
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(multiplicity-qa

--- a/PWGDQ/TableProducer/CMakeLists.txt
+++ b/PWGDQ/TableProducer/CMakeLists.txt
@@ -11,10 +11,10 @@
 
 o2physics_add_dpl_workflow(table-maker
                     SOURCES tableMaker.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(table-maker-mc
                     SOURCES tableMakerMC.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2physics_add_dpl_workflow(track-index-skims-creator
                     SOURCES HFTrackIndexSkimsCreator.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing ROOT::EG
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2::DetectorsVertexing ROOT::EG
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(candidate-creator-2prong


### PR DESCRIPTION
The `eventSelectionLabels` are not used so they were removed
If they were needed something similar to the `aliasLabels` would be needed