### PR TITLE
cpplint: Ignore unapproved C++11 headers

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-build/namespaces,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo
+filter=-build/c++11,-build/namespaces,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo


### PR DESCRIPTION
This category of errors seems to be only related to Chromium development.
See
- https://stackoverflow.com/questions/33653326/google-style-guide-chrono-is-an-unapproved-c11-header
- https://github.com/iotaledger/entangled/issues/213