### PR TITLE
[EMCAL-888] Add caloLabelConverter task

### DIFF
--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -99,3 +99,8 @@ o2physics_add_dpl_workflow(track-to-collision-associator
                     SOURCES trackToCollisionAssociator.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(calo-label-converter
+                    SOURCES caloLabelConverter.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework
+                COMPONENT_NAME Analysis)

--- a/Common/TableProducer/caloLabelConverter.cxx
+++ b/Common/TableProducer/caloLabelConverter.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts the old McCaloLabels_000 table to the new McCaloLabels_001 table where we have a variable size array for associated MCParticles for each calo cell
+struct caloLabelConverter {
+  Produces<aod::McCaloLabels_001> McCaloLabels_001;
+
+  void process(aod::McCaloLabels_000 const& mccalolabelTable)
+  {
+    std::vector<float> amplitude = {0};
+    std::vector<int32_t> particleId = {0};
+    for (auto& mccalolabel : mccalolabelTable) {
+      particleId[0] = mccalolabel.mcParticleId();
+      // Repopulate new table
+      McCaloLabels_001(
+        particleId,
+        mccalolabel.mcMask(),
+        amplitude);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<caloLabelConverter>(cfgc),
+  };
+}


### PR DESCRIPTION
- Add caloLabelConverter task to convert McCaloLabels_000 to McCaloLabels_001 for backwards compatibility. The amplitude fraction which is new in McCaloLabels_001 will be initilised with 0 since we don't have that information in tge old McCaloLabels_000. This change is connected to https://github.com/AliceO2Group/AliceO2/pull/10670