### PR TITLE
Ml model update

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -166,7 +166,8 @@ struct tpcPid {
           headers = ccdbApi.retrieveHeaders(networkPathCCDB.value, metadata, ccdbTimestamp.value);
           if (retrieveSuccess) {
             network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value, strtoul(headers["Valid-From"].c_str(), NULL, 0), strtoul(headers["Valid-Until"].c_str(), NULL, 0));
-            network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.)); /// Init the model evaluations
+            std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+            network.evalModel(dummyInput); /// Init the model evaluations
           } else {
             LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
           }
@@ -177,7 +178,8 @@ struct tpcPid {
           }
           LOG(info) << "Using local file [" << networkPathLocally.value << "] for the TPC PID response correction.";
           network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value);
-          network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.)); // This is an initialisation and might reduce the overhead of the model
+          std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+          network.evalModel(dummyInput); // This is an initialisation and might reduce the overhead of the model
         }
       } else {
         return;
@@ -221,7 +223,9 @@ struct tpcPid {
           headers = ccdbApi.retrieveHeaders(networkPathCCDB.value, metadata, bc.timestamp());
           if (retrieveSuccess) {
             network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value, strtoul(headers["Valid-From"].c_str(), NULL, 0), strtoul(headers["Valid-Until"].c_str(), NULL, 0));
-            network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.));
+
+            std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+            network.evalModel(dummyInput);
           } else {
             LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
           }

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -166,7 +166,8 @@ struct tpcPidFull {
           headers = ccdbApi.retrieveHeaders(networkPathCCDB.value, metadata, ccdbTimestamp.value);
           if (retrieveSuccess) {
             network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value, strtoul(headers["Valid-From"].c_str(), NULL, 0), strtoul(headers["Valid-Until"].c_str(), NULL, 0));
-            network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.)); /// Init the model evaluations
+            std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+            network.evalModel(dummyInput); /// Init the model evaluations
           } else {
             LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
           }
@@ -177,7 +178,8 @@ struct tpcPidFull {
           }
           LOG(info) << "Using local file [" << networkPathLocally.value << "] for the TPC PID response correction.";
           network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value);
-          network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.)); // This is an initialisation and might reduce the overhead of the model
+          std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+          network.evalModel(dummyInput); // This is an initialisation and might reduce the overhead of the model
         }
       } else {
         return;
@@ -220,7 +222,8 @@ struct tpcPidFull {
           headers = ccdbApi.retrieveHeaders(networkPathCCDB.value, metadata, bc.timestamp());
           if (retrieveSuccess) {
             network.initModel(networkPathLocally.value, enableNetworkOptimizations.value, networkSetNumThreads.value, strtoul(headers["Valid-From"].c_str(), NULL, 0), strtoul(headers["Valid-Until"].c_str(), NULL, 0));
-            network.evalModel(std::vector<float>(network.getNumInputNodes(), 1.));
+            std::vector<float> dummyInput(network.getNumInputNodes(), 1.);
+            network.evalModel(dummyInput);
           } else {
             LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
           }

--- a/PWGHF/TableProducer/candidateSelectorLcMl.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLcMl.cxx
@@ -110,7 +110,8 @@ struct HfCandidateSelectorLcMl {
           LOGF(warning, "Model for Lc with negative input shape likely because converted with hummingbird, setting it to 1.");
           inputShapes[0][0] = 1;
         }
-        model.evalModel(std::vector<float>(model.getNumInputNodes(), 1.)); /// Init the model evaluations
+        std::vector<float> dummyInput(model.getNumInputNodes(), 1.);
+        model.evalModel(dummyInput); // Init the model evaluations
         dataTypeML = session->GetInputTypeInfo(0).GetTensorTypeAndShapeInfo().GetElementType();
       } else {
         LOG(fatal) << "Error encountered while fetching/loading the ML model from CCDB! Maybe the ML model doesn't exist yet for this runnumber/timestamp?";

--- a/Tools/ML/model.cxx
+++ b/Tools/ML/model.cxx
@@ -100,42 +100,6 @@ void OnnxModel::initModel(std::string localPath, bool enableOptimizations, int t
   LOG(info) << "--- Model initialized! ---";
 }
 
-float* OnnxModel::evalModel(std::vector<Ort::Value> input)
-{
-  LOG(debug) << "Shape of input (tensor): " << printShape(input[0].GetTensorTypeAndShapeInfo().GetShape());
-  // assert(input[0].GetTensorTypeAndShapeInfo().GetShape() == getNumInputNodes()); --> Fails build in debug mode, TODO: assertion should be checked somehow
-
-  try {
-    auto outputTensors = mSession->Run(mInputNames, input, mOutputNames);
-    LOG(debug) << "Shape of output (tensor): " << printShape(outputTensors[0].GetTensorTypeAndShapeInfo().GetShape());
-    // assert(outputTensors[0].GetTensorTypeAndShapeInfo().GetShape() == getNumOutputNodes());
-    float* outputValues = outputTensors[0].GetTensorMutableData<float>();
-    return outputValues;
-  } catch (const Ort::Exception& exception) {
-    LOG(error) << "Error running model inference: " << exception.what();
-  }
-  return nullptr;
-}
-
-float* OnnxModel::evalModel(std::vector<float> input)
-{
-  int64_t size = input.size();
-  assert(size % mInputShapes[0][1] == 0);
-  std::vector<int64_t> inputShape{size / mInputShapes[0][1], mInputShapes[0][1]};
-  std::vector<Ort::Value> inputTensors;
-  inputTensors.emplace_back(Ort::Experimental::Value::CreateTensor<float>(input.data(), size, inputShape));
-  LOG(debug) << "Shape of input (vector): " << printShape(inputShape);
-  try {
-    auto outputTensors = mSession->Run(mInputNames, inputTensors, mOutputNames);
-    LOG(debug) << "Shape of output (tensor): " << printShape(outputTensors[0].GetTensorTypeAndShapeInfo().GetShape());
-    float* outputValues = outputTensors[0].GetTensorMutableData<float>();
-    return outputValues;
-  } catch (const Ort::Exception& exception) {
-    LOG(error) << "Error running model inference: " << exception.what();
-  }
-  return nullptr;
-}
-
 void OnnxModel::setActiveThreads(int threads)
 {
   activeThreads = threads;

--- a/Tools/ML/model.h
+++ b/Tools/ML/model.h
@@ -58,7 +58,7 @@ class OnnxModel
 
     try {
       auto outputTensors = mSession->Run(mInputNames, input, mOutputNames);
-      LOG(info) << "Number of output tensors: " << outputTensors.size();
+      LOG(debug) << "Number of output tensors: " << outputTensors.size();
       if (outputTensors.size() != mOutputNames.size()) {
         LOG(fatal) << "Number of output tensors: " << outputTensors.size() << " does not agree with the model specified size: " << mOutputNames.size();
       }

--- a/Tools/ML/model.h
+++ b/Tools/ML/model.h
@@ -48,8 +48,45 @@ class OnnxModel
 
   // Inferencing
   void initModel(std::string, bool = false, int = 0, uint64_t = 0, uint64_t = 0);
-  float* evalModel(std::vector<Ort::Value>);
-  float* evalModel(std::vector<float>);
+
+  // template methods -- best to define them in header
+  template <typename T>
+  T* evalModel(std::vector<Ort::Value>& input)
+  {
+    LOG(debug) << "Input tensor shape: " << printShape(input[0].GetTensorTypeAndShapeInfo().GetShape());
+    // assert(input[0].GetTensorTypeAndShapeInfo().GetShape() == getNumInputNodes()); --> Fails build in debug mode, TODO: assertion should be checked somehow
+
+    try {
+      auto outputTensors = mSession->Run(mInputNames, input, mOutputNames);
+      LOG(info) << "Number of output tensors: " << outputTensors.size();
+      if (outputTensors.size() != mOutputNames.size()) {
+        LOG(fatal) << "Number of output tensors: " << outputTensors.size() << " does not agree with the model specified size: " << mOutputNames.size();
+      }
+      for (std::size_t i = 0; i < outputTensors.size(); i++) {
+        LOG(debug) << "Output tensor shape: " << printShape(outputTensors[i].GetTensorTypeAndShapeInfo().GetShape());
+        if (outputTensors[i].GetTensorTypeAndShapeInfo().GetShape() != mOutputShapes[i]) {
+          LOG(fatal) << "Shape of tensor " << i << " does not agree with model specification! Output: " << printShape(outputTensors[i].GetTensorTypeAndShapeInfo().GetShape()) << " model: " << printShape(mOutputShapes[i]);
+        }
+      }
+      T* outputValues = outputTensors.back().GetTensorMutableData<T>();
+      return outputValues;
+    } catch (const Ort::Exception& exception) {
+      LOG(error) << "Error running model inference: " << exception.what();
+    }
+    return nullptr;
+  }
+
+  template <typename T>
+  T* evalModel(std::vector<T>& input)
+  {
+    int64_t size = input.size();
+    assert(size % mInputShapes[0][1] == 0);
+    std::vector<int64_t> inputShape{size / mInputShapes[0][1], mInputShapes[0][1]};
+    std::vector<Ort::Value> inputTensors;
+    inputTensors.emplace_back(Ort::Experimental::Value::CreateTensor<T>(input.data(), size, inputShape));
+    LOG(debug) << "Input shape calculated from vector: " << printShape(inputShape);
+    return evalModel<T>(inputTensors);
+  }
 
   // Reset session
   void resetSession() { mSession.reset(new Ort::Experimental::Session{*mEnv, modelPath, sessionOptions}); }


### PR DESCRIPTION
Hi @fcatalan92 @ChSonnabend 

Recently I developed a Lc selector that uses BDT models developed by Fabrizio. I used the ML framework, but I needed some adjustments for BDT:
- different output types, not only floats
- BDT has output values in tensor[1], not tensor[0]. Currently, my solution is to use the outputs from the last tensor in a vector. In case someone else will have a yet different model with different outputs, we can again make adjustments.

Let me know if the changes there are fine for you.