### PR TITLE
DPG: Fix histogram index calculation

### DIFF
--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -90,354 +90,354 @@ struct QaEfficiency {
   OutputObj<THashList> listEfficiencyData{"EfficiencyData"};
   // Histograms
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry histosPos{"HistosPos", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry histosNeg{"HistosNeg", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry histosPosPdg{"HistosPosPdg", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry histosNegPdg{"HistosNegPdg", {}, OutputObjHandlingPolicy::AnalysisObject};
   static constexpr int nHistograms = nSpecies * 2;
 
   // Pt
-  static constexpr std::string_view hPtIts[nHistograms] = {"MC/el/pos/pt/its", "MC/mu/pos/pt/its", "MC/pi/pos/pt/its",
-                                                           "MC/ka/pos/pt/its", "MC/pr/pos/pt/its", "MC/de/pos/pt/its",
-                                                           "MC/tr/pos/pt/its", "MC/he/pos/pt/its", "MC/al/pos/pt/its",
-                                                           "MC/el/neg/pt/its", "MC/mu/neg/pt/its", "MC/pi/neg/pt/its",
-                                                           "MC/ka/neg/pt/its", "MC/pr/neg/pt/its", "MC/de/neg/pt/its",
-                                                           "MC/tr/neg/pt/its", "MC/he/neg/pt/its", "MC/al/neg/pt/its"};
-  static constexpr std::string_view hPtTpc[nHistograms] = {"MC/el/pos/pt/tpc", "MC/mu/pos/pt/tpc", "MC/pi/pos/pt/tpc",
-                                                           "MC/ka/pos/pt/tpc", "MC/pr/pos/pt/tpc", "MC/de/pos/pt/tpc",
-                                                           "MC/tr/pos/pt/tpc", "MC/he/pos/pt/tpc", "MC/al/pos/pt/tpc",
-                                                           "MC/el/neg/pt/tpc", "MC/mu/neg/pt/tpc", "MC/pi/neg/pt/tpc",
-                                                           "MC/ka/neg/pt/tpc", "MC/pr/neg/pt/tpc", "MC/de/neg/pt/tpc",
-                                                           "MC/tr/neg/pt/tpc", "MC/he/neg/pt/tpc", "MC/al/neg/pt/tpc"};
-  static constexpr std::string_view hPtItsTpc[nHistograms] = {"MC/el/pos/pt/its_tpc", "MC/mu/pos/pt/its_tpc", "MC/pi/pos/pt/its_tpc",
-                                                              "MC/ka/pos/pt/its_tpc", "MC/pr/pos/pt/its_tpc", "MC/de/pos/pt/its_tpc",
-                                                              "MC/tr/pos/pt/its_tpc", "MC/he/pos/pt/its_tpc", "MC/al/pos/pt/its_tpc",
-                                                              "MC/el/neg/pt/its_tpc", "MC/mu/neg/pt/its_tpc", "MC/pi/neg/pt/its_tpc",
-                                                              "MC/ka/neg/pt/its_tpc", "MC/pr/neg/pt/its_tpc", "MC/de/neg/pt/its_tpc",
-                                                              "MC/tr/neg/pt/its_tpc", "MC/he/neg/pt/its_tpc", "MC/al/neg/pt/its_tpc"};
-  static constexpr std::string_view hPtItsTof[nHistograms] = {"MC/el/pos/pt/its_tof", "MC/mu/pos/pt/its_tof", "MC/pi/pos/pt/its_tof",
-                                                              "MC/ka/pos/pt/its_tof", "MC/pr/pos/pt/its_tof", "MC/de/pos/pt/its_tof",
-                                                              "MC/tr/pos/pt/its_tof", "MC/he/pos/pt/its_tof", "MC/al/pos/pt/its_tof",
-                                                              "MC/el/neg/pt/its_tof", "MC/mu/neg/pt/its_tof", "MC/pi/neg/pt/its_tof",
-                                                              "MC/ka/neg/pt/its_tof", "MC/pr/neg/pt/its_tof", "MC/de/neg/pt/its_tof",
-                                                              "MC/tr/neg/pt/its_tof", "MC/he/neg/pt/its_tof", "MC/al/neg/pt/its_tof"};
-  static constexpr std::string_view hPtTpcTof[nHistograms] = {"MC/el/pos/pt/tpc_tof", "MC/mu/pos/pt/tpc_tof", "MC/pi/pos/pt/tpc_tof",
-                                                              "MC/ka/pos/pt/tpc_tof", "MC/pr/pos/pt/tpc_tof", "MC/de/pos/pt/tpc_tof",
-                                                              "MC/tr/pos/pt/tpc_tof", "MC/he/pos/pt/tpc_tof", "MC/al/pos/pt/tpc_tof",
-                                                              "MC/el/neg/pt/tpc_tof", "MC/mu/neg/pt/tpc_tof", "MC/pi/neg/pt/tpc_tof",
-                                                              "MC/ka/neg/pt/tpc_tof", "MC/pr/neg/pt/tpc_tof", "MC/de/neg/pt/tpc_tof",
-                                                              "MC/tr/neg/pt/tpc_tof", "MC/he/neg/pt/tpc_tof", "MC/al/neg/pt/tpc_tof"};
-  static constexpr std::string_view hPtItsTpcTof[nHistograms] = {"MC/el/pos/pt/its_tpc_tof", "MC/mu/pos/pt/its_tpc_tof", "MC/pi/pos/pt/its_tpc_tof",
-                                                                 "MC/ka/pos/pt/its_tpc_tof", "MC/pr/pos/pt/its_tpc_tof", "MC/de/pos/pt/its_tpc_tof",
-                                                                 "MC/tr/pos/pt/its_tpc_tof", "MC/he/pos/pt/its_tpc_tof", "MC/al/pos/pt/its_tpc_tof",
-                                                                 "MC/el/neg/pt/its_tpc_tof", "MC/mu/neg/pt/its_tpc_tof", "MC/pi/neg/pt/its_tpc_tof",
-                                                                 "MC/ka/neg/pt/its_tpc_tof", "MC/pr/neg/pt/its_tpc_tof", "MC/de/neg/pt/its_tpc_tof",
-                                                                 "MC/tr/neg/pt/its_tpc_tof", "MC/he/neg/pt/its_tpc_tof", "MC/al/neg/pt/its_tpc_tof"};
-  static constexpr std::string_view hPtItsTpcTrdTof[nHistograms] = {"MC/el/pos/pt/its_tpc_trd_tof", "MC/mu/pos/pt/its_tpc_trd_tof", "MC/pi/pos/pt/its_tpc_trd_tof",
-                                                                    "MC/ka/pos/pt/its_tpc_trd_tof", "MC/pr/pos/pt/its_tpc_trd_tof", "MC/de/pos/pt/its_tpc_trd_tof",
-                                                                    "MC/tr/pos/pt/its_tpc_trd_tof", "MC/he/pos/pt/its_tpc_trd_tof", "MC/al/pos/pt/its_tpc_trd_tof",
-                                                                    "MC/el/neg/pt/its_tpc_trd_tof", "MC/mu/neg/pt/its_tpc_trd_tof", "MC/pi/neg/pt/its_tpc_trd_tof",
-                                                                    "MC/ka/neg/pt/its_tpc_trd_tof", "MC/pr/neg/pt/its_tpc_trd_tof", "MC/de/neg/pt/its_tpc_trd_tof",
-                                                                    "MC/tr/neg/pt/its_tpc_trd_tof", "MC/he/neg/pt/its_tpc_trd_tof", "MC/al/neg/pt/its_tpc_trd_tof"};
-  static constexpr std::string_view hPtItsTpcTrd[nHistograms] = {"MC/el/pos/pt/its_tpc_trd", "MC/mu/pos/pt/its_tpc_trd", "MC/pi/pos/pt/its_tpc_trd",
-                                                                 "MC/ka/pos/pt/its_tpc_trd", "MC/pr/pos/pt/its_tpc_trd", "MC/de/pos/pt/its_tpc_trd",
-                                                                 "MC/tr/pos/pt/its_tpc_trd", "MC/he/pos/pt/its_tpc_trd", "MC/al/pos/pt/its_tpc_trd",
-                                                                 "MC/el/neg/pt/its_tpc_trd", "MC/mu/neg/pt/its_tpc_trd", "MC/pi/neg/pt/its_tpc_trd",
-                                                                 "MC/ka/neg/pt/its_tpc_trd", "MC/pr/neg/pt/its_tpc_trd", "MC/de/neg/pt/its_tpc_trd",
-                                                                 "MC/tr/neg/pt/its_tpc_trd", "MC/he/neg/pt/its_tpc_trd", "MC/al/neg/pt/its_tpc_trd"};
-  static constexpr std::string_view hPtTrkItsTpc[nHistograms] = {"MC/el/pos/pt/trk/its_tpc", "MC/mu/pos/pt/trk/its_tpc", "MC/pi/pos/pt/trk/its_tpc",
-                                                                 "MC/ka/pos/pt/trk/its_tpc", "MC/pr/pos/pt/trk/its_tpc", "MC/de/pos/pt/trk/its_tpc",
-                                                                 "MC/tr/pos/pt/trk/its_tpc", "MC/he/pos/pt/trk/its_tpc", "MC/al/pos/pt/trk/its_tpc",
-                                                                 "MC/el/neg/pt/trk/its_tpc", "MC/mu/neg/pt/trk/its_tpc", "MC/pi/neg/pt/trk/its_tpc",
-                                                                 "MC/ka/neg/pt/trk/its_tpc", "MC/pr/neg/pt/trk/its_tpc", "MC/de/neg/pt/trk/its_tpc",
-                                                                 "MC/tr/neg/pt/trk/its_tpc", "MC/he/neg/pt/trk/its_tpc", "MC/al/neg/pt/trk/its_tpc"};
-  static constexpr std::string_view hPtGenerated[nHistograms] = {"MC/el/pos/pt/generated", "MC/mu/pos/pt/generated", "MC/pi/pos/pt/generated",
-                                                                 "MC/ka/pos/pt/generated", "MC/pr/pos/pt/generated", "MC/de/pos/pt/generated",
-                                                                 "MC/tr/pos/pt/generated", "MC/he/pos/pt/generated", "MC/al/pos/pt/generated",
-                                                                 "MC/el/neg/pt/generated", "MC/mu/neg/pt/generated", "MC/pi/neg/pt/generated",
-                                                                 "MC/ka/neg/pt/generated", "MC/pr/neg/pt/generated", "MC/de/neg/pt/generated",
-                                                                 "MC/tr/neg/pt/generated", "MC/he/neg/pt/generated", "MC/al/neg/pt/generated"};
+  static constexpr std::string_view hPtIts[nHistograms] = {"MC/el/pos_pdg/pt/its", "MC/mu/pos_pdg/pt/its", "MC/pi/pos_pdg/pt/its",
+                                                           "MC/ka/pos_pdg/pt/its", "MC/pr/pos_pdg/pt/its", "MC/de/pos_pdg/pt/its",
+                                                           "MC/tr/pos_pdg/pt/its", "MC/he/pos_pdg/pt/its", "MC/al/pos_pdg/pt/its",
+                                                           "MC/el/neg_pdg/pt/its", "MC/mu/neg_pdg/pt/its", "MC/pi/neg_pdg/pt/its",
+                                                           "MC/ka/neg_pdg/pt/its", "MC/pr/neg_pdg/pt/its", "MC/de/neg_pdg/pt/its",
+                                                           "MC/tr/neg_pdg/pt/its", "MC/he/neg_pdg/pt/its", "MC/al/neg_pdg/pt/its"};
+  static constexpr std::string_view hPtTpc[nHistograms] = {"MC/el/pos_pdg/pt/tpc", "MC/mu/pos_pdg/pt/tpc", "MC/pi/pos_pdg/pt/tpc",
+                                                           "MC/ka/pos_pdg/pt/tpc", "MC/pr/pos_pdg/pt/tpc", "MC/de/pos_pdg/pt/tpc",
+                                                           "MC/tr/pos_pdg/pt/tpc", "MC/he/pos_pdg/pt/tpc", "MC/al/pos_pdg/pt/tpc",
+                                                           "MC/el/neg_pdg/pt/tpc", "MC/mu/neg_pdg/pt/tpc", "MC/pi/neg_pdg/pt/tpc",
+                                                           "MC/ka/neg_pdg/pt/tpc", "MC/pr/neg_pdg/pt/tpc", "MC/de/neg_pdg/pt/tpc",
+                                                           "MC/tr/neg_pdg/pt/tpc", "MC/he/neg_pdg/pt/tpc", "MC/al/neg_pdg/pt/tpc"};
+  static constexpr std::string_view hPtItsTpc[nHistograms] = {"MC/el/pos_pdg/pt/its_tpc", "MC/mu/pos_pdg/pt/its_tpc", "MC/pi/pos_pdg/pt/its_tpc",
+                                                              "MC/ka/pos_pdg/pt/its_tpc", "MC/pr/pos_pdg/pt/its_tpc", "MC/de/pos_pdg/pt/its_tpc",
+                                                              "MC/tr/pos_pdg/pt/its_tpc", "MC/he/pos_pdg/pt/its_tpc", "MC/al/pos_pdg/pt/its_tpc",
+                                                              "MC/el/neg_pdg/pt/its_tpc", "MC/mu/neg_pdg/pt/its_tpc", "MC/pi/neg_pdg/pt/its_tpc",
+                                                              "MC/ka/neg_pdg/pt/its_tpc", "MC/pr/neg_pdg/pt/its_tpc", "MC/de/neg_pdg/pt/its_tpc",
+                                                              "MC/tr/neg_pdg/pt/its_tpc", "MC/he/neg_pdg/pt/its_tpc", "MC/al/neg_pdg/pt/its_tpc"};
+  static constexpr std::string_view hPtItsTof[nHistograms] = {"MC/el/pos_pdg/pt/its_tof", "MC/mu/pos_pdg/pt/its_tof", "MC/pi/pos_pdg/pt/its_tof",
+                                                              "MC/ka/pos_pdg/pt/its_tof", "MC/pr/pos_pdg/pt/its_tof", "MC/de/pos_pdg/pt/its_tof",
+                                                              "MC/tr/pos_pdg/pt/its_tof", "MC/he/pos_pdg/pt/its_tof", "MC/al/pos_pdg/pt/its_tof",
+                                                              "MC/el/neg_pdg/pt/its_tof", "MC/mu/neg_pdg/pt/its_tof", "MC/pi/neg_pdg/pt/its_tof",
+                                                              "MC/ka/neg_pdg/pt/its_tof", "MC/pr/neg_pdg/pt/its_tof", "MC/de/neg_pdg/pt/its_tof",
+                                                              "MC/tr/neg_pdg/pt/its_tof", "MC/he/neg_pdg/pt/its_tof", "MC/al/neg_pdg/pt/its_tof"};
+  static constexpr std::string_view hPtTpcTof[nHistograms] = {"MC/el/pos_pdg/pt/tpc_tof", "MC/mu/pos_pdg/pt/tpc_tof", "MC/pi/pos_pdg/pt/tpc_tof",
+                                                              "MC/ka/pos_pdg/pt/tpc_tof", "MC/pr/pos_pdg/pt/tpc_tof", "MC/de/pos_pdg/pt/tpc_tof",
+                                                              "MC/tr/pos_pdg/pt/tpc_tof", "MC/he/pos_pdg/pt/tpc_tof", "MC/al/pos_pdg/pt/tpc_tof",
+                                                              "MC/el/neg_pdg/pt/tpc_tof", "MC/mu/neg_pdg/pt/tpc_tof", "MC/pi/neg_pdg/pt/tpc_tof",
+                                                              "MC/ka/neg_pdg/pt/tpc_tof", "MC/pr/neg_pdg/pt/tpc_tof", "MC/de/neg_pdg/pt/tpc_tof",
+                                                              "MC/tr/neg_pdg/pt/tpc_tof", "MC/he/neg_pdg/pt/tpc_tof", "MC/al/neg_pdg/pt/tpc_tof"};
+  static constexpr std::string_view hPtItsTpcTof[nHistograms] = {"MC/el/pos_pdg/pt/its_tpc_tof", "MC/mu/pos_pdg/pt/its_tpc_tof", "MC/pi/pos_pdg/pt/its_tpc_tof",
+                                                                 "MC/ka/pos_pdg/pt/its_tpc_tof", "MC/pr/pos_pdg/pt/its_tpc_tof", "MC/de/pos_pdg/pt/its_tpc_tof",
+                                                                 "MC/tr/pos_pdg/pt/its_tpc_tof", "MC/he/pos_pdg/pt/its_tpc_tof", "MC/al/pos_pdg/pt/its_tpc_tof",
+                                                                 "MC/el/neg_pdg/pt/its_tpc_tof", "MC/mu/neg_pdg/pt/its_tpc_tof", "MC/pi/neg_pdg/pt/its_tpc_tof",
+                                                                 "MC/ka/neg_pdg/pt/its_tpc_tof", "MC/pr/neg_pdg/pt/its_tpc_tof", "MC/de/neg_pdg/pt/its_tpc_tof",
+                                                                 "MC/tr/neg_pdg/pt/its_tpc_tof", "MC/he/neg_pdg/pt/its_tpc_tof", "MC/al/neg_pdg/pt/its_tpc_tof"};
+  static constexpr std::string_view hPtItsTpcTrdTof[nHistograms] = {"MC/el/pos_pdg/pt/its_tpc_trd_tof", "MC/mu/pos_pdg/pt/its_tpc_trd_tof", "MC/pi/pos_pdg/pt/its_tpc_trd_tof",
+                                                                    "MC/ka/pos_pdg/pt/its_tpc_trd_tof", "MC/pr/pos_pdg/pt/its_tpc_trd_tof", "MC/de/pos_pdg/pt/its_tpc_trd_tof",
+                                                                    "MC/tr/pos_pdg/pt/its_tpc_trd_tof", "MC/he/pos_pdg/pt/its_tpc_trd_tof", "MC/al/pos_pdg/pt/its_tpc_trd_tof",
+                                                                    "MC/el/neg_pdg/pt/its_tpc_trd_tof", "MC/mu/neg_pdg/pt/its_tpc_trd_tof", "MC/pi/neg_pdg/pt/its_tpc_trd_tof",
+                                                                    "MC/ka/neg_pdg/pt/its_tpc_trd_tof", "MC/pr/neg_pdg/pt/its_tpc_trd_tof", "MC/de/neg_pdg/pt/its_tpc_trd_tof",
+                                                                    "MC/tr/neg_pdg/pt/its_tpc_trd_tof", "MC/he/neg_pdg/pt/its_tpc_trd_tof", "MC/al/neg_pdg/pt/its_tpc_trd_tof"};
+  static constexpr std::string_view hPtItsTpcTrd[nHistograms] = {"MC/el/pos_pdg/pt/its_tpc_trd", "MC/mu/pos_pdg/pt/its_tpc_trd", "MC/pi/pos_pdg/pt/its_tpc_trd",
+                                                                 "MC/ka/pos_pdg/pt/its_tpc_trd", "MC/pr/pos_pdg/pt/its_tpc_trd", "MC/de/pos_pdg/pt/its_tpc_trd",
+                                                                 "MC/tr/pos_pdg/pt/its_tpc_trd", "MC/he/pos_pdg/pt/its_tpc_trd", "MC/al/pos_pdg/pt/its_tpc_trd",
+                                                                 "MC/el/neg_pdg/pt/its_tpc_trd", "MC/mu/neg_pdg/pt/its_tpc_trd", "MC/pi/neg_pdg/pt/its_tpc_trd",
+                                                                 "MC/ka/neg_pdg/pt/its_tpc_trd", "MC/pr/neg_pdg/pt/its_tpc_trd", "MC/de/neg_pdg/pt/its_tpc_trd",
+                                                                 "MC/tr/neg_pdg/pt/its_tpc_trd", "MC/he/neg_pdg/pt/its_tpc_trd", "MC/al/neg_pdg/pt/its_tpc_trd"};
+  static constexpr std::string_view hPtTrkItsTpc[nHistograms] = {"MC/el/pos_pdg/pt/trk/its_tpc", "MC/mu/pos_pdg/pt/trk/its_tpc", "MC/pi/pos_pdg/pt/trk/its_tpc",
+                                                                 "MC/ka/pos_pdg/pt/trk/its_tpc", "MC/pr/pos_pdg/pt/trk/its_tpc", "MC/de/pos_pdg/pt/trk/its_tpc",
+                                                                 "MC/tr/pos_pdg/pt/trk/its_tpc", "MC/he/pos_pdg/pt/trk/its_tpc", "MC/al/pos_pdg/pt/trk/its_tpc",
+                                                                 "MC/el/neg_pdg/pt/trk/its_tpc", "MC/mu/neg_pdg/pt/trk/its_tpc", "MC/pi/neg_pdg/pt/trk/its_tpc",
+                                                                 "MC/ka/neg_pdg/pt/trk/its_tpc", "MC/pr/neg_pdg/pt/trk/its_tpc", "MC/de/neg_pdg/pt/trk/its_tpc",
+                                                                 "MC/tr/neg_pdg/pt/trk/its_tpc", "MC/he/neg_pdg/pt/trk/its_tpc", "MC/al/neg_pdg/pt/trk/its_tpc"};
+  static constexpr std::string_view hPtGenerated[nHistograms] = {"MC/el/pos_pdg/pt/generated", "MC/mu/pos_pdg/pt/generated", "MC/pi/pos_pdg/pt/generated",
+                                                                 "MC/ka/pos_pdg/pt/generated", "MC/pr/pos_pdg/pt/generated", "MC/de/pos_pdg/pt/generated",
+                                                                 "MC/tr/pos_pdg/pt/generated", "MC/he/pos_pdg/pt/generated", "MC/al/pos_pdg/pt/generated",
+                                                                 "MC/el/neg_pdg/pt/generated", "MC/mu/neg_pdg/pt/generated", "MC/pi/neg_pdg/pt/generated",
+                                                                 "MC/ka/neg_pdg/pt/generated", "MC/pr/neg_pdg/pt/generated", "MC/de/neg_pdg/pt/generated",
+                                                                 "MC/tr/neg_pdg/pt/generated", "MC/he/neg_pdg/pt/generated", "MC/al/neg_pdg/pt/generated"};
 
   // Pt for primaries
-  static constexpr std::string_view hPtItsPrm[nHistograms] = {"MC/el/pos/pt/prm/its", "MC/mu/pos/pt/prm/its", "MC/pi/pos/pt/prm/its",
-                                                              "MC/ka/pos/pt/prm/its", "MC/pr/pos/pt/prm/its", "MC/de/pos/pt/prm/its",
-                                                              "MC/tr/pos/pt/prm/its", "MC/he/pos/pt/prm/its", "MC/al/pos/pt/prm/its",
-                                                              "MC/el/neg/pt/prm/its", "MC/mu/neg/pt/prm/its", "MC/pi/neg/pt/prm/its",
-                                                              "MC/ka/neg/pt/prm/its", "MC/pr/neg/pt/prm/its", "MC/de/neg/pt/prm/its",
-                                                              "MC/tr/neg/pt/prm/its", "MC/he/neg/pt/prm/its", "MC/al/neg/pt/prm/its"};
-  static constexpr std::string_view hPtItsTpcPrm[nHistograms] = {"MC/el/pos/pt/prm/its_tpc", "MC/mu/pos/pt/prm/its_tpc", "MC/pi/pos/pt/prm/its_tpc",
-                                                                 "MC/ka/pos/pt/prm/its_tpc", "MC/pr/pos/pt/prm/its_tpc", "MC/de/pos/pt/prm/its_tpc",
-                                                                 "MC/tr/pos/pt/prm/its_tpc", "MC/he/pos/pt/prm/its_tpc", "MC/al/pos/pt/prm/its_tpc",
-                                                                 "MC/el/neg/pt/prm/its_tpc", "MC/mu/neg/pt/prm/its_tpc", "MC/pi/neg/pt/prm/its_tpc",
-                                                                 "MC/ka/neg/pt/prm/its_tpc", "MC/pr/neg/pt/prm/its_tpc", "MC/de/neg/pt/prm/its_tpc",
-                                                                 "MC/tr/neg/pt/prm/its_tpc", "MC/he/neg/pt/prm/its_tpc", "MC/al/neg/pt/prm/its_tpc"};
-  static constexpr std::string_view hPtTrkItsTpcPrm[nHistograms] = {"MC/el/pos/pt/prm/trk/its_tpc", "MC/mu/pos/pt/prm/trk/its_tpc", "MC/pi/pos/pt/prm/trk/its_tpc",
-                                                                    "MC/ka/pos/pt/prm/trk/its_tpc", "MC/pr/pos/pt/prm/trk/its_tpc", "MC/de/pos/pt/prm/trk/its_tpc",
-                                                                    "MC/tr/pos/pt/prm/trk/its_tpc", "MC/he/pos/pt/prm/trk/its_tpc", "MC/al/pos/pt/prm/trk/its_tpc",
-                                                                    "MC/el/neg/pt/prm/trk/its_tpc", "MC/mu/neg/pt/prm/trk/its_tpc", "MC/pi/neg/pt/prm/trk/its_tpc",
-                                                                    "MC/ka/neg/pt/prm/trk/its_tpc", "MC/pr/neg/pt/prm/trk/its_tpc", "MC/de/neg/pt/prm/trk/its_tpc",
-                                                                    "MC/tr/neg/pt/prm/trk/its_tpc", "MC/he/neg/pt/prm/trk/its_tpc", "MC/al/neg/pt/prm/trk/its_tpc"};
-  static constexpr std::string_view hPtItsTpcTofPrm[nHistograms] = {"MC/el/pos/pt/prm/its_tpc_tof", "MC/mu/pos/pt/prm/its_tpc_tof", "MC/pi/pos/pt/prm/its_tpc_tof",
-                                                                    "MC/ka/pos/pt/prm/its_tpc_tof", "MC/pr/pos/pt/prm/its_tpc_tof", "MC/de/pos/pt/prm/its_tpc_tof",
-                                                                    "MC/tr/pos/pt/prm/its_tpc_tof", "MC/he/pos/pt/prm/its_tpc_tof", "MC/al/pos/pt/prm/its_tpc_tof",
-                                                                    "MC/el/neg/pt/prm/its_tpc_tof", "MC/mu/neg/pt/prm/its_tpc_tof", "MC/pi/neg/pt/prm/its_tpc_tof",
-                                                                    "MC/ka/neg/pt/prm/its_tpc_tof", "MC/pr/neg/pt/prm/its_tpc_tof", "MC/de/neg/pt/prm/its_tpc_tof",
-                                                                    "MC/tr/neg/pt/prm/its_tpc_tof", "MC/he/neg/pt/prm/its_tpc_tof", "MC/al/neg/pt/prm/its_tpc_tof"};
-  static constexpr std::string_view hPtGeneratedPrm[nHistograms] = {"MC/el/pos/pt/prm/generated", "MC/mu/pos/pt/prm/generated", "MC/pi/pos/pt/prm/generated",
-                                                                    "MC/ka/pos/pt/prm/generated", "MC/pr/pos/pt/prm/generated", "MC/de/pos/pt/prm/generated",
-                                                                    "MC/tr/pos/pt/prm/generated", "MC/he/pos/pt/prm/generated", "MC/al/pos/pt/prm/generated",
-                                                                    "MC/el/neg/pt/prm/generated", "MC/mu/neg/pt/prm/generated", "MC/pi/neg/pt/prm/generated",
-                                                                    "MC/ka/neg/pt/prm/generated", "MC/pr/neg/pt/prm/generated", "MC/de/neg/pt/prm/generated",
-                                                                    "MC/tr/neg/pt/prm/generated", "MC/he/neg/pt/prm/generated", "MC/al/neg/pt/prm/generated"};
+  static constexpr std::string_view hPtItsPrm[nHistograms] = {"MC/el/pos_pdg/pt/prm/its", "MC/mu/pos_pdg/pt/prm/its", "MC/pi/pos_pdg/pt/prm/its",
+                                                              "MC/ka/pos_pdg/pt/prm/its", "MC/pr/pos_pdg/pt/prm/its", "MC/de/pos_pdg/pt/prm/its",
+                                                              "MC/tr/pos_pdg/pt/prm/its", "MC/he/pos_pdg/pt/prm/its", "MC/al/pos_pdg/pt/prm/its",
+                                                              "MC/el/neg_pdg/pt/prm/its", "MC/mu/neg_pdg/pt/prm/its", "MC/pi/neg_pdg/pt/prm/its",
+                                                              "MC/ka/neg_pdg/pt/prm/its", "MC/pr/neg_pdg/pt/prm/its", "MC/de/neg_pdg/pt/prm/its",
+                                                              "MC/tr/neg_pdg/pt/prm/its", "MC/he/neg_pdg/pt/prm/its", "MC/al/neg_pdg/pt/prm/its"};
+  static constexpr std::string_view hPtItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/pt/prm/its_tpc", "MC/mu/pos_pdg/pt/prm/its_tpc", "MC/pi/pos_pdg/pt/prm/its_tpc",
+                                                                 "MC/ka/pos_pdg/pt/prm/its_tpc", "MC/pr/pos_pdg/pt/prm/its_tpc", "MC/de/pos_pdg/pt/prm/its_tpc",
+                                                                 "MC/tr/pos_pdg/pt/prm/its_tpc", "MC/he/pos_pdg/pt/prm/its_tpc", "MC/al/pos_pdg/pt/prm/its_tpc",
+                                                                 "MC/el/neg_pdg/pt/prm/its_tpc", "MC/mu/neg_pdg/pt/prm/its_tpc", "MC/pi/neg_pdg/pt/prm/its_tpc",
+                                                                 "MC/ka/neg_pdg/pt/prm/its_tpc", "MC/pr/neg_pdg/pt/prm/its_tpc", "MC/de/neg_pdg/pt/prm/its_tpc",
+                                                                 "MC/tr/neg_pdg/pt/prm/its_tpc", "MC/he/neg_pdg/pt/prm/its_tpc", "MC/al/neg_pdg/pt/prm/its_tpc"};
+  static constexpr std::string_view hPtTrkItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/pt/prm/trk/its_tpc", "MC/mu/pos_pdg/pt/prm/trk/its_tpc", "MC/pi/pos_pdg/pt/prm/trk/its_tpc",
+                                                                    "MC/ka/pos_pdg/pt/prm/trk/its_tpc", "MC/pr/pos_pdg/pt/prm/trk/its_tpc", "MC/de/pos_pdg/pt/prm/trk/its_tpc",
+                                                                    "MC/tr/pos_pdg/pt/prm/trk/its_tpc", "MC/he/pos_pdg/pt/prm/trk/its_tpc", "MC/al/pos_pdg/pt/prm/trk/its_tpc",
+                                                                    "MC/el/neg_pdg/pt/prm/trk/its_tpc", "MC/mu/neg_pdg/pt/prm/trk/its_tpc", "MC/pi/neg_pdg/pt/prm/trk/its_tpc",
+                                                                    "MC/ka/neg_pdg/pt/prm/trk/its_tpc", "MC/pr/neg_pdg/pt/prm/trk/its_tpc", "MC/de/neg_pdg/pt/prm/trk/its_tpc",
+                                                                    "MC/tr/neg_pdg/pt/prm/trk/its_tpc", "MC/he/neg_pdg/pt/prm/trk/its_tpc", "MC/al/neg_pdg/pt/prm/trk/its_tpc"};
+  static constexpr std::string_view hPtItsTpcTofPrm[nHistograms] = {"MC/el/pos_pdg/pt/prm/its_tpc_tof", "MC/mu/pos_pdg/pt/prm/its_tpc_tof", "MC/pi/pos_pdg/pt/prm/its_tpc_tof",
+                                                                    "MC/ka/pos_pdg/pt/prm/its_tpc_tof", "MC/pr/pos_pdg/pt/prm/its_tpc_tof", "MC/de/pos_pdg/pt/prm/its_tpc_tof",
+                                                                    "MC/tr/pos_pdg/pt/prm/its_tpc_tof", "MC/he/pos_pdg/pt/prm/its_tpc_tof", "MC/al/pos_pdg/pt/prm/its_tpc_tof",
+                                                                    "MC/el/neg_pdg/pt/prm/its_tpc_tof", "MC/mu/neg_pdg/pt/prm/its_tpc_tof", "MC/pi/neg_pdg/pt/prm/its_tpc_tof",
+                                                                    "MC/ka/neg_pdg/pt/prm/its_tpc_tof", "MC/pr/neg_pdg/pt/prm/its_tpc_tof", "MC/de/neg_pdg/pt/prm/its_tpc_tof",
+                                                                    "MC/tr/neg_pdg/pt/prm/its_tpc_tof", "MC/he/neg_pdg/pt/prm/its_tpc_tof", "MC/al/neg_pdg/pt/prm/its_tpc_tof"};
+  static constexpr std::string_view hPtGeneratedPrm[nHistograms] = {"MC/el/pos_pdg/pt/prm/generated", "MC/mu/pos_pdg/pt/prm/generated", "MC/pi/pos_pdg/pt/prm/generated",
+                                                                    "MC/ka/pos_pdg/pt/prm/generated", "MC/pr/pos_pdg/pt/prm/generated", "MC/de/pos_pdg/pt/prm/generated",
+                                                                    "MC/tr/pos_pdg/pt/prm/generated", "MC/he/pos_pdg/pt/prm/generated", "MC/al/pos_pdg/pt/prm/generated",
+                                                                    "MC/el/neg_pdg/pt/prm/generated", "MC/mu/neg_pdg/pt/prm/generated", "MC/pi/neg_pdg/pt/prm/generated",
+                                                                    "MC/ka/neg_pdg/pt/prm/generated", "MC/pr/neg_pdg/pt/prm/generated", "MC/de/neg_pdg/pt/prm/generated",
+                                                                    "MC/tr/neg_pdg/pt/prm/generated", "MC/he/neg_pdg/pt/prm/generated", "MC/al/neg_pdg/pt/prm/generated"};
 
   // Pt for secondaries from weak decay
-  static constexpr std::string_view hPtItsTpcStr[nHistograms] = {"MC/el/pos/pt/str/its_tpc", "MC/mu/pos/pt/str/its_tpc", "MC/pi/pos/pt/str/its_tpc",
-                                                                 "MC/ka/pos/pt/str/its_tpc", "MC/pr/pos/pt/str/its_tpc", "MC/de/pos/pt/str/its_tpc",
-                                                                 "MC/tr/pos/pt/str/its_tpc", "MC/he/pos/pt/str/its_tpc", "MC/al/pos/pt/str/its_tpc",
-                                                                 "MC/el/neg/pt/str/its_tpc", "MC/mu/neg/pt/str/its_tpc", "MC/pi/neg/pt/str/its_tpc",
-                                                                 "MC/ka/neg/pt/str/its_tpc", "MC/pr/neg/pt/str/its_tpc", "MC/de/neg/pt/str/its_tpc",
-                                                                 "MC/tr/neg/pt/str/its_tpc", "MC/he/neg/pt/str/its_tpc", "MC/al/neg/pt/str/its_tpc"};
-  static constexpr std::string_view hPtTrkItsTpcStr[nHistograms] = {"MC/el/pos/pt/str/trk/its_tpc", "MC/mu/pos/pt/str/trk/its_tpc", "MC/pi/pos/pt/str/trk/its_tpc",
-                                                                    "MC/ka/pos/pt/str/trk/its_tpc", "MC/pr/pos/pt/str/trk/its_tpc", "MC/de/pos/pt/str/trk/its_tpc",
-                                                                    "MC/tr/pos/pt/str/trk/its_tpc", "MC/he/pos/pt/str/trk/its_tpc", "MC/al/pos/pt/str/trk/its_tpc",
-                                                                    "MC/el/neg/pt/str/trk/its_tpc", "MC/mu/neg/pt/str/trk/its_tpc", "MC/pi/neg/pt/str/trk/its_tpc",
-                                                                    "MC/ka/neg/pt/str/trk/its_tpc", "MC/pr/neg/pt/str/trk/its_tpc", "MC/de/neg/pt/str/trk/its_tpc",
-                                                                    "MC/tr/neg/pt/str/trk/its_tpc", "MC/he/neg/pt/str/trk/its_tpc", "MC/al/neg/pt/str/trk/its_tpc"};
-  static constexpr std::string_view hPtItsTpcTofStr[nHistograms] = {"MC/el/pos/pt/str/its_tpc_tof", "MC/mu/pos/pt/str/its_tpc_tof", "MC/pi/pos/pt/str/its_tpc_tof",
-                                                                    "MC/ka/pos/pt/str/its_tpc_tof", "MC/pr/pos/pt/str/its_tpc_tof", "MC/de/pos/pt/str/its_tpc_tof",
-                                                                    "MC/tr/pos/pt/str/its_tpc_tof", "MC/he/pos/pt/str/its_tpc_tof", "MC/al/pos/pt/str/its_tpc_tof",
-                                                                    "MC/el/neg/pt/str/its_tpc_tof", "MC/mu/neg/pt/str/its_tpc_tof", "MC/pi/neg/pt/str/its_tpc_tof",
-                                                                    "MC/ka/neg/pt/str/its_tpc_tof", "MC/pr/neg/pt/str/its_tpc_tof", "MC/de/neg/pt/str/its_tpc_tof",
-                                                                    "MC/tr/neg/pt/str/its_tpc_tof", "MC/he/neg/pt/str/its_tpc_tof", "MC/al/neg/pt/str/its_tpc_tof"};
-  static constexpr std::string_view hPtGeneratedStr[nHistograms] = {"MC/el/pos/pt/str/generated", "MC/mu/pos/pt/str/generated", "MC/pi/pos/pt/str/generated",
-                                                                    "MC/ka/pos/pt/str/generated", "MC/pr/pos/pt/str/generated", "MC/de/pos/pt/str/generated",
-                                                                    "MC/tr/pos/pt/str/generated", "MC/he/pos/pt/str/generated", "MC/al/pos/pt/str/generated",
-                                                                    "MC/el/neg/pt/str/generated", "MC/mu/neg/pt/str/generated", "MC/pi/neg/pt/str/generated",
-                                                                    "MC/ka/neg/pt/str/generated", "MC/pr/neg/pt/str/generated", "MC/de/neg/pt/str/generated",
-                                                                    "MC/tr/neg/pt/str/generated", "MC/he/neg/pt/str/generated", "MC/al/neg/pt/str/generated"};
+  static constexpr std::string_view hPtItsTpcStr[nHistograms] = {"MC/el/pos_pdg/pt/str/its_tpc", "MC/mu/pos_pdg/pt/str/its_tpc", "MC/pi/pos_pdg/pt/str/its_tpc",
+                                                                 "MC/ka/pos_pdg/pt/str/its_tpc", "MC/pr/pos_pdg/pt/str/its_tpc", "MC/de/pos_pdg/pt/str/its_tpc",
+                                                                 "MC/tr/pos_pdg/pt/str/its_tpc", "MC/he/pos_pdg/pt/str/its_tpc", "MC/al/pos_pdg/pt/str/its_tpc",
+                                                                 "MC/el/neg_pdg/pt/str/its_tpc", "MC/mu/neg_pdg/pt/str/its_tpc", "MC/pi/neg_pdg/pt/str/its_tpc",
+                                                                 "MC/ka/neg_pdg/pt/str/its_tpc", "MC/pr/neg_pdg/pt/str/its_tpc", "MC/de/neg_pdg/pt/str/its_tpc",
+                                                                 "MC/tr/neg_pdg/pt/str/its_tpc", "MC/he/neg_pdg/pt/str/its_tpc", "MC/al/neg_pdg/pt/str/its_tpc"};
+  static constexpr std::string_view hPtTrkItsTpcStr[nHistograms] = {"MC/el/pos_pdg/pt/str/trk/its_tpc", "MC/mu/pos_pdg/pt/str/trk/its_tpc", "MC/pi/pos_pdg/pt/str/trk/its_tpc",
+                                                                    "MC/ka/pos_pdg/pt/str/trk/its_tpc", "MC/pr/pos_pdg/pt/str/trk/its_tpc", "MC/de/pos_pdg/pt/str/trk/its_tpc",
+                                                                    "MC/tr/pos_pdg/pt/str/trk/its_tpc", "MC/he/pos_pdg/pt/str/trk/its_tpc", "MC/al/pos_pdg/pt/str/trk/its_tpc",
+                                                                    "MC/el/neg_pdg/pt/str/trk/its_tpc", "MC/mu/neg_pdg/pt/str/trk/its_tpc", "MC/pi/neg_pdg/pt/str/trk/its_tpc",
+                                                                    "MC/ka/neg_pdg/pt/str/trk/its_tpc", "MC/pr/neg_pdg/pt/str/trk/its_tpc", "MC/de/neg_pdg/pt/str/trk/its_tpc",
+                                                                    "MC/tr/neg_pdg/pt/str/trk/its_tpc", "MC/he/neg_pdg/pt/str/trk/its_tpc", "MC/al/neg_pdg/pt/str/trk/its_tpc"};
+  static constexpr std::string_view hPtItsTpcTofStr[nHistograms] = {"MC/el/pos_pdg/pt/str/its_tpc_tof", "MC/mu/pos_pdg/pt/str/its_tpc_tof", "MC/pi/pos_pdg/pt/str/its_tpc_tof",
+                                                                    "MC/ka/pos_pdg/pt/str/its_tpc_tof", "MC/pr/pos_pdg/pt/str/its_tpc_tof", "MC/de/pos_pdg/pt/str/its_tpc_tof",
+                                                                    "MC/tr/pos_pdg/pt/str/its_tpc_tof", "MC/he/pos_pdg/pt/str/its_tpc_tof", "MC/al/pos_pdg/pt/str/its_tpc_tof",
+                                                                    "MC/el/neg_pdg/pt/str/its_tpc_tof", "MC/mu/neg_pdg/pt/str/its_tpc_tof", "MC/pi/neg_pdg/pt/str/its_tpc_tof",
+                                                                    "MC/ka/neg_pdg/pt/str/its_tpc_tof", "MC/pr/neg_pdg/pt/str/its_tpc_tof", "MC/de/neg_pdg/pt/str/its_tpc_tof",
+                                                                    "MC/tr/neg_pdg/pt/str/its_tpc_tof", "MC/he/neg_pdg/pt/str/its_tpc_tof", "MC/al/neg_pdg/pt/str/its_tpc_tof"};
+  static constexpr std::string_view hPtGeneratedStr[nHistograms] = {"MC/el/pos_pdg/pt/str/generated", "MC/mu/pos_pdg/pt/str/generated", "MC/pi/pos_pdg/pt/str/generated",
+                                                                    "MC/ka/pos_pdg/pt/str/generated", "MC/pr/pos_pdg/pt/str/generated", "MC/de/pos_pdg/pt/str/generated",
+                                                                    "MC/tr/pos_pdg/pt/str/generated", "MC/he/pos_pdg/pt/str/generated", "MC/al/pos_pdg/pt/str/generated",
+                                                                    "MC/el/neg_pdg/pt/str/generated", "MC/mu/neg_pdg/pt/str/generated", "MC/pi/neg_pdg/pt/str/generated",
+                                                                    "MC/ka/neg_pdg/pt/str/generated", "MC/pr/neg_pdg/pt/str/generated", "MC/de/neg_pdg/pt/str/generated",
+                                                                    "MC/tr/neg_pdg/pt/str/generated", "MC/he/neg_pdg/pt/str/generated", "MC/al/neg_pdg/pt/str/generated"};
 
   // Pt for secondaries from material
-  static constexpr std::string_view hPtItsTpcMat[nHistograms] = {"MC/el/pos/pt/mat/its_tpc", "MC/mu/pos/pt/mat/its_tpc", "MC/pi/pos/pt/mat/its_tpc",
-                                                                 "MC/ka/pos/pt/mat/its_tpc", "MC/pr/pos/pt/mat/its_tpc", "MC/de/pos/pt/mat/its_tpc",
-                                                                 "MC/tr/pos/pt/mat/its_tpc", "MC/he/pos/pt/mat/its_tpc", "MC/al/pos/pt/mat/its_tpc",
-                                                                 "MC/el/neg/pt/mat/its_tpc", "MC/mu/neg/pt/mat/its_tpc", "MC/pi/neg/pt/mat/its_tpc",
-                                                                 "MC/ka/neg/pt/mat/its_tpc", "MC/pr/neg/pt/mat/its_tpc", "MC/de/neg/pt/mat/its_tpc",
-                                                                 "MC/tr/neg/pt/mat/its_tpc", "MC/he/neg/pt/mat/its_tpc", "MC/al/neg/pt/mat/its_tpc"};
-  static constexpr std::string_view hPtTrkItsTpcMat[nHistograms] = {"MC/el/pos/pt/mat/trk/its_tpc", "MC/mu/pos/pt/mat/trk/its_tpc", "MC/pi/pos/pt/mat/trk/its_tpc",
-                                                                    "MC/ka/pos/pt/mat/trk/its_tpc", "MC/pr/pos/pt/mat/trk/its_tpc", "MC/de/pos/pt/mat/trk/its_tpc",
-                                                                    "MC/tr/pos/pt/mat/trk/its_tpc", "MC/he/pos/pt/mat/trk/its_tpc", "MC/al/pos/pt/mat/trk/its_tpc",
-                                                                    "MC/el/neg/pt/mat/trk/its_tpc", "MC/mu/neg/pt/mat/trk/its_tpc", "MC/pi/neg/pt/mat/trk/its_tpc",
-                                                                    "MC/ka/neg/pt/mat/trk/its_tpc", "MC/pr/neg/pt/mat/trk/its_tpc", "MC/de/neg/pt/mat/trk/its_tpc",
-                                                                    "MC/tr/neg/pt/mat/trk/its_tpc", "MC/he/neg/pt/mat/trk/its_tpc", "MC/al/neg/pt/mat/trk/its_tpc"};
-  static constexpr std::string_view hPtItsTpcTofMat[nHistograms] = {"MC/el/pos/pt/mat/its_tpc_tof", "MC/mu/pos/pt/mat/its_tpc_tof", "MC/pi/pos/pt/mat/its_tpc_tof",
-                                                                    "MC/ka/pos/pt/mat/its_tpc_tof", "MC/pr/pos/pt/mat/its_tpc_tof", "MC/de/pos/pt/mat/its_tpc_tof",
-                                                                    "MC/tr/pos/pt/mat/its_tpc_tof", "MC/he/pos/pt/mat/its_tpc_tof", "MC/al/pos/pt/mat/its_tpc_tof",
-                                                                    "MC/el/neg/pt/mat/its_tpc_tof", "MC/mu/neg/pt/mat/its_tpc_tof", "MC/pi/neg/pt/mat/its_tpc_tof",
-                                                                    "MC/ka/neg/pt/mat/its_tpc_tof", "MC/pr/neg/pt/mat/its_tpc_tof", "MC/de/neg/pt/mat/its_tpc_tof",
-                                                                    "MC/tr/neg/pt/mat/its_tpc_tof", "MC/he/neg/pt/mat/its_tpc_tof", "MC/al/neg/pt/mat/its_tpc_tof"};
-  static constexpr std::string_view hPtGeneratedMat[nHistograms] = {"MC/el/pos/pt/mat/generated", "MC/mu/pos/pt/mat/generated", "MC/pi/pos/pt/mat/generated",
-                                                                    "MC/ka/pos/pt/mat/generated", "MC/pr/pos/pt/mat/generated", "MC/de/pos/pt/mat/generated",
-                                                                    "MC/tr/pos/pt/mat/generated", "MC/he/pos/pt/mat/generated", "MC/al/pos/pt/mat/generated",
-                                                                    "MC/el/neg/pt/mat/generated", "MC/mu/neg/pt/mat/generated", "MC/pi/neg/pt/mat/generated",
-                                                                    "MC/ka/neg/pt/mat/generated", "MC/pr/neg/pt/mat/generated", "MC/de/neg/pt/mat/generated",
-                                                                    "MC/tr/neg/pt/mat/generated", "MC/he/neg/pt/mat/generated", "MC/al/neg/pt/mat/generated"};
+  static constexpr std::string_view hPtItsTpcMat[nHistograms] = {"MC/el/pos_pdg/pt/mat/its_tpc", "MC/mu/pos_pdg/pt/mat/its_tpc", "MC/pi/pos_pdg/pt/mat/its_tpc",
+                                                                 "MC/ka/pos_pdg/pt/mat/its_tpc", "MC/pr/pos_pdg/pt/mat/its_tpc", "MC/de/pos_pdg/pt/mat/its_tpc",
+                                                                 "MC/tr/pos_pdg/pt/mat/its_tpc", "MC/he/pos_pdg/pt/mat/its_tpc", "MC/al/pos_pdg/pt/mat/its_tpc",
+                                                                 "MC/el/neg_pdg/pt/mat/its_tpc", "MC/mu/neg_pdg/pt/mat/its_tpc", "MC/pi/neg_pdg/pt/mat/its_tpc",
+                                                                 "MC/ka/neg_pdg/pt/mat/its_tpc", "MC/pr/neg_pdg/pt/mat/its_tpc", "MC/de/neg_pdg/pt/mat/its_tpc",
+                                                                 "MC/tr/neg_pdg/pt/mat/its_tpc", "MC/he/neg_pdg/pt/mat/its_tpc", "MC/al/neg_pdg/pt/mat/its_tpc"};
+  static constexpr std::string_view hPtTrkItsTpcMat[nHistograms] = {"MC/el/pos_pdg/pt/mat/trk/its_tpc", "MC/mu/pos_pdg/pt/mat/trk/its_tpc", "MC/pi/pos_pdg/pt/mat/trk/its_tpc",
+                                                                    "MC/ka/pos_pdg/pt/mat/trk/its_tpc", "MC/pr/pos_pdg/pt/mat/trk/its_tpc", "MC/de/pos_pdg/pt/mat/trk/its_tpc",
+                                                                    "MC/tr/pos_pdg/pt/mat/trk/its_tpc", "MC/he/pos_pdg/pt/mat/trk/its_tpc", "MC/al/pos_pdg/pt/mat/trk/its_tpc",
+                                                                    "MC/el/neg_pdg/pt/mat/trk/its_tpc", "MC/mu/neg_pdg/pt/mat/trk/its_tpc", "MC/pi/neg_pdg/pt/mat/trk/its_tpc",
+                                                                    "MC/ka/neg_pdg/pt/mat/trk/its_tpc", "MC/pr/neg_pdg/pt/mat/trk/its_tpc", "MC/de/neg_pdg/pt/mat/trk/its_tpc",
+                                                                    "MC/tr/neg_pdg/pt/mat/trk/its_tpc", "MC/he/neg_pdg/pt/mat/trk/its_tpc", "MC/al/neg_pdg/pt/mat/trk/its_tpc"};
+  static constexpr std::string_view hPtItsTpcTofMat[nHistograms] = {"MC/el/pos_pdg/pt/mat/its_tpc_tof", "MC/mu/pos_pdg/pt/mat/its_tpc_tof", "MC/pi/pos_pdg/pt/mat/its_tpc_tof",
+                                                                    "MC/ka/pos_pdg/pt/mat/its_tpc_tof", "MC/pr/pos_pdg/pt/mat/its_tpc_tof", "MC/de/pos_pdg/pt/mat/its_tpc_tof",
+                                                                    "MC/tr/pos_pdg/pt/mat/its_tpc_tof", "MC/he/pos_pdg/pt/mat/its_tpc_tof", "MC/al/pos_pdg/pt/mat/its_tpc_tof",
+                                                                    "MC/el/neg_pdg/pt/mat/its_tpc_tof", "MC/mu/neg_pdg/pt/mat/its_tpc_tof", "MC/pi/neg_pdg/pt/mat/its_tpc_tof",
+                                                                    "MC/ka/neg_pdg/pt/mat/its_tpc_tof", "MC/pr/neg_pdg/pt/mat/its_tpc_tof", "MC/de/neg_pdg/pt/mat/its_tpc_tof",
+                                                                    "MC/tr/neg_pdg/pt/mat/its_tpc_tof", "MC/he/neg_pdg/pt/mat/its_tpc_tof", "MC/al/neg_pdg/pt/mat/its_tpc_tof"};
+  static constexpr std::string_view hPtGeneratedMat[nHistograms] = {"MC/el/pos_pdg/pt/mat/generated", "MC/mu/pos_pdg/pt/mat/generated", "MC/pi/pos_pdg/pt/mat/generated",
+                                                                    "MC/ka/pos_pdg/pt/mat/generated", "MC/pr/pos_pdg/pt/mat/generated", "MC/de/pos_pdg/pt/mat/generated",
+                                                                    "MC/tr/pos_pdg/pt/mat/generated", "MC/he/pos_pdg/pt/mat/generated", "MC/al/pos_pdg/pt/mat/generated",
+                                                                    "MC/el/neg_pdg/pt/mat/generated", "MC/mu/neg_pdg/pt/mat/generated", "MC/pi/neg_pdg/pt/mat/generated",
+                                                                    "MC/ka/neg_pdg/pt/mat/generated", "MC/pr/neg_pdg/pt/mat/generated", "MC/de/neg_pdg/pt/mat/generated",
+                                                                    "MC/tr/neg_pdg/pt/mat/generated", "MC/he/neg_pdg/pt/mat/generated", "MC/al/neg_pdg/pt/mat/generated"};
 
   // P
-  static constexpr std::string_view hPItsTpc[nHistograms] = {"MC/el/pos/p/its_tpc", "MC/mu/pos/p/its_tpc", "MC/pi/pos/p/its_tpc",
-                                                             "MC/ka/pos/p/its_tpc", "MC/pr/pos/p/its_tpc", "MC/de/pos/p/its_tpc",
-                                                             "MC/tr/pos/p/its_tpc", "MC/he/pos/p/its_tpc", "MC/al/pos/p/its_tpc",
-                                                             "MC/el/neg/p/its_tpc", "MC/mu/neg/p/its_tpc", "MC/pi/neg/p/its_tpc",
-                                                             "MC/ka/neg/p/its_tpc", "MC/pr/neg/p/its_tpc", "MC/de/neg/p/its_tpc",
-                                                             "MC/tr/neg/p/its_tpc", "MC/he/neg/p/its_tpc", "MC/al/neg/p/its_tpc"};
-  static constexpr std::string_view hPTrkItsTpc[nHistograms] = {"MC/el/pos/p/trk/its_tpc", "MC/mu/pos/p/trk/its_tpc", "MC/pi/pos/p/trk/its_tpc",
-                                                                "MC/ka/pos/p/trk/its_tpc", "MC/pr/pos/p/trk/its_tpc", "MC/de/pos/p/trk/its_tpc",
-                                                                "MC/tr/pos/p/trk/its_tpc", "MC/he/pos/p/trk/its_tpc", "MC/al/pos/p/trk/its_tpc",
-                                                                "MC/el/neg/p/trk/its_tpc", "MC/mu/neg/p/trk/its_tpc", "MC/pi/neg/p/trk/its_tpc",
-                                                                "MC/ka/neg/p/trk/its_tpc", "MC/pr/neg/p/trk/its_tpc", "MC/de/neg/p/trk/its_tpc",
-                                                                "MC/tr/neg/p/trk/its_tpc", "MC/he/neg/p/trk/its_tpc", "MC/al/neg/p/trk/its_tpc"};
-  static constexpr std::string_view hPItsTpcTof[nHistograms] = {"MC/el/pos/p/its_tpc_tof", "MC/mu/pos/p/its_tpc_tof", "MC/pi/pos/p/its_tpc_tof",
-                                                                "MC/ka/pos/p/its_tpc_tof", "MC/pr/pos/p/its_tpc_tof", "MC/de/pos/p/its_tpc_tof",
-                                                                "MC/tr/pos/p/its_tpc_tof", "MC/he/pos/p/its_tpc_tof", "MC/al/pos/p/its_tpc_tof",
-                                                                "MC/el/neg/p/its_tpc_tof", "MC/mu/neg/p/its_tpc_tof", "MC/pi/neg/p/its_tpc_tof",
-                                                                "MC/ka/neg/p/its_tpc_tof", "MC/pr/neg/p/its_tpc_tof", "MC/de/neg/p/its_tpc_tof",
-                                                                "MC/tr/neg/p/its_tpc_tof", "MC/he/neg/p/its_tpc_tof", "MC/al/neg/p/its_tpc_tof"};
-  static constexpr std::string_view hPGenerated[nHistograms] = {"MC/el/pos/p/generated", "MC/mu/pos/p/generated", "MC/pi/pos/p/generated",
-                                                                "MC/ka/pos/p/generated", "MC/pr/pos/p/generated", "MC/de/pos/p/generated",
-                                                                "MC/tr/pos/p/generated", "MC/he/pos/p/generated", "MC/al/pos/p/generated",
-                                                                "MC/el/neg/p/generated", "MC/mu/neg/p/generated", "MC/pi/neg/p/generated",
-                                                                "MC/ka/neg/p/generated", "MC/pr/neg/p/generated", "MC/de/neg/p/generated",
-                                                                "MC/tr/neg/p/generated", "MC/he/neg/p/generated", "MC/al/neg/p/generated"};
+  static constexpr std::string_view hPItsTpc[nHistograms] = {"MC/el/pos_pdg/p/its_tpc", "MC/mu/pos_pdg/p/its_tpc", "MC/pi/pos_pdg/p/its_tpc",
+                                                             "MC/ka/pos_pdg/p/its_tpc", "MC/pr/pos_pdg/p/its_tpc", "MC/de/pos_pdg/p/its_tpc",
+                                                             "MC/tr/pos_pdg/p/its_tpc", "MC/he/pos_pdg/p/its_tpc", "MC/al/pos_pdg/p/its_tpc",
+                                                             "MC/el/neg_pdg/p/its_tpc", "MC/mu/neg_pdg/p/its_tpc", "MC/pi/neg_pdg/p/its_tpc",
+                                                             "MC/ka/neg_pdg/p/its_tpc", "MC/pr/neg_pdg/p/its_tpc", "MC/de/neg_pdg/p/its_tpc",
+                                                             "MC/tr/neg_pdg/p/its_tpc", "MC/he/neg_pdg/p/its_tpc", "MC/al/neg_pdg/p/its_tpc"};
+  static constexpr std::string_view hPTrkItsTpc[nHistograms] = {"MC/el/pos_pdg/p/trk/its_tpc", "MC/mu/pos_pdg/p/trk/its_tpc", "MC/pi/pos_pdg/p/trk/its_tpc",
+                                                                "MC/ka/pos_pdg/p/trk/its_tpc", "MC/pr/pos_pdg/p/trk/its_tpc", "MC/de/pos_pdg/p/trk/its_tpc",
+                                                                "MC/tr/pos_pdg/p/trk/its_tpc", "MC/he/pos_pdg/p/trk/its_tpc", "MC/al/pos_pdg/p/trk/its_tpc",
+                                                                "MC/el/neg_pdg/p/trk/its_tpc", "MC/mu/neg_pdg/p/trk/its_tpc", "MC/pi/neg_pdg/p/trk/its_tpc",
+                                                                "MC/ka/neg_pdg/p/trk/its_tpc", "MC/pr/neg_pdg/p/trk/its_tpc", "MC/de/neg_pdg/p/trk/its_tpc",
+                                                                "MC/tr/neg_pdg/p/trk/its_tpc", "MC/he/neg_pdg/p/trk/its_tpc", "MC/al/neg_pdg/p/trk/its_tpc"};
+  static constexpr std::string_view hPItsTpcTof[nHistograms] = {"MC/el/pos_pdg/p/its_tpc_tof", "MC/mu/pos_pdg/p/its_tpc_tof", "MC/pi/pos_pdg/p/its_tpc_tof",
+                                                                "MC/ka/pos_pdg/p/its_tpc_tof", "MC/pr/pos_pdg/p/its_tpc_tof", "MC/de/pos_pdg/p/its_tpc_tof",
+                                                                "MC/tr/pos_pdg/p/its_tpc_tof", "MC/he/pos_pdg/p/its_tpc_tof", "MC/al/pos_pdg/p/its_tpc_tof",
+                                                                "MC/el/neg_pdg/p/its_tpc_tof", "MC/mu/neg_pdg/p/its_tpc_tof", "MC/pi/neg_pdg/p/its_tpc_tof",
+                                                                "MC/ka/neg_pdg/p/its_tpc_tof", "MC/pr/neg_pdg/p/its_tpc_tof", "MC/de/neg_pdg/p/its_tpc_tof",
+                                                                "MC/tr/neg_pdg/p/its_tpc_tof", "MC/he/neg_pdg/p/its_tpc_tof", "MC/al/neg_pdg/p/its_tpc_tof"};
+  static constexpr std::string_view hPGenerated[nHistograms] = {"MC/el/pos_pdg/p/generated", "MC/mu/pos_pdg/p/generated", "MC/pi/pos_pdg/p/generated",
+                                                                "MC/ka/pos_pdg/p/generated", "MC/pr/pos_pdg/p/generated", "MC/de/pos_pdg/p/generated",
+                                                                "MC/tr/pos_pdg/p/generated", "MC/he/pos_pdg/p/generated", "MC/al/pos_pdg/p/generated",
+                                                                "MC/el/neg_pdg/p/generated", "MC/mu/neg_pdg/p/generated", "MC/pi/neg_pdg/p/generated",
+                                                                "MC/ka/neg_pdg/p/generated", "MC/pr/neg_pdg/p/generated", "MC/de/neg_pdg/p/generated",
+                                                                "MC/tr/neg_pdg/p/generated", "MC/he/neg_pdg/p/generated", "MC/al/neg_pdg/p/generated"};
 
   // Eta
-  static constexpr std::string_view hEtaItsTpc[nHistograms] = {"MC/el/pos/eta/its_tpc", "MC/mu/pos/eta/its_tpc", "MC/pi/pos/eta/its_tpc",
-                                                               "MC/ka/pos/eta/its_tpc", "MC/pr/pos/eta/its_tpc", "MC/de/pos/eta/its_tpc",
-                                                               "MC/tr/pos/eta/its_tpc", "MC/he/pos/eta/its_tpc", "MC/al/pos/eta/its_tpc",
-                                                               "MC/el/neg/eta/its_tpc", "MC/mu/neg/eta/its_tpc", "MC/pi/neg/eta/its_tpc",
-                                                               "MC/ka/neg/eta/its_tpc", "MC/pr/neg/eta/its_tpc", "MC/de/neg/eta/its_tpc",
-                                                               "MC/tr/neg/eta/its_tpc", "MC/he/neg/eta/its_tpc", "MC/al/neg/eta/its_tpc"};
-  static constexpr std::string_view hEtaTrkItsTpc[nHistograms] = {"MC/el/pos/eta/trk/its_tpc", "MC/mu/pos/eta/trk/its_tpc", "MC/pi/pos/eta/trk/its_tpc",
-                                                                  "MC/ka/pos/eta/trk/its_tpc", "MC/pr/pos/eta/trk/its_tpc", "MC/de/pos/eta/trk/its_tpc",
-                                                                  "MC/tr/pos/eta/trk/its_tpc", "MC/he/pos/eta/trk/its_tpc", "MC/al/pos/eta/trk/its_tpc",
-                                                                  "MC/el/neg/eta/trk/its_tpc", "MC/mu/neg/eta/trk/its_tpc", "MC/pi/neg/eta/trk/its_tpc",
-                                                                  "MC/ka/neg/eta/trk/its_tpc", "MC/pr/neg/eta/trk/its_tpc", "MC/de/neg/eta/trk/its_tpc",
-                                                                  "MC/tr/neg/eta/trk/its_tpc", "MC/he/neg/eta/trk/its_tpc", "MC/al/neg/eta/trk/its_tpc"};
-  static constexpr std::string_view hEtaItsTpcTof[nHistograms] = {"MC/el/pos/eta/its_tpc_tof", "MC/mu/pos/eta/its_tpc_tof", "MC/pi/pos/eta/its_tpc_tof",
-                                                                  "MC/ka/pos/eta/its_tpc_tof", "MC/pr/pos/eta/its_tpc_tof", "MC/de/pos/eta/its_tpc_tof",
-                                                                  "MC/tr/pos/eta/its_tpc_tof", "MC/he/pos/eta/its_tpc_tof", "MC/al/pos/eta/its_tpc_tof",
-                                                                  "MC/el/neg/eta/its_tpc_tof", "MC/mu/neg/eta/its_tpc_tof", "MC/pi/neg/eta/its_tpc_tof",
-                                                                  "MC/ka/neg/eta/its_tpc_tof", "MC/pr/neg/eta/its_tpc_tof", "MC/de/neg/eta/its_tpc_tof",
-                                                                  "MC/tr/neg/eta/its_tpc_tof", "MC/he/neg/eta/its_tpc_tof", "MC/al/neg/eta/its_tpc_tof"};
-  static constexpr std::string_view hEtaGenerated[nHistograms] = {"MC/el/pos/eta/generated", "MC/mu/pos/eta/generated", "MC/pi/pos/eta/generated",
-                                                                  "MC/ka/pos/eta/generated", "MC/pr/pos/eta/generated", "MC/de/pos/eta/generated",
-                                                                  "MC/tr/pos/eta/generated", "MC/he/pos/eta/generated", "MC/al/pos/eta/generated",
-                                                                  "MC/el/neg/eta/generated", "MC/mu/neg/eta/generated", "MC/pi/neg/eta/generated",
-                                                                  "MC/ka/neg/eta/generated", "MC/pr/neg/eta/generated", "MC/de/neg/eta/generated",
-                                                                  "MC/tr/neg/eta/generated", "MC/he/neg/eta/generated", "MC/al/neg/eta/generated"};
+  static constexpr std::string_view hEtaItsTpc[nHistograms] = {"MC/el/pos_pdg/eta/its_tpc", "MC/mu/pos_pdg/eta/its_tpc", "MC/pi/pos_pdg/eta/its_tpc",
+                                                               "MC/ka/pos_pdg/eta/its_tpc", "MC/pr/pos_pdg/eta/its_tpc", "MC/de/pos_pdg/eta/its_tpc",
+                                                               "MC/tr/pos_pdg/eta/its_tpc", "MC/he/pos_pdg/eta/its_tpc", "MC/al/pos_pdg/eta/its_tpc",
+                                                               "MC/el/neg_pdg/eta/its_tpc", "MC/mu/neg_pdg/eta/its_tpc", "MC/pi/neg_pdg/eta/its_tpc",
+                                                               "MC/ka/neg_pdg/eta/its_tpc", "MC/pr/neg_pdg/eta/its_tpc", "MC/de/neg_pdg/eta/its_tpc",
+                                                               "MC/tr/neg_pdg/eta/its_tpc", "MC/he/neg_pdg/eta/its_tpc", "MC/al/neg_pdg/eta/its_tpc"};
+  static constexpr std::string_view hEtaTrkItsTpc[nHistograms] = {"MC/el/pos_pdg/eta/trk/its_tpc", "MC/mu/pos_pdg/eta/trk/its_tpc", "MC/pi/pos_pdg/eta/trk/its_tpc",
+                                                                  "MC/ka/pos_pdg/eta/trk/its_tpc", "MC/pr/pos_pdg/eta/trk/its_tpc", "MC/de/pos_pdg/eta/trk/its_tpc",
+                                                                  "MC/tr/pos_pdg/eta/trk/its_tpc", "MC/he/pos_pdg/eta/trk/its_tpc", "MC/al/pos_pdg/eta/trk/its_tpc",
+                                                                  "MC/el/neg_pdg/eta/trk/its_tpc", "MC/mu/neg_pdg/eta/trk/its_tpc", "MC/pi/neg_pdg/eta/trk/its_tpc",
+                                                                  "MC/ka/neg_pdg/eta/trk/its_tpc", "MC/pr/neg_pdg/eta/trk/its_tpc", "MC/de/neg_pdg/eta/trk/its_tpc",
+                                                                  "MC/tr/neg_pdg/eta/trk/its_tpc", "MC/he/neg_pdg/eta/trk/its_tpc", "MC/al/neg_pdg/eta/trk/its_tpc"};
+  static constexpr std::string_view hEtaItsTpcTof[nHistograms] = {"MC/el/pos_pdg/eta/its_tpc_tof", "MC/mu/pos_pdg/eta/its_tpc_tof", "MC/pi/pos_pdg/eta/its_tpc_tof",
+                                                                  "MC/ka/pos_pdg/eta/its_tpc_tof", "MC/pr/pos_pdg/eta/its_tpc_tof", "MC/de/pos_pdg/eta/its_tpc_tof",
+                                                                  "MC/tr/pos_pdg/eta/its_tpc_tof", "MC/he/pos_pdg/eta/its_tpc_tof", "MC/al/pos_pdg/eta/its_tpc_tof",
+                                                                  "MC/el/neg_pdg/eta/its_tpc_tof", "MC/mu/neg_pdg/eta/its_tpc_tof", "MC/pi/neg_pdg/eta/its_tpc_tof",
+                                                                  "MC/ka/neg_pdg/eta/its_tpc_tof", "MC/pr/neg_pdg/eta/its_tpc_tof", "MC/de/neg_pdg/eta/its_tpc_tof",
+                                                                  "MC/tr/neg_pdg/eta/its_tpc_tof", "MC/he/neg_pdg/eta/its_tpc_tof", "MC/al/neg_pdg/eta/its_tpc_tof"};
+  static constexpr std::string_view hEtaGenerated[nHistograms] = {"MC/el/pos_pdg/eta/generated", "MC/mu/pos_pdg/eta/generated", "MC/pi/pos_pdg/eta/generated",
+                                                                  "MC/ka/pos_pdg/eta/generated", "MC/pr/pos_pdg/eta/generated", "MC/de/pos_pdg/eta/generated",
+                                                                  "MC/tr/pos_pdg/eta/generated", "MC/he/pos_pdg/eta/generated", "MC/al/pos_pdg/eta/generated",
+                                                                  "MC/el/neg_pdg/eta/generated", "MC/mu/neg_pdg/eta/generated", "MC/pi/neg_pdg/eta/generated",
+                                                                  "MC/ka/neg_pdg/eta/generated", "MC/pr/neg_pdg/eta/generated", "MC/de/neg_pdg/eta/generated",
+                                                                  "MC/tr/neg_pdg/eta/generated", "MC/he/neg_pdg/eta/generated", "MC/al/neg_pdg/eta/generated"};
 
   // Eta for primaries
-  static constexpr std::string_view hEtaItsTpcPrm[nHistograms] = {"MC/el/pos/eta/prm/its_tpc", "MC/mu/pos/eta/prm/its_tpc", "MC/pi/pos/eta/prm/its_tpc",
-                                                                  "MC/ka/pos/eta/prm/its_tpc", "MC/pr/pos/eta/prm/its_tpc", "MC/de/pos/eta/prm/its_tpc",
-                                                                  "MC/tr/pos/eta/prm/its_tpc", "MC/he/pos/eta/prm/its_tpc", "MC/al/pos/eta/prm/its_tpc",
-                                                                  "MC/el/neg/eta/prm/its_tpc", "MC/mu/neg/eta/prm/its_tpc", "MC/pi/neg/eta/prm/its_tpc",
-                                                                  "MC/ka/neg/eta/prm/its_tpc", "MC/pr/neg/eta/prm/its_tpc", "MC/de/neg/eta/prm/its_tpc",
-                                                                  "MC/tr/neg/eta/prm/its_tpc", "MC/he/neg/eta/prm/its_tpc", "MC/al/neg/eta/prm/its_tpc"};
-  static constexpr std::string_view hEtaTrkItsTpcPrm[nHistograms] = {"MC/el/pos/eta/prm/trk/its_tpc", "MC/mu/pos/eta/prm/trk/its_tpc", "MC/pi/pos/eta/prm/trk/its_tpc",
-                                                                     "MC/ka/pos/eta/prm/trk/its_tpc", "MC/pr/pos/eta/prm/trk/its_tpc", "MC/de/pos/eta/prm/trk/its_tpc",
-                                                                     "MC/tr/pos/eta/prm/trk/its_tpc", "MC/he/pos/eta/prm/trk/its_tpc", "MC/al/pos/eta/prm/trk/its_tpc",
-                                                                     "MC/el/neg/eta/prm/trk/its_tpc", "MC/mu/neg/eta/prm/trk/its_tpc", "MC/pi/neg/eta/prm/trk/its_tpc",
-                                                                     "MC/ka/neg/eta/prm/trk/its_tpc", "MC/pr/neg/eta/prm/trk/its_tpc", "MC/de/neg/eta/prm/trk/its_tpc",
-                                                                     "MC/tr/neg/eta/prm/trk/its_tpc", "MC/he/neg/eta/prm/trk/its_tpc", "MC/al/neg/eta/prm/trk/its_tpc"};
-  static constexpr std::string_view hEtaItsTpcTofPrm[nHistograms] = {"MC/el/pos/eta/prm/its_tpc_tof", "MC/mu/pos/eta/prm/its_tpc_tof", "MC/pi/pos/eta/prm/its_tpc_tof",
-                                                                     "MC/ka/pos/eta/prm/its_tpc_tof", "MC/pr/pos/eta/prm/its_tpc_tof", "MC/de/pos/eta/prm/its_tpc_tof",
-                                                                     "MC/tr/pos/eta/prm/its_tpc_tof", "MC/he/pos/eta/prm/its_tpc_tof", "MC/al/pos/eta/prm/its_tpc_tof",
-                                                                     "MC/el/neg/eta/prm/its_tpc_tof", "MC/mu/neg/eta/prm/its_tpc_tof", "MC/pi/neg/eta/prm/its_tpc_tof",
-                                                                     "MC/ka/neg/eta/prm/its_tpc_tof", "MC/pr/neg/eta/prm/its_tpc_tof", "MC/de/neg/eta/prm/its_tpc_tof",
-                                                                     "MC/tr/neg/eta/prm/its_tpc_tof", "MC/he/neg/eta/prm/its_tpc_tof", "MC/al/neg/eta/prm/its_tpc_tof"};
-  static constexpr std::string_view hEtaGeneratedPrm[nHistograms] = {"MC/el/pos/eta/prm/generated", "MC/mu/pos/eta/prm/generated", "MC/pi/pos/eta/prm/generated",
-                                                                     "MC/ka/pos/eta/prm/generated", "MC/pr/pos/eta/prm/generated", "MC/de/pos/eta/prm/generated",
-                                                                     "MC/tr/pos/eta/prm/generated", "MC/he/pos/eta/prm/generated", "MC/al/pos/eta/prm/generated",
-                                                                     "MC/el/neg/eta/prm/generated", "MC/mu/neg/eta/prm/generated", "MC/pi/neg/eta/prm/generated",
-                                                                     "MC/ka/neg/eta/prm/generated", "MC/pr/neg/eta/prm/generated", "MC/de/neg/eta/prm/generated",
-                                                                     "MC/tr/neg/eta/prm/generated", "MC/he/neg/eta/prm/generated", "MC/al/neg/eta/prm/generated"};
+  static constexpr std::string_view hEtaItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/eta/prm/its_tpc", "MC/mu/pos_pdg/eta/prm/its_tpc", "MC/pi/pos_pdg/eta/prm/its_tpc",
+                                                                  "MC/ka/pos_pdg/eta/prm/its_tpc", "MC/pr/pos_pdg/eta/prm/its_tpc", "MC/de/pos_pdg/eta/prm/its_tpc",
+                                                                  "MC/tr/pos_pdg/eta/prm/its_tpc", "MC/he/pos_pdg/eta/prm/its_tpc", "MC/al/pos_pdg/eta/prm/its_tpc",
+                                                                  "MC/el/neg_pdg/eta/prm/its_tpc", "MC/mu/neg_pdg/eta/prm/its_tpc", "MC/pi/neg_pdg/eta/prm/its_tpc",
+                                                                  "MC/ka/neg_pdg/eta/prm/its_tpc", "MC/pr/neg_pdg/eta/prm/its_tpc", "MC/de/neg_pdg/eta/prm/its_tpc",
+                                                                  "MC/tr/neg_pdg/eta/prm/its_tpc", "MC/he/neg_pdg/eta/prm/its_tpc", "MC/al/neg_pdg/eta/prm/its_tpc"};
+  static constexpr std::string_view hEtaTrkItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/eta/prm/trk/its_tpc", "MC/mu/pos_pdg/eta/prm/trk/its_tpc", "MC/pi/pos_pdg/eta/prm/trk/its_tpc",
+                                                                     "MC/ka/pos_pdg/eta/prm/trk/its_tpc", "MC/pr/pos_pdg/eta/prm/trk/its_tpc", "MC/de/pos_pdg/eta/prm/trk/its_tpc",
+                                                                     "MC/tr/pos_pdg/eta/prm/trk/its_tpc", "MC/he/pos_pdg/eta/prm/trk/its_tpc", "MC/al/pos_pdg/eta/prm/trk/its_tpc",
+                                                                     "MC/el/neg_pdg/eta/prm/trk/its_tpc", "MC/mu/neg_pdg/eta/prm/trk/its_tpc", "MC/pi/neg_pdg/eta/prm/trk/its_tpc",
+                                                                     "MC/ka/neg_pdg/eta/prm/trk/its_tpc", "MC/pr/neg_pdg/eta/prm/trk/its_tpc", "MC/de/neg_pdg/eta/prm/trk/its_tpc",
+                                                                     "MC/tr/neg_pdg/eta/prm/trk/its_tpc", "MC/he/neg_pdg/eta/prm/trk/its_tpc", "MC/al/neg_pdg/eta/prm/trk/its_tpc"};
+  static constexpr std::string_view hEtaItsTpcTofPrm[nHistograms] = {"MC/el/pos_pdg/eta/prm/its_tpc_tof", "MC/mu/pos_pdg/eta/prm/its_tpc_tof", "MC/pi/pos_pdg/eta/prm/its_tpc_tof",
+                                                                     "MC/ka/pos_pdg/eta/prm/its_tpc_tof", "MC/pr/pos_pdg/eta/prm/its_tpc_tof", "MC/de/pos_pdg/eta/prm/its_tpc_tof",
+                                                                     "MC/tr/pos_pdg/eta/prm/its_tpc_tof", "MC/he/pos_pdg/eta/prm/its_tpc_tof", "MC/al/pos_pdg/eta/prm/its_tpc_tof",
+                                                                     "MC/el/neg_pdg/eta/prm/its_tpc_tof", "MC/mu/neg_pdg/eta/prm/its_tpc_tof", "MC/pi/neg_pdg/eta/prm/its_tpc_tof",
+                                                                     "MC/ka/neg_pdg/eta/prm/its_tpc_tof", "MC/pr/neg_pdg/eta/prm/its_tpc_tof", "MC/de/neg_pdg/eta/prm/its_tpc_tof",
+                                                                     "MC/tr/neg_pdg/eta/prm/its_tpc_tof", "MC/he/neg_pdg/eta/prm/its_tpc_tof", "MC/al/neg_pdg/eta/prm/its_tpc_tof"};
+  static constexpr std::string_view hEtaGeneratedPrm[nHistograms] = {"MC/el/pos_pdg/eta/prm/generated", "MC/mu/pos_pdg/eta/prm/generated", "MC/pi/pos_pdg/eta/prm/generated",
+                                                                     "MC/ka/pos_pdg/eta/prm/generated", "MC/pr/pos_pdg/eta/prm/generated", "MC/de/pos_pdg/eta/prm/generated",
+                                                                     "MC/tr/pos_pdg/eta/prm/generated", "MC/he/pos_pdg/eta/prm/generated", "MC/al/pos_pdg/eta/prm/generated",
+                                                                     "MC/el/neg_pdg/eta/prm/generated", "MC/mu/neg_pdg/eta/prm/generated", "MC/pi/neg_pdg/eta/prm/generated",
+                                                                     "MC/ka/neg_pdg/eta/prm/generated", "MC/pr/neg_pdg/eta/prm/generated", "MC/de/neg_pdg/eta/prm/generated",
+                                                                     "MC/tr/neg_pdg/eta/prm/generated", "MC/he/neg_pdg/eta/prm/generated", "MC/al/neg_pdg/eta/prm/generated"};
 
   // Y
-  static constexpr std::string_view hYItsTpc[nHistograms] = {"MC/el/pos/y/its_tpc", "MC/mu/pos/y/its_tpc", "MC/pi/pos/y/its_tpc",
-                                                             "MC/ka/pos/y/its_tpc", "MC/pr/pos/y/its_tpc", "MC/de/pos/y/its_tpc",
-                                                             "MC/tr/pos/y/its_tpc", "MC/he/pos/y/its_tpc", "MC/al/pos/y/its_tpc",
-                                                             "MC/el/neg/y/its_tpc", "MC/mu/neg/y/its_tpc", "MC/pi/neg/y/its_tpc",
-                                                             "MC/ka/neg/y/its_tpc", "MC/pr/neg/y/its_tpc", "MC/de/neg/y/its_tpc",
-                                                             "MC/tr/neg/y/its_tpc", "MC/he/neg/y/its_tpc", "MC/al/neg/y/its_tpc"};
-  static constexpr std::string_view hYItsTpcTof[nHistograms] = {"MC/el/pos/y/its_tpc_tof", "MC/mu/pos/y/its_tpc_tof", "MC/pi/pos/y/its_tpc_tof",
-                                                                "MC/ka/pos/y/its_tpc_tof", "MC/pr/pos/y/its_tpc_tof", "MC/de/pos/y/its_tpc_tof",
-                                                                "MC/tr/pos/y/its_tpc_tof", "MC/he/pos/y/its_tpc_tof", "MC/al/pos/y/its_tpc_tof",
-                                                                "MC/el/neg/y/its_tpc_tof", "MC/mu/neg/y/its_tpc_tof", "MC/pi/neg/y/its_tpc_tof",
-                                                                "MC/ka/neg/y/its_tpc_tof", "MC/pr/neg/y/its_tpc_tof", "MC/de/neg/y/its_tpc_tof",
-                                                                "MC/tr/neg/y/its_tpc_tof", "MC/he/neg/y/its_tpc_tof", "MC/al/neg/y/its_tpc_tof"};
-  static constexpr std::string_view hYGenerated[nHistograms] = {"MC/el/pos/y/generated", "MC/mu/pos/y/generated", "MC/pi/pos/y/generated",
-                                                                "MC/ka/pos/y/generated", "MC/pr/pos/y/generated", "MC/de/pos/y/generated",
-                                                                "MC/tr/pos/y/generated", "MC/he/pos/y/generated", "MC/al/pos/y/generated",
-                                                                "MC/el/neg/y/generated", "MC/mu/neg/y/generated", "MC/pi/neg/y/generated",
-                                                                "MC/ka/neg/y/generated", "MC/pr/neg/y/generated", "MC/de/neg/y/generated",
-                                                                "MC/tr/neg/y/generated", "MC/he/neg/y/generated", "MC/al/neg/y/generated"};
+  static constexpr std::string_view hYItsTpc[nHistograms] = {"MC/el/pos_pdg/y/its_tpc", "MC/mu/pos_pdg/y/its_tpc", "MC/pi/pos_pdg/y/its_tpc",
+                                                             "MC/ka/pos_pdg/y/its_tpc", "MC/pr/pos_pdg/y/its_tpc", "MC/de/pos_pdg/y/its_tpc",
+                                                             "MC/tr/pos_pdg/y/its_tpc", "MC/he/pos_pdg/y/its_tpc", "MC/al/pos_pdg/y/its_tpc",
+                                                             "MC/el/neg_pdg/y/its_tpc", "MC/mu/neg_pdg/y/its_tpc", "MC/pi/neg_pdg/y/its_tpc",
+                                                             "MC/ka/neg_pdg/y/its_tpc", "MC/pr/neg_pdg/y/its_tpc", "MC/de/neg_pdg/y/its_tpc",
+                                                             "MC/tr/neg_pdg/y/its_tpc", "MC/he/neg_pdg/y/its_tpc", "MC/al/neg_pdg/y/its_tpc"};
+  static constexpr std::string_view hYItsTpcTof[nHistograms] = {"MC/el/pos_pdg/y/its_tpc_tof", "MC/mu/pos_pdg/y/its_tpc_tof", "MC/pi/pos_pdg/y/its_tpc_tof",
+                                                                "MC/ka/pos_pdg/y/its_tpc_tof", "MC/pr/pos_pdg/y/its_tpc_tof", "MC/de/pos_pdg/y/its_tpc_tof",
+                                                                "MC/tr/pos_pdg/y/its_tpc_tof", "MC/he/pos_pdg/y/its_tpc_tof", "MC/al/pos_pdg/y/its_tpc_tof",
+                                                                "MC/el/neg_pdg/y/its_tpc_tof", "MC/mu/neg_pdg/y/its_tpc_tof", "MC/pi/neg_pdg/y/its_tpc_tof",
+                                                                "MC/ka/neg_pdg/y/its_tpc_tof", "MC/pr/neg_pdg/y/its_tpc_tof", "MC/de/neg_pdg/y/its_tpc_tof",
+                                                                "MC/tr/neg_pdg/y/its_tpc_tof", "MC/he/neg_pdg/y/its_tpc_tof", "MC/al/neg_pdg/y/its_tpc_tof"};
+  static constexpr std::string_view hYGenerated[nHistograms] = {"MC/el/pos_pdg/y/generated", "MC/mu/pos_pdg/y/generated", "MC/pi/pos_pdg/y/generated",
+                                                                "MC/ka/pos_pdg/y/generated", "MC/pr/pos_pdg/y/generated", "MC/de/pos_pdg/y/generated",
+                                                                "MC/tr/pos_pdg/y/generated", "MC/he/pos_pdg/y/generated", "MC/al/pos_pdg/y/generated",
+                                                                "MC/el/neg_pdg/y/generated", "MC/mu/neg_pdg/y/generated", "MC/pi/neg_pdg/y/generated",
+                                                                "MC/ka/neg_pdg/y/generated", "MC/pr/neg_pdg/y/generated", "MC/de/neg_pdg/y/generated",
+                                                                "MC/tr/neg_pdg/y/generated", "MC/he/neg_pdg/y/generated", "MC/al/neg_pdg/y/generated"};
 
   // Phi
-  static constexpr std::string_view hPhiItsTpc[nHistograms] = {"MC/el/pos/phi/its_tpc", "MC/mu/pos/phi/its_tpc", "MC/pi/pos/phi/its_tpc",
-                                                               "MC/ka/pos/phi/its_tpc", "MC/pr/pos/phi/its_tpc", "MC/de/pos/phi/its_tpc",
-                                                               "MC/tr/pos/phi/its_tpc", "MC/he/pos/phi/its_tpc", "MC/al/pos/phi/its_tpc",
-                                                               "MC/el/neg/phi/its_tpc", "MC/mu/neg/phi/its_tpc", "MC/pi/neg/phi/its_tpc",
-                                                               "MC/ka/neg/phi/its_tpc", "MC/pr/neg/phi/its_tpc", "MC/de/neg/phi/its_tpc",
-                                                               "MC/tr/neg/phi/its_tpc", "MC/he/neg/phi/its_tpc", "MC/al/neg/phi/its_tpc"};
-  static constexpr std::string_view hPhiTrkItsTpc[nHistograms] = {"MC/el/pos/phi/trk/its_tpc", "MC/mu/pos/phi/trk/its_tpc", "MC/pi/pos/phi/trk/its_tpc",
-                                                                  "MC/ka/pos/phi/trk/its_tpc", "MC/pr/pos/phi/trk/its_tpc", "MC/de/pos/phi/trk/its_tpc",
-                                                                  "MC/tr/pos/phi/trk/its_tpc", "MC/he/pos/phi/trk/its_tpc", "MC/al/pos/phi/trk/its_tpc",
-                                                                  "MC/el/neg/phi/trk/its_tpc", "MC/mu/neg/phi/trk/its_tpc", "MC/pi/neg/phi/trk/its_tpc",
-                                                                  "MC/ka/neg/phi/trk/its_tpc", "MC/pr/neg/phi/trk/its_tpc", "MC/de/neg/phi/trk/its_tpc",
-                                                                  "MC/tr/neg/phi/trk/its_tpc", "MC/he/neg/phi/trk/its_tpc", "MC/al/neg/phi/trk/its_tpc"};
-  static constexpr std::string_view hPhiItsTpcTof[nHistograms] = {"MC/el/pos/phi/its_tpc_tof", "MC/mu/pos/phi/its_tpc_tof", "MC/pi/pos/phi/its_tpc_tof",
-                                                                  "MC/ka/pos/phi/its_tpc_tof", "MC/pr/pos/phi/its_tpc_tof", "MC/de/pos/phi/its_tpc_tof",
-                                                                  "MC/tr/pos/phi/its_tpc_tof", "MC/he/pos/phi/its_tpc_tof", "MC/al/pos/phi/its_tpc_tof",
-                                                                  "MC/el/neg/phi/its_tpc_tof", "MC/mu/neg/phi/its_tpc_tof", "MC/pi/neg/phi/its_tpc_tof",
-                                                                  "MC/ka/neg/phi/its_tpc_tof", "MC/pr/neg/phi/its_tpc_tof", "MC/de/neg/phi/its_tpc_tof",
-                                                                  "MC/tr/neg/phi/its_tpc_tof", "MC/he/neg/phi/its_tpc_tof", "MC/al/neg/phi/its_tpc_tof"};
-  static constexpr std::string_view hPhiGenerated[nHistograms] = {"MC/el/pos/phi/generated", "MC/mu/pos/phi/generated", "MC/pi/pos/phi/generated",
-                                                                  "MC/ka/pos/phi/generated", "MC/pr/pos/phi/generated", "MC/de/pos/phi/generated",
-                                                                  "MC/tr/pos/phi/generated", "MC/he/pos/phi/generated", "MC/al/pos/phi/generated",
-                                                                  "MC/el/neg/phi/generated", "MC/mu/neg/phi/generated", "MC/pi/neg/phi/generated",
-                                                                  "MC/ka/neg/phi/generated", "MC/pr/neg/phi/generated", "MC/de/neg/phi/generated",
-                                                                  "MC/tr/neg/phi/generated", "MC/he/neg/phi/generated", "MC/al/neg/phi/generated"};
+  static constexpr std::string_view hPhiItsTpc[nHistograms] = {"MC/el/pos_pdg/phi/its_tpc", "MC/mu/pos_pdg/phi/its_tpc", "MC/pi/pos_pdg/phi/its_tpc",
+                                                               "MC/ka/pos_pdg/phi/its_tpc", "MC/pr/pos_pdg/phi/its_tpc", "MC/de/pos_pdg/phi/its_tpc",
+                                                               "MC/tr/pos_pdg/phi/its_tpc", "MC/he/pos_pdg/phi/its_tpc", "MC/al/pos_pdg/phi/its_tpc",
+                                                               "MC/el/neg_pdg/phi/its_tpc", "MC/mu/neg_pdg/phi/its_tpc", "MC/pi/neg_pdg/phi/its_tpc",
+                                                               "MC/ka/neg_pdg/phi/its_tpc", "MC/pr/neg_pdg/phi/its_tpc", "MC/de/neg_pdg/phi/its_tpc",
+                                                               "MC/tr/neg_pdg/phi/its_tpc", "MC/he/neg_pdg/phi/its_tpc", "MC/al/neg_pdg/phi/its_tpc"};
+  static constexpr std::string_view hPhiTrkItsTpc[nHistograms] = {"MC/el/pos_pdg/phi/trk/its_tpc", "MC/mu/pos_pdg/phi/trk/its_tpc", "MC/pi/pos_pdg/phi/trk/its_tpc",
+                                                                  "MC/ka/pos_pdg/phi/trk/its_tpc", "MC/pr/pos_pdg/phi/trk/its_tpc", "MC/de/pos_pdg/phi/trk/its_tpc",
+                                                                  "MC/tr/pos_pdg/phi/trk/its_tpc", "MC/he/pos_pdg/phi/trk/its_tpc", "MC/al/pos_pdg/phi/trk/its_tpc",
+                                                                  "MC/el/neg_pdg/phi/trk/its_tpc", "MC/mu/neg_pdg/phi/trk/its_tpc", "MC/pi/neg_pdg/phi/trk/its_tpc",
+                                                                  "MC/ka/neg_pdg/phi/trk/its_tpc", "MC/pr/neg_pdg/phi/trk/its_tpc", "MC/de/neg_pdg/phi/trk/its_tpc",
+                                                                  "MC/tr/neg_pdg/phi/trk/its_tpc", "MC/he/neg_pdg/phi/trk/its_tpc", "MC/al/neg_pdg/phi/trk/its_tpc"};
+  static constexpr std::string_view hPhiItsTpcTof[nHistograms] = {"MC/el/pos_pdg/phi/its_tpc_tof", "MC/mu/pos_pdg/phi/its_tpc_tof", "MC/pi/pos_pdg/phi/its_tpc_tof",
+                                                                  "MC/ka/pos_pdg/phi/its_tpc_tof", "MC/pr/pos_pdg/phi/its_tpc_tof", "MC/de/pos_pdg/phi/its_tpc_tof",
+                                                                  "MC/tr/pos_pdg/phi/its_tpc_tof", "MC/he/pos_pdg/phi/its_tpc_tof", "MC/al/pos_pdg/phi/its_tpc_tof",
+                                                                  "MC/el/neg_pdg/phi/its_tpc_tof", "MC/mu/neg_pdg/phi/its_tpc_tof", "MC/pi/neg_pdg/phi/its_tpc_tof",
+                                                                  "MC/ka/neg_pdg/phi/its_tpc_tof", "MC/pr/neg_pdg/phi/its_tpc_tof", "MC/de/neg_pdg/phi/its_tpc_tof",
+                                                                  "MC/tr/neg_pdg/phi/its_tpc_tof", "MC/he/neg_pdg/phi/its_tpc_tof", "MC/al/neg_pdg/phi/its_tpc_tof"};
+  static constexpr std::string_view hPhiGenerated[nHistograms] = {"MC/el/pos_pdg/phi/generated", "MC/mu/pos_pdg/phi/generated", "MC/pi/pos_pdg/phi/generated",
+                                                                  "MC/ka/pos_pdg/phi/generated", "MC/pr/pos_pdg/phi/generated", "MC/de/pos_pdg/phi/generated",
+                                                                  "MC/tr/pos_pdg/phi/generated", "MC/he/pos_pdg/phi/generated", "MC/al/pos_pdg/phi/generated",
+                                                                  "MC/el/neg_pdg/phi/generated", "MC/mu/neg_pdg/phi/generated", "MC/pi/neg_pdg/phi/generated",
+                                                                  "MC/ka/neg_pdg/phi/generated", "MC/pr/neg_pdg/phi/generated", "MC/de/neg_pdg/phi/generated",
+                                                                  "MC/tr/neg_pdg/phi/generated", "MC/he/neg_pdg/phi/generated", "MC/al/neg_pdg/phi/generated"};
 
   // Phi for primaries
-  static constexpr std::string_view hPhiItsTpcPrm[nHistograms] = {"MC/el/pos/phi/prm/its_tpc", "MC/mu/pos/phi/prm/its_tpc", "MC/pi/pos/phi/prm/its_tpc",
-                                                                  "MC/ka/pos/phi/prm/its_tpc", "MC/pr/pos/phi/prm/its_tpc", "MC/de/pos/phi/prm/its_tpc",
-                                                                  "MC/tr/pos/phi/prm/its_tpc", "MC/he/pos/phi/prm/its_tpc", "MC/al/pos/phi/prm/its_tpc",
-                                                                  "MC/el/neg/phi/prm/its_tpc", "MC/mu/neg/phi/prm/its_tpc", "MC/pi/neg/phi/prm/its_tpc",
-                                                                  "MC/ka/neg/phi/prm/its_tpc", "MC/pr/neg/phi/prm/its_tpc", "MC/de/neg/phi/prm/its_tpc",
-                                                                  "MC/tr/neg/phi/prm/its_tpc", "MC/he/neg/phi/prm/its_tpc", "MC/al/neg/phi/prm/its_tpc"};
-  static constexpr std::string_view hPhiTrkItsTpcPrm[nHistograms] = {"MC/el/pos/phi/prm/trk/its_tpc", "MC/mu/pos/phi/prm/trk/its_tpc", "MC/pi/pos/phi/prm/trk/its_tpc",
-                                                                     "MC/ka/pos/phi/prm/trk/its_tpc", "MC/pr/pos/phi/prm/trk/its_tpc", "MC/de/pos/phi/prm/trk/its_tpc",
-                                                                     "MC/tr/pos/phi/prm/trk/its_tpc", "MC/he/pos/phi/prm/trk/its_tpc", "MC/al/pos/phi/prm/trk/its_tpc",
-                                                                     "MC/el/neg/phi/prm/trk/its_tpc", "MC/mu/neg/phi/prm/trk/its_tpc", "MC/pi/neg/phi/prm/trk/its_tpc",
-                                                                     "MC/ka/neg/phi/prm/trk/its_tpc", "MC/pr/neg/phi/prm/trk/its_tpc", "MC/de/neg/phi/prm/trk/its_tpc",
-                                                                     "MC/tr/neg/phi/prm/trk/its_tpc", "MC/he/neg/phi/prm/trk/its_tpc", "MC/al/neg/phi/prm/trk/its_tpc"};
-  static constexpr std::string_view hPhiItsTpcTofPrm[nHistograms] = {"MC/el/pos/phi/prm/its_tpc_tof", "MC/mu/pos/phi/prm/its_tpc_tof", "MC/pi/pos/phi/prm/its_tpc_tof",
-                                                                     "MC/ka/pos/phi/prm/its_tpc_tof", "MC/pr/pos/phi/prm/its_tpc_tof", "MC/de/pos/phi/prm/its_tpc_tof",
-                                                                     "MC/tr/pos/phi/prm/its_tpc_tof", "MC/he/pos/phi/prm/its_tpc_tof", "MC/al/pos/phi/prm/its_tpc_tof",
-                                                                     "MC/el/neg/phi/prm/its_tpc_tof", "MC/mu/neg/phi/prm/its_tpc_tof", "MC/pi/neg/phi/prm/its_tpc_tof",
-                                                                     "MC/ka/neg/phi/prm/its_tpc_tof", "MC/pr/neg/phi/prm/its_tpc_tof", "MC/de/neg/phi/prm/its_tpc_tof",
-                                                                     "MC/tr/neg/phi/prm/its_tpc_tof", "MC/he/neg/phi/prm/its_tpc_tof", "MC/al/neg/phi/prm/its_tpc_tof"};
-  static constexpr std::string_view hPhiGeneratedPrm[nHistograms] = {"MC/el/pos/phi/prm/generated", "MC/mu/pos/phi/prm/generated", "MC/pi/pos/phi/prm/generated",
-                                                                     "MC/ka/pos/phi/prm/generated", "MC/pr/pos/phi/prm/generated", "MC/de/pos/phi/prm/generated",
-                                                                     "MC/tr/pos/phi/prm/generated", "MC/he/pos/phi/prm/generated", "MC/al/pos/phi/prm/generated",
-                                                                     "MC/el/neg/phi/prm/generated", "MC/mu/neg/phi/prm/generated", "MC/pi/neg/phi/prm/generated",
-                                                                     "MC/ka/neg/phi/prm/generated", "MC/pr/neg/phi/prm/generated", "MC/de/neg/phi/prm/generated",
-                                                                     "MC/tr/neg/phi/prm/generated", "MC/he/neg/phi/prm/generated", "MC/al/neg/phi/prm/generated"};
+  static constexpr std::string_view hPhiItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/phi/prm/its_tpc", "MC/mu/pos_pdg/phi/prm/its_tpc", "MC/pi/pos_pdg/phi/prm/its_tpc",
+                                                                  "MC/ka/pos_pdg/phi/prm/its_tpc", "MC/pr/pos_pdg/phi/prm/its_tpc", "MC/de/pos_pdg/phi/prm/its_tpc",
+                                                                  "MC/tr/pos_pdg/phi/prm/its_tpc", "MC/he/pos_pdg/phi/prm/its_tpc", "MC/al/pos_pdg/phi/prm/its_tpc",
+                                                                  "MC/el/neg_pdg/phi/prm/its_tpc", "MC/mu/neg_pdg/phi/prm/its_tpc", "MC/pi/neg_pdg/phi/prm/its_tpc",
+                                                                  "MC/ka/neg_pdg/phi/prm/its_tpc", "MC/pr/neg_pdg/phi/prm/its_tpc", "MC/de/neg_pdg/phi/prm/its_tpc",
+                                                                  "MC/tr/neg_pdg/phi/prm/its_tpc", "MC/he/neg_pdg/phi/prm/its_tpc", "MC/al/neg_pdg/phi/prm/its_tpc"};
+  static constexpr std::string_view hPhiTrkItsTpcPrm[nHistograms] = {"MC/el/pos_pdg/phi/prm/trk/its_tpc", "MC/mu/pos_pdg/phi/prm/trk/its_tpc", "MC/pi/pos_pdg/phi/prm/trk/its_tpc",
+                                                                     "MC/ka/pos_pdg/phi/prm/trk/its_tpc", "MC/pr/pos_pdg/phi/prm/trk/its_tpc", "MC/de/pos_pdg/phi/prm/trk/its_tpc",
+                                                                     "MC/tr/pos_pdg/phi/prm/trk/its_tpc", "MC/he/pos_pdg/phi/prm/trk/its_tpc", "MC/al/pos_pdg/phi/prm/trk/its_tpc",
+                                                                     "MC/el/neg_pdg/phi/prm/trk/its_tpc", "MC/mu/neg_pdg/phi/prm/trk/its_tpc", "MC/pi/neg_pdg/phi/prm/trk/its_tpc",
+                                                                     "MC/ka/neg_pdg/phi/prm/trk/its_tpc", "MC/pr/neg_pdg/phi/prm/trk/its_tpc", "MC/de/neg_pdg/phi/prm/trk/its_tpc",
+                                                                     "MC/tr/neg_pdg/phi/prm/trk/its_tpc", "MC/he/neg_pdg/phi/prm/trk/its_tpc", "MC/al/neg_pdg/phi/prm/trk/its_tpc"};
+  static constexpr std::string_view hPhiItsTpcTofPrm[nHistograms] = {"MC/el/pos_pdg/phi/prm/its_tpc_tof", "MC/mu/pos_pdg/phi/prm/its_tpc_tof", "MC/pi/pos_pdg/phi/prm/its_tpc_tof",
+                                                                     "MC/ka/pos_pdg/phi/prm/its_tpc_tof", "MC/pr/pos_pdg/phi/prm/its_tpc_tof", "MC/de/pos_pdg/phi/prm/its_tpc_tof",
+                                                                     "MC/tr/pos_pdg/phi/prm/its_tpc_tof", "MC/he/pos_pdg/phi/prm/its_tpc_tof", "MC/al/pos_pdg/phi/prm/its_tpc_tof",
+                                                                     "MC/el/neg_pdg/phi/prm/its_tpc_tof", "MC/mu/neg_pdg/phi/prm/its_tpc_tof", "MC/pi/neg_pdg/phi/prm/its_tpc_tof",
+                                                                     "MC/ka/neg_pdg/phi/prm/its_tpc_tof", "MC/pr/neg_pdg/phi/prm/its_tpc_tof", "MC/de/neg_pdg/phi/prm/its_tpc_tof",
+                                                                     "MC/tr/neg_pdg/phi/prm/its_tpc_tof", "MC/he/neg_pdg/phi/prm/its_tpc_tof", "MC/al/neg_pdg/phi/prm/its_tpc_tof"};
+  static constexpr std::string_view hPhiGeneratedPrm[nHistograms] = {"MC/el/pos_pdg/phi/prm/generated", "MC/mu/pos_pdg/phi/prm/generated", "MC/pi/pos_pdg/phi/prm/generated",
+                                                                     "MC/ka/pos_pdg/phi/prm/generated", "MC/pr/pos_pdg/phi/prm/generated", "MC/de/pos_pdg/phi/prm/generated",
+                                                                     "MC/tr/pos_pdg/phi/prm/generated", "MC/he/pos_pdg/phi/prm/generated", "MC/al/pos_pdg/phi/prm/generated",
+                                                                     "MC/el/neg_pdg/phi/prm/generated", "MC/mu/neg_pdg/phi/prm/generated", "MC/pi/neg_pdg/phi/prm/generated",
+                                                                     "MC/ka/neg_pdg/phi/prm/generated", "MC/pr/neg_pdg/phi/prm/generated", "MC/de/neg_pdg/phi/prm/generated",
+                                                                     "MC/tr/neg_pdg/phi/prm/generated", "MC/he/neg_pdg/phi/prm/generated", "MC/al/neg_pdg/phi/prm/generated"};
 
   // Pt-Eta
-  static constexpr std::string_view hPtEtaItsTpc[nHistograms] = {"MC/el/pos/pteta/its_tpc", "MC/mu/pos/pteta/its_tpc", "MC/pi/pos/pteta/its_tpc",
-                                                                 "MC/ka/pos/pteta/its_tpc", "MC/pr/pos/pteta/its_tpc", "MC/de/pos/pteta/its_tpc",
-                                                                 "MC/tr/pos/pteta/its_tpc", "MC/he/pos/pteta/its_tpc", "MC/al/pos/pteta/its_tpc",
-                                                                 "MC/el/neg/pteta/its_tpc", "MC/mu/neg/pteta/its_tpc", "MC/pi/neg/pteta/its_tpc",
-                                                                 "MC/ka/neg/pteta/its_tpc", "MC/pr/neg/pteta/its_tpc", "MC/de/neg/pteta/its_tpc",
-                                                                 "MC/tr/neg/pteta/its_tpc", "MC/he/neg/pteta/its_tpc", "MC/al/neg/pteta/its_tpc"};
-  static constexpr std::string_view hPtEtaTrkItsTpc[nHistograms] = {"MC/el/pos/pteta/trk/its_tpc", "MC/mu/pos/pteta/trk/its_tpc", "MC/pi/pos/pteta/trk/its_tpc",
-                                                                    "MC/ka/pos/pteta/trk/its_tpc", "MC/pr/pos/pteta/trk/its_tpc", "MC/de/pos/pteta/trk/its_tpc",
-                                                                    "MC/tr/pos/pteta/trk/its_tpc", "MC/he/pos/pteta/trk/its_tpc", "MC/al/pos/pteta/trk/its_tpc",
-                                                                    "MC/el/neg/pteta/trk/its_tpc", "MC/mu/neg/pteta/trk/its_tpc", "MC/pi/neg/pteta/trk/its_tpc",
-                                                                    "MC/ka/neg/pteta/trk/its_tpc", "MC/pr/neg/pteta/trk/its_tpc", "MC/de/neg/pteta/trk/its_tpc",
-                                                                    "MC/tr/neg/pteta/trk/its_tpc", "MC/he/neg/pteta/trk/its_tpc", "MC/al/neg/pteta/trk/its_tpc"};
-  static constexpr std::string_view hPtEtaItsTpcTof[nHistograms] = {"MC/el/pos/pteta/its_tpc_tof", "MC/mu/pos/pteta/its_tpc_tof", "MC/pi/pos/pteta/its_tpc_tof",
-                                                                    "MC/ka/pos/pteta/its_tpc_tof", "MC/pr/pos/pteta/its_tpc_tof", "MC/de/pos/pteta/its_tpc_tof",
-                                                                    "MC/tr/pos/pteta/its_tpc_tof", "MC/he/pos/pteta/its_tpc_tof", "MC/al/pos/pteta/its_tpc_tof",
-                                                                    "MC/el/neg/pteta/its_tpc_tof", "MC/mu/neg/pteta/its_tpc_tof", "MC/pi/neg/pteta/its_tpc_tof",
-                                                                    "MC/ka/neg/pteta/its_tpc_tof", "MC/pr/neg/pteta/its_tpc_tof", "MC/de/neg/pteta/its_tpc_tof",
-                                                                    "MC/tr/neg/pteta/its_tpc_tof", "MC/he/neg/pteta/its_tpc_tof", "MC/al/neg/pteta/its_tpc_tof"};
-  static constexpr std::string_view hPtEtaGenerated[nHistograms] = {"MC/el/pos/pteta/generated", "MC/mu/pos/pteta/generated", "MC/pi/pos/pteta/generated",
-                                                                    "MC/ka/pos/pteta/generated", "MC/pr/pos/pteta/generated", "MC/de/pos/pteta/generated",
-                                                                    "MC/tr/pos/pteta/generated", "MC/he/pos/pteta/generated", "MC/al/pos/pteta/generated",
-                                                                    "MC/el/neg/pteta/generated", "MC/mu/neg/pteta/generated", "MC/pi/neg/pteta/generated",
-                                                                    "MC/ka/neg/pteta/generated", "MC/pr/neg/pteta/generated", "MC/de/neg/pteta/generated",
-                                                                    "MC/tr/neg/pteta/generated", "MC/he/neg/pteta/generated", "MC/al/neg/pteta/generated"};
+  static constexpr std::string_view hPtEtaItsTpc[nHistograms] = {"MC/el/pos_pdg/pteta/its_tpc", "MC/mu/pos_pdg/pteta/its_tpc", "MC/pi/pos_pdg/pteta/its_tpc",
+                                                                 "MC/ka/pos_pdg/pteta/its_tpc", "MC/pr/pos_pdg/pteta/its_tpc", "MC/de/pos_pdg/pteta/its_tpc",
+                                                                 "MC/tr/pos_pdg/pteta/its_tpc", "MC/he/pos_pdg/pteta/its_tpc", "MC/al/pos_pdg/pteta/its_tpc",
+                                                                 "MC/el/neg_pdg/pteta/its_tpc", "MC/mu/neg_pdg/pteta/its_tpc", "MC/pi/neg_pdg/pteta/its_tpc",
+                                                                 "MC/ka/neg_pdg/pteta/its_tpc", "MC/pr/neg_pdg/pteta/its_tpc", "MC/de/neg_pdg/pteta/its_tpc",
+                                                                 "MC/tr/neg_pdg/pteta/its_tpc", "MC/he/neg_pdg/pteta/its_tpc", "MC/al/neg_pdg/pteta/its_tpc"};
+  static constexpr std::string_view hPtEtaTrkItsTpc[nHistograms] = {"MC/el/pos_pdg/pteta/trk/its_tpc", "MC/mu/pos_pdg/pteta/trk/its_tpc", "MC/pi/pos_pdg/pteta/trk/its_tpc",
+                                                                    "MC/ka/pos_pdg/pteta/trk/its_tpc", "MC/pr/pos_pdg/pteta/trk/its_tpc", "MC/de/pos_pdg/pteta/trk/its_tpc",
+                                                                    "MC/tr/pos_pdg/pteta/trk/its_tpc", "MC/he/pos_pdg/pteta/trk/its_tpc", "MC/al/pos_pdg/pteta/trk/its_tpc",
+                                                                    "MC/el/neg_pdg/pteta/trk/its_tpc", "MC/mu/neg_pdg/pteta/trk/its_tpc", "MC/pi/neg_pdg/pteta/trk/its_tpc",
+                                                                    "MC/ka/neg_pdg/pteta/trk/its_tpc", "MC/pr/neg_pdg/pteta/trk/its_tpc", "MC/de/neg_pdg/pteta/trk/its_tpc",
+                                                                    "MC/tr/neg_pdg/pteta/trk/its_tpc", "MC/he/neg_pdg/pteta/trk/its_tpc", "MC/al/neg_pdg/pteta/trk/its_tpc"};
+  static constexpr std::string_view hPtEtaItsTpcTof[nHistograms] = {"MC/el/pos_pdg/pteta/its_tpc_tof", "MC/mu/pos_pdg/pteta/its_tpc_tof", "MC/pi/pos_pdg/pteta/its_tpc_tof",
+                                                                    "MC/ka/pos_pdg/pteta/its_tpc_tof", "MC/pr/pos_pdg/pteta/its_tpc_tof", "MC/de/pos_pdg/pteta/its_tpc_tof",
+                                                                    "MC/tr/pos_pdg/pteta/its_tpc_tof", "MC/he/pos_pdg/pteta/its_tpc_tof", "MC/al/pos_pdg/pteta/its_tpc_tof",
+                                                                    "MC/el/neg_pdg/pteta/its_tpc_tof", "MC/mu/neg_pdg/pteta/its_tpc_tof", "MC/pi/neg_pdg/pteta/its_tpc_tof",
+                                                                    "MC/ka/neg_pdg/pteta/its_tpc_tof", "MC/pr/neg_pdg/pteta/its_tpc_tof", "MC/de/neg_pdg/pteta/its_tpc_tof",
+                                                                    "MC/tr/neg_pdg/pteta/its_tpc_tof", "MC/he/neg_pdg/pteta/its_tpc_tof", "MC/al/neg_pdg/pteta/its_tpc_tof"};
+  static constexpr std::string_view hPtEtaGenerated[nHistograms] = {"MC/el/pos_pdg/pteta/generated", "MC/mu/pos_pdg/pteta/generated", "MC/pi/pos_pdg/pteta/generated",
+                                                                    "MC/ka/pos_pdg/pteta/generated", "MC/pr/pos_pdg/pteta/generated", "MC/de/pos_pdg/pteta/generated",
+                                                                    "MC/tr/pos_pdg/pteta/generated", "MC/he/pos_pdg/pteta/generated", "MC/al/pos_pdg/pteta/generated",
+                                                                    "MC/el/neg_pdg/pteta/generated", "MC/mu/neg_pdg/pteta/generated", "MC/pi/neg_pdg/pteta/generated",
+                                                                    "MC/ka/neg_pdg/pteta/generated", "MC/pr/neg_pdg/pteta/generated", "MC/de/neg_pdg/pteta/generated",
+                                                                    "MC/tr/neg_pdg/pteta/generated", "MC/he/neg_pdg/pteta/generated", "MC/al/neg_pdg/pteta/generated"};
 
-  static const char* particleName(int charge, o2::track::PID::ID id)
+  static const char* particleName(int pdgSign, o2::track::PID::ID id)
   {
-    return Form("%s %s", charge == 0 ? "Positive" : "Negative", o2::track::PID::getName(id));
+    return Form("%s %s", pdgSign == 0 ? "Positive PDG" : "Negative PDG", o2::track::PID::getName(id));
   }
 
-  template <int charge, o2::track::PID::ID id>
+  template <int pdgSign, o2::track::PID::ID id>
   void makeMCHistograms(const bool doMakeHistograms)
   {
     if (!doMakeHistograms) {
       return;
     }
 
-    if constexpr (charge == 0) {
+    if constexpr (pdgSign == 0) {
       if (!doPositivePDG) { // Positive
         return;
       }
-    } else if constexpr (charge == 1) {
+    } else if constexpr (pdgSign == 1) {
       if (!doNegativePDG) { // Negative
         return;
       }
     } else {
-      LOG(fatal) << "Can't interpret charge " << charge;
+      LOG(fatal) << "Can't interpret pdgSign " << pdgSign;
     }
 
     AxisSpec axisPt{ptBins, "#it{p}_{T} (GeV/#it{c})"};
@@ -450,8 +450,8 @@ struct QaEfficiency {
     const AxisSpec axisY{yBins, "#it{y}"};
     const AxisSpec axisPhi{phiBins, "#it{#varphi} (rad)"};
 
-    const char* partName = particleName(charge, id);
-    LOG(info) << "Preparing histograms for particle: " << partName << " charge " << charge;
+    const char* partName = particleName(pdgSign, id);
+    LOG(info) << "Preparing histograms for particle: " << partName << " pdgSign " << pdgSign;
 
     const TString tagPt = Form("%s #it{#eta} [%.2f,%.2f] #it{y} [%.2f,%.2f] #it{#varphi} [%.2f,%.2f]",
                                partName,
@@ -482,10 +482,10 @@ struct QaEfficiency {
                                   phiMin, phiMax,
                                   yMin, yMax);
 
-    const int histogramIndex = id + charge * nSpecies;
-    HistogramRegistry* registry = &histosPos;
-    if (charge == 1) {
-      registry = &histosNeg;
+    const int histogramIndex = id + pdgSign * nSpecies;
+    HistogramRegistry* registry = &histosPosPdg;
+    if (pdgSign == 1) {
+      registry = &histosNegPdg;
     }
 
     registry->add(hPtIts[histogramIndex].data(), "ITS tracks " + tagPt, kTH1F, {axisPt});
@@ -554,7 +554,7 @@ struct QaEfficiency {
     LOG(info) << "Done with particle: " << partName;
   }
 
-  template <int charge, o2::track::PID::ID id>
+  template <int pdgSign, o2::track::PID::ID id>
   void makeMCEfficiency(const bool doMakeHistograms)
   {
     if (!doMakeHistograms) {
@@ -565,27 +565,27 @@ struct QaEfficiency {
       return;
     }
 
-    if constexpr (charge == 0) {
+    if constexpr (pdgSign == 0) {
       if (!doPositivePDG) { // Positive
         return;
       }
-    } else if constexpr (charge == 1) {
+    } else if constexpr (pdgSign == 1) {
       if (!doNegativePDG) { // Negative
         return;
       }
     } else {
-      LOG(fatal) << "Can't interpret charge index";
+      LOG(fatal) << "Can't interpret pdgSign index";
     }
 
-    const TString partName = particleName(charge, id);
+    const TString partName = particleName(pdgSign, id);
     LOG(info) << "Making TEfficiency for MC for particle " << partName;
     THashList* subList = new THashList();
     subList->SetName(partName);
     listEfficiencyMC->Add(subList);
 
-    HistogramRegistry* registry = &histosPos;
-    if (charge == 1) {
-      registry = &histosNeg;
+    HistogramRegistry* registry = &histosPosPdg;
+    if (pdgSign == 1) {
+      registry = &histosNegPdg;
     }
 
     auto makeEfficiency = [&](const TString effname, auto templateHisto) { // 1D efficiencies
@@ -602,7 +602,7 @@ struct QaEfficiency {
       }
     };
 
-    const int histogramIndex = id + charge * nSpecies;
+    const int histogramIndex = id + pdgSign * nSpecies;
 
     makeEfficiency("ITS_vsPt", HIST(hPtIts[histogramIndex]));
     makeEfficiency("TPC_vsPt", HIST(hPtTpc[histogramIndex]));
@@ -742,26 +742,26 @@ struct QaEfficiency {
 
     listEfficiencyMC.setObject(new THashList);
 
-    static_for<0, 1>([&](auto charge) {
-      makeMCHistograms<charge, o2::track::PID::Electron>(doEl);
-      makeMCHistograms<charge, o2::track::PID::Muon>(doMu);
-      makeMCHistograms<charge, o2::track::PID::Pion>(doPi);
-      makeMCHistograms<charge, o2::track::PID::Kaon>(doKa);
-      makeMCHistograms<charge, o2::track::PID::Proton>(doPr);
-      makeMCHistograms<charge, o2::track::PID::Deuteron>(doDe);
-      makeMCHistograms<charge, o2::track::PID::Triton>(doTr);
-      makeMCHistograms<charge, o2::track::PID::Helium3>(doHe);
-      makeMCHistograms<charge, o2::track::PID::Alpha>(doAl);
+    static_for<0, 1>([&](auto pdgSign) {
+      makeMCHistograms<pdgSign, o2::track::PID::Electron>(doEl);
+      makeMCHistograms<pdgSign, o2::track::PID::Muon>(doMu);
+      makeMCHistograms<pdgSign, o2::track::PID::Pion>(doPi);
+      makeMCHistograms<pdgSign, o2::track::PID::Kaon>(doKa);
+      makeMCHistograms<pdgSign, o2::track::PID::Proton>(doPr);
+      makeMCHistograms<pdgSign, o2::track::PID::Deuteron>(doDe);
+      makeMCHistograms<pdgSign, o2::track::PID::Triton>(doTr);
+      makeMCHistograms<pdgSign, o2::track::PID::Helium3>(doHe);
+      makeMCHistograms<pdgSign, o2::track::PID::Alpha>(doAl);
 
-      makeMCEfficiency<charge, o2::track::PID::Electron>(doEl);
-      makeMCEfficiency<charge, o2::track::PID::Muon>(doMu);
-      makeMCEfficiency<charge, o2::track::PID::Pion>(doPi);
-      makeMCEfficiency<charge, o2::track::PID::Kaon>(doKa);
-      makeMCEfficiency<charge, o2::track::PID::Proton>(doPr);
-      makeMCEfficiency<charge, o2::track::PID::Deuteron>(doDe);
-      makeMCEfficiency<charge, o2::track::PID::Triton>(doTr);
-      makeMCEfficiency<charge, o2::track::PID::Helium3>(doHe);
-      makeMCEfficiency<charge, o2::track::PID::Alpha>(doAl);
+      makeMCEfficiency<pdgSign, o2::track::PID::Electron>(doEl);
+      makeMCEfficiency<pdgSign, o2::track::PID::Muon>(doMu);
+      makeMCEfficiency<pdgSign, o2::track::PID::Pion>(doPi);
+      makeMCEfficiency<pdgSign, o2::track::PID::Kaon>(doKa);
+      makeMCEfficiency<pdgSign, o2::track::PID::Proton>(doPr);
+      makeMCEfficiency<pdgSign, o2::track::PID::Deuteron>(doDe);
+      makeMCEfficiency<pdgSign, o2::track::PID::Triton>(doTr);
+      makeMCEfficiency<pdgSign, o2::track::PID::Helium3>(doHe);
+      makeMCEfficiency<pdgSign, o2::track::PID::Alpha>(doAl);
     });
   }
 
@@ -966,29 +966,29 @@ struct QaEfficiency {
     }
   }
 
-  template <int charge, o2::track::PID::ID id, typename particleType>
+  template <int pdgSign, o2::track::PID::ID id, typename particleType>
   bool isPdgSelected(const particleType& mcParticle)
   {
-    static_assert(charge == 0 || charge == 1);
+    static_assert(pdgSign == 0 || pdgSign == 1);
     static_assert(id > 0 || id < nSpecies);
 
     // Selecting a specific PDG
-    if constexpr (charge == 0) {
+    if constexpr (pdgSign == 0) {
       return mcParticle.pdgCode() == PDGs[id];
     } else {
       return mcParticle.pdgCode() == -PDGs[id];
     }
   }
 
-  template <int charge, o2::track::PID::ID id, typename trackType>
+  template <int pdgSign, o2::track::PID::ID id, typename trackType>
   void fillMCTrackHistograms(const trackType& track, const bool doMakeHistograms)
   {
-    static_assert(charge == 0 || charge == 1);
+    static_assert(pdgSign == 0 || pdgSign == 1);
     if (!doMakeHistograms) {
       return;
     }
 
-    if constexpr (charge == 0) {
+    if constexpr (pdgSign == 0) {
       if (!doPositivePDG) {
         return;
       }
@@ -998,16 +998,16 @@ struct QaEfficiency {
       }
     }
 
-    HistogramRegistry* h = &histosPos;
-    if constexpr (charge == 1) {
-      h = &histosNeg;
+    HistogramRegistry* h = &histosPosPdg;
+    if constexpr (pdgSign == 1) {
+      h = &histosNegPdg;
     }
 
-    constexpr int histogramIndex = id + charge * nSpecies;
-    LOG(debug) << "fillMCTrackHistograms for charge '" << charge << "' and id '" << static_cast<int>(id) << "' " << particleName(charge, id) << " with index " << histogramIndex;
+    constexpr int histogramIndex = id + pdgSign * nSpecies;
+    LOG(debug) << "fillMCTrackHistograms for pdgSign '" << pdgSign << "' and id '" << static_cast<int>(id) << "' " << particleName(pdgSign, id) << " with index " << histogramIndex;
     const auto mcParticle = track.mcParticle();
 
-    if (!isPdgSelected<charge, id>(mcParticle)) { // Selecting PDG code
+    if (!isPdgSelected<pdgSign, id>(mcParticle)) { // Selecting PDG code
       return;
     }
 
@@ -1102,15 +1102,15 @@ struct QaEfficiency {
     }
   }
 
-  template <int charge, o2::track::PID::ID id, typename particleType>
+  template <int pdgSign, o2::track::PID::ID id, typename particleType>
   void fillMCParticleHistograms(const particleType& mcParticle, const bool doMakeHistograms)
   {
-    static_assert(charge == 0 || charge == 1);
+    static_assert(pdgSign == 0 || pdgSign == 1);
     if (!doMakeHistograms) {
       return;
     }
 
-    if constexpr (charge == 0) {
+    if constexpr (pdgSign == 0) {
       if (!doPositivePDG) {
         return;
       }
@@ -1120,14 +1120,14 @@ struct QaEfficiency {
       }
     }
 
-    HistogramRegistry* h = &histosPos;
-    if (charge == 1) {
-      h = &histosNeg;
+    HistogramRegistry* h = &histosPosPdg;
+    if (pdgSign == 1) {
+      h = &histosNegPdg;
     }
 
-    constexpr int histogramIndex = id + charge * nSpecies;
-    LOG(debug) << "fillMCParticleHistograms for charge '" << charge << "' and id '" << static_cast<int>(id) << "' " << particleName(charge, id) << " with index " << histogramIndex;
-    if (!isPdgSelected<charge, id>(mcParticle)) { // Selecting PDG code
+    constexpr int histogramIndex = id + pdgSign * nSpecies;
+    LOG(debug) << "fillMCParticleHistograms for pdgSign '" << pdgSign << "' and id '" << static_cast<int>(id) << "' " << particleName(pdgSign, id) << " with index " << histogramIndex;
+    if (!isPdgSelected<pdgSign, id>(mcParticle)) { // Selecting PDG code
       return;
     }
     histos.fill(HIST("MC/particleSelection"), 6 + id);
@@ -1162,15 +1162,15 @@ struct QaEfficiency {
     }
   }
 
-  template <int charge, o2::track::PID::ID id>
+  template <int pdgSign, o2::track::PID::ID id>
   void fillMCEfficiency(const bool doMakeHistograms)
   {
     if (!doMakeHistograms) {
       return;
     }
 
-    static_assert(charge == 0 || charge == 1);
-    if constexpr (charge == 0) {
+    static_assert(pdgSign == 0 || pdgSign == 1);
+    if constexpr (pdgSign == 0) {
       if (!doPositivePDG) {
         return;
       }
@@ -1183,14 +1183,14 @@ struct QaEfficiency {
       return;
     }
 
-    HistogramRegistry* registry = &histosPos;
-    if (charge == 1) {
-      registry = &histosNeg;
+    HistogramRegistry* registry = &histosPosPdg;
+    if (pdgSign == 1) {
+      registry = &histosNegPdg;
     }
 
-    constexpr int histogramIndex = id + charge * nSpecies;
+    constexpr int histogramIndex = id + pdgSign * nSpecies;
 
-    const char* partName = particleName(charge, id);
+    const char* partName = particleName(pdgSign, id);
     LOG(debug) << "Filling efficiency for particle " << static_cast<int>(id) << " " << partName;
     THashList* subList = static_cast<THashList*>(listEfficiencyMC->FindObject(partName));
     if (!subList) {
@@ -1495,16 +1495,16 @@ struct QaEfficiency {
         }
         // Filling variable histograms
         histos.fill(HIST("MC/trackLength"), track.length());
-        static_for<0, 1>([&](auto charge) {
-          fillMCTrackHistograms<charge, o2::track::PID::Electron>(track, doEl);
-          fillMCTrackHistograms<charge, o2::track::PID::Muon>(track, doMu);
-          fillMCTrackHistograms<charge, o2::track::PID::Pion>(track, doPi);
-          fillMCTrackHistograms<charge, o2::track::PID::Kaon>(track, doKa);
-          fillMCTrackHistograms<charge, o2::track::PID::Proton>(track, doPr);
-          fillMCTrackHistograms<charge, o2::track::PID::Deuteron>(track, doDe);
-          fillMCTrackHistograms<charge, o2::track::PID::Triton>(track, doTr);
-          fillMCTrackHistograms<charge, o2::track::PID::Helium3>(track, doHe);
-          fillMCTrackHistograms<charge, o2::track::PID::Alpha>(track, doAl);
+        static_for<0, 1>([&](auto pdgSign) {
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Electron>(track, doEl);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Muon>(track, doMu);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Pion>(track, doPi);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Kaon>(track, doKa);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Proton>(track, doPr);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Deuteron>(track, doDe);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Triton>(track, doTr);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Helium3>(track, doHe);
+          fillMCTrackHistograms<pdgSign, o2::track::PID::Alpha>(track, doAl);
         });
       }
     }
@@ -1519,31 +1519,31 @@ struct QaEfficiency {
         continue;
       }
 
-      static_for<0, 1>([&](auto charge) {
-        fillMCParticleHistograms<charge, o2::track::PID::Electron>(mcParticle, doEl);
-        fillMCParticleHistograms<charge, o2::track::PID::Muon>(mcParticle, doMu);
-        fillMCParticleHistograms<charge, o2::track::PID::Pion>(mcParticle, doPi);
-        fillMCParticleHistograms<charge, o2::track::PID::Kaon>(mcParticle, doKa);
-        fillMCParticleHistograms<charge, o2::track::PID::Proton>(mcParticle, doPr);
-        fillMCParticleHistograms<charge, o2::track::PID::Deuteron>(mcParticle, doDe);
-        fillMCParticleHistograms<charge, o2::track::PID::Triton>(mcParticle, doTr);
-        fillMCParticleHistograms<charge, o2::track::PID::Helium3>(mcParticle, doHe);
-        fillMCParticleHistograms<charge, o2::track::PID::Alpha>(mcParticle, doAl);
+      static_for<0, 1>([&](auto pdgSign) {
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Electron>(mcParticle, doEl);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Muon>(mcParticle, doMu);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Pion>(mcParticle, doPi);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Kaon>(mcParticle, doKa);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Proton>(mcParticle, doPr);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Deuteron>(mcParticle, doDe);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Triton>(mcParticle, doTr);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Helium3>(mcParticle, doHe);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Alpha>(mcParticle, doAl);
       });
     }
     histos.fill(HIST("MC/eventMultiplicity"), dNdEta * 0.5f / 2.f);
 
     // Fill TEfficiencies
-    static_for<0, 1>([&](auto charge) {
-      fillMCEfficiency<charge, o2::track::PID::Electron>(doEl);
-      fillMCEfficiency<charge, o2::track::PID::Muon>(doMu);
-      fillMCEfficiency<charge, o2::track::PID::Pion>(doPi);
-      fillMCEfficiency<charge, o2::track::PID::Kaon>(doKa);
-      fillMCEfficiency<charge, o2::track::PID::Proton>(doPr);
-      fillMCEfficiency<charge, o2::track::PID::Deuteron>(doDe);
-      fillMCEfficiency<charge, o2::track::PID::Triton>(doTr);
-      fillMCEfficiency<charge, o2::track::PID::Helium3>(doHe);
-      fillMCEfficiency<charge, o2::track::PID::Alpha>(doAl);
+    static_for<0, 1>([&](auto pdgSign) {
+      fillMCEfficiency<pdgSign, o2::track::PID::Electron>(doEl);
+      fillMCEfficiency<pdgSign, o2::track::PID::Muon>(doMu);
+      fillMCEfficiency<pdgSign, o2::track::PID::Pion>(doPi);
+      fillMCEfficiency<pdgSign, o2::track::PID::Kaon>(doKa);
+      fillMCEfficiency<pdgSign, o2::track::PID::Proton>(doPr);
+      fillMCEfficiency<pdgSign, o2::track::PID::Deuteron>(doDe);
+      fillMCEfficiency<pdgSign, o2::track::PID::Triton>(doTr);
+      fillMCEfficiency<pdgSign, o2::track::PID::Helium3>(doHe);
+      fillMCEfficiency<pdgSign, o2::track::PID::Alpha>(doAl);
     });
   }
   PROCESS_SWITCH(QaEfficiency, processMC, "process MC", false);
@@ -1559,16 +1559,16 @@ struct QaEfficiency {
       }
       // Filling variable histograms
       histos.fill(HIST("MC/trackLength"), track.length());
-      static_for<0, 1>([&](auto charge) {
-        fillMCTrackHistograms<charge, o2::track::PID::Electron>(track, doEl);
-        fillMCTrackHistograms<charge, o2::track::PID::Muon>(track, doMu);
-        fillMCTrackHistograms<charge, o2::track::PID::Pion>(track, doPi);
-        fillMCTrackHistograms<charge, o2::track::PID::Kaon>(track, doKa);
-        fillMCTrackHistograms<charge, o2::track::PID::Proton>(track, doPr);
-        fillMCTrackHistograms<charge, o2::track::PID::Deuteron>(track, doDe);
-        fillMCTrackHistograms<charge, o2::track::PID::Triton>(track, doTr);
-        fillMCTrackHistograms<charge, o2::track::PID::Helium3>(track, doHe);
-        fillMCTrackHistograms<charge, o2::track::PID::Alpha>(track, doAl);
+      static_for<0, 1>([&](auto pdgSign) {
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Electron>(track, doEl);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Muon>(track, doMu);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Pion>(track, doPi);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Kaon>(track, doKa);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Proton>(track, doPr);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Deuteron>(track, doDe);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Triton>(track, doTr);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Helium3>(track, doHe);
+        fillMCTrackHistograms<pdgSign, o2::track::PID::Alpha>(track, doAl);
       });
     }
 
@@ -1577,30 +1577,30 @@ struct QaEfficiency {
         continue;
       }
 
-      static_for<0, 1>([&](auto charge) {
-        fillMCParticleHistograms<charge, o2::track::PID::Electron>(mcParticle, doEl);
-        fillMCParticleHistograms<charge, o2::track::PID::Muon>(mcParticle, doMu);
-        fillMCParticleHistograms<charge, o2::track::PID::Pion>(mcParticle, doPi);
-        fillMCParticleHistograms<charge, o2::track::PID::Kaon>(mcParticle, doKa);
-        fillMCParticleHistograms<charge, o2::track::PID::Proton>(mcParticle, doPr);
-        fillMCParticleHistograms<charge, o2::track::PID::Deuteron>(mcParticle, doDe);
-        fillMCParticleHistograms<charge, o2::track::PID::Triton>(mcParticle, doTr);
-        fillMCParticleHistograms<charge, o2::track::PID::Helium3>(mcParticle, doHe);
-        fillMCParticleHistograms<charge, o2::track::PID::Alpha>(mcParticle, doAl);
+      static_for<0, 1>([&](auto pdgSign) {
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Electron>(mcParticle, doEl);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Muon>(mcParticle, doMu);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Pion>(mcParticle, doPi);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Kaon>(mcParticle, doKa);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Proton>(mcParticle, doPr);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Deuteron>(mcParticle, doDe);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Triton>(mcParticle, doTr);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Helium3>(mcParticle, doHe);
+        fillMCParticleHistograms<pdgSign, o2::track::PID::Alpha>(mcParticle, doAl);
       });
     }
 
     // Fill TEfficiencies
-    static_for<0, 1>([&](auto charge) {
-      fillMCEfficiency<charge, o2::track::PID::Electron>(doEl);
-      fillMCEfficiency<charge, o2::track::PID::Muon>(doMu);
-      fillMCEfficiency<charge, o2::track::PID::Pion>(doPi);
-      fillMCEfficiency<charge, o2::track::PID::Kaon>(doKa);
-      fillMCEfficiency<charge, o2::track::PID::Proton>(doPr);
-      fillMCEfficiency<charge, o2::track::PID::Deuteron>(doDe);
-      fillMCEfficiency<charge, o2::track::PID::Triton>(doTr);
-      fillMCEfficiency<charge, o2::track::PID::Helium3>(doHe);
-      fillMCEfficiency<charge, o2::track::PID::Alpha>(doAl);
+    static_for<0, 1>([&](auto pdgSign) {
+      fillMCEfficiency<pdgSign, o2::track::PID::Electron>(doEl);
+      fillMCEfficiency<pdgSign, o2::track::PID::Muon>(doMu);
+      fillMCEfficiency<pdgSign, o2::track::PID::Pion>(doPi);
+      fillMCEfficiency<pdgSign, o2::track::PID::Kaon>(doKa);
+      fillMCEfficiency<pdgSign, o2::track::PID::Proton>(doPr);
+      fillMCEfficiency<pdgSign, o2::track::PID::Deuteron>(doDe);
+      fillMCEfficiency<pdgSign, o2::track::PID::Triton>(doTr);
+      fillMCEfficiency<pdgSign, o2::track::PID::Helium3>(doHe);
+      fillMCEfficiency<pdgSign, o2::track::PID::Alpha>(doAl);
     });
   }
   PROCESS_SWITCH(QaEfficiency, processMCWithoutCollisions, "process MC without the collision association", false);

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -19,7 +19,6 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
-#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/StaticFor.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/Track.h"
@@ -32,7 +31,6 @@
 #include "TPDGCode.h"
 #include "TEfficiency.h"
 #include "THashList.h"
-#include <TDatabasePDG.h>
 
 using namespace o2::framework;
 
@@ -87,8 +85,6 @@ struct QaEfficiency {
   Configurable<float> maxDcaXYFactor{"maxDcaXYFactor", 1.f, "Additional cut on the maximum value of the DCA xy (multiplicative factor)"};
   Configurable<float> maxDcaZ{"maxDcaZ", 2.f, "Additional cut on the maximum value of the DCA z"};
   Configurable<float> minTPCNClsFound{"minTPCNClsFound", 0.f, "Additional cut on the minimum value of the number of found clusters in the TPC"};
-
-  Service<O2DatabasePDG> pdg;
 
   OutputObj<THashList> listEfficiencyMC{"EfficiencyMC"};
   OutputObj<THashList> listEfficiencyData{"EfficiencyData"};
@@ -976,13 +972,12 @@ struct QaEfficiency {
     static_assert(charge == 0 || charge == 1);
     static_assert(id > 0 || id < nSpecies);
 
-    int sign = -1.0;
-    TParticlePDG* pdgparticle = pdg->GetParticle(mcParticle.pdgCode());
-    if (pdgparticle != nullptr) {
-      sign = (pdgparticle->Charge() > 0) ? 0.0 : ((pdgparticle->Charge() < 0) ? 1.0 : -1.0);
+    // Selecting a specific PDG
+    if constexpr (charge == 0) {
+      return mcParticle.pdgCode() == PDGs[id];
+    } else {
+      return mcParticle.pdgCode() == -PDGs[id];
     }
-
-    return std::abs(mcParticle.pdgCode()) == PDGs[id] && sign == charge;
   }
 
   template <int charge, o2::track::PID::ID id, typename trackType>

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -1135,7 +1135,7 @@ struct QaEfficiency {
     if (!isPdgSelected<charge, id>(mcParticle)) { // Selecting PDG code
       return;
     }
-    histos.fill(HIST("MC/particleSelection"), 7 + id);
+    histos.fill(HIST("MC/particleSelection"), 6 + id);
 
     h->fill(HIST(hPGenerated[histogramIndex]), mcParticle.p());
     h->fill(HIST(hPtGenerated[histogramIndex]), mcParticle.pt());
@@ -1366,7 +1366,7 @@ struct QaEfficiency {
       histos.fill(countingHisto, 2); // Tracks with particles (i.e. no fakes)
       const auto mcParticle = track.mcParticle();
       if (!isInAcceptance(mcParticle, countingHisto, 2)) {
-        // 2: pt cut 3: eta cut 4: phi cut 5: y cut
+        // 3: pt cut 4: eta cut 5: phi cut 6: y cut
         return false;
       }
 

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -13,6 +13,7 @@
 /// \file   qaEfficiency.cxx
 /// \author Nicolò Jacazio nicolo.jacazio@cern.ch
 /// \brief  Task to analyse both data and MC to produce efficiency vs pT, eta and phi.
+///         In MC the efficiency for particles is computed according to the PDG code (sign included and not charge)
 ///
 
 // O2 includes


### PR DESCRIPTION
Follow-up to the yesterday's discussion.
The original code doesn't work well in the case of negative particles / positive antiparticles like electrons/positrons.