### PR TITLE
PWGDQ: Correction to cut setting lmeePID_TPChadrejTOFrecRun3

### DIFF
--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -597,7 +597,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   if (!nameStr.compare("tpc_pion_rejection_highp")) {
     TF1* f1minPi = new TF1("f1minPi", "[0]+[1]*x", 0, 10);
     f1minPi->SetParameters(60, 4.);
-    cut->AddCut(VarManager::kTPCsignal, f1minPi, 90., true, VarManager::kPin, 0.0, 10, false);
+    cut->AddCut(VarManager::kTPCsignal, f1minPi, 90., false, VarManager::kPin, 0.0, 10, false);
     return cut;
   }
 


### PR DESCRIPTION
Resolving an issue of the current cut setting "lmeePID_TPChadrejTOFrecRun3" in PWGDQ/Core/CutsLibrary.h.

Currently the signal is rejected instead of kept.
By setting the 4th variable (which is responsible to exclude signal) to false, the selection is kept.

