### PR TITLE
PWGHF: remove nITSClusters selection on pi<-casc

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
@@ -271,9 +271,6 @@ struct HfCandidateSelectorToXiPi {
       if (trackPiFromOmeg.itsNClsInnerBarrel() < nClustersItsInnBarrMin) {
         resultSelections = false;
       }
-      if (trackPiFromCasc.itsNCls() < nClustersItsMin) {
-        resultSelections = false;
-      }
 
       // track-level PID selection
       int pidProton = -999;


### PR DESCRIPTION
Only one deletion:
- remove nITSClusters selection on pi<-casc