### PR TITLE
Revert "PID: Using TrackExtra instead of tracks"

### DIFF
--- a/Common/TableProducer/PID/pidTPCBase.cxx
+++ b/Common/TableProducer/PID/pidTPCBase.cxx
@@ -37,9 +37,7 @@ struct PidMultiplicity {
   Produces<aod::PIDMults> mult;
 
   // For vertex-Z corrections in calibration
-  // using Trks = soa::Join<aod::Tracks, aod::TracksExtra>;
-  using Trks = aod::TracksExtra;
-  Partition<Trks> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
+  Partition<soa::Join<aod::Tracks, aod::TracksExtra>> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
   bool enableTable = false;
 
   void init(InitContext& initContext)
@@ -52,7 +50,7 @@ struct PidMultiplicity {
     }
   }
 
-  void process(aod::Collision const& collision, Trks const& tracksExtra)
+  void process(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksExtra> const& tracksExtra)
   {
     if (!enableTable) {
       return;


### PR DESCRIPTION
Reverts AliceO2Group/O2Physics#2061

the previous PR makes test with Run2 converted data fail, we will further investigate this during the week