### PR TITLE
[PWG-DQ] Fix CCDB Path for dqFlow Task

### DIFF
--- a/PWGDQ/Tasks/dqFlow.cxx
+++ b/PWGDQ/Tasks/dqFlow.cxx
@@ -146,10 +146,6 @@ struct AnalysisQvector {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     ccdb->setCreatedNotAfter(fConfigNoLaterThan.value);
-    auto histCCDB = ccdb->get<TH1F>(fConfigCCDBPath.value);
-    if (!histCCDB) {
-      LOGF(fatal, "CCDB histogram not found");
-    }
 
     VarManager::SetDefaultVarNames();
 


### PR DESCRIPTION
Fixing the CCDB issue for dqFlow Task like tableReader https://github.com/AliceO2Group/O2Physics/pull/1299.

Also CCDB path can be commented like https://github.com/AliceO2Group/O2Physics/pull/1322 for hyperloop operations but  CCDB path is used in the dqFlow task unlike tableReader so I want to keep there