### PR TITLE
Remove direct slicer uses

### DIFF
--- a/PWGCF/Tasks/correlations.cxx
+++ b/PWGCF/Tasks/correlations.cxx
@@ -13,7 +13,6 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include <CCDB/BasicCCDBManager.h>
-#include "Framework/GroupSlicer.h"
 #include "Framework/StepTHn.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/RunningWorkflowInfo.h"

--- a/PWGHF/HFC/Tasks/taskFlow.cxx
+++ b/PWGHF/HFC/Tasks/taskFlow.cxx
@@ -18,7 +18,6 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "CCDB/BasicCCDBManager.h"
-#include "Framework/GroupSlicer.h"
 #include "Framework/StepTHn.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/RunningWorkflowInfo.h"


### PR DESCRIPTION
This removes direct usage of `GroupSlicer` class in favor of `Preslice` declaration. Framework mechanisms for grouping will be updated to use caches and thus reduce time used for table slicing, however it will make direct usage of `GroupSlicer` more complicated and invalidate the current code. 

This _should_ produce identical behavior, however, the people responsible for this particular code should validate the change. This also will improve performance of the relevant tasks slightly. 