### PR TITLE
Remove TOF Signal from common user space

### DIFF
--- a/Common/Core/PID/PIDResponse.h
+++ b/Common/Core/PID/PIDResponse.h
@@ -27,6 +27,9 @@
 #include "ReconstructionDataFormats/PID.h"
 #include "Framework/Logger.h"
 
+// ROOT includes
+#include "TMath.h"
+
 namespace o2::aod
 {
 namespace pidutils
@@ -353,6 +356,15 @@ const auto tofExpSignalDiff(const o2::track::PID::ID index, const TrackType& tra
   }
 }
 
+// Value of the TOF computed from the track beta in ps
+template <typename TrackType>
+const auto tofFromBeta(const TrackType& track)
+{
+  static constexpr float kCSPEED = TMath::C() * 1.0e2f * 1.0e-12f; /// Speed of light in TOF units (cm/ps)
+  // beta = length / (tofSignal - collisionTime) / kCSPEED
+  return track.length() / (track.beta() * kCSPEED);
+}
+
 template <class T>
 using hasTPCEl = decltype(std::declval<T&>().tpcNSigmaEl());
 template <class T>
@@ -662,11 +674,6 @@ const auto tpcExpSignalDiff(const o2::track::PID::ID index, const TrackType& tra
 
 } // namespace pidutils
 
-namespace pidtofsignal
-{
-DECLARE_SOA_COLUMN(TOFSignal, tofSignal, float); //! TOF signal from track time
-} // namespace pidtofsignal
-
 namespace pidtofbeta
 {
 DECLARE_SOA_COLUMN(Beta, beta, float);           //! TOF beta
@@ -778,9 +785,6 @@ DEFINE_UNWRAP_NSIGMA_COLUMN(TOFNSigmaHe, tofNSigmaHe); //! Unwrapped (float) nsi
 DEFINE_UNWRAP_NSIGMA_COLUMN(TOFNSigmaAl, tofNSigmaAl); //! Unwrapped (float) nsigma with the TOF detector for alpha
 
 } // namespace pidtof_tiny
-
-DECLARE_SOA_TABLE(TOFSignal, "AOD", "TOFSignal", //! Table of the TOF signal
-                  pidtofsignal::TOFSignal);
 
 DECLARE_SOA_TABLE(pidTOFbeta, "AOD", "pidTOFbeta", //! Table of the TOF beta
                   pidtofbeta::Beta, pidtofbeta::BetaError,

--- a/Common/TableProducer/PID/CMakeLists.txt
+++ b/Common/TableProducer/PID/CMakeLists.txt
@@ -18,7 +18,7 @@ o2physics_add_dpl_workflow(pid-tof
 
 o2physics_add_dpl_workflow(pid-tof-beta
                     SOURCES pidTOFbeta.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::TOFBase
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(pid-tof-qa-mc
@@ -59,5 +59,5 @@ o2physics_add_dpl_workflow(pid-hmpid-qa
 
 o2physics_add_dpl_workflow(pid-bayes
                     SOURCES pidBayes.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::TOFBase
                     COMPONENT_NAME Analysis)

--- a/Common/TableProducer/PID/pidBayes.cxx
+++ b/Common/TableProducer/PID/pidBayes.cxx
@@ -27,6 +27,7 @@
 #include "Common/Core/PID/TPCPIDResponse.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/TrackSelectionTables.h"
+#include "pidTOFBase.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -295,7 +296,7 @@ struct bayesPid {
 
   /// Response of the TOF detector
   template <o2::track::PID::ID pid>
-  using respTOF = tof::ExpTimes<Trks::iterator, pid>;
+  using respTOF = o2::pid::tof::ExpTimes<Trks::iterator, pid>;
 
   /// Compute PID probabilities for TOF
   template <o2::track::PID::ID pid>

--- a/Common/TableProducer/PID/pidTOF.cxx
+++ b/Common/TableProducer/PID/pidTOF.cxx
@@ -28,7 +28,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "TableHelper.h"
 #include "Framework/StaticFor.h"
-#include "TOFBase/EventTimeMaker.h"
 #include "pidTOFBase.h"
 
 using namespace o2;

--- a/Common/TableProducer/PID/pidTOFBase.h
+++ b/Common/TableProducer/PID/pidTOFBase.h
@@ -22,12 +22,26 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/EventSelection.h"
 #include <CCDB/BasicCCDBManager.h>
+#include "TOFBase/EventTimeMaker.h"
 #include "TableHelper.h"
 
 using namespace o2;
 using namespace o2::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+
+namespace o2::aod
+{
+
+namespace pidtofsignal
+{
+DECLARE_SOA_COLUMN(TOFSignal, tofSignal, float); //! TOF signal from track time
+} // namespace pidtofsignal
+
+DECLARE_SOA_TABLE(TOFSignal, "AOD", "TOFSignal", //! Table of the TOF signal
+                  pidtofsignal::TOFSignal);
+
+} // namespace o2::aod
 
 /// Task to produce the TOF signal from the trackTime information
 struct tofSignal {

--- a/Common/TableProducer/PID/pidTOFFull.cxx
+++ b/Common/TableProducer/PID/pidTOFFull.cxx
@@ -28,7 +28,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "TableHelper.h"
 #include "Framework/StaticFor.h"
-#include "TOFBase/EventTimeMaker.h"
 #include "pidTOFBase.h"
 
 using namespace o2;

--- a/Common/TableProducer/PID/pidTOFbeta.cxx
+++ b/Common/TableProducer/PID/pidTOFbeta.cxx
@@ -15,6 +15,7 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/Core/PID/PIDResponse.h"
 #include "Common/Core/PID/PIDTOF.h"
+#include "pidTOFBase.h"
 
 using namespace o2;
 using namespace o2::pid;
@@ -34,7 +35,7 @@ struct tofPidBeta {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TOFSignal>;
   using Colls = aod::Collisions;
   Produces<aod::pidTOFbeta> tablePIDBeta;
-  tof::Beta<Trks::iterator> responseBeta;
+  o2::pid::tof::Beta<Trks::iterator> responseBeta;
   Configurable<float> expreso{"tof-expreso", 80, "Expected resolution for the computation of the expected beta"};
 
   void init(o2::framework::InitContext&)

--- a/EventFiltering/PWGUD/diffractionFilter.cxx
+++ b/EventFiltering/PWGUD/diffractionFilter.cxx
@@ -83,7 +83,7 @@ struct DGFilterRun3 {
   using BCs = soa::Join<aod::BCs, aod::BcSels, aod::Run3MatchedToBCSparse>;
   using BC = BCs::iterator;
   using TCs = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection,
-                        aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::TOFSignal, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr>;
+                        aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr>;
   // using MFs = aod::MFTTracks;
   using FWs = aod::FwdTracks;
 

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -43,7 +43,7 @@ using FilteredFullCollision = soa::Join<aod::Collisions,
                                         aod::EvSels,
                                         aod::Mults>::iterator;
 using FilteredFullTracks = soa::Join<aod::FullTracks,
-                                     aod::TracksExtended, aod::TOFSignal,
+                                     aod::TracksExtended,
                                      aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
                                      aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
                                      aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -44,7 +44,7 @@ using FilteredFullCollision = soa::Join<aod::Collisions,
                                         aod::EvSels,
                                         aod::Mults>::iterator;
 using FilteredFullTracks = soa::Join<aod::FullTracks,
-                                     aod::TracksExtended, aod::TOFSignal,
+                                     aod::TracksExtended,
                                      aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
                                      aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
                                      aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,

--- a/PWGLF/Tasks/NucleiSpectraTask.cxx
+++ b/PWGLF/Tasks/NucleiSpectraTask.cxx
@@ -69,7 +69,7 @@ struct NucleiSpectraTask {
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == (uint8_t) true);
 
-  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksExtended, aod::pidTPCFullHe, aod::pidTOFFullHe, aod::TrackSelection, aod::TOFSignal>>;
+  using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksExtended, aod::pidTPCFullHe, aod::pidTOFFullHe, aod::TrackSelection, aod::pidTOFbeta>>;
 
   void process(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision, TrackCandidates const& tracks)
   {
@@ -114,10 +114,7 @@ struct NucleiSpectraTask {
         if (!track.hasTOF()) {
           continue;
         }
-        Float_t tofTime = track.tofSignal();
-        Float_t tofLength = track.length();
-        Float_t beta = tofLength / (TMath::C() * 1e-10 * tofTime);
-        spectra.fill(HIST("histTofSignalData"), track.tpcInnerParam() * track.sign(), beta);
+        spectra.fill(HIST("histTofSignalData"), track.tpcInnerParam() * track.sign(), track.beta());
         spectra.fill(HIST("histTofNsigmaData"), track.pt() * 2.0, track.tofNSigmaHe());
         if (abs(track.tofNSigmaHe()) < 4.0) {
           //

--- a/PWGLF/Tasks/spectraTOFtiny.cxx
+++ b/PWGLF/Tasks/spectraTOFtiny.cxx
@@ -74,7 +74,7 @@ struct tofSpectraTiny {
                                     aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
                                     aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe,
                                     aod::pidTOFTr, aod::pidTOFHe, aod::pidTOFAl,
-                                    aod::TOFSignal, aod::TrackSelection>;
+                                    aod::TrackSelection>;
   void process(aod::Collision const& collision,
                TrackCandidates const& tracks)
   {

--- a/Tools/PIDML/pidML.h
+++ b/Tools/PIDML/pidML.h
@@ -24,6 +24,7 @@ DECLARE_SOA_COLUMN(Px, px, float);                                 //! Non-dynam
 DECLARE_SOA_COLUMN(Py, py, float);                                 //! Non-dynamic column with track y-momentum
 DECLARE_SOA_COLUMN(Pz, pz, float);                                 //! Non-dynamic column with track z-momentum
 DECLARE_SOA_COLUMN(Sign, sign, float);                             //! Non-dynamic column with track sign
+DECLARE_SOA_COLUMN(TOFSignal, tofSignal, float);                   //! Private version of the TOF signal
 DECLARE_SOA_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, uint8_t); //!
 DECLARE_SOA_COLUMN(TOFExpSignalDiffEl, tofExpSignalDiffEl, float); //! Difference between signal and expected for electron
 DECLARE_SOA_COLUMN(TPCExpSignalDiffEl, tpcExpSignalDiffEl, float); //! Difference between signal and expected for electron
@@ -46,7 +47,7 @@ DECLARE_SOA_TABLE(PidTracksReal, "AOD", "PIDTRACKSREAL", //! Real tracks for pre
                   aod::track::TRDSignal,
                   aod::track::TrackEtaEMCAL,
                   aod::track::TrackPhiEMCAL,
-                  aod::pidtofsignal::TOFSignal,
+                  aod::pidtracks::TOFSignal,
                   aod::pidtofbeta::Beta,
                   pidtracks::P,
                   aod::track::Pt,
@@ -102,7 +103,7 @@ DECLARE_SOA_TABLE(PidTracksMc, "AOD", "PIDTRACKSMC", //! MC tracks for training
                   aod::track::TRDSignal,
                   aod::track::TrackEtaEMCAL,
                   aod::track::TrackPhiEMCAL,
-                  aod::pidtofsignal::TOFSignal,
+                  aod::pidtracks::TOFSignal,
                   aod::pidtofbeta::Beta,
                   pidtracks::P,
                   aod::track::Pt,

--- a/Tools/PIDML/pidMLProducer.cxx
+++ b/Tools/PIDML/pidMLProducer.cxx
@@ -31,7 +31,7 @@ struct CreateTableMc {
   Produces<aod::PidTracksMc> pidTracksTable;
 
   Filter trackFilter = aod::track::isGlobalTrack == (uint8_t) true;
-  using BigTracksMC = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::pidTPCFullEl, aod::pidTOFFullEl, aod::pidTPCFullMu, aod::pidTOFFullMu, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TrackSelection, aod::TOFSignal, aod::McTrackLabels>>;
+  using BigTracksMC = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::pidTPCFullEl, aod::pidTOFFullEl, aod::pidTPCFullMu, aod::pidTOFFullMu, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TrackSelection, aod::McTrackLabels>>;
   using MyCollision = soa::Join<aod::Collisions, aod::CentV0Ms, aod::Mults>::iterator;
 
   void process(MyCollision const& collision, BigTracksMC const& tracks, aod::McParticles_000 const& mctracks)
@@ -45,7 +45,7 @@ struct CreateTableMc {
                      collision.multZNA(), collision.multZNC(),
                      collision.multTracklets(), collision.multTPC(),
                      track.tpcSignal(), track.trdSignal(), track.trackEtaEmcal(), track.trackPhiEmcal(),
-                     track.tofSignal(), track.beta(),
+                     o2::aod::pidutils::tofFromBeta(track), track.beta(),
                      track.p(), track.pt(), track.px(), track.py(), track.pz(),
                      track.sign(),
                      track.x(), track.y(), track.z(),
@@ -73,7 +73,7 @@ struct CreateTableReal {
   Produces<aod::PidTracksReal> pidTracksTable;
 
   Filter trackFilter = aod::track::isGlobalTrack == (uint8_t) true;
-  using BigTracks = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::pidTPCFullEl, aod::pidTOFFullEl, aod::pidTPCFullMu, aod::pidTOFFullMu, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TrackSelection, aod::TOFSignal>>;
+  using BigTracks = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::pidTPCFullEl, aod::pidTOFFullEl, aod::pidTPCFullMu, aod::pidTOFFullMu, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TrackSelection>>;
   using MyCollision = soa::Join<aod::Collisions, aod::CentV0Ms, aod::Mults>::iterator;
 
   void process(MyCollision const& collision, BigTracks const& tracks)
@@ -85,7 +85,7 @@ struct CreateTableReal {
                      collision.multZNA(), collision.multZNC(),
                      collision.multTracklets(), collision.multTPC(),
                      track.tpcSignal(), track.trdSignal(), track.trackEtaEmcal(), track.trackPhiEmcal(),
-                     track.tofSignal(), track.beta(),
+                     o2::aod::pidutils::tofFromBeta(track), track.beta(),
                      track.p(), track.pt(), track.px(), track.py(), track.pz(),
                      track.sign(),
                      track.x(), track.y(), track.z(),

--- a/Tools/PIDML/pidOnnxModel.h
+++ b/Tools/PIDML/pidOnnxModel.h
@@ -134,10 +134,11 @@ struct PidONNXModel {
   template <typename T>
   std::vector<float> createInputsSingle(const T& track)
   {
+
     // TODO: Hardcoded for now. Planning to implement RowView extension to get runtime access to selected columns
     // sign is short, trackType and tpcNClsShared uint8_t
     float scaledTPCSignal = (track.tpcSignal() - mScalingParams.at("fTPCSignal").first) / mScalingParams.at("fTPCSignal").second;
-    float scaledTOFSignal = (track.tofSignal() - mScalingParams.at("fTOFSignal").first) / mScalingParams.at("fTOFSignal").second;
+    float scaledTOFSignal = (o2::aod::pidutils::tofFromBeta(track) - mScalingParams.at("fTOFSignal").first) / mScalingParams.at("fTOFSignal").second;
     float scaledX = (track.x() - mScalingParams.at("fX").first) / mScalingParams.at("fX").second;
     float scaledY = (track.y() - mScalingParams.at("fY").first) / mScalingParams.at("fY").second;
     float scaledZ = (track.z() - mScalingParams.at("fZ").first) / mScalingParams.at("fZ").second;

--- a/Tools/PIDML/qaPidML.cxx
+++ b/Tools/PIDML/qaPidML.cxx
@@ -370,7 +370,7 @@ struct pidml {
   }
 
   Filter trackFilter = aod::track::isGlobalTrack == static_cast<uint8_t>(true);
-  using pidTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels, aod::TracksExtended, aod::TrackSelection, aod::pidTOFbeta, aod::TOFSignal>>;
+  using pidTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels, aod::TracksExtended, aod::TrackSelection, aod::pidTOFbeta>>;
   void process(pidTracks const& tracks, aod::McParticles const& mcParticles)
   {
     for (auto& track : tracks) {

--- a/Tools/PIDML/simpleApplyPidOnnxModel.cxx
+++ b/Tools/PIDML/simpleApplyPidOnnxModel.cxx
@@ -55,7 +55,7 @@ struct SimpleApplyOnnxModelTask {
   // Minimum table requirements for sample model:
   // TPC signal (FullTracks), TOF signal (TOFSignal), TOF beta (pidTOFbeta), dcaXY and dcaZ (TracksExtended)
   // Filter on isGlobalTrack (TracksSelection)
-  using BigTracks = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::TrackSelection, aod::TOFSignal>>;
+  using BigTracks = soa::Filtered<soa::Join<aod::FullTracks, aod::TracksExtended, aod::pidTOFbeta, aod::TrackSelection>>;
 
   void init(InitContext const&)
   {


### PR DESCRIPTION
The TOF signal itself (especially in Run3) cannot be used alone to achieve PID, I propose therefore to keep it as a utility table and have it handled only by PID specific tasks. Of course it can always be computed also in specific tasks but I don't know if this will be a common use case.
Please have a look at the propose code modifications, there should not be significant changes apart in the ML section.
Thanks a lot! 