### PR TITLE
[PWGJE: Preparation Validation Framework] Implementing reduced set of trackcuts as filtBit5 

### DIFF
--- a/ALICE3/TableProducer/alice3-trackselection.cxx
+++ b/ALICE3/TableProducer/alice3-trackselection.cxx
@@ -71,7 +71,7 @@ struct Alice3TrackSelectionTask {
         histos.fill(HIST("eta/selected"), track.eta());
       }
 
-      filterTable(sel, 1, false, false, false, false);
+      filterTable(sel, 1, false, false, false, false, false);
     }
   }
 };

--- a/Common/Core/TrackSelectionDefaults.cxx
+++ b/Common/Core/TrackSelectionDefaults.cxx
@@ -107,4 +107,24 @@ TrackSelection getGlobalTrackSelectionRun3HF()
   return selectedTracks;
 }
 
+// Reduced default track selection for jet validation based on hybrid cuts for converted (based on ESD's from run 2) A02D's
+TrackSelection getJEGlobalTrackSelectionRun2()
+{
+  TrackSelection selectedTracks;
+  selectedTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
+  selectedTracks.SetMinNCrossedRowsTPC(70);
+  selectedTracks.SetMinNCrossedRowsOverFindableClustersTPC(0.8f);
+  selectedTracks.SetMaxChi2PerClusterTPC(4.f);
+  selectedTracks.SetRequireTPCRefit(true);
+  selectedTracks.SetRequireITSRefit(true);
+  selectedTracks.SetRequireHitsInITSLayers(1, {0, 1}); // one hit in any SPD layer
+  selectedTracks.SetMaxChi2PerClusterITS(36.f);
+  selectedTracks.SetPtRange(0.1f, 1e10f); // slightly lower initial cut for maximal flexibility
+  selectedTracks.SetEtaRange(-0.9f, 0.9f);
+  selectedTracks.SetMaxDcaXY(2.4f);
+  selectedTracks.SetMaxDcaZ(3.2f);
+
+  return selectedTracks;
+}
+
 #endif

--- a/Common/Core/TrackSelectionDefaults.h
+++ b/Common/Core/TrackSelectionDefaults.h
@@ -37,4 +37,7 @@ TrackSelection getGlobalTrackSelectionRun3Nuclei();
 // Default track selection for HF analysis (global tracks, with its points, but no tight selection for primary) in run3
 TrackSelection getGlobalTrackSelectionRun3HF();
 
+// Global track selection for Run2 JE Hybrid tracks requiring one hit in the SPD and reduced set of cuts
+TrackSelection getJEGlobalTrackSelectionRun2();
+
 #endif // COMMON_CORE_TRACKSELECTIONDEFAULTS_H_

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -142,7 +142,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
-		  track::TrackCutFlagFb5,
+                  track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -142,6 +142,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
+		  track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -84,6 +84,7 @@ DECLARE_SOA_COLUMN(TrackCutFlagFb1, trackCutFlagFb1, bool);                    /
 DECLARE_SOA_COLUMN(TrackCutFlagFb2, trackCutFlagFb2, bool);                    //! Flag with the single cut passed flagged for the second selection criteria (as general but 2 point2 in ITS IB)
 DECLARE_SOA_COLUMN(TrackCutFlagFb3, trackCutFlagFb3, bool);                    //! Flag with the single cut passed flagged for the third selection criteria (HF-like: global w/o tight DCA selection)
 DECLARE_SOA_COLUMN(TrackCutFlagFb4, trackCutFlagFb4, bool);                    //! Flag with the single cut passed flagged for the fourth selection criteria (nuclei)
+DECLARE_SOA_COLUMN(TrackCutFlagFb5, trackCutFlagFb5, bool);                    //! Flag with the single cut passed flagged for the fith selection criteria (jet validation - reduced set of cuts)
 
 #define DECLARE_DYN_TRKSEL_COLUMN(name, getter, mask) \
   DECLARE_SOA_DYNAMIC_COLUMN(name, getter, [](TrackSelectionFlags::flagtype flags) -> bool { return TrackSelectionFlags::checkFlag(flags, mask); });

--- a/Common/TableProducer/trackselection.cxx
+++ b/Common/TableProducer/trackselection.cxx
@@ -53,6 +53,7 @@ struct TrackSelectionTask {
   TrackSelection filtBit2;
   TrackSelection filtBit3;
   TrackSelection filtBit4;
+  TrachSelection filtBit5;
 
   void init(InitContext&)
   {
@@ -112,6 +113,8 @@ struct TrackSelectionTask {
     filtBit3 = getGlobalTrackSelectionRun3HF();
 
     filtBit4 = getGlobalTrackSelectionRun3Nuclei();
+
+    filtBit5 = getJEGlobalTrackSelectionRun2(); // Jet validation requires reduced set of cuts
   }
 
   void process(soa::Join<aod::FullTracks, aod::TracksDCA> const& tracks)
@@ -128,9 +131,10 @@ struct TrackSelectionTask {
         o2::aod::track::TrackSelectionFlags::flagtype trackflagFB2 = filtBit2.IsSelectedMask(track);
         // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB3 = filtBit3.IsSelectedMask(track); // only temporarily commented, will be used
         // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB4 = filtBit4.IsSelectedMask(track);
+        // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB5 = filtBit5.IsSelectedMask(track);
 
         filterTable((uint8_t)0,
-                    globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track));
+                    globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track), filtBit5.IsSelected(track));
         if (produceFBextendedTable) {
           filterTableDetail(o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kTrackType),
                             o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kPtRange),
@@ -157,7 +161,7 @@ struct TrackSelectionTask {
     for (auto& track : tracks) {
       o2::aod::track::TrackSelectionFlags::flagtype trackflagGlob = globalTracks.IsSelectedMask(track);
       filterTable((uint8_t)globalTracksSDD.IsSelected(track),
-                  globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track));
+                  globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track), filtBit5.IsSelected(track));
       if (produceFBextendedTable) {
         filterTableDetail(o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kTrackType),
                           o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kPtRange),

--- a/Common/TableProducer/trackselection.cxx
+++ b/Common/TableProducer/trackselection.cxx
@@ -53,7 +53,7 @@ struct TrackSelectionTask {
   TrackSelection filtBit2;
   TrackSelection filtBit3;
   TrackSelection filtBit4;
-  TrachSelection filtBit5;
+  TrackSelection filtBit5;
 
   void init(InitContext&)
   {


### PR DESCRIPTION
Hello,
for the jet validation (performed on ESD's) from AliPhysics to O2Physics we want to recreate the Run2 jet-hybrid-tracks. They require less, and even rougher dca cuts. Once this PR is approved and merged the missing code for the jetfinder validation can be pushed to #2048 (or directly to O2Physics if both PR's are approved). 
These changes would facilitate and speed up our work - Many thanks in advance !
Johanna

*Ps @njacazio , @mfaggin I told you about this before and hope it is still okey (even if the filterbits are replaced at some point).