### PR TITLE
[EMCAL-670] Quick fix for unsorted fIndexBCs_foundBC

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -58,7 +58,7 @@ struct EmcalCorrectionTask {
 
   // Preslices
   Preslice<myGlobTracks> perCollision = o2::aod::track::collisionId;
-  Preslice<collEventSels> collisionsPerFoundBC = aod::evsel::foundBCId;
+  // Preslice<collEventSels> collisionsPerFoundBC = aod::evsel::foundBCId;
   Preslice<aod::Collisions> collisionsPerBC = aod::collision::bcId;
   Preslice<filteredCells> cellsPerFoundBC = aod::calo::bcId;
 
@@ -214,17 +214,28 @@ struct EmcalCorrectionTask {
       // Convert aod::Calo to o2::emcal::Cell which can be used with the clusterizer.
       // In particular, we need to filter only EMCAL cells.
 
+      // Since aod::evsel::foundBCId is not sorted we can't use sliceBy anymore.
+      // Anton is working on a fix for sliceBy and soa::SmallGroups so that we can
+      // use them again. For now we need to do the following
+      int nColInBc = 0;
+      for (auto& col : collisions) {
+        if (col.foundBCId() == bc.globalIndex()) {
+          nColInBc++;
+        }
+      }
       // Get the collisions matched to the BC using foundBCId of the collision
-      auto collisionsInFoundBC = collisions.sliceBy(collisionsPerFoundBC, bc.globalIndex());
+      // auto collisionsInFoundBC = collisions.sliceBy(collisionsPerFoundBC, bc.globalIndex());
       auto cellsInBC = cells.sliceBy(cellsPerFoundBC, bc.globalIndex());
 
       if (!cellsInBC.size()) {
         LOG(debug) << "No cells found for BC";
-        countBC(collisionsInFoundBC.size(), false);
+        // countBC(collisionsInFoundBC.size(), false);
+        countBC(nColInBc, false);
         continue;
       }
       // Counters for BCs with matched collisions
-      countBC(collisionsInFoundBC.size(), true);
+      // countBC(collisionsInFoundBC.size(), true);
+      countBC(nColInBc, true);
       std::vector<o2::emcal::Cell> cellsBC;
       std::vector<int64_t> cellIndicesBC;
       for (auto& cell : cellsInBC) {
@@ -256,28 +267,34 @@ struct EmcalCorrectionTask {
       for (size_t iClusterizer = 0; iClusterizer < mClusterizers.size(); iClusterizer++) {
         cellsToCluster(iClusterizer, cellsBC);
 
-        if (collisionsInFoundBC.size() == 1) {
+        // if (collisionsInFoundBC.size() == 1) {
+        if (nColInBc == 1) {
           // dummy loop to get the first collision
-          for (const auto& col : collisionsInFoundBC) {
-            mHistManager.fill(HIST("hCollPerBC"), 1);
-            mHistManager.fill(HIST("hCollisionType"), 1);
-            math_utils::Point3D<float> vertex_pos = {col.posX(), col.posY(), col.posZ()};
+          // for (const auto& col : collisionsInFoundBC) {
+          for (const auto& col : collisions) {
+            if (col.foundBCId() == bc.globalIndex()) {
+              mHistManager.fill(HIST("hCollPerBC"), 1);
+              mHistManager.fill(HIST("hCollisionType"), 1);
+              math_utils::Point3D<float> vertex_pos = {col.posX(), col.posY(), col.posZ()};
 
-            std::vector<std::vector<int>> clusterToTrackIndexMap;
-            std::vector<std::vector<int>> trackToClusterIndexMap;
-            std::tuple<std::vector<std::vector<int>>, std::vector<std::vector<int>>> IndexMapPair{clusterToTrackIndexMap, trackToClusterIndexMap};
-            std::vector<int64_t> trackGlobalIndex;
-            doTrackMatching<collEventSels::iterator>(col, tracks, IndexMapPair, vertex_pos, trackGlobalIndex);
+              std::vector<std::vector<int>> clusterToTrackIndexMap;
+              std::vector<std::vector<int>> trackToClusterIndexMap;
+              std::tuple<std::vector<std::vector<int>>, std::vector<std::vector<int>>> IndexMapPair{clusterToTrackIndexMap, trackToClusterIndexMap};
+              std::vector<int64_t> trackGlobalIndex;
+              doTrackMatching<collEventSels::iterator>(col, tracks, IndexMapPair, vertex_pos, trackGlobalIndex);
 
-            // Store the clusters in the table where a matching collision could
-            // be identified.
-            FillClusterTable<collEventSels::iterator>(col, vertex_pos, iClusterizer, cellIndicesBC, IndexMapPair, trackGlobalIndex);
+              // Store the clusters in the table where a matching collision could
+              // be identified.
+              FillClusterTable<collEventSels::iterator>(col, vertex_pos, iClusterizer, cellIndicesBC, IndexMapPair, trackGlobalIndex);
+            }
           }
         } else { // ambiguous
           // LOG(warning) << "No vertex found for event. Assuming (0,0,0).";
           bool hasCollision = false;
-          mHistManager.fill(HIST("hCollPerBC"), collisionsInFoundBC.size());
-          if (collisionsInFoundBC.size() == 0) {
+          // mHistManager.fill(HIST("hCollPerBC"), collisionsInFoundBC.size());
+          mHistManager.fill(HIST("hCollPerBC"), nColInBc);
+          // if (collisionsInFoundBC.size() == 0) {
+          if (nColInBc == 0) {
             mHistManager.fill(HIST("hCollisionType"), 0);
           } else {
             hasCollision = true;


### PR DESCRIPTION
- Since the fIndexBCs_foundBC indedx is not sorted (anymore?) we need to make adjustments. Anton proposed to use soa::SmallGroups, however, we realised that this would not work with the current implementation. It needs an update, where you can specify by which index column it would be grouped. Also an update to the sliceBy function to handle unsorted indices is on the way. Until then I suggest to use this quick fix, so that we can still use the fIndexBCs_foundBC.