### PR TITLE
Use de-ref via V0link in casc builder, other fixes

### DIFF
--- a/Common/DataModel/StrangenessTables.h
+++ b/Common/DataModel/StrangenessTables.h
@@ -310,14 +310,6 @@ DECLARE_SOA_EXTENDED_TABLE_USER(CascDataExt, CascDataOrigin, "CascDATAEXT", //!
 
 using CascDataFull = CascDataExt;
 
-namespace v0ind
-{
-DECLARE_SOA_INDEX_COLUMN(V0, v0);           // the biggest object
-DECLARE_SOA_INDEX_COLUMN(V0Data, v0data);   // the skimmed object
-DECLARE_SOA_INDEX_COLUMN(Cascade, cascade); // the part that will use the previous ones
-} // namespace v0ind
-DECLARE_SOA_INDEX_TABLE_EXCLUSIVE_USER(MatchedV0Cascades, V0s, "MATCHEDV0CASC", v0ind::V0DataId, v0ind::V0Id, v0ind::CascadeId);
-
 } // namespace o2::aod
 
 #endif // O2_ANALYSIS_STRANGENESSTABLES_H_

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -111,12 +111,12 @@ struct cascadeBuilder {
     for (auto& casc : cascades) {
       auto v0index = casc.v0_as<o2::aod::V0sLinked>();
       hCascCandidate->Fill(0.5); //considered
-      if( !(v0index.has_v0Data()) ){
+      if (!(v0index.has_v0Data())) {
         //cascdataLink(-1);
         continue; //skip those cascades for which V0 doesn't exist
       }
       auto v0 = v0index.v0Data(); //de-reference index to correct v0data in case it exists
-      
+
       std::array<float, 3> pVtx = {v0.collision().posX(), v0.collision().posY(), v0.collision().posZ()};
       hCascCandidate->Fill(1.5); //has matched V0
       if (tpcrefit) {
@@ -199,8 +199,6 @@ struct cascadeBuilder {
       std::array<float, 3> pvecneg = {0.};
       std::array<float, 3> pvecbach = {0.};
 
-
-
       // Acquire basic tracks
       auto pTrack = getTrackParCov(v0.posTrack_as<FullTracksExt>());
       auto nTrack = getTrackParCov(v0.negTrack_as<FullTracksExt>());
@@ -254,7 +252,7 @@ struct cascadeBuilder {
           }
           fitterCasc.getTrack(1).getPxPyPzGlo(pvecbach);
         } // end if cascade recoed
-      }else{
+      } else {
         //cascdataLink(-1);
         continue;
       }

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -62,18 +62,12 @@ using std::array;
 
 using FullTracksExt = soa::Join<aod::FullTracks, aod::TracksCov, aod::TracksExtended>;
 
-struct cascadeDoIndexing {
-  Builds<aod::MatchedV0Cascades> var;
-  void init(InitContext const&) {}
-};
-
 /// Cascade builder task: rebuilds cascades
 struct cascadeBuilder {
   Produces<aod::CascData> cascdata;
 
   OutputObj<TH1F> hEventCounter{TH1F("hEventCounter", "", 1, 0, 1)};
-  OutputObj<TH1F> hCascFiltered{TH1F("hCascFiltered", "", 15, 0, 15)};
-  OutputObj<TH1F> hCascCandidate{TH1F("hCascCandidate", "", 10, 0, 10)};
+  OutputObj<TH1F> hCascCandidate{TH1F("hCascCandidate", "", 20, 0, 20)};
 
   // Configurables
   Configurable<double> d_bz{"d_bz", -5.0, "bz field"};
@@ -81,16 +75,16 @@ struct cascadeBuilder {
 
   Configurable<int> mincrossedrows{"mincrossedrows", -1, "min crossed rows"};
   Configurable<float> dcav0topv{"dcav0topv", .1, "DCA V0 To PV"};
-  Configurable<double> cospaV0{"cospaV0", .98, "CosPA V0"};
-  Configurable<float> lambdamasswindow{"lambdamasswindow", .006, "Distance from Lambda mass"};
-  Configurable<float> dcav0dau{"dcav0dau", .6, "DCA V0 Daughters"};
+  Configurable<double> cospaV0{"cospaV0", .95, "CosPA V0"};
+  Configurable<float> lambdamasswindow{"lambdamasswindow", .012, "Distance from Lambda mass"};
+  Configurable<float> dcav0dau{"dcav0dau", 1.5, "DCA V0 Daughters"};
   Configurable<float> dcanegtopv{"dcanegtopv", .1, "DCA Neg To PV"};
   Configurable<float> dcapostopv{"dcapostopv", .1, "DCA Pos To PV"};
   Configurable<float> dcabachtopv{"dcabachtopv", .1, "DCA Bach To PV"};
-  Configurable<bool> tpcrefit{"tpcrefit", true, "demand TPC refit"};
+  Configurable<bool> tpcrefit{"tpcrefit", false, "demand TPC refit"};
   Configurable<double> v0radius{"v0radius", 0.9, "v0radius"};
 
-  void process(aod::MatchedV0Cascades const& MatchedV0Cascades, aod::V0Datas const&, aod::Cascades const&, aod::Collisions const&, FullTracksExt const&)
+  void process(aod::Collision const& collision, aod::V0sLinked const&, aod::V0Datas const& v0data, aod::Cascades const& cascades, FullTracksExt const&)
   {
     // Define o2 fitter, 2-prong
     o2::vertexing::DCAFitterN<2> fitterV0, fitterCasc;
@@ -114,72 +108,89 @@ struct cascadeBuilder {
 
     hEventCounter->Fill(0.5);
 
-    for (auto& cascIndexLUT : MatchedV0Cascades) {
-      auto v0 = cascIndexLUT.v0data();
-      auto casc = cascIndexLUT.cascade();
-
+    for (auto& casc : cascades) {
+      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
+      hCascCandidate->Fill(0.5); //considered
+      if( !(v0index.has_v0Data()) ){
+        //cascdataLink(-1);
+        continue; //skip those cascades for which V0 doesn't exist
+      }
+      auto v0 = v0index.v0Data(); //de-reference index to correct v0data in case it exists
+      
       std::array<float, 3> pVtx = {v0.collision().posX(), v0.collision().posY(), v0.collision().posZ()};
-
+      hCascCandidate->Fill(1.5); //has matched V0
       if (tpcrefit) {
         if (!(v0.posTrack_as<FullTracksExt>().trackType() & o2::aod::track::TPCrefit)) {
           continue; // TPC refit
         }
-        hCascFiltered->Fill(1.5);
+        hCascCandidate->Fill(2.5);
         if (!(v0.negTrack_as<FullTracksExt>().trackType() & o2::aod::track::TPCrefit)) {
           continue; // TPC refit
         }
-        hCascFiltered->Fill(2.5);
+        hCascCandidate->Fill(3.5);
         if (!(casc.bachelor_as<FullTracksExt>().trackType() & o2::aod::track::TPCrefit)) {
+          //cascdataLink(-1);
           continue; // TPC refit
         }
-        hCascFiltered->Fill(3.5);
+        hCascCandidate->Fill(4.5);
       }
       if (v0.posTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(4.5);
+      hCascCandidate->Fill(5.5);
       if (v0.negTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(5.5);
+      hCascCandidate->Fill(6.5);
       if (casc.bachelor_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(6.5);
+      hCascCandidate->Fill(7.5);
       if (fabs(v0.posTrack_as<FullTracksExt>().dcaXY()) < dcapostopv) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(7.5);
+      hCascCandidate->Fill(8.5);
       if (fabs(v0.negTrack_as<FullTracksExt>().dcaXY()) < dcanegtopv) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(8.5);
+      hCascCandidate->Fill(9.5);
       if (fabs(casc.bachelor_as<FullTracksExt>().dcaXY()) < dcabachtopv) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(9.5);
+      hCascCandidate->Fill(10.5);
 
       // V0 selections
       if (fabs(v0.mLambda() - 1.116) > lambdamasswindow && fabs(v0.mAntiLambda() - 1.116) > lambdamasswindow) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(10.5);
+      hCascCandidate->Fill(11.5);
       if (v0.dcaV0daughters() > dcav0dau) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(11.5);
+      hCascCandidate->Fill(12.5);
       if (v0.v0radius() < v0radius) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(12.5);
+      hCascCandidate->Fill(13.5);
       if (v0.v0cosPA(pVtx[0], pVtx[1], pVtx[2]) < cospaV0) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(13.5);
+      hCascCandidate->Fill(14.5);
       if (v0.dcav0topv(pVtx[0], pVtx[1], pVtx[2]) < dcav0topv) {
+        //cascdataLink(-1);
         continue;
       }
-      hCascFiltered->Fill(14.5);
+      hCascCandidate->Fill(15.5);
 
       auto charge = -1;
       std::array<float, 3> pos = {0.};
@@ -188,7 +199,7 @@ struct cascadeBuilder {
       std::array<float, 3> pvecneg = {0.};
       std::array<float, 3> pvecbach = {0.};
 
-      hCascCandidate->Fill(0.5);
+
 
       // Acquire basic tracks
       auto pTrack = getTrackParCov(v0.posTrack_as<FullTracksExt>());
@@ -201,7 +212,6 @@ struct cascadeBuilder {
       int nCand = fitterV0.process(pTrack, nTrack);
       if (nCand != 0) {
         fitterV0.propagateTracksToVertex();
-        hCascCandidate->Fill(1.5);
         const auto& v0vtx = fitterV0.getPCACandidate();
         for (int i = 0; i < 3; i++) {
           pos[i] = v0vtx[i];
@@ -244,8 +254,12 @@ struct cascadeBuilder {
           }
           fitterCasc.getTrack(1).getPxPyPzGlo(pvecbach);
         } // end if cascade recoed
-      }   // end if v0 recoed
+      }else{
+        //cascdataLink(-1);
+        continue;
+      }
       // Fill table, please
+      hCascCandidate->Fill(16.5); //this is the master fill: if this is filled, viable candidate
       cascdata(
         v0.globalIndex(),
         casc.bachelor_as<FullTracksExt>().globalIndex(),
@@ -271,7 +285,6 @@ struct cascadeInitializer {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<cascadeDoIndexing>(cfgc),
     adaptAnalysisTask<cascadeBuilder>(cfgc),
     adaptAnalysisTask<cascadeInitializer>(cfgc)};
 }


### PR DESCRIPTION
This uses an alternate way of accessing cascades, as discussed with @jgrosseo. 

The hCascCandidate histogram now does proper bookkeeping of the cascade candidate generation, with bins 1-17 storing the various selection levelss (i.e. 0 -> all candidates considered, 16 -> candidate passing everything and correctly built). This should allow for further quick debugging in case of difficulties. 

Still to be implemented: material corrections + some further minor tuning. 