### PR TITLE
Fix EM integration and empty BC ranges

### DIFF
--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -183,7 +183,7 @@ using BCRange = BCRanges::iterator;
 constexpr int NumberOfFilters{10};
 constexpr std::array<char[32], NumberOfFilters> AvailableFilters{"NucleiFilters", "DiffractionFilters", "DqFilters", "HfFilters", "CFFilters", "JetFilters", "FullJetFilters", "StrangenessFilters", "MultFilters", "PhotFilters"};
 constexpr std::array<char[16], NumberOfFilters> FilterDescriptions{"NucleiFilters", "DiffFilters", "DqFilters", "HfFilters", "CFFilters", "JetFilters", "FullJetFilters", "LFStrgFilters", "MultFilters", "PhotFilters"};
-constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-fje-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter", "o2-analysis-phot-filter"};
+constexpr std::array<char[128], NumberOfFilters> FilteringTaskNames{"o2-analysis-nuclei-filter", "o2-analysis-diffraction-filter", "o2-analysis-dq-filter-pp", "o2-analysis-hf-filter", "o2-analysis-cf-filter", "o2-analysis-je-filter", "o2-analysis-fje-filter", "o2-analysis-lf-strangeness-filter", "o2-analysis-mult-filter", "o2-analysis-em-filter"};
 constexpr o2::framework::pack<NucleiFilters, DiffractionFilters, DqFilters, HfFilters, CFFilters, JetFilters, FullJetFilters, StrangenessFilters, MultFilters, PhotFilters> FiltersPack;
 static_assert(o2::framework::pack_size(FiltersPack) == NumberOfFilters);
 

--- a/EventFiltering/selectBCRange.cxx
+++ b/EventFiltering/selectBCRange.cxx
@@ -85,6 +85,7 @@ struct BCRangeSelector {
         auto bcRange = udhelpers::compatibleBCs(collision, nTimeRes, bcs, nMinBSs);
         if (bcRange.size() == 0) {
           LOGF(warning, "No compatible BCs found for collision that the framework assigned to BC %i", filt.hasGlobalBCId());
+          filt++;
           continue;
         }
         // update list of ranges

--- a/EventFiltering/selectBCRange.cxx
+++ b/EventFiltering/selectBCRange.cxx
@@ -83,7 +83,10 @@ struct BCRangeSelector {
 
         // get range of compatible BCs
         auto bcRange = udhelpers::compatibleBCs(collision, nTimeRes, bcs, nMinBSs);
-
+        if (bcRange.size() == 0) {
+          LOGF(warning, "No compatible BCs found for collision that the framework assigned to BC %i", filt.hasGlobalBCId());
+          continue;
+        }
         // update list of ranges
         auto bcfirst = bcRange.rawIteratorAt(0);
         auto bclast = bcRange.rawIteratorAt(bcRange.size() - 1);


### PR DESCRIPTION
Hi @peressounko: your task was not read by the CEFP; now, it should be appropriately integrated.
Hi @pbuehler: this is not a solution, but at least the chain will not crash anymore. Whenever you have the proper fix, feel free to open the PR!