### PR TITLE
Workaround for triggerBC in apass2/3

### DIFF
--- a/Common/CCDB/macros/upload_trigger_aliases_run3.C
+++ b/Common/CCDB/macros/upload_trigger_aliases_run3.C
@@ -80,7 +80,8 @@ void upload_trigger_aliases_run3()
     // read CTP config
     metadata["runNumber"] = Form("%d", run);
     auto ctpcfg = ccdb.retrieveFromTFileAny<o2::ctp::CTPConfiguration>("CTP/Config/Config", metadata, ts);
-    if (!ctpcfg) continue;
+    if (!ctpcfg)
+      continue;
 
     if (run == 529414) { // adding tolerance to sor for this run
       sor = 1668809980000;
@@ -107,6 +108,6 @@ void upload_trigger_aliases_run3()
       }
     }
     aliases->Print();
-    ccdb.storeAsTFileAny(aliases, "EventSelection/TriggerAliases", metadata, sor, eor+10000); // adding tolerance of 10s to eor
+    ccdb.storeAsTFileAny(aliases, "EventSelection/TriggerAliases", metadata, sor, eor + 10000); // adding tolerance of 10s to eor
   }
 }

--- a/Common/CCDB/macros/upload_trigger_aliases_run3.C
+++ b/Common/CCDB/macros/upload_trigger_aliases_run3.C
@@ -52,13 +52,23 @@ void upload_trigger_aliases_run3()
     runs.push_back(r);
   }
 
+  if (1) {
+    ULong64_t sor = 1543767116001;
+    ULong64_t eor = 1669611662530;
+    TriggerAliases* aliases = new TriggerAliases();
+    metadata["runNumber"] = "default";
+    ccdb.storeAsTFileAny(aliases, "EventSelection/TriggerAliases", metadata, sor, eor);
+  }
+
   for (auto& run : runs) {
     LOGP(info, "run = {}", run);
+    if (run < 519903)
+      continue; // no CTP info
     if (run == 527349)
       continue; // no CTP info
     if (run == 527963)
       continue; // no CTP info
-    if (run <= 528537)
+    if (run == 528537)
       continue; // no CTP info
     if (run == 528543)
       continue; // no CTP info
@@ -70,6 +80,12 @@ void upload_trigger_aliases_run3()
     // read CTP config
     metadata["runNumber"] = Form("%d", run);
     auto ctpcfg = ccdb.retrieveFromTFileAny<o2::ctp::CTPConfiguration>("CTP/Config/Config", metadata, ts);
+    if (!ctpcfg) continue;
+
+    if (run == 529414) { // adding tolerance to sor for this run
+      sor = 1668809980000;
+    }
+
     std::vector<o2::ctp::CTPClass> classes = ctpcfg->getCTPClasses();
     // ctpcfg->printConfigString();
     // create trigger aliases
@@ -91,6 +107,6 @@ void upload_trigger_aliases_run3()
       }
     }
     aliases->Print();
-    ccdb.storeAsTFileAny(aliases, "EventSelection/TriggerAliases", metadata, sor, eor);
+    ccdb.storeAsTFileAny(aliases, "EventSelection/TriggerAliases", metadata, sor, eor+10000); // adding tolerance of 10s to eor
   }
 }

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -34,7 +34,7 @@ struct BcSelectionTask {
   Produces<aod::BcSels> bcsel;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
-  Configurable<int> triggerBcShift{"triggerBcShift", 0, "set to -294 for apass2/apass3 in LHC22o-t"};
+  Configurable<int> confTriggerBcShift{"triggerBcShift", 999, "set to -294 for apass2/apass3 in LHC22o-t"};
 
   void init(InitContext&)
   {
@@ -195,7 +195,12 @@ struct BcSelectionTask {
     for (auto& bc : bcs) {
       mapGlobalBCtoBcId[bc.globalBC()] = bc.globalIndex();
     }
-
+    int triggerBcShift = confTriggerBcShift;
+    if (confTriggerBcShift==999) {
+      int run = bcs.iteratorAt(0).runNumber();
+      triggerBcShift = (run<=526766 || (run>=526886 && run<=527237) || (run>=527259 && run<=527518) || run==527523 || run==527734) ? 0 : -294;
+    }
+    
     for (auto bc : bcs) {
       EventSelectionParams* par = ccdb->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", bc.timestamp());
       TriggerAliases* aliases = ccdb->getForTimeStamp<TriggerAliases>("EventSelection/TriggerAliases", bc.timestamp());

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -34,6 +34,7 @@ struct BcSelectionTask {
   Produces<aod::BcSels> bcsel;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  Configurable<int> triggerBcShift{"triggerBcShift", 0, "set to -294 for apass2/apass3 in LHC22o-t"};
 
   void init(InitContext&)
   {
@@ -201,7 +202,7 @@ struct BcSelectionTask {
       int32_t alias[kNaliases] = {0};
 
       // workaround for pp2022 apass2-apass3 (trigger info is shifted by -294 bcs)
-      int32_t triggerBcId = mapGlobalBCtoBcId[bc.globalBC() - 294];
+      int32_t triggerBcId = mapGlobalBCtoBcId[bc.globalBC() + triggerBcShift];
       if (triggerBcId) {
         auto triggerBc = bcs.iteratorAt(triggerBcId);
         uint64_t triggerMask = triggerBc.triggerMask();

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -196,11 +196,11 @@ struct BcSelectionTask {
       mapGlobalBCtoBcId[bc.globalBC()] = bc.globalIndex();
     }
     int triggerBcShift = confTriggerBcShift;
-    if (confTriggerBcShift==999) {
+    if (confTriggerBcShift == 999) {
       int run = bcs.iteratorAt(0).runNumber();
-      triggerBcShift = (run<=526766 || (run>=526886 && run<=527237) || (run>=527259 && run<=527518) || run==527523 || run==527734) ? 0 : -294;
+      triggerBcShift = (run <= 526766 || (run >= 526886 && run <= 527237) || (run >= 527259 && run <= 527518) || run == 527523 || run == 527734) ? 0 : -294;
     }
-    
+
     for (auto bc : bcs) {
       EventSelectionParams* par = ccdb->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", bc.timestamp());
       TriggerAliases* aliases = ccdb->getForTimeStamp<TriggerAliases>("EventSelection/TriggerAliases", bc.timestamp());

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -28,7 +28,7 @@ using namespace evsel;
 using BCsRun2 = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps, aod::BcSels, aod::Run2MatchedToBCSparse>;
 using BCsRun3 = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels, aod::Run3MatchedToBCSparse>;
 using ColEvSels = soa::Join<aod::Collisions, aod::EvSels>;
-
+using FullTracksIU = soa::Join<aod::TracksIU, aod::TracksExtra>;
 struct EventSelectionQaTask {
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Configurable<int> nGlobalBCs{"nGlobalBCs", 100000, "number of global bcs"};
@@ -450,12 +450,12 @@ struct EventSelectionQaTask {
   }
   PROCESS_SWITCH(EventSelectionQaTask, processRun2, "Process Run2 event selection QA", true);
 
-  Preslice<aod::FullTracks> perCollision = aod::track::collisionId;
+  Preslice<FullTracksIU> perCollision = aod::track::collisionId;
   Preslice<ColEvSels> perFoundBC = aod::evsel::foundBCId;
 
   void processRun3(
     ColEvSels const& cols,
-    aod::FullTracks const& tracks,
+    FullTracksIU const& tracks,
     aod::AmbiguousTracks const& ambTracks,
     BCsRun3 const& bcs,
     aod::Zdcs const& zdcs,


### PR DESCRIPTION
* Workaround for triggerBC in apass2/3 (shifted by -294 bcs)
* Use TracksIU instead of Tracks in the evselQA
* latest macro for uploads of trigger aliases