### PR TITLE
Policy entity for orchestrating skimming and analysis

### DIFF
--- a/PWGCF/TwoParticleCorrelations/Core/CMakeLists.txt
+++ b/PWGCF/TwoParticleCorrelations/Core/CMakeLists.txt
@@ -15,6 +15,7 @@ o2physics_add_library(TwoPartCorrCore
                                TrackSelectionFilterAndAnalysis.cxx
                                PIDSelectionFilterAndAnalysis.cxx
                                EventSelectionFilterAndAnalysis.cxx
+                               FilterAndAnalysisFramework.cxx
                       PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore)
 
 o2physics_target_root_dictionary(TwoPartCorrCore
@@ -23,4 +24,5 @@ o2physics_target_root_dictionary(TwoPartCorrCore
                                          TrackSelectionFilterAndAnalysis.h
                                          PIDSelectionFilterAndAnalysis.h
                                          EventSelectionFilterAndAnalysis.h
+                                         FilterAndAnalysisFramework.h
                                  LINKDEF TwoPartCorrLinkDef.h)

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
@@ -13,8 +13,10 @@
 #include <TList.h>
 #include <TObjString.h>
 
-#include <fairlogger/Logger.h>
 #include "FilterAndAnalysisFramework.h"
+#include <map>
+#include <string>
+#include <fairlogger/Logger.h>
 
 using namespace o2;
 using namespace o2::analysis::PWGCF;
@@ -50,10 +52,10 @@ void FilterAndAnalysisFramework::RegisterConfiguration()
   LOGF(info, "Registering configuration into CCDB for date %s", filterdate.data());
 
   /* sanity checks */
-  if (_fTrackFilter == nullptr or _fEventFilter == nullptr or _fPIDFilter == nullptr) {
+  if (_fTrackFilter == nullptr || _fEventFilter == nullptr || _fPIDFilter == nullptr) {
     LOGF(fatal, "Configuration not stored yet, please use SetConfiguration(evtf, trkf, pidf, mode), or configuration already registered");
   }
-  if (fTrackFilter != nullptr or fEventFilter != nullptr or fPIDFilter != nullptr) {
+  if (fTrackFilter != nullptr ||r fEventFilter != nullptr || fPIDFilter != nullptr) {
     LOGF(fatal, "Configuration already registered");
   }
 
@@ -103,7 +105,7 @@ void FilterAndAnalysisFramework::RegisterConfiguration()
     auto domatch = [&signatures](int index, auto filter) {
       return (strcmp(signatures->At(index)->GetName(), filter->getCutStringSignature().Data()) == 0);
     };
-    if (domatch(0, _fEventFilter) and domatch(1, _fTrackFilter) and domatch(2, _fPIDFilter)) {
+    if (domatch(0, _fEventFilter) && domatch(1, _fTrackFilter) && domatch(2, _fPIDFilter)) {
       /* signatures match so configuration already registered and available for skimming and/or analysis */
       LOGF(info, "Filter signatures already registered in the CCDB. You can proceed with the skimming and/or analysis");
     } else {
@@ -132,10 +134,10 @@ void FilterAndAnalysisFramework::Init()
   LOGF(info, "Initializing filter configuration from date %s", filterdate.data());
 
   /* sanity checks */
-  if (_fTrackFilter == nullptr or _fEventFilter == nullptr or _fPIDFilter == nullptr) {
+  if (_fTrackFilter == nullptr || _fEventFilter == nullptr || _fPIDFilter == nullptr) {
     LOGF(fatal, "Configuration not stored yet, please use SetConfiguration(evtf, trkf, pidf, mode, force), or configuration already initalized");
   }
-  if (fTrackFilter != nullptr or fEventFilter != nullptr or fPIDFilter != nullptr) {
+  if (fTrackFilter != nullptr || fEventFilter != nullptr || fPIDFilter != nullptr) {
     LOGF(fatal, "Configuration already initialized");
   }
 
@@ -163,7 +165,7 @@ void FilterAndAnalysisFramework::Init()
     auto domatch = [&signatures](int index, auto filter) {
       return (strcmp(signatures->At(index)->GetName(), filter->getCutStringSignature().Data()) == 0);
     };
-    if (domatch(0, _fEventFilter) and domatch(1, _fTrackFilter) and domatch(2, _fPIDFilter)) {
+    if (domatch(0, _fEventFilter) && domatch(1, _fTrackFilter) && domatch(2, _fPIDFilter)) {
       /* signatures match the configuration proceed with skimming and/or analysis */
       LOGF(info, "Filter signatures registered in the CCDB. Proceeding with the skimming and/or analysis");
       fEventFilter = _fEventFilter;

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
@@ -9,18 +9,14 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <boost/regex.hpp>
-#include <TObjArray.h>
+#include <iomanip>
+#include <TList.h>
+#include <TObjString.h>
 
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoAHelpers.h"
+#include <fairlogger/Logger.h>
 #include "FilterAndAnalysisFramework.h"
 
 using namespace o2;
-using namespace o2::framework;
-using namespace o2::soa;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::PWGCF;
 
 ClassImp(FilterAndAnalysisFramework);
@@ -28,22 +24,164 @@ ClassImp(FilterAndAnalysisFramework);
 /// \brief Default constructor
 FilterAndAnalysisFramework::FilterAndAnalysisFramework()
   : TNamed(),
-    ccdb(nullptr),
+    ccdburl(""),
+    ccdbpath(""),
+    filterdate(""),
+    forceupdate(false),
     fTrackFilter(nullptr),
     fEventFilter(nullptr),
-    fPIDFilter(nullptr)
+    fPIDFilter(nullptr),
+    _fTrackFilter(nullptr),
+    _fEventFilter(nullptr),
+    _fPIDFilter(nullptr)
 {
 }
 
 /// \brief Named constructor for a concrete operating mode
-FilterAndAnalysisFramework::FilterAndAnalysisFramework(EventSelectionConfigurable& evtf, TrackSelectionConfigurable& trkf, PIDSelectionConfigurable& pidf, SelectionFilterAndAnalysis::selmodes mode)
-  : TNamed(),
-    ccdb(nullptr),
-    fTrackFilter(nullptr),
-    fEventFilter(nullptr),
-    fPIDFilter(nullptr)
+void FilterAndAnalysisFramework::SetConfiguration(EventSelectionConfigurable& evtf, TrackSelectionConfigurable& trkf, PIDSelectionConfigurable& pidf, SelectionFilterAndAnalysis::selmodes mode)
 {
-  fTrackFilter = new PWGCF::TrackSelectionFilterAndAnalysis(trkf, mode);
-  fEventFilter = new PWGCF::EventSelectionFilterAndAnalysis(evtf, mode);
-  fPIDFilter = new PWGCF::PIDSelectionFilterAndAnalysis(pidf, mode);
+  _fTrackFilter = new PWGCF::TrackSelectionFilterAndAnalysis(trkf, mode);
+  _fEventFilter = new PWGCF::EventSelectionFilterAndAnalysis(evtf, mode);
+  _fPIDFilter = new PWGCF::PIDSelectionFilterAndAnalysis(pidf, mode);
+}
+
+void FilterAndAnalysisFramework::RegisterConfiguration()
+{
+  LOGF(info, "Registering configuration into CCDB for date %s", filterdate.data());
+
+  /* sanity checks */
+  if (_fTrackFilter == nullptr or _fEventFilter == nullptr or _fPIDFilter == nullptr) {
+    LOGF(fatal, "Configuration not stored yet, please use SetConfiguration(evtf, trkf, pidf, mode), or configuration already registered");
+  }
+  if (fTrackFilter != nullptr or fEventFilter != nullptr or fPIDFilter != nullptr) {
+    LOGF(fatal, "Configuration already registered");
+  }
+
+  TList* signatures = nullptr;
+  std::tm t{};
+  /* we set noon for checking */
+  std::istringstream ss(filterdate + "1200");
+  /* let's extract the timestamp */
+  ss >> std::get_time(&t, "%Y%m%d%H%M");
+  if (ss.fail()) {
+    LOGF(fatal, "Wrong skimming filter date format. Please use YYYYMMDD");
+  }
+  std::time_t time_stamp = mktime(&t);
+  /* and get it in ms */
+  uint64_t timestamp = 1000 * time_stamp;
+  /* let's prepare the sot and eot */
+  uint64_t sot = timestamp - (12 * 60 * 60 * 1000);        /* the beginning of the day */
+  uint64_t eot = timestamp + (12 * 60 * 60 * 1000 - 1000); /* one second before the end of the day */
+
+  /* get access to the CCDB */
+  o2::ccdb::CcdbApi* ccdb = new o2::ccdb::CcdbApi();
+  ccdb->init(ccdburl);
+  o2::ccdb::BasicCCDBManager* ccdbm = &o2::ccdb::BasicCCDBManager::instance();
+  ccdbm->setFatalWhenNull(false); /* we need to check the availability of objects */
+  ccdbm->setURL(ccdburl);
+  signatures = ccdbm->getForTimeStamp<TList>(ccdbpath, timestamp);
+
+  auto storesignatures = [&]() {
+    TList* siglst = new TList();
+    siglst->SetOwner();
+    siglst->SetName("Skimming signatures");
+    siglst->Add(new TObjString(_fEventFilter->getCutStringSignature().Data()));
+    siglst->Add(new TObjString(_fTrackFilter->getCutStringSignature().Data()));
+    siglst->Add(new TObjString(_fPIDFilter->getCutStringSignature().Data()));
+    std::map<std::string, std::string> metadata = {{"FilterDate", filterdate}};
+    ccdb->storeAsTFileAny<TList>(siglst, ccdbpath, metadata, sot, eot);
+    fEventFilter = _fEventFilter;
+    fTrackFilter = _fTrackFilter;
+    fPIDFilter = _fPIDFilter;
+    _fEventFilter = nullptr;
+    _fTrackFilter = nullptr;
+    _fPIDFilter = nullptr;
+  };
+
+  if (signatures != nullptr) {
+    /* signatures already stored in the CCDB, check if they match with the current configuration */
+    auto domatch = [&signatures](int index, auto filter) {
+      return (strcmp(signatures->At(index)->GetName(), filter->getCutStringSignature().Data()) == 0);
+    };
+    if (domatch(0, _fEventFilter) and domatch(1, _fTrackFilter) and domatch(2, _fPIDFilter)) {
+      /* signatures match so configuration already registered and available for skimming and/or analysis */
+      LOGF(info, "Filter signatures already registered in the CCDB. You can proceed with the skimming and/or analysis");
+    } else {
+      /* signatures don't match the version on the CCDB */
+      if (forceupdate) {
+        /* forced update required so store the configuration signatures in the CCDB */
+        LOGF(info, "Filter configuration signatures registered into the CCDB");
+        storesignatures();
+      } else {
+        /* no forced update required, inform the user */
+        LOGF(error, "The filter configuration signatures for the requested date don't match the ones available at the CCDB");
+        LOGF(error, "If the new filter configuration is registered the previous one will not be anylonger available");
+        LOGF(error, "If you agree on that please invoke againg the registering with --forced=true");
+        LOGF(error, "Nothing was done!!!");
+      }
+    }
+  } else {
+    /* signatures not stored in the CCDB, let's store them */
+    LOGF(info, "Filter configuration signatures registered into the CCDB");
+    storesignatures();
+  }
+}
+
+void FilterAndAnalysisFramework::Init()
+{
+  LOGF(info, "Initializing filter configuration from date %s", filterdate.data());
+
+  /* sanity checks */
+  if (_fTrackFilter == nullptr or _fEventFilter == nullptr or _fPIDFilter == nullptr) {
+    LOGF(fatal, "Configuration not stored yet, please use SetConfiguration(evtf, trkf, pidf, mode, force), or configuration already initalized");
+  }
+  if (fTrackFilter != nullptr or fEventFilter != nullptr or fPIDFilter != nullptr) {
+    LOGF(fatal, "Configuration already initialized");
+  }
+
+  TList* signatures = nullptr;
+  std::tm t{};
+  /* we set noon for checking */
+  std::istringstream ss(filterdate + "1200");
+  /* let's extract the timestamp */
+  ss >> std::get_time(&t, "%Y%m%d%H%M");
+  if (ss.fail()) {
+    LOGF(fatal, "Wrong skimming filter date format. Please use YYYYMMDD");
+  }
+  std::time_t time_stamp = mktime(&t);
+  /* and get it in ms */
+  uint64_t timestamp = 1000 * time_stamp;
+
+  /* get access to the CCDB */
+  o2::ccdb::BasicCCDBManager* ccdbm = &o2::ccdb::BasicCCDBManager::instance();
+  ccdbm->setFatalWhenNull(false); /* we need to check the availability of objects */
+  ccdbm->setURL(ccdburl);
+  signatures = ccdbm->getForTimeStamp<TList>(ccdbpath, timestamp);
+
+  if (signatures != nullptr) {
+    /* signatures registered in the CCDB, check if they match with the current configuration */
+    auto domatch = [&signatures](int index, auto filter) {
+      return (strcmp(signatures->At(index)->GetName(), filter->getCutStringSignature().Data()) == 0);
+    };
+    if (domatch(0, _fEventFilter) and domatch(1, _fTrackFilter) and domatch(2, _fPIDFilter)) {
+      /* signatures match the configuration proceed with skimming and/or analysis */
+      LOGF(info, "Filter signatures registered in the CCDB. Proceeding with the skimming and/or analysis");
+      fEventFilter = _fEventFilter;
+      fTrackFilter = _fTrackFilter;
+      fPIDFilter = _fPIDFilter;
+      _fEventFilter = nullptr;
+      _fTrackFilter = nullptr;
+      _fPIDFilter = nullptr;
+    } else {
+      /* signatures don't match the version on the CCDB */
+      LOGF(fatal,
+           "The stored configuration signatures don't match with the ones registered at the CCDB\n"
+           "\t\tEither you are trying to use a new filter configuration which is not registerd, please register it,\n"
+           "\t\tor you have changed the configuration for carrying your analysis, but it will not match the skimmed data,\n"
+           "\t\tplease do not modify the configuration, just the selection \"yes\" \"not\" flags.");
+    }
+  } else {
+    /* signatures not stored in the CCDB, abort! */
+    LOGF(fatal, "Filter configuration signatures not stored in the CCDB!!! We cannot proceed!!!");
+  }
 }

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/regex.hpp>
+#include <TObjArray.h>
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "FilterAndAnalysisFramework.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::soa;
+using namespace o2::framework::expressions;
+using namespace o2::analysis::PWGCF;
+
+ClassImp(FilterAndAnalysisFramework);
+
+/// \brief Default constructor
+FilterAndAnalysisFramework::FilterAndAnalysisFramework()
+  : TNamed(),
+    ccdb(nullptr),
+    fTrackFilter(nullptr),
+    fEventFilter(nullptr),
+    fPIDFilter(nullptr)
+{
+}
+
+/// \brief Named constructor for a concrete operating mode
+FilterAndAnalysisFramework::FilterAndAnalysisFramework(EventSelectionConfigurable& evtf, TrackSelectionConfigurable& trkf, PIDSelectionConfigurable& pidf, SelectionFilterAndAnalysis::selmodes mode)
+  : TNamed(),
+    ccdb(nullptr),
+    fTrackFilter(nullptr),
+    fEventFilter(nullptr),
+    fPIDFilter(nullptr)
+{
+  fTrackFilter = new PWGCF::TrackSelectionFilterAndAnalysis(trkf, mode);
+  fEventFilter = new PWGCF::EventSelectionFilterAndAnalysis(evtf, mode);
+  fPIDFilter = new PWGCF::PIDSelectionFilterAndAnalysis(pidf, mode);
+}

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
@@ -55,7 +55,7 @@ void FilterAndAnalysisFramework::RegisterConfiguration()
   if (_fTrackFilter == nullptr || _fEventFilter == nullptr || _fPIDFilter == nullptr) {
     LOGF(fatal, "Configuration not stored yet, please use SetConfiguration(evtf, trkf, pidf, mode), or configuration already registered");
   }
-  if (fTrackFilter != nullptr ||r fEventFilter != nullptr || fPIDFilter != nullptr) {
+  if (fTrackFilter != nullptr || fEventFilter != nullptr || fPIDFilter != nullptr) {
     LOGF(fatal, "Configuration already registered");
   }
 

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.cxx
@@ -9,14 +9,14 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <fairlogger/Logger.h>
 #include <iomanip>
+#include <map>
+#include <string>
 #include <TList.h>
 #include <TObjString.h>
 
 #include "FilterAndAnalysisFramework.h"
-#include <map>
-#include <string>
-#include <fairlogger/Logger.h>
 
 using namespace o2;
 using namespace o2::analysis::PWGCF;

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
@@ -32,9 +32,20 @@ namespace PWGCF
 /// \brief Base class for filter and selection once filetered
 class FilterAndAnalysisFramework : public TNamed
 {
+  friend void registerConfiguration(FilterAndAnalysisFramework*);
+
  public:
   FilterAndAnalysisFramework();
-  FilterAndAnalysisFramework(EventSelectionConfigurable&, TrackSelectionConfigurable&, PIDSelectionConfigurable&, SelectionFilterAndAnalysis::selmodes mode);
+  FilterAndAnalysisFramework(std::string& url, std::string& path, std::string& date, bool force = false)
+    : ccdburl(url), ccdbpath(path), filterdate(date), forceupdate(force) {}
+
+  void SetConfiguration(EventSelectionConfigurable&, TrackSelectionConfigurable&, PIDSelectionConfigurable&, SelectionFilterAndAnalysis::selmodes mode);
+
+ protected:
+  void RegisterConfiguration();
+
+ public:
+  void Init();
 
   /// \brief get the valid (armed) mask associated to the configuration of the different objects
   /// \return the corresponding armed mask
@@ -73,7 +84,7 @@ class FilterAndAnalysisFramework : public TNamed
   template <typename TrackToFilter>
   uint64_t FilterTrackPID(TrackToFilter const& track)
   {
-    fPIDFilter->Filter(track);
+    return fPIDFilter->Filter(track);
   }
   /// \brief get the event multiplicities
   std::vector<float> GetCollisionMultiplicities() { return fEventFilter->GetMultiplicities(); }
@@ -84,15 +95,23 @@ class FilterAndAnalysisFramework : public TNamed
   const TString& getEventFilterCutStringSignature() { return fEventFilter->getCutStringSignature(); }
   const TString& getTrackFilterCutStringSignature() { return fTrackFilter->getCutStringSignature(); }
   const TString& getPIDFilterCutStringSignature() { return fPIDFilter->getCutStringSignature(); }
-  o2::ccdb::BasicCCDBManager* ccdb = nullptr;
 
  private:
+  std::string ccdburl = "";
+  std::string ccdbpath = "";
+  std::string filterdate = "";
+  bool forceupdate = false;
   PWGCF::TrackSelectionFilterAndAnalysis* fTrackFilter = nullptr; /// the track filter
   PWGCF::EventSelectionFilterAndAnalysis* fEventFilter = nullptr; /// the event filter
   PWGCF::PIDSelectionFilterAndAnalysis* fPIDFilter = nullptr;     /// the PID filter
+  PWGCF::TrackSelectionFilterAndAnalysis* _fTrackFilter = nullptr; /// the track filter temporal storage until initialized
+  PWGCF::EventSelectionFilterAndAnalysis* _fEventFilter = nullptr; /// the event filter temporal storage until initialized
+  PWGCF::PIDSelectionFilterAndAnalysis* _fPIDFilter = nullptr;     /// the PID filter temporal storage until initialized
 
   ClassDefNV(FilterAndAnalysisFramework, 1)
 };
+
+extern void registerConfiguration(o2::analysis::PWGCF::FilterAndAnalysisFramework*);
 
 } // namespace PWGCF
 } // namespace analysis

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
@@ -8,18 +8,18 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FILTERANDANALYSISFRAMEWORK_H
-#define FILTERANDANALYSISFRAMEWORK_H
+#ifndef PWGCF_TWOPARTICLECORRELATIONS_CORE_FILTERANDANALYSISFRAMEWORK_H_
+#define PWGCF_TWOPARTICLECORRELATIONS_CORE_FILTERANDANALYSISFRAMEWORK_H_
 
 #include <vector>
 #include <string>
+#include <CCDB/BasicCCDBManager.h>
 #include <Rtypes.h>
 #include <TString.h>
 #include <TObject.h>
 #include <TNamed.h>
 #include <TList.h>
 
-#include <CCDB/BasicCCDBManager.h>
 #include "PWGCF/TwoParticleCorrelations/Core/EventSelectionFilterAndAnalysis.h"
 #include "PWGCF/TwoParticleCorrelations/Core/TrackSelectionFilterAndAnalysis.h"
 #include "PWGCF/TwoParticleCorrelations/Core/PIDSelectionFilterAndAnalysis.h"
@@ -119,4 +119,4 @@ extern void registerConfiguration(o2::analysis::PWGCF::FilterAndAnalysisFramewor
 } // namespace analysis
 } // namespace o2
 
-#endif //
+#endif // PWGCF_TWOPARTICLECORRELATIONS_CORE_FILTERANDANALYSISFRAMEWORK_H_

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
@@ -11,6 +11,8 @@
 #ifndef FILTERANDANALYSISFRAMEWORK_H
 #define FILTERANDANALYSISFRAMEWORK_H
 
+#include <vector>
+#include <string>
 #include <Rtypes.h>
 #include <TString.h>
 #include <TObject.h>
@@ -117,4 +119,4 @@ extern void registerConfiguration(o2::analysis::PWGCF::FilterAndAnalysisFramewor
 } // namespace analysis
 } // namespace o2
 
-#endif // FILTERANDANALYSISFRAMEWORK_H
+#endif //

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
@@ -1,0 +1,101 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FILTERANDANALYSISFRAMEWORK_H
+#define FILTERANDANALYSISFRAMEWORK_H
+
+#include <Rtypes.h>
+#include <TString.h>
+#include <TObject.h>
+#include <TNamed.h>
+#include <TList.h>
+
+#include <CCDB/BasicCCDBManager.h>
+#include "PWGCF/TwoParticleCorrelations/Core/EventSelectionFilterAndAnalysis.h"
+#include "PWGCF/TwoParticleCorrelations/Core/TrackSelectionFilterAndAnalysis.h"
+#include "PWGCF/TwoParticleCorrelations/Core/PIDSelectionFilterAndAnalysis.h"
+
+namespace o2
+{
+namespace analysis
+{
+namespace PWGCF
+{
+
+/// \brief Base class for filter and selection once filetered
+class FilterAndAnalysisFramework : public TNamed
+{
+ public:
+  FilterAndAnalysisFramework();
+  FilterAndAnalysisFramework(EventSelectionConfigurable&, TrackSelectionConfigurable&, PIDSelectionConfigurable&, SelectionFilterAndAnalysis::selmodes mode);
+
+  /// \brief get the valid (armed) mask associated to the configuration of the different objects
+  /// \return the corresponding armed mask
+  uint64_t getCollisionMask() { return fEventFilter->getMask(); }
+  uint64_t getTrackMask() { return fTrackFilter->getMask(); }
+  uint64_t getPIDMask() { return fPIDFilter->getMask(); }
+  /// \brief get the valid (armed) optional part mask associated to the configuration of the different objects
+  /// \return the corresponding armed optional mask
+  /// A clear example of the optional part mask is the mask of the multiplicity classes
+  /// where only one of the available in the whole mask will be flagged
+  std::vector<uint64_t>& getCollisionOptMask() { return fEventFilter->getOptMask(); }
+  std::vector<uint64_t>& getTrackOptMask() { return fTrackFilter->getOptMask(); }
+  std::vector<uint64_t>& getPIDOptMask() { return fPIDFilter->getOptMask(); }
+  /// \brief provides the optional part mask of the different objects in a printable shape
+  TString printCollisionOptionalMasks() const { return fEventFilter->printOptionalMasks(); }
+  TString printTrackOptionalMasks() const { return fTrackFilter->printOptionalMasks(); }
+  TString printPIDOptionalMasks() const { return fPIDFilter->printOptionalMasks(); }
+  /// \brief get the valid (armed) mandatory part mask associated to the configuration of the different objects
+  /// \return the corresponding armed forced mask
+  /// A clear example of the mandatory part mask is the mask of the zvertex and their
+  /// alternatives where only a concrete one is required to be flagged
+  uint64_t getCollisionForcedMask() { return fEventFilter->getForcedMask(); }
+  uint64_t getTrackForcedMask() { return fTrackFilter->getForcedMask(); }
+  uint64_t getPIDForcedMask() { return fPIDFilter->getForcedMask(); }
+  /// \brief filter the different objects
+  template <typename CollisionToFilter, typename AssociatedTracks>
+  uint64_t FilterCollision(CollisionToFilter const& col, AssociatedTracks const& trks, int bfield)
+  {
+    return fEventFilter->Filter(col, trks, bfield);
+  }
+  template <typename TrackToFilter>
+  uint64_t FilterTrack(TrackToFilter const& track)
+  {
+    return fTrackFilter->Filter(track);
+  }
+  template <typename TrackToFilter>
+  uint64_t FilterTrackPID(TrackToFilter const& track)
+  {
+    fPIDFilter->Filter(track);
+  }
+  /// \brief get the event multiplicities
+  std::vector<float> GetCollisionMultiplicities() { return fEventFilter->GetMultiplicities(); }
+  /// \brief Gets the index of the active multiplicity value within the multiplicities array
+  int getCollisionMultiplicityIndex() { return fEventFilter->getMultiplicityIndex(); }
+
+  /// \brief get the cut string signatures
+  const TString& getEventFilterCutStringSignature() { return fEventFilter->getCutStringSignature(); }
+  const TString& getTrackFilterCutStringSignature() { return fTrackFilter->getCutStringSignature(); }
+  const TString& getPIDFilterCutStringSignature() { return fPIDFilter->getCutStringSignature(); }
+  o2::ccdb::BasicCCDBManager* ccdb = nullptr;
+
+ private:
+  PWGCF::TrackSelectionFilterAndAnalysis* fTrackFilter = nullptr; /// the track filter
+  PWGCF::EventSelectionFilterAndAnalysis* fEventFilter = nullptr; /// the event filter
+  PWGCF::PIDSelectionFilterAndAnalysis* fPIDFilter = nullptr;     /// the PID filter
+
+  ClassDefNV(FilterAndAnalysisFramework, 1)
+};
+
+} // namespace PWGCF
+} // namespace analysis
+} // namespace o2
+
+#endif // FILTERANDANALYSISFRAMEWORK_H

--- a/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
+++ b/PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h
@@ -11,9 +11,9 @@
 #ifndef PWGCF_TWOPARTICLECORRELATIONS_CORE_FILTERANDANALYSISFRAMEWORK_H_
 #define PWGCF_TWOPARTICLECORRELATIONS_CORE_FILTERANDANALYSISFRAMEWORK_H_
 
+#include <CCDB/BasicCCDBManager.h>
 #include <vector>
 #include <string>
-#include <CCDB/BasicCCDBManager.h>
 #include <Rtypes.h>
 #include <TString.h>
 #include <TObject.h>

--- a/PWGCF/TwoParticleCorrelations/Core/TwoPartCorrLinkDef.h
+++ b/PWGCF/TwoParticleCorrelations/Core/TwoPartCorrLinkDef.h
@@ -8,6 +8,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#ifndef PWGCF_TWOPARTICLECORRELATIONS_CORE_TWOPARTCORRLINKDEF_H_
+#define PWGCF_TWOPARTICLECORRELATIONS_CORE_TWOPARTCORRLINKDEF_H_
 
 #pragma link off all globals;
 #pragma link off all classes;
@@ -48,3 +50,5 @@
 #pragma link C++ class o2::analysis::PWGCF::EventSelectionFilterAndAnalysis::PileUpRejBrick + ;
 #pragma link C++ class o2::analysis::PWGCF::EventSelectionFilterAndAnalysis + ;
 #pragma link C++ class o2::analysis::PWGCF::FilterAndAnalysisFramework + ;
+
+#endif // PWGCF_TWOPARTICLECORRELATIONS_CORE_TWOPARTCORRLINKDEF_H_

--- a/PWGCF/TwoParticleCorrelations/Core/TwoPartCorrLinkDef.h
+++ b/PWGCF/TwoParticleCorrelations/Core/TwoPartCorrLinkDef.h
@@ -47,3 +47,4 @@
 #pragma link C++ class o2::analysis::PWGCF::EventSelectionFilterAndAnalysis::MultiplicityBrick + ;
 #pragma link C++ class o2::analysis::PWGCF::EventSelectionFilterAndAnalysis::PileUpRejBrick + ;
 #pragma link C++ class o2::analysis::PWGCF::EventSelectionFilterAndAnalysis + ;
+#pragma link C++ class o2::analysis::PWGCF::FilterAndAnalysisFramework + ;

--- a/PWGCF/TwoParticleCorrelations/TableProducer/CMakeLists.txt
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/CMakeLists.txt
@@ -9,6 +9,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+o2physics_add_dpl_workflow(twopartcorr-register-skim
+                           SOURCES twoParticleCorrelationsRegisterSkimming.cxx
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::TwoPartCorrCore
+                           COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(twopartcorr-skim
                            SOURCES twoParticleCorrelationsSkimming.cxx
                            PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::TwoPartCorrCore

--- a/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
@@ -61,4 +61,10 @@ struct : o2::framework::ConfigurableGroup {
 #endif
 } pidfilter;
 
+struct : o2::framework::ConfigurableGroup {
+  o2::framework::Configurable<std::string> ccdburl{"ccdburl", "http://ccdb-test.cern.ch:8080", "url of the skimming ccdb repository"};
+  o2::framework::Configurable<std::string> ccdbpath{"ccdbpath", "Users/v/victor/Skimming", "url of the skimming ccdb repository"};
+  o2::framework::Configurable<std::string> filterdate{"filterdate", "20221115", "the date for the skimming production with the current filter configuration"};
+} filterccdb;
+
 #endif // O2_ANALYSIS_CFSKIMMINGCONF_H

--- a/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
@@ -13,6 +13,8 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/ASoAHelpers.h"
+#include <vector>
+#include <string>
 
 struct : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<std::vector<std::string>> bfield{"evtflt_bfield", {"positive-yes", "negative-yes"}, "B filed polarity cut: both 'yes' default, anything else alternative"};
@@ -67,4 +69,4 @@ struct : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<std::string> filterdate{"filterdate", "20221115", "the date for the skimming production with the current filter configuration"};
 } filterccdb;
 
-#endif // O2_ANALYSIS_CFSKIMMINGCONF_H
+#endif // PWGCF_TWOPARTICLECORRELATIONS_TABLEPRODUCER_SKIMMINGCONF_H_

--- a/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h
@@ -8,13 +8,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef O2_ANALYSIS_CFSKIMMINGCONF_H
-#define O2_ANALYSIS_CFSKIMMINGCONF_H
+#ifndef PWGCF_TWOPARTICLECORRELATIONS_TABLEPRODUCER_SKIMMINGCONF_H_
+#define PWGCF_TWOPARTICLECORRELATIONS_TABLEPRODUCER_SKIMMINGCONF_H_
 
-#include "Framework/AnalysisTask.h"
-#include "Framework/ASoAHelpers.h"
 #include <vector>
 #include <string>
+#include "Framework/AnalysisTask.h"
+#include "Framework/ASoAHelpers.h"
 
 struct : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<std::vector<std::string>> bfield{"evtflt_bfield", {"positive-yes", "negative-yes"}, "B filed polarity cut: both 'yes' default, anything else alternative"};

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <cmath>
+
 #include "Framework/AnalysisTask.h"
 #include "PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h"
 #include "PWGCF/TwoParticleCorrelations/DataModel/TwoParticleCorrelationsSkimmed.h"
@@ -24,8 +26,6 @@
 #include <TH2.h>
 #include <TH3.h>
 #include <TProfile3D.h>
-
-#include <cmath>
 
 using namespace o2;
 using namespace o2::framework;
@@ -102,7 +102,7 @@ struct TwoParticleCorrelationsFilter {
     LOGF(info, "TwoParticleCorrelationsFilter::init(), collision selection masks 0x%016lx, %s, and 0x%016lx and multiplicity index %d", collisionmask, fFilterFramework->printCollisionOptionalMasks().Data(), collisionmask_forced, fMultiplicityIndex);
     LOGF(info, "TwoParticleCorrelationsFilter::init(), track selection masks 0x%016lx, %s, and 0x%016lx ", trackmask, fFilterFramework->printTrackOptionalMasks().Data(), trackmask_forced);
     LOGF(info, "TwoParticleCorrelationsFilter::init(), PID selection masks 0x%016lx, %s, and 0x%016lx ", pidmask, fFilterFramework->printPIDOptionalMasks().Data(), pidmask_forced);
-    if (collisionmask == uint64_t(0) or trackmask == uint64_t(0)) {
+    if (collisionmask == uint64_t(0) || trackmask == uint64_t(0)) {
       LOGF(fatal, "TwoParticleCorrelationsFilter::init() null masks, selecting everything!!!");
     }
     /* TODO: check the cuts signatures against the CCDB contents */
@@ -123,12 +123,12 @@ struct TwoParticleCorrelationsFilter {
       return all;
     };
 
-    if ((collision.selflags() & collisionmask_forced) == collisionmask_forced and passOptions(collisionmask_opt, collision.selflags())) {
+    if ((collision.selflags() & collisionmask_forced) == collisionmask_forced && passOptions(collisionmask_opt, collision.selflags())) {
       LOGF(TWOPFILTERLOGCOLLISIONS, ">> Accepted collision with mask 0x%016lx and %ld unfiltered tracks", collision.selflags(), tracks.size());
       acceptedcollisions(collision.centmult()[fMultiplicityIndex], uint8_t(true));
       int nAcceptedTracks = 0;
       for (const auto& track : tracks) {
-        if ((track.trackflags() & trackmask_forced) == trackmask_forced and passOptions(trackmask_opt, track.trackflags())) {
+        if ((track.trackflags() & trackmask_forced) == trackmask_forced && passOptions(trackmask_opt, track.trackflags())) {
           accepteddtracks(0); // TODO: the kind of accepted track
           nAcceptedTracks++;
         } else {

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
@@ -61,7 +61,7 @@ struct TwoParticleCorrelationsFilter {
   Produces<aod::TwoPAcceptedGenCollisions> acceptedgencollisions;
   Produces<aod::TwoPFilteredParticles> acceptedgentracks;
 
-#include "skimmingconf.h"
+#include "PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h"
 
   int nReportedTracks;
   //  HistogramRegistry historeg;

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
@@ -85,7 +85,9 @@ struct TwoParticleCorrelationsFilter {
     PWGCF::PIDSelectionConfigurable pidsel(pidfilter.pidtpcfilter.tpcel, pidfilter.pidtpcfilter.tpcmu, pidfilter.pidtpcfilter.tpcpi, pidfilter.pidtpcfilter.tpcka, pidfilter.pidtpcfilter.tpcpr,
                                            pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr);
 #endif
-    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
+    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(filterccdb.ccdburl.value, filterccdb.ccdbpath.value, filterccdb.filterdate.value);
+    fFilterFramework->SetConfiguration(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
+    fFilterFramework->Init();
     nReportedTracks = 0;
     collisionmask = fFilterFramework->getCollisionMask();
     collisionmask_opt = fFilterFramework->getCollisionOptMask();

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsFiltering.cxx
@@ -10,9 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/AnalysisTask.h"
-#include "PWGCF/TwoParticleCorrelations/Core/EventSelectionFilterAndAnalysis.h"
-#include "PWGCF/TwoParticleCorrelations/Core/TrackSelectionFilterAndAnalysis.h"
-#include "PWGCF/TwoParticleCorrelations/Core/PIDSelectionFilterAndAnalysis.h"
+#include "PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h"
 #include "PWGCF/TwoParticleCorrelations/DataModel/TwoParticleCorrelationsSkimmed.h"
 #include "PWGCF/TwoParticleCorrelations/DataModel/TwoParticleCorrelationsFiltered.h"
 #include "Framework/runDataProcessing.h"
@@ -50,9 +48,7 @@ uint64_t pidmask = 0UL;
 std::vector<uint64_t> pidmask_opt;
 uint64_t pidmask_forced = 0UL;
 
-PWGCF::EventSelectionFilterAndAnalysis* fCollisionFilter = nullptr;
-PWGCF::TrackSelectionFilterAndAnalysis* fTrackFilter = nullptr;
-PWGCF::PIDSelectionFilterAndAnalysis* fPIDFilter = nullptr;
+PWGCF::FilterAndAnalysisFramework* fFilterFramework = nullptr;
 
 int fMultiplicityIndex = -1; //! the index to the multiplicity values array
 } // namespace o2::analysis::twopfilter
@@ -78,12 +74,9 @@ struct TwoParticleCorrelationsFilter {
 
     /* collision filtering configuration */
     PWGCF::EventSelectionConfigurable eventsel(eventfilter.bfield, eventfilter.centmultsel, {}, eventfilter.zvtxsel, {});
-    fCollisionFilter = new PWGCF::EventSelectionFilterAndAnalysis(eventsel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
-
     /* track filtering configuration */
     PWGCF::TrackSelectionConfigurable trksel(trackfilter.ttype, trackfilter.nclstpc, trackfilter.nxrtpc, trackfilter.nclsits, trackfilter.chi2clustpc,
                                              trackfilter.chi2clusits, trackfilter.xrofctpc, trackfilter.dcaxy, trackfilter.dcaz, trackfilter.ptrange, trackfilter.etarange);
-    fTrackFilter = new PWGCF::TrackSelectionFilterAndAnalysis(trksel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
 #ifdef INCORPORATEBAYESIANPID
     PWGCF::PIDSelectionConfigurable pidsel(pidfilter.pidtpcfilter.tpcel, pidfilter.pidtpcfilter.tpcmu, pidfilter.pidtpcfilter.tpcpi, pidfilter.pidtpcfilter.tpcka, pidfilter.pidtpcfilter.tpcpr,
                                            pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr,
@@ -92,29 +85,28 @@ struct TwoParticleCorrelationsFilter {
     PWGCF::PIDSelectionConfigurable pidsel(pidfilter.pidtpcfilter.tpcel, pidfilter.pidtpcfilter.tpcmu, pidfilter.pidtpcfilter.tpcpi, pidfilter.pidtpcfilter.tpcka, pidfilter.pidtpcfilter.tpcpr,
                                            pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr);
 #endif
-    fPIDFilter = new PWGCF::PIDSelectionFilterAndAnalysis(pidsel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
-
+    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kAnalysis);
     nReportedTracks = 0;
-    collisionmask = fCollisionFilter->getMask();
-    collisionmask_opt = fCollisionFilter->getOptMask();
-    collisionmask_forced = fCollisionFilter->getForcedMask();
-    fMultiplicityIndex = fCollisionFilter->getMultiplicityIndex();
-    trackmask = fTrackFilter->getMask();
-    trackmask_opt = fTrackFilter->getOptMask();
-    trackmask_forced = fTrackFilter->getForcedMask();
-    pidmask = fPIDFilter->getMask();
-    pidmask_opt = fPIDFilter->getOptMask();
-    pidmask_forced = fPIDFilter->getForcedMask();
-    LOGF(info, "TwoParticleCorrelationsFilter::init(), collision selection masks 0x%016lx, %s, and 0x%016lx and multiplicity index %d", collisionmask, fCollisionFilter->printOptionalMasks().Data(), collisionmask_forced, fMultiplicityIndex);
-    LOGF(info, "TwoParticleCorrelationsFilter::init(), track selection masks 0x%016lx, %s, and 0x%016lx ", trackmask, fTrackFilter->printOptionalMasks().Data(), trackmask_forced);
-    LOGF(info, "TwoParticleCorrelationsFilter::init(), PID selection masks 0x%016lx, %s, and 0x%016lx ", pidmask, fPIDFilter->printOptionalMasks().Data(), pidmask_forced);
+    collisionmask = fFilterFramework->getCollisionMask();
+    collisionmask_opt = fFilterFramework->getCollisionOptMask();
+    collisionmask_forced = fFilterFramework->getCollisionForcedMask();
+    fMultiplicityIndex = fFilterFramework->getCollisionMultiplicityIndex();
+    trackmask = fFilterFramework->getTrackMask();
+    trackmask_opt = fFilterFramework->getTrackOptMask();
+    trackmask_forced = fFilterFramework->getTrackForcedMask();
+    pidmask = fFilterFramework->getPIDMask();
+    pidmask_opt = fFilterFramework->getPIDOptMask();
+    pidmask_forced = fFilterFramework->getPIDForcedMask();
+    LOGF(info, "TwoParticleCorrelationsFilter::init(), collision selection masks 0x%016lx, %s, and 0x%016lx and multiplicity index %d", collisionmask, fFilterFramework->printCollisionOptionalMasks().Data(), collisionmask_forced, fMultiplicityIndex);
+    LOGF(info, "TwoParticleCorrelationsFilter::init(), track selection masks 0x%016lx, %s, and 0x%016lx ", trackmask, fFilterFramework->printTrackOptionalMasks().Data(), trackmask_forced);
+    LOGF(info, "TwoParticleCorrelationsFilter::init(), PID selection masks 0x%016lx, %s, and 0x%016lx ", pidmask, fFilterFramework->printPIDOptionalMasks().Data(), pidmask_forced);
     if (collisionmask == uint64_t(0) or trackmask == uint64_t(0)) {
       LOGF(fatal, "TwoParticleCorrelationsFilter::init() null masks, selecting everything!!!");
     }
     /* TODO: check the cuts signatures against the CCDB contents */
-    LOGF(info, "Collision skimming signature: %s", fCollisionFilter->getCutStringSignature().Data());
-    LOGF(info, "Track skimming signature: %s", fTrackFilter->getCutStringSignature().Data());
-    LOGF(info, "PID skimming signature: %s", fPIDFilter->getCutStringSignature().Data());
+    LOGF(info, "Collision skimming signature: %s", fFilterFramework->getEventFilterCutStringSignature().Data());
+    LOGF(info, "Track skimming signature: %s", fFilterFramework->getTrackFilterCutStringSignature().Data());
+    LOGF(info, "PID skimming signature: %s", fFilterFramework->getPIDFilterCutStringSignature().Data());
   }
 
   void processRun2(aod::CFCollision const& collision, aod::CFTracks const& tracks)

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsRegisterSkimming.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsRegisterSkimming.cxx
@@ -9,12 +9,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <CCDB/BasicCCDBManager.h>
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h"
 #include "Framework/runDataProcessing.h"
-#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::framework;
@@ -31,7 +31,7 @@ struct TwoParticleCorrelationsRegisterSkimming {
   bool registered = false;
   PWGCF::FilterAndAnalysisFramework* fFilterFramework = nullptr;
 
-#include "skimmingconf.h"
+#include "PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h"
 
   void init(InitContext const&)
   {
@@ -59,7 +59,7 @@ struct TwoParticleCorrelationsRegisterSkimming {
 
   void process(aod::Collisions const&)
   {
-    if (not registered) {
+    if (!registered) {
       LOGF(info, "Registering filter configuration");
       PWGCF::registerConfiguration(fFilterFramework);
       registered = true;

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsRegisterSkimming.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsRegisterSkimming.cxx
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h"
+#include "Framework/runDataProcessing.h"
+#include <CCDB/BasicCCDBManager.h>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::soa;
+using namespace o2::framework::expressions;
+using namespace o2::analysis;
+
+void o2::analysis::PWGCF::registerConfiguration(PWGCF::FilterAndAnalysisFramework* fFilterFramework)
+{
+  fFilterFramework->RegisterConfiguration();
+}
+
+struct TwoParticleCorrelationsRegisterSkimming {
+  bool registered = false;
+  PWGCF::FilterAndAnalysisFramework* fFilterFramework = nullptr;
+
+#include "skimmingconf.h"
+
+  void init(InitContext const&)
+  {
+
+    LOGF(info, "TwoParticleCorrelationsRegisterSkimming::init()");
+
+    /* collision filtering configuration */
+    PWGCF::EventSelectionConfigurable eventsel(eventfilter.bfield, eventfilter.centmultsel, {}, eventfilter.zvtxsel, eventfilter.pileuprej);
+    /* track filtering configuration */
+    PWGCF::TrackSelectionConfigurable trksel(trackfilter.ttype, trackfilter.nclstpc, trackfilter.nxrtpc, trackfilter.nclsits, trackfilter.chi2clustpc,
+                                             trackfilter.chi2clusits, trackfilter.xrofctpc, trackfilter.dcaxy, trackfilter.dcaz, trackfilter.ptrange, trackfilter.etarange);
+#ifdef INCORPORATEBAYESIANPID
+    PWGCF::PIDSelectionConfigurable pidsel(pidfilter.pidtpcfilter.tpcel, pidfilter.pidtpcfilter.tpcmu, pidfilter.pidtpcfilter.tpcpi, pidfilter.pidtpcfilter.tpcka, pidfilter.pidtpcfilter.tpcpr,
+                                           pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr,
+                                           pidfilter.pidbayesfilter.bayel, pidfilter.pidbayesfilter.baymu, pidfilter.pidbayesfilter.baypi, pidfilter.pidbayesfilter.bayka, pidfilter.pidbayesfilter.baypr);
+#else
+    PWGCF::PIDSelectionConfigurable pidsel(pidfilter.pidtpcfilter.tpcel, pidfilter.pidtpcfilter.tpcmu, pidfilter.pidtpcfilter.tpcpi, pidfilter.pidtpcfilter.tpcka, pidfilter.pidtpcfilter.tpcpr,
+                                           pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr);
+#endif
+
+    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(filterccdb.ccdburl.value, filterccdb.ccdbpath.value, filterccdb.filterdate.value);
+    fFilterFramework->SetConfiguration(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kFilter);
+    registered = false;
+  }
+
+  void process(aod::Collisions const&)
+  {
+    if (not registered) {
+      LOGF(info, "Registering filter configuration");
+      PWGCF::registerConfiguration(fFilterFramework);
+      registered = true;
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<TwoParticleCorrelationsRegisterSkimming>(cfgc)};
+  return workflow;
+}

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsSkimming.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsSkimming.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <CCDB/BasicCCDBManager.h>
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
@@ -20,7 +21,6 @@
 #include "PWGCF/TwoParticleCorrelations/Core/FilterAndAnalysisFramework.h"
 #include "Framework/runDataProcessing.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::framework;
@@ -100,7 +100,7 @@ struct TwoParticleCorrelationsSkimming {
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
-#include "skimmingconf.h"
+#include "PWGCF/TwoParticleCorrelations/TableProducer/skimmingconf.h"
 
   int nReportedTracks;
   int runNumber = 0;
@@ -172,27 +172,27 @@ struct TwoParticleCorrelationsSkimming {
 
     // NOT CONFIGURABLE EVENT SELECTION
     /* incomplete data acquisition */
-    if (not TESTBIT(eventcuts, kIncompleteDAQ)) {
+    if (!TESTBIT(eventcuts, kIncompleteDAQ)) {
       accepted = false;
     }
     /* pile-up */
     /* TODO: check if this is also valid for Run 1 data */
-    if (not TESTBIT(eventcuts, kPileupInMultBins) or
-        not TESTBIT(eventcuts, kTrackletsVsClusters) or
-        not TESTBIT(eventcuts, kPileUpMV) or
-        not TESTBIT(eventcuts, kTimeRangeCut) or
-        not TESTBIT(eventcuts, kTPCPileUp) or
-        TESTBIT(eventcuts, kIsPileupFromSPD) or
+    if (!TESTBIT(eventcuts, kPileupInMultBins) ||
+        !TESTBIT(eventcuts, kTrackletsVsClusters) ||
+        !TESTBIT(eventcuts, kPileUpMV) ||
+        !TESTBIT(eventcuts, kTimeRangeCut) ||
+        !TESTBIT(eventcuts, kTPCPileUp) ||
+        TESTBIT(eventcuts, kIsPileupFromSPD) ||
         TESTBIT(eventcuts, kIsV0PFPileup)) {
       accepted = false;
     }
     /* TPC issues*/
-    if (TESTBIT(eventcuts, kIsTPCHVdip) or
+    if (TESTBIT(eventcuts, kIsTPCHVdip) ||
         TESTBIT(eventcuts, kIsTPCLaserWarmUp)) {
       accepted = false;
     }
     /* vertex */
-    if (not TESTBIT(eventcuts, kNonZeroNContribs) or
+    if (!TESTBIT(eventcuts, kNonZeroNContribs) ||
         (((collision.flags() & Run2VertexerZ) == Run2VertexerZ) && collision.covZZ() < 0.25)) {
       accepted = false;
     }
@@ -233,7 +233,7 @@ struct TwoParticleCorrelationsSkimming {
           skimmtrackpid(pidmask);
           nFilteredTracks++;
         }
-        if (trkmask != 0UL and nReportedTracks < 1000) {
+        if (trkmask != 0UL && nReportedTracks < 1000) {
           if (nCollisionReportedTracks < 20) {
             LOGF(LOGTRACKTRACKS, "  Got track mask 0x%016lx and PID mask 0x%016lx", trkmask, pidmask);
             LOGF(LOGTRACKTRACKS, "    TPC clusters %d, Chi2 per TPC cluster %f, pT %f, eta %f, track type %d",

--- a/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsSkimming.cxx
+++ b/PWGCF/TwoParticleCorrelations/TableProducer/twoParticleCorrelationsSkimming.cxx
@@ -142,7 +142,9 @@ struct TwoParticleCorrelationsSkimming {
                                            pidfilter.pidtoffilter.tpcel, pidfilter.pidtoffilter.tpcmu, pidfilter.pidtoffilter.tpcpi, pidfilter.pidtoffilter.tpcka, pidfilter.pidtoffilter.tpcpr);
 #endif
 
-    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kFilter);
+    fFilterFramework = new PWGCF::FilterAndAnalysisFramework(filterccdb.ccdburl.value, filterccdb.ccdbpath.value, filterccdb.filterdate.value);
+    fFilterFramework->SetConfiguration(eventsel, trksel, pidsel, PWGCF::SelectionFilterAndAnalysis::kFilter);
+    fFilterFramework->Init();
     nReportedTracks = 0;
 
     /* TODO: upload the cuts signatures to the CCDB */


### PR DESCRIPTION
Now the signature of the skimming configuration is stored in the CCDB and the check of the consistency between skimmed data configuration and analysis configuration is supported