### PR TITLE
PWGHF: Move to using chi2 in vertexer

### DIFF
--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -37,6 +37,8 @@ struct HfCandidateCreator2Prong {
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
   // Configurable<double> bz{"bz", 5., "magnetic field"};
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
   Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
@@ -100,7 +102,8 @@ struct HfCandidateCreator2Prong {
     df.setMaxDZIni(maxDZIni);
     df.setMinParamChange(minParamChange);
     df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(true);
+    df.setUseAbsDCA(useAbsDCA);
+    df.setWeightedFinalPCA(useWeightedFinalPCA);
 
     // loop over pairs of track indices
     for (const auto& rowTrackIndexProng2 : rowsTrackIndexProng2) {

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -43,6 +43,8 @@ struct HfCandidateCreator3Prong {
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
   // Configurable<double> bz{"bz", 5., "magnetic field"};
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
   Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
@@ -105,7 +107,8 @@ struct HfCandidateCreator3Prong {
     df.setMaxDZIni(maxDZIni);
     df.setMinParamChange(minParamChange);
     df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(true);
+    df.setUseAbsDCA(useAbsDCA);
+    df.setWeightedFinalPCA(useWeightedFinalPCA);
 
     // loop over triplets of track indices
     for (const auto& rowTrackIndexProng3 : rowsTrackIndexProng3) {

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -103,7 +103,6 @@ struct HfCandidateCreatorB0 {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
 
     // Initial fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
     o2::vertexing::DCAFitterN<3> df3;
@@ -113,7 +112,6 @@ struct HfCandidateCreatorB0 {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(true);
 
     // loop over D candidates
     for (auto const& dCand : dCands) {

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -369,11 +369,11 @@ struct HfCandidateCreatorB0Expressions {
       flag = 0;
       origin = 0;
       // B0 → D- π+
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kB0, array{-int(pdg::Code::kDPlus), +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kB0, array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
         // Match D- -> π- K+ π-
         auto candDMC = particlesMC.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking D- -> π- K+ π-");
-        if (RecoDecay::isMatchedMCGen(particlesMC, candDMC, -int(pdg::Code::kDPlus), array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, candDMC, -static_cast<int>(pdg::Code::kDPlus), array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
           flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -48,7 +48,6 @@ struct HfCandidateCreatorBplus {
   Configurable<double> maxDZIni{"maxDZIni", 999, "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations if chi2/chi2old > this"};
-  Configurable<bool> useAbsDCA{"useAbsDCA", true, "use absolute DCAs"};
   // selection
   Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
   Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
@@ -108,7 +107,6 @@ struct HfCandidateCreatorBplus {
     bfitter.setMaxR(maxR);
     bfitter.setMinParamChange(minParamChange);
     bfitter.setMinRelChi2Change(minRelChi2Change);
-    bfitter.setUseAbsDCA(useAbsDCA);
 
     // Initial fitter to redo D-vertex to get extrapolated daughter tracks
     o2::vertexing::DCAFitterN<2> df;
@@ -116,7 +114,6 @@ struct HfCandidateCreatorBplus {
     df.setMaxR(maxR);
     df.setMinParamChange(minParamChange);
     df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(useAbsDCA);
 
     // loop over pairs of track indices
     for (auto& candidate : candidates) {

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -119,7 +119,6 @@ struct HfCandidateCreatorCascade {
     df.setMaxDZIni(maxDZIni);
     df.setMinParamChange(minParamChange);
     df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(true);
 
     // loop over pairs of track indeces
     for (const auto& casc : rowsTrackIndexCasc) {

--- a/PWGHF/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/TableProducer/candidateCreatorChic.cxx
@@ -88,7 +88,6 @@ struct HfCandidateCreatorChic {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
 
     // loop over Jpsi candidates
     for (auto& jpsiCand : jpsiCands) {

--- a/PWGHF/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/TableProducer/candidateCreatorChic.cxx
@@ -137,7 +137,7 @@ struct HfCandidateCreatorChic {
           continue;
         }
 
-        array<float, 3> pvecGamma{(float)ecal.px(), (float)ecal.py(), (float)ecal.pz()};
+        array<float, 3> pvecGamma{static_cast<float>(ecal.px()), static_cast<float>(ecal.py()), static_cast<float>(ecal.pz())};
 
         // get track impact parameters
         // This modifies track momenta!
@@ -242,7 +242,7 @@ struct HfCandidateCreatorChicMc {
           hMassEMatched->Fill(sqrt(candidate.prong1().px() * candidate.prong1().px() + candidate.prong1().py() * candidate.prong1().py() + candidate.prong1().pz() * candidate.prong1().pz()));
           if (particleMother.has_daughters()) {
             std::vector<int> arrAllDaughtersIndex;
-            RecoDecay::getDaughters(particleMother, &arrAllDaughtersIndex, array{(int)(kGamma), (int)(pdg::Code::kJPsi)}, 1);
+            RecoDecay::getDaughters(particleMother, &arrAllDaughtersIndex, array{static_cast<int>(kGamma), static_cast<int>(pdg::Code::kJPsi)}, 1);
             if (arrAllDaughtersIndex.size() == 2) {
               flag = 1 << hf_cand_chic::DecayType::ChicToJpsiToMuMuGamma;
               hMassChicToJpsiToMuMuGammaMatched->Fill(invMassChicToJpsiGamma(candidate));
@@ -265,10 +265,10 @@ struct HfCandidateCreatorChicMc {
       channel = 0;
 
       // chi_c → J/ψ gamma
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kChiC1, array{(int)(pdg::Code::kJPsi), (int)(kGamma)}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kChiC1, array{static_cast<int>(pdg::Code::kJPsi), static_cast<int>(kGamma)}, true)) {
         // Match J/psi --> e+e-
         std::vector<int> arrDaughter;
-        RecoDecay::getDaughters(particle, &arrDaughter, array{(int)(pdg::Code::kJPsi)}, 1);
+        RecoDecay::getDaughters(particle, &arrDaughter, array{static_cast<int>(pdg::Code::kJPsi)}, 1);
         auto jpsiCandMC = particlesMC.rawIteratorAt(arrDaughter[0]);
         if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdg::Code::kJPsi, array{+kElectron, -kElectron}, true)) {
           flag = 1 << hf_cand_chic::DecayType::ChicToJpsiToEEGamma;

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -84,7 +84,6 @@ struct HfCandidateCreatorLb {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
 
     // 3-prong vertex fitter (to rebuild Lc vertex)
     o2::vertexing::DCAFitterN<3> df3;
@@ -94,7 +93,6 @@ struct HfCandidateCreatorLb {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(true);
 
     // loop over Lc candidates
     for (auto& lcCand : lcCands) {

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -270,11 +270,11 @@ struct HfCandidateCreatorLbMc {
       flag = 0;
       origin = 0;
       // Λb → Λc+ π-
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaB0, array{int(pdg::Code::kLambdaCPlus), -kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaB0, array{static_cast<int>(pdg::Code::kLambdaCPlus), -kPiPlus}, true)) {
         // Match Λc+ -> pKπ
         auto LcCandMC = particlesMC.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking Λc+ → p K- π+");
-        if (RecoDecay::isMatchedMCGen(particlesMC, LcCandMC, int(pdg::Code::kLambdaCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, LcCandMC, static_cast<int>(pdg::Code::kLambdaCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
           flag = sign * (1 << hf_cand_lb::DecayType::LbToLcPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -55,8 +55,6 @@ struct HfCandidateCreatorToXiPi {
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
-  Configurable<bool> useAbsDCA{"useAbsDCA", true, "use absolute DCA for vertexing"};
-  Configurable<bool> useWeightedPCA{"useWeightedPCA", false, "vertices use cov matrices"};
   Configurable<bool> refitWithMatCorr{"refitWithMatCorr", true, "when doing propagateTracksToVertex, propagate tracks to vtx with material corrections and rerun minimization"};
   Configurable<bool> rejDiffCollTrack{"rejDiffCollTrack", true, "Reject tracks coming from different collisions"};
 
@@ -113,8 +111,6 @@ struct HfCandidateCreatorToXiPi {
     df.setMaxDZIni(maxDZIni);
     df.setMinParamChange(minParamChange);
     df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(useAbsDCA);
-    df.setWeightedFinalPCA(useWeightedPCA);
     df.setRefitWithMatCorr(refitWithMatCorr);
 
     double massPionFromPDG = RecoDecay::getMassPDG(kPiPlus);    // pdg code 211

--- a/PWGHF/TableProducer/candidateCreatorX.cxx
+++ b/PWGHF/TableProducer/candidateCreatorX.cxx
@@ -86,7 +86,6 @@ struct HfCandidateCreatorX {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
 
     // 3-prong vertex fitter
     o2::vertexing::DCAFitterN<3> df3;
@@ -96,7 +95,6 @@ struct HfCandidateCreatorX {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(true);
 
     // loop over Jpsi candidates
     for (auto& jpsiCand : jpsiCands) {

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -56,7 +56,7 @@ struct HfCandidateCreatorXicc {
 
   double massPi = RecoDecay::getMassPDG(kPiPlus);
   double massK = RecoDecay::getMassPDG(kKPlus);
-  double massXic = RecoDecay::getMassPDG(int(pdg::Code::kXiCPlus));
+  double massXic = RecoDecay::getMassPDG(static_cast<int>(pdg::Code::kXiCPlus));
   double massXicc{0.};
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic);
@@ -244,11 +244,11 @@ struct HfCandidateCreatorXiccMc {
       flag = 0;
       origin = 0;
       // Xicc → Xic + π+
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCCPlusPlus, array{int(pdg::Code::kXiCPlus), +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCCPlusPlus, array{static_cast<int>(pdg::Code::kXiCPlus), +kPiPlus}, true)) {
         // Match Xic -> pKπ
         auto XicCandMC = particlesMC.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking Ξc± → p± K∓ π±");
-        if (RecoDecay::isMatchedMCGen(particlesMC, XicCandMC, int(pdg::Code::kXiCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, XicCandMC, static_cast<int>(pdg::Code::kXiCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
           flag = sign * (1 << DecayType::XiccToXicPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -77,7 +77,6 @@ struct HfCandidateCreatorXicc {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(true);
 
     // 2-prong vertex fitter to build the Xicc vertex
     o2::vertexing::DCAFitterN<2> df2;
@@ -87,7 +86,6 @@ struct HfCandidateCreatorXicc {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
 
     for (auto& xicCand : xicCands) {
       if (!(xicCand.hfflag() & 1 << o2::aod::hf_cand_3prong::XicToPKPi)) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -891,7 +891,8 @@ struct HfTrackIndexSkimCreator {
   // vertexing
   // Configurable<double> bz{"bz", 5., "magnetic field kG"};
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
-  Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
   Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
@@ -1540,6 +1541,7 @@ struct HfTrackIndexSkimCreator {
       df2.setMinParamChange(minParamChange);
       df2.setMinRelChi2Change(minRelChi2Change);
       df2.setUseAbsDCA(useAbsDCA);
+      df2.setWeightedFinalPCA(useWeightedFinalPCA);
 
       // 3-prong vertex fitter
       o2::vertexing::DCAFitterN<3> df3;
@@ -1550,6 +1552,7 @@ struct HfTrackIndexSkimCreator {
       df3.setMinParamChange(minParamChange);
       df3.setMinRelChi2Change(minRelChi2Change);
       df3.setUseAbsDCA(useAbsDCA);
+      df3.setWeightedFinalPCA(useWeightedFinalPCA);
 
       // used to calculate number of candidiates per event
       auto nCand2 = rowTrackIndexProng2.lastIndex();
@@ -2252,7 +2255,8 @@ struct HfTrackIndexSkimCreatorCascades {
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations if chi2/chi2old > this"};
-  Configurable<bool> useAbsDCA{"useAbsDCA", true, "Use Abs DCAs"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
   // quality cut
   Configurable<bool> doCutQuality{"doCutQuality", true, "apply quality cuts"};
   // track cuts for bachelor
@@ -2366,6 +2370,7 @@ struct HfTrackIndexSkimCreatorCascades {
       // fitter.setMaxDZIni(1e9); // used in cascadeproducer.cxx, but not for the 2 prongs
       // fitter.setMaxChi2(1e9);  // used in cascadeproducer.cxx, but not for the 2 prongs
       fitter.setUseAbsDCA(useAbsDCA);
+      fitter.setWeightedFinalPCA(useWeightedFinalPCA);
 
       // fist we loop over the bachelor candidate
 
@@ -2551,7 +2556,8 @@ struct HfTrackIndexSkimCreatorLfCascades {
   Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any X is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations if chi2/chi2old > this"};
-  Configurable<bool> useAbsDCA{"useAbsDCA", true, "Use Abs DCAs"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
   Configurable<bool> rejDiffCollTrack{"rejDiffCollTrack", true, "Reject tracks coming from different collisions"};
 
   // quality cut
@@ -2759,6 +2765,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
       df2.setMinParamChange(minParamChange);
       df2.setMinRelChi2Change(minRelChi2Change);
       df2.setUseAbsDCA(useAbsDCA);
+      df2.setWeightedFinalPCA(useWeightedFinalPCA);
 
       // 3-prong vertex fitter
       o2::vertexing::DCAFitterN<3> df3;
@@ -2769,6 +2776,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
       df3.setMinParamChange(minParamChange);
       df3.setMinRelChi2Change(minRelChi2Change);
       df3.setUseAbsDCA(useAbsDCA);
+      df3.setWeightedFinalPCA(useWeightedFinalPCA);
 
       // cascade loop
       auto thisCollId = collision.globalIndex();
@@ -2812,6 +2820,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
         dfc.setMinParamChange(minParamChange);
         dfc.setMinRelChi2Change(minRelChi2Change);
         dfc.setUseAbsDCA(useAbsDCA);
+        dfc.setWeightedFinalPCA(useWeightedFinalPCA);
 
         auto trackParVarXiDauCharged = getTrackParCov(trackXiDauCharged);
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -29,9 +29,9 @@
 #include "DataFormatsParameters/GRPMagField.h" // for PV refit
 #include "DataFormatsParameters/GRPObject.h"   // for PV refit
 #include "DCAFitter/DCAFitterN.h"
-#include "DetectorsBase/GeometryManager.h"     // for PV refit
-#include "DetectorsBase/Propagator.h"          // for PV refit
-#include "DetectorsVertexing/PVertexer.h"      // for PV refit
+#include "DetectorsBase/GeometryManager.h" // for PV refit
+#include "DetectorsBase/Propagator.h"      // for PV refit
+#include "DetectorsVertexing/PVertexer.h"  // for PV refit
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
@@ -114,8 +114,8 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
     triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
 
     if (fillHistograms) {
-      constexpr int nBinsEvents = 2 + EventRejection::NEventRejection;
-      std::string labels[nBinsEvents];
+      constexpr int kNBinsEvents = 2 + EventRejection::NEventRejection;
+      std::string labels[kNBinsEvents];
       labels[0] = "processed";
       labels[1] = "selected";
       labels[2 + EventRejection::Trigger] = "rej. trigger";
@@ -124,9 +124,9 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
       labels[2 + EventRejection::PositionZ] = "rej. #it{z}";
       labels[2 + EventRejection::NContrib] = "rej. # of contributors";
       labels[2 + EventRejection::Chi2] = "rej. #it{#chi}^{2}";
-      AxisSpec axisEvents = {nBinsEvents, 0.5, nBinsEvents + 0.5, ""};
+      AxisSpec axisEvents = {kNBinsEvents, 0.5, kNBinsEvents + 0.5, ""};
       registry.add("hEvents", "Events;;entries", HistType::kTH1F, {axisEvents});
-      for (int iBin = 0; iBin < nBinsEvents; iBin++) {
+      for (int iBin = 0; iBin < kNBinsEvents; iBin++) {
         registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
       }
       // primary vertex histograms
@@ -933,17 +933,17 @@ struct HfTrackIndexSkimCreator {
 
   // int nColls{0}; //can be added to run over limited collisions per file - for tesing purposes
 
-  static const int n2ProngDecays = hf_cand_2prong::DecayType::N2ProngDecays; // number of 2-prong hadron types
-  static const int n3ProngDecays = hf_cand_3prong::DecayType::N3ProngDecays; // number of 3-prong hadron types
-  static const int nCuts2Prong = 4;                                          // how many different selections are made on 2-prongs
-  static const int nCuts3Prong = 4;                                          // how many different selections are made on 3-prongs
-  std::array<std::array<std::array<double, 2>, 2>, n2ProngDecays> arrMass2Prong;
-  std::array<std::array<std::array<double, 3>, 2>, n3ProngDecays> arrMass3Prong;
+  static constexpr int kN2ProngDecays = hf_cand_2prong::DecayType::N2ProngDecays; // number of 2-prong hadron types
+  static constexpr int kN3ProngDecays = hf_cand_3prong::DecayType::N3ProngDecays; // number of 3-prong hadron types
+  static constexpr int kNCuts2Prong = 4;                                          // how many different selections are made on 2-prongs
+  static constexpr int kNCuts3Prong = 4;                                          // how many different selections are made on 3-prongs
+  std::array<std::array<std::array<double, 2>, 2>, kN2ProngDecays> arrMass2Prong;
+  std::array<std::array<std::array<double, 3>, 2>, kN3ProngDecays> arrMass3Prong;
   // arrays of 2-prong and 3-prong cuts
-  std::array<LabeledArray<double>, n2ProngDecays> cut2Prong;
-  std::array<std::vector<double>, n2ProngDecays> pTBins2Prong;
-  std::array<LabeledArray<double>, n3ProngDecays> cut3Prong;
-  std::array<std::vector<double>, n3ProngDecays> pTBins3Prong;
+  std::array<LabeledArray<double>, kN2ProngDecays> cut2Prong;
+  std::array<std::vector<double>, kN2ProngDecays> pTBins2Prong;
+  std::array<LabeledArray<double>, kN3ProngDecays> cut3Prong;
+  std::array<std::vector<double>, kN3ProngDecays> pTBins3Prong;
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using TracksWithPVRefitAndDCA = soa::Join<aod::BigTracks, aod::TracksDCA, aod::HfPvRefitTrack>;
@@ -1073,7 +1073,7 @@ struct HfTrackIndexSkimCreator {
     static std::vector<int> massMinIndex;
     static std::vector<int> massMaxIndex;
     static std::vector<int> d0d0Index;
-    static auto cacheIndices = [](std::array<LabeledArray<double>, n2ProngDecays>& cut2Prong, std::vector<int>& mins, std::vector<int>& maxs, std::vector<int>& d0d0) {
+    static auto cacheIndices = [](std::array<LabeledArray<double>, kN2ProngDecays>& cut2Prong, std::vector<int>& mins, std::vector<int>& maxs, std::vector<int>& d0d0) {
       mins.resize(cut2Prong.size());
       maxs.resize(cut2Prong.size());
       d0d0.resize(cut2Prong.size());
@@ -1089,7 +1089,7 @@ struct HfTrackIndexSkimCreator {
     auto arrMom = array{pVecTrack0, pVecTrack1};
     auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1) + ptTolerance; // add tolerance because of no reco decay vertex
 
-    for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
+    for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
 
       // pT
       auto pTBin = findBin(&pTBins2Prong[iDecay2P], pT);
@@ -1151,7 +1151,7 @@ struct HfTrackIndexSkimCreator {
     /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
     static std::vector<int> massMinIndex;
     static std::vector<int> massMaxIndex;
-    static auto cacheIndices = [](std::array<LabeledArray<double>, n3ProngDecays>& cut3Prong, std::vector<int>& mins, std::vector<int>& maxs) {
+    static auto cacheIndices = [](std::array<LabeledArray<double>, kN3ProngDecays>& cut3Prong, std::vector<int>& mins, std::vector<int>& maxs) {
       mins.resize(cut3Prong.size());
       maxs.resize(cut3Prong.size());
       for (size_t iDecay3P = 0; iDecay3P < cut3Prong.size(); ++iDecay3P) {
@@ -1165,7 +1165,7 @@ struct HfTrackIndexSkimCreator {
     auto arrMom = array{pVecTrack0, pVecTrack1, pVecTrack2};
     auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + ptTolerance; // add tolerance because of no reco decay vertex
 
-    for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+    for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
 
       // pT
       auto pTBin = findBin(&pTBins3Prong[iDecay3P], pT);
@@ -1216,7 +1216,7 @@ struct HfTrackIndexSkimCreator {
 
       /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
       static std::vector<int> cospIndex;
-      static auto cacheIndices = [](std::array<LabeledArray<double>, n2ProngDecays>& cut2Prong, std::vector<int>& cosp) {
+      static auto cacheIndices = [](std::array<LabeledArray<double>, kN2ProngDecays>& cut2Prong, std::vector<int>& cosp) {
         cosp.resize(cut2Prong.size());
         for (size_t iDecay2P = 0; iDecay2P < cut2Prong.size(); ++iDecay2P) {
           cosp[iDecay2P] = cut2Prong[iDecay2P].colmap.find("cosp")->second;
@@ -1225,7 +1225,7 @@ struct HfTrackIndexSkimCreator {
       };
       cacheIndices(cut2Prong, cospIndex);
 
-      for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
+      for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
 
         // pT
         auto pTBin = findBin(&pTBins2Prong[iDecay2P], RecoDecay::pt(pVecCand));
@@ -1265,7 +1265,7 @@ struct HfTrackIndexSkimCreator {
       /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
       static std::vector<int> cospIndex;
       static std::vector<int> decLenIndex;
-      static auto cacheIndices = [](std::array<LabeledArray<double>, n3ProngDecays>& cut3Prong, std::vector<int>& cosp, std::vector<int>& decL) {
+      static auto cacheIndices = [](std::array<LabeledArray<double>, kN3ProngDecays>& cut3Prong, std::vector<int>& cosp, std::vector<int>& decL) {
         cosp.resize(cut3Prong.size());
         decL.resize(cut3Prong.size());
         for (size_t iDecay3P = 0; iDecay3P < cut3Prong.size(); ++iDecay3P) {
@@ -1276,7 +1276,7 @@ struct HfTrackIndexSkimCreator {
       };
       cacheIndices(cut3Prong, cospIndex, decLenIndex);
 
-      for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+      for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
 
         // pT
         auto pTBin = findBin(&pTBins3Prong[iDecay3P], RecoDecay::pt(pVecCand));
@@ -1517,16 +1517,16 @@ struct HfTrackIndexSkimCreator {
 
       // auto centrality = collision.centV0M(); //FIXME add centrality when option for variations to the process function appears
 
-      int n2ProngBit = BIT(n2ProngDecays) - 1; // bit value for 2-prong candidates where each candidate is one bit and they are all set to 1
-      int n3ProngBit = BIT(n3ProngDecays) - 1; // bit value for 3-prong candidates where each candidate is one bit and they are all set to 1
+      int n2ProngBit = BIT(kN2ProngDecays) - 1; // bit value for 2-prong candidates where each candidate is one bit and they are all set to 1
+      int n3ProngBit = BIT(kN3ProngDecays) - 1; // bit value for 3-prong candidates where each candidate is one bit and they are all set to 1
 
-      bool cutStatus2Prong[n2ProngDecays][nCuts2Prong];
-      bool cutStatus3Prong[n3ProngDecays][nCuts3Prong];
-      int nCutStatus2ProngBit = BIT(nCuts2Prong) - 1; // bit value for selection status for each 2-prong candidate where each selection is one bit and they are all set to 1
-      int nCutStatus3ProngBit = BIT(nCuts3Prong) - 1; // bit value for selection status for each 3-prong candidate where each selection is one bit and they are all set to 1
+      bool cutStatus2Prong[kN2ProngDecays][kNCuts2Prong];
+      bool cutStatus3Prong[kN3ProngDecays][kNCuts3Prong];
+      int nCutStatus2ProngBit = BIT(kNCuts2Prong) - 1; // bit value for selection status for each 2-prong candidate where each selection is one bit and they are all set to 1
+      int nCutStatus3ProngBit = BIT(kNCuts3Prong) - 1; // bit value for selection status for each 3-prong candidate where each selection is one bit and they are all set to 1
 
-      int whichHypo2Prong[n2ProngDecays];
-      int whichHypo3Prong[n3ProngDecays];
+      int whichHypo2Prong[kN2ProngDecays];
+      int whichHypo3Prong[kN3ProngDecays];
 
       // set the magnetic field from CCDB
       auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
@@ -1619,8 +1619,8 @@ struct HfTrackIndexSkimCreator {
           int isSelected2ProngCand = n2ProngBit; // bitmap for checking status of two-prong candidates (1 is true, 0 is rejected)
 
           if (debug) {
-            for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
-              for (int iCut = 0; iCut < nCuts2Prong; iCut++) {
+            for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
+              for (int iCut = 0; iCut < kNCuts2Prong; iCut++) {
                 cutStatus2Prong[iDecay2P][iCut] = true;
               }
             }
@@ -1721,16 +1721,16 @@ struct HfTrackIndexSkimCreator {
                                  pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
 
                 if (debug) {
-                  int Prong2CutStatus[n2ProngDecays];
-                  for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
+                  int Prong2CutStatus[kN2ProngDecays];
+                  for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                     Prong2CutStatus[iDecay2P] = nCutStatus2ProngBit;
-                    for (int iCut = 0; iCut < nCuts2Prong; iCut++) {
+                    for (int iCut = 0; iCut < kNCuts2Prong; iCut++) {
                       if (!cutStatus2Prong[iDecay2P][iCut]) {
                         CLRBIT(Prong2CutStatus[iDecay2P], iCut);
                       }
                     }
                   }
-                  rowProng2CutStatus(Prong2CutStatus[0], Prong2CutStatus[1], Prong2CutStatus[2]); // FIXME when we can do this by looping over n2ProngDecays
+                  rowProng2CutStatus(Prong2CutStatus[0], Prong2CutStatus[1], Prong2CutStatus[2]); // FIXME when we can do this by looping over kN2ProngDecays
                 }
 
                 // fill histograms
@@ -1739,7 +1739,7 @@ struct HfTrackIndexSkimCreator {
                   registry.fill(HIST("hVtx2ProngY"), secondaryVertex2[1]);
                   registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
                   array<array<float, 3>, 2> arrMom = {pvec0, pvec1};
-                  for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
+                  for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                     if (TESTBIT(isSelected2ProngCand, iDecay2P)) {
                       if (whichHypo2Prong[iDecay2P] == 1 || whichHypo2Prong[iDecay2P] == 3) {
                         auto mass2Prong = RecoDecay::m(arrMom, arrMass2Prong[iDecay2P][0]);
@@ -1802,8 +1802,8 @@ struct HfTrackIndexSkimCreator {
               int isSelected3ProngCand = n3ProngBit;
 
               if (debug) {
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
-                  for (int iCut = 0; iCut < nCuts3Prong; iCut++) {
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
+                  for (int iCut = 0; iCut < kNCuts3Prong; iCut++) {
                     cutStatus3Prong[iDecay3P][iCut] = true;
                   }
                 }
@@ -1938,16 +1938,16 @@ struct HfTrackIndexSkimCreator {
                                pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
 
               if (debug) {
-                int Prong3CutStatus[n3ProngDecays];
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+                int Prong3CutStatus[kN3ProngDecays];
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   Prong3CutStatus[iDecay3P] = nCutStatus3ProngBit;
-                  for (int iCut = 0; iCut < nCuts3Prong; iCut++) {
+                  for (int iCut = 0; iCut < kNCuts3Prong; iCut++) {
                     if (!cutStatus3Prong[iDecay3P][iCut]) {
                       CLRBIT(Prong3CutStatus[iDecay3P], iCut);
                     }
                   }
                 }
-                rowProng3CutStatus(Prong3CutStatus[0], Prong3CutStatus[1], Prong3CutStatus[2], Prong3CutStatus[3]); // FIXME when we can do this by looping over n3ProngDecays
+                rowProng3CutStatus(Prong3CutStatus[0], Prong3CutStatus[1], Prong3CutStatus[2], Prong3CutStatus[3]); // FIXME when we can do this by looping over kN3ProngDecays
               }
 
               // fill histograms
@@ -1956,7 +1956,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
                 array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (whichHypo3Prong[iDecay3P] == 1 || whichHypo3Prong[iDecay3P] == 3) {
                       auto mass3Prong = RecoDecay::m(arr3Mom, arrMass3Prong[iDecay3P][0]);
@@ -2019,8 +2019,8 @@ struct HfTrackIndexSkimCreator {
               int isSelected3ProngCand = n3ProngBit;
 
               if (debug) {
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
-                  for (int iCut = 0; iCut < nCuts3Prong; iCut++) {
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
+                  for (int iCut = 0; iCut < kNCuts3Prong; iCut++) {
                     cutStatus3Prong[iDecay3P][iCut] = true;
                   }
                 }
@@ -2156,16 +2156,16 @@ struct HfTrackIndexSkimCreator {
                                pvRefitCovMatrix3Prong1Pos2Neg[0], pvRefitCovMatrix3Prong1Pos2Neg[1], pvRefitCovMatrix3Prong1Pos2Neg[2], pvRefitCovMatrix3Prong1Pos2Neg[3], pvRefitCovMatrix3Prong1Pos2Neg[4], pvRefitCovMatrix3Prong1Pos2Neg[5]);
 
               if (debug) {
-                int Prong3CutStatus[n3ProngDecays];
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+                int Prong3CutStatus[kN3ProngDecays];
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   Prong3CutStatus[iDecay3P] = nCutStatus3ProngBit;
-                  for (int iCut = 0; iCut < nCuts3Prong; iCut++) {
+                  for (int iCut = 0; iCut < kNCuts3Prong; iCut++) {
                     if (!cutStatus3Prong[iDecay3P][iCut]) {
                       CLRBIT(Prong3CutStatus[iDecay3P], iCut);
                     }
                   }
                 }
-                rowProng3CutStatus(Prong3CutStatus[0], Prong3CutStatus[1], Prong3CutStatus[2], Prong3CutStatus[3]); // FIXME when we can do this by looping over n3ProngDecays
+                rowProng3CutStatus(Prong3CutStatus[0], Prong3CutStatus[1], Prong3CutStatus[2], Prong3CutStatus[3]); // FIXME when we can do this by looping over kN3ProngDecays
               }
 
               // fill histograms
@@ -2174,7 +2174,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
                 array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (whichHypo3Prong[iDecay3P] == 1 || whichHypo3Prong[iDecay3P] == 3) {
                       auto mass3Prong = RecoDecay::m(arr3Mom, arrMass3Prong[iDecay3P][0]);
@@ -2594,10 +2594,10 @@ struct HfTrackIndexSkimCreatorLfCascades {
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
   int runNumber;
 
-  static const int n2ProngDecays = hf_cand_casc_lf_2prong::DecayType::N2ProngDecays; // number of 2-prong hadron types
-  static const int n3ProngDecays = hf_cand_casc_lf_3prong::DecayType::N3ProngDecays; // number of 3-prong hadron types
-  std::array<std::array<std::array<double, 2>, 2>, n2ProngDecays> arrMass2Prong;
-  std::array<std::array<std::array<double, 3>, 2>, n3ProngDecays> arrMass3Prong;
+  static constexpr int kN2ProngDecays = hf_cand_casc_lf_2prong::DecayType::N2ProngDecays; // number of 2-prong hadron types
+  static constexpr int kN3ProngDecays = hf_cand_casc_lf_3prong::DecayType::N3ProngDecays; // number of 3-prong hadron types
+  std::array<std::array<std::array<double, 2>, 2>, kN2ProngDecays> arrMass2Prong;
+  std::array<std::array<std::array<double, 3>, 2>, kN3ProngDecays> arrMass3Prong;
 
   // histograms
   HistogramRegistry registry{"registry"};
@@ -2929,7 +2929,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
 
                 array<array<float, 3>, 3> arr3Mom = {pVec1, pVec2, pVec3};
-                for (int iDecay3P = 0; iDecay3P < n3ProngDecays; iDecay3P++) {
+                for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   auto mass3Prong = RecoDecay::m(arr3Mom, arrMass3Prong[iDecay3P][0]);
                   switch (iDecay3P) {
                     case hf_cand_casc_lf_3prong::DecayType::XicplusToXiPiPi:
@@ -2964,7 +2964,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
             registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
 
             array<array<float, 3>, 2> arrMom = {pVec1, pVec2};
-            for (int iDecay2P = 0; iDecay2P < n2ProngDecays; iDecay2P++) {
+            for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
               auto mass2Prong = RecoDecay::m(arrMom, arrMass2Prong[iDecay2P][0]);
               switch (iDecay2P) {
                 case hf_cand_casc_lf_2prong::DecayType::XiczeroToXiPi:


### PR DESCRIPTION
@vkucera I implemented what was discussed at the last HF O2 meeting. 
To not bloat the configuration too much, I have hardcoded the settings of the vertexer to the default minimisation (which is the chi2 one) everywhere unless for the `HfTrackIndexSkimCreator`, `HfCandidateCreator2Prong`, and `HfCandidateCreator3Prong` which could be used for further testing.