### PR TITLE
Small fix in trigger task

### DIFF
--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -222,29 +222,39 @@ struct DQBarrelTrackSelection {
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(tracksBarrel.size());
+    int CollisionId = -1;
 
     VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
-    for (auto& collision : collisions) {
-      // fill event information which might be needed in histograms or cuts that combine track and event properties
-      VarManager::FillEvent<TEventFillMap>(collision);
-    }
- 
+
     for (auto& track : tracksBarrel) {
       filterMap = uint32_t(0);
-      VarManager::FillTrack<TTrackFillMap>(track);
-      if (fConfigQA) {
-        fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
-      }
-      int i = 0;
-      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
-        if ((*cut).IsSelected(VarManager::fgValues)) {
-          filterMap |= (uint32_t(1) << i);
-          if (fConfigQA) {
-            fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+      if (!track.has_collision()) {
+        trackSel(uint32_t(0));
+      } else {
+        // fill event information which might be needed in histograms or cuts that combine track and event properties
+        if (track.collisionId() != CollisionId) { // check if the track belongs to a different event than the previous one
+          CollisionId = track.collisionId();
+          for (auto& collision : collisions) {
+            if (track.collisionId() == collision.index()) {
+              VarManager::FillEvent<TEventFillMap>(collision);
+            }
           }
         }
+        VarManager::FillTrack<TTrackFillMap>(track);
+        if (fConfigQA) {
+          fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
+        }
+        int i = 0;
+        for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+          if ((*cut).IsSelected(VarManager::fgValues)) {
+            filterMap |= (uint32_t(1) << i);
+            if (fConfigQA) {
+              fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+            }
+          }
+        }
+        trackSel(filterMap);
       }
-      trackSel(filterMap);
     } // end loop over tracks
   }
 
@@ -312,30 +322,40 @@ struct DQMuonsSelection {
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(muons.size());
+    int CollisionId = -1;
 
     VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
-    for (auto& collision : collisions) {
-      // fill event information which might be needed in histograms or cuts that combine track and event properties
-      VarManager::FillEvent<TEventFillMap>(collision);
-    }
 
     for (auto& muon : muons) {
       filterMap = uint32_t(0);
-      VarManager::FillTrack<TMuonFillMap>(muon);
-      if (fConfigQA) {
-        fHistMan->FillHistClass("Muon_BeforeCuts", VarManager::fgValues);
-      }
-      int i = 0;
-      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
-        if ((*cut).IsSelected(VarManager::fgValues)) {
-          filterMap |= (uint32_t(1) << i);
-          if (fConfigQA) {
-            fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+      if (!muon.has_collision()) {
+        trackSel(uint32_t(0));
+      } else {
+        // fill event information which might be needed in histograms or cuts that combine track and event properties
+        if (muon.collisionId() != CollisionId) { // check if the track belongs to a different event than the previous one
+          CollisionId = muon.collisionId();
+          for (auto& collision : collisions) {
+            if (muon.collisionId() == collision.index()) {
+              VarManager::FillEvent<TEventFillMap>(collision);
+            }
           }
         }
+        VarManager::FillTrack<TMuonFillMap>(muon);
+        if (fConfigQA) {
+          fHistMan->FillHistClass("Muon_BeforeCuts", VarManager::fgValues);
+        }
+        int i = 0;
+        for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+          if ((*cut).IsSelected(VarManager::fgValues)) {
+            filterMap |= (uint32_t(1) << i);
+            if (fConfigQA) {
+              fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+            }
+          }
+        }
+        trackSel(filterMap);
       }
-      trackSel(filterMap);
-    }
+    } // end loop over tracks
   }
 
   void processSelection(MyEvents const& collisions, aod::BCs const& bcs, MyMuons const& muons)

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -331,8 +331,8 @@ struct DQMuonsSelection {
         // fill event information which might be needed in histograms or cuts that combine track and event properties
         if (muon.collisionId() != CollisionId) { // check if the track belongs to a different event than the previous one
           CollisionId = muon.collisionId();
-            auto collision = muon.template collision_as<TEvent>();
-              VarManager::FillEvent<TEventFillMap>(collision);
+          auto collision = muon.template collision_as<TEvent>();
+          VarManager::FillEvent<TEventFillMap>(collision);
         }
         VarManager::FillTrack<TMuonFillMap>(muon);
         if (fConfigQA) {

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -217,14 +217,18 @@ struct DQBarrelTrackSelection {
     }
   }
 
-  template <uint32_t TTrackFillMap, typename TTracks>
-  void runTrackSelection(TTracks const& tracksBarrel)
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks>
+  void runTrackSelection(TEvent const& collisions, aod::BCs const& bcs, TTracks const& tracksBarrel)
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(tracksBarrel.size());
 
     VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
-
+    for (auto& collision : collisions) {
+      // fill event information which might be needed in histograms or cuts that combine track and event properties
+      VarManager::FillEvent<TEventFillMap>(collision);
+    }
+ 
     for (auto& track : tracksBarrel) {
       filterMap = uint32_t(0);
       VarManager::FillTrack<TTrackFillMap>(track);
@@ -244,13 +248,13 @@ struct DQBarrelTrackSelection {
     } // end loop over tracks
   }
 
-  void processSelection(MyBarrelTracks const& tracks)
+  void processSelection(MyEvents const& collisions, aod::BCs const& bcs, MyBarrelTracks const& tracks)
   {
-    runTrackSelection<gkTrackFillMap>(tracks);
+    runTrackSelection<gkEventFillMap, gkTrackFillMap>(collisions, bcs, tracks);
   }
-  void processSelectionTiny(MyBarrelTracksTiny const& tracks)
+  void processSelectionTiny(MyEvents const& collisions, aod::BCs const& bcs, MyBarrelTracksTiny const& tracks)
   {
-    runTrackSelection<gkTrackFillMap>(tracks);
+    runTrackSelection<gkEventFillMap, gkTrackFillMap>(collisions, bcs, tracks);
   }
   void processDummy(MyEvents&)
   {
@@ -303,13 +307,17 @@ struct DQMuonsSelection {
     }
   }
 
-  template <uint32_t TMuonFillMap, typename TMuons>
-  void runMuonSelection(TMuons const& muons)
+  template <uint32_t TEventFillMap, uint32_t TMuonFillMap, typename TEvent, typename TMuons>
+  void runMuonSelection(TEvent const& collisions, aod::BCs const& bcs, TMuons const& muons)
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(muons.size());
 
     VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
+    for (auto& collision : collisions) {
+      // fill event information which might be needed in histograms or cuts that combine track and event properties
+      VarManager::FillEvent<TEventFillMap>(collision);
+    }
 
     for (auto& muon : muons) {
       filterMap = uint32_t(0);
@@ -330,9 +338,9 @@ struct DQMuonsSelection {
     }
   }
 
-  void processSelection(MyMuons const& muons)
+  void processSelection(MyEvents const& collisions, aod::BCs const& bcs, MyMuons const& muons)
   {
-    runMuonSelection<gkMuonFillMap>(muons);
+    runMuonSelection<gkEventFillMap, gkMuonFillMap>(collisions, bcs, muons);
   }
   void processDummy(MyEvents&)
   {

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -217,15 +217,13 @@ struct DQBarrelTrackSelection {
     }
   }
 
-  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks>
-  void runTrackSelection(TEvent const& collision, aod::BCs const& bcs, TTracks const& tracksBarrel)
+  template <uint32_t TTrackFillMap, typename TTracks>
+  void runTrackSelection(TTracks const& tracksBarrel)
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(tracksBarrel.size());
 
     VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
-    // fill event information which might be needed in histograms or cuts that combine track and event properties
-    VarManager::FillEvent<TEventFillMap>(collision);
 
     for (auto& track : tracksBarrel) {
       filterMap = uint32_t(0);
@@ -246,13 +244,13 @@ struct DQBarrelTrackSelection {
     } // end loop over tracks
   }
 
-  void processSelection(MyEvents::iterator const& collision, aod::BCs const& bcs, MyBarrelTracks const& tracks)
+  void processSelection(MyBarrelTracks const& tracks)
   {
-    runTrackSelection<gkEventFillMap, gkTrackFillMap>(collision, bcs, tracks);
+    runTrackSelection<gkTrackFillMap>(tracks);
   }
-  void processSelectionTiny(MyEvents::iterator const& collision, aod::BCs const& bcs, MyBarrelTracksTiny const& tracks)
+  void processSelectionTiny(MyBarrelTracksTiny const& tracks)
   {
-    runTrackSelection<gkEventFillMap, gkTrackFillMap>(collision, bcs, tracks);
+    runTrackSelection<gkTrackFillMap>(tracks);
   }
   void processDummy(MyEvents&)
   {
@@ -305,15 +303,13 @@ struct DQMuonsSelection {
     }
   }
 
-  template <uint32_t TEventFillMap, uint32_t TMuonFillMap, typename TEvent, typename TMuons>
-  void runMuonSelection(TEvent const& collision, aod::BCs const& bcs, TMuons const& muons)
+  template <uint32_t TMuonFillMap, typename TMuons>
+  void runMuonSelection(TMuons const& muons)
   {
     uint32_t filterMap = uint32_t(0);
     trackSel.reserve(muons.size());
 
     VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
-    // fill event information which might be needed in histograms/cuts that combine track and event properties
-    VarManager::FillEvent<TEventFillMap>(collision);
 
     for (auto& muon : muons) {
       filterMap = uint32_t(0);
@@ -334,9 +330,9 @@ struct DQMuonsSelection {
     }
   }
 
-  void processSelection(MyEvents::iterator const& collision, aod::BCs const& bcs, MyMuons const& muons)
+  void processSelection(MyMuons const& muons)
   {
-    runMuonSelection<gkEventFillMap, gkMuonFillMap>(collision, bcs, muons);
+    runMuonSelection<gkMuonFillMap>(muons);
   }
   void processDummy(MyEvents&)
   {

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -234,11 +234,8 @@ struct DQBarrelTrackSelection {
         // fill event information which might be needed in histograms or cuts that combine track and event properties
         if (track.collisionId() != CollisionId) { // check if the track belongs to a different event than the previous one
           CollisionId = track.collisionId();
-          for (auto& collision : collisions) {
-            if (track.collisionId() == collision.index()) {
-              VarManager::FillEvent<TEventFillMap>(collision);
-            }
-          }
+          auto collision = track.template collision_as<TEvent>();
+          VarManager::FillEvent<TEventFillMap>(collision);
         }
         VarManager::FillTrack<TTrackFillMap>(track);
         if (fConfigQA) {
@@ -334,11 +331,8 @@ struct DQMuonsSelection {
         // fill event information which might be needed in histograms or cuts that combine track and event properties
         if (muon.collisionId() != CollisionId) { // check if the track belongs to a different event than the previous one
           CollisionId = muon.collisionId();
-          for (auto& collision : collisions) {
-            if (muon.collisionId() == collision.index()) {
+            auto collision = muon.template collision_as<TEvent>();
               VarManager::FillEvent<TEventFillMap>(collision);
-            }
-          }
         }
         VarManager::FillTrack<TMuonFillMap>(muon);
         if (fConfigQA) {


### PR DESCRIPTION
Change in the track selection task so that the Selection flag table has always the same size as the track table.
Track selection does not need to run on both tracks and events