### PR TITLE
AddHeaderOnlyLibrary :: trying to make it work - WIP

### DIFF
--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -65,7 +65,7 @@ function(o2physics_add_header_only_library baseTargetName)
     target_link_libraries(${target} INTERFACE ${A_INTERFACE_LINK_LIBRARIES})
   endif()
   install(DIRECTORY ${A_INCLUDE_DIRECTORIES}/
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h")
 
   install(TARGETS ${target}
           EXPORT O2PhysicsTargets

--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -42,6 +42,10 @@ function(o2physics_add_header_only_library baseTargetName)
   # namespace O2Physics::)
   set_property(TARGET ${target} PROPERTY EXPORT_NAME ${baseTargetName})
 
+  if(A_TARGETVARNAME)
+    set(${A_TARGETVARNAME} ${target} PARENT_SCOPE)
+  endif()
+
   if(NOT A_INCLUDE_DIRECTORIES)
     get_filename_component(dir include ABSOLUTE)
     if(EXISTS ${dir})
@@ -60,6 +64,8 @@ function(o2physics_add_header_only_library baseTargetName)
   if(A_INTERFACE_LINK_LIBRARIES)
     target_link_libraries(${target} INTERFACE ${A_INTERFACE_LINK_LIBRARIES})
   endif()
+  install(DIRECTORY ${A_INCLUDE_DIRECTORIES}/
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   install(TARGETS ${target}
           EXPORT O2PhysicsTargets


### PR DESCRIPTION
@TimoWilken So, trying to make O2PhysicsAddHeaderOnlyLibrary.cmake work, i tried these modifications but i still get:
```
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: [0/1] Install the project...
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Install configuration: "RELWITHDEBINFO"
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/CaloClusters.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/Multiplicity.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/TrackSelectionTables.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/PIDResponse.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/Centrality.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/FT0Corrected.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Up-to-date: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include/DataModel/EventSelection.h
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: -- Installing: /software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: CMake Error: failed to create symbolic link '/software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include': File exists
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: CMake Error at Common/DataModel/cmake_install.cmake:46 (file):
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   file INSTALL cannot duplicate symlink
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   "/software/physics-tools/alicebuild/sw/SOURCES/O2Physics/o2physics/0" at
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   "/software/physics-tools/alicebuild/sw/slc7_x86-64/O2Physics/o2physics-local3/include":
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   Inappropriate ioctl for device.
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics: Call Stack (most recent call first):
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   Common/cmake_install.cmake:47 (include)
2022-10-28@21:19:53:DEBUG:O2Physics:O2Physics:o2physics:   cmake_install.cmake:47 (include)
```

from BUILD directory i see that Common/DataModel/cmake_install.cmake have as a last part:
```
if("x${CMAKE_INSTALL_COMPONENT}x" STREQUAL "xUnspecifiedx" OR NOT CMAKE_INSTALL_COMPONENT)
  file(INSTALL DESTINATION "${CMAKE_INSTALL_PREFIX}/include" TYPE DIRECTORY FILES
    "/software/physics-tools/alicebuild/sw/SOURCES/O2Physics/o2physics/0/Common/DataModel"
    "/software/physics-tools/alicebuild/sw/SOURCES/O2Physics/o2physics/0/"
    FILES_MATCHING REGEX "/[^/]*\\.h$")
endif()
```

Any idea what could be the problem?
Thanks a lot!!
