### PR TITLE
Add extension to TraCascData table

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -1210,6 +1210,7 @@ struct cascadePreselector {
 /// Extends the cascdata table with expression columns
 struct cascadeInitializer {
   Spawns<aod::CascData> cascdataext;
+  Spawns<aod::TraCascData> tracascdataext;
   void init(InitContext const&) {}
 };
 


### PR DESCRIPTION
* adds an extension `Spawns` command to the cascade builder, required to extend the tracked cascade table with additional standard LF variables
* thanks a lot for finding this @qgp !