### PR TITLE
aod-merger: add option to skip non-existing files

### DIFF
--- a/Common/Core/aodMerger.cxx
+++ b/Common/Core/aodMerger.cxx
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <getopt.h>
 
+#include "TSystem.h"
 #include "TFile.h"
 #include "TTree.h"
 #include "TList.h"
@@ -272,6 +273,12 @@ int main(int argc, char* argv[])
 
   outputFile->Write();
   outputFile->Close();
+
+  // in case of failure, remove the incomplete file
+  if (exitCode) {
+    printf("Removing incomplete output file %s.\n", outputFile->GetName());
+    gSystem->Unlink(outputFile->GetName());
+  }
 
   printf("AOD merger finished.\n");
 


### PR DESCRIPTION
avoids crashes if the inputs.txt list for some reason contains files that dont exist or are not reachable