### PR TITLE
Output table of CEFP (first implementation)

### DIFF
--- a/EventFiltering/PWGLF/nucleiFilter.cxx
+++ b/EventFiltering/PWGLF/nucleiFilter.cxx
@@ -87,12 +87,10 @@ struct nucleiFilter {
     }
   }
 
-  Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::isGlobalTrack == static_cast<uint8_t>(1u));
 
-  using SelectedCollisions = soa::Filtered<aod::Collisions>;
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksExtended, aod::pidTPCFullDe, aod::pidTPCFullTr, aod::pidTPCFullHe, aod::pidTPCFullAl, aod::pidTOFFullDe, aod::pidTOFFullTr, aod::pidTOFFullHe, aod::pidTOFFullAl>>;
-  void process(SelectedCollisions::iterator const& collision, TrackCandidates const& tracks)
+  void process(aod::Collisions::iterator const& collision, TrackCandidates const& tracks)
   {
     // collision process loop
     bool keepEvent[nNuclei]{false};

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -220,12 +220,8 @@ struct centralEventFilterTask {
     if (outDecision.size() != nColls) {
       LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
     }
-    auto columnBCId{collTabPtr->GetColumnByName("BC")};
-    auto columnCollTime{collTabPtr->GetColumnByName("CollisionTime")};
-
-    if (columnBCId->num_chunks() != columnCollTime->num_chunks()) {
-      LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
-    }
+    auto columnBCId{collTabPtr->GetColumnByName("fIndexBCs")};
+    auto columnCollTime{collTabPtr->GetColumnByName("fCollisionTime")};
 
     int entryD = 0;
 
@@ -265,6 +261,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
         if (std::string_view(workflow["workflow_name"].GetString()) == std::string_view(FilteringTaskNames[iFilter])) {
           inputs.emplace_back(std::string(AvailableFilters[iFilter]), "AOD", FilterDescriptions[iFilter], 0, Lifetime::Timeframe);
           enabledFilters[iFilter] = true;
+          LOG(info) << "    * Adding inputs from " << AvailableFilters[iFilter] << " to workflow";
           break;
         }
       }

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -216,8 +216,7 @@ struct centralEventFilterTask {
     //Filling output table
     auto collTabConsumer = pc.inputs().get<TableConsumer>("Collisions");
     auto collTabPtr{collTabConsumer->asArrowTable()};
-    int64_t nColls{collTabPtr->num_rows()};
-    if (outDecision.size() != nColls) {
+    if (outDecision.size() != static_cast<uint64_t>(collTabPtr->num_rows())) {
       LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
     }
     auto columnBCId{collTabPtr->GetColumnByName("fIndexBCs")};

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -236,7 +236,7 @@ struct centralEventFilterTask {
       auto BCArray = std::static_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chunkBC);
       auto CollTimeArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTime);
       for (int64_t iD{0}; iD < chunkBC->length(); ++iD) {
-        tags(BCArray->Value(iD),CollTimeArray->Value(iD),outDecision[iD]);
+        tags(BCArray->Value(iD), CollTimeArray->Value(iD), outDecision[iD]);
         entryD++;
       }
     }

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -105,6 +105,7 @@ static const float defaultDownscaling[32][1]{
 struct centralEventFilterTask {
 
   HistogramRegistry scalers{"scalers", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+  Produces<aod::CefpDecisions> tags;
 
   FILTER_CONFIGURABLE(NucleiFilters);
   FILTER_CONFIGURABLE(DiffractionFilters);
@@ -168,6 +169,7 @@ struct centralEventFilterTask {
     auto mFiltered{scalers.get<TH1>(HIST("mFiltered"))};
 
     int64_t nEvents{-1};
+    std::vector<bool> outDecision;
     for (auto& tableName : mDownscaling) {
       if (!pc.inputs().isValid(tableName.first)) {
         LOG(fatal) << tableName.first << " table is not valid.";
@@ -180,6 +182,9 @@ struct centralEventFilterTask {
         LOG(fatal) << "Inconsistent number of rows across trigger tables.";
       }
 
+      if (outDecision.size() == 0)
+        outDecision.resize(nEvents, false);
+
       auto schema{tablePtr->schema()};
       for (auto& colName : tableName.second) {
         int bin{mScalers->GetXaxis()->FindBin(colName.first.data())};
@@ -187,6 +192,7 @@ struct centralEventFilterTask {
         auto column{tablePtr->GetColumnByName(colName.first)};
         double downscaling{colName.second};
         if (column) {
+          int entry = 0;
           for (int64_t iC{0}; iC < column->num_chunks(); ++iC) {
             auto chunk{column->chunk(iC)};
             auto boolArray = std::static_pointer_cast<arrow::BooleanArray>(chunk);
@@ -195,8 +201,10 @@ struct centralEventFilterTask {
                 mScalers->Fill(binCenter);
                 if (mUniformGenerator(mGeneratorEngine) < downscaling) {
                   mFiltered->Fill(binCenter);
+                  outDecision[entry] = true;
                 }
               }
+              entry++;
             }
           }
         }
@@ -204,6 +212,34 @@ struct centralEventFilterTask {
     }
     mScalers->SetBinContent(1, mScalers->GetBinContent(1) + nEvents);
     mFiltered->SetBinContent(1, mFiltered->GetBinContent(1) + nEvents);
+
+    //Filling output table
+    auto collTabConsumer = pc.inputs().get<TableConsumer>("Collisions");
+    auto collTabPtr{collTabConsumer->asArrowTable()};
+    int64_t nColls{collTabPtr->num_rows()};
+    if (outDecision.size() != nColls) {
+      LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
+    }
+    auto columnBCId{collTabPtr->GetColumnByName("BC")};
+    auto columnCollTime{collTabPtr->GetColumnByName("CollisionTime")};
+
+    if (columnBCId->num_chunks() != columnCollTime->num_chunks()) {
+      LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
+    }
+
+    int entryD = 0;
+
+    for (int64_t iC{0}; iC < columnBCId->num_chunks(); ++iC) {
+      auto chunkBC{columnBCId->chunk(iC)};
+      auto chunkCollTime{columnCollTime->chunk(iC)};
+
+      auto BCArray = std::static_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chunkBC);
+      auto CollTimeArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTime);
+      for (int64_t iD{0}; iD < chunkBC->length(); ++iD) {
+        tags(BCArray->Value(iD),CollTimeArray->Value(iD),outDecision[iD]);
+        entryD++;
+      }
+    }
   }
 
   std::mt19937_64 mGeneratorEngine;
@@ -213,6 +249,7 @@ struct centralEventFilterTask {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
   std::vector<InputSpec> inputs;
+  inputs.emplace_back("Collisions", "AOD", "COLLISION", 0, Lifetime::Timeframe);
 
   auto config = cfg.options().get<std::string>("train_config");
   Document d;

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -65,14 +65,14 @@ DECLARE_SOA_COLUMN(HighTrackMultOverlap, hasHighTrackMultOverlap, bool); //! hig
 
 } // namespace filtering
 
-namespace decision 
+namespace decision
 {
 
-DECLARE_SOA_COLUMN(BCId, hasBCId, int); //! Bunch crossing Id
-DECLARE_SOA_COLUMN(CollisionTime, hasCollisionTime, float); //! Collision time 
-DECLARE_SOA_COLUMN(CefpSelected, hasCefpSelected, bool); //! CEFP decision
+DECLARE_SOA_COLUMN(BCId, hasBCId, int);                     //! Bunch crossing Id
+DECLARE_SOA_COLUMN(CollisionTime, hasCollisionTime, float); //! Collision time
+DECLARE_SOA_COLUMN(CefpSelected, hasCefpSelected, bool);    //! CEFP decision
 
-}
+} // namespace decision
 
 // nuclei
 DECLARE_SOA_TABLE(NucleiFilters, "AOD", "NucleiFilters", //!

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -65,6 +65,15 @@ DECLARE_SOA_COLUMN(HighTrackMultOverlap, hasHighTrackMultOverlap, bool); //! hig
 
 } // namespace filtering
 
+namespace decision 
+{
+
+DECLARE_SOA_COLUMN(BCId, hasBCId, int); //! Bunch crossing Id
+DECLARE_SOA_COLUMN(CollisionTime, hasCollisionTime, float); //! Collision time 
+DECLARE_SOA_COLUMN(CefpSelected, hasCefpSelected, bool); //! CEFP decision
+
+}
+
 // nuclei
 DECLARE_SOA_TABLE(NucleiFilters, "AOD", "NucleiFilters", //!
                   filtering::H2, filtering::H3, filtering::He3, filtering::He4);
@@ -107,6 +116,11 @@ using StrangenessFilter = StrangenessFilters::iterator;
 DECLARE_SOA_TABLE(MultFilters, "AOD", "MultFilters", //!
                   filtering::LeadingPtTrack, filtering::HighMultFv0, filtering::HighTrackMult, filtering::HighTrackMultTrans, filtering::HighTrackMultOverlap);
 using MultFilter = MultFilters::iterator;
+
+// cefp decision
+DECLARE_SOA_TABLE(CefpDecisions, "AOD", "CefpDecision", //!
+                  decision::BCId, decision::CollisionTime, decision::CefpSelected);
+using CefpDecision = CefpDecisions::iterator;
 
 /// List of the available filters, the description of their tables and the name of the tasks
 constexpr int NumberOfFilters{8};


### PR DESCRIPTION
First implementation of the output table of the CEFP. 
This table contains the BCId, the collision time and the CEFP decision and it will be consumed by the reconstruction.