### PR TITLE
Tracked cascade labeler process added

### DIFF
--- a/PWGLF/TableProducer/cascadelabelbuilder.cxx
+++ b/PWGLF/TableProducer/cascadelabelbuilder.cxx
@@ -46,11 +46,12 @@ using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 struct cascadeLabelBuilder {
   Produces<aod::McCascLabels> casclabels; // MC labels for cascades
+  Produces<aod::McTraCascLabels> tracasclabels; // MC labels for cascades
   void init(InitContext const&) {}
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   // build cascade labels
-  void process(aod::Collision const& collision, aod::CascDataExt const& casctable, aod::V0sLinked const&, aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const&)
+  void processCascades(aod::CascDatas const& casctable, aod::V0sLinked const&, aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const&)
   {
     for (auto& casc : casctable) {
       // Loop over those that actually have the corresponding V0 associated to them
@@ -98,6 +99,59 @@ struct cascadeLabelBuilder {
         lLabel);
     } // end casctable loop
   }
+  PROCESS_SWITCH(cascadeLabelBuilder, processCascades, "Produce regular cascade label tables", true);
+
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  // build tracked cascade labels
+  void processTrackedCascades(aod::TraCascDatas const& casctable, aod::V0sLinked const&, aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const&)
+  {
+    for (auto& casc : casctable) {
+      // Loop over those that actually have the corresponding V0 associated to them
+      auto v0 = casc.v0_as<o2::aod::V0sLinked>();
+      if (!(v0.has_v0Data())) {
+        casclabels(-1);
+        continue; // skip those cascades for which V0 doesn't exist
+      }
+      auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
+      int lLabel = -1;
+
+      // Acquire all three daughter tracks, please
+      auto lBachTrack = casc.bachelor_as<aod::McTrackLabels>();
+      auto lNegTrack = v0data.negTrack_as<aod::McTrackLabels>();
+      auto lPosTrack = v0data.posTrack_as<aod::McTrackLabels>();
+
+      // Association check
+      // There might be smarter ways of doing this in the future
+      if (lNegTrack.has_mcParticle() && lPosTrack.has_mcParticle() && lBachTrack.has_mcParticle()) {
+        auto lMCBachTrack = lBachTrack.mcParticle_as<aod::McParticles>();
+        auto lMCNegTrack = lNegTrack.mcParticle_as<aod::McParticles>();
+        auto lMCPosTrack = lPosTrack.mcParticle_as<aod::McParticles>();
+
+        // Step 1: check if the mother is the same, go up a level
+        if (lMCNegTrack.has_mothers() && lMCPosTrack.has_mothers()) {
+          for (auto& lNegMother : lMCNegTrack.mothers_as<aod::McParticles>()) {
+            for (auto& lPosMother : lMCPosTrack.mothers_as<aod::McParticles>()) {
+              if (lNegMother == lPosMother) {
+                // if we got to this level, it means the mother particle exists and is the same
+                // now we have to go one level up and compare to the bachelor mother too
+                for (auto& lV0Mother : lNegMother.mothers_as<aod::McParticles>()) {
+                  for (auto& lBachMother : lMCBachTrack.mothers_as<aod::McParticles>()) {
+                    if (lV0Mother == lBachMother) {
+                      lLabel = lV0Mother.globalIndex();
+                    }
+                  }
+                } // end conditional V0-bach pair
+              }   // end neg = pos mother conditional
+            }
+          } // end loop neg/pos mothers
+        }   // end conditional of mothers existing
+      }     // end association check
+      // Construct label table (note: this will be joinable with CascDatas)
+      tracasclabels(
+        lLabel);
+    } // end casctable loop
+  }
+  PROCESS_SWITCH(cascadeLabelBuilder, processTrackedCascades, "Produce tracked cascade label tables", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
* adds a second process function to the cascade labeler such that also the tracked cascades can have labels for posterior use. The functionality - like in the standard cascade table - is such that a MC label table joinable with the tracked cascades is created, mirroring the existing functionality of `tracks`. It is then easy to simply to `mcParticle()` to get the mother particle of the decay without looping over daughters in any task that runs afterwards. 
* this should hopefully help with the AO2D testing @qgp @fmazzasc @mpuccio 