### PR TITLE
PWGHF: make LctoK0sP cut matrix configurable

### DIFF
--- a/PWGHF/Core/HFSelectorCuts.h
+++ b/PWGHF/Core/HFSelectorCuts.h
@@ -303,6 +303,50 @@ static const std::vector<std::string> pTBinLabels = {
 static const std::vector<std::string> cutVarLabels = {"m", "pT p", "pT K", "pT Pi", "Chi2PCA", "decay length", "cos pointing angle"};
 } // namespace hf_cuts_lc_topkpi
 
+namespace hf_cuts_lc_tok0sp
+{
+static constexpr int npTBins = 8;
+static constexpr int nCutVars = 8;
+// default values for the pT bin edges (can be used to configure histogram axis)
+// offset by 1 from the bin numbers in cuts array
+constexpr double pTBins[npTBins + 1] = {
+  1.,
+  2.,
+  3.,
+  4.,
+  5.,
+  6.,
+  8.,
+  12.,
+  24.};
+auto pTBins_v = std::vector<double>{pTBins, pTBins + npTBins + 1};
+
+// default values for the cuts
+//mK0s(GeV)     mLambdas(GeV)    mGammas(GeV)    ptp     ptK0sdau     ptK0s     d0p     d0K0
+constexpr double cuts[npTBins][nCutVars] = {{0.008, 0.005, 0.1, 0.5, 0.3, 0.6, 0.05, 999999.},  // 1 < pt < 2
+                                            {0.008, 0.005, 0.1, 0.5, 0.4, 1.3, 0.05, 999999.},  // 2 < pt < 3
+                                            {0.009, 0.005, 0.1, 0.6, 0.4, 1.3, 0.05, 999999.},  // 3 < pt < 4
+                                            {0.011, 0.005, 0.1, 0.6, 0.4, 1.4, 0.05, 999999.},  // 4 < pt < 5
+                                            {0.013, 0.005, 0.1, 0.6, 0.4, 1.4, 0.06, 999999.},  // 5 < pt < 6
+                                            {0.013, 0.005, 0.1, 0.9, 0.4, 1.6, 0.09, 999999.},  // 6 < pt < 8
+                                            {0.016, 0.005, 0.1, 0.9, 0.4, 1.7, 0.10, 999999.},  // 8 < pt < 12
+                                            {0.019, 0.005, 0.1, 1.0, 0.4, 1.9, 0.20, 999999.}}; // 12 < pt < 24
+
+// row labels
+static const std::vector<std::string> pTBinLabels = {
+  "pT bin 0",
+  "pT bin 1",
+  "pT bin 2",
+  "pT bin 3",
+  "pT bin 4",
+  "pT bin 5",
+  "pT bin 6",
+  "pT bin 7"};
+
+// column labels
+static const std::vector<std::string> cutVarLabels = {"mK0s", "mLambda", "mGamma", "ptBach", "ptV0Dau", "ptV0", "d0Bach", "d0V0"};
+} // namespace hf_cuts_lc_tok0sp
+
 namespace hf_cuts_dplus_topikpi
 {
 static const int npTBins = 12;

--- a/PWGHF/Core/HFSelectorCuts.h
+++ b/PWGHF/Core/HFSelectorCuts.h
@@ -322,7 +322,7 @@ constexpr double pTBins[npTBins + 1] = {
 auto pTBins_v = std::vector<double>{pTBins, pTBins + npTBins + 1};
 
 // default values for the cuts
-//mK0s(GeV)     mLambdas(GeV)    mGammas(GeV)    ptp     ptK0sdau     ptK0s     d0p     d0K0
+// mK0s(GeV)     mLambdas(GeV)    mGammas(GeV)    ptp     ptK0sdau     ptK0s     d0p     d0K0
 constexpr double cuts[npTBins][nCutVars] = {{0.008, 0.005, 0.1, 0.5, 0.3, 0.6, 0.05, 999999.},  // 1 < pt < 2
                                             {0.008, 0.005, 0.1, 0.5, 0.4, 1.3, 0.05, 999999.},  // 2 < pt < 3
                                             {0.009, 0.005, 0.1, 0.6, 0.4, 1.3, 0.05, 999999.},  // 3 < pt < 4

--- a/PWGHF/DataModel/HFSecondaryVertex.h
+++ b/PWGHF/DataModel/HFSecondaryVertex.h
@@ -557,7 +557,8 @@ DECLARE_SOA_TABLE(HfCandCascBase, "AOD", "HFCANDCASCBASE", //!
                   v0data::V0CosPA<v0data::X, v0data::Y, v0data::Z, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, collision::PosX, collision::PosY, collision::PosZ>,
                   v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                   v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-                  v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>);
+                  v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                  v0data::MGamma<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>);
 //                  ,
 //                  v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
 //                  v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,

--- a/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
@@ -28,12 +28,12 @@ using namespace o2::framework;
 using namespace o2::aod::hf_cand_casc;
 using namespace o2::analysis::hf_cuts_lc_tok0sp;
 
-
+//#define MY_DEBUG
 #ifdef MY_DEBUG
-#define MY_DEBUG_MSG(condition, cmd) \
-  if (condition) {                   \
-    cmd;                             \
-  }
+#define MY_DEBUG_MSG(condition, cmd)
+if (condition) {
+  cmd;
+}
 using MyBigTracks = soa::Join<aod::BigTracksPID, aod::McTrackLabels>;
 #else
 #define MY_DEBUG_MSG(condition, cmd)
@@ -58,7 +58,7 @@ struct HFLcK0sPCandidateSelector {
   Configurable<double> TPCNClsFindablePIDCut{"TPCNClsFindablePIDCut", 50., "Lower bound of TPC findable clusters for good PID"};
   Configurable<bool> requireTPC{"requireTPC", true, "Flag to require a positive Number of found clusters in TPC"};
 
-  //cuts
+  // cuts
   Configurable<std::vector<double>> pTBins{"pTBins", std::vector<double>{hf_cuts_lc_tok0sp::pTBins_v}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"Lc_to_K0s_p_cuts", {hf_cuts_lc_tok0sp::cuts[0], npTBins, nCutVars, pTBinLabels, cutVarLabels}, "Lc candidate selection per pT bin"};
 
@@ -87,53 +87,53 @@ struct HFLcK0sPCandidateSelector {
   bool selectionTopol(const T& hfCandCascade)
   {
     auto candPt = hfCandCascade.pt();
-    int ptBin = findBin(pTBins,candPt);
+    int ptBin = findBin(pTBins, candPt);
     if (ptBin == -1) {
       return false;
     }
 
     if (candPt < pTCandMin || candPt >= pTCandMax) {
       LOG(debug) << "cand pt (first check) cut failed: from cascade --> " << candPt << ", cut --> " << pTCandMax;
-      return false; //check that the candidate pT is within the analysis range
+      return false; // check that the candidate pT is within the analysis range
     }
 
-    if (std::abs(hfCandCascade.mK0Short() - RecoDecay::getMassPDG(kK0Short)) > cuts->get(ptBin,"mK0s")) {
-      LOG(debug) << "massK0s cut failed: from v0 in cascade, K0s --> " << hfCandCascade.mK0Short() << ", in PDG K0s --> " << RecoDecay::getMassPDG(kK0Short) << ", cut --> " << cuts->get(ptBin,"mK0s");
+    if (std::abs(hfCandCascade.mK0Short() - RecoDecay::getMassPDG(kK0Short)) > cuts->get(ptBin, "mK0s")) {
+      LOG(debug) << "massK0s cut failed: from v0 in cascade, K0s --> " << hfCandCascade.mK0Short() << ", in PDG K0s --> " << RecoDecay::getMassPDG(kK0Short) << ", cut --> " << cuts->get(ptBin, "mK0s");
       return false; // mass of the K0s
     }
 
-    if ((std::abs(hfCandCascade.mLambda() - RecoDecay::getMassPDG(kLambda0)) < cuts->get(ptBin,"mLambda")) || (std::abs(hfCandCascade.mAntiLambda() - RecoDecay::getMassPDG(kLambda0)) < cuts->get(ptBin,"mLambda"))) {
-      LOG(debug) << "mass L cut failed: from v0 in cascade, Lambda --> " << hfCandCascade.mLambda() << ", AntiLambda --> " << hfCandCascade.mAntiLambda() << ", in PDG, Lambda --> " << RecoDecay::getMassPDG(kLambda0) << ", cut --> " << cuts->get(ptBin,"mLambda");
+    if ((std::abs(hfCandCascade.mLambda() - RecoDecay::getMassPDG(kLambda0)) < cuts->get(ptBin, "mLambda")) || (std::abs(hfCandCascade.mAntiLambda() - RecoDecay::getMassPDG(kLambda0)) < cuts->get(ptBin, "mLambda"))) {
+      LOG(debug) << "mass L cut failed: from v0 in cascade, Lambda --> " << hfCandCascade.mLambda() << ", AntiLambda --> " << hfCandCascade.mAntiLambda() << ", in PDG, Lambda --> " << RecoDecay::getMassPDG(kLambda0) << ", cut --> " << cuts->get(ptBin, "mLambda");
       return false; // mass of the Lambda
     }
 
-    if (std::abs(InvMassGamma(hfCandCascade) - RecoDecay::getMassPDG(kGamma)) < cuts->get(ptBin,"mGamma")) {
-      LOG(debug) << "mass gamma cut failed: from v0 in cascade, gamma --> " << InvMassGamma(hfCandCascade) << ", cut --> " << cuts->get(ptBin,"mGamma");
+    if (std::abs(InvMassGamma(hfCandCascade) - RecoDecay::getMassPDG(kGamma)) < cuts->get(ptBin, "mGamma")) {
+      LOG(debug) << "mass gamma cut failed: from v0 in cascade, gamma --> " << InvMassGamma(hfCandCascade) << ", cut --> " << cuts->get(ptBin, "mGamma");
       return false; // mass of the Gamma
     }
 
-    if (hfCandCascade.ptProng0() < cuts->get(ptBin,"ptBach")) {
-      LOG(debug) << "bach pt cut failed, from cascade --> " << hfCandCascade.ptProng0() << " , cut --> " << cuts->get(ptBin,"ptBach");
+    if (hfCandCascade.ptProng0() < cuts->get(ptBin, "ptBach")) {
+      LOG(debug) << "bach pt cut failed, from cascade --> " << hfCandCascade.ptProng0() << " , cut --> " << cuts->get(ptBin, "ptBach");
       return false; // pt of the p
     }
 
-    if (hfCandCascade.ptV0Pos() < cuts->get(ptBin,"ptV0Dau")) {
-      LOG(debug) << "v0 pos daugh pt cut failed, from cascade --> " << hfCandCascade.ptV0Pos() << ", cut --> " << cuts->get(ptBin,"ptV0Dau");
+    if (hfCandCascade.ptV0Pos() < cuts->get(ptBin, "ptV0Dau")) {
+      LOG(debug) << "v0 pos daugh pt cut failed, from cascade --> " << hfCandCascade.ptV0Pos() << ", cut --> " << cuts->get(ptBin, "ptV0Dau");
       return false; // pt of the K0
     }
 
-    if (hfCandCascade.ptV0Neg() < cuts->get(ptBin,"ptV0Dau")) {
-      LOG(debug) << "v0 neg daugh pt cut failed, from cascade --> " << hfCandCascade.ptV0Neg() << ", cut --> " << cuts->get(ptBin,"ptV0Dau");
+    if (hfCandCascade.ptV0Neg() < cuts->get(ptBin, "ptV0Dau")) {
+      LOG(debug) << "v0 neg daugh pt cut failed, from cascade --> " << hfCandCascade.ptV0Neg() << ", cut --> " << cuts->get(ptBin, "ptV0Dau");
       return false; // pt of the K0
     }
 
-    if (hfCandCascade.ptProng1() < cuts->get(ptBin,"ptV0")) {
-      LOG(debug) << "cand pt cut failed, from cascade --> " << hfCandCascade.ptProng1() << ", cut --> " << cuts->get(ptBin,"ptV0");
+    if (hfCandCascade.ptProng1() < cuts->get(ptBin, "ptV0")) {
+      LOG(debug) << "cand pt cut failed, from cascade --> " << hfCandCascade.ptProng1() << ", cut --> " << cuts->get(ptBin, "ptV0");
       return false; // pt of the Lc
     }
 
-    if (std::abs(hfCandCascade.impactParameter0()) > cuts->get(ptBin,"d0Bach")) {
-      LOG(debug) << "d0 bach cut failed, in cascade --> " << hfCandCascade.impactParameter0() << ", cut --> " << cuts->get(ptBin,"d0Bach");
+    if (std::abs(hfCandCascade.impactParameter0()) > cuts->get(ptBin, "d0Bach")) {
+      LOG(debug) << "d0 bach cut failed, in cascade --> " << hfCandCascade.impactParameter0() << ", cut --> " << cuts->get(ptBin, "d0Bach");
       return false; // d0 of the bachelor
     }
 
@@ -144,8 +144,8 @@ struct HFLcK0sPCandidateSelector {
     }
     */
 
-    if (std::abs(hfCandCascade.impactParameter1()) > cuts->get(ptBin,"d0V0")) {
-      LOG(debug) << "d0 v0 cut failed, in cascade --> " << hfCandCascade.impactParameter1() << ", cut --> " << cuts->get(ptBin,"d0V0");
+    if (std::abs(hfCandCascade.impactParameter1()) > cuts->get(ptBin, "d0V0")) {
+      LOG(debug) << "d0 v0 cut failed, in cascade --> " << hfCandCascade.impactParameter1() << ", cut --> " << cuts->get(ptBin, "d0V0");
       return false; // d0 of the v0
     }
 
@@ -203,7 +203,7 @@ struct HFLcK0sPCandidateSelector {
   template <typename T>
   bool selectionPIDTPC(const T& track, double nSigmaCut)
   {
-    double nSigma = 100.0; //arbitarily large value
+    double nSigma = 100.0; // arbitarily large value
     nSigma = track.tpcNSigmaPr();
     LOG(debug) << "nSigma for bachelor = " << nSigma << ", cut at " << nSigmaCut;
     return std::abs(nSigma) < nSigmaCut;
@@ -261,7 +261,7 @@ struct HFLcK0sPCandidateSelector {
       } else {
         statusTPC = 2; //positive PID
       }
-	*/
+  */
       } else {
         statusTPC = 1;
       }
@@ -298,12 +298,12 @@ struct HFLcK0sPCandidateSelector {
   void process(aod::HfCandCascade const& candidates, MyBigTracks const& tracks)
   {
     int statusLc = 0; // final selection flag : 0-rejected  1-accepted
-    //bool topolLc = 0;
+    // bool topolLc = 0;
     int pidProton = -1;
-    //int pidLc = -1;
+    // int pidLc = -1;
 
-    for (auto& candidate : candidates) { //looping over cascade candidates
-      const auto& bach = candidate.index0_as<MyBigTracks>(); //bachelor track
+    for (const auto& candidate : candidates) {               // looping over cascade candidates
+      const auto& bach = candidate.index0_as<MyBigTracks>(); // bachelor track
 #ifdef MY_DEBUG
       auto indexV0DaughPos = candidate.posTrack_as<MyBigTracks>().mcParticleId();
       auto indexV0DaughNeg = candidate.negTrack_as<MyBigTracks>().mcParticleId();
@@ -312,7 +312,7 @@ struct HFLcK0sPCandidateSelector {
       bool isK0SfromLc = isK0SfromLcFunc(indexV0DaughPos, indexV0DaughNeg, indexK0Spos, indexK0Sneg);
 #endif
       MY_DEBUG_MSG(isLc, printf("\n"); LOG(info) << "In selector: correct Lc found: proton --> " << indexBach << ", posTrack --> " << indexV0DaughPos << ", negTrack --> " << indexV0DaughNeg);
-      //MY_DEBUG_MSG(isLc != 1, printf("\n"); LOG(info) << "In selector: wrong Lc found: proton --> " << indexBach << ", posTrack --> " << indexV0DaughPos << ", negTrack --> " << indexV0DaughNeg);
+      // MY_DEBUG_MSG(isLc != 1, printf("\n"); LOG(info) << "In selector: wrong Lc found: proton --> " << indexBach << ", posTrack --> " << indexV0DaughPos << ", negTrack --> " << indexV0DaughNeg);
 
       statusLc = 0;
       /* // not needed for the Lc
@@ -322,7 +322,7 @@ struct HFLcK0sPCandidateSelector {
       }
       */
 
-      //topolLc = true;
+      // topolLc = true;
       pidProton = -1;
 
       // daughter track validity selection
@@ -333,8 +333,8 @@ struct HFLcK0sPCandidateSelector {
         continue;
       }
 
-      //implement filter bit 4 cut - should be done before this task at the track selection level
-      //need to add special cuts (additional cuts on decay length and d0 norm)
+      // implement filter bit 4 cut - should be done before this task at the track selection level
+      // need to add special cuts (additional cuts on decay length and d0 norm)
       LOG(debug) << "selectionTopol(candidate) = " << selectionTopol(candidate);
       if (!selectionTopol(candidate)) {
         MY_DEBUG_MSG(isLc, LOG(info) << "In selector: Lc rejected due to topological selections");

--- a/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
@@ -360,6 +360,7 @@ struct HFLcK0sPCandidateSelector {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfcg)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<HFLcK0sPCandidateSelector>(cfcg, TaskName{"hf-lc-tok0sp-candidate-selector"})};
+  WorkflowSpec workflow{};
+  workflow.push_back(adaptAnalysisTask<HFLcK0sPCandidateSelector>(cfcg));
+  return workflow;
 }

--- a/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
@@ -40,7 +40,7 @@ using MyBigTracks = soa::Join<aod::BigTracksPID, aod::McTrackLabels>;
 using MyBigTracks = aod::BigTracksPID;
 #endif
 
-struct HFLcK0sPCandidateSelector {
+struct HfLcTok0spCandidateSelector {
 
   Produces<aod::HFSelLcK0sPCandidate> hfSelLcK0sPCandidate;
 
@@ -361,6 +361,6 @@ struct HFLcK0sPCandidateSelector {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfcg)
 {
   WorkflowSpec workflow{};
-  workflow.push_back(adaptAnalysisTask<HFLcK0sPCandidateSelector>(cfcg));
+  workflow.push_back(adaptAnalysisTask<HfLcTok0spCandidateSelector>(cfcg));
   return workflow;
 }

--- a/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
+++ b/PWGHF/TableProducer/HFLcK0sPCandidateSelector.cxx
@@ -107,8 +107,8 @@ struct HFLcK0sPCandidateSelector {
       return false; // mass of the Lambda
     }
 
-    if (std::abs(InvMassGamma(hfCandCascade) - RecoDecay::getMassPDG(kGamma)) < cuts->get(ptBin, "mGamma")) {
-      LOG(debug) << "mass gamma cut failed: from v0 in cascade, gamma --> " << InvMassGamma(hfCandCascade) << ", cut --> " << cuts->get(ptBin, "mGamma");
+    if (std::abs(hfCandCascade.mGamma() - RecoDecay::getMassPDG(kGamma)) < cuts->get(ptBin, "mGamma")) {
+      LOG(debug) << "mass gamma cut failed: from v0 in cascade, gamma --> " << hfCandCascade.mGamma() << ", cut --> " << cuts->get(ptBin, "mGamma");
       return false; // mass of the Gamma
     }
 


### PR DESCRIPTION
- make the cuts and the ptBins for the Lc->K0sP analysis configurable via the .json config file (analogous to the other tasks, defaults defined in HFSelectorCuts.h)
- changed nonsensical cut on the candidates's pt in the cut matrix to a cut on the V0's pt

Related PR: https://github.com/AliceO2Group/Run3Analysisvalidation/pull/362