### PR TITLE
Change default binning of PID QA tasks

### DIFF
--- a/DPG/Tasks/AOTTrack/PID/qaPIDTOF.h
+++ b/DPG/Tasks/AOTTrack/PID/qaPIDTOF.h
@@ -167,9 +167,9 @@ struct tofPidQa {
   Configurable<int> nBinsExpSigma{"nBinsExpSigma", 200, "Number of bins for the ExpSigma"};
   Configurable<float> minExpSigma{"minExpSigma", 0.f, "Minimum ExpSigma in range"};
   Configurable<float> maxExpSigma{"maxExpSigma", 200.f, "Maximum ExpSigma in range"};
-  Configurable<int> nBinsNSigma{"nBinsNSigma", 200, "Number of bins for the NSigma"};
-  Configurable<float> minNSigma{"minNSigma", -10.f, "Minimum NSigma in range"};
-  Configurable<float> maxNSigma{"maxNSigma", 10.f, "Maximum NSigma in range"};
+  Configurable<int> nBinsNSigma{"nBinsNSigma", 401, "Number of bins for the NSigma"};
+  Configurable<float> minNSigma{"minNSigma", -10.025f, "Minimum NSigma in range"};
+  Configurable<float> maxNSigma{"maxNSigma", 10.025f, "Maximum NSigma in range"};
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply event selection cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   Configurable<bool> applyTrackCut{"applyTrackCut", false, "Flag to apply standard track cuts"};
   Configurable<bool> applyRapidityCut{"applyRapidityCut", false, "Flag to apply rapidity cut"};

--- a/DPG/Tasks/AOTTrack/PID/qaPIDTPC.h
+++ b/DPG/Tasks/AOTTrack/PID/qaPIDTPC.h
@@ -15,6 +15,9 @@
 /// \brief  Header file for QA tasks of the TPC PID quantities
 ///
 
+#ifndef DPG_TASKS_AOTTRACK_PID_QAPIDTPC_H_
+#define DPG_TASKS_AOTTRACK_PID_QAPIDTPC_H_
+
 #include "Framework/HistogramRegistry.h"
 #include "Framework/StaticFor.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -465,3 +468,5 @@ struct tpcPidQa {
   makeProcessFunction(aod::pidTPCFullAl, aod::pidTOFFullAl, Alpha);
 #undef makeProcessFunction
 };
+
+#endif // DPG_TASKS_AOTTRACK_PID_QAPIDTPC_H_

--- a/DPG/Tasks/AOTTrack/PID/qaPIDTPC.h
+++ b/DPG/Tasks/AOTTrack/PID/qaPIDTPC.h
@@ -102,9 +102,9 @@ struct tpcPidQa {
   Configurable<int> nBinsExpSigma{"nBinsExpSigma", 200, "Number of bins for the ExpSigma"};
   Configurable<float> minExpSigma{"minExpSigma", 0.f, "Minimum ExpSigma in range"};
   Configurable<float> maxExpSigma{"maxExpSigma", 200.f, "Maximum ExpSigma in range"};
-  Configurable<int> nBinsNSigma{"nBinsNSigma", 200, "Number of bins for the NSigma"};
-  Configurable<float> minNSigma{"minNSigma", -10.f, "Minimum NSigma in range"};
-  Configurable<float> maxNSigma{"maxNSigma", 10.f, "Maximum NSigma in range"};
+  Configurable<int> nBinsNSigma{"nBinsNSigma", 401, "Number of bins for the NSigma"};
+  Configurable<float> minNSigma{"minNSigma", -10.025f, "Minimum NSigma in range"};
+  Configurable<float> maxNSigma{"maxNSigma", 10.025f, "Maximum NSigma in range"};
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply event selection cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   Configurable<bool> applyTrackCut{"applyTrackCut", false, "Flag to apply standard track cuts"};
   Configurable<bool> applyRapidityCut{"applyRapidityCut", false, "Flag to apply rapidity cut"};


### PR DESCRIPTION
Changes default parameters of the nsigma axis for the TPC and TOF QA tasks, to avoid filling/plotting issues due to the discrete binning in the "tiny" PID tables.