### PR TITLE
PWGDQ: Table Reader, fix bug in muon histogram filling

### DIFF
--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -986,7 +986,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses, Configurab
           dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_proton");
         }
       }
-      if (classStr.Contains("Muons")) {
+      if (classStr.Contains("Muon")) {
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
       }
     }


### PR DESCRIPTION
Quick fix of table reader.
Misspelling prevents filling of muon histograms