### PR TITLE
PWGEM/PhotonMeson: changed LOG info call

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/produceMesonCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/produceMesonCalo.cxx
@@ -102,14 +102,15 @@ struct produceMesonCalo {
     spectra.add("SameEvent_PtMother_PtGamma", "SameEvent_PtMother_PtGamma", defaultPtMotherPtGammaHist, true);
 
     spectra.add("Photon_Eta_Phi", "Photon_Eta_Phi", defaultEtaPhiHist, true);
+
+    LOG(info) << "| Timing cut: " << minTime << "< t < " << maxTime << std::endl;
+    LOG(info) << "| M02 cut: " << minM02 << "< M02 < " << maxM02 << std::endl;
   }
 
   void
     processRec(aod::Collision const&,
                aod::SkimEMCClusters const& caloclusters)
   {
-    LOG(info) << "| Timing cut: " << minTime << "< t < " << maxTime << std::endl;
-    LOG(info) << "| M02 cut: " << minM02 << "< M02 < " << maxM02 << std::endl;
     for (auto& [gamma0, gamma1] :
          combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(caloclusters,
                                                                     caloclusters))) {

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -55,12 +55,13 @@ struct skimmerGammaCalo {
     hCaloClusterFilter->GetXaxis()->SetBinLabel(2, "time cut");
     hCaloClusterFilter->GetXaxis()->SetBinLabel(3, "M02 cut");
     hCaloClusterFilter->GetXaxis()->SetBinLabel(4, "out");
+
+    LOG(info) << "| Timing cut: " << minTime << " < t < " << maxTime << std::endl;
+    LOG(info) << "| M02 cut: " << minM02 << " < M02 < " << maxM02 << std::endl;
   }
 
   void processRec(aod::Collision const&, aod::EMCALClusters const& emcclusters, aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks)
   {
-    LOG(info) << "| Timing cut: " << minTime << "< t < " << maxTime << std::endl;
-    LOG(info) << "| M02 cut: " << minM02 << "< M02 < " << maxM02 << std::endl;
     for (const auto& emccluster : emcclusters) {
       historeg.fill(HIST("hCaloClusterEIn"), emccluster.energy());
       historeg.fill(HIST("hCaloClusterFilter"), 0);


### PR DESCRIPTION
- moved LOG(info) calls from the process function to the init function to reduce the time it's called