### PR TITLE
Correction of a bug in filterPP.cxx + new cut in the CutsLibrary.h file

### DIFF
--- a/PWGDQ/Core/CutsLibrary.h
+++ b/PWGDQ/Core/CutsLibrary.h
@@ -313,6 +313,11 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("jpsi_TPCPID_debug4"));
     return cut;
   }
+  if (!nameStr.compare("LMee_TPCPost_calib_debug1")) {
+    cut->AddCut(GetAnalysisCut("lmee_trackCut_debug"));
+    cut->AddCut(GetAnalysisCut("lmee_TPCPID_debug1"));
+    return cut;
+  }
   //---------------------------------------------------------------------------------------
   // NOTE: Below there are several TPC pid cuts used for studies of the dE/dx degradation
   //    and its impact on the high lumi pp quarkonia triggers
@@ -742,6 +747,13 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kITSncls, 2.5, 7.5);
     return cut;
   }
+  if (!nameStr.compare("lmee_trackCut_debug")) {
+    cut->AddCut(VarManager::kEta, -0.9, 0.9);
+    cut->AddCut(VarManager::kTPCchi2, 0.0, 4.0);
+    cut->AddCut(VarManager::kTPCncls, 80., 159);
+    cut->AddCut(VarManager::kITSncls, 0.0, 7.5);
+    return cut;
+  }
   if (!nameStr.compare("jpsi_TPCPID_debug1")) {
     cut->AddCut(VarManager::kTPCnSigmaEl_Corr, -3.0, 3.0);
     cut->AddCut(VarManager::kTPCnSigmaPi_Corr, 2.5, 999);
@@ -770,6 +782,10 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kTPCnSigmaEl_Corr, -4.0, 4.0);
     cut->AddCut(VarManager::kTPCnSigmaPi_Corr, 2.5, 999);
     cut->AddCut(VarManager::kTPCnSigmaPr_Corr, 2.5, 999);
+    return cut;
+  }
+  if (!nameStr.compare("lmee_TPCPID_debug1")) {
+    cut->AddCut(VarManager::kTPCnSigmaEl_Corr, -5.0, 5.0);
     return cut;
   }
   if (!nameStr.compare("highPtHadron")) {

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -429,7 +429,7 @@ struct DQFilterPPTask {
           fMuonPairCuts[icut] = (*dqcuts::GetCompositeCut(sel->At(1)->GetName()));
           fMuonRunPairing.push_back(true);
           fMuonNreqObjs.push_back(std::atoi(sel->At(2)->GetName()));
-          fMuonPairHistNames[icut] = Form("PairsMuonSEPM_%s_%s", sel->At(0)->GetName(), sel->At(1)->GetName());
+          fMuonPairHistNames[icut] = Form("PairsForwardSEPM_%s_%s", sel->At(0)->GetName(), sel->At(1)->GetName());
         } else {
           fMuonNreqObjs.push_back(std::atoi(sel->At(1)->GetName()));
           fMuonRunPairing.push_back(false);
@@ -690,7 +690,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
       if (classStr.Contains("Barrel")) {
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
       }
-      if (classStr.Contains("Muon")) {
+      if (classStr.Contains("Forward")) {
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon");
       }
     }


### PR DESCRIPTION
In filterPP.cxx : naming the single muon and dimuon histogram manager with "Muon" seemed to confuse the histogram manager on which histograms to fill. Therefore the dimuon histogram manager with "PairForward" to avoid any confusions

In CutsLibrary.h :  add a cut for low pT dielectron analyis : |n sigma e TPC| < 5, without momentum cut, |eta_e| < 0.9, chi2 TPC < 4, N TPC crossed rows > 80, Ncls ITS > 0