### PR TITLE
PWGDQ/EM: Adjust prefitler to use composite cuts and provide BField, …

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -661,7 +661,7 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   // lmee pair cuts
 
   if (!nameStr.compare("pairPhiV")) {
-    AnalysisCompositeCut* cut_pairPhiV = new AnalysisCompositeCut("cut_pairPhiV", "cut_pairPhiV", kFALSE);
+    AnalysisCompositeCut* cut_pairPhiV = new AnalysisCompositeCut("cut_pairPhiV", "cut_pairPhiV", kTRUE);
     cut_pairPhiV->AddCut(GetAnalysisCut("pairLowMass"));
     cut_pairPhiV->AddCut(GetAnalysisCut("pairPhiV"));
     cut->AddCut(cut_pairPhiV);
@@ -963,7 +963,6 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   //
   AnalysisCut* cut = new AnalysisCut(cutName, cutName);
   std::string nameStr = cutName;
-
   // ---------------------------------------------------------------
   // Event cuts
   if (!nameStr.compare("eventStandard")) {
@@ -1686,12 +1685,12 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   }
 
   if (!nameStr.compare("pairPhiV")) {
-    cut->AddCut(VarManager::kPairPhiv, 2., 3.2, true);
+    cut->AddCut(VarManager::kPairPhiv, 2., 3.2);
     return cut;
   }
 
   if (!nameStr.compare("pairLowMass")) {
-    cut->AddCut(VarManager::kMass, 0., 0.1, true);
+    cut->AddCut(VarManager::kMass, 0., 0.1);
     return cut;
   }
 

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1119,28 +1119,60 @@ void VarManager::FillPair(T1 const& t1, T2 const& t2, float* values)
 
     float bz = fgFitterTwoProngBarrel.getBz();
 
+    bool swapTracks = false;
+    if (v1.Pt() < v2.Pt()) { // ordering of track, pt1 > pt2
+      ROOT::Math::PtEtaPhiMVector v3 = v1;
+      v1 = v2;
+      v2 = v3;
+      swapTracks = true;
+    }
+
     // momentum of e+ and e- in (ax,ay,az) axis. Note that az=0 by definition.
     // vector product of pep X pem
     float vpx = 0, vpy = 0, vpz = 0;
     if (t1.sign() * t2.sign() > 0) { // Like Sign
-      if (bz * t1.sign() < 0) {
-        vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
-        vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
-        vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
-      } else {
-        vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
-        vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
-        vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+      if (!swapTracks) {
+        if (bz * t1.sign() < 0) {
+          vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
+          vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
+          vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
+        } else {
+          vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
+          vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
+          vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+        }
+      } else { // swaped tracks
+        if (bz * t2.sign() < 0) {
+          vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
+          vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
+          vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
+        } else {
+          vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
+          vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
+          vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+        }
       }
     } else { // Unlike Sign
-      if (bz * t1.sign() > 0) {
-        vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
-        vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
-        vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
-      } else {
-        vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
-        vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
-        vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+      if (!swapTracks) {
+        if (bz * t1.sign() > 0) {
+          vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
+          vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
+          vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
+        } else {
+          vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
+          vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
+          vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+        }
+      } else { // swaped tracks
+        if (bz * t2.sign() > 0) {
+          vpx = v1.Py() * v2.Pz() - v1.Pz() * v2.Py();
+          vpy = v1.Pz() * v2.Px() - v1.Px() * v2.Pz();
+          vpz = v1.Px() * v2.Py() - v1.Py() * v2.Px();
+        } else {
+          vpx = v2.Py() * v1.Pz() - v2.Pz() * v1.Py();
+          vpy = v2.Pz() * v1.Px() - v2.Px() * v1.Pz();
+          vpz = v2.Px() * v1.Py() - v2.Py() * v1.Px();
+        }
       }
     }
 


### PR DESCRIPTION
…change def. of PhiV


Adjust phiV cuts to the way the prefilter works.

Introduce ordering of pt to calculate phiV.

Pass magnetic field to prefilter by using `VarManager::SetupTwoProngDCAFitter(5.0f, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, true);`

Rename the prefilter flag which vetos specific tracks

Invert pair cut selection in SameEventPairing