### PR TITLE
PID: Decouple multiplicity from TPC PID

### DIFF
--- a/Common/TableProducer/PID/CMakeLists.txt
+++ b/Common/TableProducer/PID/CMakeLists.txt
@@ -33,6 +33,11 @@ o2physics_add_dpl_workflow(pid-tof-full
 
 # TPC
 
+o2physics_add_dpl_workflow(pid-tpc-base
+                    SOURCES pidTPCBase.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(pid-tpc
                     SOURCES pidTPC.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::MLCore

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -34,6 +34,7 @@
 #include "Common/DataModel/Multiplicity.h"
 #include "TableHelper.h"
 #include "Tools/ML/model.h"
+#include "pidTPCBase.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -54,7 +55,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 /// Task to produce the response table
 struct tpcPid {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
-  using Coll = soa::Join<aod::Collisions, aod::Mults>;
+  using Coll = soa::Join<aod::Collisions, aod::PIDMults>;
 
   // Tables to produce
   Produces<o2::aod::pidTPCEl> tablePIDEl;

--- a/Common/TableProducer/PID/pidTPCBase.cxx
+++ b/Common/TableProducer/PID/pidTPCBase.cxx
@@ -10,9 +10,9 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// \file   pidTOFBase.cxx
+/// \file   pidTPCBase.cxx
 /// \author Nicolò Jacazio nicolo.jacazio@cern.ch
-/// \brief  Base to build tasks for TOF PID tasks.
+/// \brief  Base to build tasks for TPC PID tasks.
 ///
 
 #include <utility>
@@ -21,7 +21,6 @@
 
 // O2 includes
 #include "CCDB/BasicCCDBManager.h"
-#include "TOFBase/EventTimeMaker.h"
 #include "Framework/AnalysisTask.h"
 #include "ReconstructionDataFormats/Track.h"
 
@@ -49,7 +48,7 @@ struct PidMultiplicity {
   {
     LOG(info) << "Initializing PID Mult Task";
     // Checking that the table is requested in the workflow and enabling it
-    enableTable = isTableRequiredInWorkflow(initContext, "TOFSignal");
+    enableTable = isTableRequiredInWorkflow(initContext, "PIDMults");
     if (enableTable) {
       LOG(info) << "Table TPC PID Multiplicity enabled!";
     }

--- a/Common/TableProducer/PID/pidTPCBase.cxx
+++ b/Common/TableProducer/PID/pidTPCBase.cxx
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   pidTOFBase.cxx
+/// \author Nicolò Jacazio nicolo.jacazio@cern.ch
+/// \brief  Base to build tasks for TOF PID tasks.
+///
+
+#include <utility>
+#include <vector>
+#include <string>
+
+// O2 includes
+#include "CCDB/BasicCCDBManager.h"
+#include "TOFBase/EventTimeMaker.h"
+#include "Framework/AnalysisTask.h"
+#include "ReconstructionDataFormats/Track.h"
+
+// O2Physics includes
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/FT0Corrected.h"
+#include "TableHelper.h"
+#include "pidTPCBase.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::track;
+
+struct PidMultiplicity {
+  Produces<aod::PIDMults> mult;
+
+  //For vertex-Z corrections in calibration
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
+  bool enableTable = false;
+
+  void init(InitContext& initContext)
+  {
+    LOG(info) << "Initializing PID Mult Task";
+    // Checking that the table is requested in the workflow and enabling it
+    enableTable = isTableRequiredInWorkflow(initContext, "TOFSignal");
+    if (enableTable) {
+      LOG(info) << "Table TPC PID Multiplicity enabled!";
+    }
+  }
+
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra)
+  {
+    if (!enableTable) {
+      return;
+    }
+    auto tracksGrouped = tracksWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex());
+    mult(tracksGrouped.size());
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<PidMultiplicity>(cfgc)};
+}

--- a/Common/TableProducer/PID/pidTPCBase.h
+++ b/Common/TableProducer/PID/pidTPCBase.h
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   pidTPCBase.h
+/// \author Nicolò Jacazio nicolo.jacazio@cern.ch
+/// \brief  Base to build tasks for TPC PID tasks.
+///
+
+#ifndef COMMON_TABLEPRODUCER_PID_PIDTPCBASE_H_
+#define COMMON_TABLEPRODUCER_PID_PIDTPCBASE_H_
+
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/PIDResponse.h"
+
+using namespace o2;
+using namespace o2::track;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+namespace o2::aod
+{
+
+DECLARE_SOA_TABLE(PIDMults, "AOD", "PIDMults", //! TPC auxiliary table for the PID
+                  mult::MultTPC);
+using PIDMult = PIDMults::iterator;
+
+} // namespace o2::aod
+
+#endif // COMMON_TABLEPRODUCER_PID_PIDTPCBASE_H_

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -34,6 +34,7 @@
 #include "Common/DataModel/Multiplicity.h"
 #include "TableHelper.h"
 #include "Tools/ML/model.h"
+#include "pidTPCBase.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -54,7 +55,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 /// Task to produce the response table
 struct tpcPidFull {
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
-  using Coll = soa::Join<aod::Collisions, aod::Mults>;
+  using Coll = soa::Join<aod::Collisions, aod::PIDMults>;
 
   // Tables to produce
   Produces<o2::aod::pidTPCFullEl> tablePIDEl;


### PR DESCRIPTION
@jezwilkinson @chiarazampolli @noferini @strogolo  here's my proposal of decoupling, we should add a dependency on o2-analysis-pid-tpc-base to both PID tasks, I tested it and it works, what do you think? We could also make sure that the value in the other table is picked up from the one of the TPC, of course it creates another dependency, I don't know if this is what we want