### PR TITLE
Adding back the TPCPIDResponse.h into CMakeLists.txt and AnalysisCoreLinkDef.h

### DIFF
--- a/Common/Core/AnalysisCoreLinkDef.h
+++ b/Common/Core/AnalysisCoreLinkDef.h
@@ -18,5 +18,7 @@
 #pragma link C++ class o2::pid::Parameters + ;
 #pragma link C++ class o2::pid::Parametrization + ;
 
+#pragma link C++ class o2::pid::tpc::Response + ;
+
 #pragma link C++ class o2::pid::tof::TOFReso + ;
 #pragma link C++ class OrbitRange + ;

--- a/Common/Core/CMakeLists.txt
+++ b/Common/Core/CMakeLists.txt
@@ -23,6 +23,7 @@ o2physics_target_root_dictionary(AnalysisCore
                         PID/DetectorResponse.h
                         PID/PIDTOF.h
                         PID/TOFReso.h
+                        PID/TPCPIDResponse.h
               LINKDEF AnalysisCoreLinkDef.h)
 
 o2physics_add_executable(merger


### PR DESCRIPTION
This PR intends to fix the missing TPCPIDResponse.h headers into the CMakeLists.txt and AnalysisCoreLinkDef.h files in O2Physics/Common/Core