### PR TITLE
cascade DCAxy now from proper propagation

### DIFF
--- a/DPG/Tasks/AOTTrack/qaEventTrack.cxx
+++ b/DPG/Tasks/AOTTrack/qaEventTrack.cxx
@@ -154,6 +154,7 @@ struct qaEventTrack {
     histos.add("Events/posYvsNContrib", "", kTH2D, {axisVertexPosY, axisVertexNumContrib});
     histos.add("Events/posZvsNContrib", "", kTH2D, {axisVertexPosZ, axisVertexNumContrib});
     histos.add("Events/nContrib", "", kTH1D, {axisVertexNumContrib});
+    histos.add("Events/nContribVsFilteredMult", "", kTH2D, {axisVertexNumContrib, axisTrackMultiplicity});
     histos.add("Events/nContribVsMult", "", kTH2D, {axisVertexNumContrib, axisTrackMultiplicity});
     histos.add("Events/vertexChi2", ";#chi^{2}", kTH1D, {{100, 0, 100}});
 
@@ -164,6 +165,7 @@ struct qaEventTrack {
     histos.add("Events/covYZ", ";Cov_{yz} [cm^{2}]", kTH1D, {axisVertexCov});
     histos.add("Events/covZZ", ";Cov_{zz} [cm^{2}]", kTH1D, {axisVertexCov});
 
+    histos.add("Events/nFilteredTracks", "", kTH1D, {axisTrackMultiplicity});
     histos.add("Events/nTracks", "", kTH1D, {axisTrackMultiplicity});
 
     if (doprocessMC || doprocessRun2ConvertedMC) {
@@ -844,14 +846,14 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
     return;
   }
 
-  int nTracks = 0;
+  int nFilteredTracks = 0;
   for (const auto& track : tracks) {
     histos.fill(HIST("Tracks/selection"), 1.f);
     if (!isSelectedTrack<IS_MC>(track)) {
       continue;
     }
     histos.fill(HIST("Tracks/selection"), 2.f);
-    ++nTracks;
+    ++nFilteredTracks;
     if (track.passedTrackType()) {
       histos.fill(HIST("Tracks/selection"), 3.f);
     }
@@ -991,7 +993,8 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
   histos.fill(HIST("Events/posZvsNContrib"), collision.posZ(), collision.numContrib());
 
   histos.fill(HIST("Events/nContrib"), collision.numContrib());
-  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), nTracks);
+  histos.fill(HIST("Events/nContribVsFilteredMult"), collision.numContrib(), nFilteredTracks);
+  histos.fill(HIST("Events/nContribVsMult"), collision.numContrib(), tracksUnfiltered.size());
   histos.fill(HIST("Events/vertexChi2"), collision.chi2());
 
   histos.fill(HIST("Events/covXX"), collision.covXX());
@@ -1001,7 +1004,8 @@ void qaEventTrack::fillRecoHistogramsGroupedTracks(const C& collision, const T& 
   histos.fill(HIST("Events/covYZ"), collision.covYZ());
   histos.fill(HIST("Events/covZZ"), collision.covZZ());
 
-  histos.fill(HIST("Events/nTracks"), nTracks);
+  histos.fill(HIST("Events/nFilteredTracks"), nFilteredTracks);
+  histos.fill(HIST("Events/nTracks"), tracksUnfiltered.size());
 
   // vertex resolution
   if constexpr (IS_MC) {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -337,7 +337,6 @@ DECLARE_SOA_TABLE(CascData, "AOD", "CASCDATA", //!
                   cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
                   cascdata::CascCosPA<cascdata::X, cascdata::Y, cascdata::Z, cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
                   cascdata::DCAV0ToPV<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
-                  cascdata::DCACascToPV<cascdata::X, cascdata::Y, cascdata::Z, cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
 
                   // Invariant masses
                   cascdata::MLambda<cascdata::Sign, cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg>,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -259,6 +259,7 @@ DECLARE_SOA_COLUMN(DCACascDaughters, dcacascdaughters, float); //!
 DECLARE_SOA_COLUMN(DCAPosToPV, dcapostopv, float);             //!
 DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);             //!
 DECLARE_SOA_COLUMN(DCABachToPV, dcabachtopv, float);           //!
+DECLARE_SOA_COLUMN(DCACascToPV, dcacasctopv, float);           //!
 
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
@@ -281,8 +282,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(V0CosPA, v0cosPA, //!
 DECLARE_SOA_DYNAMIC_COLUMN(CascCosPA, casccosPA, //!
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(array{pvX, pvY, pvZ}, array{X, Y, Z}, array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DCAV0ToPV, dcav0topv, //!
-                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
-DECLARE_SOA_DYNAMIC_COLUMN(DCACascToPV, dcacasctopv, //!
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
 
 // Calculated on the fly with mass assumption + dynamic tables
@@ -329,7 +328,7 @@ DECLARE_SOA_TABLE(CascData, "AOD", "CASCDATA", //!
                   cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg,
                   cascdata::PxBach, cascdata::PyBach, cascdata::PzBach,
                   cascdata::DCAV0Daughters, cascdata::DCACascDaughters,
-                  cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV,
+                  cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV, cascdata::DCACascToPV,
 
                   // Dynamic columns
                   cascdata::Pt<cascdataext::Px, cascdataext::Py>,

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -206,7 +206,7 @@ struct cascadeBuilder {
       }
       auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
 
-      std::array<float, 3> pVtx = {v0data.collision().posX(), v0data.collision().posY(), v0data.collision().posZ()};
+      std::array<float, 3> pVtx = {casc.collision().posX(), casc.collision().posY(), casc.collision().posZ()};
 
       auto bachTrackCast = casc.bachelor_as<TCascTracksTo>();
       auto posTrackCast = v0data.posTrack_as<TCascTracksTo>();
@@ -407,24 +407,33 @@ struct cascadeBuilder {
 
       // Fill table, please
       hCascCandidate->Fill(16.5); // this is the master fill: if this is filled, viable candidate
-
+      
       if (casc.collisionId() < 0)
         hCascCandidate->Fill(17.5);
       if (casc.collisionId() >= 0)
         hCascCandidate->Fill(18.5);
-
+      
+      //Calculate DCAxy of the cascade (with bending)
+      auto lCascadeTrack = fitter.createParentTrackPar();
+      gpu::gpustd::array<float, 2> dcaInfo;
+      dcaInfo[0] = 999;
+      dcaInfo[1] = 999;
+      
+      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorr, &dcaInfo);
+      
       cascdata(
-        v0.globalIndex(),
-        bachTrackCast.globalIndex(),
-        casc.collisionId(),
-        charge, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
-        pvecpos[0], pvecpos[1], pvecpos[2],
-        pvecneg[0], pvecneg[1], pvecneg[2],
-        pvecbach[0], pvecbach[1], pvecbach[2],
-        fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
-        posTrackCast.dcaXY(),
-        negTrackCast.dcaXY(),
-        bachTrackCast.dcaXY());
+               v0.globalIndex(),
+               bachTrackCast.globalIndex(),
+               casc.collisionId(),
+               charge, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
+               pvecpos[0], pvecpos[1], pvecpos[2],
+               pvecneg[0], pvecneg[1], pvecneg[2],
+               pvecbach[0], pvecbach[1], pvecbach[2],
+               fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
+               posTrackCast.dcaXY(),
+               negTrackCast.dcaXY(),
+               bachTrackCast.dcaXY(),
+               dcaInfo[0]);
     }
   }
 

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -414,12 +414,14 @@ struct cascadeBuilder {
         hCascCandidate->Fill(18.5);
       
       //Calculate DCAxy of the cascade (with bending)
-      auto lCascadeTrack = fitter.createParentTrackPar();
+      auto lCascadeTrack = fitterCasc.createParentTrackPar();
+      lCascadeTrack.setAbsCharge(charge); // to be sure
+      lCascadeTrack.setPID(o2::track::PID::XiMinus); // FIXME: not OK for omegas
       gpu::gpustd::array<float, 2> dcaInfo;
       dcaInfo[0] = 999;
       dcaInfo[1] = 999;
       
-      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorr, &dcaInfo);
+      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, &dcaInfo);
       
       cascdata(
                v0.globalIndex(),

--- a/PWGLF/TableProducer/cascadefinder.cxx
+++ b/PWGLF/TableProducer/cascadefinder.cxx
@@ -268,6 +268,16 @@ struct cascadefinder {
               posXi[i] = cascvtx[i];
             }
             fitterCasc.getTrack(1).getPxPyPzGlo(pvecbach);
+            
+            //Calculate DCAxy of the cascade (with bending)
+            auto lCascadeTrack = fitterCasc.createParentTrackPar();
+            lCascadeTrack.setAbsCharge(-1); // to be sure
+            lCascadeTrack.setPID(o2::track::PID::XiMinus); // FIXME: not OK for omegas
+            gpu::gpustd::array<float, 2> dcaInfo;
+            dcaInfo[0] = 999;
+            dcaInfo[1] = 999;
+            
+            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, &dcaInfo);
 
             lNCand++;
             // If we got here, it means this is a good candidate!
@@ -279,7 +289,8 @@ struct cascadefinder {
                      fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
                      v0.dcapostopv(),
                      v0.dcanegtopv(),
-                     t0id.dcaXY());
+                     t0id.dcaXY(),
+                     dcaInfo[0]);
           } // end if cascade recoed
         }   // end loop over bachelor
       }     // end if v0 recoed
@@ -342,12 +353,14 @@ struct cascadefinder {
             fitterCasc.getTrack(1).getPxPyPzGlo(pvecbach);
             
             //Calculate DCAxy of the cascade (with bending)
-            auto lCascadeTrack = fitter.createParentTrackPar();
+            auto lCascadeTrack = fitterCasc.createParentTrackPar();
+            lCascadeTrack.setAbsCharge(+1); // to be sure
+            lCascadeTrack.setPID(o2::track::PID::XiMinus); // FIXME: not OK for omegas
             gpu::gpustd::array<float, 2> dcaInfo;
             dcaInfo[0] = 999;
             dcaInfo[1] = 999;
             
-            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorr, &dcaInfo);
+            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, &dcaInfo);
 
             lNCand++;
             // If we got here, it means this is a good candidate!

--- a/PWGLF/TableProducer/cascadefinder.cxx
+++ b/PWGLF/TableProducer/cascadefinder.cxx
@@ -340,6 +340,14 @@ struct cascadefinder {
               posXi[i] = cascvtx[i];
             }
             fitterCasc.getTrack(1).getPxPyPzGlo(pvecbach);
+            
+            //Calculate DCAxy of the cascade (with bending)
+            auto lCascadeTrack = fitter.createParentTrackPar();
+            gpu::gpustd::array<float, 2> dcaInfo;
+            dcaInfo[0] = 999;
+            dcaInfo[1] = 999;
+            
+            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorr, &dcaInfo);
 
             lNCand++;
             // If we got here, it means this is a good candidate!
@@ -351,7 +359,8 @@ struct cascadefinder {
                      fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
                      v0.dcapostopv(),
                      v0.dcanegtopv(),
-                     t0id.dcaXY());
+                     t0id.dcaXY(),
+                     dcaInfo[0]);
           } // end if cascade recoed
         }   // end loop over bachelor
       }     // end if v0 recoed


### PR DESCRIPTION
This commit replaces the straight-line cascade DCAxy calculation with a proper DCAxy calculated from a track propagation call that could even use material corrections (disabled by default, to be checked further). This is a very minor change but partially this already goes in the direction of having this information calculated independently perhaps even with more information (e.g. strangeness tracking). 