### PR TITLE
PWGEM: streamline library linking

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2physics_add_dpl_workflow(skimmergammaconversions
                     SOURCES skimmerGammaConversions.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::DetectorsVertexing
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(skimmergammaconversionstruthonlymc

--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -11,40 +11,40 @@
 
 o2physics_add_dpl_workflow(skimmergammaconversions
                     SOURCES skimmerGammaConversions.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::DCAFitter O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(skimmergammaconversionstruthonlymc
                     SOURCES skimmerGammaConversionsTruthOnlyMc.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(create-pcm
                     SOURCES createPCM.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(create-emreduced-event
                     SOURCES createEMReducedEvent.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(skimmergammacalo
                     SOURCES skimmerGammaCalo.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(skimmer-phos
                     SOURCES skimmerPHOS.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(gamma-table-producer
                     SOURCES GammaTableProducer.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(produce-meson-calo
                     SOURCES produceMesonCalo.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)

--- a/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
@@ -27,7 +27,7 @@
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/Core/RecoDecay.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DataFormatsParameters/GRPObject.h"

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversions.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversions.cxx
@@ -49,7 +49,7 @@
 #include "DataFormatsParameters/GRPMagField.h"
 #include "CCDB/BasicCCDBManager.h"
 
-#include "DetectorsVertexing/HelixHelper.h"
+#include "DCAFitter/HelixHelper.h"
 #include "ReconstructionDataFormats/TrackFwd.h"
 #include "Common/Core/trackUtilities.h"
 


### PR DESCRIPTION
* remove unnecessary links to DetectorsBase
* Move to linking DCAFitter dedicated library instead of DetectorsVertexing