### PR TITLE
Change type Run2 trigger aliaslabels

### DIFF
--- a/Common/CCDB/TriggerAliases.cxx
+++ b/Common/CCDB/TriggerAliases.cxx
@@ -12,7 +12,7 @@
 #include "Common/CCDB/TriggerAliases.h"
 #include "Framework/Logger.h"
 
-const char* aliasLabels[kNaliases] = {
+std::string aliasLabels[kNaliases] = {
   "kINT7",
   "kEMC7",
   "kINT7inMUON",

--- a/Common/CCDB/TriggerAliases.h
+++ b/Common/CCDB/TriggerAliases.h
@@ -44,7 +44,7 @@ enum triggerAliases {
   kNaliases
 };
 
-extern const char* aliasLabels[kNaliases];
+extern std::string aliasLabels[kNaliases];
 
 class TriggerAliases
 {

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -238,9 +238,9 @@ struct EventSelectionQaTask {
       histos.get<TH1>(HIST("hSelMask"))->GetXaxis()->SetBinLabel(i + 1, selectionLabels[i]);
     }
     for (int i = 0; i < kNaliases; i++) {
-      histos.get<TH1>(HIST("hColCounterAll"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i]);
-      histos.get<TH1>(HIST("hColCounterAcc"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i]);
-      histos.get<TH1>(HIST("hBcCounterAll"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i]);
+      histos.get<TH1>(HIST("hColCounterAll"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i].data());
+      histos.get<TH1>(HIST("hColCounterAcc"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i].data());
+      histos.get<TH1>(HIST("hBcCounterAll"))->GetXaxis()->SetBinLabel(i + 1, aliasLabels[i].data());
     }
 
     histos.add("hParams", "", kTH1D, {{2, 0, 2.}});

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -508,7 +508,7 @@ struct TableMaker {
       histEvents->GetXaxis()->SetBinLabel(ib, (*label).Data());
     }
     for (int ib = 1; ib <= kNaliases; ib++) {
-      histEvents->GetYaxis()->SetBinLabel(ib, aliasLabels[ib - 1]);
+      histEvents->GetYaxis()->SetBinLabel(ib, aliasLabels[ib - 1].data());
     }
     histEvents->GetYaxis()->SetBinLabel(kNaliases + 1, "Total");
     fStatsList->Add(histEvents);

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -712,7 +712,7 @@ struct TableMakerMC {
       histEvents->GetXaxis()->SetBinLabel(ib, (*label).Data());
     }
     for (int ib = 1; ib <= kNaliases; ib++) {
-      histEvents->GetYaxis()->SetBinLabel(ib, aliasLabels[ib - 1]);
+      histEvents->GetYaxis()->SetBinLabel(ib, aliasLabels[ib - 1].data());
     }
     histEvents->GetYaxis()->SetBinLabel(kNaliases + 1, "Total");
     fStatsList->Add(histEvents);

--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -109,12 +109,14 @@ struct HfTagSelCollisions {
   Configurable<double> chi2Max{"chi2Max", 0., "max. chi^2 of primary-vertex reconstruction"};
   Configurable<std::string> triggerClassName{"triggerClassName", "kINT7", "trigger class"};
   Configurable<bool> useSel8Trigger{"useSel8Trigger", false, "use sel8 trigger condition, for Run3 studies"};
-  int triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
+  int triggerClass;
 
   HistogramRegistry registry{"registry", {{"hNContributors", "Number of vertex contributors;entries", {HistType::kTH1F, {{20001, -0.5, 20000.5}}}}}};
 
   void init(InitContext const&)
   {
+    triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
+
     const int nBinsEvents = 2 + EventRejection::NEventRejection;
     std::string labels[nBinsEvents];
     labels[0] = "processed";
@@ -130,6 +132,10 @@ struct HfTagSelCollisions {
     for (int iBin = 0; iBin < nBinsEvents; iBin++) {
       registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
     }
+    // primary vertex histograms
+    registry.add("hPrimVtxX", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -0.5, 0.5}}});
+    registry.add("hPrimVtxY", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -0.5, 0.5}}});
+    registry.add("hPrimVtxZ", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -20., 20.}}});
   }
 
   /// Primary-vertex selection
@@ -205,6 +211,9 @@ struct HfTagSelCollisions {
     // selected events
     if (fillHistograms && statusCollision == 0) {
       registry.fill(HIST("hEvents"), 2);
+      registry.fill(HIST("hPrimVtxX"), collision.posX());
+      registry.fill(HIST("hPrimVtxY"), collision.posY());
+      registry.fill(HIST("hPrimVtxZ"), collision.posZ());
     }
 
     // fill table row


### PR DESCRIPTION
Change of type `aliasLabels` from `const char*` to `std::string` is required to use it as a lookup table to find the corresponding enum value from a configurable string (which is the strategy in HF).

To me this looks as a trivial change, but maybe I'm missing something why it should be a `char*` array? @ekryshen @jgrosseo ?

If it should remain a `char*` array, we should think of a better strategy to do the trigger selection in HF, since right now events are selected based on the condition that the **next** event has a kINT7 trigger enabled (independent of what trigger you set in the json file). @vkucera 