### PR TITLE
PWGHF: B field setting from CCDB.

### DIFF
--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -34,7 +34,7 @@ struct HFCandidateCreator2Prong {
   Produces<aod::HfCandProng2Base> rowCandidateBase;
 
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
-  //Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
+  // Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
   Configurable<bool> b_propdca{"b_propdca", true, "create tracks version propagated to PCA"};
   Configurable<double> d_maxr{"d_maxr", 200., "reject PCA's above this radius"};
   Configurable<double> d_maxdzini{"d_maxdzini", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -87,7 +87,7 @@ struct HFCandidateCreator2Prong {
   {
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df;
-    //df.setBz(magneticField);
+    // df.setBz(magneticField);
     df.setPropagateToPCA(b_propdca);
     df.setMaxR(d_maxr);
     df.setMaxDZIni(d_maxdzini);
@@ -107,14 +107,15 @@ struct HFCandidateCreator2Prong {
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
       /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
       auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
-      if(mRunNumber != bc.runNumber()){
+      if (mRunNumber != bc.runNumber()) {
         LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
-        initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+        initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
         magneticField = o2::base::Propagator::Instance()->getNominalBz();
         LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
-        df.setBz(magneticField);
-        df.print();
+        // df.setBz(magneticField); /// put it outside the 'if'! Otherwise we have a difference wrt bz Configurable (< 1 permille) in Run2 conv. data
+        // df.print();
       }
+      df.setBz(magneticField);
 
       // reconstruct the 2-prong secondary vertex
       if (df.process(trackParVarPos1, trackParVarNeg1) == 0) {

--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -18,9 +18,9 @@
 #include "Framework/AnalysisTask.h"
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h"
 #include "Common/Core/trackUtilities.h"
 #include "ReconstructionDataFormats/DCA.h"
-#include "PWGHF/Utils/UtilsBfieldCCDB.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -58,7 +58,7 @@ struct HFCandidateCreator2Prong {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  int mRunNumber;
+  int runNumber;
 
   float toMicrometers = 10000.; // from cm to µm
 
@@ -77,7 +77,7 @@ struct HFCandidateCreator2Prong {
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
       ccdb->get<TGeoManager>(ccdbPathGeo);
     }
-    mRunNumber = 0;
+    runNumber = 0;
   }
 
   void process(aod::Collisions const& collisions,
@@ -107,9 +107,9 @@ struct HFCandidateCreator2Prong {
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
       /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
       auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
-      if (mRunNumber != bc.runNumber()) {
-        LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
-        initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+      if (runNumber != bc.runNumber()) {
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
+        initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
         magneticField = o2::base::Propagator::Instance()->getNominalBz();
         LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
         // df.setBz(magneticField); /// put it outside the 'if'! Otherwise we have a difference wrt bz Configurable (< 1 permille) in Run2 conv. data

--- a/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator2Prong.cxx
@@ -20,6 +20,7 @@
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "Common/Core/trackUtilities.h"
 #include "ReconstructionDataFormats/DCA.h"
+#include "PWGHF/Utils/UtilsBfieldCCDB.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -33,7 +34,7 @@ struct HFCandidateCreator2Prong {
   Produces<aod::HfCandProng2Base> rowCandidateBase;
 
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
-  Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
+  //Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
   Configurable<bool> b_propdca{"b_propdca", true, "create tracks version propagated to PCA"};
   Configurable<double> d_maxr{"d_maxr", 200., "reject PCA's above this radius"};
   Configurable<double> d_maxdzini{"d_maxdzini", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -47,20 +48,46 @@ struct HFCandidateCreator2Prong {
   OutputObj<TH2F> hDcaXYProngs{TH2F("hDcaXYProngs", "DCAxy of 2-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
   OutputObj<TH2F> hDcaZProngs{TH2F("hDcaZProngs", "DCAz of 2-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
 
+  /// magnetic field setting from CCDB
+  Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
+  Configurable<std::string> ccdbUrl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
+  Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  int mRunNumber;
+
   float toMicrometers = 10000.; // from cm to µm
 
   double massPi = RecoDecay::getMassPDG(kPiPlus);
   double massK = RecoDecay::getMassPDG(kKPlus);
   double massPiK{0.};
   double massKPi{0.};
+  double magneticField = 0.;
+
+  void init(InitContext const&)
+  {
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(ccdbPathGeo);
+    }
+    mRunNumber = 0;
+  }
 
   void process(aod::Collisions const& collisions,
                soa::Join<aod::Hf2Prongs, aod::HfPvRefitProng2> const& rowsTrackIndexProng2,
-               aod::BigTracks const& tracks)
+               aod::BigTracks const& tracks,
+               aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df;
-    df.setBz(magneticField);
+    //df.setBz(magneticField);
     df.setPropagateToPCA(b_propdca);
     df.setMaxR(d_maxr);
     df.setMaxDZIni(d_maxdzini);
@@ -75,6 +102,19 @@ struct HFCandidateCreator2Prong {
       auto trackParVarPos1 = getTrackParCov(track0);
       auto trackParVarNeg1 = getTrackParCov(track1);
       auto collision = track0.collision();
+
+      /// Set the magnetic field from ccdb.
+      /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
+      /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
+      auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
+      if(mRunNumber != bc.runNumber()){
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
+        initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+        magneticField = o2::base::Propagator::Instance()->getNominalBz();
+        LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
+        df.setBz(magneticField);
+        df.print();
+      }
 
       // reconstruct the 2-prong secondary vertex
       if (df.process(trackParVarPos1, trackParVarNeg1) == 0) {

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -20,6 +20,7 @@
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
 #include "Common/Core/trackUtilities.h"
 #include "ReconstructionDataFormats/DCA.h"
+#include "PWGHF/Utils/UtilsBfieldCCDB.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -39,7 +40,7 @@ struct HFCandidateCreator3Prong {
   Produces<aod::HfCandProng3Base> rowCandidateBase;
 
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
-  Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
+  //Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
   Configurable<bool> b_propdca{"b_propdca", true, "create tracks version propagated to PCA"};
   Configurable<double> d_maxr{"d_maxr", 200., "reject PCA's above this radius"};
   Configurable<double> d_maxdzini{"d_maxdzini", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -53,19 +54,45 @@ struct HFCandidateCreator3Prong {
   OutputObj<TH2F> hDcaXYProngs{TH2F("hDcaXYProngs", "DCAxy of 3-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
   OutputObj<TH2F> hDcaZProngs{TH2F("hDcaZProngs", "DCAz of 3-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
 
+  /// magnetic field setting from CCDB
+  Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
+  Configurable<std::string> ccdbUrl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
+  Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  int mRunNumber;
+
   float toMicrometers = 10000.; // from cm to µm
 
   double massPi = RecoDecay::getMassPDG(kPiPlus);
   double massK = RecoDecay::getMassPDG(kKPlus);
   double massPiKPi{0.};
+  double magneticField = 0.;
+
+  void init(InitContext const&)
+  {
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(ccdbPathGeo);
+    }
+    mRunNumber = 0;
+  }
 
   void process(aod::Collisions const& collisions,
                soa::Join<aod::Hf3Prongs, aod::HfPvRefitProng3> const& rowsTrackIndexProng3,
-               aod::BigTracks const& tracks)
+               aod::BigTracks const& tracks,
+               aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 3-prong vertex fitter
     o2::vertexing::DCAFitterN<3> df;
-    df.setBz(magneticField);
+    //df.setBz(magneticField);
     df.setPropagateToPCA(b_propdca);
     df.setMaxR(d_maxr);
     df.setMaxDZIni(d_maxdzini);
@@ -82,6 +109,19 @@ struct HFCandidateCreator3Prong {
       auto trackParVar1 = getTrackParCov(track1);
       auto trackParVar2 = getTrackParCov(track2);
       auto collision = track0.collision();
+
+      /// Set the magnetic field from ccdb.
+      /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
+      /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
+      auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
+      if(mRunNumber != bc.runNumber()){
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
+        initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+        magneticField = o2::base::Propagator::Instance()->getNominalBz();
+        LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
+        df.setBz(magneticField);
+        df.print();
+      }
 
       // reconstruct the 3-prong secondary vertex
       if (df.process(trackParVar0, trackParVar1, trackParVar2) == 0) {

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -18,9 +18,9 @@
 #include "Framework/AnalysisTask.h"
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "PWGHF/DataModel/HFSecondaryVertex.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h"
 #include "Common/Core/trackUtilities.h"
 #include "ReconstructionDataFormats/DCA.h"
-#include "PWGHF/Utils/UtilsBfieldCCDB.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -64,7 +64,7 @@ struct HFCandidateCreator3Prong {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  int mRunNumber;
+  int runNumber;
 
   float toMicrometers = 10000.; // from cm to µm
 
@@ -82,7 +82,7 @@ struct HFCandidateCreator3Prong {
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
       ccdb->get<TGeoManager>(ccdbPathGeo);
     }
-    mRunNumber = 0;
+    runNumber = 0;
   }
 
   void process(aod::Collisions const& collisions,
@@ -114,9 +114,9 @@ struct HFCandidateCreator3Prong {
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
       /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
       auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
-      if (mRunNumber != bc.runNumber()) {
-        LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
-        initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+      if (runNumber != bc.runNumber()) {
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
+        initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
         magneticField = o2::base::Propagator::Instance()->getNominalBz();
         LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
         // df.setBz(magneticField); /// put it outside the 'if'! Otherwise we have a difference wrt bz Configurable (< 1 permille) in Run2 conv. data

--- a/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/HFCandidateCreator3Prong.cxx
@@ -40,7 +40,7 @@ struct HFCandidateCreator3Prong {
   Produces<aod::HfCandProng3Base> rowCandidateBase;
 
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
-  //Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
+  // Configurable<double> magneticField{"d_bz", 5., "magnetic field"};
   Configurable<bool> b_propdca{"b_propdca", true, "create tracks version propagated to PCA"};
   Configurable<double> d_maxr{"d_maxr", 200., "reject PCA's above this radius"};
   Configurable<double> d_maxdzini{"d_maxdzini", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -92,7 +92,7 @@ struct HFCandidateCreator3Prong {
   {
     // 3-prong vertex fitter
     o2::vertexing::DCAFitterN<3> df;
-    //df.setBz(magneticField);
+    // df.setBz(magneticField);
     df.setPropagateToPCA(b_propdca);
     df.setMaxR(d_maxr);
     df.setMaxDZIni(d_maxdzini);
@@ -114,14 +114,15 @@ struct HFCandidateCreator3Prong {
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
       /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
       auto bc = track0.collision().bc_as<aod::BCsWithTimestamps>();
-      if(mRunNumber != bc.runNumber()){
+      if (mRunNumber != bc.runNumber()) {
         LOG(info) << ">>>>>>>>>>>> Current run number: " << mRunNumber;
-        initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+        initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
         magneticField = o2::base::Propagator::Instance()->getNominalBz();
         LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
-        df.setBz(magneticField);
-        df.print();
+        // df.setBz(magneticField); /// put it outside the 'if'! Otherwise we have a difference wrt bz Configurable (< 1 permille) in Run2 conv. data
+        // df.print();
       }
+      df.setBz(magneticField);
 
       // reconstruct the 3-prong secondary vertex
       if (df.process(trackParVar0, trackParVar1, trackParVar2) == 0) {

--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -35,7 +35,7 @@
 #include "DetectorsBase/Propagator.h"          // for PV refit
 #include "DetectorsBase/GeometryManager.h"     // for PV refit
 #include "DataFormatsParameters/GRPMagField.h" // for PV refit
-#include "PWGHF/Utils/UtilsBfieldCCDB.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h"
 
 #include <algorithm>
 
@@ -301,7 +301,7 @@ struct HfTagSelTracks {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  int mRunNumber;
+  int runNumber;
 
   HistogramRegistry registry{
     "registry",
@@ -371,7 +371,7 @@ struct HfTagSelTracks {
       if (!o2::base::GeometryManager::isGeometryLoaded()) {
         ccdb->get<TGeoManager>(ccdbPathGeo);
       }
-      mRunNumber = 0;
+      runNumber = 0;
     }
   }
 
@@ -419,8 +419,8 @@ struct HfTagSelTracks {
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
-    /*if (mRunNumber != bc.runNumber()) {
+    initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+    /*if (runNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
         o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
@@ -442,7 +442,7 @@ struct HfTagSelTracks {
         }
       }
 
-      mRunNumber = bc.runNumber();
+      runNumber = bc.runNumber();
     }*/
 
     // build the VertexBase to initialize the vertexer
@@ -891,7 +891,7 @@ struct HfTrackIndexSkimsCreator {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  int mRunNumber;
+  int runNumber;
 
   HistogramRegistry registry{
     "registry",
@@ -996,7 +996,7 @@ struct HfTrackIndexSkimsCreator {
       if (!o2::base::GeometryManager::isGeometryLoaded()) {
         ccdb->get<TGeoManager>(ccdbPathGeo);
       }
-      mRunNumber = 0;
+      runNumber = 0;
     }
   }
 
@@ -1284,8 +1284,8 @@ struct HfTrackIndexSkimsCreator {
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
-    /*if (mRunNumber != bc.runNumber()) {
+    initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+    /*if (runNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
         o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
@@ -1307,7 +1307,7 @@ struct HfTrackIndexSkimsCreator {
         }
       }
 
-      mRunNumber = bc.runNumber();
+      runNumber = bc.runNumber();
     }*/
 
     // build the VertexBase to initialize the vertexer
@@ -1496,7 +1496,7 @@ struct HfTrackIndexSkimsCreator {
 
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
 
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df2;
@@ -2200,7 +2200,7 @@ struct HfTrackIndexSkimsCreatorCascades {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-  int mRunNumber;
+  int runNumber;
 
   // for debugging
 #ifdef MY_DEBUG
@@ -2236,7 +2236,7 @@ struct HfTrackIndexSkimsCreatorCascades {
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
       ccdb->get<TGeoManager>(ccdbPathGeo);
     }
-    mRunNumber = 0;
+    runNumber = 0;
   }
 
   Filter filterSelectCollisions = (aod::hf_selcollision::whyRejectColl == 0);
@@ -2258,7 +2258,7 @@ struct HfTrackIndexSkimsCreatorCascades {
 
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
 
     // Define o2 fitter, 2-prong
     o2::vertexing::DCAFitterN<2> fitter;

--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -258,7 +258,7 @@ struct HfTagSelTracks {
 
   Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
   Configurable<bool> debug{"debug", true, "debug mode"};
-  //Configurable<double> bz{"bz", 5., "bz field"};
+  // Configurable<double> bz{"bz", 5., "bz field"};
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the considered track"};
   Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
   // quality cut
@@ -419,7 +419,7 @@ struct HfTagSelTracks {
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
     /*if (mRunNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
@@ -849,7 +849,7 @@ struct HfTrackIndexSkimsCreator {
   // preselection parameters
   Configurable<double> pTTolerance{"pTTolerance", 0.1, "pT tolerance in GeV/c for applying preselections before vertex reconstruction"};
   // vertexing parameters
-  //Configurable<double> bz{"bz", 5., "magnetic field kG"};
+  // Configurable<double> bz{"bz", 5., "magnetic field kG"};
   Configurable<bool> propToDCA{"propToDCA", true, "create tracks version propagated to PCA"};
   Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
   Configurable<double> maxRad{"maxRad", 200., "reject PCA's above this radius"};
@@ -1284,7 +1284,7 @@ struct HfTrackIndexSkimsCreator {
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
     /*if (mRunNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
@@ -1496,7 +1496,7 @@ struct HfTrackIndexSkimsCreator {
 
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
 
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df2;
@@ -2152,7 +2152,7 @@ struct HfTrackIndexSkimsCreatorCascades {
   // Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
 
   // vertexing parameters
-  //Configurable<double> bZ{"bZ", 5., "magnetic field"};
+  // Configurable<double> bZ{"bZ", 5., "magnetic field"};
   Configurable<bool> propDCA{"propDCA", true, "create tracks version propagated to PCA"};
   Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -2258,7 +2258,7 @@ struct HfTrackIndexSkimsCreatorCascades {
 
     // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    initCCDB(bc, mRunNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
 
     // Define o2 fitter, 2-prong
     o2::vertexing::DCAFitterN<2> fitter;

--- a/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
+++ b/PWGHF/TableProducer/HFTrackIndexSkimsCreator.cxx
@@ -35,6 +35,7 @@
 #include "DetectorsBase/Propagator.h"          // for PV refit
 #include "DetectorsBase/GeometryManager.h"     // for PV refit
 #include "DataFormatsParameters/GRPMagField.h" // for PV refit
+#include "PWGHF/Utils/UtilsBfieldCCDB.h"
 
 #include <algorithm>
 
@@ -257,7 +258,7 @@ struct HfTagSelTracks {
 
   Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
   Configurable<bool> debug{"debug", true, "debug mode"};
-  Configurable<double> bz{"bz", 5., "bz field"};
+  //Configurable<double> bz{"bz", 5., "bz field"};
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the considered track"};
   Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
   // quality cut
@@ -286,7 +287,8 @@ struct HfTagSelTracks {
   Configurable<std::string> ccdbUrl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
   Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
-  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
 
   // for debugging
 #ifdef MY_DEBUG
@@ -298,7 +300,7 @@ struct HfTagSelTracks {
   // Needed for PV refitting
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
-  // o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   int mRunNumber;
 
   HistogramRegistry registry{
@@ -415,10 +417,10 @@ struct HfTagSelTracks {
     std::vector<bool> vecPvRefitContributorUsed(vecPvContributorGlobId.size(), true);
 
     /// Prepare the vertex refitting
-    // Get the magnetic field for the Propagator
-    o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+    // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    if (mRunNumber != bc.runNumber()) {
+    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    /*if (mRunNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
         o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
@@ -430,7 +432,7 @@ struct HfTagSelTracks {
           LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
         }
       } else { // Run 3 GRP object
-        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
+        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrpMag, bc.timestamp());
         if (grpo != nullptr) {
           o2::base::Propagator::initFieldFromGRP(grpo);
           o2::base::Propagator::Instance()->setMatLUT(lut);
@@ -441,7 +443,7 @@ struct HfTagSelTracks {
       }
 
       mRunNumber = bc.runNumber();
-    }
+    }*/
 
     // build the VertexBase to initialize the vertexer
     o2::dataformats::VertexBase primVtx;
@@ -847,7 +849,7 @@ struct HfTrackIndexSkimsCreator {
   // preselection parameters
   Configurable<double> pTTolerance{"pTTolerance", 0.1, "pT tolerance in GeV/c for applying preselections before vertex reconstruction"};
   // vertexing parameters
-  Configurable<double> bz{"bz", 5., "magnetic field kG"};
+  //Configurable<double> bz{"bz", 5., "magnetic field kG"};
   Configurable<bool> propToDCA{"propToDCA", true, "create tracks version propagated to PCA"};
   Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
   Configurable<double> maxRad{"maxRad", 200., "reject PCA's above this radius"};
@@ -882,12 +884,13 @@ struct HfTrackIndexSkimsCreator {
   Configurable<std::string> ccdbUrl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
   Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
-  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
 
   // Needed for PV refitting
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::base::MatLayerCylSet* lut;
-  // o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   int mRunNumber;
 
   HistogramRegistry registry{
@@ -1279,10 +1282,10 @@ struct HfTrackIndexSkimsCreator {
     std::vector<bool> vecPvRefitContributorUsed(vecPvContributorGlobId.size(), true);
 
     /// Prepare the vertex refitting
-    // Get the magnetic field for the Propagator
-    // o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+    // set the magnetic field from CCDB
     auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
-    if (mRunNumber != bc.runNumber()) {
+    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+    /*if (mRunNumber != bc.runNumber()) {
 
       if (isRun2) { // Run 2 GRP object
         o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
@@ -1294,7 +1297,7 @@ struct HfTrackIndexSkimsCreator {
           LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
         }
       } else { // Run 3 GRP object
-        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
+        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrpMag, bc.timestamp());
         if (grpo != nullptr) {
           o2::base::Propagator::initFieldFromGRP(grpo);
           o2::base::Propagator::Instance()->setMatLUT(lut);
@@ -1305,7 +1308,7 @@ struct HfTrackIndexSkimsCreator {
       }
 
       mRunNumber = bc.runNumber();
-    }
+    }*/
 
     // build the VertexBase to initialize the vertexer
     o2::dataformats::VertexBase primVtx;
@@ -1491,9 +1494,13 @@ struct HfTrackIndexSkimsCreator {
     int whichHypo2Prong[n2ProngDecays];
     int whichHypo3Prong[n3ProngDecays];
 
+    // set the magnetic field from CCDB
+    auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df2;
-    df2.setBz(bz);
+    df2.setBz(o2::base::Propagator::Instance()->getNominalBz());
     df2.setPropagateToPCA(propToDCA);
     df2.setMaxR(maxRad);
     df2.setMaxDZIni(maxDZIni);
@@ -1503,7 +1510,7 @@ struct HfTrackIndexSkimsCreator {
 
     // 3-prong vertex fitter
     o2::vertexing::DCAFitterN<3> df3;
-    df3.setBz(bz);
+    df3.setBz(o2::base::Propagator::Instance()->getNominalBz());
     df3.setPropagateToPCA(propToDCA);
     df3.setMaxR(maxRad);
     df3.setMaxDZIni(maxDZIni);
@@ -2145,7 +2152,7 @@ struct HfTrackIndexSkimsCreatorCascades {
   // Configurable<int> triggerindex{"triggerindex", -1, "trigger index"};
 
   // vertexing parameters
-  Configurable<double> bZ{"bZ", 5., "magnetic field"};
+  //Configurable<double> bZ{"bZ", 5., "magnetic field"};
   Configurable<bool> propDCA{"propDCA", true, "create tracks version propagated to PCA"};
   Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
@@ -2183,6 +2190,18 @@ struct HfTrackIndexSkimsCreatorCascades {
   Configurable<double> cutCascInvMassLc{"cutCascInvMassLc", 1., "Lc candidate invariant mass difference wrt PDG"}; // for PbPb 2018: use 0.2
   // Configurable<double> cutCascDCADaughters{"cutCascDCADaughters", .1, "DCA between V0 and bachelor in cascade"};
 
+  // magnetic field setting from CCDB
+  Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
+  Configurable<std::string> ccdbUrl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
+  Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  int mRunNumber;
+
   // for debugging
 #ifdef MY_DEBUG
   Configurable<std::vector<int>> indexK0Spos{"indexK0Spos", {729, 2866, 4754, 5457, 6891, 7824, 9243, 9810}, "indices of K0S positive daughters, for debug"};
@@ -2208,6 +2227,18 @@ struct HfTrackIndexSkimsCreatorCascades {
   double massLc = RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus);
   double mass2K0sP{0.}; // WHY HERE?
 
+  void init(InitContext const&)
+  {
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(ccdbPathGeo);
+    }
+    mRunNumber = 0;
+  }
+
   Filter filterSelectCollisions = (aod::hf_selcollision::whyRejectColl == 0);
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HFSelCollision>>;
@@ -2225,9 +2256,13 @@ struct HfTrackIndexSkimsCreatorCascades {
                ) // TODO: I am now assuming that the V0s are already filtered with my cuts (David's work to come)
   {
 
+    // set the magnetic field from CCDB
+    auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+    initCCDB(bc, mRunNumber, ccdb, isRun2?ccdbPathGrp:ccdbPathGrpMag, lut, isRun2);
+
     // Define o2 fitter, 2-prong
     o2::vertexing::DCAFitterN<2> fitter;
-    fitter.setBz(bZ);
+    fitter.setBz(o2::base::Propagator::Instance()->getNominalBz());
     fitter.setPropagateToPCA(propDCA);
     fitter.setMaxR(maxR);
     fitter.setMinParamChange(minParamChange);
@@ -2342,9 +2377,9 @@ struct HfTrackIndexSkimsCreatorCascades {
         MY_DEBUG_MSG(isK0SfromLc, LOG(info) << "KEPT! K0S from Lc with daughters " << indexV0DaughPos << " and " << indexV0DaughNeg);
 
         auto trackParCovV0DaughPos = getTrackParCov(trackV0DaughPos);
-        trackParCovV0DaughPos.propagateTo(v0.posX(), bZ); // propagate the track to the X closest to the V0 vertex
+        trackParCovV0DaughPos.propagateTo(v0.posX(), o2::base::Propagator::Instance()->getNominalBz()); // propagate the track to the X closest to the V0 vertex
         auto trackParCovV0DaughNeg = getTrackParCov(trackV0DaughNeg);
-        trackParCovV0DaughNeg.propagateTo(v0.negX(), bZ); // propagate the track to the X closest to the V0 vertex
+        trackParCovV0DaughNeg.propagateTo(v0.negX(), o2::base::Propagator::Instance()->getNominalBz()); // propagate the track to the X closest to the V0 vertex
         std::array<float, 3> pVecV0 = {0., 0., 0.};
         std::array<float, 3> pVecBach = {0., 0., 0.};
 

--- a/PWGHF/Utils/UtilsBfieldCCDB.h
+++ b/PWGHF/Utils/UtilsBfieldCCDB.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file UtilsBfieldCCDB.h
+/// \brief Utility to set the B field in analysis querying it from CCDB
+/// \author Mattia Faggin <mfaggin@cern.ch>, University and INFN Padova, Italy
+
+#include "Framework/AnalysisDataModel.h"
+#include "ReconstructionDataFormats/Vertex.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "Framework/AnalysisHelpers.h"
+
+/// @brief function to setup the grp object from magnetic field (w/o matCorr for propagation)
+/// @param bc is the bunch crossing
+/// @param mRunNumber is an int with the run umber of the prvious iteration. If at the current iteration it changes, then the grp object is updated
+/// @param ccdb is the o2::ccdb::BasicCCDBManager object
+/// @param ccdbPathGrp is the path where the GRP oject is stored
+/// @param lut is a pointer to the o2::base::MatLayerCylSet object
+/// @param isRun2 tells whether we are analysing Run2 converted data or not (different GRP object type)
+void initCCDB(o2::aod::BCsWithTimestamps::iterator const& bc, int& mRunNumber,
+o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, std::string ccdbPathGrp, o2::base::MatLayerCylSet* lut,
+bool isRun2) {
+
+    if (mRunNumber != bc.runNumber()) {
+
+      LOG(info) << "====== initCCDB function called (isRun2==" << isRun2 << ")";
+      if (isRun2) { // Run 2 GRP object
+        o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
+        if (grpo != nullptr) {
+          o2::base::Propagator::initFieldFromGRP(grpo);
+          o2::base::Propagator::Instance()->setMatLUT(lut);
+          LOGF(info, "Setting magnetic field to %d kG for run %d from its GRP CCDB object (type o2::parameters::GRPObject)", grpo->getNominalL3Field(), bc.runNumber());
+        } else {
+          LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+        }
+      } else { // Run 3 GRP object
+        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
+        if (grpo != nullptr) {
+          o2::base::Propagator::initFieldFromGRP(grpo);
+          o2::base::Propagator::Instance()->setMatLUT(lut);
+          LOG(info) << "Setting magnetic field to current" << grpo->getL3Current() << " A for run" << bc.runNumber() << " from its GRP CCDB object (type o2::parameters::GRPMagField)";
+        } else {
+          LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+        }
+      }
+      mRunNumber = bc.runNumber();
+      
+    }
+    return;
+} /// end initCCDB

--- a/PWGHF/Utils/UtilsBfieldCCDB.h
+++ b/PWGHF/Utils/UtilsBfieldCCDB.h
@@ -30,33 +30,33 @@
 /// @param lut is a pointer to the o2::base::MatLayerCylSet object
 /// @param isRun2 tells whether we are analysing Run2 converted data or not (different GRP object type)
 void initCCDB(o2::aod::BCsWithTimestamps::iterator const& bc, int& mRunNumber,
-o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, std::string ccdbPathGrp, o2::base::MatLayerCylSet* lut,
-bool isRun2) {
+              o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, std::string ccdbPathGrp, o2::base::MatLayerCylSet* lut,
+              bool isRun2)
+{
 
-    if (mRunNumber != bc.runNumber()) {
+  if (mRunNumber != bc.runNumber()) {
 
-      LOG(info) << "====== initCCDB function called (isRun2==" << isRun2 << ")";
-      if (isRun2) { // Run 2 GRP object
-        o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
-        if (grpo != nullptr) {
-          o2::base::Propagator::initFieldFromGRP(grpo);
-          o2::base::Propagator::Instance()->setMatLUT(lut);
-          LOGF(info, "Setting magnetic field to %d kG for run %d from its GRP CCDB object (type o2::parameters::GRPObject)", grpo->getNominalL3Field(), bc.runNumber());
-        } else {
-          LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
-        }
-      } else { // Run 3 GRP object
-        o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
-        if (grpo != nullptr) {
-          o2::base::Propagator::initFieldFromGRP(grpo);
-          o2::base::Propagator::Instance()->setMatLUT(lut);
-          LOG(info) << "Setting magnetic field to current" << grpo->getL3Current() << " A for run" << bc.runNumber() << " from its GRP CCDB object (type o2::parameters::GRPMagField)";
-        } else {
-          LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
-        }
+    LOG(info) << "====== initCCDB function called (isRun2==" << isRun2 << ")";
+    if (isRun2) { // Run 2 GRP object
+      o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
+      if (grpo != nullptr) {
+        o2::base::Propagator::initFieldFromGRP(grpo);
+        o2::base::Propagator::Instance()->setMatLUT(lut);
+        LOGF(info, "Setting magnetic field to %d kG for run %d from its GRP CCDB object (type o2::parameters::GRPObject)", grpo->getNominalL3Field(), bc.runNumber());
+      } else {
+        LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
       }
-      mRunNumber = bc.runNumber();
-      
+    } else { // Run 3 GRP object
+      o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
+      if (grpo != nullptr) {
+        o2::base::Propagator::initFieldFromGRP(grpo);
+        o2::base::Propagator::Instance()->setMatLUT(lut);
+        LOG(info) << "Setting magnetic field to current" << grpo->getL3Current() << " A for run" << bc.runNumber() << " from its GRP CCDB object (type o2::parameters::GRPMagField)";
+      } else {
+        LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+      }
     }
-    return;
+    mRunNumber = bc.runNumber();
+  }
+  return;
 } /// end initCCDB

--- a/PWGHF/Utils/utilsBfieldCCDB.h
+++ b/PWGHF/Utils/utilsBfieldCCDB.h
@@ -13,50 +13,43 @@
 /// \brief Utility to set the B field in analysis querying it from CCDB
 /// \author Mattia Faggin <mfaggin@cern.ch>, University and INFN Padova, Italy
 
-#include "Framework/AnalysisDataModel.h"
-#include "ReconstructionDataFormats/Vertex.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
 #include "DataFormatsParameters/GRPMagField.h"
-#include "Framework/AnalysisHelpers.h"
+#include "DetectorsBase/GeometryManager.h"
 
-/// @brief function to setup the grp object from magnetic field (w/o matCorr for propagation)
-/// @param bc is the bunch crossing
-/// @param mRunNumber is an int with the run umber of the prvious iteration. If at the current iteration it changes, then the grp object is updated
-/// @param ccdb is the o2::ccdb::BasicCCDBManager object
-/// @param ccdbPathGrp is the path where the GRP oject is stored
-/// @param lut is a pointer to the o2::base::MatLayerCylSet object
-/// @param isRun2 tells whether we are analysing Run2 converted data or not (different GRP object type)
+/// \brief Sets up the grp object for magnetic field (w/o matCorr for propagation)
+/// \param bc is the bunch crossing
+/// \param mRunNumber is an int with the run umber of the previous iteration. If at the current iteration it changes, then the grp object is updated
+/// \param ccdb is the o2::ccdb::BasicCCDBManager object
+/// \param ccdbPathGrp is the path where the GRP oject is stored
+/// \param lut is a pointer to the o2::base::MatLayerCylSet object
+/// \param isRun2 tells whether we are analysing Run2 converted data or not (different GRP object type)
 void initCCDB(o2::aod::BCsWithTimestamps::iterator const& bc, int& mRunNumber,
-              o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, std::string ccdbPathGrp, o2::base::MatLayerCylSet* lut,
+              o2::framework::Service<o2::ccdb::BasicCCDBManager> const& ccdb, std::string ccdbPathGrp, o2::base::MatLayerCylSet* lut,
               bool isRun2)
 {
 
   if (mRunNumber != bc.runNumber()) {
 
-    LOG(info) << "====== initCCDB function called (isRun2==" << isRun2 << ")";
+    LOGF(info, "====== initCCDB function called (isRun2==%d)", isRun2);
     if (isRun2) { // Run 2 GRP object
       o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(ccdbPathGrp, bc.timestamp());
-      if (grpo != nullptr) {
-        o2::base::Propagator::initFieldFromGRP(grpo);
-        o2::base::Propagator::Instance()->setMatLUT(lut);
-        LOGF(info, "Setting magnetic field to %d kG for run %d from its GRP CCDB object (type o2::parameters::GRPObject)", grpo->getNominalL3Field(), bc.runNumber());
-      } else {
+      if (grpo == nullptr) {
         LOGF(fatal, "Run 2 GRP object (type o2::parameters::GRPObject) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
       }
+      o2::base::Propagator::initFieldFromGRP(grpo);
+      o2::base::Propagator::Instance()->setMatLUT(lut);
+      LOGF(info, "Setting magnetic field to %d kG for run %d from its GRP CCDB object (type o2::parameters::GRPObject)", grpo->getNominalL3Field(), bc.runNumber());
     } else { // Run 3 GRP object
       o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrp, bc.timestamp());
-      if (grpo != nullptr) {
-        o2::base::Propagator::initFieldFromGRP(grpo);
-        o2::base::Propagator::Instance()->setMatLUT(lut);
-        LOG(info) << "Setting magnetic field to current" << grpo->getL3Current() << " A for run" << bc.runNumber() << " from its GRP CCDB object (type o2::parameters::GRPMagField)";
-      } else {
+      if (grpo == nullptr) {
         LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
       }
+      o2::base::Propagator::initFieldFromGRP(grpo);
+      o2::base::Propagator::Instance()->setMatLUT(lut);
+      LOGF(info, "Setting magnetic field to current %f A for run %d from its GRP CCDB object (type o2::parameters::GRPMagField)", grpo->getL3Current(), bc.runNumber());
     }
     mRunNumber = bc.runNumber();
   }
-  return;
 } /// end initCCDB

--- a/PWGHF/Utils/utilsBfieldCCDB.h
+++ b/PWGHF/Utils/utilsBfieldCCDB.h
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file UtilsBfieldCCDB.h
+/// \file utilsBfieldCCDB.h
 /// \brief Utility to set the B field in analysis querying it from CCDB
 /// \author Mattia Faggin <mfaggin@cern.ch>, University and INFN Padova, Italy
 


### PR DESCRIPTION
- Common utility to query the CCDB and set the magnetic field in the `o2::base::Propagator` object
- Implemented for `HFTracksIndexSkimCreator.cxx` and `HFCandidateCreator2,3Prong`
- Missing for multi-decay candidate creators (eg: `B0`, `B+`)