### PR TITLE
CombinationsFullIndexPolicy in track-v0 task

### DIFF
--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -150,7 +150,7 @@ struct femtoDreamPairTaskTrackV0 {
       trackHistoPartTwo.fillQA(part);
     }
     /// Now build the combinations
-    for (auto& [p1, p2] : combinations(groupPartsOne, groupPartsTwo)) {
+    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
       if (p1.p() > cfgCutTable->get("PartOne", "MaxP") || p1.pt() > cfgCutTable->get("PartOne", "MaxPt")) {
         continue;
       }


### PR DESCRIPTION
Change the Combinations Policy to Full index policy in the same event process function of the pair-track-v0 task.
Note that previously, most of the pairs were lost because of the from index policy.
This change fixes that issue