### PR TITLE
PWGHF: Fix B0 workflow and modify PID selections in Dplus selector

### DIFF
--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -60,61 +60,7 @@ struct HfTaskB0 {
     registry.add("hDecLenXYErr", "B^{0} candidates;B^{0} candidate decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hIPProd", "B^{0} candidates;B^{0} candidate impact parameter product;entries", {HistType::kTH2F, {{100, -0.5, 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hInvMassD", "B^{0} candidates;prong0, D^{#minus} inv. mass (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0, 5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-  }
 
-  void process(aod::Collision const& collision, soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi>> const& candidates, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, aod::BigTracks const&)
-  {
-    for (auto const& candidate : candidates) {
-      if (TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
-        continue;
-      }
-      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
-        continue;
-      }
-
-      auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
-      auto candPi = candidate.prong1_as<aod::BigTracks>();
-
-      registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), candidate.pt());
-      registry.fill(HIST("hPtCand"), candidate.pt());
-      registry.fill(HIST("hPtProng0"), candidate.ptProng0());
-      registry.fill(HIST("hPtProng1"), candidate.ptProng1());
-      registry.fill(HIST("hIPProd"), candidate.impactParameterProduct(), candidate.pt());
-      registry.fill(HIST("hDecLength"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
-      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("hCPA"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("hEta"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("hRapidity"), yB0(candidate), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
-      if (candPi.sign() < 0) {
-        registry.fill(HIST("hInvMassD"), invMassDplusToPiKPi(candD), candidate.pt());
-      }
-    } // candidate loop
-  }   // process
-};    // struct
-
-/// B0 MC analysis and fill histograms
-struct HfTaskB0Mc {
-  Configurable<int> selectionFlagB0{"selectionFlagB0", 1, "Selection Flag for B0"};
-  Configurable<double> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
-  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
-
-  Filter filterSelectCandidates = (aod::hf_sel_candidate_b0::isSelB0ToDPi >= selectionFlagB0);
-
-  HistogramRegistry registry{
-    "registry",
-    {{"hPtRecSig", "B0 candidates (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}}},
-     {"hPtRecBg", "B0 candidates (unmatched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}}},
-     {"hPtGenSig", "B0 candidates (matched);candidate #it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 10.}}}},
-     {"hPtGen", "MC particles (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}}}}};
-
-  void init(o2::framework::InitContext&)
-  {
     registry.add("hEtaGen", "MC particles (matched);B^{0} candidate #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hYGen", "MC particles (matched);B^{0} candidate #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hPtProng0Gen", "MC particles (matched);prong 0 (D^{#minus}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
@@ -159,28 +105,71 @@ struct HfTaskB0Mc {
     registry.add("hChi2PCARecBg", "B^{0} candidates (unmatched);sum of distances of the secondary vertex to its prongs;entries", {HistType::kTH2F, {{240, -0.01, 0.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hThetaStarRecSig", "B^{0} candidates (matched);B^{0} #cos(#theta^{*});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hThetaStarRecBg", "B^{0} candidates (unmatched);B^{0} #cos(#theta^{*});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("hPtRecSig", "B0 candidates (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtRecBg", "B0 candidates (unmatched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtGenSig", "B0 candidates (matched);candidate #it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 10.}}});
+    registry.add("hPtGen", "MC particles (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
   }
 
-  void processMc(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi, aod::HfCandB0McRec>> const& candidates,
-                 soa::Join<aod::McParticles, aod::HfCandB0McGen> const& particlesMC, aod::BigTracksMC const& tracks, aod::HfCand3Prong const&)
+  using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
+  void process(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi>> const& candidates, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksWithSel const&)
   {
-    // MC rec
     for (auto const& candidate : candidates) {
-      if (TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
       if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
         continue;
       }
-      auto candD = candidate.prong0_as<aod::HfCand3Prong>();
-      if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
 
+      auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
+      auto candPi = candidate.prong1_as<TracksWithSel>();
+
+      registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), candidate.pt());
+      registry.fill(HIST("hPtCand"), candidate.pt());
+      registry.fill(HIST("hPtProng0"), candidate.ptProng0());
+      registry.fill(HIST("hPtProng1"), candidate.ptProng1());
+      registry.fill(HIST("hIPProd"), candidate.impactParameterProduct(), candidate.pt());
+      registry.fill(HIST("hDecLength"), candidate.decayLength(), candidate.pt());
+      registry.fill(HIST("hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
+      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), candidate.pt());
+      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), candidate.pt());
+      registry.fill(HIST("hCPA"), candidate.cpa(), candidate.pt());
+      registry.fill(HIST("hEta"), candidate.eta(), candidate.pt());
+      registry.fill(HIST("hRapidity"), yB0(candidate), candidate.pt());
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
+      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
+      registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
+      registry.fill(HIST("hInvMassD"), invMassDplusToPiKPi(candD), candidate.pt());
+    } // candidate loop
+  }   // process
+
+  /// B0 MC analysis and fill histograms
+  void processMc(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi, aod::HfCandB0McRec>> const& candidates,
+                 soa::Join<aod::McParticles, aod::HfCandB0McGen> const& particlesMC,
+                 aod::BigTracksMC const& tracks,
+                 soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec> const&)
+  {
+    // MC rec
+    for (auto const& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+        continue;
+      }
+      // auto candD = candidate.prong0_as<aod::HfCand3Prong>();
+      auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec>>();
+      if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong1_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCandB0McGen>>(), pdg::Code::kB0, true);
         auto particleMother = particlesMC.rawIteratorAt(indexMother);
+
         registry.fill(HIST("hPtGenSig"), particleMother.pt());
         registry.fill(HIST("hPtRecSig"), candidate.pt());
         registry.fill(HIST("hCPARecSig"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hCPAxyRecSig"), candidate.cpa(), candidate.pt());
+        registry.fill(HIST("hCPAxyRecSig"), candidate.cpaXY(), candidate.pt());
         registry.fill(HIST("hEtaRecSig"), candidate.eta(), candidate.pt());
         registry.fill(HIST("hRapidityRecSig"), yB0(candidate), candidate.pt());
         registry.fill(HIST("hDecLengthRecSig"), candidate.decayLength(), candidate.pt());
@@ -199,7 +188,7 @@ struct HfTaskB0Mc {
       } else {
         registry.fill(HIST("hPtRecBg"), candidate.pt());
         registry.fill(HIST("hCPARecBg"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hCPAxyRecBg"), candidate.cpa(), candidate.pt());
+        registry.fill(HIST("hCPAxyRecBg"), candidate.cpaXY(), candidate.pt());
         registry.fill(HIST("hEtaRecBg"), candidate.eta(), candidate.pt());
         registry.fill(HIST("hRapidityRecBg"), yB0(candidate), candidate.pt());
         registry.fill(HIST("hDecLengthRecBg"), candidate.decayLength(), candidate.pt());
@@ -223,7 +212,7 @@ struct HfTaskB0Mc {
     for (auto const& particle : particlesMC) {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
           continue;
         }
@@ -253,13 +242,10 @@ struct HfTaskB0Mc {
       }
     } // gen
   }   // process
-  PROCESS_SWITCH(HfTaskB0Mc, processMc, "Process MC", false);
+  PROCESS_SWITCH(HfTaskB0, processMc, "Process MC", false);
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{};
-  workflow.push_back(adaptAnalysisTask<HfTaskB0>(cfgc));
-  workflow.push_back(adaptAnalysisTask<HfTaskB0Mc>(cfgc));
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<HfTaskB0>(cfgc)};
 }

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -61,14 +61,14 @@ struct HfTaskB0 {
     registry.add("hIPProd", "B^{0} candidates;B^{0} candidate impact parameter product;entries", {HistType::kTH2F, {{100, -0.5, 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hInvMassD", "B^{0} candidates;prong0, D^{#minus} inv. mass (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0, 5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
 
-    registry.add("hEtaGen", "MC particles (matched);B^{0} candidate #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hYGen", "MC particles (matched);B^{0} candidate #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng0Gen", "MC particles (matched);prong 0 (D^{#minus}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng1Gen", "MC particles (matched);prong 1 (#pi^{-}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hYProng0Gen", "MC particles (matched);prong 0 (D^{#minus}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hYProng1Gen", "MC particles (matched);prong 1 (#pi^{-}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaProng0Gen", "MC particles (matched);prong 0 (B^{0}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaProng1Gen", "MC particles (matched);prong 1 (#pi^{-}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaGen", "MC particles (generated);B^{0} candidate #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYGen", "MC particles (generated);B^{0} candidate #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng0Gen", "MC particles (generated);prong 0 (D^{#minus}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYProng0Gen", "MC particles (generated);prong 0 (D^{#minus}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaProng0Gen", "MC particles (generated);prong 0 (B^{0}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hCPARecSig", "B^{0} candidates (matched);B^{0} candidate cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hCPARecBg", "B^{0} candidates (unmatched);B^{0} candidate cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hCPAxyRecSig", "B^{0} candidates (matched);B^{0} candidate CPAxy;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
@@ -98,18 +98,16 @@ struct HfTaskB0 {
     registry.add("hDecLengthDRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hDecLengthNormRecSig", "B^{0} candidates (matched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hDecLengthNormRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hImpParProdB0RecSig", "B^{0} candidates (matched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.5, 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hImpParProdB0RecBg", "B^{0} candidates (unmatched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.5, 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hImpParProdB0RecSig", "B^{0} candidates (matched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.01, 0.01}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hImpParProdB0RecBg", "B^{0} candidates (unmatched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.01, 0.01}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
 
     registry.add("hChi2PCARecSig", "B^{0} candidates (matched);sum of distances of the secondary vertex to its prongs;entries", {HistType::kTH2F, {{240, -0.01, 0.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hChi2PCARecBg", "B^{0} candidates (unmatched);sum of distances of the secondary vertex to its prongs;entries", {HistType::kTH2F, {{240, -0.01, 0.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hThetaStarRecSig", "B^{0} candidates (matched);B^{0} #cos(#theta^{*});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hThetaStarRecBg", "B^{0} candidates (unmatched);B^{0} #cos(#theta^{*});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
 
     registry.add("hPtRecSig", "B0 candidates (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
     registry.add("hPtRecBg", "B0 candidates (unmatched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
-    registry.add("hPtGenSig", "B0 candidates (matched);candidate #it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 10.}}});
-    registry.add("hPtGen", "MC particles (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtGenSig", "B0 candidates (gen+rec);candidate #it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 10.}}});
+    registry.add("hPtGen", "MC particles (generated);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
   }
 
   using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
@@ -184,7 +182,6 @@ struct HfTaskB0 {
         registry.fill(HIST("hCPADRecSig"), candD.cpa(), candidate.pt());
         registry.fill(HIST("hDecLengthDRecSig"), candD.decayLength(), candidate.pt());
         registry.fill(HIST("hChi2PCARecSig"), candidate.chi2PCA(), candidate.pt());
-        // registry.fill(HIST("hThetaStarRecSig"), candidate.cosThetaStar(), candidate.pt());
       } else {
         registry.fill(HIST("hPtRecBg"), candidate.pt());
         registry.fill(HIST("hCPARecBg"), candidate.cpa(), candidate.pt());
@@ -203,7 +200,6 @@ struct HfTaskB0 {
         registry.fill(HIST("hCPADRecBg"), candD.cpa(), candidate.pt());
         registry.fill(HIST("hDecLengthDRecBg"), candD.decayLength(), candidate.pt());
         registry.fill(HIST("hChi2PCARecBg"), candidate.chi2PCA(), candidate.pt());
-        // registry.fill(HIST("hThetaStarRecBg"), candidate.cosThetaStar(), candidate.pt());
       }
     } // rec
 

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -160,7 +160,7 @@ struct HfTaskB0 {
       if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
         continue;
       }
-      // auto candD = candidate.prong0_as<aod::HfCand3Prong>();
+
       auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec>>();
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong1_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCandB0McGen>>(), pdg::Code::kB0, true);
@@ -212,7 +212,7 @@ struct HfTaskB0 {
     for (auto const& particle : particlesMC) {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
         if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -124,7 +124,7 @@ struct HfTaskB0 {
       }
 
       auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
-      auto candPi = candidate.prong1_as<TracksWithSel>();
+      // auto candPi = candidate.prong1_as<TracksWithSel>();
 
       registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), candidate.pt());
       registry.fill(HIST("hPtCand"), candidate.pt());

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -124,23 +124,25 @@ struct HfTaskB0 {
       auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
       // auto candPi = candidate.prong1_as<TracksWithSel>();
 
-      registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), candidate.pt());
-      registry.fill(HIST("hPtCand"), candidate.pt());
+      auto ptCandB0 = candidate.pt();
+
+      registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), ptCandB0);
+      registry.fill(HIST("hPtCand"), ptCandB0);
       registry.fill(HIST("hPtProng0"), candidate.ptProng0());
       registry.fill(HIST("hPtProng1"), candidate.ptProng1());
-      registry.fill(HIST("hIPProd"), candidate.impactParameterProduct(), candidate.pt());
-      registry.fill(HIST("hDecLength"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
-      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("hCPA"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("hEta"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("hRapidity"), yB0(candidate), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
-      registry.fill(HIST("hInvMassD"), invMassDplusToPiKPi(candD), candidate.pt());
+      registry.fill(HIST("hIPProd"), candidate.impactParameterProduct(), ptCandB0);
+      registry.fill(HIST("hDecLength"), candidate.decayLength(), ptCandB0);
+      registry.fill(HIST("hDecLengthXY"), candidate.decayLengthXY(), ptCandB0);
+      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), ptCandB0);
+      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), ptCandB0);
+      registry.fill(HIST("hCPA"), candidate.cpa(), ptCandB0);
+      registry.fill(HIST("hEta"), candidate.eta(), ptCandB0);
+      registry.fill(HIST("hRapidity"), yB0(candidate), ptCandB0);
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), ptCandB0);
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), ptCandB0);
+      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), ptCandB0);
+      registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), ptCandB0);
+      registry.fill(HIST("hInvMassD"), invMassDplusToPiKPi(candD), ptCandB0);
     } // candidate loop
   }   // process
 
@@ -159,47 +161,49 @@ struct HfTaskB0 {
         continue;
       }
 
+      auto ptCandB0 = candidate.pt();
+
       auto candD = candidate.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec>>();
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong1_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCandB0McGen>>(), pdg::Code::kB0, true);
         auto particleMother = particlesMC.rawIteratorAt(indexMother);
 
         registry.fill(HIST("hPtGenSig"), particleMother.pt());
-        registry.fill(HIST("hPtRecSig"), candidate.pt());
-        registry.fill(HIST("hCPARecSig"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hCPAxyRecSig"), candidate.cpaXY(), candidate.pt());
-        registry.fill(HIST("hEtaRecSig"), candidate.eta(), candidate.pt());
-        registry.fill(HIST("hRapidityRecSig"), yB0(candidate), candidate.pt());
-        registry.fill(HIST("hDecLengthRecSig"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("hDecLengthXYRecSig"), candidate.decayLengthXY(), candidate.pt());
-        registry.fill(HIST("hMassRecSig"), invMassB0ToDPi(candidate), candidate.pt());
-        registry.fill(HIST("hd0Prong0RecSig"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("hd0Prong1RecSig"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("hPtProng0RecSig"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("hPtProng1RecSig"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("hImpParProdB0RecSig"), candidate.impactParameterProduct(), candidate.pt());
-        registry.fill(HIST("hDecLengthNormRecSig"), candidate.decayLengthXYNormalised(), candidate.pt());
-        registry.fill(HIST("hCPADRecSig"), candD.cpa(), candidate.pt());
-        registry.fill(HIST("hDecLengthDRecSig"), candD.decayLength(), candidate.pt());
-        registry.fill(HIST("hChi2PCARecSig"), candidate.chi2PCA(), candidate.pt());
+        registry.fill(HIST("hPtRecSig"), ptCandB0);
+        registry.fill(HIST("hCPARecSig"), candidate.cpa(), ptCandB0);
+        registry.fill(HIST("hCPAxyRecSig"), candidate.cpaXY(), ptCandB0);
+        registry.fill(HIST("hEtaRecSig"), candidate.eta(), ptCandB0);
+        registry.fill(HIST("hRapidityRecSig"), yB0(candidate), ptCandB0);
+        registry.fill(HIST("hDecLengthRecSig"), candidate.decayLength(), ptCandB0);
+        registry.fill(HIST("hDecLengthXYRecSig"), candidate.decayLengthXY(), ptCandB0);
+        registry.fill(HIST("hMassRecSig"), invMassB0ToDPi(candidate), ptCandB0);
+        registry.fill(HIST("hd0Prong0RecSig"), candidate.impactParameter0(), ptCandB0);
+        registry.fill(HIST("hd0Prong1RecSig"), candidate.impactParameter1(), ptCandB0);
+        registry.fill(HIST("hPtProng0RecSig"), candidate.ptProng0(), ptCandB0);
+        registry.fill(HIST("hPtProng1RecSig"), candidate.ptProng1(), ptCandB0);
+        registry.fill(HIST("hImpParProdB0RecSig"), candidate.impactParameterProduct(), ptCandB0);
+        registry.fill(HIST("hDecLengthNormRecSig"), candidate.decayLengthXYNormalised(), ptCandB0);
+        registry.fill(HIST("hCPADRecSig"), candD.cpa(), ptCandB0);
+        registry.fill(HIST("hDecLengthDRecSig"), candD.decayLength(), ptCandB0);
+        registry.fill(HIST("hChi2PCARecSig"), candidate.chi2PCA(), ptCandB0);
       } else {
-        registry.fill(HIST("hPtRecBg"), candidate.pt());
-        registry.fill(HIST("hCPARecBg"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hCPAxyRecBg"), candidate.cpaXY(), candidate.pt());
-        registry.fill(HIST("hEtaRecBg"), candidate.eta(), candidate.pt());
-        registry.fill(HIST("hRapidityRecBg"), yB0(candidate), candidate.pt());
-        registry.fill(HIST("hDecLengthRecBg"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("hDecLengthXYRecBg"), candidate.decayLengthXY(), candidate.pt());
-        registry.fill(HIST("hMassRecBg"), invMassB0ToDPi(candidate), candidate.pt());
-        registry.fill(HIST("hd0Prong0RecBg"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("hd0Prong1RecBg"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("hPtProng0RecBg"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("hPtProng1RecBg"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("hImpParProdB0RecBg"), candidate.impactParameterProduct(), candidate.pt());
-        registry.fill(HIST("hDecLengthNormRecBg"), candidate.decayLengthXYNormalised(), candidate.pt());
-        registry.fill(HIST("hCPADRecBg"), candD.cpa(), candidate.pt());
-        registry.fill(HIST("hDecLengthDRecBg"), candD.decayLength(), candidate.pt());
-        registry.fill(HIST("hChi2PCARecBg"), candidate.chi2PCA(), candidate.pt());
+        registry.fill(HIST("hPtRecBg"), ptCandB0);
+        registry.fill(HIST("hCPARecBg"), candidate.cpa(), ptCandB0);
+        registry.fill(HIST("hCPAxyRecBg"), candidate.cpaXY(), ptCandB0);
+        registry.fill(HIST("hEtaRecBg"), candidate.eta(), ptCandB0);
+        registry.fill(HIST("hRapidityRecBg"), yB0(candidate), ptCandB0);
+        registry.fill(HIST("hDecLengthRecBg"), candidate.decayLength(), ptCandB0);
+        registry.fill(HIST("hDecLengthXYRecBg"), candidate.decayLengthXY(), ptCandB0);
+        registry.fill(HIST("hMassRecBg"), invMassB0ToDPi(candidate), ptCandB0);
+        registry.fill(HIST("hd0Prong0RecBg"), candidate.impactParameter0(), ptCandB0);
+        registry.fill(HIST("hd0Prong1RecBg"), candidate.impactParameter1(), ptCandB0);
+        registry.fill(HIST("hPtProng0RecBg"), candidate.ptProng0(), ptCandB0);
+        registry.fill(HIST("hPtProng1RecBg"), candidate.ptProng1(), ptCandB0);
+        registry.fill(HIST("hImpParProdB0RecBg"), candidate.impactParameterProduct(), ptCandB0);
+        registry.fill(HIST("hDecLengthNormRecBg"), candidate.decayLengthXYNormalised(), ptCandB0);
+        registry.fill(HIST("hCPADRecBg"), candD.cpa(), ptCandB0);
+        registry.fill(HIST("hDecLengthDRecBg"), candD.decayLength(), ptCandB0);
+        registry.fill(HIST("hChi2PCARecBg"), candidate.chi2PCA(), ptCandB0);
       }
     } // rec
 
@@ -208,6 +212,7 @@ struct HfTaskB0 {
     for (auto const& particle : particlesMC) {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
+        auto ptParticle = particle.pt();
         auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
         if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
           continue;
@@ -222,19 +227,19 @@ struct HfTaskB0 {
           counter++;
         }
 
-        registry.fill(HIST("hPtProng0Gen"), ptProngs[0], particle.pt());
-        registry.fill(HIST("hPtProng1Gen"), ptProngs[1], particle.pt());
-        registry.fill(HIST("hYProng0Gen"), yProngs[0], particle.pt());
-        registry.fill(HIST("hYProng1Gen"), yProngs[1], particle.pt());
-        registry.fill(HIST("hEtaProng0Gen"), etaProngs[0], particle.pt());
-        registry.fill(HIST("hEtaProng1Gen"), etaProngs[1], particle.pt());
+        registry.fill(HIST("hPtProng0Gen"), ptProngs[0], ptParticle);
+        registry.fill(HIST("hPtProng1Gen"), ptProngs[1], ptParticle);
+        registry.fill(HIST("hYProng0Gen"), yProngs[0], ptParticle);
+        registry.fill(HIST("hYProng1Gen"), yProngs[1], ptParticle);
+        registry.fill(HIST("hEtaProng0Gen"), etaProngs[0], ptParticle);
+        registry.fill(HIST("hEtaProng1Gen"), etaProngs[1], ptParticle);
 
         //  if (yCandMax >= 0. && (std::abs(yProngs[0]) > yCandMax || std::abs(yProngs[1]) > yCandMax))
         //    continue;
 
-        registry.fill(HIST("hPtGen"), particle.pt());
-        registry.fill(HIST("hYGen"), yParticle, particle.pt());
-        registry.fill(HIST("hEtaGen"), particle.eta(), particle.pt());
+        registry.fill(HIST("hPtGen"), ptParticle);
+        registry.fill(HIST("hYGen"), yParticle, ptParticle);
+        registry.fill(HIST("hEtaGen"), particle.eta(), ptParticle);
       }
     } // gen
   }   // process

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -59,6 +59,11 @@ struct HfCandidateCreatorB0 {
   double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
   double massDPi{0.};
 
+  using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
+
+  Filter filterSelectTracks = (!usePionIsGlobalTrackWoDCA) || ((usePionIsGlobalTrackWoDCA) && requireGlobalTrackWoDCAInFilter());
+  Filter filterSelectCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagD);
+
   OutputObj<TH1F> hMassDToPiKPi{TH1F("hMassDToPiKPi", "D^{#minus} candidates;inv. mass (p^{#minus} K^{#plus} #pi^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
   OutputObj<TH1F> hPtD{TH1F("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
@@ -86,11 +91,6 @@ struct HfCandidateCreatorB0 {
     }
     return true;
   }
-
-  using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
-
-  Filter filterSelectTracks = (!usePionIsGlobalTrackWoDCA) || ((usePionIsGlobalTrackWoDCA) && requireGlobalTrackWoDCAInFilter());
-  Filter filterSelectCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagD);
 
   void process(aod::Collision const& collision,
                soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>> const& candsD,

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -38,11 +38,11 @@ namespace o2::aod
 {
 namespace hf_cand_b0_config
 {
-DECLARE_SOA_COLUMN(SelectionFlagD, mySelectionFlagD, int);
+DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int);
 } // namespace hf_cand_b0_config
 
 DECLARE_SOA_TABLE(HfCandB0Config, "AOD", "HFCANDB0CONFIG", //!
-                  hf_cand_b0_config::SelectionFlagD);
+                  hf_cand_b0_config::MySelectionFlagD);
 } // namespace o2::aod
 
 /// Reconstruction of B0 candidates

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -105,7 +105,8 @@ struct HfCandidateCreatorB0 {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(true);
+    df2.setUseAbsDCA(useAbsDCA);
+    df2.setWeightedFinalPCA(useWeightedFinalPCA);
 
     // Initial fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
     o2::vertexing::DCAFitterN<3> df3;
@@ -115,7 +116,8 @@ struct HfCandidateCreatorB0 {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(true);
+    df3.setUseAbsDCA(useAbsDCA);
+    df3.setWeightedFinalPCA(useWeightedFinalPCA);
 
     // loop over D candidates
     for (const auto& candD : candsD) {

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -121,15 +121,7 @@ struct HfCandidateCreatorB0 {
 
     // loop over D candidates
     for (const auto& candD : candsD) {
-      if (!TESTBIT(candD.hfflag(), hf_cand_3prong::DecayType::DplusToPiKPi)) {
-        // FIXME: useless(?) this condition gives a flag=0 in DPlusToPiKPi selector
-        // and we filter flag>=1
-        continue;
-      }
-      if (candD.isSelDplusToPiKPi() >= selectionFlagD) {
-        // FIXME: useless(?) as candidates are already filtered
-        hMassDToPiKPi->Fill(invMassDplusToPiKPi(candD), candD.pt());
-      }
+      hMassDToPiKPi->Fill(invMassDplusToPiKPi(candD), candD.pt());
       hPtD->Fill(candD.pt());
       hCPAD->Fill(candD.cpa());
 

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -59,7 +59,7 @@ struct HfCandidateCreatorB0 {
   double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
   double massDPi{0.};
 
-  OutputObj<TH1F> hMassDToPiKPi{TH1F("hMassB0ToPiKPi", "D^{#minus} candidates;inv. mass (p^{#minus} K^{#plus} #pi^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
+  OutputObj<TH1F> hMassDToPiKPi{TH1F("hMassDToPiKPi", "D^{#minus} candidates;inv. mass (p^{#minus} K^{#plus} #pi^{#minus}) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
   OutputObj<TH1F> hPtD{TH1F("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hCPAD{TH1F("hCPAD", "D^{#minus} candidates;D^{#minus} cosine of pointing angle;entries", 110, -1.1, 1.1)};
@@ -93,7 +93,7 @@ struct HfCandidateCreatorB0 {
   Filter filterSelectCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagD);
 
   void process(aod::Collision const& collision,
-               soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>> const& dCands,
+               soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>> const& candsD,
                TracksWithSel const&,
                soa::Filtered<TracksWithSel> const& tracksPion)
   {
@@ -105,8 +105,7 @@ struct HfCandidateCreatorB0 {
     df2.setMaxDZIni(maxDZIni);
     df2.setMinParamChange(minParamChange);
     df2.setMinRelChi2Change(minRelChi2Change);
-    df2.setUseAbsDCA(useAbsDCA);
-    df2.setWeightedFinalPCA(useWeightedFinalPCA);
+    df2.setUseAbsDCA(true);
 
     // Initial fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
     o2::vertexing::DCAFitterN<3> df3;
@@ -116,208 +115,131 @@ struct HfCandidateCreatorB0 {
     df3.setMaxDZIni(maxDZIni);
     df3.setMinParamChange(minParamChange);
     df3.setMinRelChi2Change(minRelChi2Change);
-    df3.setUseAbsDCA(useAbsDCA);
-    df3.setWeightedFinalPCA(useWeightedFinalPCA);
+    df3.setUseAbsDCA(true);
 
     // loop over D candidates
-    for (auto const& dCand : dCands) {
-      if (!TESTBIT(dCand.hfflag(), hf_cand_3prong::DecayType::DplusToPiKPi)) {
+    for (const auto& candD : candsD) {
+      if (!TESTBIT(candD.hfflag(), hf_cand_3prong::DecayType::DplusToPiKPi)) {
+        // FIXME: useless(?) this condition gives a flag=0 in DPlusToPiKPi selector
+        // and we filter flag>=1
         continue;
       }
-      hMassDToPiKPi->Fill(invMassDplusToPiKPi(dCand), dCand.pt());
-      hPtD->Fill(dCand.pt());
-      hCPAD->Fill(dCand.cpa());
+      if (candD.isSelDplusToPiKPi() >= selectionFlagD) {
+        // FIXME: useless(?) as candidates are already filtered
+        hMassDToPiKPi->Fill(invMassDplusToPiKPi(candD), candD.pt());
+      }
+      hPtD->Fill(candD.pt());
+      hCPAD->Fill(candD.cpa());
 
       // track0 <-> pi, track1 <-> K, track2 <-> pi
-      auto track0 = dCand.prong0_as<TracksWithSel>();
-      auto track1 = dCand.prong1_as<TracksWithSel>();
-      auto track2 = dCand.prong2_as<TracksWithSel>();
-      auto trackParVar0 = getTrackParCov(track0);
-      auto trackParVar1 = getTrackParCov(track1);
-      auto trackParVar2 = getTrackParCov(track2);
+      auto track0 = candD.prong0_as<TracksWithSel>();
+      auto track1 = candD.prong1_as<TracksWithSel>();
+      auto track2 = candD.prong2_as<TracksWithSel>();
+      auto trackParCov0 = getTrackParCov(track0);
+      auto trackParCov1 = getTrackParCov(track1);
+      auto trackParCov2 = getTrackParCov(track2);
 
       // reconstruct 3-prong secondary vertex (D±)
-      if (df3.process(trackParVar0, trackParVar1, trackParVar2) == 0) {
+      if (df3.process(trackParCov0, trackParCov1, trackParCov2) == 0) {
         continue;
       }
 
       const auto& secondaryVertex = df3.getPCACandidate();
-      trackParVar0.propagateTo(secondaryVertex[0], bz);
-      trackParVar1.propagateTo(secondaryVertex[0], bz);
-      trackParVar2.propagateTo(secondaryVertex[0], bz);
+      trackParCov0.propagateTo(secondaryVertex[0], bz);
+      trackParCov1.propagateTo(secondaryVertex[0], bz);
+      trackParCov2.propagateTo(secondaryVertex[0], bz);
 
       // D∓ → π∓ K± π∓
       array<float, 3> pVecpiK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
       array<float, 3> pVecD = {pVecpiK[0] + track2.px(), pVecpiK[1] + track2.py(), pVecpiK[2] + track2.pz()};
-      auto trackParVarPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecpiK, df3.calcPCACovMatrixFlat(),
-                                                trackParVar0, trackParVar1, {0, 0}, {0, 0});
-      auto trackParVarD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(),
-                                              trackParVarPiK, trackParVar2, {0, 0}, {0, 0});
+      auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecpiK, df3.calcPCACovMatrixFlat(),
+                                                trackParCov0, trackParCov1, {0, 0}, {0, 0});
+      auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(),
+                                              trackParCovPiK, trackParCov2, {0, 0}, {0, 0});
 
-      int index0D = dCand.prong0Id();
-      int index1D = dCand.prong1Id();
-      int index2D = dCand.prong2Id();
+      int index0D = track0.globalIndex();
+      int index1D = track1.globalIndex();
+      int index2D = track2.globalIndex();
 
-      // loop on D-
-      // D- → π- K+ π-
-      // we don't have direct access to D sign so we use the sign of the daughters (the pion track0 here)
-      if (track0.sign() < 0) {
-        // loop over pions
-        for (auto const& trackPion : tracksPion) {
-          // minimum pT selection
-          if (trackPion.pt() < ptPionMin || !isSelectedTrackDCA(trackPion)) {
-            continue;
-          }
-          // we reject pions that are D daughters
-          if (trackPion.globalIndex() == index0D || trackPion.globalIndex() == index1D || trackPion.globalIndex() == index2D) {
-            continue;
-          }
-          // we only keep pi+ to combine them with Dminus and reconstruct B0
-          if (trackPion.sign() < 0) {
-            continue;
-          }
+      // loop over pions
+      for (const auto& trackPion : tracksPion) {
+        // minimum pT selection
+        if (trackPion.pt() < ptPionMin || !isSelectedTrackDCA(trackPion)) {
+          continue;
+        }
+        // reject pions that are D daughters
+        if (trackPion.globalIndex() == index0D || trackPion.globalIndex() == index1D || trackPion.globalIndex() == index2D) {
+          continue;
+        }
+        // reject pi and D with same sign
+        if (trackPion.sign() * track0.sign() > 0) {
+          continue;
+        }
 
-          hPtPion->Fill(trackPion.pt());
-          array<float, 3> pVecPion;
-          auto trackParVarPi = getTrackParCov(trackPion);
+        hPtPion->Fill(trackPion.pt());
+        array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+        ;
+        auto trackParCovPi = getTrackParCov(trackPion);
 
-          // ---------------------------------
-          // reconstruct the 2-prong B0 vertex
-          if (df2.process(trackParVarD, trackParVarPi) == 0) {
-            continue;
-          }
+        // ---------------------------------
+        // reconstruct the 2-prong B0 vertex
+        if (df2.process(trackParCovD, trackParCovPi) == 0) {
+          continue;
+        }
 
-          // calculate invariant mass
-          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
-          if (std::abs(massDPi - massB0) > invMassWindowB0) {
-            continue;
-          }
-
+        // calculate invariant mass
+        auto arrayMomenta = array{pVecD, pVecPion};
+        massDPi = RecoDecay::m(std::move(arrayMomenta), array{massD, massPi});
+        if (candD.isSelDplusToPiKPi() > 0) {
           hMassB0ToDPi->Fill(massDPi);
+        }
 
-          // calculate relevant properties
-          const auto& secondaryVertexB0 = df2.getPCACandidate();
-          auto chi2PCA = df2.getChi2AtPCACandidate();
-          auto covMatrixPCA = df2.calcPCACovMatrixFlat();
+        // calculate relevant properties
+        const auto& secondaryVertexB0 = df2.getPCACandidate();
+        auto chi2PCA = df2.getChi2AtPCACandidate();
+        auto covMatrixPCA = df2.calcPCACovMatrixFlat();
 
-          df2.propagateTracksToVertex();
-          df2.getTrack(0).getPxPyPzGlo(pVecD);
-          df2.getTrack(1).getPxPyPzGlo(pVecPion);
+        // must be called before getTrack query
+        df2.propagateTracksToVertex();
+        // track.getPxPyPzGlo(pVec) modifies pVec of track
+        df2.getTrack(0).getPxPyPzGlo(pVecD);
+        df2.getTrack(1).getPxPyPzGlo(pVecPion);
 
-          auto primaryVertex = getPrimaryVertex(collision);
-          auto covMatrixPV = primaryVertex.getCov();
-          o2::dataformats::DCA impactParameter0;
-          o2::dataformats::DCA impactParameter1;
-          trackParVarD.propagateToDCA(primaryVertex, bz, &impactParameter0);
-          trackParVarPi.propagateToDCA(primaryVertex, bz, &impactParameter1);
+        auto primaryVertex = getPrimaryVertex(collision);
+        auto covMatrixPV = primaryVertex.getCov();
+        o2::dataformats::DCA impactParameter0;
+        o2::dataformats::DCA impactParameter1;
+        trackParCovD.propagateToDCA(primaryVertex, bz, &impactParameter0);
+        trackParCovPi.propagateToDCA(primaryVertex, bz, &impactParameter1);
 
-          hCovSVXX->Fill(covMatrixPCA[0]);
-          hCovPVXX->Fill(covMatrixPV[0]);
+        hCovSVXX->Fill(covMatrixPCA[0]);
+        hCovPVXX->Fill(covMatrixPV[0]);
 
-          // get uncertainty of the decay length
-          double phi, theta;
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
-          auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
-          auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
+        // get uncertainty of the decay length
+        double phi, theta;
+        // getPointDirection modifies phi and theta
+        getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
+        auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
+        auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
-          int hfFlag = BIT(hf_cand_b0::DecayType::B0ToDPi);
+        int hfFlag = BIT(hf_cand_b0::DecayType::B0ToDPi);
 
-          // fill the candidate table for the B0 here:
-          rowCandidateBase(collision.globalIndex(),
-                           collision.posX(), collision.posY(), collision.posZ(),
-                           secondaryVertexB0[0], secondaryVertexB0[1], secondaryVertexB0[2],
-                           errorDecayLength, errorDecayLengthXY,
-                           chi2PCA,
-                           pVecD[0], pVecD[1], pVecD[2],
-                           pVecPion[0], pVecPion[1], pVecPion[2],
-                           impactParameter0.getY(), impactParameter1.getY(),
-                           std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
-                           dCand.globalIndex(), trackPion.globalIndex(),
-                           hfFlag);
-
-        } // pi+ loop
-      }   // if D-
-
-      // loop on D+
-      // D+ → π+ K- π+
-      // we now loop on the D+
-      if (track0.sign() > 0) {
-        // loop over pions
-        for (auto const& trackPion : tracksPion) {
-          // minimum pT selection
-          if (trackPion.pt() < ptPionMin || !isSelectedTrackDCA(trackPion)) {
-            continue;
-          }
-          // we reject pions that are D daughters
-          if (trackPion.globalIndex() == index0D || trackPion.globalIndex() == index1D || trackPion.globalIndex() == index2D) {
-            continue;
-          }
-          // we onnly keep pi- to combine them with D+ and reconstruct B0bar
-          if (trackPion.sign() > 0) {
-            continue;
-          }
-
-          hPtPion->Fill(trackPion.pt());
-          array<float, 3> pVecPion;
-          auto trackParVarPi = getTrackParCov(trackPion);
-
-          // ---------------------------------
-          // reconstruct the 2-prong B0bar vertex
-          if (df2.process(trackParVarD, trackParVarPi) == 0) {
-            continue;
-          }
-
-          // calculate invariant mass
-          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
-          hMassB0ToDPi->Fill(massDPi);
-          if (std::abs(massDPi - massB0) > invMassWindowB0) {
-            continue;
-          }
-
-          // calculate relevant properties
-          const auto& secondaryVertexB0 = df2.getPCACandidate();
-          auto chi2PCA = df2.getChi2AtPCACandidate();
-          auto covMatrixPCA = df2.calcPCACovMatrixFlat();
-
-          df2.propagateTracksToVertex();
-          df2.getTrack(0).getPxPyPzGlo(pVecD);
-          df2.getTrack(1).getPxPyPzGlo(pVecPion);
-
-          auto primaryVertex = getPrimaryVertex(collision);
-          auto covMatrixPV = primaryVertex.getCov();
-          o2::dataformats::DCA impactParameter0;
-          o2::dataformats::DCA impactParameter1;
-          trackParVarD.propagateToDCA(primaryVertex, bz, &impactParameter0);
-          trackParVarPi.propagateToDCA(primaryVertex, bz, &impactParameter1);
-
-          hCovSVXX->Fill(covMatrixPCA[0]);
-          hCovPVXX->Fill(covMatrixPV[0]);
-
-          // get uncertainty of the decay length
-          double phi, theta;
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
-          auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
-          auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
-
-          int hfFlag = BIT(hf_cand_b0::DecayType::B0ToDPi);
-
-          // fill the candidate table for the B0 here:
-          rowCandidateBase(collision.globalIndex(),
-                           collision.posX(), collision.posY(), collision.posZ(),
-                           secondaryVertexB0[0], secondaryVertexB0[1], secondaryVertexB0[2],
-                           errorDecayLength, errorDecayLengthXY,
-                           chi2PCA,
-                           pVecD[0], pVecD[1], pVecD[2],
-                           pVecPion[0], pVecPion[1], pVecPion[2],
-                           impactParameter0.getY(), impactParameter1.getY(),
-                           std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
-                           dCand.globalIndex(), trackPion.globalIndex(),
-                           hfFlag);
-        } // pi- loop
-      }   // if D+
-    }     // D loop
-  }       // process
-};        // struct
+        // fill the candidate table for the B0 here:
+        rowCandidateBase(collision.globalIndex(),
+                         collision.posX(), collision.posY(), collision.posZ(),
+                         secondaryVertexB0[0], secondaryVertexB0[1], secondaryVertexB0[2],
+                         errorDecayLength, errorDecayLengthXY,
+                         chi2PCA,
+                         pVecD[0], pVecD[1], pVecD[2],
+                         pVecPion[0], pVecPion[1], pVecPion[2],
+                         impactParameter0.getY(), impactParameter1.getY(),
+                         std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
+                         candD.globalIndex(), trackPion.globalIndex(),
+                         hfFlag);
+      } // pi loop
+    }   // D loop
+  }     // process
+};      // struct
 
 /// Extends the base table with expression columns and performs MC matching.
 struct HfCandidateCreatorB0Expressions {
@@ -325,11 +247,14 @@ struct HfCandidateCreatorB0Expressions {
   Produces<aod::HfCandB0McRec> rowMcMatchRec; // table defined in CandidateReconstructionTables.h
   Produces<aod::HfCandB0McGen> rowMcMatchGen; // table defined in CandidateReconstructionTables.h
 
-  void processMc(aod::HfCand3Prong const&,
+  void init(InitContext const&) {}
+
+  void processMc(aod::HfCand3Prong const& dplus,
                  aod::BigTracksMC const& tracks,
                  aod::McParticles const& particlesMC)
   {
     rowCandidateB0->bindExternalIndices(&tracks);
+    rowCandidateB0->bindExternalIndices(&dplus);
 
     int indexRec = -1;
     int8_t sign = 0;
@@ -344,7 +269,7 @@ struct HfCandidateCreatorB0Expressions {
       flag = 0;
       origin = 0;
       debug = 0;
-      auto candD = candidate.prong0();
+      auto candD = candidate.prong0_as<aod::HfCand3Prong>();
       auto arrayDaughters = array{candD.prong0_as<aod::BigTracksMC>(),
                                   candD.prong1_as<aod::BigTracksMC>(),
                                   candD.prong2_as<aod::BigTracksMC>(),
@@ -367,7 +292,7 @@ struct HfCandidateCreatorB0Expressions {
         }
       }
       rowMcMatchRec(flag, origin, debug);
-    }
+    } // rec
 
     // Match generated particles.
     for (auto const& particle : particlesMC) {
@@ -384,10 +309,10 @@ struct HfCandidateCreatorB0Expressions {
         }
       }
       rowMcMatchGen(flag, origin);
-    }
-  }
+    } // gen
+  }   // processMc
   PROCESS_SWITCH(HfCandidateCreatorB0Expressions, processMc, "Process MC", false);
-};
+}; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -180,9 +180,7 @@ struct HfCandidateCreatorB0 {
 
         hPtPion->Fill(trackPion.pt());
         array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
-        ;
         auto trackParCovPi = getTrackParCov(trackPion);
-
         // ---------------------------------
         // reconstruct the 2-prong B0 vertex
         if (df2.process(trackParCovD, trackParCovPi) == 0) {
@@ -190,11 +188,11 @@ struct HfCandidateCreatorB0 {
         }
 
         // calculate invariant mass
-        auto arrayMomenta = array{pVecD, pVecPion};
-        massDPi = RecoDecay::m(std::move(arrayMomenta), array{massD, massPi});
-        if (candD.isSelDplusToPiKPi() > 0) {
-          hMassB0ToDPi->Fill(massDPi);
+        massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+        if (std::abs(massDPi - massB0) > invMassWindowB0) {
+          continue;
         }
+        hMassB0ToDPi->Fill(massDPi);
 
         // calculate relevant properties
         const auto& secondaryVertexB0 = df2.getPCACandidate();
@@ -271,7 +269,7 @@ struct HfCandidateCreatorB0Expressions {
       flag = 0;
       origin = 0;
       debug = 0;
-      auto candD = candidate.prong0_as<aod::HfCand3Prong>();
+      auto candD = candidate.prong0();
       auto arrayDaughters = array{candD.prong0_as<aod::BigTracksMC>(),
                                   candD.prong1_as<aod::BigTracksMC>(),
                                   candD.prong2_as<aod::BigTracksMC>(),

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -51,11 +51,11 @@ struct HfCandidateSelectorB0ToDPi {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_b0_to_d_pi::cuts[0], nBinsPt, nCutVars, labelsPt, labelsCutVar}, "B0 candidate selection per pT bin"};
 
-  // Apply topological cuts as defined in SelectorCuts.h
-  // \param hfCandB0 is the B0 candidate
-  // \param hfCandD is prong1 of B0 candidate
-  // \param trackPi is prong1 of B0 candidate
-  // \return true if candidate passes all selections
+  /// Apply topological cuts as defined in SelectorCuts.h
+  /// \param hfCandB0 is the B0 candidate
+  /// \param hfCandD is prong1 of B0 candidate
+  /// \param trackPi is prong1 of B0 candidate
+  /// \return true if candidate passes all selections
   template <typename T1, typename T2, typename T3>
   bool selectionTopol(const T1& hfCandB0, const T2& hfCandD, const T3& trackPi)
   {
@@ -125,9 +125,9 @@ struct HfCandidateSelectorB0ToDPi {
     return true;
   }
 
-  // Apply PID selection
-  // \param pidTrackPi is the PID status of trackPi (prong1 of B0 candidate)
-  // \return true if prong1 of B0 candidate passes all selections
+  /// Apply PID selection
+  /// \param pidTrackPi is the PID status of trackPi (prong1 of B0 candidate)
+  /// \return true if prong1 of B0 candidate passes all selections
   template <typename T = int>
   bool selectionPID(const T& pidTrackPi)
   {

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -122,7 +122,7 @@ struct HfCandidateSelectorB0ToDPi {
 
   // Apply PID selection; return true if candidate passes all selections
   template <typename T>
-  bool selectionPID(const T& pidTrackPi) 
+  bool selectionPID(const T& pidTrackPi)
   {
     if (pidTrackPi != TrackSelectorPID::Status::PIDAccepted) {
       return false;
@@ -152,7 +152,7 @@ struct HfCandidateSelectorB0ToDPi {
         // LOGF(info, "B0 candidate selection failed at hfflag check");
         continue;
       }
-      SETBIT(statusB0ToDPi, aod::SelectionStep::RecoSkims); // RecoSkims = 0 --> statusB0ToDPi = 1 
+      SETBIT(statusB0ToDPi, aod::SelectionStep::RecoSkims); // RecoSkims = 0 --> statusB0ToDPi = 1
 
       auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
       auto trackPi = hfCandB0.prong1_as<TracksPIDWithSel>();

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -51,6 +51,8 @@ struct HfCandidateSelectorB0ToDPi {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_b0_to_d_pi::cuts[0], nBinsPt, nCutVars, labelsPt, labelsCutVar}, "B0 candidate selection per pT bin"};
 
+  using TracksPIDWithSel = soa::Join<aod::BigTracksPIDExtended, aod::TrackSelection>;
+
   /// Apply topological cuts as defined in SelectorCuts.h
   /// \param hfCandB0 is the B0 candidate
   /// \param hfCandD is prong1 of B0 candidate
@@ -140,8 +142,6 @@ struct HfCandidateSelectorB0ToDPi {
 
     return true;
   }
-
-  using TracksPIDWithSel = soa::Join<aod::BigTracksPIDExtended, aod::TrackSelection>;
 
   void process(aod::HfCandB0 const& hfCandsB0, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksPIDWithSel const&)
   {

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -123,32 +123,30 @@ struct HfCandidateSelectorB0ToDPi {
 
   using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
 
-  void process(aod::HfCandB0 const& hfCandB0s, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksWithSel const&)
+  void process(aod::HfCandB0::iterator const& hfCandB0, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksWithSel const&)
   {
-    for (auto const& hfCandB0 : hfCandB0s) { // looping over B0 candidates
-      int statusB0 = 0;
+    int statusB0 = 0;
 
-      // check if flagged as B0 → D- π+
-      if (!TESTBIT(hfCandB0.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
-        hfSelB0ToDPiCandidate(statusB0);
-        // Printf("B0 candidate selection failed at hfflag check");
-        continue;
-      }
-
-      // D is always index0 and pi is index1 by default
-      auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
-      auto trackPi = hfCandB0.prong1_as<TracksWithSel>();
-
-      // topological cuts
-      if (!selectionTopol(hfCandB0, candD, trackPi)) {
-        hfSelB0ToDPiCandidate(statusB0);
-        // Printf("B0 candidate selection failed at selection topology");
-        continue;
-      }
-
-      hfSelB0ToDPiCandidate(1);
-      // Printf("B0 candidate selection successful, candidate should be selected");
+    // check if flagged as B0 → D- π+
+    if (!TESTBIT(hfCandB0.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+      hfSelB0ToDPiCandidate(statusB0);
+      // Printf("B0 candidate selection failed at hfflag check");
+      return;
     }
+
+    // D is always index0 and pi is index1 by default
+    auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
+    auto trackPi = hfCandB0.prong1_as<TracksWithSel>();
+
+    // topological cuts
+    if (!selectionTopol(hfCandB0, candD, trackPi)) {
+      hfSelB0ToDPiCandidate(statusB0);
+      // Printf("B0 candidate selection failed at selection topology");
+      return;
+    }
+
+    hfSelB0ToDPiCandidate(1);
+    // Printf("B0 candidate selection successful, candidate should be selected");
   }
 };
 

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -76,7 +76,7 @@ struct HfCandidateSelectorB0ToDPi {
     }
 
     // D- pt
-    if (hfCandD.pt() < cuts->get(pTBin, "pT D^{#minus}")) {
+    if (hfCandD.pt() < cuts->get(pTBin, "pT D")) {
       return false;
     }
 
@@ -121,10 +121,11 @@ struct HfCandidateSelectorB0ToDPi {
     return true;
   }
 
-  void process(aod::HfCandB0 const& hfCandB0s, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, aod::BigTracksPID const&)
+  using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
+
+  void process(aod::HfCandB0 const& hfCandB0s, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksWithSel const&)
   {
     for (auto const& hfCandB0 : hfCandB0s) { // looping over B0 candidates
-
       int statusB0 = 0;
 
       // check if flagged as B0 → D- π+
@@ -135,9 +136,8 @@ struct HfCandidateSelectorB0ToDPi {
       }
 
       // D is always index0 and pi is index1 by default
-      // auto candD = hfCandD.prong0();
       auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
-      auto trackPi = hfCandB0.prong1_as<aod::BigTracksPID>();
+      auto trackPi = hfCandB0.prong1_as<TracksWithSel>();
 
       // topological cuts
       if (!selectionTopol(hfCandB0, candD, trackPi)) {
@@ -154,7 +154,5 @@ struct HfCandidateSelectorB0ToDPi {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{};
-  workflow.push_back(adaptAnalysisTask<HfCandidateSelectorB0ToDPi>(cfgc));
-  return workflow;
+  return WorkflowSpec{adaptAnalysisTask<HfCandidateSelectorB0ToDPi>(cfgc)};
 }

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -189,8 +189,7 @@ struct HfCandidateSelectorB0ToDPi {
           continue;
         }
         SETBIT(statusB0ToDPi, aod::SelectionStep::RecoPID); // RecoPID = 2 --> statusB0ToDPi = 7
-      }
-      else {
+      } else {
         if (TESTBIT(candD.isSelDplusToPiKPi(), aod::SelectionStep::RecoPID)) {
           LOG(warning) << "No PID selections required on B0 daughters (usePid=false) but PID selections on D candidates were required a priori (selectionFlagD=7). Set selectionFlagD<7 in hf-candidate-creator-b0";
           hfSelB0ToDPiCandidate(statusB0ToDPi);

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -16,7 +16,7 @@
 
 #include "Common/Core/TrackSelectorPID.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/RunningWorkflowInfo.h"
+// #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/AnalysisTask.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -35,11 +35,11 @@ namespace o2::aod
 {
 namespace hf_cand_b0_config
 {
-DECLARE_SOA_COLUMN(SelectionFlagD, mySelectionFlagD, int);
+DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int);
 } // namespace hf_cand_b0_config
 
 DECLARE_SOA_TABLE(HfCandB0Config, "AOD", "HFCANDB0CONFIG", //!
-                  hf_cand_b0_config::SelectionFlagD);
+                  hf_cand_b0_config::MySelectionFlagD);
 } // namespace o2::aod
 
 struct HfCandidateSelectorB0ToDPi {
@@ -66,7 +66,7 @@ struct HfCandidateSelectorB0ToDPi {
   // check if selectionFlagD (defined in candidateCreatorB0.cxx) and usePid configurables are in sync
   bool selectionFlagDAndUsePidInSync = true;
   // FIXME: store B0 creator configurable (until https://alice.its.cern.ch/jira/browse/O2-3582 solved)
-  int selectionFlagD = -1;
+  int mySelectionFlagD = -1;
 
   using TracksPIDWithSel = soa::Join<aod::BigTracksPIDExtended, aod::TrackSelection>;
 
@@ -193,13 +193,13 @@ struct HfCandidateSelectorB0ToDPi {
   {
     // FIXME: get B0 creator configurable (until https://alice.its.cern.ch/jira/browse/O2-3582 solved)
     for (const auto& config : configs) {
-      selectionFlagD = config.mySelectionFlagD();
+      mySelectionFlagD = config.mySelectionFlagD();
 
-      if (usePid && !TESTBIT(selectionFlagD, SelectionStep::RecoPID)) {
+      if (usePid && !TESTBIT(mySelectionFlagD, SelectionStep::RecoPID)) {
         selectionFlagDAndUsePidInSync = false;
         LOG(warning) << "PID selections required on B0 daughters (usePid=true) but no PID selections on D candidates were required a priori (selectionFlagD<7). Set selectionFlagD=7 in hf-candidate-creator-b0";
       }
-      if (!usePid && TESTBIT(selectionFlagD, SelectionStep::RecoPID)) {
+      if (!usePid && TESTBIT(mySelectionFlagD, SelectionStep::RecoPID)) {
         selectionFlagDAndUsePidInSync = false;
         LOG(warning) << "No PID selections required on B0 daughters (usePid=false) but PID selections on D candidates were required a priori (selectionFlagD=7). Set selectionFlagD<7 in hf-candidate-creator-b0";
       }

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -105,11 +105,11 @@ struct HfCandidateSelectorDplusToPiKPi {
     return true;
   }
 
-  // Apply PID selection
-  // \param pidTrackPos1Pion is the PID status of trackPos1 (prong0 of D candidate)
-  // \param pidTrackNegKaon is the PID status of trackNeg (prong1 of D candidate)
-  // \param pidTrackPos2Pion is the PID status of trackPos2 (prong2 of D candidate)
-  // \return true if prongs pass all selections
+  /// Apply PID selection
+  /// \param pidTrackPos1Pion is the PID status of trackPos1 (prong0 of D candidate)
+  /// \param pidTrackNegKaon is the PID status of trackNeg (prong1 of D candidate)
+  /// \param pidTrackPos2Pion is the PID status of trackPos2 (prong2 of D candidate)
+  /// \return true if prongs pass all selections
   template <typename T = int>
   bool selectionPID(const T& pidTrackPos1Pion, const T& pidTrackNegKaon, const T& pidTrackPos2Pion)
   {

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -113,16 +113,16 @@ struct HfCandidateSelectorDplusToPiKPi {
   template <typename T = int>
   bool selectionPID(const T& pidTrackPos1Pion, const T& pidTrackNegKaon, const T& pidTrackPos2Pion)
   {
-    if (!acceptPIDNotApplicable && 
-       (pidTrackPos1Pion != TrackSelectorPID::Status::PIDAccepted ||
-        pidTrackNegKaon != TrackSelectorPID::Status::PIDAccepted ||
-        pidTrackPos2Pion != TrackSelectorPID::Status::PIDAccepted)) {
+    if (!acceptPIDNotApplicable &&
+        (pidTrackPos1Pion != TrackSelectorPID::Status::PIDAccepted ||
+         pidTrackNegKaon != TrackSelectorPID::Status::PIDAccepted ||
+         pidTrackPos2Pion != TrackSelectorPID::Status::PIDAccepted)) {
       return false;
     }
-    if (acceptPIDNotApplicable && 
-       (pidTrackPos1Pion == TrackSelectorPID::Status::PIDRejected ||
-        pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||
-        pidTrackPos2Pion == TrackSelectorPID::Status::PIDRejected)) {
+    if (acceptPIDNotApplicable &&
+        (pidTrackPos1Pion == TrackSelectorPID::Status::PIDRejected ||
+         pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||
+         pidTrackPos2Pion == TrackSelectorPID::Status::PIDRejected)) {
       return false;
     }
 

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -32,6 +32,8 @@ struct HfCandidateSelectorDplusToPiKPi {
 
   Configurable<double> ptCandMin{"ptCandMin", 1., "Lower bound of candidate pT"};
   Configurable<double> ptCandMax{"ptCandMax", 36., "Upper bound of candidate pT"};
+  // PID option
+  Configurable<bool> acceptPIDNotApplicable{"acceptPIDNotApplicable", false, "Switch to accept Status::PIDNotApplicable [(NotApplicable for one detector) and (NotApplicable or Conditional for the other)] in PID selection"};
   // TPC PID
   Configurable<double> ptPidTpcMin{"ptPidTpcMin", 0.15, "Lower bound of track pT for TPC PID"};
   Configurable<double> ptPidTpcMax{"ptPidTpcMax", 20., "Upper bound of track pT for TPC PID"};
@@ -103,6 +105,30 @@ struct HfCandidateSelectorDplusToPiKPi {
     return true;
   }
 
+  // Apply PID selection
+  // \param pidTrackPos1Pion is the PID status of trackPos1 (prong0 of D candidate)
+  // \param pidTrackNegKaon is the PID status of trackNeg (prong1 of D candidate)
+  // \param pidTrackPos2Pion is the PID status of trackPos2 (prong2 of D candidate)
+  // \return true if prongs pass all selections
+  template <typename T = int>
+  bool selectionPID(const T& pidTrackPos1Pion, const T& pidTrackNegKaon, const T& pidTrackPos2Pion)
+  {
+    if (!acceptPIDNotApplicable && 
+       (pidTrackPos1Pion != TrackSelectorPID::Status::PIDAccepted ||
+        pidTrackNegKaon != TrackSelectorPID::Status::PIDAccepted ||
+        pidTrackPos2Pion != TrackSelectorPID::Status::PIDAccepted)) {
+      return false;
+    }
+    if (acceptPIDNotApplicable && 
+       (pidTrackPos1Pion == TrackSelectorPID::Status::PIDRejected ||
+        pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||
+        pidTrackPos2Pion == TrackSelectorPID::Status::PIDRejected)) {
+      return false;
+    }
+
+    return true;
+  }
+
   void process(aod::HfCand3Prong const& candidates, aod::BigTracksPID const&)
   {
     TrackSelectorPID selectorPion(kPiPlus);
@@ -148,13 +174,11 @@ struct HfCandidateSelectorDplusToPiKPi {
       SETBIT(statusDplusToPiKPi, aod::SelectionStep::RecoTopol);
 
       // track-level PID selection
-      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos1);
-      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
-      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos2);
+      int pidTrackPos1Pion = selectorPion.getStatusTrackPIDTpcAndTof(trackPos1);
+      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcAndTof(trackNeg);
+      int pidTrackPos2Pion = selectorPion.getStatusTrackPIDTpcAndTof(trackPos2);
 
-      if (pidTrackPos1Pion == TrackSelectorPID::Status::PIDRejected ||
-          pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||
-          pidTrackPos2Pion == TrackSelectorPID::Status::PIDRejected) { // exclude D±
+      if (!selectionPID(pidTrackPos1Pion, pidTrackNegKaon, pidTrackPos2Pion)) { // exclude D±
         hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);
         continue;
       }

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -33,7 +33,7 @@ struct HfCandidateSelectorDplusToPiKPi {
   Configurable<double> ptCandMin{"ptCandMin", 1., "Lower bound of candidate pT"};
   Configurable<double> ptCandMax{"ptCandMax", 36., "Upper bound of candidate pT"};
   // PID option
-  Configurable<bool> acceptPIDNotApplicable{"acceptPIDNotApplicable", false, "Switch to accept Status::PIDNotApplicable [(NotApplicable for one detector) and (NotApplicable or Conditional for the other)] in PID selection"};
+  Configurable<bool> acceptPIDNotApplicable{"acceptPIDNotApplicable", true, "Switch to accept Status::PIDNotApplicable [(NotApplicable for one detector) and (NotApplicable or Conditional for the other)] in PID selection"};
   // TPC PID
   Configurable<double> ptPidTpcMin{"ptPidTpcMin", 0.15, "Lower bound of track pT for TPC PID"};
   Configurable<double> ptPidTpcMax{"ptPidTpcMax", 20., "Upper bound of track pT for TPC PID"};


### PR DESCRIPTION
Hey @fgrosa @iouribelikov  !

Here are the fixes applied to the B0 workflow, everything works (I get filled histograms in output of the execution command line) but there still might be some mistakes :)

One of the main modifications I applied to the candidate creator is removing the double loop on D+/D-: I now check the sign of `sign(D) * sign(Pi)` to only keep pairs that have opposite electric charge.

Also, the `processMc` functions work as well.

-----------------------------------------------------------------------------------------
List of fixes:

- `candidateSelectorDpluToPiKPi.cxx`
  - modify PID selection (put in a function): TpcOrTof --> TpcAndTof + add configurable to accept PIDNotApplicable status (default value set to `true`)
- `candidateCreatorB0.cxx`
  - [loop over D- & loop over Pi+] + [loop over D+ & loop over Pi-] --> reject DPi pairs with same electric charge signs + loop over pions
  - subscribe to `HfCand3Prong` in `processMc` and bind indices
- `candidateSelectorB0ToDPi.cxx`
  - pT cut on D candidate: "pT D^{#minus}" --> "pT D" (defined in `SelectorCuts.h`)
  - subscribe to `TracksWithSel` instead of `BigTracksPID`
  - add PID selection (TpcAndTof) + add configurable to accept `PIDNotApplicable` status (default value set to `true`)
  - sync settings of `selectionFlagD` (from B0 creator) and `usePid` [temporary solution using AOD table]
- `taskB0.cxx`
  -  subscribe to `TracksWithSel` instead of `BigTracksPID`
  - fix condition on `candidate.hfflag()` in `processMc` (a `!` was missing in front of `TESTBIT` in the if loop)