### PR TITLE
Fix build on MacOS Monterey

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 project(O2Physics
         VERSION 0.0.1
-        LANGUAGES CXX
+        LANGUAGES C CXX
         DESCRIPTION "Physics Analysis for O2")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Apparently, CMake doesn't enable the "C" language by default for some users, which we need to use some O2Physics dependencies (like LibFFI).

This fixes a problem reported by email on alice-project-analysis-task-force.