### PR TITLE
Find dependencies: Get description instead of binding.

### DIFF
--- a/Scripts/find_dependencies.py
+++ b/Scripts/find_dependencies.py
@@ -92,7 +92,7 @@ def get_inputs(specs_wf: dict, device=""):
     for dev in specs_wf:
         if device and dev["name"] != device:
             continue
-        list_inputs += [i["binding"] for i in dev["inputs"] if i["origin"] == "AOD"]
+        list_inputs += [i["description"] for i in dev["inputs"] if i["origin"] == "AOD"]
     return list(dict.fromkeys(list_inputs))  # Remove duplicities
 
 
@@ -104,7 +104,7 @@ def get_outputs(specs_wf: dict, device=""):
     for dev in specs_wf:
         if device and dev["name"] != device:
             continue
-        list_outputs += [i["binding"] for i in dev["outputs"] if i["origin"] == "AOD"]
+        list_outputs += [i["description"] for i in dev["outputs"] if i["origin"] == "AOD"]
     return list(dict.fromkeys(list_outputs))  # Remove duplicities
 
 

--- a/Scripts/find_dependencies.py
+++ b/Scripts/find_dependencies.py
@@ -104,7 +104,9 @@ def get_outputs(specs_wf: dict, device=""):
     for dev in specs_wf:
         if device and dev["name"] != device:
             continue
-        list_outputs += [i["description"] for i in dev["outputs"] if i["origin"] == "AOD"]
+        list_outputs += [
+            i["description"] for i in dev["outputs"] if i["origin"] == "AOD"
+        ]
     return list(dict.fromkeys(list_outputs))  # Remove duplicities
 
 


### PR DESCRIPTION
@ddobrigk 
This fix makes it possible to look for the tree name, which is what the O2 error reports.

**Rationale:**
For a table declared as:
```c++
DECLARE_SOA_TABLE(TableType, "AOD", "TreeName",
```
that cannot be found, O2 throws the error:
```
Couldn't get TTree "DF_<...>/O2treename ...
```
`TableType` appears in the field `binding` in the JSON file (with suffix `Extension` for extended tables), whereas `TreeName` appears in the field `description`.

**Note:**
If `TableType` and `TreeName` are different (modulo capitalisation), it is actually impossible to find the table producer by following the [instructions in the troubleshooting documentation](https://aliceo2group.github.io/analysis-framework/docs/troubleshooting/#tree-not-found), because the [automatically generated list of tables](https://aliceo2group.github.io/analysis-framework/docs/datamodel/) only lists `TableType` and not `TreeName`.
E.g. see the mentioned example of finding `v0dataext`, which is declared as
```c++
DECLARE_SOA_EXTENDED_TABLE_USER(V0Datas, StoredV0Datas, "V0DATAEXT",
```
and therefore impossible to find in the documentation, which would only show `V0Datas` (if the LF tables were there, which they are not).

**Caveats**
- `TableType` (which is how the table appears in the task subscription) is not shown to the user anywhere.
- Table versions are not resolved because they all have the same description in the JSON file.