### PR TITLE
Workaround crash in track-extension

### DIFF
--- a/Common/TableProducer/trackextension.cxx
+++ b/Common/TableProducer/trackextension.cxx
@@ -71,7 +71,7 @@ struct TrackExtension {
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbpath_lut));
 
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
-      ccdb->get<TGeoManager>(ccdbpath_geo);
+    //  ccdb->get<TGeoManager>(ccdbpath_geo);
     }
     mRunNumber = 0;
     mMagField = 0.0;

--- a/Common/TableProducer/trackextension.cxx
+++ b/Common/TableProducer/trackextension.cxx
@@ -71,7 +71,7 @@ struct TrackExtension {
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbpath_lut));
 
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
-    //  ccdb->get<TGeoManager>(ccdbpath_geo);
+      //  ccdb->get<TGeoManager>(ccdbpath_geo);
     }
     mRunNumber = 0;
     mMagField = 0.0;


### PR DESCRIPTION
Without this we get a segfault on exit (probably due to a  double delete) on the grid. Moreover, when compiling with `-fsanitize=address` it complains about:

```
[47474:track-extension]: ==47474==ERROR: AddressSanitizer: SEGV on unknown address 0x7f893300006d (pc 0x00000041ef1c bp 0x60b000236000 sp 0x7fffaf0c9f48 T0)
[47474:track-extension]: ==47474==The signal is caused by a READ memory access.
[47474:track-extension]:     #0 0x41ef1c in std::_Sp_counted_ptr<TGeoManager*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /home/alitrain/eulisse/sw2/ubuntu1804_x86-64/GCC-Toolchain/v10.2.0-alice2-1/include/c++/10.2.0/bits/shared_ptr_base.h:380
```

With this change in, address sanitizer does not complain.