### PR TITLE
Speedup compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ CMakeFiles/
 build
 compile_commands.json
 .DS_Store
+.cache

--- a/Common/Core/CMakeLists.txt
+++ b/Common/Core/CMakeLists.txt
@@ -9,11 +9,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+o2physics_add_library(PrecompiledO2Framework
+  SOURCES dummy.cxx
+  PUBLIC_LINK_LIBRARIES O2::Framework
+  PRECOMPILED_HEADERS <Framework/AnalysisTask.h>
+  <Framework/runDataProcessing.h>
+  )
+
 o2physics_add_library(AnalysisCore
                SOURCES TrackSelection.cxx
                        OrbitRange.cxx
                        PID/ParamBase.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+               )
+
 
 o2physics_target_root_dictionary(AnalysisCore
               HEADERS   TrackSelection.h

--- a/Common/Core/dummy.cxx
+++ b/Common/Core/dummy.cxx
@@ -1,0 +1,5 @@
+#include "Framework/WorkflowSpec.h"
+using namespace o2::framework;
+WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const&){
+  return WorkflowSpec{};
+}

--- a/cmake/O2PhysicsAddExecutable.cmake
+++ b/cmake/O2PhysicsAddExecutable.cmake
@@ -50,7 +50,7 @@ function(o2physics_add_executable baseTargetName)
                         A
                         "IS_TEST;NO_INSTALL;IS_BENCHMARK"
                         "COMPONENT_NAME;TARGETVARNAME"
-                        "SOURCES;PUBLIC_LINK_LIBRARIES;JOB_POOL")
+                        "SOURCES;PUBLIC_LINK_LIBRARIES;JOB_POOL;REUSE_PRECOMPILED_HEADERS_FROM")
 
   if(A_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "Got trailing arguments ${A_UNPARSED_ARGUMENTS}")
@@ -133,6 +133,10 @@ function(o2physics_add_executable baseTargetName)
     endif()
     target_link_libraries(${target} PUBLIC ${lib})
   endforeach()
+
+  if(A_REUSE_PRECOMPILED_HEADERS_FROM)
+    target_precompile_headers(${target} REUSE_FROM ${A_REUSE_PRECOMPILED_HEADERS_FROM})
+  endif()
 
   if(NOT A_NO_INSTALL)
     # install the executable

--- a/cmake/O2PhysicsAddLibrary.cmake
+++ b/cmake/O2PhysicsAddLibrary.cmake
@@ -59,6 +59,8 @@ include(O2PhysicsNameTarget)
 #   (e.g. by protobuf). Note that if you do specify this parameter it replaces
 #   the default, it does not add to them.
 #
+# * PRECOMPILED_HEADERS (not needed in most cases) : the list of headers which
+#   will be precompiled and installed with the library.
 function(o2physics_add_library baseTargetName)
 
   cmake_parse_arguments(
@@ -67,7 +69,7 @@ function(o2physics_add_library baseTargetName)
     A
     ""
     "TARGETVARNAME"
-    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES;PRIVATE_LINK_LIBRARIES;INSTALL_HEADERS"
+    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES;PRIVATE_LINK_LIBRARIES;INSTALL_HEADERS;PRECOMPILED_HEADERS"
     )
 
   if(A_UNPARSED_ARGUMENTS)
@@ -114,6 +116,9 @@ function(o2physics_add_library baseTargetName)
       endif()
       target_link_libraries(${target} PRIVATE ${L})
     endforeach()
+  endif()
+  if (A_PRECOMPILED_HEADERS)
+    target_precompile_headers(${target} PUBLIC ${A_PRECOMPILED_HEADERS})
   endif()
   # set the public include directories if available
   if(A_PUBLIC_INCLUDE_DIRECTORIES)

--- a/cmake/O2PhysicsAddWorkflow.cmake
+++ b/cmake/O2PhysicsAddWorkflow.cmake
@@ -38,7 +38,8 @@ function(o2physics_add_dpl_workflow baseTargetName)
   o2physics_add_executable(${baseTargetName}
     COMPONENT_NAME ${A_COMPONENT_NAME} TARGETVARNAME targetExeName
     SOURCES ${A_SOURCES}
-    PUBLIC_LINK_LIBRARIES O2::Framework ${A_PUBLIC_LINK_LIBRARIES})
+    PUBLIC_LINK_LIBRARIES O2::Framework ${A_PUBLIC_LINK_LIBRARIES}
+    REUSE_PRECOMPILED_HEADERS_FROM O2Physics::PrecompiledO2Framework)
 
   if(A_TARGETVARNAME)
     set(${A_TARGETVARNAME}


### PR DESCRIPTION
It looks like a significant amount of compilation time can be saved by using precompiled headers. 

When compiling the Tutorials we have that before this:

```Bash
Analyzing build trace from 'report.txt'...
**** Time summary:
Compilation (110 times):
Parsing (frontend):         1059.3 s
Codegen & opts (backend):   1214.2 s

```

after:

```cpp
Analyzing build trace from 'report.txt'...
**** Time summary:
Compilation (113 times):
  Parsing (frontend):          660.6 s
  Codegen & opts (backend):   1188.6 s
```

the extra files are of course the precompiled bits and of course the impact is mostly on the frontend, while codegen and optimization stay the same.
