### PR TITLE
Builder changes 

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -83,7 +83,10 @@ struct cascadeBuilder {
   // Configurables
   Configurable<double> d_bz_input{"d_bz", -999, "bz field"};
   Configurable<bool> d_UseAbsDCA{"d_UseAbsDCA", true, "Use Abs DCAs"};
+  Configurable<bool> d_UseWeightedPCA{"d_UseWeightedPCA", true, "Vertices use cov matrices"};
+  Configurable<int> useMatCorrType{"useMatCorrType", 0, "0: none, 1: TGeo, 2: LUT"};
 
+  // Selections
   Configurable<int> mincrossedrows{"mincrossedrows", -1, "min crossed rows"};
   Configurable<float> dcav0topv{"dcav0topv", .01, "DCA V0 To PV"};
   Configurable<double> cospaV0{"cospaV0", .9, "CosPA V0"};
@@ -172,6 +175,7 @@ struct cascadeBuilder {
     fitterV0.setMaxDZIni(1e9);
     fitterV0.setMaxChi2(1e9);
     fitterV0.setUseAbsDCA(d_UseAbsDCA);
+    fitterV0.setWeightedFinalPCA(d_UseWeightedPCA);
 
     fitterCasc.setBz(d_bz);
     fitterCasc.setPropagateToPCA(true);
@@ -181,6 +185,7 @@ struct cascadeBuilder {
     fitterCasc.setMaxDZIni(1e9);
     fitterCasc.setMaxChi2(1e9);
     fitterCasc.setUseAbsDCA(d_UseAbsDCA);
+    fitterCasc.setWeightedFinalPCA(d_UseWeightedPCA);
 
     for (auto& casc : cascades) {
       auto v0 = casc.v0_as<o2::aod::V0sLinked>();
@@ -285,9 +290,35 @@ struct cascadeBuilder {
       if (bachTrackCast.signed1Pt() > 0) {
         charge = +1;
       }
+      // Act on copies for minimization
+      auto pTrackCopy = o2::track::TrackParCov(pTrack);
+      auto nTrackCopy = o2::track::TrackParCov(nTrack);
 
-      int nCand = fitterV0.process(pTrack, nTrack);
+      int nCand = fitterV0.process(pTrackCopy, nTrackCopy);
       if (nCand != 0) {
+        fitterV0.propagateTracksToVertex();
+        double finalXpos = fitterV0.getTrack(0).getX();
+        double finalXneg = fitterV0.getTrack(1).getX();
+
+        // Rotate to desired alpha
+        pTrack.rotateParam(fitterV0.getTrack(0).getAlpha());
+        nTrack.rotateParam(fitterV0.getTrack(1).getAlpha());
+
+        // Retry closer to minimum with material corrections
+        o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+        if (useMatCorrType == 1)
+          matCorr = o2::base::Propagator::MatCorrType::USEMatCorrTGeo;
+        if (useMatCorrType == 2)
+          matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+
+        o2::base::Propagator::Instance()->propagateToX(pTrack, finalXpos, d_bz, maxSnp, maxStep, matCorr);
+        o2::base::Propagator::Instance()->propagateToX(nTrack, finalXneg, d_bz, maxSnp, maxStep, matCorr);
+
+        nCand = fitterV0.process(pTrack, nTrack);
+        if (nCand == 0) {
+          continue;
+        }
+
         fitterV0.propagateTracksToVertex();
         const auto& v0vtx = fitterV0.getPCACandidate();
         for (int i = 0; i < 3; i++) {
@@ -321,7 +352,24 @@ struct cascadeBuilder {
 
         auto tV0 = o2::track::TrackParCov(vertex, momentum, covV0, 0);
         tV0.setQ2Pt(0); // No bending, please
-        int nCand2 = fitterCasc.process(tV0, bTrack);
+        
+        // Act on copies for minimization
+        auto tV0Copy = o2::track::TrackParCov(tV0);
+        auto bTrackCopy = o2::track::TrackParCov(bTrack);
+
+        int nCand2 = fitterCasc.process(tV0Copy, bTrackCopy);
+        double finalXv0 = fitterCasc.getTrack(0).getX();
+        double finalXbach = fitterCasc.getTrack(1).getX();
+
+        // Rotate to desired alpha
+        tV0.rotateParam(fitterCasc.getTrack(0).getAlpha());
+        bTrack.rotateParam(fitterCasc.getTrack(1).getAlpha());
+
+        o2::base::Propagator::Instance()->propagateToX(tV0, finalXv0, d_bz, maxSnp, maxStep, matCorr);
+        //No material correction in V0 backpropagation to minimum
+        o2::base::Propagator::Instance()->propagateToX(bTrack, finalXbach, d_bz, maxSnp, maxStep, o2::base::Propagator::MatCorrType::USEMatCorrNONE);
+
+        nCand2 = fitterCasc.process(tV0, bTrack);
         if (nCand2 != 0) {
           fitterCasc.propagateTracksToVertex();
           hCascCandidate->Fill(2.5);
@@ -335,6 +383,7 @@ struct cascadeBuilder {
         // cascdataLink(-1);
         continue;
       }
+
       // Fill table, please
       hCascCandidate->Fill(16.5); // this is the master fill: if this is filled, viable candidate
 

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -127,6 +127,9 @@ struct lambdakzeroBuilder {
   // Configurables
   // Configurable<int> d_UseAbsDCA{"d_UseAbsDCA", 1, "Use Abs DCAs"}; uncomment this once we want to use the weighted DCA
   Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
+  
+  Configurable<bool> d_UseAbsDCA{"d_UseAbsDCA", true, "Use Abs DCAs"};
+  Configurable<bool> d_UseWeightedPCA{"d_UseWeightedPCA", true, "Vertices use cov matrices"};
 
   // Selection criteria
   Configurable<double> v0cospa{"v0cospa", 0.995, "V0 CosPA"}; // double -> N.B. dcos(x)/dx = 0 at x=0)
@@ -214,7 +217,8 @@ struct lambdakzeroBuilder {
     fitter.setMinRelChi2Change(0.9);
     fitter.setMaxDZIni(1e9);
     fitter.setMaxChi2(1e9);
-    fitter.setUseAbsDCA(true); // use d_UseAbsDCA once we want to use the weighted DCA
+    fitter.setUseAbsDCA(d_UseAbsDCA);
+    fitter.setWeightedFinalPCA(d_UseWeightedPCA);
 
     registry.fill(HIST("hEventCounter"), 0.5);
 


### PR DESCRIPTION
- Add option to use cov matrices of tracks as weights in the calculation of decay point (to be checked!). Default true to match Run 2 operation. Parameter name: `d_UseWeightedPCA`
- Add option to change material correction for cascades