### PR TITLE
Collision covariance matrix: converter with fix

### DIFF
--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -70,6 +70,11 @@ o2physics_add_dpl_workflow(fdd-converter
                     SOURCES fddConverter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework
                 COMPONENT_NAME Analysis)
+                
+o2physics_add_dpl_workflow(collision-converter
+                    SOURCES collisionConverter.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework
+                COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(calo-clusters
                     SOURCES caloClusterProducer.cxx

--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -70,7 +70,7 @@ o2physics_add_dpl_workflow(fdd-converter
                     SOURCES fddConverter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework
                 COMPONENT_NAME Analysis)
-                
+
 o2physics_add_dpl_workflow(collision-converter
                     SOURCES collisionConverter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework

--- a/Common/TableProducer/collisionConverter.cxx
+++ b/Common/TableProducer/collisionConverter.cxx
@@ -1,0 +1,45 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Swaps covariance matrix elements if the data is known to be bogus (collision_000 is bogus)
+struct collisionConverter {
+  Produces<aod::Collisions_001> Collisions_001;
+
+  void process(aod::Collisions_000::iterator const& collision)
+  {
+    //Simple swap of XZ and YY with respect to expectations
+    Collisions_001(
+               collision.bcId(),
+               collision.posX(), collision.posY(), collision.posZ(),
+               collision.covXX(),
+               collision.covXY(),
+               collision.covXZ(), //deliberate: Collisions_001 expects YY
+               collision.covYY(), //deliberate: Collisions_001 expects XZ
+               collision.covYZ(),
+               collision.covZZ(),
+               collision.flags(), collision.chi2(), collision.numContrib(),
+               collision.collisionTime(), collision.collisionTimeRes()
+               );
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<collisionConverter>(cfgc),
+  };
+}

--- a/Common/TableProducer/collisionConverter.cxx
+++ b/Common/TableProducer/collisionConverter.cxx
@@ -19,20 +19,23 @@ using namespace o2::framework;
 struct collisionConverter {
   Produces<aod::Collisions_001> Collisions_001;
 
-  void process(aod::Collisions_000::iterator const& collision)
+  void process(aod::Collisions_000 const& collisionTable)
   {
-    // Simple swap of XZ and YY with respect to expectations
-    Collisions_001(
-      collision.bcId(),
-      collision.posX(), collision.posY(), collision.posZ(),
-      collision.covXX(),
-      collision.covXY(),
-      collision.covXZ(), // deliberate: Collisions_001 expects YY
-      collision.covYY(), // deliberate: Collisions_001 expects XZ
-      collision.covYZ(),
-      collision.covZZ(),
-      collision.flags(), collision.chi2(), collision.numContrib(),
-      collision.collisionTime(), collision.collisionTimeRes());
+    for (auto& collision : collisionTable) {
+      //Simple swap of XZ and YY with respect to expectations
+      Collisions_001(
+                 collision.bcId(),
+                 collision.posX(), collision.posY(), collision.posZ(),
+                 collision.covXX(),
+                 collision.covXY(),
+                 collision.covXZ(), //deliberate: Collisions_001 expects YY
+                 collision.covYY(), //deliberate: Collisions_001 expects XZ
+                 collision.covYZ(),
+                 collision.covZZ(),
+                 collision.flags(), collision.chi2(), collision.numContrib(),
+                 collision.collisionTime(), collision.collisionTimeRes()
+                 );
+    }
   }
 };
 


### PR DESCRIPTION
* adds collision converter task to swap XZ and YY elements of collision covariance matrix 
* more information on the problem this intends to fix is [here](https://indico.cern.ch/event/1219192/contributions/5128952/attachments/2542060/4376840/DDChinellato-MondayMeeting-7Nov2022-1.pdf) 
* goes together with https://github.com/AliceO2Group/AliceO2/pull/10424