### PR TITLE
Some CMake fixes/improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(O2Physics
         VERSION 0.0.1
@@ -18,8 +18,6 @@ project(O2Physics
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set_property(GLOBAL PROPERTY REPORT_UNDEFINED_PROPERTIES)
-
-include(GNUInstallDirs)
 
 cmake_host_system_information(RESULT _totalmem QUERY TOTAL_PHYSICAL_MEMORY)
 math(EXPR _total_analysis_jobs "(${_totalmem}-4096)/4096")
@@ -35,12 +33,6 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 endif()
-
-# Dependencies
-find_package(O2 CONFIG REQUIRED)
-find_package(ONNXRuntime::ONNXRuntime CONFIG)
-
-feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 include(O2PhysicsDefineOptions)
 o2physics_define_options()
@@ -64,8 +56,6 @@ include(O2PhysicsTargetRootDictionary)
 include(O2PhysicsSetROOTPCMDependencies)
 include(O2PhysicsDataFile)
 include(AddRootDictionary)
-
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Main targets of the project in various subdirectories. Order matters.
 add_subdirectory(Common)

--- a/Common/Core/CMakeLists.txt
+++ b/Common/Core/CMakeLists.txt
@@ -14,7 +14,7 @@ o2physics_add_library(AnalysisCore
                        OrbitRange.cxx
                        PID/ParamBase.cxx
                        TrackSelectionDefaults.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore ROOT::EG O2::CCDB ROOT::Physics)
+               PUBLIC_LINK_LIBRARIES O2::Framework ROOT::EG O2::CCDB ROOT::Physics)
 
 o2physics_target_root_dictionary(AnalysisCore
               HEADERS   TrackSelection.h

--- a/Common/DataModel/CMakeLists.txt
+++ b/Common/DataModel/CMakeLists.txt
@@ -9,9 +9,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(DataModel)
-add_subdirectory(Core)
-add_subdirectory(CCDB)
-add_subdirectory(Tasks)
-add_subdirectory(TableProducer)
-add_subdirectory(Tools)
+o2physics_add_header_only_library(DataModel)

--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -18,6 +18,7 @@ o2physics_add_dpl_workflow(trackextension
                                           O2::ReconstructionDataFormats
                                           O2::DetectorsBase
                                           O2::DetectorsCommonDataFormats
+                                          O2Physics::DataModel
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(trackselection
@@ -72,7 +73,7 @@ o2physics_add_dpl_workflow(fdd-converter
 
 o2physics_add_dpl_workflow(calo-clusters
                     SOURCES caloClusterProducer.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsPHOS O2::PHOSBase O2::PHOSReconstruction
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsPHOS O2::PHOSBase O2::PHOSReconstruction O2Physics::DataModel
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(fwdtrackextension

--- a/Tools/PIDML/CMakeLists.txt
+++ b/Tools/PIDML/CMakeLists.txt
@@ -18,13 +18,13 @@ o2physics_add_dpl_workflow(pid-ml-producer
 o2physics_add_dpl_workflow(simple-apply-pid-onnx-model
                            SOURCES simpleApplyPidOnnxModel.cxx
                            JOB_POOL analysis
-                           PUBLIC_LINK_LIBRARIES O2::Framework ONNXRuntime::ONNXRuntime O2::CCDB
+                           PUBLIC_LINK_LIBRARIES O2::Framework ONNXRuntime::ONNXRuntime O2::CCDB O2Physics::DataModel
                            COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(simple-apply-pid-onnx-interface
                            SOURCES simpleApplyPidOnnxInterface.cxx
                            JOB_POOL analysis
-                           PUBLIC_LINK_LIBRARIES O2::Framework ONNXRuntime::ONNXRuntime O2::CCDB
+                           PUBLIC_LINK_LIBRARIES O2::Framework ONNXRuntime::ONNXRuntime O2::CCDB O2Physics::DataModel
                            COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(qa-pid

--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -35,11 +35,11 @@ function(o2physics_add_header_only_library baseTargetName)
 
   # define the target and its O2:: alias
   add_library(${target} INTERFACE)
-  add_library(O2::${baseTargetName} ALIAS ${target})
+  add_library(O2Physics::${baseTargetName} ALIAS ${target})
 
-  # set the export name so that packages using O2 can reference the target as
-  # O2::${baseTargetName} as well (assuming the export is installed with
-  # namespace O2::)
+  # set the export name so that packages using O2Physics can reference the target as
+  # O2Physics::${baseTargetName} as well (assuming the export is installed with
+  # namespace O2Physics::)
   set_property(TARGET ${target} PROPERTY EXPORT_NAME ${baseTargetName})
 
   if(NOT A_INCLUDE_DIRECTORIES)
@@ -48,18 +48,18 @@ function(o2physics_add_header_only_library baseTargetName)
       set(A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${dir}>)
     else()
       set(A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)
+      list(APPEND A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
     endif()
   endif()
 
   target_include_directories(
     ${target}
-    INTERFACE $<BUILD_INTERFACE:${A_INCLUDE_DIRECTORIES}>)
+    INTERFACE $<BUILD_INTERFACE:${A_INCLUDE_DIRECTORIES}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   if(A_INTERFACE_LINK_LIBRARIES)
     target_link_libraries(${target} INTERFACE ${A_INTERFACE_LINK_LIBRARIES})
   endif()
-  install(DIRECTORY ${A_INCLUDE_DIRECTORIES}/
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   install(TARGETS ${target}
           EXPORT O2PhysicsTargets

--- a/cmake/O2PhysicsAddLibrary.cmake
+++ b/cmake/O2PhysicsAddLibrary.cmake
@@ -130,6 +130,11 @@ function(o2physics_add_library baseTargetName)
     target_include_directories(
       ${target}
       PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)
+
+    # add top level directory so e.g. the #include "Common/Core/xxx.h" will work
+    target_include_directories(
+      ${target}
+      PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
   endif()
 
   # set the private include directories if available

--- a/dependencies/FindKFParticle.cmake
+++ b/dependencies/FindKFParticle.cmake
@@ -25,6 +25,7 @@ find_library(KFPARTICLE_LIBPATH "KFParticle"
 
 mark_as_advanced(KFPARTICLE_LIBPATH)
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(KFParticle DEFAULT_MSG
                                   KFPARTICLE_LIBPATH KFPARTICLE_INCLUDE_DIR)
 

--- a/dependencies/FindONNXRuntime::ONNXRuntime.cmake
+++ b/dependencies/FindONNXRuntime::ONNXRuntime.cmake
@@ -1,0 +1,18 @@
+include_guard()
+
+find_package(ONNXRuntime::ONNXRuntime CONFIG)
+
+if (NOT ONNXRuntime::ONNXRuntime_FOUND)
+  message(WARNING "No config found for ONNXRuntime::ONNXRuntime. Trying pkgconfig version")
+  find_package(PkgConfig)
+  pkg_check_modules(ONNXRuntime REQUIRED IMPORTED_TARGET GLOBAL libonnxruntime)
+
+  if (TARGET PkgConfig::ONNXRuntime)
+     message(WARNING "Creating alias ONNXRuntime::ONNXRuntime")
+     add_library(ONNXRuntime::ONNXRuntime ALIAS PkgConfig::ONNXRuntime)
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(ONNXRuntime::ONNXRuntime
+                                    REQUIRED_VARS ONNXRuntime_LINK_LIBRARIES)
+endif()

--- a/dependencies/Findfjcontrib.cmake
+++ b/dependencies/Findfjcontrib.cmake
@@ -1,0 +1,26 @@
+
+if (TARGET FastJet::Contrib)
+   # nothing to do, target is already there
+   set(fjcontrib_FOUND TRUE)
+   return()
+endif()
+
+find_library(fjcontrib_LIBRARY_SHARED NAMES libfastjetcontribfragile.dylib libfastjetcontribfragile.so PATHS ${fjcontrib_ROOT}/lib)
+
+if (fjcontrib_LIBRARY_SHARED)
+      add_library(fjcontrib SHARED IMPORTED)
+      get_filename_component(libdir ${fjcontrib_LIBRARY_SHARED} DIRECTORY)
+      get_filename_component(incdir ${libdir}/../include ABSOLUTE)
+      set_target_properties(fjcontrib PROPERTIES IMPORTED_LOCATION
+                            ${fjcontrib_LIBRARY_SHARED}
+                            INTERFACE_LINK_DIRECTORIES ${libdir}
+                            INTERFACE_INCLUDE_DIRECTORIES ${incdir})
+      set_target_properties(fjcontrib PROPERTIES IMPORTED_GLOBAL TRUE)
+      add_library(FastJet::Contrib ALIAS fjcontrib)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(fjcontrib REQUIRED_VARS fjcontrib_LIBRARY_SHARED)
+
+mark_as_advanced(fjcontrib_LIBRARY_SHARED)
+

--- a/dependencies/O2PhysicsDependencies.cmake
+++ b/dependencies/O2PhysicsDependencies.cmake
@@ -13,8 +13,17 @@ include_guard()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
-# Find required packages
+include(FeatureSummary)
+
+find_package(O2 CONFIG)
+set_package_properties(O2 PROPERTIES TYPE REQUIRED)
+
 find_package(KFParticle)
 set_package_properties(KFParticle PROPERTIES TYPE REQUIRED)
+
+find_package(fjcontrib)
+set_package_properties(fjcontrib PROPERTIES TYPE REQUIRED)
+
+find_package(ONNXRuntime::ONNXRuntime)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)


### PR DESCRIPTION
@hristov @TimoWilken  A few fixes / improvements (hopefully) in some CMake files for your consideration : 

- the `o2physics_add_header_only_library` was creating libraries in the `O2::` namespace instead of `O2Physics::' one (which might explain the failed attempt by @adriansev #1324) 
- with the fix above DataModel can now be a proper (header-only) library
- the two added CMake find modules are not strictly necessary for a stack completely driven by aliBuild, but helps in case e.g. ONNXRuntime is installed by other means (and should not hurt 100% alibuild stacks)


