### PR TITLE
DPG: update ITS-TPC match. eff. workflow to improve the comparison with QC.

### DIFF
--- a/DPG/Tasks/AOTTrack/qaMatchEff.cxx
+++ b/DPG/Tasks/AOTTrack/qaMatchEff.cxx
@@ -36,10 +36,14 @@ struct qaMatchEff {
   // Track selections
   Configurable<bool> b_useTrackSelections{"b_useTrackSelections", false, "Boolean to switch the track selections on/off."};
   // kinematics
+  Configurable<float> ptMinCutInnerWallTPC{"ptMinCutInnerWallTPC", 0.1f, "Minimum transverse momentum calculated at the inner wall of TPC (GeV/c)"};
   Configurable<float> ptMinCut{"ptMinCut", 0.1f, "Minimum transverse momentum (GeV/c)"};
   Configurable<float> ptMaxCut{"ptMaxCut", 100.f, "Maximum transverse momentum (GeV/c)"};
   Configurable<float> etaMinCut{"etaMinCut", -2.0f, "Minimum pseudorapidity"};
   Configurable<float> etaMaxCut{"etaMaxCut", 2.0f, "Maximum pseudorapidity"};
+  Configurable<float> dcaXYMaxCut{"dcaXYMaxCut", 1000000.0f, "Maximum dcaXY (cm)"};
+  // Configurable<float> dcaMaxCut{"dcaMaxCut", 1000000.0f, "Maximum dca (cm)"};
+  Configurable<bool> b_useTPCinnerWallPt{"b_useTPCinnerWallPt", false, "Boolean to switch the usage of pt calculated at the inner wall of TPC on/off."};
   // TPC
   Configurable<int> tpcNClusterMin{"tpcNClusterMin", 0, "Minimum number of clusters in TPC"};
   Configurable<int> tpcNCrossedRowsMin{"tpcNCrossedRowsMin", 70, "Minimum number of crossed rows in TPC"};
@@ -109,6 +113,7 @@ struct qaMatchEff {
       // kinematics
       cutObject.SetEtaRange(etaMinCut, etaMaxCut);
       cutObject.SetPtRange(ptMinCut, ptMaxCut);
+      cutObject.SetMaxDcaXY(dcaXYMaxCut); /// max for dca implementend by hand in isTrackSelectedKineCuts
       // TPC
       cutObject.SetMinNClustersTPC(tpcNClusterMin);
       cutObject.SetMinNCrossedRowsTPC(tpcNCrossedRowsMin);
@@ -312,8 +317,16 @@ struct qaMatchEff {
       return true; // no track selections applied
     if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kPtRange))
       return false;
+    if (b_useTPCinnerWallPt && (track.tpcInnerParam() * track.tpcInnerParam() / (1 + track.tgl() * track.tgl())) < ptMinCutInnerWallTPC * ptMinCutInnerWallTPC) {
+      return false; // pt selection active only if the required pt is that calculated at the inner wall of TPC
+    }
     if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kEtaRange))
       return false;
+    if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kDCAxy))
+      return false;
+    // dcaZ selection to simulate the dca cut in QC ()
+    // if ( abs(track.dcaZ()) < sqrt( dcaMaxCut*dcaMaxCut - track.dcaXY()*track.dcaXY() ) )
+    //  return false;
     return true;
   }
   /// Function applying the TPC selections
@@ -349,14 +362,14 @@ struct qaMatchEff {
   // //
   // // fill histos for TPC (all tracks)
   // void fillAllTPC(){
-  //   histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(jT.pt());
+  //   histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(trackPt);
   //   histos.get<TH1>(HIST("MC/phihist_tpc"))->Fill(jT.phi());
   //   histos.get<TH1>(HIST("MC/etahist_tpc"))->Fill(jT.eta());
   // }
   // //
   // // fill histos for TPC+ITS (all tracks)
   // void fillAllTPCITS(){
-  //   histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(jT.pt());
+  //   histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(trackPt);
   //   histos.get<TH1>(HIST("MC/phihist_tpcits"))->Fill(jT.phi());
   //   histos.get<TH1>(HIST("MC/etahist_tpcits"))->Fill(jT.eta());
   // }
@@ -377,6 +390,15 @@ struct qaMatchEff {
     //
     //
     for (auto& jT : jTracks) {
+
+      float trackPt = jT.pt();
+      if (b_useTPCinnerWallPt) {
+        /// Using pt calculated at the inner wall of TPC
+        /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
+        const float tgl = jT.tgl();
+        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+      }
+
       // kinematic track seletions for all tracks
       if (!isTrackSelectedKineCuts(jT))
         continue;
@@ -405,24 +427,24 @@ struct qaMatchEff {
       //
       // all tracks, no conditions
       if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-        histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(jT.pt());
+        histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(trackPt);
         histos.get<TH1>(HIST("MC/phihist_tpc"))->Fill(jT.phi());
         histos.get<TH1>(HIST("MC/etahist_tpc"))->Fill(jT.eta());
         if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpcits"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpcits"))->Fill(jT.eta());
         } //  end if ITS
       }   //  end if TPC
       //
       // all tracks with pt>0.5
-      if (jT.pt() > 0.5) {
+      if (trackPt > 0.5) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_05"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_05"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_05"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_05"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_05"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_05"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_05"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_05"))->Fill(jT.eta());
           } //  end if ITS
@@ -432,11 +454,11 @@ struct qaMatchEff {
       // positive only
       if (jT.signed1Pt() > 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_pos"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_pos"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_pos"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_pos"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_pos"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_pos"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_pos"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_pos"))->Fill(jT.eta());
           } //  end if ITS
@@ -447,11 +469,11 @@ struct qaMatchEff {
       // negative only
       if (jT.signed1Pt() < 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_neg"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_neg"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_neg"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_neg"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_neg"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_neg"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_neg"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_neg"))->Fill(jT.eta());
           } //  end if ITS
@@ -462,11 +484,11 @@ struct qaMatchEff {
       // only primaries
       if (mcpart.isPhysicalPrimary()) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_prim"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_prim"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_prim"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_prim"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_prim"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_prim"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_prim"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_prim"))->Fill(jT.eta());
           } //  end if ITS
@@ -476,11 +498,11 @@ struct qaMatchEff {
       // only secondaries from decay
       else if (mcpart.getProcess() == 4) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_secd"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_secd"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_secd"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_secd"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_secd"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_secd"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_secd"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_secd"))->Fill(jT.eta());
           } //  end if ITS
@@ -489,11 +511,11 @@ struct qaMatchEff {
         // only secondaries from material
         else {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_secm"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_secm"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_secm"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_secm"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_secm"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_secm"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_secm"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_secm"))->Fill(jT.eta());
             } //  end if ITS
@@ -505,11 +527,11 @@ struct qaMatchEff {
       // protons only
       if (tpPDGCode == 2212) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_P"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_P"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_P"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_P"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_P"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_P"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_P"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_P"))->Fill(jT.eta());
           } //  end if ITS
@@ -521,11 +543,11 @@ struct qaMatchEff {
         //
         // all tracks
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_pi"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_pi"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_pi"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_pi"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_pi"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_pi"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_pi"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_pi"))->Fill(jT.eta());
           } //  end if ITS
@@ -534,11 +556,11 @@ struct qaMatchEff {
         // only primary pions
         if (mcpart.isPhysicalPrimary()) {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_pi_prim"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_pi_prim"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_pi_prim"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_pi_prim"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_prim"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_prim"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_pi_prim"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_pi_prim"))->Fill(jT.eta());
             } //  end if ITS
@@ -548,11 +570,11 @@ struct qaMatchEff {
         // only secondary pions from decay
         else if (mcpart.getProcess() == 4) {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_pi_secd"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_pi_secd"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_pi_secd"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_pi_secd"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secd"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secd"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_pi_secd"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_pi_secd"))->Fill(jT.eta());
             } //  end if ITS
@@ -561,11 +583,11 @@ struct qaMatchEff {
           // only secondary pions from material
           else {
             if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpc_pi_secm"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpc_pi_secm"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpc_pi_secm"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpc_pi_secm"))->Fill(jT.eta());
               if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-                histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secm"))->Fill(jT.pt());
+                histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secm"))->Fill(trackPt);
                 histos.get<TH1>(HIST("MC/phihist_tpcits_pi_secm"))->Fill(jT.phi());
                 histos.get<TH1>(HIST("MC/etahist_tpcits_pi_secm"))->Fill(jT.eta());
               } //  end if ITS
@@ -587,12 +609,12 @@ struct qaMatchEff {
           pdg_fill = -10.0;
         //
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_nopi"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_nopi"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_nopi"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_nopi"))->Fill(jT.eta());
           histos.get<TH1>(HIST("MC/pdghist_den"))->Fill(pdg_fill);
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_nopi"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_nopi"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_nopi"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_nopi"))->Fill(jT.eta());
             histos.get<TH1>(HIST("MC/pdghist_num"))->Fill(pdg_fill);
@@ -603,11 +625,11 @@ struct qaMatchEff {
       // kaons only
       if (tpPDGCode == 321) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_K"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_K"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_K"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_K"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_K"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_K"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_K"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_K"))->Fill(jT.eta());
           } //  end if ITS
@@ -617,11 +639,11 @@ struct qaMatchEff {
       // pions and kaons together
       if (tpPDGCode == 211 || tpPDGCode == 321) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_piK"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_piK"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_piK"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_piK"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_piK"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_piK"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_piK"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_piK"))->Fill(jT.eta());
           } //  end if ITS
@@ -644,6 +666,15 @@ struct qaMatchEff {
     //
     //
     for (auto& jT : jTracks) {
+
+      float trackPt = jT.pt();
+      if (b_useTPCinnerWallPt) {
+        /// Using pt calculated at the inner wall of TPC
+        /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
+        const float tgl = jT.tgl();
+        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+      }
+
       // kinematic track seletions for all tracks
       if (!isTrackSelectedKineCuts(jT))
         continue;
@@ -672,24 +703,24 @@ struct qaMatchEff {
       //
       // all tracks, no conditions
       if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-        histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(jT.pt());
+        histos.get<TH1>(HIST("MC/pthist_tpc"))->Fill(trackPt);
         histos.get<TH1>(HIST("MC/phihist_tpc"))->Fill(jT.phi());
         histos.get<TH1>(HIST("MC/etahist_tpc"))->Fill(jT.eta());
         if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpcits"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpcits"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpcits"))->Fill(jT.eta());
         } //  end if ITS
       }   //  end if TPC
       //
       // all tracks with pt>0.5
-      if (jT.pt() > 0.5) {
+      if (trackPt > 0.5) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_05"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_05"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_05"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_05"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_05"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_05"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_05"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_05"))->Fill(jT.eta());
           } //  end if ITS
@@ -699,11 +730,11 @@ struct qaMatchEff {
       // positive only
       if (jT.signed1Pt() > 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_pos"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_pos"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_pos"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_pos"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_pos"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_pos"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_pos"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_pos"))->Fill(jT.eta());
           } //  end if ITS
@@ -714,11 +745,11 @@ struct qaMatchEff {
       // negative only
       if (jT.signed1Pt() < 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_neg"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_neg"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_neg"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_neg"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_neg"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_neg"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_neg"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_neg"))->Fill(jT.eta());
           } //  end if ITS
@@ -729,11 +760,11 @@ struct qaMatchEff {
       // only primaries
       if (mcpart.isPhysicalPrimary()) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_prim"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_prim"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_prim"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_prim"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_prim"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_prim"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_prim"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_prim"))->Fill(jT.eta());
           } //  end if ITS
@@ -743,11 +774,11 @@ struct qaMatchEff {
       // only secondaries from decay
       else if (mcpart.getProcess() == 4) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_secd"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_secd"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_secd"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_secd"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_secd"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_secd"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_secd"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_secd"))->Fill(jT.eta());
           } //  end if ITS
@@ -756,11 +787,11 @@ struct qaMatchEff {
         // only secondaries from material
         else {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_secm"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_secm"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_secm"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_secm"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_secm"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_secm"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_secm"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_secm"))->Fill(jT.eta());
             } //  end if ITS
@@ -772,11 +803,11 @@ struct qaMatchEff {
       // protons only
       if (tpPDGCode == 2212) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_P"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_P"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_P"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_P"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_P"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_P"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_P"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_P"))->Fill(jT.eta());
           } //  end if ITS
@@ -788,11 +819,11 @@ struct qaMatchEff {
         //
         // all tracks
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_pi"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_pi"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_pi"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_pi"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_pi"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_pi"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_pi"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_pi"))->Fill(jT.eta());
           } //  end if ITS
@@ -801,11 +832,11 @@ struct qaMatchEff {
         // only primary pions
         if (mcpart.isPhysicalPrimary()) {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_pi_prim"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_pi_prim"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_pi_prim"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_pi_prim"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_prim"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_prim"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_pi_prim"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_pi_prim"))->Fill(jT.eta());
             } //  end if ITS
@@ -815,11 +846,11 @@ struct qaMatchEff {
         // only secondary pions from decay
         else if (mcpart.getProcess() == 4) {
           if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpc_pi_secd"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpc_pi_secd"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpc_pi_secd"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpc_pi_secd"))->Fill(jT.eta());
             if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secd"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secd"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpcits_pi_secd"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpcits_pi_secd"))->Fill(jT.eta());
             } //  end if ITS
@@ -828,11 +859,11 @@ struct qaMatchEff {
           // only secondary pions from material
           else {
             if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-              histos.get<TH1>(HIST("MC/pthist_tpc_pi_secm"))->Fill(jT.pt());
+              histos.get<TH1>(HIST("MC/pthist_tpc_pi_secm"))->Fill(trackPt);
               histos.get<TH1>(HIST("MC/phihist_tpc_pi_secm"))->Fill(jT.phi());
               histos.get<TH1>(HIST("MC/etahist_tpc_pi_secm"))->Fill(jT.eta());
               if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-                histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secm"))->Fill(jT.pt());
+                histos.get<TH1>(HIST("MC/pthist_tpcits_pi_secm"))->Fill(trackPt);
                 histos.get<TH1>(HIST("MC/phihist_tpcits_pi_secm"))->Fill(jT.phi());
                 histos.get<TH1>(HIST("MC/etahist_tpcits_pi_secm"))->Fill(jT.eta());
               } //  end if ITS
@@ -854,12 +885,12 @@ struct qaMatchEff {
           pdg_fill = -10.0;
         //
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_nopi"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_nopi"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_nopi"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_nopi"))->Fill(jT.eta());
           histos.get<TH1>(HIST("MC/pdghist_den"))->Fill(pdg_fill);
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_nopi"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_nopi"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_nopi"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_nopi"))->Fill(jT.eta());
             histos.get<TH1>(HIST("MC/pdghist_num"))->Fill(pdg_fill);
@@ -870,11 +901,11 @@ struct qaMatchEff {
       // kaons only
       if (tpPDGCode == 321) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_K"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_K"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_K"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_K"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_K"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_K"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_K"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_K"))->Fill(jT.eta());
           } //  end if ITS
@@ -884,11 +915,11 @@ struct qaMatchEff {
       // pions and kaons together
       if (tpPDGCode == 211 || tpPDGCode == 321) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("MC/pthist_tpc_piK"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("MC/pthist_tpc_piK"))->Fill(trackPt);
           histos.get<TH1>(HIST("MC/phihist_tpc_piK"))->Fill(jT.phi());
           histos.get<TH1>(HIST("MC/etahist_tpc_piK"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("MC/pthist_tpcits_piK"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("MC/pthist_tpcits_piK"))->Fill(trackPt);
             histos.get<TH1>(HIST("MC/phihist_tpcits_piK"))->Fill(jT.phi());
             histos.get<TH1>(HIST("MC/etahist_tpcits_piK"))->Fill(jT.eta());
           } //  end if ITS
@@ -911,6 +942,15 @@ struct qaMatchEff {
     //
     //
     for (auto& jT : jTracks) {
+
+      float trackPt = jT.pt();
+      if (b_useTPCinnerWallPt) {
+        /// Using pt calculated at the inner wall of TPC
+        /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
+        const float tgl = jT.tgl();
+        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+      }
+
       // kinematic track seletions for all tracks
       if (!isTrackSelectedKineCuts(jT))
         continue;
@@ -919,20 +959,20 @@ struct qaMatchEff {
       //
       // all tracks, no conditions
       if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-        histos.get<TH1>(HIST("data/pthist_tpc"))->Fill(jT.pt());
+        histos.get<TH1>(HIST("data/pthist_tpc"))->Fill(trackPt);
         histos.get<TH1>(HIST("data/phihist_tpc"))->Fill(jT.phi());
         histos.get<TH1>(HIST("data/etahist_tpc"))->Fill(jT.eta());
-        if (jT.pt() > 0.5) {
-          histos.get<TH1>(HIST("data/pthist_tpc_05"))->Fill(jT.pt());
+        if (trackPt > 0.5) {
+          histos.get<TH1>(HIST("data/pthist_tpc_05"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_05"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_05"))->Fill(jT.eta());
         }
         if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpcits"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpcits"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpcits"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpcits"))->Fill(jT.eta());
-          if (jT.pt() > 0.5) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_05"))->Fill(jT.pt());
+          if (trackPt > 0.5) {
+            histos.get<TH1>(HIST("data/pthist_tpcits_05"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_05"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_05"))->Fill(jT.eta());
           }
@@ -943,11 +983,11 @@ struct qaMatchEff {
       // positive only
       if (jT.signed1Pt() > 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpc_pos"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpc_pos"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_pos"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_pos"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_pos"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("data/pthist_tpcits_pos"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_pos"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_pos"))->Fill(jT.eta());
           } //  end if ITS
@@ -958,11 +998,11 @@ struct qaMatchEff {
       // negative only
       if (jT.signed1Pt() < 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpc_neg"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpc_neg"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_neg"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_neg"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_neg"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("data/pthist_tpcits_neg"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_neg"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_neg"))->Fill(jT.eta());
           } //  end if ITS
@@ -987,6 +1027,15 @@ struct qaMatchEff {
     //
     //
     for (auto& jT : jTracks) {
+
+      float trackPt = jT.pt();
+      if (b_useTPCinnerWallPt) {
+        /// Using pt calculated at the inner wall of TPC
+        /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
+        const float tgl = jT.tgl();
+        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+      }
+
       // kinematic track seletions for all tracks
       if (!isTrackSelectedKineCuts(jT))
         continue;
@@ -995,20 +1044,20 @@ struct qaMatchEff {
       //
       // all tracks, no conditions
       if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-        histos.get<TH1>(HIST("data/pthist_tpc"))->Fill(jT.pt());
+        histos.get<TH1>(HIST("data/pthist_tpc"))->Fill(trackPt);
         histos.get<TH1>(HIST("data/phihist_tpc"))->Fill(jT.phi());
         histos.get<TH1>(HIST("data/etahist_tpc"))->Fill(jT.eta());
-        if (jT.pt() > 0.5) {
-          histos.get<TH1>(HIST("data/pthist_tpc_05"))->Fill(jT.pt());
+        if (trackPt > 0.5) {
+          histos.get<TH1>(HIST("data/pthist_tpc_05"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_05"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_05"))->Fill(jT.eta());
         }
         if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpcits"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpcits"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpcits"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpcits"))->Fill(jT.eta());
-          if (jT.pt() > 0.5) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_05"))->Fill(jT.pt());
+          if (trackPt > 0.5) {
+            histos.get<TH1>(HIST("data/pthist_tpcits_05"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_05"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_05"))->Fill(jT.eta());
           }
@@ -1019,11 +1068,11 @@ struct qaMatchEff {
       // positive only
       if (jT.signed1Pt() > 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpc_pos"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpc_pos"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_pos"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_pos"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_pos"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("data/pthist_tpcits_pos"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_pos"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_pos"))->Fill(jT.eta());
           } //  end if ITS
@@ -1034,11 +1083,11 @@ struct qaMatchEff {
       // negative only
       if (jT.signed1Pt() < 0) {
         if (jT.hasTPC() && isTrackSelectedTPCCuts(jT)) {
-          histos.get<TH1>(HIST("data/pthist_tpc_neg"))->Fill(jT.pt());
+          histos.get<TH1>(HIST("data/pthist_tpc_neg"))->Fill(trackPt);
           histos.get<TH1>(HIST("data/phihist_tpc_neg"))->Fill(jT.phi());
           histos.get<TH1>(HIST("data/etahist_tpc_neg"))->Fill(jT.eta());
           if (jT.hasITS() && isTrackSelectedITSCuts(jT)) {
-            histos.get<TH1>(HIST("data/pthist_tpcits_neg"))->Fill(jT.pt());
+            histos.get<TH1>(HIST("data/pthist_tpcits_neg"))->Fill(trackPt);
             histos.get<TH1>(HIST("data/phihist_tpcits_neg"))->Fill(jT.phi());
             histos.get<TH1>(HIST("data/etahist_tpcits_neg"))->Fill(jT.eta());
           } //  end if ITS

--- a/DPG/Tasks/AOTTrack/qaMatchEff.cxx
+++ b/DPG/Tasks/AOTTrack/qaMatchEff.cxx
@@ -90,6 +90,10 @@ struct qaMatchEff {
   //
   // Track selection object
   TrackSelection cutObject;
+  //
+  //
+  // pt calculated at the inner wall of TPC
+  float trackPtInParamTPC = -1.;
   // Init function
   //
   void init(InitContext&)
@@ -309,6 +313,15 @@ struct qaMatchEff {
 
   } // end initMC
 
+  /// Function calculatind the pt at inner wall of TPC
+  template <typename T>
+  float computePtInParamTPC(T& track)
+  {
+    /// Using pt calculated at the inner wall of TPC
+    /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
+    return track.tpcInnerParam() / sqrt(1. + track.tgl() * track.tgl());
+  }
+
   /// Function applying the kinematic selections
   template <typename T>
   bool isTrackSelectedKineCuts(T& track)
@@ -317,7 +330,7 @@ struct qaMatchEff {
       return true; // no track selections applied
     if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kPtRange))
       return false;
-    if (b_useTPCinnerWallPt && (track.tpcInnerParam() * track.tpcInnerParam() / (1 + track.tgl() * track.tgl())) < ptMinCutInnerWallTPC * ptMinCutInnerWallTPC) {
+    if (b_useTPCinnerWallPt && computePtInParamTPC(track) < ptMinCutInnerWallTPC) {
       return false; // pt selection active only if the required pt is that calculated at the inner wall of TPC
     }
     if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kEtaRange))
@@ -395,8 +408,7 @@ struct qaMatchEff {
       if (b_useTPCinnerWallPt) {
         /// Using pt calculated at the inner wall of TPC
         /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
-        const float tgl = jT.tgl();
-        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+        trackPt = computePtInParamTPC(jT);
       }
 
       // kinematic track seletions for all tracks
@@ -671,8 +683,7 @@ struct qaMatchEff {
       if (b_useTPCinnerWallPt) {
         /// Using pt calculated at the inner wall of TPC
         /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
-        const float tgl = jT.tgl();
-        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+        trackPt = computePtInParamTPC(jT);
       }
 
       // kinematic track seletions for all tracks
@@ -947,8 +958,7 @@ struct qaMatchEff {
       if (b_useTPCinnerWallPt) {
         /// Using pt calculated at the inner wall of TPC
         /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
-        const float tgl = jT.tgl();
-        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+        trackPt = computePtInParamTPC(jT);
       }
 
       // kinematic track seletions for all tracks
@@ -1032,8 +1042,7 @@ struct qaMatchEff {
       if (b_useTPCinnerWallPt) {
         /// Using pt calculated at the inner wall of TPC
         /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
-        const float tgl = jT.tgl();
-        trackPt = jT.tpcInnerParam() / sqrt(1 + tgl * tgl);
+        trackPt = computePtInParamTPC(jT);
       }
 
       // kinematic track seletions for all tracks

--- a/DPG/Tasks/AOTTrack/qaMatchEff.cxx
+++ b/DPG/Tasks/AOTTrack/qaMatchEff.cxx
@@ -319,7 +319,7 @@ struct qaMatchEff {
   {
     /// Using pt calculated at the inner wall of TPC
     /// Caveat: tgl still from tracking: this is not the value of tgl at the inner wall of TPC
-    return track.tpcInnerParam() / sqrt(1. + track.tgl() * track.tgl());
+    return track.tpcInnerParam() / sqrt(1.f + track.tgl() * track.tgl());
   }
 
   /// Function applying the kinematic selections


### PR DESCRIPTION
 - dcaXY selection added;
 - possibility to use pt(TPC), i.e. calculated from the inner wall of TPC.

CAVEATS:
 - selections on TPC kinematic variables not possible in AO2Ds. Only pt(TPC) cut is applied "by hand" when pt(TPC) is enabled;
 - pt(TPC) calculated using tan(lambda) from tracking (value at the inner wall of TPC not available).