### PR TITLE
PWGMM: dndeta: refit ambiguous tracks

### DIFF
--- a/PWGMM/Mult/TableProducer/CMakeLists.txt
+++ b/PWGMM/Mult/TableProducer/CMakeLists.txt
@@ -13,3 +13,8 @@ o2physics_add_dpl_workflow(particles-to-tracks
                     SOURCES particles2tracks.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(track-propagation
+                    SOURCES trackPropagation.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::ReconstructionDataFormats O2::DetectorsCommonDataFormats
+                    COMPONENT_NAME Analysis)

--- a/PWGMM/Mult/TableProducer/trackPropagation.cxx
+++ b/PWGMM/Mult/TableProducer/trackPropagation.cxx
@@ -1,0 +1,173 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Task to add a table of track parameters propagated to the primary vertex
+//
+
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbApi.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "CommonConstants/GeomConstants.h"
+#include "CommonUtils/NameConf.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/DCA.h"
+
+// The Run 3 AO2D stores the tracks at the point of innermost update. For a
+// track with ITS this is the innermost (or second innermost) ITS layer. For a
+// track without ITS, this is the TPC inner wall or for loopers in the TPC even
+// a radius beyond that. In order to use the track parameters, the tracks have
+// to be propagated to the collision vertex which is done by this task. The task
+// consumes the TracksIU and TracksCovIU tables and produces Tracks and
+// TracksCov to which then the user analysis can subscribe.
+//
+// This task is not needed for Run 2 converted data.
+// There are two versions of the task (see process flags), one producing also
+// the covariance matrix and the other only the tracks table.
+
+// This is an alternative version of the propagation task with special treatment
+// of ambiguous tracks
+
+using namespace o2;
+using namespace o2::framework;
+// using namespace o2::framework::expressions;
+
+namespace o2::aod
+{
+namespace track
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(BestCollision, bestCollision, int32_t, Collisions, "");
+DECLARE_SOA_COLUMN(BestDCAXY, bestDCAXY, float);
+DECLARE_SOA_COLUMN(BestDCAZ, bestDCAZ, float);
+DECLARE_SOA_COLUMN(PtStatic, pts, float);
+DECLARE_SOA_COLUMN(PStatic, ps, float);
+DECLARE_SOA_COLUMN(EtaStatic, etas, float);
+DECLARE_SOA_COLUMN(PhiStatic, phis, float);
+} // namespace track
+DECLARE_SOA_TABLE(BestCollisions, "AOD", "BESTCOLL",
+                  aod::track::BestCollisionId, aod::track::BestDCAXY,
+                  aod::track::BestDCAZ, track::X, track::Alpha, track::Y,
+                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,
+                  track::PtStatic, track::PStatic, track::EtaStatic,
+                  track::PhiStatic);
+} // namespace o2::aod
+
+struct AmbiguousTrackPropagation {
+  Produces<aod::BestCollisions> tracksBestCollisions;
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+
+  int runNumber = -1;
+
+  o2::base::Propagator::MatCorrType matCorr =
+    o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+
+  o2::parameters::GRPMagField* grpmag = nullptr;
+
+  Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
+
+  using ExtBCs = soa::Join<aod::BCs, aod::Timestamps, aod::MatchedBCCollisionsSparse>;
+
+  void init(o2::framework::InitContext& initContext)
+  {
+    ccdb->setURL(ccdburl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(geoPath);
+    }
+  }
+
+  void initCCDB(ExtBCs::iterator const& bc)
+  {
+    if (runNumber == bc.runNumber()) {
+      return;
+    }
+    grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
+    LOG(info) << "Setting magnetic field to current " << grpmag->getL3Current()
+              << " A for run " << bc.runNumber()
+              << " from its GRPMagField CCDB object";
+    o2::base::Propagator::initFieldFromGRP(grpmag);
+    runNumber = bc.runNumber();
+  }
+
+  Preslice<aod::AmbiguousTracks> perTrack = aod::ambiguous::trackId;
+
+  void process(soa::Join<aod::Tracks, aod::TracksExtra> const&,
+               aod::Collisions const&, ExtBCs const& bcs,
+               aod::AmbiguousTracks const& atracks)
+  {
+    if (bcs.size() == 0) {
+      return;
+    }
+    initCCDB(bcs.begin());
+
+    gpu::gpustd::array<float, 2> dcaInfo;
+    float bestDCA[2];
+
+    for (auto& atrack : atracks) {
+      dcaInfo[0] = 999;
+      dcaInfo[1] = 999;
+      bestDCA[0] = 999;
+      bestDCA[1] = 999;
+
+      auto track = atrack.track_as<soa::Join<aod::Tracks, aod::TracksExtra>>();
+      auto bestCol = track.has_collision() ? track.collisionId() : -1;
+
+      // Only re-propagate tracks which have passed the innermost wall of the
+      // TPC (e.g. skipping loopers etc).
+      auto trackPar = getTrackPar(track);
+      if (track.x() < o2::constants::geom::XTPCInnerRef + 0.1) {
+        auto compatibleBCs = atrack.bc_as<ExtBCs>();
+        for (auto& bc : compatibleBCs) {
+          if (!bc.has_collision()) {
+            continue;
+          }
+          auto collision = bc.collision();
+          o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, matCorr, &dcaInfo);
+          if ((dcaInfo[0] < bestDCA[0]) && (dcaInfo[1] < bestDCA[1])) {
+            bestCol = collision.globalIndex();
+            bestDCA[0] = dcaInfo[0];
+            bestDCA[1] = dcaInfo[1];
+          }
+        }
+      }
+      tracksBestCollisions(
+        bestCol, dcaInfo[0], dcaInfo[1], trackPar.getX(), trackPar.getAlpha(),
+        trackPar.getY(), trackPar.getZ(), trackPar.getSnp(),
+        trackPar.getTgl(), trackPar.getQ2Pt(), trackPar.getPt(),
+        trackPar.getP(), trackPar.getEta(), trackPar.getPhi());
+    }
+  }
+};
+
+//****************************************************************************************
+/**
+ * Workflow definition.
+ */
+//****************************************************************************************
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{adaptAnalysisTask<AmbiguousTrackPropagation>(cfgc)};
+  return workflow;
+}

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -10,22 +10,43 @@
 // or submit itself to any jurisdiction.
 
 #include <cmath>
-#include "Framework/Configurable.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoAHelpers.h"
-#include "Framework/RuntimeError.h"
-#include "Framework/runDataProcessing.h"
 
-#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "Common/CCDB/EventSelectionParams.h"
-#include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "CommonConstants/MathConstants.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/Configurable.h"
+#include "Framework/RuntimeError.h"
+#include "Framework/runDataProcessing.h"
 #include "Index.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "TDatabasePDG.h"
+
+namespace o2::aod
+{
+namespace track
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(BestCollision, bestCollision, int32_t, Collisions,
+                              "");
+DECLARE_SOA_COLUMN(BestDCAXY, bestDCAXY, float);
+DECLARE_SOA_COLUMN(BestDCAZ, bestDCAZ, float);
+DECLARE_SOA_COLUMN(PtStatic, pts, float);
+DECLARE_SOA_COLUMN(PStatic, ps, float);
+DECLARE_SOA_COLUMN(EtaStatic, etas, float);
+DECLARE_SOA_COLUMN(PhiStatic, phis, float);
+} // namespace track
+DECLARE_SOA_TABLE(BestCollisions, "AOD", "BESTCOLL",
+                  aod::track::BestCollisionId, aod::track::BestDCAXY,
+                  aod::track::BestDCAZ, track::X, track::Alpha, track::Y,
+                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,
+                  track::PtStatic, track::PStatic, track::EtaStatic,
+                  track::PhiStatic);
+} // namespace o2::aod
 
 using namespace o2;
 using namespace o2::framework;
@@ -40,16 +61,17 @@ AxisSpec MultAxis = {301, -0.5, 300.5};
 AxisSpec PhiAxis = {629, 0, 2 * M_PI};
 AxisSpec PtAxis = {2401, -0.005, 24.005};
 
-static constexpr TrackSelectionFlags::flagtype trackSelectionITS = TrackSelectionFlags::kITSNCls |
-                                                                   TrackSelectionFlags::kITSChi2NDF |
-                                                                   TrackSelectionFlags::kITSHits;
+static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
+  TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
+  TrackSelectionFlags::kITSHits;
 
-static constexpr TrackSelectionFlags::flagtype trackSelectionTPC = TrackSelectionFlags::kTPCNCls |
-                                                                   TrackSelectionFlags::kTPCCrossedRowsOverNCls |
-                                                                   TrackSelectionFlags::kTPCChi2NDF;
+static constexpr TrackSelectionFlags::flagtype trackSelectionTPC =
+  TrackSelectionFlags::kTPCNCls |
+  TrackSelectionFlags::kTPCCrossedRowsOverNCls |
+  TrackSelectionFlags::kTPCChi2NDF;
 
-static constexpr TrackSelectionFlags::flagtype trackSelectionDCA = TrackSelectionFlags::kDCAz |
-                                                                   TrackSelectionFlags::kDCAxy;
+static constexpr TrackSelectionFlags::flagtype trackSelectionDCA =
+  TrackSelectionFlags::kDCAz | TrackSelectionFlags::kDCAxy;
 
 using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 
@@ -63,17 +85,19 @@ struct MultiplicityCounter {
   HistogramRegistry registry{
     "registry",
     {
-      {"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}},         //
-      {"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}},              //
-      {"Tracks/EtaZvtx_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}},          //
-      {"Tracks/PhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}},                  //
-      {"Tracks/Control/PtEta", " ; p_{T} (GeV/c); #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}},             //
-      {"Tracks/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}}, //
-      {"Tracks/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}},   //
-      {"Events/Selection", ";status;events", {HistType::kTH1F, {{7, 0.5, 7.5}}}},                           //
-      {"Events/Control/Chi2", " ; #chi^2", {HistType::kTH1F, {{101, -0.1, 10.1}}}},                         //
-      {"Events/Control/TimeResolution", " ; t (ms)", {HistType::kTH1F, {{1001, -0.1, 100.1}}}}              //
-    }                                                                                                       //
+      {"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}},               //
+      {"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}},                    //
+      {"Tracks/EtaZvtx_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}},                //
+      {"Tracks/PhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}},                        //
+      {"Tracks/Control/PtEta", " ; p_{T} (GeV/c); #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}},                   //
+      {"Tracks/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}},       //
+      {"Tracks/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}},         //
+      {"Tracks/Control/ExtraTracksEtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}}, //
+      {"Tracks/Control/ExtraTracksPhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}},     //
+      {"Events/Selection", ";status;events", {HistType::kTH1F, {{7, 0.5, 7.5}}}},                                 //
+      {"Events/Control/Chi2", " ; #chi^2", {HistType::kTH1F, {{101, -0.1, 10.1}}}},                               //
+      {"Events/Control/TimeResolution", " ; t (ms)", {HistType::kTH1F, {{1001, -0.1, 100.1}}}}                    //
+    }                                                                                                             //
   };
 
   void init(InitContext&)
@@ -134,11 +158,14 @@ struct MultiplicityCounter {
   }
 
   using FullBCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels>;
-  void processEventStat(FullBCs const& bcs, soa::Join<aod::Collisions, aod::EvSels> const& collisions)
+  void processEventStat(
+    FullBCs const& bcs,
+    soa::Join<aod::Collisions, aod::EvSels> const& collisions)
   {
     std::vector<typename std::decay_t<decltype(collisions)>::iterator> cols;
     for (auto& bc : bcs) {
-      if (!useEvSel || (bc.selection()[evsel::kIsBBT0A] & bc.selection()[evsel::kIsBBT0C]) != 0) {
+      if (!useEvSel || (bc.selection()[evsel::kIsBBT0A] &
+                        bc.selection()[evsel::kIsBBT0C]) != 0) {
         registry.fill(HIST("Events/Selection"), 5.);
         cols.clear();
         for (auto& collision : collisions) {
@@ -174,9 +201,17 @@ struct MultiplicityCounter {
 
   using ExTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA>;
   using FiTracks = soa::Filtered<ExTracks>;
-  Partition<FiTracks> sample = (nabs(aod::track::eta) < estimatorEta) && ((aod::track::trackCutFlag & trackSelectionDCA) == trackSelectionDCA);
+  Partition<FiTracks> sample = (nabs(aod::track::eta) < estimatorEta) &&
+                               ((aod::track::trackCutFlag & trackSelectionDCA) == trackSelectionDCA);
 
-  void processCounting(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, FiTracks const& tracks)
+  expressions::Filter atrackFilter = (nabs(aod::track::etas) < estimatorEta) &&
+                                     (nabs(aod::track::bestDCAZ) <= 2.f) &&
+                                     (nabs(aod::track::bestDCAXY) <= ((0.0105f + 0.0350f / npow(aod::track::pts, 1.1f))));
+
+  void processCounting(
+    soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision,
+    FiTracks const& tracks,
+    soa::SmallGroups<soa::Join<aod::AmbiguousTracks, aod::BestCollisions>> const& atracks)
   {
     registry.fill(HIST("Events/Selection"), 1.);
     if (!useEvSel || collision.sel8()) {
@@ -198,6 +233,12 @@ struct MultiplicityCounter {
           registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
         }
       }
+
+      for (auto& track : atracks) {
+        registry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), track.etas(), z);
+        registry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), track.phis(), track.etas());
+      }
+
     } else {
       registry.fill(HIST("Events/Selection"), 4.);
     }
@@ -214,10 +255,10 @@ struct MultiplicityCounter {
   Partition<ParticlesI> primariesI = ((aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) &&
                                      (nabs(aod::mcparticle::eta) < estimatorEta);
 
-  void processTrackEfficiencyIndexed(soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions,
-                                     aod::McCollisions const&,
-                                     ParticlesI const&,
-                                     soa::Filtered<LabeledTracksEx> const& tracks)
+  void processTrackEfficiencyIndexed(
+    soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions,
+    aod::McCollisions const&, ParticlesI const&,
+    soa::Filtered<LabeledTracksEx> const& tracks)
   {
     for (auto& collision : collisions) {
       if (useEvSel && !collision.sel8()) {
@@ -303,10 +344,10 @@ struct MultiplicityCounter {
   PROCESS_SWITCH(MultiplicityCounter, processTrackEfficiencyIndexed, "Calculate tracking efficiency vs pt (indexed)", false);
 
   Partition<soa::Filtered<LabeledTracksEx>> lsample = nabs(aod::track::eta) < estimatorEta;
-  void processTrackEfficiency(soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions,
-                              aod::McCollisions const&,
-                              Particles const& mcParticles,
-                              soa::Filtered<LabeledTracksEx> const&)
+  void processTrackEfficiency(
+    soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions,
+    aod::McCollisions const&, Particles const& mcParticles,
+    soa::Filtered<LabeledTracksEx> const&)
   {
     for (auto& collision : collisions) {
       if (useEvSel && !collision.sel8()) {
@@ -347,7 +388,10 @@ struct MultiplicityCounter {
 
   PROCESS_SWITCH(MultiplicityCounter, processTrackEfficiency, "Calculate tracking efficiency vs pt", false);
 
-  void processGen(aod::McCollisions::iterator const& mcCollision, o2::soa::SmallGroups<soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels>> const& collisions, Particles const& particles, FiTracks const& /*tracks*/)
+  void processGen(
+    aod::McCollisions::iterator const& mcCollision,
+    o2::soa::SmallGroups<soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels>> const& collisions,
+    Particles const& particles, FiTracks const& /*tracks*/)
   {
     auto perCollisionMCSample = mcSample->sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex());
     auto nCharged = 0;
@@ -431,8 +475,7 @@ struct MultiplicityCounter {
   PROCESS_SWITCH(MultiplicityCounter, processGen, "Process generator-level info", false);
 };
 
-WorkflowSpec
-  defineDataProcessing(ConfigContext const& cfgc)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{adaptAnalysisTask<MultiplicityCounter>(cfgc)};
 }


### PR DESCRIPTION
This is a first attempt to account for ambiguous tracks by trying to associate them to compatible collisions. The best collision is determined as one for which DCA is the smallest, out of all collisions (if any) associated to compatible BCs. 
A dedicated task produces a table, joinable with `AmbiguousTracks` that contains collision index and refitted track parameters. 

@fgrosa this may also work for you, you can access ambiguous tracks, re-associated to a (single) collision by subscribing to `soa::SmallGroups<soa::Join<aod::AmbiguousTracks, aod::BestCollisions>> const& atracks`. Note that this simple method does not create duplicated associations.