### PR TITLE
MegaLinter: Checkout the right merge commit 

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -26,6 +26,8 @@ jobs:
           # Checkout the HEAD of the PR instead of the merge commit.
           # This may include unrelated files if the PR branch is not up to date with the upstream.
           # ref: ${{ github.event.pull_request.head.sha }}
+          # Checkout the merge commit.
+          ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 0
           # So we can use secrets.ALIBUILD_GITHUB_TOKEN to push later.
           persist-credentials: false


### PR DESCRIPTION
Running on the merge commit is necessary to get the right list of modified files.
@TimoWilken 

Problem with listing the modified files reported: https://github.com/oxsecurity/megalinter/issues/2125