### PR TITLE
PWGHF: added protection to D0-h correlation task

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -141,7 +141,7 @@ struct HfCorrelatorD0Hadrons {
   /// D0-h correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
   void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
   {
-    //protection against empty tables to be sliced
+    // protection against empty tables to be sliced
     if (selectedD0Candidates.size() == 0) {
       return;
     }
@@ -269,7 +269,7 @@ struct HfCorrelatorD0Hadrons {
 
   void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfCand2ProngMcRec> const& candidates)
   {
-    //protection against empty tables to be sliced
+    // protection against empty tables to be sliced
     if (selectedD0candidatesMC.size() == 0) {
       return;
     }

--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -141,6 +141,10 @@ struct HfCorrelatorD0Hadrons {
   /// D0-h correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
   void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
   {
+    //protection against empty tables to be sliced
+    if (selectedD0Candidates.size() == 0) {
+      return;
+    }
     int nTracks = 0;
     if (collision.numContrib() > 1) {
       for (const auto& track : tracks) {
@@ -265,7 +269,10 @@ struct HfCorrelatorD0Hadrons {
 
   void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfCand2ProngMcRec> const& candidates)
   {
-
+    //protection against empty tables to be sliced
+    if (selectedD0candidatesMC.size() == 0) {
+      return;
+    }
     int nTracks = 0;
     if (collision.numContrib() > 1) {
       for (const auto& track : tracks) {


### PR DESCRIPTION
Added protection for avoiding having empty tables to which sliceByCached method is applied, in D0-h correlation task