### PR TITLE
Implement setter function to check MC signal from mother to daughter

### DIFF
--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -104,7 +104,7 @@ void MCProng::SetUseANDonSourceBits(int generation, bool option /*=true*/)
 }
 
 //________________________________________________________________________________________________________________
-void MCProng::SetDirectionOfGeneration(int generation, bool intime /*=false*/)
+void MCProng::SetSignalInTime(int generation, bool intime /*=false*/)
 {
   if (generation < 0 || generation >= fNGenerations) {
     return;

--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -18,6 +18,7 @@ ClassImp(MCProng);
 
 //________________________________________________________________________________________________________________
 MCProng::MCProng() : fNGenerations(0),
+                     fCheckGenerationsInTime(0),
                      fPDGcodes({}),
                      fCheckBothCharges({}),
                      fExcludePDG({}),
@@ -28,7 +29,8 @@ MCProng::MCProng() : fNGenerations(0),
 }
 
 //________________________________________________________________________________________________________________
-MCProng::MCProng(int n) : fNGenerations(n)
+MCProng::MCProng(int n) : fNGenerations(n),
+                          fCheckGenerationsInTime(0)
 {
   fPDGcodes.reserve(n);
   fCheckBothCharges.reserve(n);
@@ -49,13 +51,14 @@ MCProng::MCProng(int n) : fNGenerations(n)
 //________________________________________________________________________________________________________________
 MCProng::MCProng(int n, const std::vector<int> pdgs, const std::vector<bool> checkBothCharges, const std::vector<bool> excludePDG,
                  const std::vector<uint64_t> sourceBits, const std::vector<uint64_t> excludeSource,
-                 const std::vector<bool> useANDonSourceBitMap) : fNGenerations(n),
-                                                                 fPDGcodes(pdgs),
-                                                                 fCheckBothCharges(checkBothCharges),
-                                                                 fExcludePDG(excludePDG),
-                                                                 fSourceBits(sourceBits),
-                                                                 fExcludeSource(excludeSource),
-                                                                 fUseANDonSourceBitMap(useANDonSourceBitMap){};
+                 const std::vector<bool> useANDonSourceBitMap, bool checkGenerationsInTime) : fNGenerations(n),
+                                                                                              fPDGcodes(pdgs),
+                                                                                              fCheckBothCharges(checkBothCharges),
+                                                                                              fExcludePDG(excludePDG),
+                                                                                              fSourceBits(sourceBits),
+                                                                                              fExcludeSource(excludeSource),
+                                                                                              fUseANDonSourceBitMap(useANDonSourceBitMap),
+                                                                                              fCheckGenerationsInTime(checkGenerationsInTime){};
 
 //________________________________________________________________________________________________________________
 void MCProng::SetPDGcode(int generation, int code, bool checkBothCharges /*= false*/, bool exclude /*= false*/)
@@ -101,12 +104,21 @@ void MCProng::SetUseANDonSourceBits(int generation, bool option /*=true*/)
 }
 
 //________________________________________________________________________________________________________________
+void MCProng::SetDirectionOfGeneration(int generation, bool intime /*=false*/)
+{
+  if (generation < 0 || generation >= fNGenerations) {
+    return;
+  }
+  fCheckGenerationsInTime = intime;
+}
+
+//________________________________________________________________________________________________________________
 void MCProng::Print() const
 {
   for (int i = 0; i < fNGenerations; i++) {
     std::cout << "Generation #" << i << " PDGcode(" << fPDGcodes[i] << ") CheckBothCharges(" << fCheckBothCharges[i]
               << ") ExcludePDG(" << fExcludePDG[i] << ")  SourceBits(" << fSourceBits[i] << ") ExcludeSource(" << fExcludeSource[i]
-              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ")" << std::endl;
+              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ") CheckGenerationsInTime(" << fCheckGenerationsInTime << ")" << std::endl;
   }
 }
 

--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -104,11 +104,8 @@ void MCProng::SetUseANDonSourceBits(int generation, bool option /*=true*/)
 }
 
 //________________________________________________________________________________________________________________
-void MCProng::SetSignalInTime(int generation, bool intime /*=false*/)
+void MCProng::SetSignalInTime(bool intime /*=false*/)
 {
-  if (generation < 0 || generation >= fNGenerations) {
-    return;
-  }
   fCheckGenerationsInTime = intime;
 }
 

--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -18,13 +18,13 @@ ClassImp(MCProng);
 
 //________________________________________________________________________________________________________________
 MCProng::MCProng() : fNGenerations(0),
-                     fCheckGenerationsInTime(0),
                      fPDGcodes({}),
                      fCheckBothCharges({}),
                      fExcludePDG({}),
                      fSourceBits({}),
                      fExcludeSource({}),
-                     fUseANDonSourceBitMap({})
+                     fUseANDonSourceBitMap({}),
+                     fCheckGenerationsInTime(0)
 {
 }
 

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -18,8 +18,8 @@
 //          bit maps with a bit dedicated to each source (MCProng::Source), bit map on whether the specified source to be excluded,
 //          whether to use AND among all specified source requirements
 
-/* The PDG codes us the PYTHIA standard. 
-A few non-existent PYTHIA codes are used to select more than one PYTHIA code. 
+/* The PDG codes us the PYTHIA standard.
+A few non-existent PYTHIA codes are used to select more than one PYTHIA code.
 
 0 - default, accepts all PYTHIA codes
 100 - light unflavoured mesons in the code range 100-199

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -79,7 +79,7 @@ class MCProng
   MCProng();
   MCProng(int n);
   MCProng(int n, std::vector<int> pdgs, std::vector<bool> checkBothCharges, std::vector<bool> excludePDG,
-          std::vector<uint64_t> sourceBits, std::vector<uint64_t> excludeSource, std::vector<bool> useANDonSourceBitMap);
+          std::vector<uint64_t> sourceBits, std::vector<uint64_t> excludeSource, std::vector<bool> useANDonSourceBitMap, bool fCheckGenerationsInTime = false);
   MCProng(const MCProng& c) = default;
   virtual ~MCProng() = default;
 
@@ -87,11 +87,13 @@ class MCProng
   void SetSources(int generation, uint64_t bits, uint64_t exclude = 0, bool useANDonSourceBits = true);
   void SetSourceBit(int generation, int sourceBit, bool exclude = false);
   void SetUseANDonSourceBits(int generation, bool option = true);
+  void SetDirectionOfGeneration(int generation, bool intime = false); // set variable to check generations in time or back in time (default)
   void Print() const;
   bool TestPDG(int i, int pdgCode) const;
   bool ComparePDG(int pdg, int prongPDG, bool checkBothCharges = false, bool exclude = false) const;
 
   int fNGenerations;
+  bool fCheckGenerationsInTime;
   std::vector<int> fPDGcodes;
   std::vector<bool> fCheckBothCharges;
   std::vector<bool> fExcludePDG;

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -87,7 +87,7 @@ class MCProng
   void SetSources(int generation, uint64_t bits, uint64_t exclude = 0, bool useANDonSourceBits = true);
   void SetSourceBit(int generation, int sourceBit, bool exclude = false);
   void SetUseANDonSourceBits(int generation, bool option = true);
-  void SetDirectionOfGeneration(int generation, bool intime = false); // set variable to check generations in time or back in time (default)
+  void SetSignalInTime(int generation, bool intime = false); // set variable to check generations in time or back in time (default)
   void Print() const;
   bool TestPDG(int i, int pdgCode) const;
   bool ComparePDG(int pdg, int prongPDG, bool checkBothCharges = false, bool exclude = false) const;

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -101,6 +101,6 @@ class MCProng
   std::vector<uint64_t> fExcludeSource;
   std::vector<bool> fUseANDonSourceBitMap;
 
-  ClassDef(MCProng, 1);
+  ClassDef(MCProng, 2);
 };
 #endif

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -93,13 +93,13 @@ class MCProng
   bool ComparePDG(int pdg, int prongPDG, bool checkBothCharges = false, bool exclude = false) const;
 
   int fNGenerations;
-  bool fCheckGenerationsInTime;
   std::vector<int> fPDGcodes;
   std::vector<bool> fCheckBothCharges;
   std::vector<bool> fExcludePDG;
   std::vector<uint64_t> fSourceBits;
   std::vector<uint64_t> fExcludeSource;
   std::vector<bool> fUseANDonSourceBitMap;
+  bool fCheckGenerationsInTime;
 
   ClassDef(MCProng, 2);
 };

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -87,7 +87,7 @@ class MCProng
   void SetSources(int generation, uint64_t bits, uint64_t exclude = 0, bool useANDonSourceBits = true);
   void SetSourceBit(int generation, int sourceBit, bool exclude = false);
   void SetUseANDonSourceBits(int generation, bool option = true);
-  void SetSignalInTime(int generation, bool intime = false); // set variable to check generations in time or back in time (default)
+  void SetSignalInTime(bool intime = false); // set variable to check generations in time or back in time (default)
   void Print() const;
   bool TestPDG(int i, int pdgCode) const;
   bool ComparePDG(int pdg, int prongPDG, bool checkBothCharges = false, bool exclude = false) const;

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -130,18 +130,20 @@ class MCSignal : public TNamed
 template <typename U, typename T>
 bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& track)
 {
+  // // if generations are checked in time (grandmother->mother->daughter) reverse order of MCProng variables to start at the end
+  // if (fProngs[i].fCheckGenerationsInTime) {
+  //   std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
+  //   std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
+  //   std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
+  //   std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
+  //   std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
+  //   std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
+  // }
+
   auto currentMCParticle = track;
+  
   // loop over the generations specified for this prong
   for (int j = 0; j < fProngs[i].fNGenerations; j++) {
-    // if generations are checked in time (grandmother->mother->daughter) reverse order of MCProng variables to start at the end
-    if (fProngs[i].fCheckGenerationsInTime) {
-      std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
-      std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
-      std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
-      std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
-      std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
-      std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
-    }
     // check the PDG code
     if (!fProngs[i].TestPDG(j, currentMCParticle.pdgCode())) {
       return false;
@@ -160,27 +162,54 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
     // if checking back in time: look for mother
     // else (checking in time): look for daughter
     if (!fProngs[i].fCheckGenerationsInTime) {
-      // make sure that a mother exists in the stack before moving one generation further in history
-      if (!currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
-        return false;
-      }
-      if (currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
-        /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
-          LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
-        }*/
-        currentMCParticle = currentMCParticle.template mothers_first_as<U>();
-        // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
-        // currentMCParticle = currentMCParticle.template mother0_as<U>();
-      }
+      // if (currentMCParticle.has_mothers() > 0) {
+                                    // printf("CheckGenInTime = %i \n", fProngs[i].fCheckGenerationsInTime);
+                                    // printf("currentPart pdg = %i \n", currentMCParticle.pdgCode());
+                                    // printf("fProng.NGenerations = %i \n", fProngs[i].fNGenerations);
+                                    // for (int k = 0; k < fProngs[i].fNGenerations; k++) {
+                                    //   printf("fProng.pdg(kGen=%i) = %i \n", k, fProngs[i].fPDGcodes[k]);
+                                    // }
+                                    // printf("currentParticle.hasMothers = %i \n", currentMCParticle.has_mothers());
+
+        // make sure that a mother exists in the stack before moving one generation further in history
+        if (!currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
+          return false;
+        }
+        if (currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
+          /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
+            LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
+          }*/
+          currentMCParticle = currentMCParticle.template mothers_first_as<U>();
+                                    // printf("changed to mother particle pdg = %i \n", currentMCParticle.pdgCode());
+          // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
+          // currentMCParticle = currentMCParticle.template mother0_as<U>();
+        }
+      // }
     } else {
-      // make sure that a daughter exists in the stack before moving one generation younger
-      if (!currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-        return false;
-      }
-      if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-        currentMCParticle = currentMCParticle.template mothers_first_as<U>();
-        // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
-      }
+      // if (currentMCParticle.has_daughters() > 0) {
+                                    // printf("CheckGenInTime = %i \n", fProngs[i].fCheckGenerationsInTime);
+                                    // printf("currentPart pdg = %i \n", currentMCParticle.pdgCode());
+                                    // printf("fProng.NGenerations = %i \n", fProngs[i].fNGenerations);
+                                    // for (int k = 0; k < fProngs[i].fNGenerations; k++) {
+                                    //   printf("fProng.pdg(kGen=%i) = %i \n", k, fProngs[i].fPDGcodes[k]);
+                                    // }
+                                    // printf("currentParticle.hasDaugthers = %i \n", currentMCParticle.has_daughters());
+        // make sure that a daughter exists in the stack before moving one generation younger
+        if (!currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
+          return false;
+        }
+        if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
+          auto daughtersSlice = currentMCParticle.template daughters_as<U>();
+                                    // printf("DaughtersSlice.size = %i \n", daughtersSlice.size());
+          for (auto d : daughtersSlice) {
+                                      // printf("daughterPart pdg = %i \n", d.pdgCode());
+            currentMCParticle = d;
+                                      // printf("changed currentPart pdg = %i \n", currentMCParticle.pdgCode());
+          }
+          // currentMCParticle = mcStack.iteratorAt(currentMCParticle.daughtersIds()[0]);
+        }
+        // printf(" -------------- \n");
+      // }
     }
   }
 
@@ -188,14 +217,14 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
     currentMCParticle = track;
     for (int j = 0; j < fProngs[i].fNGenerations; j++) {
       // if generations are checked in time (grandmother->mother->daughter) reverse order of MCProng variables to start at the end
-      if (fProngs[i].fCheckGenerationsInTime) {
-        std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
-        std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
-        std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
-        std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
-        std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
-        std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
-      }
+      // if (fProngs[i].fCheckGenerationsInTime) {
+      //   std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
+      //   std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
+      //   std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
+      //   std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
+      //   std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
+      //   std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
+      // }
       if (!fProngs[i].fSourceBits[j]) {
         // no sources required for this generation
         continue;
@@ -262,7 +291,7 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
           return false;
         }
         if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-          currentMCParticle = currentMCParticle.template mothers_first_as<U>();
+          // currentMCParticle = currentMCParticle.template mothers_first_as<U>();
           // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
         }
       }

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -130,18 +130,7 @@ class MCSignal : public TNamed
 template <typename U, typename T>
 bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& track)
 {
-  // // if generations are checked in time (grandmother->mother->daughter) reverse order of MCProng variables to start at the end
-  // if (fProngs[i].fCheckGenerationsInTime) {
-  //   std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
-  //   std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
-  //   std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
-  //   std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
-  //   std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
-  //   std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
-  // }
-
   auto currentMCParticle = track;
-  
   // loop over the generations specified for this prong
   for (int j = 0; j < fProngs[i].fNGenerations; j++) {
     // check the PDG code
@@ -162,69 +151,43 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
     // if checking back in time: look for mother
     // else (checking in time): look for daughter
     if (!fProngs[i].fCheckGenerationsInTime) {
-      // if (currentMCParticle.has_mothers() > 0) {
-                                    // printf("CheckGenInTime = %i \n", fProngs[i].fCheckGenerationsInTime);
-                                    // printf("currentPart pdg = %i \n", currentMCParticle.pdgCode());
-                                    // printf("fProng.NGenerations = %i \n", fProngs[i].fNGenerations);
-                                    // for (int k = 0; k < fProngs[i].fNGenerations; k++) {
-                                    //   printf("fProng.pdg(kGen=%i) = %i \n", k, fProngs[i].fPDGcodes[k]);
-                                    // }
-                                    // printf("currentParticle.hasMothers = %i \n", currentMCParticle.has_mothers());
-
-        // make sure that a mother exists in the stack before moving one generation further in history
-        if (!currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
-          return false;
+      // make sure that a mother exists in the stack before moving one generation further in history
+      if (!currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
+        return false;
+      }
+      /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
+        LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
+      }*/
+      // currentMCParticle = currentMCParticle.template mothers_first_as<U>();
+      if (currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
+        const auto& mothersSlice = currentMCParticle.template mothers_as<U>();
+        for (auto& mother : mothersSlice) {
+          currentMCParticle = mother;
         }
-        if (currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
-          /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
-            LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
-          }*/
-          currentMCParticle = currentMCParticle.template mothers_first_as<U>();
-                                    // printf("changed to mother particle pdg = %i \n", currentMCParticle.pdgCode());
-          // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
-          // currentMCParticle = currentMCParticle.template mother0_as<U>();
-        }
-      // }
+        // printf("changed to mother particle pdg = %i \n", currentMCParticle.pdgCode());
+        // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
+        // currentMCParticle = currentMCParticle.template mother0_as<U>();
+      }
     } else {
-      // if (currentMCParticle.has_daughters() > 0) {
-                                    // printf("CheckGenInTime = %i \n", fProngs[i].fCheckGenerationsInTime);
-                                    // printf("currentPart pdg = %i \n", currentMCParticle.pdgCode());
-                                    // printf("fProng.NGenerations = %i \n", fProngs[i].fNGenerations);
-                                    // for (int k = 0; k < fProngs[i].fNGenerations; k++) {
-                                    //   printf("fProng.pdg(kGen=%i) = %i \n", k, fProngs[i].fPDGcodes[k]);
-                                    // }
-                                    // printf("currentParticle.hasDaugthers = %i \n", currentMCParticle.has_daughters());
-        // make sure that a daughter exists in the stack before moving one generation younger
-        if (!currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-          return false;
-        }
-        if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-          auto daughtersSlice = currentMCParticle.template daughters_as<U>();
-                                    // printf("DaughtersSlice.size = %i \n", daughtersSlice.size());
-          for (auto d : daughtersSlice) {
-                                      // printf("daughterPart pdg = %i \n", d.pdgCode());
+      // make sure that a daughter exists in the stack before moving one generation younger
+      if (!currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
+        return false;
+      }
+      if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
+        const auto& daughtersSlice = currentMCParticle.template daughters_as<U>();
+        for (auto& d : daughtersSlice) {
+          if (abs(d.pdgCode()) == fProngs[i].fPDGcodes[j + 1]) {
             currentMCParticle = d;
-                                      // printf("changed currentPart pdg = %i \n", currentMCParticle.pdgCode());
+            break;
           }
-          // currentMCParticle = mcStack.iteratorAt(currentMCParticle.daughtersIds()[0]);
         }
-        // printf(" -------------- \n");
-      // }
+      }
     }
   }
 
   if (checkSources) {
     currentMCParticle = track;
     for (int j = 0; j < fProngs[i].fNGenerations; j++) {
-      // if generations are checked in time (grandmother->mother->daughter) reverse order of MCProng variables to start at the end
-      // if (fProngs[i].fCheckGenerationsInTime) {
-      //   std::reverse(fProngs[i].fPDGcodes.begin(), fProngs[i].fPDGcodes.end());
-      //   std::reverse(fProngs[i].fCheckBothCharges.begin(), fProngs[i].fCheckBothCharges.end());
-      //   std::reverse(fProngs[i].fExcludePDG.begin(), fProngs[i].fExcludePDG.end());
-      //   std::reverse(fProngs[i].fSourceBits.begin(), fProngs[i].fSourceBits.end());
-      //   std::reverse(fProngs[i].fExcludeSource.begin(), fProngs[i].fExcludeSource.end());
-      //   std::reverse(fProngs[i].fUseANDonSourceBitMap.begin(), fProngs[i].fUseANDonSourceBitMap.end());
-      // }
       if (!fProngs[i].fSourceBits[j]) {
         // no sources required for this generation
         continue;
@@ -293,6 +256,15 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
         if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
           // currentMCParticle = currentMCParticle.template mothers_first_as<U>();
           // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
+        }
+        if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
+          const auto& daughtersSlice = currentMCParticle.template daughters_as<U>();
+          for (auto& d : daughtersSlice) {
+            if (abs(d.pdgCode()) == fProngs[i].fPDGcodes[j + 1]) {
+              currentMCParticle = d;
+              break;
+            }
+          }
         }
       }
     }

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -158,13 +158,8 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
       /*for (auto& m : mcParticle.mothers_as<aod::McParticles_001>()) {
         LOGF(debug, "M2 %d %d", mcParticle.globalIndex(), m.globalIndex());
       }*/
-      // currentMCParticle = currentMCParticle.template mothers_first_as<U>();
       if (currentMCParticle.has_mothers() && j < fProngs[i].fNGenerations - 1) {
-        const auto& mothersSlice = currentMCParticle.template mothers_as<U>();
-        for (auto& mother : mothersSlice) {
-          currentMCParticle = mother;
-        }
-        // printf("changed to mother particle pdg = %i \n", currentMCParticle.pdgCode());
+        currentMCParticle = currentMCParticle.template mothers_first_as<U>();
         // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
         // currentMCParticle = currentMCParticle.template mother0_as<U>();
       }

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -171,7 +171,7 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
       if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
         const auto& daughtersSlice = currentMCParticle.template daughters_as<U>();
         for (auto& d : daughtersSlice) {
-          if (abs(d.pdgCode()) == fProngs[i].fPDGcodes[j + 1]) {
+          if (fProngs[i].TestPDG(j + 1, d.pdgCode())) {
             currentMCParticle = d;
             break;
           }
@@ -244,6 +244,7 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
         }*/
       } else {
         // move one generation further in history
+        // pong history will be moved to the branch of the first daughter that matches the PDG requirement
         // make sure that a daughter exists in the stack before moving one generation younger
         if (!currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
           return false;
@@ -255,7 +256,7 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
         if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
           const auto& daughtersSlice = currentMCParticle.template daughters_as<U>();
           for (auto& d : daughtersSlice) {
-            if (abs(d.pdgCode()) == fProngs[i].fPDGcodes[j + 1]) {
+            if (fProngs[i].TestPDG(j + 1, d.pdgCode())) {
               currentMCParticle = d;
               break;
             }

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -250,10 +250,6 @@ bool MCSignal::CheckProng(int i, bool checkSources, const U& mcStack, const T& t
           return false;
         }
         if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
-          // currentMCParticle = currentMCParticle.template mothers_first_as<U>();
-          // currentMCParticle = mcStack.iteratorAt(currentMCParticle.mothersIds()[0]);
-        }
-        if (currentMCParticle.has_daughters() && j < fProngs[i].fNGenerations - 1) {
           const auto& daughtersSlice = currentMCParticle.template daughters_as<U>();
           for (auto& d : daughtersSlice) {
             if (fProngs[i].TestPDG(j + 1, d.pdgCode())) {

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -284,7 +284,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("eFromLMeeLFQ")) {
     MCProng prong(2, {11, 900}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    prong.SetDirectionOfGeneration(0, true);  // set direction to check generation in time (true) or back in time (false)
+    prong.SetSignalInTime(0, false);  // set direction to check generation in time (true) or back in time (false)
     signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -283,9 +283,9 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
   if (!nameStr.compare("eFromLMeeLFQ")) {
     MCProng prong(2, {11, 900}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
-    //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    prong.SetSignalInTime(0, false);  // set direction to check generation in time (true) or back in time (false)
-    signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    prong.SetSignalInTime(0, false);                                                          // set direction to check generation in time (true) or back in time (false)
+    signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }
   if (!nameStr.compare("eFromLMeeLF")) {

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -284,6 +284,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("eFromLMeeLFQ")) {
     MCProng prong(2, {11, 900}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    prong.SetDirectionOfGeneration(0, true);  // set direction to check generation in time (true) or back in time (false)
     signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -45,6 +45,11 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Primary electrons", {prong}, {-1}); // define the signal using the full constructor
     return signal;
   }
+  if (!nameStr.compare("photon")) {
+    MCProng prong(1, {22}, {true}, {false}, {0}, {0}, {false}); // define 1-generation prong using the full constructor
+    signal = new MCSignal(name, "Photon", {prong}, {-1});       // define the signal using the full constructor
+    return signal;
+  }
   if (!nameStr.compare("kaonFromPhi")) {
     MCProng prong(2, {321, 333}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}); // define 2-generation prong using the full constructor
     signal = new MCSignal(name, "Kaons from phi-mesons", {prong}, {-1});                        // define the signal using the full constructor
@@ -173,22 +178,28 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Electrons from pi0 decays", {prong}, {-1});
     return signal;
   }
+  if (!nameStr.compare("Pi0decayTOe")) {
+    MCProng prong(2, {111, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prong.SetSignalInTime(0, true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    signal = new MCSignal(name, "Pi0 decays into an electron", {prong}, {-1});
+    return signal;
+  }
   if (!nameStr.compare("Pi0")) {
     MCProng prong(1, {111}, {true}, {false}, {0}, {0}, {false});
-    //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
     signal = new MCSignal(name, "Pi0", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("LMeeLFQ")) {
     MCProng prong(1, {900}, {true}, {false}, {0}, {0}, {false});
-    //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    signal = new MCSignal(name, "light flavor mesons + quarkonia", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi,jpsi,psi2s
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    signal = new MCSignal(name, "light flavor mesons + quarkonia", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s
     return signal;
   }
   if (!nameStr.compare("LMeeLF")) {
     MCProng prong(1, {901}, {true}, {false}, {0}, {0}, {false});
-    //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    signal = new MCSignal(name, "ligh flavor mesons", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    signal = new MCSignal(name, "ligh flavor mesons", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi
     return signal;
   }
   if (!nameStr.compare("electronFromDs")) {
@@ -199,6 +210,11 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("dsMeson")) {
     MCProng prong(1, {431}, {true}, {false}, {0}, {0}, {true});
     signal = new MCSignal(name, "Ds mesons", {prong}, {-1});
+    return signal;
+  }
+  if (!nameStr.compare("electronFromPC")) {
+    MCProng prong(2, {11, 22}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    signal = new MCSignal(name, "electron from a photon conversion", {prong}, {-1});
     return signal;
   }
 
@@ -230,7 +246,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
 
-  //LMEE single signals
+  // LMEE single signals
   if (!nameStr.compare("eFromPi0")) {
     MCProng prong(2, {11, 111}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "Electrons from pi0 decays", {prong}, {-1});
@@ -288,10 +304,17 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }
+  if (!nameStr.compare("LFQdecayToE")) {
+    MCProng prong(2, {900, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    prong.SetSignalInTime(0, true);                                                    // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    signal = new MCSignal(name, "LF meson  + quarkonia decays into e", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
+    return signal;
+  }
   if (!nameStr.compare("eFromLMeeLF")) {
     MCProng prong(2, {11, 901}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
-    //prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    signal = new MCSignal(name, "Electrons from LF meson decays", {prong}, {-1}); //pi0,eta,eta',rho,omega,phi mesons
+    // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
+    signal = new MCSignal(name, "Electrons from LF meson decays", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi mesons
     return signal;
   }
   if (!nameStr.compare("eFromHc")) {
@@ -334,9 +357,15 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Electrons from open charmed hadron decays from b hadron decays", {prong}, {-1});
     return signal;
   }
+  //   if (!nameStr.compare("LFQtoPC")) {
+  //   MCProng prong(3, {900, 22, 11}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
+  //   prong.SetSignalInTime(0, true);  // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+  //   signal = new MCSignal(name, "LF meson + quarkonia decays into photon conversion electron", {prong}, {-1});
+  //   return signal;
+  // }
 
   //_________________________________________________________________________________________________________________________
-  //LMEE pair signals for LF, same mother
+  // LMEE pair signals for LF, same mother
   if (!nameStr.compare("eeFromPi0")) {
     MCProng prong(2, {11, 111}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "ee pairs from pi0 decays", {prong, prong}, {1, 1}); // signal at pair level
@@ -398,29 +427,29 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
 
-  //LMEE pair signals for HF
-  //c->e and c->e (prompt)
+  // LMEE pair signals for HF
+  // c->e and c->e (prompt)
   if (!nameStr.compare("eeFromCC")) {
     MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
     signal = new MCSignal(name, "ee pairs from c->e and c->e", {prong, prong}, {-1, -1}); // signal at pair level
     return signal;
   }
 
-  //b->e and b->e
+  // b->e and b->e
   if (!nameStr.compare("eeFromBB")) {
     MCProng prong(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "ee pairs from b->e and b->e", {prong, prong}, {-1, -1}); // signal at pair level
     return signal;
   }
 
-  //b->c->e and b->c->e
+  // b->c->e and b->c->e
   if (!nameStr.compare("eeFromBtoC")) {
     MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
     signal = new MCSignal(name, "ee pairs from b->c->e and b->c->e", {prong, prong}, {-1, -1}); // signal at pair level
     return signal;
   }
 
-  //b->e and b->c->e
+  // b->e and b->c->e
   if (!nameStr.compare("eeFromBandBtoC")) {
     MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
@@ -428,7 +457,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
 
-  //b->e and b->c->e (single b)
+  // b->e and b->c->e (single b)
   if (!nameStr.compare("eeFromSingleBandBtoC")) {
     MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -180,7 +180,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
   if (!nameStr.compare("Pi0decayTOe")) {
     MCProng prong(2, {111, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
-    prong.SetSignalInTime(0, true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    prong.SetSignalInTime(true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
     signal = new MCSignal(name, "Pi0 decays into an electron", {prong}, {-1});
     return signal;
   }
@@ -300,14 +300,14 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("eFromLMeeLFQ")) {
     MCProng prong(2, {11, 900}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    prong.SetSignalInTime(0, false);                                                          // set direction to check generation in time (true) or back in time (false)
+    prong.SetSignalInTime(false);                                                             // set direction to check generation in time (true) or back in time (false)
     signal = new MCSignal(name, "Electrons from LF meson + quarkonia decays", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }
   if (!nameStr.compare("LFQdecayToE")) {
     MCProng prong(2, {900, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
-    prong.SetSignalInTime(0, true);                                                    // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    prong.SetSignalInTime(true);                                                       // set direction to check for daughters (true, in time) or for mothers (false, back in time)
     signal = new MCSignal(name, "LF meson  + quarkonia decays into e", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
     return signal;
   }
@@ -359,7 +359,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
   //   if (!nameStr.compare("LFQtoPC")) {
   //   MCProng prong(3, {900, 22, 11}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
-  //   prong.SetSignalInTime(0, true);  // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+  //   prong.SetSignalInTime(true);  // set direction to check for daughters (true, in time) or for mothers (false, back in time)
   //   signal = new MCSignal(name, "LF meson + quarkonia decays into photon conversion electron", {prong}, {-1});
   //   return signal;
   // }

--- a/PWGEM/Tasks/CMakeLists.txt
+++ b/PWGEM/Tasks/CMakeLists.txt
@@ -18,3 +18,8 @@ o2physics_add_dpl_workflow(phoscluqa
                     SOURCES phosCluQA.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::DetectorsVertexing O2::PHOSBase
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(analysemcsignal
+                    SOURCES analysemcsignal.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)

--- a/PWGEM/Tasks/CMakeLists.txt
+++ b/PWGEM/Tasks/CMakeLists.txt
@@ -18,8 +18,3 @@ o2physics_add_dpl_workflow(phoscluqa
                     SOURCES phosCluQA.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::DetectorsVertexing O2::PHOSBase
                     COMPONENT_NAME Analysis)
-
-o2physics_add_dpl_workflow(analysemcsignal
-                    SOURCES analysemcsignal.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
-                    COMPONENT_NAME Analysis)


### PR DESCRIPTION
Implemented a setter function in the MCprong files to give the option, when defining a MCsignal in the MCSignalLibrary.h to check the MC signal from the mother to the daughter (In time).

Therefore the MC signal needs the mother pdg code as first entry and its daughter as second:
e.g. 
```
  if (!nameStr.compare("LFQdecayToE")) {
    MCProng prong(2, {900, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
    prong.SetSignalInTime(0, true);                                                    // set direction to check for daughters (true, in time) or for mothers (false, back in time)
    signal = new MCSignal(name, "LF meson  + quarkonia decays into e", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi,jpsi,psi2s mesons
    return signal;
  }
```

The CheckProng function in MCSignal.h then checks the boolean `fCheckGenerationsInTime` whether we have to check in the next generation for a mother or daughters.

If we look for daughters, we check if there is one, and if so if it has a pdg code of the next generation.
If it is true it uses the first daughter that fulfils that requirement and sets it as current particle to check for further generations.

(Note: There is no option currently to check multiple daughters in the same generation that would fulfil the MC signal.)