### PR TITLE
MegaLinter: Make concurrency groups unique per PR

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -11,7 +11,7 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ env.PR_NUMBER }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -11,7 +11,7 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ env.PR_NUMBER }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
@TimoWilken I suspect that this has been causing cancellation of the action runs due to ongoing checks in other PRs.
Could you please check?