### PR TITLE
PWGHF: Define version 001 of track-index skim creator tables to fix Run2 validation

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -148,7 +148,7 @@ DECLARE_SOA_TABLE(HfCascades, "AOD", "HFCASCADE", //! Table for HF candidates wi
                   hf_track_index::V0Id);
 using HfCascade = HfCascades::iterator;
 
-DECLARE_SOA_TABLE(Hf3Prongs_000, "AOD", "HF3PRONG", //! Table for HF 3 prong candidates
+DECLARE_SOA_TABLE(Hf3Prongs_000, "AOD", "HF3PRONG", //! Table for HF 3 prong candidates (Run 2 converted format)
                   o2::soa::Index<>,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -131,7 +131,7 @@ DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong can
                   hf_track_index::Prong1Id,
                   hf_track_index::HFflag);
 
-DECLARE_SOA_TABLE_VERSIONED(Hf2Prongs_001, "AOD", "HF2PRONG", 1, //! Table for HF 2 prong candidates
+DECLARE_SOA_TABLE_VERSIONED(Hf2Prongs_001, "AOD", "HF2PRONG", 1, //! Table for HF 2 prong candidates (Run 3 format)
                             o2::soa::Index<>,
                             hf_track_association::CollisionId,
                             hf_track_index::Prong0Id,

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -125,7 +125,7 @@ DECLARE_SOA_COLUMN(FlagDsToKKPi, flagDsToKKPi, uint8_t);         //!
 DECLARE_SOA_COLUMN(FlagXicToPKPi, flagXicToPKPi, uint8_t);       //!
 } // namespace hf_track_index
 
-DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates
+DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates (Run 2 converted format)
                   o2::soa::Index<>,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -155,7 +155,7 @@ DECLARE_SOA_TABLE(Hf3Prongs_000, "AOD", "HF3PRONG", //! Table for HF 3 prong can
                   hf_track_index::Prong2Id,
                   hf_track_index::HFflag);
 
-DECLARE_SOA_TABLE_VERSIONED(Hf3Prongs_001, "AOD", "HF3PRONG", 1, //! Table for HF 3 prong candidates
+DECLARE_SOA_TABLE_VERSIONED(Hf3Prongs_001, "AOD", "HF3PRONG", 1, //! Table for HF 3 prong candidates (Run 3 format)
                             o2::soa::Index<>,
                             hf_track_association::CollisionId,
                             hf_track_index::Prong0Id,

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -125,12 +125,20 @@ DECLARE_SOA_COLUMN(FlagDsToKKPi, flagDsToKKPi, uint8_t);         //!
 DECLARE_SOA_COLUMN(FlagXicToPKPi, flagXicToPKPi, uint8_t);       //!
 } // namespace hf_track_index
 
-DECLARE_SOA_TABLE(Hf2Prongs, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates
+DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates
                   o2::soa::Index<>,
-                  hf_track_association::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,
                   hf_track_index::HFflag);
+
+DECLARE_SOA_TABLE_VERSIONED(Hf2Prongs_001, "AOD", "HF2PRONG", 1, //! Table for HF 2 prong candidates
+                            o2::soa::Index<>,
+                            hf_track_association::CollisionId,
+                            hf_track_index::Prong0Id,
+                            hf_track_index::Prong1Id,
+                            hf_track_index::HFflag);
+
+using Hf2Prongs = Hf2Prongs_001;
 using Hf2Prong = Hf2Prongs::iterator;
 
 DECLARE_SOA_TABLE(HfCascades, "AOD", "HFCASCADE", //! Table for HF candidates with a V0
@@ -140,13 +148,22 @@ DECLARE_SOA_TABLE(HfCascades, "AOD", "HFCASCADE", //! Table for HF candidates wi
                   hf_track_index::V0Id);
 using HfCascade = HfCascades::iterator;
 
-DECLARE_SOA_TABLE(Hf3Prongs, "AOD", "HF3PRONG", //! Table for HF 3 prong candidates
+DECLARE_SOA_TABLE(Hf3Prongs_000, "AOD", "HF3PRONG", //! Table for HF 3 prong candidates
                   o2::soa::Index<>,
-                  hf_track_association::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,
                   hf_track_index::Prong2Id,
                   hf_track_index::HFflag);
+
+DECLARE_SOA_TABLE_VERSIONED(Hf3Prongs_001, "AOD", "HF3PRONG", 1, //! Table for HF 3 prong candidates
+                            o2::soa::Index<>,
+                            hf_track_association::CollisionId,
+                            hf_track_index::Prong0Id,
+                            hf_track_index::Prong1Id,
+                            hf_track_index::Prong2Id,
+                            hf_track_index::HFflag);
+
+using Hf3Prongs = Hf3Prongs_001;
 using Hf3Prong = Hf3Prongs::iterator;
 
 DECLARE_SOA_TABLE(HfCascLf2Prongs, "AOD", "HFCASCLF2PRONG", //! Table for HF 2 prong candidates with a Cascade

--- a/PWGHF/TableProducer/refitPvDummy.cxx
+++ b/PWGHF/TableProducer/refitPvDummy.cxx
@@ -29,11 +29,13 @@ struct HfRefitPvDummy {
   // Tables to be added
   Produces<aod::HfPvRefit2Prong> rowProng2PVrefit;
   Produces<aod::HfPvRefit3Prong> rowProng3PVrefit;
+  Produces<aod::Hf2Prongs_001> rowProng2WithCollId;
+  Produces<aod::Hf3Prongs_001> rowProng3WithCollId;
 
   // process function
   void process(aod::Collisions const& collisions,
-               aod::Hf2Prongs const& rowsTrackIndexProng2,
-               aod::Hf3Prongs const& rowsTrackIndexProng3,
+               aod::Hf2Prongs_000 const& rowsTrackIndexProng2,
+               aod::Hf3Prongs_000 const& rowsTrackIndexProng3,
                aod::Tracks const&)
   {
 
@@ -48,6 +50,9 @@ struct HfRefitPvDummy {
       // fill table row with coordinates of origial PV (dummy)
       rowProng2PVrefit(primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                        primaryVertex.getSigmaX2(), primaryVertex.getSigmaXY(), primaryVertex.getSigmaY2(), primaryVertex.getSigmaXZ(), primaryVertex.getSigmaYZ(), primaryVertex.getSigmaZ2());
+
+      // fill version 001 of candidate table, containing also the collision ID
+      rowProng2WithCollId(collision.globalIndex(), rowTrackIndexProng2.prong0Id(), rowTrackIndexProng2.prong1Id(), rowTrackIndexProng2.hfflag());
     }
 
     // dummy tables for 3 prong candidates
@@ -61,6 +66,9 @@ struct HfRefitPvDummy {
       // fill table row with coordinates of origial PV (dummy)
       rowProng3PVrefit(primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                        primaryVertex.getSigmaX2(), primaryVertex.getSigmaXY(), primaryVertex.getSigmaY2(), primaryVertex.getSigmaXZ(), primaryVertex.getSigmaYZ(), primaryVertex.getSigmaZ2());
+
+      // fill version 001 of candidate table, containing also the collision ID
+      rowProng3WithCollId(collision.globalIndex(), rowTrackIndexProng3.prong0Id(), rowTrackIndexProng3.prong1Id(), rowTrackIndexProng3.prong2Id(), rowTrackIndexProng3.hfflag());
     }
   } // end of process function
 };


### PR DESCRIPTION
@vkucera this PR fixes the the bug spotted by @jgrosseo due to the introduction of the collision id in the tables produced in the track-index-skim-creator as a consequence of the development for the treatment of the ambiguous tracks.
In fact, in the Run2 converted data, the collision id is not present, hence it has to be added on the fly.