### PR TITLE
Move ALICE 3 to dedicated DCAFitter library

### DIFF
--- a/ALICE3/Tasks/CMakeLists.txt
+++ b/ALICE3/Tasks/CMakeLists.txt
@@ -41,5 +41,5 @@ o2physics_add_dpl_workflow(alice3-pid-ftof-qa
 
 o2physics_add_dpl_workflow(alice3-cdeuteron
                     SOURCES alice3-cdeuteron.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing
+                    PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)

--- a/ALICE3/Tasks/alice3-cdeuteron.cxx
+++ b/ALICE3/Tasks/alice3-cdeuteron.cxx
@@ -19,7 +19,7 @@
 #include "Framework/HistogramRegistry.h"
 #include "ReconstructionDataFormats/PID.h"
 #include "Common/Core/RecoDecay.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/Core/trackUtilities.h"
 


### PR DESCRIPTION
This PR moves the existing ALICE 3 code to the new standalone DCAFitter library to avoid depending on DetectorsVertexing unnecessarily. 