### PR TITLE
Scripts: Add a debugging script to extract useful information from an O2 log file.

### DIFF
--- a/Scripts/CMakeLists.txt
+++ b/Scripts/CMakeLists.txt
@@ -9,7 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-install(FILES find_dependencies.py
+install(FILES debug_info.sh
+              find_dependencies.py
               update_ccdb.py
         PERMISSIONS GROUP_READ GROUP_EXECUTE OWNER_EXECUTE OWNER_WRITE OWNER_READ WORLD_EXECUTE WORLD_READ
         DESTINATION share/scripts/)

--- a/Scripts/debug_info.sh
+++ b/Scripts/debug_info.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+# @brief Extract useful debugging information from an O2 log file.
+#
+# This script extracts the following information from an O2 log file:
+# - devices (omitting internal-dpl...)
+# - input files
+# - warnings
+# - errors
+#
+# @author Vít Kučera <vit.kucera@cern.ch>, Inha University
+# @date 2023-02-15
+
+LOG=""
+DEVICES=0
+INPUT=0
+WARNINGS=0
+ERRORS=0
+
+# Print devices.
+PrintDevices() {
+  echo -e "\nDevices:"
+  grep "\\[INFO\\] Starting " "$LOG" | grep -v "internal-dpl" | cut -d" " -f3 | sort
+}
+
+# Print input files.
+PrintInputFiles() {
+  echo -e "\nInput files:"
+  grep "\\[INFO\\] Read info: " "$LOG" | cut -d= -f2 | cut -d, -f1 | sort
+}
+
+# Print warnings.
+PrintWarnings() {
+  echo -e "\nWarnings:"
+  grep \
+  -e "\\[WARN\\]" \
+  -e "Warning in " \
+  "$LOG" | sort -u
+}
+
+# Print errors.
+PrintErrors() {
+  echo -e "\nErrors:"
+  grep \
+  -e "\\[ERROR\\]" \
+  -e "\\[FATAL\\]" \
+  -e "segmentation" \
+  -e "Segmentation" \
+  -e "command not found" \
+  -e "Error:" \
+  -e "Error in " \
+  "$LOG" | sort -u
+}
+
+# Print out a help message.
+Help() {
+  echo "Usage: $(basename "$0") -f LOGFILE [-d] [-i] [-w] [-e] [-h] "
+  echo "-d  Show devices."
+  echo "-i  Show input files."
+  echo "-w  Show warnings."
+  echo "-e  Show errors."
+}
+
+####################################################################################################
+
+# Parse command line options.
+while getopts ":hf:diwe" opt; do
+  case ${opt} in
+    h)
+      Help; exit 0;;
+    f)
+      LOG="$OPTARG";;
+    d)
+      DEVICES=1;;
+    i)
+      INPUT=1;;
+    w)
+      WARNINGS=1;;
+    e)
+      ERRORS=1;;
+    \?)
+      echo "Error: Invalid option: $OPTARG" 1>&2; Help; exit 1;;
+    :)
+      echo "Error: Invalid option: $OPTARG requires an argument." 1>&2; Help; exit 1;;
+  esac
+done
+
+# Check a valid input file.
+[ "$LOG" ] || { echo "Error: Provide a log file." 1>&2; exit 1; }
+[ -f "$LOG" ] || { echo "Error: File $LOG does not exist." 1>&2; exit 1; }
+
+[ $DEVICES -eq 1 ] && PrintDevices
+[ $INPUT -eq 1 ] && PrintInputFiles
+[ $WARNINGS -eq 1 ] && PrintWarnings
+[ $ERRORS -eq 1 ] && PrintErrors
+
+exit 0

--- a/Scripts/debug_info.sh
+++ b/Scripts/debug_info.sh
@@ -59,6 +59,7 @@ PrintErrors() {
   -e "\\[FATAL\\]" \
   -e "segmentation" \
   -e "Segmentation" \
+  -e "SEGMENTATION" \
   -e "command not found" \
   -e "Error:" \
   -e "Error in " \

--- a/Scripts/debug_info.sh
+++ b/Scripts/debug_info.sh
@@ -18,6 +18,8 @@
 # - input files
 # - warnings
 # - errors
+# If a missing tree is reported, the find_dependencies.py script is executed if possible,
+# otherwise corresponding instructions are provided.
 #
 # @author Vít Kučera <vit.kucera@cern.ch>, Inha University
 # @date 2023-02-15
@@ -61,6 +63,19 @@ PrintErrors() {
   -e "Error:" \
   -e "Error in " \
   "$LOG" | sort -u
+  # Try to get the producers of the missing table.
+  if grep -q "Couldn't get TTree " "$LOG"; then
+    table=$(grep "Couldn't get TTree " "$LOG" | cut -d\" -f2 | cut -d/ -f2)
+    table=${table:2} # Remove "O2"
+    if [ "$O2PHYSICS_ROOT" ]; then
+      echo -e "\nTrying to find the producers of the missing table: $table"
+      "$O2PHYSICS_ROOT/share/scripts/find_dependencies.py" -t "$table"
+    else
+      echo -e "\nTo find the producers of the missing table: $table"
+      echo "- Load the O2Physics environment"
+      echo "- Execute: \$O2PHYSICS_ROOT/share/scripts/find_dependencies.py -t $table"
+    fi
+  fi
 }
 
 # Print out a help message.


### PR DESCRIPTION
This script extracts the following information from an O2 log file:
- devices (omitting `internal-dpl...`)
- input files
- warnings
- errors

If a missing tree is reported, the `find_dependencies.py` script is executed if possible,
otherwise corresponding instructions are provided.

```
Usage: debug_info.sh -f LOGFILE [-d] [-i] [-w] [-e] [-h] 
-d  Show devices.
-i  Show input files.
-w  Show warnings.
-e  Show errors.
```
