### PR TITLE
[EMCAL-888] caloLabelConverter: Preparation for removal of mask column

### DIFF
--- a/Common/TableProducer/caloLabelConverter.cxx
+++ b/Common/TableProducer/caloLabelConverter.cxx
@@ -23,14 +23,13 @@ struct caloLabelConverter {
   {
     std::vector<float> amplitude = {0};
     std::vector<int32_t> particleId = {0};
-    for (auto& mccalolabel : mccalolabelTable) {
-      particleId[0] = mccalolabel.mcParticleId();
-      // Repopulate new table
-      McCaloLabels_001(
-        particleId,
-        mccalolabel.mcMask(),
-        amplitude);
-    }
+    // for (auto& mccalolabel : mccalolabelTable) {
+    //   particleId[0] = mccalolabel.mcParticleId();
+    //   // Repopulate new table
+    //   McCaloLabels_001(
+    //     particleId,
+    //     amplitude);
+    // }
   }
 };
 


### PR DESCRIPTION
**caloLabelConverter**:
- After some consideration we decided that we do not need the mask column in the McCaloLabel table so we dropped it. This commit is just to adapt the caloLabelConverter to this change in the table structure. As a starting point the filling will be commented out until the changes to the data structure are merged in O2.