### PR TITLE
[WIP] Implementing background subtraction in the JE framework

### DIFF
--- a/PWGJE/Core/CMakeLists.txt
+++ b/PWGJE/Core/CMakeLists.txt
@@ -12,10 +12,12 @@
 if(FastJet_FOUND)
 o2physics_add_library(PWGJECore
                SOURCES  JetFinder.cxx
+                        JetBkgSubUtils.cxx
                PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore FastJet::FastJet FastJet::Contrib)
 
 o2physics_target_root_dictionary(PWGJECore
               HEADERS JetFinder.h
                       JetUtilities.h
+                      JetBkgSubUtils.h
               LINKDEF PWGJECoreLinkDef.h)
 endif()

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -14,6 +14,7 @@
 // Author: Hadi Hassan
 #include "PWGJE/Core/JetBkgSubUtils.h"
 #include "Framework/Logger.h"
+#include "TVector2.h"
 
 JetBkgSubUtils::JetBkgSubUtils(float jetBkgR, float bkgPhiMin, float bkgPhiMax, float bkgEtaMin, float bkgEtaMax, float constSubAlpha, float constSubRMax, fastjet::GhostedAreaSpec ghostAreaSpec) : mJetBkgR(jetBkgR),
                                                                                                                                                                                                      mBkgPhiMin(bkgPhiMin),
@@ -26,11 +27,11 @@ JetBkgSubUtils::JetBkgSubUtils(float jetBkgR, float bkgPhiMin, float bkgPhiMax, 
 
 {
   mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
-  mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area, mGhostAreaSpec);
+  mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
   mSelRho = fastjet::SelectorRapRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax) && !fastjet::SelectorNHardest(2); // here we have to put rap range, to be checked!
 }
 
-double JetBkgSubUtils::estimateRhoAreaMedian(std::vector<fastjet::PseudoJet>& inputParticles, bool doAreaSparse)
+double JetBkgSubUtils::estimateRhoAreaMedian(std::vector<fastjet::PseudoJet>& inputParticles)
 {
 
   if (inputParticles.size() == 0) {
@@ -60,7 +61,7 @@ double JetBkgSubUtils::estimateRhoAreaMedian(std::vector<fastjet::PseudoJet>& in
   // calculate Rho as the median of the jet pT / jet area
   double rho = TMath::Median<double>(rhovector.size(), rhovector.data());
 
-  if (doAreaSparse) {
+  if (mDoSparseSub) {
     // calculate The ocupancy factor, which the ratio of covered area / total area
     double occupancyFactor = totalAreaCovered > 0 ? totaljetAreaPhys / totalAreaCovered : 1.;
     rho *= occupancyFactor;
@@ -79,30 +80,30 @@ double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>
   double perpPtDensity1 = 0;
   double perpPtDensity2 = 0;
 
-  fastjet::Selector selLeadingJet = fastjet::SelectorEtaRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax);
+  fastjet::Selector selectJet = fastjet::SelectorEtaRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax);
 
-  std::vector<fastjet::PseudoJet> leadingJets = fastjet::sorted_by_pt(selLeadingJet(jets));
+  std::vector<fastjet::PseudoJet> selectedJets = fastjet::sorted_by_pt(selectJet(jets));
 
-  if (leadingJets.size() == 0) {
+  if (selectedJets.size() == 0) {
     return 0.0;
   }
 
-  fastjet::PseudoJet leadingJet = leadingJets[0];
+  fastjet::PseudoJet leadingJet = selectedJets[0];
 
   double dPhi1 = 999.;
   double dPhi2 = 999.;
   double dEta = 999.;
   double PerpendicularConeAxisPhi1 = 999., PerpendicularConeAxisPhi2 = 999.;
   // build 2 perp cones in phi around the leading jet (right and left of the jet)
-  PerpendicularConeAxisPhi1 = ((leadingJet.phi() + (M_PI / 2.)) > (2 * M_PI)) ? leadingJet.phi() - ((3. / 2.) * M_PI) : leadingJet.phi() + (M_PI / 2.);
-  PerpendicularConeAxisPhi2 = ((leadingJet.phi() - (M_PI / 2.)) < 0) ? leadingJet.phi() + ((3. / 2.) * M_PI) : leadingJet.phi() - (M_PI / 2.);
+  PerpendicularConeAxisPhi1 = TVector2::Phi_0_2pi(leadingJet.phi() + (M_PI / 2.));
+  PerpendicularConeAxisPhi2 = TVector2::Phi_0_2pi(leadingJet.phi() - (M_PI / 2.));
 
   for (auto& particle : inputParticles) {
     // sum the momentum of all paricles that fill the two cones
-    dPhi1 = TMath::Abs(particle.phi() - PerpendicularConeAxisPhi1);
-    dPhi1 = (dPhi1 > M_PI) ? 2 * M_PI - dPhi1 : dPhi1;
-    dPhi2 = TMath::Abs(particle.phi() - PerpendicularConeAxisPhi2);
-    dPhi2 = (dPhi2 > M_PI) ? 2 * M_PI - dPhi2 : dPhi2;
+    dPhi1 = particle.phi() - PerpendicularConeAxisPhi1;
+    dPhi1 = TVector2::Phi_mpi_pi(dPhi1);
+    dPhi2 = particle.phi() - PerpendicularConeAxisPhi2;
+    dPhi2 = TVector2::Phi_mpi_pi(dPhi2);
     dEta = leadingJet.eta() - particle.eta();
     if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= mJetBkgR) {
       perpPtDensity1 += particle.perp();
@@ -122,22 +123,22 @@ double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>
 /// Sets the background subtraction estimater pointer
 void JetBkgSubUtils::setBkgE()
 {
-  bkgE = decltype(bkgE)(new fastjet::JetMedianBackgroundEstimator(mSelRho, mJetDefBkg, mAreaDefBkg));
+  mbkgE = decltype(mbkgE)(new fastjet::JetMedianBackgroundEstimator(mSelRho, mJetDefBkg, mAreaDefBkg));
 }
 
 /// Sets the background subtraction object
-fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, const std::vector<fastjet::PseudoJet>& jets)
+fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, std::vector<fastjet::PseudoJet>& jets)
 {
+
+  if (bkgSubMode == BkgSubMode::rhoSparseSub) {
+    mDoSparseSub = true;
+  }
+
   fastjet::Subtractor sub;
 
-  if (bkgSubMode == BkgSubMode::rhoMedianAreaSub) {
+  if (bkgSubMode == BkgSubMode::rhoMedianAreaSub || bkgSubMode == BkgSubMode::rhoSparseSub) {
 
     rhoParam = estimateRhoAreaMedian(inputParticles);
-    sub = fastjet::Subtractor(rhoParam);
-
-  } else if (bkgSubMode == BkgSubMode::rhoSparseSub) {
-
-    rhoParam = estimateRhoAreaMedian(inputParticles, true);
     sub = fastjet::Subtractor(rhoParam);
 
   } else if (bkgSubMode == BkgSubMode::rhoPerpConeSub) {
@@ -151,25 +152,52 @@ fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inpu
   } else if (bkgSubMode == BkgSubMode::rhoAreaSub) {
 
     setBkgE();
-    bkgE->set_particles(inputParticles);
-    sub = fastjet::Subtractor(bkgE.get());
-    rhoParam = bkgE->estimate().rho();
+    mbkgE->set_particles(inputParticles);
+    sub = fastjet::Subtractor(mbkgE.get());
+    rhoParam = mbkgE->estimate().rho();
 
   } else if (bkgSubMode == BkgSubMode::constSub) { // event or jetwise
 
     setBkgE();
-    bkgE->set_particles(inputParticles);
-    rhoParam = bkgE->estimate().rho();
+    mbkgE->set_particles(inputParticles);
+    rhoParam = mbkgE->estimate().rho();
     std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
-    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{bkgE.get()}};
+    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{mbkgE.get()}};
     constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
     constituentSub->set_max_distance(mConstSubRMax);
     constituentSub->set_alpha(mConstSubAlpha);
     constituentSub->set_ghost_area(mGhostAreaSpec.ghost_area());
     constituentSub->set_max_eta(mBkgEtaMax);
-    constituentSub->set_background_estimator(bkgE.get());
+    constituentSub->set_background_estimator(mbkgE.get());
 
     inputParticles = constituentSub->subtract_event(inputParticles);
+
+  } else if (bkgSubMode == BkgSubMode::jetconstSub) {
+
+    if (jets.size() == 0) {
+      return sub;
+    }
+
+    setBkgE();
+    fastjet::BackgroundJetScalarPtDensity scalarPtDensity;
+    mbkgE->set_jet_density_class(&scalarPtDensity); // this changes the computation of pt of patches from vector sum to scalar sum. The scalar sum seems more reasonable.
+    mbkgE->set_particles(inputParticles);
+
+    fastjet::contrib::ConstituentSubtractor subtractor(mbkgE.get());
+    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
+    subtractor.set_max_distance(mConstSubRMax);
+    subtractor.set_alpha(mConstSubAlpha);
+    subtractor.set_ghost_area(mGhostAreaSpec.ghost_area());
+    subtractor.set_max_eta(mBkgEtaMax);
+
+    // by default, the masses of all particles are set to zero.
+    // this sets the same background estimator to be used for deltaMass density, rho_m, as for pt density, rho:
+    subtractor.set_do_mass_subtraction();
+    subtractor.set_common_bge_for_rho_and_rhom();
+
+    // Unfortunately this method doesn't work, it crashes with error:
+    // fastjet::Error:  One or more of this composite jet's pieces does not support area
+    jets = subtractor(jets);
 
   } else {
     rhoParam = 0.;

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -1,0 +1,182 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// jet finder task
+//
+// Author: Hadi Hassan
+#include "PWGJE/Core/JetBkgSubUtils.h"
+#include "Framework/Logger.h"
+
+JetBkgSubUtils::JetBkgSubUtils(float jetBkgR, float bkgPhiMin, float bkgPhiMax, float bkgEtaMin, float bkgEtaMax, float constSubAlpha, float constSubRMax, fastjet::GhostedAreaSpec ghostAreaSpec) : mJetBkgR(jetBkgR),
+                                                                                                                                                                                                     mBkgPhiMin(bkgPhiMin),
+                                                                                                                                                                                                     mBkgPhiMax(bkgPhiMax),
+                                                                                                                                                                                                     mBkgEtaMin(bkgEtaMin),
+                                                                                                                                                                                                     mBkgEtaMax(bkgEtaMax),
+                                                                                                                                                                                                     mConstSubAlpha(constSubAlpha),
+                                                                                                                                                                                                     mConstSubRMax(constSubRMax),
+                                                                                                                                                                                                     mGhostAreaSpec(ghostAreaSpec)
+
+{
+  mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
+  mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area, mGhostAreaSpec);
+  mSelRho = fastjet::SelectorRapRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax) && !fastjet::SelectorNHardest(2); // here we have to put rap range, to be checked!
+}
+
+double JetBkgSubUtils::estimateRhoAreaMedian(std::vector<fastjet::PseudoJet>& inputParticles, bool doAreaSparse)
+{
+
+  if (inputParticles.size() == 0) {
+    return 0.0;
+  }
+
+  // cluster the kT jets
+  fastjet::ClusterSequenceArea clusterSeq(inputParticles, mJetDefBkg, mAreaDefBkg);
+
+  // select jets in detector acceptance
+  std::vector<fastjet::PseudoJet> alljets = mSelRho(clusterSeq.inclusive_jets());
+
+  double totaljetAreaPhys(0), totalAreaCovered(0);
+  std::vector<double> rhovector;
+
+  // Fill a vector for pT/area to be used for the median
+  for (auto& ijet : alljets) {
+
+    // Physical area/ Physical jets (no ghost)
+    if (!clusterSeq.is_pure_ghost(ijet)) {
+      rhovector.push_back(ijet.perp() / ijet.area());
+      totaljetAreaPhys += ijet.area();
+    }
+    // Full area
+    totalAreaCovered += ijet.area();
+  }
+  // calculate Rho as the median of the jet pT / jet area
+  double rho = TMath::Median<double>(rhovector.size(), rhovector.data());
+
+  if (doAreaSparse) {
+    // calculate The ocupancy factor, which the ratio of covered area / total area
+    double occupancyFactor = totalAreaCovered > 0 ? totaljetAreaPhys / totalAreaCovered : 1.;
+    rho *= occupancyFactor;
+  }
+
+  return rho;
+}
+
+double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets)
+{
+
+  if (inputParticles.size() == 0 || jets.size() == 0) {
+    return 0.0;
+  }
+
+  double perpPtDensity1 = 0;
+  double perpPtDensity2 = 0;
+
+  fastjet::Selector selLeadingJet = fastjet::SelectorEtaRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax);
+
+  std::vector<fastjet::PseudoJet> leadingJets = fastjet::sorted_by_pt(selLeadingJet(jets));
+
+  if (leadingJets.size() == 0) {
+    return 0.0;
+  }
+
+  fastjet::PseudoJet leadingJet = leadingJets[0];
+
+  double dPhi1 = 999.;
+  double dPhi2 = 999.;
+  double dEta = 999.;
+  double PerpendicularConeAxisPhi1 = 999., PerpendicularConeAxisPhi2 = 999.;
+  // build 2 perp cones in phi around the leading jet (right and left of the jet)
+  PerpendicularConeAxisPhi1 = ((leadingJet.phi() + (M_PI / 2.)) > (2 * M_PI)) ? leadingJet.phi() - ((3. / 2.) * M_PI) : leadingJet.phi() + (M_PI / 2.);
+  PerpendicularConeAxisPhi2 = ((leadingJet.phi() - (M_PI / 2.)) < 0) ? leadingJet.phi() + ((3. / 2.) * M_PI) : leadingJet.phi() - (M_PI / 2.);
+
+  for (auto& particle : inputParticles) {
+    // sum the momentum of all paricles that fill the two cones
+    dPhi1 = TMath::Abs(particle.phi() - PerpendicularConeAxisPhi1);
+    dPhi1 = (dPhi1 > M_PI) ? 2 * M_PI - dPhi1 : dPhi1;
+    dPhi2 = TMath::Abs(particle.phi() - PerpendicularConeAxisPhi2);
+    dPhi2 = (dPhi2 > M_PI) ? 2 * M_PI - dPhi2 : dPhi2;
+    dEta = leadingJet.eta() - particle.eta();
+    if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= mJetBkgR) {
+      perpPtDensity1 += particle.perp();
+    }
+
+    if (TMath::Sqrt(dPhi2 * dPhi2 + dEta * dEta) <= mJetBkgR) {
+      perpPtDensity2 += particle.perp();
+    }
+  }
+
+  // Caculate rho as the ratio of average pT of the two cones / the cone area
+  Double_t perpPtDensity = (perpPtDensity1 + perpPtDensity2) / (2 * M_PI * mJetBkgR * mJetBkgR);
+
+  return perpPtDensity;
+}
+
+/// Sets the background subtraction estimater pointer
+void JetBkgSubUtils::setBkgE()
+{
+  bkgE = decltype(bkgE)(new fastjet::JetMedianBackgroundEstimator(mSelRho, mJetDefBkg, mAreaDefBkg));
+}
+
+/// Sets the background subtraction object
+fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, const std::vector<fastjet::PseudoJet>& jets)
+{
+  fastjet::Subtractor sub;
+
+  if (bkgSubMode == BkgSubMode::rhoMedianAreaSub) {
+
+    rhoParam = estimateRhoAreaMedian(inputParticles);
+    sub = fastjet::Subtractor(rhoParam);
+
+  } else if (bkgSubMode == BkgSubMode::rhoSparseSub) {
+
+    rhoParam = estimateRhoAreaMedian(inputParticles, true);
+    sub = fastjet::Subtractor(rhoParam);
+
+  } else if (bkgSubMode == BkgSubMode::rhoPerpConeSub) {
+
+    if (jets.size() == 0) {
+      return sub;
+    }
+    rhoParam = estimateRhoPerpCone(inputParticles, jets);
+    sub = fastjet::Subtractor(rhoParam);
+
+  } else if (bkgSubMode == BkgSubMode::rhoAreaSub) {
+
+    setBkgE();
+    bkgE->set_particles(inputParticles);
+    sub = fastjet::Subtractor(bkgE.get());
+    rhoParam = bkgE->estimate().rho();
+
+  } else if (bkgSubMode == BkgSubMode::constSub) { // event or jetwise
+
+    setBkgE();
+    bkgE->set_particles(inputParticles);
+    rhoParam = bkgE->estimate().rho();
+    std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
+    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{bkgE.get()}};
+    constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
+    constituentSub->set_max_distance(mConstSubRMax);
+    constituentSub->set_alpha(mConstSubAlpha);
+    constituentSub->set_ghost_area(mGhostAreaSpec.ghost_area());
+    constituentSub->set_max_eta(mBkgEtaMax);
+    constituentSub->set_background_estimator(bkgE.get());
+
+    inputParticles = constituentSub->subtract_event(inputParticles);
+
+  } else {
+    rhoParam = 0.;
+    if (bkgSubMode != BkgSubMode::none) {
+      LOGF(error, "requested subtraction mode not implemented!");
+    }
+  }
+
+  return sub;
+}

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -1,0 +1,106 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file JetBkgSubUtils.h
+/// \brief Jet background subtraction utilities
+///
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, JYU
+
+#ifndef O2_ANALYSIS_JETBKGSUBUTILS_H
+#define O2_ANALYSIS_JETBKGSUBUTILS_H
+
+#include <memory>
+#include <vector>
+
+#include <TMath.h>
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
+#include "fastjet/tools/Subtractor.hh"
+#include "fastjet/contrib/ConstituentSubtractor.hh"
+
+#include "Framework/Logger.h"
+
+enum class BkgSubMode { none,
+                        rhoAreaSub,
+                        constSub,
+                        rhoSparseSub,
+                        rhoPerpConeSub,
+                        rhoMedianAreaSub
+};
+
+class JetBkgSubUtils
+{
+
+ public:
+  // Default contructor
+  JetBkgSubUtils() = default;
+
+  JetBkgSubUtils(float jetBkgR_out, float bkgPhiMin_out, float bkgPhiMax_out, float bkgEtaMin_out, float bkgEtaMax_out, float constSubAlpha_out, float constSubRMax_out, fastjet::GhostedAreaSpec ghostAreaSpec_out);
+
+  // Default destructor
+  ~JetBkgSubUtils() = default;
+
+  /// @brief Setting the jet algorithm and the recombination scheme
+  void setJetAlgorithmAndScheme(fastjet::JetAlgorithm algorithmBkg, fastjet::RecombinationScheme recombSchemeBkg)
+  {
+    mAlgorithmBkg = algorithmBkg;
+    mRecombSchemeBkg = recombSchemeBkg;
+  }
+
+  /// @brief Method for estimating the jet background density using the median method or the sparse method
+  /// @param inputParticles (all particles in the event)
+  /// @param doAreaSparse flag whether to use the sparse area method
+  /// @return Rho, the underlying event density
+  double estimateRhoAreaMedian(std::vector<fastjet::PseudoJet>& inputParticles, bool doAreaSparse = false);
+
+  /// @brief Background estimator using the perpendicular cone method
+  /// @param inputParticles
+  /// @param jets (all jets in the event)
+  /// @return Rho, the underlying event density
+  double estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
+
+  /// @brief method that reconstruct the bkgsub object and estimates rho
+  /// @param inputParticles
+  /// @param jets (all jets in the event)
+  /// @param rhoParam the underlying evvent density (to be set)
+  /// @param bkgSubMode the background subtraction method
+  /// @param jets signal jets (needed for the perp cone method)
+  /// @return sub, the background subtractor
+  fastjet::Subtractor setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode = BkgSubMode::none, const std::vector<fastjet::PseudoJet>& jets = std::vector<fastjet::PseudoJet>());
+
+  /// Sets the background subtraction estimater pointer
+  void setBkgE();
+
+ protected:
+  float mJetBkgR = 0.2;
+  float mBkgPhiMin = 0.;
+  float mBkgPhiMax = 2 * M_PI;
+  float mBkgEtaMin = -0.9;
+  float mBkgEtaMax = 0.9;
+  float mConstSubAlpha = 1.0;
+  float mConstSubRMax = 0.6;
+
+  std::unique_ptr<fastjet::BackgroundEstimatorBase> bkgE;
+
+  fastjet::GhostedAreaSpec mGhostAreaSpec = fastjet::GhostedAreaSpec();
+  fastjet::JetAlgorithm mAlgorithmBkg = fastjet::kt_algorithm;
+  fastjet::RecombinationScheme mRecombSchemeBkg = fastjet::E_scheme;
+  fastjet::JetDefinition mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
+  fastjet::AreaDefinition mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
+  fastjet::Selector mSelRho = fastjet::Selector();
+
+}; // class JetBkgSubUtils
+
+#endif

--- a/PWGJE/Core/JetFinder.cxx
+++ b/PWGJE/Core/JetFinder.cxx
@@ -14,60 +14,28 @@
 // Author: Jochen Klein, Nima Zardoshti
 #include "PWGJE/Core/JetFinder.h"
 #include "Framework/Logger.h"
+#include "PWGJE/Core/JetBkgSubUtils.h"
 
 /// Sets the jet finding parameters
 void JetFinder::setParams()
 {
 
   if (!isReclustering) {
-    jetEtaMin = etaMin + jetR; //in aliphysics this was (-etaMax + 0.95*jetR)
+    jetEtaMin = etaMin + jetR; // in aliphysics this was (-etaMax + 0.95*jetR)
     jetEtaMax = etaMax - jetR;
   } else {
     jetR = 5.0 * jetR;
   }
 
-  //selGhosts =fastjet::SelectorRapRange(ghostEtaMin,ghostEtaMax) && fastjet::SelectorPhiRange(phiMin,phiMax);
-  //ghostAreaSpec=fastjet::GhostedAreaSpec(selGhosts,ghostRepeatN,ghostArea,gridScatter,ktScatter,ghostktMean);
-  ghostAreaSpec = fastjet::GhostedAreaSpec(ghostEtaMax, ghostRepeatN, ghostArea, gridScatter, ktScatter, ghostktMean); //the first argument is rapidity not pseudorapidity, to be checked
+  // selGhosts =fastjet::SelectorRapRange(ghostEtaMin,ghostEtaMax) && fastjet::SelectorPhiRange(phiMin,phiMax);
+  // ghostAreaSpec=fastjet::GhostedAreaSpec(selGhosts,ghostRepeatN,ghostArea,gridScatter,ktScatter,ghostktMean);
+  ghostAreaSpec = fastjet::GhostedAreaSpec(ghostEtaMax, ghostRepeatN, ghostArea, gridScatter, ktScatter, ghostktMean); // the first argument is rapidity not pseudorapidity, to be checked
   jetDef = fastjet::JetDefinition(algorithm, jetR, recombScheme, strategy);
   areaDef = fastjet::AreaDefinition(areaType, ghostAreaSpec);
   selJets = fastjet::SelectorPtRange(jetPtMin, jetPtMax) && fastjet::SelectorEtaRange(jetEtaMin, jetEtaMax) && fastjet::SelectorPhiRange(jetPhiMin, jetPhiMax);
-  jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, strategyBkg);
-  areaDefBkg = fastjet::AreaDefinition(areaTypeBkg, ghostAreaSpec);
-  selRho = fastjet::SelectorRapRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax); //&& !fastjet::SelectorNHardest(2)    //here we have to put rap range, to be checked!
-}
 
-/// Sets the background subtraction estimater pointer
-void JetFinder::setBkgE()
-{
-  if (bkgSubMode == BkgSubMode::rhoAreaSub || bkgSubMode == BkgSubMode::constSub) {
-    bkgE = decltype(bkgE)(new fastjet::JetMedianBackgroundEstimator(selRho, jetDefBkg, areaDefBkg));
-  } else {
-    if (bkgSubMode != BkgSubMode::none) {
-      LOGF(error, "requested subtraction mode not implemented!");
-    }
-  }
-}
-
-/// Sets the background subtraction pointer
-void JetFinder::setSub()
-{
-  //if rho < 1e-6 it is set to 1e-6 in AliPhysics
-  if (bkgSubMode == BkgSubMode::rhoAreaSub) {
-    sub = decltype(sub){new fastjet::Subtractor{bkgE.get()}};
-  } else if (bkgSubMode == BkgSubMode::constSub) { //event or jetwise
-    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{bkgE.get()}};
-    constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
-    constituentSub->set_max_distance(constSubRMax);
-    constituentSub->set_alpha(constSubAlpha);
-    constituentSub->set_ghost_area(ghostArea);
-    constituentSub->set_max_eta(bkgEtaMax);
-    constituentSub->set_background_estimator(bkgE.get()); //what about rho_m
-  } else {
-    if (bkgSubMode != BkgSubMode::none) {
-      LOGF(error, "requested subtraction mode not implemented!");
-    }
-  }
+  mSubUtils = std::make_unique<JetBkgSubUtils>(jetR, bkgPhiMin, bkgPhiMax, bkgEtaMin, bkgEtaMax, constSubAlpha, constSubRMax, ghostAreaSpec);
+  mSubUtils->setJetAlgorithmAndScheme(algorithmBkg, recombSchemeBkg);
 }
 
 /// Performs jet finding
@@ -75,21 +43,20 @@ void JetFinder::setSub()
 /// \param inputParticles vector of input particles/tracks
 /// \param jets veector of jets to be filled
 /// \return ClusterSequenceArea object needed to access constituents
-fastjet::ClusterSequenceArea JetFinder::findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets) //ideally find a way of passing the cluster sequence as a reeference
+fastjet::ClusterSequenceArea JetFinder::findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets) // ideally find a way of passing the cluster sequence as a reeference
 {
   setParams();
-  setBkgE();
   jets.clear();
 
-  if (bkgE) {
-    bkgE->set_particles(inputParticles);
-    setSub();
-  }
-  if (constituentSub) {
-    inputParticles = constituentSub->subtract_event(inputParticles);
-  }
+  sub = mSubUtils->setSub(inputParticles, mRho, bkgSubMode);
+
   fastjet::ClusterSequenceArea clusterSeq(inputParticles, jetDef, areaDef);
-  jets = sub ? (*sub)(clusterSeq.inclusive_jets()) : clusterSeq.inclusive_jets();
+
+  if (bkgSubMode == BkgSubMode::rhoPerpConeSub) {
+    sub = mSubUtils->setSub(inputParticles, mRho, bkgSubMode, clusterSeq.inclusive_jets());
+  }
+
+  jets = (mRho > DBL_EPSILON && bkgSubMode != BkgSubMode::constSub) ? (sub)(clusterSeq.inclusive_jets()) : clusterSeq.inclusive_jets();
   jets = selJets(jets);
   if (isReclustering) {
     jetR = jetR / 5.0;

--- a/PWGJE/Core/JetFinder.h
+++ b/PWGJE/Core/JetFinder.h
@@ -23,21 +23,18 @@
 #include <TPDGCode.h>
 #include <TMath.h>
 
+#include "JetBkgSubUtils.h"
+
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/ClusterSequenceArea.hh"
 #include "fastjet/AreaDefinition.hh"
 #include "fastjet/JetDefinition.hh"
-#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
 #include "fastjet/tools/Subtractor.hh"
-#include "fastjet/contrib/ConstituentSubtractor.hh"
 
 class JetFinder
 {
 
  public:
-  enum class BkgSubMode { none,
-                          rhoAreaSub,
-                          constSub };
   BkgSubMode bkgSubMode;
 
   void setBkgSubMode(BkgSubMode bSM) { bkgSubMode = bSM; }
@@ -77,7 +74,7 @@ class JetFinder
   float bkgPhiMax;
   float bkgEtaMin;
   float bkgEtaMax;
-
+  float mRho;
   float constSubAlpha;
   float constSubRMax;
 
@@ -95,11 +92,6 @@ class JetFinder
 
   fastjet::JetAlgorithm algorithmBkg;
   fastjet::RecombinationScheme recombSchemeBkg;
-  fastjet::Strategy strategyBkg;
-  fastjet::AreaType areaTypeBkg;
-  fastjet::JetDefinition jetDefBkg;
-  fastjet::AreaDefinition areaDefBkg;
-  fastjet::Selector selRho;
 
   /// Default constructor
   explicit JetFinder(float eta_Min = -0.9, float eta_Max = 0.9, float phi_Min = 0.0, float phi_Max = 2 * M_PI) : bkgSubMode(BkgSubMode::none),
@@ -126,6 +118,7 @@ class JetFinder
                                                                                                                  bkgPhiMax(phi_Max),
                                                                                                                  bkgEtaMin(eta_Min),
                                                                                                                  bkgEtaMax(eta_Max),
+                                                                                                                 mRho(0.),
                                                                                                                  constSubAlpha(1.0),
                                                                                                                  constSubRMax(0.6),
                                                                                                                  isReclustering(false),
@@ -134,9 +127,7 @@ class JetFinder
                                                                                                                  strategy(fastjet::Best),
                                                                                                                  areaType(fastjet::active_area),
                                                                                                                  algorithmBkg(fastjet::JetAlgorithm(fastjet::kt_algorithm)),
-                                                                                                                 recombSchemeBkg(fastjet::RecombinationScheme(fastjet::E_scheme)),
-                                                                                                                 strategyBkg(fastjet::Best),
-                                                                                                                 areaTypeBkg(fastjet::active_area)
+                                                                                                                 recombSchemeBkg(fastjet::RecombinationScheme(fastjet::E_scheme))
   {
 
     // default constructor
@@ -145,14 +136,13 @@ class JetFinder
   /// Default destructor
   ~JetFinder() = default;
 
+  float getRho() const
+  {
+    return mRho;
+  }
+
   /// Sets the jet finding parameters
   void setParams();
-
-  /// Sets the background subtraction estimater pointer
-  void setBkgE();
-
-  /// Sets the background subtraction pointer
-  void setSub();
 
   /// Performs jet finding
   /// \note the input particle and jet lists are passed by reference
@@ -162,11 +152,8 @@ class JetFinder
   fastjet::ClusterSequenceArea findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets); // ideally find a way of passing the cluster sequence as a reeference
 
  private:
-  // void setParams();
-  // void setBkgSub();
-  std::unique_ptr<fastjet::BackgroundEstimatorBase> bkgE;
-  std::unique_ptr<fastjet::Subtractor> sub;
-  std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
+  fastjet::Subtractor sub;
+  std::unique_ptr<JetBkgSubUtils> mSubUtils;
 
   ClassDefNV(JetFinder, 1);
 };

--- a/PWGJE/Core/JetFinder.h
+++ b/PWGJE/Core/JetFinder.h
@@ -74,7 +74,7 @@ class JetFinder
   float bkgPhiMax;
   float bkgEtaMin;
   float bkgEtaMax;
-  float mRho;
+  float bkgRho;
   float constSubAlpha;
   float constSubRMax;
 
@@ -118,7 +118,7 @@ class JetFinder
                                                                                                                  bkgPhiMax(phi_Max),
                                                                                                                  bkgEtaMin(eta_Min),
                                                                                                                  bkgEtaMax(eta_Max),
-                                                                                                                 mRho(0.),
+                                                                                                                 bkgRho(0.),
                                                                                                                  constSubAlpha(1.0),
                                                                                                                  constSubRMax(0.6),
                                                                                                                  isReclustering(false),
@@ -138,7 +138,7 @@ class JetFinder
 
   float getRho() const
   {
-    return mRho;
+    return bkgRho;
   }
 
   /// Sets the jet finding parameters
@@ -153,7 +153,7 @@ class JetFinder
 
  private:
   fastjet::Subtractor sub;
-  std::unique_ptr<JetBkgSubUtils> mSubUtils;
+  std::unique_ptr<JetBkgSubUtils> subUtils;
 
   ClassDefNV(JetFinder, 1);
 };

--- a/PWGJE/Core/PWGJECoreLinkDef.h
+++ b/PWGJE/Core/PWGJECoreLinkDef.h
@@ -14,4 +14,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class JetFinder + ;
+#pragma link C++ class JetBkgSubUtils + ;
 #pragma link C++ namespace JetUtilities + ;


### PR DESCRIPTION
Implementing background subtraction methods in the O2Physics PWGJE framework. The methods that were added are as follows:
1. Median background estimator (as in AliPhysics)
2. Rho sparse estimator, which is used for sparse events like in pp or p-Pb.
3. The perpendicular cone method (used in few papers).
4. The fastjet builtin median background estimator (it's a little bit different from the AliPhysics one).
5. The fastjet builtin constituent subtraction method.

Also the JetFinder class has been clean, and all the stuff related to Bkg. Sub has been moved to a new class.