### PR TITLE
Fix histograms names in filterPP.cxx

### DIFF
--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -688,10 +688,10 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
 
     if (classStr.Contains("Pairs")) {
       if (classStr.Contains("Barrel")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_barrel", "vertexing-barrel");
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "vertexing-barrel");
       }
       if (classStr.Contains("Forward")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair_dimuon");
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "dimuon_vertexing-forward");
       }
     }
   }

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -691,7 +691,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "vertexing-barrel");
       }
       if (classStr.Contains("Forward")) {
-        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "dimuon_vertexing-forward");
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "dimuon,vertexing-forward");
       }
     }
   }


### PR DESCRIPTION
Fix the naming convention of the histograms in filterPP.cxx to match the new names in the HistogramLibrary.h