### PR TITLE
Add KFParticle to dependencies

### DIFF
--- a/dependencies/FindKFParticle.cmake
+++ b/dependencies/FindKFParticle.cmake
@@ -1,0 +1,41 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+# add KFParticle::KFParticle as library to targets depending on KFParticle
+
+
+#if (NOT DEFINED KFParticle_DIR)
+#        set(KFParticle_DIR "$ENV{KFPARTICLE_ROOT}")
+#endif()
+
+find_path(KFPARTICLE_INCLUDE_DIR KFParticle.h
+        PATH_SUFFIXES "include"
+        HINTS "$ENV{KFPARTICLE_ROOT}")
+find_library(KFPARTICLE_LIBPATH "KFParticle"
+        PATH_SUFFIXES "lib"
+        HINTS "$ENV{KFPARTICLE_ROOT}")
+
+mark_as_advanced(KFPARTICLE_LIBPATH)
+
+find_package_handle_standard_args(KFParticle DEFAULT_MSG
+                                  KFPARTICLE_LIBPATH KFPARTICLE_INCLUDE_DIR)
+
+if(KFPARTICLE_FOUND)
+   set(KFPARTICLE_LIBRARIES ${KFPARTICLE_LIBPATH})
+   set(KFPARTICLE_INCLUDE_DIRS ${KFPARTICLE_INCLUDE_DIR})
+   # add target
+   if(NOT TARGET KFParticle::KFParticle)
+      add_library(KFParticle::KFParticle IMPORTED INTERFACE)
+      set_target_properties(KFParticle::KFParticle PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${KFPARTICLE_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${KFPARTICLE_INCLUDE_DIR}")
+   endif()
+endif()

--- a/dependencies/O2PhysicsDependencies.cmake
+++ b/dependencies/O2PhysicsDependencies.cmake
@@ -13,9 +13,8 @@ include_guard()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
-#set(KFParticle_DIR "$ENV{KFPARTICLE_ROOT}")
+# Find required packages
 find_package(KFParticle)
 set_package_properties(KFParticle PROPERTIES TYPE REQUIRED)
-feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
-# Required
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/dependencies/O2PhysicsDependencies.cmake
+++ b/dependencies/O2PhysicsDependencies.cmake
@@ -9,5 +9,13 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-include("${CMAKE_CURRENT_LIST_DIR}/O2PhysicsCompileFlags.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/O2PhysicsDependencies.cmake")
+include_guard()
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
+
+#set(KFParticle_DIR "$ENV{KFPARTICLE_ROOT}")
+find_package(KFParticle)
+set_package_properties(KFParticle PROPERTIES TYPE REQUIRED)
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+
+# Required


### PR DESCRIPTION
This commit adds the necessary CMake find_package commands to find the KFParticle package in O2Physics so that it can be used in analysis tasks.

Currently KFParticle is defined in alidist as a dependency of O2, so is already built as part of the software chain, but is not explicitly included for O2Physics -- not sure if this means we would also need a corresponding change in alidist (see previous discussion in https://github.com/AliceO2Group/AliceO2/pull/6992 where it was suggested to move the dependency from O2 to O2Physics instead)