### PR TITLE
Bugfix FilterQA

### DIFF
--- a/EventFiltering/PWGCF/CFFilterAll.cxx
+++ b/EventFiltering/PWGCF/CFFilterAll.cxx
@@ -1665,8 +1665,8 @@ struct CFFilter {
         for (auto iDeuteron = deuterons.begin(); iDeuteron != deuterons.end(); ++iDeuteron) {
           for (auto iLambda = lambdas.begin(); iLambda != lambdas.end(); ++iLambda) {
             kstar = getkstar(*iDeuteron, *iLambda);
+            registry.fill(HIST("ld/fSE_particle"), kstar);
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kLD)) {
-              registry.fill(HIST("ld/fSE_particle"), kstar);
               lowKstarPairs[CFTrigger::kLD] += 1;
             }
           }
@@ -1674,8 +1674,8 @@ struct CFFilter {
         for (auto iAntiDeuteron = antideuterons.begin(); iAntiDeuteron != antideuterons.end(); ++iAntiDeuteron) {
           for (auto iAntiLambda = antilambdas.begin(); iAntiLambda != antilambdas.end(); ++iAntiLambda) {
             kstar = getkstar(*iAntiDeuteron, *iAntiLambda);
+            registry.fill(HIST("ld/fSE_antiparticle"), kstar);
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kLD)) {
-              registry.fill(HIST("ld/fSE_antiparticle"), kstar);
               lowKstarPairs[CFTrigger::kLD] += 1;
             }
           }

--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -1152,8 +1152,6 @@ struct CFFilterQA {
 
     if (isSelectedEvent(col)) {
 
-      outputCollision(col.posZ(), col.multFV0M(), col.multNTracksPV(), -2, -2);
-
       registry.fill(HIST("EventCuts/fMultiplicityAfter"), col.multNTracksPV());
       registry.fill(HIST("EventCuts/fZvtxAfter"), col.posZ());
 
@@ -1658,6 +1656,8 @@ struct CFFilterQA {
     if (ConfKeepAllSelectedParticles.value ||
         keepEvent3N[CFTrigger::kPPP] || keepEvent3N[CFTrigger::kPPL] || keepEvent3N[CFTrigger::kPLL] || keepEvent3N[CFTrigger::kLLL] ||
         keepEvent2N[CFTrigger::kPP] || keepEvent2N[CFTrigger::kPL]) {
+
+      outputCollision(col.posZ(), col.multFV0M(), col.multNTracksPV(), -2, -2);
 
       registry.fill(HIST("fProcessedEvents"), 1);
 


### PR DESCRIPTION
Only keep trigger events, otherwise the event mixing is not working properly.