### PR TITLE
Adding additional cuts to reduce the size of the output

### DIFF
--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -203,6 +203,29 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("lmeePID_TPChadrejTOFrecRun3")) {
+    cut->AddCut(GetAnalysisCut("lmeeLowBKine"));
+    cut->AddCut(GetAnalysisCut("TightGlobalTrackRun3"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+
+    AnalysisCompositeCut* cut_tpc_hadrej = new AnalysisCompositeCut("pid_TPChadrej", "pid_TPChadrej", kTRUE);
+    cut_tpc_hadrej->AddCut(GetAnalysisCut("tpc_electron"));
+    cut_tpc_hadrej->AddCut(GetAnalysisCut("tpc_pion_rejection_highp"));
+    cut_tpc_hadrej->AddCut(GetAnalysisCut("tpc_kaon_rejection"));
+    cut_tpc_hadrej->AddCut(GetAnalysisCut("tpc_proton_rejection"));
+
+    AnalysisCompositeCut* cut_tof_rec = new AnalysisCompositeCut("pid_tof_rec", "pid_tof_rec", kTRUE);
+    cut_tof_rec->AddCut(GetAnalysisCut("tpc_electron"));
+    cut_tof_rec->AddCut(GetAnalysisCut("tof_electron_loose"));
+    cut_tof_rec->AddCut(GetAnalysisCut("tpc_pion_rejection_highp"));
+
+    AnalysisCompositeCut* cut_pid_OR = new AnalysisCompositeCut("pid_TPChadrejTOFrec", "pid_TPChadrejTOFrec", kFALSE);
+    cut_pid_OR->AddCut(cut_tpc_hadrej);
+    cut_pid_OR->AddCut(cut_tof_rec);
+    cut->AddCut(cut_pid_OR);
+    return cut;
+  }
+
   if (!nameStr.compare("lmeePID_TPChadrej")) {
     cut->AddCut(GetAnalysisCut("lmeeStandardKine"));
     cut->AddCut(GetAnalysisCut("TightGlobalTrack"));
@@ -251,7 +274,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
-    if (!nameStr.compare("lmee_GlobalTrackRun3_TPC_ePID_lowPt")) {
+  if (!nameStr.compare("lmee_GlobalTrackRun3_TPC_ePID_lowPt")) {
     cut->AddCut(GetAnalysisCut("lmeeLowBKine"));
     cut->AddCut(GetAnalysisCut("TightGlobalTrackRun3"));
     cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
@@ -545,6 +568,13 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("tpc_pion_rejection_highp")) {
+    TF1* f1minPi = new TF1("f1minPi", "[0]+[1]*x", 0, 10);
+    f1minPi->SetParameters(60, 4.);
+    cut->AddCut(VarManager::kTPCsignal, f1minPi, 90., true, VarManager::kPin, 0.0, 10, false);
+    return cut;
+  }
+
   if (!nameStr.compare("tpc_kaon_rejection")) {
     TF1* f1minKa = new TF1("f1minKa", "[0]+[1]*x", 0, 10);
     f1minKa->SetParameters(220, -300);
@@ -570,6 +600,11 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
 
   if (!nameStr.compare("tof_electron")) {
     cut->AddCut(VarManager::kTOFbeta, 0.99, 1.01, false, VarManager::kPin, 0.0, 1e+10, false);
+    return cut;
+  }
+
+  if (!nameStr.compare("tof_electron_loose")) {
+    cut->AddCut(VarManager::kTOFbeta, 0.95, 1.05, false, VarManager::kPin, 0.0, 1e+10, false);
     return cut;
   }
 

--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -251,6 +251,14 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+    if (!nameStr.compare("lmee_GlobalTrackRun3_TPC_ePID_lowPt")) {
+    cut->AddCut(GetAnalysisCut("lmeeLowBKine"));
+    cut->AddCut(GetAnalysisCut("TightGlobalTrackRun3"));
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrack"));
+    cut->AddCut(GetAnalysisCut("tpc_electron"));
+    return cut;
+  }
+
   if (!nameStr.compare("muonQualityCuts")) {
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
     return cut;


### PR DESCRIPTION
Adding two more cut settings for dielectric analysis:

- lmeePID_TPChadrejTOFrecRun3
- lmee_GlobalTrackRun3_TPC_ePID_lowPt

These apply loose and some stricter PID cuts to select electrons.

This should reduce the size of the output, necessary for a train.