### PR TITLE
PWGHF: Clarify and extend PID selections

### DIFF
--- a/Common/Core/TrackSelectorPID.h
+++ b/Common/Core/TrackSelectorPID.h
@@ -94,7 +94,7 @@ class TrackSelectorPID
     mNSigmaTPCMax = nsMax;
   }
 
-  /// Set TPC nσ range in which a track should be conditionally accepted if combined with TOF.
+  /// Set TPC nσ range in which a track should be conditionally accepted if combined with TOF. Set to 0 to disable.
   void setRangeNSigmaTPCCondTOF(float nsMin, float nsMax)
   {
     mNSigmaTPCMinCondTOF = nsMin;
@@ -196,7 +196,7 @@ class TrackSelectorPID
     mNSigmaTOFMax = nsMax;
   }
 
-  /// Set TOF nσ range in which a track should be conditionally accepted if combined with TPC.
+  /// Set TOF nσ range in which a track should be conditionally accepted if combined with TPC. Set to 0 to disable.
   void setRangeNSigmaTOFCondTPC(float nsMin, float nsMax)
   {
     mNSigmaTOFMinCondTPC = nsMin;
@@ -432,17 +432,51 @@ class TrackSelectorPID
 
   // Combined selection (TPC + TOF)
 
-  /// Returns status of combined PID (TPC + TOF) selection for a given track.
+  /// Returns status of combined PID (TPC or TOF) selection for a given track.
   /// \param track  track
-  /// \return status of combined PID (TPC + TOF) (see TrackSelectorPID::Status)
+  /// \return status of combined PID (TPC or TOF) (see TrackSelectorPID::Status)
   template <typename T>
-  int getStatusTrackPIDAll(const T& track)
+  int getStatusTrackPIDTpcOrTof(const T& track)
   {
     int statusTPC = getStatusTrackPIDTPC(track);
     int statusTOF = getStatusTrackPIDTOF(track);
 
     if (statusTPC == Status::PIDAccepted || statusTOF == Status::PIDAccepted) {
-      return Status::PIDAccepted; // what if we have Accepted for one and Rejected for the other?
+      return Status::PIDAccepted;
+    }
+    if (statusTPC == Status::PIDConditional && statusTOF == Status::PIDConditional) {
+      return Status::PIDAccepted;
+    }
+    if (statusTPC == Status::PIDRejected || statusTOF == Status::PIDRejected) {
+      return Status::PIDRejected;
+    }
+    return Status::PIDNotApplicable; // (NotApplicable for one detector) and (NotApplicable or Conditional for the other)
+  }
+
+  /// Returns status of combined PID (TPC and TOF) selection for a given track when both detectors are applicable. Returns status of single PID otherwise.
+  /// \param track  track
+  /// \return status of combined PID (TPC and TOF) (see TrackSelectorPID::Status)
+  template <typename T>
+  int getStatusTrackPIDTpcAndTof(const T& track)
+  {
+
+    int statusTPC = Status::PIDNotApplicable;
+    if (track.hasTPC()) {
+      statusTPC = getStatusTrackPIDTPC(track);
+    }
+    int statusTOF = Status::PIDNotApplicable;
+    if (track.hasTOF()) {
+      statusTOF = getStatusTrackPIDTOF(track);
+    }
+
+    if (statusTPC == Status::PIDAccepted && statusTOF == Status::PIDAccepted) {
+      return Status::PIDAccepted;
+    }
+    if (statusTPC == Status::PIDAccepted && statusTOF == Status::PIDNotApplicable) {
+      return Status::PIDAccepted;
+    }
+    if (statusTPC == Status::PIDNotApplicable && statusTOF == Status::PIDAccepted) {
+      return Status::PIDAccepted;
     }
     if (statusTPC == Status::PIDConditional && statusTOF == Status::PIDConditional) {
       return Status::PIDAccepted;
@@ -625,24 +659,24 @@ class TrackSelectorPID
   float mPtTPCMax = 100.;              ///< maximum pT for TPC PID [GeV/c]
   float mNSigmaTPCMin = -3.;           ///< minimum number of TPC σ
   float mNSigmaTPCMax = 3.;            ///< maximum number of TPC σ
-  float mNSigmaTPCMinCondTOF = -1000.; ///< minimum number of TPC σ if combined with TOF
-  float mNSigmaTPCMaxCondTOF = 1000.;  ///< maximum number of TPC σ if combined with TOF
+  float mNSigmaTPCMinCondTOF = 0.;     ///< minimum number of TPC σ if combined with TOF
+  float mNSigmaTPCMaxCondTOF = 0.;     ///< maximum number of TPC σ if combined with TOF
 
   // TOF
   float mPtTOFMin = 0.;                ///< minimum pT for TOF PID [GeV/c]
   float mPtTOFMax = 100.;              ///< maximum pT for TOF PID [GeV/c]
   float mNSigmaTOFMin = -3.;           ///< minimum number of TOF σ
   float mNSigmaTOFMax = 3.;            ///< maximum number of TOF σ
-  float mNSigmaTOFMinCondTPC = -1000.; ///< minimum number of TOF σ if combined with TPC
-  float mNSigmaTOFMaxCondTPC = 1000.;  ///< maximum number of TOF σ if combined with TPC
+  float mNSigmaTOFMinCondTPC = 0.;     ///< minimum number of TOF σ if combined with TPC
+  float mNSigmaTOFMaxCondTPC = 0.;     ///< maximum number of TOF σ if combined with TPC
 
   // RICH
   float mPtRICHMin = 0.;                ///< minimum pT for RICH PID [GeV/c]
   float mPtRICHMax = 100.;              ///< maximum pT for RICH PID [GeV/c]
   float mNSigmaRICHMin = -3.;           ///< minimum number of RICH σ
   float mNSigmaRICHMax = 3.;            ///< maximum number of RICH σ
-  float mNSigmaRICHMinCondTOF = -1000.; ///< minimum number of RICH σ if combined with TOF
-  float mNSigmaRICHMaxCondTOF = 1000.;  ///< maximum number of RICH σ if combined with TOF
+  float mNSigmaRICHMinCondTOF = 0.;     ///< minimum number of RICH σ if combined with TOF
+  float mNSigmaRICHMaxCondTOF = 0.;     ///< maximum number of RICH σ if combined with TOF
 
   // Bayesian
   float mPtBayesMin = 0.;    ///< minimum pT for Bayesian PID [GeV/c]

--- a/Common/Core/TrackSelectorPID.h
+++ b/Common/Core/TrackSelectorPID.h
@@ -14,8 +14,8 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 
-#ifndef O2_ANALYSIS_TRACKSELECTORPID_H_
-#define O2_ANALYSIS_TRACKSELECTORPID_H_
+#ifndef COMMON_CORE_TRACKSELECTORPID_H_
+#define COMMON_CORE_TRACKSELECTORPID_H_
 
 #include <TPDGCode.h>
 
@@ -472,10 +472,10 @@ class TrackSelectorPID
     if (statusTPC == Status::PIDAccepted && statusTOF == Status::PIDAccepted) {
       return Status::PIDAccepted;
     }
-    if (statusTPC == Status::PIDAccepted && statusTOF == Status::PIDNotApplicable) {
+    if (statusTPC == Status::PIDAccepted && (statusTOF == Status::PIDNotApplicable || statusTOF == Status::PIDConditional)) {
       return Status::PIDAccepted;
     }
-    if (statusTPC == Status::PIDNotApplicable && statusTOF == Status::PIDAccepted) {
+    if ((statusTPC == Status::PIDNotApplicable || statusTPC == Status::PIDConditional) && statusTOF == Status::PIDAccepted) {
       return Status::PIDAccepted;
     }
     if (statusTPC == Status::PIDConditional && statusTOF == Status::PIDConditional) {
@@ -684,4 +684,4 @@ class TrackSelectorPID
   float mProbBayesMin = -1.; ///< minium Bayesian probability [%]
 };
 
-#endif // O2_ANALYSIS_TRACKSELECTORPID_H_
+#endif // COMMON_CORE_TRACKSELECTORPID_H_

--- a/PWGHF/TableProducer/candidateSelectorBplusToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorBplusToD0Pi.cxx
@@ -158,7 +158,7 @@ struct HfCandidateSelectorBplusToD0Pi {
 
       if (usePid) {
         // PID applied
-        if (selectorPion.getStatusTrackPIDAll(trackPi) != TrackSelectorPID::Status::PIDAccepted) {
+        if (selectorPion.getStatusTrackPIDTpcOrTof(trackPi) != TrackSelectorPID::Status::PIDAccepted) {
           // Printf("PID not successful");
           hfSelBplusToD0PiCandidate(statusBplus);
           continue;

--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -229,10 +229,10 @@ struct HfCandidateSelectorD0 {
       statusCand = 1;
 
       // track-level PID selection
-      int pidTrackPosKaon = selectorKaon.getStatusTrackPIDAll(trackPos);
-      int pidTrackPosPion = selectorPion.getStatusTrackPIDAll(trackPos);
-      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
-      int pidTrackNegPion = selectorPion.getStatusTrackPIDAll(trackNeg);
+      int pidTrackPosKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackPos);
+      int pidTrackPosPion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos);
+      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
+      int pidTrackNegPion = selectorPion.getStatusTrackPIDTpcOrTof(trackNeg);
 
       int pidD0 = -1;
       int pidD0bar = -1;

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -148,9 +148,9 @@ struct HfCandidateSelectorDplusToPiKPi {
       SETBIT(statusDplusToPiKPi, aod::SelectionStep::RecoTopol);
 
       // track-level PID selection
-      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDAll(trackPos1);
-      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
-      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDAll(trackPos2);
+      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
+      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
+      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
 
       if (pidTrackPos1Pion == TrackSelectorPID::Status::PIDRejected ||
           pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -184,11 +184,11 @@ struct HfCandidateSelectorDsToKKPi {
       }
 
       // track-level PID selection
-      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDAll(trackPos1);
-      int pidTrackPos1Kaon = selectorKaon.getStatusTrackPIDAll(trackPos1);
-      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDAll(trackPos2);
-      int pidTrackPos2Kaon = selectorKaon.getStatusTrackPIDAll(trackPos2);
-      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
+      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
+      int pidTrackPos1Kaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackPos1);
+      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
+      int pidTrackPos2Kaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackPos2);
+      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
 
       bool pidDsToKKPi = !(pidTrackPos1Kaon == TrackSelectorPID::Status::PIDRejected ||
                            pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -207,11 +207,11 @@ struct HfCandidateSelectorLc {
         pidLcToPiKP = 1;
       } else {
         // track-level PID selection
-        int pidTrackPos1Proton = selectorProton.getStatusTrackPIDAll(trackPos1);
-        int pidTrackPos2Proton = selectorProton.getStatusTrackPIDAll(trackPos2);
-        int pidTrackPos1Pion = selectorPion.getStatusTrackPIDAll(trackPos1);
-        int pidTrackPos2Pion = selectorPion.getStatusTrackPIDAll(trackPos2);
-        int pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
+        int pidTrackPos1Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos1);
+        int pidTrackPos2Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos2);
+        int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
+        int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
+        int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
 
         if (pidTrackPos1Proton == TrackSelectorPID::Status::PIDAccepted &&
             pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted &&

--- a/PWGHF/TableProducer/candidateSelectorLcMl.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLcMl.cxx
@@ -188,11 +188,11 @@ struct HfCandidateSelectorLcMl {
         pidLcToPiKP = 1;
       } else {
         // track-level PID selection
-        int pidTrackPos1Proton = selectorProton.getStatusTrackPIDAll(trackPos1);
-        int pidTrackPos2Proton = selectorProton.getStatusTrackPIDAll(trackPos2);
-        int pidTrackPos1Pion = selectorPion.getStatusTrackPIDAll(trackPos1);
-        int pidTrackPos2Pion = selectorPion.getStatusTrackPIDAll(trackPos2);
-        int pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
+        int pidTrackPos1Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos1);
+        int pidTrackPos2Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos2);
+        int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
+        int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
+        int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
 
         if (pidTrackPos1Proton == TrackSelectorPID::Status::PIDAccepted &&
             pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted &&

--- a/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
@@ -275,10 +275,10 @@ struct HfCandidateSelectorToXiPi {
         pidPiFromCasc = selectorPion.getStatusTrackPIDTPC(trackPiFromCasc);
         pidPiFromOme = selectorPion.getStatusTrackPIDTPC(trackPiFromOmeg);
       } else if (usePidTpcTofCombined) {
-        pidProton = selectorProton.getStatusTrackPIDAll(trackPrFromLam);
-        pidPiFromLam = selectorPion.getStatusTrackPIDAll(trackPiFromLam);
-        pidPiFromCasc = selectorPion.getStatusTrackPIDAll(trackPiFromCasc);
-        pidPiFromOme = selectorPion.getStatusTrackPIDAll(trackPiFromOmeg);
+        pidProton = selectorProton.getStatusTrackPIDTpcOrTof(trackPrFromLam);
+        pidPiFromLam = selectorPion.getStatusTrackPIDTpcOrTof(trackPiFromLam);
+        pidPiFromCasc = selectorPion.getStatusTrackPIDTpcOrTof(trackPiFromCasc);
+        pidPiFromOme = selectorPion.getStatusTrackPIDTpcOrTof(trackPiFromOmeg);
       }
 
       bool statusPidLambda = false;

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -204,11 +204,11 @@ struct HfCandidateSelectorXicToPKPi {
         pidXicToPiKP = 1;
       } else {
         // track-level PID selection
-        auto pidTrackPos1Proton = selectorProton.getStatusTrackPIDAll(trackPos1);
-        auto pidTrackPos2Proton = selectorProton.getStatusTrackPIDAll(trackPos2);
-        auto pidTrackPos1Pion = selectorPion.getStatusTrackPIDAll(trackPos1);
-        auto pidTrackPos2Pion = selectorPion.getStatusTrackPIDAll(trackPos2);
-        auto pidTrackNegKaon = selectorKaon.getStatusTrackPIDAll(trackNeg);
+        auto pidTrackPos1Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos1);
+        auto pidTrackPos2Proton = selectorProton.getStatusTrackPIDTpcOrTof(trackPos2);
+        auto pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
+        auto pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
+        auto pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
 
         if (pidTrackPos1Proton == TrackSelectorPID::Status::PIDAccepted &&
             pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted &&

--- a/PWGHF/TableProducer/candidateSelectorXiccToPKPiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXiccToPKPiPi.cxx
@@ -159,7 +159,7 @@ struct HfCandidateSelectorXiccToPKPiPi {
         pidPi = 1;
       } else {
         // track-level PID selection
-        int pidPion = selectorPion.getStatusTrackPIDAll(trackPi);
+        int pidPion = selectorPion.getStatusTrackPIDTpcOrTof(trackPi);
         if (pidPion == TrackSelectorPID::Status::PIDAccepted) {
           pidPi = 1;
         }

--- a/Tools/KFparticle/qaKFParticle.cxx
+++ b/Tools/KFparticle/qaKFParticle.cxx
@@ -791,10 +791,10 @@ struct qaKFParticle {
       float TOFnSigmaNegKa = 0;
       int source = 0;
 
-      int pidKaonTr1 = selectorKaon.getStatusTrackPIDAll(track1);
-      int pidKaonTr2 = selectorKaon.getStatusTrackPIDAll(track2);
-      int pidPionTr1 = selectorPion.getStatusTrackPIDAll(track1);
-      int pidPionTr2 = selectorPion.getStatusTrackPIDAll(track2);
+      int pidKaonTr1 = selectorKaon.getStatusTrackPIDTpcOrTof(track1);
+      int pidKaonTr2 = selectorKaon.getStatusTrackPIDTpcOrTof(track2);
+      int pidPionTr1 = selectorPion.getStatusTrackPIDTpcOrTof(track1);
+      int pidPionTr2 = selectorPion.getStatusTrackPIDTpcOrTof(track2);
 
       if (track1.isPVContributor() || track2.isPVContributor()) {
         PVContributor = 1;
@@ -1120,10 +1120,10 @@ struct qaKFParticle {
       float TOFnSigmaPosKa = 0;
       float TOFnSigmaNegKa = 0;
 
-      int pidKaonTr1 = selectorKaon.getStatusTrackPIDAll(track1);
-      int pidKaonTr2 = selectorKaon.getStatusTrackPIDAll(track2);
-      int pidPionTr1 = selectorPion.getStatusTrackPIDAll(track1);
-      int pidPionTr2 = selectorPion.getStatusTrackPIDAll(track2);
+      int pidKaonTr1 = selectorKaon.getStatusTrackPIDTpcOrTof(track1);
+      int pidKaonTr2 = selectorKaon.getStatusTrackPIDTpcOrTof(track2);
+      int pidPionTr1 = selectorPion.getStatusTrackPIDTpcOrTof(track1);
+      int pidPionTr2 = selectorPion.getStatusTrackPIDTpcOrTof(track2);
 
       if (track1.isPVContributor() || track2.isPVContributor()) {
         PVContributor = 1;


### PR DESCRIPTION
- Clarify by renaming `getStatusTrackPIDAll` to `getStatusTrackPIDTpcOrTof` and initialising `nSigma..Cond..` to `0` (which means disabled) instead of `±1000` (which means a completely open PID selection)
- Adding the D2H Run2 PID strategy: TpcAndTof or TPC only in case TOF not available (and vice versa when TPC not available) as `getStatusTrackPIDTpcAndTof`

@vkucera, what do you think? 