### PR TITLE
Using kIsPileupFromSPD instead of kPileupInMultBins

### DIFF
--- a/Common/CCDB/macros/upload_event_selection_params.C
+++ b/Common/CCDB/macros/upload_event_selection_params.C
@@ -86,7 +86,7 @@ void upload_event_selection_params()
   period[n] = "lhc15i";
   par[n] = new EventSelectionParams(0);
   par[n]->SetOnVsOfParams(-223.155660, 7.117266, -6.218793, 0.543201);
-  runFirst[n] = 235193;
+  runFirst[n] = 235196;
   runLast[n] = 236866;
 
   n++;
@@ -114,12 +114,12 @@ void upload_event_selection_params()
   period[n] = "lhc15o1";
   par[n] = new EventSelectionParams(3);
   runFirst[n] = 244824;
-  runLast[n] = 245725;
+  runLast[n] = 245705;
 
   n++;
   period[n] = "lhc15o2";
   par[n] = new EventSelectionParams(3);
-  runFirst[n] = 245794;
+  runFirst[n] = 245829;
   runLast[n] = 246994;
 
   n++;
@@ -127,7 +127,7 @@ void upload_event_selection_params()
   par[n] = new EventSelectionParams(3);
   par[n]->fZNSumMean = -123.1;
   par[n]->fZNDifMean = 123.1;
-  runFirst[n] = 245726;
+  runFirst[n] = 245729;
   runLast[n] = 245793;
 
   n++;
@@ -152,7 +152,7 @@ void upload_event_selection_params()
   n++;
   period[n] = "lhc16t_pPb";
   par[n] = new EventSelectionParams(1);
-  runFirst[n] = 267132;
+  runFirst[n] = 267161;
   runLast[n] = 267166;
 
   n++;
@@ -202,12 +202,11 @@ void upload_event_selection_params()
       printf(" .... is not new, skipping\n");
       continue;
     }
-    printf("\n");
-
     headersFirst = ccdb.retrieveHeaders(Form("RCT/RunInformation/%i", runFirst[i]), metadataRCT, -1);
     headersLast = ccdb.retrieveHeaders(Form("RCT/RunInformation/%i", runLast[i]), metadataRCT, -1);
     ULong64_t sor = atol(headersFirst["SOR"].c_str());
     ULong64_t eor = atol(headersLast["EOR"].c_str());
+    printf("sor=%llu eor=%llu\n", sor, eor);
     metadata["period"] = period[i];
     metadata["run_first"] = Form("%d", runFirst[i]);
     metadata["run_last"] = Form("%d", runLast[i]);

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -149,7 +149,7 @@ struct BcSelectionTask {
       selection[kNoIncompleteDAQ] = (eventCuts & 1 << aod::kIncompleteDAQ) > 0;
       selection[kNoTPCLaserWarmUp] = (eventCuts & 1 << aod::kIsTPCLaserWarmUp) == 0;
       selection[kNoTPCHVdip] = (eventCuts & 1 << aod::kIsTPCHVdip) == 0;
-      selection[kNoPileupFromSPD] = (eventCuts & 1 << aod::kPileupInMultBins) > 0; // TODO replace with kNoPileupFromSPD
+      selection[kNoPileupFromSPD] = (eventCuts & 1 << aod::kIsPileupFromSPD) == 0;
       selection[kNoV0PFPileup] = (eventCuts & 1 << aod::kIsV0PFPileup) == 0;
 
       int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -602,7 +602,7 @@ struct EventSelectionQaTask {
       histos.fill(HIST("hNcontribAcc"), nContributors);
     }
   }
-  PROCESS_SWITCH(EventSelectionQaTask, processRun3, "Process Run3 event selection QA", true);
+  PROCESS_SWITCH(EventSelectionQaTask, processRun3, "Process Run3 event selection QA", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
* kIsPultupFromSPD flags fixed in run2-converted data. Using kIsPileupFromSPD instead of kPileupInMultBins workaround
* fixed run ranges in upload_event_selection_params.C
* processRun3 set to false by default in eventSelectionQa