### PR TITLE
Improve strangeness builder preselectors

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -753,7 +753,7 @@ struct cascadePreselector {
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all cascades are built. It will simply tag everything as true.
-  void processBuildAll(aod::Cascades const& cascades, TracksWithExtra const&)
+  void processBuildAll(aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, TracksWithExtra const&)
   {
     for (auto& casc : cascades) {
       bool lIsQualityInteresting = false;

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -100,18 +100,20 @@ DECLARE_SOA_TABLE(CascTags, "AOD", "CASCTAGS",
 // use parameters + cov mat non-propagated, aux info + (extension propagated)
 using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA>;
 using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TracksDCA>;
+using TracksWithExtra = soa::Join<aod::TracksIU, aod::TracksExtra>;
 
 // For dE/dx association in pre-selection
-using TracksWithPID = soa::Join<aod::Tracks, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfKa, aod::pidTPCLfPr, aod::pidTPCLfHe>;
+using TracksWithPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCLfPi, aod::pidTPCLfKa, aod::pidTPCLfPr>;
 
 // For MC and dE/dx association
-using TracksWithPIDandLabels = soa::Join<aod::Tracks, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfKa, aod::pidTPCLfPr, aod::pidTPCLfHe, aod::McTrackLabels>;
+using TracksWithPIDandLabels = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCLfPi, aod::pidTPCLfKa, aod::pidTPCLfPr, aod::McTrackLabels>;
 
+// Pre-selected V0s
 using V0full = soa::Join<aod::V0Datas, aod::V0Covs>;
 using TaggedCascades = soa::Join<aod::Cascades, aod::CascTags>;
 
 // For MC association in pre-selection
-using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
+using LabeledTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels>;
 
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 // Builder task: rebuilds multi-strange candidates
@@ -126,7 +128,6 @@ struct cascadeBuilder {
   Configurable<int> createCascCovMats{"createCascCovMats", -1, {"Produces V0 cov matrices. -1: auto, 0: don't, 1: yes. Default: auto (-1)"}};
 
   // Topological selection criteria
-  Configurable<int> mincrossedrows{"mincrossedrows", 70, "min crossed rows"};
   Configurable<int> tpcrefit{"tpcrefit", 0, "demand TPC refit"};
   Configurable<float> dcabachtopv{"dcabachtopv", .05, "DCA Bach To PV"};
   Configurable<float> cascradius{"cascradius", 0.9, "cascradius"};
@@ -164,7 +165,6 @@ struct cascadeBuilder {
   enum cascstep { kCascAll = 0,
                   kCascLambdaMass,
                   kBachTPCrefit,
-                  kBachCrossedRows,
                   kBachDCAxy,
                   kCascDCADau,
                   kCascCosPA,
@@ -445,10 +445,6 @@ struct cascadeBuilder {
       }
     }
     statisticsRegistry.cascstats[kBachTPCrefit]++;
-    if (bachTrack.tpcNClsCrossedRows() < mincrossedrows) {
-      return false;
-    }
-    statisticsRegistry.cascstats[kBachCrossedRows]++;
 
     // bachelor DCA track to PV
     if (TMath::Abs(bachTrack.dcaXY()) < dcabachtopv)
@@ -607,8 +603,37 @@ struct cascadePreselector {
   // dEdx pre-selection compatibility
   Configurable<float> ddEdxPreSelectionWindow{"ddEdxPreSelectionWindow", 7, "Nsigma window for dE/dx preselection"};
 
+  // tpc quality pre-selection
+  Configurable<int> dTPCNCrossedRows{"dTPCNCrossedRows", 50, "Minimum TPC crossed rows"};
+
+  // context-aware selections
+  Configurable<bool> dPreselectOnlyBaryons{"dPreselectOnlyBaryons", false, "apply TPC dE/dx and quality only to baryon daughters"};
+
   void init(InitContext const&) {}
 
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// function to check track quality
+  template <class TTracksTo, typename TCascadeObject>
+  void checkTrackQuality(TCascadeObject const& lCascadeCandidate, bool& lIsInteresting, bool lIsXiMinus, bool lIsXiPlus, bool lIsOmegaMinus, bool lIsOmegaPlus)
+  {
+    lIsInteresting = false;
+    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
+    if (!(v0.has_v0Data())) {
+      lIsInteresting = false;
+      return;
+    }
+    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
+
+    // Acquire all three daughter tracks, please
+    auto lBachTrack = lCascadeCandidate.template bachelor_as<TTracksTo>();
+    auto lNegTrack = v0data.template negTrack_as<TTracksTo>();
+    auto lPosTrack = v0data.template posTrack_as<TTracksTo>();
+
+    if ( ( lIsXiMinus || lIsOmegaMinus ) && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) && (lBachTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+    if ( ( lIsXiPlus || lIsOmegaPlus ) && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) && (lBachTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+  }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check PDG association
   template <class TTracksTo, typename TCascadeObject>
@@ -728,12 +753,15 @@ struct cascadePreselector {
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all cascades are built. It will simply tag everything as true.
-  void processBuildAll(aod::Cascades const& cascades)
+  void processBuildAll(aod::Cascades const& cascades, TracksWithExtra const&)
   {
-    for (int ii = 0; ii < cascades.size(); ii++)
-      casctags(true,
+    for (auto& casc : cascades) {
+      bool lIsQualityInteresting = false;
+      checkTrackQuality<TracksWithExtra>(casc, lIsQualityInteresting, true, true, true, true);
+      casctags(lIsQualityInteresting,
                true, true, true, true,
                true, true, true, true);
+    }
   }
   PROCESS_SWITCH(cascadePreselector, processBuildAll, "Switch to build all cascades", true);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -741,13 +769,15 @@ struct cascadePreselector {
   {
     for (auto& casc : cascades) {
       bool lIsInteresting = false;
+      bool lIsQualityInteresting = false;
       bool lIsTrueXiMinus = false;
       bool lIsTrueXiPlus = false;
       bool lIsTrueOmegaMinus = false;
       bool lIsTrueOmegaPlus = false;
 
       checkPDG<LabeledTracks>(casc, lIsInteresting, lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus);
-      casctags(lIsInteresting,
+      checkTrackQuality<LabeledTracks>(casc, lIsQualityInteresting, true, true, true, true);
+      casctags(lIsInteresting * lIsQualityInteresting,
                lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus,
                true, true, true, true);
     } // end cascades loop
@@ -758,13 +788,15 @@ struct cascadePreselector {
   {
     for (auto& casc : cascades) {
       bool lIsInteresting = false;
+      bool lIsQualityInteresting = false;
       bool lIsdEdxXiMinus = false;
       bool lIsdEdxXiPlus = false;
       bool lIsdEdxOmegaMinus = false;
       bool lIsdEdxOmegaPlus = false;
 
       checkdEdx<TracksWithPID>(casc, lIsInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      casctags(lIsInteresting,
+      checkTrackQuality<TracksWithPID>(casc, lIsQualityInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
+      casctags(lIsInteresting * lIsQualityInteresting,
                true, true, true, true,
                lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
     }
@@ -775,6 +807,7 @@ struct cascadePreselector {
   {
     for (auto& casc : cascades) {
       bool lIsdEdxInteresting = false;
+      bool lIsQualityInteresting = false;
       bool lIsdEdxXiMinus = false;
       bool lIsdEdxXiPlus = false;
       bool lIsdEdxOmegaMinus = false;
@@ -788,7 +821,8 @@ struct cascadePreselector {
 
       checkPDG<TracksWithPIDandLabels>(casc, lIsTrueInteresting, lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus);
       checkdEdx<TracksWithPIDandLabels>(casc, lIsdEdxInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      casctags(lIsTrueInteresting * lIsdEdxInteresting,
+      checkTrackQuality<TracksWithPIDandLabels>(casc, lIsQualityInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
+      casctags(lIsTrueInteresting * lIsdEdxInteresting * lIsQualityInteresting,
                lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus,
                lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
     }

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -109,18 +109,19 @@ DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
 // use parameters + cov mat non-propagated, aux info + (extension propagated)
 using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA>;
 using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TracksDCA>;
+using TracksWithExtra = soa::Join<aod::TracksIU, aod::TracksExtra>;
 
 // For dE/dx association in pre-selection
-using TracksWithPID = soa::Join<aod::Tracks, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfPr, aod::pidTPCLfHe>;
+using TracksWithPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfPr, aod::pidTPCLfHe>;
 
 // For MC and dE/dx association
-using TracksWithPIDandLabels = soa::Join<aod::Tracks, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfPr, aod::pidTPCLfHe, aod::McTrackLabels>;
+using TracksWithPIDandLabels = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCLfEl, aod::pidTPCLfPi, aod::pidTPCLfPr, aod::pidTPCLfHe, aod::McTrackLabels>;
 
 // Pre-selected V0s
 using TaggedV0s = soa::Join<aod::V0s, aod::V0Tags>;
 
 // For MC association in pre-selection
-using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
+using LabeledTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels>;
 
 struct lambdakzeroBuilder {
   Produces<aod::StoredV0Datas> v0data;
@@ -132,9 +133,6 @@ struct lambdakzeroBuilder {
 
   // use auto-detect configuration
   Configurable<bool> d_UseAutodetectMode{"d_UseAutodetectMode", true, "Autodetect requested topo sels"};
-
-  // Topological selection criteria
-  Configurable<int> mincrossedrows{"mincrossedrows", 70, "min crossed rows"};
 
   Configurable<float> dcanegtopv{"dcanegtopv", .1, "DCA Neg To PV"};
   Configurable<float> dcapostopv{"dcapostopv", .1, "DCA Pos To PV"};
@@ -171,7 +169,6 @@ struct lambdakzeroBuilder {
 
   enum v0step { kV0All = 0,
                 kV0TPCrefit,
-                kV0CrossedRows,
                 kV0DCAxy,
                 kV0DCADau,
                 kV0CosPA,
@@ -426,12 +423,6 @@ struct lambdakzeroBuilder {
 
     // Passes TPC refit
     statisticsRegistry.v0stats[kV0TPCrefit]++;
-    if (posTrack.tpcNClsCrossedRows() < mincrossedrows || negTrack.tpcNClsCrossedRows() < mincrossedrows) {
-      return false;
-    }
-
-    // passes crossed rows
-    statisticsRegistry.v0stats[kV0CrossedRows]++;
     if (fabs(posTrack.dcaXY()) < dcapostopv || fabs(negTrack.dcaXY()) < dcanegtopv) {
       return false;
     }
@@ -609,8 +600,37 @@ struct lambdakzeroPreselector {
   // dEdx pre-selection compatibility
   Configurable<float> ddEdxPreSelectionWindow{"ddEdxPreSelectionWindow", 7, "Nsigma window for dE/dx preselection"};
 
+  // tpc quality pre-selection
+  Configurable<int> dTPCNCrossedRows{"dTPCNCrossedRows", 50, "Minimum TPC crossed rows"};
+
+  // context-aware selections
+  Configurable<bool> dPreselectOnlyBaryons{"dPreselectOnlyBaryons", false, "apply TPC dE/dx and quality only to baryon daughters"};
+
   void init(InitContext const&) {}
 
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// function to check track quality
+  template <class TTracksTo, typename TV0Object>
+  void checkTrackQuality(TV0Object const& lV0Candidate, bool& lIsInteresting, bool lIsGamma, bool lIsK0Short, bool lIsLambda, bool lIsAntiLambda, bool lIsHypertriton, bool lIsAntiHypertriton)
+  {
+    lIsInteresting = false;
+    auto lNegTrack = lV0Candidate.template negTrack_as<TTracksTo>();
+    auto lPosTrack = lV0Candidate.template posTrack_as<TTracksTo>();
+  
+    //No baryons in decay
+    if ( ( lIsGamma || lIsK0Short ) && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows) )
+      lIsInteresting = true;
+    //With baryons in decay
+    if ( lIsLambda && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+    if ( lIsAntiLambda && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+    if ( lIsHypertriton && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+    if ( lIsHypertriton && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) ) )
+      lIsInteresting = true;
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check PDG association
   template <class TTracksTo, typename TV0Object>
   void checkPDG(TV0Object const& lV0Candidate, bool& lIsInteresting, bool& lIsGamma, bool& lIsK0Short, bool& lIsLambda, bool& lIsAntiLambda, bool& lIsHypertriton, bool& lIsAntiHypertriton)
@@ -680,26 +700,26 @@ struct lambdakzeroPreselector {
       lIsK0Short = 1;
       lIsInteresting = 1;
     }
-    if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
+    if ((TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons )&&
         TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
         ddEdxPreSelectLambda) {
       lIsLambda = 1;
       lIsInteresting = 1;
     }
     if (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
+        (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons )&&
         ddEdxPreSelectAntiLambda) {
       lIsAntiLambda = 1;
       lIsInteresting = 1;
     }
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow &&
+        (TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons )&&
         ddEdxPreSelectHypertriton) {
       lIsHypertriton = 1;
       lIsInteresting = 1;
     }
-    if (TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lPosTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow &&
+    if ((TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons )&&
+        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
         ddEdxPreSelectAntiHypertriton) {
       lIsAntiHypertriton = 1;
       lIsInteresting = 1;
@@ -707,12 +727,15 @@ struct lambdakzeroPreselector {
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all V0s are built. It will simply tag everything as true.
-  void processBuildAll(aod::V0s const& v0table)
+  void processBuildAll(aod::V0s const& v0table, TracksWithExtra const&)
   {
-    for (int ii = 0; ii < v0table.size(); ii++)
-      v0tags(true,
+    for (auto& v0 : v0table) {
+      bool lIsQualityInteresting = false;
+      checkTrackQuality<TracksWithExtra>(v0, lIsQualityInteresting, true, true, true, true, true, true);
+      v0tags(lIsQualityInteresting,
              true, true, true, true, true, true,
              true, true, true, true, true, true);
+    }
   }
   PROCESS_SWITCH(lambdakzeroPreselector, processBuildAll, "Switch to build all V0s", true);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -727,8 +750,11 @@ struct lambdakzeroPreselector {
       bool lIsTrueHypertriton = false;
       bool lIsTrueAntiHypertriton = false;
 
+      bool lIsQualityInteresting = false;
+
       checkPDG<LabeledTracks>(v0, lIsInteresting, lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton);
-      v0tags(lIsInteresting,
+      checkTrackQuality<LabeledTracks>(v0, lIsQualityInteresting, true, true, true, true, true, true);
+      v0tags(lIsInteresting * lIsQualityInteresting,
              lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton,
              true, true, true, true, true, true);
     }
@@ -746,8 +772,11 @@ struct lambdakzeroPreselector {
       bool lIsdEdxHypertriton = false;
       bool lIsdEdxAntiHypertriton = false;
 
+      bool lIsQualityInteresting = false;
+
       checkdEdx<TracksWithPID>(v0, lIsInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      v0tags(lIsInteresting,
+      checkTrackQuality<TracksWithPID>(v0, lIsQualityInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
+      v0tags(lIsInteresting * lIsQualityInteresting,
              true, true, true, true, true, true,
              lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
     }
@@ -773,9 +802,12 @@ struct lambdakzeroPreselector {
       bool lIsdEdxHypertriton = false;
       bool lIsdEdxAntiHypertriton = false;
 
+      bool lIsQualityInteresting = false;
+
       checkPDG<TracksWithPIDandLabels>(v0, lIsTrueInteresting, lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton);
       checkdEdx<TracksWithPIDandLabels>(v0, lIsdEdxInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      v0tags(lIsTrueInteresting * lIsdEdxInteresting,
+      checkTrackQuality<TracksWithPIDandLabels>(v0, lIsQualityInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
+      v0tags(lIsTrueInteresting * lIsdEdxInteresting * lIsQualityInteresting,
              lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton,
              lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
     }


### PR DESCRIPTION
Based on needs for software triggering and the content shown at the [AOT meeting of the 12th](https://indico.cern.ch/event/1236818/contributions/5203341/attachments/2574614/4439297/DDChinellato-2023-StrangenessReconstructionInO2-02.pdf). 

This PR adds the possibility to pre-filter TPC Ncrossedrows at the preselector level, avoiding loops on candidates with ITS-only tracks if not required (and with the filtering being arrow-based). It also adds an extra flag such that TPC requirements (dE/dx and Ncrossedrows) can optionally only be applied to baryon/heavy daughters. To preserve standard operation, the new flag defaults to false; using it will make it possible to also explore strangeness measurements with the meson prong not having dE/dx information. @ChiaraDeMartin95 and @ercolessi : this is relevant for you :-D

@strogolo @mpuccio @jgrosseo this could potentially also help a bit with the CEFP performance but let's proceed cautiously. I will still investigate further before suggesting any change in those configurations, of course. 