### PR TITLE
Fix PR auto-approval script

### DIFF
--- a/.github/workflows/codeowner-self-approval.yml
+++ b/.github/workflows/codeowner-self-approval.yml
@@ -1,99 +1,116 @@
 name: PR self-approval
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - auto_merge_enabled
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   approve:
     runs-on: ubuntu-latest
     # Only run if the PR author enabled auto-merge, not someone else.
-    if: github.event.sender.login == github.event.pull_request.user.login
+    # Also run if a new approval was created, as this affects whether we can
+    # auto-approve. There is a risk of infinite loops here, though -- when we
+    # submit our review, that'll trigger this workflow again, so only run if
+    # someone other than us (i.e. alibuild) reviewed.
+    if: >-
+      (github.event.action == 'submitted' &&
+       github.event.review.state == 'approved' &&
+       github.event.sender.login != 'alibuild') ||
+      (github.event.action == 'auto_merge_enabled' &&
+       github.event.sender.login == github.event.pull_request.user.login)
 
     steps:
-      # Check out in order to get CODEOWNERS.
-      - uses: actions/checkout@v2
-        with:
-          # Always use the latest CODEOWNERS file, *not* the one from the PR!
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-
       - name: Install dependencies
-        run: pip install PyGithub
+        run: pip install codeowners PyGithub
 
-      # First, parse filename patterns in CODEOWNERS using git-check-ignore(1)
-      # to get the applicable code owners for this PR.
-      - name: Parse CODEOWNERS
-        id: owners
-        shell: bash -exo pipefail {0}
-        run: |
-          git config --global init.defaultBranch master  # avoid annoying warning
-          git init ../tmp  # temporary repo for .gitignore parsing
-          awk '!/^[[:space:]]*(#|$)/ {print $1}' CODEOWNERS > ../tmp/.gitignore
-          # Find changed files in PR and which CODEOWNERS entries match them.
-          curl -fsSL "${{ github.event.pull_request.diff_url }}" |
-            sed -rn 's,^diff --git a/(.*) b/(.*)$,\1\n\2,p' | uniq |
-            git -C ../tmp check-ignore -v --no-index --stdin |
-            cut -d: -f2 |
-            sed 's/$/p/' > extract-lines.sed
-          # Extract user names applicable to this PR. Same format as CODEOWNERS,
-          # but without the leading pattern, so we just have usernames separated
-          # by spaces and newlines.
-          echo "::set-output name=owners::$(
-            grep -vE '^[[:space:]]*(#|$)' CODEOWNERS |
-              sed -nf extract-lines.sed |
-              sed 's/^[^[:space:]]*[[:space:]]*//' |
-              tr '\n' ';'
-          )"
-
-      # Finally, approve, if the author is only editing files owned by themselves.
-      - name: Check author is allowed to self-approve
+      # Approve the PR, if the author is only editing files owned by themselves.
+      - name: Auto-approve PR if permitted
         shell: python
         env:
-          submitter: ${{ github.event.sender.login }}
+          submitter: ${{ github.event.pull_request.user.login }}
           pr: ${{ github.event.pull_request.number }}
           repo: ${{ github.event.repository.full_name }}
-          owners: ${{ steps.owners.outputs.owners }}
-          github_token: ${{ secrets.ALIBUILD_GITHUB_TOKEN }}
+          github_token: ${{ secrets.alibuild_github_token }}
         run: |
-          import functools, github, os
+          import os
+          import sys
+          from functools import lru_cache
+          from codeowners import CodeOwners
+          from github import Github, UnknownObjectException
 
-          gh = github.Github(os.environ['github_token'])
-          submitter = os.environ['submitter']
+          # Cache results of this function so we don't have to look up team
+          # membership multiple times.
+          @lru_cache(maxsize=None)
+          def matches_owner(owner):
+              '''Return whether the PR's submitter matches the given owner.
 
-          @functools.lru_cache(maxsize=None)
-          def matches_owner(user_or_team):
-              user_or_team = user_or_team.lstrip('@')
-              org, is_team, team_name = user_or_team.partition('/')
-              if not is_team:
-                  return user_or_team == submitter
-              try:
-                  gh.get_organization(org) \
-                    .get_team_by_slug(team_name) \
-                    .get_team_membership(submitter)
-              except github.UnknownObjectException:
-                  return False
-              return True
+              owner is a (type, name) tuple, as returned by the CodeOwners.of
+              function. EMAIL owners cannot be handled currently, and will raise
+              a ValueError.
+              '''
+              owner_type, owner_name = owner
+              if owner_type == 'USERNAME':
+                  return owner_name.lstrip('@') == os.environ['submitter']
+              elif owner_type == 'TEAM':
+                  org, _, team_name = user_or_team.lstrip('@').partition('/')
+                  try:
+                      gh.get_organization(org) \
+                        .get_team_by_slug(team_name) \
+                        .get_team_membership(os.environ['submitter'])
+                  except UnknownObjectException:
+                      return False   # submitter is not a member of this team
+                  return True
+              elif owner_type == 'EMAIL':
+                  # We can't resolve email addresses to GitHub usernames using
+                  # GitHub's API.
+                  raise ValueError('cannot handle email addresses in CODEOWNERS')
+              else:
+                  raise ValueError(f'unknown owner type {owner_type}')
 
-          def check_lines():
-              auto_approve = True
-              # owners is a string containing semicolon-separated records of
-              # space-separated usernames. At least one username per record must
-              # match the submitter (taking teams into account), and all lines
-              # must have a matching username.
-              for line in os.environ['owners'].strip(';').split(';'):
-                  line_owners = line.split()
-                  assert all(o.startswith('@') for o in line_owners), \
-                      'failed to parse CODEOWNERS'
-                  if not any(map(matches_owner, line_owners)):
-                      print('::warning::Not auto-approving as you are not one of',
-                            ', '.join(line_owners))
-                      auto_approve = False
-              return auto_approve
+          gh = Github(os.environ['github_token'])
+          repo = gh.get_repo(os.environ['repo'])
+          pr = repo.get_pull(int(os.environ['pr']))
+          owners = CodeOwners(repo.get_contents('CODEOWNERS')
+                                  .decoded_content.decode('utf-8'))
+          approvals_from = {review.user for review in pr.get_reviews()
+                            if review.state == 'APPROVED'}
 
-          if check_lines():
-              gh.get_repo(os.environ['repo']) \
-                .get_pull(int(os.environ['pr'])) \
-                .create_review(event='APPROVE',
-                               body=f'Auto-approving on behalf of @{submitter}.')
+          # At least one username per CODEOWNERS line must match the submitter
+          # (taking teams into account), and all lines must have a matching
+          # username. If the PR author is not the codeowner for a file, then if
+          # a codeowner of that file approved this PR, we'll still auto-approve.
+          auto_approve = True
+          for filename in (f.filename for f in pr.get_files()):
+              file_owners, line = owners.matching_line(filename)
+              file_owners_names = {name for _, name in file_owners}
+              if approvals_from & file_owners_names:
+                  print(f'{filename}: OK: you have approval from the code'
+                        ' owners of this file, specifically:',
+                        ', '.join(approvals_from & file_owners_names),
+                        f' (CODEOWNERS line {line})', file=sys.stderr)
+              elif any(map(matches_owner, file_owners)):
+                  print(f'{filename}: OK: you are a code owner of this file'
+                        f' (CODEOWNERS line {line})', file=sys.stderr)
+              else:
+                  print('::warning::Not auto-approving as none of',
+                        ', '.join(file_owners_names),
+                        f'have approved this PR as owners of {filename}'
+                        f' (CODEOWNERS line {line})', file=sys.stderr)
+                  # Don't break out of the loop, so that we print every
+                  # non-matching CODEOWNERS rule for information.
+                  auto_approve = False
+
+          if auto_approve:
+              print('Approving PR', file=sys.stderr)
+              pr.create_review(event='APPROVE', body=(
+                  f'Auto-approving on behalf of @{os.environ["submitter"]}.'
+              ))
+          else:
+              print('::warning::Not approving PR. You can see whose approval'
+                    ' you need in the messages above. This check will run again'
+                    " when someone approves this PR, or when the PR's author"
+                    ' disables and reenables auto-merge.', file=sys.stderr)


### PR DESCRIPTION
1. Parse the CODEOWNERS file properly -- `git check-ignore` uses slightly different syntax and precedence rules, so we can't use that.
2. if another codeowner has already approved the PR, then consider that OK for the relevant CODEOWNER lines.

   This means that if e.g. a PR authored by A changes files Fa and Fb, and A owns Fa, and B owns Fb, then auto-approval is still possible as long as B approves the PR.

Not properly tested yet, though I should be able to do that on Monday.