### PR TITLE
PWGHF: Handle ambiguous tracks in B0 candidate creator and get bz from CCDB

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -175,9 +175,9 @@ struct HfCandidateCreatorB0 {
         std::array<float, 3> pVec1 = {track1.px(), track1.py(), track1.pz()};
         std::array<float, 3> pVec2 = {track2.px(), track2.py(), track2.pz()};
 
-        auto dca0 = o2::dataformats::DCA(track0.dcaXY(), track0.dcaZ());
-        auto dca1 = o2::dataformats::DCA(track1.dcaXY(), track1.dcaZ());
-        auto dca2 = o2::dataformats::DCA(track2.dcaXY(), track2.dcaZ());
+        auto dca0 = o2::dataformats::DCA(track0.dcaXY(), track0.dcaZ(), track0.cYY(), track0.cZY(), track0.cZZ());
+        auto dca1 = o2::dataformats::DCA(track1.dcaXY(), track1.dcaZ(), track1.cYY(), track1.cZY(), track1.cZZ());
+        auto dca2 = o2::dataformats::DCA(track2.dcaXY(), track2.dcaZ(), track2.cYY(), track2.cZY(), track2.cZZ());
 
         // repropagate tracks to this collision if needed
         if (track0.collisionId() != thisCollId) {


### PR DESCRIPTION
Hi @fgrosa ! Here is the new structure of the code:

- Loop over `aod::Collision const& collisions`
- Loop over D candidates associated to this collision
- Repropagate the daughter(s) to this collision if needed
- Propagate D daughters to D decay vertex and get `pVec` of these daughters at this vertex (previsouly, I was getting the impulsion of the `track0,1,2` and not the `pVec` values (modified by `getPxPyPz`). 
Is it better to call `getPxPyPz` (from [trackUtilities.h](https://github.com/AliceO2Group/O2Physics/blob/master/Common/Core/trackUtilities.h#L97)) or `getPxPyPzGlo` (from [TrackParametrization](https://github.com/AliceO2Group/AliceO2/blob/dev/DataFormats/Reconstruction/src/TrackParametrization.cxx#L127)) ?
- Loop over tracks associated to this collision
- Propagate D and Pion candidates to B0 vertex (to get their impulsion at this vertex)
- Propagate D and Pion candidates to primary vertex to get their imapct parameter

Also, I had two remarks:
- I don't initialize`pVec0,1,2`  as I update it via `getPxPyPz`;
- I define `dca0,1,2` but don't initialize it because it is modified by `propagateToDCA` (when called) and because I don't use the dca of the D daughters anyway.
If this is okay, I will remove the comments on these lines.

---------------------------------------------
New modifications applied:
- choose `getPxPyPzGlo`
- modify initialization of `o2::dataformat::DCA` objects for D daughters
- get `bz` value from CCDB