### PR TITLE
[EMCAL-734] fixed cluster definition and added ambiguous clusters

### DIFF
--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -27,12 +27,12 @@ namespace emcalcluster
 // define global cluster definitions
 // the V1 algorithm is not yet implemented, but the V3 algorithm is
 // New definitions should be added here!
-const EMCALClusterDefinition kV1Default(ClusterAlgorithm_t::kV1, 0, 1, "kV1Default", 0.1, 0.5, -10000, 10000, 0.03);
-const EMCALClusterDefinition kV1Variation1(ClusterAlgorithm_t::kV3, 1, 1, "kV1Variation1", 0.1, 0.3, -10000, 10000, 0.03);
-const EMCALClusterDefinition kV1Variation2(ClusterAlgorithm_t::kV3, 2, 1, "kV1Variation2", 0.1, 0.2, -10000, 10000, 0.03);
-const EMCALClusterDefinition kV3Default(ClusterAlgorithm_t::kV3, 10, 1, "kV3Default", 0.1, 0.5, -10000, 10000, 0.03);
-const EMCALClusterDefinition kV3Variation1(ClusterAlgorithm_t::kV3, 11, 1, "kV3Variation1", 0.1, 0.3, -10000, 10000, 0.03);
-const EMCALClusterDefinition kV3Variation2(ClusterAlgorithm_t::kV3, 12, 1, "kV3Variation2", 0.1, 0.2, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV1Default(ClusterAlgorithm_t::kV1, 0, 1, "kV1Default", 0.5, 0.1, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV1Variation1(ClusterAlgorithm_t::kV3, 1, 1, "kV1Variation1", 0.3, 0.1, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV1Variation2(ClusterAlgorithm_t::kV3, 2, 1, "kV1Variation2", 0.2, 0.1, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Default(ClusterAlgorithm_t::kV3, 10, 1, "kV3Default", 0.5, 0.1, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Variation1(ClusterAlgorithm_t::kV3, 11, 1, "kV3Variation1", 0.3, 0.1, -10000, 10000, 0.03);
+const EMCALClusterDefinition kV3Variation2(ClusterAlgorithm_t::kV3, 12, 1, "kV3Variation2", 0.2, 0.1, -10000, 10000, 0.03);
 
 /// \brief function returns EMCALClusterDefinition for the given name
 /// \param name name of the cluster definition

--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -103,6 +103,11 @@ struct EmcalCorrectionTask {
       mClusterizers.emplace_back(std::make_unique<o2::emcal::Clusterizer<o2::emcal::Cell>>(1, clusterDefinition.timeMin, clusterDefinition.timeMax, clusterDefinition.gradientCut, true, clusterDefinition.seedEnergy, clusterDefinition.minCellEnergy));
       mClusterFactories.emplace_back(std::make_unique<o2::emcal::ClusterFactory<o2::emcal::Cell>>());
       LOG(info) << "Cluster definition initialized: " << clusterDefinition.toString();
+      LOG(info) << "timeMin: " << clusterDefinition.timeMin;
+      LOG(info) << "timeMax: " << clusterDefinition.timeMax;
+      LOG(info) << "gradientCut: " << clusterDefinition.gradientCut;
+      LOG(info) << "seedEnergy: " << clusterDefinition.seedEnergy;
+      LOG(info) << "minCellEnergy: " << clusterDefinition.minCellEnergy;
     }
     for (auto& clusterizer : mClusterizers) {
       clusterizer->setGeometry(geometry);
@@ -142,7 +147,6 @@ struct EmcalCorrectionTask {
       }
       // LOG(debug) << "Cell E: " << cell.getEnergy();
       // LOG(debug) << "Cell E: " << cell;
-
       mEmcalCells.emplace_back(o2::emcal::Cell(
         cell.cellNumber(),
         cell.amplitude(),
@@ -187,8 +191,8 @@ struct EmcalCorrectionTask {
       mClusterFactories.at(i)->setClustersContainer(*emcalClusters);
       mClusterFactories.at(i)->setCellsContainer(mEmcalCells);
       mClusterFactories.at(i)->setCellsIndicesContainer(*emcalClustersInputIndices);
-      LOG(debug) << "Cluster factory set up.";
 
+      LOG(debug) << "Cluster factory set up.";
       // Convert to analysis clusters.
       for (int icl = 0; icl < mClusterFactories.at(i)->getNumberOfClusters(); icl++) {
         auto analysisCluster = mClusterFactories.at(i)->buildCluster(icl);


### PR DESCRIPTION
- fixed a typo in the cluster definition where seed and aggregation threshold were swapper
- added processing function to cluster QA task that allows to process ambiguous clusters only (or pilot beam data where no vertex is available)