### PR TITLE
RecoDecay, PWGHF: Add protection for index double-counting

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -681,8 +681,7 @@ class RecoDecay
           getDaughters(particlesMC, particlesMC.rawIteratorAt(idxDau), list, arrPDGFinal, depthMax, stage);
         }
       }
-    }
-    else if (particle.daughtersIds().front() == particle.daughtersIds().back() && particle.daughtersIds().front() <= particlesMC.size()) {
+    } else if (particle.daughtersIds().front() == particle.daughtersIds().back() && particle.daughtersIds().front() <= particlesMC.size()) {
       getDaughters(particlesMC, particlesMC.rawIteratorAt(particle.daughtersIds().front()), list, arrPDGFinal, depthMax, stage);
     }
   }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -675,8 +675,15 @@ class RecoDecay
     //printf("Stage %d: %d (PDG %d) -> %d-%d\n", stage, index, PDGParticle, indexDaughterFirst, indexDaughterLast);
     // Call itself to get daughters of daughters recursively.
     stage++;
-    for (auto& idxDau : particle.daughtersIds()) {
-      getDaughters(particlesMC, particlesMC.rawIteratorAt(idxDau), list, arrPDGFinal, depthMax, stage);
+    if (particle.daughtersIds().front() != particle.daughtersIds().back()) {
+      for (auto& idxDau : particle.daughtersIds()) {
+        if (idxDau < particlesMC.size()) {
+          getDaughters(particlesMC, particlesMC.rawIteratorAt(idxDau), list, arrPDGFinal, depthMax, stage);
+        }
+      }
+    }
+    else if (particle.daughtersIds().front() == particle.daughtersIds().back() && particle.daughtersIds().front() <= particlesMC.size()) {
+      getDaughters(particlesMC, particlesMC.rawIteratorAt(particle.daughtersIds().front()), list, arrPDGFinal, depthMax, stage);
     }
   }
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -677,11 +677,9 @@ class RecoDecay
     stage++;
     if (particle.daughtersIds().front() != particle.daughtersIds().back()) {
       for (auto& idxDau : particle.daughtersIds()) {
-        if (idxDau < particlesMC.size()) {
-          getDaughters(particlesMC, particlesMC.rawIteratorAt(idxDau), list, arrPDGFinal, depthMax, stage);
-        }
+        getDaughters(particlesMC, particlesMC.rawIteratorAt(idxDau), list, arrPDGFinal, depthMax, stage);
       }
-    } else if (particle.daughtersIds().front() == particle.daughtersIds().back() && particle.daughtersIds().front() <= particlesMC.size()) {
+    } else {
       getDaughters(particlesMC, particlesMC.rawIteratorAt(particle.daughtersIds().front()), list, arrPDGFinal, depthMax, stage);
     }
   }
@@ -848,7 +846,7 @@ class RecoDecay
     // Check the PDG codes of the decay products.
     if (N > 0) {
       //Printf("MC Gen: Checking %d daughters", N);
-      std::vector<int> arrAllDaughtersIndex;            // vector of indices of all daughters
+      std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters
       // Check the daughter indices.
       if (!candidate.has_daughters()) {
         //Printf("MC Gen: Rejected: bad daughter index range: %d-%d", candidate.daughtersIds().front(), candidate.daughtersIds().back());
@@ -874,7 +872,7 @@ class RecoDecay
       // Check daughters' PDG codes.
       for (auto indexDaughterI : arrAllDaughtersIndex) {
         auto candidateDaughterI = particlesMC.rawIteratorAt(indexDaughterI); // ith daughter particle
-        auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();        // PDG code of the ith daughter
+        auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();           // PDG code of the ith daughter
         //Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);
         bool isPDGFound = false; // Is the PDG code of this daughter among the remaining expected PDG codes?
         for (std::size_t iProngCp = 0; iProngCp < N; ++iProngCp) {


### PR DESCRIPTION
@jgrosseo @vkucera I noticed that sometimes the indices are overflow (@aalkin told me something similar in a private chat when helping me with the debugging). This causes a segmentation violation (e.g. I debugged downloading locally the same inputs used for this hyperloop train https://alimonitor.cern.ch/train-workdir/tests/0002/00020645/stdout.log). I remember that this could be likely avoided asking for primary particles from a chat with @jgrosseo, but I also think that the method in `RecoDecay.h` should be generic for any usecase (also non primary particles). Let me know if you have different opinions or suggestions for better implementations!