### PR TITLE
Add option to only do tracked cascades

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -115,6 +115,7 @@ struct cascadeBuilder {
   Configurable<int> rejDiffCollTracks{"rejDiffCollTracks", 0, "rejDiffCollTracks"};
   Configurable<bool> d_doTrackQA{"d_doTrackQA", false, "do track QA"};
   Configurable<bool> d_doStraTrackQA{"d_doStraTrackQA", false, "do strangeness tracking QA"};
+  Configurable<bool> d_GenerateOnlyTrackedCascades{"d_GenerateOnlyTrackedCascades", false, "Skip cascades that aren't tracked"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -767,6 +768,15 @@ struct cascadeBuilder {
     statisticsRegistry.eventCounter++;
 
     for (auto& cascade : cascades) {
+      // check if cascade is tracked - sliceBy is our friend!
+      const uint64_t cascIdx = cascade.globalIndex();
+      auto trackedCascadesSliced = trackedCascades.sliceBy(perCascade, cascIdx);
+
+      // if only tracked cascades are desired, skip this candidate before doing anything (speed)
+      if( trackedCascadesSliced.size() == 0 && d_GenerateOnlyTrackedCascades ){ 
+        continue; // wasn't tracked
+      }
+
       bool validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade);
       if (!validCascadeCandidate)
         continue; // doesn't pass cascade selections
@@ -829,9 +839,6 @@ struct cascadeBuilder {
           registry.fill(HIST("hDCACascadeToPVOmegaPlus"), lPt, cascadecandidate.cascDCAxy);
       }
 
-      // check if cascade is tracked - sliceBy is our friend!
-      const uint64_t cascIdx = cascade.globalIndex();
-      auto trackedCascadesSliced = trackedCascades.sliceBy(perCascade, cascIdx);
       if (trackedCascadesSliced.size() > 0) {
         auto trackedCascade = trackedCascadesSliced.begin(); // first and only element
 

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -114,6 +114,7 @@ struct cascadeBuilder {
   Configurable<int> useMatCorrTypeCasc{"useMatCorrTypeCasc", 2, "0: none, 1: TGeo, 2: LUT"};
   Configurable<int> rejDiffCollTracks{"rejDiffCollTracks", 0, "rejDiffCollTracks"};
   Configurable<bool> d_doTrackQA{"d_doTrackQA", false, "do track QA"};
+  Configurable<bool> d_doStraTrackQA{"d_doStraTrackQA", false, "do strangeness tracking QA"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -127,9 +128,12 @@ struct cascadeBuilder {
   Configurable<int> dQANBinsRadius{"dQANBinsRadius", 500, "Number of radius bins in QA histo"};
   Configurable<int> dQANBinsPtCoarse{"dQANBinsPtCoarse", 10, "Number of pT bins in QA histo"};
   Configurable<int> dQANBinsMass{"dQANBinsMass", 400, "Number of mass bins for QA histograms"};
+  Configurable<int> dQANBinsDCAxy{"dQANBinsDCAxy", 200, "DCAxy of cascade to PV"};
   Configurable<float> dQAMaxPt{"dQAMaxPt", 5, "max pT in QA histo"};
+  Configurable<float> dQAMaxDCA{"dQAMaxDCA", 1, "max DCAxy QA histo"};
   Configurable<float> dQAXiMassWindow{"dQAXiMassWindow", 0.005, "Xi mass window for ITS cluster map QA"};
   Configurable<float> dQAOmegaMassWindow{"dQAOmegaMassWindow", 0.005, "Omega mass window for ITS cluster map QA"};
+
 
   int mRunNumber;
   float d_bz;
@@ -240,6 +244,7 @@ struct cascadeBuilder {
       const AxisSpec axisVsPtCoarse{(int)dQANBinsPtCoarse, 0, dQAMaxPt, "#it{p}_{T} (GeV/c)"};
       const AxisSpec axisXiMass{(int)dQANBinsMass, 1.222f, 1.422f, "Inv. Mass (GeV/c^{2})"};
       const AxisSpec axisOmegaMass{(int)dQANBinsMass, 1.572f, 1.772f, "Inv. Mass (GeV/c^{2})"};
+      const AxisSpec axisCascadeDCAtoPV{(int)dQANBinsDCAxy, -dQAMaxDCA,dQAMaxDCA, "DCA_{xy} (cm)"};
 
       registry.add("h2dXiMinusMass", "h2dXiMinusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
       registry.add("h2dXiPlusMass", "h2dXiPlusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
@@ -263,6 +268,38 @@ struct cascadeBuilder {
       registry.add("h2dITSCluMap_OmegaPlusPositive", "h2dITSCluMap_OmegaPlusPositive", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_OmegaPlusNegative", "h2dITSCluMap_OmegaPlusNegative", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_OmegaPlusBachelor", "h2dITSCluMap_OmegaPlusBachelor", kTH2D, {axisITSCluMap, axisRadius});
+
+      // if basic strangeness tracking QA is desired, do it here 
+      // convenience: equivalence between regular cascade and tracked cascade is easy to check here 
+      //              -> completely automatic, easy comparison of 'trackable' candidates (<< all)ß
+
+      if(d_doStraTrackQA){
+        // Step 1: mass versus transverse momentum, original variety (given it was tracked)
+        registry.add("h2dTrackableXiMinusMass", "h2dTrackableXiMinusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
+        registry.add("h2dTrackableXiPlusMass", "h2dTrackableXiPlusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
+        registry.add("h2dTrackableOmegaMinusMass", "h2dTrackableOmegaMinusMass", kTH2F, {axisVsPtCoarse, axisOmegaMass});
+        registry.add("h2dTrackableOmegaPlusMass", "h2dTrackableOmegaPlusMass", kTH2F, {axisVsPtCoarse, axisOmegaMass});
+        registry.add("h2dTrackedXiMinusMass", "h2dTrackedXiMinusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
+        registry.add("h2dTrackedXiPlusMass", "h2dTrackedXiPlusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
+        registry.add("h2dTrackedOmegaMinusMass", "h2dTrackedOmegaMinusMass", kTH2F, {axisVsPtCoarse, axisOmegaMass});
+        registry.add("h2dTrackedOmegaPlusMass", "h2dTrackedOmegaPlusMass", kTH2F, {axisVsPtCoarse, axisOmegaMass});
+
+        // Step 2: DCA, original variety (all) / trackable / tracked
+        registry.add("hDCACascadeToPVXiMinus", "hDCACascadeToPVXiMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCACascadeToPVXiPlus", "hDCACascadeToPVXiPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCACascadeToPVOmegaMinus", "hDCACascadeToPVOmegaMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCACascadeToPVOmegaPlus", "hDCACascadeToPVOmegaPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackableCascadeToPVXiMinus", "hDCATrackableCascadeToPVXiMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackableCascadeToPVXiPlus", "hDCATrackableCascadeToPVXiPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackableCascadeToPVOmegaMinus", "hDCATrackableCascadeToPVOmegaMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackableCascadeToPVOmegaPlus", "hDCATrackableCascadeToPVOmegaPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackedCascadeToPVXiMinus", "hDCATrackedCascadeToPVXiMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackedCascadeToPVXiPlus", "hDCATrackedCascadeToPVXiPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackedCascadeToPVOmegaMinus", "hDCATrackedCascadeToPVOmegaMinus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+        registry.add("hDCATrackedCascadeToPVOmegaPlus", "hDCATrackedCascadeToPVOmegaPlus", kTH2F, {axisVsPtCoarse, axisCascadeDCAtoPV});
+
+        // work in progress: more to be added!
+      }
     }
 
     mRunNumber = 0;
@@ -627,39 +664,36 @@ struct cascadeBuilder {
 
     if (d_doQA) {
       // Calculate masses
-      auto lXiMass = RecoDecay::m(array{array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}, array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassPionCharged});
-      auto lOmegaMass = RecoDecay::m(array{array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}, array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}}, array{o2::constants::physics::MassLambda, o2::constants::physics::MassKaonCharged});
-
-      auto lPt = RecoDecay::sqrtSumOfSquares(v0.pxpos() + v0.pxneg() + cascadecandidate.bachP[0], v0.pypos() + v0.pyneg() + cascadecandidate.bachP[0]);
+      auto lPt = RecoDecay::sqrtSumOfSquares(v0.pxpos() + v0.pxneg() + cascadecandidate.bachP[0], v0.pypos() + v0.pyneg() + cascadecandidate.bachP[1]);
 
       // Fill basic mass histograms
       // Note: all presel bools are true if unchecked
       if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
-        registry.fill(HIST("h2dXiMinusMass"), lPt, lXiMass);
+        registry.fill(HIST("h2dXiMinusMass"), lPt, cascadecandidate.mXi);
       if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
-        registry.fill(HIST("h2dXiPlusMass"), lPt, lXiMass);
+        registry.fill(HIST("h2dXiPlusMass"), lPt, cascadecandidate.mXi);
       if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
-        registry.fill(HIST("h2dOmegaMinusMass"), lPt, lOmegaMass);
+        registry.fill(HIST("h2dOmegaMinusMass"), lPt, cascadecandidate.mOmega);
       if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
-        registry.fill(HIST("h2dOmegaPlusMass"), lPt, lOmegaMass);
+        registry.fill(HIST("h2dOmegaPlusMass"), lPt, cascadecandidate.mOmega);
 
       // Fill ITS cluster maps with specific mass cuts
-      if (TMath::Abs(lXiMass - 1.322) < dQAXiMassWindow && cascade.isXiMinusCandidate() && cascade.isTrueXiMinus()) {
+      if (TMath::Abs(cascadecandidate.mXi - 1.322) < dQAXiMassWindow && cascade.isXiMinusCandidate() && cascade.isTrueXiMinus()) {
         registry.fill(HIST("h2dITSCluMap_XiMinusPositive"), (float)posTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_XiMinusNegative"), (float)negTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_XiMinusBachelor"), (float)bachTrack.itsClusterMap(), cascadecandidate.cascradius);
       }
-      if (TMath::Abs(lXiMass - 1.322) < dQAXiMassWindow && cascade.isXiPlusCandidate() && cascade.isTrueXiPlus()) {
+      if (TMath::Abs(cascadecandidate.mXi - 1.322) < dQAXiMassWindow && cascade.isXiPlusCandidate() && cascade.isTrueXiPlus()) {
         registry.fill(HIST("h2dITSCluMap_XiPlusPositive"), (float)posTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_XiPlusNegative"), (float)negTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_XiPlusBachelor"), (float)bachTrack.itsClusterMap(), cascadecandidate.cascradius);
       }
-      if (TMath::Abs(lXiMass - 1.672) < dQAOmegaMassWindow && cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus()) {
+      if (TMath::Abs(cascadecandidate.mOmega - 1.672) < dQAOmegaMassWindow && cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus()) {
         registry.fill(HIST("h2dITSCluMap_OmegaMinusPositive"), (float)posTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_OmegaMinusNegative"), (float)negTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_OmegaMinusBachelor"), (float)bachTrack.itsClusterMap(), cascadecandidate.cascradius);
       }
-      if (TMath::Abs(lXiMass - 1.672) < dQAOmegaMassWindow && cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus()) {
+      if (TMath::Abs(cascadecandidate.mOmega - 1.672) < dQAOmegaMassWindow && cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus()) {
         registry.fill(HIST("h2dITSCluMap_OmegaPlusPositive"), (float)posTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_OmegaPlusNegative"), (float)negTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_OmegaPlusBachelor"), (float)bachTrack.itsClusterMap(), cascadecandidate.cascradius);
@@ -781,6 +815,20 @@ struct cascadeBuilder {
         casccovs(positionCovariance, momentumCovariance);
       }
 
+      float lPt = 0.0f;
+      if( d_doStraTrackQA ) { 
+        // Fill standard DCA histograms for all candidates (irrespectively of strangeness tracking)
+        lPt = RecoDecay::sqrtSumOfSquares(cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0] + cascadecandidate.bachP[0], cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1] + cascadecandidate.bachP[1]);
+        if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
+          registry.fill(HIST("hDCACascadeToPVXiMinus"), lPt, cascadecandidate.cascDCAxy);
+        if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
+          registry.fill(HIST("hDCACascadeToPVXiPlus"), lPt, cascadecandidate.cascDCAxy);
+        if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
+          registry.fill(HIST("hDCACascadeToPVOmegaMinus"), lPt, cascadecandidate.cascDCAxy);
+        if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
+          registry.fill(HIST("hDCACascadeToPVOmegaPlus"), lPt, cascadecandidate.cascDCAxy);
+      }
+
       // check if cascade is tracked - sliceBy is our friend!
       const uint64_t cascIdx = cascade.globalIndex();
       auto trackedCascadesSliced = trackedCascades.sliceBy(perCascade, cascIdx);
@@ -800,6 +848,50 @@ struct cascadeBuilder {
         gpu::gpustd::array<float, 2> dcaInfo;
         lCascadeTrack.setPID(o2::track::PID::XiMinus); // FIXME: not OK for omegas
         o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, cascadeTrackPar, 2.f, matCorrCascade, &dcaInfo);
+        
+        if( d_doStraTrackQA ) { 
+          // do QA, compare with non-tracked
+              
+          // Fill standard DCA histograms for all tracked candidates with ORIGINAL properties
+          if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
+            registry.fill(HIST("hDCATrackableCascadeToPVXiMinus"), lPt, cascadecandidate.cascDCAxy);
+          if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
+            registry.fill(HIST("hDCATrackableCascadeToPVXiPlus"), lPt, cascadecandidate.cascDCAxy);
+          if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
+            registry.fill(HIST("hDCATrackableCascadeToPVOmegaMinus"), lPt, cascadecandidate.cascDCAxy);
+          if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
+            registry.fill(HIST("hDCATrackableCascadeToPVOmegaPlus"), lPt, cascadecandidate.cascDCAxy);
+
+          // Fill standard DCA histograms for all tracked candidates with ORIGINAL properties
+          if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
+            registry.fill(HIST("hDCATrackedCascadeToPVXiMinus"), lPt, dcaInfo[0]);
+          if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
+            registry.fill(HIST("hDCATrackedCascadeToPVXiPlus"), lPt, dcaInfo[0]);
+          if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
+            registry.fill(HIST("hDCATrackedCascadeToPVOmegaMinus"), lPt, dcaInfo[0]);
+          if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
+            registry.fill(HIST("hDCATrackedCascadeToPVOmegaPlus"), lPt, dcaInfo[0]);
+
+          // Invariant mass check
+          if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
+            registry.fill(HIST("h2dTrackableXiMinusMass"), lPt, cascadecandidate.mXi);
+          if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
+            registry.fill(HIST("h2dTrackableXiPlusMass"), lPt, cascadecandidate.mXi);
+          if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
+            registry.fill(HIST("h2dTrackableOmegaMinusMass"), lPt, cascadecandidate.mOmega);
+          if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
+            registry.fill(HIST("h2dTrackableOmegaPlusMass"), lPt, cascadecandidate.mOmega);
+
+          if (cascade.isXiMinusCandidate() && cascade.isTrueXiMinus())
+            registry.fill(HIST("h2dTrackedXiMinusMass"), lPt, trackedCascade.xiMass());
+          if (cascade.isXiPlusCandidate() && cascade.isTrueXiPlus())
+            registry.fill(HIST("h2dTrackedXiPlusMass"), lPt, trackedCascade.xiMass());
+          if (cascade.isOmegaMinusCandidate() && cascade.isTrueOmegaMinus())
+            registry.fill(HIST("h2dTrackedOmegaMinusMass"), lPt, trackedCascade.omegaMass());
+          if (cascade.isOmegaPlusCandidate() && cascade.isTrueOmegaPlus())
+            registry.fill(HIST("h2dTrackedOmegaPlusMass"), lPt, trackedCascade.omegaMass());
+        }
+        
         // Override cascDCAxy with the strangeness-tracked information
         cascadecandidate.cascDCAxy = dcaInfo[0];
 


### PR DESCRIPTION
* this commit adds an option to do the cascade variables only for cascades that were actually tracked
* will save a good fraction of the CPU consumption in case only tracked cascades are of interest 