### PR TITLE
Strangeness tracking for cascade builders

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -276,6 +276,8 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, ""); //!
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                     //!
 // General cascade properties: position, momentum
 DECLARE_SOA_COLUMN(Sign, sign, int);         //!
+DECLARE_SOA_COLUMN(MXi, mXi, float);     //!
+DECLARE_SOA_COLUMN(MOmega, mOmega, float);     //!
 DECLARE_SOA_COLUMN(PxPos, pxpos, float);     //!
 DECLARE_SOA_COLUMN(PyPos, pypos, float);     //!
 DECLARE_SOA_COLUMN(PzPos, pzpos, float);     //!
@@ -285,6 +287,9 @@ DECLARE_SOA_COLUMN(PzNeg, pzneg, float);     //!
 DECLARE_SOA_COLUMN(PxBach, pxbach, float);   //!
 DECLARE_SOA_COLUMN(PyBach, pybach, float);   //!
 DECLARE_SOA_COLUMN(PzBach, pzbach, float);   //!
+DECLARE_SOA_COLUMN(Px, px, float);         //! cascade momentum X
+DECLARE_SOA_COLUMN(Py, py, float);         //! cascade momentum Y
+DECLARE_SOA_COLUMN(Pz, pz, float);         //! cascade momentum Z
 DECLARE_SOA_COLUMN(X, x, float);             //!
 DECLARE_SOA_COLUMN(Y, y, float);             //!
 DECLARE_SOA_COLUMN(Z, z, float);             //!
@@ -303,6 +308,11 @@ DECLARE_SOA_COLUMN(DCACascToPV, dcacasctopv, float);           //!
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
+
+// Saved from strangeness tracking
+DECLARE_SOA_COLUMN(MatchingChi2, matchingChi2, float); //!
+DECLARE_SOA_COLUMN(TopologyChi2, topologyChi2, float); //!
+DECLARE_SOA_COLUMN(ItsClsSize, itsCluSize, int); //!
 
 // Derived expressions
 // Momenta
@@ -328,11 +338,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(MLambda, mLambda, //!
                            [](int charge, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, charge < 0 ? array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged} : array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
 // Calculated on the fly with mass assumption + dynamic tables
 
-DECLARE_SOA_DYNAMIC_COLUMN(MXi, mXi, //!
-                           [](float pxbach, float pybach, float pzbach, float PxLambda, float PyLambda, float PzLambda) -> float { return RecoDecay::m(array{array{pxbach, pybach, pzbach}, array{PxLambda, PyLambda, PzLambda}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassLambda}); });
-DECLARE_SOA_DYNAMIC_COLUMN(MOmega, mOmega, //!
-                           [](float pxbach, float pybach, float pzbach, float PxLambda, float PyLambda, float PzLambda) -> float { return RecoDecay::m(array{array{pxbach, pybach, pzbach}, array{PxLambda, PyLambda, PzLambda}}, array{o2::constants::physics::MassKaonCharged, o2::constants::physics::MassLambda}); });
-
 DECLARE_SOA_DYNAMIC_COLUMN(YXi, yXi, //!
                            [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassXiMinus); });
 DECLARE_SOA_DYNAMIC_COLUMN(YOmega, yOmega, //!
@@ -351,53 +356,79 @@ DECLARE_SOA_EXPRESSION_COLUMN(PyLambda, pylambda, //!
                               float, 1.f * aod::cascdata::pypos + 1.f * aod::cascdata::pyneg);
 DECLARE_SOA_EXPRESSION_COLUMN(PzLambda, pzlambda, //!
                               float, 1.f * aod::cascdata::pzpos + 1.f * aod::cascdata::pzneg);
-DECLARE_SOA_EXPRESSION_COLUMN(Px, px, //!
-                              float, 1.f * aod::cascdata::pxpos + 1.f * aod::cascdata::pxneg + 1.f * aod::cascdata::pxbach);
-DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //!
-                              float, 1.f * aod::cascdata::pypos + 1.f * aod::cascdata::pyneg + 1.f * aod::cascdata::pybach);
-DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //!
-                              float, 1.f * aod::cascdata::pzpos + 1.f * aod::cascdata::pzneg + 1.f * aod::cascdata::pzbach);
 } // namespace cascdataext
 
 DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
                   o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId,
-
-                  cascdata::Sign,
+                  cascdata::Sign, cascdata::MXi, cascdata::MOmega,
                   cascdata::X, cascdata::Y, cascdata::Z,
                   cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda,
                   cascdata::PxPos, cascdata::PyPos, cascdata::PzPos,
                   cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg,
                   cascdata::PxBach, cascdata::PyBach, cascdata::PzBach,
+                  cascdata::Px, cascdata::Py, cascdata::Pz,
                   cascdata::DCAV0Daughters, cascdata::DCACascDaughters,
                   cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV, cascdata::DCACascToPV,
 
                   // Dynamic columns
-                  cascdata::Pt<cascdataext::Px, cascdataext::Py>,
+                  cascdata::Pt<cascdata::Px, cascdata::Py>,
                   cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
                   cascdata::CascRadius<cascdata::X, cascdata::Y>,
                   cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
-                  cascdata::CascCosPA<cascdata::X, cascdata::Y, cascdata::Z, cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
+                  cascdata::CascCosPA<cascdata::X, cascdata::Y, cascdata::Z, cascdata::Px, cascdata::Py, cascdata::Pz>,
                   cascdata::DCAV0ToPV<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
 
                   // Invariant masses
                   cascdata::MLambda<cascdata::Sign, cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg>,
-                  cascdata::MXi<cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
-                  cascdata::MOmega<cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
+
                   // Longitudinal
-                  cascdata::YXi<cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
-                  cascdata::YOmega<cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
-                  cascdata::Eta<cascdataext::Px, cascdataext::Py, cascdataext::Pz>,
-                  cascdata::Phi<cascdataext::Px, cascdataext::Py>);
+                  cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Phi<cascdata::Px, cascdata::Py>);
+
+DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
+                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId,
+                  cascdata::Sign, cascdata::MXi, cascdata::MOmega,
+                  cascdata::X, cascdata::Y, cascdata::Z,
+                  cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda,
+                  cascdata::PxPos, cascdata::PyPos, cascdata::PzPos,
+                  cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg,
+                  cascdata::PxBach, cascdata::PyBach, cascdata::PzBach,
+                  cascdata::Px, cascdata::Py, cascdata::Pz,
+                  cascdata::DCAV0Daughters, cascdata::DCACascDaughters,
+                  cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV, cascdata::DCACascToPV,
+                  cascdata::MatchingChi2, cascdata::TopologyChi2, cascdata::ItsClsSize,
+
+                  // Dynamic columns
+                  cascdata::Pt<cascdata::Px, cascdata::Py>,
+                  cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
+                  cascdata::CascRadius<cascdata::X, cascdata::Y>,
+                  cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
+                  cascdata::CascCosPA<cascdata::X, cascdata::Y, cascdata::Z, cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::DCAV0ToPV<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
+
+                  // Invariant masses
+                  cascdata::MLambda<cascdata::Sign, cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg>,
+
+                  // Longitudinal
+                  cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Phi<cascdata::Px, cascdata::Py>);
 
 DECLARE_SOA_TABLE_FULL(CascCovs, "CascCovs", "AOD", "CASCCOVS", //!
                        cascdata::PositionCovMat, cascdata::MomentumCovMat);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(CascDatas, StoredCascDatas, "CascDATAEXT", //!
-                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda,
-                                cascdataext::Px, cascdataext::Py, cascdataext::Pz);
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(TraCascDatas, StoredTraCascDatas, "TraCascDATAEXT", //!
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
 
 using CascData = CascDatas::iterator;
+using TraCascData = TraCascDatas::iterator;
 
 // For compatibility with previous table declarations
 using CascDataFull = CascDatas;
@@ -470,6 +501,16 @@ DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for Cascade
 DECLARE_SOA_TABLE(McCascLabels, "AOD", "MCCASCLABEL", //! Table joinable with CascData containing the MC labels
                   mccasclabel::McParticleId);
 using McCascLabel = McCascLabels::iterator;
+
+//Definition of labels for tracked cascades
+namespace mctracasclabel
+{
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for V0
+} // namespace mctracasclabel
+
+DECLARE_SOA_TABLE(McTraCascLabels, "AOD", "MCTRACASCLABEL", //! Table joinable to cascdata containing the MC labels
+                  mctracasclabel::McParticleId);
+using McTraCascLabel = McTraCascLabels::iterator;
 
 } // namespace o2::aod
 

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -89,6 +89,7 @@ using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
 // Builder task: rebuilds multi-strange candidates
 struct cascadeBuilder {
   Produces<aod::StoredCascDatas> cascdata;
+  Produces<aod::StoredTraCascDatas> trackedcascdata;
   Produces<aod::CascCovs> casccovs; // if requested by someone
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
@@ -142,6 +143,7 @@ struct cascadeBuilder {
 
   // For manual sliceBy
   Preslice<aod::Cascades> perCollision = o2::aod::cascade::collisionId;
+  Preslice<aod::TrackedCascades> perCascade = o2::aod::strangenesstracking::cascadeId;
 
   // Define o2 fitter, 2-prong, active memory (no need to redefine per event)
   o2::vertexing::DCAFitterN<2> fitter;
@@ -152,6 +154,7 @@ struct cascadeBuilder {
                   kCascDCADau,
                   kCascCosPA,
                   kCascRadius,
+                  kCascTracked,
                   kNCascSteps };
 
   // Helper struct to pass cascade information
@@ -172,6 +175,8 @@ struct cascadeBuilder {
     float v0dcadau;
     float v0dcapostopv;
     float v0dcanegtopv;
+    float mXi; 
+    float mOmega;
   } cascadecandidate;
 
   o2::track::TrackParCov lBachelorTrack;
@@ -281,11 +286,17 @@ struct cascadeBuilder {
       lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
     }
 
-    if (doprocessRun2 == false && doprocessRun3 == false) {
-      LOGF(fatal, "Neither processRun2 nor processRun3 enabled. Please choose one.");
+    if (doprocessRun2 == false && doprocessRun3 == false && doprocessRun3withStrangenessTracking == false) {
+      LOGF(fatal, "Neither processRun2 nor processRun3 nor processRun3withstrangenesstracking enabled. Please choose one!");
     }
     if (doprocessRun2 == true && doprocessRun3 == true) {
       LOGF(fatal, "Cannot enable processRun2 and processRun3 at the same time. Please choose one.");
+    }
+    if (doprocessRun3 == true && doprocessRun3withStrangenessTracking == true) {
+      LOGF(fatal, "Cannot enable processRun3 and processRun3withstrangenesstracking at the same time. Please choose one.");
+    }
+    if (doprocessRun2 == true && doprocessRun3withStrangenessTracking == true) {
+      LOGF(fatal, "Cannot enable processRun2 and processRun3withstrangenesstracking at the same time. Please choose one.");
     }
 
     if (d_UseAutodetectMode) {
@@ -585,6 +596,10 @@ struct cascadeBuilder {
     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorrCascade, &dcaInfo);
     cascadecandidate.cascDCAxy = dcaInfo[0];
 
+    // Calculate masses a priori
+    cascadecandidate.mXi = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassLambda});
+    cascadecandidate.mOmega = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassKaonCharged, o2::constants::physics::MassLambda});
+
     // Populate information
     cascadecandidate.v0Id = v0index.globalIndex();
     cascadecandidate.bachelorId = bachTrack.globalIndex();
@@ -668,12 +683,74 @@ struct cascadeBuilder {
                cascade.globalIndex(),
                cascadecandidate.bachelorId,
                cascade.collisionId(),
-               cascadecandidate.charge,
+               cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
                cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
                cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
                cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
                cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+               cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
+               cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
+               cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
+               cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
+               cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
+               cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy); // <--- no corresponding stratrack information available
+
+      // populate cascade covariance matrices if required by any other task
+      if (createCascCovMats) {
+        // Calculate position covariance matrix
+        auto covVtxV = fitter.calcPCACovMatrix(0);
+        // std::array<float, 6> positionCovariance;
+        float positionCovariance[6];
+        positionCovariance[0] = covVtxV(0, 0);
+        positionCovariance[1] = covVtxV(1, 0);
+        positionCovariance[2] = covVtxV(1, 1);
+        positionCovariance[3] = covVtxV(2, 0);
+        positionCovariance[4] = covVtxV(2, 1);
+        positionCovariance[5] = covVtxV(2, 2);
+        // store momentum covariance matrix
+        std::array<float, 21> covTv0 = {0.};
+        std::array<float, 21> covTbachelor = {0.};
+        // std::array<float, 6> momentumCovariance;
+        float momentumCovariance[6];
+        lV0Track.getCovXYZPxPyPzGlo(covTv0);
+        lBachelorTrack.getCovXYZPxPyPzGlo(covTbachelor);
+        constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
+        for (int i = 0; i < 6; i++) {
+          momentumCovariance[i] = covTv0[MomInd[i]] + covTbachelor[MomInd[i]];
+        }
+        casccovs(positionCovariance, momentumCovariance);
+      }
+    }
+    // En masse filling at end of process call
+    fillHistos();
+    resetHistos();
+  }
+
+  template <class TTrackTo, typename TCascTable, typename TStraTrack>
+  void buildStrangenessTablesWithStrangenessTracking(TCascTable const& cascades, TStraTrack const& trackedCascades)
+  {
+    statisticsRegistry.eventCounter++;
+
+    for (auto& cascade : cascades) {
+      bool validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade);
+      if (!validCascadeCandidate)
+        continue; // doesn't pass cascade selections
+
+      //fill regular table (no strangeness tracking)
+      cascdata(cascadecandidate.v0Id,
+               cascade.globalIndex(),
+               cascadecandidate.bachelorId,
+               cascade.collisionId(),
+               cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
+               cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
+               cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
+               cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
+               cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
+               cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+               cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0],
+               cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1],
+               cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2],
                cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
                cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
                cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy);
@@ -702,6 +779,47 @@ struct cascadeBuilder {
           momentumCovariance[i] = covTv0[MomInd[i]] + covTbachelor[MomInd[i]];
         }
         casccovs(positionCovariance, momentumCovariance);
+      }
+
+      // check if cascade is tracked - sliceBy is our friend!
+      const uint64_t cascIdx = cascade.globalIndex();
+      auto trackedCascadesSliced = trackedCascades.sliceBy(perCascade, cascIdx);
+      if( trackedCascadesSliced.size() > 0 ) {
+        auto trackedCascade = trackedCascadesSliced.begin(); // first and only element
+
+        // cascade track exists in AO2D, prefer information from that source!
+        statisticsRegistry.cascstats[kCascTracked]++; // bookkeep how many we tracked overall
+
+        // Initialize trackParCov
+        if ( !trackedCascade.has_track() ) continue; // safety (should be fine but depends on future stratrack dev)
+        // Track casting to <TTracksTo>
+        auto cascadeTrack = trackedCascade.template track_as<TTrackTo>();
+        auto cascadeTrackPar = getTrackPar(cascadeTrack);
+        auto const& collision = cascade.collision();
+        gpu::gpustd::array<float, 2> dcaInfo;
+        lCascadeTrack.setPID(o2::track::PID::XiMinus);       // FIXME: not OK for omegas
+        o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, cascadeTrackPar, 2.f, matCorrCascade, &dcaInfo);
+        // Override cascDCAxy with the strangeness-tracked information
+        cascadecandidate.cascDCAxy = dcaInfo[0];   
+        
+        std::array<float, 3> cascadeMomentumVector;
+        cascadeTrackPar.getPxPyPzGlo(cascadeMomentumVector);
+
+        trackedcascdata(cascadecandidate.v0Id,
+               cascade.globalIndex(),
+               cascadecandidate.bachelorId,
+               cascade.collisionId(),
+               cascadecandidate.charge, trackedCascade.xiMass(), trackedCascade.omegaMass(), // <--- stratrack masses
+               trackedCascade.decayX(), trackedCascade.decayY(), trackedCascade.decayZ(), // <--- stratrack position
+               cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
+               cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
+               cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
+               cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+               cascadeMomentumVector[0], cascadeMomentumVector[1], cascadeMomentumVector[2], // <--- stratrack momentum
+               cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
+               cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
+               cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, // <--- stratrack (cascDCAxy)
+               trackedCascade.matchingChi2(), trackedCascade.topologyChi2(), trackedCascade.itsClsSize()); // <--- stratrack fit info
       }
     }
     // En masse filling at end of process call
@@ -736,6 +854,20 @@ struct cascadeBuilder {
     }
   }
   PROCESS_SWITCH(cascadeBuilder, processRun3, "Produce Run 3 cascade tables", false);
+
+  void processRun3withStrangenessTracking(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::TrackedCascades const& trackedCascades)
+  {
+    for (const auto& collision : collisions) {
+      // Fire up CCDB
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      initCCDB(bc);
+      // Do analysis with collision-grouped V0s, retain full collision information
+      const uint64_t collIdx = collision.globalIndex();
+      auto CascadeTable_thisCollision = cascades.sliceBy(perCollision, collIdx);
+      buildStrangenessTablesWithStrangenessTracking<FullTracksExtIU>(CascadeTable_thisCollision, trackedCascades);
+    }
+  }
+  PROCESS_SWITCH(cascadeBuilder, processRun3withStrangenessTracking, "Produce Run 3 cascade tables with strangeness tracking", false);
 };
 
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*

--- a/PWGLF/TableProducer/cascadefinder.cxx
+++ b/PWGLF/TableProducer/cascadefinder.cxx
@@ -249,13 +249,20 @@ struct cascadefinder {
 
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, &dcaInfo);
 
+            auto lXiMass = RecoDecay::m(array{array{pvecpos[0] + pvecneg[0], pvecpos[1] + pvecneg[1], pvecpos[2] + pvecneg[2]}, array{pvecbach[0], pvecbach[1], pvecbach[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassPionCharged});
+            auto lOmegaMass = RecoDecay::m(array{array{pvecpos[0] + pvecneg[0], pvecpos[1] + pvecneg[1], pvecpos[2] + pvecneg[2]}, array{pvecbach[0], pvecbach[1], pvecbach[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassKaonCharged});
+
             lNCand++;
             // If we got here, it means this is a good candidate!
             cascdata(v0.globalIndex(), -1, v0.posTrack().globalIndex(), v0.negTrack().collisionId(),
-                     -1, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
+                     -1, lXiMass, lOmegaMass,
+                     posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],
                      pvecneg[0], pvecneg[1], pvecneg[2],
                      pvecbach[0], pvecbach[1], pvecbach[2],
+                     pvecbach[0] + pvecpos[0] + pvecneg[0], // <--- redundant but ok
+                     pvecbach[1] + pvecpos[1] + pvecneg[1], // <--- redundant but ok
+                     pvecbach[2] + pvecpos[2] + pvecneg[2], // <--- redundant but ok
                      fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
                      v0.dcapostopv(),
                      v0.dcanegtopv(),
@@ -332,13 +339,20 @@ struct cascadefinder {
 
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, &dcaInfo);
 
+            auto lXiMass = RecoDecay::m(array{array{pvecpos[0] + pvecneg[0], pvecpos[1] + pvecneg[1], pvecpos[2] + pvecneg[2]}, array{pvecbach[0], pvecbach[1], pvecbach[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassPionCharged});
+            auto lOmegaMass = RecoDecay::m(array{array{pvecpos[0] + pvecneg[0], pvecpos[1] + pvecneg[1], pvecpos[2] + pvecneg[2]}, array{pvecbach[0], pvecbach[1], pvecbach[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassKaonCharged});
+
             lNCand++;
             // If we got here, it means this is a good candidate!
             cascdata(v0.globalIndex(), -1, v0.posTrack().globalIndex(), v0.negTrack().collisionId(),
-                     +1, posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
+                     +1, lXiMass, lOmegaMass,
+                     posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],
                      pvecneg[0], pvecneg[1], pvecneg[2],
                      pvecbach[0], pvecbach[1], pvecbach[2],
+                     pvecbach[0] + pvecpos[0] + pvecneg[0], // <--- redundant but ok
+                     pvecbach[1] + pvecpos[1] + pvecneg[1], // <--- redundant but ok
+                     pvecbach[2] + pvecpos[2] + pvecneg[2], // <--- redundant but ok
                      fitterV0.getChi2AtPCACandidate(), fitterCasc.getChi2AtPCACandidate(),
                      v0.dcapostopv(),
                      v0.dcanegtopv(),

--- a/PWGLF/Tasks/cascadeanalysis.cxx
+++ b/PWGLF/Tasks/cascadeanalysis.cxx
@@ -295,31 +295,31 @@ struct cascadeAnalysis {
       if (casc.sign() < 0) {                         // FIXME: could be done better...
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.mOmega());
           }
         }
       } else {
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.mOmega());
           }
         }
       }

--- a/PWGLF/Tasks/cascadeanalysisMC.cxx
+++ b/PWGLF/Tasks/cascadeanalysisMC.cxx
@@ -357,31 +357,31 @@ struct cascadeAnalysisMC {
       if (casc.sign() < 0) {                         // FIXME: could be done better...
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi && ((!assocMC) || (lPDG == 3312))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om && ((!assocMC) || (lPDG == 3334))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.mOmega());
           }
         }
       } else {
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi && ((!assocMC) || (lPDG == -3312))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.template mXi());
+            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om && ((!assocMC) || (lPDG == -3334))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.template mOmega());
+            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.mOmega());
           }
         }
       }


### PR DESCRIPTION
* creates a process function (disabled by default) that creates a tracked cascade table for posterior analysis 
* the tracked cascade table (`TraCascData`) is currently kept separate from the main cascade table (`CascData`) for development purposes - possibility to unify to be studied once development is more advanced 
* further testing pending