### PR TITLE
add QA option (def false) for ITS clu map

### DIFF
--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -157,6 +157,16 @@ struct lambdakzeroBuilder {
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
+  // generate and fill extra QA histograms is requested
+  Configurable<bool> d_doQA{"d_doQA", false, "Do basic QA"};
+  Configurable<int> dQANBinsRadius{"dQANBinsRadius", 500, "Number of radius bins in QA histo"};
+  Configurable<int> dQANBinsPtCoarse{"dQANBinsPtCoarse", 10, "Number of pT bins in QA histo"};
+  Configurable<int> dQANBinsMass{"dQANBinsMass", 400, "Number of mass bins for QA histograms"};
+  Configurable<float> dQAMaxPt{"dQAMaxPt", 5, "max pT in QA histo"};
+  Configurable<float> dQAK0ShortMassWindow{"dQAK0ShortMassWindow", 0.005, "K0 mass window for ITS cluster map QA"};
+  Configurable<float> dQALambdaMassWindow{"dQALambdaMassWindow", 0.005, "Lambda/AntiLambda mass window for ITS cluster map QA"};
+  
+
   int mRunNumber;
   float d_bz;
   float maxSnp;  // max sine phi for propagation
@@ -244,6 +254,35 @@ struct lambdakzeroBuilder {
   void init(InitContext& context)
   {
     resetHistos();
+
+    //Optionally, add extra QA histograms to processing chain
+    if(d_doQA){
+      // Basic histograms containing invariant masses of all built candidates
+      const AxisSpec axisVsPtCoarse{(int)dQANBinsPtCoarse, 0, dQAMaxPt, "#it{p}_{T} (GeV/c)"};
+      const AxisSpec axisGammaMass{(int)dQANBinsMass, 0.000f, 0.400f, "Inv. Mass (GeV/c^{2})"};
+      const AxisSpec axisK0ShortMass{(int)dQANBinsMass, 0.400f, 0.600f, "Inv. Mass (GeV/c^{2})"};
+      const AxisSpec axisLambdaMass{(int)dQANBinsMass, 1.01f, 1.21f, "Inv. Mass (GeV/c^{2})"};
+      const AxisSpec axisHypertritonMass{(int)dQANBinsMass, 2.900f, 3.300f, "Inv. Mass (GeV/c^{2})"};
+
+      registry.add("h2dGammaMass", "h2dGammaMass", kTH2F, {axisVsPtCoarse, axisGammaMass});
+      registry.add("h2dK0ShortMass", "h2dK0ShortMass", kTH2F, {axisVsPtCoarse, axisK0ShortMass});
+      registry.add("h2dLambdaMass", "h2dLambdaMass", kTH2F, {axisVsPtCoarse, axisLambdaMass});
+      registry.add("h2dAntiLambdaMass", "h2dAntiLambdaMass", kTH2F, {axisVsPtCoarse, axisLambdaMass});
+      registry.add("h2dHypertritonMass", "h2dHypertritonMass", kTH2F, {axisVsPtCoarse, axisHypertritonMass});
+      registry.add("h2dAntiHypertritonMass", "h2dAntiHypertritonMass", kTH2F, {axisVsPtCoarse, axisHypertritonMass});
+      
+      // bit packed ITS cluster map
+      const AxisSpec axisITSCluMap{(int)128, -0.5f, +127.5f, "Packed ITS map"};
+      const AxisSpec axisRadius{(int)dQANBinsRadius, 0.0f, +50.0f, "Radius (cm)"};
+      
+      //Histogram to bookkeep cluster maps
+      registry.add("h2dITSCluMap_K0ShortPositive", "h2dITSCluMap_K0ShortPositive", kTH2D, {axisITSCluMap, axisRadius});
+      registry.add("h2dITSCluMap_K0ShortNegative", "h2dITSCluMap_K0ShortNegative", kTH2D, {axisITSCluMap, axisRadius});
+      registry.add("h2dITSCluMap_LambdaPositive", "h2dITSCluMap_LambdaPositive", kTH2D, {axisITSCluMap, axisRadius});
+      registry.add("h2dITSCluMap_LambdaNegative", "h2dITSCluMap_LambdaNegative", kTH2D, {axisITSCluMap, axisRadius});
+      registry.add("h2dITSCluMap_AntiLambdaPositive", "h2dITSCluMap_AntiLambdaPositive", kTH2D, {axisITSCluMap, axisRadius});
+      registry.add("h2dITSCluMap_AntiLambdaNegative", "h2dITSCluMap_AntiLambdaNegative", kTH2D, {axisITSCluMap, axisRadius});
+    }
 
     mRunNumber = 0;
     d_bz = 0;
@@ -541,6 +580,44 @@ struct lambdakzeroBuilder {
       if (negTrack.itsNCls() < 10)
         statisticsRegistry.negITSclu[negTrack.itsNCls()]++;
     }
+    
+    
+    if(d_doQA){
+      // Calculate masses
+      auto lGammaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
+      auto lK0ShortMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
+      auto lLambdaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
+      auto lAntiLambdaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
+      auto lHypertritonMass = RecoDecay::m(array{array{2.0f * v0candidate.posP[0], 2.0f * v0candidate.posP[1], 2.0f * v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged});
+      auto lAntiHypertritonMass = RecoDecay::m(array{array{2.0f * v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{2.0f * v0candidate.negP[0], 2.0f * v0candidate.negP[1], 2.0f * v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3});
+
+      auto lPt = RecoDecay::sqrtSumOfSquares(v0candidate.posP[0] + v0candidate.negP[0], v0candidate.posP[1] + v0candidate.negP[1]);
+      auto lPtHy = RecoDecay::sqrtSumOfSquares(2.0f * (v0candidate.posP[0] + v0candidate.negP[0]), v0candidate.posP[1] + v0candidate.negP[1]);
+      auto lPtAnHy = RecoDecay::sqrtSumOfSquares(v0candidate.posP[0] + v0candidate.negP[0], 2.0f * (v0candidate.posP[1] + v0candidate.negP[1]));
+      
+      // Fill basic mass histograms
+      registry.fill(HIST("h2dGammaMass"), lPt, lGammaMass);
+      registry.fill(HIST("h2dK0ShortMass"), lPt, lK0ShortMass);
+      registry.fill(HIST("h2dLambdaMass"), lPt, lLambdaMass);
+      registry.fill(HIST("h2dAntiLambdaMass"), lPt, lAntiLambdaMass);
+      registry.fill(HIST("h2dHypertritonMass"), lPtHy, lHypertritonMass);
+      registry.fill(HIST("h2dAntiHypertritonMass"), lPtAnHy, lAntiHypertritonMass);
+
+      // Fill ITS cluster maps with specific mass cuts
+      if( TMath::Abs(lK0ShortMass - 0.497) < dQAK0ShortMassWindow ){
+        registry.fill(HIST("h2dITSCluMap_K0ShortPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
+        registry.fill(HIST("h2dITSCluMap_K0ShortNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
+      }
+      if( TMath::Abs(lLambdaMass - 1.116) < dQALambdaMassWindow ){
+        registry.fill(HIST("h2dITSCluMap_LambdaPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
+        registry.fill(HIST("h2dITSCluMap_LambdaNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
+      }
+      if( TMath::Abs(lAntiLambdaMass - 1.116) < dQALambdaMassWindow ){
+        registry.fill(HIST("h2dITSCluMap_AntiLambdaPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
+        registry.fill(HIST("h2dITSCluMap_AntiLambdaNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
+      }
+    }
+    
     return true;
   }
 

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -587,7 +587,7 @@ struct lambdakzeroBuilder {
       auto lLambdaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
       auto lAntiLambdaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
       auto lHypertritonMass = RecoDecay::m(array{array{2.0f * v0candidate.posP[0], 2.0f * v0candidate.posP[1], 2.0f * v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged});
-      auto lAntiHypertritonMass = RecoDecay::m(array{array{2.0f * v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{2.0f * v0candidate.negP[0], 2.0f * v0candidate.negP[1], 2.0f * v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3});
+      auto lAntiHypertritonMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{2.0f * v0candidate.negP[0], 2.0f * v0candidate.negP[1], 2.0f * v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3});
 
       auto lPt = RecoDecay::sqrtSumOfSquares(v0candidate.posP[0] + v0candidate.negP[0], v0candidate.posP[1] + v0candidate.negP[1]);
       auto lPtHy = RecoDecay::sqrtSumOfSquares(2.0f * (v0candidate.posP[0] + v0candidate.negP[0]), v0candidate.posP[1] + v0candidate.negP[1]);

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -165,6 +165,7 @@ struct lambdakzeroBuilder {
   Configurable<float> dQAMaxPt{"dQAMaxPt", 5, "max pT in QA histo"};
   Configurable<float> dQAK0ShortMassWindow{"dQAK0ShortMassWindow", 0.005, "K0 mass window for ITS cluster map QA"};
   Configurable<float> dQALambdaMassWindow{"dQALambdaMassWindow", 0.005, "Lambda/AntiLambda mass window for ITS cluster map QA"};
+  
 
   int mRunNumber;
   float d_bz;
@@ -254,8 +255,8 @@ struct lambdakzeroBuilder {
   {
     resetHistos();
 
-    // Optionally, add extra QA histograms to processing chain
-    if (d_doQA) {
+    //Optionally, add extra QA histograms to processing chain
+    if(d_doQA){
       // Basic histograms containing invariant masses of all built candidates
       const AxisSpec axisVsPtCoarse{(int)dQANBinsPtCoarse, 0, dQAMaxPt, "#it{p}_{T} (GeV/c)"};
       const AxisSpec axisGammaMass{(int)dQANBinsMass, 0.000f, 0.400f, "Inv. Mass (GeV/c^{2})"};
@@ -273,8 +274,8 @@ struct lambdakzeroBuilder {
       // bit packed ITS cluster map
       const AxisSpec axisITSCluMap{(int)128, -0.5f, +127.5f, "Packed ITS map"};
       const AxisSpec axisRadius{(int)dQANBinsRadius, 0.0f, +50.0f, "Radius (cm)"};
-
-      // Histogram to bookkeep cluster maps
+      
+      //Histogram to bookkeep cluster maps
       registry.add("h2dITSCluMap_K0ShortPositive", "h2dITSCluMap_K0ShortPositive", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_K0ShortNegative", "h2dITSCluMap_K0ShortNegative", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_LambdaPositive", "h2dITSCluMap_LambdaPositive", kTH2D, {axisITSCluMap, axisRadius});
@@ -579,8 +580,9 @@ struct lambdakzeroBuilder {
       if (negTrack.itsNCls() < 10)
         statisticsRegistry.negITSclu[negTrack.itsNCls()]++;
     }
-
-    if (d_doQA) {
+    
+    
+    if(d_doQA){
       // Calculate masses
       auto lGammaMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
       auto lK0ShortMass = RecoDecay::m(array{array{v0candidate.posP[0], v0candidate.posP[1], v0candidate.posP[2]}, array{v0candidate.negP[0], v0candidate.negP[1], v0candidate.negP[2]}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
@@ -592,30 +594,37 @@ struct lambdakzeroBuilder {
       auto lPt = RecoDecay::sqrtSumOfSquares(v0candidate.posP[0] + v0candidate.negP[0], v0candidate.posP[1] + v0candidate.negP[1]);
       auto lPtHy = RecoDecay::sqrtSumOfSquares(2.0f * (v0candidate.posP[0] + v0candidate.negP[0]), v0candidate.posP[1] + v0candidate.negP[1]);
       auto lPtAnHy = RecoDecay::sqrtSumOfSquares(v0candidate.posP[0] + v0candidate.negP[0], 2.0f * (v0candidate.posP[1] + v0candidate.negP[1]));
-
+      
       // Fill basic mass histograms
-      registry.fill(HIST("h2dGammaMass"), lPt, lGammaMass);
-      registry.fill(HIST("h2dK0ShortMass"), lPt, lK0ShortMass);
-      registry.fill(HIST("h2dLambdaMass"), lPt, lLambdaMass);
-      registry.fill(HIST("h2dAntiLambdaMass"), lPt, lAntiLambdaMass);
-      registry.fill(HIST("h2dHypertritonMass"), lPtHy, lHypertritonMass);
-      registry.fill(HIST("h2dAntiHypertritonMass"), lPtAnHy, lAntiHypertritonMass);
+      // Note: all presel bools are true if unchecked
+      if( V0.isGammaCandidate() && V0.isTrueGamma() )
+        registry.fill(HIST("h2dGammaMass"), lPt, lGammaMass);
+      if( V0.isK0ShortCandidate() && V0.isTrueK0Short() )
+        registry.fill(HIST("h2dK0ShortMass"), lPt, lK0ShortMass);
+      if( V0.isLambdaCandidate() && V0.isTrueLambda() )
+        registry.fill(HIST("h2dLambdaMass"), lPt, lLambdaMass);
+      if( V0.isAntiLambdaCandidate() && V0.isTrueAntiLambda() )
+        registry.fill(HIST("h2dAntiLambdaMass"), lPt, lAntiLambdaMass);
+      if( V0.isHypertritonCandidate() && V0.isTrueHypertriton() )
+        registry.fill(HIST("h2dHypertritonMass"), lPtHy, lHypertritonMass);
+      if( V0.isAntiHypertritonCandidate() && V0.isTrueAntiHypertriton() )
+        registry.fill(HIST("h2dAntiHypertritonMass"), lPtAnHy, lAntiHypertritonMass);
 
       // Fill ITS cluster maps with specific mass cuts
-      if (TMath::Abs(lK0ShortMass - 0.497) < dQAK0ShortMassWindow) {
+      if( TMath::Abs(lK0ShortMass - 0.497) < dQAK0ShortMassWindow && V0.isK0ShortCandidate() && V0.isTrueK0Short() ){
         registry.fill(HIST("h2dITSCluMap_K0ShortPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
         registry.fill(HIST("h2dITSCluMap_K0ShortNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
       }
-      if (TMath::Abs(lLambdaMass - 1.116) < dQALambdaMassWindow) {
+      if( TMath::Abs(lLambdaMass - 1.116) < dQALambdaMassWindow && V0.isLambdaCandidate() && V0.isTrueLambda() ){
         registry.fill(HIST("h2dITSCluMap_LambdaPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
         registry.fill(HIST("h2dITSCluMap_LambdaNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
       }
-      if (TMath::Abs(lAntiLambdaMass - 1.116) < dQALambdaMassWindow) {
+      if( TMath::Abs(lAntiLambdaMass - 1.116) < dQALambdaMassWindow && V0.isAntiLambdaCandidate() && V0.isTrueAntiLambda() ){
         registry.fill(HIST("h2dITSCluMap_AntiLambdaPositive"), (float)posTrack.itsClusterMap(), v0candidate.V0radius);
         registry.fill(HIST("h2dITSCluMap_AntiLambdaNegative"), (float)negTrack.itsClusterMap(), v0candidate.V0radius);
       }
     }
-
+    
     return true;
   }
 
@@ -732,8 +741,6 @@ struct lambdakzeroPreselector {
 
   // context-aware selections
   Configurable<bool> dPreselectOnlyBaryons{"dPreselectOnlyBaryons", false, "apply TPC dE/dx and quality only to baryon daughters"};
-
-  void init(InitContext const&) {}
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check track quality


### PR DESCRIPTION
This PR adds a QA option for the `lambdakzerobuilder` such that it is able to bookkeep ITS cluster maps very flexibly, with fully customizable binning. Since these are 2D histograms that are heavy, they are only created in memory in case the option to QA is enabled (default: disabled, of course). To be tested further