### PR TITLE
Fix CCDB access in TPC PID response handler tool

### DIFF
--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -12,7 +12,7 @@
 ///
 /// \file handleParamTPCResponse.cxx
 /// \author Jeremy Wilkinson
-/// \brief exec for writing and reading Response object
+/// \brief exec for writing and reading TPC PID Response object
 
 #include <array>
 #include <fstream>
@@ -26,16 +26,7 @@ using namespace o2::pid::tpc;
 bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv[])
 {
   options.add_options()(
-    "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database e.g. http://ccdb-test.cern.ch:8080 or http://alice-ccdb.cern.ch")(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TPC"), "CCDB path for storage/retrieval")(
-    "rct-path", bpo::value<std::string>()->default_value("RCT/Info/RunInformation"), "path to the ccdb RCT objects for the SOR/EOR timestamps")(
-    "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity. If 0 and runnumber != 0 it will be set to the run SOR")(
-    "stop,S", bpo::value<long>()->default_value(0), "Stop timestamp of object validity. If 0 and runnumber != 0 it will be set to the run EOR")(
-    "timestamp,T", bpo::value<long>()->default_value(-1), "Timestamp of the object to retrieve, used in alternative to the run number")(
-    "runnumber,R", bpo::value<unsigned int>()->default_value(0), "Timestamp of the object to retrieve, used in alternative to the timestamp (if 0 using the timestamp)")(
-    "delete-previous,delete_previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
-    "save-to-file,file,f,o", bpo::value<std::string>()->default_value(""), "Option to save parametrization to file instead of uploading to ccdb")(
-    "read-from-file,i", bpo::value<std::string>()->default_value(""), "Option to get parametrization from a file")(
     "objname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be stored in file")(
     "inobjname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be read from file in 'push' mode")(
     "bb0", bpo::value<float>()->default_value(0.03209809958934784f), "Bethe-Bloch parameter 0")(
@@ -51,9 +42,9 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "paramChargeFactor", bpo::value<float>()->default_value(2.299999952316284f), "Charge factor value")(
     "paramMultNormalization", bpo::value<float>()->default_value(11000.), "Multiplicity Normalization")(
     "useDefaultParam", bpo::value<bool>()->default_value(true), "Use default sigma parametrisation")(
-    "dryrun,D", bpo::value<int>()->default_value(0), "Perform a dryrun check before uploading")(
     "mode", bpo::value<string>()->default_value(""), "Running mode ('read' from file, 'write' to file, 'pull' from CCDB, 'push' to CCDB)")(
     "help,h", "Produce help message.");
+  setStandardOpt(options);
   try {
     bpo::store(parse_command_line(argc, argv, options), arguments);
 
@@ -84,11 +75,6 @@ int main(int argc, char* argv[])
 
   const std::string urlCCDB = arguments["url"].as<std::string>();
   const auto pathCCDB = arguments["ccdb-path"].as<std::string>();
-  auto startTime = arguments["start"].as<long>();
-  auto endTime = arguments["stop"].as<long>();
-  const auto runnumber = arguments["runnumber"].as<unsigned int>();
-  auto timestamp = arguments["timestamp"].as<long>();
-  const int optDelete = arguments["delete-previous"].as<int>();
 
   const std::string outFilename = arguments["save-to-file"].as<std::string>();
   const std::string inFilename = arguments["read-from-file"].as<std::string>();
@@ -135,17 +121,13 @@ int main(int argc, char* argv[])
   }
 
   if (optMode.compare("push") == 0 || optMode.compare("pull") == 0) { // Initialise CCDB if in push/pull mode
-    api.init(urlCCDB);
-    if (!api.isHostReachable()) {
-      LOG(warning) << "CCDB mode (push/pull) enabled but host " << urlCCDB << " is unreachable.";
-      return 1;
-    }
-    setupTimestamps(timestamp, startTime, endTime);
+    initCCDBApi();
+    setupTimestamps(ccdbTimestamp, validityStart, validityStop);
   }
 
   if (optMode.compare("read") == 0) { // Read existing object from local file
     if (inFilename.empty()) {
-      LOG(error) << "read mode defined with no input file, please set --read-from-file";
+      LOG(error) << "Read mode defined with no input file, please set --read-from-file";
       return 1;
     }
 
@@ -215,20 +197,18 @@ int main(int argc, char* argv[])
     if (optMode.compare("push") == 0) {
       LOG(info) << "Attempting to push object to CCDB";
 
-      if (optDelete) {
-        api.truncate(pathCCDB);
-      }
       std::map<std::string, std::string> metadata;
-      if (runnumber != 0) {
-        metadata["runnumber"] = Form("%i", runnumber);
+      if (minRunNumber != 0) {
+        metadata["min-runnumber"] = Form("%i", minRunNumber);
+        metadata["max-runnumber"] = Form("%i", maxRunNumber);
       }
-      storeOnCCDB(pathCCDB + "/" + objname, metadata, startTime, endTime, tpc);
+      storeOnCCDB(pathCCDB + "/" + objname, metadata, validityStart, validityStop, tpc);
     }
   }
 
   else if (optMode.compare("pull") == 0) { // pull existing from CCDB; write out to file if requested
     LOG(info) << "Attempting to pull object from CCDB (" << urlCCDB << "): " << pathCCDB << "/" << objname;
-    tpc = retrieveFromCCDB<Response>(pathCCDB + "/" + objname, timestamp);
+    tpc = retrieveFromCCDB<Response>(pathCCDB + "/" + objname, ccdbTimestamp);
 
     tpc->PrintAll();
 

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -28,7 +28,7 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
   options.add_options()(
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TPC"), "CCDB path for storage/retrieval")(
     "objname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be stored in file")(
-    "inobjname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be read from file in 'push' mode")(
+    "inobjname", bpo::value<std::string>()->default_value("Response"), "Object name to be read from file in 'push' mode")(
     "bb0", bpo::value<float>()->default_value(0.03209809958934784f), "Bethe-Bloch parameter 0")(
     "bb1", bpo::value<float>()->default_value(19.9768009185791f), "Bethe-Bloch parameter 1")(
     "bb2", bpo::value<float>()->default_value(2.5266601063857674e-16f), "Bethe-Bloch parameter 2")(


### PR DESCRIPTION
TPC PID response handler's CCDB access was broken by a previous commit that modified the timestamp initialisation in handleParamBase.h (#934). This PR fixes the incompatibility and removes redundancies with the options that were added to the base header.

Only impacts the parameter object handler tool; the analysis tasks are unaffected.