### PR TITLE
Simplify TOF PID Response parameter usage

### DIFF
--- a/ALICE3/Core/TOFResoALICE3.h
+++ b/ALICE3/Core/TOFResoALICE3.h
@@ -20,7 +20,9 @@
 #define O2_ANALYSIS_PID_TOFRESOALICE3_H_
 
 // O2 includes
-#include "Common/Core/PID/ParamBase.h"
+#include "PID/ParamBase.h"
+#include "PID/DetectorResponse.h"
+#include "PID/PIDTOF.h"
 #include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tof

--- a/ALICE3/TableProducer/alice3-pidTOF.cxx
+++ b/ALICE3/TableProducer/alice3-pidTOF.cxx
@@ -22,7 +22,6 @@
 #include "ReconstructionDataFormats/Track.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/PID/PIDTOF.h"
 #include "ALICE3/Core/TOFResoALICE3.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Framework/RunningWorkflowInfo.h"
@@ -125,8 +124,7 @@ struct ALICE3pidTOFTask {
       return -999.f;
     }
     return ((track.trackTime() - track.collision().collisionTime()) * 1000.f - tof::ExpTimes<Trks::iterator, id>::ComputeExpectedTime(track.tofExpMom() / o2::pid::tof::kCSPEED,
-                                                                                                                                      track.length(),
-                                                                                                                                      o2::track::PID::getMass2Z(id))) /
+                                                                                                                                      track.length())) /
            sigma<id>(track);
   }
   void process(Trks const& tracks, Coll const&)

--- a/Common/Core/AnalysisCoreLinkDef.h
+++ b/Common/Core/AnalysisCoreLinkDef.h
@@ -16,7 +16,9 @@
 #pragma link C++ class TrackSelection + ;
 
 #pragma link C++ class o2::pid::Parameters + ;
+#pragma link C++ class o2::pid::PidParameters < 5> + ;
 #pragma link C++ class o2::pid::Parametrization + ;
 
 #pragma link C++ class o2::pid::tof::TOFReso + ;
+#pragma link C++ class o2::pid::tof::TOFResoParams + ;
 #pragma link C++ class OrbitRange + ;

--- a/Common/Core/PID/ParamBase.cxx
+++ b/Common/Core/PID/ParamBase.cxx
@@ -17,7 +17,7 @@
 ///        These are the basic storage elements to be kept in the CCDB
 ///
 
-#include "Common/Core/PID/ParamBase.h"
+#include "PID/ParamBase.h"
 #include "Framework/Logger.h"
 #include "TFile.h"
 

--- a/Common/Core/PID/TOFReso.h
+++ b/Common/Core/PID/TOFReso.h
@@ -20,7 +20,6 @@
 #define O2_ANALYSIS_PID_TOFRESO_H_
 
 // O2 includes
-#include "Common/Core/PID/ParamBase.h"
 #include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tof
@@ -50,7 +49,7 @@ class TOFReso : public Parametrization
     const float sigma = dpp * time / (1. + mom * mom / (mass * mass));
     return sqrt(sigma * sigma + mParameters[3] * mParameters[3] / mom / mom + mParameters[4] * mParameters[4] + evtimereso * evtimereso);
   }
-  ClassDef(TOFReso, 1);
+  ClassDefOverride(TOFReso, 1);
 };
 
 } // namespace o2::pid::tof

--- a/Common/TableProducer/PID/pidBayes.cxx
+++ b/Common/TableProducer/PID/pidBayes.cxx
@@ -22,8 +22,6 @@
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/Array2D.h"
 #include <CCDB/BasicCCDBManager.h>
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/PID/PIDTOF.h"
 #include "Common/Core/PID/TPCPIDResponse.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/TrackSelectionTables.h"

--- a/Common/TableProducer/PID/pidTOFBase.h
+++ b/Common/TableProducer/PID/pidTOFBase.h
@@ -15,6 +15,10 @@
 /// \brief  Base to build tasks for TOF PID tasks.
 ///
 
+#include "PID/ParamBase.h"
+#include "PID/DetectorResponse.h"
+#include "PID/PIDTOF.h"
+
 #include "Common/DataModel/PIDResponse.h"
 
 using namespace o2;

--- a/Common/TableProducer/PID/pidTOFFull.cxx
+++ b/Common/TableProducer/PID/pidTOFFull.cxx
@@ -18,11 +18,12 @@
 ///
 
 // O2 includes
+#include <CCDB/BasicCCDBManager.h>
+#include "TOFBase/EventTimeMaker.h"
 #include "Framework/AnalysisTask.h"
 #include "ReconstructionDataFormats/Track.h"
-#include <CCDB/BasicCCDBManager.h>
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/PID/PIDTOF.h"
+
+// O2Physics includes
 #include "TableHelper.h"
 #include "pidTOFBase.h"
 #include "DPG/Tasks/qaPIDTOF.h"
@@ -53,11 +54,11 @@ struct tofPidFull {
   Produces<o2::aod::pidTOFFullTr> tablePIDTr;
   Produces<o2::aod::pidTOFFullHe> tablePIDHe;
   Produces<o2::aod::pidTOFFullAl> tablePIDAl;
-  // Detector response and input parameters
-  DetectorResponse response;
+  // Detector response parameters
+  o2::pid::tof::TOFResoParams mRespParams;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if emtpy the parametrization is not taken from file"};
-  Configurable<std::string> sigmaname{"param-sigma", "TOFReso", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
+  Configurable<std::string> sigmaname{"param-sigma", "TOFResoParams", "Name of the parametrization for the expected sigma, used in both file and CCDB mode"};
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TOF", "Path of the TOF parametrization on the CCDB"};
   Configurable<long> timestamp{"ccdb-timestamp", -1, "timestamp of the object"};
@@ -77,6 +78,10 @@ struct tofPidFull {
 
   void init(o2::framework::InitContext& initContext)
   {
+    if (doprocessWSlice == true && doprocessWoSlice == true) {
+      LOGF(fatal, "Cannot enable processWoSlice and processWSlice at the same time. Please choose one.");
+    }
+
     // Checking the tables are requested in the workflow and enabling them
     auto enableFlag = [&](const std::string particle, Configurable<int>& flag) {
       enableFlagIfTableRequired(initContext, "pidTOFFull" + particle, flag);
@@ -100,16 +105,17 @@ struct tofPidFull {
     // Not later than now objects
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
     //
-    const std::vector<float> p = {0.008, 0.008, 0.002, 40.0};
-    response.SetParameters(DetectorResponse::kSigma, p);
     const std::string fname = paramfile.value;
     if (!fname.empty()) { // Loading the parametrization from file
       LOG(info) << "Loading exp. sigma parametrization from file" << fname << ", using param: " << sigmaname.value;
-      response.LoadParamFromFile(fname.data(), sigmaname.value, DetectorResponse::kSigma);
+      mRespParams.LoadParamFromFile(fname.data(), sigmaname.value);
     } else { // Loading it from CCDB
       parametrizationPath = ccdbPath.value + "/" + sigmaname.value;
-      LOG(info) << "Loading exp. sigma parametrization from CCDB, using path: '" << parametrizationPath << "' for timestamp " << timestamp.value;
-      response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(parametrizationPath, timestamp.value));
+      if (!enableTimeDependentResponse) {
+        LOG(info) << "Loading exp. sigma parametrization from CCDB, using path: '" << parametrizationPath << "' for timestamp " << timestamp.value;
+        mRespParams.SetParameters(ccdb->getForTimeStamp<o2::pid::tof::TOFResoParams>(parametrizationPath, timestamp.value));
+        mRespParams.Print();
+      }
     }
   }
 
@@ -118,7 +124,7 @@ struct tofPidFull {
   Preslice<Trks> perCollision = aod::track::collisionId;
   template <o2::track::PID::ID pid>
   using ResponseImplementation = o2::pid::tof::ExpTimes<Trks::iterator, pid>;
-  void process(Trks const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const&)
+  void processWSlice(Trks const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const&)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
     constexpr auto responseMu = ResponseImplementation<PID::Muon>();
@@ -149,7 +155,7 @@ struct tofPidFull {
 
     int lastCollisionId = -1;          // Last collision ID analysed
     for (auto const& track : tracks) { // Loop on all tracks
-      if (!track.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time)
+      if (!track.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
         auto makeTableEmpty = [&](const Configurable<int>& flag, auto& table) {
           if (flag.value != 1) {
             return;
@@ -179,7 +185,7 @@ struct tofPidFull {
       timestamp.value = track.collision().bc_as<aod::BCsWithTimestamps>().timestamp();
       if (enableTimeDependentResponse) {
         LOG(debug) << "Updating parametrization from path '" << parametrizationPath << "' and timestamp " << timestamp.value;
-        response.LoadParam(DetectorResponse::kSigma, ccdb->getForTimeStamp<Parametrization>(parametrizationPath, timestamp));
+        mRespParams.SetParameters(ccdb->getForTimeStamp<o2::pid::tof::TOFResoParams>(parametrizationPath, timestamp));
       }
 
       const auto& tracksInCollision = tracks.sliceBy(perCollision, lastCollisionId);
@@ -189,8 +195,8 @@ struct tofPidFull {
           if (flag.value != 1) {
             return;
           }
-          table(responsePID.GetExpectedSigma(response, trkInColl),
-                responsePID.GetSeparation(response, trkInColl));
+          table(responsePID.GetExpectedSigma(mRespParams, trkInColl),
+                responsePID.GetSeparation(mRespParams, trkInColl));
         };
 
         makeTable(pidEl, tablePIDEl, responseEl);
@@ -205,6 +211,88 @@ struct tofPidFull {
       }
     }
   }
+  PROCESS_SWITCH(tofPidFull, processWSlice, "Process with track slices", true);
+
+  void processWoSlice(Trks const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const&)
+  {
+    constexpr auto responseEl = ResponseImplementation<PID::Electron>();
+    constexpr auto responseMu = ResponseImplementation<PID::Muon>();
+    constexpr auto responsePi = ResponseImplementation<PID::Pion>();
+    constexpr auto responseKa = ResponseImplementation<PID::Kaon>();
+    constexpr auto responsePr = ResponseImplementation<PID::Proton>();
+    constexpr auto responseDe = ResponseImplementation<PID::Deuteron>();
+    constexpr auto responseTr = ResponseImplementation<PID::Triton>();
+    constexpr auto responseHe = ResponseImplementation<PID::Helium3>();
+    constexpr auto responseAl = ResponseImplementation<PID::Alpha>();
+
+    auto reserveTable = [&tracks](const Configurable<int>& flag, auto& table) {
+      if (flag.value != 1) {
+        return;
+      }
+      table.reserve(tracks.size());
+    };
+
+    reserveTable(pidEl, tablePIDEl);
+    reserveTable(pidMu, tablePIDMu);
+    reserveTable(pidPi, tablePIDPi);
+    reserveTable(pidKa, tablePIDKa);
+    reserveTable(pidPr, tablePIDPr);
+    reserveTable(pidDe, tablePIDDe);
+    reserveTable(pidTr, tablePIDTr);
+    reserveTable(pidHe, tablePIDHe);
+    reserveTable(pidAl, tablePIDAl);
+
+    int lastCollisionId = -1;          // Last collision ID analysed
+    for (auto const& track : tracks) { // Loop on all tracks
+      if (!track.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
+        auto makeTableEmpty = [&](const Configurable<int>& flag, auto& table) {
+          if (flag.value != 1) {
+            return;
+          }
+          table(-999.f, -999.f);
+        };
+
+        makeTableEmpty(pidEl, tablePIDEl);
+        makeTableEmpty(pidMu, tablePIDMu);
+        makeTableEmpty(pidPi, tablePIDPi);
+        makeTableEmpty(pidKa, tablePIDKa);
+        makeTableEmpty(pidPr, tablePIDPr);
+        makeTableEmpty(pidDe, tablePIDDe);
+        makeTableEmpty(pidTr, tablePIDTr);
+        makeTableEmpty(pidHe, tablePIDHe);
+        makeTableEmpty(pidAl, tablePIDAl);
+
+        continue;
+      }
+
+      if (enableTimeDependentResponse && (track.collisionId() != lastCollisionId)) { // Time dependent calib is enabled and this is a new collision
+        lastCollisionId = track.collisionId();                                       // Cache last collision ID
+        timestamp.value = track.collision().bc_as<aod::BCsWithTimestamps>().timestamp();
+        LOG(debug) << "Updating parametrization from path '" << parametrizationPath << "' and timestamp " << timestamp.value;
+        mRespParams.SetParameters(ccdb->getForTimeStamp<o2::pid::tof::TOFResoParams>(parametrizationPath, timestamp));
+      }
+
+      // Check and fill enabled tables
+      auto makeTable = [&track, this](const Configurable<int>& flag, auto& table, const auto& responsePID) {
+        if (flag.value != 1) {
+          return;
+        }
+        table(responsePID.GetExpectedSigma(mRespParams, track),
+              responsePID.GetSeparation(mRespParams, track));
+      };
+
+      makeTable(pidEl, tablePIDEl, responseEl);
+      makeTable(pidMu, tablePIDMu, responseMu);
+      makeTable(pidPi, tablePIDPi, responsePi);
+      makeTable(pidKa, tablePIDKa, responseKa);
+      makeTable(pidPr, tablePIDPr, responsePr);
+      makeTable(pidDe, tablePIDDe, responseDe);
+      makeTable(pidTr, tablePIDTr, responseTr);
+      makeTable(pidHe, tablePIDHe, responseHe);
+      makeTable(pidAl, tablePIDAl, responseAl);
+    }
+  }
+  PROCESS_SWITCH(tofPidFull, processWoSlice, "Process without track slices", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Common/TableProducer/PID/pidTOFbeta.cxx
+++ b/Common/TableProducer/PID/pidTOFbeta.cxx
@@ -19,8 +19,6 @@
 // O2 includes
 #include "Framework/AnalysisTask.h"
 #include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/PID/PIDTOF.h"
 #include "pidTOFBase.h"
 #include "TableHelper.h"
 #include "DPG/Tasks/qaPIDTOF.h"

--- a/Common/Tools/handleParamTOFReso.cxx
+++ b/Common/Tools/handleParamTOFReso.cxx
@@ -13,36 +13,56 @@
 /// \file   handleParamTOFReso.cxx
 /// \author Nicolò Jacazio nicolo.jacazio@cern.ch
 /// \since  2020-06-22
-/// \brief  A simple tool to produce Bethe Bloch parametrization objects for the TOF PID Response
+/// \brief  A simple tool to produce resolution parametrization objects for the TOF PID Response
 ///
 
-#include "Common/Core/PID/TOFReso.h"
+#include "TGraph.h"
+#include "TSystem.h"
+#include "TCanvas.h"
+
+#include "PID/ParamBase.h"
+#include "PID/DetectorResponse.h"
+#include "PID/PIDTOF.h"
+#include "PID/TOFReso.h"
 #include "handleParamBase.h"
 
+#include <chrono>
+using namespace std::chrono;
 using namespace o2::pid::tof;
+using namespace o2::pid;
+
+// Utility class
+struct DebugTrack { // Track that mimics the O2 data structure
+  float mp = 0.1f;
+  float p() const { return mp; }
+  bool isEvTimeDefined() const { return true; }
+  bool hasTOF() const { return true; }
+  float tofEvTime() const { return 0.f; }
+  float tofEvTimeErr() const { return 20.f; }
+  float length() const { return 400.f; }
+  float tofSignal() const { return length() * 1.01 / kCSPEED; }
+  int trackType() const { return 0; };
+  float tofExpMom() const
+  {
+    constexpr float mass = o2::constants::physics::MassPionCharged; // default pid = pion
+    const float expBeta = (length() / (tofSignal() * kCSPEED));
+    return mass * expBeta / std::sqrt(1.f - expBeta * expBeta);
+  }
+
+} debugTrack;
 
 bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv[])
 {
   options.add_options()(
-    "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database e.g. http://ccdb-test.cern.ch:8080 or http://alice-ccdb.cern.ch")(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TOF"), "CCDB path for storage/retrieval")(
-    "rct-path", bpo::value<std::string>()->default_value("RCT/Info/RunInformation"), "path to the ccdb RCT objects for the SOR/EOR timestamps")(
-    "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity. If 0 and runnumber != 0 it will be set to the run SOR")(
-    "stop,S", bpo::value<long>()->default_value(0), "Stop timestamp of object validity. If 0 and runnumber != 0 it will be set to the run EOR")(
-    "timestamp,T", bpo::value<long>()->default_value(-1), "Timestamp of the object to retrieve, used in alternative to the run number")(
-    "runnumber,R", bpo::value<unsigned int>()->default_value(0), "Timestamp of the object to retrieve, used in alternative to the timestamp (if 0 using the timestamp)")(
-    "delete-previous,delete_previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
-    "save-to-file,file,f,o", bpo::value<std::string>()->default_value(""), "Option to save parametrization to file instead of uploading to ccdb")(
-    "read-from-file,i", bpo::value<std::string>()->default_value(""), "Option to get parametrization from a file")(
-    "reso-name,n", bpo::value<std::string>()->default_value("TOFReso"), "Name of the parametrization object")(
-    "mode,m", bpo::value<unsigned int>()->default_value(1), "Working mode: 0 push 1 pull and test")(
+    "reso-name,n", bpo::value<std::string>()->default_value("TOFResoParams"), "Name of the parametrization object")(
+    "mode,m", bpo::value<unsigned int>()->default_value(1), "Working mode: 0 push, 1 pull and test, 2 create and performance")(
     "p0", bpo::value<float>()->default_value(0.008f), "Parameter 0 of the TOF resolution")(
     "p1", bpo::value<float>()->default_value(0.008f), "Parameter 1 of the TOF resolution")(
     "p2", bpo::value<float>()->default_value(0.002f), "Parameter 2 of the TOF resolution")(
     "p3", bpo::value<float>()->default_value(40.0f), "Parameter 3 of the TOF resolution")(
-    "p4", bpo::value<float>()->default_value(60.0f), "Parameter 4 of the TOF resolution: average TOF resolution")(
-    "verbose,v", bpo::value<int>()->default_value(0), "Verbose level 0, 1")(
-    "help,h", "Produce help message.");
+    "p4", bpo::value<float>()->default_value(60.0f), "Parameter 4 of the TOF resolution: average TOF resolution");
+  setStandardOpt(options);
   try {
     bpo::store(parse_command_line(argc, argv, options), arguments);
 
@@ -71,40 +91,30 @@ int main(int argc, char* argv[])
 
   // Fetch options
   const auto mode = arguments["mode"].as<unsigned int>();
-  const auto runnumber = arguments["runnumber"].as<unsigned int>();
-  auto timestamp = arguments["timestamp"].as<long>();
-  const auto path = arguments["ccdb-path"].as<std::string>();
-  auto start = arguments["start"].as<long>();
-  auto stop = arguments["stop"].as<long>();
+  const auto ccdbPath = arguments["ccdb-path"].as<std::string>() + "/" + arguments["reso-name"].as<std::string>();
 
   // Init CCDB
-  const std::string url = arguments["url"].as<std::string>();
-  api.init(url);
-  if (!api.isHostReachable()) {
-    LOG(warning) << "CCDB host " << url << " is not reacheable, cannot go forward";
-    return 1;
-  }
+  initCCDBApi();
 
   // Init timestamps
-  setupTimestamps(timestamp, start, stop);
+  setupTimestamps(ccdbTimestamp, validityStart, validityStop);
 
-  TOFReso* reso = nullptr;
-  const std::string reso_name = arguments["reso-name"].as<std::string>();
+  TOFReso* resoOld = nullptr;
+  TOFResoParams* reso = nullptr;
   if (mode == 0) { // Push mode
     LOG(info) << "Handling TOF parametrization in create mode";
     const std::string input_file_name = arguments["read-from-file"].as<std::string>();
-    if (!input_file_name.empty()) {
-      TFile f(input_file_name.data(), "READ");
-      if (!f.IsOpen()) {
-        LOG(warning) << "Input file " << input_file_name << " is not reacheable, cannot get param from file";
-      }
-      f.GetObject(reso_name.c_str(), reso);
-      f.Close();
-    }
-    if (!reso) {
-      reso = new TOFReso();
-      const std::vector<float> resoparams = {arguments["p0"].as<float>(), arguments["p1"].as<float>(), arguments["p2"].as<float>(), arguments["p3"].as<float>(), arguments["p4"].as<float>()};
-      reso->SetParameters(resoparams);
+    reso = new TOFResoParams();
+    if (!input_file_name.empty()) { // Load parameters from input file
+      LOG(info) << "Loading parameters from file";
+      reso->LoadParamFromFile(input_file_name.c_str(), arguments["reso-name"].as<std::string>().c_str());
+    } else { // Create new object
+      LOG(info) << "Loading parameters from command line";
+      reso->SetParameters(std::array<float, 5>{arguments["p0"].as<float>(),
+                                               arguments["p1"].as<float>(),
+                                               arguments["p2"].as<float>(),
+                                               arguments["p3"].as<float>(),
+                                               arguments["p4"].as<float>()});
     }
     reso->Print();
     const std::string fname = arguments["save-to-file"].as<std::string>();
@@ -112,32 +122,96 @@ int main(int argc, char* argv[])
       LOG(info) << "Saving parametrization to file " << fname;
       TFile f(fname.data(), "RECREATE");
       reso->Write();
-      reso->GetParameters().Write();
       f.ls();
       f.Close();
     } else { // Saving it to CCDB
-      LOG(info) << "Saving parametrization to CCDB " << path << " with validity " << start << " "
-                << stop;
+      LOG(info) << "Saving parametrization to CCDB " << ccdbPath << " with validity " << validityStart << " "
+                << validityStop;
 
       std::map<std::string, std::string> metadata;
-      if (runnumber != 0) {
-        metadata["runnumber"] = Form("%i", runnumber);
+      if (minRunNumber != 0) {
+        metadata["min-runnumber"] = Form("%i", minRunNumber);
+        metadata["max-runnumber"] = Form("%i", maxRunNumber);
       }
-      // Storing parametrization objects
-      storeOnCCDB(path + "/" + reso_name, metadata, start, stop, reso);
+      reso->AddToMetadata(metadata);
       // Storing parametrization parameters
-      o2::pid::Parameters* params;
-      reso->GetParameters(params);
-      storeOnCCDB(path + "/Parameters/" + reso_name, metadata, start, stop, params);
+      storeOnCCDB(ccdbPath, metadata, validityStart, validityStop, reso);
     }
-  } else { // Pull and test mode
+  } else if (mode == 1) { // Pull and test mode
     LOG(info) << "Handling TOF parametrization in test mode for timestamp "
-              << timestamp << " -> " << timeStampToHReadble(timestamp);
-    const float x[7] = {1, 1, 1, 1, 1, 1, 1}; // mom, time, ev. reso, mass, length, sigma1pt, pt
-    reso = retrieveFromCCDB<TOFReso>(path + "/" + reso_name, timestamp);
+              << ccdbTimestamp << " -> " << timeStampToHReadble(ccdbTimestamp);
+    reso = retrieveFromCCDB<TOFResoParams>(ccdbPath, ccdbTimestamp);
     reso->Print();
-    LOG(info) << "TOF expected resolution at p=" << x[0] << " GeV/c "
-              << " and mass " << x[3] << ":" << reso->operator()(x);
+    using RespImp = ExpTimes<DebugTrack, 2>;
+    LOG(info) << "TOF expected resolution at p=" << debugTrack.p() << " GeV/c and mass " << RespImp::mMassZ << ":" << RespImp::GetExpectedSigma(*reso, debugTrack);
+  } else { // Create and test + performance
+    LOG(info) << "Creating TOF parametrization and testing";
+    reso = new TOFResoParams();
+    reso->Print();
+    DetectorResponse response;
+    if (!resoOld) {
+      resoOld = new TOFReso();
+      const std::vector<float> resoparams = {arguments["p0"].as<float>(), arguments["p1"].as<float>(), arguments["p2"].as<float>(), arguments["p3"].as<float>(), arguments["p4"].as<float>()};
+      resoOld->SetParameters(resoparams);
+    }
+    response.LoadParam(DetectorResponse::kSigma, resoOld);
+    // Draw it
+    using RespImp = ExpTimes<DebugTrack, 2>;
+    //
+    std::map<std::string, TGraph*> graphs;
+    graphs["ExpSigma"] = new TGraph();
+    graphs["NSigma"] = new TGraph();
+    graphs["durationExpSigma"] = new TGraph();
+    graphs["durationNSigma"] = new TGraph();
+    //
+    graphs["ExpSigmaOld"] = new TGraph();
+    graphs["NSigmaOld"] = new TGraph();
+    graphs["durationExpSigmaOld"] = new TGraph();
+    graphs["durationNSigmaOld"] = new TGraph();
+    const int nsamp = 1000;
+    for (int i = 0; i < nsamp; i++) {
+      debugTrack.mp += 0.01f;
+      //
+      auto start = high_resolution_clock::now();
+      RespImp::GetExpectedSigma(*reso, debugTrack);
+      auto stop = high_resolution_clock::now();
+      auto duration = duration_cast<nanoseconds>(stop - start).count();
+      graphs["ExpSigma"]->SetPoint(i, debugTrack.p(), RespImp::GetExpectedSigma(*reso, debugTrack));
+      graphs["durationExpSigma"]->SetPoint(i + 1, i, duration);
+      //
+      start = high_resolution_clock::now();
+      RespImp::GetSeparation(*reso, debugTrack);
+      stop = high_resolution_clock::now();
+      duration = duration_cast<nanoseconds>(stop - start).count();
+      graphs["NSigma"]->SetPoint(i, debugTrack.p(), RespImp::GetSeparation(*reso, debugTrack));
+      graphs["durationNSigma"]->SetPoint(i + 1, i, duration);
+      //
+      start = high_resolution_clock::now();
+      RespImp::GetExpectedSigma(response, debugTrack);
+      stop = high_resolution_clock::now();
+      duration = duration_cast<nanoseconds>(stop - start).count();
+      graphs["ExpSigmaOld"]->SetPoint(i, debugTrack.p(), RespImp::GetExpectedSigma(*reso, debugTrack));
+      graphs["durationExpSigmaOld"]->SetPoint(i + 1, i, duration);
+      //
+      start = high_resolution_clock::now();
+      RespImp::GetSeparation(response, debugTrack);
+      stop = high_resolution_clock::now();
+      duration = duration_cast<nanoseconds>(stop - start).count();
+      graphs["NSigmaOld"]->SetPoint(i, debugTrack.p(), RespImp::GetSeparation(*reso, debugTrack));
+      graphs["durationNSigmaOld"]->SetPoint(i + 1, i, duration);
+    }
+    TFile fdebug("/tmp/tofParamDebug.root", "UPDATE");
+    TString dn = Form("%i", fdebug.GetListOfKeys()->GetEntries());
+    LOG(info) << "Saving performance graphs to " << fdebug.GetName() << " iteration " << dn;
+    fdebug.mkdir(dn);
+    fdebug.cd(dn);
+    for (const auto& i : graphs) {
+      i.second->SetName(i.first.c_str());
+      i.second->SetTitle(i.first.c_str());
+      i.second->Write();
+    }
+    fdebug.Close();
+    LOG(info) << "TOF expected resolution at p=" << debugTrack.p() << " GeV/c and mass " << RespImp::mMassZ << ": " << RespImp::GetExpectedSigma(*reso, debugTrack) << " ps";
   }
 
   return 0;

--- a/DPG/Tasks/qaPIDTOF.cxx
+++ b/DPG/Tasks/qaPIDTOF.cxx
@@ -16,6 +16,7 @@
 ///
 
 #include "Framework/AnalysisTask.h"
+#include "Common/TableProducer/PID/pidTOFBase.h"
 #include "qaPIDTOF.h"
 #include "Framework/runDataProcessing.h"
 

--- a/DPG/Tasks/qaPIDTOFMC.cxx
+++ b/DPG/Tasks/qaPIDTOFMC.cxx
@@ -17,17 +17,11 @@
 
 // O2 includes
 #include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
-#include "ReconstructionDataFormats/Track.h"
-#include <CCDB/BasicCCDBManager.h>
 #include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/PID/PIDTOF.h"
 
 using namespace o2;
 using namespace o2::framework;
-using namespace o2::pid;
 using namespace o2::framework::expressions;
 using namespace o2::track;
 
@@ -43,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 #include "Framework/runDataProcessing.h"
 
+/// Task to produce the TOF QA plots
 template <o2::track::PID::ID pid_type>
 struct pidTOFTaskQA {
 

--- a/DPG/Tasks/qaPIDTPC.h
+++ b/DPG/Tasks/qaPIDTPC.h
@@ -10,16 +10,16 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file   qaTPC.h
+/// \file   qaPIDTPC.h
 /// \author Nicolò Jacazio nicolo.jacazio@cern.ch
 /// \brief  Header file for QA tasks of the TPC PID quantities
 ///
 
-#include "Common/DataModel/PIDResponse.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/StaticFor.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/PIDResponse.h"
 
 using namespace o2;
 using namespace o2::framework;

--- a/DPG/Tasks/qaPIDTPCMC.cxx
+++ b/DPG/Tasks/qaPIDTPCMC.cxx
@@ -17,11 +17,7 @@
 
 // O2 includes
 #include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
-#include "ReconstructionDataFormats/Track.h"
-#include <CCDB/BasicCCDBManager.h>
 #include "Common/DataModel/PIDResponse.h"
 
 using namespace o2;
@@ -41,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 #include "Framework/runDataProcessing.h"
 
+/// Task to produce the TPC QA plots
 template <o2::track::PID::ID pid_type>
 struct pidTPCTaskQA {
 


### PR DESCRIPTION
- bypass previous DetectorResponse common structure (will be removed)

- New structure holds only parameters
  - Implementation is left in code only
  - Add additional param getter
  - Using data member as mass defined at compile time
  - Fix warning of overriding streamers

- Simplify TOF param handler
  - Add performance plotting
  - Add validity based on run range
  - Add parameters to metadata

- Add PID simple mode w/o slicing
  - Add possibility to turn on and off slices

- Extend TOF PID tasks
  - Fix pidTOF switches
  - Update default par name to TOFResoParams, add FT0 only ev time
  - Clean includes

- Extend TOF QA plots
  - Add ev time reso
  - Fill ev time per class