### PR TITLE
MC finders for synthetic findable exercise 

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -447,17 +447,27 @@ namespace mcv0label
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for V0
 } // namespace mcv0label
 
-DECLARE_SOA_TABLE(McV0Labels, "AOD", "MCV0LABEL", //! Table joinable to V0data containing the MC labels
+DECLARE_SOA_TABLE(McV0Labels, "AOD", "MCV0LABEL", //! Table joinable with V0Data containing the MC labels
                   mcv0label::McParticleId);
 using McV0Label = McV0Labels::iterator;
+
+// Definition of labels for V0s // Full table, joinable with V0 (CAUTION: NOT WITH V0DATA)
+namespace mcfullv0label
+{
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for V0
+} // namespace mcfullv0label
+
+DECLARE_SOA_TABLE(McFullV0Labels, "AOD", "MCFULLV0LABEL", //! Table joinable with V0
+                  mcfullv0label::McParticleId);
+using McFullV0Label = McFullV0Labels::iterator;
 
 // Definition of labels for cascades
 namespace mccasclabel
 {
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for V0
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for Cascade
 } // namespace mccasclabel
 
-DECLARE_SOA_TABLE(McCascLabels, "AOD", "MCCASCLABEL", //! Table joinable to V0data containing the MC labels
+DECLARE_SOA_TABLE(McCascLabels, "AOD", "MCCASCLABEL", //! Table joinable with CascData containing the MC labels
                   mccasclabel::McParticleId);
 using McCascLabel = McCascLabels::iterator;
 

--- a/PWGLF/TableProducer/CMakeLists.txt
+++ b/PWGLF/TableProducer/CMakeLists.txt
@@ -31,6 +31,11 @@ o2physics_add_dpl_workflow(lambdakzerofinder
                     PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(lambdakzeromcfinder
+                    SOURCES lambdakzeromcfinder.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(cascadebuilder
                     SOURCES cascadebuilder.cxx
                     PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
@@ -44,6 +49,11 @@ o2physics_add_dpl_workflow(cascadelabelbuilder
 o2physics_add_dpl_workflow(cascadefinder
                     SOURCES cascadefinder.cxx
                     PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(cascademcfinder
+                    SOURCES cascademcfinder.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(hstrangecorrelationfilter

--- a/PWGLF/TableProducer/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/cascademcfinder.cxx
@@ -97,19 +97,17 @@ struct cascademcfinder {
             for (auto const& v0 : v0s) {
               if (v0.mcParticleId() == daughter.globalIndex()) {
                 trackIndexV0 = v0.globalIndex();
+                break;
               }
             }
-            if (trackIndexBachelor >= 0)
-              break; // both found, stop
           }          // end lambda search
           if (TMath::Abs(daughter.pdgCode()) == 211 || TMath::Abs(daughter.pdgCode()) == 321) {
             for (auto const& track : trackList) {
               if (track.mcParticleId() == daughter.globalIndex()) {
                 trackIndexBachelor = track.globalIndex();
+                break;
               }
             }
-            if (trackIndexV0 >= 0)
-              break; // both found, stop
           }          // end bachelor search
         }
       }

--- a/PWGLF/TableProducer/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/cascademcfinder.cxx
@@ -1,0 +1,159 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// V0 MC finder task
+// -----------------
+//
+//    This task allows for the re-creation of the cascade table (not the CascData table)
+//    using pure MC information. It serves the purpose of cross-checking the
+//    maximum efficiency attainable in a perfect vertexing algorithm.
+//
+//    Nota bene: special attention could still be dedicated to the PV
+//               reconstruction efficiency.
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "CCDB/BasicCCDBManager.h"
+
+#include <TFile.h>
+#include <TLorentzVector.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <Math/Vector4D.h>
+#include <TPDGCode.h>
+#include <TDatabasePDG.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+using namespace ROOT::Math;
+
+using LabeledTracks = soa::Join<aod::TracksIU, aod::McTrackLabels>;
+using LabeledFullV0s = soa::Join<aod::V0s, aod::McFullV0Labels>;
+
+struct cascademcfinder {
+  Produces<aod::Cascades> cascades;
+
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  // Configurables for selecting which particles to generate
+  Configurable<bool> findXiMinus{"findXiMinus", true, "findXiMinus"};
+  Configurable<bool> findXiPlus{"findXiPlus", true, "findXiPlus"};
+  Configurable<bool> findOmegaMinus{"findOmegaMinus", true, "findOmegaMinus"};
+  Configurable<bool> findOmegaPlus{"findOmegaPlus", true, "findOmegaPlus"};
+
+  void init(InitContext& context)
+  {
+    // initialize histograms
+    const AxisSpec axisNTimesCollRecoed{(int)10, -0.5f, +9.5f, ""};
+
+    histos.add("hNTimesCollRecoed", "hNTimesCollRecoed", kTH1F, {axisNTimesCollRecoed});
+  }
+
+  template <typename TmcParticle, typename TTrackList, typename TV0List>
+  void PopulateCascade(TmcParticle const& mcParticle, TTrackList const& trackList, TV0List const& v0s, int bestCollisionIndex)
+  {
+    int trackIndexBachelor = -1;
+    int trackIndexV0 = -1;
+    if (mcParticle.template has_daughters()) {
+      auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
+      if (daughters.size() == 2) {
+        for (auto const& daughter : daughters) { // might be better ways of doing this but ok
+          // option 1: this is the lambda daughter
+          if (TMath::Abs(daughter.pdgCode()) == 3122) {
+            for (auto const& v0 : v0s) {
+              if (v0.mcParticleId() == daughter.globalIndex()) {
+                trackIndexV0 = v0.globalIndex();
+              }
+            }
+            if (trackIndexBachelor >= 0)
+              break; // both found, stop
+          }          // end lambda search
+          if (TMath::Abs(daughter.pdgCode()) == 211 || TMath::Abs(daughter.pdgCode()) == 321) {
+            for (auto const& track : trackList) {
+              if (track.mcParticleId() == daughter.globalIndex()) {
+                trackIndexBachelor = track.globalIndex();
+              }
+            }
+            if (trackIndexV0 >= 0)
+              break; // both found, stop
+          }          // end bachelor search
+        }
+      }
+    }
+    if (trackIndexBachelor >= 0 && trackIndexV0 >= 0) {
+      cascades(bestCollisionIndex, trackIndexV0, trackIndexBachelor);
+    }
+  }
+
+  void process(aod::McCollision const& mcCollision, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions, LabeledTracks const& tracks, aod::McParticles const& mcParticles, LabeledFullV0s const& v0s)
+  {
+    // Resolve collision (note: this loop is only over recoed collisions)
+    histos.fill(HIST("hNTimesCollRecoed"), collisions.size());
+    if (collisions.size() < 1)
+      return; // not recoed, can't do anything, skip
+    int biggestNContribs = -1;
+    int bestCollisionIndex = -1;
+    for (auto& collision : collisions) {
+      if (biggestNContribs < collision.numContrib()) {
+        biggestNContribs = collision.numContrib();
+        bestCollisionIndex = collision.globalIndex();
+      }
+    }
+
+    // Iterate over MC collisions, identify particles that are desired
+    for (auto& mcParticle : mcParticles) {
+      if (mcParticle.pdgCode() == 3312 && findXiMinus) {
+        PopulateCascade(mcParticle, tracks, v0s, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == -3312 && findXiPlus) {
+        PopulateCascade(mcParticle, tracks, v0s, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == 3334 && findOmegaMinus) {
+        PopulateCascade(mcParticle, tracks, v0s, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == -3334 && findOmegaPlus) {
+        PopulateCascade(mcParticle, tracks, v0s, bestCollisionIndex);
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<cascademcfinder>(cfgc, TaskName{"lf-cascademcfinder"})};
+}

--- a/PWGLF/TableProducer/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/lambdakzeromcfinder.cxx
@@ -73,6 +73,8 @@ struct lambdakzeromcfinder {
   Configurable<bool> findK0Short{"findK0Short", true, "findK0Short"};
   Configurable<bool> findLambda{"findLambda", true, "findLambda"};
   Configurable<bool> findAntiLambda{"findAntiLambda", true, "findAntiLambda"};
+  Configurable<bool> findHyperTriton{"findHyperTriton", false, "findHyperTriton"};
+  Configurable<bool> findAntiHyperTriton{"findAntiHyperTriton", false, "findAntiHyperTriton"};
 
   void init(InitContext& context)
   {
@@ -134,6 +136,12 @@ struct lambdakzeromcfinder {
         PopulateV0s(mcParticle, tracks, bestCollisionIndex);
       }
       if (mcParticle.pdgCode() == -3122 && findAntiLambda) {
+        PopulateV0s(mcParticle, tracks, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == 1010010030 && findHyperTriton) {
+        PopulateV0s(mcParticle, tracks, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() ==-1010010030 && findAntiHyperTriton) {
         PopulateV0s(mcParticle, tracks, bestCollisionIndex);
       }
     }

--- a/PWGLF/TableProducer/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/lambdakzeromcfinder.cxx
@@ -1,0 +1,147 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// V0 MC finder task
+// -----------------
+//
+//    This task allows for the re-creation of the V0 table (not the V0Data table)
+//    using pure MC information. It serves the purpose of cross-checking the
+//    maximum efficiency attainable in a perfect vertexing algorithm.
+//
+//    Nota bene: special attention could still be dedicated to the PV
+//               reconstruction efficiency.
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "CCDB/BasicCCDBManager.h"
+
+#include <TFile.h>
+#include <TLorentzVector.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <Math/Vector4D.h>
+#include <TPDGCode.h>
+#include <TDatabasePDG.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+using namespace ROOT::Math;
+
+using LabeledTracks = soa::Join<aod::TracksIU, aod::McTrackLabels>;
+
+struct lambdakzeromcfinder {
+  Produces<aod::V0s> v0;
+  Produces<aod::McFullV0Labels> fullv0labels;
+
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  // Configurables for selecting which particles to generate
+  Configurable<bool> findK0Short{"findK0Short", true, "findK0Short"};
+  Configurable<bool> findLambda{"findLambda", true, "findLambda"};
+  Configurable<bool> findAntiLambda{"findAntiLambda", true, "findAntiLambda"};
+
+  void init(InitContext& context)
+  {
+    // initialize histograms
+    const AxisSpec axisNTimesCollRecoed{(int)10, -0.5f, +9.5f, ""};
+
+    histos.add("hNTimesCollRecoed", "hNTimesCollRecoed", kTH1F, {axisNTimesCollRecoed});
+  }
+
+  template <typename TmcParticle, typename TTrackList>
+  void PopulateV0s(TmcParticle const& mcParticle, TTrackList const& trackList, int bestCollisionIndex)
+  {
+    int trackIndex1 = -1;
+    int trackIndex2 = -1;
+    if (mcParticle.template has_daughters()) {
+      auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
+      if (daughters.size() == 2) {
+        for (auto const& daughter : daughters) { // might be better ways of doing this but ok
+          for (auto const& track : trackList) {
+            if (track.mcParticleId() == daughter.globalIndex()) {
+              if (trackIndex1 <= 0)
+                trackIndex1 = track.globalIndex();
+              if (trackIndex1 >= 0) {
+                trackIndex2 = track.globalIndex();
+                break; // stop looking, both found
+              }
+            }
+          }
+        }
+      }
+    }
+    if (trackIndex1 >= 0 && trackIndex2 >= 0) {
+      v0(bestCollisionIndex, trackIndex1, trackIndex2);
+      fullv0labels(mcParticle.globalIndex());
+    }
+  }
+
+  void process(aod::McCollision const& mcCollision, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions, LabeledTracks const& tracks, aod::McParticles const& mcParticles)
+  {
+    // Resolve collision (note: this loop is only over recoed collisions)
+    histos.fill(HIST("hNTimesCollRecoed"), collisions.size());
+    if (collisions.size() < 1)
+      return; // not recoed, can't do anything, skip
+    int biggestNContribs = -1;
+    int bestCollisionIndex = -1;
+    for (auto& collision : collisions) {
+      if (biggestNContribs < collision.numContrib()) {
+        biggestNContribs = collision.numContrib();
+        bestCollisionIndex = collision.globalIndex();
+      }
+    }
+
+    // Iterate over MC collisions, identify particles that are desired
+    for (auto& mcParticle : mcParticles) {
+      if (mcParticle.pdgCode() == 310 && findK0Short) {
+        PopulateV0s(mcParticle, tracks, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == 3122 && findLambda) {
+        PopulateV0s(mcParticle, tracks, bestCollisionIndex);
+      }
+      if (mcParticle.pdgCode() == -3122 && findAntiLambda) {
+        PopulateV0s(mcParticle, tracks, bestCollisionIndex);
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<lambdakzeromcfinder>(cfgc, TaskName{"lf-lambdakzeromcfinder"})};
+}


### PR DESCRIPTION
This PR adds the tasks `lambdakzeromcfinder` and `cascademcfinder` that re-reconstruct the V0 and Cascade index tables from MC, and then the *regular builder* (and even MC QC tasks such as the `straRecoStudy`) can be used fully transparently to build and study the pure-MC-index pairs or triplets. Since no track quality requirements whatsoever are applied to the index rebuilding, this will allow for a synthetic exercise in which the maximum attainable efficiency ('findable') is calculable at analysis level. N.B.: this does not take into account collision reconstruction efficiency. 