### PR TITLE
PWGJE: Fix PR2048 adding template in missing lines

### DIFF
--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -204,8 +204,8 @@ struct JetFinderTask {
           if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::track)) {
             trackconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
-            clusterconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
+            clusterconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
         }
         constituentsTable(jetsTable.lastIndex(), trackconst, clusterconst, std::vector<int>());


### PR DESCRIPTION
This is a fix to the PR #2048.

Adding template in line:
constituent.template user_info ...