### PR TITLE
Add task to check consistency of MC data model in AO2D files

### DIFF
--- a/Common/Tasks/CMakeLists.txt
+++ b/Common/Tasks/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(check-data-model
                   PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                   COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(check-data-model-mc
+                  SOURCES checkDataModelMC.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                  COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(orbit-range
                   SOURCES orbitRangeTask.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/Common/Tasks/checkDataModelMC.cxx
+++ b/Common/Tasks/checkDataModelMC.cxx
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \brief Load all tables in the data model to check if they can be read correctly
+/// \author
+/// \since
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+/// Check the complete list of indices of final-state daughters of an MC particle.
+/// \param particlesMC  table with MC particles
+/// \param particle  MC particle
+template <typename T>
+void checkDaughters(const T& particlesMC,
+                    const typename T::iterator& particle)
+{
+  if (particle.has_daughters()) {
+    for (auto& idxDau : particle.daughtersIds()) {
+      if (idxDau > particlesMC.size()) {
+        LOG(fatal) << "MC particle " << particle.globalIndex() << " with PDG " << particle.pdgCode() << " has daughter with index " << idxDau << " > MC particle table size (" << particlesMC.size() << ")";
+      }
+    }
+  }
+}
+
+template <typename Table>
+struct LoadTable {
+  OutputObj<TH1F> counter{TH1F("counter", "counter", 2, 0., 2)};
+  void process(Table const& table)
+  {
+    LOGF(info, "Table has %d entries", table.size());
+    counter->Fill(0.5);
+    counter->Fill(1.5, table.size());
+  }
+};
+
+struct CheckMcParticlesIndices {
+  void process(aod::McParticles const& particlesMC)
+  {
+    for (auto& particle : particlesMC) {
+      checkDaughters(particlesMC, particle);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<LoadTable<aod::McParticles>>(cfgc, TaskName("McParticles")),
+    adaptAnalysisTask<LoadTable<aod::McCollisions>>(cfgc, TaskName("McCollisions")),
+    adaptAnalysisTask<LoadTable<aod::McTrackLabels>>(cfgc, TaskName("McTrackLabels")),
+    adaptAnalysisTask<LoadTable<aod::McFwdTrackLabels>>(cfgc, TaskName("McFwdTrackLabels")),
+    adaptAnalysisTask<LoadTable<aod::McMFTTrackLabels>>(cfgc, TaskName("McMFTTrackLabels")),
+    adaptAnalysisTask<CheckMcParticlesIndices>(cfgc)};
+}


### PR DESCRIPTION
@jgrosseo I tested it offline with the file that gave me the issue with the HF code (see https://github.com/AliceO2Group/O2Physics/pull/567) and indeed it returns fatal error as expected. The same for other files of the same production (almost all those tested).