### PR TITLE
foundFT0, foundFV0 and foundBC as index columns

### DIFF
--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -78,37 +78,37 @@ namespace evsel
 // TODO bool arrays are not supported? Storing in int32 for the moment
 DECLARE_SOA_COLUMN(Alias, alias, int32_t[kNaliases]);
 DECLARE_SOA_COLUMN(Selection, selection, int32_t[kNsel]);
-DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool);                 //! Beam-beam time in V0A
-DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool);                 //! Beam-beam time in V0C
-DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool);                 //! Beam-gas time in V0A
-DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool);                 //! Beam-gas time in V0C
-DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool);                 //! Beam-beam time in FDA
-DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool);                 //! Beam-beam time in FDC
-DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool);                 //! Beam-gas time in FDA
-DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool);                 //! Beam-gas time in FDC
-DECLARE_SOA_COLUMN(MultRingV0A, multRingV0A, float[5]); //! V0A multiplicity per ring (4 rings in run2, 5 rings in run3)
-DECLARE_SOA_COLUMN(MultRingV0C, multRingV0C, float[4]); //! V0C multiplicity per ring (4 rings in run2)
-DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t); //! Number of SPD clusters in two layers
-DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);        //! Tracklet multiplicity
-DECLARE_SOA_COLUMN(Sel7, sel7, bool);                   //! Event selection decision based on V0A & V0C
-DECLARE_SOA_COLUMN(Sel8, sel8, bool);                   //! Event selection decision based on TVX
-DECLARE_SOA_COLUMN(FoundBC, foundBC, int32_t);          //! BC entry index in BCs table (-1 if doesn't exist)
-DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int32_t);        //! FT0 entry index in FT0s table (-1 if doesn't exist)
-DECLARE_SOA_COLUMN(FoundFV0, foundFV0, int32_t);        //! FV0 entry index in FV0A table (-1 if doesn't exist)
+DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool);                                     //! Beam-beam time in V0A
+DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool);                                     //! Beam-beam time in V0C
+DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool);                                     //! Beam-gas time in V0A
+DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool);                                     //! Beam-gas time in V0C
+DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool);                                     //! Beam-beam time in FDA
+DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool);                                     //! Beam-beam time in FDC
+DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool);                                     //! Beam-gas time in FDA
+DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool);                                     //! Beam-gas time in FDC
+DECLARE_SOA_COLUMN(MultRingV0A, multRingV0A, float[5]);                     //! V0A multiplicity per ring (4 rings in run2, 5 rings in run3)
+DECLARE_SOA_COLUMN(MultRingV0C, multRingV0C, float[4]);                     //! V0C multiplicity per ring (4 rings in run2)
+DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t);                     //! Number of SPD clusters in two layers
+DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);                            //! Tracklet multiplicity
+DECLARE_SOA_COLUMN(Sel7, sel7, bool);                                       //! Event selection decision based on V0A & V0C
+DECLARE_SOA_COLUMN(Sel8, sel8, bool);                                       //! Event selection decision based on TVX
+DECLARE_SOA_INDEX_COLUMN_FULL(FoundBC, foundBC, int, BCs, "_foundBC");      //! BC entry index in BCs table (-1 if doesn't exist)
+DECLARE_SOA_INDEX_COLUMN_FULL(FoundFT0, foundFT0, int, FT0s, "_foundFT0");  //! FT0 entry index in FT0s table (-1 if doesn't exist)
+DECLARE_SOA_INDEX_COLUMN_FULL(FoundFV0, foundFV0, int, FV0As, "_foundFV0"); //! FV0 entry index in FV0As table (-1 if doesn't exist)
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
-                  evsel::Sel7, evsel::Sel8, evsel::FoundBC, evsel::FoundFT0, evsel::FoundFV0);
+                  evsel::Sel7, evsel::Sel8, evsel::FoundBCId, evsel::FoundFT0Id, evsel::FoundFV0Id);
 using EvSel = EvSels::iterator;
 
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0, evsel::FoundFV0);
+                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0Id, evsel::FoundFV0Id);
 using BcSel = BcSels::iterator;
 } // namespace o2::aod
 

--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -92,6 +92,7 @@ DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t); //! Number of SPD cluste
 DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);        //! Tracklet multiplicity
 DECLARE_SOA_COLUMN(Sel7, sel7, bool);                   //! Event selection decision based on V0A & V0C
 DECLARE_SOA_COLUMN(Sel8, sel8, bool);                   //! Event selection decision based on TVX
+DECLARE_SOA_COLUMN(FoundBC, foundBC, int32_t);          //! BC entry index in BCs table (-1 if doesn't exist)
 DECLARE_SOA_COLUMN(FoundFT0, foundFT0, int32_t);        //! FT0 entry index in FT0s table (-1 if doesn't exist)
 DECLARE_SOA_COLUMN(FoundFV0, foundFV0, int32_t);        //! FV0 entry index in FV0A table (-1 if doesn't exist)
 } // namespace evsel
@@ -100,7 +101,7 @@ DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
-                  evsel::Sel7, evsel::Sel8, evsel::FoundFT0, evsel::FoundFV0);
+                  evsel::Sel7, evsel::Sel8, evsel::FoundBC, evsel::FoundFT0, evsel::FoundFV0);
 using EvSel = EvSels::iterator;
 
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -368,6 +368,7 @@ struct EventSelectionTask {
   void processRun2(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
+    int32_t foundBC = bc.index();
     int32_t foundFT0 = bc.foundFT0();
     int32_t foundFV0 = bc.foundFV0();
 
@@ -425,7 +426,7 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundFT0, foundFV0);
+          foundBC, foundFT0, foundFV0);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun2, "Process Run2 event selection", true);
 
@@ -470,6 +471,8 @@ struct EventSelectionTask {
         bc.moveByIndex(backwardMoveCount + forwardMoveCount); // move forward
       }                                                       // else keep backward bc
     }
+    
+    int32_t foundBC = bc.index();
     foundFT0 = bc.foundFT0();
 
     int32_t foundFV0 = bc.foundFV0();
@@ -522,7 +525,7 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundFT0, foundFV0);
+          foundBC, foundFT0, foundFV0);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun3, "Process Run3 event selection", false);
 };

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -368,9 +368,9 @@ struct EventSelectionTask {
   void processRun2(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)
   {
     auto bc = col.bc_as<BCsWithBcSels>();
-    int32_t foundBC = bc.index();
-    int32_t foundFT0 = bc.foundFT0();
-    int32_t foundFV0 = bc.foundFV0();
+    int32_t foundBC = bc.globalIndex();
+    int32_t foundFT0 = bc.foundFT0Id();
+    int32_t foundFV0 = bc.foundFV0Id();
 
     // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
@@ -441,13 +441,12 @@ struct EventSelectionTask {
       deltaBC = customDeltaBC;
     }
 
-    int32_t foundFT0 = bc.foundFT0();
-    if (foundFT0 < 0) { // search in +/-4 sigma around meanBC
+    if (bc.has_foundFT0()) { // search in +/-4 sigma around meanBC
       // search forward
       int forwardMoveCount = 0;
       int64_t forwardBcDist = deltaBC + 1;
       for (; bc != bcs.end() && int64_t(bc.globalBC()) <= meanBC + deltaBC; ++bc, ++forwardMoveCount) {
-        if (bc.foundFT0() >= 0) {
+        if (bc.has_foundFT0()) {
           forwardBcDist = bc.globalBC() - meanBC;
           break;
         }
@@ -457,7 +456,7 @@ struct EventSelectionTask {
       int backwardMoveCount = 0;
       int64_t backwardBcDist = deltaBC + 1;
       for (; int64_t(bc.globalBC()) >= meanBC - deltaBC; --bc, ++backwardMoveCount) {
-        if (bc.foundFT0() >= 0) {
+        if (bc.has_foundFT0()) {
           backwardBcDist = meanBC - bc.globalBC();
           break;
         }
@@ -471,11 +470,11 @@ struct EventSelectionTask {
         bc.moveByIndex(backwardMoveCount + forwardMoveCount); // move forward
       }                                                       // else keep backward bc
     }
-    
-    int32_t foundBC = bc.index();
-    foundFT0 = bc.foundFT0();
 
-    int32_t foundFV0 = bc.foundFV0();
+    int32_t foundBC = bc.globalIndex();
+    int32_t foundFT0 = bc.foundFT0Id();
+    int32_t foundFV0 = bc.foundFV0Id();
+
     LOGP(debug, "foundFT0 = {}", foundFT0);
 
     // copy alias decisions from bcsel table

--- a/Common/TableProducer/ft0CorrectedTable.cxx
+++ b/Common/TableProducer/ft0CorrectedTable.cxx
@@ -30,13 +30,12 @@ struct FT0CorrectedTable {
   void process(BCsWithMatchings const& bcs, soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::FT0s const& ft0s)
   {
     for (auto& collision : collisions) {
-      int64_t foundFT0 = collision.foundFT0();
       float vertexPV = collision.posZ();
       float vertex_corr = vertexPV / o2::constants::physics::LightSpeedCm2NS;
       float t0A = 1e10;
       float t0C = 1e10;
-      if (foundFT0 != -1) {
-        auto ft0 = ft0s.iteratorAt(foundFT0);
+      if (collision.has_foundFT0()) {
+        auto ft0 = collision.foundFT0();
         int triggersignals = ft0.triggerMask();
         bool ora = (triggersignals & (1 << 0)) != 0;
         bool orc = (triggersignals & (1 << 1)) != 0;

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -75,34 +75,32 @@ struct MultiplicityTableTaskIndexed {
 
   void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra, aod::BCs const& bcs, aod::Zdcs const& zdcs, aod::FV0As const& fv0as, aod::FT0s const& ft0s)
   {
-      float multV0A = -1.f;
-      float multV0C = -1.f;
-      float multT0A = -1.f;
-      float multT0C = -1.f;
-      float multZNA = -1.f;
-      float multZNC = -1.f;
-      int multTracklets = -1;
-      int multTPC = tracksWithTPC.size();
-      const float* aAmplitudesA;
-      const float* aAmplitudesC;
+    float multV0A = -1.f;
+    float multV0C = -1.f;
+    float multT0A = -1.f;
+    float multT0C = -1.f;
+    float multZNA = -1.f;
+    float multZNC = -1.f;
+    int multTracklets = -1;
+    int multTPC = tracksWithTPC.size();
+    const float* aAmplitudesA;
+    const float* aAmplitudesC;
 
-      // using FT0 row index from event selection task
-      int64_t foundFT0 = collision.foundFT0();
-
-      if (foundFT0 != -1) {
-        auto ft0 = ft0s.iteratorAt(foundFT0);
-        aAmplitudesA = ft0.amplitudeA();
-        aAmplitudesC = ft0.amplitudeC();
-        for (int i = 0; i < 96; i++) {
-          multT0A += aAmplitudesA[i];
-        }
-        for (int i = 0; i < 112; i++) {
-          multT0C += aAmplitudesC[i];
-        }
+    // using FT0 row index from event selection task
+    if (collision.has_foundFT0()) {
+      auto ft0 = collision.foundFT0();
+      aAmplitudesA = ft0.amplitudeA();
+      aAmplitudesC = ft0.amplitudeC();
+      for (int i = 0; i < 96; i++) {
+        multT0A += aAmplitudesA[i];
       }
+      for (int i = 0; i < 112; i++) {
+        multT0C += aAmplitudesC[i];
+      }
+    }
 
-      LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
-      mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+    mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", false);
 };

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -265,7 +265,7 @@ struct EventSelectionQaPerCollisionRun3 {
     histos.fill(HIST("hNcontrib"), nContributors);
     uint64_t globalBc = col.bc().globalBC();
     histos.fill(HIST("hGlobalBcCol"), globalBc);
-    if (col.foundFT0() >= 0) {
+    if (col.has_foundFT0()) {
       histos.fill(HIST("hNcontribFT0"), nContributors);
       histos.fill(HIST("hGlobalBcColFT0"), globalBc);
     }

--- a/Common/Tasks/ft0Qa.cxx
+++ b/Common/Tasks/ft0Qa.cxx
@@ -39,28 +39,29 @@ struct FT0Qa {
   OutputObj<TH2F> hT0V0mult{TH2F("hT0V0mult", "T0A vs V0 multiplicity;V0Mult;T0Mmult", 500, 0., 15000., 200, 0., 2000.)};
   OutputObj<TH2F> hT0V0time{TH2F("hT0V0time", "T0A vs V0 time ;V0time;T0A", 200, -2, 2., 200, -2, 2)};
 
-  //Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
+  // Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
 
   void process(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::FT0sCorrected>::iterator const& col, aod::FT0s const& ft0s, aod::FV0As const& fv0s)
   {
-    int64_t foundFT0 = col.foundFT0();
     float sumAmpFT0 = 0;
     float sumAmpFV0 = 0;
-    if (foundFT0 != -1) {
-      auto ft0 = ft0s.iteratorAt(foundFT0);
+    if (col.has_foundFT0()) {
+      auto ft0 = col.foundFT0();
       LOGF(debug, "multV0A=%5.0f;  multT0A=%5.0f; PV=%f; T0vertex=%f; T0A=%f; T0C=%f; T0AC=%f ", col.multV0A(), col.multT0A(), col.posZ(), col.t0ACorrected(), col.t0CCorrected(), col.t0AC(), ft0.posZ());
       if (col.t0ACorrectedValid()) {
         hT0A->Fill(col.t0ACorrected());
-        auto fv0 = fv0s.iteratorAt(foundFT0);
-        float fv0Time = fv0.time();
-        hT0V0time->Fill(fv0Time, ft0.timeA());
-        for (int ich = 0; ich < 96; ich++) {
-          sumAmpFT0 += ft0.amplitudeA()[ich];
+        if (col.has_foundFV0()) {
+          auto fv0 = col.foundFV0();
+          float fv0Time = fv0.time();
+          hT0V0time->Fill(fv0Time, ft0.timeA());
+          for (int ich = 0; ich < 96; ich++) {
+            sumAmpFT0 += ft0.amplitudeA()[ich];
+          }
+          for (int ich = 0; ich < 48; ich++) {
+            sumAmpFV0 += fv0.amplitude()[ich];
+          }
+          hT0V0mult->Fill(sumAmpFV0, sumAmpFT0);
         }
-        for (int ich = 0; ich < 48; ich++) {
-          sumAmpFV0 += fv0.amplitude()[ich];
-        }
-        hT0V0mult->Fill(sumAmpFV0, sumAmpFT0);
       }
       if (col.t0CCorrectedValid()) {
         hT0C->Fill(col.t0CCorrected());

--- a/PWGMM/Tasks/dndeta.h
+++ b/PWGMM/Tasks/dndeta.h
@@ -155,7 +155,7 @@ struct PseudorapidityDensity {
         registry.fill(HIST("EventSelection"), 4);
         cols.clear();
         for (auto& collision : collisions) {
-          if ((collision.foundFT0() >= 0) && (ft0s.iteratorAt(collision.foundFT0()).bcId() == bc.globalIndex())) {
+          if ((collision.has_foundFT0()) && (collision.foundFT0().bcId() == bc.globalIndex())) {
             cols.emplace_back(collision);
           }
         }


### PR DESCRIPTION
* Added foundBC index to EvSel table
* Declared foundFT0, foundFV0 and foundBC as index columns
* Changes in user tasks:
    - Check for foundFT0==-1 via collision.has_foundFT0()
    - Access data directly via collision.foundFT0() instead of iterator_at(foundFT0).