### PR TITLE
PWGHF: improving X(3872) candidate selection

### DIFF
--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -107,15 +107,15 @@ struct HFCandidateCreatorX {
         continue;
       }
       if (jpsiCand.isSelJpsiToEE() > 0) {
-	      if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+        if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	      }
+	}
         hMassJpsiToEE->Fill(InvMassJpsiToEE(jpsiCand));
       }
       if (jpsiCand.isSelJpsiToMuMu() > 0) {
         if (TMath::Abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	      }
+	}
         hMassJpsiToMuMu->Fill(InvMassJpsiToMuMu(jpsiCand));
       }
 
@@ -146,7 +146,7 @@ struct HFCandidateCreatorX {
 
       // loop over pi+ candidates
       for (auto& trackPos : tracks) {
-	      if (trackPos.pt() < ptPionMin) {
+	if (trackPos.pt() < ptPionMin) {
           continue;
         }
         hPtPion->Fill(trackPos.pt());

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -109,13 +109,13 @@ struct HFCandidateCreatorX {
       if (jpsiCand.isSelJpsiToEE() > 0) {
         if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	}
+        }
         hMassJpsiToEE->Fill(InvMassJpsiToEE(jpsiCand));
       }
       if (jpsiCand.isSelJpsiToMuMu() > 0) {
         if (TMath::Abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	}
+        }
         hMassJpsiToMuMu->Fill(InvMassJpsiToMuMu(jpsiCand));
       }
 
@@ -146,7 +146,7 @@ struct HFCandidateCreatorX {
 
       // loop over pi+ candidates
       for (auto& trackPos : tracks) {
-	if (trackPos.pt() < ptPionMin) {
+        if (trackPos.pt() < ptPionMin) {
           continue;
         }
         hPtPion->Fill(trackPos.pt());

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -56,7 +56,6 @@ struct HFCandidateCreatorX {
   OutputObj<TH1F> hMassJpsiToEE{TH1F("hMassJpsiToEE", "J/#psi candidates;inv. mass (e^{#plus} e^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
   OutputObj<TH1F> hMassJpsiToMuMu{TH1F("hMassJpsiToMuMu", "J/#psi candidates;inv. mass (#mu^{#plus} #mu^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
   OutputObj<TH1F> hPtJpsi{TH1F("hPtJpsi", "J/#psi candidates;candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
-  OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi candidates;candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hCPAJpsi{TH1F("hCPAJpsi", "J/#psi candidates;cosine of pointing angle;entries", 110, -1.1, 1.1)};
   OutputObj<TH1F> hMassXToJpsiToEEPiPi{TH1F("hMassXToJpsiToEEPiPi", "3-prong candidates;inv. mass (J/#psi (#rightarrow e+ e-) #pi+ #pi-) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
   OutputObj<TH1F> hMassXToJpsiToMuMuPiPi{TH1F("hMassXToJpsiToMuMuPiPi", "3-prong candidates;inv. mass (J/#psi (#rightarrow #mu+ #mu-) #pi+ #pi-) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
@@ -107,13 +106,13 @@ struct HFCandidateCreatorX {
         continue;
       }
       if (jpsiCand.isSelJpsiToEE() > 0) {
-        if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+        if (std::abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
         }
         hMassJpsiToEE->Fill(InvMassJpsiToEE(jpsiCand));
       }
       if (jpsiCand.isSelJpsiToMuMu() > 0) {
-        if (TMath::Abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+        if (std::abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
         }
         hMassJpsiToMuMu->Fill(InvMassJpsiToMuMu(jpsiCand));
@@ -149,7 +148,6 @@ struct HFCandidateCreatorX {
         if (trackPos.pt() < ptPionMin) {
           continue;
         }
-        hPtPion->Fill(trackPos.pt());
         if (trackPos.sign() < 0) { // select only positive tracks - use partitions?
           continue;
         }
@@ -162,7 +160,6 @@ struct HFCandidateCreatorX {
           if (trackNeg.pt() < ptPionMin) {
             continue;
           }
-          hPtPion->Fill(trackNeg.pt());
           if (trackNeg.sign() > 0) { // select only negative tracks - use partitions?
             continue;
           }

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -50,7 +50,7 @@ struct HFCandidateCreatorX {
   Configurable<double> d_maxdzini{"d_maxdzini", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> d_minparamchange{"d_minparamchange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> d_minrelchi2change{"d_minrelchi2change", 0.9, "stop iterations is chi2/chi2old > this"};
-  Configurable<double> ptPionMin{"ptPionMin", 0.15, "minimum pion pT threshold (GeV/c)"};
+  Configurable<double> ptPionMin{"ptPionMin", 1., "minimum pion pT threshold (GeV/c)"};
   Configurable<bool> b_dovalplots{"b_dovalplots", true, "do validation plots"};
 
   OutputObj<TH1F> hMassJpsiToEE{TH1F("hMassJpsiToEE", "J/#psi candidates;inv. mass (e^{#plus} e^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
@@ -69,6 +69,7 @@ struct HFCandidateCreatorX {
 
   Configurable<int> d_selectionFlagJpsi{"d_selectionFlagJpsi", 1, "Selection Flag for Jpsi"};
   Configurable<double> cutYCandMax{"cutYCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> diffMassJpsiPDG{"diffMassJpsiPDG", 0.07, "max. diff. between Jpsi rec. and PDG mass"};
   Filter filterSelectCandidates = (aod::hf_selcandidate_jpsi::isSelJpsiToEE >= d_selectionFlagJpsi || aod::hf_selcandidate_jpsi::isSelJpsiToMuMu >= d_selectionFlagJpsi);
 
   void process(aod::Collision const& collision,
@@ -106,11 +107,18 @@ struct HFCandidateCreatorX {
         continue;
       }
       if (jpsiCand.isSelJpsiToEE() > 0) {
+	if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+          continue;
+	}
         hMassJpsiToEE->Fill(InvMassJpsiToEE(jpsiCand));
       }
       if (jpsiCand.isSelJpsiToMuMu() > 0) {
+        if (TMath::Abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+          continue;
+	}
         hMassJpsiToMuMu->Fill(InvMassJpsiToMuMu(jpsiCand));
       }
+
       hPtJpsi->Fill(jpsiCand.pt());
       hCPAJpsi->Fill(jpsiCand.cpa());
       // create Jpsi track to pass to DCA fitter; use cand table + rebuild vertex
@@ -138,29 +146,29 @@ struct HFCandidateCreatorX {
 
       // loop over pi+ candidates
       for (auto& trackPos : tracks) {
+	if (trackPos.pt() < ptPionMin) {
+          continue;
+        }
+        hPtPion->Fill(trackPos.pt());
         if (trackPos.sign() < 0) { // select only positive tracks - use partitions?
           continue;
         }
         if (trackPos.globalIndex() == index0Jpsi) {
           continue;
         }
-        if (trackPos.pt() < ptPionMin) {
-          continue;
-        }
-        hPtPion->Fill(trackPos.pt());
 
         // loop over pi- candidates
         for (auto& trackNeg : tracks) {
+          if (trackNeg.pt() < ptPionMin) {
+            continue;
+          }
+          hPtPion->Fill(trackNeg.pt());
           if (trackNeg.sign() > 0) { // select only negative tracks - use partitions?
             continue;
           }
           if (trackNeg.globalIndex() == index1Jpsi) {
             continue;
           }
-          if (trackNeg.pt() < ptPionMin) {
-            continue;
-          }
-          hPtPion->Fill(trackNeg.pt());
 
           auto trackParVarPos = getTrackParCov(trackPos);
           auto trackParVarNeg = getTrackParCov(trackNeg);

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -107,15 +107,15 @@ struct HFCandidateCreatorX {
         continue;
       }
       if (jpsiCand.isSelJpsiToEE() > 0) {
-	if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
+	      if (TMath::Abs(InvMassJpsiToEE(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	}
+	      }
         hMassJpsiToEE->Fill(InvMassJpsiToEE(jpsiCand));
       }
       if (jpsiCand.isSelJpsiToMuMu() > 0) {
         if (TMath::Abs(InvMassJpsiToMuMu(jpsiCand) - massJpsi) > diffMassJpsiPDG) {
           continue;
-	}
+	      }
         hMassJpsiToMuMu->Fill(InvMassJpsiToMuMu(jpsiCand));
       }
 
@@ -146,7 +146,7 @@ struct HFCandidateCreatorX {
 
       // loop over pi+ candidates
       for (auto& trackPos : tracks) {
-	if (trackPos.pt() < ptPionMin) {
+	      if (trackPos.pt() < ptPionMin) {
           continue;
         }
         hPtPion->Fill(trackPos.pt());


### PR DESCRIPTION
Improving the selection of the X(3872) in the candidate creator adding configurable cuts on Jpsi mass and pion pT