### PR TITLE
PWGHF: Add possibility to split B0 workflow in two separate workflows

### DIFF
--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -14,6 +14,11 @@ o2physics_add_dpl_workflow(task-b0
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(reduced-task-b0
+                    SOURCES reducedTaskB0.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(task-bplus
                     SOURCES taskBplus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGHF/D2H/Tasks/reducedTaskB0.cxx
+++ b/PWGHF/D2H/Tasks/reducedTaskB0.cxx
@@ -1,0 +1,258 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file taskB0.cxx
+/// \brief B0 → D- π+ → (π- K+ π-) π+ analysis task
+///
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/DataModel/ReducedDataModel.h"
+#include "PWGHF/Core/SelectorCuts.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::analysis;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod::hf_cand_b0; // from CandidateReconstructionTables.h
+
+/// B0 analysis task
+struct HfReducedTaskB0 {
+  Configurable<int> selectionFlagB0{"selectionFlagB0", 1, "Selection Flag for B0"};
+  Configurable<double> yCandMax{"yCandMax", -1, "max. cand. rapidity"};
+  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
+
+  float etaMaxAcceptance = 0.8;
+  float ptMinAcceptance = 0.1;
+
+  Filter filterSelectCandidates = (aod::hf_sel_candidate_b0::isSelB0ToDPi >= selectionFlagB0);
+
+  HistogramRegistry registry{
+    "registry",
+    {{"hPtProng0", "B0 candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0., 50.}}}},
+     {"hPtProng1", "B0 candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{200, 0., 10.}}}},
+     {"hPtCand", "B0 candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0., 50.}}}}}};
+
+  void init(o2::framework::InitContext&)
+  {
+    registry.add("hMass", "B^{0} candidates;inv. mass D^{#minus}#pi^{#plus} (GeV/#it{c}^{2});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{500, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLength", "B^{0} candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 0.4}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthXY", "B^{0} candidates;decay length xy (cm);entries", {HistType::kTH2F, {{200, 0., 0.4}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong0", "B^{0} candidates;prong 0 (D^{#minus}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong1", "B^{0} candidates;prong 1 (#pi^{#plus}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPA", "B^{0} candidates;B^{0} candidate cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEta", "B^{0} candidates;B^{0} candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hRapidity", "B^{0} candidates;B^{0} candidate #it{y};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hImpParErr", "B^{0} candidates;B^{0} candidate impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLenErr", "B^{0} candidates;B^{0} candidate decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLenXYErr", "B^{0} candidates;B^{0} candidate decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hIPProd", "B^{0} candidates;B^{0} candidate impact parameter product;entries", {HistType::kTH2F, {{100, -0.5, 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hInvMassD", "B^{0} candidates;prong0, D^{#minus} inv. mass (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0, 5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("hEtaGen", "MC particles (generated);B^{0} candidate #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYGen", "MC particles (generated);B^{0} candidate #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaGenWithProngsInAcceptance", "MC particles (generated-daughters in acceptance);B^{0} candidate #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYGenWithProngsInAcceptance", "MC particles (generated-daughters in acceptance);B^{0} candidate #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng0Gen", "MC particles (generated);prong 0 (D^{#minus}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{p}_{T}^{gen} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYProng0Gen", "MC particles (generated);prong 0 (D^{#minus}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hYProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{y}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaProng0Gen", "MC particles (generated);prong 0 (B^{0}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaProng1Gen", "MC particles (generated);prong 1 (#pi^{-}) #it{#eta}^{gen};entries", {HistType::kTH2F, {{100, -2, 2}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPARecSig", "B^{0} candidates (matched);B^{0} candidate cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPARecBg", "B^{0} candidates (unmatched);B^{0} candidate cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPAxyRecSig", "B^{0} candidates (matched);B^{0} candidate CPAxy;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPAxyRecBg", "B^{0} candidates (unmatched);B^{0} candidate CPAxy;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPADRecSig", "B^{0} candidates (matched);prong 0 (D^{#minus}) cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCPADRecBg", "B^{0} candidates (unmatched);prong 0 (D^{#minus}) cosine of pointing angle;entries", {HistType::kTH2F, {{220, 0., 1.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaRecSig", "B^{0} candidates (matched);B^{0} candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hEtaRecBg", "B^{0} candidates (unmatched);B^{0} candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hRapidityRecSig", "B^{0} candidates (matched);B^{0} candidate #it{y};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hRapidityRecBg", "B^{0} candidates (unmatched);B^{0} candidate #it{#y};entries", {HistType::kTH2F, {{100, -2., 2.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("hPtProng0RecSig", "B^{0} candidates (matched);prong 0 (D^{#minus}) #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng1RecSig", "B^{0} candidates (matched);prong 1 (#pi^{#minus}) #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng0RecBg", "B^{0} candidates (unmatched);prong 0 (D^{#minus}) #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtProng1RecBg", "B^{0} candidates (unmatched);prong 1 (#pi^{#minus}) #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH2F, {{100, 0., 10.}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassRecSig", "B^{0} candidates (matched);inv. mass D^{#minus}#pi^{+} (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{300, 4.0, 7.00}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassRecBg", "B^{0} candidates (unmatched);inv. mass D^{#minus}#pi^{+} (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{300, 4.0, 7.0}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong0RecSig", "B^{0} candidates (matched);prong 0 (D^{#minus}}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{200, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong1RecSig", "B^{0} candidates (matched);prong 1 (#pi^{#minus}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{200, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong0RecBg", "B^{0} candidates (unmatched);prong 0 (D^{#minus}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{200, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hd0Prong1RecBg", "B^{0} candidates (unmatched);prong 1 (#pi^{#minus}) DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{200, -0.05, 0.05}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthRecSig", "B^{0} candidates (matched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthXYRecSig", "B^{0} candidates (matched);B^{0} candidate decay length xy (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthXYRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length xy(cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthDRecSig", "B^{0} candidates (matched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthDRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthNormRecSig", "B^{0} candidates (matched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hDecLengthNormRecBg", "B^{0} candidates (unmatched);B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {{100, 0., 0.5}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hImpParProdB0RecSig", "B^{0} candidates (matched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.01, 0.01}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hImpParProdB0RecBg", "B^{0} candidates (unmatched);B^{0} candidate impact parameter product ;entries", {HistType::kTH2F, {{100, -0.01, 0.01}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("hChi2PCARecSig", "B^{0} candidates (matched);sum of distances of the secondary vertex to its prongs;entries", {HistType::kTH2F, {{240, -0.01, 0.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hChi2PCARecBg", "B^{0} candidates (unmatched);sum of distances of the secondary vertex to its prongs;entries", {HistType::kTH2F, {{240, -0.01, 0.1}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("hPtRecSig", "B0 candidates (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtRecBg", "B0 candidates (unmatched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtGenSig", "B0 candidates (gen+rec);candidate #it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 10.}}});
+    registry.add("hPtGen", "MC particles (generated);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+    registry.add("hPtGenWithProngsInAcceptance", "MC particles (generated-daughters in acceptance);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{300, 0., 30.}}});
+  }
+
+  /// Selection of B0 daughter in geometrical acceptance
+  /// \param etaProng is the pseudorapidity of B0 prong
+  /// \param ptProng is the pT of B0 prong
+  /// \return true if prong is in geometrical acceptance
+  template <typename T = float>
+  bool isProngInAcceptance(const T& etaProng, const T& ptProng)
+  {
+    return std::abs(etaProng) <= etaMaxAcceptance && ptProng >= ptMinAcceptance;
+  }
+
+  void process(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi>> const& candidates,
+               aod::HfReducedCand3Prong const&)
+  {
+    for (auto const& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+        continue;
+      }
+
+      auto ptCandB0 = candidate.pt();
+      auto candD = candidate.prong0_as<aod::HfReducedCand3Prong>();
+
+      registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), ptCandB0);
+      registry.fill(HIST("hPtCand"), ptCandB0);
+      registry.fill(HIST("hPtProng0"), candidate.ptProng0());
+      registry.fill(HIST("hPtProng1"), candidate.ptProng1());
+      registry.fill(HIST("hIPProd"), candidate.impactParameterProduct(), ptCandB0);
+      registry.fill(HIST("hDecLength"), candidate.decayLength(), ptCandB0);
+      registry.fill(HIST("hDecLengthXY"), candidate.decayLengthXY(), ptCandB0);
+      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), ptCandB0);
+      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), ptCandB0);
+      registry.fill(HIST("hCPA"), candidate.cpa(), ptCandB0);
+      registry.fill(HIST("hEta"), candidate.eta(), ptCandB0);
+      registry.fill(HIST("hRapidity"), yB0(candidate), ptCandB0);
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), ptCandB0);
+      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), ptCandB0);
+      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), ptCandB0);
+      registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), ptCandB0);
+      registry.fill(HIST("hInvMassD"), candD.invMass(), ptCandB0);
+    } // candidate loop
+  }   // process
+
+  /// B0 MC analysis and fill histograms
+  void processMc(soa::Join<aod::HfCandB0, aod::HfReducedB0McRec> const& candidates,
+                 aod::HfReducedB0McGen const& particlesMc,
+                 aod::HfReducedCand3Prong const&)
+  {
+    // MC rec
+    for (auto const& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+        continue;
+      }
+
+      auto ptCandB0 = candidate.pt();
+      auto candD = candidate.prong0_as<aod::HfReducedCand3Prong>();
+
+      if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
+        registry.fill(HIST("hPtGenSig"), candidate.ptMother());
+        registry.fill(HIST("hPtRecSig"), ptCandB0);
+        registry.fill(HIST("hCPARecSig"), candidate.cpa(), ptCandB0);
+        registry.fill(HIST("hCPAxyRecSig"), candidate.cpaXY(), ptCandB0);
+        registry.fill(HIST("hEtaRecSig"), candidate.eta(), ptCandB0);
+        registry.fill(HIST("hRapidityRecSig"), yB0(candidate), ptCandB0);
+        registry.fill(HIST("hDecLengthRecSig"), candidate.decayLength(), ptCandB0);
+        registry.fill(HIST("hDecLengthXYRecSig"), candidate.decayLengthXY(), ptCandB0);
+        registry.fill(HIST("hMassRecSig"), invMassB0ToDPi(candidate), ptCandB0);
+        registry.fill(HIST("hd0Prong0RecSig"), candidate.impactParameter0(), ptCandB0);
+        registry.fill(HIST("hd0Prong1RecSig"), candidate.impactParameter1(), ptCandB0);
+        registry.fill(HIST("hPtProng0RecSig"), candidate.ptProng0(), ptCandB0);
+        registry.fill(HIST("hPtProng1RecSig"), candidate.ptProng1(), ptCandB0);
+        registry.fill(HIST("hImpParProdB0RecSig"), candidate.impactParameterProduct(), ptCandB0);
+        registry.fill(HIST("hDecLengthNormRecSig"), candidate.decayLengthXYNormalised(), ptCandB0);
+        registry.fill(HIST("hCPADRecSig"), candD.cpa(), ptCandB0);
+        registry.fill(HIST("hDecLengthDRecSig"), candD.decayLength(), ptCandB0);
+        registry.fill(HIST("hChi2PCARecSig"), candidate.chi2PCA(), ptCandB0);
+      } else {
+        registry.fill(HIST("hPtRecBg"), ptCandB0);
+        registry.fill(HIST("hCPARecBg"), candidate.cpa(), ptCandB0);
+        registry.fill(HIST("hCPAxyRecBg"), candidate.cpaXY(), ptCandB0);
+        registry.fill(HIST("hEtaRecBg"), candidate.eta(), ptCandB0);
+        registry.fill(HIST("hRapidityRecBg"), yB0(candidate), ptCandB0);
+        registry.fill(HIST("hDecLengthRecBg"), candidate.decayLength(), ptCandB0);
+        registry.fill(HIST("hDecLengthXYRecBg"), candidate.decayLengthXY(), ptCandB0);
+        registry.fill(HIST("hMassRecBg"), invMassB0ToDPi(candidate), ptCandB0);
+        registry.fill(HIST("hd0Prong0RecBg"), candidate.impactParameter0(), ptCandB0);
+        registry.fill(HIST("hd0Prong1RecBg"), candidate.impactParameter1(), ptCandB0);
+        registry.fill(HIST("hPtProng0RecBg"), candidate.ptProng0(), ptCandB0);
+        registry.fill(HIST("hPtProng1RecBg"), candidate.ptProng1(), ptCandB0);
+        registry.fill(HIST("hImpParProdB0RecBg"), candidate.impactParameterProduct(), ptCandB0);
+        registry.fill(HIST("hDecLengthNormRecBg"), candidate.decayLengthXYNormalised(), ptCandB0);
+        registry.fill(HIST("hCPADRecBg"), candD.cpa(), ptCandB0);
+        registry.fill(HIST("hDecLengthDRecBg"), candD.decayLength(), ptCandB0);
+        registry.fill(HIST("hChi2PCARecBg"), candidate.chi2PCA(), ptCandB0);
+      }
+    } // rec
+
+    // MC gen. level
+    // Printf("MC Particles: %d", particlesMc.size());
+    for (auto const& particle : particlesMc) {
+      auto ptParticle = particle.pt();
+      auto yParticle = particle.y();
+      auto etaParticle = particle.eta();
+      if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+        continue;
+      }
+
+      std::array<float, 2> ptProngs = {particle.ptProng0(), particle.ptProng1()};
+      std::array<float, 2> yProngs = {particle.yProng0(), particle.yProng1()};
+      std::array<float, 2> etaProngs = {particle.etaProng0(), particle.etaProng1()};
+
+      registry.fill(HIST("hPtProng0Gen"), ptProngs[0], ptParticle);
+      registry.fill(HIST("hPtProng1Gen"), ptProngs[1], ptParticle);
+      registry.fill(HIST("hYProng0Gen"), yProngs[0], ptParticle);
+      registry.fill(HIST("hYProng1Gen"), yProngs[1], ptParticle);
+      registry.fill(HIST("hEtaProng0Gen"), etaProngs[0], ptParticle);
+      registry.fill(HIST("hEtaProng1Gen"), etaProngs[1], ptParticle);
+
+      registry.fill(HIST("hPtGen"), ptParticle);
+      registry.fill(HIST("hYGen"), yParticle, ptParticle);
+      registry.fill(HIST("hEtaGen"), etaParticle, ptParticle);
+
+      // reject B0 daughters that are not in geometrical acceptance
+      if (!isProngInAcceptance(etaProngs[0], ptProngs[0]) || !isProngInAcceptance(etaProngs[1], ptProngs[1])) {
+        continue;
+      }
+      registry.fill(HIST("hPtGenWithProngsInAcceptance"), ptParticle);
+      registry.fill(HIST("hYGenWithProngsInAcceptance"), yParticle, ptParticle);
+      registry.fill(HIST("hEtaGenWithProngsInAcceptance"), etaParticle, ptParticle);
+    } // gen
+  }   // process
+  PROCESS_SWITCH(HfReducedTaskB0, processMc, "Process MC", false);
+}; // struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfReducedTaskB0>(cfgc)};
+}

--- a/PWGHF/DataModel/ReducedDataModel.h
+++ b/PWGHF/DataModel/ReducedDataModel.h
@@ -182,17 +182,17 @@ DECLARE_SOA_TABLE(HfReducedCand3Prong, "AOD", "HFREDCAND3PRONG", //! Table with 
 namespace hf_b0_mc
 {
 // MC Rec
-DECLARE_SOA_COLUMN(PtMother, ptMother, float); //!
+DECLARE_SOA_COLUMN(PtMother, ptMother, float); //! Transverse momentum of the mother in GeV/c
 // MC Gen
-DECLARE_SOA_COLUMN(Pt, pt, float);
-DECLARE_SOA_COLUMN(Y, y, float);
-DECLARE_SOA_COLUMN(Eta, eta, float);
-DECLARE_SOA_COLUMN(PtProng0, ptProng0, float);
-DECLARE_SOA_COLUMN(YProng0, yProng0, float);
-DECLARE_SOA_COLUMN(EtaProng0, etaProng0, float);
-DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);
-DECLARE_SOA_COLUMN(YProng1, yProng1, float);
-DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float);
+DECLARE_SOA_COLUMN(Pt, pt, float);               //! Transverse momentum of the track in GeV/c
+DECLARE_SOA_COLUMN(Y, y, float);                 //! Rapidity of the track
+DECLARE_SOA_COLUMN(Eta, eta, float);             //! Pseudorapidity of the track
+DECLARE_SOA_COLUMN(PtProng0, ptProng0, float);   //! Transverse momentum of the track's prong0 in GeV/c
+DECLARE_SOA_COLUMN(YProng0, yProng0, float);     //! Rapidity of the track's prong0
+DECLARE_SOA_COLUMN(EtaProng0, etaProng0, float); //! Pseudorapidity of the track's prong0
+DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);   //! Transverse momentum of the track's prong1 in GeV/c
+DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's prong1
+DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
 // table with results of reconstruction level MC matching

--- a/PWGHF/DataModel/ReducedDataModel.h
+++ b/PWGHF/DataModel/ReducedDataModel.h
@@ -37,9 +37,9 @@ namespace aod
 {
 namespace hf_reduced_collision
 {
-DECLARE_SOA_COLUMN(Bz, bz, float); //! Magnetic field in z-direction 
+DECLARE_SOA_COLUMN(Bz, bz, float); //! Magnetic field in z-direction
 // keep track of the number of studied events (for normalization purposes)
-DECLARE_SOA_COLUMN(OriginalAODId, originalAODId, int); //! User-defined index of COLLISION table processed
+DECLARE_SOA_COLUMN(OriginalAODId, originalAODId, int);     //! User-defined index of COLLISION table processed
 DECLARE_SOA_COLUMN(OriginalAODSize, originalAODSize, int); //! Size of COLLISION table processed
 } // namespace hf_reduced_collision
 
@@ -120,7 +120,7 @@ DECLARE_SOA_COLUMN(Pz, pz, float); //! Momentum in z-direction in GeV/c
 
 namespace hf_reduced_track_index
 {
-DECLARE_SOA_INDEX_COLUMN(Track, track); //! Track index
+DECLARE_SOA_INDEX_COLUMN(Track, track);   //! Track index
 DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool); //! Flag to check if track has a TPC match
 DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool); //! Flag to check if track has a TOF match
 } // namespace hf_reduced_track_index
@@ -137,7 +137,7 @@ DECLARE_SOA_COLUMN(Pt, pt, float); //! Transverse momentum of the track in GeV/c
 } // namespace hf_track_pid_with_sel
 
 // table with all attributes needed to call getStatusTrackPIDTpcAndTof() in the selector task
-DECLARE_SOA_TABLE(HfReducedTracksPIDWithSel, "AOD", "HFREDTRACKPID",  //! Table with PID track information for reduced workflow
+DECLARE_SOA_TABLE(HfReducedTracksPIDWithSel, "AOD", "HFREDTRACKPID", //! Table with PID track information for reduced workflow
                   o2::soa::Index<>,
                   track::CollisionId,
                   hf_track_pid_with_sel::Pt,
@@ -156,9 +156,9 @@ DECLARE_SOA_TABLE(HfReducedTracksPIDWithSel, "AOD", "HFREDTRACKPID",  //! Table 
 
 namespace hf_reduced_cand_3prong
 {
-DECLARE_SOA_COLUMN(CPA, cpa, float); //! Cosinus pointing angle
+DECLARE_SOA_COLUMN(CPA, cpa, float);                 //! Cosinus pointing angle
 DECLARE_SOA_COLUMN(DecayLength, decayLength, float); //! Decay length in cm
-DECLARE_SOA_COLUMN(InvMass, invMass, float); //! Invariant mass of 3prong candidate in GeV/c2
+DECLARE_SOA_COLUMN(InvMass, invMass, float);         //! Invariant mass of 3prong candidate in GeV/c2
 
 template <typename T>
 auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)

--- a/PWGHF/DataModel/ReducedDataModel.h
+++ b/PWGHF/DataModel/ReducedDataModel.h
@@ -1,0 +1,247 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ReducedDataModel.h
+/// \brief Header file with definition of methods and tables
+//  used to fold (unfold) track and primary vertex information by writing (reading) AO2Ds
+/// \note
+///
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#ifndef PWGHF_DATAMODEL_REDUCED_DATA_MODEL_H_
+#define PWGHF_DATAMODEL_REDUCED_DATA_MODEL_H_
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/Vertex.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+namespace o2
+{
+namespace aod
+{
+namespace hf_reduced_collision
+{
+DECLARE_SOA_COLUMN(Bz, bz, float); //! Magnetic field in z-direction 
+// keep track of the number of studied events (for normalization purposes)
+DECLARE_SOA_COLUMN(OriginalAODId, originalAODId, int); //! User-defined index of COLLISION table processed
+DECLARE_SOA_COLUMN(OriginalAODSize, originalAODSize, int); //! Size of COLLISION table processed
+} // namespace hf_reduced_collision
+
+DECLARE_SOA_TABLE(HfReducedCollisions, "AOD", "HFREDCOLLISION", //! Table with collision for reduced workflow
+                  track::CollisionId,                           // FIXME : soa::Index<> does not work event with DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions, aod::HfReducedCollisions)
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  collision::CovXX,
+                  collision::CovXY,
+                  collision::CovYY,
+                  collision::CovXZ,
+                  collision::CovYZ,
+                  collision::CovZZ,
+                  hf_reduced_collision::Bz,
+                  hf_reduced_collision::OriginalAODId,
+                  hf_reduced_collision::OriginalAODSize);
+
+namespace hf_track_par_cov
+{
+// CAREFUL: the getters names shall be the same as the ones of the getTrackParCov method in Common/Core/trackUtilities.h
+DECLARE_SOA_COLUMN(X, x, float);            //! X of track evaluation
+DECLARE_SOA_COLUMN(Alpha, alpha, float);    //! Track frame angle
+DECLARE_SOA_COLUMN(Y, y, float);            //! Y of track evaluation
+DECLARE_SOA_COLUMN(Z, z, float);            //! Z of track evaluation
+DECLARE_SOA_COLUMN(Snp, snp, float);        //! sin(phi)
+DECLARE_SOA_COLUMN(Tgl, tgl, float);        //! tan(lambda)
+DECLARE_SOA_COLUMN(Q2Pt, signed1Pt, float); //! (sign of charge)/Pt in c/GeV
+
+DECLARE_SOA_COLUMN(SigY2, cYY, float);          //! Covariance matrix
+DECLARE_SOA_COLUMN(SigZY, cZY, float);          //! Covariance matrix
+DECLARE_SOA_COLUMN(SigZ2, cZZ, float);          //! Covariance matrix
+DECLARE_SOA_COLUMN(SigSnpY, cSnpY, float);      //! Covariance matrix
+DECLARE_SOA_COLUMN(SigSnpZ, cSnpZ, float);      //! Covariance matrix
+DECLARE_SOA_COLUMN(SigSnp2, cSnpSnp, float);    //! Covariance matrix
+DECLARE_SOA_COLUMN(SigTglY, cTglY, float);      //! Covariance matrix
+DECLARE_SOA_COLUMN(SigTglZ, cTglZ, float);      //! Covariance matrix
+DECLARE_SOA_COLUMN(SigTglSnp, cTglSnp, float);  //! Covariance matrix
+DECLARE_SOA_COLUMN(SigTgl2, cTglTgl, float);    //! Covariance matrix
+DECLARE_SOA_COLUMN(SigQ2PtY, c1PtY, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(SigQ2PtZ, c1PtZ, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(SigQ2PtSnp, c1PtSnp, float); //! Covariance matrix
+DECLARE_SOA_COLUMN(SigQ2PtTgl, c1PtTgl, float); //! Covariance matrix
+DECLARE_SOA_COLUMN(SigQ2Pt2, c1Pt21Pt2, float); //! Covariance matrix
+
+DECLARE_SOA_COLUMN(Px, px, float); //! Momentum in x-direction in GeV/c
+DECLARE_SOA_COLUMN(Py, py, float); //! Momentum in y-direction in GeV/c
+DECLARE_SOA_COLUMN(Pz, pz, float); //! Momentum in z-direction in GeV/c
+} // namespace hf_track_par_cov
+
+// general columns
+#define HFTRACKPARCOV_COLUMNS     \
+  hf_track_par_cov::X,            \
+    hf_track_par_cov::Alpha,      \
+    hf_track_par_cov::Y,          \
+    hf_track_par_cov::Z,          \
+    hf_track_par_cov::Snp,        \
+    hf_track_par_cov::Tgl,        \
+    hf_track_par_cov::Q2Pt,       \
+    hf_track_par_cov::SigY2,      \
+    hf_track_par_cov::SigZY,      \
+    hf_track_par_cov::SigZ2,      \
+    hf_track_par_cov::SigSnpY,    \
+    hf_track_par_cov::SigSnpZ,    \
+    hf_track_par_cov::SigSnp2,    \
+    hf_track_par_cov::SigTglY,    \
+    hf_track_par_cov::SigTglZ,    \
+    hf_track_par_cov::SigTglSnp,  \
+    hf_track_par_cov::SigTgl2,    \
+    hf_track_par_cov::SigQ2PtY,   \
+    hf_track_par_cov::SigQ2PtZ,   \
+    hf_track_par_cov::SigQ2PtSnp, \
+    hf_track_par_cov::SigQ2PtTgl, \
+    hf_track_par_cov::SigQ2Pt2,   \
+    hf_track_par_cov::Px,         \
+    hf_track_par_cov::Py,         \
+    hf_track_par_cov::Pz
+
+namespace hf_reduced_track_index
+{
+DECLARE_SOA_INDEX_COLUMN(Track, track); //! Track index
+DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool); //! Flag to check if track has a TPC match
+DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool); //! Flag to check if track has a TOF match
+} // namespace hf_reduced_track_index
+
+DECLARE_SOA_TABLE(HfReducedTracksWithSel, "AOD", "HFREDTRACKWSEL", //! Table with track information for reduced workflow
+                  soa::Index<>,
+                  hf_reduced_track_index::TrackId,
+                  track::CollisionId,
+                  HFTRACKPARCOV_COLUMNS);
+
+namespace hf_track_pid_with_sel
+{
+DECLARE_SOA_COLUMN(Pt, pt, float); //! Transverse momentum of the track in GeV/c
+} // namespace hf_track_pid_with_sel
+
+// table with all attributes needed to call getStatusTrackPIDTpcAndTof() in the selector task
+DECLARE_SOA_TABLE(HfReducedTracksPIDWithSel, "AOD", "HFREDTRACKPID",  //! Table with PID track information for reduced workflow
+                  o2::soa::Index<>,
+                  track::CollisionId,
+                  hf_track_pid_with_sel::Pt,
+                  hf_reduced_track_index::HasTPC,
+                  hf_reduced_track_index::HasTOF,
+                  pidtpc::TPCNSigmaEl,
+                  pidtpc::TPCNSigmaMu,
+                  pidtpc::TPCNSigmaPi,
+                  pidtpc::TPCNSigmaKa,
+                  pidtpc::TPCNSigmaPr,
+                  pidtof::TOFNSigmaEl,
+                  pidtof::TOFNSigmaMu,
+                  pidtof::TOFNSigmaPi,
+                  pidtof::TOFNSigmaKa,
+                  pidtof::TOFNSigmaPr);
+
+namespace hf_reduced_cand_3prong
+{
+DECLARE_SOA_COLUMN(CPA, cpa, float); //! Cosinus pointing angle
+DECLARE_SOA_COLUMN(DecayLength, decayLength, float); //! Decay length in cm
+DECLARE_SOA_COLUMN(InvMass, invMass, float); //! Invariant mass of 3prong candidate in GeV/c2
+
+template <typename T>
+auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)
+{
+  return RecoDecay::m(array{array{pVec0}, array{pVec1}, array{pVec2}},
+                      array{RecoDecay::getMassPDG(kPiPlus),
+                            RecoDecay::getMassPDG(kKPlus),
+                            RecoDecay::getMassPDG(kPiPlus)});
+}
+} // namespace hf_reduced_cand_3prong
+
+DECLARE_SOA_TABLE(HfReducedCand3Prong, "AOD", "HFREDCAND3PRONG", //! Table with 3prong candidate information for reduced workflow
+                  o2::soa::Index<>,
+                  hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_track_index::Prong2Id,
+                  track::CollisionId,
+                  HFTRACKPARCOV_COLUMNS,
+                  hf_reduced_cand_3prong::CPA,
+                  hf_reduced_cand_3prong::DecayLength,
+                  hf_reduced_cand_3prong::InvMass);
+
+namespace hf_b0_mc
+{
+// MC Rec
+DECLARE_SOA_COLUMN(PtMother, ptMother, float); //!
+// MC Gen
+DECLARE_SOA_COLUMN(Pt, pt, float);
+DECLARE_SOA_COLUMN(Y, y, float);
+DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(PtProng0, ptProng0, float);
+DECLARE_SOA_COLUMN(YProng0, yProng0, float);
+DECLARE_SOA_COLUMN(EtaProng0, etaProng0, float);
+DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);
+DECLARE_SOA_COLUMN(YProng1, yProng1, float);
+DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float);
+} // namespace hf_b0_mc
+
+// table with results of reconstruction level MC matching
+DECLARE_SOA_TABLE(HfReducedDPiMcRec, "AOD", "HFREDDPIMCREC", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
+                  hf_cand_b0::Prong0Id,
+                  hf_track_index::Prong1Id,
+                  hf_cand_b0::FlagMcMatchRec,
+                  hf_cand_b0::OriginMcRec,
+                  hf_cand_b0::DebugMcRec,
+                  hf_b0_mc::PtMother);
+
+// Table with same size as HFCANDB0
+DECLARE_SOA_TABLE(HfReducedB0McRec, "AOD", "HFREDB0MCREC", //! Reconstruction-level MC information on B0 candidates for reduced workflow
+                  hf_cand_b0::FlagMcMatchRec,
+                  hf_cand_b0::OriginMcRec,
+                  hf_cand_b0::DebugMcRec,
+                  hf_b0_mc::PtMother);
+
+DECLARE_SOA_TABLE(HfReducedB0McGen, "AOD", "HFREDB0MCGEN", //! Generation-level MC information on B0 candidates for reduced workflow
+                  hf_cand_b0::FlagMcMatchGen,
+                  hf_cand_b0::OriginMcGen,
+                  hf_b0_mc::Pt,
+                  hf_b0_mc::Y,
+                  hf_b0_mc::Eta,
+                  hf_b0_mc::PtProng0,
+                  hf_b0_mc::YProng0,
+                  hf_b0_mc::EtaProng0,
+                  hf_b0_mc::PtProng1,
+                  hf_b0_mc::YProng1,
+                  hf_b0_mc::EtaProng1);
+
+// store all configurables values used in the first part of the workflow
+// so we can use them in the B0 part
+namespace hf_cand_b0_config
+{
+DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int); //! Flag to filter selected D+ mesons
+} // namespace hf_cand_b0_config
+
+DECLARE_SOA_TABLE(HfCandB0Config, "AOD", "HFCANDB0CONFIG", //! Table with configurables information for reduced workflow
+                  hf_cand_b0_config::MySelectionFlagD);
+
+} // namespace aod
+
+namespace soa
+{
+DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfReducedCand3Prong);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfReducedTracksWithSel);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfReducedTracksPIDWithSel);
+} // namespace soa
+} // namespace o2
+
+#endif // PWGHF_DATAMODEL_REDUCED_DATA_MODEL_H_

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -49,6 +49,16 @@ o2physics_add_dpl_workflow(candidate-creator-b0
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DCAFitter
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(reduced-creator-dplus-pi
+                    SOURCES reducedDataCreatorDplusPi.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DCAFitter
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(reduced-creator-b0
+                    SOURCES reducedCandidateCreatorB0.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DCAFitter
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(candidate-creator-bplus
                     SOURCES candidateCreatorBplus.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DCAFitter
@@ -196,6 +206,11 @@ o2physics_add_dpl_workflow(candidate-selector-lc-to-k0s-p
 
 o2physics_add_dpl_workflow(candidate-selector-b0-to-d-pi
                     SOURCES candidateSelectorB0ToDPi.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(reduced-selector-b0-to-d-pi
+                    SOURCES reducedCandidateSelectorB0ToDPi.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGHF/TableProducer/reducedCandidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/reducedCandidateCreatorB0.cxx
@@ -1,0 +1,219 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file reducedCandidateCreatorB0.cxx
+/// \brief Reconstruction of B0 candidates
+/// \note Adapted from candidateCreatorXicc.cxx
+///
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "PWGHF/DataModel/ReducedDataModel.h"
+
+#include "DCAFitter/DCAFitterN.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/CollisionAssociation.h"
+#include "ReconstructionDataFormats/DCA.h"
+#include "ReconstructionDataFormats/V0.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+/// Reconstruction of B0 candidates
+struct HfReducedCandidateCreatorB0 {
+  Produces<aod::HfCandB0Base> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+
+  // vertexing
+  Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
+  Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
+  Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B0 is smaller than this"};
+  Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
+  // selection
+  Configurable<double> invMassWindowB0{"invMassWindowB0", 0.3, "invariant-mass window for B0 candidates"};
+
+  double massPi = RecoDecay::getMassPDG(kPiPlus);
+  double massD = RecoDecay::getMassPDG(pdg::Code::kDMinus);
+  double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
+  double massDPi{0.};
+  double bz{0.};
+
+  std::vector<int> aodIds = {};
+
+  // Fitter for B vertex (2-prong vertex filter)
+  o2::vertexing::DCAFitterN<2> df2;
+
+  HistogramRegistry registry{"registry"};
+
+  void init(InitContext const&)
+  {
+    // histograms
+    registry.add("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
+
+    // Initialize fitter
+    df2.setPropagateToPCA(propagateToPCA);
+    df2.setMaxR(maxR);
+    df2.setMaxDZIni(maxDZIni);
+    df2.setMinParamChange(minParamChange);
+    df2.setMinRelChi2Change(minRelChi2Change);
+    df2.setUseAbsDCA(useAbsDCA);
+    df2.setWeightedFinalPCA(useWeightedFinalPCA);
+  }
+
+  void process(aod::HfReducedCollisions const& collisions,
+               aod::HfReducedCand3Prong const& candsD,
+               aod::HfReducedTracksWithSel const& tracksPion)
+  {
+    static int ncol = 0;
+
+    for (const auto& collision : collisions) {
+      // handle normalization
+      int aodId = collision.originalAODId();
+      if (!std::count(aodIds.begin(), aodIds.end(), aodId)) {
+        // fill histogram with collision.originalAODSize();
+        registry.fill(HIST("hEvents"), 1, collision.originalAODSize());
+        aodIds.emplace_back(aodId);
+      }
+
+      auto thisCollId = collision.collisionId(); // FIXME : works only with column CollisionId
+      auto primaryVertex = getPrimaryVertex(collision);
+      auto covMatrixPV = primaryVertex.getCov();
+
+      if (ncol % 10000 == 0) {
+        LOG(info) << ncol << " collisions parsed";
+      }
+      ncol++;
+
+      /// Set the magnetic field from ccdb
+      bz = collision.bz();
+      df2.setBz(bz);
+
+      // FIXME : partitioning is slower than using if loops
+      // Partition<aod::HfReducedCand3Prong> candsDThisColl = hf_track_par_cov::collisionId == thisCollId;
+      // candsDThisColl.bindTable(candsD);
+      for (const auto& candD : candsD) {
+        if (candD.collisionId() != thisCollId) {
+          continue;
+        }
+        auto trackParCovD = getTrackParCov(candD);
+        std::array<float, 3> pVecD = {candD.px(), candD.py(), candD.pz()};
+
+        // FIXME
+        // Partition<aod::HfReducedTracksWithSel> tracksPionThisColl = hf_track_par_cov::collisionId == thisCollId;
+        // tracksPionThisColl.bindTable(tracksPion);
+        for (const auto& trackPion : tracksPion) {
+          if (trackPion.collisionId() != thisCollId) {
+            continue;
+          }
+          auto trackParCovPi = getTrackParCov(trackPion);
+          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+
+          auto massDPi_before = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+
+          // ---------------------------------
+          // reconstruct the 2-prong B0 vertex
+          if (df2.process(trackParCovD, trackParCovPi) == 0) {
+            continue;
+          }
+          // DPi passed B0 reconstruction
+
+          // calculate relevant properties
+          const auto& secondaryVertexB0 = df2.getPCACandidate();
+          auto chi2PCA = df2.getChi2AtPCACandidate();
+          auto covMatrixPCA = df2.calcPCACovMatrixFlat();
+          registry.fill(HIST("hCovSVXX"), covMatrixPCA[0]);
+          registry.fill(HIST("hCovPVXX"), covMatrixPV[0]);
+
+          // propagate D and Pi to the B0 vertex
+          df2.propagateTracksToVertex();
+          // track.getPxPyPzGlo(pVec) modifies pVec of track
+          df2.getTrack(0).getPxPyPzGlo(pVecD);    // momentum of D at the B0 vertex
+          df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
+
+          // compute invariant
+          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+
+          if (std::abs(massDPi - massB0) < invMassWindowB0 && std::abs(massDPi_before - massB0) > invMassWindowB0) {
+            LOG(info) << "Mass before = " << massDPi_before << " , mass after = " << massDPi;
+            LOG(info) << "Delta mass before = " << std::abs(massDPi_before - massB0) << " , delta mass after = " << std::abs(massDPi - massB0);
+          }
+
+          if (std::abs(massDPi - massB0) > invMassWindowB0) {
+            continue;
+          }
+          registry.fill(HIST("hMassB0ToDPi"), massDPi);
+
+          // compute impact parameters of D and Pi
+          o2::dataformats::DCA dcaD;
+          o2::dataformats::DCA dcaPion;
+          trackParCovD.propagateToDCA(primaryVertex, bz, &dcaD);
+          trackParCovPi.propagateToDCA(primaryVertex, bz, &dcaPion);
+
+          // get uncertainty of the decay length
+          double phi, theta;
+          // getPointDirection modifies phi and theta
+          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
+          auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
+          auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
+
+          int hfFlag = BIT(hf_cand_b0::DecayType::B0ToDPi);
+
+          // fill the candidate table for the B0 here:
+          rowCandidateBase(thisCollId,
+                           collision.posX(), collision.posY(), collision.posZ(),
+                           secondaryVertexB0[0], secondaryVertexB0[1], secondaryVertexB0[2],
+                           errorDecayLength, errorDecayLengthXY,
+                           chi2PCA,
+                           pVecD[0], pVecD[1], pVecD[2],
+                           pVecPion[0], pVecPion[1], pVecPion[2],
+                           dcaD.getY(), dcaPion.getY(),
+                           std::sqrt(dcaD.getSigmaY2()), std::sqrt(dcaPion.getSigmaY2()),
+                           candD.globalIndex(), trackPion.globalIndex(),
+                           hfFlag);
+        } // pi loop
+      }   // D loop
+    }     // collision loop
+  }       // process
+};        // struct
+
+struct HfReducedCandidateCreatorB0Expressions {
+  Spawns<aod::HfCandB0Ext> rowCandidateB0;
+  Produces<aod::HfReducedB0McRec> rowB0McRec;
+
+  void processMc(HfReducedDPiMcRec const& rowsDPiMcRec)
+  {
+    for (const auto& candB0 : *rowCandidateB0) {
+      for (const auto& rowDPiMcRec : rowsDPiMcRec) {
+        if ((rowDPiMcRec.prong0Id() != candB0.prong0Id()) || (rowDPiMcRec.prong1Id() != candB0.prong1Id())) {
+          continue;
+        }
+        rowB0McRec(rowDPiMcRec.flagMcMatchRec(), rowDPiMcRec.originMcRec(), rowDPiMcRec.debugMcRec(), rowDPiMcRec.ptMother());
+      }
+    }
+  }
+  PROCESS_SWITCH(HfReducedCandidateCreatorB0Expressions, processMc, "Process MC", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfReducedCandidateCreatorB0>(cfgc),
+                      adaptAnalysisTask<HfReducedCandidateCreatorB0Expressions>(cfgc)};
+}

--- a/PWGHF/TableProducer/reducedCandidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/reducedCandidateSelectorB0ToDPi.cxx
@@ -1,0 +1,261 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file candidateSelectorB0ToDPi.cxx
+/// \brief B0 → D- π+ candidate selector
+///
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#include "Common/Core/TrackSelectorPID.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "PWGHF/Core/SelectorCuts.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/DataModel/ReducedDataModel.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::aod::hf_cand_b0; // from CandidateReconstructionTables.h
+using namespace o2::analysis;
+using namespace o2::analysis::hf_cuts_b0_to_d_pi; // from SelectorCuts.h
+
+struct HfReducedCandidateSelectorB0ToDPi {
+  Produces<aod::HfSelB0ToDPi> hfSelB0ToDPiCandidate; // table defined in CandidateSelectionTables.h
+
+  Configurable<double> ptCandMin{"ptCandMin", 0., "Lower bound of candidate pT"};
+  Configurable<double> ptCandMax{"ptCandMax", 50., "Upper bound of candidate pT"};
+  // Enable PID
+  Configurable<bool> usePid{"usePid", true, "Switch for PID selection at track level"};
+  Configurable<bool> acceptPIDNotApplicable{"acceptPIDNotApplicable", true, "Switch to accept Status::PIDNotApplicable [(NotApplicable for one detector) and (NotApplicable or Conditional for the other)] in PID selection"};
+  // TPC PID
+  Configurable<double> ptPidTpcMin{"ptPidTpcMin", 0.15, "Lower bound of track pT for TPC PID"};
+  Configurable<double> ptPidTpcMax{"ptPidTpcMax", 20., "Upper bound of track pT for TPC PID"};
+  Configurable<double> nSigmaTpcMax{"nSigmaTpcMax", 5., "Nsigma cut on TPC only"};
+  Configurable<double> nSigmaTpcCombinedMax{"nSigmaTpcCombinedMax", 5., "Nsigma cut on TPC combined with TOF"};
+  // TOF PID
+  Configurable<double> ptPidTofMin{"ptPidTofMin", 0.15, "Lower bound of track pT for TOF PID"};
+  Configurable<double> ptPidTofMax{"ptPidTofMax", 20., "Upper bound of track pT for TOF PID"};
+  Configurable<double> nSigmaTofMax{"nSigmaTofMax", 5., "Nsigma cut on TOF only"};
+  Configurable<double> nSigmaTofCombinedMax{"nSigmaTofCombinedMax", 5., "Nsigma cut on TOF combined with TPC"};
+  // topological cuts
+  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
+  Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_b0_to_d_pi::cuts[0], nBinsPt, nCutVars, labelsPt, labelsCutVar}, "B0 candidate selection per pT bin"};
+  // QA switch
+  Configurable<bool> activateQA{"activateQA", false, "Flag to enable QA histogram"};
+  // check if selectionFlagD (defined in candidateCreatorB0.cxx) and usePid configurables are in sync
+  bool selectionFlagDAndUsePidInSync = true;
+  // FIXME: store B0 creator configurable (until https://alice.its.cern.ch/jira/browse/O2-3582 solved)
+  int mySelectionFlagD = -1;
+
+  TrackSelectorPID selectorPion;
+
+  HistogramRegistry registry{"registry"};
+
+  void init(InitContext const& initContext)
+  {
+    if (usePid) {
+      selectorPion.setPDG(kPiPlus);
+      selectorPion.setRangePtTPC(ptPidTpcMin, ptPidTpcMax);
+      selectorPion.setRangeNSigmaTPC(-nSigmaTpcMax, nSigmaTpcMax);
+      selectorPion.setRangeNSigmaTPCCondTOF(-nSigmaTpcCombinedMax, nSigmaTpcCombinedMax);
+      selectorPion.setRangePtTOF(ptPidTofMin, ptPidTofMax);
+      selectorPion.setRangeNSigmaTOF(-nSigmaTofMax, nSigmaTofMax);
+      selectorPion.setRangeNSigmaTOFCondTPC(-nSigmaTofCombinedMax, nSigmaTofCombinedMax);
+    }
+
+    if (activateQA) {
+      constexpr int kNBinsSelections = 1 + SelectionStep::NSelectionSteps;
+      std::string labels[kNBinsSelections];
+      labels[0] = "No selection";
+      labels[1 + SelectionStep::RecoSkims] = "Skims selection";
+      labels[1 + SelectionStep::RecoTopol] = "Skims & Topological selections";
+      labels[1 + SelectionStep::RecoPID] = "Skims & Topological & PID selections";
+      static const AxisSpec axisSelections = {kNBinsSelections, 0.5, kNBinsSelections + 0.5, ""};
+      registry.add("hSelections", "Selections;;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisSelections, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+      for (int iBin = 0; iBin < kNBinsSelections; ++iBin) {
+        registry.get<TH2>(HIST("hSelections"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
+      }
+    }
+  }
+
+  /// Apply topological cuts as defined in SelectorCuts.h
+  /// \param hfCandB0 is the B0 candidate
+  /// \param hfCandD is prong1 of B0 candidate
+  /// \param trackPi is prong1 of B0 candidate
+  /// \return true if candidate passes all selections
+  template <typename T>
+  bool selectionTopol(const T& hfCandB0)
+  {
+    auto candpT = hfCandB0.pt();
+    auto ptD = RecoDecay::pt(hfCandB0.pxProng0(), hfCandB0.pyProng0());
+    auto ptPi = RecoDecay::pt(hfCandB0.pxProng1(), hfCandB0.pyProng1());
+
+    int pTBin = findBin(binsPt, candpT);
+    if (pTBin == -1) {
+      // LOGF(info, "B0 topol selection failed at getpTBin");
+      return false;
+    }
+
+    // // check that the candidate pT is within the analysis range
+    // if (candpT < ptCandMin || candpT >= ptCandMax) {
+    //   return false;
+    // }
+
+    // B0 mass cut
+    if (std::abs(invMassB0ToDPi(hfCandB0) - RecoDecay::getMassPDG(pdg::Code::kB0)) > cuts->get(pTBin, "m")) {
+      // Printf("B0 topol selection failed at mass diff check");
+      return false;
+    }
+
+    // pion pt
+    if (ptPi < cuts->get(pTBin, "pT Pi")) {
+      return false;
+    }
+
+    // D- pt
+    if (ptD < cuts->get(pTBin, "pT D")) {
+      return false;
+    }
+
+    /*
+    // D mass cut | already applied in candidateSelectorDplusToPiKPi.cxx
+    if (std::abs(hf_cand_3prong::invMassDplusToPiKPi(hfCandD) - RecoDecay::getMassPDG(pdg::Code::kDMinus)) > cuts->get(pTBin, "DeltaMD")) {
+      return false;
+    }
+    */
+
+    // B0 Decay length
+    if (hfCandB0.decayLength() < cuts->get(pTBin, "B0 decLen")) {
+      return false;
+    }
+
+    // B0 Decay length XY
+    if (hfCandB0.decayLengthXY() < cuts->get(pTBin, "B0 decLenXY")) {
+      return false;
+    }
+
+    // B0 chi2PCA cut
+    if (hfCandB0.chi2PCA() > cuts->get(pTBin, "Chi2PCA")) {
+      return false;
+    }
+
+    // B0 CPA cut
+    if (hfCandB0.cpa() < cuts->get(pTBin, "CPA")) {
+      return false;
+    }
+
+    // d0 of pi
+    if (std::abs(hfCandB0.impactParameter1()) < cuts->get(pTBin, "d0 Pi")) {
+      return false;
+    }
+
+    // d0 of D
+    if (std::abs(hfCandB0.impactParameter0()) < cuts->get(pTBin, "d0 D")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Apply PID selection
+  /// \param pidTrackPi is the PID status of trackPi (prong1 of B0 candidate)
+  /// \return true if prong1 of B0 candidate passes all selections
+  template <typename T = int>
+  bool selectionPID(const T& pidTrackPi)
+  {
+    if (!acceptPIDNotApplicable && pidTrackPi != TrackSelectorPID::Status::PIDAccepted) {
+      return false;
+    }
+    if (acceptPIDNotApplicable && pidTrackPi == TrackSelectorPID::Status::PIDRejected) {
+      return false;
+    }
+
+    return true;
+  }
+
+  void process(HfCandB0 const& hfCandsB0,
+               HfReducedTracksPIDWithSel const&,
+               HfCandB0Config const& configs)
+  {
+    // get DplusPi creator configurable
+    for (const auto& config : configs) {
+      mySelectionFlagD = config.mySelectionFlagD();
+
+      if (usePid && !TESTBIT(mySelectionFlagD, SelectionStep::RecoPID)) {
+        selectionFlagDAndUsePidInSync = false;
+        LOG(warning) << "PID selections required on B0 daughters (usePid=true) but no PID selections on D candidates were required a priori (selectionFlagD<7). Set selectionFlagD=7 in hf-candidate-creator-b0";
+      }
+      if (!usePid && TESTBIT(mySelectionFlagD, SelectionStep::RecoPID)) {
+        selectionFlagDAndUsePidInSync = false;
+        LOG(warning) << "No PID selections required on B0 daughters (usePid=false) but PID selections on D candidates were required a priori (selectionFlagD=7). Set selectionFlagD<7 in hf-candidate-creator-b0";
+      }
+    }
+
+    for (const auto& hfCandB0 : hfCandsB0) {
+      int statusB0ToDPi = 0;
+      auto ptCandB0 = hfCandB0.pt();
+
+      // check if flagged as B0 → D π
+      if (!TESTBIT(hfCandB0.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        hfSelB0ToDPiCandidate(statusB0ToDPi);
+        if (activateQA) {
+          registry.fill(HIST("hSelections"), 1, ptCandB0);
+        }
+        // LOGF(info, "B0 candidate selection failed at hfflag check");
+        continue;
+      }
+      SETBIT(statusB0ToDPi, SelectionStep::RecoSkims); // RecoSkims = 0 --> statusB0ToDPi = 1
+      if (activateQA) {
+        registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoSkims, ptCandB0);
+      }
+
+      // topological cuts
+      if (!selectionTopol(hfCandB0)) {
+        hfSelB0ToDPiCandidate(statusB0ToDPi);
+        // LOGF(info, "B0 candidate selection failed at topology selection");
+        continue;
+      }
+      SETBIT(statusB0ToDPi, SelectionStep::RecoTopol); // RecoTopol = 1 --> statusB0ToDPi = 3
+      if (activateQA) {
+        registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoTopol, ptCandB0);
+      }
+
+      // checking if selectionFlagD and usePid are in sync
+      if (!selectionFlagDAndUsePidInSync) {
+        hfSelB0ToDPiCandidate(statusB0ToDPi);
+        continue;
+      }
+      // track-level PID selection
+      auto trackPi = hfCandB0.prong1_as<HfReducedTracksPIDWithSel>();
+      if (usePid) {
+        int pidTrackPi = selectorPion.getStatusTrackPIDTpcAndTof(trackPi);
+        if (!selectionPID(pidTrackPi)) {
+          // LOGF(info, "B0 candidate selection failed at PID selection");
+          hfSelB0ToDPiCandidate(statusB0ToDPi);
+          continue;
+        }
+        SETBIT(statusB0ToDPi, SelectionStep::RecoPID); // RecoPID = 2 --> statusB0ToDPi = 7
+        if (activateQA) {
+          registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoPID, ptCandB0);
+        }
+      }
+      hfSelB0ToDPiCandidate(statusB0ToDPi);
+      // LOGF(info, "B0 candidate selection passed all selections");
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfReducedCandidateSelectorB0ToDPi>(cfgc)};
+}

--- a/PWGHF/TableProducer/reducedDataCreatorDplusPi.cxx
+++ b/PWGHF/TableProducer/reducedDataCreatorDplusPi.cxx
@@ -1,0 +1,481 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file reducedDataCreatorDplusPi.cxx
+/// \brief Selection of Dplus and Pions tracks
+/// \note
+///
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/CollisionAssociation.h"
+#include "ReconstructionDataFormats/DCA.h"
+#include "ReconstructionDataFormats/V0.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/DataModel/ReducedDataModel.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+// event types
+enum Event : int {
+  Processed = 0,
+  noDPiSelected,
+  DPiSelected,
+  kNEvent
+};
+
+/// Selection of Dplus and Pions
+struct HfReducedDataCreatorDplusPi {
+  // Produces AOD tables to store track information
+  Produces<aod::HfReducedCollisions> hfReducedCollision;
+  Produces<aod::HfReducedTracksWithSel> hfTrackPion;
+  Produces<aod::HfReducedTracksPIDWithSel> hfTrackPIDPion;
+  Produces<aod::HfReducedCand3Prong> hfCand3Prong;
+  Produces<aod::HfCandB0Config> rowCandidateConfig;
+
+  // vertexing
+  // Configurable<double> bz{"bz", 5., "magnetic field"};
+  Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
+  Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
+  Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B0 is smaller than this"};
+  Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
+  // selection
+  Configurable<bool> usePionIsGlobalTrackWoDCA{"usePionIsGlobalTrackWoDCA", true, "check isGlobalTrackWoDCA status for pions, for Run3 studies"};
+  Configurable<double> ptPionMin{"ptPionMin", 0.5, "minimum pion pT threshold (GeV/c)"};
+  Configurable<std::vector<double>> binsPtPion{"binsPtPion", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for pion DCA XY pT-dependent cut"};
+  Configurable<LabeledArray<double>> cutsTrackPionDCA{"cutsTrackPionDCA", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for pions"};
+  Configurable<double> invMassWindowB0{"invMassWindowB0", 0.3, "invariant-mass window for B0 candidates"};
+  Configurable<int> selectionFlagD{"selectionFlagD", 1, "Selection Flag for D"};
+
+  // magnetic field setting from CCDB
+  Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
+  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
+  Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  int runNumber;
+
+  double massPi = RecoDecay::getMassPDG(kPiPlus);
+  double massD = RecoDecay::getMassPDG(pdg::Code::kDMinus);
+  double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
+  double massDPi{0.};
+  double invMassD{0.};
+  double bz{0.};
+
+  bool isHfCandB0ConfigFilled = false;
+
+  // Fitter to redo D-vertex to get extrapolated daughter tracks (3-prong vertex filter)
+  o2::vertexing::DCAFitterN<3> df3;
+
+  // using TracksWithSel = soa::Join<aod::BigTracksExtended, aod::TrackSelection>;
+  using TracksPIDWithSel = soa::Join<aod::BigTracksPIDExtended, aod::TrackSelection>;
+
+  Filter filterSelectCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagD);
+  using CandsDFiltered = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>;
+  Preslice<CandsDFiltered> candsDPerCollision = aod::track_association::collisionId;
+
+  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+
+  HistogramRegistry registry{"registry"};
+
+  void init(InitContext const&)
+  {
+    // histograms
+    constexpr int kNBinsEvents = kNEvent;
+    std::string labels[kNBinsEvents];
+    labels[Event::Processed] = "processed";
+    labels[Event::noDPiSelected] = "without DPi pairs";
+    labels[Event::DPiSelected] = "with DPi pairs";
+    static const AxisSpec axisEvents = {kNBinsEvents, 0.5, kNBinsEvents + 0.5, ""};
+    registry.add("hEvents", "Events;;entries", HistType::kTH1F, {axisEvents});
+    for (int iBin = 0; iBin < kNBinsEvents; iBin++) {
+      registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
+    }
+
+    registry.add("hMassDToPiKPi", "D^{#minus} candidates;inv. mass (p^{#minus} K^{#plus} #pi^{#minus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}});
+    registry.add("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("hCPAD", "D^{#minus} candidates;D^{#minus} cosine of pointing angle;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
+
+    // Initialize fitter
+    df3.setPropagateToPCA(propagateToPCA);
+    df3.setMaxR(maxR);
+    df3.setMaxDZIni(maxDZIni);
+    df3.setMinParamChange(minParamChange);
+    df3.setMinRelChi2Change(minRelChi2Change);
+    df3.setUseAbsDCA(useAbsDCA);
+    df3.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Configure CCDB access
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdb->get<TGeoManager>(ccdbPathGeo);
+    }
+    runNumber = 0;
+  }
+
+  /// Pion selection (D Pi <-- B0)
+  /// \param trackPion is a track with the pion hypothesis
+  /// \param track0 is prong0 of selected D candidate
+  /// \param track1 is prong1 of selected D candidate
+  /// \param track2 is prong2 of selected D candidate
+  /// \param indexD is an array of globalIndex of each D prong
+  /// \return true if trackPion passes all cuts
+  template <typename T1, typename T2>
+  bool isPionSelected(const T1& trackPion, const T2& track0, const T2& track1, const T2& track2)
+  {
+    // check isGlobalTrackWoDCA status for pions if wanted
+    if (usePionIsGlobalTrackWoDCA && !trackPion.isGlobalTrackWoDCA()) {
+      return false;
+    }
+    // minimum pT selection
+    if (trackPion.pt() < ptPionMin || !isSelectedTrackDCA(trackPion)) {
+      return false;
+    }
+    // reject pions that are D daughters
+    if (trackPion.globalIndex() == track0.globalIndex() || trackPion.globalIndex() == track1.globalIndex() || trackPion.globalIndex() == track2.globalIndex()) {
+      return false;
+    }
+    // reject pi D with same sign as D
+    if (trackPion.sign() * track0.sign() > 0) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Single-track cuts for pions on dcaXY
+  /// \param track is a track
+  /// \return true if track passes all cuts
+  template <typename T>
+  bool isSelectedTrackDCA(const T& track)
+  {
+    auto pTBinTrack = findBin(binsPtPion, track.pt());
+    if (pTBinTrack == -1) {
+      return false;
+    }
+
+    if (std::abs(track.dcaXY()) < cutsTrackPionDCA->get(pTBinTrack, "min_dcaxytoprimary")) {
+      return false; // minimum DCAxy
+    }
+    if (std::abs(track.dcaXY()) > cutsTrackPionDCA->get(pTBinTrack, "max_dcaxytoprimary")) {
+      return false; // maximum DCAxy
+    }
+    return true;
+  }
+
+  void process(aod::Collisions const& collisions,
+               CandsDFiltered const& candsD,
+               aod::TrackAssoc const& trackIndices,
+               TracksPIDWithSel const&,
+               aod::BCsWithTimestamps const&)
+  {
+    // store configurables needed for B0 workflow
+    if (!isHfCandB0ConfigFilled) {
+      int mySelectionFlagD = selectionFlagD;
+      rowCandidateConfig(mySelectionFlagD);
+      isHfCandB0ConfigFilled = true;
+    }
+
+    // handle normalization by the right number of collisions
+    auto collisionTableSize = collisions.tableSize();
+    // identify the original AOD table by collisionTableId
+    // that shall be incremented for each process function
+    // i.e. for each new aod::Collisions table called
+    static int collisionTableId = 0;
+    collisionTableId++;
+
+    static int ncol = 0;
+    for (const auto& collision : collisions) {
+      ncol++;
+      std::vector<int> selectedTracksPion = {};
+      bool fillHfReducedCollision = false;
+      auto primaryVertex = getPrimaryVertex(collision);
+      if (ncol % 10000 == 0) {
+        LOG(info) << ncol << " collisions parsed";
+      }
+
+      /// Set the magnetic field from ccdb.
+      /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
+      /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      if (runNumber != bc.runNumber()) {
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
+        initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+        bz = o2::base::Propagator::Instance()->getNominalBz();
+        LOG(info) << ">>>>>>>>>>>> Magnetic field: " << bz;
+      }
+      df3.setBz(bz);
+
+      auto thisCollId = collision.globalIndex();
+      auto candsDThisColl = candsD.sliceBy(candsDPerCollision, thisCollId);
+
+      for (const auto& candD : candsDThisColl) {
+        bool fillHfCand3Prong = false;
+        float invMassD;
+
+        registry.fill(HIST("hMassDToPiKPi"), invMassDplusToPiKPi(candD));
+        registry.fill(HIST("hPtD"), candD.pt());
+        registry.fill(HIST("hCPAD"), candD.cpa());
+
+        // track0 <-> pi, track1 <-> K, track2 <-> pi
+        auto track0 = candD.prong0_as<TracksPIDWithSel>();
+        auto track1 = candD.prong1_as<TracksPIDWithSel>();
+        auto track2 = candD.prong2_as<TracksPIDWithSel>();
+        auto trackParCov0 = getTrackParCov(track0);
+        auto trackParCov1 = getTrackParCov(track1);
+        auto trackParCov2 = getTrackParCov(track2);
+
+        std::array<float, 3> pVec0 = {track0.px(), track0.py(), track0.pz()};
+        std::array<float, 3> pVec1 = {track1.px(), track1.py(), track1.pz()};
+        std::array<float, 3> pVec2 = {track2.px(), track2.py(), track2.pz()};
+
+        auto dca0 = o2::dataformats::DCA(track0.dcaXY(), track0.dcaZ(), track0.cYY(), track0.cZY(), track0.cZZ());
+        auto dca1 = o2::dataformats::DCA(track1.dcaXY(), track1.dcaZ(), track1.cYY(), track1.cZY(), track1.cZZ());
+        auto dca2 = o2::dataformats::DCA(track2.dcaXY(), track2.dcaZ(), track2.cYY(), track2.cZY(), track2.cZZ());
+
+        // repropagate tracks to this collision if needed
+        if (track0.collisionId() != thisCollId) {
+          trackParCov0.propagateToDCA(primaryVertex, bz, &dca0);
+        }
+
+        if (track1.collisionId() != thisCollId) {
+          trackParCov1.propagateToDCA(primaryVertex, bz, &dca1);
+        }
+
+        if (track2.collisionId() != thisCollId) {
+          trackParCov2.propagateToDCA(primaryVertex, bz, &dca2);
+        }
+
+        // ---------------------------------
+        // reconstruct 3-prong secondary vertex (D±)
+        if (df3.process(trackParCov0, trackParCov1, trackParCov2) == 0) {
+          continue;
+        }
+
+        const auto& secondaryVertexD = df3.getPCACandidate();
+        // propagate the 3 prongs to the secondary vertex
+        trackParCov0.propagateTo(secondaryVertexD[0], bz);
+        trackParCov1.propagateTo(secondaryVertexD[0], bz);
+        trackParCov2.propagateTo(secondaryVertexD[0], bz);
+
+        // update pVec of tracks
+        df3.getTrack(0).getPxPyPzGlo(pVec0);
+        df3.getTrack(1).getPxPyPzGlo(pVec1);
+        df3.getTrack(2).getPxPyPzGlo(pVec2);
+
+        // D∓ → π∓ K± π∓
+        std::array<float, 3> pVecPiK = RecoDecay::pVec(pVec0, pVec1);
+        std::array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1, pVec2);
+        auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(),
+                                                  trackParCov0, trackParCov1, {0, 0}, {0, 0});
+        auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(),
+                                                trackParCovPiK, trackParCov2, {0, 0}, {0, 0});
+
+        auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+        for (const auto& trackId : trackIdsThisCollision) {
+          auto trackPion = trackId.track_as<TracksPIDWithSel>();
+
+          // apply selections on pion tracks
+          if (!isPionSelected(trackPion, track0, track1, track2) || !isSelectedTrackDCA(trackPion)) {
+            continue;
+          }
+          registry.fill(HIST("hPtPion"), trackPion.pt());
+          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          // compute invariant mass and apply selection
+          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+          if (std::abs(massDPi - massB0) > invMassWindowB0) {
+            continue;
+          }
+
+          invMassD = hf_reduced_cand_3prong::invMassDplusToPiKPi(pVec0, pVec1, pVec2);
+
+          // fill Pion tracks table
+          // if information on track already stored, go to next track
+          if (!std::count(selectedTracksPion.begin(), selectedTracksPion.end(), trackPion.globalIndex())) {
+            hfTrackPion(trackPion.globalIndex(), thisCollId,
+                        trackPion.x(), trackPion.alpha(),
+                        trackPion.y(), trackPion.z(), trackPion.snp(),
+                        trackPion.tgl(), trackPion.signed1Pt(),
+                        trackPion.cYY(), trackPion.cZY(), trackPion.cZZ(),
+                        trackPion.cSnpY(), trackPion.cSnpZ(),
+                        trackPion.cSnpSnp(), trackPion.cTglY(), trackPion.cTglZ(),
+                        trackPion.cTglSnp(), trackPion.cTglTgl(),
+                        trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
+                        trackPion.c1PtTgl(), trackPion.c1Pt21Pt2(),
+                        trackPion.px(), trackPion.py(), trackPion.pz());
+            hfTrackPIDPion(thisCollId, trackPion.pt(),
+                           trackPion.hasTPC(), trackPion.hasTOF(),
+                           trackPion.tpcNSigmaEl(), trackPion.tpcNSigmaMu(), trackPion.tpcNSigmaPi(), trackPion.tpcNSigmaKa(), trackPion.tpcNSigmaPr(),
+                           trackPion.tofNSigmaEl(), trackPion.tofNSigmaMu(), trackPion.tofNSigmaPi(), trackPion.tofNSigmaKa(), trackPion.tofNSigmaPr());
+            // add trackPion.globalIndex() to a list
+            // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another D candidate
+            selectedTracksPion.emplace_back(trackPion.globalIndex());
+          }
+          fillHfCand3Prong = true;
+        }                       // pion loop
+        if (fillHfCand3Prong) { // fill candDplus table only once per D candidate
+          hfCand3Prong(track0.globalIndex(), track1.globalIndex(), track2.globalIndex(),
+                       thisCollId,
+                       trackParCovD.getX(), trackParCovD.getAlpha(),
+                       trackParCovD.getY(), trackParCovD.getZ(), trackParCovD.getSnp(),
+                       trackParCovD.getTgl(), trackParCovD.getQ2Pt(),
+                       trackParCovD.getSigmaY2(), trackParCovD.getSigmaZY(), trackParCovD.getSigmaZ2(),
+                       trackParCovD.getSigmaSnpY(), trackParCovD.getSigmaSnpZ(),
+                       trackParCovD.getSigmaSnp2(), trackParCovD.getSigmaTglY(), trackParCovD.getSigmaTglZ(),
+                       trackParCovD.getSigmaTglSnp(), trackParCovD.getSigmaTgl2(),
+                       trackParCovD.getSigma1PtY(), trackParCovD.getSigma1PtZ(), trackParCovD.getSigma1PtSnp(),
+                       trackParCovD.getSigma1PtTgl(), trackParCovD.getSigma1Pt2(),
+                       pVecD[0], pVecD[1], pVecD[2],
+                       candD.cpa(),
+                       candD.decayLength(),
+                       invMassD);
+          fillHfReducedCollision = true;
+        }
+      } // candsD loop
+      registry.fill(HIST("hEvents"), 1 + Event::Processed);
+      if (!fillHfReducedCollision) {
+        registry.fill(HIST("hEvents"), 1 + Event::noDPiSelected);
+        continue;
+      }
+      registry.fill(HIST("hEvents"), 1 + Event::DPiSelected);
+      // fill collision table if it contains a DPi pair a minima
+      hfReducedCollision(thisCollId,
+                         collision.posX(), collision.posY(), collision.posZ(),
+                         collision.covXX(), collision.covXY(), collision.covYY(),
+                         collision.covXZ(), collision.covYZ(), collision.covZZ(),
+                         bz,
+                         collisionTableId, collisionTableSize);
+    } // collision
+  }   // process
+};    // struct
+
+/// Extends the base table with expression columns and performs MC matching.
+struct HfReducedDataCreatorDplusPiExpressions {
+  Produces<aod::HfReducedDPiMcRec> rowHfReducedDPiMcRec;
+  Produces<aod::HfReducedB0McGen> rowHfReducedB0McGen;
+
+  void init(InitContext const&) {}
+
+  void processMc(aod::HfReducedCand3Prong const& candsD,
+                 aod::HfReducedTracksWithSel const& tracksPion,
+                 aod::BigTracksMC const&,
+                 aod::McParticles const& particlesMc)
+  {
+    int indexRec = -1;
+    int8_t sign = 0;
+    int8_t flag = 0;
+    int8_t origin = 0;
+    int8_t debug = 0;
+
+    for (const auto& candD : candsD) {
+      auto arrayDaughtersD = array{candD.prong0_as<aod::BigTracksMC>(),
+                                   candD.prong1_as<aod::BigTracksMC>(),
+                                   candD.prong2_as<aod::BigTracksMC>()};
+
+      for (const auto& trackPion : tracksPion) {
+        if (trackPion.collisionId() != candD.collisionId()) {
+          continue;
+        }
+        // const auto& trackId = trackPion.globalIndex();
+        auto arrayDaughtersB0 = array{candD.prong0_as<aod::BigTracksMC>(),
+                                      candD.prong1_as<aod::BigTracksMC>(),
+                                      candD.prong2_as<aod::BigTracksMC>(),
+                                      trackPion.track_as<aod::BigTracksMC>()};
+        // B0 → D- π+ → (π- K+ π-) π+
+        // Printf("Checking B0 → D- π+");
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);
+        if (indexRec > -1) {
+          // D- → π- K+ π-
+          // Printf("Checking D- → π- K+ π-");
+          indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+          if (indexRec > -1) {
+            flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
+          } else {
+            debug = 1;
+            LOGF(info, "WARNING: B0 decays in the expected final state but the condition on the intermediate state is not fulfilled");
+          }
+        }
+        auto indexMother = RecoDecay::getMother(particlesMc, trackPion.track_as<aod::BigTracksMC>().mcParticle_as<aod::McParticles>(), pdg::Code::kB0, true);
+        auto particleMother = particlesMc.rawIteratorAt(indexMother);
+
+        rowHfReducedDPiMcRec(candD.globalIndex(), trackPion.globalIndex(), flag, origin, debug, particleMother.pt());
+      }
+    } // rec
+
+    // Match generated particles.
+    for (auto const& particle : particlesMc) {
+      // Printf("New gen. candidate");
+      flag = 0;
+      origin = 0;
+      // B0 → D- π+
+      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
+        // Match D- -> π- K+ π-
+        auto candDMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
+        // Printf("Checking D- -> π- K+ π-");
+        if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
+          flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
+        }
+      }
+
+      // save information for B0 task
+      if (!TESTBIT(std::abs(flag), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+
+      auto ptParticle = particle.pt();
+      auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+      auto etaParticle = particle.eta();
+
+      std::array<float, 2> ptProngs;
+      std::array<float, 2> yProngs;
+      std::array<float, 2> etaProngs;
+      int counter = 0;
+      for (auto const& daught : particle.daughters_as<aod::McParticles>()) {
+        ptProngs[counter] = daught.pt();
+        etaProngs[counter] = daught.eta();
+        yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+        counter++;
+      }
+      rowHfReducedB0McGen(flag, origin,
+                          ptParticle, yParticle, etaParticle,
+                          ptProngs[0], yProngs[0], etaProngs[0],
+                          ptProngs[1], yProngs[1], etaProngs[1]);
+    } // gen
+
+  } // processMc
+  PROCESS_SWITCH(HfReducedDataCreatorDplusPiExpressions, processMc, "Process MC", false);
+}; // struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HfReducedDataCreatorDplusPi>(cfgc),
+    adaptAnalysisTask<HfReducedDataCreatorDplusPiExpressions>(cfgc)};
+}


### PR DESCRIPTION
Hi @fgrosa @iouribelikov , here is the result of the "workflow splitting". The goal is to split the whole B0 workflow in two parts:

(usual workflow up to DPlusPi pair creation) `workflow1` --> `reducedAODs` --> `workflow 2` (B0 creator, selector and task)

`workflow 1` would run on Hyperloop, produce `reducedAODs` files that shall be consumed by `workflow 2`. This `workflow 2` could then run locally (or on Hyperloop) with way lower computation time (allowing faster testing/modifications of the B0-dedicated tasks).

Only collisions containing at least one DPi pair are saved in `reducedAODs`, this requires a careful handling of the total number of collisions studied for normalization purposes. In this spirit, we store the size of each `COLLISION` table called in `process` function of `ReducedDataCreatorDplusPi.cxx`  and associate a `collisionTableId` to it (to avoid overcounting in `reducedCandidateCreatorB0.cxx`).

New files introduced:
- `ReducedDataModel.h` : header file with all needed table and methods 
- `ReducedDataCreatorDplusPi.cxx` : task to produce DPi pairs and fill `reducedAODs`
- `reducedCandidateCreatorB0.cxx` : task to create B0 candidates only consuming `reducedAODs`
- `reducedCandidateSelectorB0ToDPi.cxx` : task to select B0 candidates consuming B0 creator output and `reducedAODs`
- `reducedTaskB0.cxx` : analysis task consuming B0 creator&selector outputs, along with  `reducedAODs`