### PR TITLE
Tutorials: adapt to new sliceBy

### DIFF
--- a/Tutorials/src/associatedExample.cxx
+++ b/Tutorials/src/associatedExample.cxx
@@ -100,6 +100,8 @@ struct ConsumeColExtra {
 };
 
 struct PartitionColExtra {
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
+
   using myCol = soa::Join<aod::Collisions, aod::CollisionsExtra>;
 
   void process(myCol const& collisions, aod::Tracks const& tracks)
@@ -113,7 +115,7 @@ struct PartitionColExtra {
     LOGF(info, "Bin 0-10");
     for (auto& col : multbin0_10) {
       // ... find all the associated tracks
-      auto groupedTracks = tracks.sliceBy(aod::track::collisionId, col.globalIndex());
+      auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
       LOGF(info, "Collision %d; Ntrk = %d vs %d", col.globalIndex(), col.mult(), groupedTracks.size());
       if (groupedTracks.size() > 0) {
         auto track = groupedTracks.begin();
@@ -123,13 +125,13 @@ struct PartitionColExtra {
 
     LOGF(info, "Bin 10-30");
     for (auto& col : multbin10_30) {
-      auto groupedTracks = tracks.sliceBy(aod::track::collisionId, col.globalIndex());
+      auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
       LOGF(info, "Collision %d; Ntrk = %d vs %d", col.globalIndex(), col.mult(), groupedTracks.size());
     }
 
     LOGF(info, "Bin 30-100");
     for (auto& col : multbin30_100) {
-      auto groupedTracks = tracks.sliceBy(aod::track::collisionId, col.globalIndex());
+      auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
       LOGF(info, "Collision %d; Ntrk = %d vs %d", col.globalIndex(), col.mult(), groupedTracks.size());
     }
   }

--- a/Tutorials/src/extendedColumns.cxx
+++ b/Tutorials/src/extendedColumns.cxx
@@ -28,6 +28,8 @@ using namespace o2;
 using namespace o2::framework;
 
 struct ExtendTable {
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
+
   void process(aod::Collisions const& collisions, aod::Tracks const& tracks)
   {
     // note that this needs to be done only once, as it is done for the whole table
@@ -35,7 +37,7 @@ struct ExtendTable {
     // goes out of scope
     auto table_extension = soa::Extend<aod::Tracks, aod::extension::P2>(tracks);
     for (auto& collision : collisions) {
-      auto trackSlice = table_extension.sliceBy(aod::track::collisionId, collision.globalIndex());
+      auto trackSlice = table_extension.sliceBy(perCollision, collision.globalIndex());
       LOGP(info, "Collision {}", collision.globalIndex());
       for (auto& row : trackSlice) {
         if (row.trackType() != 3) {

--- a/Tutorials/src/mcHistograms.cxx
+++ b/Tutorials/src/mcHistograms.cxx
@@ -155,8 +155,11 @@ struct LoopOverMcMatched {
 
   Configurable<int> reduceOutput{"reduce-output", 0, "Suppress info level output (0 = all output, 1 = per collision, 2 = none)"};
 
+  using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
+
   void process(aod::McCollision const& mcCollision, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions,
-               soa::Join<aod::Tracks, aod::McTrackLabels> const& tracks, aod::McParticles const& mcParticles)
+               LabeledTracks const& tracks, aod::McParticles const& mcParticles)
   {
     // access MC truth information with mcCollision() and mcParticle() methods
     if (reduceOutput < 2) {
@@ -168,7 +171,7 @@ struct LoopOverMcMatched {
       }
 
       // NOTE this will be replaced by a improved grouping in the future
-      auto groupedTracks = tracks.sliceBy(aod::track::collisionId, collision.globalIndex());
+      auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       if (reduceOutput < 2) {
         LOGF(info, "  which has %d tracks", groupedTracks.size());
       }


### PR DESCRIPTION
Updates tutorials to use new `sliceBy` variant with framework-managed cache.

Depends on https://github.com/AliceO2Group/AliceO2/pull/9213.