### PR TITLE
PWGHF: Extend HF MC task with more outputs and channels

### DIFF
--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -27,11 +27,13 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::aod;
 
-namespace 
+namespace
 {
-  static const int nCharmHad = 7;
-  static const std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
-}
+static const int nCharmHad = 7;
+static const std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
+static const std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}", "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
+static const std::array<std::string, nCharmHad> particleNames = {"Dplus", "Dstar", "D0", "Ds", "Lc2pKpi", "Xic2pKpi", "Jpsi2ee"};
+} // namespace
 
 /// Gen Level Validation
 ///
@@ -72,12 +74,11 @@ struct ValidationGenLevel {
 
   void init(o2::framework::InitContext&)
   {
-    std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}",  "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
     hCharmHaronsPtDistr = registry.add<TH2>("hCharmHaronsPtDistr", "Pt distribution vs charm hadron; ; #it{p}_{T}^{gen} (GeV/#it{c})", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
     hCharmHaronsYDistr = registry.add<TH2>("hCharmHaronsYDistr", "Y distribution vs charm hadron; ; #it{y}^{gen}", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
     for (auto iBin = 1; iBin <= nCharmHad; ++iBin) {
-      hCharmHaronsPtDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin-1].data());
-      hCharmHaronsYDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin-1].data());
+      hCharmHaronsPtDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
+      hCharmHaronsYDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
     }
   }
 
@@ -195,9 +196,6 @@ struct ValidationRecLevel {
   HistogramRegistry registry{"registry", {}};
   void init(o2::framework::InitContext&)
   {
-    std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}",  "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
-    std::array<std::string, nCharmHad> particleNames = {"Dplus", "Dstar", "D0", "Ds", "Lc2pKpi", "Xic2pKpi", "Jpsi2ee"};
-
     for (auto iHad = 0; iHad < nCharmHad; ++iHad) {
       histPt[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Pt difference reco - MC %s; #it{p}_{T}^{reco} - #it{p}_{T}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
       histPx[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Px difference reco - MC %s; #it{p}_{x}^{reco} - #it{p}_{x}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -11,7 +11,7 @@
 
 /// \file HFMCValidation.cxx
 /// \brief Monte Carlo validation task
-/// \note Gen. and rec. level validation
+/// \note gen and rec. level validation
 ///
 /// \author Antonio Palasciano <antonio.palasciano@cern.ch>, Università degli Studi di Bari & INFN, Sezione di Bari
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
@@ -29,10 +29,10 @@ using namespace o2::aod;
 
 namespace
 {
-static const int nCharmHad = 7;
-static const std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
-static const std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}", "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
-static const std::array<std::string, nCharmHad> particleNames = {"Dplus", "Dstar", "D0", "Ds", "Lc2pKpi", "Xic2pKpi", "Jpsi2ee"};
+static const int nCharmHadrons = 7;
+static const std::array<int, nCharmHadrons> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
+static const std::array<std::string, nCharmHadrons> labels = {"D^{#plus}", "D*^{#plus}", "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
+static const std::array<std::string, nCharmHadrons> particleNames = {"Dplus", "Dstar", "D0", "Ds", "Lc2pKpi", "Xic2pKpi", "Jpsi2ee"};
 } // namespace
 
 /// Gen Level Validation
@@ -40,24 +40,24 @@ static const std::array<std::string, nCharmHad> particleNames = {"Dplus", "Dstar
 /// - Number of HF quarks produced per collision
 /// - Number of D±      → π± K∓ π±        per collision
 ///             D*±     → π± K∓ π±,
-///             Ds±     → K± K∓ π±,
 ///             D0(bar) → π± K∓,
+///             Ds±     → K± K∓ π±,
 ///             Λc±     → p(bar) K∓ π±
 ///             Ξc±     → p(bar) K∓ π±
 ///             J/psi   → e∓ e±
 /// - Momentum Conservation for these particles
 
 struct ValidationGenLevel {
-  std::shared_ptr<TH1> hCharmHaronsPtDistr, hCharmHaronsYDistr;
+  std::shared_ptr<TH1> hCharmHadronsPtDistr, hCharmHadronsYDistr;
 
   HistogramRegistry registry{
     "registry",
     {{"hMomentumCheck", "Mom. Conservation (1 = true, 0 = false) (#it{#epsilon} = 1 MeV/#it{c}); Mom. Conservation result; entries", {HistType::kTH1F, {{2, -0.5, +1.5}}}},
-     {"hPtDiffMotherDaughterGen", "Pt Difference Mother-Daughters; #Delta#it{p}_{T}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
-     {"hPxDiffMotherDaughterGen", "Px Difference Mother-Daughters; #Delta#it{p}_{x}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
-     {"hPyDiffMotherDaughterGen", "Py Difference Mother-Daughters; #Delta#it{p}_{y}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
-     {"hPzDiffMotherDaughterGen", "Pz Difference Mother-Daughters; #Delta#it{p}_{z}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
-     {"hPdiffMotherDaughterGen", "P  Difference Mother-Daughters; #Delta#it{p}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
+     {"hPtDiffMotherDaughterGen", "Pt Difference Mother-Daughters; #Delta#it{p}_{T}^{gen} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
+     {"hPxDiffMotherDaughterGen", "Px Difference Mother-Daughters; #Delta#it{p}_{x}^{gen} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
+     {"hPyDiffMotherDaughterGen", "Py Difference Mother-Daughters; #Delta#it{p}_{y}^{gen} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
+     {"hPzDiffMotherDaughterGen", "Pz Difference Mother-Daughters; #Delta#it{p}_{z}^{gen} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
+     {"hPdiffMotherDaughterGen", "P  Difference Mother-Daughters; #Delta#it{p}^{gen} (GeV/#it{c}); entries", {HistType::kTH1F, {{100, -0.01, 0.01}}}},
      {"hCountAverageC", "Event counter - Average Number Charm quark; Events Per Collision; entries", {HistType::kTH1F, {{20, 0., 20.}}}},
      {"hCountAverageB", "Event counter - Average Number Beauty quark; Events Per Collision; entries", {HistType::kTH1F, {{20, 0., 20.}}}},
      {"hCountAverageCbar", "Event counter - Average Number Anti-Charm quark; Events Per Collision; entries", {HistType::kTH1F, {{20, 0., 20.}}}},
@@ -74,11 +74,11 @@ struct ValidationGenLevel {
 
   void init(o2::framework::InitContext&)
   {
-    hCharmHaronsPtDistr = registry.add<TH2>("hCharmHaronsPtDistr", "Pt distribution vs charm hadron; ; #it{p}_{T}^{gen} (GeV/#it{c})", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
-    hCharmHaronsYDistr = registry.add<TH2>("hCharmHaronsYDistr", "Y distribution vs charm hadron; ; #it{y}^{gen}", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
-    for (auto iBin = 1; iBin <= nCharmHad; ++iBin) {
-      hCharmHaronsPtDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
-      hCharmHaronsYDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
+    hCharmHadronsPtDistr = registry.add<TH2>("hCharmHadronsPtDistr", "Pt distribution vs charm hadron; ; #it{p}_{T}^{gen} (GeV/#it{c})", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
+    hCharmHadronsYDistr = registry.add<TH2>("hCharmHadronsYDistr", "Y distribution vs charm hadron; ; #it{y}^{gen}", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
+    for (auto iBin = 1; iBin <= nCharmHadrons; ++iBin) {
+      hCharmHadronsPtDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
+      hCharmHadronsYDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin - 1].data());
     }
   }
 
@@ -90,9 +90,9 @@ struct ValidationGenLevel {
     int bBarPerCollision = 0;
 
     //Particles and their decay checked in the second part of the task
-    std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
-    std::array<std::array<int, 3>, nCharmHad> arrPDGFinal = {{{kPiPlus, kPiPlus, -kKPlus}, {kPiPlus, kPiPlus, -kKPlus}, {-kKPlus, kPiPlus, 0}, {kPiPlus, kKPlus, -kKPlus}, {kProton, -kKPlus, kPiPlus}, {kProton, -kKPlus, kPiPlus}, {kElectron, -kElectron, 0}}};
-    std::array<int, nCharmHad> counter{0};
+    std::array<int, nCharmHadrons> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
+    std::array<std::array<int, 3>, nCharmHadrons> arrPDGFinal = {{{kPiPlus, kPiPlus, -kKPlus}, {kPiPlus, kPiPlus, -kKPlus}, {-kKPlus, kPiPlus, 0}, {kPiPlus, kKPlus, -kKPlus}, {kProton, -kKPlus, kPiPlus}, {kProton, -kKPlus, kPiPlus}, {kElectron, -kElectron, 0}}};
+    std::array<int, nCharmHadrons> counter{0};
     std::vector<int> listDaughters{};
 
     for (auto& particle : particlesMC) {
@@ -125,7 +125,7 @@ struct ValidationGenLevel {
       double sumPxDau = 0.;
       double sumPyDau = 0.;
       double sumPzDau = 0.;
-      bool momentumCheck = 1;
+      bool momentumCheck = true;
       listDaughters.clear();
 
       // Checking the decay of the particles and the momentum conservation
@@ -148,19 +148,19 @@ struct ValidationGenLevel {
           auto pyDiff = particle.py() - sumPyDau;
           auto pzDiff = particle.pz() - sumPzDau;
           if (std::abs(pxDiff) > 0.001 || std::abs(pyDiff) > 0.001 || std::abs(pzDiff) > 0.001) {
-            momentumCheck = 0;
+            momentumCheck = false;
           }
           double pDiff = RecoDecay::P(pxDiff, pyDiff, pzDiff);
           double ptDiff = RecoDecay::Pt(pxDiff, pyDiff);
           //Filling histograms with per-component momentum conservation
-          registry.fill(HIST("hMomentumCheck"), momentumCheck);
+          registry.fill(HIST("hMomentumCheck"), float(momentumCheck));
           registry.fill(HIST("hPxDiffMotherDaughterGen"), pxDiff);
           registry.fill(HIST("hPyDiffMotherDaughterGen"), pyDiff);
           registry.fill(HIST("hPzDiffMotherDaughterGen"), pzDiff);
           registry.fill(HIST("hPdiffMotherDaughterGen"), pDiff);
           registry.fill(HIST("hPtDiffMotherDaughterGen"), ptDiff);
-          hCharmHaronsPtDistr->Fill(whichHadron, particle.pt());
-          hCharmHaronsYDistr->Fill(whichHadron, particle.y());
+          hCharmHadronsPtDistr->Fill(whichHadron, particle.pt());
+          hCharmHadronsYDistr->Fill(whichHadron, particle.y());
         }
       }
     } //end particles
@@ -190,21 +190,21 @@ struct ValidationGenLevel {
 ///   - Gen-Rec Level Difference for secondary Vertex coordinates and decay length;
 struct ValidationRecLevel {
 
-  static const int nCharmHad = 7;
-  std::array<std::shared_ptr<TH1>, nCharmHad> histPt, histPx, histPy, histPz, histSecVx, histSecVy, histSecVz, histDecLen;
+  static const int nCharmHadrons = 7;
+  std::array<std::shared_ptr<TH1>, nCharmHadrons> histPt, histPx, histPy, histPz, histSecondaryVertexX, histSecondaryVertexY, histSecondaryVertexZ, histDecayLength;
 
   HistogramRegistry registry{"registry", {}};
   void init(o2::framework::InitContext&)
   {
-    for (auto iHad = 0; iHad < nCharmHad; ++iHad) {
-      histPt[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Pt difference reco - MC %s; #it{p}_{T}^{reco} - #it{p}_{T}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
-      histPx[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Px difference reco - MC %s; #it{p}_{x}^{reco} - #it{p}_{x}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
-      histPy[iHad] = registry.add<TH1>(Form("histPy%s", particleNames[iHad].data()), Form("Py difference reco - MC %s; #it{p}_{y}^{reco} - #it{p}_{y}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
-      histPz[iHad] = registry.add<TH1>(Form("histPz%s", particleNames[iHad].data()), Form("Pz difference reco - MC %s; #it{p}_{z}^{reco} - #it{p}_{z}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
-      histSecVx[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta x (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
-      histSecVy[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta y (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
-      histSecVz[iHad] = registry.add<TH1>(Form("histPy%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta z (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
-      histDecLen[iHad] = registry.add<TH1>(Form("histPz%s", particleNames[iHad].data()), Form("Pz difference reco - MC (%s); #Delta L (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+    for (auto iHad = 0; iHad < nCharmHadrons; ++iHad) {
+      histPt[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Pt difference reco - MC %s; #it{p}_{T}^{reco} - #it{p}_{T}^{gen} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPx[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Px difference reco - MC %s; #it{p}_{x}^{reco} - #it{p}_{x}^{gen} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPy[iHad] = registry.add<TH1>(Form("histPy%s", particleNames[iHad].data()), Form("Py difference reco - MC %s; #it{p}_{y}^{reco} - #it{p}_{y}^{gen} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPz[iHad] = registry.add<TH1>(Form("histPz%s", particleNames[iHad].data()), Form("Pz difference reco - MC %s; #it{p}_{z}^{reco} - #it{p}_{z}^{gen} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histSecondaryVertexX[iHad] = registry.add<TH1>(Form("histSecondaryVertexX%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta x (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histSecondaryVertexY[iHad] = registry.add<TH1>(Form("histSecondaryVertexY%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta y (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histSecondaryVertexZ[iHad] = registry.add<TH1>(Form("histSecondaryVertexZ%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta z (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histDecayLength[iHad] = registry.add<TH1>(Form("histDecayLength%s", particleNames[iHad].data()), Form("Pz difference reco - MC (%s); #Delta L (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
     }
   }
 
@@ -245,10 +245,10 @@ struct ValidationRecLevel {
         double vertexMoth[3] = {mother.vx(), mother.vy(), mother.vz()};
         auto decayLength = RecoDecay::distance(vertexMoth, vertexDau);
 
-        histSecVx[whichHad]->Fill(cand2Prong.xSecondaryVertex() - vertexDau[0]);
-        histSecVy[whichHad]->Fill(cand2Prong.ySecondaryVertex() - vertexDau[1]);
-        histSecVz[whichHad]->Fill(cand2Prong.zSecondaryVertex() - vertexDau[2]);
-        histDecLen[whichHad]->Fill(cand2Prong.decayLength() - decayLength);
+        histSecondaryVertexX[whichHad]->Fill(cand2Prong.xSecondaryVertex() - vertexDau[0]);
+        histSecondaryVertexY[whichHad]->Fill(cand2Prong.ySecondaryVertex() - vertexDau[1]);
+        histSecondaryVertexZ[whichHad]->Fill(cand2Prong.zSecondaryVertex() - vertexDau[2]);
+        histDecayLength[whichHad]->Fill(cand2Prong.decayLength() - decayLength);
       }
     } //end loop on 2-prong candidates
 
@@ -291,10 +291,10 @@ struct ValidationRecLevel {
         double vertexMoth[3] = {mother.vx(), mother.vy(), mother.vz()};
         auto decayLength = RecoDecay::distance(vertexMoth, vertexDau);
 
-        histSecVx[whichHad]->Fill(cand3Prong.xSecondaryVertex() - vertexDau[0]);
-        histSecVy[whichHad]->Fill(cand3Prong.ySecondaryVertex() - vertexDau[1]);
-        histSecVz[whichHad]->Fill(cand3Prong.zSecondaryVertex() - vertexDau[2]);
-        histDecLen[whichHad]->Fill(cand3Prong.decayLength() - decayLength);
+        histSecondaryVertexX[whichHad]->Fill(cand3Prong.xSecondaryVertex() - vertexDau[0]);
+        histSecondaryVertexY[whichHad]->Fill(cand3Prong.ySecondaryVertex() - vertexDau[1]);
+        histSecondaryVertexZ[whichHad]->Fill(cand3Prong.zSecondaryVertex() - vertexDau[2]);
+        histDecayLength[whichHad]->Fill(cand3Prong.decayLength() - decayLength);
       }
     } //end loop on 3-prong candidates
   }   //end process

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -210,8 +210,8 @@ struct ValidationRecLevel {
     }
   }
 
-  using HfCandProng2WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng2, aod::HfCandProng2MCRec>>;
-  using HfCandProng3WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng3, aod::HfCandProng3MCRec>>;
+  using HfCandProng2WithMCRec = soa::Join<aod::HfCandProng2, aod::HfCandProng2MCRec>;
+  using HfCandProng3WithMCRec = soa::Join<aod::HfCandProng3, aod::HfCandProng3MCRec>;
 
   void process(HfCandProng2WithMCRec const& cand2Prongs, HfCandProng3WithMCRec const& cand3Prongs, aod::BigTracksMC const& tracks, aod::McParticles const& particlesMC)
   {

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -157,7 +157,7 @@ struct ValidationGenLevel {
           registry.fill(HIST("hPxDiffMotherDaughterGen"), pxDiff);
           registry.fill(HIST("hPyDiffMotherDaughterGen"), pyDiff);
           registry.fill(HIST("hPzDiffMotherDaughterGen"), pzDiff);
-          registry.fill(HIST("hPdiffMotherDaughterGen"), pDiff);
+          registry.fill(HIST("hPDiffMotherDaughterGen"), pDiff);
           registry.fill(HIST("hPtDiffMotherDaughterGen"), ptDiff);
           hCharmHadronsPtDistr->Fill(whichHadron, particle.pt());
           hCharmHadronsYDistr->Fill(whichHadron, particle.y());

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -27,15 +27,27 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::aod;
 
+namespace 
+{
+  static const int nCharmHad = 7;
+  static const std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
+}
+
 /// Gen Level Validation
 ///
 /// - Number of HF quarks produced per collision
 /// - Number of D±      → π± K∓ π±        per collision
 ///             D*±     → π± K∓ π±,
+///             Ds±     → K± K∓ π±,
 ///             D0(bar) → π± K∓,
 ///             Λc±     → p(bar) K∓ π±
+///             Ξc±     → p(bar) K∓ π±
+///             J/psi   → e∓ e±
 /// - Momentum Conservation for these particles
+
 struct ValidationGenLevel {
+  std::shared_ptr<TH1> hCharmHaronsPtDistr, hCharmHaronsYDistr;
+
   HistogramRegistry registry{
     "registry",
     {{"hMomentumCheck", "Mom. Conservation (1 = true, 0 = false) (#it{#epsilon} = 1 MeV/#it{c}); Mom. Conservation result; entries", {HistType::kTH1F, {{2, -0.5, +1.5}}}},
@@ -50,8 +62,24 @@ struct ValidationGenLevel {
      {"hCountAverageBbar", "Event counter - Average Number Anti-Beauty quark; Events Per Collision; entries", {HistType::kTH1F, {{20, 0., 20.}}}},
      {"hCounterPerCollisionDzero", "Event counter - D0; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
      {"hCounterPerCollisionDplus", "Event counter - DPlus; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
+     {"hCounterPerCollisionDs", "Event counter - Ds; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
      {"hCounterPerCollisionDstar", "Event counter - Dstar; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
-     {"hCounterPerCollisionLambdaC", "Event counter - LambdaC; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}}}};
+     {"hCounterPerCollisionLambdaC", "Event counter - LambdaC; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
+     {"hCounterPerCollisionXiC", "Event counter - XiC; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
+     {"hCounterPerCollisionJPsi", "Event counter - JPsi; Events Per Collision; entries", {HistType::kTH1F, {{10, -0.5, +9.5}}}},
+     {"hPtVsYCharmQuark", "Y vs. Pt - charm quarks ; #it{p}_{T}^{gen} (GeV/#it{c}); #it{y}^{gen}", {HistType::kTH2F, {{100, 0., 50.}, {100, -5., 5.}}}},
+     {"hPtVsYBeautyQuark", "Y vs. Pt - beauty quarks ; #it{p}_{T}^{gen} (GeV/#it{c}); #it{y}^{gen}", {HistType::kTH2F, {{100, 0., 50.}, {100, -5., 5.}}}}}};
+
+  void init(o2::framework::InitContext&)
+  {
+    std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}",  "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
+    hCharmHaronsPtDistr = registry.add<TH2>("hCharmHaronsPtDistr", "Pt distribution vs charm hadron; ; #it{p}_{T}^{gen} (GeV/#it{c})", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
+    hCharmHaronsYDistr = registry.add<TH2>("hCharmHaronsYDistr", "Y distribution vs charm hadron; ; #it{y}^{gen}", HistType::kTH2F, {{7, -0.5, 6.5}, {100, 0., 50.}});
+    for (auto iBin = 1; iBin <= nCharmHad; ++iBin) {
+      hCharmHaronsPtDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin-1].data());
+      hCharmHaronsYDistr->GetXaxis()->SetBinLabel(iBin, labels[iBin-1].data());
+    }
+  }
 
   void process(aod::McCollision const& mccollision, aod::McParticles const& particlesMC)
   {
@@ -59,15 +87,12 @@ struct ValidationGenLevel {
     int cBarPerCollision = 0;
     int bPerCollision = 0;
     int bBarPerCollision = 0;
-    double sumPxDau, sumPyDau, sumPzDau;
-    bool momentumCheck;
-    double pxDiff, pyDiff, pzDiff;
 
     //Particles and their decay checked in the second part of the task
-    std::array<int, 4> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, pdg::Code::kLambdaCPlus};
-    std::array<std::array<int, 3>, 4> arrPDGFinal = {{{kPiPlus, kPiPlus, -kKPlus}, {kPiPlus, kPiPlus, -kKPlus}, {-kKPlus, kPiPlus, 0}, {kProton, -kKPlus, kPiPlus}}};
-    int counter[4] = {0, 0, 0, 0};
-    std::vector<int> listDaughters;
+    std::array<int, nCharmHad> PDGArrayParticle = {pdg::Code::kDPlus, 413, pdg::Code::kD0, 431, pdg::Code::kLambdaCPlus, pdg::Code::kXiCPlus, pdg::Code::kJpsi};
+    std::array<std::array<int, 3>, nCharmHad> arrPDGFinal = {{{kPiPlus, kPiPlus, -kKPlus}, {kPiPlus, kPiPlus, -kKPlus}, {-kKPlus, kPiPlus, 0}, {kPiPlus, kKPlus, -kKPlus}, {kProton, -kKPlus, kPiPlus}, {kProton, -kKPlus, kPiPlus}, {kElectron, -kElectron, 0}}};
+    std::array<int, nCharmHad> counter{0};
+    std::vector<int> listDaughters{};
 
     for (auto& particle : particlesMC) {
       int particlePdgCode = particle.pdgCode();
@@ -79,42 +104,48 @@ struct ValidationGenLevel {
         switch (particlePdgCode) {
           case kCharm:
             cPerCollision++;
+            registry.fill(HIST("hPtVsYCharmQuark"), particle.pt(), particle.y());
             break;
           case kCharmBar:
             cBarPerCollision++;
+            registry.fill(HIST("hPtVsYCharmQuark"), particle.pt(), particle.y());
             break;
           case kBottom:
             bPerCollision++;
+            registry.fill(HIST("hPtVsYBeautyQuark"), particle.pt(), particle.y());
             break;
           case kBottomBar:
             bBarPerCollision++;
+            registry.fill(HIST("hPtVsYBeautyQuark"), particle.pt(), particle.y());
             break;
         }
       }
 
-      sumPxDau = 0;
-      sumPyDau = 0;
-      sumPzDau = 0;
-      momentumCheck = 1;
+      double sumPxDau = 0.;
+      double sumPyDau = 0.;
+      double sumPzDau = 0.;
+      bool momentumCheck = 1;
       listDaughters.clear();
 
       // Checking the decay of the particles and the momentum conservation
-      for (std::size_t iD = 0; iD < PDGArrayParticle.size(); iD++) {
+      for (std::size_t iD = 0; iD < PDGArrayParticle.size(); ++iD) {
+        int whichHadron = -1;
         if (std::abs(particlePdgCode) == PDGArrayParticle[iD]) {
+          whichHadron = iD;
           RecoDecay::getDaughters(particlesMC, particle, &listDaughters, arrPDGFinal[iD], -1);
           std::size_t arrayPDGsize = arrPDGFinal[iD].size() - std::count(arrPDGFinal[iD].begin(), arrPDGFinal[iD].end(), 0);
           if (listDaughters.size() == arrayPDGsize) {
             counter[iD]++;
           }
-          for (std::size_t i = 0; i < listDaughters.size(); i++) {
-            auto daughter = particlesMC.rawIteratorAt(listDaughters.at(i));
+          for (std::size_t iDau = 0; iDau < listDaughters.size(); ++iDau) {
+            auto daughter = particlesMC.rawIteratorAt(listDaughters.at(iDau));
             sumPxDau += daughter.px();
             sumPyDau += daughter.py();
             sumPzDau += daughter.pz();
           }
-          pxDiff = particle.px() - sumPxDau;
-          pyDiff = particle.py() - sumPyDau;
-          pzDiff = particle.pz() - sumPzDau;
+          auto pxDiff = particle.px() - sumPxDau;
+          auto pyDiff = particle.py() - sumPyDau;
+          auto pzDiff = particle.pz() - sumPzDau;
           if (std::abs(pxDiff) > 0.001 || std::abs(pyDiff) > 0.001 || std::abs(pzDiff) > 0.001) {
             momentumCheck = 0;
           }
@@ -127,6 +158,8 @@ struct ValidationGenLevel {
           registry.fill(HIST("hPzDiffMotherDaughterGen"), pzDiff);
           registry.fill(HIST("hPdiffMotherDaughterGen"), pDiff);
           registry.fill(HIST("hPtDiffMotherDaughterGen"), ptDiff);
+          hCharmHaronsPtDistr->Fill(whichHadron, particle.pt());
+          hCharmHaronsYDistr->Fill(whichHadron, particle.y());
         }
       }
     } //end particles
@@ -137,61 +170,138 @@ struct ValidationGenLevel {
     registry.fill(HIST("hCounterPerCollisionDplus"), counter[0]);
     registry.fill(HIST("hCounterPerCollisionDstar"), counter[1]);
     registry.fill(HIST("hCounterPerCollisionDzero"), counter[2]);
-    registry.fill(HIST("hCounterPerCollisionLambdaC"), counter[3]);
+    registry.fill(HIST("hCounterPerCollisionDs"), counter[3]);
+    registry.fill(HIST("hCounterPerCollisionLambdaC"), counter[4]);
+    registry.fill(HIST("hCounterPerCollisionXiC"), counter[5]);
+    registry.fill(HIST("hCounterPerCollisionJPsi"), counter[6]);
   }
 };
 
 /// Rec Level Validation
 ///
-/// Only D0 matched candidates:
+/// D±      → π± K∓ π±
+/// Ds±     → K± K∓ π±,
+/// D0(bar) → π± K∓,
+/// Λc±     → p(bar) K∓ π±
+/// Ξc±     → p(bar) K∓ π±
+/// J/psi   → e∓ e±
 ///   - Gen-Rec Level Momentum Difference per component;
 ///   - Gen-Rec Level Difference for secondary Vertex coordinates and decay length;
 struct ValidationRecLevel {
-  HistogramRegistry registry{
-    "registry",
-    {{"histPt", "Pt difference reco - MC; #it{p}_{T}^{reco} - #it{p}_{T}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{2000, -1, 1}}}},
-     {"histPx", "Px difference reco - MC; #it{p}_{x}^{reco} - #it{p}_{x}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{2000, -1, 1}}}},
-     {"histPy", "Py difference reco - MC; #it{p}_{y}^{reco} - #it{p}_{y}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{2000, -1, 1}}}},
-     {"histPz", "Pz difference reco - MC; #it{p}_{z}^{reco} - #it{p}_{z}^{gen.} (GeV/#it{c}); entries", {HistType::kTH1F, {{2000, -1, 1}}}},
-     {"histSecVx", "Sec. Vertex difference reco - MC (MC matched); #Delta x (cm); entries", {HistType::kTH1F, {{200, -1, 1}}}},
-     {"histSecVy", "Sec. Vertex difference reco - MC (MC matched); #Delta y (cm); entries", {HistType::kTH1F, {{200, -1, 1}}}},
-     {"histSecVz", "Sec. Vertex difference reco - MC (MC matched); #Delta z (cm); entries", {HistType::kTH1F, {{200, -1, 1}}}},
-     {"histDecLen", "Decay Length difference reco - MC (MC matched); #Delta L (cm); entries", {HistType::kTH1F, {{200, -1, 1}}}}}};
+
+  static const int nCharmHad = 7;
+  std::array<std::shared_ptr<TH1>, nCharmHad> histPt, histPx, histPy, histPz, histSecVx, histSecVy, histSecVz, histDecLen;
+
+  HistogramRegistry registry{"registry", {}};
+  void init(o2::framework::InitContext&)
+  {
+    std::array<std::string, nCharmHad> labels = {"D^{#plus}", "D*^{#plus}",  "D^{0}", "D_{s}^{#plus}", "#Lambda_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "#Xi_{c}^{#plus} #rightarrow pK^{#minus}#pi^{#plus}", "J/#psi #rightarrow e^{#plus}e^{#minus}"};
+    std::array<std::string, nCharmHad> particleNames = {"Dplus", "Dstar", "D0", "Ds", "Lc2pKpi", "Xic2pKpi", "Jpsi2ee"};
+
+    for (auto iHad = 0; iHad < nCharmHad; ++iHad) {
+      histPt[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Pt difference reco - MC %s; #it{p}_{T}^{reco} - #it{p}_{T}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPx[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Px difference reco - MC %s; #it{p}_{x}^{reco} - #it{p}_{x}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPy[iHad] = registry.add<TH1>(Form("histPy%s", particleNames[iHad].data()), Form("Py difference reco - MC %s; #it{p}_{y}^{reco} - #it{p}_{y}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histPz[iHad] = registry.add<TH1>(Form("histPz%s", particleNames[iHad].data()), Form("Pz difference reco - MC %s; #it{p}_{z}^{reco} - #it{p}_{z}^{gen.} (GeV/#it{c}); entries", labels[iHad].data()), HistType::kTH1F, {{2000, -1, 1}});
+      histSecVx[iHad] = registry.add<TH1>(Form("histPt%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta x (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histSecVy[iHad] = registry.add<TH1>(Form("histPx%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta y (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histSecVz[iHad] = registry.add<TH1>(Form("histPy%s", particleNames[iHad].data()), Form("Sec. Vertex difference reco - MC (MC matched) - %s; #Delta z (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+      histDecLen[iHad] = registry.add<TH1>(Form("histPz%s", particleNames[iHad].data()), Form("Pz difference reco - MC (%s); #Delta L (cm); entries", labels[iHad].data()), HistType::kTH1F, {{200, -1, 1}});
+    }
+  }
 
   Configurable<int> d_selectionFlagD0{"d_selectionFlagD0", 0, "Selection Flag for D0"};
   Configurable<int> d_selectionFlagD0bar{"d_selectionFlagD0bar", 0, "Selection Flag for D0bar"};
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_d0::isSelD0 >= d_selectionFlagD0 || aod::hf_selcandidate_d0::isSelD0bar >= d_selectionFlagD0bar);
+  using HfCandProng2WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng2, aod::HfCandProng2MCRec>>;
+  using HfCandProng3WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng3, aod::HfCandProng3MCRec>>;
 
-  void process(soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate, aod::HfCandProng2MCRec>> const& candidates, aod::BigTracksMC const& tracks, aod::McParticles const& particlesMC)
+  void process(HfCandProng2WithMCRec const& cand2Prongs, HfCandProng3WithMCRec const& cand3Prongs, aod::BigTracksMC const& tracks, aod::McParticles const& particlesMC)
   {
-    int indexParticle = 0;
-    double decayLength;
-    for (auto& candidate : candidates) {
-      if (!(candidate.hfflag() & 1 << hf_cand_prong2::DecayType::D0ToPiK)) {
+    // loop over 2-prong candidates
+    for (auto& cand2Prong : cand2Prongs) {
+
+      // determine which kind of candidate it is
+      bool isD0Sel = TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_prong2::DecayType::D0ToPiK);
+      bool isJPsiSel = TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_prong2::DecayType::JpsiToEE);
+      if (!isD0Sel && !isJPsiSel) {
         continue;
       }
-      if (std::abs(candidate.flagMCMatchRec()) == 1 << hf_cand_prong2::DecayType::D0ToPiK) {
-        if (candidate.index0_as<aod::BigTracksMC>().has_mcParticle()) {
-          indexParticle = RecoDecay::getMother(particlesMC, candidate.index0_as<aod::BigTracksMC>().mcParticle(), pdg::Code::kD0, true);
+      int whichHad = -1;
+      if (isD0Sel && TESTBIT(std::abs(cand2Prong.flagMCMatchRec()), hf_cand_prong2::DecayType::D0ToPiK)) {
+        whichHad = 2;
+      } else if (isJPsiSel && TESTBIT(std::abs(cand2Prong.flagMCMatchRec()), hf_cand_prong2::DecayType::JpsiToEE)) {
+        whichHad = 6;
+      }
+
+      if (whichHad >= 0) {
+        int indexParticle = 0;
+        if (cand2Prong.index0_as<aod::BigTracksMC>().has_mcParticle()) {
+          indexParticle = RecoDecay::getMother(particlesMC, cand2Prong.index0_as<aod::BigTracksMC>().mcParticle(), PDGArrayParticle[whichHad], true);
         }
         auto mother = particlesMC.rawIteratorAt(indexParticle);
-        registry.fill(HIST("histPt"), candidate.pt() - mother.pt());
-        registry.fill(HIST("histPx"), candidate.px() - mother.px());
-        registry.fill(HIST("histPy"), candidate.py() - mother.py());
-        registry.fill(HIST("histPz"), candidate.pz() - mother.pz());
+        histPt[whichHad]->Fill(cand2Prong.pt() - mother.pt());
+        histPx[whichHad]->Fill(cand2Prong.px() - mother.px());
+        histPy[whichHad]->Fill(cand2Prong.py() - mother.py());
+        histPz[whichHad]->Fill(cand2Prong.pz() - mother.pz());
         //Compare Secondary vertex and decay length with MC
         auto daughter0 = mother.daughters_as<aod::McParticles>().begin();
         double vertexDau[3] = {daughter0.vx(), daughter0.vy(), daughter0.vz()};
         double vertexMoth[3] = {mother.vx(), mother.vy(), mother.vz()};
-        decayLength = RecoDecay::distance(vertexMoth, vertexDau);
+        auto decayLength = RecoDecay::distance(vertexMoth, vertexDau);
 
-        registry.fill(HIST("histSecVx"), candidate.xSecondaryVertex() - vertexDau[0]);
-        registry.fill(HIST("histSecVy"), candidate.ySecondaryVertex() - vertexDau[1]);
-        registry.fill(HIST("histSecVz"), candidate.zSecondaryVertex() - vertexDau[2]);
-        registry.fill(HIST("histDecLen"), candidate.decayLength() - decayLength);
+        histSecVx[whichHad]->Fill(cand2Prong.xSecondaryVertex() - vertexDau[0]);
+        histSecVy[whichHad]->Fill(cand2Prong.ySecondaryVertex() - vertexDau[1]);
+        histSecVz[whichHad]->Fill(cand2Prong.zSecondaryVertex() - vertexDau[2]);
+        histDecLen[whichHad]->Fill(cand2Prong.decayLength() - decayLength);
       }
-    } //end loop on candidates
+    } //end loop on 2-prong candidates
+
+    // loop over 3-prong candidates
+    for (auto& cand3Prong : cand3Prongs) {
+
+      // determine which kind of candidate it is
+      bool isDPlusSel = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DPlusToPiKPi);
+      bool isDStarSel = false; // FIXME: add proper check when D* will be added in HF vertexing
+      bool isDsSel = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::DsToPiKK);
+      bool isLcSel = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::LcToPKPi);
+      bool isXicSel = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_prong3::DecayType::XicToPKPi);
+      if (!isDPlusSel && !isDStarSel && !isDsSel && !isLcSel && !isXicSel) {
+        continue;
+      }
+      int whichHad = -1;
+      if (isDPlusSel && TESTBIT(std::abs(cand3Prong.flagMCMatchRec()), hf_cand_prong3::DecayType::DPlusToPiKPi)) {
+        whichHad = 0;
+      } else if (isDsSel && TESTBIT(std::abs(cand3Prong.flagMCMatchRec()), hf_cand_prong3::DecayType::DsToPiKK)) {
+        whichHad = 3;
+      } else if (isLcSel && TESTBIT(std::abs(cand3Prong.flagMCMatchRec()), hf_cand_prong3::DecayType::LcToPKPi)) {
+        whichHad = 4;
+      } else if (isXicSel && TESTBIT(std::abs(cand3Prong.flagMCMatchRec()), hf_cand_prong3::DecayType::XicToPKPi)) {
+        whichHad = 5;
+      }
+
+      if (whichHad >= 0) {
+        int indexParticle = 0;
+        if (cand3Prong.index0_as<aod::BigTracksMC>().has_mcParticle()) {
+          indexParticle = RecoDecay::getMother(particlesMC, cand3Prong.index0_as<aod::BigTracksMC>().mcParticle(), PDGArrayParticle[whichHad], true);
+        }
+        auto mother = particlesMC.rawIteratorAt(indexParticle);
+        histPt[whichHad]->Fill(cand3Prong.pt() - mother.pt());
+        histPx[whichHad]->Fill(cand3Prong.px() - mother.px());
+        histPy[whichHad]->Fill(cand3Prong.py() - mother.py());
+        histPz[whichHad]->Fill(cand3Prong.pz() - mother.pz());
+        //Compare Secondary vertex and decay length with MC
+        auto daughter0 = mother.daughters_as<aod::McParticles>().begin();
+        double vertexDau[3] = {daughter0.vx(), daughter0.vy(), daughter0.vz()};
+        double vertexMoth[3] = {mother.vx(), mother.vy(), mother.vz()};
+        auto decayLength = RecoDecay::distance(vertexMoth, vertexDau);
+
+        histSecVx[whichHad]->Fill(cand3Prong.xSecondaryVertex() - vertexDau[0]);
+        histSecVy[whichHad]->Fill(cand3Prong.ySecondaryVertex() - vertexDau[1]);
+        histSecVz[whichHad]->Fill(cand3Prong.zSecondaryVertex() - vertexDau[2]);
+        histDecLen[whichHad]->Fill(cand3Prong.decayLength() - decayLength);
+      }
+    } //end loop on 3-prong candidates
   }   //end process
 };
 

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -210,9 +210,6 @@ struct ValidationRecLevel {
     }
   }
 
-  Configurable<int> d_selectionFlagD0{"d_selectionFlagD0", 0, "Selection Flag for D0"};
-  Configurable<int> d_selectionFlagD0bar{"d_selectionFlagD0bar", 0, "Selection Flag for D0bar"};
-
   using HfCandProng2WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng2, aod::HfCandProng2MCRec>>;
   using HfCandProng3WithMCRec = soa::Filtered<soa::Join<aod::HfCandProng3, aod::HfCandProng3MCRec>>;
 


### PR DESCRIPTION
This PR adds more histograms and decay channels to the MC validation task. For the reco part I removed the dependency from the selector to allow the checks for several decay channels without requiring the dependency on all the selectors. I think that for the quantities checked in this task there is also no need to apply refined selections and the preselections are enough. Let me know if you agree @vkucera @apalasciano @mmazzilli!