### PR TITLE
PWGHF: substitute Filters with Partitions in DDbar correlation codes

### DIFF
--- a/PWGHF/HFC/TableProducer/HFCorrelatorD0D0bar.cxx
+++ b/PWGHF/HFC/TableProducer/HFCorrelatorD0D0bar.cxx
@@ -235,7 +235,7 @@ struct HfCorrelatorD0D0bar {
 
   PROCESS_SWITCH(HfCorrelatorD0D0bar, processData, "Process data", false);
 
-  /// D0-D0bar correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied) 
+  /// D0-D0bar correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
   Partition<soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate, aod::HfCandProng2MCRec>> selectedD0candidatesMC = aod::hf_selcandidate_d0::isSelD0 >= selectionFlagD0 || aod::hf_selcandidate_d0::isSelD0bar >= selectionFlagD0bar;
 
   void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCandProng2, aod::HFSelD0Candidate, aod::HfCandProng2MCRec> const& candidates)
@@ -438,7 +438,7 @@ struct HfCorrelatorD0D0bar {
             if (std::abs(particle1.eta()) < etaCut && std::abs(particle2.eta()) < etaCut && particle1.pt() > ptCut && particle2.pt() > ptCut) { // fill with D and Dbar acceptance checks
               registry.fill(HIST("hDDbarVsEtaCut"), etaCut - epsilon, ptCut + epsilon);
             }
-            if (rightDecayChannels) { //fill with D and Dbar daughter particls acceptance checks
+            if (rightDecayChannels) { // fill with D and Dbar daughter particls acceptance checks
               bool candidate1DauInAcc = true;
               bool candidate2DauInAcc = true;
               for (auto& dau : particle1.daughters_as<MCParticlesPlus>()) {
@@ -479,7 +479,7 @@ struct HfCorrelatorD0D0bar {
         continue;
       }
       int partMothPDG = particle1.mothers_as<MCParticlesPlus>().front().pdgCode();
-      //check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
+      // check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
       if (partMothPDG == particle1.pdgCode()) {
         continue;
       }

--- a/PWGHF/HFC/TableProducer/HFCorrelatorD0D0barBarrelFullPID.cxx
+++ b/PWGHF/HFC/TableProducer/HFCorrelatorD0D0barBarrelFullPID.cxx
@@ -438,7 +438,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
             if (std::abs(particle1.eta()) < etaCut && std::abs(particle2.eta()) < etaCut && particle1.pt() > ptCut && particle2.pt() > ptCut) { // fill with D and Dbar acceptance checks
               registry.fill(HIST("hDDbarVsEtaCut"), etaCut - epsilon, ptCut + epsilon);
             }
-            if (rightDecayChannels) { //fill with D and Dbar daughter particls acceptance checks
+            if (rightDecayChannels) { // fill with D and Dbar daughter particls acceptance checks
               bool candidate1DauInAcc = true;
               bool candidate2DauInAcc = true;
               for (auto& dau : particle1.daughters_as<MCParticlesPlus>()) {
@@ -479,7 +479,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         continue;
       }
       int partMothPDG = particle1.mothers_as<MCParticlesPlus>().front().pdgCode();
-      //check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
+      // check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
       if (partMothPDG == particle1.pdgCode()) {
         continue;
       }

--- a/PWGHF/HFC/TableProducer/HFCorrelatorD0D0barBarrelFullPID.cxx
+++ b/PWGHF/HFC/TableProducer/HFCorrelatorD0D0barBarrelFullPID.cxx
@@ -126,10 +126,10 @@ struct HfCorrelatorD0D0barBarrelFullPid {
     registry.add("hCountCtriggersMCGen", "c trigger particles - MC gen;;N of trigger c quark", {HistType::kTH2F, {{1, -0.5, 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
   }
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0TOFplusRICHPID >= selectionFlagD0 || aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0barTOFplusRICHPID >= selectionFlagD0bar);
+  Partition<soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel>> selectedD0candidates = (aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0TOFplusRICHPID >= selectionFlagD0 || aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0barTOFplusRICHPID >= selectionFlagD0bar);
 
   /// D0-D0bar correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
-  void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel>> const& candidates)
+  void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel> const& candidates)
   {
     int nTracks = 0;
     if (collision.numContrib() > 1) {
@@ -149,7 +149,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
     }
     registry.fill(HIST("hMultiplicity"), nTracks);
 
-    for (auto& candidate1 : candidates) {
+    for (auto& candidate1 : selectedD0candidates) {
       if (cutYCandMax >= 0. && std::abs(YD0(candidate1)) > cutYCandMax) {
         continue;
       }
@@ -188,7 +188,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
       if (candidate1.isSelD0TOFplusRICHPID() < selectionFlagD0) {
         continue;
       }
-      for (auto& candidate2 : candidates) {
+      for (auto& candidate2 : selectedD0candidates) {
         if (!(candidate2.hfflag() & 1 << DecayType::D0ToPiK)) { // check decay channel flag for candidate2
           continue;
         }
@@ -236,7 +236,9 @@ struct HfCorrelatorD0D0barBarrelFullPid {
   PROCESS_SWITCH(HfCorrelatorD0D0barBarrelFullPid, processData, "Process data", false);
 
   /// D0-D0bar correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
-  void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel, aod::HfCandProng2MCRec>> const& candidates)
+  Partition<soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel, aod::HfCandProng2MCRec>> selectedD0candidatesMC = (aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0TOFplusRICHPID >= selectionFlagD0 || aod::hf_selcandidate_d0_ALICE3_Barrel::isSelD0barTOFplusRICHPID >= selectionFlagD0bar);
+
+  void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCandProng2, aod::HFSelD0CandidateALICE3Barrel, aod::HfCandProng2MCRec> const& candidates)
   {
     int nTracks = 0;
     if (collision.numContrib() > 1) {
@@ -261,7 +263,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
     bool flagD0Reflection = false;
     bool flagD0barSignal = false;
     bool flagD0barReflection = false;
-    for (auto& candidate1 : candidates) {
+    for (auto& candidate1 : selectedD0candidatesMC) {
       // check decay channel flag for candidate1
       if (!(candidate1.hfflag() & 1 << DecayType::D0ToPiK)) {
         continue;
@@ -315,7 +317,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
       }
       flagD0Signal = candidate1.flagMCMatchRec() == 1 << DecayType::D0ToPiK;        // flagD0Signal 'true' if candidate1 matched to D0 (particle)
       flagD0Reflection = candidate1.flagMCMatchRec() == -(1 << DecayType::D0ToPiK); // flagD0Reflection 'true' if candidate1, selected as D0 (particle), is matched to D0bar (antiparticle)
-      for (auto& candidate2 : candidates) {
+      for (auto& candidate2 : selectedD0candidatesMC) {
         if (!(candidate2.hfflag() & 1 << DecayType::D0ToPiK)) { // check decay channel flag for candidate2
           continue;
         }

--- a/PWGHF/HFC/TableProducer/HFCorrelatorDplusDminus.cxx
+++ b/PWGHF/HFC/TableProducer/HFCorrelatorDplusDminus.cxx
@@ -422,7 +422,7 @@ struct HfCorrelatorDplusDminus {
             if (std::abs(particle1.eta()) < etaCut && std::abs(particle2.eta()) < etaCut && particle1.pt() > ptCut && particle2.pt() > ptCut) {
               registry.fill(HIST("hDDbarVsEtaCut"), etaCut - epsilon, ptCut + epsilon);
             }
-            if (rightDecayChannels) { //fill with D and Dbar daughter particls acceptance checks
+            if (rightDecayChannels) { // fill with D and Dbar daughter particls acceptance checks
               bool candidate1DauInAcc = true;
               bool candidate2DauInAcc = true;
               for (auto& dau : particle1.daughters_as<MCParticlesPlus3Prong>()) {
@@ -463,7 +463,7 @@ struct HfCorrelatorDplusDminus {
         continue;
       }
       int partMothPDG = particle1.mothers_as<MCParticlesPlus2Prong>().front().pdgCode();
-      //check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
+      // check whether mothers of quark c/cbar are still '4'/'-4' particles - in that case the c/cbar quark comes from its own fragmentation, skip it
       if (partMothPDG == particle1.pdgCode()) {
         continue;
       }
@@ -498,7 +498,7 @@ struct HfCorrelatorDplusDminus {
         if (cutPtCandMin >= 0. && particle2.pt() < cutPtCandMin) {
           continue;
         }
-        //check whether mothers of quark cbar (from associated loop) are still '-4' particles - in that case the cbar quark comes from its own fragmentation, skip it
+        // check whether mothers of quark cbar (from associated loop) are still '-4' particles - in that case the cbar quark comes from its own fragmentation, skip it
         if (particle2.mothers_as<MCParticlesPlus2Prong>().front().pdgCode() == PDG_t::kCharmBar) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/HFCorrelatorDplusDminus.cxx
+++ b/PWGHF/HFC/TableProducer/HFCorrelatorDplusDminus.cxx
@@ -126,10 +126,10 @@ struct HfCorrelatorDplusDminus {
     registry.add("hCountCtriggersMCGen", "c trigger particles - MC gen;;N of trigger c quark", {HistType::kTH2F, {{1, -0.5, 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
   }
 
-  Filter filterSelectCandidates = (aod::hf_selcandidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus);
+  Partition<soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate>> selectedDPlusCandidates = aod::hf_selcandidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
 
   /// Dplus-Dminus correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
-  void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate>> const& candidates, aod::BigTracks const& bigtracks)
+  void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate> const& candidates, aod::BigTracks const& bigtracks)
   {
     int nTracks = 0;
     if (collision.numContrib() > 1) {
@@ -149,7 +149,7 @@ struct HfCorrelatorDplusDminus {
     }
     registry.fill(HIST("hMultiplicity"), nTracks);
 
-    for (auto& candidate1 : candidates) {
+    for (auto& candidate1 : selectedDPlusCandidates) {
       if (cutYCandMax >= 0. && std::abs(YDPlus(candidate1)) > cutYCandMax) {
         continue;
       }
@@ -194,7 +194,7 @@ struct HfCorrelatorDplusDminus {
       if (outerParticleSign != 1) {
         continue;
       }
-      for (auto& candidate2 : candidates) {
+      for (auto& candidate2 : selectedDPlusCandidates) {
         // check decay channel flag for candidate2
         if (!(candidate2.hfflag() & 1 << DecayType::DPlusToPiKPi)) { // probably dummy since already selected? not sure...
           continue;
@@ -235,7 +235,9 @@ struct HfCorrelatorDplusDminus {
   PROCESS_SWITCH(HfCorrelatorDplusDminus, processData, "Process data", false);
 
   /// Dplus-Dminus correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
-  void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate, aod::HfCandProng3MCRec>> const& candidates, aod::BigTracks const& bigtracks)
+  Partition<soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate, aod::HfCandProng3MCRec>> selectedDPlusCandidatesMC = aod::hf_selcandidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
+
+  void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCandProng3, aod::HFSelDplusToPiKPiCandidate, aod::HfCandProng3MCRec> const& candidates, aod::BigTracks const& bigtracks)
   {
     int nTracks = 0;
     if (collision.numContrib() > 1) {
@@ -258,7 +260,7 @@ struct HfCorrelatorDplusDminus {
     // MC reco level
     bool flagDplusSignal = false;
     bool flagDminusSignal = false;
-    for (auto& candidate1 : candidates) {
+    for (auto& candidate1 : selectedDPlusCandidatesMC) {
       // check decay channel flag for candidate1
       if (!(candidate1.hfflag() & 1 << DecayType::DPlusToPiKPi)) {
         continue;
@@ -309,7 +311,7 @@ struct HfCorrelatorDplusDminus {
         continue; // reject Dminus in outer loop
       }
       flagDplusSignal = std::abs(candidate1.flagMCMatchRec()) == 1 << DecayType::DPlusToPiKPi; // flagDplusSignal 'true' if candidate1 matched to Dplus
-      for (auto& candidate2 : candidates) {
+      for (auto& candidate2 : selectedDPlusCandidatesMC) {
         if (!(candidate2.hfflag() & 1 << DecayType::DPlusToPiKPi)) { // check decay channel flag for candidate2
           continue;
         }


### PR DESCRIPTION
Switch from Filters to Partitions in DDbar correlation codes to be fully consistent with mulitple processes, subscribing to different sets of joined tables