### PR TITLE
PWGDQ: Introduce hisogram for PdgCode for mc tracks and their mothers…

### DIFF
--- a/PWGDQ/Core/HistogramsLibrary.h
+++ b/PWGDQ/Core/HistogramsLibrary.h
@@ -277,6 +277,8 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "Pt_vs_PtMC", "pT vs MC pT", false, 50, 0.0, 10.0, VarManager::kPt, 50, 0.0, 10.0, VarManager::kMCPt);
       hm->AddHistogram(histClass, "Eta_vs_EtaMC", "#eta vs MC #eta", false, 50, -1.0, 1.0, VarManager::kEta, 50, -1.0, 1.0, VarManager::kMCEta);
       hm->AddHistogram(histClass, "Phi_vs_PhiMC", "#varphi vs MC #varphi", false, 50, 0.0, 6.3, VarManager::kPhi, 50, 0.0, 6.3, VarManager::kMCPhi);
+      hm->AddHistogram(histClass, "TrackPDGcode", "PDG code of track", false, 10001, -5000, 5000, VarManager::kMCPdgCode);
+      hm->AddHistogram(histClass, "MotherPDGcode", "PDG code of mother", false, 10001, -5000, 5000, VarManager::kMCMotherPdgCode);
     }
   }
   if (groupStr.Contains("mctruth_pair")) {

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -860,8 +860,8 @@ void VarManager::FillTrack(T const& track, float* values)
 
     // compute TPC postcalibrated electron nsigma based on calibration histograms from CCDB
     if (fgUsedVars[kTPCnSigmaEl_Corr] && fgRunTPCPostCalibration[0]) {
-      TH3F* calibMean = (TH3F*)fgCalibs[kTPCElectronMean];
-      TH3F* calibSigma = (TH3F*)fgCalibs[kTPCElectronSigma];
+      TH3F* calibMean = reinterpret_cast<TH3F*>(fgCalibs[kTPCElectronMean]);
+      TH3F* calibSigma = reinterpret_cast<TH3F*>(fgCalibs[kTPCElectronSigma]);
 
       int binTPCncls = calibMean->GetXaxis()->FindBin(values[kTPCncls]);
       binTPCncls = (binTPCncls == 0 ? 1 : binTPCncls);
@@ -879,8 +879,8 @@ void VarManager::FillTrack(T const& track, float* values)
     }
     // compute TPC postcalibrated pion nsigma if required
     if (fgUsedVars[kTPCnSigmaPi_Corr] && fgRunTPCPostCalibration[1]) {
-      TH3F* calibMean = (TH3F*)fgCalibs[kTPCPionMean];
-      TH3F* calibSigma = (TH3F*)fgCalibs[kTPCPionSigma];
+      TH3F* calibMean = reinterpret_cast<TH3F*>(fgCalibs[kTPCPionMean]);
+      TH3F* calibSigma = reinterpret_cast<TH3F*>(fgCalibs[kTPCPionSigma]);
 
       int binTPCncls = calibMean->GetXaxis()->FindBin(values[kTPCncls]);
       binTPCncls = (binTPCncls == 0 ? 1 : binTPCncls);
@@ -898,8 +898,8 @@ void VarManager::FillTrack(T const& track, float* values)
     }
     // compute TPC postcalibrated proton nsigma if required
     if (fgUsedVars[kTPCnSigmaPr_Corr] && fgRunTPCPostCalibration[3]) {
-      TH3F* calibMean = (TH3F*)fgCalibs[kTPCProtonMean];
-      TH3F* calibSigma = (TH3F*)fgCalibs[kTPCProtonSigma];
+      TH3F* calibMean = reinterpret_cast<TH3F*>(fgCalibs[kTPCProtonMean]);
+      TH3F* calibSigma = reinterpret_cast<TH3F*>(fgCalibs[kTPCProtonSigma]);
 
       int binTPCncls = calibMean->GetXaxis()->FindBin(values[kTPCncls]);
       binTPCncls = (binTPCncls == 0 ? 1 : binTPCncls);

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -282,6 +282,9 @@ class VarManager : public TObject
     kMCParticleGeneratorId,
     kNMCParticleVariables,
 
+    // MC mother particle variables
+    kMCMotherPdgCode,
+
     // Pair variables
     kCandidateId,
     kPairType,
@@ -420,6 +423,8 @@ class VarManager : public TObject
   static void FillEvent(T const& event, float* values = nullptr);
   template <uint32_t fillMap, typename T>
   static void FillTrack(T const& track, float* values = nullptr);
+  template <uint32_t fillMap, typename U, typename T>
+  static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename T1, typename T2>
   static void FillPair(T1 const& t1, T2 const& t2, float* values = nullptr);
   template <int pairType, typename T1, typename T2>
@@ -963,6 +968,18 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMass] = track.mass();
   }
 
+  // Derived quantities which can be computed based on already filled variables
+  FillTrackDerived(values);
+}
+
+template <uint32_t fillMap, typename U, typename T>
+void VarManager::FillTrackMC(const U& mcStack, T const& track, float* values)
+{
+  if (!values) {
+    values = fgValues;
+  }
+
+  // Quantities based on the mc particle table
   if constexpr ((fillMap & ParticleMC) > 0) {
     values[kMCPdgCode] = track.pdgCode();
     values[kMCParticleWeight] = track.weight();
@@ -978,9 +995,12 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMCEta] = track.eta();
     values[kMCY] = track.y();
     values[kMCParticleGeneratorId] = track.producedByGenerator();
+    if (track.has_mothers()) {
+      auto mother = track.template mothers_first_as<U>();
+      values[kMCMotherPdgCode] = mother.pdgCode();
+    }
   }
 
-  // Derived quantities which can be computed based on already filled variables
   FillTrackDerived(values);
 }
 

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -423,7 +423,7 @@ class VarManager : public TObject
   static void FillEvent(T const& event, float* values = nullptr);
   template <uint32_t fillMap, typename T>
   static void FillTrack(T const& track, float* values = nullptr);
-  template <uint32_t fillMap, typename U, typename T>
+  template <typename U, typename T>
   static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename T1, typename T2>
   static void FillPair(T1 const& t1, T2 const& t2, float* values = nullptr);
@@ -972,7 +972,7 @@ void VarManager::FillTrack(T const& track, float* values)
   FillTrackDerived(values);
 }
 
-template <uint32_t fillMap, typename U, typename T>
+template <typename U, typename T>
 void VarManager::FillTrackMC(const U& mcStack, T const& track, float* values)
 {
   if (!values) {
@@ -980,25 +980,23 @@ void VarManager::FillTrackMC(const U& mcStack, T const& track, float* values)
   }
 
   // Quantities based on the mc particle table
-  if constexpr ((fillMap & ParticleMC) > 0) {
-    values[kMCPdgCode] = track.pdgCode();
-    values[kMCParticleWeight] = track.weight();
-    values[kMCPx] = track.px();
-    values[kMCPy] = track.py();
-    values[kMCPz] = track.pz();
-    values[kMCE] = track.e();
-    values[kMCVx] = track.vx();
-    values[kMCVy] = track.vy();
-    values[kMCVz] = track.vz();
-    values[kMCPt] = track.pt();
-    values[kMCPhi] = track.phi();
-    values[kMCEta] = track.eta();
-    values[kMCY] = track.y();
-    values[kMCParticleGeneratorId] = track.producedByGenerator();
-    if (track.has_mothers()) {
-      auto mother = track.template mothers_first_as<U>();
-      values[kMCMotherPdgCode] = mother.pdgCode();
-    }
+  values[kMCPdgCode] = track.pdgCode();
+  values[kMCParticleWeight] = track.weight();
+  values[kMCPx] = track.px();
+  values[kMCPy] = track.py();
+  values[kMCPz] = track.pz();
+  values[kMCE] = track.e();
+  values[kMCVx] = track.vx();
+  values[kMCVy] = track.vy();
+  values[kMCVz] = track.vz();
+  values[kMCPt] = track.pt();
+  values[kMCPhi] = track.phi();
+  values[kMCEta] = track.eta();
+  values[kMCY] = track.y();
+  values[kMCParticleGeneratorId] = track.producedByGenerator();
+  if (track.has_mothers()) {
+    auto mother = track.template mothers_first_as<U>();
+    values[kMCMotherPdgCode] = mother.pdgCode();
   }
 
   FillTrackDerived(values);

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -16,6 +16,8 @@
 //   The skimmed MC stack includes the MC truth particles corresponding to the list of user specified MC signals (see MCsignal.h)
 //    and the MC truth particles corresponding to the reconstructed tracks selected by the specified track cuts on reconstructed data.
 
+#include <iostream>
+#include "TList.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
@@ -37,8 +39,6 @@
 #include "PWGDQ/Core/MCSignalLibrary.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/TrackSelectionTables.h"
-#include "TList.h"
-#include <iostream>
 
 using std::cout;
 using std::endl;
@@ -329,10 +329,10 @@ struct TableMakerMC {
       // fill stats information, before selections
       for (int i = 0; i < kNaliases; i++) {
         if (triggerAliases & (uint32_t(1) << i)) {
-          ((TH2I*)fStatsList->At(0))->Fill(2.0, float(i));
+          (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(2.0, static_cast<float>(i));
         }
       }
-      ((TH2I*)fStatsList->At(0))->Fill(2.0, float(kNaliases));
+      (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(2.0, static_cast<float>(kNaliases));
 
       if (!fEventCut->IsSelected(VarManager::fgValues)) {
         continue;
@@ -345,10 +345,10 @@ struct TableMakerMC {
       // fill stats information, after selections
       for (int i = 0; i < kNaliases; i++) {
         if (triggerAliases & (uint32_t(1) << i)) {
-          ((TH2I*)fStatsList->At(0))->Fill(3.0, float(i));
+          (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(3.0, static_cast<float>(i));
         }
       }
-      ((TH2I*)fStatsList->At(0))->Fill(3.0, float(kNaliases));
+      (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(3.0, static_cast<float>(kNaliases));
 
       event(tag, collision.bc().runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes());
       eventExtended(collision.bc().globalBC(), collision.bc().triggerMask(), 0, triggerAliases, VarManager::fgValues[VarManager::kCentVZERO]);
@@ -451,7 +451,7 @@ struct TableMakerMC {
                   fHistMan->FillHistClass(Form("Ambiguous_TrackBarrel_%s", cut.GetName()), VarManager::fgValues);
                 }
               }
-              ((TH1I*)fStatsList->At(1))->Fill(float(i));
+              (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(static_cast<float>(i));
             }
             i++;
           }
@@ -470,7 +470,7 @@ struct TableMakerMC {
             trackFilteringTag |= (uint64_t(track.pidbit()) << 2);
             for (int iv0 = 0; iv0 < 5; iv0++) {
               if (track.pidbit() & (uint8_t(1) << iv0)) {
-                ((TH1I*)fStatsList->At(1))->Fill(fTrackCuts.size() + float(iv0));
+                (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(fTrackCuts.size() + static_cast<float>(iv0));
               }
             }
           }
@@ -574,7 +574,7 @@ struct TableMakerMC {
               if (fConfigQA) {
                 fHistMan->FillHistClass(Form("Muons_%s", cut.GetName()), VarManager::fgValues);
               }
-              ((TH1I*)fStatsList->At(2))->Fill(float(i));
+              (reinterpret_cast<TH1I*>(fStatsList->At(2)))->Fill(static_cast<float>(i));
             }
             i++;
           }
@@ -621,10 +621,14 @@ struct TableMakerMC {
             if (cut.IsSelected(VarManager::fgValues)) {
               trackTempFilterMap |= (uint8_t(1) << i);
               fHistMan->FillHistClass(Form("Muons_%s", cut.GetName()), VarManager::fgValues);
+<<<<<<< HEAD
               if (fIsAmbiguous && isAmbiguous == 1) {
                 fHistMan->FillHistClass(Form("Ambiguous_Muons_%s", cut.GetName()), VarManager::fgValues);
               }
               ((TH1I*)fStatsList->At(2))->Fill(float(i));
+=======
+              (reinterpret_cast<TH1I*>(fStatsList->At(2)))->Fill(static_cast<float>(i));
+>>>>>>> a773096a (PWGDQ: fix old MegaLinter errors)
             }
             i++;
           }
@@ -666,21 +670,19 @@ struct TableMakerMC {
 
           // update the matching MCH/MFT index
 
-          if (int(muon.trackType()) == 0 || int(muon.trackType()) == 2) { // MCH-MFT or GLB track
+          if (static_cast<int>(muon.trackType()) == 0 || static_cast<int>(muon.trackType()) == 2) { // MCH-MFT or GLB track
             int matchIdx = muon.matchMCHTrackId() - muon.offsets();
             if (newEntryNb.count(matchIdx) > 0) {                                                  // if the key exists which means the match will not get deleted
               newMatchIndex[muon.index()] = newEntryNb[matchIdx];                                  // update the match for this muon to the updated entry of the match
               newMatchIndex[muon.index()] += muonBasic.lastIndex() + 1 - newEntryNb[muon.index()]; // adding the offset of muons, muonBasic.lastIndex() start at -1
-              if (int(muon.trackType()) == 0) {                                                    // for now only do this to global tracks
+              if (static_cast<int>(muon.trackType()) == 0) {                                       // for now only do this to global tracks
                 newMatchIndex[matchIdx] = newEntryNb[muon.index()];                                // add the  updated index of this muon as a match to mch track
                 newMatchIndex[matchIdx] += muonBasic.lastIndex() + 1 - newEntryNb[muon.index()];   // adding the offset, muonBasic.lastIndex() start at -1
               }
             } else {
               newMatchIndex[muon.index()] = -1;
             }
-          }
-
-          else if (int(muon.trackType() == 4)) { // an MCH track
+          } else if (static_cast<int>(muon.trackType() == 4)) { // an MCH track
             // in this case the matches should be filled from the other types but we need to check
             if (newMatchIndex.count(muon.index()) == 0) {
               newMatchIndex[muon.index()] = -1;
@@ -749,11 +751,11 @@ struct TableMakerMC {
               mctrack.vx(), mctrack.vy(), mctrack.vz(), mctrack.vt(), mcflags);
       for (unsigned int isig = 0; isig < fMCSignals.size(); isig++) {
         if (mcflags & (uint16_t(1) << isig)) {
-          ((TH1I*)fStatsList->At(3))->Fill(float(isig));
+          (reinterpret_cast<TH1I*>(fStatsList->At(3)))->Fill(static_cast<float>(isig));
         }
       }
       if (mcflags == 0) {
-        ((TH1I*)fStatsList->At(3))->Fill(float(fMCSignals.size()));
+        (reinterpret_cast<TH1I*>(fStatsList->At(3)))->Fill(static_cast<float>(fMCSignals.size()));
       }
     } // end loop over labels
 
@@ -930,10 +932,10 @@ struct TableMakerMC {
   {
     for (int i = 0; i < kNaliases; i++) {
       if (bc.alias()[i] > 0) {
-        ((TH2I*)fStatsList->At(0))->Fill(0.0, float(i));
+        (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(0.0, static_cast<float>(i));
       }
     }
-    ((TH2I*)fStatsList->At(0))->Fill(0.0, float(kNaliases));
+    (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(0.0, static_cast<float>(kNaliases));
   }
 
   PROCESS_SWITCH(TableMakerMC, processFull, "Produce both barrel and muon skims", false);

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -88,7 +88,6 @@ constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::Track | 
 constexpr static uint32_t gkTrackFillMapWithDalitzBits = gkTrackFillMap | VarManager::ObjTypes::DalitzBits;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
-constexpr static uint32_t gkParticleMCFillMap = VarManager::ObjTypes::ParticleMC;
 constexpr static uint32_t gkMuonFillMapWithAmbi = VarManager::ObjTypes::Muon | VarManager::ObjTypes::AmbiMuon;
 constexpr static uint32_t gkTrackFillMapWithAmbi = VarManager::ObjTypes::Track | VarManager::ObjTypes::AmbiTrack;
 
@@ -388,7 +387,7 @@ struct TableMakerMC {
           // if any of the MC signals was matched, then fill histograms and write that MC particle into the new stack
           // fill histograms for each of the signals, if found
           if (fConfigQA) {
-            VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
+            VarManager::FillTrackMC(mcTracks, mctrack);
             int j = 0;
             for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); signal++, j++) {
               if (mcflags & (uint16_t(1) << j)) {
@@ -432,7 +431,7 @@ struct TableMakerMC {
             continue;
           }
           auto mctrack = track.template mcParticle_as<aod::McParticles_001>();
-          VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
+          VarManager::FillTrackMC(mcTracks, mctrack);
 
           if (fDoDetailedQA) {
             fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
@@ -607,7 +606,7 @@ struct TableMakerMC {
           }
           auto mctrack = muon.template mcParticle_as<aod::McParticles_001>();
           VarManager::FillTrack<TMuonFillMap>(muon);
-          VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
+          VarManager::FillTrackMC(mcTracks, mctrack);
 
           if (fDoDetailedQA) {
             fHistMan->FillHistClass("Muons_BeforeCuts", VarManager::fgValues);
@@ -621,14 +620,10 @@ struct TableMakerMC {
             if (cut.IsSelected(VarManager::fgValues)) {
               trackTempFilterMap |= (uint8_t(1) << i);
               fHistMan->FillHistClass(Form("Muons_%s", cut.GetName()), VarManager::fgValues);
-<<<<<<< HEAD
               if (fIsAmbiguous && isAmbiguous == 1) {
                 fHistMan->FillHistClass(Form("Ambiguous_Muons_%s", cut.GetName()), VarManager::fgValues);
               }
-              ((TH1I*)fStatsList->At(2))->Fill(float(i));
-=======
               (reinterpret_cast<TH1I*>(fStatsList->At(2)))->Fill(static_cast<float>(i));
->>>>>>> a773096a (PWGDQ: fix old MegaLinter errors)
             }
             i++;
           }

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -296,7 +296,7 @@ struct TableMakerMC {
     uint64_t trackFilteringTag = 0;
     uint8_t trackTempFilterMap = 0;
     for (auto& collision : collisions) {
-      //TODO: investigate the collisions without corresponding mcCollision
+      // TODO: investigate the collisions without corresponding mcCollision
       if (!collision.has_mcCollision()) {
         continue;
       }
@@ -388,7 +388,7 @@ struct TableMakerMC {
           // if any of the MC signals was matched, then fill histograms and write that MC particle into the new stack
           // fill histograms for each of the signals, if found
           if (fConfigQA) {
-            VarManager::FillTrack<gkParticleMCFillMap>(mctrack);
+            VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
             int j = 0;
             for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); signal++, j++) {
               if (mcflags & (uint16_t(1) << j)) {
@@ -432,7 +432,7 @@ struct TableMakerMC {
             continue;
           }
           auto mctrack = track.template mcParticle_as<aod::McParticles_001>();
-          VarManager::FillTrack<gkParticleMCFillMap>(mctrack);
+          VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
 
           if (fDoDetailedQA) {
             fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
@@ -607,7 +607,7 @@ struct TableMakerMC {
           }
           auto mctrack = muon.template mcParticle_as<aod::McParticles_001>();
           VarManager::FillTrack<TMuonFillMap>(muon);
-          VarManager::FillTrack<gkParticleMCFillMap>(mctrack);
+          VarManager::FillTrackMC<gkParticleMCFillMap>(mcTracks, mctrack);
 
           if (fDoDetailedQA) {
             fHistMan->FillHistClass("Muons_BeforeCuts", VarManager::fgValues);


### PR DESCRIPTION
…, implemented MotherPDG in VarManager


I have introduced a new `void` called `FillTrackMC` in which the previous MC track variables are moved to and further more now the pdg code of the mother particle is calculated.
In order to get access to the mother PdgCode the MCParticle stack has to be passed to the function.

Furthermore, I introduced the corresponding histograms in the HistogramsLibrary.h