### PR TITLE
[PWGJE] Validation task for Jetfinder on run2 data

### DIFF
--- a/PWGJE/Tasks/CMakeLists.txt
+++ b/PWGJE/Tasks/CMakeLists.txt
@@ -9,6 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+
 o2physics_add_dpl_workflow(emc-cellmonitor
                     SOURCES emccellmonitor.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
@@ -51,4 +52,8 @@ if(FastJet_FOUND)
                         SOURCES jetsubstructurehfoutput.cxx
                         PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
                         COMPONENT_NAME Analysis)
+    o2physics_add_dpl_workflow(jet-validation-qa
+                        SOURCES jetvalidationqa.cxx
+                        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
+                        COMPONENT_NAME Analysis)   
 endif()

--- a/PWGJE/Tasks/CMakeLists.txt
+++ b/PWGJE/Tasks/CMakeLists.txt
@@ -55,5 +55,5 @@ if(FastJet_FOUND)
     o2physics_add_dpl_workflow(jet-validation-qa
                         SOURCES jetvalidationqa.cxx
                         PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
-                        COMPONENT_NAME Analysis)   
+                        COMPONENT_NAME Analysis)
 endif()

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -12,8 +12,8 @@
 //  \author
 //	Johanna Lömker
 //	\since Dec 2022
-// The goal would be to set up the jet, track and event/collision QA's for the validation framework 
-// Staring with the hybrid tracks 
+// The goal would be to set up the jet, track and event/collision QA's for the validation framework
+// Staring with the hybrid tracks
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -31,9 +31,9 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-using TracksJE = soa::Join<aod::Tracks, aod::TracksExtra,  aod::TracksDCA, aod::TrackSelection>;
+using TracksJE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>;
 
-struct jetTrackCollisionQa{
+struct jetTrackCollisionQa {
 
   HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
   Configurable<int> nBins{"nBins", 200, "N bins in histos"};
@@ -53,76 +53,77 @@ struct jetTrackCollisionQa{
     validationTracks.SetMinNCrossedRowsOverFindableClustersTPC(0.8f);
     validationTracks.SetMaxChi2PerClusterTPC(4.f);
     validationTracks.SetRequireTPCRefit(true);
-    validationTracks.SetRequireITSRefit(true); 
+    validationTracks.SetRequireITSRefit(true);
     validationTracks.SetRequireHitsInITSLayers(1, {0, 1}); // one hit in any SPD layer
     validationTracks.SetMaxChi2PerClusterITS(36.f);
     validationTracks.SetPtRange(0.15f, 1e10f); // the 0.15 is the original hybrid cuts
     validationTracks.SetEtaRange(-0.9f, 0.9f);
-    validationTracks.SetMaxDcaXY(2.4f);  
+    validationTracks.SetMaxDcaXY(2.4f);
     validationTracks.SetMaxDcaZ(3.2f);
     validationTracks.print();*/
-    validationTracks = getGlobalTrackSelection(); //using global tracks instead
- 
-    //histograms
-    //1)Jetvalidation from data
+    validationTracks = getGlobalTrackSelection(); // using global tracks instead
+
+    // histograms
+    // 1)Jetvalidation from data
     mHistManager.add("collisionVtxZ", "control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
-    //process jet qa
+    // process jet qa
     mHistManager.add("jetPt", "inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("jetPhi", "inclusive jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
     mHistManager.add("jetEta", "inclusive jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //process jet constituent qa - constituents as tracks
+    // process jet constituent qa - constituents as tracks
     mHistManager.add("jetConstTrackPt", "inclusive jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("jetConstTrackPhi", "inclusive jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("jetConstTrackEta", "inclusive jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //cross check the cuts from Run2Hybrid selection
+    // cross check the cuts from Run2Hybrid selection
     mHistManager.add("selectedTrackPt", "hybrid track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("selectedTrackPhi", "hybrid track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("selectedTrackEta", "hybrid track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
 
-    //leading jets per collision
+    // leading jets per collision
     mHistManager.add("leadJetPt", "track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("leadJetPhi", "track constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("leadJetEta", "track constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //leading constituents per jet in collision
+    // leading constituents per jet in collision
     mHistManager.add("leadJetConstPt", "leading jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("leadJetConstPhi", "leading jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("leadJetConstEta", "leading jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //leading selected tracks per collision
+    // leading selected tracks per collision
     mHistManager.add("leadTrackPt", "leading selected track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("leadTrackPhi", "leading selected track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("leadTrackEta", "leading selected track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
 
-    //2)Jetvalidation from MC
+    // 2)Jetvalidation from MC
     mHistManager.add("MCcollisionVtxZ", "MC control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
-    //process jet qa
+    // process jet qa
     mHistManager.add("MCjetPt", "MC inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("MCjetPhi", "MC inclusive jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
     mHistManager.add("MCjetEta", "MC inclusive jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //process jet constituent qa - constituents as tracks
+    // process jet constituent qa - constituents as tracks
     mHistManager.add("MCjetConstTrackPt", "MC inclusive jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("MCjetConstTrackPhi", "MC inclusive jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("MCjetConstTrackEta", "MC inclusive jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    //cross check the cuts from Run2Hybrid selection
+    // cross check the cuts from Run2Hybrid selection
     mHistManager.add("MCselectedTrackPt", "MC hybrid track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("MCselectedTrackPhi", "MC hybrid track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("MCselectedTrackEta", "MC hybrid track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-
   }
-  //add another process for MC studies !
+  // add another process for MC studies !
   void processData(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::Jets, aod::JetConstituents> const& jets, TracksJE const& tracks)
   {
-    if(collision.posZ() > 10){return;}
+    if (collision.posZ() > 10) {
+      return;
+    }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
 
     double leadingJetPt = -1;
     double leadingJetPhi = -1;
     double leadingJetEta = -1;
-    //jet QA hists per jet in this collision
-    for(const auto& j: jets){
+    // jet QA hists per jet in this collision
+    for (const auto& j : jets) {
       mHistManager.fill(HIST("jetPt"), j.pt());
       mHistManager.fill(HIST("jetPhi"), j.phi());
       mHistManager.fill(HIST("jetEta"), j.eta());
-      if(j.pt() > leadingJetPt){
+      if (j.pt() > leadingJetPt) {
         leadingJetPt = j.pt();
         leadingJetPhi = j.phi();
         leadingJetEta = j.eta();
@@ -131,26 +132,28 @@ struct jetTrackCollisionQa{
       double leadingConstTrackPt = -1;
       double leadingConstTrackPhi = -1;
       double leadingConstTrackEta = -1;
-      //access jet constituents as tracks
+      // access jet constituents as tracks
       for (auto& jct : j.tracks_as<TracksJE>()) {
-        if(!validationTracks.IsSelected(jct)){continue;}//check if this is really a global track - maybe adding hists for rejected tracks ?
+        if (!validationTracks.IsSelected(jct)) {
+          continue;
+        } // check if this is really a global track - maybe adding hists for rejected tracks ?
         mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
         mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
         mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
-        if(jct.pt() > leadingConstTrackPt){
+        if (jct.pt() > leadingConstTrackPt) {
           leadingConstTrackPt = jct.pt();
           leadingConstTrackPhi = jct.phi();
           leadingConstTrackEta = jct.eta();
         }
-      }//end of jet constituent loop
+      } // end of jet constituent loop
 
-      //fill leading jet constituent qa
+      // fill leading jet constituent qa
       mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
       mHistManager.fill(HIST("leadJetConstPhi"), leadingConstTrackPhi);
       mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
-    }//end of jet loop
+    } // end of jet loop
 
-    //fill leading jet qa
+    // fill leading jet qa
     mHistManager.fill(HIST("leadJetPt"), leadingJetPt);
     mHistManager.fill(HIST("leadJetPhi"), leadingJetPhi);
     mHistManager.fill(HIST("leadJetEta"), leadingJetEta);
@@ -158,30 +161,31 @@ struct jetTrackCollisionQa{
     double leadingTrackPt = -1;
     double leadingTrackPhi = -1;
     double leadingTrackEta = -1;
-    //qa histograms for selected tracks in collision
-    for(const auto& t : tracks){
-      if(!validationTracks.IsSelected(t)){continue;}//check if this is really a global track - maybe adding hists for rejected tracks ?
+    // qa histograms for selected tracks in collision
+    for (const auto& t : tracks) {
+      if (!validationTracks.IsSelected(t)) {
+        continue;
+      } // check if this is really a global track - maybe adding hists for rejected tracks ?
       mHistManager.fill(HIST("selectedTrackPt"), t.pt());
       mHistManager.fill(HIST("selectedTrackPhi"), t.phi());
       mHistManager.fill(HIST("selectedTrackEta"), t.eta());
-      if(t.pt() > leadingTrackPt){
+      if (t.pt() > leadingTrackPt) {
         leadingTrackPt = t.pt();
         leadingTrackPhi = t.phi();
         leadingTrackEta = t.eta();
       }
-    }//end of tracks loop
+    } // end of tracks loop
 
-    //fill leading selected track qa
+    // fill leading selected track qa
     mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
     mHistManager.fill(HIST("leadTrackPhi"), leadingTrackPhi);
     mHistManager.fill(HIST("leadTrackEta"), leadingTrackEta);
-  }//end process
+  } // end process
   PROCESS_SWITCH(jetTrackCollisionQa, processData, "process jets from jet-finder output", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"})
-    };
+    adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"})};
 }

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -110,9 +110,6 @@ struct jetTrackCollisionQa {
   // add another process for MC studies !
   void processData(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::Jets, aod::JetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (collision.posZ() > 10) {
-      return;
-    }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
 
     double leadingJetPt = -1;
@@ -134,9 +131,6 @@ struct jetTrackCollisionQa {
       double leadingConstTrackEta = -1;
       // access jet constituents as tracks
       for (auto& jct : j.tracks_as<TracksJE>()) {
-        if (!validationTracks.IsSelected(jct)) {
-          continue;
-        } // check if this is really a global track - maybe adding hists for rejected tracks ?
         mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
         mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
         mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -1,0 +1,187 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+//  \author
+//	Johanna Lömker
+//	\since Dec 2022
+// The goal would be to set up the jet, track and event/collision QA's for the validation framework 
+// Staring with the hybrid tracks 
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "PWGJE/DataModel/Jet.h"
+
+#include "Common/DataModel/EventSelection.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/TrackSelectionDefaults.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+using TracksJE = soa::Join<aod::Tracks, aod::TracksExtra,  aod::TracksDCA, aod::TrackSelection>;
+
+struct jetTrackCollisionQa{
+
+  HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
+  Configurable<int> nBins{"nBins", 200, "N bins in histos"};
+  Configurable<int> nBinsPt{"nBinsPt", 200, "N bins in pT histos"};
+  Configurable<int> nBinsEta{"nBinsEta", 200, "N bins in Eta histos"};
+  Configurable<int> nBinsPhi{"nBinsPhi", 200, "N bins in Phi histos"};
+
+  TrackSelection validationTracks;
+
+  void init(InitContext const&)
+  {
+    /*set trackselections - initial idea for now on hold
+    //we should not touch the getJEGlobalTrackSelectionRun2 anymore, but here we are free to modify the defaults
+    validationTracks = getJEGlobalTrackSelectionRun2();
+    validationTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
+    validationTracks.SetMinNCrossedRowsTPC(70);
+    validationTracks.SetMinNCrossedRowsOverFindableClustersTPC(0.8f);
+    validationTracks.SetMaxChi2PerClusterTPC(4.f);
+    validationTracks.SetRequireTPCRefit(true);
+    validationTracks.SetRequireITSRefit(true); 
+    validationTracks.SetRequireHitsInITSLayers(1, {0, 1}); // one hit in any SPD layer
+    validationTracks.SetMaxChi2PerClusterITS(36.f);
+    validationTracks.SetPtRange(0.15f, 1e10f); // the 0.15 is the original hybrid cuts
+    validationTracks.SetEtaRange(-0.9f, 0.9f);
+    validationTracks.SetMaxDcaXY(2.4f);  
+    validationTracks.SetMaxDcaZ(3.2f);
+    validationTracks.print();*/
+    validationTracks = getGlobalTrackSelection(); //using global tracks instead
+ 
+    //histograms
+    //1)Jetvalidation from data
+    mHistManager.add("collisionVtxZ", "control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
+    //process jet qa
+    mHistManager.add("jetPt", "inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("jetPhi", "inclusive jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
+    mHistManager.add("jetEta", "inclusive jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //process jet constituent qa - constituents as tracks
+    mHistManager.add("jetConstTrackPt", "inclusive jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("jetConstTrackPhi", "inclusive jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("jetConstTrackEta", "inclusive jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //cross check the cuts from Run2Hybrid selection
+    mHistManager.add("selectedTrackPt", "hybrid track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("selectedTrackPhi", "hybrid track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("selectedTrackEta", "hybrid track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+
+    //leading jets per collision
+    mHistManager.add("leadJetPt", "track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("leadJetPhi", "track constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("leadJetEta", "track constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //leading constituents per jet in collision
+    mHistManager.add("leadJetConstPt", "leading jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("leadJetConstPhi", "leading jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("leadJetConstEta", "leading jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //leading selected tracks per collision
+    mHistManager.add("leadTrackPt", "leading selected track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("leadTrackPhi", "leading selected track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("leadTrackEta", "leading selected track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+
+    //2)Jetvalidation from MC
+    mHistManager.add("MCcollisionVtxZ", "MC control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
+    //process jet qa
+    mHistManager.add("MCjetPt", "MC inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("MCjetPhi", "MC inclusive jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
+    mHistManager.add("MCjetEta", "MC inclusive jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //process jet constituent qa - constituents as tracks
+    mHistManager.add("MCjetConstTrackPt", "MC inclusive jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("MCjetConstTrackPhi", "MC inclusive jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("MCjetConstTrackEta", "MC inclusive jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    //cross check the cuts from Run2Hybrid selection
+    mHistManager.add("MCselectedTrackPt", "MC hybrid track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("MCselectedTrackPhi", "MC hybrid track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("MCselectedTrackEta", "MC hybrid track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+
+  }
+  //add another process for MC studies !
+  void processData(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::Jets, aod::JetConstituents> const& jets, TracksJE const& tracks)
+  {
+    if(collision.posZ() > 10){return;}
+    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
+
+    double leadingJetPt = -1;
+    double leadingJetPhi = -1;
+    double leadingJetEta = -1;
+    //jet QA hists per jet in this collision
+    for(const auto& j: jets){
+      mHistManager.fill(HIST("jetPt"), j.pt());
+      mHistManager.fill(HIST("jetPhi"), j.phi());
+      mHistManager.fill(HIST("jetEta"), j.eta());
+      if(j.pt() > leadingJetPt){
+        leadingJetPt = j.pt();
+        leadingJetPhi = j.phi();
+        leadingJetEta = j.eta();
+      }
+
+      double leadingConstTrackPt = -1;
+      double leadingConstTrackPhi = -1;
+      double leadingConstTrackEta = -1;
+      //access jet constituents as tracks
+      for (auto& jct : j.tracks_as<TracksJE>()) {
+        if(!validationTracks.IsSelected(jct)){continue;}//check if this is really a global track - maybe adding hists for rejected tracks ?
+        mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
+        mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
+        mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
+        if(jct.pt() > leadingConstTrackPt){
+          leadingConstTrackPt = jct.pt();
+          leadingConstTrackPhi = jct.phi();
+          leadingConstTrackEta = jct.eta();
+        }
+      }//end of jet constituent loop
+
+      //fill leading jet constituent qa
+      mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
+      mHistManager.fill(HIST("leadJetConstPhi"), leadingConstTrackPhi);
+      mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
+    }//end of jet loop
+
+    //fill leading jet qa
+    mHistManager.fill(HIST("leadJetPt"), leadingJetPt);
+    mHistManager.fill(HIST("leadJetPhi"), leadingJetPhi);
+    mHistManager.fill(HIST("leadJetEta"), leadingJetEta);
+
+    double leadingTrackPt = -1;
+    double leadingTrackPhi = -1;
+    double leadingTrackEta = -1;
+    //qa histograms for selected tracks in collision
+    for(const auto& t : tracks){
+      if(!validationTracks.IsSelected(t)){continue;}//check if this is really a global track - maybe adding hists for rejected tracks ?
+      mHistManager.fill(HIST("selectedTrackPt"), t.pt());
+      mHistManager.fill(HIST("selectedTrackPhi"), t.phi());
+      mHistManager.fill(HIST("selectedTrackEta"), t.eta());
+      if(t.pt() > leadingTrackPt){
+        leadingTrackPt = t.pt();
+        leadingTrackPhi = t.phi();
+        leadingTrackEta = t.eta();
+      }
+    }//end of tracks loop
+
+    //fill leading selected track qa
+    mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
+    mHistManager.fill(HIST("leadTrackPhi"), leadingTrackPhi);
+    mHistManager.fill(HIST("leadTrackEta"), leadingTrackEta);
+  }//end process
+  PROCESS_SWITCH(jetTrackCollisionQa, processData, "process jets from jet-finder output", true);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"})
+    };
+}

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -10,8 +10,8 @@
 // or submit itself to any jurisdiction.
 ///
 //  \author
-//	Johanna Lömker
-//	\since Dec 2022
+//  Johanna Lömker
+//  \since Dec 2022
 // The goal would be to set up the jet, track and event/collision QA's for the validation framework
 // Staring with the hybrid tracks
 


### PR DESCRIPTION
Hi @nzardosh , @fkrizek, 

here is the basic jet-validation-qa task, performed on **global instead of hybrid tracks**. This should allow Filip to test the validation tools before I extend the task to handle MC from run2 (and run3 ?). I propose to change the cuts in AliPhysics accordingly, or to invite experts from tracks to a discussion to find a 'hybrid track solution' for ambiguous tracks in O2Physics. 

Cheerio,
Johanna