### PR TITLE
depend on TracksIU in Run 3

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -416,7 +416,7 @@ struct EventSelectionTask {
   }
   PROCESS_SWITCH(EventSelectionTask, processRun2, "Process Run2 event selection", true);
 
-  void processRun3(aod::Collision const& col, aod::FullTracks const& tracks, BCsWithBcSels const& bcs)
+  void processRun3(aod::Collision const& col, soa::Join<aod::TracksIU, aod::TracksExtra> const& tracks, BCsWithBcSels const& bcs)
   {
     // count tracks of different types
     int nITStracks = 0;


### PR DESCRIPTION
@mpuccio as discussed just now!

@ekryshen, this changes the evsel processRun3 to depend on TracksIU and not Tracks for the track counting. It will mean that the track propagation workflow isn't necessary at all in some cases (strangeness analyses etc). Please jump up in case I am missing something