### PR TITLE
Adding Configurable to set number of threads for ONNX

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -156,13 +156,12 @@ struct tpcPid {
 
       /// Testing hyperloop core settings
       const char* alien_cores = gSystem->Getenv("ALIEN_JDL_CPUCORES");
-      if(alien_cores!=NULL){
+      if (alien_cores != NULL) {
         std::string msg_cores = "Hyperloop-run detected! Number of cores = ";
         LOGP(info, msg_cores + std::string(alien_cores));
         activeThreads = 1;
-      }
-      else{
-        if(networkSetNumThreads>0){
+      } else {
+        if (networkSetNumThreads > 0) {
           LOGP(info, "Not running on Hyperloop. Threads for neural network inference are fixed: {} threads", std::to_string(networkSetNumThreads));
         }
       }

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -143,8 +143,9 @@ struct tpcPid {
         LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
         ccdb->setTimestamp(time);
         response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      } else
+      } else {
         LOGP(info, "Initialising default TPC PID response:");
+      }
       response.PrintAll();
     }
 

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -84,6 +84,7 @@ struct tpcPid {
   Configurable<std::string> networkPathLocally{"networkPathLocally", "network.onnx", "(std::string) Path to the local .onnx file. If autofetching is enabled, then this is where the files will be downloaded"};
   Configurable<bool> enableNetworkOptimizations{"enableNetworkOptimizations", 1, "(bool) If the neural network correction is used, this enables GraphOptimizationLevel::ORT_ENABLE_EXTENDED in the ONNX session"};
   Configurable<std::string> networkPathCCDB{"networkPathCCDB", "Analysis/PID/TPC/ML", "Path on CCDB"};
+  Configurable<int> networkSetNumThreads{"networkSetNumThreads", 0, "Especially important for running on a SLURM cluster. Sets the number of threads used for execution."};
   // Configuration flags to include and exclude particle hypotheses
   Configurable<int> pidEl{"pid-el", -1, {"Produce PID information for the Electron mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
   Configurable<int> pidMu{"pid-mu", -1, {"Produce PID information for the Muon mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
@@ -163,7 +164,8 @@ struct tpcPid {
             Network temp_net(networkPathLocally.value,
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
-                             enableNetworkOptimizations.value);
+                             enableNetworkOptimizations.value,
+                             networkSetNumThreads.value);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {
@@ -176,7 +178,8 @@ struct tpcPid {
           }
           LOG(info) << "Using local file [" << networkPathLocally.value << "] for the TPC PID response correction.";
           Network temp_net(networkPathLocally.value,
-                           enableNetworkOptimizations.value);
+                           enableNetworkOptimizations.value,
+                           networkSetNumThreads.value);
           network = temp_net;
           network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
         }
@@ -235,7 +238,8 @@ struct tpcPid {
             Network temp_net(networkPathLocally.value,
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
-                             enableNetworkOptimizations.value);
+                             enableNetworkOptimizations.value,
+                             networkSetNumThreads.value);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -157,8 +157,7 @@ struct tpcPid {
       /// Testing hyperloop core settings
       const char* alien_cores = gSystem->Getenv("ALIEN_JDL_CPUCORES");
       if (alien_cores != NULL) {
-        std::string msg_cores = "Hyperloop-run detected! Number of cores = ";
-        LOGP(info, msg_cores + std::string(alien_cores));
+        LOGP(info, "Hyperloop test/Grid job detected! Number of cores = {}. Setting threads anyway to 1.", alien_cores);
         activeThreads = 1;
       } else {
         if (networkSetNumThreads > 0) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -156,13 +156,12 @@ struct tpcPidFull {
 
       /// Testing hyperloop core settings
       const char* alien_cores = gSystem->Getenv("ALIEN_JDL_CPUCORES");
-      if(alien_cores!=NULL){
+      if (alien_cores != NULL) {
         std::string msg_cores = "Hyperloop-run detected! Number of cores = ";
         LOGP(info, msg_cores + std::string(alien_cores));
         activeThreads = 1;
-      }
-      else{
-        if(networkSetNumThreads>0){
+      } else {
+        if (networkSetNumThreads > 0) {
           LOGP(info, "Not running on Hyperloop. Threads for neural network inference are fixed: {} threads", std::to_string(networkSetNumThreads));
         }
       }

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -84,6 +84,7 @@ struct tpcPidFull {
   Configurable<std::string> networkPathLocally{"networkPathLocally", "network.onnx", "(std::string) Path to the local .onnx file. If autofetching is enabled, then this is where the files will be downloaded"};
   Configurable<bool> enableNetworkOptimizations{"enableNetworkOptimizations", 1, "(bool) If the neural network correction is used, this enables GraphOptimizationLevel::ORT_ENABLE_EXTENDED in the ONNX session"};
   Configurable<std::string> networkPathCCDB{"networkPathCCDB", "Analysis/PID/TPC/ML", "Path on CCDB"};
+  Configurable<int> networkSetNumThreads{"networkSetNumThreads", 0, "Especially important for running on a SLURM cluster. Sets the number of threads used for execution."};
   // Configuration flags to include and exclude particle hypotheses
   Configurable<int> pidEl{"pid-el", -1, {"Produce PID information for the Electron mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
   Configurable<int> pidMu{"pid-mu", -1, {"Produce PID information for the Muon mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
@@ -163,7 +164,8 @@ struct tpcPidFull {
             Network temp_net(networkPathLocally.value,
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
-                             enableNetworkOptimizations.value);
+                             enableNetworkOptimizations.value,
+                             networkSetNumThreads.value);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {
@@ -176,7 +178,8 @@ struct tpcPidFull {
           }
           LOG(info) << "Using local file [" << networkPathLocally.value << "] for the TPC PID response correction.";
           Network temp_net(networkPathLocally.value,
-                           enableNetworkOptimizations.value);
+                           enableNetworkOptimizations.value,
+                           networkSetNumThreads.value);
           network = temp_net;
           network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
         }
@@ -234,7 +237,8 @@ struct tpcPidFull {
             Network temp_net(networkPathLocally.value,
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
-                             enableNetworkOptimizations.value);
+                             enableNetworkOptimizations.value,
+                             networkSetNumThreads.value);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -24,9 +24,9 @@
 #include "TSystem.h"
 
 // O2 includes
+#include <CCDB/BasicCCDBManager.h>
 #include "Framework/AnalysisTask.h"
 #include "ReconstructionDataFormats/Track.h"
-#include <CCDB/BasicCCDBManager.h>
 #include "CCDB/CcdbApi.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/Core/PID/TPCPIDResponse.h"
@@ -78,7 +78,7 @@ struct tpcPidFull {
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if empty the parametrization is not taken from file"};
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC/Response", "Path of the TPC parametrization on the CCDB"};
-  Configurable<long> ccdbTimestamp{"ccdb-timestamp", 0, "timestamp of the object used to query in CCDB the detector response. Exceptions: -1 gets the latest object, 0 gets the run dependent timestamp"};
+  Configurable<uint64_t> ccdbTimestamp{"ccdb-timestamp", 0, "timestamp of the object used to query in CCDB the detector response. Exceptions: -1 gets the latest object, 0 gets the run dependent timestamp"};
   // Parameters for loading network from a file / downloading the file
   Configurable<bool> useNetworkCorrection{"useNetworkCorrection", 0, "(bool) Wether or not to use the network correction for the TPC dE/dx signal"};
   Configurable<bool> autofetchNetworks{"autofetchNetworks", 1, "(bool) Automatically fetches networks from CCDB for the correct run number"};
@@ -129,7 +129,7 @@ struct tpcPidFull {
         response.SetParameters(responseptr);
       } catch (...) {
         LOGF(fatal, "Loading the TPC PID Response from file {} failed!", fname);
-      };
+      }
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
@@ -143,8 +143,9 @@ struct tpcPidFull {
         LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
         ccdb->setTimestamp(time);
         response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      } else
+      } else {
         LOGP(info, "Initialising default TPC PID response:");
+      }
       response.PrintAll();
     }
 
@@ -213,7 +214,7 @@ struct tpcPidFull {
                aod::BCsWithTimestamps const&)
   {
 
-    const unsigned long tracks_size = tracks.size();
+    const uint64_t tracks_size = tracks.size();
 
     auto reserveTable = [&tracks_size](const Configurable<int>& flag, auto& table) {
       if (flag.value != 1) {
@@ -270,15 +271,15 @@ struct tpcPidFull {
       // Defining some network parameters
       int input_dimensions = network.getInputDimensions();
       int output_dimensions = network.getOutputDimensions();
-      const unsigned long track_prop_size = input_dimensions * tracks_size;
-      const unsigned long prediction_size = output_dimensions * tracks_size;
+      const uint64_t track_prop_size = input_dimensions * tracks_size;
+      const uint64_t prediction_size = output_dimensions * tracks_size;
 
       network_prediction = std::vector<float>(prediction_size * 9); // For each mass hypotheses
       const float nNclNormalization = response.GetNClNormalization();
       float duration_network = 0;
 
       std::vector<float> track_properties(track_prop_size);
-      unsigned long counter_track_props = 0;
+      uint64_t counter_track_props = 0;
       int loop_counter = 0;
 
       // Filling a std::vector<float> to be evaluated by the network
@@ -298,7 +299,7 @@ struct tpcPidFull {
         float* output_network = network.evalNetwork(track_properties);
         auto stop_network_eval = std::chrono::high_resolution_clock::now();
         duration_network += std::chrono::duration<float, std::ratio<1, 1000000000>>(stop_network_eval - start_network_eval).count();
-        for (unsigned long i = 0; i < prediction_size; i += output_dimensions) {
+        for (uint64_t i = 0; i < prediction_size; i += output_dimensions) {
           for (int j = 0; j < output_dimensions; j++) {
             network_prediction[i + j + prediction_size * loop_counter] = output_network[i + j];
           }
@@ -315,7 +316,7 @@ struct tpcPidFull {
     }
 
     int lastCollisionId = -1; // Last collision ID analysed
-    unsigned long count_tracks = 0;
+    uint64_t count_tracks = 0;
 
     for (auto const& trk : tracks) {
       // Loop on Tracks

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -157,8 +157,7 @@ struct tpcPidFull {
       /// Testing hyperloop core settings
       const char* alien_cores = gSystem->Getenv("ALIEN_JDL_CPUCORES");
       if (alien_cores != NULL) {
-        std::string msg_cores = "Hyperloop-run detected! Number of cores = ";
-        LOGP(info, msg_cores + std::string(alien_cores));
+        LOGP(info, "Hyperloop test/Grid job detected! Number of cores = {}. Setting threads anyway to 1.", alien_cores);
         activeThreads = 1;
       } else {
         if (networkSetNumThreads > 0) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -21,6 +21,7 @@
 
 // ROOT includes
 #include "TFile.h"
+#include "TSystem.h"
 
 // O2 includes
 #include "Framework/AnalysisTask.h"
@@ -96,6 +97,9 @@ struct tpcPidFull {
   Configurable<int> pidHe{"pid-he", -1, {"Produce PID information for the Helium3 mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
   Configurable<int> pidAl{"pid-al", -1, {"Produce PID information for the Alpha mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
 
+  // Thread configuration
+  int activeThreads = networkSetNumThreads.value;
+
   // Paramatrization configuration
   bool useCCDBParam = false;
 
@@ -115,6 +119,7 @@ struct tpcPidFull {
     enableFlag("He", pidHe);
     enableFlag("Al", pidAl);
 
+    /// TPC PID Response
     const TString fname = paramfile.value;
     if (fname != "") { // Loading the parametrization from file
       LOGP(info, "Loading TPC response from file {}", fname);
@@ -143,9 +148,26 @@ struct tpcPidFull {
       response.PrintAll();
     }
 
+    /// Neural network init for TPC PID
+
     if (!useNetworkCorrection) {
       return;
     } else {
+
+      /// Testing hyperloop core settings
+      const char* alien_cores = gSystem->Getenv("ALIEN_JDL_CPUCORES");
+      if(alien_cores!=NULL){
+        std::string msg_cores = "Hyperloop-run detected! Number of cores = ";
+        LOGP(info, msg_cores + std::string(alien_cores));
+        activeThreads = 1;
+      }
+      else{
+        if(networkSetNumThreads>0){
+          LOGP(info, "Not running on Hyperloop. Threads for neural network inference are fixed: {} threads", std::to_string(networkSetNumThreads));
+        }
+      }
+
+      /// CCDB and auto-fetching
       ccdbApi.init(url);
       if (!autofetchNetworks) {
         if (ccdbTimestamp > 0) {
@@ -165,7 +187,7 @@ struct tpcPidFull {
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
                              enableNetworkOptimizations.value,
-                             networkSetNumThreads.value);
+                             activeThreads);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {
@@ -179,7 +201,7 @@ struct tpcPidFull {
           LOG(info) << "Using local file [" << networkPathLocally.value << "] for the TPC PID response correction.";
           Network temp_net(networkPathLocally.value,
                            enableNetworkOptimizations.value,
-                           networkSetNumThreads.value);
+                           activeThreads);
           network = temp_net;
           network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
         }
@@ -238,7 +260,7 @@ struct tpcPidFull {
                              strtoul(headers["Valid-From"].c_str(), NULL, 0),
                              strtoul(headers["Valid-Until"].c_str(), NULL, 0),
                              enableNetworkOptimizations.value,
-                             networkSetNumThreads.value);
+                             activeThreads);
             network = temp_net;
             network.evalNetwork(std::vector<float>(network.getInputDimensions(), 1.)); // This is an initialisation and might reduce the overhead of the model
           } else {

--- a/Common/TableProducer/PID/pidTPCML.cxx
+++ b/Common/TableProducer/PID/pidTPCML.cxx
@@ -40,7 +40,8 @@ std::string Network::printShape(const std::vector<int64_t>& v)
 }
 
 Network::Network(std::string path,
-                 bool enableOptimization = true)
+                 bool enableOptimization = true,
+                 int numThreads = 0)
 {
 
   /*
@@ -57,6 +58,10 @@ Network::Network(std::string path,
   mEnv = std::make_shared<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "pid-neural-network");
   if (enableOptimization) {
     sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
+  }
+  if (numThreads > 0) {
+    // Setting the number of threads, potentially try: unsigned int nThreads = std::thread::hardware_concurrency();
+    sessionOptions.SetIntraOpNumThreads(numThreads);
   }
 
   mSession.reset(new Ort::Experimental::Session{*mEnv, path, sessionOptions});
@@ -83,7 +88,8 @@ Network::Network(std::string path,
 Network::Network(std::string path,
                  unsigned long start,
                  unsigned long end,
-                 bool enableOptimization = true)
+                 bool enableOptimization = true,
+                 int numThreads = 0)
 {
 
   /*
@@ -100,6 +106,10 @@ Network::Network(std::string path,
   mEnv = std::make_shared<Ort::Env>(ORT_LOGGING_LEVEL_WARNING, "pid-neural-network");
   if (enableOptimization) {
     sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
+  }
+  if (numThreads > 0) {
+    // Setting the number of threads, potentially try: unsigned int nThreads = std::thread::hardware_concurrency();
+    sessionOptions.SetIntraOpNumThreads(numThreads);
   }
 
   mSession.reset(new Ort::Experimental::Session{*mEnv, path, sessionOptions});

--- a/Common/TableProducer/PID/pidTPCML.cxx
+++ b/Common/TableProducer/PID/pidTPCML.cxx
@@ -17,15 +17,18 @@
 ///
 /// \brief    A class for loading an ONNX neural network and evaluating it for the TPC PID response
 ///
+
+// C++ and system includes
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
 #include <vector>
 
+// ROOT includes
 #include "TSystem.h"
 
 // O2 includes
 #include "Framework/Logger.h"
 #include "Common/TableProducer/PID/pidTPCML.h"
 #include "ReconstructionDataFormats/PID.h"
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
 
 namespace o2::pid::tpc
 {
@@ -86,8 +89,8 @@ Network::Network(std::string path,
 } // Network::Network(std::string, bool)
 
 Network::Network(std::string path,
-                 unsigned long start,
-                 unsigned long end,
+                 uint64_t start,
+                 uint64_t end,
                  bool enableOptimization = true,
                  int numThreads = 0)
 {
@@ -96,8 +99,8 @@ Network::Network(std::string path,
   Constructor: Creating a class instance from a file and enabling optimizations with the boolean option.
   - Input:
     -- path:                std::string   ; Local path to the model file;
-    -- start:               unsigned long ; Timestamp validity of model (start)
-    -- pathAlien:           unsigned long ; Timestamp validity of model (end)
+    -- start:               uint64_t ; Timestamp validity of model (start)
+    -- pathAlien:           uint64_t ; Timestamp validity of model (end)
     -- enableOptimization:  bool          ; enabling optimizations for the loaded model in the session options;
   */
 
@@ -135,7 +138,7 @@ Network::Network(std::string path,
 
   LOG(info) << "--- Network initialized! ---";
 
-} // Network::Network(std::string, unsigned long, unsigned long, bool)
+} // Network::Network(std::string, uint64_t, uint64_t, bool)
 
 Network& Network::operator=(Network& inst)
 {

--- a/Common/TableProducer/PID/pidTPCML.h
+++ b/Common/TableProducer/PID/pidTPCML.h
@@ -18,15 +18,18 @@
 /// \brief    A class for loading an ONNX neural network and evaluating it for the TPC PID response
 ///
 
-#ifndef O2_PID_TPC_ML_H_
-#define O2_PID_TPC_ML_H_
+#ifndef COMMON_TABLEPRODUCER_PID_PIDTPCML_H_
+#define COMMON_TABLEPRODUCER_PID_PIDTPCML_H_
 
-// O2 includes
-#include "ReconstructionDataFormats/PID.h"
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+// C++ and system includes
 #include <vector>
 #include <array>
 #include <string>
+#include <memory>
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+
+// O2 includes
+#include "ReconstructionDataFormats/PID.h"
 
 namespace o2::pid::tpc
 {
@@ -82,4 +85,4 @@ class Network
 
 } // namespace o2::pid::tpc
 
-#endif // O2_PID_TPC_ML_H_
+#endif // COMMON_TABLEPRODUCER_PID_PIDTPCML_H_

--- a/Common/TableProducer/PID/pidTPCML.h
+++ b/Common/TableProducer/PID/pidTPCML.h
@@ -54,7 +54,7 @@ class Network
   // Getters & Setters
   int getInputDimensions() const { return mInputShapes[0][1]; }
   int getOutputDimensions() const { return mOutputShapes[0][1]; }
-  uint64_t  getValidityFrom() const { return valid_from; }
+  uint64_t getValidityFrom() const { return valid_from; }
   uint64_t getValidityUntil() const { return valid_until; }
   void setValidityFrom(uint64_t t) { valid_from = t; }
   void setValidityUntil(uint64_t t) { valid_until = t; }

--- a/Common/TableProducer/PID/pidTPCML.h
+++ b/Common/TableProducer/PID/pidTPCML.h
@@ -76,7 +76,7 @@ class Network
   std::string printShape(const std::vector<int64_t>& v);
 
   // Class version
-  ClassDefNV(Network, 3);
+  ClassDefNV(Network, 4);
 
 }; // class Network
 

--- a/Common/TableProducer/PID/pidTPCML.h
+++ b/Common/TableProducer/PID/pidTPCML.h
@@ -36,8 +36,8 @@ class Network
  public:
   // Constructor, destructor and copy-constructor
   Network() = default;
-  Network(std::string, bool);
-  Network(std::string, unsigned long, unsigned long, bool); // initialization with timestamps
+  Network(std::string, bool, int);
+  Network(std::string, unsigned long, unsigned long, bool, int); // initialization with timestamps
   ~Network() = default;
 
   // Operators

--- a/Common/TableProducer/PID/pidTPCML.h
+++ b/Common/TableProducer/PID/pidTPCML.h
@@ -22,11 +22,11 @@
 #define COMMON_TABLEPRODUCER_PID_PIDTPCML_H_
 
 // C++ and system includes
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
 #include <vector>
 #include <array>
 #include <string>
 #include <memory>
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
 
 // O2 includes
 #include "ReconstructionDataFormats/PID.h"
@@ -40,7 +40,7 @@ class Network
   // Constructor, destructor and copy-constructor
   Network() = default;
   Network(std::string, bool, int);
-  Network(std::string, unsigned long, unsigned long, bool, int); // initialization with timestamps
+  Network(std::string, uint64_t, uint64_t, bool, int); // initialization with timestamps
   ~Network() = default;
 
   // Operators
@@ -54,15 +54,15 @@ class Network
   // Getters & Setters
   int getInputDimensions() const { return mInputShapes[0][1]; }
   int getOutputDimensions() const { return mOutputShapes[0][1]; }
-  unsigned long getValidityFrom() const { return valid_from; }
-  unsigned long getValidityUntil() const { return valid_until; }
-  void setValidityFrom(unsigned long t) { valid_from = t; }
-  void setValidityUntil(unsigned long t) { valid_until = t; }
+  uint64_t  getValidityFrom() const { return valid_from; }
+  uint64_t getValidityUntil() const { return valid_until; }
+  void setValidityFrom(uint64_t t) { valid_from = t; }
+  void setValidityUntil(uint64_t t) { valid_until = t; }
 
  private:
   // Range of validity in timestamps
-  unsigned long valid_from = 0;
-  unsigned long valid_until = 0;
+  uint64_t valid_from = 0;
+  uint64_t valid_until = 0;
 
   // Environment variables for the ONNX runtime
   std::shared_ptr<Ort::Env> mEnv = nullptr;


### PR DESCRIPTION
It was noticed that upon running within singularity containers on a SLURM cluster, ONNX has difficulties to allocate the correct resources if the number of CPU's is limited. A manually set value for the number of available threads fixed this issue. This should not affect the code any further, since the default value lets ONNX choose the number of threads automatically.