### PR TITLE
Install python scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ add_subdirectory(Tools)
 add_subdirectory(Tutorials)
 add_subdirectory(EventFiltering)
 
+add_subdirectory(Scripts)
+
 # Testing and packaging only needed if we are the top level directory
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   add_subdirectory(packaging)

--- a/Scripts/CMakeLists.txt
+++ b/Scripts/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+install(FILES find_dependencies.py
+              update_ccdb.py
+        PERMISSIONS GROUP_READ GROUP_EXECUTE OWNER_EXECUTE OWNER_WRITE OWNER_READ WORLD_EXECUTE WORLD_READ
+        DESTINATION share/scripts/)


### PR DESCRIPTION
* since anyway only useful in alienv, they can now be run via ${O2PHYSICS_ROOT}/share/scripts/<script>.py --> no need to run from SOURCE dir (which is not well-defined)

* can be used via cvmfs --> GRID/Hyperloop