### PR TITLE
export the cmake info for usage of O2Physics as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ include(O2PhysicsAddWorkflow)
 include(O2PhysicsAddLibrary)
 include(O2PhysicsAddHeaderOnlyLibrary)
 include(O2PhysicsTargetRootDictionary)
+include(O2PhysicsSetROOTPCMDependencies)
+include(O2PhysicsDataFile)
+include(AddRootDictionary)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -81,3 +84,11 @@ add_subdirectory(PWGUD)
 add_subdirectory(Tools)
 add_subdirectory(Tutorials)
 add_subdirectory(EventFiltering)
+
+# Testing and packaging only needed if we are the top level directory
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  add_subdirectory(packaging)
+endif()
+
+set_root_pcm_dependencies()
+

--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -62,6 +62,6 @@ function(o2physics_add_header_only_library baseTargetName)
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   install(TARGETS ${target}
-          EXPORT O2Targets
+          EXPORT O2PhysicsTargets
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endfunction()

--- a/cmake/O2PhysicsAddLibrary.cmake
+++ b/cmake/O2PhysicsAddLibrary.cmake
@@ -17,7 +17,7 @@ include(O2PhysicsNameTarget)
 # o2physics_add_library(baseTargetName SOURCES c1.cxx c2.cxx .....) defines a new
 # target of type "library" composed of the given sources. It also defines an
 # alias named O2Physics::baseTargetName. The generated library will be called
-# libO2Physics[baseTargetName].(dylib|so|.a) (for exact naming see the 
+# libO2Physics[baseTargetName].(dylib|so|.a) (for exact naming see the
 # o2physics_name_target function). For each source c1.cxx a header c1.h is installed
 # if it exists in the same directory.
 #
@@ -33,7 +33,7 @@ include(O2PhysicsNameTarget)
 #   to use the fully qualified target name (i.e. including the namespace part)
 #   even for internal (O2) targets.
 #
-# * INSTALL_HEADERS (not needed in most cases): the list of additional headers 
+# * INSTALL_HEADERS (not needed in most cases): the list of additional headers
 #   which should be installed with the library. Not needed for each source
 #   c1.cxx where the header c1.h is found in the same folder. Those are installed
 #   automatically.
@@ -165,7 +165,7 @@ function(o2physics_add_library baseTargetName)
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-  # Install header for each source (if exists) 
+  # Install header for each source (if exists)
   if(A_SOURCES)
     foreach(d IN LISTS A_SOURCES)
       # Replace .cxx -> .h

--- a/cmake/O2PhysicsAddLibrary.cmake
+++ b/cmake/O2PhysicsAddLibrary.cmake
@@ -161,7 +161,7 @@ function(o2physics_add_library baseTargetName)
   # The EXPORT must come first in the list of parameters
   #
   install(TARGETS ${target}
-          EXPORT O2Targets
+          EXPORT O2PhysicsTargets
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/cmake/O2PhysicsDataFile.cmake
+++ b/cmake/O2PhysicsDataFile.cmake
@@ -1,0 +1,62 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+#
+# o2_data_file(COPY src DESTINATION dest) is a convenience function to copy and
+# install src into dest in a single command. dest should be a relative path.
+#
+# The install occurs only in the installation phase (if any) and puts src into
+# ${CMAKE_INSTALL_DATADIR}/dest
+#
+# The copy always happens at configure time and puts src into
+# ${CMAKE_BINARY_DIR}/stage/{CMAKE_INSTALL_DATADIR}/dest
+#
+# Note that when src denotes directories src and src/ means different things :
+#
+# o2_add_file(COPY src/ DESTINATION dest) will copy the _content_ of src into
+# dest, while o2_add_file(COPY src DESTINATION dest) will copy the directory src
+# into dest.
+#
+function(o2_data_file)
+
+  cmake_parse_arguments(PARSE_ARGV
+                        0
+                        A
+                        ""
+                        "DESTINATION"
+                        "COPY")
+
+  if(A_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR "Unexpected unparsed arguments: ${A_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(IS_ABSOLUTE ${A_DESTINATION})
+    message(FATAL_ERROR "DESTINATION should be a relative path")
+  endif()
+
+  foreach(D IN LISTS A_COPY)
+    get_filename_component(adir ${D} ABSOLUTE)
+    if(IS_DIRECTORY ${adir})
+      install(DIRECTORY ${D}
+              DESTINATION ${CMAKE_INSTALL_DATADIR}/${A_DESTINATION})
+    else()
+
+      install(FILES ${D} DESTINATION ${CMAKE_INSTALL_DATADIR}/${A_DESTINATION})
+    endif()
+  endforeach()
+
+  file(
+    COPY ${A_COPY}
+    DESTINATION
+      ${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR}/${A_DESTINATION})
+
+endfunction()

--- a/cmake/O2PhysicsSetROOTPCMDependencies.cmake
+++ b/cmake/O2PhysicsSetROOTPCMDependencies.cmake
@@ -1,0 +1,43 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+include_guard()
+
+set(O2PHYSICS_TARGETPCMMAP_TARGET "" CACHE INTERNAL "target/PCM map (target)")
+set(O2PHYSICS_TARGETPCMMAP_PCM "" CACHE INTERNAL "target/PCM map (pcm)")
+
+function(set_root_pcm_dependencies)
+  foreach(target pcm IN ZIP_LISTS O2PHYSICS_TARGETPCMMAP_TARGET O2PHYSICS_TARGETPCMMAP_PCM)
+    if (NOT pcm STREQUAL "")
+      #message(STATUS "target ${target} has pcm ${pcm}")
+      list(APPEND target_pcms_${target} ${pcm})
+    endif()
+  endforeach()
+
+  foreach(target pcm IN ZIP_LISTS O2PHYSICS_TARGETPCMMAP_TARGET O2PHYSICS_TARGETPCMMAP_PCM)
+    if (NOT pcm STREQUAL "")
+      unset(pcm_dep_list)
+      get_target_property(dep_targets ${target} LINK_LIBRARIES)
+      foreach(dep_target IN LISTS dep_targets)
+        if (dep_target MATCHES "^O2PHYSICS::")
+          string(REPLACE "O2PHYSICS::" "" dep_target ${dep_target})
+          o2physics_name_target(${dep_target} NAME dep_target)
+          #message(STATUS "target ${target} depends on ${dep_target}")
+          foreach(dep_pcm IN LISTS target_pcms_${dep_target})
+            #message(STATUS "${pcm} depends on ${dep_pcm}")
+            list(APPEND pcm_dep_list ${dep_pcm})
+          endforeach()
+        endif()
+      endforeach()
+      set(list_pcm_deps_${target} "${pcm_dep_list}" CACHE INTERNAL "List of pcm dependencies for ${target}")
+    endif()
+  endforeach()
+endfunction()

--- a/cmake/rootcling_wrapper.sh.in
+++ b/cmake/rootcling_wrapper.sh.in
@@ -1,0 +1,113 @@
+#!/bin/bash -e
+
+# rootcling_wrapper.sh -- wrap call to rootcling to trap some warnings
+# we want to treat as errors :
+#
+# Warning: Unused class rule
+#
+#
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --rootmap_library_name)
+    ROOTMAP_LIBRARY_NAME="$2"
+    shift 2
+    ;;
+  --include_dirs)
+    INCLUDE_DIRS="$2"
+    shift 2
+    ;;
+  --compile_defs)
+    COMPILE_DEFINITIONS="$2"
+    shift 2
+    ;;
+  --headers)
+    HEADERS="$2"
+    shift 2
+    ;;
+  --ld_library_path)
+    LD_LIBRARY_PATH="$2"
+    shift 2
+    ;;
+  --dictionary_file)
+    DICTIONARY_FILE="$2"
+    shift 2
+    ;;
+  --rootmap_file)
+    ROOTMAP_FILE="$2"
+    shift 2
+    ;;
+  --pcmdeps)
+    PCMDEPS="$2"
+    shift 2
+    ;;
+  *)
+    if [[ -z "$1" ]]; then
+      shift
+    else
+      echo "Parameter unknown: $1" >&2
+      exit 1
+    fi
+    ;;
+  esac
+done
+
+if [[ ! $ROOTMAP_LIBRARY_NAME ]]; then
+  echo "--rootmap_library_name option is mandatory but was not given" >&2
+  exit 1
+fi
+
+if [[ ! $INCLUDE_DIRS ]]; then
+  echo "--include_dirs option is mandatory but was not given" >&2
+  exit 1
+fi
+
+if [[ ! $DICTIONARY_FILE ]]; then
+  echo "--dictionary_file option is mandatory but was not given" >&2
+  exit 1
+fi
+
+if [[ ! $ROOTMAP_FILE ]]; then
+  echo "--rootmap_file option is mandatory but was not given" >&2
+  exit 1
+fi
+
+case $OSTYPE in
+  darwin*)
+    unset PCMDEPS
+    ;;
+  *)
+    ;;
+esac
+
+LOGFILE=${DICTIONARY_FILE}.log
+
+@CMAKE_COMMAND@ -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} @ROOT_rootcling_CMD@ \
+  -f $DICTIONARY_FILE \
+  -inlineInputHeader \
+  -noGlobalUsingStd \
+  -rmf ${ROOTMAP_FILE} \
+  -rml ${ROOTMAP_LIBRARY_NAME} \
+  ${INCLUDE_DIRS//;/ } \
+  ${COMPILE_DEFINITIONS//;/ } \
+  ${PCMDEPS:+-m }${PCMDEPS//;/ -m } \
+  ${HEADERS//;/ } \
+  > ${LOGFILE} 2>&1 || cat ${LOGFILE} >&2
+
+if [[ $? != "0" ]]; then
+  rm $DICTIONARY_FILE
+  exit 1
+fi
+
+MSG="Warning: Unused class rule"
+if [[ -s ${LOGFILE} ]]; then
+  WARNINGS=$(grep -c "${MSG}" ${LOGFILE} || :)
+  if [[ ! $WARNINGS == 0 ]]; then
+    echo "ERROR: please fix the warnings below about unused class rule" >&2
+    grep "$MSG" ${LOGFILE} >&2
+    rm $DICTIONARY_FILE
+    exit 1
+  fi
+fi
+
+exit 0

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+include(CPack)
+
+install(EXPORT O2PhysicsTargets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/O2Physics
+        NAMESPACE O2Physics::
+        FILE O2PhysicsTargets.cmake)
+
+install(FILES O2PhysicsConfig.cmake ../cmake/AddRootDictionary.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/O2Physics)
+
+install(FILES ../cmake/rootcling_wrapper.sh.in
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/O2Physics
+        PERMISSIONS OWNER_READ
+                    OWNER_WRITE
+                    OWNER_EXECUTE
+                    GROUP_READ
+                    GROUP_EXECUTE
+                    WORLD_READ
+                    WORLD_EXECUTE)
+
+install(DIRECTORY ../dependencies/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/O2Physics)

--- a/packaging/O2PhysicsConfig.cmake
+++ b/packaging/O2PhysicsConfig.cmake
@@ -1,0 +1,18 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+include("${CMAKE_CURRENT_LIST_DIR}/O2PhysicsDependencies.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/O2PhysicsTargets.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/AddRootDictionary.cmake")
+
+message(STATUS "!!! Using new O2Physics targets. That's a good thing.")


### PR DESCRIPTION
For many reasons (including Open Access) would be required to be able to use O2Physics as (external) dependency for various downstream projects.
So far this is work in progress, as i do not understand the complete cmake structure of O2 which i tried to copy to O2Physics
At this moment the error that i get is:
```
2022-09-21@12:36:05:DEBUG:O2Physics:O2Physics:o2physics: -- Configuring done
2022-09-21@12:36:12:DEBUG:O2Physics:O2Physics:o2physics: CMake Error: INSTALL(EXPORT) given unknown export "O2PhysicsTargets"
```
and it's not clear to me where to look

@ktf @TimoWilken guys, if you have time to take a look maybe you can spot some obvious problem given your experience with the cmake insides of O2.
Thanks a lot!