### PR TITLE
add protection from missing mcCollision

### DIFF
--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -244,7 +244,7 @@ struct TableMakerMC {
     uint64_t trackFilteringTag = 0;
     uint8_t trackTempFilterMap = 0;
     for (auto& collision : collisions) {
-      //TODO: investigate the collisions without corresponding mcCollision 
+      //TODO: investigate the collisions without corresponding mcCollision
       if (!collision.has_mcCollision()) {
         continue;
       }

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -244,6 +244,7 @@ struct TableMakerMC {
     uint64_t trackFilteringTag = 0;
     uint8_t trackTempFilterMap = 0;
     for (auto& collision : collisions) {
+      //TODO: investigate the collisions without corresponding mcCollision 
       if (!collision.has_mcCollision()) {
         continue;
       }

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -244,6 +244,9 @@ struct TableMakerMC {
     uint64_t trackFilteringTag = 0;
     uint8_t trackTempFilterMap = 0;
     for (auto& collision : collisions) {
+      if (!collision.has_mcCollision()) {
+        continue;
+      }
       // get the trigger aliases
       uint32_t triggerAliases = 0;
       for (int i = 0; i < kNaliases; i++) {


### PR DESCRIPTION
In Run3 there can be "fake collisions". That means one might encounter collisions where there exists no corresponding MC Collision.