### PR TITLE
Custom deltaBC, foundFV0 and bug fixes

### DIFF
--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -72,36 +72,6 @@ enum EventSelectionFlags {
   kNsel
 };
 
-// In a struct to avoid warnings if that is not used in all executables which include this file
-struct EventSelectionLabels {
-  static constexpr const char* labels[kNsel] = {
-    "kIsBBV0A",
-    "kIsBBV0C",
-    "kIsBBFDA",
-    "kIsBBFDC",
-    "kNoBGV0A",
-    "kNoBGV0C",
-    "kNoBGFDA",
-    "kNoBGFDC",
-    "kIsBBT0A",
-    "kIsBBT0C",
-    "kIsBBZNA",
-    "kIsBBZNC",
-    "kNoBGZNA",
-    "kNoBGZNC",
-    "kNoV0MOnVsOfPileup",
-    "kNoSPDOnVsOfPileup",
-    "kNoV0Casymmetry",
-    "kIsGoodTimeRange",
-    "kNoIncompleteDAQ",
-    "kNoTPCLaserWarmUp",
-    "kNoTPCHVdip",
-    "kNoPileupFromSPD",
-    "kNoV0PFPileup",
-    "kNoSPDClsVsTklBG",
-    "kNoV0C012vsTklBG"};
-};
-
 // collision-joinable event selection decisions
 namespace evsel
 {
@@ -123,20 +93,21 @@ DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);        //! Tracklet multiplicit
 DECLARE_SOA_COLUMN(Sel7, sel7, bool);                   //! Event selection decision based on V0A & V0C
 DECLARE_SOA_COLUMN(Sel8, sel8, bool);                   //! Event selection decision based on TVX
 DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int64_t);        //! FT0 entry index in FT0s table (-1 if doesn't exist)
+DECLARE_SOA_COLUMN(FoundFV0, foundFV0, int64_t);        //! FV0 entry index in FV0A table (-1 if doesn't exist)
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
-                  evsel::Sel7, evsel::Sel8, evsel::FoundFT0);
+                  evsel::Sel7, evsel::Sel8, evsel::FoundFT0, evsel::FoundFV0);
 using EvSel = EvSels::iterator;
 
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0);
+                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0, evsel::FoundFV0);
 using BcSel = BcSels::iterator;
 } // namespace o2::aod
 

--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -92,8 +92,8 @@ DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t); //! Number of SPD cluste
 DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);        //! Tracklet multiplicity
 DECLARE_SOA_COLUMN(Sel7, sel7, bool);                   //! Event selection decision based on V0A & V0C
 DECLARE_SOA_COLUMN(Sel8, sel8, bool);                   //! Event selection decision based on TVX
-DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int64_t);        //! FT0 entry index in FT0s table (-1 if doesn't exist)
-DECLARE_SOA_COLUMN(FoundFV0, foundFV0, int64_t);        //! FV0 entry index in FV0A table (-1 if doesn't exist)
+DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int32_t);        //! FT0 entry index in FT0s table (-1 if doesn't exist)
+DECLARE_SOA_COLUMN(FoundFV0, foundFV0, int32_t);        //! FV0 entry index in FV0A table (-1 if doesn't exist)
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
                   evsel::Alias, evsel::Selection,

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -207,8 +207,8 @@ struct BcSelectionTask {
       selection[kNoPileupFromSPD] = (eventCuts & 1 << aod::kIsPileupFromSPD) == 0;
       selection[kNoV0PFPileup] = (eventCuts & 1 << aod::kIsV0PFPileup) == 0;
 
-      int64_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
-      int64_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
+      int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
+      int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
 
       // Fill bc selection columns
       bcsel(alias, selection,
@@ -276,8 +276,8 @@ struct BcSelectionTask {
 
       uint32_t spdClusters = 0;
 
-      int64_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
-      int64_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
+      int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
+      int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
       LOGP(debug, "foundFT0={}\n", foundFT0);
       // Fill bc selection columns
       bcsel(alias, selection,
@@ -368,8 +368,8 @@ struct EventSelectionTask {
   void processRun2(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
-    int64_t foundFT0 = bc.foundFT0();
-    int64_t foundFV0 = bc.foundFV0();
+    int32_t foundFT0 = bc.foundFT0();
+    int32_t foundFV0 = bc.foundFV0();
 
     // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
@@ -440,7 +440,7 @@ struct EventSelectionTask {
       deltaBC = customDeltaBC;
     }
 
-    int64_t foundFT0 = bc.foundFT0();
+    int32_t foundFT0 = bc.foundFT0();
     if (foundFT0 < 0) { // search in +/-4 sigma around meanBC
       // search forward
       int forwardMoveCount = 0;
@@ -472,7 +472,7 @@ struct EventSelectionTask {
     }
     foundFT0 = bc.foundFT0();
 
-    int64_t foundFV0 = bc.foundFV0();
+    int32_t foundFV0 = bc.foundFV0();
     LOGP(debug, "foundFT0 = {}", foundFT0);
 
     // copy alias decisions from bcsel table

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -208,12 +208,13 @@ struct BcSelectionTask {
       selection[kNoV0PFPileup] = (eventCuts & 1 << aod::kIsV0PFPileup) == 0;
 
       int64_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
+      int64_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
 
       // Fill bc selection columns
       bcsel(alias, selection,
             bbV0A, bbV0C, bgV0A, bgV0C,
             bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0);
+            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun2, "Process Run2 event selection", true);
@@ -276,12 +277,13 @@ struct BcSelectionTask {
       uint32_t spdClusters = 0;
 
       int64_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
+      int64_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
       LOGP(debug, "foundFT0={}\n", foundFT0);
       // Fill bc selection columns
       bcsel(alias, selection,
             bbV0A, bbV0C, bgV0A, bgV0C,
             bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0);
+            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun3, "Process Run3 event selection", false);
@@ -291,6 +293,7 @@ struct EventSelectionTask {
   Produces<aod::EvSels> evsel;
   Configurable<std::string> syst{"syst", "PbPb", "pp, pPb, Pbp, PbPb, XeXe"}; // TODO determine from AOD metadata or from CCDB
   Configurable<int> muonSelection{"muonSelection", 0, "0 - barrel, 1 - muon selection with pileup cuts, 2 - muon selection without pileup cuts"};
+  Configurable<int> customDeltaBC{"customDeltaBC", 300, "custom BC delta for FIT-collision matching"};
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Partition<aod::Tracks> tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
   EvSelParameters par;
@@ -366,6 +369,7 @@ struct EventSelectionTask {
   {
     auto bc = col.bc_as<BCsWithBcSels>();
     int64_t foundFT0 = bc.foundFT0();
+    int64_t foundFV0 = bc.foundFV0();
 
     // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
@@ -421,25 +425,29 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundFT0);
+          foundFT0, foundFV0);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun2, "Process Run2 event selection", true);
 
   void processRun3(aod::Collision const& col, BCsWithBcSels const& bcs)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
-    int64_t foundFT0 = bc.foundFT0();
+    uint64_t apprBC = bc.globalBC();
+    int64_t meanBC = apprBC - std::lround(col.collisionTime() / o2::constants::lhc::LHCBunchSpacingNS);
+    int64_t deltaBC = std::ceil(col.collisionTimeRes() / o2::constants::lhc::LHCBunchSpacingNS * 4);
+    // use custom delta
+    if (customDeltaBC > 0) {
+      deltaBC = customDeltaBC;
+    }
 
+    int64_t foundFT0 = bc.foundFT0();
     if (foundFT0 < 0) { // search in +/-4 sigma around meanBC
-      int64_t apprBC = bc.globalBC();
-      int64_t meanBC = apprBC - std::lround(col.collisionTime() / o2::constants::lhc::LHCBunchSpacingNS);
-      int64_t deltaBC = std::ceil(col.collisionTimeRes() / o2::constants::lhc::LHCBunchSpacingNS * 4);
       // search forward
       int forwardMoveCount = 0;
       int64_t forwardBcDist = deltaBC + 1;
-      for (; bc != bcs.end() && apprBC - meanBC <= deltaBC; ++bc, ++forwardMoveCount) {
+      for (; bc != bcs.end() && int64_t(bc.globalBC()) <= meanBC + deltaBC; ++bc, ++forwardMoveCount) {
         if (bc.foundFT0() >= 0) {
-          forwardBcDist = apprBC - meanBC;
+          forwardBcDist = bc.globalBC() - meanBC;
           break;
         }
       }
@@ -447,19 +455,25 @@ struct EventSelectionTask {
       // search backward
       int backwardMoveCount = 0;
       int64_t backwardBcDist = deltaBC + 1;
-      for (; bc != bcs.begin() && apprBC - meanBC >= -deltaBC; --bc, --backwardMoveCount) {
+      for (; int64_t(bc.globalBC()) >= meanBC - deltaBC; --bc, ++backwardMoveCount) {
         if (bc.foundFT0() >= 0) {
-          backwardBcDist = meanBC - apprBC;
+          backwardBcDist = meanBC - bc.globalBC();
+          break;
+        }
+        if (bc == bcs.begin()) {
           break;
         }
       }
       if (forwardBcDist > deltaBC && backwardBcDist > deltaBC) {
-        bc.moveByIndex(-backwardMoveCount); // return to nominal bc if neighbouring ft0 is not found
+        bc.moveByIndex(backwardMoveCount); // return to nominal bc if neighbouring ft0 is not found
       } else if (forwardBcDist < backwardBcDist) {
-        bc.moveByIndex(-backwardMoveCount + forwardMoveCount); // move forward
-      }
+        bc.moveByIndex(backwardMoveCount + forwardMoveCount); // move forward
+      }                                                       // else keep backward bc
     }
-    LOGP(debug, "{}", bc.foundFT0());
+    foundFT0 = bc.foundFT0();
+
+    int64_t foundFV0 = bc.foundFV0();
+    LOGP(debug, "foundFT0 = {}", foundFT0);
 
     // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
@@ -508,7 +522,7 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundFT0);
+          foundFT0, foundFV0);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun3, "Process Run3 event selection", false);
 };


### PR DESCRIPTION
* custom deltaBC for collision-FT0 matching window, set to 300 bcs by default. Used as a workaround to increase FT0 matching efficiency for pilot beams
* foundFV0 index added in bcsel and evsel tables
* bux fixes in collision-FT0 matching algorithm