### PR TITLE
PWGHF: Fix typo while filling QA histograms

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -243,14 +243,14 @@ struct HfCandidateSelectorB0ToDPi {
       if (!TESTBIT(hfCandB0.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         hfSelB0ToDPiCandidate(statusB0ToDPi);
         if (activateQA) {
-          registry.fill(HIST("hSelections"), 0, ptCandB0);
+          registry.fill(HIST("hSelections"), 1, ptCandB0);
         }
         // LOGF(info, "B0 candidate selection failed at hfflag check");
         continue;
       }
       SETBIT(statusB0ToDPi, SelectionStep::RecoSkims); // RecoSkims = 0 --> statusB0ToDPi = 1
       if (activateQA) {
-        registry.fill(HIST("hSelections"), 1 + SelectionStep::RecoSkims, ptCandB0);
+        registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoSkims, ptCandB0);
       }
 
       auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
@@ -264,7 +264,7 @@ struct HfCandidateSelectorB0ToDPi {
       }
       SETBIT(statusB0ToDPi, SelectionStep::RecoTopol); // RecoTopol = 1 --> statusB0ToDPi = 3
       if (activateQA) {
-        registry.fill(HIST("hSelections"), 1 + SelectionStep::RecoTopol, ptCandB0);
+        registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoTopol, ptCandB0);
       }
 
       // checking if selectionFlagD and usePid are in sync
@@ -282,7 +282,7 @@ struct HfCandidateSelectorB0ToDPi {
         }
         SETBIT(statusB0ToDPi, SelectionStep::RecoPID); // RecoPID = 2 --> statusB0ToDPi = 7
         if (activateQA) {
-          registry.fill(HIST("hSelections"), 1 + SelectionStep::RecoPID, ptCandB0);
+          registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoPID, ptCandB0);
         }
       }
 

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -175,13 +175,13 @@ struct HfCandidateSelectorDplusToPiKPi {
       if (!TESTBIT(candidate.hfflag(), DecayType::DplusToPiKPi)) {
         hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);
         if (activateQA) {
-          registry.fill(HIST("hSelections"), 0, ptCand);
+          registry.fill(HIST("hSelections"), 1, ptCand);
         }
         continue;
       }
       SETBIT(statusDplusToPiKPi, aod::SelectionStep::RecoSkims);
       if (activateQA) {
-        registry.fill(HIST("hSelections"), 1 + aod::SelectionStep::RecoSkims, ptCand);
+        registry.fill(HIST("hSelections"), 2 + aod::SelectionStep::RecoSkims, ptCand);
       }
 
       auto trackPos1 = candidate.prong0_as<aod::BigTracksPID>(); // positive daughter (negative for the antiparticles)
@@ -205,7 +205,7 @@ struct HfCandidateSelectorDplusToPiKPi {
       }
       SETBIT(statusDplusToPiKPi, aod::SelectionStep::RecoTopol);
       if (activateQA) {
-        registry.fill(HIST("hSelections"), 1 + aod::SelectionStep::RecoTopol, ptCand);
+        registry.fill(HIST("hSelections"), 2 + aod::SelectionStep::RecoTopol, ptCand);
       }
 
       // track-level PID selection
@@ -219,7 +219,7 @@ struct HfCandidateSelectorDplusToPiKPi {
       }
       SETBIT(statusDplusToPiKPi, aod::SelectionStep::RecoPID);
       if (activateQA) {
-        registry.fill(HIST("hSelections"), 1 + aod::SelectionStep::RecoPID, ptCand);
+        registry.fill(HIST("hSelections"), 2 + aod::SelectionStep::RecoPID, ptCand);
       }
 
       hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);


### PR DESCRIPTION
Hi, I noticed a typo in Dplus and B0 selectors. When filling QA histograms, it started from bin 0 instead of starting from bin 1, the information was then translated of one bin to the left in the output histogram, hence not matching the x axis legend.