### PR TITLE
CEFP: Fixing to cefpTask and filterTables

### DIFF
--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -108,6 +108,12 @@ struct centralEventFilterTask {
 
   FILTER_CONFIGURABLE(NucleiFilters);
   FILTER_CONFIGURABLE(DiffractionFilters);
+  FILTER_CONFIGURABLE(DqFilters);
+  FILTER_CONFIGURABLE(HfFilters);
+  FILTER_CONFIGURABLE(CFFilters);
+  FILTER_CONFIGURABLE(JetFilters);
+  FILTER_CONFIGURABLE(StrangenessFilters);
+  FILTER_CONFIGURABLE(MultFilters);
 
   void init(o2::framework::InitContext& initc)
   {

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -108,7 +108,7 @@ using MultFilter = MultFilters::iterator;
 
 /// List of the available filters, the description of their tables and the name of the tasks
 constexpr int NumberOfFilters{8};
-constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "DileptonQuarkoniaFilters", "HeavyFlavourFilters", "CorrelationFilters", "JetFilters", "StrangenessFilters", "MultFilters"};
+constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "DqFilters", "HfFilters", "CFFilters", "JetFilters", "StrangenessFilters", "MultFilters"};
 constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "DQFilters", "HFFilters", "CFFilters", "JetFilters", "LFStrgFilters", "MultFilters"};
 constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter"};
 constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, DqFilters, HfFilters, CFFilters, JetFilters, StrangenessFilters, MultFilters> FiltersPack;

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -110,7 +110,7 @@ using MultFilter = MultFilters::iterator;
 constexpr int NumberOfFilters{8};
 constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "DqFilters", "HfFilters", "CFFilters", "JetFilters", "StrangenessFilters", "MultFilters"};
 constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "DQFilters", "HFFilters", "CFFilters", "JetFilters", "LFStrgFilters", "MultFilters"};
-constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter"};
+constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-threebodyfemto-filter", "o2-analysis-je-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter"};
 constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, DqFilters, HfFilters, CFFilters, JetFilters, StrangenessFilters, MultFilters> FiltersPack;
 static_assert(o2::framework::pack_size(FiltersPack) == NumberOfFilters);
 


### PR DESCRIPTION
I prepared this PR to update and fix the following issue:
- add the `FILTER_CONFIGURABLE()` for `DQ, HF, CF, Jet, Strangeness, Mult` filters which were missing
- fix the `AvailableFilters` for `DQ, HF, CF`. The previous names were not matching the related filterTable names.
- fix the `FilteringTaskNames` for `CF` which was not matching the implemented workflow (i.e. `o2-analysis-cf-threebodyfemto-filter`)

Thanks and regards,
Stefano 