### PR TITLE
Fix copyright notice in CMake files

### DIFF
--- a/Common/Tools/Multiplicity/CMakeLists.txt
+++ b/Common/Tools/Multiplicity/CMakeLists.txt
@@ -1,12 +1,12 @@
-#Copyright 2019 - 2020 CERN and copyright holders of ALICE O2.
-#See https: //alice-o2.web.cern.ch/copyright for details of the copyright holders.
-#All rights not expressly granted are reserved.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-#This software is distributed under the terms of the GNU General Public
-#License v3(GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
-#In applying this license CERN does not waive the privileges and immunities
-#granted to it by virtue of its status as an Intergovernmental Organization
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
 o2physics_add_library(multTools

--- a/PWGUD/Tasks/CMakeLists.txt
+++ b/PWGUD/Tasks/CMakeLists.txt
@@ -1,12 +1,12 @@
-#Copyright 2019 - 2020 CERN and copyright holders of ALICE O2.
-#See https: // alice-o2.web.cern.ch/copyright for details of the copyright holders.
-#All rights not expressly granted are reserved.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-#This software is distributed under the terms of the GNU General Public
-#License v3(GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
-#In applying this license CERN does not waive the privileges and immunities
-#granted to it by virtue of its status as an Intergovernmental Organization
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
 o2physics_add_dpl_workflow(upc


### PR DESCRIPTION
Some CMake files have a copyright notice with messed-up formatting. This fixes them, in preparation for the CI copyright check to also cover CMake files (see alisw/ali-bot#1199).