### PR TITLE
Update for UPC candidate producer

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -170,16 +170,20 @@ using UDCollisionsSel = UDCollisionsSels::iterator;
 
 namespace udtrack
 {
-DECLARE_SOA_INDEX_COLUMN(UDCollision, udCollision);         //!
-DECLARE_SOA_COLUMN(Px, px, float);                          //!
-DECLARE_SOA_COLUMN(Py, py, float);                          //!
-DECLARE_SOA_COLUMN(Pz, pz, float);                          //!
-DECLARE_SOA_COLUMN(Sign, sign, int);                        //!
-DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);           //!
-DECLARE_SOA_COLUMN(TrackTime, trackTime, double);           //!
-DECLARE_SOA_COLUMN(TrackTimeRes, trackTimeRes, float);      //! time resolution
-DECLARE_SOA_COLUMN(DetectorMap, detectorMap, uint8_t);      //!
-DECLARE_SOA_COLUMN(IsAmbiguous, isAmbiguous, bool);         //!
+DECLARE_SOA_INDEX_COLUMN(UDCollision, udCollision);    //!
+DECLARE_SOA_COLUMN(Px, px, float);                     //!
+DECLARE_SOA_COLUMN(Py, py, float);                     //!
+DECLARE_SOA_COLUMN(Pz, pz, float);                     //!
+DECLARE_SOA_COLUMN(Sign, sign, int);                   //!
+DECLARE_SOA_COLUMN(GlobalBC, globalBC, uint64_t);      //!
+DECLARE_SOA_COLUMN(TrackTime, trackTime, double);      //!
+DECLARE_SOA_COLUMN(TrackTimeRes, trackTimeRes, float); //! time resolution
+DECLARE_SOA_COLUMN(DetectorMap, detectorMap, uint8_t); //!
+DECLARE_SOA_COLUMN(CollisionId, collisionId, int32_t); //! Id of original collision if any, -1 if ambiguous
+DECLARE_SOA_DYNAMIC_COLUMN(IsAmbiguous, isAmbiguous,
+                           [](int32_t collisionId) -> bool {
+                             return collisionId == -1;
+                           });                              //!
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt,                          //!
                            [](float px, float py) -> float {
@@ -237,8 +241,9 @@ DECLARE_SOA_TABLE(UDTracksDCA, "AOD", "UDTRACKDCA",
                   track::DcaXY)
 
 DECLARE_SOA_TABLE(UDTracksFlags, "AOD", "UDTRACKFLAG",
-                  udtrack::IsAmbiguous,
-                  udtrack::IsPVContributor);
+                  udtrack::CollisionId,
+                  udtrack::IsPVContributor,
+                  udtrack::IsAmbiguous<udtrack::CollisionId>);
 
 using UDTrack = UDTracks::iterator;
 using UDTrackCov = UDTracksCov::iterator;

--- a/PWGUD/TableProducer/DGBCCandProducer.cxx
+++ b/PWGUD/TableProducer/DGBCCandProducer.cxx
@@ -329,7 +329,7 @@ struct DGBCCandProducer {
                       track.length(),
                       track.tofExpMom(),
                       track.detectorMap());
-    outputTracksFlag(track.has_collision(),
+    outputTracksFlag(track.has_collision() ? track.collisionId() : -1,
                      track.isPVContributor());
   }
 


### PR DESCRIPTION
* Switch from collecting FIT signals in all BCs to individual checks for each event candidate
* Return usage of `fMaxNContrib` configurable -- ability to limit number of contributors in a collision for TOF tracks
* Add `CollisionId` column to `UDTracksFlags` table. `IsAmbiguous` made dynamic for compatibility 