### PR TITLE
Fixing Kaon PID in FemtoWorld

### DIFF
--- a/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
+++ b/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
@@ -159,8 +159,8 @@ struct femtoWorldProducerTask {
   Configurable<float> ConfInvKaonMassUpLimit{"ConfInvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   // PHI Daughters (Kaons)
-  Configurable<float> ConfInvMassLowLimitPhi{"ConfInvMassLowLimitPhi", 1.05, "Lower limit of the Phi invariant mass"};
-  Configurable<float> ConfInvMassUpLimitPhi{"ConfInvMassUpLimitPhi", 1.30, "Upper limit of the Phi invariant mass"};
+  Configurable<float> ConfInvMassLowLimitPhi{"ConfInvMassLowLimitPhi", 1.005, "Lower limit of the Phi invariant mass"}; // change that to do invariant mass cut
+  Configurable<float> ConfInvMassUpLimitPhi{"ConfInvMassUpLimitPhi", 1.035, "Upper limit of the Phi invariant mass"};
 
   Configurable<bool> ConfRejectKaonsPhi{"ConfRejectKaonsPhi", false, "Switch to reject kaons"};
   Configurable<float> ConfInvKaonMassLowLimitPhi{"ConfInvKaonMassLowLimitPhi", 0.48, "Lower limit of the Phi invariant mass for Kaon rejection"};
@@ -273,29 +273,6 @@ struct femtoWorldProducerTask {
   }
 
   // PID
-  bool IsKaonTPCdEdxNSigma(float mom, float nsigmaK) // true if accepted, false if rejected
-  {
-    if (mom < 0.4 && TMath::Abs(nsigmaK) < 2.0)
-      return true;
-    if (mom >= 0.4 && mom < 0.5 && TMath::Abs(nsigmaK) < 1.0)
-      return true;
-    if (mom > 0.5 && TMath::Abs(nsigmaK) < 3.0)
-      return true;
-
-    return false;
-  }
-
-  bool IsKaonTOFNSigma(float mom, float nsigmaK) // true if accepted, false if rejected
-  {
-    if (mom >= 0.45 && mom < 0.8 && TMath::Abs(nsigmaK) < 2.0)
-      return true;
-    if (mom >= 0.8 && mom < 1.0 && TMath::Abs(nsigmaK) < 1.5)
-      return true;
-    if (mom > 1.0 && TMath::Abs(nsigmaK) < 1.0)
-      return true;
-    return false;
-  }
-
   bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
   {
     bool fNsigmaTPCTOF = true;


### PR DESCRIPTION
I've changed PID function for Kaons and I've added a small change in the invariant mass cut for phi mesons