### PR TITLE
Fix public link libraries for EM filter

### DIFF
--- a/EventFiltering/CMakeLists.txt
+++ b/EventFiltering/CMakeLists.txt
@@ -85,5 +85,5 @@ o2physics_add_dpl_workflow(mult-filter
 
 o2physics_add_dpl_workflow(em-filter
                            SOURCES PWGEM/photonFilter.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
                            COMPONENT_NAME Analysis)


### PR DESCRIPTION
Update PUBLIC_LINK_LIBRARIES for EM filter to be used in the CEFP