### PR TITLE
PWGHF: bugfix for v0 indices in HfCascades

### DIFF
--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2433,7 +2433,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
         // fill table row
         rowTrackIndexCasc(bach.globalIndex(),
-                          v0.globalIndex());
+                          v0.v0Id());
         // fill histograms
         if (fillHistograms) {
           MY_DEBUG_MSG(isK0SfromLc && isProtonFromLc && isLc, LOG(info) << "KEPT! True Lc from proton " << indexBach << " and K0S pos " << indexV0DaughPos << " and neg " << indexV0DaughNeg);


### PR DESCRIPTION
This seems to be a bug in which V0 index is written into the HfCascades table, because the wrong V0s are then picked up in the candidateCreatorCascade.

Compare to how the V0s are loaded in the candidateCreatorCascade:

https://github.com/AliceO2Group/O2Physics/blob/27d0817f4c5ea57083ed56b53c47fe66b3ac9ca1/PWGHF/TableProducer/candidateCreatorCascade.cxx#L111