### PR TITLE
Counters should use double

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -23,7 +23,7 @@ using namespace o2::framework;
 #include "CommonConstants/LHCConstants.h"
 #include "Framework/HistogramRegistry.h"
 #include "DataFormatsFT0/Digit.h"
-#include "TH1F.h"
+#include "TH1D.h"
 using namespace evsel;
 
 using BCsWithRun2InfosTimestampsAndMatches = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps, aod::Run2MatchedToBCSparse>;
@@ -43,7 +43,7 @@ struct BcSelectionTask {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    histos.add("hCounterTVX", "", kTH1F, {{1, 0., 1.}});
+    histos.add("hCounterTVX", "", kTH1D, {{1, 0., 1.}});
   }
 
   void processRun2(
@@ -341,8 +341,8 @@ struct EventSelectionTask {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    histos.add("hColCounterAll", "", kTH1F, {{1, 0., 1.}});
-    histos.add("hColCounterAcc", "", kTH1F, {{1, 0., 1.}});
+    histos.add("hColCounterAll", "", kTH1D, {{1, 0., 1.}});
+    histos.add("hColCounterAcc", "", kTH1D, {{1, 0., 1.}});
   }
 
   void processRun2(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)


### PR DESCRIPTION
The issue is the following:
```
root [0] float n = 4.1e9
(float) 4.10000e+09f
root [1] float newN = n + 1.f
(float) 4.10000e+09f
root [2] newN - n
(float) 0.00000f
```
for large runs, this is happening systematically. With doubles this is still fine until 10e15
```
root [0] double n = 4.1e15
(double) 4.1000000e+15
root [1] double newN = n + 1.
(double) 4.1000000e+15
root [2] newN - n
(double) 1.0000000
```