### PR TITLE
Implementing background subtraction in the JE framework

### DIFF
--- a/PWGJE/Core/CMakeLists.txt
+++ b/PWGJE/Core/CMakeLists.txt
@@ -11,7 +11,8 @@
 
 if(FastJet_FOUND)
 o2physics_add_library(PWGJECore
-               SOURCES  JetFinder.cxx
+               SOURCES  FastJetUtilities.cxx
+                        JetFinder.cxx
                         JetBkgSubUtils.cxx
                PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore FastJet::FastJet FastJet::Contrib)
 

--- a/PWGJE/Core/CMakeLists.txt
+++ b/PWGJE/Core/CMakeLists.txt
@@ -12,11 +12,13 @@
 if(FastJet_FOUND)
 o2physics_add_library(PWGJECore
                SOURCES  JetFinder.cxx
+                        JetBkgSubUtils.cxx
                PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore FastJet::FastJet FastJet::Contrib)
 
 o2physics_target_root_dictionary(PWGJECore
               HEADERS JetFinder.h
                       JetUtilities.h
                       FastJetUtilities.h
+                      JetBkgSubUtils.h
               LINKDEF PWGJECoreLinkDef.h)
 endif()

--- a/PWGJE/Core/FastJetUtilities.cxx
+++ b/PWGJE/Core/FastJetUtilities.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FastJetUtilities.h"
+
+void FastJetUtilities::setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index, int status)
+{
+  fastjet_user_info* user_info = new fastjet_user_info(status, index); // FIXME: can setting this as a pointer be avoided?
+  constituents.back().set_user_info(user_info);
+  if (index != -99999999) { // FIXME: needed for constituent subtraction as user_info is not propagated, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
+    int i = index;
+    if (status == static_cast<int>(JetConstituentStatus::track)) {
+      i = i + 1;
+    }
+    if (status == static_cast<int>(JetConstituentStatus::cluster)) {
+      i = -1 * (i + 1);
+    }
+    if (status == static_cast<int>(JetConstituentStatus::candidateHF)) {
+      i = 0;
+    }
+    constituents.back().set_user_index(i); // FIXME: needed for constituent subtraction, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
+  }
+}
+
+// Selector of HF candidates
+fastjet::Selector FastJetUtilities::SelectorIsHFCand()
+{
+  return fastjet::Selector(new SW_IsHFCand());
+}

--- a/PWGJE/Core/FastJetUtilities.h
+++ b/PWGJE/Core/FastJetUtilities.h
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <tuple>
 #include <vector>
+#include <string>
 
 #include "fastjet/PseudoJet.hh"
 #include "fastjet/Selector.hh"
@@ -69,24 +70,7 @@ class fastjet_user_info : public fastjet::PseudoJet::UserInfoBase
  * @param status status of constituent type
  */
 
-void setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track))
-{
-  fastjet_user_info* user_info = new fastjet_user_info(status, index); // FIXME: can setting this as a pointer be avoided?
-  constituents.back().set_user_info(user_info);
-  if (index != -99999999) { // FIXME: needed for constituent subtraction as user_info is not propagated, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
-    int i = index;
-    if (status == static_cast<int>(JetConstituentStatus::track)) {
-      i = i + 1;
-    }
-    if (status == static_cast<int>(JetConstituentStatus::cluster)) {
-      i = -1 * (i + 1);
-    }
-    if (status == static_cast<int>(JetConstituentStatus::candidateHF)) {
-      i = 0;
-    }
-    constituents.back().set_user_index(i); // FIXME: needed for constituent subtraction, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
-  }
-}
+void setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track));
 
 // Class defined to select the HF candidate particle
 class SW_IsHFCand : public fastjet::SelectorWorker
@@ -108,10 +92,7 @@ class SW_IsHFCand : public fastjet::SelectorWorker
 };
 
 // Selector of HF candidates
-fastjet::Selector SelectorIsHFCand()
-{
-  return fastjet::Selector(new SW_IsHFCand());
-}
+fastjet::Selector SelectorIsHFCand();
 
 /**
  * Add track as a pseudojet object to the fastjet vector

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -12,43 +12,46 @@
 // jet finder task
 //
 // Author: Hadi Hassan, Universiy of Jväskylä, hadi.hassan@cern.ch
-// #include "PWGJE/Core/FastJetUtilities.h"
+#include <memory>
+#include <tuple>
+#include "Framework/Logger.h"
+#include "Common/Core/RecoDecay.h"
 #include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/Core/JetBkgSubUtils.h"
-#include "Framework/Logger.h"
-#include "TVector2.h"
-#include <memory>
+#include "PWGJE/Core/FastJetUtilities.h"
 
-JetBkgSubUtils::JetBkgSubUtils(float jetBkgR, float bkgPhiMin, float bkgPhiMax, float bkgEtaMin, float bkgEtaMax, float constSubAlpha, float constSubRMax, fastjet::GhostedAreaSpec ghostAreaSpec) : mJetBkgR(jetBkgR),
-                                                                                                                                                                                                     mBkgPhiMin(bkgPhiMin),
-                                                                                                                                                                                                     mBkgPhiMax(bkgPhiMax),
-                                                                                                                                                                                                     mBkgEtaMin(bkgEtaMin),
-                                                                                                                                                                                                     mBkgEtaMax(bkgEtaMax),
-                                                                                                                                                                                                     mConstSubAlpha(constSubAlpha),
-                                                                                                                                                                                                     mConstSubRMax(constSubRMax),
-                                                                                                                                                                                                     mGhostAreaSpec(ghostAreaSpec)
+JetBkgSubUtils::JetBkgSubUtils(float jetBkgR_out, float constSubAlpha_out, float constSubRMax_out, float bkgEtaMin_out, float bkgEtaMax_out, float bkgPhiMin_out, float bkgPhiMax_out, fastjet::GhostedAreaSpec ghostAreaSpec_out, int nHardReject) : jetBkgR(jetBkgR_out),
+                                                                                                                                                                                                                                                      constSubAlpha(constSubAlpha_out),
+                                                                                                                                                                                                                                                      constSubRMax(constSubRMax_out),
+                                                                                                                                                                                                                                                      bkgEtaMin(bkgEtaMin_out),
+                                                                                                                                                                                                                                                      bkgEtaMax(bkgEtaMax_out),
+                                                                                                                                                                                                                                                      bkgPhiMin(bkgPhiMin_out),
+                                                                                                                                                                                                                                                      bkgPhiMax(bkgPhiMax_out),
+                                                                                                                                                                                                                                                      ghostAreaSpec(ghostAreaSpec_out)
 
 {
-  mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
-  mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
-  mSelRho = fastjet::SelectorRapRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax) && !fastjet::SelectorNHardest(2); // here we have to put rap range, to be checked!
+  // Note: if you are using the PerpCone method you should jetBkgR to be the same as the anit_kt jets R, otherwise use R=0.2
+  jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, fastjet::Best);
+  areaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, ghostAreaSpec);
+  selRho = fastjet::SelectorRapRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax) && !fastjet::SelectorNHardest(nHardReject); // here we have to put rap range, to be checked!
 }
 
-double JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles)
+std::tuple<double, double> JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles)
 {
 
   if (inputParticles.size() == 0) {
-    return 0.0;
+    return std::make_tuple(0.0, 0.0);
   }
 
   // cluster the kT jets
-  fastjet::ClusterSequenceArea clusterSeq(inputParticles, mJetDefBkg, mAreaDefBkg);
+  fastjet::ClusterSequenceArea clusterSeq(inputParticles, jetDefBkg, areaDefBkg);
 
   // select jets in detector acceptance
-  std::vector<fastjet::PseudoJet> alljets = mSelRho(clusterSeq.inclusive_jets());
+  std::vector<fastjet::PseudoJet> alljets = selRho(clusterSeq.inclusive_jets());
 
   double totaljetAreaPhys(0), totalAreaCovered(0);
   std::vector<double> rhovector;
+  std::vector<double> rhoMvector;
 
   // Fill a vector for pT/area to be used for the median
   for (auto& ijet : alljets) {
@@ -56,6 +59,8 @@ double JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJe
     // Physical area/ Physical jets (no ghost)
     if (!clusterSeq.is_pure_ghost(ijet)) {
       rhovector.push_back(ijet.perp() / ijet.area());
+      rhoMvector.push_back(getM(ijet) / ijet.area());
+
       totaljetAreaPhys += ijet.area();
     }
     // Full area
@@ -63,32 +68,36 @@ double JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJe
   }
   // calculate Rho as the median of the jet pT / jet area
   double rho = TMath::Median<double>(rhovector.size(), rhovector.data());
+  double rhoM = TMath::Median<double>(rhoMvector.size(), rhoMvector.data());
 
-  if (mDoSparseSub) {
+  if (doSparseSub) {
     // calculate The ocupancy factor, which the ratio of covered area / total area
     double occupancyFactor = totalAreaCovered > 0 ? totaljetAreaPhys / totalAreaCovered : 1.;
     rho *= occupancyFactor;
+    rhoM *= occupancyFactor;
   }
 
-  return rho;
+  return std::make_tuple(rho, rhoM);
 }
 
-double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets)
+std::tuple<double, double> JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets)
 {
 
   if (inputParticles.size() == 0 || jets.size() == 0) {
-    return 0.0;
+    return std::make_tuple(0.0, 0.0);
   }
 
   double perpPtDensity1 = 0;
   double perpPtDensity2 = 0;
+  double perpMtDensity1 = 0;
+  double perpMtDensity2 = 0;
 
-  fastjet::Selector selectJet = fastjet::SelectorEtaRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax);
+  fastjet::Selector selectJet = fastjet::SelectorEtaRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax);
 
   std::vector<fastjet::PseudoJet> selectedJets = fastjet::sorted_by_pt(selectJet(jets));
 
   if (selectedJets.size() == 0) {
-    return 0.0;
+    return std::make_tuple(0.0, 0.0);
   }
 
   fastjet::PseudoJet leadingJet = selectedJets[0];
@@ -98,135 +107,131 @@ double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>
   double dEta = 999.;
   double PerpendicularConeAxisPhi1 = 999., PerpendicularConeAxisPhi2 = 999.;
   // build 2 perp cones in phi around the leading jet (right and left of the jet)
-  PerpendicularConeAxisPhi1 = TVector2::Phi_0_2pi(leadingJet.phi() + (M_PI / 2.));
-  PerpendicularConeAxisPhi2 = TVector2::Phi_0_2pi(leadingJet.phi() - (M_PI / 2.));
+  PerpendicularConeAxisPhi1 = RecoDecay::constrainAngle<double, double>(leadingJet.phi() + (M_PI / 2.)); // This will contrain the angel between 0-2Pi
+  PerpendicularConeAxisPhi2 = RecoDecay::constrainAngle<double, double>(leadingJet.phi() - (M_PI / 2.)); // This will contrain the angel between 0-2Pi
 
   for (auto& particle : inputParticles) {
     // sum the momentum of all paricles that fill the two cones
     dPhi1 = particle.phi() - PerpendicularConeAxisPhi1;
-    dPhi1 = TVector2::Phi_mpi_pi(dPhi1);
+    dPhi1 = RecoDecay::constrainAngle<double, double>(dPhi1, -M_PI);
     dPhi2 = particle.phi() - PerpendicularConeAxisPhi2;
-    dPhi2 = TVector2::Phi_mpi_pi(dPhi2);
+    dPhi2 = RecoDecay::constrainAngle<double, double>(dPhi2, -M_PI);
     dEta = leadingJet.eta() - particle.eta();
-    if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= mJetBkgR) {
+    if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= jetBkgR) {
       perpPtDensity1 += particle.perp();
+      perpMtDensity1 += particle.mt();
     }
 
-    if (TMath::Sqrt(dPhi2 * dPhi2 + dEta * dEta) <= mJetBkgR) {
+    if (TMath::Sqrt(dPhi2 * dPhi2 + dEta * dEta) <= jetBkgR) {
       perpPtDensity2 += particle.perp();
+      perpMtDensity2 += particle.mt();
     }
   }
 
   // Caculate rho as the ratio of average pT of the two cones / the cone area
-  Double_t perpPtDensity = (perpPtDensity1 + perpPtDensity2) / (2 * M_PI * mJetBkgR * mJetBkgR);
+  double perpPtDensity = (perpPtDensity1 + perpPtDensity2) / (2 * M_PI * jetBkgR * jetBkgR);
+  double perpMtDensity = (perpMtDensity1 + perpMtDensity2) / (2 * M_PI * jetBkgR * jetBkgR);
 
-  return perpPtDensity;
-}
-
-/// Sets the background subtraction estimater pointer
-void JetBkgSubUtils::setBkgE()
-{
-  mbkgE = decltype(mbkgE)(new fastjet::JetMedianBackgroundEstimator(mSelRho, mJetDefBkg, mAreaDefBkg));
+  return std::make_tuple(perpPtDensity, perpMtDensity);
 }
 
 /// Sets the background subtraction object
-fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, std::vector<fastjet::PseudoJet>& jets)
+fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets, float& rhoParam, float& rhoMParam, BkgSubEstimator bkgSubEst, BkgSubMode bkgSubMode)
 {
 
-  if (bkgSubMode == BkgSubMode::rhoSparseSub) {
-    mDoSparseSub = true;
+  if (bkgSubEst == BkgSubEstimator::medianRhoSparse) {
+    doSparseSub = true;
   }
 
   fastjet::Subtractor sub;
-  // fastjet::Selector removeHFCand = !FastJetUtilities::SelectorIsHFCand();
-  fastjet::Selector removeHFCand;
+  fastjet::Selector selRemoveHFCand = !FastJetUtilities::SelectorIsHFCand();
 
-  if (bkgSubMode == BkgSubMode::rhoMedianAreaSub || bkgSubMode == BkgSubMode::rhoSparseSub) {
+  if (bkgSubEst == BkgSubEstimator::medianRho || bkgSubEst == BkgSubEstimator::medianRhoSparse) {
 
-    rhoParam = estimateRhoAreaMedian(removeHFCand(inputParticles));
-    sub = fastjet::Subtractor(rhoParam);
-
-  } else if (bkgSubMode == BkgSubMode::rhoPerpConeSub) {
+    std::tie(rhoParam, rhoMParam) = estimateRhoAreaMedian(removeHFCand ? selRemoveHFCand(inputParticles) : inputParticles);
+  } else if (bkgSubEst == BkgSubEstimator::perpCone) {
 
     if (jets.size() == 0) {
       return sub;
     }
-    rhoParam = estimateRhoPerpCone(removeHFCand(inputParticles), jets);
-    sub = fastjet::Subtractor(rhoParam);
+    std::tie(rhoParam, rhoMParam) = estimateRhoPerpCone(removeHFCand ? selRemoveHFCand(inputParticles) : inputParticles, jets);
+  } else {
+    rhoParam = 0.;
+    rhoMParam = 0.;
+    if (bkgSubEst != BkgSubEstimator::none) {
+      LOGF(error, "requested estimator not implemented!");
+    }
+  }
 
-  } else if (bkgSubMode == BkgSubMode::rhoAreaSub) {
+  if (bkgSubMode == BkgSubMode::eventConstSub) { // eventwise subtraction
 
-    setBkgE();
-    mbkgE->set_particles(removeHFCand(inputParticles));
-    sub = fastjet::Subtractor(mbkgE.get());
-    rhoParam = mbkgE->estimate().rho();
+    fastjet::contrib::ConstituentSubtractor constituentSub(rhoParam, rhoMParam);
+    constituentSub.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); /// deltaR=sqrt((y_i-y_j)^2+(phi_i-phi_j)^2)), longitudinal Lorentz invariant
+    constituentSub.set_max_distance(constSubRMax);
+    constituentSub.set_alpha(constSubAlpha);
+    constituentSub.set_ghost_area(ghostAreaSpec.ghost_area());
+    constituentSub.set_max_eta(bkgEtaMax);
+    if (removeHFCand) {
+      constituentSub.set_particle_selector(&selRemoveHFCand);
+    }
 
-  } else if (bkgSubMode == BkgSubMode::constSub) { // event or jetwise
+    constituentSub.set_do_mass_subtraction();
 
-    setBkgE();
-    mbkgE->set_particles(inputParticles);
-    rhoParam = mbkgE->estimate().rho();
-    std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
-    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{mbkgE.get()}};
-    constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
-    constituentSub->set_max_distance(mConstSubRMax);
-    constituentSub->set_alpha(mConstSubAlpha);
-    constituentSub->set_ghost_area(mGhostAreaSpec.ghost_area());
-    constituentSub->set_max_eta(mBkgEtaMax);
-    constituentSub->set_background_estimator(mbkgE.get());
-    constituentSub->set_particle_selector(&removeHFCand);
+    inputParticles = constituentSub.subtract_event(inputParticles);
 
-    inputParticles = constituentSub->subtract_event(inputParticles);
+    for (auto& track : inputParticles) {
+      if (track.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
+        std::cout << "HF candidate found after eventwise constituent subtraction\n";
+      }
+    }
 
-  } else if (bkgSubMode == BkgSubMode::jetconstSub) {
+  } else if (bkgSubMode == BkgSubMode::jetConstSub) { // jetwise subtraction
 
     if (jets.size() == 0) {
       return sub;
     }
-
-    setBkgE();
-    fastjet::BackgroundJetScalarPtDensity scalarPtDensity;
-    mbkgE->set_jet_density_class(&scalarPtDensity); // this changes the computation of pt of patches from vector sum to scalar sum. The scalar sum seems more reasonable.
-    mbkgE->set_particles(inputParticles);
 
     // FIXME There is a bug in fastjet ConstituentSubtractor at line 180, subtraction should be done on selected particles
     // The ConstituentSubtractor also needs to be modified such that it write the area information into the output jet
-    fastjet::contrib::ConstituentSubtractor subtractor(mbkgE.get());
-    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
-    subtractor.set_max_distance(mConstSubRMax);
-    subtractor.set_alpha(mConstSubAlpha);
-    subtractor.set_ghost_area(mGhostAreaSpec.ghost_area());
-    subtractor.set_max_eta(mBkgEtaMax);
-    subtractor.set_particle_selector(&removeHFCand);
-
-    // by default, the masses of all particles are set to zero.
-    // this sets the same background estimator to be used for deltaMass density, rho_m, as for pt density, rho:
-    subtractor.set_do_mass_subtraction();
-    subtractor.set_common_bge_for_rho_and_rhom();
-
-    // FIXME There are some problems with this method, it doesn't propagate the constituents index and user_info
-    // Another problem is that, inorder to use the area information we had to take the cluster sequence from
-    // the unsubtracted jets and associate with the subtracted with jets. Because of this, when looping over
-    // constituents you will get the unsubtracted constituents instead of the subtracted one, and you will also
-    // get the area of the unsubtracted jets instead of the new are. But the four momentum of the jet is the
-    // true one for the subtracted jets.
-    std::vector<fastjet::PseudoJet> subtractedJets;
-    for (auto& jet : jets) {
-      fastjet::PseudoJet subJet = subtractor(jet);
-      subJet.set_structure_shared_ptr(jet.structure_shared_ptr());
-      subJet.set_cluster_hist_index(jet.cluster_hist_index());
-      subtractedJets.push_back(subJet);
+    fastjet::contrib::ConstituentSubtractor subtractor(rhoParam, rhoMParam);
+    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); /// deltaR=sqrt((y_i-y_j)^2+(phi_i-phi_j)^2)), longitudinal Lorentz invariant
+    subtractor.set_max_distance(constSubRMax);
+    subtractor.set_alpha(constSubAlpha);
+    subtractor.set_ghost_area(ghostAreaSpec.ghost_area());
+    subtractor.set_max_eta(bkgEtaMax);
+    if (removeHFCand) {
+      subtractor.set_particle_selector(&selRemoveHFCand);
     }
-    jets.clear();
-    jets = subtractedJets;
-    // jets = subtractor(jets);
 
+    // by default, the masses of all particles are set to zero. With this flag the jet mass will also be subtracted
+    subtractor.set_do_mass_subtraction();
+
+    // FIXME There are some problems with this method, it doesn't propagate the constituents user_info
+    // Another problem is that, This method doesn't propagate the area information, since after constituent subtraction
+    // the jet structure will change, so it no longer has the same area. fastjet developers said calculatig the area
+    // information will difficult
+    jets = subtractor(jets);
+
+  } else if (bkgSubMode == BkgSubMode::rhoAreaSub) {
+    sub = fastjet::Subtractor(rhoParam, rhoMParam);
   } else {
     rhoParam = 0.;
+    rhoMParam = 0.;
     if (bkgSubMode != BkgSubMode::none) {
       LOGF(error, "requested subtraction mode not implemented!");
     }
   }
 
   return sub;
+}
+
+double JetBkgSubUtils::getM(fastjet::PseudoJet jet) const
+{
+
+  double sum(0);
+  for (auto cons : jet.constituents()) {
+    sum += TMath::Sqrt(cons.m() * cons.m() + cons.pt() * cons.pt()) - cons.pt(); // sqrt(E^2-P^2+pt^2)=sqrt(E^2-pz^2)
+  }
+
+  return sum;
 }

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -1,0 +1,232 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// jet finder task
+//
+// Author: Hadi Hassan, Universiy of Jväskylä, hadi.hassan@cern.ch
+// #include "PWGJE/Core/FastJetUtilities.h"
+#include "PWGJE/Core/JetUtilities.h"
+#include "PWGJE/Core/JetBkgSubUtils.h"
+#include "Framework/Logger.h"
+#include "TVector2.h"
+#include <memory>
+
+JetBkgSubUtils::JetBkgSubUtils(float jetBkgR, float bkgPhiMin, float bkgPhiMax, float bkgEtaMin, float bkgEtaMax, float constSubAlpha, float constSubRMax, fastjet::GhostedAreaSpec ghostAreaSpec) : mJetBkgR(jetBkgR),
+                                                                                                                                                                                                     mBkgPhiMin(bkgPhiMin),
+                                                                                                                                                                                                     mBkgPhiMax(bkgPhiMax),
+                                                                                                                                                                                                     mBkgEtaMin(bkgEtaMin),
+                                                                                                                                                                                                     mBkgEtaMax(bkgEtaMax),
+                                                                                                                                                                                                     mConstSubAlpha(constSubAlpha),
+                                                                                                                                                                                                     mConstSubRMax(constSubRMax),
+                                                                                                                                                                                                     mGhostAreaSpec(ghostAreaSpec)
+
+{
+  mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
+  mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
+  mSelRho = fastjet::SelectorRapRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax) && !fastjet::SelectorNHardest(2); // here we have to put rap range, to be checked!
+}
+
+double JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles)
+{
+
+  if (inputParticles.size() == 0) {
+    return 0.0;
+  }
+
+  // cluster the kT jets
+  fastjet::ClusterSequenceArea clusterSeq(inputParticles, mJetDefBkg, mAreaDefBkg);
+
+  // select jets in detector acceptance
+  std::vector<fastjet::PseudoJet> alljets = mSelRho(clusterSeq.inclusive_jets());
+
+  double totaljetAreaPhys(0), totalAreaCovered(0);
+  std::vector<double> rhovector;
+
+  // Fill a vector for pT/area to be used for the median
+  for (auto& ijet : alljets) {
+
+    // Physical area/ Physical jets (no ghost)
+    if (!clusterSeq.is_pure_ghost(ijet)) {
+      rhovector.push_back(ijet.perp() / ijet.area());
+      totaljetAreaPhys += ijet.area();
+    }
+    // Full area
+    totalAreaCovered += ijet.area();
+  }
+  // calculate Rho as the median of the jet pT / jet area
+  double rho = TMath::Median<double>(rhovector.size(), rhovector.data());
+
+  if (mDoSparseSub) {
+    // calculate The ocupancy factor, which the ratio of covered area / total area
+    double occupancyFactor = totalAreaCovered > 0 ? totaljetAreaPhys / totalAreaCovered : 1.;
+    rho *= occupancyFactor;
+  }
+
+  return rho;
+}
+
+double JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets)
+{
+
+  if (inputParticles.size() == 0 || jets.size() == 0) {
+    return 0.0;
+  }
+
+  double perpPtDensity1 = 0;
+  double perpPtDensity2 = 0;
+
+  fastjet::Selector selectJet = fastjet::SelectorEtaRange(mBkgEtaMin, mBkgEtaMax) && fastjet::SelectorPhiRange(mBkgPhiMin, mBkgPhiMax);
+
+  std::vector<fastjet::PseudoJet> selectedJets = fastjet::sorted_by_pt(selectJet(jets));
+
+  if (selectedJets.size() == 0) {
+    return 0.0;
+  }
+
+  fastjet::PseudoJet leadingJet = selectedJets[0];
+
+  double dPhi1 = 999.;
+  double dPhi2 = 999.;
+  double dEta = 999.;
+  double PerpendicularConeAxisPhi1 = 999., PerpendicularConeAxisPhi2 = 999.;
+  // build 2 perp cones in phi around the leading jet (right and left of the jet)
+  PerpendicularConeAxisPhi1 = TVector2::Phi_0_2pi(leadingJet.phi() + (M_PI / 2.));
+  PerpendicularConeAxisPhi2 = TVector2::Phi_0_2pi(leadingJet.phi() - (M_PI / 2.));
+
+  for (auto& particle : inputParticles) {
+    // sum the momentum of all paricles that fill the two cones
+    dPhi1 = particle.phi() - PerpendicularConeAxisPhi1;
+    dPhi1 = TVector2::Phi_mpi_pi(dPhi1);
+    dPhi2 = particle.phi() - PerpendicularConeAxisPhi2;
+    dPhi2 = TVector2::Phi_mpi_pi(dPhi2);
+    dEta = leadingJet.eta() - particle.eta();
+    if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= mJetBkgR) {
+      perpPtDensity1 += particle.perp();
+    }
+
+    if (TMath::Sqrt(dPhi2 * dPhi2 + dEta * dEta) <= mJetBkgR) {
+      perpPtDensity2 += particle.perp();
+    }
+  }
+
+  // Caculate rho as the ratio of average pT of the two cones / the cone area
+  Double_t perpPtDensity = (perpPtDensity1 + perpPtDensity2) / (2 * M_PI * mJetBkgR * mJetBkgR);
+
+  return perpPtDensity;
+}
+
+/// Sets the background subtraction estimater pointer
+void JetBkgSubUtils::setBkgE()
+{
+  mbkgE = decltype(mbkgE)(new fastjet::JetMedianBackgroundEstimator(mSelRho, mJetDefBkg, mAreaDefBkg));
+}
+
+/// Sets the background subtraction object
+fastjet::Subtractor JetBkgSubUtils::setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, std::vector<fastjet::PseudoJet>& jets)
+{
+
+  if (bkgSubMode == BkgSubMode::rhoSparseSub) {
+    mDoSparseSub = true;
+  }
+
+  fastjet::Subtractor sub;
+  // fastjet::Selector removeHFCand = !FastJetUtilities::SelectorIsHFCand();
+  fastjet::Selector removeHFCand;
+
+  if (bkgSubMode == BkgSubMode::rhoMedianAreaSub || bkgSubMode == BkgSubMode::rhoSparseSub) {
+
+    rhoParam = estimateRhoAreaMedian(removeHFCand(inputParticles));
+    sub = fastjet::Subtractor(rhoParam);
+
+  } else if (bkgSubMode == BkgSubMode::rhoPerpConeSub) {
+
+    if (jets.size() == 0) {
+      return sub;
+    }
+    rhoParam = estimateRhoPerpCone(removeHFCand(inputParticles), jets);
+    sub = fastjet::Subtractor(rhoParam);
+
+  } else if (bkgSubMode == BkgSubMode::rhoAreaSub) {
+
+    setBkgE();
+    mbkgE->set_particles(removeHFCand(inputParticles));
+    sub = fastjet::Subtractor(mbkgE.get());
+    rhoParam = mbkgE->estimate().rho();
+
+  } else if (bkgSubMode == BkgSubMode::constSub) { // event or jetwise
+
+    setBkgE();
+    mbkgE->set_particles(inputParticles);
+    rhoParam = mbkgE->estimate().rho();
+    std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
+    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{mbkgE.get()}};
+    constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
+    constituentSub->set_max_distance(mConstSubRMax);
+    constituentSub->set_alpha(mConstSubAlpha);
+    constituentSub->set_ghost_area(mGhostAreaSpec.ghost_area());
+    constituentSub->set_max_eta(mBkgEtaMax);
+    constituentSub->set_background_estimator(mbkgE.get());
+    constituentSub->set_particle_selector(&removeHFCand);
+
+    inputParticles = constituentSub->subtract_event(inputParticles);
+
+  } else if (bkgSubMode == BkgSubMode::jetconstSub) {
+
+    if (jets.size() == 0) {
+      return sub;
+    }
+
+    setBkgE();
+    fastjet::BackgroundJetScalarPtDensity scalarPtDensity;
+    mbkgE->set_jet_density_class(&scalarPtDensity); // this changes the computation of pt of patches from vector sum to scalar sum. The scalar sum seems more reasonable.
+    mbkgE->set_particles(inputParticles);
+
+    // FIXME There is a bug in fastjet ConstituentSubtractor at line 180, subtraction should be done on selected particles
+    // The ConstituentSubtractor also needs to be modified such that it write the area information into the output jet
+    fastjet::contrib::ConstituentSubtractor subtractor(mbkgE.get());
+    subtractor.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
+    subtractor.set_max_distance(mConstSubRMax);
+    subtractor.set_alpha(mConstSubAlpha);
+    subtractor.set_ghost_area(mGhostAreaSpec.ghost_area());
+    subtractor.set_max_eta(mBkgEtaMax);
+    subtractor.set_particle_selector(&removeHFCand);
+
+    // by default, the masses of all particles are set to zero.
+    // this sets the same background estimator to be used for deltaMass density, rho_m, as for pt density, rho:
+    subtractor.set_do_mass_subtraction();
+    subtractor.set_common_bge_for_rho_and_rhom();
+
+    // FIXME There are some problems with this method, it doesn't propagate the constituents index and user_info
+    // Another problem is that, inorder to use the area information we had to take the cluster sequence from
+    // the unsubtracted jets and associate with the subtracted with jets. Because of this, when looping over
+    // constituents you will get the unsubtracted constituents instead of the subtracted one, and you will also
+    // get the area of the unsubtracted jets instead of the new are. But the four momentum of the jet is the
+    // true one for the subtracted jets.
+    std::vector<fastjet::PseudoJet> subtractedJets;
+    for (auto& jet : jets) {
+      fastjet::PseudoJet subJet = subtractor(jet);
+      subJet.set_structure_shared_ptr(jet.structure_shared_ptr());
+      subJet.set_cluster_hist_index(jet.cluster_hist_index());
+      subtractedJets.push_back(subJet);
+    }
+    jets.clear();
+    jets = subtractedJets;
+    // jets = subtractor(jets);
+
+  } else {
+    rhoParam = 0.;
+    if (bkgSubMode != BkgSubMode::none) {
+      LOGF(error, "requested subtraction mode not implemented!");
+    }
+  }
+
+  return sub;
+}

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -1,0 +1,145 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file JetBkgSubUtils.h
+/// \brief Jet background subtraction utilities
+///
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, JYU
+
+#ifndef PWGJE_CORE_JETBKGSUBUTILS_H_
+#define PWGJE_CORE_JETBKGSUBUTILS_H_
+
+#include <string>
+#include <memory>
+#include <vector>
+#include <TMath.h>
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
+#include "fastjet/tools/Subtractor.hh"
+#include "fastjet/contrib/ConstituentSubtractor.hh"
+
+#include "Framework/Logger.h"
+
+enum class BkgSubMode { none = 0,
+                        rhoAreaSub = 1,
+                        constSub = 2,
+                        rhoSparseSub = 3,
+                        rhoPerpConeSub = 4,
+                        rhoMedianAreaSub = 5,
+                        jetconstSub = 6
+};
+
+class JetBkgSubUtils
+{
+
+ public:
+  // Default contructor
+  JetBkgSubUtils() = default;
+
+  JetBkgSubUtils(float jetBkgR_out = 0.2, float bkgPhiMin_out = 0., float bkgPhiMax_out = 2 * M_PI, float bkgEtaMin_out = -0.9, float bkgEtaMax_out = 0.9,
+                 float constSubAlpha_out = 1., float constSubRMax_out = 0.6, fastjet::GhostedAreaSpec ghostAreaSpec_out = fastjet::GhostedAreaSpec());
+
+  // Default destructor
+  ~JetBkgSubUtils() = default;
+
+  /// @brief Setting the jet algorithm and the recombination scheme
+  void setJetAlgorithmAndScheme(fastjet::JetAlgorithm algorithmBkg, fastjet::RecombinationScheme recombSchemeBkg)
+  {
+    mAlgorithmBkg = algorithmBkg;
+    mRecombSchemeBkg = recombSchemeBkg;
+  }
+
+  /// @brief Method for estimating the jet background density using the median method or the sparse method
+  /// @param inputParticles (all particles in the event)
+  /// @return Rho, the underlying event density
+  double estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles);
+
+  /// @brief Background estimator using the perpendicular cone method
+  /// @param inputParticles
+  /// @param jets (all jets in the event)
+  /// @return Rho, the underlying event density
+  double estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
+
+  /// @brief method that reconstruct the bkgsub object and estimates rho
+  /// @param inputParticles
+  /// @param jets (all jets in the event)
+  /// @param rhoParam the underlying evvent density (to be set)
+  /// @param bkgSubMode the background subtraction method
+  /// @param jets signal jets (needed for the perp cone method)
+  /// @return sub, the background subtractor
+  fastjet::Subtractor setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, std::vector<fastjet::PseudoJet>& jets);
+
+  /// Sets the background subtraction estimater pointer
+  void setBkgE();
+
+  // Setters
+  void setJetBkgR(float jetbkgR) { mJetBkgR = jetbkgR; }
+  void setPhiMinMax(float phimin, float phimax)
+  {
+    mBkgPhiMin = phimin;
+    mBkgPhiMax = phimax;
+  }
+  void setEtaMinMax(float etamin, float etamax)
+  {
+    mBkgEtaMin = etamin;
+    mBkgEtaMax = etamax;
+  }
+  void setConstSubAlphaRMax(float alpha, float rmax)
+  {
+    mConstSubAlpha = alpha;
+    mConstSubRMax = rmax;
+  }
+  void setDoRhoSparseSub(bool dosparse = true) { mDoSparseSub = dosparse; }
+  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec) { mGhostAreaSpec = ghostAreaSpec; }
+  void setJetDefinition(fastjet::JetDefinition jetdefbkg) { mJetDefBkg = jetdefbkg; }
+  void setAreaDefinition(fastjet::AreaDefinition areaDefBkg) { mAreaDefBkg = areaDefBkg; }
+  void setRhoSelector(fastjet::Selector selRho) { mSelRho = selRho; }
+
+  // Getters
+  float getJetBkgR() const { return mJetBkgR; }
+  float getPhiMin() const { return mBkgPhiMin; }
+  float getPhiMax() const { return mBkgPhiMax; }
+  float getEtaMin() const { return mBkgEtaMin; }
+  float getEtaMax() const { return mBkgEtaMax; }
+  float getConstSubAlpha() const { return mConstSubAlpha; }
+  float getConstSubRMax() const { return mConstSubRMax; }
+  float getDoRhoSparseSub() const { return mDoSparseSub; }
+  fastjet::GhostedAreaSpec getGhostAreaSpec() const { return mGhostAreaSpec; }
+  fastjet::JetDefinition getJetDefinition() const { return mJetDefBkg; }
+  fastjet::AreaDefinition getAreaDefinition() const { return mAreaDefBkg; }
+  fastjet::Selector getRhoSelector() const { return mSelRho; }
+
+ protected:
+  float mJetBkgR = 0.2;
+  float mBkgPhiMin = 0.;
+  float mBkgPhiMax = 2 * M_PI;
+  float mBkgEtaMin = -0.9;
+  float mBkgEtaMax = 0.9;
+  float mConstSubAlpha = 1.0;
+  float mConstSubRMax = 0.6;
+  bool mDoSparseSub = false; /// flag whether to do background subtraction for sparse systems.
+
+  std::unique_ptr<fastjet::JetMedianBackgroundEstimator> mbkgE;
+
+  fastjet::GhostedAreaSpec mGhostAreaSpec = fastjet::GhostedAreaSpec();
+  fastjet::JetAlgorithm mAlgorithmBkg = fastjet::kt_algorithm;
+  fastjet::RecombinationScheme mRecombSchemeBkg = fastjet::E_scheme;
+  fastjet::JetDefinition mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
+  fastjet::AreaDefinition mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
+  fastjet::Selector mSelRho = fastjet::Selector();
+
+}; // class JetBkgSubUtils
+
+#endif // PWGJE_CORE_JETBKGSUBUTILS_H_

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <memory>
+#include <tuple>
 #include <vector>
 #include <TMath.h>
 
@@ -32,13 +33,16 @@
 
 #include "Framework/Logger.h"
 
+enum class BkgSubEstimator { none = 0,
+                             medianRho = 1,
+                             medianRhoSparse = 2,
+                             perpCone = 3
+};
+
 enum class BkgSubMode { none = 0,
                         rhoAreaSub = 1,
-                        constSub = 2,
-                        rhoSparseSub = 3,
-                        rhoPerpConeSub = 4,
-                        rhoMedianAreaSub = 5,
-                        jetconstSub = 6
+                        eventConstSub = 2,
+                        jetConstSub = 3
 };
 
 class JetBkgSubUtils
@@ -48,97 +52,97 @@ class JetBkgSubUtils
   // Default contructor
   JetBkgSubUtils() = default;
 
-  JetBkgSubUtils(float jetBkgR_out = 0.2, float bkgPhiMin_out = 0., float bkgPhiMax_out = 2 * M_PI, float bkgEtaMin_out = -0.9, float bkgEtaMax_out = 0.9,
-                 float constSubAlpha_out = 1., float constSubRMax_out = 0.6, fastjet::GhostedAreaSpec ghostAreaSpec_out = fastjet::GhostedAreaSpec());
+  JetBkgSubUtils(float jetBkgR_out = 0.2, float constSubAlpha_out = 1., float constSubRMax_out = 0.6, float bkgEtaMin_out = -0.8, float bkgEtaMax_out = 0.8,
+                 float bkgPhiMin_out = 0., float bkgPhiMax_out = 2 * M_PI, fastjet::GhostedAreaSpec ghostAreaSpec_out = fastjet::GhostedAreaSpec(), int nHardReject = 2);
 
   // Default destructor
   ~JetBkgSubUtils() = default;
 
   /// @brief Setting the jet algorithm and the recombination scheme
-  void setJetAlgorithmAndScheme(fastjet::JetAlgorithm algorithmBkg, fastjet::RecombinationScheme recombSchemeBkg)
+  void setJetAlgorithmAndScheme(fastjet::JetAlgorithm algorithmBkg_out, fastjet::RecombinationScheme recombSchemeBkg_out)
   {
-    mAlgorithmBkg = algorithmBkg;
-    mRecombSchemeBkg = recombSchemeBkg;
+    algorithmBkg = algorithmBkg_out;
+    recombSchemeBkg = recombSchemeBkg_out;
   }
 
   /// @brief Method for estimating the jet background density using the median method or the sparse method
   /// @param inputParticles (all particles in the event)
-  /// @return Rho, the underlying event density
-  double estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles);
+  /// @return Rho, RhoM the underlying event density
+  std::tuple<double, double> estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles);
 
   /// @brief Background estimator using the perpendicular cone method
   /// @param inputParticles
   /// @param jets (all jets in the event)
-  /// @return Rho, the underlying event density
-  double estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
+  /// @return Rho, RhoM the underlying event density
+  std::tuple<double, double> estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
 
   /// @brief method that reconstruct the bkgsub object and estimates rho
   /// @param inputParticles
   /// @param jets (all jets in the event)
   /// @param rhoParam the underlying evvent density (to be set)
   /// @param bkgSubMode the background subtraction method
-  /// @param jets signal jets (needed for the perp cone method)
   /// @return sub, the background subtractor
-  fastjet::Subtractor setSub(std::vector<fastjet::PseudoJet>& inputParticles, float& rhoParam, BkgSubMode bkgSubMode, std::vector<fastjet::PseudoJet>& jets);
-
-  /// Sets the background subtraction estimater pointer
-  void setBkgE();
+  fastjet::Subtractor setSub(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets, float& rhoParam, float& rhoMParam, BkgSubEstimator bkgSubEst, BkgSubMode bkgSubMode);
 
   // Setters
-  void setJetBkgR(float jetbkgR) { mJetBkgR = jetbkgR; }
-  void setPhiMinMax(float phimin, float phimax)
+  void setJetBkgR(float jetbkgR_out) { jetBkgR = jetbkgR_out; }
+  void setPhiMinMax(float phimin_out, float phimax_out)
   {
-    mBkgPhiMin = phimin;
-    mBkgPhiMax = phimax;
+    bkgPhiMin = phimin_out;
+    bkgPhiMax = phimax_out;
   }
-  void setEtaMinMax(float etamin, float etamax)
+  void setEtaMinMax(float etamin_out, float etamax_out)
   {
-    mBkgEtaMin = etamin;
-    mBkgEtaMax = etamax;
+    bkgEtaMin = etamin_out;
+    bkgEtaMax = etamax_out;
   }
-  void setConstSubAlphaRMax(float alpha, float rmax)
+  void setConstSubAlphaRMax(float alpha_out, float rmax_out)
   {
-    mConstSubAlpha = alpha;
-    mConstSubRMax = rmax;
+    constSubAlpha = alpha_out;
+    constSubRMax = rmax_out;
   }
-  void setDoRhoSparseSub(bool dosparse = true) { mDoSparseSub = dosparse; }
-  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec) { mGhostAreaSpec = ghostAreaSpec; }
-  void setJetDefinition(fastjet::JetDefinition jetdefbkg) { mJetDefBkg = jetdefbkg; }
-  void setAreaDefinition(fastjet::AreaDefinition areaDefBkg) { mAreaDefBkg = areaDefBkg; }
-  void setRhoSelector(fastjet::Selector selRho) { mSelRho = selRho; }
+  void setDoRhoSparseSub(bool dosparse_out = true) { doSparseSub = dosparse_out; }
+  void setRemoveHFCandidate(bool removecandidate = true) { removeHFCand = removecandidate; }
+  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec_out) { ghostAreaSpec = ghostAreaSpec_out; }
+  void setJetDefinition(fastjet::JetDefinition jetdefbkg_out) { jetDefBkg = jetdefbkg_out; }
+  void setAreaDefinition(fastjet::AreaDefinition areaDefBkg_out) { areaDefBkg = areaDefBkg_out; }
+  void setRhoSelector(fastjet::Selector selRho_out) { selRho = selRho_out; }
 
   // Getters
-  float getJetBkgR() const { return mJetBkgR; }
-  float getPhiMin() const { return mBkgPhiMin; }
-  float getPhiMax() const { return mBkgPhiMax; }
-  float getEtaMin() const { return mBkgEtaMin; }
-  float getEtaMax() const { return mBkgEtaMax; }
-  float getConstSubAlpha() const { return mConstSubAlpha; }
-  float getConstSubRMax() const { return mConstSubRMax; }
-  float getDoRhoSparseSub() const { return mDoSparseSub; }
-  fastjet::GhostedAreaSpec getGhostAreaSpec() const { return mGhostAreaSpec; }
-  fastjet::JetDefinition getJetDefinition() const { return mJetDefBkg; }
-  fastjet::AreaDefinition getAreaDefinition() const { return mAreaDefBkg; }
-  fastjet::Selector getRhoSelector() const { return mSelRho; }
+  float getJetBkgR() const { return jetBkgR; }
+  float getPhiMin() const { return bkgPhiMin; }
+  float getPhiMax() const { return bkgPhiMax; }
+  float getEtaMin() const { return bkgEtaMin; }
+  float getEtaMax() const { return bkgEtaMax; }
+  float getConstSubAlpha() const { return constSubAlpha; }
+  float getConstSubRMax() const { return constSubRMax; }
+  float getDoRhoSparseSub() const { return doSparseSub; }
+  float getRemoveHFCandidate() const { return removeHFCand; }
+  fastjet::GhostedAreaSpec getGhostAreaSpec() const { return ghostAreaSpec; }
+  fastjet::JetDefinition getJetDefinition() const { return jetDefBkg; }
+  fastjet::AreaDefinition getAreaDefinition() const { return areaDefBkg; }
+  fastjet::Selector getRhoSelector() const { return selRho; }
+
+  // Calculate the jet mass
+  double getM(fastjet::PseudoJet jet) const;
 
  protected:
-  float mJetBkgR = 0.2;
-  float mBkgPhiMin = 0.;
-  float mBkgPhiMax = 2 * M_PI;
-  float mBkgEtaMin = -0.9;
-  float mBkgEtaMax = 0.9;
-  float mConstSubAlpha = 1.0;
-  float mConstSubRMax = 0.6;
-  bool mDoSparseSub = false; /// flag whether to do background subtraction for sparse systems.
+  float jetBkgR = 0.2;
+  float constSubAlpha = 1.0;
+  float constSubRMax = 0.6;
+  float bkgEtaMin = -0.8;
+  float bkgEtaMax = 0.8;
+  float bkgPhiMin = 0.;
+  float bkgPhiMax = 2 * M_PI;
+  bool doSparseSub = false;  /// flag whether to do background subtraction for sparse systems.
+  bool removeHFCand = false; /// flag whether to remove the HF candidate from the list of particles
 
-  std::unique_ptr<fastjet::JetMedianBackgroundEstimator> mbkgE;
-
-  fastjet::GhostedAreaSpec mGhostAreaSpec = fastjet::GhostedAreaSpec();
-  fastjet::JetAlgorithm mAlgorithmBkg = fastjet::kt_algorithm;
-  fastjet::RecombinationScheme mRecombSchemeBkg = fastjet::E_scheme;
-  fastjet::JetDefinition mJetDefBkg = fastjet::JetDefinition(mAlgorithmBkg, mJetBkgR, mRecombSchemeBkg, fastjet::Best);
-  fastjet::AreaDefinition mAreaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, mGhostAreaSpec);
-  fastjet::Selector mSelRho = fastjet::Selector();
+  fastjet::GhostedAreaSpec ghostAreaSpec = fastjet::GhostedAreaSpec();
+  fastjet::JetAlgorithm algorithmBkg = fastjet::kt_algorithm;
+  fastjet::RecombinationScheme recombSchemeBkg = fastjet::E_scheme;
+  fastjet::JetDefinition jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, fastjet::Best);
+  fastjet::AreaDefinition areaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, ghostAreaSpec);
+  fastjet::Selector selRho = fastjet::Selector();
 
 }; // class JetBkgSubUtils
 

--- a/PWGJE/Core/JetFinder.h
+++ b/PWGJE/Core/JetFinder.h
@@ -42,8 +42,10 @@ class JetFinder
 
  public:
   BkgSubMode bkgSubMode;
+  BkgSubEstimator bkgSubEst;
 
   void setBkgSubMode(BkgSubMode bSM) { bkgSubMode = bSM; }
+  void setBkgSubEstimator(BkgSubEstimator bSE) { bkgSubEst = bSE; }
 
   /// Performs jet finding
   /// \note the input particle and jet lists are passed by reference
@@ -81,6 +83,7 @@ class JetFinder
   float bkgEtaMin;
   float bkgEtaMax;
   float bkgRho;
+  float bkgRhoM;
   float constSubAlpha;
   float constSubRMax;
 
@@ -123,9 +126,10 @@ class JetFinder
                                                                                                                  jetBkgR(0.2),
                                                                                                                  bkgPhiMin(phi_Min),
                                                                                                                  bkgPhiMax(phi_Max),
-                                                                                                                 bkgEtaMin(eta_Min),
-                                                                                                                 bkgEtaMax(eta_Max),
+                                                                                                                 bkgEtaMin(-0.8),
+                                                                                                                 bkgEtaMax(0.8),
                                                                                                                  bkgRho(0.),
+                                                                                                                 bkgRhoM(0.),
                                                                                                                  constSubAlpha(1.0),
                                                                                                                  constSubRMax(0.6),
                                                                                                                  isReclustering(false),
@@ -148,6 +152,13 @@ class JetFinder
   {
     return bkgRho;
   }
+
+  float getRhoM() const
+  {
+    return bkgRhoM;
+  }
+
+  void setRemoveHFCand(bool removeHF_out = true) { subUtils->setRemoveHFCandidate(removeHF_out); }
 
   /// Sets the jet finding parameters
   void setParams();

--- a/PWGJE/Core/PWGJECoreLinkDef.h
+++ b/PWGJE/Core/PWGJECoreLinkDef.h
@@ -17,6 +17,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class JetFinder + ;
+#pragma link C++ class JetBkgSubUtils + ;
 #pragma link C++ namespace JetUtilities + ;
 #pragma link C++ namespace FastJetUtilities + ;
 

--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -27,7 +27,8 @@ struct JetFinderTask {
   Produces<ConstituentTable> constituentsTable;
   Produces<ConstituentSubTable> constituentsSubTable;
 
-  Configurable<int> bkgSubMode{"BkgSubMode", 0, "background subtraction method. 0 = none, 1 = rhoAreaSub, 2 = constSub, 3 = rhoSparseSub, 4 = rhoPerpConeSub, 5 = rhoMedianAreaSub, 6 = jetconstSub"};
+  Configurable<int> bkgSubEstimator{"BkgSubEstimator", 0, "background subtraction estimator. 0 = none, 1 = medianRho, 2 = medianRhoSparse, 3 = perpCone"};
+  Configurable<int> bkgSubMode{"BkgSubMode", 0, "background subtraction method. 0 = none, 1 = rhoAreaSub, 2 = eventConstSub, 3 = jetConstSub"};
 
   // event level configurables
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
@@ -69,6 +70,7 @@ struct JetFinderTask {
   JetFinder jetFinder;
   std::vector<fastjet::PseudoJet> inputParticles;
 
+  BkgSubEstimator _bkgSubEst;
   BkgSubMode _bkgSubMode;
 
   bool doConstSub = false;
@@ -77,12 +79,14 @@ struct JetFinderTask {
   {
     trackSelection = static_cast<std::string>(trackSelections);
 
+    _bkgSubEst = static_cast<BkgSubEstimator>(static_cast<int>(bkgSubEstimator));
     _bkgSubMode = static_cast<BkgSubMode>(static_cast<int>(bkgSubMode));
 
-    if (_bkgSubMode == BkgSubMode::constSub || _bkgSubMode == BkgSubMode::jetconstSub) {
+    if (_bkgSubMode == BkgSubMode::eventConstSub || _bkgSubMode == BkgSubMode::jetConstSub) {
       doConstSub = true;
     }
 
+    jetFinder.setBkgSubEstimator(_bkgSubEst);
     jetFinder.setBkgSubMode(_bkgSubMode);
 
     jetFinder.etaMin = trackEtaMin;

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <string>
+#include <optional>
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -166,8 +167,10 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
       std::vector<int> trackconst;
       std::vector<int> candconst;
       std::vector<int> clusterconst;
+      // FIXME unfortunately the jetwise consistuent subtractor doesn't propagate the jet area
+      // We contacted the fastjet developers and they said this is very difficult
       jetsTable(collision, jet.pt(), jet.eta(), jet.phi(),
-                jet.E(), jet.m(), jet.area(), std::round(R * 100));
+                jet.E(), jet.m(), jet.has_area() ? jet.area() : -1., std::round(R * 100));
       for (const auto& constituent : sorted_by_pt(jet.constituents())) {
         // need to add seperate thing for constituent subtraction
         if (DoConstSub) {

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -170,7 +170,7 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
                 jet.E(), jet.m(), jet.area(), std::round(R * 100));
       for (const auto& constituent : sorted_by_pt(jet.constituents())) {
         // need to add seperate thing for constituent subtraction
-        if (DoConstSub) { // FIXME: needs to be addressed in Haadi's PR
+        if (DoConstSub) {
           constituentsSubTable(jetsTable.lastIndex(), constituent.pt(), constituent.eta(), constituent.phi(),
                                constituent.E(), constituent.m(), constituent.user_index());
         }

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -28,7 +28,8 @@ struct JetFinderHFTask {
   Produces<ConstituentTable> constituentsTable;
   Produces<ConstituentSubTable> constituentsSubTable;
 
-  Configurable<int> bkgSubMode{"BkgSubMode", 0, "background subtraction method. 0 = none, 1 = rhoAreaSub, 2 = constSub, 3 = rhoSparseSub, 4 = rhoPerpConeSub, 5 = rhoMedianAreaSub, 6 = jetconstSub"};
+  Configurable<int> bkgSubEstimator{"BkgSubEstimator", 0, "background subtraction estimator. 0 = none, 1 = medianRho, 2 = medianRhoSparse, 3 = perpCone"};
+  Configurable<int> bkgSubMode{"BkgSubMode", 0, "background subtraction method. 0 = none, 1 = rhoAreaSub, 2 = eventConstSub, 3 = jetConstSub"};
 
   // event level configurables
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
@@ -58,6 +59,7 @@ struct JetFinderHFTask {
   Configurable<float> candYMax{"candYMax", 0.8, "maximum candidate eta"};
   // HF candidiate selection configurables
   Configurable<bool> rejectBackgroundMCCandidates{"rejectBackgroundMCCandidates", true, "reject background HF candidates at MC detector level"};
+  Configurable<bool> removeHFCadBkgSub{"removeHFCadBkgSub", false, "Remove HF candidate from the background estimation (when doing background subtraction)"};
   Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
   Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
   Configurable<int> selectionFlagLcToPKPi{"selectionFlagLcToPKPi", 1, "Selection Flag for Lc->PKPi"};
@@ -80,6 +82,7 @@ struct JetFinderHFTask {
   JetFinder jetFinder;
   std::vector<fastjet::PseudoJet> inputParticles;
 
+  BkgSubEstimator _bkgSubEst;
   BkgSubMode _bkgSubMode;
 
   bool doConstSub = false;
@@ -91,13 +94,18 @@ struct JetFinderHFTask {
   {
     trackSelection = static_cast<std::string>(trackSelections);
 
+    _bkgSubEst = static_cast<BkgSubEstimator>(static_cast<int>(bkgSubEstimator));
     _bkgSubMode = static_cast<BkgSubMode>(static_cast<int>(bkgSubMode));
 
-    if (_bkgSubMode == BkgSubMode::constSub || _bkgSubMode == BkgSubMode::jetconstSub) {
+    if (_bkgSubMode == BkgSubMode::eventConstSub || _bkgSubMode == BkgSubMode::jetConstSub) {
       doConstSub = true;
     }
 
+    jetFinder.setBkgSubEstimator(_bkgSubEst);
     jetFinder.setBkgSubMode(_bkgSubMode);
+    if (removeHFCadBkgSub) {
+      jetFinder.setRemoveHFCand(removeHFCadBkgSub);
+    }
 
     jetFinder.etaMin = trackEtaMin;
     jetFinder.etaMax = trackEtaMax;


### PR DESCRIPTION
Implementing background subtraction methods in the O2Physics PWGJE framework. The methods that were added are as follows:
-     Median background estimator (as in AliPhysics)
-     Rho sparse estimator, which is used for sparse events like in pp or p-Pb.
-     The perpendicular cone method (used in few papers).
-     The fastjet builtin median background estimator (it's a little bit different from the AliPhysics one).
-     The fastjet builtin constituent subtraction method (event wise).
-     The fastjet builtin constituent subtraction jet-by-jet.