### PR TITLE
[EMCAL-734] split EMCal cluster table and added cluster definition class

### DIFF
--- a/PWGJE/DataModel/EMCALClusterDefinition.h
+++ b/PWGJE/DataModel/EMCALClusterDefinition.h
@@ -1,0 +1,115 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Class for the cluster definition, i.e. what is considered a cluster by the clusterizer.
+// The cluster definition contains information about the used algorithm, seed threshold,
+// cell energy, gradient as well as timing cut
+//
+// Author: Florian Jonas
+
+#ifndef O2_ANALYSIS_DATAMODEL_EMCALCLUSTERDEFINITION
+#define O2_ANALYSIS_DATAMODEL_EMCALCLUSTERDEFINITION
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+enum class ClusterAlgorithm_t {
+  kV1,
+  kV3
+};
+/// \struct EMCALClusterDefinition
+/// \brief struct for the cluster definition, i.e. what is considered a cluster by the clusterizer.
+/// The cluster definition contains information about the used algorithm, seed threshold,
+/// cell energy, gradient as well as timing cut
+struct EMCALClusterDefinition {
+  ClusterAlgorithm_t algorithm;
+  int storageID = -1;              // integer ID used to store cluster definition in a flat table
+  int selectedCellType = 1;        // EMCal cell type (CURRENTLY NOT USED TO AVOID MULTIPLE CELL LOOPS)
+  std::string name = "kUndefined"; // name of the cluster definition
+  double seedEnergy = 0.1;         // seed threshold (GeV)
+  double minCellEnergy = 0.05;     // minimum cell energy (GeV)
+  double timeMin = -10000;         // minimum time (ns)
+  double timeMax = 10000;          // maximum time (ns)
+  double gradientCut = 0.03;       // gradient cut
+
+  // default constructor
+  EMCALClusterDefinition() = default;
+  // constructor
+  EMCALClusterDefinition(ClusterAlgorithm_t pAlgorithm, int pStorageID, int pSelectedCellType, std::string pName, double pSeedEnergy, double pMinCellEnergy, double pTimeMin, double pTimeMax, double pGradientCut)
+  {
+    algorithm = pAlgorithm;
+    storageID = pStorageID;
+    selectedCellType = pSelectedCellType;
+    name = pName;
+    seedEnergy = pSeedEnergy;
+    minCellEnergy = pMinCellEnergy;
+    timeMin = pTimeMin;
+    timeMax = pTimeMax;
+    gradientCut = pGradientCut;
+  }
+
+  // implement comparison operators for int std::string and ClusterAlgorithm_t
+  bool operator==(const EMCALClusterDefinition& rhs) const
+  {
+    return (algorithm == rhs.algorithm && storageID == rhs.storageID && name == rhs.name && seedEnergy == rhs.seedEnergy && minCellEnergy == rhs.minCellEnergy && timeMin == rhs.timeMin && timeMax == rhs.timeMax && gradientCut == rhs.gradientCut);
+  }
+  bool operator!=(const EMCALClusterDefinition& rhs) const
+  {
+    return !(*this == rhs);
+  }
+  bool operator==(const int rhs) const
+  {
+    return (storageID == rhs);
+  }
+  bool operator!=(const int rhs) const
+  {
+    return !(storageID == rhs);
+  }
+  bool operator==(const std::string& rhs) const
+  {
+    return (name == rhs);
+  }
+  bool operator!=(const std::string& rhs) const
+  {
+    return !(name == rhs);
+  }
+  bool operator==(const ClusterAlgorithm_t rhs) const
+  {
+    return (algorithm == rhs);
+  }
+  bool operator!=(const ClusterAlgorithm_t rhs) const
+  {
+    return !(algorithm == rhs);
+  }
+
+  // cast to int
+  operator int() const
+  {
+    return storageID;
+  }
+
+  operator std::string() const
+  {
+    return name;
+  }
+
+  operator ClusterAlgorithm_t() const
+  {
+    return algorithm;
+  }
+  std::string toString() const
+  {
+    return name;
+  }
+}; // class EMCALClusterDefinition
+} // namespace o2::aod
+#endif

--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -56,21 +56,21 @@ const EMCALClusterDefinition getClusterDefinitionFromString(const std::string& c
   }
 };
 
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                        //!
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                                      //!
-DECLARE_SOA_COLUMN(ID, id, int);                                       //!
-DECLARE_SOA_COLUMN(Energy, energy, float);                             //!
-DECLARE_SOA_COLUMN(CoreEnergy, coreEnergy, float);                     //!
-DECLARE_SOA_COLUMN(Eta, eta, float);                                   //!
-DECLARE_SOA_COLUMN(Phi, phi, float);                                   //!
-DECLARE_SOA_COLUMN(M02, m02, float);                                   //!
-DECLARE_SOA_COLUMN(M20, m20, float);                                   //!
-DECLARE_SOA_COLUMN(NCells, nCells, int);                               //!
-DECLARE_SOA_COLUMN(Time, time, float);                                 //!
-DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                          //!
-DECLARE_SOA_COLUMN(DistanceToBadChannel, distanceToBadChannel, float); //!
-DECLARE_SOA_COLUMN(NLM, nlm, int);                                     //!
-DECLARE_SOA_COLUMN(Definition, definition, int);                       //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                        //! collisionID used as index for matched clusters
+DECLARE_SOA_INDEX_COLUMN(BC, bc);                                      //! bunch crossing ID used as index for ambiguous clusters
+DECLARE_SOA_COLUMN(ID, id, int);                                       //! cluster ID identifying cluster in event
+DECLARE_SOA_COLUMN(Energy, energy, float);                             //! cluster energy (GeV)
+DECLARE_SOA_COLUMN(CoreEnergy, coreEnergy, float);                     //! cluster core energy (GeV)
+DECLARE_SOA_COLUMN(Eta, eta, float);                                   //! cluster pseudorapidity (calculated using vertex)
+DECLARE_SOA_COLUMN(Phi, phi, float);                                   //! cluster azimuthal angle (calculated using vertex)
+DECLARE_SOA_COLUMN(M02, m02, float);                                   //! shower shape long axis
+DECLARE_SOA_COLUMN(M20, m20, float);                                   //! shower shape short axis
+DECLARE_SOA_COLUMN(NCells, nCells, int);                               //! number of cells in cluster
+DECLARE_SOA_COLUMN(Time, time, float);                                 //! cluster time (ns)
+DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                          //! flag to mark cluster as exotic
+DECLARE_SOA_COLUMN(DistanceToBadChannel, distanceToBadChannel, float); //! distance to bad channel
+DECLARE_SOA_COLUMN(NLM, nlm, int);                                     //! number of local maxima
+DECLARE_SOA_COLUMN(Definition, definition, int);                       //! cluster definition, see EMCALClusterDefinition.h
 
 } // namespace emcalcluster
 // table of clusters that could be matched to a collision

--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -17,11 +17,46 @@
 #define O2_ANALYSIS_DATAMODEL_EMCALCLUSTERS
 
 #include "Framework/AnalysisDataModel.h"
+#include "EMCALClusterDefinition.h"
 
 namespace o2::aod
 {
 namespace emcalcluster
 {
+
+// define global cluster definitions
+// the V1 algorithm is not yet implemented, but the V3 algorithm is
+// New definitions should be added here!
+const EMCALClusterDefinition kV1Default(ClusterAlgorithm_t::kV1, 0, 1, "kV1Default", 0.1, 0.5, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV1Variation1(ClusterAlgorithm_t::kV3, 1, 1, "kV1Variation1", 0.1, 0.3, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV1Variation2(ClusterAlgorithm_t::kV3, 2, 1, "kV1Variation2", 0.1, 0.2, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Default(ClusterAlgorithm_t::kV3, 10, 1, "kV3Default", 0.1, 0.5, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Variation1(ClusterAlgorithm_t::kV3, 11, 1, "kV3Variation1", 0.1, 0.3, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Variation2(ClusterAlgorithm_t::kV3, 12, 1, "kV3Variation2", 0.1, 0.2, -10000, 10000, 0.03);
+
+/// \brief function returns EMCALClusterDefinition for the given name
+/// \param name name of the cluster definition
+/// \return EMCALClusterDefinition for the given name
+const EMCALClusterDefinition getClusterDefinitionFromString(const std::string& clusterDefinitionName)
+{
+  if (clusterDefinitionName == "kV1Default") {
+    return kV1Default;
+  } else if (clusterDefinitionName == "kV1Variation1") {
+    return kV1Variation1;
+  } else if (clusterDefinitionName == "kV1Variation2") {
+    return kV1Variation2;
+  } else if (clusterDefinitionName == "kV3Default") {
+    return kV3Default;
+  } else if (clusterDefinitionName == "kV3Variation1") {
+    return kV3Variation1;
+  } else if (clusterDefinitionName == "kV3Variation2") {
+    return kV3Variation2;
+  } else {
+    throw std::invalid_argument("Cluster definition name not recognized");
+  }
+};
+
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                        //!
 DECLARE_SOA_INDEX_COLUMN(BC, bc);                                      //!
 DECLARE_SOA_COLUMN(ID, id, int);                                       //!
 DECLARE_SOA_COLUMN(Energy, energy, float);                             //!
@@ -35,16 +70,24 @@ DECLARE_SOA_COLUMN(Time, time, float);                                 //!
 DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                          //!
 DECLARE_SOA_COLUMN(DistanceToBadChannel, distanceToBadChannel, float); //!
 DECLARE_SOA_COLUMN(NLM, nlm, int);                                     //!
+DECLARE_SOA_COLUMN(Definition, definition, int);                       //!
 
 } // namespace emcalcluster
-
+// table of clusters that could be matched to a collision
 DECLARE_SOA_TABLE(EMCALClusters, "AOD", "EMCALCLUSTERS", //!
+                  o2::soa::Index<>, emcalcluster::CollisionId, emcalcluster::ID, emcalcluster::Energy,
+                  emcalcluster::CoreEnergy, emcalcluster::Eta, emcalcluster::Phi, emcalcluster::M02,
+                  emcalcluster::M20, emcalcluster::NCells, emcalcluster::Time,
+                  emcalcluster::IsExotic, emcalcluster::DistanceToBadChannel, emcalcluster::NLM, emcalcluster::Definition);
+// table of ambiguous clusters that could not be matched to a collision
+DECLARE_SOA_TABLE(EMCALAmbiguousClusters, "AOD", "EMCALAMBCLUS", //!
                   o2::soa::Index<>, emcalcluster::BCId, emcalcluster::ID, emcalcluster::Energy,
                   emcalcluster::CoreEnergy, emcalcluster::Eta, emcalcluster::Phi, emcalcluster::M02,
                   emcalcluster::M20, emcalcluster::NCells, emcalcluster::Time,
-                  emcalcluster::IsExotic, emcalcluster::DistanceToBadChannel, emcalcluster::NLM);
+                  emcalcluster::IsExotic, emcalcluster::DistanceToBadChannel, emcalcluster::NLM, emcalcluster::Definition);
 
 using EMCALCluster = EMCALClusters::iterator;
+using EMCALAmbiguousCluster = EMCALAmbiguousClusters::iterator;
 
 } // namespace o2::aod
 

--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -11,7 +11,7 @@
 
 // EMCAL Correction Task
 //
-// Author: Raymond Ehlers
+// Author: Raymond Ehlers & Florian Jonas
 
 #include <algorithm>
 #include <cmath>
@@ -40,31 +40,25 @@ using namespace o2::framework::expressions;
 
 struct EmcalCorrectionTask {
   Produces<o2::aod::EMCALClusters> clusters;
+  Produces<o2::aod::EMCALAmbiguousClusters> clustersAmbiguous;
 
   // Options for the clusterization
   // 1 corresponds to EMCAL cells based on the Run2 definition.
   Configurable<int> selectedCellType{"selectedCellType", 1, "EMCAL Cell type"};
-  Configurable<double> seedEnergy{"seedEnergy", 0.1, "Clusterizer seed energy."};
-  Configurable<double> minCellEnergy{"minCellEnergy", 0.05, "Clusterizer minimum cell energy."};
-  // TODO: Check this range, especially after change to the conversion...
-  Configurable<double> timeCut{"timeCut", 10000, "Cell time cut"};
-  Configurable<double> timeMin{"timeMin", 0, "Min cell time"};
-  Configurable<double> timeMax{"timeMax", 10000, "Max cell time"};
-  Configurable<bool> enableEnergyGradientCut{"enableEnergyGradientCut", true, "Enable energy gradient cut."};
-  Configurable<double> gradientCut{"gradientCut", 0.03, "Clusterizer energy gradient cut."};
-
+  Configurable<std::string> clusterDefinitions{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default. Multiple definitions can be specified separated by comma"};
   // CDB service (for geometry)
   Service<o2::ccdb::BasicCCDBManager> mCcdbManager;
 
   // Clusterizer and related
   // Apparently streaming these objects really doesn't work, and causes problems for setting up the workflow.
   // So we use unique_ptr and define them below.
-  std::unique_ptr<o2::emcal::Clusterizer<o2::emcal::Cell>> mClusterizer;
-  std::unique_ptr<o2::emcal::ClusterFactory<o2::emcal::Cell>> mClusterFactory;
+  std::vector<std::unique_ptr<o2::emcal::Clusterizer<o2::emcal::Cell>>> mClusterizers;
+  std::vector<std::unique_ptr<o2::emcal::ClusterFactory<o2::emcal::Cell>>> mClusterFactories;
   // Cells and clusters
   std::vector<o2::emcal::Cell> mEmcalCells;
   std::vector<o2::emcal::AnalysisCluster> mAnalysisClusters;
 
+  std::vector<o2::aod::EMCALClusterDefinition> mClusterDefinitions;
   // QA
   // NOTE: This is not comprehensive.
   OutputObj<TH1F> hCellE{"hCellE"};
@@ -95,14 +89,29 @@ struct EmcalCorrectionTask {
       LOG(error) << "Failure accessing geometry";
     }
 
-    // Setup clusterizer
-    LOG(debug) << "Init clusterizer!";
-    mClusterizer = decltype(mClusterizer)(new o2::emcal::Clusterizer<o2::emcal::Cell>());
-    mClusterizer->initialize(timeCut, timeMin, timeMax, gradientCut, enableEnergyGradientCut, seedEnergy, minCellEnergy);
-    mClusterizer->setGeometry(geometry);
-    LOG(debug) << "Done with clusterizer. Setup cluster factory.";
-    // Setup cluster factory.
-    mClusterFactory = decltype(mClusterFactory)(new o2::emcal::ClusterFactory<o2::emcal::Cell>());
+    // read all the cluster definitions specified in the options
+    if (clusterDefinitions->length()) {
+      std::stringstream parser(clusterDefinitions.value);
+      std::string token;
+      o2::aod::EMCALClusterDefinition clusDef;
+      while (std::getline(parser, token, ',')) {
+        clusDef = o2::aod::emcalcluster::getClusterDefinitionFromString(token);
+        mClusterDefinitions.push_back(clusDef);
+      }
+    }
+    for (auto& clusterDefinition : mClusterDefinitions) {
+      mClusterizers.emplace_back(std::make_unique<o2::emcal::Clusterizer<o2::emcal::Cell>>(1, clusterDefinition.timeMin, clusterDefinition.timeMax, clusterDefinition.gradientCut, true, clusterDefinition.seedEnergy, clusterDefinition.minCellEnergy));
+      mClusterFactories.emplace_back(std::make_unique<o2::emcal::ClusterFactory<o2::emcal::Cell>>());
+      LOG(info) << "Cluster definition initialized: " << clusterDefinition.toString();
+    }
+    for (auto& clusterizer : mClusterizers) {
+      clusterizer->setGeometry(geometry);
+    }
+
+    if (mClusterizers.size() == 0) {
+      LOG(error) << "No cluster definitions specified!";
+    }
+
     LOG(debug) << "Completed init!";
 
     // Setup QA hists.
@@ -146,9 +155,9 @@ struct EmcalCorrectionTask {
     for (auto& cell : mEmcalCells) {
       hCellE->Fill(cell.getEnergy());
       hCellTowerID->Fill(cell.getTower());
-      auto res = mClusterizer->getGeometry()->EtaPhiFromIndex(cell.getTower());
+      auto res = mClusterizers.at(0)->getGeometry()->EtaPhiFromIndex(cell.getTower());
       hCellEtaPhi->Fill(std::get<0>(res), TVector2::Phi_0_2pi(std::get<1>(res)));
-      res = mClusterizer->getGeometry()->GlobalRowColFromIndex(cell.getTower());
+      res = mClusterizers.at(0)->getGeometry()->GlobalRowColFromIndex(cell.getTower());
       // NOTE: Reversed column and row because it's more natural for presentatin.
       hCellRowCol->Fill(std::get<1>(res), std::get<0>(res));
     }
@@ -160,70 +169,92 @@ struct EmcalCorrectionTask {
     }
 
     LOG(debug) << "Converted cells. Contains: " << mEmcalCells.size() << ". Originally " << cells.size() << ". About to run clusterizer.";
+    // this is a test
+    // Run the clusterizers
+    LOG(debug) << "Running clusterizers";
+    Int_t i = 0;
+    for (auto& clusterizer : mClusterizers) {
+      clusterizer->findClusters(mEmcalCells);
 
-    // Run the clusterizer
-    mClusterizer->findClusters(mEmcalCells);
-    LOG(debug) << "Found clusters.";
-    auto emcalClusters = mClusterizer->getFoundClusters();
-    auto emcalClustersInputIndices = mClusterizer->getFoundClustersInputIndices();
-    LOG(debug) << "Retrieved results. About to setup cluster factory.";
+      auto emcalClusters = clusterizer->getFoundClusters();
+      auto emcalClustersInputIndices = clusterizer->getFoundClustersInputIndices();
+      LOG(debug) << "Retrieved results. About to setup cluster factory.";
 
-    // Convert to analysis clusters.
-    // First, the cluster factory requires cluster and cell information in order to build the clusters.
-    mAnalysisClusters.clear();
-    mClusterFactory->reset();
-    mClusterFactory->setClustersContainer(*emcalClusters);
-    mClusterFactory->setCellsContainer(mEmcalCells);
-    mClusterFactory->setCellsIndicesContainer(*emcalClustersInputIndices);
-    LOG(debug) << "Cluster factory set up.";
+      // Convert to analysis clusters.
+      // First, the cluster factory requires cluster and cell information in order to build the clusters.
+      mAnalysisClusters.clear();
+      mClusterFactories.at(i)->reset();
+      mClusterFactories.at(i)->setClustersContainer(*emcalClusters);
+      mClusterFactories.at(i)->setCellsContainer(mEmcalCells);
+      mClusterFactories.at(i)->setCellsIndicesContainer(*emcalClustersInputIndices);
+      LOG(debug) << "Cluster factory set up.";
 
-    // Convert to analysis clusters.
-    for (int icl = 0; icl < mClusterFactory->getNumberOfClusters(); icl++) {
-      auto analysisCluster = mClusterFactory->buildCluster(icl);
-      mAnalysisClusters.emplace_back(analysisCluster);
-    }
-    LOG(debug) << "Converted to analysis clusters.";
-
-    float vx = 0, vy = 0, vz = 0;
-    bool hasCollision = false;
-    if (collisions.size() > 1) {
-      LOG(error) << "More than one collision in the bc. This is not supported.";
-    } else {
-      for (const auto& col : collisions) {
-        if (col.bc() != bc) {
-          continue;
-        }
-        vx = col.posX();
-        vy = col.posY();
-        vz = col.posZ();
-        hasCollision = true;
+      // Convert to analysis clusters.
+      for (int icl = 0; icl < mClusterFactories.at(i)->getNumberOfClusters(); icl++) {
+        auto analysisCluster = mClusterFactories.at(i)->buildCluster(icl);
+        mAnalysisClusters.emplace_back(analysisCluster);
       }
-    }
-    if (!hasCollision) {
-      LOG(warning) << "No vertex found for event. Assuming (0,0,0).";
-    }
+      LOG(debug) << "Converted to analysis clusters.";
 
-    // Store the clusters in the table
-    clusters.reserve(mAnalysisClusters.size());
-    for (const auto& cluster : mAnalysisClusters) {
-      // Determine the cluster eta, phi, correcting for the vertex position.
-      auto pos = cluster.getGlobalPosition();
-      pos = pos - math_utils::Point3D<float>{vx, vy, vz};
-      // Normalize the vector and rescale by energy.
-      pos *= (cluster.E() / std::sqrt(pos.Mag2()));
+      float vx = 0, vy = 0, vz = 0;
+      bool hasCollision = false;
+      if (collisions.size() > 1) {
+        LOG(error) << "More than one collision in the bc. This is not supported.";
+      } else {
+        // dummy loop to get the first collision
+        for (const auto& col : collisions) {
+          vx = col.posX();
+          vy = col.posY();
+          vz = col.posZ();
+          hasCollision = true;
 
-      // We have our necessary properties. Now we store outputs
+          // we found a collision, put the clusters into the none ambiguous table
+          clusters.reserve(mAnalysisClusters.size());
+          for (const auto& cluster : mAnalysisClusters) {
 
-      // LOG(debug) << "Cluster E: " << cluster.E();
-      clusters(bc, cluster.getID(), cluster.E(), cluster.getCoreEnergy(), pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()),
-               cluster.getM02(), cluster.getM20(), cluster.getNCells(), cluster.getClusterTime(),
-               cluster.getIsExotic(), cluster.getDistanceToBadChannel(), cluster.getNExMax());
-      // if (cluster.E() < 0.300) {
-      //     continue;
-      // }
-      hClusterE->Fill(cluster.E());
-      hClusterEtaPhi->Fill(pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()));
-    }
+            // Determine the cluster eta, phi, correcting for the vertex position.
+            auto pos = cluster.getGlobalPosition();
+            pos = pos - math_utils::Point3D<float>{vx, vy, vz};
+            // Normalize the vector and rescale by energy.
+            pos *= (cluster.E() / std::sqrt(pos.Mag2()));
+
+            // save to table
+            LOG(debug) << "Writing cluster definition " << static_cast<int>(mClusterDefinitions.at(i)) << " to table.";
+            clusters(col, cluster.getID(), cluster.E(), cluster.getCoreEnergy(), pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()),
+                     cluster.getM02(), cluster.getM20(), cluster.getNCells(), cluster.getClusterTime(),
+                     cluster.getIsExotic(), cluster.getDistanceToBadChannel(), cluster.getNExMax(), static_cast<int>(mClusterDefinitions.at(i)));
+
+            // fill histograms
+            hClusterE->Fill(cluster.E());
+            hClusterEtaPhi->Fill(pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()));
+          } // end of cluster loop
+        }   // end of collision loop
+      }
+      if (!hasCollision) {
+        LOG(warning) << "No vertex found for event. Assuming (0,0,0).";
+      }
+
+      // Store the clusters in the table where a mathcing collision could
+      // be identified.
+      if (!hasCollision) { // ambiguous
+        clustersAmbiguous.reserve(mAnalysisClusters.size());
+        for (const auto& cluster : mAnalysisClusters) {
+          auto pos = cluster.getGlobalPosition();
+          pos = pos - math_utils::Point3D<float>{vx, vy, vz};
+          // Normalize the vector and rescale by energy.
+          pos *= (cluster.E() / std::sqrt(pos.Mag2()));
+
+          // We have our necessary properties. Now we store outputs
+
+          // LOG(debug) << "Cluster E: " << cluster.E();
+          clustersAmbiguous(bc, cluster.getID(), cluster.E(), cluster.getCoreEnergy(), pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()),
+                            cluster.getM02(), cluster.getM20(), cluster.getNCells(), cluster.getClusterTime(),
+                            cluster.getIsExotic(), cluster.getDistanceToBadChannel(), cluster.getNExMax(), static_cast<int>(mClusterDefinitions.at(i)));
+        }
+      }
+      LOG(debug) << "Cluster loop done for clusterizer " << i;
+      i++;
+    } // end of clusterizer loop
     LOG(debug) << "Done with process.";
   }
 };

--- a/PWGJE/Tasks/emcclustermonitor.cxx
+++ b/PWGJE/Tasks/emcclustermonitor.cxx
@@ -50,30 +50,36 @@
 /// Simple event selection using the flag doEventSel is provided, which selects INT7 events if set to 1
 /// For pilot beam data, instead of relying on the event selection, one can veto specific BC IDS using the flag
 /// fDoVetoBCID.
-
+using namespace o2::framework;
+using namespace o2::framework::expressions;
 using collisionEvSelIt = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels>::iterator;
-
+using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
 struct ClusterMonitor {
-  o2::framework::HistogramRegistry mHistManager{"ClusterMonitorHistograms"};
+  HistogramRegistry mHistManager{"ClusterMonitorHistograms"};
   o2::emcal::Geometry* mGeometry = nullptr;
 
   // configurable parameters
   // TODO adapt mDoEventSel switch to also allow selection of other triggers (e.g. EMC7)
-  o2::framework::Configurable<bool> mDoEventSel{"doEventSel", 0, "demand kINT7"};
-  o2::framework::Configurable<std::string> mVetoBCID{"vetoBCID", "", "BC ID(s) to be excluded, this should be used as an alternative to the event selection"};
-  o2::framework::Configurable<std::string> mSelectBCID{"selectBCID", "all", "BC ID(s) to be included, this should be used as an alternative to the event selection"};
-  o2::framework::Configurable<double> mVertexCut{"vertexCut", -1, "apply z-vertex cut with value in cm"};
+  Configurable<bool> mDoEventSel{"doEventSel", 0, "demand kINT7"};
+  Configurable<std::string> mVetoBCID{"vetoBCID", "", "BC ID(s) to be excluded, this should be used as an alternative to the event selection"};
+  Configurable<std::string> mSelectBCID{"selectBCID", "all", "BC ID(s) to be included, this should be used as an alternative to the event selection"};
+  Configurable<double> mVertexCut{"vertexCut", -1, "apply z-vertex cut with value in cm"};
+  Configurable<std::string> mClusterDefinition{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
   std::vector<int> mVetoBCIDs;
   std::vector<int> mSelectBCIDs;
 
-  // TODO add multiple configurables that allow to cut on cluster properties
+  // define cluster filter. It selects only those clusters which are of the type
+  // specified in the string mClusterDefinition,e.g. kV3Default, which is V3 clusterizer with default
+  // clusterization parameters
+  o2::aod::EMCALClusterDefinition clusDef = o2::aod::emcalcluster::getClusterDefinitionFromString(mClusterDefinition.value);
+  Filter clusterDefinitionSelection = o2::aod::emcalcluster::definition == static_cast<int>(clusDef);
 
   /// \brief Create output histograms and initialize geometry
-  void init(o2::framework::InitContext const&)
+  void init(InitContext const&)
   {
     // create histograms
-    using o2HistType = o2::framework::HistType;
-    using o2Axis = o2::framework::AxisSpec;
+    using o2HistType = HistType;
+    using o2Axis = AxisSpec;
 
     // load geometry just in case we need it
     mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
@@ -98,6 +104,7 @@ struct ClusterMonitor {
 
     // cluster properties
     mHistManager.add("clusterE", "Energy of cluster", o2HistType::kTH1F, {energyAxis});
+    mHistManager.add("clusterE_SimpleBinning", "Energy of cluster", o2HistType::kTH1F, {{400, 0, 100}});
     mHistManager.add("clusterEtaPhi", "Eta and phi of cluster", o2HistType::kTH2F, {{100, -1, 1}, {100, 0, 2 * TMath::Pi()}});
     mHistManager.add("clusterM02", "M02 of cluster", o2HistType::kTH1F, {{400, 0, 5}});
     mHistManager.add("clusterM20", "M20 of cluster", o2HistType::kTH1F, {{400, 0, 2.5}});
@@ -127,8 +134,8 @@ struct ClusterMonitor {
       }
     }
   }
-  /// \brief Process EMCAL clusters
-  void process(collisionEvSelIt const& theCollision, o2::aod::EMCALClusters const& clusters, o2::aod::BCs const& bcs)
+  /// \brief Process EMCAL clusters that are matched to a collisions
+  void process(collisionEvSelIt const& theCollision, selectedClusters const& clusters, o2::aod::BCs const& bcs)
   {
     mHistManager.fill(HIST("eventsAll"), 1);
 
@@ -136,12 +143,12 @@ struct ClusterMonitor {
     // currently the event selection is hard coded to kINT7
     // but other selections are possible that are defined in TriggerAliases.h
     if (mDoEventSel && (!theCollision.alias()[kINT7])) {
-      LOG(info) << "Event not selected becaus it is not kINT7, skipping";
+      LOG(debug) << "Event not selected becaus it is not kINT7, skipping";
       return;
     }
     mHistManager.fill(HIST("eventVertexZAll"), theCollision.posZ());
-    if (mVertexCut > 0 && theCollision.posZ() > mVertexCut) {
-      LOG(info) << "Event not selected because of z-vertex cut z= " << theCollision.posZ() << " > " << mVertexCut << " cm, skipping";
+    if (mVertexCut > 0 && TMath::Abs(theCollision.posZ()) > mVertexCut) {
+      LOG(debug) << "Event not selected because of z-vertex cut z= " << theCollision.posZ() << " > " << mVertexCut << " cm, skipping";
       return;
     }
     mHistManager.fill(HIST("eventsSelected"), 1);
@@ -149,6 +156,7 @@ struct ClusterMonitor {
 
     // loop over bc , if requested (mVetoBCID >= 0), reject everything from a certain BC
     // this can be used as alternative to event selection (e.g. for pilot beam data)
+    // TODO: remove this loop and put it in separate process function that only takes care of ambiguous clusters
     for (const auto& bc : bcs) {
       o2::InteractionRecord eventIR;
       eventIR.setFromLong(bc.globalBC());
@@ -164,24 +172,18 @@ struct ClusterMonitor {
     }
 
     // loop over all clusters from accepted collision
+    // auto eventClusters = clusters.select(o2::aod::emcalcluster::bcId == theCollision.bc().globalBC());
     for (const auto& cluster : clusters) {
       // fill histograms of cluster properties
       // in this implementation the cluster properties are directly
       // loaded from the flat table, in the future one should
       // consider using the AnalysisCluster object to work with
       // after loading.
-      o2::InteractionRecord eventIR;
-      eventIR.setFromLong(cluster.bc().globalBC());
-      if (std::find(mVetoBCIDs.begin(), mVetoBCIDs.end(), eventIR.bc) != mVetoBCIDs.end()) {
-        continue;
-      }
-      if (mSelectBCIDs.size() && (std::find(mSelectBCIDs.begin(), mSelectBCIDs.end(), eventIR.bc) == mSelectBCIDs.end())) {
-        continue;
-      }
       LOG(debug) << "Cluster energy: " << cluster.energy();
       LOG(debug) << "Cluster time: " << cluster.time();
       LOG(debug) << "Cluster M02: " << cluster.m02();
       mHistManager.fill(HIST("clusterE"), cluster.energy());
+      mHistManager.fill(HIST("clusterE_SimpleBinning"), cluster.energy());
       mHistManager.fill(HIST("clusterEtaPhi"), cluster.eta(), cluster.phi());
       mHistManager.fill(HIST("clusterM02"), cluster.m02());
       mHistManager.fill(HIST("clusterM20"), cluster.m20());
@@ -219,27 +221,35 @@ struct ClusterMonitor {
   /// \return vector with bin limits
   std::vector<double> makeEnergyBinningAliPhysics() const
   {
-    
+
     std::vector<double> result;
     Int_t nBinsClusterE = 235;
-    for(Int_t i=0; i<nBinsClusterE+1;i++){
-      if (i < 1) result.emplace_back(0.3*i);
-      else if(i<55) result.emplace_back(0.3+0.05*(i-1));
-      else if(i<105) result.emplace_back(3.+0.1*(i-55));
-      else if(i<140) result.emplace_back(8.+0.2*(i-105));
-      else if(i<170) result.emplace_back(15.+0.5*(i-140));
-      else if(i<190) result.emplace_back(30.+1.0*(i-170));
-      else if(i<215) result.emplace_back(50.+2.0*(i-190));
-      else if(i<235) result.emplace_back(100.+5.0*(i-215));
-      else if(i<245) result.emplace_back(200.+10.0*(i-235));
-      
+    for (Int_t i = 0; i < nBinsClusterE + 1; i++) {
+      if (i < 1)
+        result.emplace_back(0.3 * i);
+      else if (i < 55)
+        result.emplace_back(0.3 + 0.05 * (i - 1));
+      else if (i < 105)
+        result.emplace_back(3. + 0.1 * (i - 55));
+      else if (i < 140)
+        result.emplace_back(8. + 0.2 * (i - 105));
+      else if (i < 170)
+        result.emplace_back(15. + 0.5 * (i - 140));
+      else if (i < 190)
+        result.emplace_back(30. + 1.0 * (i - 170));
+      else if (i < 215)
+        result.emplace_back(50. + 2.0 * (i - 190));
+      else if (i < 235)
+        result.emplace_back(100. + 5.0 * (i - 215));
+      else if (i < 245)
+        result.emplace_back(200. + 10.0 * (i - 235));
     }
     return result;
   }
 };
 
-o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return o2::framework::WorkflowSpec{
-    o2::framework::adaptAnalysisTask<ClusterMonitor>(cfgc)};
+  return WorkflowSpec{
+    adaptAnalysisTask<ClusterMonitor>(cfgc)};
 }


### PR DESCRIPTION
This PR is the beginning of the efforts to solve two problems:
1. Allow multiple clusterizers to run at the same time, even though there is only a single table for emcal clusters
2. Deal with clusters that could not be matched to a collisions ID

The first problem is solved by introducing a EMCalClusterDefinition class that contains all the information about what is considered as a cluster. This information is then stored as an int in the cluster table. It has the added advantage that it can also be used for easy steering of the EMCal correction framework. In the current implementation, the correction framework can be given an arbitrary number of cluster definitions as a string separated by commas.

The second problem is solved by using two exclusive tables, where one table contains clusters which could not be matched to a collisionID, which uses the BCID as an index. For clusters that could be matched to a collision the table uses collisionID as an index.

The task [PWGJE/Tasks/emcclustermonitor.cxx] illustrates how to access clusters that were matched to a collision. The requested ClusterDefinition can be given by the user as a string. Once the framework evolves to allow backwards communication, the correctionframework could check what clusterdefinitions are requested by the various tasks.

In the future a second process function will be added to the emcclustermonitor to illustrate how to access ambigous clusters and cut on the BCIDs. In addition, some work is still needed to validate the clusterizer and matching to collisionID