### PR TITLE
PWGHF: add check on PDG code for Lc 1st daughter in MC.

### DIFF
--- a/DPG/Tasks/AOTTrack/qaEventTrack.cxx
+++ b/DPG/Tasks/AOTTrack/qaEventTrack.cxx
@@ -152,6 +152,7 @@ struct qaEventTrack {
     histos.add("Events/posYvsNContrib", "", kTH2D, {axisVertexPosY, axisVertexNumContrib});
     histos.add("Events/posZvsNContrib", "", kTH2D, {axisVertexPosZ, axisVertexNumContrib});
     histos.add("Events/nContrib", "", kTH1D, {axisVertexNumContrib});
+    histos.add("Events/nContribVsFilteredMult", "", kTH2D, {axisVertexNumContrib, axisTrackMultiplicity});
     histos.add("Events/nContribVsMult", "", kTH2D, {axisVertexNumContrib, axisTrackMultiplicity});
     histos.add("Events/vertexChi2", ";#chi^{2}", kTH1D, {{100, 0, 100}});
 
@@ -988,7 +989,8 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
   histos.fill(HIST("Events/posZvsNContrib"), collision.posZ(), collision.numContrib());
 
   histos.fill(HIST("Events/nContrib"), collision.numContrib());
-  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), nFilteredTracks);
+  histos.fill(HIST("Events/nContribVsFilteredMult"), collision.numContrib(), nFilteredTracks);
+  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), tracksUnfiltered.size());
   histos.fill(HIST("Events/vertexChi2"), collision.chi2());
 
   histos.fill(HIST("Events/covXX"), collision.covXX());

--- a/DPG/Tasks/AOTTrack/qaEventTrack.cxx
+++ b/DPG/Tasks/AOTTrack/qaEventTrack.cxx
@@ -162,6 +162,7 @@ struct qaEventTrack {
     histos.add("Events/covYZ", ";Cov_{yz} [cm^{2}]", kTH1D, {axisVertexCov});
     histos.add("Events/covZZ", ";Cov_{zz} [cm^{2}]", kTH1D, {axisVertexCov});
 
+    histos.add("Events/nFilteredTracks", "", kTH1D, {axisTrackMultiplicity});
     histos.add("Events/nTracks", "", kTH1D, {axisTrackMultiplicity});
 
     if (doprocessMC || doprocessRun2ConvertedMC) {
@@ -840,14 +841,14 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
     return;
   }
 
-  int nTracks = 0;
+  int nFilteredTracks = 0;
   for (const auto& track : tracks) {
     histos.fill(HIST("Tracks/selection"), 1.f);
     if (!isSelectedTrack<IS_MC>(track)) {
       continue;
     }
     histos.fill(HIST("Tracks/selection"), 2.f);
-    ++nTracks;
+    ++nFilteredTracks;
     if (track.passedTrackType()) {
       histos.fill(HIST("Tracks/selection"), 3.f);
     }
@@ -987,7 +988,7 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
   histos.fill(HIST("Events/posZvsNContrib"), collision.posZ(), collision.numContrib());
 
   histos.fill(HIST("Events/nContrib"), collision.numContrib());
-  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), nTracks);
+  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), nFilteredTracks);
   histos.fill(HIST("Events/vertexChi2"), collision.chi2());
 
   histos.fill(HIST("Events/covXX"), collision.covXX());
@@ -997,7 +998,8 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
   histos.fill(HIST("Events/covYZ"), collision.covYZ());
   histos.fill(HIST("Events/covZZ"), collision.covZZ());
 
-  histos.fill(HIST("Events/nTracks"), nTracks);
+  histos.fill(HIST("Events/nFilteredTracks"), nFilteredTracks);
+  histos.fill(HIST("Events/nTracks"), tracksUnfiltered.size());
 
   // vertex resolution
   if constexpr (IS_MC) {

--- a/PWGHF/Tasks/taskLc.cxx
+++ b/PWGHF/Tasks/taskLc.cxx
@@ -325,11 +325,11 @@ struct HfTaskLc {
         registry.fill(HIST("MC/generated/signal/hPtGenSig"), particleMother.pt()); // gen. level pT
         auto pt = candidate.pt();
         /// MC reconstructed signal
-        if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+        if ((candidate.isSelLcToPKPi() >= selectionFlagLc) && abs(candidate.prong0_as<aod::BigTracksMC>().mcParticle().pdgCode()) == kProton) {
           registry.fill(HIST("MC/reconstructed/signal/hMassRecSig"), invMassLcToPKPi(candidate));
           registry.fill(HIST("MC/reconstructed/signal/hMassVsPtRecSig"), invMassLcToPKPi(candidate), pt);
         }
-        if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+        if ((candidate.isSelLcToPiKP() >= selectionFlagLc) && abs(candidate.prong0_as<aod::BigTracksMC>().mcParticle().pdgCode()) == kPiPlus) {
           registry.fill(HIST("MC/reconstructed/signal/hMassRecSig"), invMassLcToPiKP(candidate));
           registry.fill(HIST("MC/reconstructed/signal/hMassVsPtRecSig"), invMassLcToPiKP(candidate), pt);
         }


### PR DESCRIPTION
Hi,
looking at the code I see that when fillinf the `MC/reconstructed` histograms for the Lc mass we do not check explicitly the real mass hypothesis, but we do only rely on the response from the reconstructon cuts (`isSelLcToPKPi` and `isSelLcToPiKP`). If we do not do it, we risk to do double counting if for our recosntructed candidate both `isSelLcToPKPi` and `isSelLcToPiKP` are `true` (even if we know that this is a real Lc from here: https://github.com/AliceO2Group/O2Physics/blob/e1a5307ef5e067be285509c3638c9e4152159b34/PWGHF/Tasks/taskLc.cxx#L321). Am I right or is there something that I am missing?