### PR TITLE
Add option to process only tracked cascades

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -117,7 +117,6 @@ struct cascadeBuilder {
   Configurable<bool> d_doStraTrackQA{"d_doStraTrackQA", false, "do strangeness tracking QA"};
   Configurable<bool> d_GenerateOnlyTrackedCascades{"d_GenerateOnlyTrackedCascades", false, "Skip cascades that aren't tracked"};
 
-
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> grpPath{"grpPath", "GLO/GRP/GRP", "Path of the grp file"};
@@ -135,7 +134,6 @@ struct cascadeBuilder {
   Configurable<float> dQAMaxDCA{"dQAMaxDCA", 1, "max DCAxy QA histo"};
   Configurable<float> dQAXiMassWindow{"dQAXiMassWindow", 0.005, "Xi mass window for ITS cluster map QA"};
   Configurable<float> dQAOmegaMassWindow{"dQAOmegaMassWindow", 0.005, "Omega mass window for ITS cluster map QA"};
-
 
   int mRunNumber;
   float d_bz;
@@ -246,7 +244,7 @@ struct cascadeBuilder {
       const AxisSpec axisVsPtCoarse{(int)dQANBinsPtCoarse, 0, dQAMaxPt, "#it{p}_{T} (GeV/c)"};
       const AxisSpec axisXiMass{(int)dQANBinsMass, 1.222f, 1.422f, "Inv. Mass (GeV/c^{2})"};
       const AxisSpec axisOmegaMass{(int)dQANBinsMass, 1.572f, 1.772f, "Inv. Mass (GeV/c^{2})"};
-      const AxisSpec axisCascadeDCAtoPV{(int)dQANBinsDCAxy, -dQAMaxDCA,dQAMaxDCA, "DCA_{xy} (cm)"};
+      const AxisSpec axisCascadeDCAtoPV{(int)dQANBinsDCAxy, -dQAMaxDCA, dQAMaxDCA, "DCA_{xy} (cm)"};
 
       registry.add("h2dXiMinusMass", "h2dXiMinusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
       registry.add("h2dXiPlusMass", "h2dXiPlusMass", kTH2F, {axisVsPtCoarse, axisXiMass});
@@ -774,7 +772,7 @@ struct cascadeBuilder {
       auto trackedCascadesSliced = trackedCascades.sliceBy(perCascade, cascIdx);
 
       // if only tracked cascades are desired, skip this candidate before doing anything (speed)
-      if( trackedCascadesSliced.size() == 0 && d_GenerateOnlyTrackedCascades ){ 
+      if (trackedCascadesSliced.size() == 0 && d_GenerateOnlyTrackedCascades) {
         continue; // wasn't tracked
       }
 


### PR DESCRIPTION
* this PR adds an option in which cascades that weren't tracked are skipped from processing. 
* this allows for a significant reduction in the overall CPU cost of the cascade building. 
* Potential improvement: redo V0s only if belonging to cascades that were tracked (coming soon)