### PR TITLE
SliceBy, firstmother and DCA in sigma

### DIFF
--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -155,7 +155,8 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
       /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
         LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
       }*/
-      currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
+      currentMCParticle = currentMCParticle.template mothers_first_as<U>();
+      //currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
       //currentMCParticle = currentMCParticle.template mother0_as<U>();
     }
   }
@@ -210,7 +211,8 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
         /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
           LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
         }*/
-        currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
+	currentMCParticle = currentMCParticle.template mothers_first_as<U>();
+        //currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
         //currentMCParticle = currentMCParticle.template mother0_as<U>();
       }
       /*if (j < fProngs[i].fNGenerations - 1) {

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -661,7 +661,7 @@ void VarManager::FillTrack(T const& track, float* values)
       }
       values[kTrackDCAxy] = track.dcaXY();
       values[kTrackDCAz] = track.dcaZ();
-      if constexpr ((fillMap & TrackCov) > 0) {
+      if constexpr ((fillMap & ReducedTrackBarrelCov) > 0) {
         if (fgUsedVars[kTrackDCAsigXY]) {
           values[kTrackDCAsigXY] = track.dcaXY() / std::sqrt(track.cYY());
         }

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -791,6 +791,7 @@ struct AnalysisSameEventPairing {
 
     runPairing<VarManager::kJpsiToEE, gkEventFillMap, gkMCEventFillMap, gkTrackFillMap>(event, tracks, tracks, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
 
@@ -805,6 +806,7 @@ struct AnalysisSameEventPairing {
 
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMap, gkMCEventFillMap, gkMuonFillMap>(event, muons, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
 
@@ -819,6 +821,7 @@ struct AnalysisSameEventPairing {
 
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
 
@@ -1075,6 +1078,7 @@ struct AnalysisDileptonTrack {
   {
     runDileptonTrack<VarManager::kBcToThreeMuons, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, tracks, dileptons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
   void processDummy(MyEvents&)


### PR DESCRIPTION
Here is a fix for the internal index after sliceBy, a fix to fill the DCA in sigma variable in the varManager for reduced track, propose way to access to the first mother by Anton. 