### PR TITLE
PWGCF: fix compiler warning in FemtoDream framework

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -13,8 +13,12 @@
 /// \brief FemtoDreamObjectSelection - Parent class of all selections
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#ifndef ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_
-#define ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_
+#ifndef PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_
+#define PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_
+
+#include <algorithm>
+#include <string>
+#include <vector>
 
 #include "FemtoDreamSelection.h"
 
@@ -92,7 +96,7 @@ class FemtoDreamObjectSelection
     }
 
     /// Then, the sorted selections are added to the overall container of cuts
-    for (const auto sel : sels) {
+    for (const auto& sel : sels) {
       mSelections.push_back(sel);
     }
   }
@@ -189,4 +193,4 @@ class FemtoDreamObjectSelection
 } // namespace femtoDream
 } // namespace o2::analysis
 
-#endif /* ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_ */
+#endif // PWGCF_FEMTODREAM_FEMTODREAMOBJECTSELECTION_H_


### PR DESCRIPTION
Warning occurs if the loop object is constant, but we we create a copy of it and do not use a reference. This is fixed with this patch. 

Also containing some changes to pass MegaLinter checks.