### PR TITLE
PWGMM: dndeta: reduce code duplication

### DIFF
--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -65,8 +65,8 @@ struct MultiplicityCounter {
   HistogramRegistry registry{
     "registry",
     {
-      {"Events/Selection", ";status;events", {HistType::kTH1F, {{7, 0.5, 7.5}}}} //
-    }                                                                            //
+      {"Events/BCSelection", ";status;count", {HistType::kTH1F, {{3, 0.5, 3.5}}}} //
+    }                                                                             //
   };
 
   std::vector<int> usedTracksIds;
@@ -76,22 +76,30 @@ struct MultiplicityCounter {
   {
     AxisSpec MultAxis = {multBinning, "N_{trk}"};
 
-    auto hstat = registry.get<TH1>(HIST("Events/Selection"));
+    auto hstat = registry.get<TH1>(HIST("Events/BCSelection"));
     auto* x = hstat->GetXaxis();
-    x->SetBinLabel(1, "All");
-    x->SetBinLabel(2, "Selected");
-    x->SetBinLabel(3, "Selected INEL>0");
-    x->SetBinLabel(4, "Rejected");
-    x->SetBinLabel(5, "Good BCs");
-    x->SetBinLabel(6, "BCs with collisions");
-    x->SetBinLabel(7, "BCs with pile-up/splitting");
+    x->SetBinLabel(1, "Good BCs");
+    x->SetBinLabel(2, "BCs with collisions");
+    x->SetBinLabel(3, "BCs with pile-up/splitting");
 
     if (doprocessEventStat) {
       registry.add({"Events/Control/Chi2", " ; #chi^2", {HistType::kTH1F, {{101, -0.1, 10.1}}}});
       registry.add({"Events/Control/TimeResolution", " ; t (ms)", {HistType::kTH1F, {{1001, -0.1, 100.1}}}});
     }
+    if (doprocessEventStatCentrality) {
+      registry.add({"Events/Centrality/Control/Chi2", " ; #chi^2; centrality", {HistType::kTH2F, {{101, -0.1, 10.1}, CentAxis}}});
+      registry.add({"Events/Centrality/Control/TimeResolution", " ; t (ms); centrality", {HistType::kTH2F, {{1001, -0.1, 100.1}, CentAxis}}});
+    }
 
     if (doprocessCounting) {
+      registry.add({"Events/Selection", ";status;events", {HistType::kTH1F, {{4, 0.5, 4.5}}}});
+      auto hstat = registry.get<TH1>(HIST("Events/Selection"));
+      auto* x = hstat->GetXaxis();
+      x->SetBinLabel(1, "All");
+      x->SetBinLabel(2, "Selected");
+      x->SetBinLabel(3, "Selected INEL>0");
+      x->SetBinLabel(4, "Rejected");
+
       registry.add({"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
       registry.add({"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
       registry.add({"Tracks/EtaZvtx_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
@@ -181,15 +189,14 @@ struct MultiplicityCounter {
   }
 
   using FullBCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels>;
-  void processEventStat(
-    FullBCs const& bcs,
-    soa::Join<aod::Collisions, aod::EvSels> const& collisions)
+  template <typename C>
+  void processEventStatGeneral(FullBCs const& bcs, C const& collisions)
   {
     std::vector<typename std::decay_t<decltype(collisions)>::iterator> cols;
     for (auto& bc : bcs) {
       if (!useEvSel || (bc.selection()[evsel::kIsBBT0A] &
                         bc.selection()[evsel::kIsBBT0C]) != 0) {
-        registry.fill(HIST("Events/Selection"), 5.);
+        registry.fill(HIST("Events/BCSelection"), 1.);
         cols.clear();
         for (auto& collision : collisions) {
           if (collision.has_foundBC()) {
@@ -202,20 +209,43 @@ struct MultiplicityCounter {
         }
         LOGP(debug, "BC {} has {} collisions", bc.globalBC(), cols.size());
         if (!cols.empty()) {
-          registry.fill(HIST("Events/Selection"), 6.);
+          registry.fill(HIST("Events/BCSelection"), 2.);
           if (cols.size() > 1) {
-            registry.fill(HIST("Events/Selection"), 7.);
+            registry.fill(HIST("Events/BCSelection"), 3.);
           }
         }
         for (auto& col : cols) {
-          registry.fill(HIST("Events/Control/Chi2"), col.chi2());
-          registry.fill(HIST("Events/Control/TimeResolution"), col.collisionTimeRes());
+          float c = 0;
+          if constexpr (C::template contains<aod::CentFT0Cs>()) {
+            c = col.centFT0C();
+            registry.fill(HIST("Events/Centrality/Control/Chi2"), col.chi2(), c);
+            registry.fill(HIST("Events/Centrality/Control/TimeResolution"), col.collisionTimeRes(), c);
+          } else {
+            registry.fill(HIST("Events/Control/Chi2"), col.chi2());
+            registry.fill(HIST("Events/Control/TimeResolution"), col.collisionTimeRes());
+          }
         }
       }
     }
   }
 
+  void processEventStat(
+    FullBCs const& bcs,
+    soa::Join<aod::Collisions, aod::EvSels> const& collisions)
+  {
+    processEventStatGeneral(bcs, collisions);
+  }
+
   PROCESS_SWITCH(MultiplicityCounter, processEventStat, "Collect event sample stats", false);
+
+  void processEventStatCentrality(
+    FullBCs const& bcs,
+    soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs> const& collisions)
+  {
+    processEventStatGeneral(bcs, collisions);
+  }
+
+  PROCESS_SWITCH(MultiplicityCounter, processEventStatCentrality, "Collect event sample stats (centrality binned)", false);
 
   // clean up used Ids each dataframe (default process is always executed first)
   void process(aod::Collisions const&)
@@ -237,14 +267,26 @@ struct MultiplicityCounter {
                                      (nabs(aod::track::bestDCAXY) <= ((0.0105f + 0.0350f / npow(aod::track::pts, 1.1f))));
   using ExCols = soa::Join<aod::Collisions, aod::EvSels>;
 
-  void processCounting(
-    ExCols::iterator const& collision,
+  template <typename C>
+  void processCountingGeneral(
+    typename C::iterator const& collision,
     FiTracks const& tracks,
     soa::SmallGroups<aod::ReassignedTracksCore> const& atracks)
   {
-    registry.fill(HIST("Events/Selection"), 1.);
+    float c = 0;
+    if constexpr (C::template contains<aod::CentFT0Cs>()) {
+      c = collision.centFT0C();
+      registry.fill(HIST("Events/Centrality/Selection"), 1., c);
+    } else {
+      registry.fill(HIST("Events/Selection"), 1.);
+    }
+
     if (!useEvSel || collision.sel8()) {
-      registry.fill(HIST("Events/Selection"), 2.);
+      if constexpr (C::template contains<aod::CentFT0Cs>()) {
+        registry.fill(HIST("Events/Centrality/Selection"), 2., c);
+      } else {
+        registry.fill(HIST("Events/Selection"), 2.);
+      }
       auto z = collision.posZ();
       usedTracksIds.clear();
 
@@ -255,24 +297,41 @@ struct MultiplicityCounter {
         if (std::abs(otrack.eta()) < estimatorEta) {
           ++Ntrks;
         }
-        registry.fill(HIST("Tracks/EtaZvtx"), otrack.eta(), z);
-        registry.fill(HIST("Tracks/PhiEta"), otrack.phi(), otrack.eta());
+        if constexpr (C::template contains<aod::CentFT0Cs>()) {
+          registry.fill(HIST("Tracks/Centrality/EtaZvtx"), otrack.eta(), z, c);
+          registry.fill(HIST("Tracks/Centrality/PhiEta"), otrack.phi(), otrack.eta(), c);
+        } else {
+          registry.fill(HIST("Tracks/EtaZvtx"), otrack.eta(), z);
+          registry.fill(HIST("Tracks/PhiEta"), otrack.phi(), otrack.eta());
+        }
         if (!otrack.has_collision()) {
-          registry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), otrack.eta(), z);
-          registry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta());
-          registry.fill(HIST("Tracks/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY());
-          registry.fill(HIST("Tracks/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ());
+          if constexpr (C::template contains<aod::CentFT0Cs>()) {
+            registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksEtaZvtx"), otrack.eta(), z, c);
+            registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta(), c);
+            registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
+            registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
+          } else {
+            registry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), otrack.eta(), z);
+            registry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta());
+            registry.fill(HIST("Tracks/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY());
+            registry.fill(HIST("Tracks/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ());
+          }
         } else if (otrack.collisionId() != track.bestCollisionId()) {
           usedTracksIdsDF.emplace_back(track.trackId());
-          registry.fill(HIST("Tracks/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z);
-          registry.fill(HIST("Tracks/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta());
-          registry.fill(HIST("Tracks/Control/ReassignedVertexCorr"), otrack.collision_as<ExCols>().posZ(), z);
-          registry.fill(HIST("Tracks/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY());
-          registry.fill(HIST("Tracks/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ());
+          if constexpr (C::template contains<aod::CentFT0Cs>()) {
+            registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z, c);
+            registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta(), c);
+            registry.fill(HIST("Tracks/Centrality/Control/ReassignedVertexCorr"), otrack.collision_as<ExColsCent>().posZ(), z, c);
+            registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
+            registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
+          } else {
+            registry.fill(HIST("Tracks/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z);
+            registry.fill(HIST("Tracks/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta());
+            registry.fill(HIST("Tracks/Control/ReassignedVertexCorr"), otrack.collision_as<ExCols>().posZ(), z);
+            registry.fill(HIST("Tracks/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY());
+            registry.fill(HIST("Tracks/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ());
+          }
         }
-        registry.fill(HIST("Tracks/Control/PtEta"), otrack.pt(), otrack.eta());
-        registry.fill(HIST("Tracks/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY());
-        registry.fill(HIST("Tracks/Control/DCAZPt"), otrack.pt(), track.bestDCAZ());
       }
       for (auto& track : tracks) {
         if (std::find(usedTracksIds.begin(), usedTracksIds.end(), track.globalIndex()) != usedTracksIds.end()) {
@@ -284,32 +343,55 @@ struct MultiplicityCounter {
         if (std::abs(track.eta()) < estimatorEta) {
           ++Ntrks;
         }
-        registry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
-        registry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
-        registry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
-        registry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
-        registry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
-      }
-
-      if (Ntrks > 0) {
-        registry.fill(HIST("Events/Selection"), 3.);
-        for (auto& track : atracks) {
-          registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.track_as<FiTracks>().eta(), z);
-        }
-        for (auto& track : tracks) {
-          if (std::find(usedTracksIds.begin(), usedTracksIds.end(), track.globalIndex()) != usedTracksIds.end()) {
-            continue;
-          }
-          if (std::find(usedTracksIdsDF.begin(), usedTracksIdsDF.end(), track.globalIndex()) != usedTracksIdsDF.end()) {
-            continue;
-          }
-          registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
+        if constexpr (C::template contains<aod::CentFT0Cs>()) {
+          registry.fill(HIST("Tracks/Centrality/EtaZvtx"), track.eta(), z, c);
+          registry.fill(HIST("Tracks/Centrality/PhiEta"), track.phi(), track.eta(), c);
+          registry.fill(HIST("Tracks/Centrality/Control/PtEta"), track.pt(), track.eta(), c);
+          registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
+          registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
+        } else {
+          registry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
+          registry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
+          registry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
+          registry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
+          registry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
         }
       }
-      registry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
+      if constexpr (C::template contains<aod::CentFT0Cs>()) {
+        registry.fill(HIST("Events/Centrality/NtrkZvtx"), Ntrks, z, c);
+      } else {
+        if (Ntrks > 0) {
+          registry.fill(HIST("Events/Selection"), 3.);
+          for (auto& track : atracks) {
+            registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.track_as<FiTracks>().eta(), z);
+          }
+          for (auto& track : tracks) {
+            if (std::find(usedTracksIds.begin(), usedTracksIds.end(), track.globalIndex()) != usedTracksIds.end()) {
+              continue;
+            }
+            if (std::find(usedTracksIdsDF.begin(), usedTracksIdsDF.end(), track.globalIndex()) != usedTracksIdsDF.end()) {
+              continue;
+            }
+            registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
+          }
+        }
+        registry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
+      }
     } else {
-      registry.fill(HIST("Events/Selection"), 4.);
+      if constexpr (C::template contains<aod::CentFT0Cs>()) {
+        registry.fill(HIST("Events/Centrality/Selection"), 3., c);
+      } else {
+        registry.fill(HIST("Events/Selection"), 3.);
+      }
     }
+  }
+
+  void processCounting(
+    ExCols::iterator const& collision,
+    FiTracks const& tracks,
+    soa::SmallGroups<aod::ReassignedTracksCore> const& atracks)
+  {
+    processCountingGeneral<ExCols>(collision, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processCounting, "Count tracks", false);
@@ -320,61 +402,7 @@ struct MultiplicityCounter {
     FiTracks const& tracks,
     soa::SmallGroups<aod::ReassignedTracksCore> const& atracks)
   {
-    auto c = collision.centFT0C();
-    registry.fill(HIST("Events/Centrality/Selection"), 1., c);
-
-    if (!useEvSel || collision.sel8()) {
-      auto z = collision.posZ();
-      registry.fill(HIST("Events/Centrality/Selection"), 2., c);
-      usedTracksIds.clear();
-
-      auto Ntrks = 0;
-      for (auto& track : atracks) {
-        auto otrack = track.track_as<FiTracks>();
-        usedTracksIds.emplace_back(track.trackId());
-        if (std::abs(otrack.eta()) < estimatorEta) {
-          ++Ntrks;
-        }
-        registry.fill(HIST("Tracks/Centrality/EtaZvtx"), otrack.eta(), z, c);
-        registry.fill(HIST("Tracks/Centrality/PhiEta"), otrack.phi(), otrack.eta(), c);
-        if (!otrack.has_collision()) {
-          registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksEtaZvtx"), otrack.eta(), z, c);
-          registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
-        } else if (otrack.collisionId() != track.bestCollisionId()) {
-          usedTracksIdsDF.emplace_back(track.trackId());
-          registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z, c);
-          registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/ReassignedVertexCorr"), otrack.collision_as<ExColsCent>().posZ(), z, c);
-          registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
-        }
-        registry.fill(HIST("Tracks/Centrality/Control/PtEta"), otrack.pt(), otrack.eta(), c);
-        registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-        registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), otrack.pt(), track.bestDCAZ(), c);
-      }
-      for (auto& track : tracks) {
-        if (std::find(usedTracksIds.begin(), usedTracksIds.end(), track.globalIndex()) != usedTracksIds.end()) {
-          continue;
-        }
-        if (std::find(usedTracksIdsDF.begin(), usedTracksIdsDF.end(), track.globalIndex()) != usedTracksIdsDF.end()) {
-          continue;
-        }
-        if (std::abs(track.eta()) < estimatorEta) {
-          ++Ntrks;
-        }
-        registry.fill(HIST("Tracks/Centrality/EtaZvtx"), track.eta(), z, c);
-        registry.fill(HIST("Tracks/Centrality/PhiEta"), track.phi(), track.eta(), c);
-        registry.fill(HIST("Tracks/Centrality/Control/PtEta"), track.pt(), track.eta(), c);
-        registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
-        registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
-      }
-
-      registry.fill(HIST("Events/Centrality/NtrkZvtx"), Ntrks, z, c);
-    } else {
-      registry.fill(HIST("Events/Centrality/Selection"), 3., c);
-    }
+    processCountingGeneral<ExColsCent>(collision, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processCountingCentrality, "Count tracks in centrality bins", false);


### PR DESCRIPTION
Using `Join::contains<>()` code for inclusive and centrality-binned versions is unified. 

Depends on https://github.com/AliceO2Group/AliceO2/pull/10578.

@ddobrigk as discussed