### PR TITLE
Improve code formatting checks

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
@@ -79,7 +80,7 @@ jobs:
           echo ::set-output name=clean::false
         fi
 
-    - name: pull-request
+    - name: Create pull request with formatting changes
       uses: alisw/pull-request@master
       with:
         source_branch: 'alibuild:alibot-cleanup-${{ github.event.pull_request.number }}'
@@ -106,7 +107,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
@@ -133,20 +135,20 @@ jobs:
         # Run copyright notice check
         COPYRIGHT=$(printf '%s' "$COPYRIGHT")  # strip trailing newline
         copyright_lines=$(echo "$COPYRIGHT" | wc -l)
-        base_commit=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
         have_err=
         while read -r file; do
           if [ "$(head -n "$copyright_lines" "$file")" != "$COPYRIGHT" ]; then
-            echo "::error::$file: missing or malformed copyright notice" >&2
+            echo "::error file=$file,line=1,endLine=$copyright_lines::Missing or malformed copyright notice"
             have_err=1
           fi
-        done < <(git diff --diff-filter d --name-only "$base_commit" -- '*.cxx' '*.h')
+        done < <(git diff --diff-filter d --name-only --merge-base \
+                     ${{ github.event.pull_request.base.sha }} -- '*.cxx' '*.h')
 
         # Tell user what to do in case of copyright notice error
         if [ -n "$have_err" ]; then
-          echo '::error::The files listed above are missing the correct copyright notice.' >&2
-          echo '::error::Make sure all your source files begin with the following exact lines:' >&2
-          echo "$COPYRIGHT" >&2
+          echo '::error::The files listed above are missing the correct copyright notice.'
+          echo '::error::Make sure all your source files begin with the following exact lines:'
+          echo "$COPYRIGHT"
           exit 1
         fi
 
@@ -181,7 +183,7 @@ jobs:
             BEGIN { exit_code = 0 }
             function error(message) {
               printf "::error file=%s,line=%i,col=%i,endColumn=%i::%s\n",
-                     FILENAME, NR, RSTART, RSTART + RLENGTH, message
+                     FILENAME, FNR, RSTART, RSTART + RLENGTH, message
               exit_code = 1
             }
             match($0, / +$/) { error("Trailing spaces found") }

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,4 +1,4 @@
-name: PR formatting
+name: Formatting
 
 on: [pull_request_target]
 
@@ -6,7 +6,7 @@ jobs:
   clang-format:
     name: clang-format
     # We need at least 20.04 to install clang-format-11.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -149,3 +149,55 @@ jobs:
           echo "$COPYRIGHT" >&2
           exit 1
         fi
+
+    whitespace:
+      name: whitespace
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # needed to get the full history
+
+      - name: Fetch upstream
+        run: |
+          # Fetch the main upstream branch to find the common ancestor
+          git remote add upstream https://github.com/AliceO2Group/O2Physics.git
+          git fetch upstream ${{ github.event.pull_request.base.ref }}
+
+      - name: Find bad spacing
+        env:
+          base_branch: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # Find changed files, ignoring binary files.
+          readarray -d '' files < \
+            <(git diff -z --diff-filter d --name-only --merge-base "upstream/$base_branch" |
+                xargs -0r sh -c 'for f in "$@"; do file -bi "$f" | grep -q charset=binary || printf "%s\\0" "$f"; done' -)
+          echo 'Changed text files are:'
+          printf '%s\n' "${files[@]}"
+          # Find tabs and trailing whitespaces in modified text files and show where they are.
+          exec awk '
+            BEGIN { exit_code = 0 }
+            function error(message) {
+              printf "::error file=%s,line=%i,col=%i,endColumn=%i::%s\n",
+                     FILENAME, NR, RSTART, RSTART + RLENGTH, message
+              exit_code = 1
+            }
+            match($0, / +$/) { error("Trailing spaces found") }
+            match($0, /\t+/) { error("Tab character found -- use spaces to indent") }
+            END {
+              if (exit_code != 0) {
+                print "::notice::Fix the errors in your editor (or with a command)"
+                print "::notice::Command tips:"
+                print "::notice::- Get list of files you changed: git diff --diff-filter d --name-only --merge-base upstream/" ENVIRON["base_branch"]
+                print "::notice::- Replace each tab with two spaces: sed -i \"s/\\t/  /g\" <files>"
+                print "::notice::- Remove trailing whitespaces: sed -i \"s/[[:space:]]*$//\" <files>"
+                print "::notice::To avoid these errors, configure your editor to:"
+                print "::notice::- Emit spaces when the Tab key is pressed."
+                print "::notice::- Display whitespace characters."
+                print "::notice::- Replace tabs with spaces and remove trailing whitespaces when a file is saved."
+              }
+              exit exit_code
+            }
+          ' "${files[@]}"


### PR DESCRIPTION
Add a whitespace check like the one in AliceO2Group/AliceO2.

Also, change the copyright header check so that it marks errors in GitHub's diff view as well.

I've not tested this workflow as a whole yet (only the `git diff` line and the awk script separately), but if it's OK, this can be merged and I'll fix issues if and when they arise.