### PR TITLE
Framework: Move to new sliceBy() syntax

### DIFF
--- a/ALICE3/Tasks/alice3-cdeuteron.cxx
+++ b/ALICE3/Tasks/alice3-cdeuteron.cxx
@@ -172,13 +172,15 @@ struct Alice3CDeuteron {
 #undef MakeHistos
   }
 
+  Preslice<aod::McParticles_000> perMcCollision = aod::mcparticle::mcCollisionId;
+
   void process(const soa::Join<o2::aod::Collisions, o2::aod::McCollisionLabels>::iterator& coll,
                const o2::aod::McCollisions& Mccoll,
                const soa::Join<o2::aod::Tracks, o2::aod::McTrackLabels, o2::aod::TracksExtra, o2::aod::TracksCov,
                                aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullDe>& tracks,
                const aod::McParticles_000& mcParticles)
   {
-    const auto particlesInCollision = mcParticles.sliceBy(aod::mcparticle::mcCollisionId, coll.mcCollision().globalIndex());
+    const auto particlesInCollision = mcParticles.sliceBy(perMcCollision, coll.mcCollision().globalIndex());
     for (const auto& i : particlesInCollision) {
       histos.get<TH1>(HIST("event/particlespdg"))->Fill(Form("%i", i.pdgCode()), 1);
       if (i.pdgCode() != 12345) {

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -385,6 +385,8 @@ struct EventSelectionQaTask {
   }
   PROCESS_SWITCH(EventSelectionQaTask, processRun2, "Process Run2 event selection QA", true);
 
+  Preslice<aod::FullTracks> perCollision = aod::track::collisionId;
+
   void processRun3(
     soa::Join<aod::Collisions, aod::EvSels> cols,
     aod::FullTracks const& tracks,
@@ -575,7 +577,7 @@ struct EventSelectionQaTask {
       histos.fill(HIST("hOrbitCol"), orbit);
       histos.fill(HIST("hBcCol"), localBC);
 
-      auto tracksGrouped = tracks.sliceBy(aod::track::collisionId, col.globalIndex());
+      auto tracksGrouped = tracks.sliceBy(perCollision, col.globalIndex());
       int nTPCtracks = 0;
       int nTOFtracks = 0;
       for (auto& track : tracksGrouped) {

--- a/DPG/Tasks/qaEventTrack.cxx
+++ b/DPG/Tasks/qaEventTrack.cxx
@@ -91,6 +91,8 @@ struct qaEventTrack {
 
   HistogramRegistry histos;
 
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
+
   void init(InitContext const&);
 
   // Function to select tracks
@@ -307,7 +309,7 @@ struct qaEventTrack {
       if (!collision.has_mcCollision()) {
         return;
       }
-      const auto& particlesInCollision = particles.sliceBy(aod::mcparticle::mcCollisionId, collision.mcCollision().globalIndex());
+      const auto& particlesInCollision = particles.sliceBy(perMcCollision, collision.mcCollision().globalIndex());
       tableNonRecoParticles.reserve(particlesInCollision.size() - nTracks);
       for (const auto& particle : particlesInCollision) {
         const auto partReconstructed = std::find(recoPartIndices.begin(), recoPartIndices.end(), particle.globalIndex()) != recoPartIndices.end();

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -213,6 +213,10 @@ struct TableMakerMC {
     fOutputList.setObject(fHistMan->GetMainHistogramList());
   }
 
+  Preslice<aod::McParticles_001> perMcCollision = aod::mcparticle::mcCollisionId;
+  Preslice<MyBarrelTracks> perCollisionTracks = aod::track::collisionId;
+  Preslice<MyMuons> perCollisionMuons = aod::fwdtrack::collisionId;
+
   // Templated function instantianed for all of the process functions
   template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons>
   void fullSkimming(TEvent const& collisions, aod::BCs const& bcs, TTracks const& tracksBarrel, TMuons const& tracksMuon,
@@ -303,7 +307,7 @@ struct TableMakerMC {
       eventMClabels(fEventLabels.find(mcCollision.globalIndex())->second, collision.mcMask());
 
       // loop over the MC truth tracks and find those that need to be written
-      auto groupedMcTracks = mcTracks.sliceBy(aod::mcparticle::mcCollisionId, mcCollision.globalIndex());
+      auto groupedMcTracks = mcTracks.sliceBy(perMcCollision, mcCollision.globalIndex());
       for (auto& mctrack : groupedMcTracks) {
         // check all the requested MC signals and fill a decision bit map
         mcflags = 0;
@@ -349,7 +353,7 @@ struct TableMakerMC {
           trackBarrelCov.reserve(tracksBarrel.size());
         }
 
-        auto groupedTracks = tracksBarrel.sliceBy(aod::track::collisionId, collision.globalIndex());
+        auto groupedTracks = tracksBarrel.sliceBy(perCollisionTracks, collision.globalIndex());
         // loop over tracks
         for (auto& track : groupedTracks) {
           trackFilteringTag = uint64_t(0);
@@ -460,7 +464,7 @@ struct TableMakerMC {
         }
         muonLabels.reserve(tracksMuon.size()); // TODO: enable this once we have fwdtrack labels
 
-        auto groupedMuons = tracksMuon.sliceBy(aod::fwdtrack::collisionId, collision.globalIndex());
+        auto groupedMuons = tracksMuon.sliceBy(perCollisionMuons, collision.globalIndex());
         // loop over muons
         for (auto& muon : groupedMuons) {
           trackFilteringTag = uint64_t(0);

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -780,6 +780,8 @@ struct AnalysisSameEventPairing {
     } //end of true pairing loop
   }   // end runMCGen
 
+  Preslice<ReducedMCTracks> perReducedMcEvent = aod::reducedtrackMC::reducedMCeventId;
+
   void processJpsiToEESkimmed(soa::Filtered<MyEventsSelected>::iterator const& event,
                               soa::Filtered<MyBarrelTracksSelected> const& tracks,
                               ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
@@ -790,7 +792,7 @@ struct AnalysisSameEventPairing {
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
 
     runPairing<VarManager::kJpsiToEE, gkEventFillMap, gkMCEventFillMap, gkTrackFillMap>(event, tracks, tracks, eventsMC, tracksMC);
-    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
@@ -805,7 +807,7 @@ struct AnalysisSameEventPairing {
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
 
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMap, gkMCEventFillMap, gkMuonFillMap>(event, muons, muons, eventsMC, tracksMC);
-    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
@@ -820,7 +822,7 @@ struct AnalysisSameEventPairing {
     VarManager::FillEvent<gkMCEventFillMap>(event.reducedMCevent());
 
     runPairing<VarManager::kJpsiToMuMu, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, muons, muons, eventsMC, tracksMC);
-    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
@@ -1074,17 +1076,19 @@ struct AnalysisDileptonTrack {
     }
   }
 
+  Preslice<ReducedMCTracks> perReducedMcEvent = aod::reducedtrackMC::reducedMCeventId;
+
   void processDimuonMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyMuonTracksSelectedWithCov const& tracks, soa::Join<aod::Dileptons, aod::DileptonsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
   {
     runDileptonTrack<VarManager::kBcToThreeMuons, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, tracks, dileptons, eventsMC, tracksMC);
-    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
   void processDielectronKaonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyBarrelTracksSelectedWithCov const& tracks, soa::Join<aod::Dileptons, aod::DileptonsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
   {
     runDileptonTrack<VarManager::kBtoJpsiEEK, gkEventFillMapWithCov, gkMCEventFillMap, gkTrackFillMap>(event, tracks, dileptons, eventsMC, tracksMC);
-    auto groupedMCTracks = tracksMC.sliceBy(aod::reducedtrackMC::reducedMCeventId, event.reducedMCevent().globalIndex());
+    auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversions.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversions.cxx
@@ -123,6 +123,8 @@ struct skimmerGammaConversions {
   }
   PROCESS_SWITCH(skimmerGammaConversions, processRec, "process reconstructed info only", true);
 
+  Preslice<aod::V0Datas> perCollision = aod::v0data::collisionId;
+
   void processMc(aod::McCollision const& theMcCollision,
                  soa::SmallGroups<soa::Join<aod::McCollisionLabels,
                                             aod::Collisions>> const& theCollisions,
@@ -142,8 +144,7 @@ struct skimmerGammaConversions {
     for (auto& lCollision : theCollisions) {
       fRegistry.fill(HIST("hCollisionZ_MCRec"), lCollision.posZ());
 
-      // todo: replace by sliceByCached
-      auto lGroupedV0s = theV0s.sliceBy(aod::v0data::collisionId, lCollision.globalIndex());
+      auto lGroupedV0s = theV0s.sliceBy(perCollision, lCollision.globalIndex());
       for (auto& lV0 : lGroupedV0s) {
 
         auto lTrackPos = lV0.template posTrack_as<tracksAndTPCInfoMC>(); // positive daughter

--- a/PWGEM/PhotonMeson/Tasks/gammaConversions.cxx
+++ b/PWGEM/PhotonMeson/Tasks/gammaConversions.cxx
@@ -387,6 +387,8 @@ struct GammaConversions {
       theV0);
   }
 
+  Preslice<aod::V0DaughterTracks> perV0 = aod::v0data::v0Id;
+
   void processRec(aod::Collisions::iterator const& theCollision,
                   aod::V0Datas const& theV0s,
                   aod::V0DaughterTracks const& theAllTracks)
@@ -397,7 +399,7 @@ struct GammaConversions {
 
     for (auto& lV0 : theV0s) {
 
-      auto lTwoV0Daughters = theAllTracks.sliceBy(aod::v0data::v0Id, lV0.v0Id());
+      auto lTwoV0Daughters = theAllTracks.sliceBy(perV0, lV0.v0Id());
       float lV0CosinePA = lV0.v0cosPA(theCollision.posX(), theCollision.posY(), theCollision.posZ());
 
       if (!processV0(lV0, lV0CosinePA, lTwoV0Daughters)) {
@@ -406,6 +408,8 @@ struct GammaConversions {
     }
   }
   PROCESS_SWITCH(GammaConversions, processRec, "process reconstructed info", true);
+
+  Preslice<aod::McGammasTrue> gperV0 = aod::v0data::v0Id;
 
   void processMc(aod::Collisions::iterator const& theCollision,
                  aod::V0Datas const& theV0s,
@@ -418,15 +422,14 @@ struct GammaConversions {
 
     for (auto& lV0 : theV0s) {
 
-      // todo: use sliceByCached
-      auto lTwoV0Daughters = theAllTracks.sliceBy(aod::v0data::v0Id, lV0.v0Id());
+      auto lTwoV0Daughters = theAllTracks.sliceBy(perV0, lV0.v0Id());
       float lV0CosinePA = lV0.v0cosPA(theCollision.posX(), theCollision.posY(), theCollision.posZ());
 
       // check if V0 passes rec cuts and fill beforeRecCuts,afterRecCuts [kRec]
       bool lV0PassesRecCuts = processV0(lV0, lV0CosinePA, lTwoV0Daughters);
 
       // check if it comes from a true photon (lMcPhotonForThisV0AsTable is a table that might be empty)
-      auto lMcPhotonForThisV0AsTable = theV0sTrue.sliceBy(aod::v0data::v0Id, lV0.v0Id());
+      auto lMcPhotonForThisV0AsTable = theV0sTrue.sliceBy(gperV0, lV0.v0Id());
       processMcPhoton(lMcPhotonForThisV0AsTable,
                       lV0,
                       lV0CosinePA,

--- a/PWGLF/TableProducer/LFTreeCreatorNuclei.cxx
+++ b/PWGLF/TableProducer/LFTreeCreatorNuclei.cxx
@@ -139,6 +139,8 @@ struct LfTreeCreatorNuclei {
     }
   }
 
+  Preslice<soa::Filtered<TrackCandidates>> perCollision = aod::track::collisionId;
+
   void processData(soa::Filtered<EventCandidates> const& collisions,
                    soa::Filtered<TrackCandidates> const& tracks, aod::BCs const&)
   {
@@ -146,7 +148,7 @@ struct LfTreeCreatorNuclei {
       if (useEvsel && !collision.sel8()) {
         continue;
       }
-      const auto& tracksInCollision = tracks.sliceBy(aod::track::collisionId, collision.globalIndex());
+      const auto& tracksInCollision = tracks.sliceBy(perCollision, collision.globalIndex());
       fillForOneEvent<false>(collision, tracksInCollision);
     }
   }
@@ -161,7 +163,7 @@ struct LfTreeCreatorNuclei {
       if (useEvsel && !collision.sel8()) {
         continue;
       }
-      const auto& tracksInCollision = tracks.sliceBy(aod::track::collisionId, collision.globalIndex());
+      const auto& tracksInCollision = tracks.sliceBy(perCollision, collision.globalIndex());
       fillForOneEvent<true>(collision, tracksInCollision);
     }
   }

--- a/PWGLF/Tasks/spectraCharged.cxx
+++ b/PWGLF/Tasks/spectraCharged.cxx
@@ -183,6 +183,8 @@ void chargedSpectra::processData(CollisionTableData::iterator const& collision, 
  * Entrypoint to processes mc.
  */
 //**************************************************************************************************
+Preslice<chargedSpectra::TrackTableMC> perCollision = aod::track::collisionId;
+
 void chargedSpectra::processMC(CollisionTableMCTrue::iterator const& mcCollision, CollisionTableMC const& collisions, TrackTableMC const& tracks, ParticleTableMC const& particles)
 {
   histos.fill(HIST("collision_ambiguity"), collisions.size());
@@ -202,7 +204,7 @@ void chargedSpectra::processMC(CollisionTableMCTrue::iterator const& mcCollision
     vars.isAcceptedEvent = false;
   } else {
     for (auto& collision : collisions) {
-      auto curTracks = tracks.sliceBy(aod::track::collisionId, collision.globalIndex());
+      auto curTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       initEvent(collision, curTracks);
       processMeas<true>(collision, curTracks);
       break; // for now look only at first collision...

--- a/PWGUD/Tasks/diffMCDataScanner.cxx
+++ b/PWGUD/Tasks/diffMCDataScanner.cxx
@@ -345,6 +345,8 @@ struct MCTracks {
   using CCs = soa::Join<aod::Collisions, aod::McCollisionLabels>;
   using CC = CCs::iterator;
 
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
+
   void process(CCs const& collisions, aod::McCollisions& McCols, aod::McParticles& McParts)
   {
 
@@ -357,7 +359,7 @@ struct MCTracks {
            collision.globalIndex(), MCCol.globalIndex(), MCCol.generatorsID());
 
       // get MCParticles which belong to MCCol
-      auto MCPartSlice = McParts.sliceBy(aod::mcparticle::mcCollisionId, MCCol.globalIndex());
+      auto MCPartSlice = McParts.sliceBy(perMcCollision, MCCol.globalIndex());
       LOGF(info, "  Number of McParticles %i", MCPartSlice.size());
 
       // loop over particles

--- a/PWGUD/Tasks/diffMCQA.cxx
+++ b/PWGUD/Tasks/diffMCQA.cxx
@@ -221,6 +221,10 @@ struct DiffMCQA {
     LOGF(info, "<DiffMCQA> Size of abcrs %i and afbcrs %i", abcrs.size(), afbcrs.size());
   }
 
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::V0s> v0PerCollision = aod::v0::collisionId;
+  Preslice<aod::Cascades> cascadePerCollision = aod::cascade::collisionId;
+
   void process(CC const& collision, BCs const& bct0s,
                TCs& tracks, FWs& fwdtracks, ATs& ambtracks, AFTs& ambfwdtarcks,
                aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds,
@@ -236,7 +240,7 @@ struct DiffMCQA {
     bool isGraniittiDiff = false;
     if (collision.has_mcCollision()) {
       auto MCCol = collision.mcCollision();
-      auto MCPartSlice = McParts.sliceBy(aod::mcparticle::mcCollisionId, MCCol.globalIndex());
+      auto MCPartSlice = McParts.sliceBy(perMcCollision, MCCol.globalIndex());
       isPythiaDiff = isPythiaCDE(MCPartSlice);
       isGraniittiDiff = isGraniittiCDE(MCPartSlice);
     }
@@ -398,7 +402,7 @@ struct DiffMCQA {
 
     // no V0s
     auto colId = collision.globalIndex();
-    const auto& V0Collision = v0s.sliceBy(aod::v0::collisionId, colId);
+    const auto& V0Collision = v0s.sliceBy(v0PerCollision, colId);
     isDGcandidate &= (V0Collision.size() == 0);
     if (isPythiaDiff) {
       registry.get<TH1>(HIST("StatDiff1"))->Fill(4., isDGcandidate * 1.);
@@ -409,7 +413,7 @@ struct DiffMCQA {
     }
 
     // no Cascades
-    const auto& CascadeCollision = cascades.sliceBy(aod::cascade::collisionId, colId);
+    const auto& CascadeCollision = cascades.sliceBy(cascadePerCollision, colId);
     isDGcandidate &= (CascadeCollision.size() == 0);
     if (isPythiaDiff) {
       registry.get<TH1>(HIST("StatDiff1"))->Fill(5., isDGcandidate * 1.);
@@ -713,7 +717,7 @@ struct FV0Signals {
       {"FV0A", "#FV0A", {HistType::kTH2F, {{48, -0.5, 47.5}, {1000, 0., 1000.}}}},
     }};
 
-  void process(aod::FV0A fv0)
+  void process(aod::FV0A const& fv0)
   {
     // side A
     for (size_t ind = 0; ind < fv0.channel().size(); ind++) {
@@ -731,7 +735,7 @@ struct FT0Signals {
       {"FT0C", "#FT0C", {HistType::kTH2F, {{112, -0.5, 111.5}, {100, 0., 200.}}}},
     }};
 
-  void process(aod::FT0 ft0)
+  void process(aod::FT0 const& ft0)
   {
     // side A
     for (size_t ind = 0; ind < ft0.channelA().size(); ind++) {
@@ -754,7 +758,7 @@ struct FDDSignals {
       {"FDDC", "#FDDC", {HistType::kTH2F, {{8, -0.5, 7.5}, {100, 0., 100.}}}},
     }};
 
-  void process(aod::FDD fdd)
+  void process(aod::FDD const& fdd)
   {
     // side A
     for (auto ind = 0; ind < 8; ind++) {
@@ -799,7 +803,7 @@ struct ZDCSignals {
       {"ZdcEnergies", "#ZdcEnergies", {HistType::kTH2F, {{22, -0.5, 21.5}, {100, 0., 1000.}}}},
     }};
 
-  void process(aod::Zdc zdc)
+  void process(aod::Zdc const& zdc)
   {
     // Zdc energies
     registry.get<TH2>(HIST("ZdcEnergies"))->Fill(0., zdc.energyZEM1());
@@ -836,7 +840,7 @@ struct CaloSignals {
       {"CaloAmplitude", "#CaloAmplitude", {HistType::kTH1F, {{100, 0, 10.}}}},
     }};
 
-  void process(aod::Calo calo)
+  void process(aod::Calo const& calo)
   {
     // cell number
     registry.get<TH1>(HIST("CaloCell"))->Fill(calo.cellNumber());

--- a/PWGUD/Tasks/diffQA.cxx
+++ b/PWGUD/Tasks/diffQA.cxx
@@ -169,6 +169,9 @@ struct DiffQA {
     afbcrs.merge();
   }
 
+  Preslice<aod::V0s> v0PerCollision = aod::v0::collisionId;
+  Preslice<aod::Cascades> cascadePerCollision = aod::cascade::collisionId;
+
   void process(CC const& collision, BCs const& bct0s,
                TCs& tracks, FWs& fwdtracks, ATs& ambtracks, AFTs& ambfwdtarcks,
                aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds,
@@ -278,12 +281,12 @@ struct DiffQA {
 
     // no V0s
     auto colId = collision.globalIndex();
-    const auto& V0Collision = v0s.sliceBy(aod::v0::collisionId, colId);
+    const auto& V0Collision = v0s.sliceBy(v0PerCollision, colId);
     isDGcandidate &= (V0Collision.size() == 0);
     registry.get<TH1>(HIST("Stat"))->Fill(4., isDGcandidate * 1.);
 
     // no Cascades
-    const auto& CascadeCollision = cascades.sliceBy(aod::cascade::collisionId, colId);
+    const auto& CascadeCollision = cascades.sliceBy(cascadePerCollision, colId);
     isDGcandidate &= (CascadeCollision.size() == 0);
     registry.get<TH1>(HIST("Stat"))->Fill(5., isDGcandidate * 1.);
 
@@ -435,7 +438,7 @@ struct FV0Signals {
       {"FV0A", "#FV0A", {HistType::kTH2F, {{48, -0.5, 47.5}, {1000, 0., 1000.}}}},
     }};
 
-  void process(aod::FV0A fv0)
+  void process(aod::FV0A const& fv0)
   {
     // side A
     for (size_t ind = 0; ind < fv0.channel().size(); ind++) {
@@ -453,7 +456,7 @@ struct FT0Signals {
       {"FT0C", "#FT0C", {HistType::kTH2F, {{112, -0.5, 111.5}, {100, 0., 200.}}}},
     }};
 
-  void process(aod::FT0 ft0)
+  void process(aod::FT0 const& ft0)
   {
     // side A
     for (size_t ind = 0; ind < ft0.channelA().size(); ind++) {
@@ -476,7 +479,7 @@ struct FDDSignals {
       {"FDDC", "#FDDC", {HistType::kTH2F, {{8, -0.5, 7.5}, {100, 0., 100.}}}},
     }};
 
-  void process(aod::FDD fdd)
+  void process(aod::FDD const& fdd)
   {
     // side A
     for (auto ind = 0; ind < 8; ind++) {
@@ -521,7 +524,7 @@ struct ZDCSignals {
       {"ZdcEnergies", "#ZdcEnergies", {HistType::kTH2F, {{22, -0.5, 21.5}, {100, 0., 1000.}}}},
     }};
 
-  void process(aod::Zdc zdc)
+  void process(aod::Zdc const& zdc)
   {
     // Zdc energies
     registry.get<TH2>(HIST("ZdcEnergies"))->Fill(0., zdc.energyZEM1());
@@ -558,7 +561,7 @@ struct CaloSignals {
       {"CaloAmplitude", "#CaloAmplitude", {HistType::kTH1F, {{100, 0, 10.}}}},
     }};
 
-  void process(aod::Calo calo)
+  void process(aod::Calo const& calo)
   {
     // cell number
     registry.get<TH1>(HIST("CaloCell"))->Fill(calo.cellNumber());


### PR DESCRIPTION
This replaces all the cases where old `sliceBy` is used by the new syntax, accompanied by `Preslice<>` declaration. Using it will ensure that the actual slicing code is run one per dataframe and its results are cached and re-used, providing considerable improvement in performance.

PR is split into individual commits, as this change needs to be verified to produce exactly the same result as original code. Specifically its interaction with filters needs to be validated. Please tests these commits and report the results here.