### PR TITLE
PWGHF: Switching the flag searchUpToQuark to true in the getCharmHadronOrigin

### DIFF
--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -210,7 +210,7 @@ struct HFCandidateCreator2ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchRec(flag, origin);
@@ -246,7 +246,7 @@ struct HFCandidateCreator2ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchGen(flag, origin);

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -260,7 +260,7 @@ struct HFCandidateCreator3ProngExpressions {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchRec(flag, origin, swapping, channel);
@@ -322,7 +322,7 @@ struct HFCandidateCreator3ProngExpressions {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorChic.cxx
@@ -249,7 +249,7 @@ struct HFCandidateCreatorChicMC {
       }
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
       rowMCMatchRec(flag, origin, channel);
     }

--- a/PWGHF/TableProducer/HFCandidateCreatorX.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreatorX.cxx
@@ -305,7 +305,7 @@ struct HFCandidateCreatorXMC {
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchRec(flag, origin, channel);
@@ -338,7 +338,7 @@ struct HFCandidateCreatorXMC {
 
       // Check whether the particle is non-prompt (from a b quark).
       if (flag != 0) {
-        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMC, particle, true);
       }
 
       rowMCMatchGen(flag, origin, channel);

--- a/PWGHF/Tasks/taskD0.cxx
+++ b/PWGHF/Tasks/taskD0.cxx
@@ -233,7 +233,7 @@ struct TaskD0 {
           if (candidate.isRecoPID() >= d_selectionPID) {
             registry.fill(HIST("hPtVsYRecSigPromptRecoPID"), ptRec, yRec);
           }
-        } else {
+        } else if (candidate.originMCRec() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtRecSigNonPrompt"), ptRec); // rec. level pT, non-prompt
           if (candidate.isRecoHFFlag() >= d_selectionHFFlag) {
             registry.fill(HIST("hPtVsYRecSigNonPromptRecoHFFlag"), ptRec, yRec);
@@ -335,7 +335,7 @@ struct TaskD0 {
         if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
           registry.fill(HIST("hPtVsYGenPrompt"), ptGen, yGen);
-        } else {
+        } else if (particle.originMCGen() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtGenNonPrompt"), ptGen);
           registry.fill(HIST("hPtVsYGenNonPrompt"), ptGen, yGen);
         }

--- a/PWGHF/Tasks/taskDPlus.cxx
+++ b/PWGHF/Tasks/taskDPlus.cxx
@@ -169,7 +169,7 @@ struct TaskDPlus {
           if (candidate.isSelDplusToPiKPi() >= d_selectionFlagDPlus) {
             registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
           }
-        } else {
+        } else if (candidate.originMCRec() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtVsYRecSigNonPrompt_RecoSkim"), ptRec, yRec);
           if (TESTBIT(candidate.isSelDplusToPiKPi(), aod::SelectionStep::RecoTopol)) {
             registry.fill(HIST("hPtVsYRecSigNonPromptRecoTopol"), ptRec, yRec);
@@ -203,7 +203,7 @@ struct TaskDPlus {
         if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
           registry.fill(HIST("hPtVsYGenPrompt"), ptGen, yGen);
-        } else {
+        } else if (particle.originMCGen() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtGenNonPrompt"), ptGen);
           registry.fill(HIST("hPtVsYGenNonPrompt"), ptGen, yGen);
         }

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -61,9 +61,9 @@ struct TaskLc {
     auto vbins = (std::vector<double>)bins;
     registry.add("hMass", "3-prong candidates;inv. mass (p K #pi) (GeV/#it{c}^{2}); p_{T}; multiplicity", {HistType::kTH3F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}, {5000, 0., 10000.}}});
     registry.add("hDecLength", "3-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -0.2, 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -0.2, 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -0.2, 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hCt", "3-prong candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH2F, {{100, 0., 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hCPA", "3-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hEta", "3-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -156,7 +156,7 @@ struct TaskLc {
         registry.fill(HIST("hPtRecSig"), ptRec); // rec. level pT
         if (candidate.originMCRec() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtRecSigPrompt"), ptRec); // rec. level pT, prompt
-        } else {
+        } else if (candidate.originMCRec() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtRecSigNonPrompt"), ptRec); // rec. level pT, non-prompt
         }
         registry.fill(HIST("hCPARecSig"), candidate.cpa());
@@ -182,7 +182,7 @@ struct TaskLc {
         registry.fill(HIST("hPtGen"), ptGen);
         if (particle.originMCGen() == RecoDecay::OriginType::Prompt) {
           registry.fill(HIST("hPtGenPrompt"), ptGen);
-        } else {
+        } else if (particle.originMCGen() == RecoDecay::OriginType::NonPrompt) {
           registry.fill(HIST("hPtGenNonPrompt"), ptGen);
         }
         registry.fill(HIST("hEtaGen"), particle.eta());


### PR DESCRIPTION
Switching this flag to true (as already done in Run2) will reject particles for witch the original quark is not found in the decay chain