### PR TITLE
[EMCAL-689] Add seperate A- and C-Side E/p plots

### DIFF
--- a/PWGJE/Tasks/emctmmonitor.cxx
+++ b/PWGJE/Tasks/emctmmonitor.cxx
@@ -144,7 +144,11 @@ struct TrackMatchingMonitor {
     mHistManager.add("clusterTM_EoverP_Pt", "E/p vs track pT", o2HistType::kTH3F, {eoverpAxis, trackptAxis, nmatchedtrack});                                                              // E/p vs track pT for the Nth closest track
     mHistManager.add("clusterTM_EvsP", "cluster E/track p", o2HistType::kTH3F, {energyAxis, trackpAxis, nmatchedtrack});                                                                  // E vs p for the Nth closest track
     mHistManager.add("clusterTM_EoverP_electron", "cluster E/electron p", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                                    // E over p vs track pT for the Nth closest electron/positron track
-    mHistManager.add("clusterTM_EoverP_hadron", "cluster E/hadron p)", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                                       // E over p vs track pT for the Nth closest hadron track
+    mHistManager.add("clusterTM_EoverP_electron_ASide", "cluster E/electron p in A-Side", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                    // E over p vs track pT for the Nth closest electron/positron track in A-Side
+    mHistManager.add("clusterTM_EoverP_electron_CSide", "cluster E/electron p in C-Side", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                    // E over p vs track pT for the Nth closest electron/positron track in C-Side
+    mHistManager.add("clusterTM_EoverP_hadron", "cluster E/hadron p", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                                        // E over p vs track pT for the Nth closest hadron track
+    mHistManager.add("clusterTM_EoverP_hadron_ASide", "cluster E/hadron p in A-Side", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                        // E over p vs track pT for the Nth closest hadron track in A-Side
+    mHistManager.add("clusterTM_EoverP_hadron_CSide", "cluster E/hadron p in C-Side", o2HistType::kTH3F, {eoverpAxis, trackpAxis, nmatchedtrack});                                        // E over p vs track pT for the Nth closest hadron track in C-Side
 
     if (mVetoBCID->length()) {
       std::stringstream parser(mVetoBCID.value);
@@ -304,11 +308,21 @@ struct TrackMatchingMonitor {
         if (match.track_as<tracksPID>().tpcNSigmaEl() >= tpcNsigmaElectron->at(0) && match.track_as<tracksPID>().tpcNSigmaEl() <= tpcNsigmaElectron->at(1)) {                 // E/p for e+/e-
           if (usePionRejection && (match.track_as<tracksPID>().tpcNSigmaPi() <= tpcNsigmaPion->at(0) || match.track_as<tracksPID>().tpcNSigmaPi() >= tpcNsigmaPion->at(1))) { // with pion rejection
             mHistManager.fill(HIST("clusterTM_EoverP_electron"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            if (match.track_as<tracksPID>().eta() >= 0.) {
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_ASide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            } else {
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_CSide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            }
           } else {
             mHistManager.fill(HIST("clusterTM_EoverP_electron"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
           }
         } else if (match.track_as<tracksPID>().tpcNSigmaEl() >= tpcNsigmaBack->at(0) && match.track_as<tracksPID>().tpcNSigmaEl() >= tpcNsigmaBack->at(1)) { // E/p for hadrons / background
           mHistManager.fill(HIST("clusterTM_EoverP_hadron"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+          if (match.track_as<tracksPID>().eta() >= 0.) {
+            mHistManager.fill(HIST("clusterTM_EoverP_hadron_ASide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+          } else {
+            mHistManager.fill(HIST("clusterTM_EoverP_hadron_CSide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+          }
         }
         if ((fabs(dEta) <= 0.01 + pow(match.track_as<tracksPID>().pt() + 4.07, -2.5)) &&
             (fabs(dPhi) <= 0.015 + pow(match.track_as<tracksPID>().pt() + 3.65, -2.)) &&


### PR DESCRIPTION
- Add electron and background A- and C-Side E/p plots to investigate A-/C-Side dependencies we currently see in Run3