### PR TITLE
Propagate momentum to PV

### DIFF
--- a/Common/DataModel/TrackPropagation.h
+++ b/Common/DataModel/TrackPropagation.h
@@ -42,6 +42,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //! z-component of the track momentum GeV/c
                              return pt * std::sinh(eta);
                            });
 
+DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! z-component of the track momentum GeV/c
+                           [](float pt, float eta) -> float {
+                             return pt * std::cosh(eta);
+                           });
+
 } // namespace trackpropagated
 
 DECLARE_SOA_TABLE(TracksPropagated, "AOD", "TRACKPROPAG", //! commonly used track parameters, propagated to the primary vertex
@@ -54,7 +59,8 @@ DECLARE_SOA_TABLE(TracksPropagated, "AOD", "TRACKPROPAG", //! commonly used trac
                   trackpropagated::Eta,
                   trackpropagated::Px<trackpropagated::Pt, trackpropagated::Phi>,
                   trackpropagated::Py<trackpropagated::Pt, trackpropagated::Phi>,
-                  trackpropagated::Pz<trackpropagated::Pt, trackpropagated::Eta>);
+                  trackpropagated::Pz<trackpropagated::Pt, trackpropagated::Eta>,
+                  trackpropagated::P<trackpropagated::Pt, trackpropagated::Eta>);
 
 using TrackPropagated = TracksPropagated::iterator;
 

--- a/Common/DataModel/TrackPropagation.h
+++ b/Common/DataModel/TrackPropagation.h
@@ -42,7 +42,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //! z-component of the track momentum GeV/c
                              return pt * std::sinh(eta);
                            });
 
-DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! z-component of the track momentum GeV/c
+DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! Momentum GeV/c
                            [](float pt, float eta) -> float {
                              return pt * std::cosh(eta);
                            });

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -582,12 +582,12 @@ void FemtoDreamTrackSelection::fillQA(T const& track, std::string_view WhichDaug
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDCAxy"), track.pt(), track.dcaXY());
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDCAz"), track.pt(), track.dcaZ());
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDCA"), track.pt(), std::sqrt(pow(track.dcaXY(), 2.) + pow(track.dcaZ(), 2.)));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hTPCdEdX"), track.tpcInnerParam(), track.tpcSignal());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_el"), track.tpcInnerParam(), track.tpcNSigmaEl());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_pi"), track.tpcInnerParam(), track.tpcNSigmaPi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_K"), track.tpcInnerParam(), track.tpcNSigmaKa());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_p"), track.tpcInnerParam(), track.tpcNSigmaPr());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_d"), track.tpcInnerParam(), track.tpcNSigmaDe());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hTPCdEdX"), track.p(), track.tpcSignal());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_el"), track.p(), track.tpcNSigmaEl());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_pi"), track.p(), track.tpcNSigmaPi());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_K"), track.p(), track.tpcNSigmaKa());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_p"), track.p(), track.tpcNSigmaPr());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTPC_d"), track.p(), track.tpcNSigmaDe());
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTOF_el"), track.p(), track.tofNSigmaEl());
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTOF_pi"), track.p(), track.tofNSigmaPi());
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/nSigmaTOF_K"), track.p(), track.tofNSigmaKa());

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -226,12 +226,12 @@ struct femtoDreamDebugTrack {
       FullQaRegistry.fill(HIST("FullTrackQA/hITSclustersIB"), part.itsNClsInnerBarrel());
       FullQaRegistry.fill(HIST("FullTrackQA/hDCAz"), part.pt(), part.dcaZ());
       FullQaRegistry.fill(HIST("FullTrackQA/hDCA"), part.pt(), std::sqrt(pow(part.dcaXY(), 2.) + pow(part.dcaZ(), 2.)));
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCdEdX"), part.tpcInnerParam(), part.tpcSignal());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_el"), part.tpcInnerParam(), part.tpcNSigmaEl());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_pi"), part.tpcInnerParam(), part.tpcNSigmaPi());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_K"), part.tpcInnerParam(), part.tpcNSigmaKa());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_p"), part.tpcInnerParam(), part.tpcNSigmaPr());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_d"), part.tpcInnerParam(), part.tpcNSigmaDe());
+      FullQaRegistry.fill(HIST("FullTrackQA/hTPCdEdX"), part.p(), part.tpcSignal());
+      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
+      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_pi"), part.p(), part.tpcNSigmaPi());
+      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_K"), part.p(), part.tpcNSigmaKa());
+      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_p"), part.p(), part.tpcNSigmaPr());
+      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_d"), part.p(), part.tpcNSigmaDe());
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_el"), part.p(), part.tofNSigmaEl());
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_pi"), part.p(), part.tofNSigmaPi());
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_K"), part.p(), part.tofNSigmaKa());

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -28,6 +28,7 @@
 #include "ReconstructionDataFormats/Track.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/StrangenessTables.h"
+#include "Common/DataModel/TrackPropagation.h"
 #include "Math/Vector4D.h"
 #include "TMath.h"
 
@@ -42,7 +43,7 @@ namespace o2::aod
 using FilteredFullCollision = soa::Filtered<soa::Join<aod::Collisions,
                                                       aod::EvSels,
                                                       aod::Mults>>::iterator;
-using FilteredFullTracks = soa::Join<aod::FullTracks,
+using FilteredFullTracks = soa::Join<aod::TracksPropagated, aod::TracksExtra,
                                      aod::TracksExtended, aod::TOFSignal,
                                      aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
                                      aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -29,6 +29,7 @@
 #include "ReconstructionDataFormats/Track.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/StrangenessTables.h"
+#include "Common/DataModel/TrackPropagation.h"
 #include "Math/Vector4D.h"
 #include "TMath.h"
 
@@ -43,7 +44,7 @@ namespace o2::aod
 using FilteredFullCollision = soa::Filtered<soa::Join<aod::Collisions,
                                                       aod::EvSels,
                                                       aod::Mults>>::iterator;
-using FilteredFullTracks = soa::Join<aod::FullTracks,
+using FilteredFullTracks = soa::Join<aod::TracksPropagated, aod::TracksExtra,
                                      aod::TracksExtended, aod::TOFSignal,
                                      aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
                                      aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,


### PR DESCRIPTION
Add momentum at the primary vertex to `TrackPropagation.h`

It is extremely important for femtoscopy analyses.

I added momentum as `DECLARE_SOA_DYNAMIC_COLUMN`. I wanted to add it as `DECLARE_SOA_EXPRESSION_COLUMN` (because it is used very often and to be consistent with `aod::Tracks`), but I could not because hyperbolic functions are not defined in `Core/Framework/BasicOps.h`.