### PR TITLE
Update binning policy class name to the new interface in new task in PWGLF

### DIFF
--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -106,7 +106,7 @@ struct phianalysis {
   void processME(o2::aod::ResoCollisions& collision,
                  o2::aod::BCsWithTimestamps const&, aod::ResoDaughters const&, aod::Reso2TracksPIDExt const&)
   {
-    ColumBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};
 
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, collision, collision)) {
 

--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -106,7 +106,7 @@ struct phianalysis {
   void processME(o2::aod::ResoCollisions& collision,
                  o2::aod::BCsWithTimestamps const&, aod::ResoDaughters const&, aod::Reso2TracksPIDExt const&)
   {
-    BinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};
+    ColumBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};
 
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, collision, collision)) {
 


### PR DESCRIPTION
Hello @BongHwi ,

recently in July I extended the mixing interface with a new binning policy type. Therefore, I will keep `ColumnBinningPolicy` and `FlexibleBinningPolicy` as precise names, and with https://github.com/AliceO2Group/AliceO2/pull/9528 I will remove the general `BinningPolicy` alias to avoid future confusions. Please let me update your code and follow with my O2 PR.

FYI, there is an up-to-date event mixing documentation at https://aliceo2group.github.io/analysis-framework/docs/framework/eventMixing.html which I update after any major change.