### PR TITLE
PWGCF: Add column to FemtoDreamCollision table for charge particle multiplicity

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -28,6 +28,7 @@ namespace o2::aod
 namespace femtodreamcollision
 {
 DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
+DECLARE_SOA_COLUMN(MultNtrPV, multNtrPV, float);   //! multiplicity of charged tracks contributing to the primary vertex
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
 DECLARE_SOA_COLUMN(MagField, magField, float);     //! Sphericity of the event
 
@@ -37,6 +38,7 @@ DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",
                   o2::soa::Index<>,
                   o2::aod::collision::PosZ,
                   femtodreamcollision::MultV0M,
+                  femtodreamcollision::MultNtrPV,
                   femtodreamcollision::Sphericity,
                   femtodreamcollision::MagField);
 using FemtoDreamCollision = FemtoDreamCollisions::iterator;

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -9,9 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODERIVED_H_
-#define ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODERIVED_H_
+#ifndef PWGCF_DATAMODEL_FEMTODERIVED_H_
+#define PWGCF_DATAMODEL_FEMTODERIVED_H_
 
+#include <cmath>
 #include "Framework/ASoA.h"
 #include "MathUtils/Utils.h"
 #include "Framework/DataTypes.h"
@@ -20,7 +21,6 @@
 #include "Framework/Expressions.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/PIDResponse.h"
-#include <cmath>
 
 namespace o2::aod
 {
@@ -220,4 +220,4 @@ using Hash = Hashes::iterator;
 
 } // namespace o2::aod
 
-#endif /* ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODERIVED_H_ */
+#endif // PWGCF_DATAMODEL_FEMTODERIVED_H_

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -60,8 +60,10 @@ class FemtoDreamCollisionSelection
     }
     mHistogramRegistry = registry;
     mHistogramRegistry->add("Event/zvtxhist", "; vtx_{z} (cm); Entries", kTH1F, {{300, -12.5, 12.5}});
-    mHistogramRegistry->add("Event/MultV0M", "; vMultV0M; Entries", kTH1F, {{600, 0, 600}});
-    mHistogramRegistry->add("Event/MultT0M", "; vMultT0M; Entries", kTH1F, {{600, 0, 600}});
+    mHistogramRegistry->add("Event/MultV0M", "; vMultV0M; Entries", kTH1F, {{16384, 0, 32768}});
+    mHistogramRegistry->add("Event/MultT0M", "; vMultT0M; Entries", kTH1F, {{4096, 0, 8192}});
+    mHistogramRegistry->add("Event/MultNTracksPV", "; vMultNTracksPV; Entries", kTH1F, {{120, 0, 120}});
+    mHistogramRegistry->add("Event/MultTPC", "; vMultTPC; Entries", kTH1I, {{600, 0, 600}});
   }
 
   /// Print some debug information
@@ -103,8 +105,14 @@ class FemtoDreamCollisionSelection
   {
     if (mHistogramRegistry) {
       mHistogramRegistry->fill(HIST("Event/zvtxhist"), col.posZ());
-      mHistogramRegistry->fill(HIST("Event/MultV0M"), col.multFV0M());
       mHistogramRegistry->fill(HIST("Event/MultT0M"), col.multFT0M());
+      mHistogramRegistry->fill(HIST("Event/MultNTracksPV"), col.multNTracksPV());
+      mHistogramRegistry->fill(HIST("Event/MultTPC"), col.multTPC());
+      if (mCheckIsRun3) {
+        mHistogramRegistry->fill(HIST("Event/MultV0M"), col.multFV0M());
+      }else{
+        mHistogramRegistry->fill(HIST("Event/MultV0M"), 0.5*(col.multFV0M())); //in AliPhysics, the VOM was defined by (V0A + V0C)/2.
+      }
     }
   }
 

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -13,15 +13,14 @@
 /// \brief FemtoDreamCollisionSelection - event selection within the o2femtodream framework
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#ifndef ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_
-#define ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_
-
-#include "Common/CCDB/TriggerAliases.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/Logger.h"
+#ifndef PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_
+#define PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_
 
 #include <string>
 #include <iostream>
+#include "Common/CCDB/TriggerAliases.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/Logger.h"
 
 using namespace o2::framework;
 
@@ -110,8 +109,8 @@ class FemtoDreamCollisionSelection
       mHistogramRegistry->fill(HIST("Event/MultTPC"), col.multTPC());
       if (mCheckIsRun3) {
         mHistogramRegistry->fill(HIST("Event/MultV0M"), col.multFV0M());
-      }else{
-        mHistogramRegistry->fill(HIST("Event/MultV0M"), 0.5*(col.multFV0M())); //in AliPhysics, the VOM was defined by (V0A + V0C)/2.
+      } else {
+        mHistogramRegistry->fill(HIST("Event/MultV0M"), 0.5 * (col.multFV0M())); // in AliPhysics, the VOM was defined by (V0A + V0C)/2.
       }
     }
   }
@@ -142,4 +141,4 @@ class FemtoDreamCollisionSelection
 };
 } // namespace o2::analysis::femtoDream
 
-#endif /* ANALYSIS_TASKS_PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_ */
+#endif // PWGCF_FEMTODREAM_FEMTODREAMCOLLISIONSELECTION_H_

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -70,7 +70,7 @@ class FemtoDreamContainer
       femtoObs = "#it{k*} (GeV/#it{c})";
     }
     std::vector<double> tmpVecMult = multBins;
-    framework::AxisSpec multAxis = {tmpVecMult, "Multiplicity"};
+    framework::AxisSpec multAxis = {tmpVecMult, "Multiplicity PV"};
     framework::AxisSpec femtoObsAxis = {kstarBins, femtoObs.c_str()};
     framework::AxisSpec kTAxis = {kTBins, "#it{k}_{T} (GeV/#it{c})"};
     framework::AxisSpec mTAxis = {mTBins, "#it{m}_{T} (GeV/#it{c}^{2})"};

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -70,7 +70,7 @@ class FemtoDreamContainer
       femtoObs = "#it{k*} (GeV/#it{c})";
     }
     std::vector<double> tmpVecMult = multBins;
-    framework::AxisSpec multAxis = {tmpVecMult, "Multiplicity PV"};
+    framework::AxisSpec multAxis = {tmpVecMult, "Multiplicity"};
     framework::AxisSpec femtoObsAxis = {kstarBins, femtoObs.c_str()};
     framework::AxisSpec kTAxis = {kTBins, "#it{k}_{T} (GeV/#it{c})"};
     framework::AxisSpec mTAxis = {mTBins, "#it{m}_{T} (GeV/#it{c}^{2})"};

--- a/PWGCF/FemtoDream/FemtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamEventHisto.h
@@ -35,7 +35,8 @@ class FemtoDreamEventHisto
   {
     mHistogramRegistry = registry;
     mHistogramRegistry->add("Event/zvtxhist", "; vtx_{z} (cm); Entries", kTH1F, {{300, -12.5, 12.5}});
-    mHistogramRegistry->add("Event/MultV0M", "; vMultV0M; Entries", kTH1F, {{600, 0, 600}});
+    mHistogramRegistry->add("Event/MultV0M", "; vMultV0M; Entries", kTH1F, {{16384, 0, 32768}});
+    mHistogramRegistry->add("Event/MultNTracksPV", "; vMultNTracksPV; Entries", kTH1F, {{120, 0, 120}});
   }
 
   /// Some basic QA of the event
@@ -46,6 +47,7 @@ class FemtoDreamEventHisto
   {
     if (mHistogramRegistry) {
       mHistogramRegistry->fill(HIST("Event/zvtxhist"), col.posZ());
+      mHistogramRegistry->fill(HIST("Event/MultNTracksPV"), col.multNtrPV());
       mHistogramRegistry->fill(HIST("Event/MultV0M"), col.multV0M());
     }
   }

--- a/PWGCF/FemtoDream/FemtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamEventHisto.h
@@ -13,8 +13,8 @@
 /// \brief FemtoDreamEventHisto - Histogram class for tracks, V0s and cascades
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#ifndef ANALYSIS_TASKS_PWGCF_O2FEMTODREAM_INCLUDE_O2FEMTODREAM_FEMTODREAMEVENTHISTO_H_
-#define ANALYSIS_TASKS_PWGCF_O2FEMTODREAM_INCLUDE_O2FEMTODREAM_FEMTODREAMEVENTHISTO_H_
+#ifndef PWGCF_FEMTODREAM_FEMTODREAMEVENTHISTO_H_
+#define PWGCF_FEMTODREAM_FEMTODREAMEVENTHISTO_H_
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "Framework/HistogramRegistry.h"
@@ -57,4 +57,4 @@ class FemtoDreamEventHisto
 };
 } // namespace o2::analysis::femtoDream
 
-#endif /* ANALYSIS_TASKS_PWGCF_O2FEMTODREAM_INCLUDE_O2FEMTODREAM_FEMTODREAMEVENTHISTO_H_ */
+#endif // PWGCF_FEMTODREAM_FEMTODREAMEVENTHISTO_H_

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -89,7 +89,7 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// Correlation part
   ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
-  //ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
+  // ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
   ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
 
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -88,8 +88,8 @@ struct femtoDreamPairTaskTrackTrack {
   std::vector<int> vPIDPartOne, vPIDPartTwo;
 
   /// Correlation part
-  // ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
-  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
+  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
+  //ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
   ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
 
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultV0M> colBinning{{CfgVtxBins, CfgMultBins}, true};
@@ -139,14 +139,14 @@ struct femtoDreamPairTaskTrackTrack {
   void processSameEvent(o2::aod::FemtoDreamCollision& col,
                         o2::aod::FemtoDreamParticles& parts)
   {
-    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multV0M()}));
+    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtrPV()}));
 
     const auto& magFieldTesla = col.magField();
 
     auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex());
     auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex());
 
-    const int multCol = col.multV0M();
+    const int multCol = col.multNtrPV();
     eventHisto.fillQA(col);
     /// Histogramming same event
     for (auto& part : groupPartsOne) {
@@ -202,7 +202,7 @@ struct femtoDreamPairTaskTrackTrack {
 
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
 
-      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), collision1.multV0M()}));
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), collision1.multNtrPV()}));
 
       auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision1.globalIndex());
       auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision2.globalIndex());
@@ -230,7 +230,7 @@ struct femtoDreamPairTaskTrackTrack {
             continue;
           }
         }
-        mixedEventCont.setPair(p1, p2, collision1.multV0M());
+        mixedEventCont.setPair(p1, p2, collision1.multNtrPV());
       }
     }
   }

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -177,10 +177,11 @@ struct femtoDreamProducerReducedTask {
     }
     const auto vtxZ = col.posZ();
     const auto spher = colCuts.computeSphericity(col, tracks);
+    const auto multNtr = col.multNTracksPV();
     /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
     int mult = 0;
     if (ConfIsRun3) {
-      mult = col.multFT0M(); /// Mult based on T0, temporary storing to be fixed and checked
+      mult = col.multFV0M(); 
     } else {
       mult = 0.5 * (col.multFV0M());
     }
@@ -190,14 +191,14 @@ struct femtoDreamProducerReducedTask {
     // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
-        outputCollision(col.posZ(), mult, colCuts.computeSphericity(col, tracks), mMagField);
+        outputCollision(col.posZ(), mult, multNtr, colCuts.computeSphericity(col, tracks), mMagField);
       }
       return;
     }
 
     colCuts.fillQA(col);
     // now the table is filled
-    outputCollision(vtxZ, mult, spher, mMagField);
+    outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
     int childIDs[2] = {0, 0}; // these IDs are necessary to keep track of the children
     for (auto& track : tracks) {

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -13,6 +13,8 @@
 /// \brief Tasks that produces the track tables used for the pairing (tracks only)
 /// \author Luca Barioglio, TU München, andreas.mathis@ph.tum.de
 
+#include "TMath.h"
+#include <CCDB/BasicCCDBManager.h>
 #include "FemtoDreamCollisionSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
@@ -31,8 +33,6 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "Math/Vector4D.h"
-#include "TMath.h"
-#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -127,7 +127,7 @@ struct femtoDreamProducerReducedTask {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
   }
 
@@ -181,7 +181,7 @@ struct femtoDreamProducerReducedTask {
     /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
     int mult = 0;
     if (ConfIsRun3) {
-      mult = col.multFV0M(); 
+      mult = col.multFV0M();
     } else {
       mult = 0.5 * (col.multFV0M());
     }

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -353,8 +353,15 @@ struct femtoDreamProducerTask {
   {
 
     const auto vtxZ = col.posZ();
-    const auto mult = col.multFV0M();
+    const auto multNtr = col.multNTracksPV();
     const auto spher = colCuts.computeSphericity(col, tracks);
+    /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
+    int mult = 0;
+    if (ConfIsRun3) {
+      mult = col.multFV0M(); 
+    } else {
+      mult = 0.5 * (col.multFV0M());
+    }
 
     // check whether the basic event selection criteria are fulfilled
     // if the basic selection is NOT fulfilled:
@@ -362,13 +369,13 @@ struct femtoDreamProducerTask {
     // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
-        outputCollision(vtxZ, mult, spher, mMagField);
+        outputCollision(vtxZ, mult, multNtr, spher, mMagField);
       }
       return;
     }
 
     colCuts.fillQA(col);
-    outputCollision(vtxZ, mult, spher, mMagField);
+    outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
     int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -358,7 +358,7 @@ struct femtoDreamProducerTask {
     /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
     int mult = 0;
     if (ConfIsRun3) {
-      mult = col.multFV0M(); 
+      mult = col.multFV0M();
     } else {
       mult = 0.5 * (col.multFV0M());
     }

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
+#include <CCDB/BasicCCDBManager.h>
 #include "FemtoDreamCollisionSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
@@ -33,7 +34,6 @@
 #include "DataFormatsParameters/GRPMagField.h"
 #include "Math/Vector4D.h"
 #include "TMath.h"
-#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -178,7 +178,7 @@ struct femtoDreamProducerTaskV0Only {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    long now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
   }
 
@@ -245,7 +245,7 @@ struct femtoDreamProducerTaskV0Only {
     /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
     int mult = 0;
     if (ConfIsRun3) {
-      mult = col.multFV0M(); 
+      mult = col.multFV0M();
     } else {
       mult = 0.5 * (col.multFV0M());
     }

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -234,22 +234,25 @@ struct femtoDreamProducerTaskV0Only {
     // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
-        outputCollision(col.posZ(), col.multFV0M(), colCuts.computeSphericity(col, tracks), mMagField);
+        outputCollision(col.posZ(), col.multFV0M(), col.multNTracksPV(), colCuts.computeSphericity(col, tracks), mMagField);
       }
       return;
     }
 
     const auto vtxZ = col.posZ();
-    const auto mult = col.multFV0M();
+    const int multNtr = col.multNTracksPV();
     const auto spher = colCuts.computeSphericity(col, tracks);
+    /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
+    int mult = 0;
+    if (ConfIsRun3) {
+      mult = col.multFV0M(); 
+    } else {
+      mult = 0.5 * (col.multFV0M());
+    }
     colCuts.fillQA(col);
 
     // now the table is filled
-    if (ConfIsRun3) {
-      outputCollision(vtxZ, col.multFT0M(), spher, mMagField);
-    } else {
-      outputCollision(vtxZ, mult, spher, mMagField);
-    }
+    outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
     int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index


### PR DESCRIPTION
Use multNtrPV to estimate the charge particle multiplicity of an event and add it as a column to FemtoDreamCollision table.

The V0M signal, which has been used so far, might not be needed in the future, but it will be kept for now. 