### PR TITLE
Collision Association: self-index is not required

### DIFF
--- a/Common/DataModel/CollisionAssociation.h
+++ b/Common/DataModel/CollisionAssociation.h
@@ -24,7 +24,7 @@ namespace track_association
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                      //! Collision index
 DECLARE_SOA_INDEX_COLUMN(Track, track);                              //! Track index
-DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN(CompatibleColl, compatibleColl); //! Array of collision indices
+DECLARE_SOA_ARRAY_INDEX_COLUMN(CompatibleColl, compatibleColl);      //! Array of collision indices
 } // namespace track_association
 
 DECLARE_SOA_TABLE(TrackAssoc, "AOD", "TRACKASSOC", //! Table for track-to-collision association for e.g. HF vertex finding - tracks can appear for several collisions

--- a/Common/DataModel/CollisionAssociation.h
+++ b/Common/DataModel/CollisionAssociation.h
@@ -32,7 +32,7 @@ DECLARE_SOA_TABLE(TrackAssoc, "AOD", "TRACKASSOC", //! Table for track-to-collis
                   track_association::TrackId);
 
 DECLARE_SOA_TABLE(TrackCompColls, "AOD", "TRACKCOMPCOLLS", //! Table with vectors of collision indices stored per track
-                  track_association::CompatibleCollIds);
+                  track_association::CollisionIds);
 } // namespace o2::aod
 
 #endif // COMMON_DATAMODEL_COLLISIONASSOCIATION_H_

--- a/Common/DataModel/CollisionAssociation.h
+++ b/Common/DataModel/CollisionAssociation.h
@@ -24,7 +24,7 @@ namespace track_association
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                      //! Collision index
 DECLARE_SOA_INDEX_COLUMN(Track, track);                              //! Track index
-DECLARE_SOA_ARRAY_INDEX_COLUMN(Collision, compatibleColl);      //! Array of collision indices
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Collision, compatibleColl);           //! Array of collision indices
 } // namespace track_association
 
 DECLARE_SOA_TABLE(TrackAssoc, "AOD", "TRACKASSOC", //! Table for track-to-collision association for e.g. HF vertex finding - tracks can appear for several collisions

--- a/Common/DataModel/CollisionAssociation.h
+++ b/Common/DataModel/CollisionAssociation.h
@@ -24,7 +24,7 @@ namespace track_association
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                      //! Collision index
 DECLARE_SOA_INDEX_COLUMN(Track, track);                              //! Track index
-DECLARE_SOA_ARRAY_INDEX_COLUMN(CompatibleColl, compatibleColl);      //! Array of collision indices
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Collision, compatibleColl);      //! Array of collision indices
 } // namespace track_association
 
 DECLARE_SOA_TABLE(TrackAssoc, "AOD", "TRACKASSOC", //! Table for track-to-collision association for e.g. HF vertex finding - tracks can appear for several collisions


### PR DESCRIPTION
Using normal, and not self-index, provides non-templated getters. 
Note that self-index would also not be bound correctly - the framework will try to set it to the table itself, and not to `Collisions`. 