### PR TITLE
Fix partition selection for TPC / Tracklets mult in multiplicity table

### DIFF
--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -38,8 +38,10 @@ struct MultiplicityTableTaskIndexed {
     float multT0C = -1.f;
     float multZNA = -1.f;
     float multZNC = -1.f;
-    int multTracklets = run2tracklets.size();
-    int multTPC = tracksWithTPC.size();
+    auto run2trackletsGrouped = run2tracklets->sliceByCached(aod::track::collisionId, collision.globalIndex());
+    auto tracksWithTPCGrouped = tracksWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex());
+    int multTracklets = run2trackletsGrouped.size();
+    int multTPC = tracksWithTPCGrouped.size();
 
     if (collision.has_fv0a()) {
       for (auto amplitude : collision.fv0a().amplitude()) {
@@ -80,7 +82,8 @@ struct MultiplicityTableTaskIndexed {
     float multZNA = -1.f;
     float multZNC = -1.f;
     int multTracklets = -1;
-    int multTPC = tracksWithTPC.size();
+    auto tracksWithTPCGrouped = tracksWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex());
+    int multTPC = tracksWithTPCGrouped.size();
 
     // using FT0 row index from event selection task
     if (collision.has_foundFT0()) {


### PR DESCRIPTION
fixes issue in multiplicity table producer to correctly use cached partitions to count TPC multiplicity & tracklet multiplicity [previously broken by change to partitions not re-calculating in each process() loop]