### PR TITLE
install DataModel includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
 project(O2Physics
         VERSION 0.0.1

--- a/Common/DataModel/CMakeLists.txt
+++ b/Common/DataModel/CMakeLists.txt
@@ -9,4 +9,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-o2physics_add_header_only_library(DataModel)
+o2physics_add_header_only_library(DataModel
+                                  HEADERS CaloClusters.h
+                                          Centrality.h
+                                          EventSelection.h
+                                          FT0Corrected.h
+                                          Multiplicity.h
+                                          PIDResponse.h
+                                          TrackSelectionTables.h)

--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -24,7 +24,7 @@ function(o2physics_add_header_only_library baseTargetName)
                         A
                         ""
                         ""
-                        "INCLUDE_DIRECTORIES;INTERFACE_LINK_LIBRARIES")
+                        "INCLUDE_DIRECTORIES;INTERFACE_LINK_LIBRARIES;HEADERS")
 
   if(A_UNPARSED_ARGUMENTS)
     message(
@@ -47,21 +47,31 @@ function(o2physics_add_header_only_library baseTargetName)
     if(EXISTS ${dir})
       set(A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${dir}>)
     else()
-      set(A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)
-      list(APPEND A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
+      set(A_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
     endif()
   endif()
 
+  # specify only the BUILD_INTERFACE directories here.
+  # the INSTALL_INTERFACE is taken care of by the
+  # install(TARGETS ... EXPORT ... INCLUDES DESTINATION) below
   target_include_directories(
     ${target}
-    INTERFACE $<BUILD_INTERFACE:${A_INCLUDE_DIRECTORIES}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    INTERFACE ${A_INCLUDE_DIRECTORIES})
 
   if(A_INTERFACE_LINK_LIBRARIES)
     target_link_libraries(${target} INTERFACE ${A_INTERFACE_LINK_LIBRARIES})
   endif()
 
+  if(A_HEADERS)
+    target_sources(${target} INTERFACE FILE_SET HEADERS FILES ${A_HEADERS})
+  endif()
+
+  # All the directories given after
+  # INCLUDES DESTINATION are added to the INTERFACE_INCLUDE_DIRECTORIES
+  # property of each installed target listed after TARGETS
   install(TARGETS ${target}
           EXPORT O2PhysicsTargets
+          FILE_SET HEADERS
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 endfunction()


### PR DESCRIPTION
an attempt at #1454

as we're using CMake >= 3.23, I guess we could use the concept of file sets to install those includes. 

Note the addition of the `HEADERS` param to `o2_physics_add_header_only_library` which is used to be explicit about which headers should be installed (i.e. which ones are part of the public interface of the "library"). Note also that in O2 it's kind of easier to know which includes are public as there's a dedicated directory for that (at the price of a strange stuttering structure `include/LIBNAME/headername.h`)

@adriansev would you have an example package that is trying to use an O2Physics installation to build something ? so I could try on my side and see whether the installation is actually usable ?
