### PR TITLE
PWGEM: fix clang errors for older versions

### DIFF
--- a/PWGEM/Dilepton/Tasks/MCtemplates.cxx
+++ b/PWGEM/Dilepton/Tasks/MCtemplates.cxx
@@ -435,7 +435,7 @@ struct AnalysisSameEventPairing {
       uint32_t mcDecision = 0;
       int isig = 0;
       for (auto sig = fRecMCSignals.begin(); sig != fRecMCSignals.end(); sig++, isig++) {
-        if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrack) > 0 ) { // for skimmed DQ model
+        if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrack) > 0) { // for skimmed DQ model
           if ((*sig).CheckSignal(false, tracksMC, t1.reducedMCTrack(), t2.reducedMCTrack())) {
             mcDecision |= (uint32_t(1) << isig);
           }

--- a/PWGEM/Dilepton/Tasks/MCtemplates.cxx
+++ b/PWGEM/Dilepton/Tasks/MCtemplates.cxx
@@ -435,12 +435,12 @@ struct AnalysisSameEventPairing {
       uint32_t mcDecision = 0;
       int isig = 0;
       for (auto sig = fRecMCSignals.begin(); sig != fRecMCSignals.end(); sig++, isig++) {
-        if constexpr (TTrackFillMap & VarManager::ObjTypes::ReducedTrack) { // for skimmed DQ model
+        if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrack) > 0 ) { // for skimmed DQ model
           if ((*sig).CheckSignal(false, tracksMC, t1.reducedMCTrack(), t2.reducedMCTrack())) {
             mcDecision |= (uint32_t(1) << isig);
           }
         }
-        if constexpr (TTrackFillMap & VarManager::ObjTypes::Track) { // for Framework data model
+        if constexpr ((TTrackFillMap & VarManager::ObjTypes::Track) > 0) { // for Framework data model
           if ((*sig).CheckSignal(false, tracksMC, t1.template mcParticle_as<aod::McParticles_001>(), t2.template mcParticle_as<aod::McParticles_001>())) {
             mcDecision |= (uint32_t(1) << isig);
           }


### PR DESCRIPTION
Fix notation of if case to be compatible with older clang compiler versions.