### PR TITLE
Addition of the Dilepton & Quarkonia triggers in the Central Event Filtering

### DIFF
--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -26,6 +26,13 @@ DECLARE_SOA_COLUMN(He4, hasHe4, bool); //!
 // diffraction
 DECLARE_SOA_COLUMN(DG, hasDG, bool); //! Double Gap events, DG
 
+// Dileptons & Quarkonia
+DECLARE_SOA_COLUMN(SingleE, hasSingleE, bool);           //! single electron trigger
+DECLARE_SOA_COLUMN(SingleMuLow, hasSingleMuLow, bool);   //! single muon with low pT trigger
+DECLARE_SOA_COLUMN(SingleMuHigh, hasSingleMuHigh, bool); //! single muon with high pT trigger
+DECLARE_SOA_COLUMN(DiElectron, hasDiElectron, bool);     //! dielectron trigger
+DECLARE_SOA_COLUMN(DiMuon, hasDiMuon, bool);             //! dimuon trigger with low pT on muons
+
 // heavy flavours
 DECLARE_SOA_COLUMN(HfHighPt, hasHfHighPt, bool); //! high-pT charm hadron
 DECLARE_SOA_COLUMN(HfBeauty, hasHfBeauty, bool); //! beauty hadron
@@ -64,6 +71,11 @@ DECLARE_SOA_TABLE(DiffractionFilters, "AOD", "DiffFilters", //! Diffraction filt
                   filtering::DG);
 using DiffractionFilter = DiffractionFilters::iterator;
 
+// Dileptons & Quarkonia
+DECLARE_SOA_TABLE(DqFilters, "AOD", "DQ Filters", //!
+                  filtering::SingleE, filtering::SingleMuLow, filtering::SingleMuHigh, filtering::DiElectron, filtering::DiMuon);
+using DqFilter = DqFilters::iterator;
+
 // heavy flavours
 DECLARE_SOA_TABLE(HfFilters, "AOD", "HF Filters", //!
                   filtering::HfHighPt, filtering::HfBeauty, filtering::HfFemto);
@@ -93,11 +105,11 @@ DECLARE_SOA_TABLE(MultFilters, "AOD", "MM Filters", //!
 using MultFilter = MultFilters::iterator;
 
 /// List of the available filters, the description of their tables and the name of the tasks
-constexpr int NumberOfFilters{7};
-constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "HeavyFlavourFilters", "CorrelationFilters", "JetFilters", "StrangenessFilters", "MultFilters"};
-constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "HFFilters", "CFFilters", "JetFilters", "LFStrgFilters", "MultFilters"};
-constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter"};
-constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, HfFilters, CFFilters, JetFilters, StrangenessFilters, MultFilters> FiltersPack;
+constexpr int NumberOfFilters{8};
+constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "DileptonQuarkoniaFilters", "HeavyFlavourFilters", "CorrelationFilters", "JetFilters", "StrangenessFilters", "MultFilters"};
+constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "DQFilters", "HFFilters", "CFFilters", "JetFilters", "LFStrgFilters", "MultFilters"};
+constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter"};
+constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, DqFilters, HfFilters, CFFilters, JetFilters, StrangenessFilters, MultFilters> FiltersPack;
 static_assert(o2::framework::pack_size(FiltersPack) == NumberOfFilters);
 
 template <typename T, typename C>

--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -87,20 +87,6 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
-  if (!nameStr.compare("kaonPID")) {
-    cut->AddCut(GetAnalysisCut("PIDStandardKine")); // standard kine cuts usually are applied via Filter in the task
-    cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
-    cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
-    return cut;
-  }
-
-  if (!nameStr.compare("kaonPID")) {
-    cut->AddCut(GetAnalysisCut("PIDStandardKine")); // standard kine cuts usually are applied via Filter in the task
-    cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
-    cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
-    return cut;
-  }
-
   //---------------------------------------------------------------------------------------
   // NOTE: Below there are several TPC pid cuts used for studies of the dE/dx degradation
   //    and its impact on the high lumi pp quarkonia triggers
@@ -225,6 +211,17 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
 
   if (!nameStr.compare("muonTightQualityCutsForTests")) {
     cut->AddCut(GetAnalysisCut("muonTightQualityCutsForTests"));
+      return cut;
+  }
+  if (!nameStr.compare("muonLowPt")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+
+  if (!nameStr.compare("muonHighPt")) {
+    cut->AddCut(GetAnalysisCut("muonHighPt"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
     return cut;
   }
 
@@ -411,16 +408,6 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
-  if (!nameStr.compare("kaonPIDnsigma")) {
-    cut->AddCut(VarManager::kTPCnSigmaKa, -3.0, 3.0);
-    return cut;
-  }
-
-  if (!nameStr.compare("kaonPIDnsigma")) {
-    cut->AddCut(VarManager::kTPCnSigmaKa, -3.0, 3.0);
-    return cut;
-  }
-
   if (!nameStr.compare("electronPIDnsigmaRandomized")) {
     cut->AddCut(VarManager::kTPCnSigmaElRandomized, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPrRandomized, 3.0, 3000.0);
@@ -488,6 +475,14 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kMuonPDca, 0.0, 594.0, false, VarManager::kMuonRAtAbsorberEnd, 17.6, 26.5);
     cut->AddCut(VarManager::kMuonPDca, 0.0, 324.0, false, VarManager::kMuonRAtAbsorberEnd, 26.5, 89.5);
     cut->AddCut(VarManager::kMuonChi2, 0.0, 1e6);
+    return cut;
+  }
+  if (!nameStr.compare("muonLowPt")) {
+    cut->AddCut(VarManager::kPt, 0.5, 1000.0);
+    return cut;
+  }
+  if (!nameStr.compare("muonHighPt")) {
+    cut->AddCut(VarManager::kPt, 4.0, 1000.0);
     return cut;
   }
 

--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -87,6 +87,20 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("kaonPID")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine")); // standard kine cuts usually are applied via Filter in the task
+    cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
+    cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
+    return cut;
+  }
+
+  if (!nameStr.compare("kaonPID")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine")); // standard kine cuts usually are applied via Filter in the task
+    cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
+    cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
+    return cut;
+  }
+
   //---------------------------------------------------------------------------------------
   // NOTE: Below there are several TPC pid cuts used for studies of the dE/dx degradation
   //    and its impact on the high lumi pp quarkonia triggers
@@ -209,10 +223,6 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
-  if (!nameStr.compare("muonTightQualityCutsForTests")) {
-    cut->AddCut(GetAnalysisCut("muonTightQualityCutsForTests"));
-    return cut;
-  }
   if (!nameStr.compare("muonLowPt")) {
     cut->AddCut(GetAnalysisCut("muonLowPt"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
@@ -222,6 +232,11 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   if (!nameStr.compare("muonHighPt")) {
     cut->AddCut(GetAnalysisCut("muonHighPt"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+
+  if (!nameStr.compare("muonTightQualityCutsForTests")) {
+    cut->AddCut(GetAnalysisCut("muonTightQualityCutsForTests"));
     return cut;
   }
 
@@ -405,6 +420,16 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPr, 3.0, 3000.0);
     cut->AddCut(VarManager::kTPCnSigmaPi, 3.0, 3000.0);
+    return cut;
+  }
+
+  if (!nameStr.compare("kaonPIDnsigma")) {
+    cut->AddCut(VarManager::kTPCnSigmaKa, -3.0, 3.0);
+    return cut;
+  }
+
+  if (!nameStr.compare("kaonPIDnsigma")) {
+    cut->AddCut(VarManager::kTPCnSigmaKa, -3.0, 3.0);
     return cut;
   }
 

--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -211,7 +211,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
 
   if (!nameStr.compare("muonTightQualityCutsForTests")) {
     cut->AddCut(GetAnalysisCut("muonTightQualityCutsForTests"));
-      return cut;
+    return cut;
   }
   if (!nameStr.compare("muonLowPt")) {
     cut->AddCut(GetAnalysisCut("muonLowPt"));

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -49,7 +49,7 @@ using namespace o2::aod;
 // Some definitions
 namespace
 {
-enum HfTriggers {
+enum DQTriggers {
   kSingleE = 0,
   kSingleMuLow,
   kSingleMuHigh,
@@ -85,12 +85,12 @@ using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::Tra
                                          aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
                                          aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta,
                                          aod::DQBarrelTrackCuts>;
-using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
-using MyMuonsSelected = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::DQMuonsCuts>;
+using MyMuons = aod::FwdTracks;
+using MyMuonsSelected = soa::Join<aod::FwdTracks, aod::DQMuonsCuts>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
-constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
@@ -159,7 +159,7 @@ struct DQBarrelTrackSelectionTask {
 
   float* fValues; // array to be used by the VarManager
 
-  Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiKineAndQuality,jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
 
   void init(o2::framework::InitContext&)
   {
@@ -231,7 +231,7 @@ struct DQMuonsSelection {
 
   float* fValues;
 
-  Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonQualityCuts,muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
+  Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
 
   void init(o2::framework::InitContext&)
   {
@@ -311,8 +311,8 @@ struct DQFilterPPTask {
   Partition<MyBarrelTracksSelected> posTracks = aod::track::signed1Pt > 0.0f && aod::dqppfilter::isBarrelSelected > uint8_t(0);
   Partition<MyBarrelTracksSelected> negTracks = aod::track::signed1Pt < 0.0f && aod::dqppfilter::isBarrelSelected > uint8_t(0);
 
-  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiKineAndQuality,jpsiPID1", "Comma separated list of barrel track cuts"};
-  Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonQualityCuts,muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
+  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
   Configurable<std::string> fConfigPairCuts{"cfgPairCuts", "pairNoCut,pairMassLow", "Comma separated list of pair cuts"};
 
   int fNTrackCuts;

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -159,7 +159,7 @@ struct DQBarrelTrackSelectionTask {
 
   float* fValues; // array to be used by the VarManager
 
-  Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiKineAndQuality,jpsiPID1", "Comma separated list of barrel track cuts"};
 
   void init(o2::framework::InitContext&)
   {
@@ -311,7 +311,7 @@ struct DQFilterPPTask {
   Partition<MyBarrelTracksSelected> posTracks = aod::track::signed1Pt > 0.0f && aod::dqppfilter::isBarrelSelected > uint8_t(0);
   Partition<MyBarrelTracksSelected> negTracks = aod::track::signed1Pt < 0.0f && aod::dqppfilter::isBarrelSelected > uint8_t(0);
 
-  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiKineAndQuality,jpsiPID1", "Comma separated list of barrel track cuts"};
   Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonQualityCuts,muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
   Configurable<std::string> fConfigPairCuts{"cfgPairCuts", "pairNoCut,pairMassLow", "Comma separated list of pair cuts"};
 

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -19,6 +19,7 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/CCDB/TriggerAliases.h"
+#include "EventFiltering/filterTables.h"
 #include "PWGDQ/DataModel/ReducedInfoTables.h"
 #include "PWGDQ/Core/VarManager.h"
 #include "PWGDQ/Core/HistogramManager.h"
@@ -52,10 +53,12 @@ namespace dqppfilter
 {
 DECLARE_SOA_COLUMN(IsDQEventSelected, isDQEventSelected, int);
 DECLARE_SOA_COLUMN(IsBarrelSelected, isBarrelSelected, uint8_t);
+DECLARE_SOA_COLUMN(IsMuonSelected, isMuonSelected, uint8_t);
 } // namespace dqppfilter
 
 DECLARE_SOA_TABLE(DQEventCuts, "AOD", "DQEVENTCUTS", dqppfilter::IsDQEventSelected);
 DECLARE_SOA_TABLE(DQBarrelTrackCuts, "AOD", "DQBARRELCUTS", dqppfilter::IsBarrelSelected);
+DECLARE_SOA_TABLE(DQMuonsCuts, "AOD", "DQMUONCUTS", dqppfilter::IsMuonSelected);
 } // namespace o2::aod
 
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
@@ -71,9 +74,12 @@ using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::Tra
                                          aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
                                          aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta,
                                          aod::DQBarrelTrackCuts>;
+using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
+using MyMuonsSelected = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::DQMuonsCuts>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
@@ -206,10 +212,86 @@ struct DQBarrelTrackSelectionTask {
   }
 };
 
+struct DQMuonsSelection {
+  Produces<aod::DQMuonsCuts> trackSel;
+  OutputObj<THashList> fOutputList{"output"};
+  HistogramManager* fHistMan;
+  std::vector<AnalysisCompositeCut> fTrackCuts;
+
+  float* fValues;
+
+  Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonQualityCuts,muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
+
+  void init(o2::framework::InitContext&)
+  {
+    DefineCuts();
+
+    fValues = new float[VarManager::kNVars];
+    VarManager::SetDefaultVarNames();
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+    fHistMan->SetUseDefaultVariableNames(kTRUE);
+    fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    TString cutNames = "TrackMuons_BeforeCuts;";
+    for (int i = 0; i < fTrackCuts.size(); i++) {
+      cutNames += Form("TrackMuons_%s;", fTrackCuts[i].GetName());
+    }
+
+    DefineHistograms(fHistMan, cutNames.Data());     // define all histograms
+    VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+  }
+
+  void DefineCuts()
+  {
+    // available cuts: muonQualityCuts
+    TString cutNamesStr = fConfigCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    // NOTE: Additional cuts to those specified via the Configurable may still be added
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+  }
+
+  void process(MyEvents::iterator const& event, MyMuons const& muons, aod::BCs const& bcs)
+  {
+    uint8_t filterMap = uint8_t(0);
+    trackSel.reserve(muons.size());
+
+    VarManager::ResetValues(0, VarManager::kNMuonTrackVariables, fValues);
+    // fill event information which might be needed in histograms that combine track and event properties
+    VarManager::FillEvent<gkEventFillMap>(event, fValues);
+
+    for (auto& muon : muons) {
+      filterMap = uint8_t(0);
+      // TODO: if a condition on the event selection is applied, the histogram output is missing
+      VarManager::FillTrack<gkMuonFillMap>(muon, fValues);
+      fHistMan->FillHistClass("TrackMuons_BeforeCuts", fValues);
+      int i = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+        if ((*cut).IsSelected(fValues)) {
+          filterMap |= (uint8_t(1) << i);
+          fHistMan->FillHistClass(Form("TrackMuons_%s", (*cut).GetName()), fValues);
+        }
+      }
+      trackSel(filterMap);
+    }
+  }
+};
+
 struct DQFilterPPTask {
   Produces<aod::DQEventFilter> eventFilter;
+  Produces<aod::DqFilters> dqtable;
   OutputObj<THashList> fOutputList{"output"};
-  OutputObj<TH2I> fStats{"stats"};
+  OutputObj<TH1I> fStatsSingleBarrel{"statsSingleBarrel"};
+  OutputObj<TH1I> fStatsSingleMuon{"statsSingleMuon"};
+  OutputObj<TH2I> fStatsBarrel{"statsBarrel"};
+  OutputObj<TH2I> fStatsMuon{"statsMuon"};
   HistogramManager* fHistMan;
   std::vector<AnalysisCompositeCut> fPairCuts;
 
@@ -219,11 +301,14 @@ struct DQFilterPPTask {
   Partition<MyBarrelTracksSelected> negTracks = aod::track::signed1Pt < 0.0f && aod::dqppfilter::isBarrelSelected > uint8_t(0);
 
   Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
-  Configurable<std::string> fConfigPairCuts{"cfgPairCuts", "pairMassLow", "Comma separated list of pair cuts"};
+  Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonQualityCuts,muonLowPt,muonHighPt", "Comma separated list of muon track cuts"};
+  Configurable<std::string> fConfigPairCuts{"cfgPairCuts", "pairNoCut,pairMassLow", "Comma separated list of pair cuts"};
 
   int fNTrackCuts;
+  int fNMuonCuts;
   int fNPairCuts;
   TObjArray* fTrkCutsNameArray;
+  TObjArray* fMuonCutsNameArray;
 
   void DefineCuts()
   {
@@ -258,37 +343,96 @@ struct DQFilterPPTask {
     TString trackCutNamesStr = fConfigTrackCuts.value;
     fTrkCutsNameArray = trackCutNamesStr.Tokenize(",");
     fNTrackCuts = fTrkCutsNameArray->GetEntries();
+    TString muonCutNamesStr = fConfigMuonCuts.value;
+    fMuonCutsNameArray = muonCutNamesStr.Tokenize(",");
+    fNMuonCuts = fMuonCutsNameArray->GetEntries();
     TString histNames = "";
     for (int i = 0; i < fNTrackCuts; i++) {
-      histNames += Form("PairsBarrelPM_%s;", fTrkCutsNameArray->At(i)->GetName());
+      histNames += Form("TrackBarrel_%s;PairsBarrelPM_%s;", fTrkCutsNameArray->At(i)->GetName(), fTrkCutsNameArray->At(i)->GetName());
+    }
+    for (int i = 0; i < fNMuonCuts; i++) {
+      histNames += Form("TrackMuons_%s;PairsMuonsPM_%s;PairsMuonsPP_%s;PairsMuonsMM_%s;", fMuonCutsNameArray->At(i)->GetName(), fMuonCutsNameArray->At(i)->GetName(), fMuonCutsNameArray->At(i)->GetName(), fMuonCutsNameArray->At(i)->GetName());
     }
     DefineHistograms(fHistMan, histNames.Data());    // define all histograms
     VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
     fOutputList.setObject(fHistMan->GetMainHistogramList());
 
     // configure the stats histogram
-    fStats.setObject(new TH2I("stats", "stats", fNPairCuts, -0.5, -0.5 + fNPairCuts, fNTrackCuts, -0.5, -0.5 + fNTrackCuts));
+    fStatsSingleBarrel.setObject(new TH1I("statsSingleBarrel", "statsSingleBarrel", fNTrackCuts, -0.5, -0.5 + fNTrackCuts));
+    for (int i = 0; i < fNTrackCuts; ++i) {
+      fStatsSingleBarrel->GetXaxis()->SetBinLabel(i + 1, fTrkCutsNameArray->At(i)->GetName());
+    }
+
+    fStatsSingleMuon.setObject(new TH1I("statsSingleMuon", "statsSingleMuon", fNMuonCuts, -0.5, -0.5 + fNMuonCuts));
+    for (int i = 0; i < fNMuonCuts; ++i) {
+      fStatsSingleMuon->GetXaxis()->SetBinLabel(i + 1, fMuonCutsNameArray->At(i)->GetName());
+    }
+
+    fStatsBarrel.setObject(new TH2I("statsBarrel", "statsBarrel", fNPairCuts, -0.5, -0.5 + fNPairCuts, fNTrackCuts, -0.5, -0.5 + fNTrackCuts));
     for (int i = 0; i < fNPairCuts; ++i) {
-      fStats->GetXaxis()->SetBinLabel(i + 1, fPairCuts[i].GetName());
+      fStatsBarrel->GetXaxis()->SetBinLabel(i + 1, fPairCuts[i].GetName());
     }
     for (int i = 0; i < fNTrackCuts; ++i) {
-      fStats->GetYaxis()->SetBinLabel(i + 1, fTrkCutsNameArray->At(i)->GetName());
+      fStatsBarrel->GetYaxis()->SetBinLabel(i + 1, fTrkCutsNameArray->At(i)->GetName());
+    }
+
+    fStatsMuon.setObject(new TH2I("statsMuon", "statsMuon", fNPairCuts, -0.5, -0.5 + fNPairCuts, fNMuonCuts, -0.5, -0.5 + fNMuonCuts));
+    for (int i = 0; i < fNPairCuts; ++i) {
+      fStatsMuon->GetXaxis()->SetBinLabel(i + 1, fPairCuts[i].GetName());
+    }
+    for (int i = 0; i < fNMuonCuts; ++i) {
+      fStatsMuon->GetYaxis()->SetBinLabel(i + 1, fMuonCutsNameArray->At(i)->GetName());
     }
   }
 
-  void process(MyEventsSelected::iterator const& event, MyBarrelTracksSelected const& tracks, aod::BCs const& bcs)
+  void
+    process(MyEventsSelected::iterator const& event, MyBarrelTracksSelected const& tracks, MyMuonsSelected const& muons, aod::BCs const& bcs)
   {
-    uint64_t filter = 0;
-    constexpr int pairType = VarManager::kJpsiToEE;
-
+    uint64_t filter = 0; // first 32 bits for dielectrin, last 32 for dimuons
+        
+    //Is event good? [0] = SingleE, [1] = SingleMulow, [2] = SingleMuHigh, [3] = DiElectron, [4] = DiMuon
+    bool keepEvent[5]{false};
+        
+    constexpr int pairTypeEE = VarManager::kJpsiToEE;
+    constexpr int pairTypeMuMu = VarManager::kJpsiToMuMu;
     if (event.isDQEventSelected() == 1) {
       // Reset the fValues array
       VarManager::ResetValues(0, VarManager::kNVars, fValues);
       VarManager::FillEvent<gkEventFillMap>(event, fValues);
+      uint8_t* singleBarrelCount = new uint8_t[fNTrackCuts];                 // single electron trigger
+      uint8_t* singleMuonsCount = new uint8_t[fNMuonCuts];                   // single muon trigger
+      uint8_t* pairsBarrelCount = new uint8_t[fNPairCuts * fNTrackCuts];     // dielectron trigger
+      uint8_t* pairsUnlikeMuonsCount = new uint8_t[fNPairCuts * fNMuonCuts]; // dimuon trigger Unlike
+      uint8_t* pairsLikeMuonsCount = new uint8_t[fNPairCuts * fNMuonCuts];   // dimuon trigger like
 
-      uint8_t* pairsCount = new uint8_t[fNPairCuts * fNTrackCuts];
       for (int i = 0; i < fNPairCuts * fNTrackCuts; i++) {
-        pairsCount[i] = 0;
+        pairsBarrelCount[i] = 0;
+      }
+      for (int i = 0; i < fNPairCuts * fNMuonCuts; i++) {
+        pairsUnlikeMuonsCount[i] = 0;
+        pairsLikeMuonsCount[i] = 0;
+      }
+      for (int i = 0; i < fNMuonCuts; i++) {
+        singleMuonsCount[i] = 0;
+      }
+      for (int i = 0; i < fNTrackCuts; i++) {
+        singleBarrelCount[i] = 0;
+      }
+
+      uint8_t cutSingleFilter = 0;
+      for (auto track : tracks) {
+        cutSingleFilter = track.isBarrelSelected();
+        if (!cutSingleFilter) {
+          continue;
+        }
+        for (int i = 0; i < fNTrackCuts; ++i) {
+          if (!(cutSingleFilter & (uint8_t(1) << i))) {
+            continue;
+          }
+          VarManager::FillTrack<gkTrackFillMap>(track, fValues);
+          fHistMan->FillHistClass(Form("TrackBarrel_%s", fTrkCutsNameArray->At(i)->GetName()), fValues);
+          singleBarrelCount[i] += 1;
+        }
       }
 
       uint8_t cutFilter = 0;
@@ -298,7 +442,7 @@ struct DQFilterPPTask {
           if (!cutFilter) { // the tracks must have at least one filter bit in common to continue
             continue;
           }
-          VarManager::FillPair<pairType>(tpos, tneg, fValues); // compute pair quantities
+          VarManager::FillPair<pairTypeEE>(tpos, tneg, fValues); // compute pair quantities
           for (int i = 0; i < fNTrackCuts; ++i) {
             if (!(cutFilter & (uint8_t(1) << i))) {
               continue;
@@ -307,24 +451,119 @@ struct DQFilterPPTask {
             int j = 0;
             for (auto cut = fPairCuts.begin(); cut != fPairCuts.end(); cut++, j++) {
               if ((*cut).IsSelected(fValues)) {
-                pairsCount[j + i * fNPairCuts] += 1;
+                pairsBarrelCount[j + i * fNPairCuts] += 1;
               }
             }
           }
         }
       }
 
-      for (int i = 0; i < fNTrackCuts; i++) {
-        for (int j = 0; j < fNPairCuts; j++) {
-          if (pairsCount[j + i * fNPairCuts] > 0) {
-            filter |= (uint64_t(1) << (j + i * fNPairCuts));
-            fStats->Fill(j, i);
+      uint8_t cutSingleMuonFilter = 0;
+      for (auto muon1 : muons) {
+        cutSingleMuonFilter = muon1.isMuonSelected();
+        if (!cutSingleMuonFilter) {
+          continue;
+        }
+        for (int i = 0; i < fNMuonCuts; ++i) {
+          if (!(cutSingleMuonFilter & (uint8_t(1) << i))) {
+            continue;
+          }
+          VarManager::FillTrack<gkMuonFillMap>(muon1, fValues);
+          fHistMan->FillHistClass(Form("TrackMuons_%s", fMuonCutsNameArray->At(i)->GetName()), fValues);
+          singleMuonsCount[i] += 1;
+        }
+      }
+
+      uint8_t cutMuonFilter = 0;
+      for (auto& [muon1, muon2] : combinations(muons, muons)) {
+        cutMuonFilter = muon1.isMuonSelected() & muon2.isMuonSelected();
+        if (!cutMuonFilter) { // the tracks must have at least one filter bit in common to continue
+          continue;
+        }
+        VarManager::FillPair<pairTypeMuMu>(muon1, muon2, fValues); // compute pair quantities
+        for (int i = 0; i < fNMuonCuts; ++i) {
+          if (!(cutMuonFilter & (uint8_t(1) << i))) {
+            continue;
+          }
+          if (muon1.sign() * muon2.sign() < 0) {
+            fHistMan->FillHistClass(Form("PairsMuonsPM_%s", fMuonCutsNameArray->At(i)->GetName()), fValues);
+          } else {
+            if (muon1.sign() > 0) {
+              fHistMan->FillHistClass(Form("PairsMuonsPP_%s", fMuonCutsNameArray->At(i)->GetName()), fValues);
+            } else {
+              fHistMan->FillHistClass(Form("PairsMuonsMM_%s", fMuonCutsNameArray->At(i)->GetName()), fValues);
+            }
+          }
+
+          int j = 0;
+          for (auto cut = fPairCuts.begin(); cut != fPairCuts.end(); cut++, j++) {
+            if ((*cut).IsSelected(fValues)) {
+              if (muon1.sign() * muon2.sign() < 0) {
+                pairsUnlikeMuonsCount[j + i * fNPairCuts] += 1;
+              } else {
+                pairsLikeMuonsCount[j + i * fNPairCuts] += 1;
+              }
+            }
           }
         }
       }
-      delete[] pairsCount;
+
+      // Fill DQ bit map
+      for (int i = 0; i < fNTrackCuts; i++) {
+        if (singleBarrelCount[i] > 0) {
+          filter |= (uint64_t(1) << i);
+          fStatsSingleBarrel->Fill(i);
+        }
+        for (int j = 0; j < fNPairCuts; j++) {
+          if (pairsBarrelCount[j + i * fNPairCuts] > 0) {
+            filter |= (uint64_t(1) << (8 + j + i * fNPairCuts));
+            fStatsBarrel->Fill(j, i);
+          }
+        }
+      }
+      for (int i = 0; i < fNMuonCuts; i++) {
+        if (singleMuonsCount[i] > 0) {
+          filter |= (uint64_t(1) << (32 + i));
+          fStatsSingleMuon->Fill(i);
+        }
+        for (int j = 0; j < fNPairCuts; j++) {
+          if (pairsUnlikeMuonsCount[j + i * fNPairCuts] > 0) {
+            filter |= (uint64_t(1) << (40 + j + i * fNPairCuts));
+            fStatsMuon->Fill(j, i);
+          }
+          if (pairsLikeMuonsCount[j + i * fNPairCuts] > 0) {
+            filter |= (uint64_t(1) << (52 + j + i * fNPairCuts));
+            //            fStatsMuon->Fill(j, i);
+          }
+        }
+      }
+
+//      // Fill event selections tag for central event filtering
+//      if (singleBarrelCount[0] > 0) {
+//        keepEvent[0] = true;
+//      }
+//      if (singleMuonsCount[1] > 0) {
+//        keepEvent[1] = true;
+//      }
+//      if (singleMuonsCount[2] > 0) {
+//        keepEvent[2] = true;
+//      }
+//      if (pairsBarrelCount[0] > 0) {
+//        keepEvent[3] = true;
+//      }
+//      if (pairsUnlikeMuonsCount[fNPairCuts] > 0) {
+//        keepEvent[4] = true;
+//      }
+
+      delete[] pairsBarrelCount;
+      delete[] pairsUnlikeMuonsCount;
+      delete[] pairsLikeMuonsCount;
+      delete[] singleMuonsCount;
+      delete[] singleBarrelCount;
     }
     eventFilter(filter);
+    //Filling the table
+    dqtable(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4]);
   }
 };
 
@@ -333,6 +572,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   return WorkflowSpec{
     adaptAnalysisTask<DQEventSelectionTask>(cfgc),
     adaptAnalysisTask<DQBarrelTrackSelectionTask>(cfgc),
+    adaptAnalysisTask<DQMuonsSelection>(cfgc),
     adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 
@@ -363,7 +603,12 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
     }
 
     if (classStr.Contains("Pairs")) {
-      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
+      if (classStr.Contains("Barrel")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
+      }
+      if (classStr.Contains("Muon")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon");
+      }
     }
   }
 }

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -184,7 +184,7 @@ struct DQBarrelTrackSelectionTask {
   void DefineCuts()
   {
     // available cuts: jpsiKineAndQuality, jpsiPID1, jpsiPID2
-    TString cutNamesStr = "jpsiPID1," + fConfigCuts.value;  // "jpsiPID1" is the fixed standard cut provided to the Central Event Filtering task
+    TString cutNamesStr = "jpsiPID1," + fConfigCuts.value; // "jpsiPID1" is the fixed standard cut provided to the Central Event Filtering task
     if (!cutNamesStr.IsNull()) {
       std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
       for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
@@ -519,24 +519,24 @@ struct DQFilterPPTask {
         }
       }
 
-        // Fill event selections tag for central event filtering
-        if (singleBarrelCount[0] > 0) { // Single Barrel count : bit 0 corresponds to "jpsiPID1" cut
-          keepEvent[0] = true;
-        }
-        if (singleMuonsCount[0] > 0) {  // Single Muon count : bit 0 corresponds to "muonLowPt" cut
-          keepEvent[1] = true;
-        }
-        if (singleMuonsCount[1] > 0) {  // Single Muon count : bit 1 corresponds to "muonHighPt" cut
-          keepEvent[2] = true;
-        }
-        if (pairsBarrelCount[0] > 0) {  // Pair Barrel count : bit 0 corresponds "jpsiPID1" & "pairNoCut"  [jPaircut + iTrackCut * fNPairCuts]
-          keepEvent[3] = true;
-        }
-        if (pairsUnlikeMuonsCount[0] > 0) { // Pair Muon count : bit 0 corresponds "muonLowPt" & "pairNoCut"  [jPaircut + iMuonCut * fNPairCuts]
-          keepEvent[4] = true;
-        }
-        //Filling the table
-        dqtable(keepEvent[kSingleE], keepEvent[kSingleMuLow], keepEvent[kSingleMuHigh], keepEvent[kDiElectron], keepEvent[kDiMuon]);
+      // Fill event selections tag for central event filtering
+      if (singleBarrelCount[0] > 0) { // Single Barrel count : bit 0 corresponds to "jpsiPID1" cut
+        keepEvent[0] = true;
+      }
+      if (singleMuonsCount[0] > 0) { // Single Muon count : bit 0 corresponds to "muonLowPt" cut
+        keepEvent[1] = true;
+      }
+      if (singleMuonsCount[1] > 0) { // Single Muon count : bit 1 corresponds to "muonHighPt" cut
+        keepEvent[2] = true;
+      }
+      if (pairsBarrelCount[0] > 0) { // Pair Barrel count : bit 0 corresponds "jpsiPID1" & "pairNoCut"  [jPaircut + iTrackCut * fNPairCuts]
+        keepEvent[3] = true;
+      }
+      if (pairsUnlikeMuonsCount[0] > 0) { // Pair Muon count : bit 0 corresponds "muonLowPt" & "pairNoCut"  [jPaircut + iMuonCut * fNPairCuts]
+        keepEvent[4] = true;
+      }
+      //Filling the table
+      dqtable(keepEvent[kSingleE], keepEvent[kSingleMuLow], keepEvent[kSingleMuHigh], keepEvent[kDiElectron], keepEvent[kDiMuon]);
 
       // Fill DQ bit map
       for (int i = 0; i < fNTrackCuts; i++) {


### PR DESCRIPTION
In filteringTables.h:
- Addition of the DQ trigger table containing :  Single Electron, Single Low Pt Muon, Single High Pt Muon, DiElectron, Dimuon triggers

In filterPP.cxx :
- Addition of the muon triggers in the filtering task
- Produces the DQTable as an output

In CutsLibrary.h :
- Addition of a high and low pT cuts for muon tracks