### PR TITLE
[EMCAL-670, EMCAL-734, EMCAL-850] Dedicated QA task for EMCAL event selection + more histograms in cluster task

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -14,6 +14,7 @@
 // Author: Raymond Ehlers & Florian Jonas
 
 #include <algorithm>
+#include <iostream>
 #include <cmath>
 
 #include "CCDB/BasicCCDBManager.h"
@@ -39,8 +40,6 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-
-using bcEvSelIt = o2::soa::Join<o2::aod::BCs, o2::aod::BcSels>::iterator;
 
 struct EmcalCorrectionTask {
   Produces<o2::aod::EMCALClusters> clusters;
@@ -79,8 +78,6 @@ struct EmcalCorrectionTask {
   OutputObj<TH2I> hCellRowCol{"hCellRowCol"};
   OutputObj<TH1F> hClusterE{"hClusterE"};
   OutputObj<TH2F> hClusterEtaPhi{"hClusterEtaPhi"};
-  OutputObj<TH1F> hCollisionMatching{"hCollisionMatching"};
-  OutputObj<TH1F> hCollisionMatchingReadout{"hCollisionMatchingReadout"};
 
   void init(InitContext const&)
   {
@@ -142,8 +139,6 @@ struct EmcalCorrectionTask {
     hCellRowCol.setObject(new TH2I("hCellRowCol", "hCellRowCol;Column;Row", 97, 0, 97, 600, 0, 600));
     hClusterE.setObject(new TH1F("hClusterE", "hClusterE", 200, 0.0, 100));
     hClusterEtaPhi.setObject(new TH2F("hClusterEtaPhi", "hClusterEtaPhi", 160, -0.8, 0.8, 72, 0, 2 * 3.14159));
-    hCollisionMatching.setObject(new TH1F("hCollisionMatching", "hCollisionMatching", 3, -0.5, 2.5));        // 0, no vertex,1 vertex found , 2 multiple vertices found
-    hCollisionMatchingReadout.setObject(new TH1F("hCollisionMatching", "hCollisionMatching", 3, -0.5, 2.5)); // 0, no vertex,1 vertex found , 2 multiple vertices found, only filled for BCs with kTVXinEMC
   }
 
   // void process(aod::Collision const& collision, soa::Filtered<aod::Tracks> const& fullTracks, aod::Calos const& cells)
@@ -151,7 +146,7 @@ struct EmcalCorrectionTask {
   // void process(aod::BCs const& bcs, aod::Collision const& collision, aod::Calos const& cells)
 
   //  Appears to need the BC to be accessed to be available in the collision table...
-  void process(bcEvSelIt const& bc, aod::Collisions const& collisions, aod::Tracks const& tracks, aod::Calos const& cells)
+  void process(aod::BC const& bc, aod::Collisions const& collisions, aod::Tracks const& tracks, aod::Calos const& cells)
   {
     LOG(debug) << "Starting process.";
     // Convert aod::Calo to o2::emcal::Cell which can be used with the clusterizer.
@@ -176,11 +171,6 @@ struct EmcalCorrectionTask {
       c++;
     }
     LOG(debug) << "Number of cells (CF): " << mEmcalCells.size();
-
-    bool isEMCALreadout = false;
-    if (bc.alias()[kTVXinEMC]) {
-      isEMCALreadout = true;
-    }
 
     // Cell QA
     // For convenience, use the clusterizer stored geometry to get the eta-phi
@@ -232,12 +222,6 @@ struct EmcalCorrectionTask {
       float vx = 0, vy = 0, vz = 0;
       bool hasCollision = false;
       if (collisions.size() > 1) {
-        if (i == 0) {
-          hCollisionMatching->Fill(2);
-          if (isEMCALreadout) {
-            hCollisionMatchingReadout->Fill(2);
-          }
-        }
         LOG(error) << "More than one collision in the bc. This is not supported.";
       } else {
         // dummy loop to get the first collision
@@ -246,12 +230,6 @@ struct EmcalCorrectionTask {
           vy = col.posY();
           vz = col.posZ();
           hasCollision = true;
-          if (i == 0) {
-            hCollisionMatching->Fill(1);
-            if (isEMCALreadout) {
-              hCollisionMatchingReadout->Fill(1);
-            }
-          }
 
           // store positions of all tracks of collision
           auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
@@ -321,19 +299,11 @@ struct EmcalCorrectionTask {
           } // end of cluster loop
         }   // end of collision loop
       }
-      if (!hasCollision) {
-        if (i == 0) {
-          hCollisionMatching->Fill(0);
-          if (isEMCALreadout) {
-            hCollisionMatchingReadout->Fill(0);
-          }
-        }
-        // LOG(warning) << "No vertex found for event. Assuming (0,0,0).";
-      }
 
       // Store the clusters in the table where a mathcing collision could
       // be identified.
       if (!hasCollision) { // ambiguous
+        // LOG(warning) << "No vertex found for event. Assuming (0,0,0).";
         int cellindex = -1;
         clustersAmbiguous.reserve(mAnalysisClusters.size());
         for (const auto& cluster : mAnalysisClusters) {

--- a/PWGJE/Tasks/CMakeLists.txt
+++ b/PWGJE/Tasks/CMakeLists.txt
@@ -9,27 +9,30 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-
 o2physics_add_dpl_workflow(emc-cellmonitor
-                    SOURCES emccellmonitor.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+    SOURCES emccellmonitor.cxx
+    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
+    COMPONENT_NAME Analysis)
 o2physics_add_dpl_workflow(emc-clustermonitor
-                    SOURCES emcclustermonitor.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
-if(FastJet_FOUND)
-o2physics_add_dpl_workflow(jet-substructure
-                    SOURCES jetsubstructure.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
-o2physics_add_dpl_workflow(jet-charged-trigger-qa
-                    SOURCES ChJetTriggerQATask.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
-o2physics_add_dpl_workflow(jet-matching-hf-qa
-                    SOURCES jetmatchinghfqa.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
-endif()
+    SOURCES emcclustermonitor.cxx
+    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
+    COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(emc-eventselection-qa
+    SOURCES emceventselectionqa.cxx
+    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
+    COMPONENT_NAME Analysis)
 
+if(FastJet_FOUND)
+    o2physics_add_dpl_workflow(jet-substructure
+        SOURCES jetsubstructure.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
+        COMPONENT_NAME Analysis)
+    o2physics_add_dpl_workflow(jet-charged-trigger-qa
+        SOURCES ChJetTriggerQATask.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
+        COMPONENT_NAME Analysis)
+    o2physics_add_dpl_workflow(jet-matching-hf-qa
+        SOURCES jetmatchinghfqa.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
+        COMPONENT_NAME Analysis)
+endif()

--- a/PWGJE/Tasks/emcclustermonitor.cxx
+++ b/PWGJE/Tasks/emcclustermonitor.cxx
@@ -53,6 +53,7 @@
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using collisionEvSelIt = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels>::iterator;
+using bcEvSelIt = o2::soa::Join<o2::aod::BCs, o2::aod::BcSels>::iterator;
 using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
 using selectedAmbiguousClusters = o2::soa::Filtered<o2::aod::EMCALAmbiguousClusters>;
 struct ClusterMonitor {
@@ -69,6 +70,8 @@ struct ClusterMonitor {
   Configurable<std::string> mSelectBCID{"selectBCID", "all", "BC ID(s) to be included, this should be used as an alternative to the event selection"};
   Configurable<double> mVertexCut{"vertexCut", -1, "apply z-vertex cut with value in cm"};
   Configurable<int> mClusterDefinition{"clusterDefinition", 10, "cluster definition to be selected, e.g. 10=kV3Default"};
+  ConfigurableAxis mClusterTimeBinning{"clustertime-binning", {1500, -600, 900}, ""};
+  ConfigurableAxis mNumberClusterBinning{"numclusters-binning", {201, -0.5, 200.5}, ""};
 
   std::vector<int> mVetoBCIDs;
   std::vector<int> mSelectBCIDs;
@@ -83,15 +86,14 @@ struct ClusterMonitor {
     // load geometry just in case we need it
     mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
 
-    // create histograms for cluster QA
-    Double_t timeMin = -600;
-    Double_t timeMax = 900;
-
     // create common axes
     LOG(info) << "Creating histograms";
     const o2Axis bcAxis{3501, -0.5, 3500.5};
     const o2Axis energyAxis{makeEnergyBinningAliPhysics(), "E_{clus} (GeV)"};
-    const o2Axis timeAxis{800, timeMin, timeMax};
+    const o2Axis amplitudeAxisLarge{1000, 0., 100., "amplitudeLarge", "Amplitude (GeV)"};
+    const o2Axis supermoduleAxis{20, -0.5, 19.5, "Supermodule ID"};
+    o2Axis timeAxis{mClusterTimeBinning, "t_{cl} (ns)"};
+    o2Axis numberClustersAxis{mNumberClusterBinning, "Number of clusters / event"};
 
     // event properties
     mHistManager.add("eventsAll", "Number of events", o2HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -100,10 +102,16 @@ struct ClusterMonitor {
     mHistManager.add("eventBCSelected", "Bunch crossing ID of event (selected events)", o2HistType::kTH1F, {bcAxis});
     mHistManager.add("eventVertexZAll", "z-vertex of event (all events)", o2HistType::kTH1F, {{200, -20, 20}});
     mHistManager.add("eventVertexZSelected", "z-vertex of event (selected events)", o2HistType::kTH1F, {{200, -20, 20}});
+    mHistManager.add("numberOfClustersEvents", "number of clusters per event (selected events)", o2HistType::kTH1F, {numberClustersAxis});
+    mHistManager.add("numberOfClustersBC", "number of clusters per bunch crossing (ambiguous BCs)", o2HistType::kTH1F, {numberClustersAxis});
+    mHistManager.add("numberOfClustersEventsRejected", "number of clusters per event (rejected events)", o2HistType::kTH1F, {numberClustersAxis});
+    mHistManager.add("numberOfClustersSMEvents", "number of clusters per supermodule per event (selected events)", o2HistType::kTH2F, {numberClustersAxis, {20, -0.5, 19.5, "SupermoduleID"}});
+    mHistManager.add("numberOfClustersSMBC", "number of clusters per supermodule per bunch crossing (ambiguous BCs)", o2HistType::kTH2F, {numberClustersAxis, {20, -0.5, 19.5, "SupermoduleID"}});
 
     // cluster properties (matched clusters)
     mHistManager.add("clusterE", "Energy of cluster", o2HistType::kTH1F, {energyAxis});
     mHistManager.add("clusterEMatched", "Energy of cluster (with match)", o2HistType::kTH1F, {energyAxis});
+    mHistManager.add("clusterESupermodule", "Energy of the cluster vs. supermoduleID", o2HistType::kTH2F, {energyAxis, supermoduleAxis});
     mHistManager.add("clusterE_SimpleBinning", "Energy of cluster", o2HistType::kTH1F, {{2000, 0, 200}});
     mHistManager.add("clusterEtaPhi", "Eta and phi of cluster", o2HistType::kTH2F, {{100, -1, 1}, {100, 0, 2 * TMath::Pi()}});
     mHistManager.add("clusterM02", "M02 of cluster", o2HistType::kTH1F, {{400, 0, 5}});
@@ -115,6 +123,14 @@ struct ClusterMonitor {
     mHistManager.add("clusterAmpFractionLeadingCell", "Fraction of energy in leading cell", o2HistType::kTH1F, {{100, 0, 1}});
     mHistManager.add("clusterTM_dEtadPhi", "cluster trackmatching dEta/dPhi", o2HistType::kTH2F, {{100, -0.4, 0.4}, {100, -0.4, 0.4}});
     mHistManager.add("clusterTM_EoverP_E", "cluster E/p (dEtadPhi<0.05)", o2HistType::kTH2F, {{500, 0, 10}, {200, 0, 100}});
+
+    // add histograms per supermodule
+    for (int ism = 0; ism < 20; ++ism) {
+      mHistManager.add(Form("clusterTimeVsESM/clusterTimeVsESM%d", ism), Form("Cluster time vs energy in Supermodule %d", ism), o2HistType::kTH2F, {timeAxis, amplitudeAxisLarge});
+      mHistManager.add(Form("clusterNcellVsESM/clusterNCellVsESM%d", ism), Form("Cluster number of cells vs energy in Supermodule %d", ism), o2HistType::kTH2F, {{50, 0, 50}, amplitudeAxisLarge});
+      mHistManager.add(Form("clusterM02VsESM/clusterM02VsESM%d", ism), Form("Cluster M02 vs energy in Supermodule %d", ism), o2HistType::kTH2F, {{400, 0, 5}, amplitudeAxisLarge});
+      mHistManager.add(Form("clusterM20VsESM/clusterM20VsESM%d", ism), Form("Cluster M20 vs energy in Supermodule %d", ism), o2HistType::kTH2F, {{400, 0, 2.5}, amplitudeAxisLarge});
+    }
 
     if (mVetoBCID->length()) {
       std::stringstream parser(mVetoBCID.value);
@@ -151,8 +167,21 @@ struct ClusterMonitor {
     // do event selection if mDoEventSel is specified
     // currently the event selection is hard coded to kINT7
     // but other selections are possible that are defined in TriggerAliases.h
-    if (mDoEventSel && (!theCollision.alias()[kINT7])) {
-      LOG(debug) << "Event not selected because it is not kINT7, skipping";
+    bool isSelected = true;
+    if (mDoEventSel) {
+      if (theCollision.bc().runNumber() < 300000) {
+        if (!theCollision.alias()[kINT7]) {
+          isSelected = false;
+        }
+      } else {
+        if (!theCollision.alias()[kTVXinEMC]) {
+          isSelected = false;
+        }
+      }
+    }
+    if (!isSelected) {
+      LOG(debug) << "Event not selected because it is not kINT7 or does not have EMCAL in readout, skipping";
+      mHistManager.fill(HIST("numberOfClustersEventsRejected"), clusters.size());
       return;
     }
     mHistManager.fill(HIST("eventVertexZAll"), theCollision.posZ());
@@ -162,8 +191,11 @@ struct ClusterMonitor {
     }
     mHistManager.fill(HIST("eventsSelected"), 1);
     mHistManager.fill(HIST("eventVertexZSelected"), theCollision.posZ());
+    mHistManager.fill(HIST("numberOfClustersEvents"), clusters.size());
 
     LOG(debug) << "bunch crossing ID" << theCollision.bcId();
+    std::array<int, 20> numberOfClustersSM;
+    std::fill(numberOfClustersSM.begin(), numberOfClustersSM.end(), 0);
     // loop over all clusters from accepted collision
     // auto eventClusters = clusters.select(o2::aod::emcalcluster::bcId == theCollision.bc().globalBC());
     for (const auto& cluster : clusters) {
@@ -189,6 +221,17 @@ struct ClusterMonitor {
       LOG(debug) << "Cluster index: " << cluster.index();
       LOG(debug) << "ncells in cluster: " << cluster.nCells();
       LOG(debug) << "real cluster id" << cluster.id();
+
+      // monitor observables per supermodule
+      try {
+        auto supermoduleID = mGeometry->SuperModuleNumberFromEtaPhi(cluster.eta(), cluster.phi());
+        mHistManager.fill(HIST("clusterESupermodule"), cluster.energy(), supermoduleID);
+        fillSupermoduleHistograms(supermoduleID, cluster.energy(), cluster.time(), cluster.nCells(), cluster.m02(), cluster.m20());
+        numberOfClustersSM[supermoduleID]++;
+      } catch (o2::emcal::InvalidPositionException& e) {
+        // Imprecision of the position at the sector boundaries, mostly due to
+        // vertex imprecision. Skip these clusters for the now.
+      }
 
       // example of loop over all cells of current cluster
       // cell.calo() allows to access the cell properties as defined in AnalysisDataModel
@@ -230,13 +273,16 @@ struct ClusterMonitor {
         t++;
       }
     }
+    for (int supermoduleID = 0; supermoduleID < 20; supermoduleID++) {
+      mHistManager.fill(HIST("numberOfClustersSMEvents"), numberOfClustersSM[supermoduleID], supermoduleID);
+    }
   }
   PROCESS_SWITCH(ClusterMonitor, processCollisions, "Process clusters from collision", false);
 
   /// \brief Process EMCAL clusters that are not matched to a collision
   /// This is not needed for most users
 
-  void processAmbiguous(o2::aod::BC const& bc, selectedAmbiguousClusters const& clusters)
+  void processAmbiguous(bcEvSelIt const& bc, selectedAmbiguousClusters const& clusters)
   {
     // loop over bc , if requested (mVetoBCID >= 0), reject everything from a certain BC
     // this can be used as alternative to event selection (e.g. for pilot beam data)
@@ -251,7 +297,26 @@ struct ClusterMonitor {
     if (mSelectBCIDs.size() && (std::find(mSelectBCIDs.begin(), mSelectBCIDs.end(), eventIR.bc) == mSelectBCIDs.end())) {
       return;
     }
+    bool isSelected = true;
+    if (mDoEventSel) {
+      if (bc.runNumber() < 300000) {
+        if (!bc.alias()[kINT7]) {
+          isSelected = false;
+        }
+      } else {
+        if (!bc.alias()[kTVXinEMC]) {
+          isSelected = false;
+        }
+      }
+    }
+    if (!isSelected) {
+      return;
+    }
     mHistManager.fill(HIST("eventBCSelected"), eventIR.bc);
+    mHistManager.fill(HIST("numberOfClustersBC"), clusters.size());
+
+    std::array<int, 20> numberOfClustersSM;
+    std::fill(numberOfClustersSM.begin(), numberOfClustersSM.end(), 0);
     // loop over ambiguous clusters
     for (const auto& cluster : clusters) {
       mHistManager.fill(HIST("clusterE"), cluster.energy());
@@ -263,13 +328,110 @@ struct ClusterMonitor {
       mHistManager.fill(HIST("clusterNLM"), cluster.nlm());
       mHistManager.fill(HIST("clusterNCells"), cluster.nCells());
       mHistManager.fill(HIST("clusterDistanceToBadChannel"), cluster.distanceToBadChannel());
+
+      try {
+        auto supermoduleID = mGeometry->SuperModuleNumberFromEtaPhi(cluster.eta(), cluster.phi());
+        mHistManager.fill(HIST("clusterESupermodule"), cluster.energy(), supermoduleID);
+        fillSupermoduleHistograms(supermoduleID, cluster.energy(), cluster.time(), cluster.nCells(), cluster.m02(), cluster.m20());
+        numberOfClustersSM[supermoduleID]++;
+      } catch (o2::emcal::InvalidPositionException& e) {
+        // Imprecision of the position at the sector boundaries, mostly due to
+        // vertex imprecision. Skip these clusters for the now.
+      }
+    }
+    for (int supermoduleID = 0; supermoduleID < 20; supermoduleID++) {
+      mHistManager.fill(HIST("numberOfClustersSMBC"), numberOfClustersSM[supermoduleID], supermoduleID);
     }
   }
   PROCESS_SWITCH(ClusterMonitor, processAmbiguous, "Process Ambiguous clusters", false);
 
+  void fillSupermoduleHistograms(int supermoduleID, double energy, double time, int ncell, double m02, double m20)
+  {
+    // workaround to have the histogram names per supermodule
+    // handled as constexpr
+    switch (supermoduleID) {
+      case 0:
+        supermoduleHistHelper<0>(energy, time, ncell, m02, m20);
+        break;
+      case 1:
+        supermoduleHistHelper<1>(energy, time, ncell, m02, m20);
+        break;
+      case 2:
+        supermoduleHistHelper<2>(energy, time, ncell, m02, m20);
+        break;
+      case 3:
+        supermoduleHistHelper<3>(energy, time, ncell, m02, m20);
+        break;
+      case 4:
+        supermoduleHistHelper<4>(energy, time, ncell, m02, m20);
+        break;
+      case 5:
+        supermoduleHistHelper<5>(energy, time, ncell, m02, m20);
+        break;
+      case 6:
+        supermoduleHistHelper<6>(energy, time, ncell, m02, m20);
+        break;
+      case 7:
+        supermoduleHistHelper<7>(energy, time, ncell, m02, m20);
+        break;
+      case 8:
+        supermoduleHistHelper<8>(energy, time, ncell, m02, m20);
+        break;
+      case 9:
+        supermoduleHistHelper<9>(energy, time, ncell, m02, m20);
+        break;
+      case 10:
+        supermoduleHistHelper<10>(energy, time, ncell, m02, m20);
+        break;
+      case 11:
+        supermoduleHistHelper<11>(energy, time, ncell, m02, m20);
+        break;
+      case 12:
+        supermoduleHistHelper<12>(energy, time, ncell, m02, m20);
+        break;
+      case 13:
+        supermoduleHistHelper<13>(energy, time, ncell, m02, m20);
+        break;
+      case 14:
+        supermoduleHistHelper<14>(energy, time, ncell, m02, m20);
+        break;
+      case 15:
+        supermoduleHistHelper<15>(energy, time, ncell, m02, m20);
+        break;
+      case 16:
+        supermoduleHistHelper<16>(energy, time, ncell, m02, m20);
+        break;
+      case 17:
+        supermoduleHistHelper<17>(energy, time, ncell, m02, m20);
+        break;
+      case 18:
+        supermoduleHistHelper<18>(energy, time, ncell, m02, m20);
+        break;
+      case 19:
+        supermoduleHistHelper<19>(energy, time, ncell, m02, m20);
+        break;
+      default:
+        break;
+    }
+  }
+
+  template <int supermoduleID>
+  void supermoduleHistHelper(double energy, double time, int ncells, double m02, double m20)
+  {
+    static constexpr std::string_view clusterEnergyTimeHist[20] = {"clusterTimeVsESM/clusterTimeVsESM0", "clusterTimeVsESM/clusterTimeVsESM1", "clusterTimeVsESM/clusterTimeVsESM2", "clusterTimeVsESM/clusterTimeVsESM3", "clusterTimeVsESM/clusterTimeVsESM4", "clusterTimeVsESM/clusterTimeVsESM5", "clusterTimeVsESM/clusterTimeVsESM6", "clusterTimeVsESM/clusterTimeVsESM7", "clusterTimeVsESM/clusterTimeVsESM8", "clusterTimeVsESM/clusterTimeVsESM9", "clusterTimeVsESM/clusterTimeVsESM10", "clusterTimeVsESM/clusterTimeVsESM11", "clusterTimeVsESM/clusterTimeVsESM12", "clusterTimeVsESM/clusterTimeVsESM13", "clusterTimeVsESM/clusterTimeVsESM14", "clusterTimeVsESM/clusterTimeVsESM15", "clusterTimeVsESM/clusterTimeVsESM16", "clusterTimeVsESM/clusterTimeVsESM17", "clusterTimeVsESM/clusterTimeVsESM18", "clusterTimeVsESM/clusterTimeVsESM19"};
+    static constexpr std::string_view clusterEnergyNcellHistSM[20] = {"clusterNcellVsESM/clusterNCellVsESM0", "clusterNcellVsESM/clusterNCellVsESM1", "clusterNcellVsESM/clusterNCellVsESM2", "clusterNcellVsESM/clusterNCellVsESM3", "clusterNcellVsESM/clusterNCellVsESM4", "clusterNcellVsESM/clusterNCellVsESM5", "clusterNcellVsESM/clusterNCellVsESM6", "clusterNcellVsESM/clusterNCellVsESM7", "clusterNcellVsESM/clusterNCellVsESM8", "clusterNcellVsESM/clusterNCellVsESM9", "clusterNcellVsESM/clusterNCellVsESM10", "clusterNcellVsESM/clusterNCellVsESM11", "clusterNcellVsESM/clusterNCellVsESM12", "clusterNcellVsESM/clusterNCellVsESM13", "clusterNcellVsESM/clusterNCellVsESM14", "clusterNcellVsESM/clusterNCellVsESM15", "clusterNcellVsESM/clusterNCellVsESM16", "clusterNcellVsESM/clusterNCellVsESM17", "clusterNcellVsESM/clusterNCellVsESM18", "clusterNcellVsESM/clusterNCellVsESM19"};
+    static constexpr std::string_view clusterEnergyM02HistSM[20] = {"clusterM02VsESM/clusterM02VsESM0", "clusterM02VsESM/clusterM02VsESM1", "clusterM02VsESM/clusterM02VsESM2", "clusterM02VsESM/clusterM02VsESM3", "clusterM02VsESM/clusterM02VsESM4", "clusterM02VsESM/clusterM02VsESM5", "clusterM02VsESM/clusterM02VsESM6", "clusterM02VsESM/clusterM02VsESM7", "clusterM02VsESM/clusterM02VsESM8", "clusterM02VsESM/clusterM02VsESM9", "clusterM02VsESM/clusterM02VsESM10", "clusterM02VsESM/clusterM02VsESM11", "clusterM02VsESM/clusterM02VsESM12", "clusterM02VsESM/clusterM02VsESM13", "clusterM02VsESM/clusterM02VsESM14", "clusterM02VsESM/clusterM02VsESM15", "clusterM02VsESM/clusterM02VsESM16", "clusterM02VsESM/clusterM02VsESM17", "clusterM02VsESM/clusterM02VsESM18", "clusterM02VsESM/clusterM02VsESM19"};
+    static constexpr std::string_view clusterEnergyM20HistSM[20] = {"clusterM20VsESM/clusterM20VsESM0", "clusterM20VsESM/clusterM20VsESM1", "clusterM20VsESM/clusterM20VsESM2", "clusterM20VsESM/clusterM20VsESM3", "clusterM20VsESM/clusterM20VsESM4", "clusterM20VsESM/clusterM20VsESM5", "clusterM20VsESM/clusterM20VsESM6", "clusterM20VsESM/clusterM20VsESM7", "clusterM20VsESM/clusterM20VsESM8", "clusterM20VsESM/clusterM20VsESM9", "clusterM20VsESM/clusterM20VsESM10", "clusterM20VsESM/clusterM20VsESM11", "clusterM20VsESM/clusterM20VsESM12", "clusterM20VsESM/clusterM20VsESM13", "clusterM20VsESM/clusterM20VsESM14", "clusterM20VsESM/clusterM20VsESM15", "clusterM20VsESM/clusterM20VsESM16", "clusterM20VsESM/clusterM20VsESM17", "clusterM20VsESM/clusterM20VsESM18", "clusterM20VsESM/clusterM20VsESM19"};
+    mHistManager.fill(HIST(clusterEnergyTimeHist[supermoduleID]), time, energy);
+    mHistManager.fill(HIST(clusterEnergyNcellHistSM[supermoduleID]), ncells, energy);
+    mHistManager.fill(HIST(clusterEnergyM02HistSM[supermoduleID]), m02, energy);
+    mHistManager.fill(HIST(clusterEnergyM20HistSM[supermoduleID]), m20, energy);
+  }
+
   /// \brief Create binning for cluster energy axis (variable bin size)
   /// \return vector with bin limits
-  std::vector<double> makeEnergyBinning() const
+  std::vector<double>
+    makeEnergyBinning() const
   {
     auto fillBinLimits = [](std::vector<double>& binlimits, double max, double binwidth) {
       auto current = *binlimits.rbegin();

--- a/PWGJE/Tasks/emceventselectionqa.cxx
+++ b/PWGJE/Tasks/emceventselectionqa.cxx
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Monitoring task for EMCAL event selection
+//
+// Author: Markus Fasel
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "Common/DataModel/EventSelection.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+using bcEvSels = o2::soa::Join<o2::aod::BCs, o2::aod::BcSels>;
+using collEventSels = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels>;
+
+struct EmcEventSelectionQA {
+  o2::framework::HistogramRegistry mHistManager{"EMCALEventSelectionQAHistograms"};
+
+  void init(o2::framework::InitContext const&)
+  {
+    using o2HistType = o2::framework::HistType;
+    using o2Axis = o2::framework::AxisSpec;
+
+    o2Axis matchingAxis{3, -0.5, 2.5, "matchingStatus", "Matching status"}, // 0, no vertex,1 vertex found , 2 multiple vertices found
+      bcAxis{4001, -0.5, 4000.5, "bcid", "BC ID"};
+
+    mHistManager.add("hCollisionMatching", "hCollisionMatching", o2HistType::kTH1F, {matchingAxis});
+    mHistManager.add("hCollisionMatchingReadout", "hCollisionMatching", o2HistType::kTH1F, {matchingAxis});
+    mHistManager.add("hBCCollisions", "Bunch crossings of found collisions", o2HistType::kTH1F, {bcAxis});
+    mHistManager.add("hBCEmcalReadout", "Bunch crossings with EMCAL trigger from CTP", o2HistType::kTH1F, {bcAxis});
+    mHistManager.add("hBCTVX", "Bunch crossings with FIT TVX trigger from CTP", o2HistType::kTH1F, {bcAxis});
+    mHistManager.add("hBCEmcalCellContent", "Bunch crossings with non-0 EMCAL cell content", o2HistType::kTH1F, {bcAxis});
+  }
+
+  Preslice<collEventSels> perFoundBC = aod::evsel::foundBCId;
+
+  void process(bcEvSels const& bcs, collEventSels const& collisions, aod::Calos const& cells)
+  {
+    for (const auto& bc : bcs) {
+      bool isEMCALreadout = false;
+      auto bcID = bc.globalBC() % 3564;
+
+      if (bc.runNumber() > 300000) {
+        // in case of run3 not all BCs contain EMCAL data, require trigger selection also for min. bias
+        // in addition select also L0/L1 triggers as triggers with EMCAL in reaodut
+        if (bc.alias()[kTVXinEMC] || bc.alias()[kEMC7] || bc.alias()[kEG1] || bc.alias()[kEG2] || bc.alias()[kEJ1] || bc.alias()[kEJ2]) {
+          isEMCALreadout = true;
+        }
+      } else {
+        // run1/2: rely on trigger cluster, runlist must contain only runs with EMCAL in readout
+        // Select min. bias trigger and EMCAL L0/L1 triggers
+        if (bc.alias()[kINT7] || bc.alias()[kEMC7] || bc.alias()[kEG1] || bc.alias()[kEG2] || bc.alias()[kEJ1] || bc.alias()[kEJ2]) {
+          isEMCALreadout = true;
+        }
+      }
+
+      // Monitoring BCs with EMCAL trigger / readout / FIT trigger
+      if (isEMCALreadout) {
+        mHistManager.fill(HIST("hBCEmcalReadout"), bcID);
+      }
+
+      if (bc.selection()[kIsTriggerTVX]) {
+        mHistManager.fill(HIST("hBCTVX"), bcID);
+      }
+
+      // Find cells:
+      int ncellsBC = 0;
+      for (const auto& cell : cells) {
+        if (cell.bc_as<bcEvSels>() == bc) {
+          ncellsBC++;
+        }
+      }
+      if (ncellsBC) {
+        mHistManager.fill(HIST("hBCEmcalCellContent"), bcID);
+      }
+
+      auto collisionsGrouped = collisions.sliceBy(perFoundBC, bc.globalIndex());
+      int collisionStatus = -1;
+      if (!collisionsGrouped.size()) {
+        collisionStatus = 0;
+      } else if (collisionsGrouped.size() == 1) {
+        collisionStatus = 1;
+      } else {
+        collisionStatus = 2;
+      }
+      if (collisionStatus >= 0) {
+        mHistManager.fill(HIST("hCollisionMatching"), collisionStatus);
+        if (isEMCALreadout) {
+          mHistManager.fill(HIST("hCollisionMatchingReadout"), collisionStatus);
+        }
+      }
+      if (collisionStatus > 0) {
+        mHistManager.fill(HIST("hBCCollisions"), bcID);
+      }
+    }
+  }
+};
+
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
+{
+  return o2::framework::WorkflowSpec{
+    o2::framework::adaptAnalysisTask<EmcEventSelectionQA>(cfgc)};
+}


### PR DESCRIPTION
- [EMCAL-670, EMCAL-850] Outsource event selection histograms to dedicated task
  + global BC % 3564 for all triggered BCs, BCs with
     EMCAL readout, BCs with EMCAL cell content and
     collisions
  + Adapt EMCAL readout check for run2 data

- [EMCAL-734] Add more histograms to cluster monitor
  + Number of clusters per event / bc total and per
     supermodule
  + Cluster energy spectrum vs. supermodule ID
  + Per supermodule:
     * Time vs. energy
     * Number of cells vs. energy
     * Shower shape parameters vs. energy