### PR TITLE
Use O2-like 4-space indents in JSON files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,3 +54,7 @@ UseTab:          Never
 # Do not format protobuf files
 Language: Proto
 DisableFormat: true
+---
+Language: Json
+# O2 dumps JSON files with 4-space indents.
+IndentWidth: 4


### PR DESCRIPTION
Configure clang-format to format JSON files like O2 would dump them, i.e. with 4-space indents. This way, we can track O2-generated JSON files in the repo directly, without having to reformat them.

Tested with an existing JSON file in the O2Physics repo; seems to work.

This came up in #2445.