### PR TITLE
PWGDQ: Streamline linked libraries

### DIFF
--- a/PWGDQ/Core/CMakeLists.txt
+++ b/PWGDQ/Core/CMakeLists.txt
@@ -21,7 +21,7 @@ o2physics_add_library(PWGDQCore
                         AnalysisCompositeCut.cxx
                         MCProng.cxx
                         MCSignal.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsVertexing)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2Physics::AnalysisCore)
 
 o2physics_target_root_dictionary(PWGDQCore
                           HEADERS   AnalysisCut.h 

--- a/PWGDQ/Core/CMakeLists.txt
+++ b/PWGDQ/Core/CMakeLists.txt
@@ -12,10 +12,10 @@
 o2physics_add_library(PWGDQCore
                SOURCES  VarManager.cxx
                         HistogramManager.cxx
-			HistogramsLibrary.cxx
-			CutsLibrary.cxx
-			MixingLibrary.cxx
-			MCSignalLibrary.cxx
+                        HistogramsLibrary.cxx
+                        CutsLibrary.cxx
+                        MixingLibrary.cxx
+                        MCSignalLibrary.cxx
                         MixingHandler.cxx
                         AnalysisCut.cxx
                         AnalysisCompositeCut.cxx
@@ -24,9 +24,9 @@ o2physics_add_library(PWGDQCore
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2Physics::AnalysisCore)
 
 o2physics_target_root_dictionary(PWGDQCore
-                          HEADERS   AnalysisCut.h 
-                                    AnalysisCompositeCut.h 
-                                    VarManager.h 
+                          HEADERS   AnalysisCut.h
+                                    AnalysisCompositeCut.h
+                                    VarManager.h
                                     HistogramManager.h
                                     CutsLibrary.h
                                     MixingHandler.h

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -34,13 +34,13 @@
 #include "Framework/DataTypes.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/Vertex.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "Common/CCDB/TriggerAliases.h"
 #include "ReconstructionDataFormats/DCA.h"
 
 #include "Math/SMatrix.h"
 #include "ReconstructionDataFormats/TrackFwd.h"
-#include "DetectorsVertexing/FwdDCAFitterN.h"
+#include "DCAFitter/FwdDCAFitterN.h"
 #include "CommonConstants/PhysicsConstants.h"
 
 using std::cout;

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -11,36 +11,36 @@
 
 o2physics_add_dpl_workflow(table-reader
                     SOURCES tableReader.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(efficiency
                     SOURCES dqEfficiency.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(dilepton-mumu
                     SOURCES dileptonMuMu.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(filter-pp
                     SOURCES filterPP.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(v0-selector
                     SOURCES v0selector.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2::DCAFitter O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DCAFitter O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(dalitz-selection
                     SOURCES DalitzSelection.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(flow
                     SOURCES dqFlow.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore O2Physics::GFWCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCore O2Physics::PWGDQCore O2Physics::GFWCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -31,7 +31,7 @@ o2physics_add_dpl_workflow(filter-pp
 
 o2physics_add_dpl_workflow(v0-selector
                     SOURCES v0selector.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore  O2::DetectorsVertexing
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2::DCAFitter O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(dalitz-selection

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -33,7 +33,7 @@
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/Core/RecoDecay.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "PWGDQ/DataModel/ReducedInfoTables.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GeometryManager.h"


### PR DESCRIPTION
* remove unnecessary linking to DetectorsBase
* Move to link to DCAFitter standalone library instead of DetectorsVertexing to reduce memory consumption