### PR TITLE
Remove string-based use of block combinations

### DIFF
--- a/PWGCF/Tasks/correlations.cxx
+++ b/PWGCF/Tasks/correlations.cxx
@@ -327,6 +327,7 @@ struct CorrelationTask {
   }
   PROCESS_SWITCH(CorrelationTask, processSameDerived, "Process same event on derived data", false);
 
+  NoBinningPolicy<aod::hash::Bin> hashBin;
   void processMixedAOD(soa::Filtered<soa::Join<aod::Collisions, aod::Hashes, aod::EvSels, aod::CentRun2V0Ms>>& collisions, aodTracks const& tracks, aod::BCsWithTimestamps const&)
   {
     // TODO loading of efficiency histogram missing here, because it will happen somehow in the CCDBConfigurable
@@ -336,7 +337,7 @@ struct CorrelationTask {
     GroupSlicer slicer(collisions, tracksTuple);
 
     // Strictly upper categorised collisions, for cfgNoMixedEvents combinations per bin, skipping those in entry -1
-    for (auto& [collision1, collision2] : selfCombinations("fBin", cfgNoMixedEvents, -1, collisions, collisions)) {
+    for (auto& [collision1, collision2] : selfCombinations(hashBin, cfgNoMixedEvents, -1, collisions, collisions)) {
 
       LOGF(info, "processMixedAOD: Mixed collisions bin: %d pair: %d (%.3f, %.3f), %d (%.3f, %.3f)", collision1.bin(), collision1.globalIndex(), collision1.posZ(), collision1.centRun2V0M(), collision2.globalIndex(), collision2.posZ(), collision2.centRun2V0M());
 
@@ -386,7 +387,7 @@ struct CorrelationTask {
     GroupSlicer slicer(collisions, tracksTuple);
 
     // Strictly upper categorised collisions, for cfgNoMixedEvents combinations per bin, skipping those in entry -1
-    for (auto& [collision1, collision2] : selfCombinations("fBin", cfgNoMixedEvents, -1, collisions, collisions)) {
+    for (auto& [collision1, collision2] : selfCombinations(hashBin, cfgNoMixedEvents, -1, collisions, collisions)) {
 
       LOGF(info, "processMixedDerived: Mixed collisions bin: %d pair: %d (%.3f, %.3f), %d (%.3f, %.3f)", collision1.bin(), collision1.globalIndex(), collision1.posZ(), collision1.centRun2V0M(), collision2.globalIndex(), collision2.posZ(), collision2.centRun2V0M());
 

--- a/PWGDQ/Tasks/dileptonEE.cxx
+++ b/PWGDQ/Tasks/dileptonEE.cxx
@@ -225,7 +225,7 @@ struct DileptonEE {
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
   std::vector<AnalysisCompositeCut> fPairCuts;
-  //NOTE: one could define also a dilepton cut, but for now basic selections can be supported using Partition
+  // NOTE: one could define also a dilepton cut, but for now basic selections can be supported using Partition
 
   float* fValues;
 
@@ -348,11 +348,13 @@ struct DQEventMixing {
   float* fValues;
   std::vector<TString> fCutNames;
 
-  //Configurable<std::string> fConfigElectronCuts{"cfgElectronCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  // Configurable<std::string> fConfigElectronCuts{"cfgElectronCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
   Configurable<std::string> fConfigElectronCuts{"cfgElectronCuts", "lmeePID_TPChadrej,lmeePID_TOFrec,lmeePID_TPChadrejTOFrec", "Comma separated list of barrel track cuts"};
 
   Filter filterEventSelected = aod::reducedevent::isEventSelected == 1;
   Filter filterTrackSelected = aod::reducedtrack::isBarrelSelected > uint8_t(0);
+
+  NoBinningPolicy<aod::reducedevent::MixingHash> hashBin;
 
   void init(o2::framework::InitContext&)
   {
@@ -387,7 +389,7 @@ struct DQEventMixing {
     GroupSlicer slicerTracks(events, tracksTuple);
 
     // Strictly upper categorised collisions, for 100 combinations per bin, skipping those in entry -1
-    for (auto& [event1, event2] : selfCombinations("fMixingHash", 10, -1, events, events)) {
+    for (auto& [event1, event2] : selfCombinations(hashBin, 10, -1, events, events)) {
 
       // event informaiton is required to fill histograms where both event and pair information is required (e.g. inv.mass vs centrality)
       VarManager::ResetValues(0, VarManager::kNVars, fValues);

--- a/PWGDQ/Tasks/dileptonMuMu.cxx
+++ b/PWGDQ/Tasks/dileptonMuMu.cxx
@@ -232,6 +232,8 @@ struct DQEventMixing {
   Filter filterMuonTrackSelected = aod::reducedtrack::isMuonSelected > uint8_t(0);
   std::vector<TString> fCentBinNames;
 
+  NoBinningPolicy<aod::reducedevent::MixingHash> hashBin;
+
   void init(o2::framework::InitContext&)
   {
     fValues = new float[VarManager::kNVars];
@@ -257,7 +259,7 @@ struct DQEventMixing {
     GroupSlicer slicerMuons(events, muonsTuple);
 
     // Strictly upper categorised collisions, for 100 combinations per bin, skipping those in entry -1
-    for (auto& [event1, event2] : selfCombinations("fMixingHash", 100, -1, events, events)) {
+    for (auto& [event1, event2] : selfCombinations(hashBin, 100, -1, events, events)) {
 
       // event informaiton is required to fill histograms where both event and pair information is required (e.g. inv.mass vs centrality)
       VarManager::ResetValues(0, VarManager::kNVars, fValues);

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -83,7 +83,7 @@ using MyMuonTracksSelectedWithCov = soa::Join<aod::ReducedMuons, aod::ReducedMuo
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
 constexpr static uint32_t gkEventFillMapWithCov = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended | VarManager::ObjTypes::ReducedEventVtxCov;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID;
-//constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
+// constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra;
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
 
@@ -363,6 +363,8 @@ struct AnalysisEventMixing {
   std::vector<std::vector<TString>> fMuonHistNames;
   std::vector<std::vector<TString>> fTrackMuonHistNames;
 
+  NoBinningPolicy<aod::reducedevent::MixingHash> hashBin;
+
   void init(o2::framework::InitContext& context)
   {
     VarManager::SetDefaultVarNames();
@@ -485,7 +487,7 @@ struct AnalysisEventMixing {
     events.bindExternalIndices(&tracks);
     auto tracksTuple = std::make_tuple(tracks);
     GroupSlicer slicerTracks(events, tracksTuple);
-    for (auto& [event1, event2] : selfCombinations("fMixingHash", 100, -1, events, events)) {
+    for (auto& [event1, event2] : selfCombinations(hashBin, 100, -1, events, events)) {
       VarManager::ResetValues(0, VarManager::kNVars);
       VarManager::FillEvent<TEventFillMap>(event1, VarManager::fgValues);
       auto it1 = slicerTracks.begin();
@@ -520,7 +522,7 @@ struct AnalysisEventMixing {
     auto muonsTuple = std::make_tuple(muons);
     GroupSlicer slicerTracks(events, tracksTuple);
     GroupSlicer slicerMuons(events, muonsTuple);
-    for (auto& [event1, event2] : selfCombinations("fMixingHash", 100, -1, events, events)) {
+    for (auto& [event1, event2] : selfCombinations(hashBin, 100, -1, events, events)) {
       VarManager::ResetValues(0, VarManager::kNVars);
       VarManager::FillEvent<TEventFillMap>(event1, VarManager::fgValues);
       auto it1 = slicerTracks.begin();


### PR DESCRIPTION
After this, backward compability will be removed from O2.