### PR TITLE
[PWGEM-8] PWGEM: Clean up of header files

### DIFF
--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -238,50 +238,45 @@ DECLARE_SOA_TABLE(McGammasTrue, "AOD", "MCGATRUE",
                   mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
                   mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
 
-namespace gammacaloreco
+namespace skimmedcluster
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                        //! collisionID used as index for matched clusters
 DECLARE_SOA_INDEX_COLUMN(BC, bc);                                      //! bunch crossing ID used as index for ambiguous clusters
 DECLARE_SOA_COLUMN(ID, id, int);                                       //! cluster ID identifying cluster in event
-DECLARE_SOA_COLUMN(Energy, energy, float);                             //! cluster energy (GeV)
-DECLARE_SOA_COLUMN(CoreEnergy, coreEnergy, float);                     //! cluster core energy (GeV)
+DECLARE_SOA_COLUMN(E, e, float);                                       //! cluster energy (GeV)
 DECLARE_SOA_COLUMN(Eta, eta, float);                                   //! cluster pseudorapidity (calculated using vertex)
 DECLARE_SOA_COLUMN(Phi, phi, float);                                   //! cluster azimuthal angle (calculated using vertex)
 DECLARE_SOA_COLUMN(M02, m02, float);                                   //! shower shape long axis
 DECLARE_SOA_COLUMN(M20, m20, float);                                   //! shower shape short axis
 DECLARE_SOA_COLUMN(NCells, nCells, int);                               //! number of cells in cluster
 DECLARE_SOA_COLUMN(Time, time, float);                                 //! cluster time (ns)
-DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                          //! flag to mark cluster as exotic
 DECLARE_SOA_COLUMN(DistanceToBadChannel, distanceToBadChannel, float); //! distance to bad channel
 DECLARE_SOA_COLUMN(NLM, nlm, int);                                     //! number of local maxima
-DECLARE_SOA_COLUMN(Definition, definition, int);                       //! cluster definition, see EMCALClusterDefinition.h
-// DECLARE_SOA_INDEX_COLUMN(Calo, calo);                                  //! linked to calo cells
-// DECLARE_SOA_INDEX_COLUMN(Track, track); //! linked to Track table only for tracks that were matched
-// DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! transverse momentum of a photon candidate 2
-//                               (gammacaloreco::energy * 2.f) / (nexp(gammacaloreco::eta) + nexp(gammacaloreco::eta * -1.f)));
-// DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float pz, float E) { return atanh(pz / E); });  //! pseudorapidity of the cluster
-// DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float px, float py) { return atan2(py, px); }); //! phi angle of the cluster
-} // namespace gammacaloreco
-DECLARE_SOA_TABLE(SkimEMCClusters, "AOD", "SKIMEMCCLUSTERS", //! table of skimmed EMCal clusters
-                  o2::soa::Index<>, gammacaloreco::CollisionId, gammacaloreco::ID, gammacaloreco::Energy, gammacaloreco::CoreEnergy,
-                  gammacaloreco::Eta, gammacaloreco::Phi, gammacaloreco::M02, gammacaloreco::M20, gammacaloreco::NCells, gammacaloreco::Time,
-                  gammacaloreco::IsExotic, gammacaloreco::DistanceToBadChannel, gammacaloreco::NLM, gammacaloreco::Definition);
+} // namespace skimmedcluster
 
+namespace emccluster
+{
+DECLARE_SOA_COLUMN(CoreEnergy, coreEnergy, float);                                                                        //! cluster core energy (GeV)
+DECLARE_SOA_COLUMN(Time, time, float);                                                                                    //! cluster time (ns)
+DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                                                                             //! flag to mark cluster as exotic
+DECLARE_SOA_COLUMN(Definition, definition, int);                                                                          //! cluster definition, see EMCALClusterDefinition.h
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float e, float eta, float m) -> float { return sqrt(e * e - m * m) / cosh(eta); }); //! cluster pt, mass to be given as argument when getter is called!
+// DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! transverse momentum of a photon candidate
+//                               (emccluster::energy * 2.f) / (nexp(emccluster::eta) + nexp(emccluster::eta * -1.f)));
+} // namespace emccluster
+DECLARE_SOA_TABLE(SkimEMCClusters, "AOD", "SKIMEMCCLUSTERS", //! table of skimmed EMCal clusters
+                  o2::soa::Index<>, skimmedcluster::CollisionId, skimmedcluster::BCId, skimmedcluster::E, emccluster::CoreEnergy,
+                  skimmedcluster::Eta, skimmedcluster::Phi, skimmedcluster::M02, skimmedcluster::M20, skimmedcluster::NCells, skimmedcluster::Time,
+                  emccluster::IsExotic, skimmedcluster::DistanceToBadChannel, skimmedcluster::NLM, emccluster::Definition,
+                  // dynamic column
+                  emccluster::Pt<skimmedcluster::E, skimmedcluster::Eta>);
+using SkimEMCCluster = SkimEMCClusters::iterator;
 namespace phoscluster
 {
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                                     //! collisionID used as index for matched clusters
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                                                   //! bunch crossing ID used as index for ambiguous clusters
 DECLARE_SOA_INDEX_COLUMN_FULL(MatchedTrack, matchedTrack, int, Tracks, "_Matched"); //! matched track index
-DECLARE_SOA_COLUMN(E, e, float);                                                    //! cluster energy (GeV)
 DECLARE_SOA_COLUMN(X, x, float);                                                    //! cluster hit position in ALICE global coordinate
 DECLARE_SOA_COLUMN(Y, y, float);                                                    //! cluster hit position in ALICE global coordinate
 DECLARE_SOA_COLUMN(Z, z, float);                                                    //! cluster hit position in ALICE global coordinate
-DECLARE_SOA_COLUMN(M02, m02, float);                                                //! shower shape long axis
-DECLARE_SOA_COLUMN(M20, m20, float);                                                //! shower shape short axis
-DECLARE_SOA_COLUMN(NCells, nCells, int);                                            //! number of cells in cluster
-DECLARE_SOA_COLUMN(Time, time, float);                                              //! cluster time (ns)
-DECLARE_SOA_COLUMN(DistanceToBadChannel, distanceToBadChannel, float);              //! distance to bad channel in cm
-DECLARE_SOA_COLUMN(NLM, nlm, int);                                                  //! number of local maxima
 // DECLARE_SOA_COLUMN(TrackEta, tracketa, float);                                      //! eta of the matched track
 // DECLARE_SOA_COLUMN(TrackPhi, trackphi, float);                                      //! phi of the matched track
 // DECLARE_SOA_COLUMN(TrackP, trackp, float);                                          //! momentum of the matched track
@@ -295,39 +290,39 @@ DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float x, float y) -> float { return Reco
 } // namespace phoscluster
 
 DECLARE_SOA_TABLE(PHOSClusters, "AOD", "PHOSCLUSTERS", //!
-                  o2::soa::Index<>, phoscluster::CollisionId, phoscluster::MatchedTrackId,
-                  phoscluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z,
-                  phoscluster::M02, phoscluster::M20, phoscluster::NCells,
-                  phoscluster::Time, phoscluster::DistanceToBadChannel, phoscluster::NLM,
+                  o2::soa::Index<>, skimmedcluster::CollisionId, phoscluster::MatchedTrackId,
+                  skimmedcluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z,
+                  skimmedcluster::M02, skimmedcluster::M20, skimmedcluster::NCells,
+                  skimmedcluster::Time, skimmedcluster::DistanceToBadChannel, skimmedcluster::NLM,
                   // phoscluster::TrackEta, phoscluster::TrackPhi, phoscluster::TrackP, phoscluster::TrackPt,
                   // dynamic column
-                  phoscluster::Px<phoscluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
-                  phoscluster::Py<phoscluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
-                  phoscluster::Pz<phoscluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
-                  phoscluster::Pt<phoscluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
+                  phoscluster::Px<skimmedcluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
+                  phoscluster::Py<skimmedcluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
+                  phoscluster::Pz<skimmedcluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
+                  phoscluster::Pt<skimmedcluster::E, phoscluster::X, phoscluster::Y, phoscluster::Z>,
                   phoscluster::Eta<phoscluster::X, phoscluster::Y, phoscluster::Z>,
                   phoscluster::Phi<phoscluster::X, phoscluster::Y>);
 using PHOSCluster = PHOSClusters::iterator;
 
-using SkimEMCCluster = SkimEMCClusters::iterator;
-
-namespace gammacellsreco
+namespace caloextra
 {
-DECLARE_SOA_INDEX_COLUMN(SkimEMCCluster, skimEMCCluster); //! SkimEMCClusterID
-DECLARE_SOA_INDEX_COLUMN(Calo, calo);                     //! CaloID (CellID)
-// DECLARE_SOA_INDEX_COLUMN(Track, track);                   //! CaloID (CellID)
+DECLARE_SOA_INDEX_COLUMN_FULL(Cluster, cluster, int, SkimEMCClusters, ""); //! reference to the gamma in the skimmed EMCal table
+DECLARE_SOA_INDEX_COLUMN_FULL(Cell, cell, int, Calos, "");                 //! reference to the gamma in the skimmed EMCal table
+// DECLARE_SOA_INDEX_COLUMN(Track, track);                   //! TrackID
 DECLARE_SOA_COLUMN(TrackEta, tracketa, float); //! eta of the matched track
 DECLARE_SOA_COLUMN(TrackPhi, trackphi, float); //! phi of the matched track
 DECLARE_SOA_COLUMN(TrackP, trackp, float);     //! momentum of the matched track
 DECLARE_SOA_COLUMN(TrackPt, trackpt, float);   //! pt of the matched track
-} // namespace gammacellsreco
+} // namespace caloextra
 
-DECLARE_SOA_TABLE(SkimEMCCells, "AOD", "SKIMEMCCELLS",                                         //! table of link between skimmed EMCal clusters and their cells
-                  o2::soa::Index<>, gammacellsreco::SkimEMCClusterId, gammacellsreco::CaloId); //!
+DECLARE_SOA_TABLE(SkimEMCCells, "AOD", "SKIMEMCCELLS",                        //! table of link between skimmed EMCal clusters and their cells
+                  o2::soa::Index<>, caloextra::ClusterId, caloextra::CellId); //!
+using SkimEMCCell = SkimEMCCells::iterator;
 
 DECLARE_SOA_TABLE(SkimEMCMTs, "AOD", "SKIMEMCMTS", //! table of link between skimmed EMCal clusters and their matched tracks
-                  o2::soa::Index<>, gammacellsreco::SkimEMCClusterId, gammacellsreco::TrackEta,
-                  gammacellsreco::TrackPhi, gammacellsreco::TrackP, gammacellsreco::TrackPt);
+                  o2::soa::Index<>, caloextra::ClusterId, caloextra::TrackEta,
+                  caloextra::TrackPhi, caloextra::TrackP, caloextra::TrackPt);
+using SkimEMCMT = SkimEMCMTs::iterator;
 
 namespace gammareco
 {
@@ -340,8 +335,8 @@ DECLARE_SOA_COLUMN(PHOSCutBit, phoscutbit, uint64_t);                           
 DECLARE_SOA_COLUMN(EMCCutBit, emccutbit, uint64_t);                              //! cut bit for EMCal photon candidates
 } // namespace gammareco
 DECLARE_SOA_TABLE(SkimGammas, "AOD", "SKIMGAMMAS", //! table of all gamma candidates (PCM, EMCal and PHOS) after cuts
-                  o2::soa::Index<>, gammacaloreco::CollisionId, gammareco::Method,
-                  gammacaloreco::Energy, gammacaloreco::Eta, gammacaloreco::Phi,
+                  o2::soa::Index<>, skimmedcluster::CollisionId, gammareco::Method,
+                  skimmedcluster::E, skimmedcluster::Eta, skimmedcluster::Phi,
                   gammareco::SkimmedEMCId, gammareco::SkimmedPHOSId);
 DECLARE_SOA_TABLE(SkimPCMCuts, "AOD", "SKIMPCMCUTS",                                  //! table of link between skimmed PCM photon candidates and their cuts
                   o2::soa::Index<>, gammareco::SkimmedPCMId, gammareco::PCMCutBit);   //!

--- a/PWGEM/PhotonMeson/TableProducer/createEMReducedEvent.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createEMReducedEvent.cxx
@@ -59,8 +59,8 @@ struct createEMReducedEvent {
     "registry"};
 
   Preslice<aod::V0Photons> perCollision_pcm = aod::v0photon::collisionId;
-  Preslice<aod::PHOSClusters> perCollision_phos = aod::phoscluster::collisionId;
-  Preslice<aod::SkimEMCClusters> perCollision_emc = aod::gammacaloreco::collisionId;
+  Preslice<aod::PHOSClusters> perCollision_phos = aod::skimmedcluster::collisionId;
+  Preslice<aod::SkimEMCClusters> perCollision_emc = aod::skimmedcluster::collisionId;
 
   void init(o2::framework::InitContext&)
   {

--- a/PWGEM/PhotonMeson/TableProducer/gammaSelection.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/gammaSelection.cxx
@@ -38,7 +38,7 @@ struct gammaSelection {
 
   uint64_t EMC_CutModeBit;
 
-  Preslice<o2::aod::SkimEMCMTs> perEMCClusterMT = o2::aod::gammacellsreco::skimEMCClusterId;
+  Preslice<o2::aod::SkimEMCMTs> perEMCClusterMT = o2::aod::caloextra::clusterId;
 
   Produces<aod::SkimGammas> tableGammaReco;
   Produces<aod::SkimEMCCuts> tableEMCCuts;

--- a/PWGEM/PhotonMeson/TableProducer/produceMesonCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/produceMesonCalo.cxx
@@ -106,23 +106,23 @@ struct produceMesonCalo {
       float openingAngle = acos((cos(gamma0.phi() - gamma1.phi()) +
                                  sinh(gamma0.eta()) * sinh(gamma1.eta())) /
                                 (cosh(gamma0.eta()) * cosh(gamma1.eta())));
-      float E = gamma0.energy() + gamma1.energy();
-      float pt0 = gamma0.energy() / cosh(gamma0.eta());
-      float pt1 = gamma1.energy() / cosh(gamma1.eta());
+      float E = gamma0.e() + gamma1.e();
+      float pt0 = gamma0.e() / cosh(gamma0.eta());
+      float pt1 = gamma1.e() / cosh(gamma1.eta());
       float px =
         pt0 * cos(gamma0.phi()) + pt1 * cos(gamma1.phi());
       float py =
         pt0 * sin(gamma0.phi()) + pt1 * sin(gamma1.phi());
       float pz =
         pt0 * sinh(gamma0.eta()) + pt1 * sinh(gamma1.eta());
-      float alpha = (gamma0.energy() - gamma1.energy()) != 0.
-                      ? (gamma0.energy() - gamma1.energy()) / (gamma0.energy() + gamma1.energy())
+      float alpha = (gamma0.e() - gamma1.e()) != 0.
+                      ? (gamma0.e() - gamma1.e()) / (gamma0.e() + gamma1.e())
                       : 0.;
       float Pt = sqrt(pt0 * pt0 + pt1 * pt1 +
                       2. * pt0 * pt1 *
                         cos(gamma0.phi() - gamma1.phi()));
       float minv =
-        sqrt(2. * gamma0.energy() * gamma1.energy() * (1. - cos(openingAngle)));
+        sqrt(2. * gamma0.e() * gamma1.e() * (1. - cos(openingAngle)));
       float eta = asinh(pz / Pt);
       float phi = atan2(py, px);
       phi = (phi < 0) ? phi + 2. * M_PI : phi;

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
@@ -222,7 +222,7 @@ struct Pi0EtaToGammaGamma {
   }
 
   Preslice<aod::V0Photons> perCollision = aod::v0photon::collisionId;
-  Preslice<aod::PHOSClusters> perCollision_phos = aod::phoscluster::collisionId;
+  Preslice<aod::PHOSClusters> perCollision_phos = aod::skimmedcluster::collisionId;
 
   template <PairType pairtype, typename TEvents, typename TPhotons1, typename TPhotons2, typename TPreslice1, typename TPreslice2>
   void SameEventPairing(TEvents const& collisions, TPhotons1 const& photons1, TPhotons2 const& photons2, TPreslice1 const& perCollision1, TPreslice2 const& perCollision2)

--- a/PWGEM/PhotonMeson/Utils/gammaSelectionCuts.h
+++ b/PWGEM/PhotonMeson/Utils/gammaSelectionCuts.h
@@ -90,9 +90,9 @@ uint64_t doM02CutEMC(int iCut, uint64_t cutbit, aod::SkimEMCCluster const& clust
 uint64_t doMinECutEMC(int iCut, uint64_t cutbit, aod::SkimEMCCluster const& cluster, HistogramRegistry& registry)
 {
   uint64_t cut_return = 0;
-  if (cutbit & ((uint64_t)1 << (uint64_t)iCut)) {        // check if current cut should be applied
-    if (cluster.energy() > emccuts::EMC_minE.at(iCut)) { // check cut itself
-      cut_return |= (1 << iCut);                         // set bit of current cut to 1 for passing the cut
+  if (cutbit & ((uint64_t)1 << (uint64_t)iCut)) {   // check if current cut should be applied
+    if (cluster.e() > emccuts::EMC_minE.at(iCut)) { // check cut itself
+      cut_return |= (1 << iCut);                    // set bit of current cut to 1 for passing the cut
     } else {
       registry.fill(HIST("hCaloCuts_EMC"), 3, iCut);
     }
@@ -124,8 +124,8 @@ uint64_t doTrackMatchingEMC(int iCut, uint64_t cutbit, aod::SkimEMCCluster const
       dPhi = track.trackphi() - cluster.phi();
       if ((fabs(dEta) <= emccuts::EMC_TM_Eta.at(iCut).at(0) + pow(track.trackpt() + emccuts::EMC_TM_Eta.at(iCut).at(1), emccuts::EMC_TM_Eta.at(iCut).at(2))) &&
           (fabs(dPhi) <= emccuts::EMC_TM_Phi.at(iCut).at(0) + pow(track.trackpt() + emccuts::EMC_TM_Phi.at(iCut).at(1), emccuts::EMC_TM_Phi.at(iCut).at(2))) &&
-          cluster.energy() / track.trackp() < emccuts::EMC_Eoverp.at(iCut)) { // check cut itself
-        hasMatchedTrack_EMC = true;                                           // set bit of current cut to 1 for passing the cut
+          cluster.e() / track.trackp() < emccuts::EMC_Eoverp.at(iCut)) { // check cut itself
+        hasMatchedTrack_EMC = true;                                      // set bit of current cut to 1 for passing the cut
       }
     }
     if (hasMatchedTrack_EMC) {
@@ -140,10 +140,10 @@ uint64_t doTrackMatchingEMC(int iCut, uint64_t cutbit, aod::SkimEMCCluster const
 uint64_t doPhotonCutsEMC(uint64_t cutbit, aod::SkimEMCCluster const& cluster, aod::SkimEMCMTs const& tracks, Preslice<o2::aod::SkimEMCMTs> perEMCClusterMT, HistogramRegistry& registry)
 {
   uint64_t cut_return = 0;
+  auto tracksMatchedEMC = tracks.sliceBy(perEMCClusterMT, cluster.globalIndex());
   for (int iCut = 0; iCut < 64; iCut++) {           // loop over max number of cut settings
     if (cutbit & ((uint64_t)1 << (uint64_t)iCut)) { // check each cut setting if it is selected
-      registry.fill(HIST("hClusterEIn"), cluster.energy(), iCut);
-      auto tracksMatchedEMC = tracks.sliceBy(perEMCClusterMT, cluster.globalIndex());
+      registry.fill(HIST("hClusterEIn"), cluster.e(), iCut);
       cut_return = doTimeCutEMC(iCut, cutbit, cluster, registry);
       // use cut_return instead of cutbit from here on to only check cut settings that we want to look at
       // where the cluster did not fail in the previous cut(s)
@@ -154,7 +154,7 @@ uint64_t doPhotonCutsEMC(uint64_t cutbit, aod::SkimEMCCluster const& cluster, ao
 
       registry.fill(HIST("hCaloCuts_EMC"), 0, iCut);
       if (cut_return & ((uint64_t)1 << (uint64_t)iCut)) {
-        registry.fill(HIST("hClusterEOut"), cluster.energy(), iCut);
+        registry.fill(HIST("hClusterEOut"), cluster.e(), iCut);
         registry.fill(HIST("hCaloCuts_EMC"), 6, iCut);
       }
     }


### PR DESCRIPTION
- gammaSelectionCuts.h:
	- put sliceBy call outside of loop to reduce CPU time

- gammaTables.h:
        - created combined namespace for calo clusters
        - added pT dynamic column for EMCal which also support analysis of particles with mass
        - renamed some namespaces to fit a common naming scheme and to easier to understand
        
- due to the renaming of some columns and some namespaces there are multiple changes over many files!