### PR TITLE
incremental update: add INEL>0 condition

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -34,6 +34,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(MultFDDM, multFDDM, //!
 DECLARE_SOA_COLUMN(MultTracklets, multTracklets, int);
 DECLARE_SOA_COLUMN(MultTPC, multTPC, int);
 DECLARE_SOA_COLUMN(MultNTracksPV, multNTracksPV, int);
+DECLARE_SOA_COLUMN(MultNTracksPVeta1, multNTracksPVeta1, int);
 
 } // namespace mult
 DECLARE_SOA_TABLE(Mults, "AOD", "MULT", //!
@@ -46,7 +47,8 @@ DECLARE_SOA_TABLE(Mults, "AOD", "MULT", //!
                   mult::MultFDDM<mult::MultFDDA, mult::MultFDDC>,
                   mult::MultTracklets,
                   mult::MultTPC,
-                  mult::MultNTracksPV);
+                  mult::MultNTracksPV,
+                  mult::MultNTracksPVeta1);
 using Mult = Mults::iterator;
 
 namespace multZeq

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -37,6 +37,7 @@ struct MultiplicityTableTaskIndexed {
   Partition<soa::Join<aod::Tracks, aod::TracksExtra>> run2tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
   Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
   Partition<soa::Join<aod::Tracks, aod::TracksExtra>> pvContribTracks = (nabs(aod::track::eta) < 0.8f) && ((aod::track::flags & (uint32_t)o2::aod::track::PVContributor) == (uint32_t)o2::aod::track::PVContributor);
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> pvContribTracksEta1 = (nabs(aod::track::eta) < 1.0f) && ((aod::track::flags & (uint32_t)o2::aod::track::PVContributor) == (uint32_t)o2::aod::track::PVContributor);
 
   int mRunNumber;
   bool lCalibLoaded;
@@ -81,6 +82,7 @@ struct MultiplicityTableTaskIndexed {
     int multTracklets = trackletsGrouped.size();
     int multTPC = tracksGrouped.size();
     int multNContribs = 0;
+    int multNContribsEta1 = 0;
 
     if (collision.has_fv0a()) {
       for (auto amplitude : collision.fv0a().amplitude()) {
@@ -108,7 +110,7 @@ struct MultiplicityTableTaskIndexed {
     }
 
     LOGF(debug, "multFV0A=%5.0f multFV0C=%5.0f multFT0A=%5.0f multFT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
-    mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs);
+    mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs, multNContribsEta1);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", true);
 
@@ -133,8 +135,10 @@ struct MultiplicityTableTaskIndexed {
 
     auto tracksGrouped = tracksWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex());
     auto pvContribsGrouped = pvContribTracks->sliceByCached(aod::track::collisionId, collision.globalIndex());
+    auto pvContribsEta1Grouped = pvContribTracksEta1->sliceByCached(aod::track::collisionId, collision.globalIndex());
     int multTPC = tracksGrouped.size();
     int multNContribs = pvContribsGrouped.size();
+    int multNContribsEta1 = pvContribsEta1Grouped.size();
 
     /* check the previous run number */
     auto bc = collision.bc();
@@ -193,7 +197,7 @@ struct MultiplicityTableTaskIndexed {
     }
 
     LOGF(debug, "multFV0A=%5.0f multFV0C=%5.0f multFT0A=%5.0f multFT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
-    mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs);
+    mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs, multNContribsEta1);
     multzeq(multZeqFV0A, multZeqFT0A, multZeqFT0C, multZeqFDDA, multZeqFDDC, multZeqNContribs);
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", false);

--- a/Common/Tasks/multiplicityQa.cxx
+++ b/Common/Tasks/multiplicityQa.cxx
@@ -39,6 +39,7 @@ struct MultiplicityQa {
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Configurable<int> selection{"sel", 7, "trigger: 7 - sel7, 8 - sel8"};
   Configurable<float> vtxZsel{"vtxZsel", 10, "max vertex Z (cm)"};
+  Configurable<bool> INELgtZERO{"INELgtZERO", 1, "0 - no, 1 - yes"};
 
   Configurable<int> NBinsMultFV0{"NBinsMultFV0", 1000, "N bins FV0"};
   Configurable<int> NBinsMultFT0{"NBinsMultFT0", 1000, "N bins FT0"};
@@ -93,6 +94,10 @@ struct MultiplicityQa {
       LOGF(fatal, "Unknown selection type! Use `--sel 7` or `--sel 8`");
     }
     histos.fill(HIST("multiplicityQa/hEventCounter"), 1.5);
+    if (INELgtZERO && col.multNTracksPVeta1() < 1) {
+      return;
+    }
+    histos.fill(HIST("multiplicityQa/hEventCounter"), 2.5);
 
     //Vertex-Z dependencies, necessary for CCDB objects
     histos.fill(HIST("multiplicityQa/hVtxZFV0A"), col.posZ(), col.multFV0A());
@@ -106,7 +111,7 @@ struct MultiplicityQa {
       return;
     }
 
-    histos.fill(HIST("multiplicityQa/hEventCounter"), 2.5);
+    histos.fill(HIST("multiplicityQa/hEventCounter"), 3.5);
 
     LOGF(debug, "multFV0A=%5.0f multFV0C=%5.0f multFV0M=%5.0f multFT0A=%5.0f multFT0C=%5.0f multFT0M=%5.0f multFDDA=%5.0f multFDDC=%5.0f", col.multFV0A(), col.multFV0C(), col.multFV0M(), col.multFT0A(), col.multFT0C(), col.multFT0M(), col.multFDDA(), col.multFDDC());
 


### PR DESCRIPTION
As per discussions in the WP4+WP14 meetings, this PR adds an INEL>0 switch to the multiplicityQa task so that pp collisions can be calibrated as they were in Run 2: with an INEL>0 (at least one charged particle within |eta|<1.0) condition applied to the calibration sample. 