### PR TITLE
PWGEM: disable CCDB reference

### DIFF
--- a/PWGEM/Dilepton/Tasks/dileptonEE.cxx
+++ b/PWGEM/Dilepton/Tasks/dileptonEE.cxx
@@ -446,14 +446,14 @@ struct AnalysisSameEventPairing {
       }
     }
 
-    ccdb->setURL(url.value);
-    ccdb->setCaching(true);
-    ccdb->setLocalObjectValidityChecking();
-    ccdb->setCreatedNotAfter(nolaterthan.value);
-    auto histCCDB = ccdb->get<TH1F>(ccdbPath.value);
-    if (!histCCDB) {
-      LOGF(fatal, "CCDB histogram not found");
-    }
+    // ccdb->setURL(url.value);
+    // ccdb->setCaching(true);
+    // ccdb->setLocalObjectValidityChecking();
+    // ccdb->setCreatedNotAfter(nolaterthan.value);
+    // auto histCCDB = ccdb->get<TH1F>(ccdbPath.value);
+    // if (!histCCDB) {
+    //   LOGF(fatal, "CCDB histogram not found");
+    // }
 
     DefineHistograms(fHistMan, histNames.Data());    // define all histograms
     VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill


### PR DESCRIPTION
Commenting out some ccdb lines which were also removed for the TableReader