### PR TITLE
increase tolerance for CYY check

### DIFF
--- a/Common/TableProducer/collisionConverter.cxx
+++ b/Common/TableProducer/collisionConverter.cxx
@@ -30,10 +30,11 @@ struct collisionConverter {
         lYY = collision.covYY();
         lXZ = collision.covXZ();
       };
-      if (lYY < -1e-8) {
+      if (lYY < -1e-6) {
         // This happened by accident!
         if (!doNotSwap) {
           LOGF(info, "Collision converter task found negative YY element!");
+          LOGF(info, "Value of C_YY = %.10f", lYY);
           LOGF(info, "This is an indication that you're looping over data");
           LOGF(info, "produced with an O2 version of late December 2022.");
           LOGF(info, "Unfortunately, O2 versions of late December 2022");


### PR DESCRIPTION
Interestingly, in MC, a very very small (order of 1 per million or less) fraction of PVs seem to have very-close-to-zero negative CYY values. This is likely a numerical precision problem (to be checked with Ruben after the holiday period). In the meantime, this PR increases the tolerance so that it doesn't trigger on that. Precision check was CYY < -1e-8, is now CYY < -1e-6.