### PR TITLE
Revert "Workaround crash in track-extension"

### DIFF
--- a/Common/TableProducer/trackextension.cxx
+++ b/Common/TableProducer/trackextension.cxx
@@ -71,7 +71,7 @@ struct TrackExtension {
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbpath_lut));
 
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
-      //  ccdb->get<TGeoManager>(ccdbpath_geo);
+      ccdb->get<TGeoManager>(ccdbpath_geo);
     }
     mRunNumber = 0;
     mMagField = 0.0;


### PR DESCRIPTION
Reverts AliceO2Group/O2Physics#402

Due to https://github.com/AliceO2Group/AliceO2/pull/7843