### PR TITLE
[PWGJE: Preparation Validation Framework] Implementing reduced set of trackcuts as filtBit5

### DIFF
--- a/ALICE3/TableProducer/alice3-trackselection.cxx
+++ b/ALICE3/TableProducer/alice3-trackselection.cxx
@@ -71,7 +71,7 @@ struct Alice3TrackSelectionTask {
         histos.fill(HIST("eta/selected"), track.eta());
       }
 
-      filterTable(sel, 1, false, false, false, false);
+      filterTable(sel, 1, false, false, false, false, false); // bool for filtB.
     }
   }
 };

--- a/Common/Core/TrackSelectionDefaults.cxx
+++ b/Common/Core/TrackSelectionDefaults.cxx
@@ -113,7 +113,7 @@ TrackSelection getJEGlobalTrackSelectionRun2()
   TrackSelection selectedTracks = getGlobalTrackSelection();
   selectedTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
   selectedTracks.SetRequireGoldenChi2(false);
-  selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10;});//std::function<float(float)>{}
+  selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10; }); // std::function<float(float)>{}
   selectedTracks.SetEtaRange(-0.9f, 0.9f);
   selectedTracks.SetMaxDcaXY(2.4f);
   selectedTracks.SetMaxDcaZ(3.2f);

--- a/Common/Core/TrackSelectionDefaults.cxx
+++ b/Common/Core/TrackSelectionDefaults.cxx
@@ -82,7 +82,7 @@ TrackSelection getGlobalTrackSelectionSDD()
 // Default track selection for nuclei analysis in run3 (STILL JUST A PLACEHOLDER)
 TrackSelection getGlobalTrackSelectionRun3Nuclei()
 {
-  return getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSibTwo);
+  return getGlobalTrackSelection();
 }
 
 // Default track selection for HF analysis (global tracks, with its points, but no tight selection for primary) in run3 (STILL JUST A PLACEHOLDER)
@@ -104,6 +104,19 @@ TrackSelection getGlobalTrackSelectionRun3HF()
   selectedTracks.SetMaxDcaZ(2.f);
   selectedTracks.SetMaxDcaXY(0.25);
 
+  return selectedTracks;
+}
+
+// Reduced default track selection for jet validation based on hybrid cuts for converted (based on ESD's from run 2) A02D's
+TrackSelection getJEGlobalTrackSelectionRun2()
+{
+  TrackSelection selectedTracks = getGlobalTrackSelection();
+  selectedTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
+  selectedTracks.SetRequireGoldenChi2(false);
+  selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10;});//std::function<float(float)>{}
+  selectedTracks.SetEtaRange(-0.9f, 0.9f);
+  selectedTracks.SetMaxDcaXY(2.4f);
+  selectedTracks.SetMaxDcaZ(3.2f);
   return selectedTracks;
 }
 

--- a/Common/Core/TrackSelectionDefaults.cxx
+++ b/Common/Core/TrackSelectionDefaults.cxx
@@ -82,7 +82,7 @@ TrackSelection getGlobalTrackSelectionSDD()
 // Default track selection for nuclei analysis in run3 (STILL JUST A PLACEHOLDER)
 TrackSelection getGlobalTrackSelectionRun3Nuclei()
 {
-  return getGlobalTrackSelection();
+  return getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSibTwo);
 }
 
 // Default track selection for HF analysis (global tracks, with its points, but no tight selection for primary) in run3 (STILL JUST A PLACEHOLDER)
@@ -113,7 +113,7 @@ TrackSelection getJEGlobalTrackSelectionRun2()
   TrackSelection selectedTracks = getGlobalTrackSelection();
   selectedTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
   selectedTracks.SetRequireGoldenChi2(false);
-  selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10; }); // std::function<float(float)>{}
+  selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10; });
   selectedTracks.SetEtaRange(-0.9f, 0.9f);
   selectedTracks.SetMaxDcaXY(2.4f);
   selectedTracks.SetMaxDcaZ(3.2f);

--- a/Common/Core/TrackSelectionDefaults.h
+++ b/Common/Core/TrackSelectionDefaults.h
@@ -37,4 +37,7 @@ TrackSelection getGlobalTrackSelectionRun3Nuclei();
 // Default track selection for HF analysis (global tracks, with its points, but no tight selection for primary) in run3
 TrackSelection getGlobalTrackSelectionRun3HF();
 
+// Global track selection for Run2 JE Hybrid tracks requiring one hit in the SPD and reduced set of cuts
+TrackSelection getJEGlobalTrackSelectionRun2();
+
 #endif // COMMON_CORE_TRACKSELECTIONDEFAULTS_H_

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -149,7 +149,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
-		              track::TrackCutFlagFb5,
+                  track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -149,7 +149,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
-                  track::TrackCutFlagFb5,
+		              track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,
@@ -158,6 +158,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::IsGlobalTrackWoPtEta<track::TrackCutFlag>,
                   track::IsGlobalTrackWoDCA<track::TrackCutFlag>,
                   track::IsGlobalTrackWoDCATPCCluster<track::TrackCutFlag>);
+                  
 
 DECLARE_SOA_TABLE(TrackSelectionExtension, "AOD", "TRACKSELEXTRA", //! Information on the track selections set by each Filter Bit
                   track::PassedTrackType,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -149,7 +149,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
-		              track::TrackCutFlagFb5,
+                  track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,
@@ -158,7 +158,6 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::IsGlobalTrackWoPtEta<track::TrackCutFlag>,
                   track::IsGlobalTrackWoDCA<track::TrackCutFlag>,
                   track::IsGlobalTrackWoDCATPCCluster<track::TrackCutFlag>);
-                  
 
 DECLARE_SOA_TABLE(TrackSelectionExtension, "AOD", "TRACKSELEXTRA", //! Information on the track selections set by each Filter Bit
                   track::PassedTrackType,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -89,6 +89,7 @@ DECLARE_SOA_COLUMN(TrackCutFlagFb1, trackCutFlagFb1, bool);                    /
 DECLARE_SOA_COLUMN(TrackCutFlagFb2, trackCutFlagFb2, bool);                    //! Flag with the single cut passed flagged for the second selection criteria (as general but 2 point2 in ITS IB)
 DECLARE_SOA_COLUMN(TrackCutFlagFb3, trackCutFlagFb3, bool);                    //! Flag with the single cut passed flagged for the third selection criteria (HF-like: global w/o tight DCA selection)
 DECLARE_SOA_COLUMN(TrackCutFlagFb4, trackCutFlagFb4, bool);                    //! Flag with the single cut passed flagged for the fourth selection criteria (nuclei)
+DECLARE_SOA_COLUMN(TrackCutFlagFb5, trackCutFlagFb5, bool);                    //! Flag with the single cut passed flagged for the fith selection criteria (jet validation - reduced set of cuts)
 
 #define DECLARE_DYN_TRKSEL_COLUMN(name, getter, mask) \
   DECLARE_SOA_DYNAMIC_COLUMN(name, getter, [](TrackSelectionFlags::flagtype flags) -> bool { return TrackSelectionFlags::checkFlag(flags, mask); });
@@ -148,14 +149,13 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
+		              track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,
                   track::IsGlobalTrack<track::TrackCutFlag>,
-                  track::IsGlobalTrackWoTPCCluster<track::TrackCutFlag>,
                   track::IsGlobalTrackWoPtEta<track::TrackCutFlag>,
-                  track::IsGlobalTrackWoDCA<track::TrackCutFlag>,
-                  track::IsGlobalTrackWoDCATPCCluster<track::TrackCutFlag>);
+                  track::IsGlobalTrackWoDCA<track::TrackCutFlag>);
 
 DECLARE_SOA_TABLE(TrackSelectionExtension, "AOD", "TRACKSELEXTRA", //! Information on the track selections set by each Filter Bit
                   track::PassedTrackType,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -149,13 +149,16 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb2,
                   track::TrackCutFlagFb3,
                   track::TrackCutFlagFb4,
-                  track::TrackCutFlagFb5,
+		              track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,
                   track::IsGlobalTrack<track::TrackCutFlag>,
+                  track::IsGlobalTrackWoTPCCluster<track::TrackCutFlag>,
                   track::IsGlobalTrackWoPtEta<track::TrackCutFlag>,
-                  track::IsGlobalTrackWoDCA<track::TrackCutFlag>);
+                  track::IsGlobalTrackWoDCA<track::TrackCutFlag>,
+                  track::IsGlobalTrackWoDCATPCCluster<track::TrackCutFlag>);
+                  
 
 DECLARE_SOA_TABLE(TrackSelectionExtension, "AOD", "TRACKSELEXTRA", //! Information on the track selections set by each Filter Bit
                   track::PassedTrackType,

--- a/Common/TableProducer/trackselection.cxx
+++ b/Common/TableProducer/trackselection.cxx
@@ -53,6 +53,7 @@ struct TrackSelectionTask {
   TrackSelection filtBit2;
   TrackSelection filtBit3;
   TrackSelection filtBit4;
+  TrackSelection filtBit5;
 
   void init(InitContext&)
   {
@@ -99,7 +100,6 @@ struct TrackSelectionTask {
       }
     }
 
-    globalTracks.print();
     // Extra requirement on the ITS -> Run 2: asking for 1 hit SDD and no hit in SPD
     globalTracksSDD = getGlobalTrackSelectionSDD();
     globalTracksSDD.SetPtRange(ptMin, ptMax);
@@ -112,15 +112,13 @@ struct TrackSelectionTask {
     filtBit3 = getGlobalTrackSelectionRun3HF();
 
     filtBit4 = getGlobalTrackSelectionRun3Nuclei();
+
+    LOG(info) << "setting up filtBit5 = getJEGlobalTrackSelectionRun2();";
+    filtBit5 = getJEGlobalTrackSelectionRun2(); // Jet validation requires reduced set of cuts
   }
 
   void process(soa::Join<aod::FullTracks, aod::TracksDCA> const& tracks)
   {
-    filterTable.reserve(tracks.size());
-    if (produceFBextendedTable) {
-      filterTableDetail.reserve(tracks.size());
-    }
-
     if (isRun3) {
       for (auto& track : tracks) {
         o2::aod::track::TrackSelectionFlags::flagtype trackflagGlob = globalTracks.IsSelectedMask(track);
@@ -128,9 +126,10 @@ struct TrackSelectionTask {
         o2::aod::track::TrackSelectionFlags::flagtype trackflagFB2 = filtBit2.IsSelectedMask(track);
         // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB3 = filtBit3.IsSelectedMask(track); // only temporarily commented, will be used
         // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB4 = filtBit4.IsSelectedMask(track);
+        // o2::aod::track::TrackSelectionFlags::flagtype trackflagFB5 = filtBit5.IsSelectedMask(track);
 
         filterTable((uint8_t)0,
-                    globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track));
+                    globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track), filtBit5.IsSelected(track));
         if (produceFBextendedTable) {
           filterTableDetail(o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kTrackType),
                             o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kPtRange),
@@ -157,7 +156,7 @@ struct TrackSelectionTask {
     for (auto& track : tracks) {
       o2::aod::track::TrackSelectionFlags::flagtype trackflagGlob = globalTracks.IsSelectedMask(track);
       filterTable((uint8_t)globalTracksSDD.IsSelected(track),
-                  globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track));
+                  globalTracks.IsSelectedMask(track), filtBit1.IsSelected(track), filtBit2.IsSelected(track), filtBit3.IsSelected(track), filtBit4.IsSelected(track), filtBit5.IsSelected(track));
       if (produceFBextendedTable) {
         filterTableDetail(o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kTrackType),
                           o2::aod::track::TrackSelectionFlags::checkFlag(trackflagGlob, o2::aod::track::TrackSelectionFlags::kPtRange),

--- a/Common/TableProducer/trackselection.cxx
+++ b/Common/TableProducer/trackselection.cxx
@@ -99,7 +99,7 @@ struct TrackSelectionTask {
         globalTracks.SetTrackType(o2::aod::track::TrackTypeEnum::TrackIU);
       }
     }
-
+    globalTracks.print();
     // Extra requirement on the ITS -> Run 2: asking for 1 hit SDD and no hit in SPD
     globalTracksSDD = getGlobalTrackSelectionSDD();
     globalTracksSDD.SetPtRange(ptMin, ptMax);
@@ -119,6 +119,10 @@ struct TrackSelectionTask {
 
   void process(soa::Join<aod::FullTracks, aod::TracksDCA> const& tracks)
   {
+    filterTable.reserve(tracks.size());
+    if (produceFBextendedTable) {
+      filterTableDetail.reserve(tracks.size());
+    }
     if (isRun3) {
       for (auto& track : tracks) {
         o2::aod::track::TrackSelectionFlags::flagtype trackflagGlob = globalTracks.IsSelectedMask(track);

--- a/DPG/Tasks/AOTTrack/MonitorFilterBit.cxx
+++ b/DPG/Tasks/AOTTrack/MonitorFilterBit.cxx
@@ -103,6 +103,8 @@ struct CheckFilterBit {
         histos.fill(HIST("Tracks/Reco/histpt3DFB3"), track.pt(), track.eta(), track.phi());
       if (track.trackCutFlagFb4())
         histos.fill(HIST("Tracks/Reco/histpt3DFB4"), track.pt(), track.eta(), track.phi());
+      if (track.trackCutFlagFb5())
+        histos.fill(HIST("Tracks/Reco/histpt3DFB5"), track.pt(), track.eta(), track.phi());
     }
   }
   PROCESS_SWITCH(CheckFilterBit, processData, "process data", true);
@@ -152,6 +154,9 @@ struct CheckFilterBit {
               if (track.trackCutFlagFb4()) {
                 histos.fill(HIST("Tracks/RecoMCPhysPrimCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
               }
+              if (track.trackCutFlagFb5()){
+                histos.fill(HIST("Tracks/RecoMCPhysPrimCollMatch/histptFB5"), track.pt(), track.eta(), track.phi());
+              }
               if (isHF == RecoDecay::OriginType::Prompt || isHF == RecoDecay::OriginType::NonPrompt) {
                 if (track.isGlobalTrack()) {
                   histos.fill(HIST("Tracks/RecoMCfromHFdecayCollMatch/histptFB0"), track.pt(), track.eta(), track.phi());
@@ -168,6 +173,9 @@ struct CheckFilterBit {
                 if (track.trackCutFlagFb4()) {
                   histos.fill(HIST("Tracks/RecoMCfromHFdecayCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
                 }
+                if (track.trackCutFlagFb5()){
+                  histos.fill(HIST("Tracks/RecoMCfromHFdecayCollMatch/histptFB5"), track.pt(), track.eta(), track.phi());
+                }
               }
             } else if (prodRadius2 > 1. && prodRadius2 < 225.) {
               if (track.isGlobalTrack())
@@ -180,6 +188,8 @@ struct CheckFilterBit {
                 histos.fill(HIST("Tracks/RecoMCRad1to15cmCollMatch/histptFB3"), track.pt(), track.eta(), track.phi());
               if (track.trackCutFlagFb4())
                 histos.fill(HIST("Tracks/RecoMCRad1to15cmCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
+              if (track.trackCutFlagFb5())
+                histos.fill(HIST("Tracks/RecoMCRad1to15cmCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
             }
             if (prodRadius2 > 1.e-8 && prodRadius2 < 0.25) {
               if (track.isGlobalTrack())
@@ -191,6 +201,8 @@ struct CheckFilterBit {
               if (track.trackCutFlagFb3())
                 histos.fill(HIST("Tracks/RecoMCRad1mumto5mmCollMatch/histptFB3"), track.pt(), track.eta(), track.phi());
               if (track.trackCutFlagFb4())
+                histos.fill(HIST("Tracks/RecoMCRad1mumto5mmCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
+              if (track.trackCutFlagFb5())
                 histos.fill(HIST("Tracks/RecoMCRad1mumto5mmCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
             }
           }

--- a/DPG/Tasks/AOTTrack/MonitorFilterBit.cxx
+++ b/DPG/Tasks/AOTTrack/MonitorFilterBit.cxx
@@ -154,7 +154,7 @@ struct CheckFilterBit {
               if (track.trackCutFlagFb4()) {
                 histos.fill(HIST("Tracks/RecoMCPhysPrimCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
               }
-              if (track.trackCutFlagFb5()){
+              if (track.trackCutFlagFb5()) {
                 histos.fill(HIST("Tracks/RecoMCPhysPrimCollMatch/histptFB5"), track.pt(), track.eta(), track.phi());
               }
               if (isHF == RecoDecay::OriginType::Prompt || isHF == RecoDecay::OriginType::NonPrompt) {
@@ -173,7 +173,7 @@ struct CheckFilterBit {
                 if (track.trackCutFlagFb4()) {
                   histos.fill(HIST("Tracks/RecoMCfromHFdecayCollMatch/histptFB4"), track.pt(), track.eta(), track.phi());
                 }
-                if (track.trackCutFlagFb5()){
+                if (track.trackCutFlagFb5()) {
                   histos.fill(HIST("Tracks/RecoMCfromHFdecayCollMatch/histptFB5"), track.pt(), track.eta(), track.phi());
                 }
               }

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -66,7 +66,7 @@ bool selectTrack(T const& track, std::string trackSelection)
     return false;
   } else if (trackSelection == "QualityTracks" && !track.isQualityTrack()) {
     return false;
-  } else if (trackSelection == "hybridTracksJE" && !track.trackCutFlagFb5()) {//isQualityTrack
+  } else if (trackSelection == "hybridTracksJE" && !track.trackCutFlagFb5()) { // isQualityTrack
     return false;
   } else {
     return true;

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -66,6 +66,8 @@ bool selectTrack(T const& track, std::string trackSelection)
     return false;
   } else if (trackSelection == "QualityTracks" && !track.isQualityTrack()) {
     return false;
+  } else if (trackSelection == "hybridTracksJE" && !track.trackCutFlagFb5()) {//isQualityTrack
+    return false;
   } else {
     return true;
   }


### PR DESCRIPTION
Dear @njacazio , @mfaggin , @arossi81, @raymondEhlers , @nzardosh , @fkrizek, 

To proceed with and improve the jetfinder validation on run2 ESD's (converted on the flight to AODs) we would like to add the filterBit5 to create very loose cuts similarly to the jethybrid cuts from complementary tracks in AliPhysics. This filterBit will not be called for hyperloop operations, unless the `DPG/Tasks/AOTTrack/MonitorFilterBit.cxx` proves them to be a good choice and other analyzers are interested in using them. For the PWGJE validation framework I propose these changes to the following files:

**Required:**

* `ALICE3/TableProducer/alice3-trackselection.cxx`: requires additional bool for the filterTable
* `Common/Core/TrackSelectionDefaults.cxx & Common/Core/TrackSelectionDefaults.h`: adding the trackselection getJEGlobalTrackSelectionRun2 which calls and resets the getGlobalTracks()
* `Common/DataModel/TrackSelectionTables.h`: extending the table with the filterBit5 
* `Common/TableProducer/trackselection.cxx`: setting up the filterBit5 with the trackselection getJEGlobalTrackSelectionRun2

**Optionally:**
* `DPG/Tasks/AOTTrack/MonitorFilterBit.cxx`: adding histograms for filterBit5 to monitor the selection with respect to the other filterBits
* `PWGJE/TableProducer/jetfinder.h`: extending the jetfinder trackselections for the updated jetvalidation.cxx (follows once this PR is merged)

Many thanks in advance.

Cheerio, Johanna !