### PR TITLE
PWGHF: treeCreatorLcToK0sP + more histograms

### DIFF
--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -42,34 +42,172 @@ struct HfTaskLcToK0sP {
   void init(InitContext& context)
   {
     // data
-    registry.add("hMassVsPtCand", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{600, 1.98f, 2.58f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hPtCand", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
-    registry.add("hPtBachVsPtCand", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtV0VsPtCand", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaCand", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {{500, -2.0f, 2.0f}}});
+    registry.add("hEtaCandVsPtCand", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {{500, -2.0f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPhiCand", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {{100, 0.f, 6.3f}}});
+    registry.add("hPhiCandVsPtCand", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {{100, 0.f, 6.3f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMass", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{600, 1.98f, 2.58f}}});
+    registry.add("hMassVsPtCand", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{600, 1.98f, 2.58f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtBach", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+    registry.add("hPtBachVsPtCand", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtV0", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+    registry.add("hPtV0VsPtCand", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Bach", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
     registry.add("hd0BachVsPtCand", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0V0", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
+    registry.add("hd0V0VsPtCand", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0V0pos", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
     registry.add("hd0V0posVsPtCand", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0V0neg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
     registry.add("hd0V0negVsPtCand", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtV0pos", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+    registry.add("hPtV0posVsPtCand", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtV0neg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+    registry.add("hPtV0negVsPtCand", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0CPA", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {{500, 0.98f, 1.0001f}}});
     registry.add("hV0CPAVsPtCand", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, 0.98f, 1.0001f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaVsPtCand", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {{500, -2.0f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hSelectionStatus", "cascade candidates;selection status;p_{T}", {HistType::kTH1F, {{5, -0.5f, 4.5f}}});
+    registry.add("hV0Radius", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {{1000, 0.f, 40.f}}});
+    registry.add("hV0RadiusVsPtCand", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {{1000, 0.f, 40.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0DCADaughters", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.f}}});
+    registry.add("hV0DCADaughtersVsPtCand", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0MK0Short", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.4f, 0.6f}}});
+    registry.add("hV0MK0ShortVsPtCand", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.4f, 0.6f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0MLambda", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+    registry.add("hV0MLambdaVsPtCand", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0MAntiLambda", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+    registry.add("hV0MAntiLambdaVsPtCand", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hV0MGamma", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.0f, 0.4f}}});
+    registry.add("hV0MGammaVsPtCand", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.0f, 0.4f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPACand", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+    registry.add("hCPACandVsPtCand", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPAxyCand", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+    registry.add("hCPAxyCandVsPtCand", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthCand", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+    registry.add("hDecLengthCandVsPtCand", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthXYCand", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+    registry.add("hDecLengthXYCandVsPtCand", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCtCand", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {{100, 0.f, 0.2f}}});
+    registry.add("hCtCandVsPtCand", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {{100, 0.f, 0.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hTPCNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+    registry.add("hPBachVsTPCNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
+    registry.add("hTOFNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+    registry.add("hPBachVsTOFNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
+
     // add MC histograms
     if (context.mOptions.get<bool>("processMc")) {
-      registry.add("hPtRecSig", "cascade candidates (MC);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
-      registry.add("hPtRecBg", "cascade candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
-      registry.add("hPtGen", "cascade (MC);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
-      registry.add("hPtGenSig", "cascade candidates (MC);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
-      registry.add("hCPAVsPtCandRecSig", "cascade candidates (matched);cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, -1.1, 1.1}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hCPAVsPtCandRecBg", "cascade candidates (unmatched);cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, -1.1, 1.1}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hV0CPAVsPtCandRecSig", "cascade candidates (matched);v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, 0.98, 1.0001}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hV0CPAVsPtCandRecBg", "cascade candidates (unmatched);v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, 0.98, 1.0001}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hEtaVsPtCandRecSig", "cascade candidates (matched);#it{#eta};p_{T}", {HistType::kTH2F, {{500, -2., 2.}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hEtaVsPtCandRecBg", "cascade candidates (unmatched);#it{#eta};p_{T}", {HistType::kTH2F, {{500, -2., 2.}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("hEtaGen", "MC particles (MC);#it{#eta};entries", {HistType::kTH1F, {{500, -2., 2.}}});
+      registry.add("MC/Rec/hPtCandRecSig", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtCandRecBg", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hEtaCandRecSig", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {{500, -2.0f, 2.0f}}});
+      registry.add("MC/Rec/hEtaCandVsPtCandRecSig", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {{500, -2.0f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hEtaCandRecBg", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {{500, -2.0f, 2.0f}}});
+      registry.add("MC/Rec/hEtaCandVsPtCandRecBg", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {{500, -2.0f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPhiCandRecSig", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {{100, 0.f, 6.3f}}});
+      registry.add("MC/Rec/hPhiCandVsPtCandRecSig", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {{100, 0.f, 6.3f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPhiCandRecBg", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {{100, 0.f, 6.3f}}});
+      registry.add("MC/Rec/hPhiCandVsPtCandRecBg", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {{100, 0.f, 6.3f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Gen/hPtCandGen", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Gen/hEtaCandGen", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {{500, -2.0f, 2.0f}}});
+      registry.add("MC/Gen/hEtaCandVsPtCandGen", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {{500, -2.0f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Gen/hPhiCandGen", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {{100, 0.f, 6.3f}}});
+      registry.add("MC/Gen/hPhiCandVsPtCandGen", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {{100, 0.f, 6.3f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hMassRecSig", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH1F, {{600, 1.98f, 2.58f}}});
+      registry.add("MC/Rec/hMassVsPtCandRecSig", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{600, 1.98f, 2.58f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hMassRecBg", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH1F, {{600, 1.98f, 2.58f}}});
+      registry.add("MC/Rec/hMassVsPtCandRecBg", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{600, 1.98f, 2.58f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtBachRecSig", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtBachVsPtCandRecSig", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtBachRecBg", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtBachVsPtCandRecBg", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0RecSig", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0VsPtCandRecSig", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0RecBg", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0VsPtCandRecBg", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0BachRecSig", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
+      registry.add("MC/Rec/hd0BachVsPtCandRecSig", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0BachRecBg", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
+      registry.add("MC/Rec/hd0BachVsPtCandRecBg", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0RecSig", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
+      registry.add("MC/Rec/hd0V0VsPtCandRecSig", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0RecBg", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{500, -0.5f, 0.5f}}});
+      registry.add("MC/Rec/hd0V0VsPtCandRecBg", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{500, -0.5f, 0.5f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0posRecSig", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
+      registry.add("MC/Rec/hd0V0posVsPtCandRecSig", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0posRecBg", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
+      registry.add("MC/Rec/hd0V0posVsPtCandRecBg", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0negRecSig", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
+      registry.add("MC/Rec/hd0V0negVsPtCandRecSig", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hd0V0negRecBg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{1000, -5.0f, 5.0f}}});
+      registry.add("MC/Rec/hd0V0negVsPtCandRecBg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {{1000, -5.0f, 5.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0posRecSig", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0posVsPtCandRecSig", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0posRecBg", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0posVsPtCandRecBg", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0negRecSig", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0negVsPtCandRecSig", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hPtV0negRecBg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0.0f, 30.0f}}});
+      registry.add("MC/Rec/hPtV0negVsPtCandRecBg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {{300, 0.0f, 30.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0CPARecSig", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {{500, 0.98f, 1.0001f}}});
+      registry.add("MC/Rec/hV0CPAVsPtCandRecSig", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, 0.98f, 1.0001f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0CPARecBg", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {{500, 0.98f, 1.0001f}}});
+      registry.add("MC/Rec/hV0CPAVsPtCandRecBg", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {{500, 0.98f, 1.0001f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0RadiusRecSig", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {{1000, 0.f, 40.f}}});
+      registry.add("MC/Rec/hV0RadiusVsPtCandRecSig", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {{1000, 0.f, 40.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0RadiusRecBg", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {{1000, 0.f, 40.f}}});
+      registry.add("MC/Rec/hV0RadiusVsPtCandRecBg", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {{1000, 0.f, 40.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0DCADaughtersRecSig", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.f}}});
+      registry.add("MC/Rec/hV0DCADaughtersVsPtCandRecSig", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0DCADaughtersRecBg", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.f}}});
+      registry.add("MC/Rec/hV0DCADaughtersVsPtCandRecBg", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MK0ShortRecSig", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.4f, 0.6f}}});
+      registry.add("MC/Rec/hV0MK0ShortVsPtCandRecSig", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.4f, 0.6f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MK0ShortRecBg", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.4f, 0.6f}}});
+      registry.add("MC/Rec/hV0MK0ShortVsPtCandRecBg", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.4f, 0.6f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MLambdaRecSig", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+      registry.add("MC/Rec/hV0MLambdaVsPtCandRecSig", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MLambdaRecBg", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+      registry.add("MC/Rec/hV0MLambdaVsPtCandRecBg", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MAntiLambdaRecSig", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+      registry.add("MC/Rec/hV0MAntiLambdaVsPtCandRecSig", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MAntiLambdaRecBg", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.0f, 1.2f}}});
+      registry.add("MC/Rec/hV0MAntiLambdaVsPtCandRecBg", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 1.0f, 1.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MGammaRecSig", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.0f, 0.4f}}});
+      registry.add("MC/Rec/hV0MGammaVsPtCandRecSig", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.0f, 0.4f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hV0MGammaRecBg", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.0f, 0.4f}}});
+      registry.add("MC/Rec/hV0MGammaVsPtCandRecBg", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {{500, 0.0f, 0.4f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCPACandRecSig", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+      registry.add("MC/Rec/hCPACandVsPtCandRecSig", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCPACandRecBg", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+      registry.add("MC/Rec/hCPACandVsPtCandRecBg", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCPAxyCandRecSig", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+      registry.add("MC/Rec/hCPAxyCandVsPtCandRecSig", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCPAxyCandRecBg", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {{110, -1.1f, 1.1f}}});
+      registry.add("MC/Rec/hCPAxyCandVsPtCandRecBg", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {{110, -1.1f, 1.1f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hDecLengthCandRecSig", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+      registry.add("MC/Rec/hDecLengthCandVsPtCandRecSig", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hDecLengthCandRecBg", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+      registry.add("MC/Rec/hDecLengthCandVsPtCandRecBg", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hDecLengthXYCandRecSig", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+      registry.add("MC/Rec/hDecLengthXYCandVsPtCandRecSig", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hDecLengthXYCandRecBg", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {{200, 0.f, 2.0f}}});
+      registry.add("MC/Rec/hDecLengthXYCandVsPtCandRecBg", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {{200, 0.f, 2.0f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCtCandRecSig", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {{100, 0.f, 0.2f}}});
+      registry.add("MC/Rec/hCtCandVsPtCandRecSig", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {{100, 0.f, 0.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hCtCandRecBg", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {{100, 0.f, 0.2f}}});
+      registry.add("MC/Rec/hCtCandVsPtCandRecBg", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {{100, 0.f, 0.2f}, {binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("MC/Rec/hTPCNSigmaPrBachRecSig", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hPBachVsTPCNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hTPCNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hPBachVsTPCNSigmaPrBachRecBg", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hTOFNSigmaPrBachRecSig", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hTOFNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {{100, -6.f, 6.f}}});
+      registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecBg", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {{100, 0.f, 10.0f}, {100, -6.f, 6.f}}});
     }
   }
 
   void
-    process(soa::Filtered<soa::Join<aod::HfCandCascExt, aod::HfSelLcToK0sP>> const& candidates)
+    process(soa::Filtered<soa::Join<aod::HfCandCascExt, aod::HfSelLcToK0sP>> const& candidates, aod::BigTracksPID const&)
   {
     // Printf("Candidates: %d", candidates.size());
     for (auto& candidate : candidates) {
@@ -79,28 +217,73 @@ struct HfTaskLcToK0sP {
         continue;
       }
       */
+
       if (etaCandMax >= 0. && std::abs(candidate.eta()) > etaCandMax) {
         // Printf("Candidate: eta rejection: %g", candidate.eta());
         continue;
       }
 
       auto ptCand = candidate.pt();
-      registry.fill(HIST("hMassVsPtCand"), invMassLcToK0sP(candidate), ptCand);
       registry.fill(HIST("hPtCand"), ptCand);
+      registry.fill(HIST("hEtaCand"), candidate.eta());
+      registry.fill(HIST("hEtaCandVsPtCand"), candidate.eta(), ptCand);
+      registry.fill(HIST("hPhiCand"), candidate.phi());
+      registry.fill(HIST("hPhiCandVsPtCand"), candidate.phi(), ptCand);
+      registry.fill(HIST("hMass"), invMassLcToK0sP(candidate));
+      registry.fill(HIST("hMassVsPtCand"), invMassLcToK0sP(candidate), ptCand);
+      registry.fill(HIST("hPtBach"), candidate.ptProng0());
       registry.fill(HIST("hPtBachVsPtCand"), candidate.ptProng0(), ptCand);
+      registry.fill(HIST("hPtV0"), candidate.ptProng1());
       registry.fill(HIST("hPtV0VsPtCand"), candidate.ptProng1(), ptCand);
+      registry.fill(HIST("hd0Bach"), candidate.impactParameter0());
       registry.fill(HIST("hd0BachVsPtCand"), candidate.impactParameter0(), ptCand);
+      registry.fill(HIST("hd0V0"), candidate.impactParameter1());
+      registry.fill(HIST("hd0V0VsPtCand"), candidate.impactParameter1(), ptCand);
+      registry.fill(HIST("hd0V0pos"), candidate.dcapostopv());
       registry.fill(HIST("hd0V0posVsPtCand"), candidate.dcapostopv(), ptCand);
+      registry.fill(HIST("hd0V0neg"), candidate.dcanegtopv());
       registry.fill(HIST("hd0V0negVsPtCand"), candidate.dcanegtopv(), ptCand);
+      registry.fill(HIST("hPtV0pos"), candidate.ptV0Pos());
+      registry.fill(HIST("hPtV0posVsPtCand"), candidate.ptV0Pos(), ptCand);
+      registry.fill(HIST("hPtV0neg"), candidate.ptV0Neg());
+      registry.fill(HIST("hPtV0negVsPtCand"), candidate.ptV0Neg(), ptCand);
+      registry.fill(HIST("hV0CPA"), candidate.v0cosPA());
       registry.fill(HIST("hV0CPAVsPtCand"), candidate.v0cosPA(), ptCand);
-      registry.fill(HIST("hEtaVsPtCand"), candidate.eta(), ptCand);
-      registry.fill(HIST("hSelectionStatus"), candidate.isSelLcToK0sP());
+      registry.fill(HIST("hV0Radius"), candidate.v0radius());
+      registry.fill(HIST("hV0RadiusVsPtCand"), candidate.v0radius(), ptCand);
+      registry.fill(HIST("hV0DCADaughters"), candidate.dcaV0daughters());
+      registry.fill(HIST("hV0DCADaughtersVsPtCand"), candidate.dcaV0daughters(), ptCand);
+      registry.fill(HIST("hV0MK0Short"), candidate.mK0Short());
+      registry.fill(HIST("hV0MK0ShortVsPtCand"), candidate.mK0Short(), ptCand);
+      registry.fill(HIST("hV0MLambda"), candidate.mLambda());
+      registry.fill(HIST("hV0MLambdaVsPtCand"), candidate.mLambda(), ptCand);
+      registry.fill(HIST("hV0MAntiLambda"), candidate.mAntiLambda());
+      registry.fill(HIST("hV0MAntiLambdaVsPtCand"), candidate.mAntiLambda(), ptCand);
+      registry.fill(HIST("hV0MGamma"), candidate.mGamma());
+      registry.fill(HIST("hV0MGammaVsPtCand"), candidate.mGamma(), ptCand);
+      registry.fill(HIST("hCPACand"), candidate.cpa());
+      registry.fill(HIST("hCPACandVsPtCand"), candidate.cpa(), ptCand);
+      registry.fill(HIST("hCPAxyCand"), candidate.cpaXY());
+      registry.fill(HIST("hCPAxyCandVsPtCand"), candidate.cpaXY(), ptCand);
+      registry.fill(HIST("hDecLengthCand"), candidate.decayLength());
+      registry.fill(HIST("hDecLengthCandVsPtCand"), candidate.decayLength(), ptCand);
+      registry.fill(HIST("hDecLengthXYCand"), candidate.decayLengthXY());
+      registry.fill(HIST("hDecLengthXYCandVsPtCand"), candidate.decayLengthXY(), ptCand);
+      registry.fill(HIST("hCtCand"), o2::aod::hf_cand_3prong::ctLc(candidate));
+      registry.fill(HIST("hCtCandVsPtCand"), o2::aod::hf_cand_3prong::ctLc(candidate), ptCand);
+      const auto& bach = candidate.prong0_as<aod::BigTracksPID>(); // bachelor track
+      registry.fill(HIST("hTPCNSigmaPrBach"), bach.tpcNSigmaPr());
+      registry.fill(HIST("hPBachVsTPCNSigmaPrBach"), bach.p(), bach.tpcNSigmaPr());
+      if (bach.hasTOF()) {
+        registry.fill(HIST("hTOFNSigmaPrBach"), bach.tofNSigmaPr());
+        registry.fill(HIST("hPBachVsTOFNSigmaPrBach"), bach.p(), bach.tofNSigmaPr());
+      }
     }
   }
 
   void processMc(soa::Filtered<soa::Join<aod::HfCandCascExt, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec>> const& candidates,
                  soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& particlesMC,
-                 aod::BigTracksMC const& tracks)
+                 aod::BigTracksMC const& tracks, aod::BigTracksPID const&)
   {
     // MC rec.
     // Printf("MC Candidates: %d", candidates.size());
@@ -109,21 +292,116 @@ struct HfTaskLcToK0sP {
         // Printf("MC Rec.: eta rejection: %g", candidate.eta());
         continue;
       }
+      const auto& bach = candidate.prong0_as<aod::BigTracksPID>(); // bachelor track
       auto ptCand = candidate.pt();
       if (std::abs(candidate.flagMcMatchRec()) == 1) {
-        // Get the corresponding MC particle.
-        auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong0_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCandCascadeMcGen>>(), pdg::Code::kLambdaCPlus, true);
-        auto particleMother = particlesMC.rawIteratorAt(indexMother);
-        registry.fill(HIST("hPtGenSig"), particleMother.pt()); // gen. level pT
-        registry.fill(HIST("hPtRecSig"), ptCand);              // rec. level pT
-        registry.fill(HIST("hCPAVsPtCandRecSig"), candidate.cpa(), ptCand);
-        registry.fill(HIST("hV0CPAVsPtCandRecSig"), candidate.v0cosPA(), ptCand);
-        registry.fill(HIST("hEtaVsPtCandRecSig"), candidate.eta(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtCandRecSig"), ptCand);
+        registry.fill(HIST("MC/Rec/hEtaCandRecSig"), candidate.eta());
+        registry.fill(HIST("MC/Rec/hEtaCandVsPtCandRecSig"), candidate.eta(), ptCand);
+        registry.fill(HIST("MC/Rec/hPhiCandRecSig"), candidate.phi());
+        registry.fill(HIST("MC/Rec/hPhiCandVsPtCandRecSig"), candidate.phi(), ptCand);
+        registry.fill(HIST("MC/Rec/hMassRecSig"), invMassLcToK0sP(candidate));
+        registry.fill(HIST("MC/Rec/hMassVsPtCandRecSig"), invMassLcToK0sP(candidate), ptCand);
+        registry.fill(HIST("MC/Rec/hPtBachRecSig"), candidate.ptProng0());
+        registry.fill(HIST("MC/Rec/hPtBachVsPtCandRecSig"), candidate.ptProng0(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0RecSig"), candidate.ptProng1());
+        registry.fill(HIST("MC/Rec/hPtV0VsPtCandRecSig"), candidate.ptProng1(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0BachRecSig"), candidate.impactParameter0());
+        registry.fill(HIST("MC/Rec/hd0BachVsPtCandRecSig"), candidate.impactParameter0(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0RecSig"), candidate.impactParameter1());
+        registry.fill(HIST("MC/Rec/hd0V0VsPtCandRecSig"), candidate.impactParameter1(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0posRecSig"), candidate.dcapostopv());
+        registry.fill(HIST("MC/Rec/hd0V0posVsPtCandRecSig"), candidate.dcapostopv(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0negRecSig"), candidate.dcanegtopv());
+        registry.fill(HIST("MC/Rec/hd0V0negVsPtCandRecSig"), candidate.dcanegtopv(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0posRecSig"), candidate.ptV0Pos());
+        registry.fill(HIST("MC/Rec/hPtV0posVsPtCandRecSig"), candidate.ptV0Pos(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0negRecSig"), candidate.ptV0Neg());
+        registry.fill(HIST("MC/Rec/hPtV0negVsPtCandRecSig"), candidate.ptV0Neg(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0CPARecSig"), candidate.v0cosPA());
+        registry.fill(HIST("MC/Rec/hV0CPAVsPtCandRecSig"), candidate.v0cosPA(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0RadiusRecSig"), candidate.v0radius());
+        registry.fill(HIST("MC/Rec/hV0RadiusVsPtCandRecSig"), candidate.v0radius(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0DCADaughtersRecSig"), candidate.dcaV0daughters());
+        registry.fill(HIST("MC/Rec/hV0DCADaughtersVsPtCandRecSig"), candidate.dcaV0daughters(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MK0ShortRecSig"), candidate.mK0Short());
+        registry.fill(HIST("MC/Rec/hV0MK0ShortVsPtCandRecSig"), candidate.mK0Short(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MLambdaRecSig"), candidate.mLambda());
+        registry.fill(HIST("MC/Rec/hV0MLambdaVsPtCandRecSig"), candidate.mLambda(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MAntiLambdaRecSig"), candidate.mAntiLambda());
+        registry.fill(HIST("MC/Rec/hV0MAntiLambdaVsPtCandRecSig"), candidate.mAntiLambda(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MGammaRecSig"), candidate.mGamma());
+        registry.fill(HIST("MC/Rec/hV0MGammaVsPtCandRecSig"), candidate.mGamma(), ptCand);
+        registry.fill(HIST("MC/Rec/hCPACandRecSig"), candidate.cpa());
+        registry.fill(HIST("MC/Rec/hCPACandVsPtCandRecSig"), candidate.cpa(), ptCand);
+        registry.fill(HIST("MC/Rec/hCPAxyCandRecSig"), candidate.cpaXY());
+        registry.fill(HIST("MC/Rec/hCPAxyCandVsPtCandRecSig"), candidate.cpaXY(), ptCand);
+        registry.fill(HIST("MC/Rec/hDecLengthCandRecSig"), candidate.decayLength());
+        registry.fill(HIST("MC/Rec/hDecLengthCandVsPtCandRecSig"), candidate.decayLength(), ptCand);
+        registry.fill(HIST("MC/Rec/hDecLengthXYCandRecSig"), candidate.decayLengthXY());
+        registry.fill(HIST("MC/Rec/hDecLengthXYCandVsPtCandRecSig"), candidate.decayLengthXY(), ptCand);
+        registry.fill(HIST("MC/Rec/hCtCandRecSig"), o2::aod::hf_cand_3prong::ctLc(candidate));
+        registry.fill(HIST("MC/Rec/hCtCandVsPtCandRecSig"), o2::aod::hf_cand_3prong::ctLc(candidate), ptCand);
+        registry.fill(HIST("MC/Rec/hTPCNSigmaPrBachRecSig"), bach.tpcNSigmaPr());
+        registry.fill(HIST("MC/Rec/hPBachVsTPCNSigmaPrBachRecSig"), bach.p(), bach.tpcNSigmaPr());
+        if (bach.hasTOF()) {
+          registry.fill(HIST("MC/Rec/hTOFNSigmaPrBachRecSig"), bach.tofNSigmaPr());
+          registry.fill(HIST("MC/Rec/hPBachVsTOFNSigmaPrBachRecSig"), bach.p(), bach.tofNSigmaPr());
+        }
       } else {
-        registry.fill(HIST("hPtRecBg"), ptCand);
-        registry.fill(HIST("hCPAVsPtCandRecBg"), candidate.cpa(), ptCand);
-        registry.fill(HIST("hV0CPAVsPtCandRecBg"), candidate.v0cosPA(), ptCand);
-        registry.fill(HIST("hEtaVsPtCandRecBg"), candidate.eta(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtCandRecBg"), ptCand);
+        registry.fill(HIST("MC/Rec/hEtaCandRecBg"), candidate.eta());
+        registry.fill(HIST("MC/Rec/hEtaCandVsPtCandRecBg"), candidate.eta(), ptCand);
+        registry.fill(HIST("MC/Rec/hPhiCandRecBg"), candidate.phi());
+        registry.fill(HIST("MC/Rec/hPhiCandVsPtCandRecBg"), candidate.phi(), ptCand);
+        registry.fill(HIST("MC/Rec/hMassRecBg"), invMassLcToK0sP(candidate));
+        registry.fill(HIST("MC/Rec/hMassVsPtCandRecBg"), invMassLcToK0sP(candidate), ptCand);
+        registry.fill(HIST("MC/Rec/hPtBachRecBg"), candidate.ptProng0());
+        registry.fill(HIST("MC/Rec/hPtBachVsPtCandRecBg"), candidate.ptProng0(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0RecBg"), candidate.ptProng1());
+        registry.fill(HIST("MC/Rec/hPtV0VsPtCandRecBg"), candidate.ptProng1(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0BachRecBg"), candidate.impactParameter0());
+        registry.fill(HIST("MC/Rec/hd0BachVsPtCandRecBg"), candidate.impactParameter0(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0RecBg"), candidate.impactParameter1());
+        registry.fill(HIST("MC/Rec/hd0V0VsPtCandRecBg"), candidate.impactParameter1(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0posRecBg"), candidate.dcapostopv());
+        registry.fill(HIST("MC/Rec/hd0V0posVsPtCandRecBg"), candidate.dcapostopv(), ptCand);
+        registry.fill(HIST("MC/Rec/hd0V0negRecBg"), candidate.dcanegtopv());
+        registry.fill(HIST("MC/Rec/hd0V0negVsPtCandRecBg"), candidate.dcanegtopv(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0posRecBg"), candidate.ptV0Pos());
+        registry.fill(HIST("MC/Rec/hPtV0posVsPtCandRecBg"), candidate.ptV0Pos(), ptCand);
+        registry.fill(HIST("MC/Rec/hPtV0negRecBg"), candidate.ptV0Neg());
+        registry.fill(HIST("MC/Rec/hPtV0negVsPtCandRecBg"), candidate.ptV0Neg(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0CPARecBg"), candidate.v0cosPA());
+        registry.fill(HIST("MC/Rec/hV0CPAVsPtCandRecBg"), candidate.v0cosPA(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0RadiusRecBg"), candidate.v0radius());
+        registry.fill(HIST("MC/Rec/hV0RadiusVsPtCandRecBg"), candidate.v0radius(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0DCADaughtersRecBg"), candidate.dcaV0daughters());
+        registry.fill(HIST("MC/Rec/hV0DCADaughtersVsPtCandRecBg"), candidate.dcaV0daughters(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MK0ShortRecBg"), candidate.mK0Short());
+        registry.fill(HIST("MC/Rec/hV0MK0ShortVsPtCandRecBg"), candidate.mK0Short(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MLambdaRecBg"), candidate.mLambda());
+        registry.fill(HIST("MC/Rec/hV0MLambdaVsPtCandRecBg"), candidate.mLambda(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MAntiLambdaRecBg"), candidate.mAntiLambda());
+        registry.fill(HIST("MC/Rec/hV0MAntiLambdaVsPtCandRecBg"), candidate.mAntiLambda(), ptCand);
+        registry.fill(HIST("MC/Rec/hV0MGammaRecBg"), candidate.mGamma());
+        registry.fill(HIST("MC/Rec/hV0MGammaVsPtCandRecBg"), candidate.mGamma(), ptCand);
+        registry.fill(HIST("MC/Rec/hCPACandRecBg"), candidate.cpa());
+        registry.fill(HIST("MC/Rec/hCPACandVsPtCandRecBg"), candidate.cpa(), ptCand);
+        registry.fill(HIST("MC/Rec/hCPAxyCandRecBg"), candidate.cpaXY());
+        registry.fill(HIST("MC/Rec/hCPAxyCandVsPtCandRecBg"), candidate.cpaXY(), ptCand);
+        registry.fill(HIST("MC/Rec/hDecLengthCandRecBg"), candidate.decayLength());
+        registry.fill(HIST("MC/Rec/hDecLengthCandVsPtCandRecBg"), candidate.decayLength(), ptCand);
+        registry.fill(HIST("MC/Rec/hDecLengthXYCandRecBg"), candidate.decayLengthXY());
+        registry.fill(HIST("MC/Rec/hDecLengthXYCandVsPtCandRecBg"), candidate.decayLengthXY(), ptCand);
+        registry.fill(HIST("MC/Rec/hCtCandRecBg"), o2::aod::hf_cand_3prong::ctLc(candidate));
+        registry.fill(HIST("MC/Rec/hCtCandVsPtCandRecBg"), o2::aod::hf_cand_3prong::ctLc(candidate), ptCand);
+        registry.fill(HIST("MC/Rec/hTPCNSigmaPrBachRecBg"), bach.tpcNSigmaPr());
+        registry.fill(HIST("MC/Rec/hPBachVsTPCNSigmaPrBachRecBg"), bach.p(), bach.tpcNSigmaPr());
+        if (bach.hasTOF()) {
+          registry.fill(HIST("MC/Rec/hTOFNSigmaPrBachRecBg"), bach.tofNSigmaPr());
+          registry.fill(HIST("MC/Rec/hPBachVsTOFNSigmaPrBachRecBg"), bach.p(), bach.tofNSigmaPr());
+        }
       }
     }
     // MC gen.
@@ -133,9 +411,13 @@ struct HfTaskLcToK0sP {
         // Printf("MC Gen.: eta rejection: %g", particle.eta());
         continue;
       }
+      auto ptCand = particle.pt();
       if (std::abs(particle.flagMcMatchGen()) == 1) {
-        registry.fill(HIST("hPtGen"), particle.pt());
-        registry.fill(HIST("hEtaGen"), particle.eta());
+        registry.fill(HIST("MC/Gen/hPtCandGen"), ptCand);
+        registry.fill(HIST("MC/Gen/hEtaCandGen"), particle.eta());
+        registry.fill(HIST("MC/Gen/hEtaCandVsPtCandGen"), particle.eta(), ptCand);
+        registry.fill(HIST("MC/Gen/hPhiCandGen"), particle.phi());
+        registry.fill(HIST("MC/Gen/hPhiCandVsPtCandGen"), particle.phi(), ptCand);
       }
     }
   }

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -529,6 +529,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtV0Neg, ptV0Neg, //!
                            [](float px, float py) { return RecoDecay::pt(px, py); });
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); //! generator level
+DECLARE_SOA_COLUMN(V0X, v0x, float);
+DECLARE_SOA_COLUMN(V0Y, v0y, float);
+DECLARE_SOA_COLUMN(V0Z, v0z, float);
 
 template <typename T>
 auto invMassLcToK0sP(const T& candidate)
@@ -555,7 +558,7 @@ DECLARE_SOA_TABLE(HfCandCascBase, "AOD", "HFCANDCASCBASE", //!
                   hf_track_index::Prong0Id,
                   hf_track_index::V0Id, // V0 index
                   // V0
-                  v0data::X, v0data::Y, v0data::Z,
+                  hf_cand_casc::V0X, hf_cand_casc::V0Y, hf_cand_casc::V0Z,
                   v0data::PosTrackId, v0data::NegTrackId, // indices of V0 tracks in FullTracks table
                   v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
                   v0data::DCAV0Daughters,
@@ -586,8 +589,8 @@ DECLARE_SOA_TABLE(HfCandCascBase, "AOD", "HFCANDCASCBASE", //!
                   // dynamic columns from V0
                   hf_cand_casc::PtV0Pos<v0data::PxPos, v0data::PyPos>, // pT of positive V0 daughter
                   hf_cand_casc::PtV0Neg<v0data::PxNeg, v0data::PyNeg>, // pT of negative V0 daughter
-                  v0data::V0Radius<v0data::X, v0data::Y>,
-                  v0data::V0CosPA<v0data::X, v0data::Y, v0data::Z, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, collision::PosX, collision::PosY, collision::PosZ>,
+                  v0data::V0Radius<hf_cand_casc::V0X, hf_cand_casc::V0Y>,
+                  v0data::V0CosPA<hf_cand_casc::V0X, hf_cand_casc::V0Y, hf_cand_casc::V0Z, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, collision::PosX, collision::PosY, collision::PosZ>,
                   v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                   v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                   v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -114,6 +114,11 @@ o2physics_add_dpl_workflow(tree-creator-chic-to-jpsi-gamma
                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                    COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(tree-creator-lc-to-k0s-p
+                    SOURCES treeCreatorLcToK0sP.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(candidate-selector-d0
                     SOURCES candidateSelectorD0.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
@@ -1,0 +1,400 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file treeCreatorLcToK0sP.cxx
+/// \brief Writer of the cascade candidates in the form of flat tables to be stored in TTrees.
+///        Intended for debug or for the local optimization of analysis on small samples.
+///        In this file are defined and filled the output tables
+///        Modified version of treeCreatorLcToPKPi.cxx
+///
+/// \author Daniel Samitz <daniel.samitz@cern.ch>
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "Common/Core/trackUtilities.h"
+#include "ReconstructionDataFormats/DCA.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+namespace o2::aod
+{
+namespace full
+{
+DECLARE_SOA_COLUMN(RSecondaryVertex, rSecondaryVertex, float);
+DECLARE_SOA_COLUMN(PtProng0, ptProng0, float);
+DECLARE_SOA_COLUMN(PProng0, pProng0, float);
+DECLARE_SOA_COLUMN(ImpactParameterNormalised0, impactParameterNormalised0, float);
+DECLARE_SOA_COLUMN(ImpactParameterXY0, impactParameterXY0, float);
+DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);
+DECLARE_SOA_COLUMN(PProng1, pProng1, float);
+DECLARE_SOA_COLUMN(ImpactParameterNormalised1, impactParameterNormalised1, float);
+DECLARE_SOA_COLUMN(ImpactParameterXY1, impactParameterXY1, float);
+DECLARE_SOA_COLUMN(CandidateSelFlag, candidateSelFlag, int8_t);
+DECLARE_SOA_COLUMN(M, m, float);
+DECLARE_SOA_COLUMN(Pt, pt, float);
+DECLARE_SOA_COLUMN(P, p, float);
+DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(Phi, phi, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(E, e, float);
+DECLARE_SOA_COLUMN(NSigTPCPr0, nsigTPCPr0, float);
+DECLARE_SOA_COLUMN(NSigTOFPr0, nsigTOFPr0, float);
+DECLARE_SOA_COLUMN(DecayLength, decayLength, float);
+DECLARE_SOA_COLUMN(DecayLengthXY, decayLengthXY, float);
+DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);
+DECLARE_SOA_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, float);
+DECLARE_SOA_COLUMN(CPA, cpa, float);
+DECLARE_SOA_COLUMN(CPAXY, cpaXY, float);
+DECLARE_SOA_COLUMN(Ct, ct, float);
+DECLARE_SOA_COLUMN(PtV0Pos, ptV0Pos, float);
+DECLARE_SOA_COLUMN(PtV0Neg, ptV0Neg, float);
+DECLARE_SOA_COLUMN(V0Radius, v0Radius, float);
+DECLARE_SOA_COLUMN(V0CosPA, v0CosPA, float);
+DECLARE_SOA_COLUMN(V0MLambda, v0MLambda, float);
+DECLARE_SOA_COLUMN(V0MAntiLambda, v0MAntiLambda, float);
+DECLARE_SOA_COLUMN(V0MK0Short, v0MK0Short, float);
+DECLARE_SOA_COLUMN(V0MGamma, v0MGamma, float);
+DECLARE_SOA_COLUMN(MCflag, mcflag, int8_t);
+// Events
+DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
+DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
+} // namespace full
+
+DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFull",
+                  collision::BCId,
+                  collision::NumContrib,
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  hf_cand::XSecondaryVertex,
+                  hf_cand::YSecondaryVertex,
+                  hf_cand::ZSecondaryVertex,
+                  hf_cand::ErrorDecayLength,
+                  hf_cand::ErrorDecayLengthXY,
+                  hf_cand::Chi2PCA,
+                  full::RSecondaryVertex,
+                  full::DecayLength,
+                  full::DecayLengthXY,
+                  full::DecayLengthNormalised,
+                  full::DecayLengthXYNormalised,
+                  full::ImpactParameterNormalised0,
+                  full::PtProng0,
+                  full::PProng0,
+                  full::ImpactParameterNormalised1,
+                  full::PtProng1,
+                  full::PProng1,
+                  hf_cand::PxProng0,
+                  hf_cand::PyProng0,
+                  hf_cand::PzProng0,
+                  hf_cand::PxProng1,
+                  hf_cand::PyProng1,
+                  hf_cand::PzProng1,
+                  hf_cand::ImpactParameter0,
+                  hf_cand::ImpactParameter1,
+                  hf_cand::ErrorImpactParameter0,
+                  hf_cand::ErrorImpactParameter1,
+                  hf_cand_casc::V0X,
+                  hf_cand_casc::V0Y,
+                  hf_cand_casc::V0Z,
+                  full::V0Radius,
+                  full::V0CosPA,
+                  full::V0MLambda,
+                  full::V0MAntiLambda,
+                  full::V0MK0Short,
+                  full::V0MGamma,
+                  v0data::DCAV0Daughters,
+                  v0data::PxPos,
+                  v0data::PyPos,
+                  v0data::PzPos,
+                  full::PtV0Pos,
+                  v0data::DCAPosToPV,
+                  v0data::PxNeg,
+                  v0data::PyNeg,
+                  v0data::PzNeg,
+                  full::PtV0Neg,
+                  v0data::DCANegToPV,
+                  full::NSigTPCPr0,
+                  full::NSigTOFPr0,
+                  full::M,
+                  full::Pt,
+                  full::P,
+                  full::CPA,
+                  full::CPAXY,
+                  full::Ct,
+                  full::Eta,
+                  full::Phi,
+                  full::Y,
+                  full::E,
+                  full::MCflag);
+
+DECLARE_SOA_TABLE(HfCandCascFullEvents, "AOD", "HFCANDCASCFullE",
+                  collision::BCId,
+                  collision::NumContrib,
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  full::IsEventReject,
+                  full::RunNumber);
+
+DECLARE_SOA_TABLE(HfCandCascFullParticles, "AOD", "HFCANDCASCFullP",
+                  collision::BCId,
+                  full::Pt,
+                  full::Eta,
+                  full::Phi,
+                  full::Y,
+                  full::MCflag);
+
+} // namespace o2::aod
+
+/// Writes the full information in an output TTree
+struct HfTreeCreatorLcToK0sP {
+  Produces<o2::aod::HfCandCascFull> rowCandidateFull;
+  Produces<o2::aod::HfCandCascFullEvents> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandCascFullParticles> rowCandidateFullParticles;
+
+  Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
+
+  void init(InitContext const&)
+  {
+  }
+
+  void processMc(aod::Collisions const& collisions,
+                 aod::McCollisions const& mccollisions,
+                 soa::Join<aod::HfCandCascade, aod::HfCandCascadeMcRec, aod::HfSelLcToK0sP> const& candidates,
+                 soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& particles,
+                 aod::BigTracksPID const& tracks)
+  {
+
+    // Filling event properties
+    rowCandidateFullEvents.reserve(collisions.size());
+    for (auto& collision : collisions) {
+      rowCandidateFullEvents(
+        collision.bcId(),
+        collision.numContrib(),
+        collision.posX(),
+        collision.posY(),
+        collision.posZ(),
+        0,
+        1);
+    }
+
+    // Filling candidate properties
+    rowCandidateFull.reserve(candidates.size());
+    for (auto& candidate : candidates) {
+      auto bach = candidate.prong0_as<aod::BigTracksPID>(); // bachelor
+      auto fillTable = [&](int FunctionSelection,
+                           float FunctionInvMass,
+                           float FunctionCt,
+                           float FunctionY,
+                           float FunctionE) {
+        double pseudoRndm = bach.pt() * 1000. - (long)(bach.pt() * 1000);
+        if (FunctionSelection >= 1 && pseudoRndm < downSampleBkgFactor) {
+          rowCandidateFull(
+            bach.collision().bcId(),
+            bach.collision().numContrib(),
+            candidate.posX(),
+            candidate.posY(),
+            candidate.posZ(),
+            candidate.xSecondaryVertex(),
+            candidate.ySecondaryVertex(),
+            candidate.zSecondaryVertex(),
+            candidate.errorDecayLength(),
+            candidate.errorDecayLengthXY(),
+            candidate.chi2PCA(),
+            candidate.rSecondaryVertex(),
+            candidate.decayLength(),
+            candidate.decayLengthXY(),
+            candidate.decayLengthNormalised(),
+            candidate.decayLengthXYNormalised(),
+            candidate.impactParameterNormalised0(),
+            candidate.ptProng0(),
+            RecoDecay::p(candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()),
+            candidate.impactParameterNormalised1(),
+            candidate.ptProng1(),
+            RecoDecay::p(candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()),
+            candidate.pxProng0(),
+            candidate.pyProng0(),
+            candidate.pzProng0(),
+            candidate.pxProng1(),
+            candidate.pyProng1(),
+            candidate.pzProng1(),
+            candidate.impactParameter0(),
+            candidate.impactParameter1(),
+            candidate.errorImpactParameter0(),
+            candidate.errorImpactParameter1(),
+            candidate.v0x(),
+            candidate.v0y(),
+            candidate.v0z(),
+            candidate.v0radius(),
+            candidate.v0cosPA(),
+            candidate.mLambda(),
+            candidate.mAntiLambda(),
+            candidate.mK0Short(),
+            candidate.mGamma(),
+            candidate.dcaV0daughters(),
+            candidate.pxpos(),
+            candidate.pypos(),
+            candidate.pzpos(),
+            candidate.ptV0Pos(),
+            candidate.dcapostopv(),
+            candidate.pxneg(),
+            candidate.pyneg(),
+            candidate.pzneg(),
+            candidate.ptV0Neg(),
+            candidate.dcanegtopv(),
+            bach.tpcNSigmaPr(),
+            bach.tofNSigmaPr(),
+            FunctionInvMass,
+            candidate.pt(),
+            candidate.p(),
+            candidate.cpa(),
+            candidate.cpaXY(),
+            FunctionCt,
+            candidate.eta(),
+            candidate.phi(),
+            FunctionY,
+            FunctionE,
+            candidate.flagMcMatchRec());
+        }
+      };
+
+      fillTable(candidate.isSelLcToK0sP(), invMassLcToK0sP(candidate), o2::aod::hf_cand_3prong::ctLc(candidate), o2::aod::hf_cand_3prong::yLc(candidate), o2::aod::hf_cand_3prong::eLc(candidate));
+    }
+
+    // Filling particle properties
+    rowCandidateFullParticles.reserve(particles.size());
+    for (auto& particle : particles) {
+      if (std::abs(particle.flagMcMatchGen()) == 1) {
+        rowCandidateFullParticles(
+          particle.mcCollision().bcId(),
+          particle.pt(),
+          particle.eta(),
+          particle.phi(),
+          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          particle.flagMcMatchGen());
+      }
+    }
+  }
+  PROCESS_SWITCH(HfTreeCreatorLcToK0sP, processMc, "Process MC tree writer", true);
+
+  void processData(aod::Collisions const& collisions,
+                   soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP> const& candidates,
+                   aod::BigTracksPID const& tracks)
+  {
+
+    // Filling event properties
+    rowCandidateFullEvents.reserve(collisions.size());
+    for (auto& collision : collisions) {
+      rowCandidateFullEvents(
+        collision.bcId(),
+        collision.numContrib(),
+        collision.posX(),
+        collision.posY(),
+        collision.posZ(),
+        0,
+        1);
+    }
+
+    // Filling candidate properties
+    rowCandidateFull.reserve(candidates.size());
+    for (auto& candidate : candidates) {
+      auto bach = candidate.prong0_as<aod::BigTracksPID>(); // bachelor
+      auto fillTable = [&](int FunctionSelection,
+                           float FunctionInvMass,
+                           float FunctionCt,
+                           float FunctionY,
+                           float FunctionE) {
+        double pseudoRndm = bach.pt() * 1000. - (long)(bach.pt() * 1000);
+        if (FunctionSelection >= 1 && pseudoRndm < downSampleBkgFactor) {
+          rowCandidateFull(
+            bach.collision().bcId(),
+            bach.collision().numContrib(),
+            candidate.posX(),
+            candidate.posY(),
+            candidate.posZ(),
+            candidate.xSecondaryVertex(),
+            candidate.ySecondaryVertex(),
+            candidate.zSecondaryVertex(),
+            candidate.errorDecayLength(),
+            candidate.errorDecayLengthXY(),
+            candidate.chi2PCA(),
+            candidate.rSecondaryVertex(),
+            candidate.decayLength(),
+            candidate.decayLengthXY(),
+            candidate.decayLengthNormalised(),
+            candidate.decayLengthXYNormalised(),
+            candidate.impactParameterNormalised0(),
+            candidate.ptProng0(),
+            RecoDecay::p(candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()),
+            candidate.impactParameterNormalised1(),
+            candidate.ptProng1(),
+            RecoDecay::p(candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()),
+            candidate.pxProng0(),
+            candidate.pyProng0(),
+            candidate.pzProng0(),
+            candidate.pxProng1(),
+            candidate.pyProng1(),
+            candidate.pzProng1(),
+            candidate.impactParameter0(),
+            candidate.impactParameter1(),
+            candidate.errorImpactParameter0(),
+            candidate.errorImpactParameter1(),
+            candidate.v0x(),
+            candidate.v0y(),
+            candidate.v0z(),
+            candidate.v0radius(),
+            candidate.v0cosPA(),
+            candidate.mLambda(),
+            candidate.mAntiLambda(),
+            candidate.mK0Short(),
+            candidate.mGamma(),
+            candidate.dcaV0daughters(),
+            candidate.pxpos(),
+            candidate.pypos(),
+            candidate.pzpos(),
+            candidate.ptV0Pos(),
+            candidate.dcapostopv(),
+            candidate.pxneg(),
+            candidate.pyneg(),
+            candidate.pzneg(),
+            candidate.ptV0Neg(),
+            candidate.dcanegtopv(),
+            bach.tpcNSigmaPr(),
+            bach.tofNSigmaPr(),
+            FunctionInvMass,
+            candidate.pt(),
+            candidate.p(),
+            candidate.cpa(),
+            candidate.cpaXY(),
+            FunctionCt,
+            candidate.eta(),
+            candidate.phi(),
+            FunctionY,
+            FunctionE,
+            0.);
+        }
+      };
+
+      fillTable(candidate.isSelLcToK0sP(), invMassLcToK0sP(candidate), o2::aod::hf_cand_3prong::ctLc(candidate), o2::aod::hf_cand_3prong::yLc(candidate), o2::aod::hf_cand_3prong::eLc(candidate));
+    }
+  }
+  PROCESS_SWITCH(HfTreeCreatorLcToK0sP, processData, "Process data tree writer", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow;
+  workflow.push_back(adaptAnalysisTask<HfTreeCreatorLcToK0sP>(cfgc));
+  return workflow;
+}


### PR DESCRIPTION
- more histograms in taskLcToK0sP
- new treeCreatorLcToK0sP
- the changes in the table `HfCandCascBase` in CandidateReconstructionTables.h are necessary to avoid an ambiguous function definition because of the two columns https://github.com/AliceO2Group/O2Physics/blob/ace94edb43c1ea6863b74e2f02d2cdc762fb73c4/PWGHF/DataModel/CandidateReconstructionTables.h#L302 (rapidity in the HF candidate tables) 
and https://github.com/AliceO2Group/O2Physics/blob/ace94edb43c1ea6863b74e2f02d2cdc762fb73c4/PWGLF/DataModel/LFStrangenessTables.h#L39  (decay position in LF v0data table).
I also think that `{candidate.v0x(), candidate.v0y(), candidate.v0z()}` is a much more intuitive name for the decay position of the V0 of the cascade candidate, than just `{candidate.x(), candidate.y(), candidate.z()}` as before, where there is no reference to the V0 at all.