### PR TITLE
Symlinks to reproduce the directory structure

### DIFF
--- a/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
+++ b/cmake/O2PhysicsAddHeaderOnlyLibrary.cmake
@@ -74,4 +74,10 @@ function(o2physics_add_header_only_library baseTargetName)
           FILE_SET HEADERS
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+  # Link subdirectories
+  install(
+    SCRIPT ${CMAKE_SOURCE_DIR}/cmake/O2PhysicsLinkAllSubDirs.cmake
+    CODE " o2physics_link_all_subdirs(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}) "
+  )
+
 endfunction()

--- a/cmake/O2PhysicsAddLibrary.cmake
+++ b/cmake/O2PhysicsAddLibrary.cmake
@@ -198,4 +198,10 @@ function(o2physics_add_library baseTargetName)
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   endif()
 
+  # Link subdirectories
+  install(
+    SCRIPT ${CMAKE_SOURCE_DIR}/cmake/O2PhysicsLinkAllSubDirs.cmake
+    CODE " o2physics_link_all_subdirs(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}) "
+  )
+
 endfunction()

--- a/cmake/O2PhysicsLinkAllSubDirs.cmake
+++ b/cmake/O2PhysicsLinkAllSubDirs.cmake
@@ -12,8 +12,8 @@
 function(o2physics_link_all_subdirs mainDir currentDir installDir)
   # Find the relative subdirectory of currentDir wrt mainDir
   # and create for each of the subdirectory levels a symlink in installDir
-  
-  # Find the relative directory
+
+  # Find the relative subdirectory
   string(REPLACE "${mainDir}" "" relDir "${currentDir}")
   # Splite the relative directory to a list of subdirectories
   string(REPLACE "/" ";" listDirs "${relDir}")

--- a/cmake/O2PhysicsLinkAllSubDirs.cmake
+++ b/cmake/O2PhysicsLinkAllSubDirs.cmake
@@ -1,0 +1,15 @@
+function(o2physics_link_all_subdirs mainDir currentDir installDir)
+  # Find the relative directory
+  string(REPLACE "${mainDir}" "" relDir "${currentDir}")
+  # Splite the relative directory to a list of subdirectories
+  string(REPLACE "/" ";" listDirs "${relDir}")
+  foreach(dir ${listDirs})
+    # Link each subdirectory inside include
+    # This helps to use #include "A/B/C/x.h" from the flat installation of header files
+    message("Linking ${dir} in ${installDir}")
+    execute_process(
+      COMMAND ln -sfh . ${dir}
+      WORKING_DIRECTORY ${installDir}
+      )
+  endforeach()
+endfunction()

--- a/cmake/O2PhysicsLinkAllSubDirs.cmake
+++ b/cmake/O2PhysicsLinkAllSubDirs.cmake
@@ -22,7 +22,7 @@ function(o2physics_link_all_subdirs mainDir currentDir installDir)
     # This helps to use #include "A/B/C/x.h" from the flat installation of header files
     message("Linking ${dir} in ${installDir}")
     execute_process(
-      COMMAND ln -sfh . ${dir}
+      COMMAND ln -sfn . ${dir}
       WORKING_DIRECTORY ${installDir}
       )
   endforeach()

--- a/cmake/O2PhysicsLinkAllSubDirs.cmake
+++ b/cmake/O2PhysicsLinkAllSubDirs.cmake
@@ -1,4 +1,18 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 function(o2physics_link_all_subdirs mainDir currentDir installDir)
+  # Find the relative subdirectory of currentDir wrt mainDir
+  # and create for each of the subdirectory levels a symlink in installDir
+  
   # Find the relative directory
   string(REPLACE "${mainDir}" "" relDir "${currentDir}")
   # Splite the relative directory to a list of subdirectories


### PR DESCRIPTION
This gives the possibility to use include files which internally refer to the original directory structure.