### PR TITLE
[PWGEM-10] Fix EMCPhotonCuts missing parameter (track)

### DIFF
--- a/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
+++ b/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <utility>
 #include <string>
+#include <optional>
 #include "Framework/Logger.h"
 #include "Framework/DataTypes.h"
 #include "Rtypes.h"
@@ -45,25 +46,25 @@ class EMCPhotonCut : public TNamed
   static const char* mCutNames[static_cast<int>(EMCPhotonCuts::kNCuts)];
 
   // Temporary function to check if cluster passes selection criteria. To be replaced by framework filters.
-  template <typename T>
-  bool IsSelected(T const& cluster) const
+  template <typename Cluster, typename Track>
+  bool IsSelected(Cluster const& cluster, std::optional<Track> const& track = std::nullopt) const
   {
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kEnergy)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kEnergy, cluster, track)) {
       return false;
     }
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kNCell)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kNCell, cluster, track)) {
       return false;
     }
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kM02)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kM02, cluster, track)) {
       return false;
     }
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kTiming)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kTiming, cluster, track)) {
       return false;
     }
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kTM)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kTM, cluster, track)) {
       return false;
     }
-    if (!IsSelectedEMCal(cluster, EMCPhotonCuts::kExotic)) {
+    if (!IsSelectedEMCal(EMCPhotonCuts::kExotic, cluster, track)) {
       return false;
     }
     return true;
@@ -72,7 +73,7 @@ class EMCPhotonCut : public TNamed
   // Temporary function to check if cluster passes a given selection criteria. To be replaced by framework filters.
   // Returns true if a cluster survives the cuts!
   template <typename Cluster, typename Track>
-  bool IsSelectedEMCal(Cluster const& cluster, Track const& track, const EMCPhotonCuts& cut) const
+  bool IsSelectedEMCal(const EMCPhotonCuts& cut, Cluster const& cluster, std::optional<Track> const& track = std::nullopt) const
   {
     float dEta = fabs(track.tracketa() - cluster.eta());
     float dPhi = fabs(track.trackphi() - cluster.phi());
@@ -90,7 +91,12 @@ class EMCPhotonCut : public TNamed
         return mMinTime <= cluster.time() && cluster.time() <= mMaxTime;
 
       case EMCPhotonCuts::kTM:
-        return (dEta > mTrackMatchingEta(track.trackpt())) || (dPhi > mTrackMatchingPhi(track.trackpt())) || (cluster.e() / track.trackp() >= mMinEoverP);
+        if (track) {
+          return (dEta > mTrackMatchingEta(track.trackpt())) || (dPhi > mTrackMatchingPhi(track.trackpt())) || (cluster.e() / track.trackp() >= mMinEoverP);
+        } else {
+          // when we don't have any tracks the cluster should always survive the TM cut!
+          return true;
+        }
 
       case EMCPhotonCuts::kExotic:
         return mUseExoticCut ? cluster.isExotic() : true;


### PR DESCRIPTION
- The track parameter of the IsSelected and IsSelectedEMCal function is now an optional parameter. Before it was needed, but not provided, which somehow compiled but would lead to seg faults when trying to run. This should fix the seg faults and gives us the option to exlucde tracks in case there are none, or we just want to run EMCal only mode.