### PR TITLE
Set to 0 indices between iterations

### DIFF
--- a/Common/Core/aodMerger.cxx
+++ b/Common/Core/aodMerger.cxx
@@ -24,7 +24,6 @@
 #include <TGrid.h>
 #include <TMap.h>
 #include <TLeaf.h>
-#include <iostream>
 
 const char* removeVersionSuffix(const char* treeName)
 {
@@ -315,7 +314,7 @@ int main(int argc, char* argv[])
         auto newMinIndexOffset = minIndexOffset;
         for (int i = 0; i < entries; i++) {
           for (auto& index : indexList) {
-            *(index.first) = 0;
+            *(index.first) = 0; // Any positive number will do, in any case it will not be filled in the output. Otherwise the previous entry is used and manipulated in the following.
           }
           inputTree->GetEntry(i);
           // shift index columns by offset

--- a/Common/Core/aodMerger.cxx
+++ b/Common/Core/aodMerger.cxx
@@ -24,6 +24,7 @@
 #include <TGrid.h>
 #include <TMap.h>
 #include <TLeaf.h>
+#include <iostream>
 
 const char* removeVersionSuffix(const char* treeName)
 {
@@ -313,6 +314,9 @@ int main(int argc, char* argv[])
         int minIndexOffset = unassignedIndexOffset[treeName];
         auto newMinIndexOffset = minIndexOffset;
         for (int i = 0; i < entries; i++) {
+          for (auto& index : indexList) {
+            *(index.first) = 0;
+          }
           inputTree->GetEntry(i);
           // shift index columns by offset
           for (const auto& idx : indexList) {


### PR DESCRIPTION
Hi @jgrosseo,

we started this debug long ago, but still surprise come along... My understanding is that if we have a VLA long `n` and in the following iteration we have `n-1` we have 1 slot with memory not managed where apparently from time to time we get rubbish. This fixes my local reproducer, @chiarazampolli is also checking with her reproducer.

Cheers,
Max
