### PR TITLE
PWGHF: remove DCA from HFSelTrack table and use TracksExtended instead

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -278,10 +278,10 @@ struct HfFilter { // Main struct for HF triggers
       return false;
     }
 
-    if (std::abs(track.dcaPrim0()) < cutsSingleTrackBeauty[candType].get(pTBinTrack, "min_dcaxytoprimary")) {
+    if (std::abs(track.dcaXY()) < cutsSingleTrackBeauty[candType].get(pTBinTrack, "min_dcaxytoprimary")) {
       return false; //minimum DCAxy
     }
-    if (std::abs(track.dcaPrim0()) > cutsSingleTrackBeauty[candType].get(pTBinTrack, "max_dcaxytoprimary")) {
+    if (std::abs(track.dcaXY()) > cutsSingleTrackBeauty[candType].get(pTBinTrack, "max_dcaxytoprimary")) {
       return false; //maximum DCAxy
     }
     return true;
@@ -339,8 +339,8 @@ struct HfFilter { // Main struct for HF triggers
 
   using HfTrackIndexProng2withColl = soa::Join<aod::HfTrackIndexProng2, aod::Colls2Prong>;
   using HfTrackIndexProng3withColl = soa::Join<aod::HfTrackIndexProng3, aod::Colls3Prong>;
-  using BigTracksWithProtonPID = soa::Join<aod::BigTracks, aod::pidTPCFullPr, aod::pidTOFFullPr>;
-  using BigTracksMCPID = soa::Join<aod::BigTracksPID, aod::BigTracksMC>;
+  using BigTracksWithProtonPID = soa::Join<aod::BigTracksExtended, aod::pidTPCFullPr, aod::pidTOFFullPr>;
+  using BigTracksMCPID = soa::Join<aod::BigTracksPIDExtended, aod::BigTracksMC>;
 
   void process(aod::Collision const& collision,
                HfTrackIndexProng2withColl const& cand2Prongs,
@@ -517,8 +517,8 @@ struct HfFilter { // Main struct for HF triggers
 
       double pseudoRndm = trackPos.pt() * 1000. - (long)(trackPos.pt() * 1000);
       if ((fillSignal && indexRec > -1) || (fillBackground && indexRec < 0 && pseudoRndm < donwSampleBkgFactor)) {
-        train2P(trackPos.pt(), trackPos.dcaPrim0(), trackPos.dcaPrim1(), trackPos.tpcNSigmaPi(), trackPos.tpcNSigmaKa(), trackPos.tofNSigmaPi(), trackPos.tofNSigmaKa(),
-                trackNeg.pt(), trackNeg.dcaPrim0(), trackNeg.dcaPrim1(), trackNeg.tpcNSigmaPi(), trackNeg.tpcNSigmaKa(), trackNeg.tofNSigmaPi(), trackNeg.tofNSigmaKa(),
+        train2P(trackPos.pt(), trackPos.dcaXY(), trackPos.dcaZ(), trackPos.tpcNSigmaPi(), trackPos.tpcNSigmaKa(), trackPos.tofNSigmaPi(), trackPos.tofNSigmaKa(),
+                trackNeg.pt(), trackNeg.dcaXY(), trackNeg.dcaZ(), trackNeg.tpcNSigmaPi(), trackNeg.tpcNSigmaKa(), trackNeg.tofNSigmaPi(), trackNeg.tofNSigmaKa(),
                 flag);
       }
     } // end loop over 2-prong candidates
@@ -576,9 +576,9 @@ struct HfFilter { // Main struct for HF triggers
 
       double pseudoRndm = trackFirst.pt() * 1000. - (long)(trackFirst.pt() * 1000);
       if ((fillSignal && indexRec > -1) || (fillBackground && indexRec < 0 && pseudoRndm < donwSampleBkgFactor)) {
-        train3P(trackFirst.pt(), trackFirst.dcaPrim0(), trackFirst.dcaPrim1(), trackFirst.tpcNSigmaPi(), trackFirst.tpcNSigmaKa(), trackFirst.tpcNSigmaPr(), trackFirst.tofNSigmaPi(), trackFirst.tofNSigmaKa(), trackFirst.tofNSigmaPr(),
-                trackSecond.pt(), trackSecond.dcaPrim0(), trackSecond.dcaPrim1(), trackSecond.tpcNSigmaPi(), trackSecond.tpcNSigmaKa(), trackSecond.tpcNSigmaPr(), trackSecond.tofNSigmaPi(), trackSecond.tofNSigmaKa(), trackSecond.tofNSigmaPr(),
-                trackThird.pt(), trackThird.dcaPrim0(), trackThird.dcaPrim1(), trackThird.tpcNSigmaPi(), trackThird.tpcNSigmaKa(), trackThird.tpcNSigmaPr(), trackThird.tofNSigmaPi(), trackThird.tofNSigmaKa(), trackThird.tofNSigmaPr(),
+        train3P(trackFirst.pt(), trackFirst.dcaXY(), trackFirst.dcaZ(), trackFirst.tpcNSigmaPi(), trackFirst.tpcNSigmaKa(), trackFirst.tpcNSigmaPr(), trackFirst.tofNSigmaPi(), trackFirst.tofNSigmaKa(), trackFirst.tofNSigmaPr(),
+                trackSecond.pt(), trackSecond.dcaXY(), trackSecond.dcaZ(), trackSecond.tpcNSigmaPi(), trackSecond.tpcNSigmaKa(), trackSecond.tpcNSigmaPr(), trackSecond.tofNSigmaPi(), trackSecond.tofNSigmaKa(), trackSecond.tofNSigmaPr(),
+                trackThird.pt(), trackThird.dcaXY(), trackThird.dcaZ(), trackThird.tpcNSigmaPi(), trackThird.tpcNSigmaKa(), trackThird.tpcNSigmaPr(), trackThird.tofNSigmaPi(), trackThird.tofNSigmaKa(), trackThird.tofNSigmaPr(),
                 flag, channel, cand3Prong.hfflag());
       }
     } // end loop over 3-prong candidates

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -24,6 +24,7 @@
 #include "PWGHF/Core/HFSelectorCuts.h"
 #include "Common/Core/PID/PIDResponse.h"
 #include "Common/DataModel/StrangenessTables.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 
 using namespace o2::analysis;
 
@@ -40,8 +41,6 @@ DECLARE_SOA_TABLE(HFSelCollision, "AOD", "HFSELCOLLISION", //!
 namespace hf_seltrack
 {
 DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int); //!
-DECLARE_SOA_COLUMN(DCAPrim0, dcaPrim0, float);   //!
-DECLARE_SOA_COLUMN(DCAPrim1, dcaPrim1, float);   //!
 DECLARE_SOA_COLUMN(PxProng, pxProng, float);     //!
 DECLARE_SOA_COLUMN(PyProng, pyProng, float);     //!
 DECLARE_SOA_COLUMN(PzProng, pzProng, float);     //!
@@ -49,17 +48,17 @@ DECLARE_SOA_COLUMN(PzProng, pzProng, float);     //!
 
 DECLARE_SOA_TABLE(HFSelTrack, "AOD", "HFSELTRACK", //!
                   hf_seltrack::IsSelProng,
-                  hf_seltrack::DCAPrim0,
-                  hf_seltrack::DCAPrim1,
                   hf_seltrack::PxProng,
                   hf_seltrack::PyProng,
                   hf_seltrack::PzProng);
 
 using BigTracks = soa::Join<Tracks, TracksCov, TracksExtra, HFSelTrack>;
+using BigTracksExtended = soa::Join<BigTracks, aod::TracksExtended>;
 using BigTracksMC = soa::Join<BigTracks, McTrackLabels>;
 using BigTracksPID = soa::Join<BigTracks,
                                aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
                                aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>;
+using BigTracksPIDExtended = soa::Join<BigTracksPID, aod::TracksExtended>;
 
 // FIXME: this is a workaround until we get the index columns to work with joins.
 

--- a/PWGHF/TableProducer/HFD0CandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelector.cxx
@@ -17,7 +17,6 @@
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/Core/TrackSelectorPID.h"

--- a/PWGHF/TableProducer/HFD0CandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelector.cxx
@@ -17,6 +17,7 @@
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/Core/TrackSelectorPID.h"
@@ -150,7 +151,7 @@ struct HFD0CandidateSelector {
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackPion.dcaPrim0()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaPrim0()) > cuts->get(pTBin, "d0K")) {
+    if (std::abs(trackPion.dcaXY()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaXY()) > cuts->get(pTBin, "d0K")) {
       return false;
     }
 
@@ -168,7 +169,7 @@ struct HFD0CandidateSelector {
     return true;
   }
 
-  void process(aod::HfCandProng2 const& candidates, aod::BigTracksPID const&)
+  void process(aod::HfCandProng2 const& candidates, aod::BigTracksPIDExtended const&)
   {
     TrackSelectorPID selectorPion(kPiPlus);
     selectorPion.setRangePtTPC(d_pidTPCMinpT, d_pidTPCMaxpT);
@@ -198,8 +199,8 @@ struct HFD0CandidateSelector {
       }
       statusHFFlag = 1;
 
-      auto trackPos = candidate.index0_as<aod::BigTracksPID>(); // positive daughter
-      auto trackNeg = candidate.index1_as<aod::BigTracksPID>(); // negative daughter
+      auto trackPos = candidate.index0_as<aod::BigTracksPIDExtended>(); // positive daughter
+      auto trackNeg = candidate.index1_as<aod::BigTracksPIDExtended>(); // negative daughter
 
       /*
       if (!daughterSelection(trackPos) || !daughterSelection(trackNeg)) {

--- a/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
@@ -171,7 +171,7 @@ struct HFD0CandidateSelectorALICE3Barrel {
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackPion.dcaPrim0()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaPrim0()) > cuts->get(pTBin, "d0K")) {
+    if (std::abs(trackPion.dcaXY()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaXY()) > cuts->get(pTBin, "d0K")) {
       return false;
     }
 
@@ -189,7 +189,7 @@ struct HFD0CandidateSelectorALICE3Barrel {
     return true;
   }
 
-  using Trks = soa::Join<aod::BigTracksPID, aod::RICHTracksIndex, aod::McTrackLabels>;
+  using Trks = soa::Join<aod::BigTracksPIDExtended, aod::RICHTracksIndex, aod::McTrackLabels>;
   void process(aod::HfCandProng2 const& candidates, Trks const& barreltracks, const aod::McParticles& mcParticles, const aod::RICHs&, const aod::FRICHs&)
   {
 

--- a/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Forward.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Forward.cxx
@@ -171,7 +171,7 @@ struct HFD0CandidateSelectorALICE3Forward {
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackPion.dcaPrim0()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaPrim0()) > cuts->get(pTBin, "d0K")) {
+    if (std::abs(trackPion.dcaXY()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaXY()) > cuts->get(pTBin, "d0K")) {
       return false;
     }
 
@@ -189,7 +189,7 @@ struct HFD0CandidateSelectorALICE3Forward {
     return true;
   }
 
-  using Trks = soa::Join<aod::BigTracksPID, aod::Tracks, aod::FRICHTracksIndex, aod::TracksExtra>;
+  using Trks = soa::Join<aod::BigTracksPIDExtended, aod::Tracks, aod::FRICHTracksIndex, aod::TracksExtra>;
   void process(aod::HfCandProng2 const& candidates, Trks const& forwardtracks, const aod::McParticles& mcParticles, const aod::RICHs&, const aod::FRICHs&)
   {
 

--- a/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
@@ -171,7 +171,7 @@ struct HFD0CandidateSelectorparametrizedPID {
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackPion.dcaPrim0()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaPrim0()) > cuts->get(pTBin, "d0K")) {
+    if (std::abs(trackPion.dcaXY()) > cuts->get(pTBin, "d0pi") || std::abs(trackKaon.dcaXY()) > cuts->get(pTBin, "d0K")) {
       return false;
     }
 
@@ -189,7 +189,7 @@ struct HFD0CandidateSelectorparametrizedPID {
     return true;
   }
 
-  using Trks = soa::Join<aod::BigTracksPID, aod::Tracks, aod::RICHTracksIndex, aod::McTrackLabels, aod::TracksExtra>;
+  using Trks = soa::Join<aod::BigTracksPIDExtended, aod::Tracks, aod::RICHTracksIndex, aod::McTrackLabels, aod::TracksExtra>;
   void process(aod::HfCandProng2 const& candidates, Trks const& barreltracks, const aod::McParticles& mcParticles, const aod::RICHs&, const aod::FRICHs&)
   {
 

--- a/PWGHF/TableProducer/HFJpsiCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFJpsiCandidateSelector.cxx
@@ -17,6 +17,7 @@
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 
 #include "Framework/AnalysisTask.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/Core/TrackSelectorPID.h"
@@ -120,12 +121,12 @@ struct HfJpsiCandidateSelector {
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackNeg.dcaPrim0()) > cuts->get(pTBin, "DCA_xy") || std::abs(trackPos.dcaPrim0()) > cuts->get(pTBin, "DCA_xy")) {
+    if (std::abs(trackNeg.dcaXY()) > cuts->get(pTBin, "DCA_xy") || std::abs(trackPos.dcaXY()) > cuts->get(pTBin, "DCA_xy")) {
       return false;
     }
 
     // cut on daughter DCA - need to add secondary vertex constraint here
-    if (std::abs(trackNeg.dcaPrim1()) > cuts->get(pTBin, "DCA_z") || std::abs(trackPos.dcaPrim1()) > cuts->get(pTBin, "DCA_z")) {
+    if (std::abs(trackNeg.dcaZ()) > cuts->get(pTBin, "DCA_z") || std::abs(trackPos.dcaZ()) > cuts->get(pTBin, "DCA_z")) {
       return false;
     }
 
@@ -138,7 +139,9 @@ struct HfJpsiCandidateSelector {
 
   using TracksPID = soa::Join<aod::BigTracksPID, aod::HfTrackIndexALICE3PID>;
 
-  void processAlice2(aod::HfCandProng2 const& candidates, aod::BigTracksPID const&)
+  using ExtendedTracksPID = soa::Join<TracksPID, aod::TracksExtended>;
+
+  void processAlice2(aod::HfCandProng2 const& candidates, aod::BigTracksPIDExtended const&)
   {
     TrackSelectorPID selectorElectron(kElectron);
     selectorElectron.setRangePtTPC(d_pidTPCMinpT, d_pidTPCMaxpT);
@@ -159,8 +162,8 @@ struct HfJpsiCandidateSelector {
         continue;
       }
 
-      auto trackPos = candidate.index0_as<aod::BigTracksPID>(); // positive daughter
-      auto trackNeg = candidate.index1_as<aod::BigTracksPID>(); // negative daughter
+      auto trackPos = candidate.index0_as<aod::BigTracksPIDExtended>(); // positive daughter
+      auto trackNeg = candidate.index1_as<aod::BigTracksPIDExtended>(); // negative daughter
 
       int selectedEETopol = 1;
       int selectedEETpc = 1;
@@ -217,7 +220,7 @@ struct HfJpsiCandidateSelector {
 
   PROCESS_SWITCH(HfJpsiCandidateSelector, processAlice2, "Use ALICE 2 detector setup", true);
 
-  void processAlice3(aod::HfCandProng2 const& candidates, TracksPID const&, aod::RICHs const&, aod::MIDs const&)
+  void processAlice3(aod::HfCandProng2 const& candidates, ExtendedTracksPID const&, aod::RICHs const&, aod::MIDs const&)
   {
     TrackSelectorPID selectorElectron(kElectron);
     selectorElectron.setRangePtTPC(d_pidTPCMinpT, d_pidTPCMaxpT);
@@ -240,8 +243,8 @@ struct HfJpsiCandidateSelector {
         continue;
       }
 
-      auto trackPos = candidate.index0_as<TracksPID>(); // positive daughter
-      auto trackNeg = candidate.index1_as<TracksPID>(); // negative daughter
+      auto trackPos = candidate.index0_as<ExtendedTracksPID>(); // positive daughter
+      auto trackNeg = candidate.index1_as<ExtendedTracksPID>(); // negative daughter
 
       int selectedEETopol = 1;
       int selectedEETpc = 1;

--- a/PWGHF/TableProducer/HFJpsiCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFJpsiCandidateSelector.cxx
@@ -17,7 +17,6 @@
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 
 #include "Framework/AnalysisTask.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/Core/TrackSelectorPID.h"

--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -503,7 +503,7 @@ struct HfTagSelTracks {
       }
 
       // fill table row
-      rowSelectedTrack(statusProng, dca[0], dca[1], track.px(), track.py(), track.pz());
+      rowSelectedTrack(statusProng, track.px(), track.py(), track.pz());
     }
   }
 };
@@ -691,7 +691,7 @@ struct HfTrackIndexSkimsCreator {
 
       // imp. par. product cut
       if (debug || TESTBIT(isSelected, iDecay2P)) {
-        auto impParProduct = hfTrack0.dcaPrim0() * hfTrack1.dcaPrim0();
+        auto impParProduct = hfTrack0.dcaXY() * hfTrack1.dcaXY();
         if (impParProduct > cut2Prong[iDecay2P].get(pTBin, d0d0Index[iDecay2P])) {
           CLRBIT(isSelected, iDecay2P);
           if (debug) {
@@ -885,7 +885,7 @@ struct HfTrackIndexSkimsCreator {
   Filter filterSelectTracks = aod::hf_seltrack::isSelProng > 0;
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HFSelCollision>>;
-  using SelectedTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::HFSelTrack>>;
+  using SelectedTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TracksExtended, aod::HFSelTrack>>;
 
   // FIXME
   //Partition<SelectedTracks> tracksPos = aod::track::signed1Pt > 0.f;

--- a/PWGHF/Tasks/HFSelOptimisation.cxx
+++ b/PWGHF/Tasks/HFSelOptimisation.cxx
@@ -17,6 +17,7 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 
@@ -171,12 +172,12 @@ struct HfSelOptimisation {
   /// \param candType is the candidate channel
   /// \param candOrig is candidate type (Prompt, NonPrompt, Bkg)
   /// \param candidate is a candidate
-  /// \param tracks is the array of doughter tracks
+  /// \param tracks is the array of daughter tracks
   template <std::size_t candType, std::size_t candOrig, typename T1, typename T2>
   void testSelections2Prong(const T1& candidate, const T2& tracks)
   {
     auto pT = candidate.pt();
-    std::array<double, 2> absDCA{std::abs(tracks[0].dcaPrim0()), std::abs(tracks[1].dcaPrim0())};
+    std::array<double, 2> absDCA{std::abs(tracks[0].dcaXY()), std::abs(tracks[1].dcaXY())};
     std::sort(absDCA.begin(), absDCA.end());
 
     std::array<double, 2> ptTrack{tracks[0].pt(), tracks[1].pt()};
@@ -224,7 +225,7 @@ struct HfSelOptimisation {
   void testSelections3Prong(const T1& candidate, const T2& tracks)
   {
     auto pT = candidate.pt();
-    std::array<double, 3> absDCA{std::abs(tracks[0].dcaPrim0()), std::abs(tracks[1].dcaPrim0()), std::abs(tracks[2].dcaPrim0())};
+    std::array<double, 3> absDCA{std::abs(tracks[0].dcaXY()), std::abs(tracks[1].dcaXY()), std::abs(tracks[2].dcaXY())};
     std::sort(absDCA.begin(), absDCA.end());
 
     std::array<double, 3> ptTrack{tracks[0].pt(), tracks[1].pt(), tracks[2].pt()};
@@ -257,15 +258,16 @@ struct HfSelOptimisation {
     }
   }
 
+  using ExtendedTracks = soa::Join<aod::BigTracks, aod::TracksExtended>;
   void process(soa::Join<aod::HfCandProng2, aod::HfCandProng2MCRec> const& cand2Prongs,
                soa::Join<aod::HfCandProng3, aod::HfCandProng3MCRec> const& cand3Prongs,
-               aod::BigTracks const&)
+               ExtendedTracks const&)
   {
     // looping over 2-prong candidates
     for (const auto& cand2Prong : cand2Prongs) {
 
-      auto trackPos = cand2Prong.index0_as<aod::BigTracks>(); // positive daughter
-      auto trackNeg = cand2Prong.index1_as<aod::BigTracks>(); // negative daughter
+      auto trackPos = cand2Prong.index0_as<ExtendedTracks>(); // positive daughter
+      auto trackNeg = cand2Prong.index1_as<ExtendedTracks>(); // negative daughter
       std::array tracks = {trackPos, trackNeg};
 
       bool isPrompt = false, isNonPrompt = false, isBkg = false;
@@ -319,9 +321,9 @@ struct HfSelOptimisation {
     // looping over 3-prong candidates
     for (const auto& cand3Prong : cand3Prongs) {
 
-      auto trackFirst = cand3Prong.index0_as<aod::BigTracks>();  // first daughter
-      auto trackSecond = cand3Prong.index1_as<aod::BigTracks>(); // second daughter
-      auto trackThird = cand3Prong.index2_as<aod::BigTracks>();  // third daughter
+      auto trackFirst = cand3Prong.index0_as<ExtendedTracks>();  // first daughter
+      auto trackSecond = cand3Prong.index1_as<ExtendedTracks>(); // second daughter
+      auto trackThird = cand3Prong.index2_as<ExtendedTracks>();  // third daughter
       std::array tracks = {trackFirst, trackSecond, trackThird};
 
       bool isPrompt = false, isNonPrompt = false, isBkg = false;

--- a/PWGHF/Tasks/HFSelOptimisation.cxx
+++ b/PWGHF/Tasks/HFSelOptimisation.cxx
@@ -17,7 +17,6 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 


### PR DESCRIPTION
* Remove DCA columns from HFSelTrack
* Add `TracksExtended` in corresponding track joins for HF tasks

This moves track DCA calculation to central  `track-extension`/`alice3-track-extension` tasks. 