### PR TITLE
[PWGEM-12] Reduce dummyProcess table subscription

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -114,6 +114,12 @@ struct skimmerGammaCalo {
     }
   }
   PROCESS_SWITCH(skimmerGammaCalo, processRec, "process only reconstructed info", true);
+
+  void processDummy(aod::Collision const& collision)
+  {
+    // do nothing
+  }
+  PROCESS_SWITCH(skimmerGammaCalo, processDummy, "Dummy function", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
@@ -191,7 +191,7 @@ struct PCMQC {
     // registry.fill(HIST("AmbV0/hNgamma"), ng_amb);
   } // end of processSame
 
-  void processDummy(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, aod::V0Photons const& v0photons)
+  void processDummy(aod::EMReducedEvents::iterator const& collision)
   {
     // do nothing
   }
@@ -571,7 +571,7 @@ struct Pi0EtaToGammaGamma {
     MixedEventPairing<PairType::kPHOSEMC>(filtered_collisions, phosclusters, emcclusters, perCollision_phos, perCollision_emc);
   }
 
-  void processDummy(soa::Join<aod::Collisions, aod::EvSels> const& collision, aod::V0Photons const& v0photons)
+  void processDummy(aod::EMReducedEvents::iterator const& collision)
   {
     // do nothing
   }


### PR DESCRIPTION
Since one always has to have one process function active and in the Pi0Eta task there is the PCMQC task which currently had the VO table even in the dependencies of the dummy process function, one would have needed V0s even when just running the Pi0Eta task for calo.