### PR TITLE
Adding extra dilepton table for muon and tracktype variable for muon

### DIFF
--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -245,6 +245,21 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("mchTrack")) {
+    cut->AddCut(GetAnalysisCut("mchTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("matchedFwd")) {
+    cut->AddCut(GetAnalysisCut("matchedFwd"));
+    return cut;
+  }
+
+  if (!nameStr.compare("matchedGlobal")) {
+    cut->AddCut(GetAnalysisCut("matchedGlobal"));
+    return cut;
+  }
+
   if (!nameStr.compare("pairNoCut")) {
     cut->AddCut(GetAnalysisCut("pairNoCut"));
     return cut;
@@ -533,6 +548,21 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kMuonPDca, 0.0, 594.0, false, VarManager::kMuonRAtAbsorberEnd, 17.6, 26.5);
     cut->AddCut(VarManager::kMuonPDca, 0.0, 324.0, false, VarManager::kMuonRAtAbsorberEnd, 26.5, 89.5);
     cut->AddCut(VarManager::kMuonChi2, 0.0, 1e6);
+    return cut;
+  }
+
+  if (!nameStr.compare("mchTrack")) {
+    cut->AddCut(VarManager::kMuonTrackType, 3.5, 4.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("matchedFwd")) {
+    cut->AddCut(VarManager::kMuonTrackType, 1.5, 2.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("matchedGlobal")) {
+    cut->AddCut(VarManager::kMuonTrackType, -0.5, 0.5);
     return cut;
   }
 

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -48,7 +48,7 @@ using Vec3D = ROOT::Math::SVector<double, 3>;
 
 // TODO: create an array holding these constants for all needed particles or check for a place where these are already defined
 static const float fgkElectronMass = 0.000511; // GeV
-static const float fgkMuonMass = 0.105;        // GeV
+static const float fgkMuonMass = 0.105658;     // GeV
 
 //_________________________________________________________________________
 class VarManager : public TObject

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -223,6 +223,7 @@ class VarManager : public TObject
     kMuonCTglTgl,
     kMuonC1Pt21Pt2,
     kNMuonTrackVariables,
+    kMuonTrackType,
 
     // MC particle variables
     kMCPdgCode,
@@ -725,6 +726,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonChi2MatchMCHMID] = track.chi2MatchMCHMID();
     values[kMuonChi2MatchMCHMFT] = track.chi2MatchMCHMFT();
     values[kMuonMatchScoreMCHMFT] = track.matchScoreMCHMFT();
+    values[kMuonTrackType] = track.trackType();
   }
   // Quantities based on the muon covariance table
   if constexpr ((fillMap & ReducedMuonCov) > 0 || (fillMap & MuonCov) > 0) {

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -257,7 +257,7 @@ DECLARE_SOA_TABLE(ReducedMuonsExtra, "AOD", "RTMUONEXTRA", //!
                   fwdtrack::NClusters, fwdtrack::PDca, fwdtrack::RAtAbsorberEnd,
                   fwdtrack::Chi2, fwdtrack::Chi2MatchMCHMID, fwdtrack::Chi2MatchMCHMFT,
                   fwdtrack::MatchScoreMCHMFT, fwdtrack::MFTTrackId, fwdtrack::MCHTrackId,
-                  fwdtrack::MCHBitMap, fwdtrack::MIDBitMap, fwdtrack::MIDBoards);
+                  fwdtrack::MCHBitMap, fwdtrack::MIDBitMap, fwdtrack::MIDBoards, fwdtrack::TrackType);
 
 // Muon covariance, TODO: the rest of the matrix should be added when needed
 DECLARE_SOA_TABLE(ReducedMuonsCov, "AOD", "RTMUONCOV",
@@ -284,6 +284,18 @@ DECLARE_SOA_TABLE(ReducedMuonsLabels, "AOD", "RTMUONSLABELS", //!
 
 using ReducedMuonsLabel = ReducedMuonsLabels::iterator;
 
+namespace dilepton_track_index
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, Tracks, "_0"); //! Index to first prong
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, Tracks, "_1"); //! Index to second prong
+}
+
+DECLARE_SOA_TABLE(Dq2Prong, "AOD", "DQ2PRONG", //! Table for HF 2 prong candidates
+                  o2::soa::Index<>,
+                  dilepton_track_index::Index0Id,
+                  dilepton_track_index::Index1Id);
+
+
 // pair information
 namespace reducedpair
 {
@@ -294,6 +306,11 @@ DECLARE_SOA_COLUMN(Eta, eta, float);                  //!
 DECLARE_SOA_COLUMN(Phi, phi, float);                  //!
 DECLARE_SOA_COLUMN(Sign, sign, int);                  //!
 DECLARE_SOA_COLUMN(FilterMap, filterMap, uint32_t);   //!
+DECLARE_SOA_COLUMN(Tauz, tauz, float);                //!
+DECLARE_SOA_COLUMN(Lz, lz, float);                    //!
+DECLARE_SOA_COLUMN(Lxy, lxy, float);                  //!
+DECLARE_SOA_COLUMN(Rap, rap, float);                    //!
+//DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
 DECLARE_SOA_DYNAMIC_COLUMN(Px, px,                    //!
                            [](float pt, float phi) -> float { return pt * std::cos(phi); });
 DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
@@ -305,7 +322,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
 } // namespace reducedpair
 
 DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
-                  reducedpair::ReducedEventId, reducedpair::Mass,
+                  reducedpair::ReducedEventId, 
+		  reducedpair::Mass,
                   reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
                   reducedpair::FilterMap,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
@@ -313,7 +331,18 @@ DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
                   reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
                   reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
 
+DECLARE_SOA_TABLE(DileptonsExtra, "AOD", "RTDILEPTONEXTRA", //!
+                  dilepton_track_index::Index0Id, dilepton_track_index::Index1Id,
+                  reducedpair::Rap,
+                  reducedpair::Tauz,
+                  reducedpair::Lz,
+                  reducedpair::Lxy);
+
+
 using Dilepton = Dileptons::iterator;
+using DileptonExtra = DileptonsExtra::iterator;
+
+
 
 namespace v0bits
 {

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -288,7 +288,7 @@ namespace dilepton_track_index
 {
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, ReducedMuons, "_0"); //! Index to first prong
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, ReducedMuons, "_1"); //! Index to second prong
-}
+} // namespace dilepton_track_index
 
 // pair information
 namespace reducedpair
@@ -303,7 +303,7 @@ DECLARE_SOA_COLUMN(FilterMap, filterMap, uint32_t);   //!
 DECLARE_SOA_COLUMN(Tauz, tauz, float);                //!
 DECLARE_SOA_COLUMN(Lz, lz, float);                    //!
 DECLARE_SOA_COLUMN(Lxy, lxy, float);                  //!
-//DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
+// DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
 DECLARE_SOA_DYNAMIC_COLUMN(Px, px,                    //!
                            [](float pt, float phi) -> float { return pt * std::cos(phi); });
 DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
@@ -313,12 +313,12 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
 DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
                            [](float pt, float eta) -> float { return pt * std::cosh(eta); });
 DECLARE_SOA_DYNAMIC_COLUMN(Rap, rap, //!
-                           [](float pt, float eta, float m) -> float { return std::log((std::sqrt(m*m+pt*pt*std::cosh(eta)*std::cosh(eta))+pt*std::sinh(eta))/std::sqrt(m*m+pt*pt)); });
+                           [](float pt, float eta, float m) -> float { return std::log((std::sqrt(m * m + pt * pt * std::cosh(eta) * std::cosh(eta)) + pt * std::sinh(eta)) / std::sqrt(m * m + pt * pt)); });
 } // namespace reducedpair
 
 DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
-                  reducedpair::ReducedEventId, 
-		  reducedpair::Mass,
+                  reducedpair::ReducedEventId,
+                  reducedpair::Mass,
                   reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
                   reducedpair::FilterMap,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
@@ -333,11 +333,8 @@ DECLARE_SOA_TABLE(DileptonsExtra, "AOD", "RTDILEPTONEXTRA", //!
                   reducedpair::Lz,
                   reducedpair::Lxy);
 
-
 using Dilepton = Dileptons::iterator;
 using DileptonExtra = DileptonsExtra::iterator;
-
-
 
 namespace v0bits
 {

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -286,14 +286,9 @@ using ReducedMuonsLabel = ReducedMuonsLabels::iterator;
 
 namespace dilepton_track_index
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, Tracks, "_0"); //! Index to first prong
-DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, Tracks, "_1"); //! Index to second prong
-} // namespace dilepton_track_index
-
-DECLARE_SOA_TABLE(Dq2Prong, "AOD", "DQ2PRONG", //! Table for HF 2 prong candidates
-                  o2::soa::Index<>,
-                  dilepton_track_index::Index0Id,
-                  dilepton_track_index::Index1Id);
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, ReducedMuons, "_0"); //! Index to first prong
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, ReducedMuons, "_1"); //! Index to second prong
+}
 
 // pair information
 namespace reducedpair
@@ -308,8 +303,7 @@ DECLARE_SOA_COLUMN(FilterMap, filterMap, uint32_t);   //!
 DECLARE_SOA_COLUMN(Tauz, tauz, float);                //!
 DECLARE_SOA_COLUMN(Lz, lz, float);                    //!
 DECLARE_SOA_COLUMN(Lxy, lxy, float);                  //!
-DECLARE_SOA_COLUMN(Rap, rap, float);                  //!
-// DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
+//DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
 DECLARE_SOA_DYNAMIC_COLUMN(Px, px,                    //!
                            [](float pt, float phi) -> float { return pt * std::cos(phi); });
 DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
@@ -318,27 +312,32 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
                            [](float pt, float eta) -> float { return pt * std::sinh(eta); });
 DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
                            [](float pt, float eta) -> float { return pt * std::cosh(eta); });
+DECLARE_SOA_DYNAMIC_COLUMN(Rap, rap, //!
+                           [](float pt, float eta, float m) -> float { return std::log((std::sqrt(m*m+pt*pt*std::cosh(eta)*std::cosh(eta))+pt*std::sinh(eta))/std::sqrt(m*m+pt*pt)); });
 } // namespace reducedpair
 
 DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
-                  reducedpair::ReducedEventId,
-                  reducedpair::Mass,
+                  reducedpair::ReducedEventId, 
+		  reducedpair::Mass,
                   reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
                   reducedpair::FilterMap,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
                   reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
                   reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);
 
 DECLARE_SOA_TABLE(DileptonsExtra, "AOD", "RTDILEPTONEXTRA", //!
                   dilepton_track_index::Index0Id, dilepton_track_index::Index1Id,
-                  reducedpair::Rap,
                   reducedpair::Tauz,
                   reducedpair::Lz,
                   reducedpair::Lxy);
 
+
 using Dilepton = Dileptons::iterator;
 using DileptonExtra = DileptonsExtra::iterator;
+
+
 
 namespace v0bits
 {

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -288,13 +288,12 @@ namespace dilepton_track_index
 {
 DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, Tracks, "_0"); //! Index to first prong
 DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, Tracks, "_1"); //! Index to second prong
-}
+} // namespace dilepton_track_index
 
 DECLARE_SOA_TABLE(Dq2Prong, "AOD", "DQ2PRONG", //! Table for HF 2 prong candidates
                   o2::soa::Index<>,
                   dilepton_track_index::Index0Id,
                   dilepton_track_index::Index1Id);
-
 
 // pair information
 namespace reducedpair
@@ -309,8 +308,8 @@ DECLARE_SOA_COLUMN(FilterMap, filterMap, uint32_t);   //!
 DECLARE_SOA_COLUMN(Tauz, tauz, float);                //!
 DECLARE_SOA_COLUMN(Lz, lz, float);                    //!
 DECLARE_SOA_COLUMN(Lxy, lxy, float);                  //!
-DECLARE_SOA_COLUMN(Rap, rap, float);                    //!
-//DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
+DECLARE_SOA_COLUMN(Rap, rap, float);                  //!
+// DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon2); //!
 DECLARE_SOA_DYNAMIC_COLUMN(Px, px,                    //!
                            [](float pt, float phi) -> float { return pt * std::cos(phi); });
 DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
@@ -322,8 +321,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
 } // namespace reducedpair
 
 DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
-                  reducedpair::ReducedEventId, 
-		  reducedpair::Mass,
+                  reducedpair::ReducedEventId,
+                  reducedpair::Mass,
                   reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
                   reducedpair::FilterMap,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
@@ -338,11 +337,8 @@ DECLARE_SOA_TABLE(DileptonsExtra, "AOD", "RTDILEPTONEXTRA", //!
                   reducedpair::Lz,
                   reducedpair::Lxy);
 
-
 using Dilepton = Dileptons::iterator;
 using DileptonExtra = DileptonsExtra::iterator;
-
-
 
 namespace v0bits
 {

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -349,7 +349,7 @@ struct TableMaker {
         muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
         muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                   muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                  muon.matchScoreMCHMFT(), muon.matchMFTTrackId(), muon.matchMCHTrackId(), muon.mchBitMap(), muon.midBitMap(), muon.midBoards());
+                  muon.matchScoreMCHMFT(), muon.matchMFTTrackId(), muon.matchMCHTrackId(), muon.mchBitMap(), muon.midBitMap(), muon.midBoards(), muon.trackType());
         if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
           muonCov(muon.x(), muon.y(), muon.z(), muon.phi(), muon.tgl(), muon.signed1Pt(),
                   muon.cXX(), muon.cXY(), muon.cYY(), muon.cPhiX(), muon.cPhiY(), muon.cPhiPhi(),

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -523,7 +523,7 @@ struct TableMakerMC {
           muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign());
           muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                     muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                    muon.matchScoreMCHMFT(), muon.matchMFTTrackId(), muon.matchMCHTrackId(), muon.mchBitMap(), muon.midBitMap(), muon.midBoards());
+                    muon.matchScoreMCHMFT(), muon.matchMFTTrackId(), muon.matchMCHTrackId(), muon.mchBitMap(), muon.midBitMap(), muon.midBoards(), muon.trackType());
           if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
             muonCov(muon.x(), muon.y(), muon.z(), muon.phi(), muon.tgl(), muon.signed1Pt(),
                     muon.cXX(), muon.cXY(), muon.cYY(), muon.cPhiX(), muon.cPhiY(), muon.cPhiPhi(),

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -567,8 +567,8 @@ struct AnalysisSameEventPairing {
           }
           fMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())
-    }    // end if processMuon
+      }    // end if(cutNames.IsNull())
+    }      // end if processMuon
 
     // NOTE: For the electron-muon pairing, the policy is that the user specifies n track and n muon cuts via configurables
     //     So for each barrel cut there is a corresponding muon cut

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -567,11 +567,11 @@ struct AnalysisSameEventPairing {
           }
           fMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())  
-    }  // end if processMuon
+      }  // end if(cutNames.IsNull())
+    }    // end if processMuon
 
     // NOTE: For the electron-muon pairing, the policy is that the user specifies n track and n muon cuts via configurables
-    //     So for each barrel cut there is a corresponding muon cut  
+    //     So for each barrel cut there is a corresponding muon cut
     /*if (enableBarrelMuonHistos) {
       TString cutNamesBarrel = fConfigTrackCuts.value;
       TString cutNamesMuon = fConfigMuonCuts.value;
@@ -579,7 +579,7 @@ struct AnalysisSameEventPairing {
         std::unique_ptr<TObjArray> objArrayBarrel(cutNamesBarrel.Tokenize(","));
         std::unique_ptr<TObjArray> objArrayMuon(cutNamesMuon.Tokenize(","));
         for (int icut = 0; icut < objArrayBarrel->GetEntries(); ++icut) {
-          if (icut >= objArrayMuon->GetEntries()) {  
+          if (icut >= objArrayMuon->GetEntries()) {
             // there are fewer muon cuts specified wrt barrel cuts
             break;
           }
@@ -607,7 +607,7 @@ struct AnalysisSameEventPairing {
           }
           fBarrelMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())  
+      }  // end if(cutNames.IsNull())
     }  // end if processBarrelMuon
     */
 
@@ -683,9 +683,8 @@ struct AnalysisSameEventPairing {
       dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap);
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == VarManager::kJpsiToMuMu) && muonHasCov) {
-        dileptonExtraList(t1.globalIndex(),t2.globalIndex(),VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
       }
-
 
       // run MC matching for this pair
       uint32_t mcDecision = 0;
@@ -774,9 +773,10 @@ struct AnalysisSameEventPairing {
     runMCGen(groupedMCTracks);
   }
 
-  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
-                                soa::Filtered<MyMuonTracksSelected> const& muons, 
-                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
+  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
+                                soa::Filtered<MyMuonTracksSelected> const& muons,
+                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
@@ -786,28 +786,29 @@ struct AnalysisSameEventPairing {
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
-  
-  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, 
-                                soa::Filtered<MyMuonTracksSelectedWithCov> const& muons, 
-                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
+
+  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event,
+                                         soa::Filtered<MyMuonTracksSelectedWithCov> const& muons,
+                                         ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-    
+
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
 
-  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
-                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons, 
+  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
+                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons,
                                   ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-    
+
     runPairing<VarManager::kElectronMuon, gkEventFillMap, gkMCEventFillMap, gkTrackFillMap>(event, tracks, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
@@ -862,7 +863,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 
     if (classStr.Contains("Pairs")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
-//      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon", "vertexing-forward");
+      //      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon", "vertexing-forward");
     }
 
     if (classStr.Contains("MCTruthGenPair")) {

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -76,10 +76,11 @@ using MyMuonTracksSelectedWithCov = soa::Join<aod::ReducedMuons, aod::ReducedMuo
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
 constexpr static uint32_t gkMCEventFillMap = VarManager::ObjTypes::ReducedEventMC;
+constexpr static uint32_t gkEventFillMapWithCov = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended | VarManager::ObjTypes::ReducedEventVtxCov;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID;
 //constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra;
-//constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
+constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
 constexpr static uint32_t gkParticleMCFillMap = VarManager::ObjTypes::ParticleMC;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
@@ -463,10 +464,12 @@ struct AnalysisMuonSelection {
 };
 
 struct AnalysisSameEventPairing {
+  Produces<aod::Dileptons> dileptonList;
+  Produces<aod::DileptonsExtra> dileptonExtraList;
   OutputObj<THashList> fOutputList{"output"};
   Filter filterEventSelected = aod::dqanalysisflags::isEventSelected == 1;
   Filter filterBarrelTrackSelected = aod::dqanalysisflags::isBarrelSelected > 0;
-  //Filter filterMuonSelected = aod::dqanalysisflags::isMuonSelected > uint8_t(0);
+  Filter filterMuonSelected = aod::dqanalysisflags::isMuonSelected > 0;
   Configurable<std::string> fConfigTrackCuts{"cfgTrackCuts", "", "Comma separated list of barrel track cuts"};
   Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "", "Comma separated list of barrel track cuts"};
   Configurable<std::string> fConfigMCRecSignals{"cfgBarrelMCRecSignals", "", "Comma separated list of MC signals (reconstructed)"};
@@ -489,7 +492,7 @@ struct AnalysisSameEventPairing {
   void init(o2::framework::InitContext& context)
   {
     bool enableBarrelHistos = context.mOptions.get<bool>("processJpsiToEESkimmed");
-    //bool enableMuonHistos = context.mOptions.get<bool>("processJpsiToMuMuSkimmed");
+    bool enableMuonHistos = context.mOptions.get<bool>("processJpsiToMuMuSkimmed") || context.mOptions.get<bool>("processJpsiToMuMuVertexingSkimmed");
     //bool enableBarrelMuonHistos = context.mOptions.get<bool>("processElectronMuonSkimmed");
 
     VarManager::SetDefaultVarNames();
@@ -535,7 +538,7 @@ struct AnalysisSameEventPairing {
       }   // end if(cutNames.IsNull())
     }     // end if processBarrel
 
-    /*if (enableMuonHistos) {
+    if (enableMuonHistos) {
       TString cutNames = fConfigMuonCuts.value;
       if (!cutNames.IsNull()) {
         std::unique_ptr<TObjArray> objArray(cutNames.Tokenize(","));
@@ -569,7 +572,7 @@ struct AnalysisSameEventPairing {
 
     // NOTE: For the electron-muon pairing, the policy is that the user specifies n track and n muon cuts via configurables
     //     So for each barrel cut there is a corresponding muon cut  
-    if (enableBarrelMuonHistos) {
+    /*if (enableBarrelMuonHistos) {
       TString cutNamesBarrel = fConfigTrackCuts.value;
       TString cutNamesMuon = fConfigMuonCuts.value;
       if (!cutNamesBarrel.IsNull()) {
@@ -653,6 +656,10 @@ struct AnalysisSameEventPairing {
 
     // Loop over two track combinations
     uint8_t twoTrackFilter = 0;
+    uint32_t dileptonFilterMap = 0;
+    dileptonList.reserve(1);
+    dileptonExtraList.reserve(1);
+
     for (auto& [t1, t2] : combinations(tracks1, tracks2)) {
       if constexpr (TPairType == VarManager::kJpsiToEE) {
         twoTrackFilter = uint32_t(t1.isBarrelSelected()) & uint32_t(t2.isBarrelSelected());
@@ -671,6 +678,14 @@ struct AnalysisSameEventPairing {
       if constexpr ((TPairType == VarManager::kJpsiToEE) || (TPairType == VarManager::kJpsiToMuMu)) {
         VarManager::FillPairVertexing<TPairType, TEventFillMap, TTrackFillMap>(event, t1, t2, VarManager::fgValues);
       }
+
+      dileptonFilterMap = twoTrackFilter;
+      dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap);
+      constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
+      if constexpr ((TPairType == VarManager::kJpsiToMuMu) && muonHasCov) {
+        dileptonExtraList(t1.globalIndex(),t2.globalIndex(),VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+      }
+
 
       // run MC matching for this pair
       uint32_t mcDecision = 0;
@@ -759,7 +774,7 @@ struct AnalysisSameEventPairing {
     runMCGen(groupedMCTracks);
   }
 
-  /*void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
+  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
                                 soa::Filtered<MyMuonTracksSelected> const& muons, 
                                 ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
@@ -772,7 +787,20 @@ struct AnalysisSameEventPairing {
     runMCGen(groupedMCTracks);
   }
   
-  void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
+  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, 
+                                soa::Filtered<MyMuonTracksSelectedWithCov> const& muons, 
+                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event);
+    VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
+    
+    runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
+    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    runMCGen(groupedMCTracks);
+  }
+
+  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
                                   soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons, 
                                   ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
@@ -790,7 +818,8 @@ struct AnalysisSameEventPairing {
   }
 
   PROCESS_SWITCH(AnalysisSameEventPairing, processJpsiToEESkimmed, "Run barrel barrel pairing on DQ skimmed tracks", false);
-  //PROCESS_SWITCH(AnalysisSameEventPairing, processJpsiToMuMuSkimmed, "Run muon muon pairing on DQ skimmed muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processJpsiToMuMuSkimmed, "Run muon muon pairing on DQ skimmed muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processJpsiToMuMuVertexingSkimmed, "Run muon muon pairing on DQ skimmed muons including vertexing", false);
   //PROCESS_SWITCH(AnalysisSameEventPairing, processElectronMuonSkimmed, "Run barrel muon pairing on DQ skimmed tracks", false);
   PROCESS_SWITCH(AnalysisSameEventPairing, processDummy, "Dummy process function", false);
 };
@@ -800,7 +829,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   return WorkflowSpec{
     adaptAnalysisTask<AnalysisEventSelection>(cfgc),
     adaptAnalysisTask<AnalysisTrackSelection>(cfgc),
-    //adaptAnalysisTask<AnalysisMuonSelection>(cfgc),
+    adaptAnalysisTask<AnalysisMuonSelection>(cfgc),
     adaptAnalysisTask<AnalysisSameEventPairing>(cfgc)};
 }
 
@@ -833,18 +862,19 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 
     if (classStr.Contains("Pairs")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
+//      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon", "vertexing-forward");
     }
 
     if (classStr.Contains("MCTruthGenPair")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "mctruth_pair");
-      /*histMan->AddHistogram(objArray->At(iclass)->GetName(), "Pt", "MC generator p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kMCPt);
-      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Eta", "MC generator #eta distribution", false, 500, -5.0, 5.0, VarManager::kMCEta);*/
+      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Pt", "MC generator p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kMCPt);
+      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Eta", "MC generator #eta distribution", false, 500, -5.0, 5.0, VarManager::kMCEta);
       histMan->AddHistogram(objArray->At(iclass)->GetName(), "Phi", "MC generator #varphi distribution", false, 500, -6.3, 6.3, VarManager::kMCPhi);
     }
     if (classStr.Contains("MCTruthGen")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "mctruth");
-      /*histMan->AddHistogram(objArray->At(iclass)->GetName(), "Pt", "MC generator p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kMCPt);
-      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Eta", "MC generator #eta distribution", false, 500, -5.0, 5.0, VarManager::kMCEta);*/
+      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Pt", "MC generator p_{T} distribution", false, 200, 0.0, 20.0, VarManager::kMCPt);
+      histMan->AddHistogram(objArray->At(iclass)->GetName(), "Eta", "MC generator #eta distribution", false, 500, -5.0, 5.0, VarManager::kMCEta);
       histMan->AddHistogram(objArray->At(iclass)->GetName(), "Phi", "MC generator #varphi distribution", false, 500, -6.3, 6.3, VarManager::kMCPhi);
     }
   } // end loop over histogram classes

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -567,11 +567,11 @@ struct AnalysisSameEventPairing {
           }
           fMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }    // end if(cutNames.IsNull())
-    }      // end if processMuon
+      }  // end if(cutNames.IsNull())  
+    }  // end if processMuon
 
     // NOTE: For the electron-muon pairing, the policy is that the user specifies n track and n muon cuts via configurables
-    //     So for each barrel cut there is a corresponding muon cut
+    //     So for each barrel cut there is a corresponding muon cut  
     /*if (enableBarrelMuonHistos) {
       TString cutNamesBarrel = fConfigTrackCuts.value;
       TString cutNamesMuon = fConfigMuonCuts.value;
@@ -579,7 +579,7 @@ struct AnalysisSameEventPairing {
         std::unique_ptr<TObjArray> objArrayBarrel(cutNamesBarrel.Tokenize(","));
         std::unique_ptr<TObjArray> objArrayMuon(cutNamesMuon.Tokenize(","));
         for (int icut = 0; icut < objArrayBarrel->GetEntries(); ++icut) {
-          if (icut >= objArrayMuon->GetEntries()) {
+          if (icut >= objArrayMuon->GetEntries()) {  
             // there are fewer muon cuts specified wrt barrel cuts
             break;
           }
@@ -607,7 +607,7 @@ struct AnalysisSameEventPairing {
           }
           fBarrelMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())
+      }  // end if(cutNames.IsNull())  
     }  // end if processBarrelMuon
     */
 
@@ -683,8 +683,9 @@ struct AnalysisSameEventPairing {
       dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap);
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == VarManager::kJpsiToMuMu) && muonHasCov) {
-        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+        dileptonExtraList(t1.globalIndex(),t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
       }
+
 
       // run MC matching for this pair
       uint32_t mcDecision = 0;
@@ -773,10 +774,9 @@ struct AnalysisSameEventPairing {
     runMCGen(groupedMCTracks);
   }
 
-  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
-                                soa::Filtered<MyMuonTracksSelected> const& muons,
-                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
-  {
+  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
+                                soa::Filtered<MyMuonTracksSelected> const& muons, 
+                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
@@ -786,29 +786,28 @@ struct AnalysisSameEventPairing {
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
-
-  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event,
-                                         soa::Filtered<MyMuonTracksSelectedWithCov> const& muons,
-                                         ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
-  {
+  
+  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, 
+                                soa::Filtered<MyMuonTracksSelectedWithCov> const& muons, 
+                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-
+    
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
 
-  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
-                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons,
+  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
+                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons, 
                                   ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-
+    
     runPairing<VarManager::kElectronMuon, gkEventFillMap, gkMCEventFillMap, gkTrackFillMap>(event, tracks, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
@@ -863,7 +862,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 
     if (classStr.Contains("Pairs")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
-      //      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon", "vertexing-forward");
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon", "vertexing-forward");
     }
 
     if (classStr.Contains("MCTruthGenPair")) {

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -567,11 +567,11 @@ struct AnalysisSameEventPairing {
           }
           fMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())  
-    }  // end if processMuon
+      }  // end if(cutNames.IsNull())
+    }    // end if processMuon
 
     // NOTE: For the electron-muon pairing, the policy is that the user specifies n track and n muon cuts via configurables
-    //     So for each barrel cut there is a corresponding muon cut  
+    //     So for each barrel cut there is a corresponding muon cut
     /*if (enableBarrelMuonHistos) {
       TString cutNamesBarrel = fConfigTrackCuts.value;
       TString cutNamesMuon = fConfigMuonCuts.value;
@@ -579,7 +579,7 @@ struct AnalysisSameEventPairing {
         std::unique_ptr<TObjArray> objArrayBarrel(cutNamesBarrel.Tokenize(","));
         std::unique_ptr<TObjArray> objArrayMuon(cutNamesMuon.Tokenize(","));
         for (int icut = 0; icut < objArrayBarrel->GetEntries(); ++icut) {
-          if (icut >= objArrayMuon->GetEntries()) {  
+          if (icut >= objArrayMuon->GetEntries()) {
             // there are fewer muon cuts specified wrt barrel cuts
             break;
           }
@@ -607,7 +607,7 @@ struct AnalysisSameEventPairing {
           }
           fBarrelMuonHistNamesMCmatched.push_back(mcSigClasses);
         }  // end loop over cuts
-      }  // end if(cutNames.IsNull())  
+      }  // end if(cutNames.IsNull())
     }  // end if processBarrelMuon
     */
 
@@ -683,9 +683,8 @@ struct AnalysisSameEventPairing {
       dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap);
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == VarManager::kJpsiToMuMu) && muonHasCov) {
-        dileptonExtraList(t1.globalIndex(),t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
       }
-
 
       // run MC matching for this pair
       uint32_t mcDecision = 0;
@@ -774,9 +773,10 @@ struct AnalysisSameEventPairing {
     runMCGen(groupedMCTracks);
   }
 
-  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
-                                soa::Filtered<MyMuonTracksSelected> const& muons, 
-                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
+  void processJpsiToMuMuSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
+                                soa::Filtered<MyMuonTracksSelected> const& muons,
+                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
@@ -786,28 +786,29 @@ struct AnalysisSameEventPairing {
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
-  
-  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, 
-                                soa::Filtered<MyMuonTracksSelectedWithCov> const& muons, 
-                                ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
+
+  void processJpsiToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event,
+                                         soa::Filtered<MyMuonTracksSelectedWithCov> const& muons,
+                                         ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-    
+
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);
   }
 
-  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, 
-                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons, 
+  /*void processElectronMuonSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
+                                  soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons,
                                   ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC) {
     // Reset the fValues array
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<gkEventFillMap>(event);
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
-    
+
     runPairing<VarManager::kElectronMuon, gkEventFillMap, gkMCEventFillMap, gkTrackFillMap>(event, tracks, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
     runMCGen(groupedMCTracks);

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -574,6 +574,7 @@ struct AnalysisEventMixing {
 struct AnalysisSameEventPairing {
 
   Produces<aod::Dileptons> dileptonList;
+  Produces<aod::DileptonsExtra> dileptonExtraList;
   OutputObj<THashList> fOutputList{"output"};
   Configurable<string> fConfigTrackCuts{"cfgTrackCuts", "", "Comma separated list of barrel track cuts"};
   Configurable<string> fConfigMuonCuts{"cfgMuonCuts", "", "Comma separated list of muon cuts"};
@@ -693,6 +694,7 @@ struct AnalysisSameEventPairing {
     uint32_t twoTrackFilter = 0;
     uint32_t dileptonFilterMap = 0;
     dileptonList.reserve(1);
+    dileptonExtraList.reserve(1);
     for (auto& [t1, t2] : combinations(tracks1, tracks2)) {
       if constexpr (TPairType == VarManager::kJpsiToEE) {
         twoTrackFilter = uint32_t(t1.isBarrelSelected()) & uint32_t(t2.isBarrelSelected()) & fTwoTrackFilterMask;
@@ -716,6 +718,11 @@ struct AnalysisSameEventPairing {
       // TODO: provide the type of pair to the dilepton table (e.g. ee, mumu, emu...)
       dileptonFilterMap = twoTrackFilter;
       dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap);
+
+      constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
+      if constexpr ((TPairType == pairTypeMuMu) && muonHasCov) {
+      	dileptonExtraList(t1.globalIndex(),t2.globalIndex(),VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+      }
 
       for (unsigned int icut = 0; icut < ncuts; icut++) {
         if (twoTrackFilter & (uint32_t(1) << icut)) {

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -721,7 +721,7 @@ struct AnalysisSameEventPairing {
 
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == pairTypeMuMu) && muonHasCov) {
-      	dileptonExtraList(t1.globalIndex(),t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
       }
 
       for (unsigned int icut = 0; icut < ncuts; icut++) {

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -721,7 +721,7 @@ struct AnalysisSameEventPairing {
 
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == pairTypeMuMu) && muonHasCov) {
-        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+      	dileptonExtraList(t1.globalIndex(),t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
       }
 
       for (unsigned int icut = 0; icut < ncuts; icut++) {

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -721,7 +721,7 @@ struct AnalysisSameEventPairing {
 
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == pairTypeMuMu) && muonHasCov) {
-      	dileptonExtraList(t1.globalIndex(),t2.globalIndex(),VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz],VarManager::fgValues[VarManager::kVertexingLz],VarManager::fgValues[VarManager::kVertexingLxy]);
+        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kRap], VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
       }
 
       for (unsigned int icut = 0; icut < ncuts; icut++) {


### PR DESCRIPTION
Adding the table DileptonExtra to fill vertexing information, indices of single tracks and rapidity.
Adding a tracktype variable for muons to the VarManager and to the ReducedMuons, as well as cuts to select specific types in the CutsLibrary.
Finally, also adding at processMuMuVertexing to the dqEfficiency task.