### PR TITLE
PWGDQ: add histogram with finer binning for low mass dimuons

### DIFF
--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -421,6 +421,9 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
         hm->AddHistogram(histClass, "Pt_Cent", "", false, 120, 0.0, 30.0, VarManager::kPt, 100, 0., 100., VarManager::kCentVZERO);
         hm->AddHistogram(histClass, "Rapidity_Cent", "", false, 200, 2.5, 4.0, VarManager::kRap, 100, 0., 100., VarManager::kCentVZERO);
       }
+      if (subGroupStr.Contains("lowmass")) {
+        hm->AddHistogram(histClass, "MassLow", "", false, 400, 0.0, 2.0, VarManager::kMass);
+      }
       if (subGroupStr.Contains("flow-dimuon")) {
         hm->AddHistogram(histClass, "Mass_u2q2", "u_{2}Q_{2}^{A} vs m", true, 125, 0.0, 5.0, VarManager::kMass, 100, -1.0, 1.0, VarManager::kU2Q2);
         hm->AddHistogram(histClass, "Mass_u3q3", "u_{3}Q_{3}^{A} vs m", true, 125, 0.0, 5.0, VarManager::kMass, 100, -1.0, 1.0, VarManager::kU3Q3);


### PR DESCRIPTION
The current binning of the dimuon invariant mass is not able to see the improvement on the low mass resonances for the global matched MFT-MCH forward tracks. In order to see this effect I added one specific histogram with a bin size of 5 MeV/c2 instead of 20 MeV/c2 (for the general one). 