### PR TITLE
Trackextension: use http://alice-ccdb.cern.ch

### DIFF
--- a/Common/TableProducer/trackextension.cxx
+++ b/Common/TableProducer/trackextension.cxx
@@ -48,7 +48,7 @@ constexpr long run3grp_timestamp = (1619781650000 + 1619781529000) / 2;
 const char* ccdbpath_lut = "GLO/Param/MatLUT";
 const char* ccdbpath_geo = "GLO/Config/Geometry";
 const char* ccdbpath_grp = "GLO/GRP/GRP";
-const char* ccdburl = "https://alice-ccdb.cern.ch"; /* test  "http://alice-ccdb.cern.ch:8080"; */
+const char* ccdburl = "http://alice-ccdb.cern.ch"; /* test  "http://alice-ccdb.cern.ch:8080"; */
 } // namespace trackextension
 } // namespace analysis
 } // namespace o2


### PR DESCRIPTION
Trackextension is the only part of the code that uses https://alice-ccdb.cern.ch. A simple
move to `http:` should solve the problem with certificates discussed on mattermost. 

This would also follow
the approach in many other places of the code (see `git grep alice-ccdb`).

Maybe the CCDB location should be a global property for all tasks anyway.