### PR TITLE
Fix event selection in charged particle spectra task

### DIFF
--- a/PWGLF/Tasks/spectraCharged.cxx
+++ b/PWGLF/Tasks/spectraCharged.cxx
@@ -275,9 +275,12 @@ void chargedSpectra::initEvent(const C& collision, const T& tracks)
   }
 
   vars.isAcceptedEvent = false;
-  // if ((collision.posZ() < 10.f) && isRun3 ? collision.sel8() : (collision.alias()[kINT7] && collision.sel7())) {
-  if ((collision.posZ() < 10.f) && collision.sel8()) { // This is only a temporary workaround and should in the future be replaced by commented line
-    vars.isAcceptedEvent = true;
+  if (collision.posZ() < 10.f) {
+    if (isRun3 ? collision.sel8() : collision.sel7()) {
+      if ((isRun3 || isMC) ? true : collision.alias()[kINT7]) {
+        vars.isAcceptedEvent = true;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Event selection is fixed so that it now also works correctly for converted Run2 MC and data @mario-krueger @yelmard 