### PR TITLE
add TPC multiplicity to multiplicity table

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -28,6 +28,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(MultV0M, multV0M, //!
 DECLARE_SOA_DYNAMIC_COLUMN(MultT0M, multT0M, //!
                            [](float multT0A, float multT0C) -> float { return multT0A + multT0C; });
 DECLARE_SOA_COLUMN(MultTracklets, multTracklets, int);
+DECLARE_SOA_COLUMN(MultTPC, multTPC, int);
 
 } // namespace mult
 DECLARE_SOA_TABLE(Mults, "AOD", "MULT", //!
@@ -36,7 +37,8 @@ DECLARE_SOA_TABLE(Mults, "AOD", "MULT", //!
                   mult::MultZNA, mult::MultZNC,
                   mult::MultV0M<mult::MultV0A, mult::MultV0C>,
                   mult::MultT0M<mult::MultT0A, mult::MultT0C>,
-                  mult::MultTracklets);
+                  mult::MultTracklets,
+                  mult::MultTPC);
 using Mult = Mults::iterator;
 } // namespace o2::aod
 

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -28,9 +28,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 struct MultiplicityTableTaskIndexed {
   Produces<aod::Mults> mult;
-  Partition<soa::aod::Tracks> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
-  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = ((aod::track::detectorMap & o2::aod::track::TPC) != 0);
-  void processRun2(aod::Run2MatchedSparse::iterator const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracks, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
+  Partition<aod::Tracks> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
+  void processRun2(aod::Run2MatchedSparse::iterator const& collision, aod::Tracks const& tracks, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
   {
     float multV0A = -1.f;
     float multV0C = -1.f;
@@ -73,7 +73,7 @@ struct MultiplicityTableTaskIndexed {
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, soa::Join<aod::Tracks, aod::TracksExtra> const& tracks, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, aod::TracksExtra const& tracksExtra, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
   {
     for (auto& collision : collisions) {
       float multV0A = -1.f;

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -28,9 +28,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 struct MultiplicityTableTaskIndexed {
   Produces<aod::Mults> mult;
-  Partition<aod::Tracks> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
-
-  void processRun2(aod::Run2MatchedSparse::iterator const& collision, aod::Tracks const& tracks, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
+  Partition<soa::aod::Tracks> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = ((aod::track::detectorMap & o2::aod::track::TPC) != 0);
+  void processRun2(aod::Run2MatchedSparse::iterator const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracks, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
   {
     float multV0A = -1.f;
     float multV0C = -1.f;
@@ -39,6 +39,7 @@ struct MultiplicityTableTaskIndexed {
     float multZNA = -1.f;
     float multZNC = -1.f;
     int multTracklets = run2tracklets.size();
+    int multTPC = tracksWithTPC.size();
 
     if (collision.has_fv0a()) {
       auto v0a = collision.fv0a();
@@ -66,12 +67,13 @@ struct MultiplicityTableTaskIndexed {
       multZNA = zdc.energyCommonZNA();
       multZNC = zdc.energyCommonZNC();
     }
-    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets);
-    mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets);
+
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+    mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, soa::Join<aod::Tracks, aod::TracksExtra> const& tracks, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
   {
     for (auto& collision : collisions) {
       float multV0A = -1.f;
@@ -81,7 +83,7 @@ struct MultiplicityTableTaskIndexed {
       float multZNA = -1.f;
       float multZNC = -1.f;
       int multTracklets = -1;
-
+      int multTPC = tracksWithTPC.size();
       const float* aAmplitudesA;
       const float* aAmplitudesC;
 
@@ -100,8 +102,8 @@ struct MultiplicityTableTaskIndexed {
         }
       }
 
-      LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets);
-      mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets);
+      LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+      mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
     }
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", false);

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -73,7 +73,7 @@ struct MultiplicityTableTaskIndexed {
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, aod::TracksExtra const& tracksExtra, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
   {
     for (auto& collision : collisions) {
       float multV0A = -1.f;
@@ -83,7 +83,7 @@ struct MultiplicityTableTaskIndexed {
       float multZNA = -1.f;
       float multZNC = -1.f;
       int multTracklets = -1;
-      int multTPC = tracksWithTPC.size();
+      int multTPC = -1;
       const float* aAmplitudesA;
       const float* aAmplitudesC;
 

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -73,7 +73,7 @@ struct MultiplicityTableTaskIndexed {
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::Tracks const& tracks, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
   {
     for (auto& collision : collisions) {
       float multV0A = -1.f;

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -28,9 +28,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 struct MultiplicityTableTaskIndexed {
   Produces<aod::Mults> mult;
-  Partition<aod::Tracks> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
   Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
-  void processRun2(aod::Run2MatchedSparse::iterator const& collision, aod::Tracks const& tracks, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
+  void processRun2(aod::Run2MatchedSparse::iterator const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const&, aod::Zdcs const&, aod::FV0As const& fv0as, aod::FV0Cs const& fv0cs, aod::FT0s const& ft0s)
   {
     float multV0A = -1.f;
     float multV0C = -1.f;


### PR DESCRIPTION
Add TPC multiplicity (estimated by # of tracks with NClsFindable >0) to mult table for run2 processing
Processing with the run3 option appears to not work (same size() method on the partition gives a single unphysical value to all rows in the dataframe), to be revisited (set to -1 in case of run3 processing for now)