### PR TITLE
fix caching behaviour for TPC CCDB objects

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -136,12 +136,12 @@ struct tpcPid {
       const std::string path = ccdbPath.value;
       const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      ccdb->setTimestamp(time);
+    //  ccdb->setTimestamp(time);
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-      response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      LOGP(info, "Loading TPC response from CCDB, using path: {} for ccdbTimestamp {}", path, time);
+    //  response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
+      LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }
 

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -134,14 +134,17 @@ struct tpcPid {
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
-      // const auto time = ccdbTimestamp.value;
+      const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      //  ccdb->setTimestamp(time);
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-      //  response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      LOGP(info, "Initialising default TPC PID response:");
+      if (time != 0) {
+        LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
+        ccdb->setTimestamp(time);
+        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
+      } else
+        LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }
 

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -134,7 +134,7 @@ struct tpcPid {
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
-      const auto time = ccdbTimestamp.value;
+      // const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
       //  ccdb->setTimestamp(time);
       ccdb->setCaching(true);

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -136,11 +136,11 @@ struct tpcPid {
       const std::string path = ccdbPath.value;
       const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-    //  ccdb->setTimestamp(time);
+      //  ccdb->setTimestamp(time);
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-    //  response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
+      //  response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
       LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -135,14 +135,18 @@ struct tpcPidFull {
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
-      // const auto time = ccdbTimestamp.value;
+      const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      // ccdb->setTimestamp(time);
+      
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-      // response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      LOGP(info, "Initialising default TPC PID response:");
+      if (time != 0) {
+        LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
+        ccdb->setTimestamp(time);
+        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
+      }
+      else LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }
 

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -137,12 +137,12 @@ struct tpcPidFull {
       const std::string path = ccdbPath.value;
       const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      ccdb->setTimestamp(time);
+      //ccdb->setTimestamp(time);
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-      response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      LOGP(info, "Loading TPC response from CCDB, using path: {} for ccdbTimestamp {}", path, time);
+      // response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
+      LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }
 
@@ -214,7 +214,7 @@ struct tpcPidFull {
       // }
     }
 
-    int lastCollisionId = -1; // Last collision ID analysed
+    int lastCollisionId = -999; // Last collision ID analysed
     unsigned long count_tracks = 0;
     const int tracks_size = tracks.size();
 
@@ -224,8 +224,7 @@ struct tpcPidFull {
         lastCollisionId = trk.collisionId();
         const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
         response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp()));
-      }
-
+      } 
       // Check and fill enabled tables
       auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracks_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {
         if (flag.value != 1) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -137,7 +137,7 @@ struct tpcPidFull {
       const std::string path = ccdbPath.value;
       const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      
+
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
@@ -145,8 +145,8 @@ struct tpcPidFull {
         LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
         ccdb->setTimestamp(time);
         response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      }
-      else LOGP(info, "Initialising default TPC PID response:");
+      } else
+        LOGP(info, "Initialising default TPC PID response:");
       response.PrintAll();
     }
 

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -214,7 +214,7 @@ struct tpcPidFull {
       // }
     }
 
-    int lastCollisionId = -999; // Last collision ID analysed
+    int lastCollisionId = -1; // Last collision ID analysed
     unsigned long count_tracks = 0;
     const int tracks_size = tracks.size();
 

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -135,7 +135,7 @@ struct tpcPidFull {
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
-      const auto time = ccdbTimestamp.value;
+      // const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
       // ccdb->setTimestamp(time);
       ccdb->setCaching(true);

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -224,7 +224,7 @@ struct tpcPidFull {
         lastCollisionId = trk.collisionId();
         const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
         response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp()));
-      } 
+      }
       // Check and fill enabled tables
       auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracks_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {
         if (flag.value != 1) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -137,7 +137,7 @@ struct tpcPidFull {
       const std::string path = ccdbPath.value;
       const auto time = ccdbTimestamp.value;
       ccdb->setURL(url.value);
-      //ccdb->setTimestamp(time);
+      // ccdb->setTimestamp(time);
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -43,12 +43,14 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "bb2", bpo::value<float>()->default_value(2.5266601063857674e-16f), "Bethe-Bloch parameter 2")(
     "bb3", bpo::value<float>()->default_value(2.7212300300598145f), "Bethe-Bloch parameter 3")(
     "bb4", bpo::value<float>()->default_value(6.080920219421387f), "Bethe-Bloch parameter 4")(
+    "s0", bpo::value<float>()->default_value(0.07), "resolution parameter 0")(
+    "s1", bpo::value<float>()->default_value(0.), "resolution parameter 1")(
     "reso-param-path", bpo::value<std::string>()->default_value(""), "Path to resolution parameter file")(
     "sigmaGlobal", bpo::value<std::string>()->default_value("5.43799e-7,0.053044,0.667584,0.0142667,0.00235175,1.22482,2.3501e-7,0.031585"), "Sigma parameters global")(
     "paramMIP", bpo::value<float>()->default_value(50.f), "MIP parameter value")(
     "paramChargeFactor", bpo::value<float>()->default_value(2.299999952316284f), "Charge factor value")(
     "paramMultNormalization", bpo::value<float>()->default_value(11000.), "Multiplicity Normalization")(
-    "useDefaultParam", bpo::value<bool>()->default_value(true), "Use default parametrizatio")(
+    "useDefaultParam", bpo::value<bool>()->default_value(true), "Use default sigma parametrisation")(
     "dryrun,D", bpo::value<int>()->default_value(0), "Perform a dryrun check before uploading")(
     "mode", bpo::value<string>()->default_value(""), "Running mode ('read' from file, 'write' to file, 'pull' from CCDB, 'push' to CCDB)")(
     "help,h", "Produce help message.");
@@ -98,6 +100,8 @@ int main(int argc, char* argv[])
   const float bb2 = arguments["bb2"].as<float>();
   const float bb3 = arguments["bb3"].as<float>();
   const float bb4 = arguments["bb4"].as<float>();
+  const float s0 = arguments["s0"].as<float>();
+  const float s1 = arguments["s1"].as<float>();
   const std::string pathResoParam = arguments["reso-param-path"].as<std::string>();
   const std::string sigmaGlobal = arguments["sigmaGlobal"].as<std::string>();
   const float mipval = arguments["paramMIP"].as<float>();
@@ -111,7 +115,7 @@ int main(int argc, char* argv[])
   }
   // create parameter arrays from commandline options
   std::array<float, 5> BBparams = {bb0, bb1, bb2, bb3, bb4};
-
+  std::array<float, 2> sparams = {s0, s1};
   std::vector<double> sigparamsGlobal;
 
   if (pathResoParam != "") { // Read resolution parameters from file
@@ -181,6 +185,7 @@ int main(int argc, char* argv[])
 
       tpc = new Response();
       tpc->SetBetheBlochParams(BBparams);
+      tpc->SetResolutionParamsDefault(sparams);
       tpc->SetResolutionParams(sigparamsGlobal);
       tpc->SetMIP(mipval);
       tpc->SetChargeFactor(chargefacval);


### PR DESCRIPTION
Previously the CCDB call made for the TPC PID response during init() was preventing newer CCDB calls during the track loop due to the caching. This patch removes the CCDB call during initialisation and the CCDB is only requested during the track loop so that the correct response object for the BC is loaded.