### PR TITLE
[EMCAL-903] Update gamma/jet trigger and EMCAL observables in jet finder

### DIFF
--- a/EventFiltering/PWGJE/fullJetFilter.cxx
+++ b/EventFiltering/PWGJE/fullJetFilter.cxx
@@ -16,6 +16,7 @@
 #include <string>
 #include <TMath.h>
 
+#include "EMCALBase/Geometry.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -42,10 +43,19 @@ using filteredJets = o2::soa::Filtered<o2::aod::Jets>;
 
 struct fullJetFilter {
   enum {
-    kJetFullHighPt = 0,
+    kEMCALReadout = 0,
+    kJetFullHighPt,
+    kJetNeutralHighPt,
     kGammaHighPtEMCAL,
     kGammaHighPtDCAL,
+    kGammaLowPtEMCAL,
+    kGammaLowPtDCAL,
     kCategories
+  };
+
+  enum class ThresholdType_t {
+    HIGH_THRESHOLD,
+    LOW_THRESHOLD
   };
 
   Produces<aod::FullJetFilters> tags;
@@ -63,13 +73,25 @@ struct fullJetFilter {
   OutputObj<TH2F> hSelectedGammaEMCALPtPhi{"hSelectedGammaEMCALPhi"};
   OutputObj<TH2F> hSelectedGammaDCALPtEta{"hSelectedGammaDCALEta"};
   OutputObj<TH2F> hSelectedGammaDCALPtPhi{"hSelectedGammaDCALPhi"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtEtaLow{"hSelectedGammaEMCALEtaLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtPhiLow{"hSelectedGammaEMCALPhiLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtEtaLow{"hSelectedGammaDCALEtaLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtPhiLow{"hSelectedGammaDCALPhiLow"};
 
   // Configurables
   Configurable<float> f_jetPtMin{"f_jetPtMin", 0.0, "minimum jet pT cut"};
   Configurable<float> f_clusterPtMin{"f_clusterPtMin", 0.0, "minimum cluster pT cut"};
   Configurable<double> f_jetR{"f_jetR", 0.2, "jet R to trigger on"};
-  Configurable<float> f_gammaPtMinEMCAL{"f_gammaPtMinEMCAL", 4.0, "minimum gamma pT cut in EMCAL"};
-  Configurable<float> f_gammaPtMinDCAL{"f_gammaPtMinDCAL", 4.0, "minimum gamma pT cut in DCAL"};
+  Configurable<int> f_JetType{"f_JetType", 0, "Jet type used for the selection (0 - full jets, 1 - neutral jets)"};
+  Configurable<int> f_ObservalbeGammaTrigger{"fObservableGammaTrigger", 0, "Observable for the gamma trigger (0 - Energy, 1 - pt)"};
+  Configurable<bool> b_PublishReadoutTrigger{"b_publishReadoutTrigger", false, "Publish EMCAL readout status as trigger flag"};
+  Configurable<bool> b_PublishNeutralJetTrigger{"b_publishNeutralJetTrigger", false, "Publish trigger on neutral jets"};
+  Configurable<float> f_gammaPtMinEMCALHigh{"f_gammaPtMinEMCALHigh", 4.0, "minimum gamma pT cut in EMCAL high threshold"};
+  Configurable<float> f_gammaPtMinEMCALLow{"f_gammaPtMinEMCALLow", 1.5, "minimum gamma pT cut in EMCAL low threshold"};
+  Configurable<float> f_gammaPtMinDCALHigh{"f_gammaPtMinDCALHigh", 4.0, "minimum gamma pT cut in DCAL high threshold"};
+  Configurable<float> f_gammaPtMinDCALLow{"f_gammaPtMinDCALLow", 1.5, "minimum gamma pT cut in DCAL low threshold"};
+  Configurable<float> f_minClusterTime{"f_minClusterTime", -999, "Min. cluster time for gamma trigger (ns)"};
+  Configurable<float> f_maxClusterTime{"f_maxClusterTime", 999, "Max. cluster time for gamma trigger (ns)"};
   Configurable<float> f_PhiEmcalOrDcal{"f_PhiEmcalOrDcal", 4, "if cluster phi is less than this value, count it to be EMCAL"};
 
   Configurable<std::string> mClusterDefinition{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
@@ -77,9 +99,11 @@ struct fullJetFilter {
   Configurable<bool> b_doGammaTrigger{"b_doGammaTrigger", true, "run the gamma trigger"};
   Configurable<bool> b_IgnoreEmcalFlag{"b_IgnoreEmcalFlag", false, "ignore the EMCAL live flag check"};
   Configurable<bool> b_DoFiducialCut{"b_DoFiducialCut", false, "do a fiducial cut on jets to check if they are in the emcal"};
+  Configurable<bool> b_RejectExoticClusters{"b_RejectExoticClusters", true, "Reject exotic clusters"};
 
   void init(o2::framework::InitContext&)
   {
+
     // Bins here
     Int_t nPtBins = 200;
     Float_t kMinPt = 0.;
@@ -93,18 +117,33 @@ struct fullJetFilter {
 
     hProcessedEvents.setObject(new TH1I("hProcessedEvents", ";;Number of filtered events", kCategories, -0.5, kCategories - 0.5));
 
-    hEmcClusterPtEta.setObject(new TH2F("hEmcClusterPtEta", "Emc Clusters;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hEmcClusterPtPhi.setObject(new TH2F("hEmcClusterPtPhi", "Emc Clusters;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedClusterPtEta.setObject(new TH2F("hSelectedClusterPtEta", "Selected Clusters;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedClusterPtPhi.setObject(new TH2F("hSelectedClusterPtPhi", "Selected Clusters;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hEmcClusterPtEta.setObject(new TH2F("hEmcClusterPtEta", Form("Emc Clusters;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hEmcClusterPtPhi.setObject(new TH2F("hEmcClusterPtPhi", Form("Emc Clusters;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedClusterPtEta.setObject(new TH2F("hSelectedClusterPtEta", Form("Selected Clusters;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedClusterPtPhi.setObject(new TH2F("hSelectedClusterPtPhi", Form("Selected Clusters;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hEmcJetPtEta.setObject(new TH2F("hEmcJetPtEta", "Emc Jets;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hEmcJetPtPhi.setObject(new TH2F("hEmcJetPtPhi", "Emc Jets;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedJetPtEta.setObject(new TH2F("hSelectedJetPtEta", "Selected Jets;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hSelectedJetPtPhi.setObject(new TH2F("hSelectedJetPtPhi", "Selected Jets;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaEMCALPtEta.setObject(new TH2F("hSelectedGammaEMCALPtEta", "Selected Gammas EMCAL;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedGammaEMCALPtPhi.setObject(new TH2F("hSelectedGammaEMCALPtPhi", "Selected Gammas EMCAL;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaDCALPtEta.setObject(new TH2F("hSelectedGammaDCALPtEta", "Selected Gammas DCAL;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedGammaDCALPtPhi.setObject(new TH2F("hSelectedGammaDCALPtPhi", "Selected Gammas DCAL;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEta.setObject(new TH2F("hSelectedGammaEMCALPtEta", Form("Selected Gammas EMCAL;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhi.setObject(new TH2F("hSelectedGammaEMCALPtPhi", Form("Selected Gammas EMCAL;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEta.setObject(new TH2F("hSelectedGammaDCALPtEta", Form("Selected Gammas DCAL;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhi.setObject(new TH2F("hSelectedGammaDCALPtPhi", Form("Selected Gammas DCAL;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaLow.setObject(new TH2F("hSelectedGammaEMCALPtEtaLow", Form("Selected Gammas EMCAL (low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhiLow.setObject(new TH2F("hSelectedGammaEMCALPtPhiLow", Form("Selected Gammas EMCAL (low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaLow.setObject(new TH2F("hSelectedGammaDCALPtEtaLow", Form("Selected Gammas DCAL (low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhiLow.setObject(new TH2F("hSelectedGammaDCALPtPhiLow", Form("Selected Gammas DCAL (low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+
+    LOG(info) << "Jet trigger: " << (b_doJetTrigger ? "on" : "off");
+    LOG(info) << "Gamma trigger: " << (b_doJetTrigger ? "on" : "off");
+    LOG(info) << "Thresholds gamma trigger: EG1 " << f_gammaPtMinEMCALHigh << " GeV, DG1 " << f_gammaPtMinDCALHigh << " GeV, EG2 " << f_gammaPtMinEMCALLow << " GeV, DG2 " << f_gammaPtMinDCALLow << " GeV";
+    LOG(info) << "Gamma trigger observable: " << (f_ObservalbeGammaTrigger == 0 ? "Energy" : "pt");
+    LOG(info) << "Jet trigger: Type: " << (f_JetType == 0 ? "Full jets" : "Neutral jets") << ", R: " << f_jetR << ", pt > " << f_jetPtMin << " cluster(" << f_clusterPtMin << ")";
+    LOG(info) << "Ignore EMCAL flag: " << (b_IgnoreEmcalFlag ? "yes" : "no");
+    LOG(info) << "Publishing neutral jet trigger: " << (b_PublishNeutralJetTrigger ? "yes" : "no");
+    LOG(info) << "Publishing EMCAL trigger: " << (b_PublishReadoutTrigger ? "yes" : "no");
+    LOG(info) << "Cluster time: " << f_minClusterTime << " ns < t < " << f_maxClusterTime << "ns";
+    LOG(info) << "Exotics rejection: " << (b_RejectExoticClusters ? "yes" : "no");
   } // init()
 
   // Declare filters
@@ -130,17 +169,40 @@ struct fullJetFilter {
     return false;
   }
 
-  Bool_t isEvtSelectedGammaEMCAL(double const& gammapt)
+  Bool_t isEvtSelectedGamma(double const& gammapt, o2::emcal::AcceptanceType_t subdet, ThresholdType_t thresholdt)
   {
-    if (gammapt > f_gammaPtMinEMCAL) {
-      return true;
+    float threshold = 0;
+    switch (subdet) {
+      case o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE: {
+        switch (thresholdt) {
+          case ThresholdType_t::HIGH_THRESHOLD: {
+            threshold = f_gammaPtMinEMCALHigh;
+            break;
+          }
+          case ThresholdType_t::LOW_THRESHOLD: {
+            threshold = f_gammaPtMinEMCALLow;
+            break;
+          }
+        }
+        break;
+      }
+      case o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE: {
+        switch (thresholdt) {
+          case ThresholdType_t::HIGH_THRESHOLD: {
+            threshold = f_gammaPtMinDCALHigh;
+            break;
+          }
+          case ThresholdType_t::LOW_THRESHOLD: {
+            threshold = f_gammaPtMinDCALLow;
+            break;
+          }
+        }
+        break;
+      }
+      case o2::emcal::AcceptanceType_t::NON_ACCEPTANCE:
+        return false;
     }
-    return false;
-  }
-
-  Bool_t isEvtSelectedGammaDCAL(double const& gammapt)
-  {
-    if (gammapt > f_gammaPtMinDCAL) {
+    if (gammapt > threshold) {
       return true;
     }
     return false;
@@ -148,7 +210,7 @@ struct fullJetFilter {
 
   Bool_t isClusterInEmcal(selectedClusters::iterator const& cluster)
   {
-    if (cluster.phi() < f_PhiEmcalOrDcal) {
+    if (TVector2::Phi_0_2pi(cluster.phi()) < f_PhiEmcalOrDcal) {
       return true;
     }
     return false;
@@ -157,11 +219,15 @@ struct fullJetFilter {
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, filteredJets const& jets, selectedClusters const& clusters)
   {
     bool keepEvent[kCategories]{false};
-    double maxClusterPtEMCAL = -1., maxClusterPtDCAL = -1., maxSelectedJetPt = -1.;
+    double maxClusterObservableEMCAL = -1., maxClusterObservableDCAL = -1., maxSelectedJetPt = -1.;
 
-    if (!collision.alias()[kTVXinEMC] && !b_IgnoreEmcalFlag) {
-      tags(keepEvent[0], keepEvent[1], keepEvent[2]);
+    if (!b_IgnoreEmcalFlag && !collision.alias()[kTVXinEMC]) {
+      tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6]);
       return; // Skip events where EMCAL is not live
+    }
+
+    if (b_PublishReadoutTrigger && collision.alias()[kTVXinEMC]) {
+      keepEvent[kEMCALReadout] = true;
     }
 
     if (b_doJetTrigger) {
@@ -180,7 +246,7 @@ struct fullJetFilter {
         }
       }
       if (isEvtSelected(maxSelectedJetPt)) {
-        keepEvent[kJetFullHighPt] = true;
+        keepEvent[f_JetType == 0 ? kJetFullHighPt : kJetNeutralHighPt] = true;
         for (const auto& jet : jets) {
           if (isJetInEmcal(jet)) {
             hSelectedJetPtEta->Fill(jet.pt(), jet.eta());
@@ -196,30 +262,42 @@ struct fullJetFilter {
     }
 
     if (b_doGammaTrigger) {
+      static constexpr std::array<ThresholdType_t, 2> thresholds = {{ThresholdType_t::HIGH_THRESHOLD, ThresholdType_t::LOW_THRESHOLD}};
+      static constexpr std::array<o2::emcal::AcceptanceType_t, 2> subdets = {{o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE, o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE}};
+      std::array<TH2*, 4> acceptanceHistsPtEta{{hSelectedGammaEMCALPtEta.object.get(), hSelectedGammaDCALPtEta.object.get(), hSelectedGammaEMCALPtEtaLow.object.get(), hSelectedGammaDCALPtEtaLow.object.get()}},
+        acceptanceHistsPtPhi{{hSelectedGammaEMCALPtPhi.object.get(), hSelectedGammaDCALPtPhi.object.get(), hSelectedGammaEMCALPtPhiLow.object.get(), hSelectedGammaDCALPtPhiLow.object.get()}};
+      struct ClusterData {
+        float mTriggerObservable;
+        float mEta;
+        float mPhi;
+      };
+      std::vector<ClusterData> analysedClusters;
       for (const auto& cluster : clusters) {
-        double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-        if (cluster.phi() < 4 && clusterPt > maxClusterPtEMCAL) {
-          maxClusterPtEMCAL = clusterPt;
-        } else if (cluster.phi() > 4 && clusterPt > maxClusterPtDCAL) {
-          maxClusterPtDCAL = clusterPt;
+        if (b_RejectExoticClusters && cluster.isExotic()) {
+          continue;
         }
-        hEmcClusterPtEta->Fill(clusterPt, cluster.eta());
-        hEmcClusterPtPhi->Fill(clusterPt, cluster.phi());
-      }
-      if (isEvtSelectedGammaEMCAL(maxClusterPtEMCAL)) {
-        keepEvent[kGammaHighPtEMCAL] = true;
-        for (const auto& cluster : clusters) {
-          double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-          hSelectedGammaEMCALPtEta->Fill(clusterPt, cluster.eta());
-          hSelectedGammaEMCALPtPhi->Fill(clusterPt, cluster.phi());
+        if (cluster.time() < f_minClusterTime || cluster.time() > f_maxClusterTime) {
+          continue;
         }
+        double observableGamma = (f_ObservalbeGammaTrigger == 0) ? cluster.energy() : cluster.energy() / std::cosh(cluster.eta());
+        if (TVector2::Phi_0_2pi(cluster.phi()) < 4 && observableGamma > maxClusterObservableEMCAL) {
+          maxClusterObservableEMCAL = observableGamma;
+        } else if (TVector2::Phi_0_2pi(cluster.phi()) > 4 && observableGamma > maxClusterObservableDCAL) {
+          maxClusterObservableDCAL = observableGamma;
+        }
+        hEmcClusterPtEta->Fill(observableGamma, cluster.eta());
+        hEmcClusterPtPhi->Fill(observableGamma, cluster.phi());
+        analysedClusters.push_back({static_cast<float>(observableGamma), cluster.eta(), cluster.phi()});
       }
-      if (isEvtSelectedGammaDCAL(maxClusterPtDCAL)) {
-        keepEvent[kGammaHighPtDCAL] = true;
-        for (const auto& cluster : clusters) {
-          double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-          hSelectedGammaDCALPtEta->Fill(clusterPt, cluster.eta());
-          hSelectedGammaDCALPtPhi->Fill(clusterPt, cluster.phi());
+      for (int ithreshold = 0; ithreshold < thresholds.size(); ithreshold++) {
+        for (int isubdet = 0; isubdet < subdets.size(); isubdet++) {
+          if (isEvtSelectedGamma(subdets[isubdet] == o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE ? maxClusterObservableEMCAL : maxClusterObservableDCAL, subdets[isubdet], thresholds[ithreshold])) {
+            keepEvent[kGammaHighPtEMCAL + ithreshold * subdets.size() + isubdet] = true;
+            for (auto& cluster : analysedClusters) {
+              acceptanceHistsPtEta[ithreshold * subdets.size() + isubdet]->Fill(cluster.mTriggerObservable, cluster.mEta);
+              acceptanceHistsPtPhi[ithreshold * subdets.size() + isubdet]->Fill(cluster.mTriggerObservable, cluster.mPhi);
+            }
+          }
         }
       }
     }
@@ -229,7 +307,7 @@ struct fullJetFilter {
         hProcessedEvents->Fill(iDecision);
       }
     }
-    tags(keepEvent[0], keepEvent[1], keepEvent[2]);
+    tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6]);
   } // process()
 };
 

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -64,9 +64,13 @@ DECLARE_SOA_COLUMN(LLL, hasLLL, bool); //! has L-L-L tripletD
 DECLARE_SOA_COLUMN(JetChHighPt, hasJetChHighPt, bool); //! high-pT charged jet
 
 // full jets
+DECLARE_SOA_COLUMN(EMCALReadout, hasEMCALinReadout, bool);       //! EMCAL readout
 DECLARE_SOA_COLUMN(JetFullHighPt, hasJetFullHighPt, bool);       //! high-pT full jet
-DECLARE_SOA_COLUMN(GammaHighPtEMCAL, hasGammaHighPtEMCAL, bool); //! high-pT photon in EMCAL
-DECLARE_SOA_COLUMN(GammaHighPtDCAL, hasGammaHighPtDCAL, bool);   //! high-pT photon in DCAL
+DECLARE_SOA_COLUMN(JetNeutralHighPt, hasJetNeutralHighPt, bool); //! high-pT neutral jet
+DECLARE_SOA_COLUMN(GammaHighPtEMCAL, hasGammaHighPtEMCAL, bool); //! Photon trigger in EMCAL, high threshold
+DECLARE_SOA_COLUMN(GammaHighPtDCAL, hasGammaHighPtDCAL, bool);   //! Photon trigger in DCAL, high threshold
+DECLARE_SOA_COLUMN(GammaLowPtEMCAL, hasGammaLowPtEMCAL, bool);   //! Photon trigger in EMCAL, low threshold
+DECLARE_SOA_COLUMN(GammaLowPtDCAL, hasGammaLowPtDCAL, bool);     //! Photon trigger in DCAL, low threshold
 
 // strangeness (lf)
 DECLARE_SOA_COLUMN(Omega, hasOmega, bool);             //! at leat 1 Omega
@@ -148,7 +152,7 @@ DECLARE_SOA_TABLE(JetFilters, "AOD", "JetFilters", //!
 using JetFilter = JetFilters::iterator;
 
 DECLARE_SOA_TABLE(FullJetFilters, "AOD", "FullJetFilters", //!
-                  filtering::JetFullHighPt, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL);
+                  filtering::EMCALReadout, filtering::JetFullHighPt, filtering::JetNeutralHighPt, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL, filtering::GammaLowPtEMCAL, filtering::GammaLowPtDCAL);
 
 using FullJetFilter = FullJetFilters::iterator;
 

--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -75,6 +75,10 @@ struct JetFinderTask {
   Configurable<float> clusterEtaCut{"clusterEtaCut", 0.7, "cluster eta cut"}; // For ECMAL: |eta| < 0.7, phi = 1.40 - 3.26
   Configurable<float> clusterPhiMinCut{"clusterPhiMinCut", -999, "cluster min phi cut"};
   Configurable<float> clusterPhiMaxCut{"clusterPhiMaxCut", 999, "cluster max phi cut"};
+  Configurable<float> clusterMinEnergy{"clusterMinEnergyCut", 0.5, "Min. cluster energy in EMCAL (GeV)"};
+  Configurable<float> clusterMinTime{"clusterMinTime", -999., "Min. Cluster time (ns)"};
+  Configurable<float> clusterMaxTime{"clusterMaxTime", 999., "Max. Cluster time (ns)"};
+  Configurable<bool> clusterRejectExotics{"clusterRejectExotics", true, "Reject exotic clusters"};
   Configurable<bool> DoRhoAreaSub{"DoRhoAreaSub", false, "do rho area subtraction"};
   Configurable<bool> DoConstSub{"DoConstSub", false, "do constituent subtraction"};
   Configurable<float> jetPtMin{"jetPtMin", 10.0, "minimum jet pT"};
@@ -92,7 +96,7 @@ struct JetFinderTask {
 
   o2::aod::EMCALClusterDefinition clusDef = o2::aod::emcalcluster::getClusterDefinitionFromString(mClusterDefinition.value);
   // Filter clusterDefinitionSelection = o2::aod::emcalcluster::definition == static_cast<int>(clusDef);
-  Filter clusterFilter = (o2::aod::emcalcluster::definition == static_cast<int>(clusDef)) && (nabs(aod::emcalcluster::eta) < clusterEtaCut) && (aod::emcalcluster::phi > clusterPhiMinCut) && (aod::emcalcluster::phi < clusterPhiMaxCut);
+  Filter clusterFilter = (o2::aod::emcalcluster::definition == static_cast<int>(clusDef)) && (nabs(aod::emcalcluster::eta) < clusterEtaCut) && (aod::emcalcluster::phi > clusterPhiMinCut) && (aod::emcalcluster::phi < clusterPhiMaxCut) && (aod::emcalcluster::energy >= clusterMinEnergy) && (aod::emcalcluster::time > clusterMinTime) && (aod::emcalcluster::time < clusterMaxTime) && (clusterRejectExotics && aod::emcalcluster::isExotic != true);
 
   std::vector<fastjet::PseudoJet> jets;
   std::vector<fastjet::PseudoJet> inputParticles;

--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -74,6 +74,12 @@ struct JetTriggerQA {
   OutputObj<TH3F> hSelectedClusterMaxPtEtaPhi{"hSelectedClusterMaxPtEtaPhi"};
   OutputObj<TH2F> hSelectedClusterMaxPtEta{"hSelectedClusterMaxPtEta"};
   OutputObj<TH2F> hSelectedClusterMaxPtPhi{"hSelectedClusterMaxPtPhi"};
+  OutputObj<TH2F> hSelectedClusterPtEtaLow{"hSelectedClusterPtEtaLow"};
+  OutputObj<TH2F> hSelectedClusterPtPhiLow{"hSelectedClusterPtPhiLow"};
+  OutputObj<TH3F> hSelectedClusterPtEtaPhiLow{"hSelectedClusterPtEtaPhiLow"};
+  OutputObj<TH3F> hSelectedClusterMaxPtEtaPhiLow{"hSelectedClusterMaxPtEtaPhiLow"};
+  OutputObj<TH2F> hSelectedClusterMaxPtEtaLow{"hSelectedClusterMaxPtEtaLow"};
+  OutputObj<TH2F> hSelectedClusterMaxPtPhiLow{"hSelectedClusterMaxPtPhiLow"};
   OutputObj<TH3F> hSelectedJetRPtTrackPt{"hSelectedJetRPtTrackPt"};
   OutputObj<TH3F> hSelectedJetRPtClusterPt{"hSelectedJetRPtClusterPt"};
   OutputObj<TH3F> hSelectedJetRPtPtd{"hSelectedJetRPtPtd"};
@@ -88,11 +94,29 @@ struct JetTriggerQA {
   OutputObj<TH2F> hSelectedGammaEMCALPtPhi{"hSelectedGammaEMCALPtPhi"};
   OutputObj<TH2F> hSelectedGammaEMCALMaxPtEta{"hSelectedGammaEMCALMaxPtEta"};
   OutputObj<TH2F> hSelectedGammaEMCALMaxPtPhi{"hSelectedGammaEMCALMaxPtPhi"};
+  OutputObj<TH2F> hSelectedGammaDCALPtEta{"hSelectedGammaDCALPtEta"};
+  OutputObj<TH2F> hSelectedGammaDCALPtPhi{"hSelectedGammaDCALPtPhi"};
+  OutputObj<TH2F> hSelectedGammaDCALMaxPtEta{"hSelectedGammaDCALMaxPtEta"};
+  OutputObj<TH2F> hSelectedGammaDCALMaxPtPhi{"hSelectedGammaDCALMaxPtPhi"};
 
   OutputObj<TH3F> hSelectedGammaEMCALPtEtaPhi{"hSelectedGammaEMCALPtEtaPhi"};
   OutputObj<TH3F> hSelectedGammaEMCALMaxPtEtaPhi{"hSelectedGammaEMCALMaxPtEtaPhi"};
   OutputObj<TH3F> hSelectedGammaDCALPtEtaPhi{"hSelectedGammaDCALPtEtaPhi"};
   OutputObj<TH3F> hSelectedGammaDCALMaxPtEtaPhi{"hSelectedGammaDCALMaxPtEtaPhi"};
+
+  OutputObj<TH2F> hSelectedGammaEMCALPtEtaLow{"hSelectedGammaEMCALPtEtaLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtPhiLow{"hSelectedGammaEMCALPtPhiLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALMaxPtEtaLow{"hSelectedGammaEMCALMaxPtEtaLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALMaxPtPhiLow{"hSelectedGammaEMCALMaxPtPhiLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtEtaLow{"hSelectedGammaDCALPtEtaLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtPhiLow{"hSelectedGammaDCALPtPhiLow"};
+  OutputObj<TH2F> hSelectedGammaDCALMaxPtEtaLow{"hSelectedGammaDCALMaxPtEtaLow"};
+  OutputObj<TH2F> hSelectedGammaDCALMaxPtPhiLow{"hSelectedGammaDCALMaxPtPhiLow"};
+
+  OutputObj<TH3F> hSelectedGammaEMCALPtEtaPhiLow{"hSelectedGammaEMCALPtEtaPhiLow"};
+  OutputObj<TH3F> hSelectedGammaEMCALMaxPtEtaPhiLow{"hSelectedGammaEMCALMaxPtEtaPhiLow"};
+  OutputObj<TH3F> hSelectedGammaDCALPtEtaPhiLow{"hSelectedGammaDCALPtEtaPhiLow"};
+  OutputObj<TH3F> hSelectedGammaDCALMaxPtEtaPhiLow{"hSelectedGammaDCALMaxPtEtaPhiLow"};
 
   OutputObj<TH3F> hJetRMaxPtJetPt{"hJetRMaxPtJetPt"};
   OutputObj<TH3F> hJetRMaxPtJetPtNoFiducial{"hJetRMaxPtJetPtNoFiducial"};
@@ -104,11 +128,15 @@ struct JetTriggerQA {
   Configurable<float> f_SD_beta{"f_SD_beta", 0.0, "soft drop beta"};
   Configurable<float> f_jetR{"f_jetR", 0.4, "jet resolution parameter that you have triggered on"};
   Configurable<float> f_PhiEmcalOrDcal{"f_PhiEmcalOrDcal", 4, "if cluster phi is less than this value, count it to be EMCAL"};
+  Configurable<float> f_minClusterTime{"f_minClusterTime", -999, "Min. cluster time for gamma trigger (ns)"};
+  Configurable<float> f_maxClusterTime{"f_maxClusterTime", 999, "Max. cluster time for gamma trigger (ns)"};
   Configurable<std::vector<float>> f_ang_kappa{"f_ang_kappa", {1.0, 1.0, 2.0}, "angularity momentum exponent"};
   Configurable<std::vector<float>> f_ang_alpha{"f_ang_alpha", {1.0, 2.0, 1.0}, "angularity angle exponent"};
   Configurable<bool> b_JetsInEmcalOnly{"b_JetsInEmcalOnly", true, "fill histograms only for jets inside the EMCAL"};
   Configurable<bool> b_IgnoreEmcalFlag{"b_IgnoreEmcalFlag", false, "ignore the EMCAL live flag check"};
   Configurable<bool> b_DoFiducialCut{"b_DoFiducialCut", false, "do a fiducial cut on jets to check if they are in the emcal"};
+  Configurable<bool> b_RejectExoticClusters{"b_RejectExoticClusters", true, "Reject exotic clusters"};
+  Configurable<int> f_GammaObservable{"f_gammaObservable", 0, "Observable for gamma trigger (0 - energy, 1 - pt)"};
 
   Configurable<float> cfgVertexCut{"cfgVertexCut", 10.0f, "Accepted z-vertex range"};
   Configurable<std::string> mClusterDefinition{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
@@ -152,28 +180,37 @@ struct JetTriggerQA {
     registry.add("jetRPtEtaPhiNoFiducial", "JetRPtEtaPhiNoFiducial", hJetRPtEtaPhiNoFiducial);
     registry.add("jetRMaxPtEtaPhiNoFiducial", "JetRMaxPtEtaPhiNoFiducial", hJetRMaxPtEtaPhiNoFiducial);
 
-    hProcessedEvents.setObject(new TH1I("hProcessedEvents", "Processed events", 8, -0.5, 7.5));
+    hProcessedEvents.setObject(new TH1I("hProcessedEvents", "Processed events", 14, -0.5, 13.5));
     hProcessedEvents->GetXaxis()->SetBinLabel(1, "MB");
     hProcessedEvents->GetXaxis()->SetBinLabel(2, "EMC");
-    hProcessedEvents->GetXaxis()->SetBinLabel(3, "Selected Jet");
-    hProcessedEvents->GetXaxis()->SetBinLabel(4, "Selected Gamma EMCAL");
-    hProcessedEvents->GetXaxis()->SetBinLabel(5, "Selected Gamma DCAL");
-    hProcessedEvents->GetXaxis()->SetBinLabel(6, "Selected Jet and Gamma EMCAL");
-    hProcessedEvents->GetXaxis()->SetBinLabel(7, "Selected Jet and Gamma DCAL");
-    hProcessedEvents->GetXaxis()->SetBinLabel(8, "Selected Gamma EMCAL and Gamma DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(3, "Selected Full Jet");
+    hProcessedEvents->GetXaxis()->SetBinLabel(4, "Selected Neutral Jet");
+    hProcessedEvents->GetXaxis()->SetBinLabel(5, "Selected Gamma high EMCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(6, "Selected Gamma high DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(7, "Selected Gamma low EMCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(8, "Selected Gamma low DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(9, "Selected full jet and Gamma high EMCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(10, "Selected full jet and Gamma high DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(11, "Selected neutral jet and Gamma high EMCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(12, "Selected neutral jet and Gamma high DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(13, "Selected Gamma high EMCAL and high Gamma DCAL");
+    hProcessedEvents->GetXaxis()->SetBinLabel(14, "Selected full jet and neutral jet");
 
     // Histograms for events where the EMCAL is live
+    std::string observableName = (f_GammaObservable == 0) ? "Energy" : "#it{p}_{T}",
+                observableAxisTitle = (f_GammaObservable == 0) ? "E (GeV)" : "#it{p}_{T} (GeV/c)",
+                observableAxisTitleMax = (f_GammaObservable == 0) ? "E^{max} (GeV)" : "#it{p}_{T}^{max} (GeV/c)";
     hJetRPtEta.setObject(new TH3F("hJetRPtEta", "Jets #it{p}_{T} and #eta;#it{R};#it{p}_{T};#eta", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hJetRPtPhi.setObject(new TH3F("hJetRPtPhi", "Jets #it{p}_{T} and #phi;#it{R};#it{p}_{T};#phi", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
     hJetRMaxPtEta.setObject(new TH3F("hJetRMaxPtEta", "Leading jets #it{p}_{T} and #eta;#it{R};#it{p}_{T};#eta", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hJetRMaxPtPhi.setObject(new TH3F("hJetRMaxPtPhi", "Leading jets #it{p}_{T} and #phi;#it{R};#it{p}_{T};#phi", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
-    hClusterPtEta.setObject(new TH2F("hClusterPtEta", "Cluster #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hClusterPtPhi.setObject(new TH2F("hClusterPtPhi", "Cluster #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hClusterPtEtaPhi.setObject(new TH3F("hClusterPtEtaPhi", "Cluster #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hClusterEMCALMaxPtEtaPhi.setObject(new TH3F("hClusterEMCALMaxPtEtaPhi", "Leading clusterEMCAL #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hClusterDCALMaxPtEtaPhi.setObject(new TH3F("hClusterDCALMaxPtEtaPhi", "Leading clusterDCAL #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hClusterMaxPtEta.setObject(new TH2F("hClusterMaxPtEta", "Leading clusters #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hClusterMaxPtPhi.setObject(new TH2F("hClusterMaxPtPhi", "Leading clusters #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hClusterPtEta.setObject(new TH2F("hClusterPtEta", Form("Cluster %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hClusterPtPhi.setObject(new TH2F("hClusterPtPhi", Form("Cluster %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hClusterPtEtaPhi.setObject(new TH3F("hClusterPtEtaPhi", Form("Cluster %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hClusterEMCALMaxPtEtaPhi.setObject(new TH3F("hClusterEMCALMaxPtEtaPhi", Form("Leading clusterEMCAL %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hClusterDCALMaxPtEtaPhi.setObject(new TH3F("hClusterDCALMaxPtEtaPhi", Form("Leading clusterDCAL %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hClusterMaxPtEta.setObject(new TH2F("hClusterMaxPtEta", Form("Leading clusters %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hClusterMaxPtPhi.setObject(new TH2F("hClusterMaxPtPhi", Form("Leading clusters %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hJetRPtTrackPt.setObject(new TH3F("hJetRPtTrackPt", "Jets;#it{p}_{T};#it{R};#it{p}_{T}^{track}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt / 2));
     hJetRPtClusterPt.setObject(new TH3F("hJetRPtClusterPt", "Jets;#it{R};#it{p}_{T};#it{p}_{T}^{clus}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt / 2));
     hJetRPtPtd.setObject(new TH3F("hJetRPtPtd", "Jets;#it{R};#it{p}_{T};ptD", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins / 2, 0., 1.));
@@ -189,12 +226,12 @@ struct JetTriggerQA {
     hSelectedJetRPtPhi.setObject(new TH3F("hSelectedJetRPtPhi", "Selected jets #it{p}_{T} and #phi;#it{R};#it{p}_{T};#phi", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedJetRMaxPtEta.setObject(new TH3F("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta;#it{R};#it{p}_{T};#eta", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hSelectedJetRMaxPtPhi.setObject(new TH3F("hSelectedJetRMaxPtPhi", "Leading selected jets #it{p}_{T} and #phi;#it{R};#it{p}_{T};#phi", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedClusterPtEta.setObject(new TH2F("hSelectedClusterPtEta", "Selected Cluster #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedClusterPtPhi.setObject(new TH2F("hSelectedClusterPtPhi", "Selected Cluster #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedClusterPtEtaPhi.setObject(new TH3F("hSelectedClusterPtEtaPhi", "Selected cluster #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedClusterMaxPtEtaPhi.setObject(new TH3F("hSelectedClusterMaxPtEtaPhi", "Leading Selected cluster #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedClusterMaxPtEta.setObject(new TH2F("hSelectedClusterMaxPtEta", "Leading selected clusters #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedClusterMaxPtPhi.setObject(new TH2F("hSelectedClusterMaxPtPhi", "Leading selected clusters #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedClusterPtEta.setObject(new TH2F("hSelectedClusterPtEta", Form("Selected Cluster %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedClusterPtPhi.setObject(new TH2F("hSelectedClusterPtPhi", Form("Selected Cluster %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedClusterPtEtaPhi.setObject(new TH3F("hSelectedClusterPtEtaPhi", Form("Selected cluster %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedClusterMaxPtEtaPhi.setObject(new TH3F("hSelectedClusterMaxPtEtaPhi", Form("Leading Selected cluster %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedClusterMaxPtEta.setObject(new TH2F("hSelectedClusterMaxPtEta", Form("Leading selected clusters %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedClusterMaxPtPhi.setObject(new TH2F("hSelectedClusterMaxPtPhi", Form("Leading selected clusters %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedJetRPtTrackPt.setObject(new TH3F("hSelectedJetRPtTrackPt", "Selected jets;#it{R};#it{p}_{T};#it{p}_{T}^{track}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt / 2));
     hSelectedJetRPtClusterPt.setObject(new TH3F("hSelectedJetRPtClusterPt", "Selected jets;#it{R};#it{p}_{T};#it{p}_{T}^{clus}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt / 2));
     hSelectedJetRPtPtd.setObject(new TH3F("hSelectedJetRPtPtd", "Selected jets;#it{R};#it{p}_{T};ptD", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins / 2, 0., 1.));
@@ -203,20 +240,36 @@ struct JetTriggerQA {
     hSelectedJetRPtZTheta.setObject(new TH3F("hSelectedJetRPtZTheta", "Selected jets;#it{R};#it{p}_{T};z#theta", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins / 2, 0., 1.));
     hSelectedJetRPtZSqTheta.setObject(new TH3F("hSelectedJetRPtZSqTheta", "Selected jets;#it{R};#it{p}_{T};z^{2} #theta", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins / 2, 0., 1.));
     hSelectedJetRPtZThetaSq.setObject(new TH3F("hSelectedJetRPtZThetaSq", "Selected jets;#it{R};#it{p}_{T};z #theta^{2}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins / 2, 0., 1.));
-    hSelectedGammaEMCALPtEta.setObject(new TH2F("hSelectedGammaEMCALPtEta", "Selected GammaEMCAL #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedGammaEMCALPtPhi.setObject(new TH2F("hSelectedGammaEMCALPtPhi", "Selected GammaEMCAL #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaEMCALPtEtaPhi.setObject(new TH3F("hSelectedGammaEMCALPtEtaPhi", "Selected GammaEMCAL #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaEMCALMaxPtEtaPhi.setObject(new TH3F("hSelectedGammaEMCALMaxPtEtaPhi", "Leading selected gammaEMCALs #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaEMCALMaxPtEta.setObject(new TH2F("hSelectedGammaEMCALMaxPtEta", "Leading selected gammaEMCALs #it{p}_{T} and #eta;#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
-    hSelectedGammaEMCALMaxPtPhi.setObject(new TH2F("hSelectedGammaEMCALMaxPtPhi", "Leading selected gammaEMCALs #it{p}_{T} and #phi;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaDCALPtEtaPhi.setObject(new TH3F("hSelectedGammaDCALPtEtaPhi", "Selected GammaDCAL #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
-    hSelectedGammaDCALMaxPtEtaPhi.setObject(new TH3F("hSelectedGammaDCALMaxPtEtaPhi", "Leading selected GammaDCALs #it{p}_{T}, #eta and #phi;#it{p}_{T};#eta;#phi", nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEta.setObject(new TH2F("hSelectedGammaEMCALPtEta", Form("Selected GammaEMCAL %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhi.setObject(new TH2F("hSelectedGammaEMCALPtPhi", Form("Selected GammaEMCAL %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEta.setObject(new TH2F("hSelectedGammaDCALPtEta", Form("Selected GammaDCAL %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhi.setObject(new TH2F("hSelectedGammaDCALPtPhi", Form("Selected GammaDCAL %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaPhi.setObject(new TH3F("hSelectedGammaEMCALPtEtaPhi", Form("Selected GammaEMCAL %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALMaxPtEtaPhi.setObject(new TH3F("hSelectedGammaEMCALMaxPtEtaPhi", Form("Leading selected gammaEMCALs %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALMaxPtEta.setObject(new TH2F("hSelectedGammaEMCALMaxPtEta", Form("Leading selected gammaEMCALs %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALMaxPtPhi.setObject(new TH2F("hSelectedGammaEMCALMaxPtPhi", Form("Leading selected gammaEMCALs %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALMaxPtEta.setObject(new TH2F("hSelectedGammaDCALMaxPtEta", Form("Leading selected gammaDCALs %s and #eta;%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALMaxPtPhi.setObject(new TH2F("hSelectedGammaDCALMaxPtPhi", Form("Leading selected gammaDCALs %s and #phi;%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaPhi.setObject(new TH3F("hSelectedGammaDCALPtEtaPhi", Form("Selected GammaDCAL %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALMaxPtEtaPhi.setObject(new TH3F("hSelectedGammaDCALMaxPtEtaPhi", Form("Leading selected GammaDCALs %s, #eta and #phi;%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaLow.setObject(new TH2F("hSelectedGammaEMCALPtEtaLow", Form("Selected GammaEMCAL %s and #eta (low threshold);%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhiLow.setObject(new TH2F("hSelectedGammaEMCALPtPhiLow", Form("Selected GammaEMCAL %s and #phi (low threshold);%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaLow.setObject(new TH2F("hSelectedGammaDCALPtEtaLow", Form("Selected GammaDCAL %s and #eta (low threshold);%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhiLow.setObject(new TH2F("hSelectedGammaDCALPtPhiLow", Form("Selected GammaDCAL %s and #phi (low threshold);%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaPhiLow.setObject(new TH3F("hSelectedGammaEMCALPtEtaPhiLow", Form("Selected GammaEMCAL %s, #eta and #phi (low threshold);%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALMaxPtEtaPhiLow.setObject(new TH3F("hSelectedGammaEMCALMaxPtEtaPhiLow", Form("Leading selected gammaEMCALs %s, #eta and #phi (low threshold);%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALMaxPtEtaLow.setObject(new TH2F("hSelectedGammaEMCALMaxPtEtaLow", Form("Leading selected gammaEMCALs %s and #eta (low threshold);%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALMaxPtPhiLow.setObject(new TH2F("hSelectedGammaEMCALMaxPtPhiLow", Form("Leading selected gammaEMCALs %s and #phi (low threshold);%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALMaxPtEtaLow.setObject(new TH2F("hSelectedGammaDCALMaxPtEtaLow", Form("Leading selected gammaDCALs %s and #eta (low threshold);%s;#eta", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALMaxPtPhiLow.setObject(new TH2F("hSelectedGammaDCALMaxPtPhiLow", Form("Leading selected gammaDCALs %s and #phi (low threshold);%s;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaPhiLow.setObject(new TH3F("hSelectedGammaDCALPtEtaPhiLow", Form("Selected GammaDCAL %s, #eta and #phi (low threshold);%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALMaxPtEtaPhiLow.setObject(new TH3F("hSelectedGammaDCALMaxPtEtaPhiLow", Form("Leading selected GammaDCALs %s, #eta and #phi (low threshold);%s;#eta;#phi", observableName.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedJetRMaxPtClusterMaxPt.setObject(new TH3F("hSelectedJetRMaxPtClusterMaxPt", "Leading selected jets and clusters;#it{R};#it{p}_{T};#it{p}_{T}^{clus}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt / 2));
 
     hJetRMaxPtJetPt.setObject(new TH3F("hJetRMaxPtJetPt", "Leading jet #it{p}_{T} vs jet #it{p}_{T};#it{R};#it{p}_{T}^{max};#it{p}_{T}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt));
     hJetRMaxPtJetPtNoFiducial.setObject(new TH3F("hJetRMaxPtJetPtNoFiducial", "Leading jet #it{p}_{T} vs jet #it{p}_{T} (no fiducial cut);#it{R};#it{p}_{T}^{max};#it{p}_{T}", nRBins, kMinR, kMaxR, nPtBins, kMinPt, kMaxPt, nPtBins, kMinPt, kMaxPt));
-    hClusterEMCALMaxPtClusterEMCALPt.setObject(new TH2F("hClusterEMCALMaxPtClusterEMCALPt", "Leading clusterEMCAL #it{p}_{T} vs clusterEMCAL #it{p}_{T};#it{p}_{T}^{max};#it{p}_{T}", nPtBins, kMinPt, kMaxPt / 2, nPtBins, kMinPt, kMaxPt / 2));
-    hClusterDCALMaxPtClusterDCALPt.setObject(new TH2F("hClusterDCALMaxPtClusterDCALPt", "Leading clusterDCAL #it{p}_{T} vs clusterDCAL #it{p}_{T};#it{p}_{T}^{max};#it{p}_{T}", nPtBins, kMinPt, kMaxPt / 2, nPtBins, kMinPt, kMaxPt / 2));
+    hClusterEMCALMaxPtClusterEMCALPt.setObject(new TH2F("hClusterEMCALMaxPtClusterEMCALPt", Form("Leading clusterEMCAL %s vs clusterEMCAL %s;%s;%s", observableName.data(), observableName.data(), observableAxisTitleMax.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPtBins, kMinPt, kMaxPt / 2));
+    hClusterDCALMaxPtClusterDCALPt.setObject(new TH2F("hClusterDCALMaxPtClusterDCALPt", Form("Leading clusterDCAL %s vs clusterDCAL %s;%s;%s", observableName.data(), observableName.data(), observableAxisTitleMax.data(), observableAxisTitle.data()), nPtBins, kMinPt, kMaxPt / 2, nPtBins, kMinPt, kMaxPt / 2));
 
     if (b_JetsInEmcalOnly) {
       hJetRPtEta->SetTitle("Jets (in emcal only) #it{p}_{T} and #eta;it{R};#it{p}_{T};#eta");
@@ -317,31 +370,51 @@ struct JetTriggerQA {
       }
     }
 
-    bool isEvtSelected = false, isEvtSelectedGammaEMCAL = false, isEvtSelectedGammaDCAL = false;
+    bool isEvtSelected = false, isEventSelectedNeutralJet = false, isEvtSelectedGammaEMCAL = false, isEvtSelectedGammaDCAL = false, isEvtSelectedGammaLowEMCAL = false, isEvtSelectedGammaLowDCAL = false;
     if (collision.hasJetFullHighPt()) {
       isEvtSelected = true;
       hProcessedEvents->Fill(2);
     }
+    if (collision.hasJetNeutralHighPt()) {
+      isEventSelectedNeutralJet = true;
+      hProcessedEvents->Fill(3);
+    }
     if (collision.hasGammaHighPtEMCAL()) {
       isEvtSelectedGammaEMCAL = true;
-      hProcessedEvents->Fill(3);
+      hProcessedEvents->Fill(4);
     }
     if (collision.hasGammaHighPtDCAL()) {
       isEvtSelectedGammaDCAL = true;
-      hProcessedEvents->Fill(4);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtEMCAL()) {
       hProcessedEvents->Fill(5);
     }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtDCAL()) {
-      isEvtSelectedGammaDCAL = true;
+    if (collision.hasGammaLowPtEMCAL()) {
+      isEvtSelectedGammaLowEMCAL = true;
       hProcessedEvents->Fill(6);
     }
-    if (collision.hasGammaHighPtEMCAL() && collision.hasGammaHighPtDCAL()) {
+    if (collision.hasGammaLowPtDCAL()) {
+      isEvtSelectedGammaLowDCAL = true;
       hProcessedEvents->Fill(7);
     }
+    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtEMCAL()) {
+      hProcessedEvents->Fill(8);
+    }
+    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtDCAL()) {
+      hProcessedEvents->Fill(9);
+    }
+    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtEMCAL()) {
+      hProcessedEvents->Fill(10);
+    }
+    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtDCAL()) {
+      hProcessedEvents->Fill(11);
+    }
+    if (collision.hasJetFullHighPt() && collision.hasJetNeutralHighPt()) {
+      hProcessedEvents->Fill(12);
+    }
+    if (collision.hasGammaHighPtEMCAL() && collision.hasGammaHighPtDCAL()) {
+      hProcessedEvents->Fill(13);
+    }
 
-    double maxClusterPtEMCAL = -1., maxClusterPtDCAL = -1.;
+    double maxClusterObservableEMCAL = -1., maxClusterObservableDCAL = -1.;
     selectedClusters::iterator maxClusterEMCAL, maxClusterDCAL;
     std::vector<aod::Jet> vecMaxJet;
     std::vector<aod::Jet> vecMaxJetNoFiducial;
@@ -420,67 +493,98 @@ struct JetTriggerQA {
       }
     } // for jets
 
+    struct ClusterData {
+      float mTriggerObservable;
+      float mEta;
+      float mPhi;
+    };
+    std::vector<ClusterData> analysedClusters;
+
     for (const auto& cluster : clusters) {
-      double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-      if (isClusterInEmcal(cluster) && clusterPt > maxClusterPtEMCAL) {
-        maxClusterPtEMCAL = clusterPt;
+      if (b_RejectExoticClusters && cluster.isExotic()) {
+        continue;
+      }
+      if (cluster.time() < f_minClusterTime || cluster.time() > f_maxClusterTime) {
+        continue;
+      }
+      double clusterObservable = (f_GammaObservable == 0) ? cluster.energy() : cluster.energy() / std::cosh(cluster.eta());
+      analysedClusters.push_back({static_cast<float>(clusterObservable), cluster.eta(), cluster.phi()});
+
+      if (isClusterInEmcal(cluster) && clusterObservable > maxClusterObservableEMCAL) {
+        maxClusterObservableEMCAL = clusterObservable;
         maxClusterEMCAL = cluster;
       }
-      if (!isClusterInEmcal(cluster) && clusterPt > maxClusterPtDCAL) {
-        maxClusterPtDCAL = clusterPt;
+      if (!isClusterInEmcal(cluster) && clusterObservable > maxClusterObservableDCAL) {
+        maxClusterObservableDCAL = clusterObservable;
         maxClusterDCAL = cluster;
       }
-      hClusterPtEta->Fill(clusterPt, cluster.eta());
-      hClusterPtPhi->Fill(clusterPt, cluster.phi());
-      hClusterPtEtaPhi->Fill(clusterPt, cluster.eta(), cluster.phi());
-      if (isEvtSelected) {
-        hSelectedClusterPtEta->Fill(clusterPt, cluster.eta());
-        hSelectedClusterPtPhi->Fill(clusterPt, cluster.phi());
-        hSelectedClusterPtEtaPhi->Fill(clusterPt, cluster.eta(), cluster.phi());
+      hClusterPtEta->Fill(clusterObservable, cluster.eta());
+      hClusterPtPhi->Fill(clusterObservable, cluster.phi());
+      hClusterPtEtaPhi->Fill(clusterObservable, cluster.eta(), cluster.phi());
+      if (isEvtSelected || isEventSelectedNeutralJet) {
+        hSelectedClusterPtEta->Fill(clusterObservable, cluster.eta());
+        hSelectedClusterPtPhi->Fill(clusterObservable, cluster.phi());
+        hSelectedClusterPtEtaPhi->Fill(clusterObservable, cluster.eta(), cluster.phi());
       }
       if (isEvtSelectedGammaEMCAL && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
-        hSelectedGammaEMCALPtEta->Fill(clusterPt, cluster.eta());
-        hSelectedGammaEMCALPtPhi->Fill(clusterPt, cluster.phi());
-        hSelectedGammaEMCALPtEtaPhi->Fill(clusterPt, cluster.eta(), cluster.phi());
+        hSelectedGammaEMCALPtEta->Fill(clusterObservable, cluster.eta());
+        hSelectedGammaEMCALPtPhi->Fill(clusterObservable, cluster.phi());
+        hSelectedGammaEMCALPtEtaPhi->Fill(clusterObservable, cluster.eta(), cluster.phi());
       }
       if (isEvtSelectedGammaDCAL && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
-        hSelectedGammaDCALPtEtaPhi->Fill(clusterPt, cluster.eta(), cluster.phi());
+        hSelectedGammaDCALPtEta->Fill(clusterObservable, cluster.eta());
+        hSelectedGammaDCALPtPhi->Fill(clusterObservable, cluster.phi());
+        hSelectedGammaDCALPtEtaPhi->Fill(clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (isEvtSelectedGammaLowEMCAL && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
+        hSelectedGammaEMCALPtEtaLow->Fill(clusterObservable, cluster.eta());
+        hSelectedGammaEMCALPtPhiLow->Fill(clusterObservable, cluster.phi());
+        hSelectedGammaEMCALPtEtaPhiLow->Fill(clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (isEvtSelectedGammaLowDCAL && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
+        hSelectedGammaDCALPtEtaLow->Fill(clusterObservable, cluster.eta());
+        hSelectedGammaDCALPtPhiLow->Fill(clusterObservable, cluster.phi());
+        hSelectedGammaDCALPtEtaPhiLow->Fill(clusterObservable, cluster.eta(), cluster.phi());
       }
     } // for clusters
 
-    if (maxClusterPtEMCAL > 0) {
+    if (maxClusterObservableEMCAL > 0) {
       // hClusterMaxPtEta->Fill(maxClusterPt, maxCluster.eta());
       // hClusterMaxPtPhi->Fill(maxClusterPt, maxCluster.phi());
-      hClusterEMCALMaxPtEtaPhi->Fill(maxClusterPtEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      for (const auto& cluster : clusters) {
-        if (!isClusterInEmcal(cluster)) { // Skip DCAL clusters
-          continue;
-        }
-        double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-        hClusterEMCALMaxPtClusterEMCALPt->Fill(maxClusterPtEMCAL, clusterPt);
+      hClusterEMCALMaxPtEtaPhi->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      for (const auto& cluster : analysedClusters) {
+        hClusterEMCALMaxPtClusterEMCALPt->Fill(maxClusterObservableEMCAL, cluster.mTriggerObservable);
       }
       if (isEvtSelected) {
-        hSelectedClusterMaxPtEta->Fill(maxClusterPtEMCAL, maxClusterEMCAL.eta());
-        hSelectedClusterMaxPtPhi->Fill(maxClusterPtEMCAL, maxClusterEMCAL.phi());
-        hSelectedClusterMaxPtEtaPhi->Fill(maxClusterPtEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        hSelectedClusterMaxPtEta->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta());
+        hSelectedClusterMaxPtPhi->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.phi());
+        hSelectedClusterMaxPtEtaPhi->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
       if (isEvtSelectedGammaEMCAL) {
-        hSelectedGammaEMCALMaxPtEta->Fill(maxClusterPtEMCAL, maxClusterEMCAL.eta());
-        hSelectedGammaEMCALMaxPtPhi->Fill(maxClusterPtEMCAL, maxClusterEMCAL.phi());
-        hSelectedGammaEMCALMaxPtEtaPhi->Fill(maxClusterPtEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        hSelectedGammaEMCALMaxPtEta->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta());
+        hSelectedGammaEMCALMaxPtPhi->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.phi());
+        hSelectedGammaEMCALMaxPtEtaPhi->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
+      if (isEvtSelectedGammaLowEMCAL) {
+        hSelectedGammaEMCALMaxPtEtaLow->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta());
+        hSelectedGammaEMCALMaxPtPhiLow->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.phi());
+        hSelectedGammaEMCALMaxPtEtaPhiLow->Fill(maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
     }
-    if (maxClusterPtDCAL > 0) {
-      hClusterDCALMaxPtEtaPhi->Fill(maxClusterPtDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      for (const auto& cluster : clusters) {
-        if (isClusterInEmcal(cluster)) { // Skip EMCAL clusters
-          continue;
-        }
-        double clusterPt = cluster.energy() / std::cosh(cluster.eta());
-        hClusterDCALMaxPtClusterDCALPt->Fill(maxClusterPtDCAL, clusterPt);
+    if (maxClusterObservableDCAL > 0) {
+      hClusterDCALMaxPtEtaPhi->Fill(maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      for (const auto& cluster : analysedClusters) {
+        hClusterDCALMaxPtClusterDCALPt->Fill(maxClusterObservableDCAL, cluster.mTriggerObservable);
       }
       if (isEvtSelectedGammaDCAL) {
-        hSelectedGammaDCALMaxPtEtaPhi->Fill(maxClusterPtDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        hSelectedGammaDCALMaxPtEta->Fill(maxClusterObservableDCAL, maxClusterDCAL.eta());
+        hSelectedGammaDCALMaxPtPhi->Fill(maxClusterObservableDCAL, maxClusterDCAL.phi());
+        hSelectedGammaDCALMaxPtEtaPhi->Fill(maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
+      if (isEvtSelectedGammaLowDCAL) {
+        hSelectedGammaDCALMaxPtEtaLow->Fill(maxClusterObservableDCAL, maxClusterDCAL.eta());
+        hSelectedGammaDCALMaxPtPhiLow->Fill(maxClusterObservableDCAL, maxClusterDCAL.phi());
+        hSelectedGammaDCALMaxPtEtaPhiLow->Fill(maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
       }
     }
 
@@ -494,10 +598,10 @@ struct JetTriggerQA {
         hSelectedJetRMaxPtEta->Fill(jetR, jetPt, jetEta);
         hSelectedJetRMaxPtPhi->Fill(jetR, jetPt, jetPhi);
       }
-      if (maxClusterPtEMCAL > 0) {
-        hJetRMaxPtClusterMaxPt->Fill(jetR, jetPt, maxClusterPtEMCAL);
+      if (maxClusterObservableEMCAL > 0) {
+        hJetRMaxPtClusterMaxPt->Fill(jetR, jetPt, maxClusterObservableEMCAL);
         if (isEvtSelected) {
-          hSelectedJetRMaxPtClusterMaxPt->Fill(jetR, jetPt, maxClusterPtEMCAL);
+          hSelectedJetRMaxPtClusterMaxPt->Fill(jetR, jetPt, maxClusterObservableEMCAL);
         }
       } // if maxClusterPt
       if (maxJet.r() == std::round(f_jetR * 100)) {


### PR DESCRIPTION
- Jet finder: Add cuts on
  - Cluster energy
  - Cluster time
  - Cluster exoticity (default: true)
- Trigger task
  - Add new tags for
    - EMCAL readout
    - Neutral jet trigger
    - Low threshold gamma triggers
- Gamma trigger:
  - Low and high thresholds
  - Cluster and exoticity cut
  - Setter for observable type pt or energy
- Jet trigger
  - Settable jet type (full or neutral jet)
- QA task:
  - Add status bits for new trigger flags
  - Add histograms for low threshold for gamma trigger
  - Settable observable type for clusters (energy or pt)