### PR TITLE
small changes to split the TPC post_calibration histogram from the existing tpcpid histogram    

### DIFF
--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -181,43 +181,42 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "TPCnSigPrRandomized_TPCnSigPr", "TPC n-#sigma(p) - randomized - vs TPC n-#sigma(p)", false, 100, -5.0, 5.0, VarManager::kTPCnSigmaPr, 100, -5.0, 5.0, VarManager::kTPCnSigmaPrRandomized);
       hm->AddHistogram(histClass, "TPCnSigPiRandomized_pIN", "TPC n-#sigma(#pi) - randomized - vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaPiRandomized);
       hm->AddHistogram(histClass, "TPCnSigPrRandomized_pIN", "TPC n-#sigma(p) - randomized - vs pIN", false, 200, 0.0, 10.0, VarManager::kPin, 100, -5.0, 5.0, VarManager::kTPCnSigmaPrRandomized);
+    }
+    if (subGroupStr.Contains("postcalib")) {
+      const int kNvarsPID = 4;
+      const int kTPCnsigmaNbins = 70;
+      double tpcNsigmaBinLims[kTPCnsigmaNbins + 1];
+      for (int i = 0; i <= kTPCnsigmaNbins; ++i)
+        tpcNsigmaBinLims[i] = -7.0 + 0.2 * i;
 
-      if (subGroupStr.Contains("postcalib")) {
-        const int kNvarsPID = 4;
-        const int kTPCnsigmaNbins = 70;
-        double tpcNsigmaBinLims[kTPCnsigmaNbins + 1];
-        for (int i = 0; i <= kTPCnsigmaNbins; ++i)
-          tpcNsigmaBinLims[i] = -7.0 + 0.2 * i;
+      const int kPinEleNbins = 10;
+      double pinEleBinLims[kPinEleNbins + 1] = {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 3.0, 4.0, 6.0};
 
-        const int kPinEleNbins = 10;
-        double pinEleBinLims[kPinEleNbins + 1] = {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 3.0, 4.0, 6.0};
+      const int kEtaNbins = 9;
+      double etaBinLimsI[kEtaNbins + 1] = {-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9};
 
-        const int kEtaNbins = 9;
-        double etaBinLimsI[kEtaNbins + 1] = {-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9};
+      const int kTPCnClusterbins = 16;
+      double tpcNclusterBinLims[kTPCnClusterbins + 1];
+      for (int i = 0; i <= kTPCnClusterbins; ++i)
+        tpcNclusterBinLims[i] = 10 * i;
 
-        const int kTPCnClusterbins = 16;
-        double tpcNclusterBinLims[kTPCnClusterbins + 1];
-        for (int i = 0; i <= kTPCnClusterbins; ++i)
-          tpcNclusterBinLims[i] = 10 * i;
+      TArrayD nSigBinLimits[kNvarsPID];
+      nSigBinLimits[0] = TArrayD(kTPCnsigmaNbins + 1, tpcNsigmaBinLims);
+      nSigBinLimits[1] = TArrayD(kTPCnClusterbins + 1, tpcNclusterBinLims);
+      nSigBinLimits[2] = TArrayD(kPinEleNbins + 1, pinEleBinLims);
+      nSigBinLimits[3] = TArrayD(kEtaNbins + 1, etaBinLimsI);
 
-        TArrayD nSigBinLimits[kNvarsPID];
-        nSigBinLimits[0] = TArrayD(kTPCnsigmaNbins + 1, tpcNsigmaBinLims);
-        nSigBinLimits[1] = TArrayD(kTPCnClusterbins + 1, tpcNclusterBinLims);
-        nSigBinLimits[2] = TArrayD(kPinEleNbins + 1, pinEleBinLims);
-        nSigBinLimits[3] = TArrayD(kEtaNbins + 1, etaBinLimsI);
-
-        if (subGroupStr.Contains("electron")) {
-          int varsPIDnSigEle[kNvarsPID] = {VarManager::kTPCnSigmaEl, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-          hm->AddHistogram(histClass, "nSigmaTPCelectron", "TPC n_{#sigma}(e) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigEle, nSigBinLimits);
-        }
-        if (subGroupStr.Contains("pion")) {
-          int varsPIDnSigPion[kNvarsPID] = {VarManager::kTPCnSigmaPi, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-          hm->AddHistogram(histClass, "nSigmaTPCpion", "TPC n_{#sigma}(pion) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigPion, nSigBinLimits);
-        }
-        if (subGroupStr.Contains("proton")) {
-          int varsPIDnSigProton[kNvarsPID] = {VarManager::kTPCnSigmaPr, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-          hm->AddHistogram(histClass, "nSigmaTPCproton", "TPC n_{#sigma}(proton) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigProton, nSigBinLimits);
-        }
+      if (subGroupStr.Contains("electron")) {
+        int varsPIDnSigEle[kNvarsPID] = {VarManager::kTPCnSigmaEl, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+        hm->AddHistogram(histClass, "nSigmaTPCelectron", "TPC n_{#sigma}(e) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigEle, nSigBinLimits);
+      }
+      if (subGroupStr.Contains("pion")) {
+        int varsPIDnSigPion[kNvarsPID] = {VarManager::kTPCnSigmaPi, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+        hm->AddHistogram(histClass, "nSigmaTPCpion", "TPC n_{#sigma}(pion) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigPion, nSigBinLimits);
+      }
+      if (subGroupStr.Contains("proton")) {
+        int varsPIDnSigProton[kNvarsPID] = {VarManager::kTPCnSigmaPr, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+        hm->AddHistogram(histClass, "nSigmaTPCproton", "TPC n_{#sigma}(proton) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigProton, nSigBinLimits);
       }
     }
     if (subGroupStr.Contains("tofpid")) {

--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -359,6 +359,4 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
   }
-
-
 }

--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -359,4 +359,42 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
   }
+
+  if (groupStr.Contains("postcalib")) {
+    const int kNvarsPID = 4;
+    const int kTPCnsigmaNbins = 70;
+    double tpcNsigmaBinLims[kTPCnsigmaNbins + 1];
+    for (int i = 0; i <= kTPCnsigmaNbins; ++i)
+      tpcNsigmaBinLims[i] = -7.0 + 0.2 * i;
+
+    const int kPinEleNbins = 10;
+    double pinEleBinLims[kPinEleNbins + 1] = {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 3.0, 4.0, 6.0};
+
+    const int kEtaNbins = 9;
+    double etaBinLimsI[kEtaNbins + 1] = {-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9};
+
+    const int kTPCnClusterbins = 16;
+    double tpcNclusterBinLims[kTPCnClusterbins + 1];
+    for (int i = 0; i <= kTPCnClusterbins; ++i)
+      tpcNclusterBinLims[i] = 10 * i;
+
+    TArrayD nSigBinLimits[kNvarsPID];
+    nSigBinLimits[0] = TArrayD(kTPCnsigmaNbins + 1, tpcNsigmaBinLims);
+    nSigBinLimits[1] = TArrayD(kTPCnClusterbins + 1, tpcNclusterBinLims);
+    nSigBinLimits[2] = TArrayD(kPinEleNbins + 1, pinEleBinLims);
+    nSigBinLimits[3] = TArrayD(kEtaNbins + 1, etaBinLimsI);
+
+    if (subGroupStr.Contains("electron")) {
+      int varsPIDnSigEle[kNvarsPID] = {VarManager::kTPCnSigmaEl, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+      hm->AddHistogram(histClass, "nSigmaTPCelectron", "TPC n_{#sigma}(e) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigEle, nSigBinLimits);
+    }
+    if (subGroupStr.Contains("pion")) {
+      int varsPIDnSigPion[kNvarsPID] = {VarManager::kTPCnSigmaPi, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+      hm->AddHistogram(histClass, "nSigmaTPCpion", "TPC n_{#sigma}(pion) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigPion, nSigBinLimits);
+    }
+    if (subGroupStr.Contains("proton")) {
+      int varsPIDnSigProton[kNvarsPID] = {VarManager::kTPCnSigmaPr, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
+      hm->AddHistogram(histClass, "nSigmaTPCproton", "TPC n_{#sigma}(proton) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigProton, nSigBinLimits);
+    }
+  }
 }

--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -360,41 +360,5 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
   }
 
-  if (groupStr.Contains("postcalib")) {
-    const int kNvarsPID = 4;
-    const int kTPCnsigmaNbins = 70;
-    double tpcNsigmaBinLims[kTPCnsigmaNbins + 1];
-    for (int i = 0; i <= kTPCnsigmaNbins; ++i)
-      tpcNsigmaBinLims[i] = -7.0 + 0.2 * i;
 
-    const int kPinEleNbins = 10;
-    double pinEleBinLims[kPinEleNbins + 1] = {0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 3.0, 4.0, 6.0};
-
-    const int kEtaNbins = 9;
-    double etaBinLimsI[kEtaNbins + 1] = {-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5, 0.7, 0.9};
-
-    const int kTPCnClusterbins = 16;
-    double tpcNclusterBinLims[kTPCnClusterbins + 1];
-    for (int i = 0; i <= kTPCnClusterbins; ++i)
-      tpcNclusterBinLims[i] = 10 * i;
-
-    TArrayD nSigBinLimits[kNvarsPID];
-    nSigBinLimits[0] = TArrayD(kTPCnsigmaNbins + 1, tpcNsigmaBinLims);
-    nSigBinLimits[1] = TArrayD(kTPCnClusterbins + 1, tpcNclusterBinLims);
-    nSigBinLimits[2] = TArrayD(kPinEleNbins + 1, pinEleBinLims);
-    nSigBinLimits[3] = TArrayD(kEtaNbins + 1, etaBinLimsI);
-
-    if (subGroupStr.Contains("electron")) {
-      int varsPIDnSigEle[kNvarsPID] = {VarManager::kTPCnSigmaEl, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-      hm->AddHistogram(histClass, "nSigmaTPCelectron", "TPC n_{#sigma}(e) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigEle, nSigBinLimits);
-    }
-    if (subGroupStr.Contains("pion")) {
-      int varsPIDnSigPion[kNvarsPID] = {VarManager::kTPCnSigmaPi, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-      hm->AddHistogram(histClass, "nSigmaTPCpion", "TPC n_{#sigma}(pion) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigPion, nSigBinLimits);
-    }
-    if (subGroupStr.Contains("proton")) {
-      int varsPIDnSigProton[kNvarsPID] = {VarManager::kTPCnSigmaPr, VarManager::kTPCncls, VarManager::kPin, VarManager::kEta};
-      hm->AddHistogram(histClass, "nSigmaTPCproton", "TPC n_{#sigma}(proton) Vs normNcluster Vs Pin Vs Eta", kNvarsPID, varsPIDnSigProton, nSigBinLimits);
-    }
-  }
 }

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -967,13 +967,13 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
       if (classStr.Contains("Barrel")) {
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "its,tpcpid,dca,tofpid");
         if (classStr.Contains("PIDCalibElectron")) {
-          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "electron");
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_electron");
         }
         if (classStr.Contains("PIDCalibPion")) {
-          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "pion");
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_pion");
         }
         if (classStr.Contains("PIDCalibProton")) {
-          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "proton");
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_proton");
         }
       }
       if (classStr.Contains("Muon")) {

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -1008,5 +1008,17 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
     if (classStr.Contains("DileptonHadronCorrelation")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-correlation");
     }
+
+    if (classStr.Contains("PIDCalib")) {
+      if (classStr.Contains("Electron")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibelectron");
+      }
+      if (classStr.Contains("Pion")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibpion");
+      }
+      if (classStr.Contains("Proton")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibproton");
+      }
+    }
   } // end loop over histogram classes
 }

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -1008,17 +1008,5 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
     if (classStr.Contains("DileptonHadronCorrelation")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-correlation");
     }
-
-    if (classStr.Contains("PIDCalib")) {
-      if (classStr.Contains("Electron")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibelectron");
-      }
-      if (classStr.Contains("Pion")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibpion");
-      }
-      if (classStr.Contains("Proton")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "postcalib", "tpcpostcalibproton");
-      }
-    }
   } // end loop over histogram classes
 }


### PR DESCRIPTION
HI, Ionut 
(1) I did small changes to split the TPC post_calibration histogram from the existing tpcpid histogram. Now once I switch off the TPC post_calibration histogram, the normal TPC PID histogram is still there. 
(2) cleaned the code by removing some empty space. 
   Cheers
Xiaozhi