### PR TITLE
PWGDQ: Add task for dalitz selection

### DIFF
--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -55,6 +55,68 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("DalitzCut1")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+    cut->AddCut(GetAnalysisCut("SPDany"));
+    cut->AddCut(GetAnalysisCut("electronPIDOnly"));
+    return cut;
+  }
+
+  if (!nameStr.compare("DalitzCut2")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+    cut->AddCut(GetAnalysisCut("SPDany"));
+    cut->AddCut(GetAnalysisCut("electronPIDPrKaPiRej"));
+    return cut;
+  }
+
+  if (!nameStr.compare("DalitzCut1SPDfirst")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+    cut->AddCut(GetAnalysisCut("SPDfirst"));
+    cut->AddCut(GetAnalysisCut("electronPIDOnly"));
+    return cut;
+  }
+
+  if (!nameStr.compare("DalitzCut2SPDfirst")) {
+    cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+    cut->AddCut(GetAnalysisCut("SPDfirst"));
+    cut->AddCut(GetAnalysisCut("electronPIDPrKaPiRej"));
+    return cut;
+  }
+
+  for (int i = 1; i <= 8; i++) {
+    if (!nameStr.compare(Form("DalitzCut1_dalitzSelected%d", i))) {
+      cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+      cut->AddCut(GetAnalysisCut("SPDany"));
+      cut->AddCut(GetAnalysisCut("electronPIDOnly"));
+      cut->AddCut(GetAnalysisCut(Form("dalitzLeg%d", i)));
+      return cut;
+    }
+
+    if (!nameStr.compare(Form("DalitzCut2_dalitzSelected%d", i))) {
+      cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+      cut->AddCut(GetAnalysisCut("SPDany"));
+      cut->AddCut(GetAnalysisCut("electronPIDPrKaPiRej"));
+      cut->AddCut(GetAnalysisCut(Form("dalitzLeg%d", i)));
+      return cut;
+    }
+
+    if (!nameStr.compare(Form("DalitzCut1SPDfirst_dalitzSelected%d", i))) {
+      cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+      cut->AddCut(GetAnalysisCut("SPDfirst"));
+      cut->AddCut(GetAnalysisCut("electronPIDOnly"));
+      cut->AddCut(GetAnalysisCut(Form("dalitzLeg%d", i)));
+      return cut;
+    }
+
+    if (!nameStr.compare(Form("DalitzCut2SPDfirst_dalitzSelected%d", i))) {
+      cut->AddCut(GetAnalysisCut("PIDStandardKine"));
+      cut->AddCut(GetAnalysisCut("SPDfirst"));
+      cut->AddCut(GetAnalysisCut("electronPIDPrKaPiRej"));
+      cut->AddCut(GetAnalysisCut(Form("dalitzLeg%d", i)));
+      return cut;
+    }
+  }
+
   if (!nameStr.compare("jpsiO2MCdebugCuts2")) {
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
@@ -66,6 +128,14 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
     cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
     cut->AddCut(GetAnalysisCut("jpsi_TPCPID_debug2"));
+    return cut;
+  }
+
+  if (!nameStr.compare("jpsiO2MCdebugCuts2_prefiltered1")) {
+    cut->AddCut(GetAnalysisCut("jpsiStandardKine"));
+    cut->AddCut(GetAnalysisCut("electronStandardQualityForO2MCdebug"));
+    cut->AddCut(GetAnalysisCut("electronPIDnsigma"));
+    cut->AddCut(GetAnalysisCut("notDalitzLeg1"));
     return cut;
   }
 
@@ -563,12 +633,29 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("pairMassLow1"));
     return cut;
   }
+
   if (!nameStr.compare("pairMassLow2")) {
     cut->AddCut(GetAnalysisCut("pairMassLow2"));
     return cut;
   }
+
   if (!nameStr.compare("pairMassLow3")) {
     cut->AddCut(GetAnalysisCut("pairMassLow3"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz1")) {
+    cut->AddCut(GetAnalysisCut("pairDalitz1"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz2")) {
+    cut->AddCut(GetAnalysisCut("pairDalitz2"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz3")) {
+    cut->AddCut(GetAnalysisCut("pairDalitz3"));
     return cut;
   }
 
@@ -648,7 +735,6 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kEta, -0.9, 0.9);
     return cut;
   }
-
   if (!nameStr.compare("jpsi_trackCut_debug")) {
     cut->AddCut(VarManager::kEta, -0.9, 0.9);
     cut->AddCut(VarManager::kTPCchi2, 0.0, 4.0);
@@ -763,6 +849,16 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCchi2, 0.0, 4.0);
     cut->AddCut(VarManager::kITSchi2, 0.1, 36.0);
     cut->AddCut(VarManager::kTPCncls, 70.0, 161.);
+    return cut;
+  }
+
+  if (!nameStr.compare("SPDfirst")) {
+    cut->AddCut(VarManager::kIsSPDfirst, 0.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("SPDany")) {
+    cut->AddCut(VarManager::kIsSPDany, 0.5, 1.5);
     return cut;
   }
 
@@ -883,6 +979,19 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPr, 2.7, 3000.0);
     cut->AddCut(VarManager::kTPCnSigmaPi, 2.7, 3000.0);
+    return cut;
+  }
+
+  if (!nameStr.compare("electronPIDPrKaPiRej")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
+    cut->AddCut(VarManager::kTPCnSigmaPr, -3.0, 3.0, true);
+    cut->AddCut(VarManager::kTPCnSigmaPi, -3.0, 3.0, true);
+    cut->AddCut(VarManager::kTPCnSigmaKa, -3.0, 3.0, true);
+    return cut;
+  }
+
+  if (!nameStr.compare("electronPIDOnly")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl, -3.0, 3.0);
     return cut;
   }
 
@@ -1010,6 +1119,18 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
+  for (int i = 1; i <= 8; i++) {
+    if (!nameStr.compare(Form("dalitzLeg%d", i))) {
+      cut->AddCut(VarManager::kIsDalitzLeg + i - 1, 0.5, 1.5);
+      return cut;
+    }
+
+    if (!nameStr.compare(Form("notDalitzLeg%d", i))) {
+      cut->AddCut(VarManager::kIsDalitzLeg + i - 1, -0.5, 0.5);
+      return cut;
+    }
+  }
+
   if (!nameStr.compare("muonQualityCuts")) {
     cut->AddCut(VarManager::kEta, -4.0, -2.5);
     cut->AddCut(VarManager::kMuonRAtAbsorberEnd, 17.6, 89.5);
@@ -1083,6 +1204,28 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
 
   if (!nameStr.compare("matchedGlobal")) {
     cut->AddCut(VarManager::kMuonTrackType, -0.5, 0.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz1")) {
+    cut->AddCut(VarManager::kMass, 0.0, 0.015, false, VarManager::kPt, 0., 1.);
+    cut->AddCut(VarManager::kMass, 0.0, 0.035, false, VarManager::kPt, 0., 1., true);
+    TF1* fcutHigh = new TF1("f1", "[0] - [0]/[1]*x", -1.5, 1.5);
+    fcutHigh->SetParameters(0.6, 0.12);
+    TF1* fcutLow = new TF1("f2", "-[0] + [0]/[1]*x", -1.5, 1.5);
+    fcutLow->SetParameters(0.6, 0.12);
+    cut->AddCut(VarManager::kPsiPair, fcutLow, fcutHigh, true, VarManager::kDeltaPhiPair, 0, 0.12);
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz2")) {
+    cut->AddCut(VarManager::kMass, 0.0, 0.015, false, VarManager::kPt, 0., 1.);
+    cut->AddCut(VarManager::kMass, 0.0, 0.035, false, VarManager::kPt, 0., 1., true);
+    return cut;
+  }
+
+  if (!nameStr.compare("pairDalitz3")) {
+    cut->AddCut(VarManager::kMass, 0.0, 0.15);
     return cut;
   }
 

--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -302,6 +302,11 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "cosThetaHE", "", false, 100, -1., 1., VarManager::kCosThetaHE);
       hm->AddHistogram(histClass, "PhiV", "", false, 100, 0.0, 3.2, VarManager::kPairPhiv);
       hm->AddHistogram(histClass, "Mass_Pt_PhiV", "", false, 125, 0.0, 5.0, VarManager::kMass, 100, 0.0, 20.0, VarManager::kPt, 100, 0.0, 3.2, VarManager::kPairPhiv);
+      if (subGroupStr.Contains("dalitz")) {
+        hm->AddHistogram(histClass, "MassLow", "", false, 500, 0.0, 0.5, VarManager::kMass);
+        hm->AddHistogram(histClass, "PsiPair", "", false, 200, -1.5, 1.5, VarManager::kPsiPair);
+        hm->AddHistogram(histClass, "PsiPair_DeltaPhi", "", false, 100, -0.5, 0.5, VarManager::kDeltaPhiPair, 100, -1.5, 1.5, VarManager::kPsiPair);
+      }
       if (subGroupStr.Contains("lmee")) {
         hm->AddHistogram(histClass, "QuadDCAabsXY", "", false, 100, -0.0, 1.0, VarManager::kQuadDCAabsXY);
       }

--- a/PWGDQ/Core/MCSignalLibrary.h
+++ b/PWGDQ/Core/MCSignalLibrary.h
@@ -276,6 +276,11 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
 
   // LMEE single signals
+  if (!nameStr.compare("eFromPhoton")) {
+    MCProng prong(2, {11, 22}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    signal = new MCSignal(name, "Electrons from photon conversion", {prong}, {-1});
+    return signal;
+  }
   if (!nameStr.compare("eFromPi0")) {
     MCProng prong(2, {11, 111}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "Electrons from pi0 decays", {prong}, {-1});

--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -449,6 +449,10 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kDeltaPhiSym] = "rad.";
   fgVariableNames[kCosThetaHE] = "cos#it{#theta}";
   fgVariableUnits[kCosThetaHE] = "";
+  fgVariableNames[kPsiPair] = "#Psi_{pair}";
+  fgVariableUnits[kPsiPair] = "rad.";
+  fgVariableNames[kDeltaPhiPair] = "#Delta#phi";
+  fgVariableUnits[kDeltaPhiPair] = "rad.";
   fgVariableNames[kQuadDCAabsXY] = "DCA_{xy}^{quad}";
   fgVariableUnits[kQuadDCAabsXY] = "cm";
   fgVariableNames[kQuadDCAsigXY] = "DCA_{xy}^{quad}";

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -242,7 +242,7 @@ class VarManager : public TObject
     kIsLegFromAntiLambda,
     kIsLegFromOmega,
     kIsProtonFromLambdaAndAntiLambda,
-    kIsDalitzLeg,  // Up to 8 dalitz selections
+    kIsDalitzLeg, // Up to 8 dalitz selections
     kNBarrelTrackVariables = kIsDalitzLeg + 8,
 
     // Muon track variables
@@ -684,11 +684,10 @@ void VarManager::FillTrack(T const& track, float* values)
       values[kIsLegFromOmega] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 6));
 
       values[kIsProtonFromLambdaAndAntiLambda] = static_cast<bool>((values[kIsLegFromLambda] * track.sign() > 0) || (values[kIsLegFromAntiLambda] * (-track.sign()) > 0));
-      
+
       for (int i = 0; i < 8; i++) {
         values[kIsDalitzLeg + i] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << (15 + i)));
       }
-
     }
   }
 
@@ -799,7 +798,7 @@ void VarManager::FillTrack(T const& track, float* values)
   }
 
   // Quantities based on the dalitz selections
-  if constexpr((fillMap & DalitzBits) > 0) {
+  if constexpr ((fillMap & DalitzBits) > 0) {
     for (int i = 0; i < 8; i++) {
       values[kIsDalitzLeg + i] = bool(track.dalitzBits() & (uint8_t(1) << i));
     }

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -686,7 +686,7 @@ void VarManager::FillTrack(T const& track, float* values)
       values[kIsProtonFromLambdaAndAntiLambda] = static_cast<bool>((values[kIsLegFromLambda] * track.sign() > 0) || (values[kIsLegFromAntiLambda] * (-track.sign()) > 0));
 
       for (int i = 0; i < 8; i++) {
-        values[kIsDalitzLeg + i] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << (15 + i)));
+        values[kIsDalitzLeg + i] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << (7 + i)));
       }
     }
   }

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -477,6 +477,13 @@ DECLARE_SOA_TABLE(V0Bits, "AOD", "V0BITS", //!
 // iterators
 using V0Bit = V0Bits::iterator;
 
+namespace DalBits
+{
+DECLARE_SOA_COLUMN(DALITZBits, dalitzBits, int); //!
+} // namespace DalBits
+
+// bit information for particle species.
+DECLARE_SOA_TABLE(DalitzBits, "AOD", "DALITZBITS", DalBits::DALITZBits);
 } // namespace o2::aod
 
 #endif // O2_Analysis_ReducedInfoTables_H_

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -479,7 +479,7 @@ using V0Bit = V0Bits::iterator;
 
 namespace DalBits
 {
-DECLARE_SOA_COLUMN(DALITZBits, dalitzBits, int); //!
+DECLARE_SOA_COLUMN(DALITZBits, dalitzBits, uint8_t); //!
 } // namespace DalBits
 
 // bit information for particle species.

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -61,10 +61,10 @@ using MyBarrelTracksWithV0Bits = soa::Join<aod::Tracks, aod::TracksExtra, aod::T
                                            aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
                                            aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta, aod::V0Bits>;
 using MyBarrelTracksWithDalitzBits = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA, aod::TrackSelection,
-                                           aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
-                                           aod::pidTPCFullKa, aod::pidTPCFullPr,
-                                           aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
-                                           aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta, aod::DalitzBits>;
+                                               aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                               aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                               aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                               aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta, aod::DalitzBits>;
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
 using MyEventsWithFilter = soa::Join<aod::Collisions, aod::EvSels, aod::DQEventFilter>;
 using MyEventsWithCent = soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>;

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -358,11 +358,11 @@ struct TableMaker {
             }
           }
         }
-
-        trackFilteringTag |= (uint64_t(trackTempFilterMap) << 7); // BIT7-14:  user track filters
         if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
-          trackFilteringTag |= (uint64_t(track.dalitzBits()) << 15); // BIT15-...: Dalitz
+          trackFilteringTag |= (uint64_t(track.dalitzBits()) << 7); // BIT7-14: Dalitz
         }
+        trackFilteringTag |= (uint64_t(trackTempFilterMap) << 15); // BIT15-...:  user track filters
+
 
         // create the track tables
         trackBasic(event.lastIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), isAmbiguous);

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -363,7 +363,6 @@ struct TableMaker {
         }
         trackFilteringTag |= (uint64_t(trackTempFilterMap) << 15); // BIT15-...:  user track filters
 
-
         // create the track tables
         trackBasic(event.lastIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), isAmbiguous);
         trackBarrel(track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -160,7 +160,7 @@ struct TableMaker {
                                context.mOptions.get<bool>("processFullWithCent") ||
                                context.mOptions.get<bool>("processBarrelOnly") || context.mOptions.get<bool>("processBarrelOnlyWithCent") ||
                                context.mOptions.get<bool>("processBarrelOnlyWithCov") || context.mOptions.get<bool>("processBarrelOnlyWithEventFilter") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits");
+                               context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits"));
     bool enableMuonHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
                              context.mOptions.get<bool>("processFullWithCent") ||
                              context.mOptions.get<bool>("processMuonOnly") || context.mOptions.get<bool>("processMuonOnlyWithCent") ||

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -438,7 +438,6 @@ struct TableMakerMC {
           }
           trackFilteringTag |= (uint64_t(trackTempFilterMap) << 15); // BIT15-...:  user track filters
 
-
           mcflags = 0;
           i = 0;     // runs over the MC signals
           int j = 0; // runs over the track cuts

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -433,10 +433,11 @@ struct TableMakerMC {
               }
             }
           }
-          trackFilteringTag |= (uint64_t(trackTempFilterMap) << 7); // BIT7-14:  user track filters
           if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
-            trackFilteringTag |= (uint64_t(track.dalitzBits()) << 15); // BIT15-...: Dalitz
+            trackFilteringTag |= (uint64_t(track.dalitzBits()) << 7); // BIT7-14: Dalitz
           }
+          trackFilteringTag |= (uint64_t(trackTempFilterMap) << 15); // BIT15-...:  user track filters
+
 
           mcflags = 0;
           i = 0;     // runs over the MC signals

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -34,7 +34,13 @@ o2physics_add_dpl_workflow(v0-selector
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore  O2::DetectorsVertexing
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(dalitz-selection
+                    SOURCES DalitzSelection.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(flow
                     SOURCES dqFlow.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore O2Physics::GFWCore
                     COMPONENT_NAME Analysis)
+

--- a/PWGDQ/Tasks/DalitzSelection.cxx
+++ b/PWGDQ/Tasks/DalitzSelection.cxx
@@ -278,7 +278,7 @@ struct dalitzPairing {
       }
     }
 
-    for (auto& track : tracks) {// Fill dalitz bits
+    for (auto& track : tracks) { // Fill dalitz bits
       dalitzbits(static_cast<int>(dalitzmap[track.globalIndex()]));
     }
   }

--- a/PWGDQ/Tasks/DalitzSelection.cxx
+++ b/PWGDQ/Tasks/DalitzSelection.cxx
@@ -40,19 +40,15 @@ using namespace o2::soa;
 using std::array;
 
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
-using MyReducedEvents = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended>;
 
 using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA,
                                  aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullMu,
                                  aod::pidTPCFullKa, aod::pidTPCFullPr,
                                  aod::pidTOFFullEl, aod::pidTOFFullPi, aod::pidTOFFullMu,
                                  aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
-using BarrelReducedTracks = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelPID>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackPID;
-constexpr static uint32_t gkReducedEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
-constexpr static uint32_t gkReducedTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID;
 
 struct dalitzPairing {
   Produces<o2::aod::DalitzBits> dalitzbits;

--- a/PWGDQ/Tasks/DalitzSelection.cxx
+++ b/PWGDQ/Tasks/DalitzSelection.cxx
@@ -279,7 +279,7 @@ struct dalitzPairing {
     }
 
     for (auto& track : tracks) { // Fill dalitz bits
-      dalitzbits(static_cast<int>(dalitzmap[track.globalIndex()]));
+      dalitzbits(dalitzmap[track.globalIndex()]);
     }
   }
 

--- a/PWGDQ/Tasks/DalitzSelection.cxx
+++ b/PWGDQ/Tasks/DalitzSelection.cxx
@@ -1,0 +1,298 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+//                Task to select electrons from dalitz decay
+//        It can produce track and pair histograms for selected tracks
+//      It creates a bitmap with selections to be stored during skimming
+//
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/DataTypes.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/CCDB/TriggerAliases.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+#include "PWGDQ/Core/VarManager.h"
+#include "PWGDQ/Core/HistogramManager.h"
+#include "PWGDQ/Core/AnalysisCut.h"
+#include "PWGDQ/Core/AnalysisCompositeCut.h"
+#include "PWGDQ/Core/HistogramsLibrary.h"
+#include "PWGDQ/Core/CutsLibrary.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod;
+using namespace o2::soa;
+using std::array;
+
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyReducedEvents = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended>;
+
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA,
+                                 aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullMu,
+                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                 aod::pidTOFFullEl, aod::pidTOFFullPi, aod::pidTOFFullMu,
+                                 aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
+using BarrelReducedTracks = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelPID>;
+
+constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::Collision;
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackPID;
+constexpr static uint32_t gkReducedEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
+constexpr static uint32_t gkReducedTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID;
+
+struct dalitzPairing {
+  Produces<o2::aod::DalitzBits> dalitzbits;
+  Preslice<MyBarrelTracks> perCollision = aod::track::collisionId;
+
+  // Configurables
+  Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandardNoINT7", "Event selection"};
+  Configurable<std::string> fConfigDalitzTrackCuts{"cfgDalitzTrackCuts", "", "Dalitz track selection cuts, separated by a comma"};
+  Configurable<std::string> fConfigDalitzPairCuts{"cfgDalitzPairCuts", "", "Dalitz pair selection cuts"};
+  Configurable<std::string> fConfigAddTrackHistogram{"cfgAddTrackHistogram", "", "Comma separated list of histograms"};
+  Configurable<bool> fQA{"cfgQA", true, "QA histograms"};
+  Configurable<float> fConfigBarrelTrackPINLow{"cfgBarrelLowPIN", 0.1f, "Low pt cut for Dalitz tracks in the barrel"};
+  Configurable<float> fConfigEtaCut{"cfgEtaCut", 0.9f, "Eta cut for Dalitz tracks in the barrel"};
+  Configurable<float> fConfigTPCNSigLow{"cfgTPCNSigElLow", -3.f, "Low TPCNSigEl cut for Dalitz tracks in the barrel"};
+  Configurable<float> fConfigTPCNSigHigh{"cfgTPCNSigElHigh", 3.f, "High TPCNsigEl cut for Dalitz tracks in the barrel"};
+
+  Filter filterBarrelTrack = o2::aod::track::tpcInnerParam >= fConfigBarrelTrackPINLow && nabs(o2::aod::track::eta) <= fConfigEtaCut && o2::aod::pidtpc::tpcNSigmaEl <= fConfigTPCNSigHigh && o2::aod::pidtpc::tpcNSigmaEl >= fConfigTPCNSigLow;
+
+  OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
+  OutputObj<TList> fStatsList{"Statistics"};  //! skimming statistics
+
+  std::map<int, uint8_t> trackmap;
+  std::map<int, uint8_t> dalitzmap;
+
+  AnalysisCompositeCut* fEventCut;
+  std::vector<AnalysisCompositeCut> fTrackCuts;
+  std::vector<AnalysisCompositeCut> fPairCuts;
+  int nCuts = 0;
+
+  HistogramManager* fHistMan;
+
+  void init(o2::framework::InitContext&)
+  {
+    // Event cuts
+    fEventCut = new AnalysisCompositeCut(true);
+    TString eventCutStr = fConfigEventCuts.value;
+    fEventCut->AddCut(dqcuts::GetAnalysisCut(eventCutStr.Data()));
+
+    // Barrel track cuts
+    TString cutNamesStr = fConfigDalitzTrackCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    // Pair cuts
+    TString cutNamesPairStr = fConfigDalitzPairCuts.value;
+    if (!cutNamesPairStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesPairStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fPairCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    if (fTrackCuts.size() != fPairCuts.size()) {
+      std::cout << "WARNING: YOU SHOULD PROVIDE THE SAME NUMBER OF TRACK AND PAIR CUTS" << std::endl;
+    }
+    nCuts = std::min(fTrackCuts.size(), fPairCuts.size());
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+    VarManager::SetDefaultVarNames();
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+    fHistMan->SetUseDefaultVariableNames(kTRUE);
+    fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    // Create the histogram class names to be added to the histogram manager
+    TString histClasses = "";
+
+    if (fQA) {
+      for (int icut = 0; icut < nCuts; icut++) {
+        AnalysisCompositeCut trackCut = fTrackCuts.at(icut);
+        AnalysisCompositeCut pairCut = fPairCuts.at(icut);
+        histClasses += Form("TrackBarrel_%s_%s;", trackCut.GetName(), pairCut.GetName());
+        histClasses += Form("Pair_%s_%s;", trackCut.GetName(), pairCut.GetName());
+      }
+    }
+
+    // Define histograms
+
+    std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+    for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+      TString classStr = objArray->At(iclass)->GetName();
+      fHistMan->AddHistClass(classStr.Data());
+
+      if (classStr.Contains("Event")) {
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "event", "");
+      }
+      TString histTrackName = fConfigAddTrackHistogram.value;
+      if (classStr.Contains("Track")) {
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", histTrackName);
+      }
+
+      if (classStr.Contains("Pair")) {
+        dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "pair", "barreldalitz");
+      }
+    }
+
+    fStatsList.setObject(new TList());
+    fStatsList->SetOwner(kTRUE);
+
+    // Dalitz selection statistics: one bin for each (track,pair) selection
+    TH1I* histTracks = new TH1I("TrackStats", "Dalitz selection statistics", nCuts, -0.5, nCuts - 0.5);
+    for (int icut = 0; icut < nCuts; icut++) {
+      AnalysisCompositeCut trackCut = fTrackCuts.at(icut);
+      AnalysisCompositeCut pairCut = fPairCuts.at(icut);
+      histTracks->GetXaxis()->SetBinLabel(icut + 1, Form("%s_%s", trackCut.GetName(), pairCut.GetName()));
+    }
+    if (fQA) {
+      fStatsList->Add(histTracks);
+    }
+
+    VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+  }
+
+  template <uint32_t TTrackFillMap, typename TTracks>
+  void runTrackSelection(TTracks const& tracksBarrel)
+  {
+    for (auto& track : tracksBarrel) {
+      uint8_t filterMap = uint8_t(0);
+      VarManager::FillTrack<TTrackFillMap>(track);
+      int i = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMap |= (uint8_t(1) << i);
+        }
+      }
+      if (filterMap) {
+        trackmap[track.globalIndex()] = filterMap;
+      }
+    } // end loop over tracks
+  }
+
+  template <uint32_t TTrackFillMap, typename TTracks>
+  void runDalitzPairing(TTracks const& tracks1, TTracks const& tracks2)
+  {
+    const int TPairType = VarManager::kDecayToEE; // For dielectron
+    for (auto& [track1, track2] : o2::soa::combinations(CombinationsStrictlyUpperIndexPolicy(tracks1, tracks2))) {
+      if (track1.sign() * track2.sign() > 0) {
+        continue;
+      }
+
+      uint8_t twoTracksFilterMap = trackmap[track1.globalIndex()] & trackmap[track2.globalIndex()];
+      if (!twoTracksFilterMap)
+        continue;
+
+      // pairing
+      VarManager::FillPair<TPairType, TTrackFillMap>(track1, track2);
+      uint8_t track1Untagged = uint8_t(0);
+      uint8_t track2Untagged = uint8_t(0);
+
+      // Fill pair selection map and fill pair histogram
+      for (int icut = 0; icut < nCuts; icut++) {
+        if (!(twoTracksFilterMap & (uint8_t(1) << icut)))
+          continue;
+        AnalysisCompositeCut pairCut = fPairCuts.at(icut);
+        if (pairCut.IsSelected(VarManager::fgValues)) {
+          if (fQA) {
+            AnalysisCompositeCut trackCut = fTrackCuts.at(icut);
+            fHistMan->FillHistClass(Form("Pair_%s_%s", trackCut.GetName(), pairCut.GetName()), VarManager::fgValues);
+          }
+
+          // Check if tracks were already tagged
+          bool b1 = dalitzmap[track1.globalIndex()] & (uint8_t(1) << icut);
+          if (!b1) {
+            track1Untagged |= (uint8_t(1) << icut);
+            if (fQA) {
+              ((TH1I*)fStatsList->At(0))->Fill(icut);
+            }
+          }
+          bool b2 = dalitzmap[track2.globalIndex()] & (uint8_t(1) << icut);
+          if (!b2) {
+            track2Untagged |= (uint8_t(1) << icut);
+            if (fQA) {
+              ((TH1I*)fStatsList->At(0))->Fill(icut);
+            }
+          }
+        }
+      }
+
+      // Tag tracks which are not already tagged
+      dalitzmap[track1.globalIndex()] |= track1Untagged;
+      dalitzmap[track2.globalIndex()] |= track2Untagged;
+
+      // Fill track histograms if not already tagged
+      if (fQA) {
+        VarManager::FillTrack<TTrackFillMap>(track1);
+        for (int icut = 0; icut < nCuts; icut++) {
+          if (track1Untagged & (uint8_t(1) << icut)) {
+            AnalysisCompositeCut trackCut = fTrackCuts.at(icut);
+            AnalysisCompositeCut pairCut = fPairCuts.at(icut);
+            fHistMan->FillHistClass(Form("TrackBarrel_%s_%s", trackCut.GetName(), pairCut.GetName()), VarManager::fgValues);
+          }
+        }
+        VarManager::FillTrack<TTrackFillMap>(track2);
+        for (int icut = 0; icut < nCuts; icut++) {
+          if (track2Untagged & (uint8_t(1) << icut)) {
+            AnalysisCompositeCut trackCut = fTrackCuts.at(icut);
+            AnalysisCompositeCut pairCut = fPairCuts.at(icut);
+            fHistMan->FillHistClass(Form("TrackBarrel_%s_%s", trackCut.GetName(), pairCut.GetName()), VarManager::fgValues);
+          }
+        }
+      }
+    } // end of tracksP,N loop
+  }
+
+  void processFullTracks(MyEvents const& collisions, soa::Filtered<MyBarrelTracks> const& filteredTracks, MyBarrelTracks const& tracks)
+  {
+    dalitzmap.clear();
+
+    for (auto& collision : collisions) {
+      trackmap.clear();
+      VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
+      VarManager::FillEvent<gkEventFillMap>(collision);
+      bool isEventSelected = fEventCut->IsSelected(VarManager::fgValues);
+
+      if (isEventSelected) {
+        auto groupedFilteredTracks = filteredTracks.sliceBy(perCollision, collision.globalIndex());
+        runTrackSelection<gkTrackFillMap>(groupedFilteredTracks);
+        runDalitzPairing<gkTrackFillMap>(groupedFilteredTracks, groupedFilteredTracks);
+      }
+    }
+
+    for (auto& track : tracks) {// Fill dalitz bits
+      dalitzbits(static_cast<int>(dalitzmap[track.globalIndex()]));
+    }
+  }
+
+  void processDummy(MyEvents&)
+  {
+  }
+
+  PROCESS_SWITCH(dalitzPairing, processFullTracks, "Run Dalitz selection on AO2D tables", false);
+  PROCESS_SWITCH(dalitzPairing, processDummy, "Do nothing", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<dalitzPairing>(cfgc)};
+}


### PR DESCRIPTION
Adding DalitzSelection.cxx for selecting electrons from dalitz decays (running on framework)
Keeping information from the dalitz Selections in tableMaker and tableMakerMC
AnalysisPrefilterSelection in the tableReader to run dalitz selection and prefilter