### PR TITLE
[PWGHF] Add protection for tracks without associated MC particle

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -724,6 +724,9 @@ class RecoDecay
     }
     // Loop over decay candidate prongs
     for (std::size_t iProng = 0; iProng < N; ++iProng) {
+      if (!arrDaughters[iProng].has_mcParticle()) {
+        return -1;
+      }
       auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
       arrDaughtersIndex[iProng] = particleI.globalIndex();
       // Get the list of daughter indices from the mother of the first prong.

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -192,7 +192,9 @@ struct HFCandidateCreator3ProngExpressions {
           flag = sign * (1 << DecayType::LcToPKPi);
 
           //Printf("Flagging the different Λc± → p± K∓ π± decay channels");
-          swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
+          if (arrayDaughters[0].has_mcParticle()) {
+            swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
+          }
           RecoDecay::getDaughters(particlesMC, particlesMC.iteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {

--- a/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
@@ -229,10 +229,15 @@ struct HFD0CandidateSelectorALICE3Barrel {
         continue;
       }
 
-      const auto mcParticlePositive = trackPos.mcParticle();
-      const auto mcParticleNegative = trackNeg.mcParticle();
-      int pdgPositive = mcParticlePositive.pdgCode();
-      int pdgNegative = mcParticleNegative.pdgCode();
+      int pdgPositive = 0;
+      int pdgNegative = 0;
+      if(trackPos.has_mcParticle()) {
+        pdgPositive = trackPos.mcParticle().pdgCode();
+      }
+      if(trackNeg.has_mcParticle()) {
+        pdgNegative = trackNeg.mcParticle().pdgCode();
+      }
+
       //std::cout << "barrel= " << pdgPositive <<"\t"<< pdgNegative << "\n";
       float nsigmaTOFNegKaon = -5000.0;
       float nsigmaRICHNegKaon = -5000.0;

--- a/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorALICE3Barrel.cxx
@@ -231,10 +231,10 @@ struct HFD0CandidateSelectorALICE3Barrel {
 
       int pdgPositive = 0;
       int pdgNegative = 0;
-      if(trackPos.has_mcParticle()) {
+      if (trackPos.has_mcParticle()) {
         pdgPositive = trackPos.mcParticle().pdgCode();
       }
-      if(trackNeg.has_mcParticle()) {
+      if (trackNeg.has_mcParticle()) {
         pdgNegative = trackNeg.mcParticle().pdgCode();
       }
 

--- a/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
@@ -234,10 +234,10 @@ struct HFD0CandidateSelectorparametrizedPID {
 
       int pdgPositive = 0;
       int pdgNegative = 0;
-      if(trackPos.has_mcParticle()) {
+      if (trackPos.has_mcParticle()) {
         pdgPositive = trackPos.mcParticle().pdgCode();
       }
-      if(trackNeg.has_mcParticle()) {
+      if (trackNeg.has_mcParticle()) {
         pdgNegative = trackNeg.mcParticle().pdgCode();
       }
 

--- a/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
+++ b/PWGHF/TableProducer/HFD0CandidateSelectorparametrizedPID.cxx
@@ -232,10 +232,14 @@ struct HFD0CandidateSelectorparametrizedPID {
         continue;
       }
 
-      const auto mcParticlePositive = trackPos.mcParticle();
-      const auto mcParticleNegative = trackNeg.mcParticle();
-      int pdgPositive = mcParticlePositive.pdgCode();
-      int pdgNegative = mcParticleNegative.pdgCode();
+      int pdgPositive = 0;
+      int pdgNegative = 0;
+      if(trackPos.has_mcParticle()) {
+        pdgPositive = trackPos.mcParticle().pdgCode();
+      }
+      if(trackNeg.has_mcParticle()) {
+        pdgNegative = trackNeg.mcParticle().pdgCode();
+      }
 
       bool selectPosPion = false;
       bool selectNegKaon = false;

--- a/PWGHF/TableProducer/HFLcCandidateSelectorparametrizedPID.cxx
+++ b/PWGHF/TableProducer/HFLcCandidateSelectorparametrizedPID.cxx
@@ -205,13 +205,13 @@ struct HFLcCandidateSelectorparametrizedPID {
       int pdgPositive1 = 0;
       int pdgPositive2 = 0;
       int pdgNegative = 0;
-      if(trackPos1.has_mcParticle()) {
+      if (trackPos1.has_mcParticle()) {
         pdgPositive1 = trackPos1.mcParticle().pdgCode();
       }
-      if(trackPos2.has_mcParticle()) {
+      if (trackPos2.has_mcParticle()) {
         pdgPositive2 = trackPos2.mcParticle().pdgCode();
       }
-      if(trackNeg.has_mcParticle()) {
+      if (trackNeg.has_mcParticle()) {
         pdgNegative = trackNeg.mcParticle().pdgCode();
       }
 

--- a/PWGHF/TableProducer/HFLcCandidateSelectorparametrizedPID.cxx
+++ b/PWGHF/TableProducer/HFLcCandidateSelectorparametrizedPID.cxx
@@ -202,12 +202,18 @@ struct HFLcCandidateSelectorparametrizedPID {
       auto etaPos2Track = std::abs(trackPos2.eta());
       auto etaNegTrack = std::abs(trackNeg.eta());
 
-      const auto mcParticlePositive1 = trackPos1.mcParticle();
-      const auto mcParticlePositive2 = trackPos2.mcParticle();
-      const auto mcParticleNegative = trackNeg.mcParticle();
-      int pdgPositive1 = mcParticlePositive1.pdgCode();
-      int pdgPositive2 = mcParticlePositive2.pdgCode();
-      int pdgNegative = mcParticleNegative.pdgCode();
+      int pdgPositive1 = 0;
+      int pdgPositive2 = 0;
+      int pdgNegative = 0;
+      if(trackPos1.has_mcParticle()) {
+        pdgPositive1 = trackPos1.mcParticle().pdgCode();
+      }
+      if(trackPos2.has_mcParticle()) {
+        pdgPositive2 = trackPos2.mcParticle().pdgCode();
+      }
+      if(trackNeg.has_mcParticle()) {
+        pdgNegative = trackNeg.mcParticle().pdgCode();
+      }
 
       bool selectPos1Proton = false;
       bool selectPos1Pion = false;

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -172,7 +172,9 @@ struct ValidationRecLevel {
         continue;
       }
       if (std::abs(candidate.flagMCMatchRec()) == 1 << hf_cand_prong2::DecayType::D0ToPiK) {
-        indexParticle = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().mcParticle(), pdg::Code::kD0, true);
+        if(candidate.index0_as<aod::BigTracksMC>().has_mcParticle()) {
+          indexParticle = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().mcParticle(), pdg::Code::kD0, true);
+        }
         auto mother = particlesMC.iteratorAt(indexParticle);
         registry.fill(HIST("histPt"), candidate.pt() - mother.pt());
         registry.fill(HIST("histPx"), candidate.px() - mother.px());

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -172,7 +172,7 @@ struct ValidationRecLevel {
         continue;
       }
       if (std::abs(candidate.flagMCMatchRec()) == 1 << hf_cand_prong2::DecayType::D0ToPiK) {
-        if(candidate.index0_as<aod::BigTracksMC>().has_mcParticle()) {
+        if (candidate.index0_as<aod::BigTracksMC>().has_mcParticle()) {
           indexParticle = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().mcParticle(), pdg::Code::kD0, true);
         }
         auto mother = particlesMC.iteratorAt(indexParticle);


### PR DESCRIPTION
* explcit check introduced in O2 PR [#7866](https://github.com/AliceO2Group/AliceO2/pull/7866) makes certain analyses fail in
  case an invalid index is found for an MCParticle associated to a track