### PR TITLE
[Common, PWGHF, Event Filtering] Implement specific method to tag prompt/nonprompt charm hadrons

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -950,14 +950,8 @@ class RecoDecay
 
             if (!searchUpToQuark) {
               if (
-                (PDGParticleIMother / 100 == 5 ||            // b mesons
-                 PDGParticleIMother / 1000 == 5 ||           // b baryons
-                 (PDGParticleIMother - 10000) / 100 == 5 ||  // bbbar resonances
-                 (PDGParticleIMother - 20000) / 100 == 5 ||  // bbbar resonances
-                 (PDGParticleIMother - 30000) / 100 == 5 ||  // bbbar resonances
-                 (PDGParticleIMother - 100000) / 100 == 5 || // bbbar resonances
-                 (PDGParticleIMother - 200000) / 100 == 5 || // bbbar resonances
-                 (PDGParticleIMother - 300000) / 100 == 5)   // bbbar resonances
+                (PDGParticleIMother / 100 == 5 || // b mesons
+                 PDGParticleIMother / 1000 == 5)  // b baryons
               ) {
                 return 2;
               }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -937,7 +937,7 @@ class RecoDecay
   template <typename T>
   static int getCharmHadronOrigin(const T& particlesMC,
                                   const typename T::iterator& particle,
-                                  const bool& searchUpToQuark = false)
+                                  const bool searchUpToQuark = false)
   {
     int stage = 0; // mother tree level (just for debugging)
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -41,20 +41,6 @@ using namespace o2::constants::math;
 /// - Monte Carlo matching of decays at track and particle level
 
 // mapping of charm-hadron origin type
-namespace o2
-{
-namespace aod
-{
-namespace hf_cand
-{
-enum OriginType { None = 0,
-                  Prompt,
-                  NonPrompt };
-} // namespace hf_cand
-} // namespace aod
-} // namespace o2
-
-using namespace o2::aod::hf_cand;
 
 class RecoDecay
 {
@@ -64,6 +50,10 @@ class RecoDecay
 
   /// Default destructor
   ~RecoDecay() = default;
+
+  enum OriginType { None = 0,
+                    Prompt,
+                    NonPrompt };
 
   // Auxiliary functions
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -40,8 +40,6 @@ using namespace o2::constants::math;
 /// - calculation of topological properties of secondary vertices
 /// - Monte Carlo matching of decays at track and particle level
 
-// mapping of charm-hadron origin type
-
 class RecoDecay
 {
  public:
@@ -51,6 +49,7 @@ class RecoDecay
   /// Default destructor
   ~RecoDecay() = default;
 
+  // mapping of charm-hadron origin type
   enum OriginType { None = 0,
                     Prompt,
                     NonPrompt };

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -913,6 +913,77 @@ class RecoDecay
     return true;
   }
 
+  /// Finds the origin (from charm hadronisation or beauty-hadron decay) of charm hadrons.
+  /// \param particlesMC  table with MC particles
+  /// \param particle  MC particle
+  /// \param searchUpToQuark if true tag origin based on charm/beauty quark otherwise on b-hadron
+  /// \return an integer corresponding to the origin (0: none, 1: prompt, 2: nonprompt) as in hf_cand::OriginType (see PWGHF/DataModel/HFSecondaryVertex.h)
+  template <typename T>
+  static int checkCharmHadronOrigin(const T& particlesMC,
+                                    const typename T::iterator& particle,
+                                    const bool& searchUpToQuark = false)
+  {
+    int stage = 0; // mother tree level (just for debugging)
+
+    // vector of vectors with mother indices; each line corresponds to a "stage"
+    std::vector<std::vector<long int>> arrayIds{};
+    std::vector<long int> initVec{particle.globalIndex()};
+    arrayIds.push_back(initVec); // the first vector contains the index of the original particle
+
+    while (arrayIds[-stage].size() > 0) {
+      // vector of mother indices for the current stage
+      std::vector<long int> arrayIdsStage{};
+      for (auto& iPart : arrayIds[-stage]) { // check all the particles that were the mothers at the previous stage
+        auto particleMother = particlesMC.rawIteratorAt(iPart - particlesMC.offset());
+        if (particleMother.has_mothers()) {
+          for (auto iMother = particleMother.mothersIds().front(); iMother <= particleMother.mothersIds().back(); ++iMother) { // loop over the mother particles of the analysed particle
+            if (std::find(arrayIdsStage.begin(), arrayIdsStage.end(), iMother) != arrayIdsStage.end()) {                       // if a mother is still present in the vector, do not check it again
+              continue;
+            }
+            auto mother = particlesMC.rawIteratorAt(iMother - particlesMC.offset());
+            // Check mother's PDG code.
+            auto PDGParticleIMother = std::abs(mother.pdgCode()); // PDG code of the mother
+            // printf("getMother: ");
+            // for (int i = stage; i < 0; i++) // Indent to make the tree look nice.
+            //   printf(" ");
+            // printf("Stage %d: Mother PDG: %d, Index: %d\n", stage, PDGParticleIMother, iMother);
+
+            if (!searchUpToQuark) {
+              if (
+                (PDGParticleIMother / 100 == 5 ||            // b mesons
+                 PDGParticleIMother / 1000 == 5 ||           // b baryons
+                 (PDGParticleIMother - 10000) / 100 == 5 ||  // bbbar resonances
+                 (PDGParticleIMother - 20000) / 100 == 5 ||  // bbbar resonances
+                 (PDGParticleIMother - 30000) / 100 == 5 ||  // bbbar resonances
+                 (PDGParticleIMother - 100000) / 100 == 5 || // bbbar resonances
+                 (PDGParticleIMother - 200000) / 100 == 5 || // bbbar resonances
+                 (PDGParticleIMother - 300000) / 100 == 5)   // bbbar resonances
+              ) {
+                return 2;
+              }
+            } else {
+              if (PDGParticleIMother == 5) { // b quark
+                return 2;
+              }
+              if (PDGParticleIMother == 4) { // c quark
+                return 1;
+              }
+            }
+            // add mother index in the vector for the current stage
+            arrayIdsStage.push_back(iMother);
+          }
+        }
+      }
+      // add vector of mother indices for the current stage
+      arrayIds.push_back(arrayIdsStage);
+      stage--;
+    }
+    if (!searchUpToQuark) {
+      return 1;
+    }
+    return 0;
+  }
+
  private:
   static std::vector<std::tuple<int, double>> mListMass; ///< list of particle masses in form (PDG code, mass)
 };

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -982,7 +982,7 @@ struct HfFilter { // Main struct for HF triggers
       auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::array{trackPos, trackNeg}, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign);
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, false);
         if (origin == OriginType::NonPrompt) {
           flag = kNonPrompt;
         } else if (origin == OriginType::Prompt) {
@@ -1041,7 +1041,7 @@ struct HfFilter { // Main struct for HF triggers
 
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, false);
         if (origin == OriginType::NonPrompt) {
           flag = kNonPrompt;
         } else {

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -21,7 +21,6 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
-#include "Common/Core/RecoDecay.h"
 
 #include "EventFiltering/filterTables.h"
 

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -982,10 +982,10 @@ struct HfFilter { // Main struct for HF triggers
       auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::array{trackPos, trackNeg}, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign);
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
         if (origin == OriginType::NonPrompt) {
           flag = kNonPrompt;
-        } else {
+        } else if (origin == OriginType::Prompt) {
           flag = kPrompt;
         }
       } else {
@@ -1041,7 +1041,7 @@ struct HfFilter { // Main struct for HF triggers
 
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
         if (origin == OriginType::NonPrompt) {
           flag = kNonPrompt;
         } else {

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -21,6 +21,7 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
+#include "Common/Core/RecoDecay.h"
 
 #include "EventFiltering/filterTables.h"
 
@@ -39,7 +40,6 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 using namespace hf_cuts_single_track;
 using namespace hf_cuts_bdt_multiclass;
 
@@ -982,10 +982,10 @@ struct HfFilter { // Main struct for HF triggers
       auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::array{trackPos, trackNeg}, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign);
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, false);
-        if (origin == OriginType::NonPrompt) {
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        if (origin == RecoDecay::OriginType::NonPrompt) {
           flag = kNonPrompt;
-        } else if (origin == OriginType::Prompt) {
+        } else if (origin == RecoDecay::OriginType::Prompt) {
           flag = kPrompt;
         }
       } else {
@@ -1041,8 +1041,8 @@ struct HfFilter { // Main struct for HF triggers
 
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, false);
-        if (origin == OriginType::NonPrompt) {
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        if (origin == RecoDecay::OriginType::NonPrompt) {
           flag = kNonPrompt;
         } else {
           flag = kPrompt;

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -292,7 +292,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterXY, impactParameterXY, //!
                            [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::impParXY(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
 
 // mapping of origin type
-enum OriginType { Prompt = 1,
+enum OriginType { None = 0,
+                  Prompt,
                   NonPrompt };
 } // namespace hf_cand
 

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -290,11 +290,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(Ct, ct, //!
                            [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) -> float { return RecoDecay::ct(array{px, py, pz}, RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}), m); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterXY, impactParameterXY, //!
                            [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::impParXY(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
-
-// mapping of origin type
-enum OriginType { None = 0,
-                  Prompt,
-                  NonPrompt };
 } // namespace hf_cand
 
 // specific 2-prong decay properties

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -20,7 +20,6 @@
 
 #include "ALICE3/DataModel/ECAL.h"
 #include "Framework/AnalysisDataModel.h"
-#include "Common/Core/RecoDecay.h"
 #include "PWGHF/Core/HFSelectorCuts.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/StrangenessTables.h"

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -20,6 +20,7 @@
 
 #include "ALICE3/DataModel/ECAL.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGHF/Core/HFSelectorCuts.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/StrangenessTables.h"

--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -210,7 +210,7 @@ struct HFCandidateCreator2ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchRec(flag, origin);
@@ -246,7 +246,7 @@ struct HFCandidateCreator2ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchGen(flag, origin);

--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -210,7 +210,7 @@ struct HFCandidateCreator2ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchRec(flag, origin);
@@ -246,7 +246,7 @@ struct HFCandidateCreator2ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchGen(flag, origin);

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -251,7 +251,7 @@ struct HFCandidateCreator3ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchRec(flag, origin, swapping, channel);
@@ -305,7 +305,7 @@ struct HFCandidateCreator3ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -251,7 +251,7 @@ struct HFCandidateCreator3ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchRec(flag, origin, swapping, channel);
@@ -305,7 +305,7 @@ struct HFCandidateCreator3ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
@@ -249,7 +249,7 @@ struct HFCandidateCreatorChicMC {
       }
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? NonPrompt : Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
       rowMCMatchRec(flag, origin, channel);
     }

--- a/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
@@ -249,7 +249,7 @@ struct HFCandidateCreatorChicMC {
       }
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
       rowMCMatchRec(flag, origin, channel);
     }

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -305,7 +305,7 @@ struct HFCandidateCreatorXMC {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchRec(flag, origin, channel);
@@ -338,7 +338,7 @@ struct HFCandidateCreatorXMC {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -305,7 +305,7 @@ struct HFCandidateCreatorXMC {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchRec(flag, origin, channel);
@@ -338,7 +338,7 @@ struct HFCandidateCreatorXMC {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = (RecoDecay::getMother(particlesMC, particle, 5, true) > -1 ? NonPrompt : Prompt);
+        origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -157,7 +157,7 @@ struct ValidationGenLevel {
           std::size_t arrayPDGsize = arrPDGFinal[iD].size() - std::count(arrPDGFinal[iD].begin(), arrPDGFinal[iD].end(), 0);
           int origin = -1;
           if (listDaughters.size() == arrayPDGsize) {
-            origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
+            origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
             if (origin == OriginType::Prompt) {
               counterPrompt[iD]++;
             } else if (origin == OriginType::NonPrompt) {

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -157,7 +157,7 @@ struct ValidationGenLevel {
           std::size_t arrayPDGsize = arrPDGFinal[iD].size() - std::count(arrPDGFinal[iD].begin(), arrPDGFinal[iD].end(), 0);
           int origin = -1;
           if (listDaughters.size() == arrayPDGsize) {
-            origin = (RecoDecay::getMother(particlesMC, particle, kBottom, true) > -1 ? OriginType::NonPrompt : OriginType::Prompt);
+            origin = RecoDecay::checkCharmHadronOrigin(particlesMC, particle, false);
             if (origin == OriginType::Prompt) {
               counterPrompt[iD]++;
             } else if (origin == OriginType::NonPrompt) {

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -19,7 +19,6 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
-#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 

--- a/PWGHF/Tasks/HFMCValidation.cxx
+++ b/PWGHF/Tasks/HFMCValidation.cxx
@@ -19,6 +19,7 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 
@@ -26,7 +27,6 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::aod;
-using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong2;
 using namespace o2::aod::hf_cand_prong3;
 
@@ -158,9 +158,9 @@ struct ValidationGenLevel {
           int origin = -1;
           if (listDaughters.size() == arrayPDGsize) {
             origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
-            if (origin == OriginType::Prompt) {
+            if (origin == RecoDecay::OriginType::Prompt) {
               counterPrompt[iD]++;
-            } else if (origin == OriginType::NonPrompt) {
+            } else if (origin == RecoDecay::OriginType::NonPrompt) {
               counterNonPrompt[iD]++;
             }
           }
@@ -190,13 +190,13 @@ struct ValidationGenLevel {
           registry.fill(HIST("hPzDiffMotherDaughterGen"), pzDiff);
           registry.fill(HIST("hPDiffMotherDaughterGen"), pDiff);
           registry.fill(HIST("hPtDiffMotherDaughterGen"), ptDiff);
-          if (origin == OriginType::Prompt) {
+          if (origin == RecoDecay::OriginType::Prompt) {
             if (std::abs(particle.y()) < 0.5) {
               hPromptCharmHadronsPtDistr->Fill(whichHadron, particle.pt());
             }
             hPromptCharmHadronsYDistr->Fill(whichHadron, particle.y());
             hPromptCharmHadronsDecLenDistr->Fill(whichHadron, decayLength * 10000);
-          } else if (origin == OriginType::NonPrompt) {
+          } else if (origin == RecoDecay::OriginType::NonPrompt) {
             if (std::abs(particle.y()) < 0.5) {
               hNonPromptCharmHadronsPtDistr->Fill(whichHadron, particle.pt());
             }
@@ -288,7 +288,7 @@ struct ValidationRecLevel {
         whichHad = 6;
       }
       int whichOrigin = -1;
-      if (cand2Prong.originMCRec() == OriginType::Prompt) {
+      if (cand2Prong.originMCRec() == RecoDecay::OriginType::Prompt) {
         whichOrigin = 0;
       } else {
         whichOrigin = 1;
@@ -353,7 +353,7 @@ struct ValidationRecLevel {
         whichHad = 5;
       }
       int whichOrigin = -1;
-      if (cand3Prong.originMCRec() == OriginType::Prompt) {
+      if (cand3Prong.originMCRec() == RecoDecay::OriginType::Prompt) {
         whichOrigin = 0;
       } else {
         whichOrigin = 1;

--- a/PWGHF/Tasks/HFSelOptimisation.cxx
+++ b/PWGHF/Tasks/HFSelOptimisation.cxx
@@ -17,13 +17,13 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 
 namespace
 {
@@ -273,7 +273,7 @@ struct HfSelOptimisation {
       for (int iDecay{0}; iDecay < n2Prong; ++iDecay) {
         if (TESTBIT(cand2Prong.hfflag(), iDecay)) {
           if (std::abs(cand2Prong.flagMCMatchRec()) == BIT(iDecay)) {
-            if (cand2Prong.originMCRec() == OriginType::Prompt) {
+            if (cand2Prong.originMCRec() == RecoDecay::OriginType::Prompt) {
               isPrompt = true;
               switch (iDecay) {
                 case o2::aod::hf_cand_prong2::DecayType::D0ToPiK:
@@ -283,7 +283,7 @@ struct HfSelOptimisation {
                   testSelections2Prong<o2::aod::hf_cand_prong2::DecayType::JpsiToEE, 0>(cand2Prong, tracks);
                   break;
               }
-            } else if (cand2Prong.originMCRec() == OriginType::NonPrompt) {
+            } else if (cand2Prong.originMCRec() == RecoDecay::OriginType::NonPrompt) {
               isNonPrompt = true;
               switch (iDecay) {
                 case o2::aod::hf_cand_prong2::DecayType::D0ToPiK:
@@ -329,7 +329,7 @@ struct HfSelOptimisation {
       for (int iDecay{0}; iDecay < n3Prong; ++iDecay) {
         if (TESTBIT(cand3Prong.hfflag(), iDecay)) {
           if (std::abs(cand3Prong.flagMCMatchRec()) == BIT(iDecay)) {
-            if (cand3Prong.originMCRec() == OriginType::Prompt) {
+            if (cand3Prong.originMCRec() == RecoDecay::OriginType::Prompt) {
               isPrompt = true;
               switch (iDecay) {
                 case o2::aod::hf_cand_prong3::DecayType::DPlusToPiKPi:
@@ -345,7 +345,7 @@ struct HfSelOptimisation {
                   testSelections3Prong<o2::aod::hf_cand_prong3::DecayType::XicToPKPi, 0>(cand3Prong, tracks);
                   break;
               }
-            } else if (cand3Prong.originMCRec() == OriginType::NonPrompt) {
+            } else if (cand3Prong.originMCRec() == RecoDecay::OriginType::NonPrompt) {
               isNonPrompt = true;
               switch (iDecay) {
                 case o2::aod::hf_cand_prong3::DecayType::DPlusToPiKPi:

--- a/PWGHF/Tasks/HFSelOptimisation.cxx
+++ b/PWGHF/Tasks/HFSelOptimisation.cxx
@@ -17,7 +17,6 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
-#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 

--- a/PWGHF/Tasks/taskD0.cxx
+++ b/PWGHF/Tasks/taskD0.cxx
@@ -17,7 +17,6 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
-#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 

--- a/PWGHF/Tasks/taskD0.cxx
+++ b/PWGHF/Tasks/taskD0.cxx
@@ -17,13 +17,13 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong2;
 using namespace o2::analysis::hf_cuts_d0_topik;
 
@@ -201,7 +201,7 @@ struct TaskD0 {
           registry.fill(HIST("hPtvsYRecSig_RecoPID"), ptRec, yRec);
         }
 
-        if (candidate.originMCRec() == OriginType::Prompt) {
+        if (candidate.originMCRec() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
           if (candidate.isRecoHFFlag() >= d_selectionHFFlag) {
             registry.fill(HIST("hPtvsYRecSigPrompt_RecoHFFlag"), ptRec, yRec);
@@ -314,7 +314,7 @@ struct TaskD0 {
         auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hPtGen"), ptGen);
         registry.fill(HIST("hPtvsYGen"), ptGen, yGen);
-        if (particle.originMCGen() == OriginType::Prompt) {
+        if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
           registry.fill(HIST("hPtvsYGenPrompt"), ptGen, yGen);
         } else {

--- a/PWGHF/Tasks/taskDPlus.cxx
+++ b/PWGHF/Tasks/taskDPlus.cxx
@@ -18,7 +18,6 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
-#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 

--- a/PWGHF/Tasks/taskDPlus.cxx
+++ b/PWGHF/Tasks/taskDPlus.cxx
@@ -18,13 +18,13 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong3;
 
 #include "Framework/runDataProcessing.h"
@@ -159,7 +159,7 @@ struct TaskDPlus {
         if (candidate.isSelDplusToPiKPi() >= d_selectionFlagDPlus) {
           registry.fill(HIST("hPtRecSig"), ptRec); // rec. level pT
         }
-        if (candidate.originMCRec() == OriginType::Prompt) {
+        if (candidate.originMCRec() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtvsYRecSigPrompt_RecoSkim"), ptRec, yRec);
           if (TESTBIT(candidate.isSelDplusToPiKPi(), aod::SelectionStep::RecoTopol)) {
             registry.fill(HIST("hPtvsYRecSigPrompt_RecoTopol"), ptRec, yRec);
@@ -201,7 +201,7 @@ struct TaskDPlus {
         }
         registry.fill(HIST("hPtGen"), ptGen);
         registry.fill(HIST("hPtvsYGen"), ptGen, yGen);
-        if (particle.originMCGen() == OriginType::Prompt) {
+        if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
           registry.fill(HIST("hPtvsYGenPrompt"), ptGen, yGen);
         } else {

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -20,13 +20,13 @@
 #include "Framework/HistogramRegistry.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
+#include "Common/Core/RecoDecay.h"
 #include "Common/Core/TrackSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong3;
 using namespace o2::analysis::hf_cuts_lc_topkpi;
 
@@ -151,7 +151,7 @@ struct TaskLc {
         registry.fill(HIST("hPtGenSig"), particleMother.pt()); // gen. level pT
         auto ptRec = candidate.pt();
         registry.fill(HIST("hPtRecSig"), ptRec); // rec. level pT
-        if (candidate.originMCRec() == OriginType::Prompt) {
+        if (candidate.originMCRec() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
         } else {
           registry.fill(HIST("hPtRecSigNonPrompt"), ptRec); // rec. level pT, non-prompt
@@ -173,7 +173,7 @@ struct TaskLc {
         }
         auto ptGen = particle.pt();
         registry.fill(HIST("hPtGen"), ptGen);
-        if (particle.originMCGen() == OriginType::Prompt) {
+        if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
         } else {
           registry.fill(HIST("hPtGenNonPrompt"), ptGen);

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -20,7 +20,6 @@
 #include "Framework/HistogramRegistry.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
-#include "Common/Core/RecoDecay.h"
 #include "Common/Core/TrackSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 

--- a/PWGHF/Tasks/taskLcCentrality.cxx
+++ b/PWGHF/Tasks/taskLcCentrality.cxx
@@ -21,11 +21,11 @@
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/DataModel/Centrality.h"
+#include "Common/Core/RecoDecay.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::hf_cand;
 using namespace o2::aod::hf_cand_prong3;
 using namespace o2::analysis::hf_cuts_lc_topkpi;
 
@@ -160,7 +160,7 @@ struct TaskLcCentralityMC {
         registry.fill(HIST("hPtGenSig"), particleMother.pt()); // gen. level pT
         auto ptRec = candidate.pt();
         registry.fill(HIST("hPtRecSig"), ptRec); // rec. level pT
-        if (candidate.originMCRec() == OriginType::Prompt) {
+        if (candidate.originMCRec() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
         } else {
           registry.fill(HIST("hPtRecSigNonPrompt"), ptRec); // rec. level pT, non-prompt
@@ -182,7 +182,7 @@ struct TaskLcCentralityMC {
         }
         auto ptGen = particle.pt();
         registry.fill(HIST("hPtGen"), ptGen);
-        if (particle.originMCGen() == OriginType::Prompt) {
+        if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
         } else {
           registry.fill(HIST("hPtGenNonPrompt"), ptGen);

--- a/PWGHF/Tasks/taskLcCentrality.cxx
+++ b/PWGHF/Tasks/taskLcCentrality.cxx
@@ -21,7 +21,6 @@
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "PWGHF/DataModel/HFCandidateSelectionTables.h"
 #include "Common/DataModel/Centrality.h"
-#include "Common/Core/RecoDecay.h"
 
 using namespace o2;
 using namespace o2::framework;


### PR DESCRIPTION
This PR implements a specific method to tag prompt/non-prompt charm hadrons, as discussed in [Nonprompt_tagging_fgrosa_2022Jul04.pdf](https://indico.cern.ch/event/1178012/contributions/4948661/attachments/2474891/4246862/Nonprompt_tagging_fgrosa_2022Jul04.pdf). 

I just have a doubt regarding the output values of the `checkCharmHadronOrigin` function: they correspond to the `hf_cand::OriginType` enum, but are independently defined since the HF code should not be included in the common one. A possible solution to have it uniquely defined would be to move the `hf_cand::OriginType` enum in the Common code, or alternatively to move the method `checkCharmHadronOrigin` in the HF code (however it could also be useful for DQ, since it can be used to tag charmonia as well). @vkucera do you have suggestions?
