### PR TITLE
Modifications for adding FDD as mult selection signal

### DIFF
--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -66,20 +66,21 @@ DECLARE_SOA_COLUMN(Sel8, sel8, bool);                                       //! 
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundBC, foundBC, int, BCs, "_foundBC");      //! BC entry index in BCs table (-1 if doesn't exist)
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundFT0, foundFT0, int, FT0s, "_foundFT0");  //! FT0 entry index in FT0s table (-1 if doesn't exist)
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundFV0, foundFV0, int, FV0As, "_foundFV0"); //! FV0 entry index in FV0As table (-1 if doesn't exist)
+DECLARE_SOA_INDEX_COLUMN_FULL(FoundFDD, foundFDD, int, FDDs, "_foundFDD");  //! FDD entry index in FDDs table (-1 if doesn't exist)
 } // namespace evsel
 DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                   evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
-                  evsel::Sel7, evsel::Sel8, evsel::FoundBCId, evsel::FoundFT0Id, evsel::FoundFV0Id);
+                  evsel::Sel7, evsel::Sel8, evsel::FoundBCId, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId);
 using EvSel = EvSels::iterator;
 
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!
                   evsel::Alias, evsel::Selection,
                   evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                   evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0Id, evsel::FoundFV0Id);
+                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId);
 using BcSel = BcSels::iterator;
 } // namespace o2::aod
 

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -17,16 +17,20 @@ namespace o2::aod
 {
 namespace mult
 {
-DECLARE_SOA_COLUMN(MultV0A, multV0A, float); //!
-DECLARE_SOA_COLUMN(MultV0C, multV0C, float); //!
-DECLARE_SOA_COLUMN(MultT0A, multT0A, float); //!
-DECLARE_SOA_COLUMN(MultT0C, multT0C, float); //!
-DECLARE_SOA_COLUMN(MultZNA, multZNA, float); //!
-DECLARE_SOA_COLUMN(MultZNC, multZNC, float); //!
-DECLARE_SOA_DYNAMIC_COLUMN(MultV0M, multV0M, //!
+DECLARE_SOA_COLUMN(MultV0A, multV0A, float);   //!
+DECLARE_SOA_COLUMN(MultV0C, multV0C, float);   //!
+DECLARE_SOA_COLUMN(MultT0A, multT0A, float);   //!
+DECLARE_SOA_COLUMN(MultT0C, multT0C, float);   //!
+DECLARE_SOA_COLUMN(MultFDDA, multFDDA, float); //!
+DECLARE_SOA_COLUMN(MultFDDC, multFDDC, float); //!
+DECLARE_SOA_COLUMN(MultZNA, multZNA, float);   //!
+DECLARE_SOA_COLUMN(MultZNC, multZNC, float);   //!
+DECLARE_SOA_DYNAMIC_COLUMN(MultV0M, multV0M,   //!
                            [](float multV0A, float multV0C) -> float { return multV0A + multV0C; });
 DECLARE_SOA_DYNAMIC_COLUMN(MultT0M, multT0M, //!
                            [](float multT0A, float multT0C) -> float { return multT0A + multT0C; });
+DECLARE_SOA_DYNAMIC_COLUMN(MultFDD, multFDD, //!
+                           [](float multFDDA, float multFDDC) -> float { return multFDDA + multFDDC; });
 DECLARE_SOA_COLUMN(MultTracklets, multTracklets, int);
 DECLARE_SOA_COLUMN(MultTPC, multTPC, int);
 
@@ -34,9 +38,11 @@ DECLARE_SOA_COLUMN(MultTPC, multTPC, int);
 DECLARE_SOA_TABLE(Mults, "AOD", "MULT", //!
                   mult::MultV0A, mult::MultV0C,
                   mult::MultT0A, mult::MultT0C,
+                  mult::MultFDDA, mult::MultFDDC,
                   mult::MultZNA, mult::MultZNC,
                   mult::MultV0M<mult::MultV0A, mult::MultV0C>,
                   mult::MultT0M<mult::MultT0A, mult::MultT0C>,
+                  mult::MultFDD<mult::MultFDDA, mult::MultFDDC>,
                   mult::MultTracklets,
                   mult::MultTPC);
 using Mult = Mults::iterator;

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -154,12 +154,13 @@ struct BcSelectionTask {
 
       int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
       int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
+      int32_t foundFDD = bc.has_fdd() ? bc.fdd().globalIndex() : -1;
 
       // Fill bc selection columns
       bcsel(alias, selection,
             bbV0A, bbV0C, bgV0A, bgV0C,
             bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0);
+            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0, foundFDD);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun2, "Process Run2 event selection", true);
@@ -229,12 +230,13 @@ struct BcSelectionTask {
 
       int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
       int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
+      int32_t foundFDD = bc.has_fdd() ? bc.fdd().globalIndex() : -1;
       LOGP(debug, "foundFT0={}\n", foundFT0);
       // Fill bc selection columns
       bcsel(alias, selection,
             bbV0A, bbV0C, bgV0A, bgV0C,
             bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0);
+            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0, foundFDD);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun3, "Process Run3 event selection", false);
@@ -273,6 +275,7 @@ struct EventSelectionTask {
     int32_t foundBC = bc.globalIndex();
     int32_t foundFT0 = bc.foundFT0Id();
     int32_t foundFV0 = bc.foundFV0Id();
+    int32_t foundFDD = bc.foundFDDId();
 
     // copy alias decisions from bcsel table
     int32_t alias[kNaliases];
@@ -330,7 +333,7 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundBC, foundFT0, foundFV0);
+          foundBC, foundFT0, foundFV0, foundFDD);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun2, "Process Run2 event selection", true);
 
@@ -378,6 +381,7 @@ struct EventSelectionTask {
     int32_t foundBC = bc.globalIndex();
     int32_t foundFT0 = bc.foundFT0Id();
     int32_t foundFV0 = bc.foundFV0Id();
+    int32_t foundFDD = bc.foundFDDId();
 
     LOGP(debug, "foundFT0 = {}", foundFT0);
 
@@ -428,7 +432,7 @@ struct EventSelectionTask {
           bbV0A, bbV0C, bgV0A, bgV0C,
           bbFDA, bbFDC, bgFDA, bgFDC,
           multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundBC, foundFT0, foundFV0);
+          foundBC, foundFT0, foundFV0, foundFDD);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun3, "Process Run3 event selection", false);
 };

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -36,6 +36,8 @@ struct MultiplicityTableTaskIndexed {
     float multV0C = -1.f;
     float multT0A = -1.f;
     float multT0C = -1.f;
+    float multFDDA = -1.f;
+    float multFDDC = -1.f;
     float multZNA = -1.f;
     float multZNC = -1.f;
     auto trackletsGrouped = run2tracklets->sliceByCached(aod::track::collisionId, collision.globalIndex());
@@ -68,8 +70,8 @@ struct MultiplicityTableTaskIndexed {
       multZNC = zdc.energyCommonZNC();
     }
 
-    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
-    mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
+    mult(multV0A, multV0C, multT0A, multT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
@@ -79,6 +81,8 @@ struct MultiplicityTableTaskIndexed {
     float multV0C = -1.f;
     float multT0A = -1.f;
     float multT0C = -1.f;
+    float multFDDA = -1.f;
+    float multFDDC = -1.f;
     float multZNA = -1.f;
     float multZNC = -1.f;
     int multTracklets = -1;
@@ -95,6 +99,16 @@ struct MultiplicityTableTaskIndexed {
         multT0C += amplitude;
       }
     }
+    // using FDD row index from event selection task
+    if (collision.has_foundFDD()) {
+      auto fdd = collision.foundFDD();
+      for (auto amplitude : fdd.amplitudeA()) {
+        multFDDA += amplitude;
+      }
+      for (auto amplitude : fdd.amplitudeC()) {
+        multFDDC += amplitude;
+      }
+    }
     // using FV0 row index from event selection task
     if (collision.has_foundFV0()) {
       auto fv0 = collision.foundFV0();
@@ -102,8 +116,8 @@ struct MultiplicityTableTaskIndexed {
         multV0A += amplitude;
       }
     }
-    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
-    mult(multV0A, multV0C, multT0A, multT0C, multZNA, multZNC, multTracklets, multTPC);
+    LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multT0A=%5.0f multT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multV0A, multV0C, multT0A, multT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
+    mult(multV0A, multV0C, multT0A, multT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", false);
 };

--- a/Common/Tasks/multiplicityQa.cxx
+++ b/Common/Tasks/multiplicityQa.cxx
@@ -29,15 +29,21 @@ using namespace o2;
 using namespace o2::framework;
 
 struct MultiplicityQa {
-  OutputObj<TH1F> hMultV0M{TH1F("hMultV0M", "", 50000, 0., 50000.)};
-  OutputObj<TH1F> hMultT0M{TH1F("hMultT0M", "", 10000, 0., 200000.)};
-  OutputObj<TH1F> hMultZNA{TH1F("hMultZNA", "", 600, 0., 240000.)};
-  OutputObj<TH1F> hMultZNC{TH1F("hMultZNC", "", 600, 0., 240000.)};
+  //Raw multiplicities
+  OutputObj<TH1F> hRawMultV0M{TH1F("hRawMultV0M", "", 50000, 0., 50000.)};
+  OutputObj<TH1F> hRawMultT0M{TH1F("hRawMultT0M", "", 10000, 0., 200000.)};
+  OutputObj<TH1F> hRawMultFDD{TH1F("hRawMultFDD", "", 10000, 0., 200000.)};
+  OutputObj<TH1F> hRawMultZNA{TH1F("hRawMultZNA", "", 600, 0., 240000.)};
+  OutputObj<TH1F> hRawMultZNC{TH1F("hRawMultZNC", "", 600, 0., 240000.)};
   OutputObj<TH2F> hMultV0MvsT0M{TH2F("hMultV0MvsT0M", ";V0M;T0M", 200, 0., 50000., 200, 0., 200000.)};
 
   //For vertex-Z corrections
-  OutputObj<TProfile> hVtxProfV0M{TProfile("hVtxProfV0M", "", 150, -15, 15)};
-  OutputObj<TProfile> hVtxProfT0M{TProfile("hVtxProfT0M", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfV0A{TProfile("hVtxProfV0A", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfV0C{TProfile("hVtxProfV0C", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfT0A{TProfile("hVtxProfT0A", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfT0C{TProfile("hVtxProfT0C", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfFDDA{TProfile("hVtxProfFDDA", "", 150, -15, 15)};
+  OutputObj<TProfile> hVtxProfFDDC{TProfile("hVtxProfFDDC", "", 150, -15, 15)};
   OutputObj<TProfile> hVtxProfZNA{TProfile("hVtxProfZNA", "", 150, -15, 15)};
   OutputObj<TProfile> hVtxProfZNC{TProfile("hVtxProfZNC", "", 150, -15, 15)};
 
@@ -65,19 +71,27 @@ struct MultiplicityQa {
     }
 
     LOGF(debug, "multV0A=%5.0f multV0C=%5.0f multV0M=%5.0f multT0A=%5.0f multT0C=%5.0f multT0M=%5.0f", col.multV0A(), col.multV0C(), col.multV0M(), col.multT0A(), col.multT0C(), col.multT0M());
-    // fill calibration histos
-    hMultV0M->Fill(col.multV0M());
-    hMultT0M->Fill(col.multT0M());
-    hMultZNA->Fill(col.multZNA());
-    hMultZNC->Fill(col.multZNC());
+
+    //Raw multiplicities
+    hRawMultV0M->Fill(col.multV0M());
+    hRawMultT0M->Fill(col.multT0M());
+    hRawMultFDD->Fill(col.multFDD());
+    hRawMultZNA->Fill(col.multZNA());
+    hRawMultZNC->Fill(col.multZNC());
     hMultV0MvsT0M->Fill(col.multV0M(), col.multT0M());
     hMultNtrackletsVsV0M->Fill(col.multV0M(), col.multTracklets());
 
-    //Vertex-Z dependencies
-    hVtxProfV0M->Fill(col.posZ(), col.multV0M());
-    hVtxProfT0M->Fill(col.posZ(), col.multT0M());
+    //Vertex-Z dependencies, necessary for CCDB objects
+    hVtxProfV0A->Fill(col.posZ(), col.multV0A());
+    hVtxProfV0C->Fill(col.posZ(), col.multV0C());
+    hVtxProfT0A->Fill(col.posZ(), col.multT0A());
+    hVtxProfT0C->Fill(col.posZ(), col.multT0C());
+    hVtxProfFDDA->Fill(col.posZ(), col.multFDDA());
+    hVtxProfFDDC->Fill(col.posZ(), col.multFDDC());
     hVtxProfZNA->Fill(col.posZ(), col.multZNA());
     hVtxProfZNC->Fill(col.posZ(), col.multZNC());
+
+    //To be added here: vertex-Z calibrated signals (actually used in calibs)
   }
 };
 


### PR DESCRIPTION
@ekryshen this is a modification that also touches the event selection classes - I hope that's alright. The point is to add FDD as an extra signal for Run 3 multiplicity selection (Note that one could save AD signals in the same slots in Run 2 converted data). Please feel free to complain, suggest changes etc. Thanks!!

@ktf @pzhristov @jgrosseo this is a small first step that's also related to [our discussion tomorrow](https://indico.cern.ch/event/1149591/). 