### PR TITLE
PWGHF: First attempt on accounting for ambiguous tracks in HF vertexing

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -84,14 +84,14 @@ DECLARE_SOA_TABLE(HfAmbTrackBase, "AOD", "HFAMBTRACKBASE",                 //!
                   track::Energy<track::Signed1Pt, track::Tgl>,             //!
                   track::Rapidity<track::Signed1Pt, track::Tgl>,           //!
                   track::Sign<track::Signed1Pt>);                          //!
-DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackExt, HfAmbTrackBase, "HFAMBTRACKExt", //! Basic track properties
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackExt, HfAmbTrackBase, "HFAMBTRACKEXT", //! Basic track properties
                            aod::track::Pt,
                            aod::track::P,
                            aod::track::Eta,
                            aod::track::Phi);
 using HfAmbTrack = HfAmbTrackExt;
 
-DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRACKCOVBASE",                                       //!
+DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRACKCOVBAS",                                       //!
                   track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,     //!
                   track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,        //!
                   track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -43,15 +43,16 @@ namespace hf_amb_tracks
 enum eTrackType { Ambiguous = 0,
                   PVContributor };
 
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);    //!
-DECLARE_SOA_INDEX_COLUMN(Track, track);            //!
-DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //!
-DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);           //!
-DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);             //!
-DECLARE_SOA_COLUMN(P, p, float);                   //!
-DECLARE_SOA_COLUMN(Pt, pt, float);                 //!
-DECLARE_SOA_COLUMN(Eta, eta, float);               //!
-DECLARE_SOA_COLUMN(Phi, phi, float);               //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                   //!
+DECLARE_SOA_INDEX_COLUMN(Track, track);                           //!
+DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t);                //!
+DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);                          //!
+DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);                            //!
+DECLARE_SOA_COLUMN(P, p, float);                                  //!
+DECLARE_SOA_COLUMN(Pt, pt, float);                                //!
+DECLARE_SOA_COLUMN(Eta, eta, float);                              //!
+DECLARE_SOA_COLUMN(Phi, phi, float);                              //!
+DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool); //!
 
 DECLARE_SOA_COLUMN(CYY, cYY, float);             //!
 DECLARE_SOA_COLUMN(CZY, cZY, float);             //!
@@ -97,10 +98,11 @@ DECLARE_SOA_TABLE(HfAmbTrackCov, "AOD", "HFAMBTRACKCOV",                        
 
 namespace hf_sel_track
 {
-DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int); //!
-DECLARE_SOA_COLUMN(PxProng, pxProng, float);     //!
-DECLARE_SOA_COLUMN(PyProng, pyProng, float);     //!
-DECLARE_SOA_COLUMN(PzProng, pzProng, float);     //!
+DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int);       //!
+DECLARE_SOA_COLUMN(IsSelProngAmb, isSelProngAmb, int); //!
+DECLARE_SOA_COLUMN(PxProng, pxProng, float);           //!
+DECLARE_SOA_COLUMN(PyProng, pyProng, float);           //!
+DECLARE_SOA_COLUMN(PzProng, pzProng, float);           //!
 } // namespace hf_sel_track
 
 DECLARE_SOA_TABLE(HfSelTrack, "AOD", "HFSELTRACK", //!
@@ -110,7 +112,7 @@ DECLARE_SOA_TABLE(HfSelTrack, "AOD", "HFSELTRACK", //!
                   hf_sel_track::PzProng);
 
 DECLARE_SOA_TABLE(HfSelAmbTrack, "AOD", "HFSELAMBTRACK", //!
-                  hf_sel_track::IsSelProng,
+                  hf_sel_track::IsSelProngAmb,
                   hf_sel_track::PxProng,
                   hf_sel_track::PyProng,
                   hf_sel_track::PzProng);

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -109,6 +109,12 @@ DECLARE_SOA_TABLE(HfSelTrack, "AOD", "HFSELTRACK", //!
                   hf_sel_track::PyProng,
                   hf_sel_track::PzProng);
 
+DECLARE_SOA_TABLE(HfSelAmbTrack, "AOD", "HFSELAMBTRACK", //!
+                  hf_sel_track::IsSelProng,
+                  hf_sel_track::PxProng,
+                  hf_sel_track::PyProng,
+                  hf_sel_track::PzProng);
+
 namespace hf_pv_refit_track
 {
 DECLARE_SOA_COLUMN(PvRefitX, pvRefitX, float);             //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -42,6 +42,10 @@ namespace hf_amb_tracks
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision); //!
 DECLARE_SOA_INDEX_COLUMN(Track, track);         //!
+
+DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //!
+enum eTrackType {Ambiguous=0, PVContributor};
+
 DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);        //!
 DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);          //!
 DECLARE_SOA_COLUMN(P, p, float);                //!
@@ -69,7 +73,8 @@ DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //!
 
 DECLARE_SOA_TABLE(HfAmbTrack, "AOD", "HFAMBTRACK",                              //!
                   o2::soa::Index<>, hf_amb_tracks::TrackId,                     //!
-                  hf_amb_tracks::CollisionId, track::X, track::Alpha, track::Y, //!
+                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,         //!
+                  track::X, track::Alpha, track::Y,                             //!
                   track::Z, track::Snp, track::Tgl, track::Signed1Pt,           //!
                   hf_amb_tracks::Pt, hf_amb_tracks::P,                          //!
                   hf_amb_tracks::Eta, hf_amb_tracks::Phi,                       //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -72,29 +72,48 @@ DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //!
 
 } // namespace hf_amb_tracks
 
-DECLARE_SOA_TABLE(HfAmbTrack, "AOD", "HFAMBTRACK",                       //!
-                  o2::soa::Index<>, hf_amb_tracks::TrackId,              //!
-                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,  //!
-                  track::X, track::Alpha, track::Y,                      //!
-                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,    //!
-                  hf_amb_tracks::Pt, hf_amb_tracks::P,                   //!
-                  hf_amb_tracks::Eta, hf_amb_tracks::Phi,                //!
-                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,             //!
-                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>, //!
-                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>, //!
-                  track::Pz<track::Signed1Pt, track::Tgl>,               //!
-                  track::Energy<track::Signed1Pt, track::Tgl>,           //!
-                  track::Rapidity<track::Signed1Pt, track::Tgl>,         //!
-                  track::Sign<track::Signed1Pt>);                        //!
+DECLARE_SOA_TABLE(HfAmbTrackBase, "AOD", "HFAMBTRACKBASE",                 //!
+                  o2::soa::Index<>, hf_amb_tracks::TrackId,                //!
+                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,    //!
+                  track::X, track::Alpha, track::Y,                        //!
+                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,      //!
+                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,               //!
+                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>,   //!
+                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>,   //!
+                  track::Pz<track::Signed1Pt, track::Tgl>,                 //!
+                  track::Energy<track::Signed1Pt, track::Tgl>,             //!
+                  track::Rapidity<track::Signed1Pt, track::Tgl>,           //!
+                  track::Sign<track::Signed1Pt>);                          //!
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackExt, HfAmbTrackBase, "HFAMBTRACKExt", //! Basic track properties
+                           aod::track::Pt,
+                           aod::track::P,
+                           aod::track::Eta,
+                           aod::track::Phi);
+using HfAmbTrack = HfAmbTrackExt;
 
-DECLARE_SOA_TABLE(HfAmbTrackCov, "AOD", "HFAMBTRACKCOV",                                                      //!
-                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,            //!
-                  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,               //!
-                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl,       //!
-                  hf_amb_tracks::CYY, hf_amb_tracks::CZY, hf_amb_tracks::CZZ, hf_amb_tracks::CSnpY,           //!
-                  hf_amb_tracks::CSnpZ, hf_amb_tracks::CSnpSnp, hf_amb_tracks::CTglY, hf_amb_tracks::CTglZ,   //!
-                  hf_amb_tracks::CTglSnp, hf_amb_tracks::CTglTgl, hf_amb_tracks::C1PtY, hf_amb_tracks::C1PtZ, //!
-                  hf_amb_tracks::C1PtSnp, hf_amb_tracks::C1PtTgl, hf_amb_tracks::C1Pt21Pt2);                  //!
+DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRACKCOVBASE",                                       //!
+                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,     //!
+                  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,        //!
+                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl //!
+);                                                                                                     //!
+
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackCovExt, HfAmbTrackCovBase, "HFAMBTRACKCOVEXT", //! Track covariance matrix
+                           aod::track::CYY,
+                           aod::track::CZY,
+                           aod::track::CZZ,
+                           aod::track::CSnpY,
+                           aod::track::CSnpZ,
+                           aod::track::CSnpSnp,
+                           aod::track::CTglY,
+                           aod::track::CTglZ,
+                           aod::track::CTglSnp,
+                           aod::track::CTglTgl,
+                           aod::track::C1PtY,
+                           aod::track::C1PtZ,
+                           aod::track::C1PtSnp,
+                           aod::track::C1PtTgl,
+                           aod::track::C1Pt21Pt2);
+using HfAmbTrackCov = HfAmbTrackCovExt;
 
 namespace hf_sel_track
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -91,13 +91,13 @@ DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackExt, HfAmbTrackBase, "HFAMBTRACKEXT", //! B
                            aod::track::Phi);
 using HfAmbTrack = HfAmbTrackExt;
 
-DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRACKCOVBAS",                                       //!
+DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRKCOVBASE",                                         //!
                   track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,     //!
                   track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,        //!
                   track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl //!
 );                                                                                                     //!
 
-DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackCovExt, HfAmbTrackCovBase, "HFAMBTRACKCOVEXT", //! Track covariance matrix
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackCovExt, HfAmbTrackCovBase, "HFAMBTRKCOVEXT", //! Track covariance matrix
                            aod::track::CYY,
                            aod::track::CZY,
                            aod::track::CZZ,

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -82,38 +82,39 @@ DECLARE_SOA_TABLE_FULL(StoredHfAmbTracks, "HfAmbTracks", "AOD", "HFAMBTRACKS", /
                        track::Pz<track::Signed1Pt, track::Tgl>,                //!
                        track::Energy<track::Signed1Pt, track::Tgl>,            //!
                        track::Rapidity<track::Signed1Pt, track::Tgl>,          //!
-                       track::Sign<track::Signed1Pt>,                          // !
+                       track::Sign<track::Signed1Pt>,                          //!
                        o2::soa::Marker<1>);                                    //!
-DECLARE_SOA_EXTENDED_TABLE(HfAmbTracks, StoredHfAmbTracks, "HFAMBTRACKS",      //! Basic track properties
-                           aod::track::Pt,
-                           aod::track::P,
-                           aod::track::Eta,
-                           aod::track::Phi);
+
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTracks, StoredHfAmbTracks, "HFAMBTRACKS", //! Basic track properties
+                           aod::track::Pt,                                //!
+                           aod::track::P,                                 //!
+                           aod::track::Eta,                               //!
+                           aod::track::Phi);                              //!
 // using HfAmbTracks = HfAmbTracksExt;
 
 DECLARE_SOA_TABLE_FULL(StoredHfAmbTracksCov, "HfAmbTracksCov", "AOD", "HFAMBTRKCOV",                         //!
                        track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,      //!
                        track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,         //!
-                       track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl, // !
+                       track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl, //!
                        o2::soa::Marker<3>                                                                    //!
 );
 
 DECLARE_SOA_EXTENDED_TABLE(HfAmbTracksCov, StoredHfAmbTracksCov, "HFAMBTRKCOV", //! Track covariance matrix
-                           aod::track::CYY,
-                           aod::track::CZY,
-                           aod::track::CZZ,
-                           aod::track::CSnpY,
-                           aod::track::CSnpZ,
-                           aod::track::CSnpSnp,
-                           aod::track::CTglY,
-                           aod::track::CTglZ,
-                           aod::track::CTglSnp,
-                           aod::track::CTglTgl,
-                           aod::track::C1PtY,
-                           aod::track::C1PtZ,
-                           aod::track::C1PtSnp,
-                           aod::track::C1PtTgl,
-                           aod::track::C1Pt21Pt2);
+                           aod::track::CYY,                                     //!
+                           aod::track::CZY,                                     //!
+                           aod::track::CZZ,                                     //!
+                           aod::track::CSnpY,                                   //!
+                           aod::track::CSnpZ,                                   //!
+                           aod::track::CSnpSnp,                                 //!
+                           aod::track::CTglY,                                   //!
+                           aod::track::CTglZ,                                   //!
+                           aod::track::CTglSnp,                                 //!
+                           aod::track::CTglTgl,                                 //!
+                           aod::track::C1PtY,                                   //!
+                           aod::track::C1PtZ,                                   //!
+                           aod::track::C1PtSnp,                                 //!
+                           aod::track::C1PtTgl,                                 //!
+                           aod::track::C1Pt21Pt2);                              //!
 // using HfAmbTracksCov = HfAmbTracksCovExt;
 
 namespace hf_sel_track
@@ -125,18 +126,18 @@ DECLARE_SOA_COLUMN(PzProng, pzProng, float);     //!
 } // namespace hf_sel_track
 
 DECLARE_SOA_TABLE(HfSelTrack, "AOD", "HFSELTRACK", //!
-                  hf_sel_track::IsSelProng,
-                  hf_sel_track::PxProng,
-                  hf_sel_track::PyProng,
-                  hf_sel_track::PzProng,
-                  o2::soa::Marker<1>);
+                  hf_sel_track::IsSelProng,        //!
+                  hf_sel_track::PxProng,           //!
+                  hf_sel_track::PyProng,           //!
+                  hf_sel_track::PzProng,           //!
+                  o2::soa::Marker<1>);             //!
 
 DECLARE_SOA_TABLE(HfSelAmbTrack, "AOD", "HFSELAMBTRACK", //!
-                  hf_sel_track::IsSelProng,
-                  hf_sel_track::PxProng,
-                  hf_sel_track::PyProng,
-                  hf_sel_track::PzProng,
-                  o2::soa::Marker<2>);
+                  hf_sel_track::IsSelProng,              //!
+                  hf_sel_track::PxProng,                 //!
+                  hf_sel_track::PyProng,                 //!
+                  hf_sel_track::PzProng,                 //!
+                  o2::soa::Marker<2>);                   //!
 
 namespace hf_pv_refit_track
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -43,8 +43,7 @@ namespace hf_amb_tracks
 enum eTrackType { Ambiguous = 0,
                   PVContributor };
 
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                   //!
-DECLARE_SOA_INDEX_COLUMN(Track, track);                           //!
+DECLARE_SOA_COLUMN(TrackId, trackId, int64_t);                    //!
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t);                //!
 DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);                          //!
 DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);                            //!
@@ -72,32 +71,34 @@ DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //!
 
 } // namespace hf_amb_tracks
 
-DECLARE_SOA_TABLE(HfAmbTrackBase, "AOD", "HFAMBTRACKBASE",                 //!
-                  o2::soa::Index<>, hf_amb_tracks::TrackId,                //!
-                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,    //!
-                  track::X, track::Alpha, track::Y,                        //!
-                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,      //!
-                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,               //!
-                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>,   //!
-                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>,   //!
-                  track::Pz<track::Signed1Pt, track::Tgl>,                 //!
-                  track::Energy<track::Signed1Pt, track::Tgl>,             //!
-                  track::Rapidity<track::Signed1Pt, track::Tgl>,           //!
-                  track::Sign<track::Signed1Pt>);                          //!
-DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackExt, HfAmbTrackBase, "HFAMBTRACKEXT", //! Basic track properties
+DECLARE_SOA_TABLE_FULL(StoredHfAmbTracks, "HfAmbTracks", "AOD", "HFAMBTRACKS", //!
+                       o2::soa::Index<>, hf_amb_tracks::TrackId,               //!
+                       track::CollisionId, hf_amb_tracks::TrackType,           //!
+                       track::X, track::Alpha, track::Y,                       //!
+                       track::Z, track::Snp, track::Tgl, track::Signed1Pt,     //!
+                       hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,              //!
+                       track::Px<track::Signed1Pt, track::Snp, track::Alpha>,  //!
+                       track::Py<track::Signed1Pt, track::Snp, track::Alpha>,  //!
+                       track::Pz<track::Signed1Pt, track::Tgl>,                //!
+                       track::Energy<track::Signed1Pt, track::Tgl>,            //!
+                       track::Rapidity<track::Signed1Pt, track::Tgl>,          //!
+                       track::Sign<track::Signed1Pt>,                          // !
+                       o2::soa::Marker<1>);                                    //!
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTracks, StoredHfAmbTracks, "HFAMBTRACKS",      //! Basic track properties
                            aod::track::Pt,
                            aod::track::P,
                            aod::track::Eta,
                            aod::track::Phi);
-using HfAmbTrack = HfAmbTrackExt;
+// using HfAmbTracks = HfAmbTracksExt;
 
-DECLARE_SOA_TABLE(HfAmbTrackCovBase, "AOD", "HFAMBTRKCOVBASE",                                         //!
-                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,     //!
-                  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,        //!
-                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl //!
-);                                                                                                     //!
+DECLARE_SOA_TABLE_FULL(StoredHfAmbTracksCov, "HfAmbTracksCov", "AOD", "HFAMBTRKCOV",                         //!
+                       track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,      //!
+                       track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,         //!
+                       track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl, // !
+                       o2::soa::Marker<3>                                                                    //!
+);
 
-DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackCovExt, HfAmbTrackCovBase, "HFAMBTRKCOVEXT", //! Track covariance matrix
+DECLARE_SOA_EXTENDED_TABLE(HfAmbTracksCov, StoredHfAmbTracksCov, "HFAMBTRKCOV", //! Track covariance matrix
                            aod::track::CYY,
                            aod::track::CZY,
                            aod::track::CZZ,
@@ -113,28 +114,29 @@ DECLARE_SOA_EXTENDED_TABLE(HfAmbTrackCovExt, HfAmbTrackCovBase, "HFAMBTRKCOVEXT"
                            aod::track::C1PtSnp,
                            aod::track::C1PtTgl,
                            aod::track::C1Pt21Pt2);
-using HfAmbTrackCov = HfAmbTrackCovExt;
+// using HfAmbTracksCov = HfAmbTracksCovExt;
 
 namespace hf_sel_track
 {
-DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int);       //!
-DECLARE_SOA_COLUMN(IsSelProngAmb, isSelProngAmb, int); //!
-DECLARE_SOA_COLUMN(PxProng, pxProng, float);           //!
-DECLARE_SOA_COLUMN(PyProng, pyProng, float);           //!
-DECLARE_SOA_COLUMN(PzProng, pzProng, float);           //!
+DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int); //!
+DECLARE_SOA_COLUMN(PxProng, pxProng, float);     //!
+DECLARE_SOA_COLUMN(PyProng, pyProng, float);     //!
+DECLARE_SOA_COLUMN(PzProng, pzProng, float);     //!
 } // namespace hf_sel_track
 
 DECLARE_SOA_TABLE(HfSelTrack, "AOD", "HFSELTRACK", //!
                   hf_sel_track::IsSelProng,
                   hf_sel_track::PxProng,
                   hf_sel_track::PyProng,
-                  hf_sel_track::PzProng);
+                  hf_sel_track::PzProng,
+                  o2::soa::Marker<1>);
 
 DECLARE_SOA_TABLE(HfSelAmbTrack, "AOD", "HFSELAMBTRACK", //!
-                  hf_sel_track::IsSelProngAmb,
+                  hf_sel_track::IsSelProng,
                   hf_sel_track::PxProng,
                   hf_sel_track::PyProng,
-                  hf_sel_track::PzProng);
+                  hf_sel_track::PzProng,
+                  o2::soa::Marker<2>);
 
 namespace hf_pv_refit_track
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -40,18 +40,18 @@ DECLARE_SOA_TABLE(HfSelCollision, "AOD", "HFSELCOLLISION", //!
 
 namespace hf_amb_tracks
 {
-DECLARE_SOA_INDEX_COLUMN(Collision, collision); //!
-DECLARE_SOA_INDEX_COLUMN(Track, track);         //!
+enum eTrackType { Ambiguous = 0,
+                  PVContributor };
 
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);    //!
+DECLARE_SOA_INDEX_COLUMN(Track, track);            //!
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //!
-enum eTrackType {Ambiguous=0, PVContributor};
-
-DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);        //!
-DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);          //!
-DECLARE_SOA_COLUMN(P, p, float);                //!
-DECLARE_SOA_COLUMN(Pt, pt, float);              //!
-DECLARE_SOA_COLUMN(Eta, eta, float);            //!
-DECLARE_SOA_COLUMN(Phi, phi, float);            //!
+DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);           //!
+DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);             //!
+DECLARE_SOA_COLUMN(P, p, float);                   //!
+DECLARE_SOA_COLUMN(Pt, pt, float);                 //!
+DECLARE_SOA_COLUMN(Eta, eta, float);               //!
+DECLARE_SOA_COLUMN(Phi, phi, float);               //!
 
 DECLARE_SOA_COLUMN(CYY, cYY, float);             //!
 DECLARE_SOA_COLUMN(CZY, cZY, float);             //!
@@ -71,20 +71,20 @@ DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //!
 
 } // namespace hf_amb_tracks
 
-DECLARE_SOA_TABLE(HfAmbTrack, "AOD", "HFAMBTRACK",                              //!
-                  o2::soa::Index<>, hf_amb_tracks::TrackId,                     //!
-                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,         //!
-                  track::X, track::Alpha, track::Y,                             //!
-                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,           //!
-                  hf_amb_tracks::Pt, hf_amb_tracks::P,                          //!
-                  hf_amb_tracks::Eta, hf_amb_tracks::Phi,                       //!
-                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,                    //!
-                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>,        //!
-                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>,        //!
-                  track::Pz<track::Signed1Pt, track::Tgl>,                      //!
-                  track::Energy<track::Signed1Pt, track::Tgl>,                  //!
-                  track::Rapidity<track::Signed1Pt, track::Tgl>,                //!
-                  track::Sign<track::Signed1Pt>);                               //!
+DECLARE_SOA_TABLE(HfAmbTrack, "AOD", "HFAMBTRACK",                       //!
+                  o2::soa::Index<>, hf_amb_tracks::TrackId,              //!
+                  hf_amb_tracks::CollisionId, hf_amb_tracks::TrackType,  //!
+                  track::X, track::Alpha, track::Y,                      //!
+                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,    //!
+                  hf_amb_tracks::Pt, hf_amb_tracks::P,                   //!
+                  hf_amb_tracks::Eta, hf_amb_tracks::Phi,                //!
+                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,             //!
+                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>, //!
+                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>, //!
+                  track::Pz<track::Signed1Pt, track::Tgl>,               //!
+                  track::Energy<track::Signed1Pt, track::Tgl>,           //!
+                  track::Rapidity<track::Signed1Pt, track::Tgl>,         //!
+                  track::Sign<track::Signed1Pt>);                        //!
 
 DECLARE_SOA_TABLE(HfAmbTrackCov, "AOD", "HFAMBTRACKCOV",                                                      //!
                   track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,            //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -38,6 +38,58 @@ DECLARE_SOA_COLUMN(WhyRejectColl, whyRejectColl, int); //!
 DECLARE_SOA_TABLE(HfSelCollision, "AOD", "HFSELCOLLISION", //!
                   hf_sel_collision::WhyRejectColl);
 
+namespace hf_amb_tracks
+{
+DECLARE_SOA_INDEX_COLUMN(Collision, collision); //!
+DECLARE_SOA_INDEX_COLUMN(Track, track);         //!
+DECLARE_SOA_COLUMN(DCAXY, dcaXY, float);        //!
+DECLARE_SOA_COLUMN(DCAZ, dcaZ, float);          //!
+DECLARE_SOA_COLUMN(P, p, float);                //!
+DECLARE_SOA_COLUMN(Pt, pt, float);              //!
+DECLARE_SOA_COLUMN(Eta, eta, float);            //!
+DECLARE_SOA_COLUMN(Phi, phi, float);            //!
+
+DECLARE_SOA_COLUMN(CYY, cYY, float);             //!
+DECLARE_SOA_COLUMN(CZY, cZY, float);             //!
+DECLARE_SOA_COLUMN(CZZ, cZZ, float);             //!
+DECLARE_SOA_COLUMN(CSnpY, cSnpY, float);         //!
+DECLARE_SOA_COLUMN(CSnpZ, cSnpZ, float);         //!
+DECLARE_SOA_COLUMN(CSnpSnp, cSnpSnp, float);     //!
+DECLARE_SOA_COLUMN(CTglY, cTglY, float);         //!
+DECLARE_SOA_COLUMN(CTglZ, cTglZ, float);         //!
+DECLARE_SOA_COLUMN(CTglSnp, cTglSnp, float);     //!
+DECLARE_SOA_COLUMN(CTglTgl, cTglTgl, float);     //!
+DECLARE_SOA_COLUMN(C1PtY, c1PtY, float);         //!
+DECLARE_SOA_COLUMN(C1PtZ, c1PtZ, float);         //!
+DECLARE_SOA_COLUMN(C1PtSnp, c1PtSnp, float);     //!
+DECLARE_SOA_COLUMN(C1PtTgl, c1PtTgl, float);     //!
+DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //!
+
+} // namespace hf_amb_tracks
+
+DECLARE_SOA_TABLE(HfAmbTrack, "AOD", "HFAMBTRACK",                              //!
+                  o2::soa::Index<>, hf_amb_tracks::TrackId,                     //!
+                  hf_amb_tracks::CollisionId, track::X, track::Alpha, track::Y, //!
+                  track::Z, track::Snp, track::Tgl, track::Signed1Pt,           //!
+                  hf_amb_tracks::Pt, hf_amb_tracks::P,                          //!
+                  hf_amb_tracks::Eta, hf_amb_tracks::Phi,                       //!
+                  hf_amb_tracks::DCAXY, hf_amb_tracks::DCAZ,                    //!
+                  track::Px<track::Signed1Pt, track::Snp, track::Alpha>,        //!
+                  track::Py<track::Signed1Pt, track::Snp, track::Alpha>,        //!
+                  track::Pz<track::Signed1Pt, track::Tgl>,                      //!
+                  track::Energy<track::Signed1Pt, track::Tgl>,                  //!
+                  track::Rapidity<track::Signed1Pt, track::Tgl>,                //!
+                  track::Sign<track::Signed1Pt>);                               //!
+
+DECLARE_SOA_TABLE(HfAmbTrackCov, "AOD", "HFAMBTRACKCOV",                                                      //!
+                  track::SigmaY, track::SigmaZ, track::SigmaSnp, track::SigmaTgl, track::Sigma1Pt,            //!
+                  track::RhoZY, track::RhoSnpY, track::RhoSnpZ, track::RhoTglY, track::RhoTglZ,               //!
+                  track::RhoTglSnp, track::Rho1PtY, track::Rho1PtZ, track::Rho1PtSnp, track::Rho1PtTgl,       //!
+                  hf_amb_tracks::CYY, hf_amb_tracks::CZY, hf_amb_tracks::CZZ, hf_amb_tracks::CSnpY,           //!
+                  hf_amb_tracks::CSnpZ, hf_amb_tracks::CSnpSnp, hf_amb_tracks::CTglY, hf_amb_tracks::CTglZ,   //!
+                  hf_amb_tracks::CTglSnp, hf_amb_tracks::CTglTgl, hf_amb_tracks::C1PtY, hf_amb_tracks::C1PtZ, //!
+                  hf_amb_tracks::C1PtSnp, hf_amb_tracks::C1PtTgl, hf_amb_tracks::C1Pt21Pt2);                  //!
+
 namespace hf_sel_track
 {
 DECLARE_SOA_COLUMN(IsSelProng, isSelProng, int); //!

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -394,7 +394,7 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
               /// Fill the table with this track propagated to the new collisions
               collIndices.push_back(collision.globalIndex());
               trackIndices.push_back(track.globalIndex());
-              trackTypes.push_back(BIT(hf_amb_tracks::Ambiguous));
+              trackTypes.push_back(BIT(hf_amb_tracks::PVContributor));
               trackX.push_back(trackParCov.getX());
               trackAlpha.push_back(trackParCov.getAlpha());
               trackY.push_back(trackParCov.getY());

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1013,14 +1013,22 @@ struct HfTrackConcat {
 
   using ConcatTrackAmb = soa::Concat<MY_TYPE1, soa::Join<aod::HfAmbTrack, aod::HfAmbTrackCov>>;
 
-  void process(const ConcatTrackAmb& tracks)
-  {
-    LOG(info) << ">>>>> HfTrackConcat::process() entered";
-    LOG(info) << ">>>>> tracks.size()=" << tracks.size();
+  using myAmbTrk = soa::Join<aod::HfAmbTrack, aod::HfAmbTrackCov>;
 
+  void process(const MY_TYPE1& tracks, const myAmbTrk& ambTracks)
+  {
+    std::vector<std::variant<MY_TYPE1::iterator, myAmbTrk::iterator>> allTracks{};
     for (auto& track : tracks) {
-      LOG(info) << ">>>>> track.signed1Pt()=" << track.signed1Pt();
+      std::variant<MY_TYPE1::iterator, myAmbTrk::iterator> a = track;
+      allTracks.push_back(a);
     }
+    for (auto& track : ambTracks) {
+      std::variant<MY_TYPE1::iterator, myAmbTrk::iterator> a = track;
+      allTracks.push_back(a);
+    }
+    LOG(info) << "allTracks.size() = " << allTracks.size();
+    LOG(info) << "tracks.size() = " << tracks.size();
+    LOG(info) << "ambTracks.size() = " << ambTracks.size();
   }
 };
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1219,16 +1219,15 @@ struct HfTrackIndexSkimCreator {
       registry.add("PvRefit/hPvRefitZChi2Minus1", "PV refit with #it{#chi}^{2}==#minus1", kTH2D, {axisCollisionZ, axisCollisionZOriginal});
       registry.add("PvRefit/hNContribPvRefitNotDoable", "N. contributors for PV refit not doable", kTH1D, {axisCollisionNContrib});
       registry.add("PvRefit/hNContribPvRefitChi2Minus1", "N. contributors original PV for PV refit #it{#chi}^{2}==#minus1", kTH1D, {axisCollisionNContrib});
-
-      ccdb->setURL(ccdbUrl);
-      ccdb->setCaching(true);
-      ccdb->setLocalObjectValidityChecking();
-      lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
-      if (!o2::base::GeometryManager::isGeometryLoaded()) {
-        ccdb->get<TGeoManager>(ccdbPathGeo);
-      }
-      runNumber = 0;
     }
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(ccdbPathGeo);
+    }
+    runNumber = 0;
   }
 
   /// Method to perform selections for 2-prong candidates before vertex reconstruction

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -311,8 +311,8 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
           if (collision.globalIndex() == track.collisionId()) {
             continue;
           }
-          uint64_t mostProbableBC = collision.bc().globalBC();         // BC of the current collision
-          for (auto& bc : ambitrack.bc_as<aod::BCsWithTimestamps>()) { // loop over BC compatible in time with the ambiguous track
+          uint64_t mostProbableBC = collision.bc_as<aod::BCsWithTimestamps>().globalBC(); // BC of the current collision
+          for (auto& bc : ambitrack.bc_as<aod::BCsWithTimestamps>()) {                    // loop over BC compatible in time with the ambiguous track
             if (bc.globalBC() == mostProbableBC) {
               initCCDB(bc, runNumber, ccdb, ccdbPathGrpMag, lut, false);
 
@@ -346,7 +346,7 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
       std::vector<int> collIDs = {};
       for (auto& coll : collisions) {
         /// count how many coll. have the current bc as most probable
-        if (bc.globalBC() == coll.bc().globalBC()) {
+        if (bc.globalBC() == coll.bc_as<aod::BCsWithTimestamps>().globalBC()) {
           collIDs.push_back(coll.globalIndex());
         }
       } /// end loop on collisiuons
@@ -2610,8 +2610,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorProduceAmbTracks>(cfgc, SetDefaultProcesses{{{"processAmbTrack", false}, {"processNoAmbTrack", true}}}));
-  // workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
-  // workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
+  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
+  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
 
   const bool doCascades = cfgc.options().get<bool>("doCascades");
   if (doCascades) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -288,10 +288,10 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
 
   using TracksWithSel = soa::Join<aod::BigTracks, aod::TrackSelection>;
 
-  void process(aod::Collisions const& collisions,
-               aod::AmbiguousTracks const& ambitracks,
-               TracksWithSel const& tracks,
-               aod::BCsWithTimestamps const& bcWithTimeStamps)
+  void processAmbTrack(aod::Collisions const& collisions,
+                       aod::AmbiguousTracks const& ambitracks,
+                       TracksWithSel const& tracks,
+                       aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
 
     o2::dataformats::DCA dcaInfoCov;
@@ -397,6 +397,8 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
 
     } /// end loop on bcs
   }
+
+  PROCESS_SWITCH(HfTrackIndexSkimCreatorProduceAmbTracks, processAmbTrack, "Activate filling of ambiguous track table", false);
 };
 
 /// Track selection
@@ -2604,6 +2606,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelCollisions>(cfgc, SetDefaultProcesses{{{"processTrigSel", false}, {"processNoTrigSel", true}}}));
   }
 
+  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorProduceAmbTracks>(cfgc));
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -286,6 +286,8 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
     runNumber = 0;
   }
 
+  void processNoAmbTrack(aod::Collisions const& collisions) {}
+
   using TracksWithSel = soa::Join<aod::BigTracks, aod::TrackSelection>;
 
   void processAmbTrack(aod::Collisions const& collisions,
@@ -398,7 +400,8 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
     } /// end loop on bcs
   }
 
-  PROCESS_SWITCH(HfTrackIndexSkimCreatorProduceAmbTracks, processAmbTrack, "Activate filling of ambiguous track table", false);
+  PROCESS_SWITCH(HfTrackIndexSkimCreatorProduceAmbTracks, processAmbTrack, "Activate process that fills ambiguous track table", false);
+  PROCESS_SWITCH(HfTrackIndexSkimCreatorProduceAmbTracks, processNoAmbTrack, "Activate process that does not fill ambiguous track table", true);
 };
 
 /// Track selection
@@ -2606,9 +2609,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelCollisions>(cfgc, SetDefaultProcesses{{{"processTrigSel", false}, {"processNoTrigSel", true}}}));
   }
 
-  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorProduceAmbTracks>(cfgc));
-  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
-  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
+  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorProduceAmbTracks>(cfgc, SetDefaultProcesses{{{"processAmbTrack", false}, {"processNoAmbTrack", true}}}));
+  // workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
+  // workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
 
   const bool doCascades = cfgc.options().get<bool>("doCascades");
   if (doCascades) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1011,8 +1011,6 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
 struct HfTrackConcat {
 
-  void init() {}
-
   using ConcatTrackAmb = soa::Concat<MY_TYPE1, soa::Join<aod::HfAmbTrack, aod::HfAmbTrackCov>>;
 
   void process(const ConcatTrackAmb& tracks)

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -23,7 +23,7 @@
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/EventSelection.h"
-//#include "Common/DataModel/Centrality.h"
+// #include "Common/DataModel/Centrality.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -80,7 +80,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 #include "Framework/runDataProcessing.h"
 
-//#define MY_DEBUG
+// #define MY_DEBUG
 
 #ifdef MY_DEBUG
 using MY_TYPE1 = soa::Join<aod::BigTracks, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;
@@ -254,8 +254,8 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
 
 // Produce table with ambiguous tracks
 struct HfTrackIndexSkimCreatorProduceAmbTracks {
-  Produces<aod::HfAmbTrack> ambTrack;
-  Produces<aod::HfAmbTrackCov> ambTrackCov;
+  Produces<aod::HfAmbTrackBase> ambTrack;
+  Produces<aod::HfAmbTrackCovBase> ambTrackCov;
 
   Configurable<bool> useIsGlobalTrackWoDCA{"useIsGlobalTrackWoDCA", true, "check isGlobalTrackWoDCA status for tracks, for Run3 studies"};
 
@@ -325,15 +325,10 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
               ambTrack(track.globalIndex(), collision.globalIndex(), BIT(hf_amb_tracks::Ambiguous), // fill the tacle with this track, as ambiguous
                        trackParCov.getX(), trackParCov.getAlpha(),
                        trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
-                       trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
-                       trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
+                       trackParCov.getQ2Pt(), dcaInfoCov.getY(), dcaInfoCov.getZ());
 
               ambTrackCov(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
-                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
-                          trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
-                          trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
-                          trackParCov.getSigma1Pt2());
+                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
             }
           }
         }
@@ -384,14 +379,9 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
               ambTrack(track.globalIndex(), collision.globalIndex(), BIT(hf_amb_tracks::PVContributor), // fill the tacle with this track, as PV contributor
                        trackParCov.getX(), trackParCov.getAlpha(),
                        trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
-                       trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
-                       trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
+                       trackParCov.getQ2Pt(), dcaInfoCov.getY(), dcaInfoCov.getZ());
               ambTrackCov(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
-                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
-                          trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
-                          trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
-                          trackParCov.getSigma1Pt2());
+                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
             } /// end second loop on collIDs
           }
         } /// end loop on tracks of the current collision
@@ -915,7 +905,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   void process(aod::Collisions const& collisions,
                MY_TYPE1 const& tracks,
                aod::BCsWithTimestamps const& bcWithTimeStamps, // for PV refit
-               aod::HfAmbTrack const& ambTracks                /// ambiguous tracks + PV contr. propagated to all other compatible collisions
+               aod::HfAmbTrackBase const& ambTracks            /// ambiguous tracks + PV contr. propagated to all other compatible collisions
 #ifdef MY_DEBUG
                ,
                aod::McParticles& mcParticles
@@ -1007,6 +997,28 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       rowSelectedAmbTrack(statusProng, ambTrack.px(), ambTrack.py(), ambTrack.pz());
     } /// end loop over ambiguous tracks + PV contr. propagated to all other compatible collisions
   }   /// end process
+};
+
+//____________________________________________________________________________________________________________________________________________
+
+struct HfTrackConcat {
+
+  Spawns<aod::HfAmbTrack> rowTrackAmb;
+  Spawns<aod::HfAmbTrackCov> rowTrackAmbCov;
+
+  void init() {}
+
+  using ConcatTrackAmb = soa::Concat<MY_TYPE1, soa::Join<aod::HfAmbTrack, aod::HfAmbTrackCov>>;
+
+  void process(const ConcatTrackAmb& tracks)
+  {
+    LOG(info) << ">>>>> HfTrackConcat::process() entered";
+    LOG(info) << ">>>>> tracks.size()=" << tracks.size();
+
+    for (auto& track : tracks) {
+      LOG(info) << ">>>>> track.signed1Pt()=" << track.signed1Pt();
+    }
+  }
 };
 
 //____________________________________________________________________________________________________________________________________________

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -394,6 +394,14 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
   PROCESS_SWITCH(HfTrackIndexSkimCreatorProduceAmbTracks, processNoAmbTrack, "Activate process that does not fill ambiguous track table", true);
 };
 
+struct HfTrackIndexSkimCreatorExtendAmbTracks {
+
+  Spawns<aod::HfAmbTrack> rowTrackAmb;
+  Spawns<aod::HfAmbTrackCov> rowTrackAmbCov;
+
+  void init(InitContext const&) {}
+};
+
 /// Track selection
 struct HfTrackIndexSkimCreatorTagSelTracks {
   Produces<aod::HfSelTrack> rowSelectedTrack;
@@ -1002,9 +1010,6 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 //____________________________________________________________________________________________________________________________________________
 
 struct HfTrackConcat {
-
-  Spawns<aod::HfAmbTrack> rowTrackAmb;
-  Spawns<aod::HfAmbTrackCov> rowTrackAmbCov;
 
   void init() {}
 
@@ -2622,6 +2627,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorProduceAmbTracks>(cfgc, SetDefaultProcesses{{{"processAmbTrack", false}, {"processNoAmbTrack", true}}}));
+  workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorExtendAmbTracks>(cfgc));
+  workflow.push_back(adaptAnalysisTask<HfTrackConcat>(cfgc));
+
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreatorTagSelTracks>(cfgc));
   workflow.push_back(adaptAnalysisTask<HfTrackIndexSkimCreator>(cfgc));
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -913,7 +913,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   void process(aod::Collisions const& collisions,
                MY_TYPE1 const& tracks,
                aod::BCsWithTimestamps const& bcWithTimeStamps, // for PV refit
-               aod::HfAmbTrackBase const& ambTracks            /// ambiguous tracks + PV contr. propagated to all other compatible collisions
+               aod::HfAmbTrack const& ambTracks                /// ambiguous tracks + PV contr. propagated to all other compatible collisions
 #ifdef MY_DEBUG
                ,
                aod::McParticles& mcParticles

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -339,32 +339,32 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
     } /// end for loop ambiguous tracks
 
     /// fill the table with tracks compatible in time with bc
-    for(auto& bc : bcWithTimeStamps) {
+    for (auto& bc : bcWithTimeStamps) {
 
       std::vector<int> collIDs = {};
-      for(auto& coll : collisions) {
+      for (auto& coll : collisions) {
         /// count how many coll. have the current bc as most probable
-        if(bc.globalBC() == coll.bc().globalBC()){
+        if (bc.globalBC() == coll.bc().globalBC()) {
           collIDs.push_back(coll.globalIndex());
         }
       } /// end loop on collisiuons
 
       /// we do not want bcs with only 1 coll
-      if(collIDs.size() < 2){
+      if (collIDs.size() < 2) {
         continue;
       }
 
-      for(int& collID : collIDs) {
+      for (int& collID : collIDs) {
 
         auto collision = collisions.rawIteratorAt(collID);
 
         /// tracks for the current collision
         const auto& tracksColl = tracks.sliceBy(perRecoCollision, collID);
 
-        for(auto& track : tracksColl){
+        for (auto& track : tracksColl) {
           /// select the tracks according to: 1) track selection; 2) is PV contributor or not
-          if((!useIsGlobalTrackWoDCA || (useIsGlobalTrackWoDCA && track.isGlobalTrackWoDCA())) && track.isPVContributor()) {
-            if(track.collisionId() == collID) { /// this is already considered in the standard track table
+          if ((!useIsGlobalTrackWoDCA || (useIsGlobalTrackWoDCA && track.isGlobalTrackWoDCA())) && track.isPVContributor()) {
+            if (track.collisionId() == collID) { /// this is already considered in the standard track table
               continue;
             }
 
@@ -380,23 +380,21 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
 
             /// Fill the table with this track propagated to the new collisions
             ambTrack(track.globalIndex(), collision.globalIndex(), BIT(hf_amb_tracks::PVContributor), // fill the tacle with this track, as PV contributor
-                       trackParCov.getX(), trackParCov.getAlpha(),
-                       trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
-                       trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
-                       trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
+                     trackParCov.getX(), trackParCov.getAlpha(),
+                     trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
+                     trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
+                     trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
             ambTrackCov(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
-                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                          trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
-                          trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
-                          trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
-                          trackParCov.getSigma1Pt2());
-
+                        std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
+                        trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
+                        trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
+                        trackParCov.getSigma1Pt2());
           }
         } /// end loop on tracks of the current collision
       }
 
     } /// end loop on bcs
-
   }
 };
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -355,44 +355,45 @@ struct HfTrackIndexSkimCreatorProduceAmbTracks {
       }
 
       for (int& collID : collIDs) {
-
-        auto collision = collisions.rawIteratorAt(collID);
-
         /// tracks for the current collision
         const auto& tracksColl = tracks.sliceBy(perRecoCollision, collID);
 
         for (auto& track : tracksColl) {
           /// select the tracks according to: 1) track selection; 2) is PV contributor or not
           if ((!useIsGlobalTrackWoDCA || (useIsGlobalTrackWoDCA && track.isGlobalTrackWoDCA())) && track.isPVContributor()) {
-            if (track.collisionId() == collID) { /// this is already considered in the standard track table
-              continue;
-            }
+            // track selection done wrt the "default" vertex (~ equivalent to IU point)
+            for(int& collIDother : collIDs) {
+              if (collIDother == collID) { /// this is already considered in the standard track table
+                continue;
+              }
+              auto collision = collisions.rawIteratorAt(collIDother);
 
-            /// At this point, wthe remaining collisions are by definition compatible in time
-            initCCDB(bc, runNumber, ccdb, ccdbPathGrpMag, lut, false);
+              /// At this point, wthe remaining collisions are by definition compatible in time
+              initCCDB(bc, runNumber, ccdb, ccdbPathGrpMag, lut, false);
 
-            // let's propagate track to collision
-            dcaInfoCov.set(999, 999, 999, 999, 999);
-            auto trackParCov = getTrackParCov(track);
-            vtx.setPos({collision.posX(), collision.posY(), collision.posZ()});
-            vtx.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
-            o2::base::Propagator::Instance()->propagateToDCABxByBz(vtx, trackParCov, 2.f, matCorr, &dcaInfoCov);
+              // let's propagate track to collision
+              dcaInfoCov.set(999, 999, 999, 999, 999);
+              auto trackParCov = getTrackParCov(track);
+              vtx.setPos({collision.posX(), collision.posY(), collision.posZ()});
+              vtx.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
+              o2::base::Propagator::Instance()->propagateToDCABxByBz(vtx, trackParCov, 2.f, matCorr, &dcaInfoCov);
 
-            /// Fill the table with this track propagated to the new collisions
-            ambTrack(track.globalIndex(), collision.globalIndex(), BIT(hf_amb_tracks::PVContributor), // fill the tacle with this track, as PV contributor
-                     trackParCov.getX(), trackParCov.getAlpha(),
-                     trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
-                     trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
-                     trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
-            ambTrackCov(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
-                        std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                        trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
-                        trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
-                        trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
-                        trackParCov.getSigma1Pt2());
+              /// Fill the table with this track propagated to the new collisions
+              ambTrack(track.globalIndex(), collision.globalIndex(), BIT(hf_amb_tracks::PVContributor), // fill the tacle with this track, as PV contributor
+                       trackParCov.getX(), trackParCov.getAlpha(),
+                       trackParCov.getY(), trackParCov.getZ(), trackParCov.getSnp(), trackParCov.getTgl(),
+                       trackParCov.getQ2Pt(), trackParCov.getPt(), trackParCov.getP(), trackParCov.getEta(),
+                       trackParCov.getPhi(), dcaInfoCov.getY(), dcaInfoCov.getZ());
+              ambTrackCov(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
+                          std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                          trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
+                          trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
+                          trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
+                          trackParCov.getSigma1Pt2());
+            } /// end second loop on collIDs
           }
         } /// end loop on tracks of the current collision
-      }
+      } /// end first loop on collIDs
 
     } /// end loop on bcs
   }


### PR DESCRIPTION
In this draft PR @mfaggin and I implemented a code that accounts for the ambiguous tracks in the HF vertexing.

In this implementation, an additional table of tracks is created cloning all the ambiguous tracks by propagating them to all the other collisions to which they are compatible. The same is done for PV contributors in case of multiple collisions per BC (in-bunch pileup).

An improved version is also under development with @jgrosseo but, in case it is decided to move ahead with this one, before merging it will require optimisation.