### PR TITLE
Implement bitmap for CEFP output

### DIFF
--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -355,9 +355,9 @@ struct centralEventFilterTask {
       }
     }
 
-    //for (auto& decision : decisions) {
-    //tags(decision.first, triggers[decision.first], decision.second);
-    //}
+    // for (auto& decision : decisions) {
+    // tags(decision.first, triggers[decision.first], decision.second);
+    // }
   }
 
   std::mt19937_64 mGeneratorEngine;

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -284,11 +284,10 @@ struct centralEventFilterTask {
         LOG(fatal) << "Inconsistent number of rows across trigger tables.";
       }
 
-      if (outDecision.size() == 0){
+      if (outDecision.size() == 0) {
         outDecision.resize(nEvents, 0u);
         outTrigger.resize(nEvents, 0u);
       }
-
 
       auto schema{tablePtr->schema()};
       for (auto& colName : tableName.second) {
@@ -346,17 +345,18 @@ struct centralEventFilterTask {
       auto CollTimeArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTime);
       auto CollTimeResArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTimeRes);
       for (int64_t iD{0}; iD < chunkBC->length(); ++iD) {
-        for(int64_t iB{0}; iB < columnGloBCId->num_chunks(); ++iB){
+        for (int64_t iB{0}; iB < columnGloBCId->num_chunks(); ++iB) {
           auto chunkGloBC{columnGloBCId->chunk(iB)};
           auto GloBCArray = std::static_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chunkGloBC);
-          if(GloBCArray->Value(BCArray->Value(iD))) GloBCId = GloBCArray->Value(BCArray->Value(iD));
+          if (GloBCArray->Value(BCArray->Value(iD)))
+            GloBCId = GloBCArray->Value(BCArray->Value(iD));
         }
         tags(BCArray->Value(iD), GloBCId, CollTimeArray->Value(iD), CollTimeResArray->Value(iD), outTrigger[iD], outDecision[iD]);
       }
     }
 
     //for (auto& decision : decisions) {
-      //tags(decision.first, triggers[decision.first], decision.second);
+    //tags(decision.first, triggers[decision.first], decision.second);
     //}
   }
 

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -284,10 +284,11 @@ struct centralEventFilterTask {
         LOG(fatal) << "Inconsistent number of rows across trigger tables.";
       }
 
-      if (outDecision.size() == 0) {
+      if (outDecision.size() == 0){
         outDecision.resize(nEvents, 0u);
         outTrigger.resize(nEvents, 0u);
       }
+
 
       auto schema{tablePtr->schema()};
       for (auto& colName : tableName.second) {
@@ -320,18 +321,23 @@ struct centralEventFilterTask {
     mFiltered->SetBinContent(1, mFiltered->GetBinContent(1) + nEvents);
 
     // Filling output table
+    auto bcTabConsumer = pc.inputs().get<TableConsumer>("BCs");
+    auto bcTabPtr{bcTabConsumer->asArrowTable()};
     auto collTabConsumer = pc.inputs().get<TableConsumer>("Collisions");
     auto collTabPtr{collTabConsumer->asArrowTable()};
     if (outDecision.size() != static_cast<uint64_t>(collTabPtr->num_rows())) {
       LOG(fatal) << "Inconsistent number of rows across Collision table and CEFP decision vector.";
     }
+    auto columnGloBCId{bcTabPtr->GetColumnByName("fGlobalBC")};
     auto columnBCId{collTabPtr->GetColumnByName("fIndexBCs")};
     auto columnCollTime{collTabPtr->GetColumnByName("fCollisionTime")};
     auto columnCollTimeRes{collTabPtr->GetColumnByName("fCollisionTimeRes")};
 
     std::unordered_map<int32_t, int64_t> triggers, decisions;
+    auto GloBCId = -999.;
 
     for (int64_t iC{0}; iC < columnBCId->num_chunks(); ++iC) {
+      LOG(info) << "columnBCId has " << columnBCId->num_chunks() << " chunks";
       auto chunkBC{columnBCId->chunk(iC)};
       auto chunkCollTime{columnCollTime->chunk(iC)};
       auto chunkCollTimeRes{columnCollTimeRes->chunk(iC)};
@@ -340,25 +346,18 @@ struct centralEventFilterTask {
       auto CollTimeArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTime);
       auto CollTimeResArray = std::static_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chunkCollTimeRes);
       for (int64_t iD{0}; iD < chunkBC->length(); ++iD) {
-        auto collTime = CollTimeArray->Value(iD);
-        auto collTimeRes = CollTimeResArray->Value(iD);
-        int32_t startBC{BCArray->Value(iD) - static_cast<int>(std::floor(collTime - cfgTimingCut * collTimeRes))};
-        int32_t endBC{BCArray->Value(iD) + static_cast<int>(std::ceil((collTime + cfgTimingCut * collTimeRes) / 25.f))};
-        for (int32_t iB{startBC}; iB < endBC; ++iB) {
-          if (decisions.find(iB) == decisions.end()) {
-            triggers[iB] = static_cast<int64_t>(outTrigger[iD]);
-            decisions[iB] = static_cast<int64_t>(outDecision[iD]);
-          } else {
-            triggers[iB] |= static_cast<int64_t>(outTrigger[iD]);
-            decisions[iB] |= static_cast<int64_t>(outDecision[iD]);
-          }
+        for(int64_t iB{0}; iB < columnGloBCId->num_chunks(); ++iB){
+          auto chunkGloBC{columnGloBCId->chunk(iB)};
+          auto GloBCArray = std::static_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chunkGloBC);
+          if(GloBCArray->Value(BCArray->Value(iD))) GloBCId = GloBCArray->Value(BCArray->Value(iD));
         }
+        tags(BCArray->Value(iD), GloBCId, CollTimeArray->Value(iD), CollTimeResArray->Value(iD), outTrigger[iD], outDecision[iD]);
       }
     }
 
-    for (auto& decision : decisions) {
-      tags(decision.first, triggers[decision.first], decision.second);
-    }
+    //for (auto& decision : decisions) {
+      //tags(decision.first, triggers[decision.first], decision.second);
+    //}
   }
 
   std::mt19937_64 mGeneratorEngine;
@@ -369,6 +368,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("Collisions", "AOD", "COLLISION", 0, Lifetime::Timeframe);
+  inputs.emplace_back("BCs", "AOD", "BC", 0, Lifetime::Timeframe);
 
   auto config = cfg.options().get<std::string>("train_config");
   Document d;

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -87,9 +87,12 @@ DECLARE_SOA_COLUMN(LeadingPtTrack, hasLeadingPtTrack, bool);               //! e
 namespace decision
 {
 
-DECLARE_SOA_COLUMN(BCId, hasBCId, int);                     //! Bunch crossing Id
-DECLARE_SOA_COLUMN(CefpTriggered, hasCefpTriggered, uint64_t); //! CEFP triggers before downscalings
-DECLARE_SOA_COLUMN(CefpSelected, hasCefpSelected, uint64_t);   //! CEFP decision
+DECLARE_SOA_COLUMN(BCId, hasBCId, int);                           //! Bunch crossing Id
+DECLARE_SOA_COLUMN(GlobalBCId, hasGlobalBCId, int);               //! Global Bunch crossing Id
+DECLARE_SOA_COLUMN(CollisionTime, hasCollisionTime, float);       //! Collision time
+DECLARE_SOA_COLUMN(CollisionTimeRes, hasCollisionTimeRes, float); //! Collision time resolution
+DECLARE_SOA_COLUMN(CefpTriggered, hasCefpTriggered, uint64_t);    //! CEFP triggers before downscalings
+DECLARE_SOA_COLUMN(CefpSelected, hasCefpSelected, uint64_t);      //! CEFP decision
 
 } // namespace decision
 
@@ -144,7 +147,7 @@ using MultFilter = MultFilters::iterator;
 
 // cefp decision
 DECLARE_SOA_TABLE(CefpDecisions, "AOD", "CefpDecision", //!
-                  decision::BCId, decision::CefpTriggered, decision::CefpSelected);
+                  decision::BCId, decision::GlobalBCId, decision::CollisionTime, decision::CollisionTimeRes, decision::CefpTriggered, decision::CefpSelected);
 using CefpDecision = CefpDecisions::iterator;
 
 /// List of the available filters, the description of their tables and the name of the tasks

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -73,14 +73,14 @@ DECLARE_SOA_COLUMN(QuadrupleXi, hasQuadrupleXi, bool); //! at least 4 Xi
 DECLARE_SOA_COLUMN(SingleXiYN, hasSingleXiYN, bool);   //! at least 1 Xi with R > 24.39 cm (YN interactions)
 
 // multiplicity
-DECLARE_SOA_COLUMN(HighTrackMult, hasHighTrackMult, bool);                 //! high trk muliplicity
-DECLARE_SOA_COLUMN(HighMultFv0, hasHighMultFv0, bool);                     //! high FV0 muliplicity
-DECLARE_SOA_COLUMN(HighFv0Flat, hasHighFv0Flat, bool);                     //! isotropic event FV0
-DECLARE_SOA_COLUMN(HighFt0Mult, hasHighFt0Mult, bool);                     //! high FT0 multiplicity
-DECLARE_SOA_COLUMN(HighFt0Flat, hasHighFt0Flat, bool);                     //! isotropic event FT0
-DECLARE_SOA_COLUMN(HighFt0cFv0Mult, hasHighFt0cFv0Mult, bool);             //! high FT0C FV0 multiplicity
-DECLARE_SOA_COLUMN(HighFt0cFv0Flat, hasHighFt0cFv0Flat, bool);             //! isotropic event FT0C FV0
-DECLARE_SOA_COLUMN(LeadingPtTrack, hasLeadingPtTrack, bool);               //! event contains leading track
+DECLARE_SOA_COLUMN(HighTrackMult, hasHighTrackMult, bool);     //! high trk muliplicity
+DECLARE_SOA_COLUMN(HighMultFv0, hasHighMultFv0, bool);         //! high FV0 muliplicity
+DECLARE_SOA_COLUMN(HighFv0Flat, hasHighFv0Flat, bool);         //! isotropic event FV0
+DECLARE_SOA_COLUMN(HighFt0Mult, hasHighFt0Mult, bool);         //! high FT0 multiplicity
+DECLARE_SOA_COLUMN(HighFt0Flat, hasHighFt0Flat, bool);         //! isotropic event FT0
+DECLARE_SOA_COLUMN(HighFt0cFv0Mult, hasHighFt0cFv0Mult, bool); //! high FT0C FV0 multiplicity
+DECLARE_SOA_COLUMN(HighFt0cFv0Flat, hasHighFt0cFv0Flat, bool); //! isotropic event FT0C FV0
+DECLARE_SOA_COLUMN(LeadingPtTrack, hasLeadingPtTrack, bool);   //! event contains leading track
 
 } // namespace filtering
 


### PR DESCRIPTION
Updates in the CEFP:
- add CefpSelected bitmap to the CEFP output table to keep track of selected triggers
- add CefpTrigger bitmap to the CEFP output table to keep track of fired triggers
- add globalBCId to the output table 
- modify the output table for future filtering per BCs