### PR TITLE
remove loading of full geometry (not req. by LUT)

### DIFF
--- a/Common/TableProducer/trackPropagation.cxx
+++ b/Common/TableProducer/trackPropagation.cxx
@@ -91,9 +91,6 @@ struct TrackPropagation {
     ccdb->setLocalObjectValidityChecking();
 
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
-    if (!o2::base::GeometryManager::isGeometryLoaded()) {
-      ccdb->get<TGeoManager>(geoPath);
-    }
   }
 
   void initCCDB(aod::BCsWithTimestamps::iterator const& bc)


### PR DESCRIPTION
This will remove the unnecessary loading of the full ALICE geometry in the track propagator (not required when propagating with the LUT approach). It will still be tested before going ahead