### PR TITLE
PWGHF: Implementation of Event Mixing for Ds-hadrons correlations

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1284,8 +1284,7 @@ DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informati
 
 DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_ds_hadron::MD,
-                  aod::hf_correlation_ds_hadron::IsSignalStatus,
-                  aod::hf_correlation_ds_hadron::IsOrigin);
+                  aod::hf_correlation_ds_hadron::IsSignalStatus);
 
 DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
                   aod::hf_correlation_ds_hadron::IsOrigin);

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1273,7 +1273,7 @@ DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);        //! Transverse momentum of
 DECLARE_SOA_COLUMN(MD, mD, float);                    //! Invariant mass of Ds
 DECLARE_SOA_COLUMN(PoolBin, poolBin, int);            //! Pool Bin for the MixedEvent
 DECLARE_SOA_COLUMN(SignalStatus, signalStatus, bool); //! Used in MC-Rec, Ds Signal
-DECLARE_SOA_COLUMN(PromptStatus, promptStatus, bool); //! Used in MC-Rec, Ds Prompt
+DECLARE_SOA_COLUMN(PromptStatus, promptStatus, bool); //! Used in MC-Rec, Ds Origin
 } // namespace hf_correlation_ds_hadron
 DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informations
                   aod::hf_correlation_ds_hadron::DeltaPhi,
@@ -1285,6 +1285,7 @@ DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs R
                   aod::hf_correlation_ds_hadron::MD,
                   aod::hf_correlation_ds_hadron::SignalStatus,
                   aod::hf_correlation_ds_hadron::PromptStatus);
+
 DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
                   aod::hf_correlation_ds_hadron::PromptStatus);
 

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1288,6 +1288,13 @@ DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs R
 DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
                   aod::hf_correlation_ds_hadron::PromptStatus);
 
+// table for selection of collisions with at least one Ds meson
+namespace hf_sel_collision_ds
+{
+DECLARE_SOA_COLUMN(DsFound, dsFound, bool); //! Ds found in a collision
+} // namespace hf_sel_collision_ds
+DECLARE_SOA_TABLE(DsSelCollision, "AOD", "DSCOLL", aod::ds_sel_collision::DsFound);
+
 // definition of columns and tables for Dplus-Hadron correlation pairs
 namespace hf_correlation_dplus_hadron
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1271,16 +1271,22 @@ DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);        //! DeltaEta between Ds an
 DECLARE_SOA_COLUMN(PtD, ptD, float);                  //! Transverse momentum of Ds
 DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);        //! Transverse momentum of Hadron
 DECLARE_SOA_COLUMN(MD, mD, float);                    //! Invariant mass of Ds
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);            //! Pool Bin for the MixedEvent
 DECLARE_SOA_COLUMN(SignalStatus, signalStatus, bool); //! Used in MC-Rec, Ds Signal
+DECLARE_SOA_COLUMN(PromptStatus, promptStatus, bool); //! Used in MC-Rec, Ds Prompt
 } // namespace hf_correlation_ds_hadron
 DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informations
                   aod::hf_correlation_ds_hadron::DeltaPhi,
                   aod::hf_correlation_ds_hadron::DeltaEta,
                   aod::hf_correlation_ds_hadron::PtD,
-                  aod::hf_correlation_ds_hadron::PtHadron);
+                  aod::hf_correlation_ds_hadron::PtHadron,
+                  aod::hf_correlation_ds_hadron::PoolBin);
 DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_ds_hadron::MD,
-                  aod::hf_correlation_ds_hadron::SignalStatus);
+                  aod::hf_correlation_ds_hadron::SignalStatus,
+                  aod::hf_correlation_ds_hadron::PromptStatus);
+DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
+                  aod::hf_correlation_ds_hadron::PromptStatus);
 
 // definition of columns and tables for Dplus-Hadron correlation pairs
 namespace hf_correlation_dplus_hadron

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1293,7 +1293,7 @@ namespace hf_sel_collision_ds
 {
 DECLARE_SOA_COLUMN(DsFound, dsFound, bool); //! Ds found in a collision
 } // namespace hf_sel_collision_ds
-DECLARE_SOA_TABLE(DsSelCollision, "AOD", "DSCOLL", aod::ds_sel_collision::DsFound);
+DECLARE_SOA_TABLE(DsSelCollision, "AOD", "DSCOLL", aod::hf_sel_collision_ds::DsFound);
 
 // definition of columns and tables for Dplus-Hadron correlation pairs
 namespace hf_correlation_dplus_hadron

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1266,14 +1266,14 @@ DECLARE_SOA_TABLE(DHadronRecoInfo, "AOD", "DHADRONRECOINFO",
 // definition of columns and tables for Ds-Hadron correlation pairs
 namespace hf_correlation_ds_hadron
 {
-DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);        //! DeltaPhi between Ds and Hadrons
-DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);        //! DeltaEta between Ds and Hadrons
-DECLARE_SOA_COLUMN(PtD, ptD, float);                  //! Transverse momentum of Ds
-DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);        //! Transverse momentum of Hadron
-DECLARE_SOA_COLUMN(MD, mD, float);                    //! Invariant mass of Ds
-DECLARE_SOA_COLUMN(PoolBin, poolBin, int);            //! Pool Bin for the MixedEvent
-DECLARE_SOA_COLUMN(SignalStatus, signalStatus, bool); //! Used in MC-Rec, Ds Signal
-DECLARE_SOA_COLUMN(PromptStatus, promptStatus, bool); //! Used in MC-Rec, Ds Origin
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);            //! DeltaPhi between Ds and Hadrons
+DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);            //! DeltaEta between Ds and Hadrons
+DECLARE_SOA_COLUMN(PtD, ptD, float);                      //! Transverse momentum of Ds
+DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);            //! Transverse momentum of Hadron
+DECLARE_SOA_COLUMN(MD, mD, float);                        //! Invariant mass of Ds
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                //! Pool Bin for the MixedEvent
+DECLARE_SOA_COLUMN(IsSignalStatus, isSignalStatus, bool); //! Used in MC-Rec, Ds Signal
+DECLARE_SOA_COLUMN(IsOrigin, isOrigin, bool);             //! Used in MC-Rec, Ds Origin Prompt or Non-Prompt
 } // namespace hf_correlation_ds_hadron
 DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informations
                   aod::hf_correlation_ds_hadron::DeltaPhi,
@@ -1281,13 +1281,14 @@ DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informati
                   aod::hf_correlation_ds_hadron::PtD,
                   aod::hf_correlation_ds_hadron::PtHadron,
                   aod::hf_correlation_ds_hadron::PoolBin);
+
 DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_ds_hadron::MD,
-                  aod::hf_correlation_ds_hadron::SignalStatus,
-                  aod::hf_correlation_ds_hadron::PromptStatus);
+                  aod::hf_correlation_ds_hadron::IsSignalStatus,
+                  aod::hf_correlation_ds_hadron::IsOrigin);
 
 DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
-                  aod::hf_correlation_ds_hadron::PromptStatus);
+                  aod::hf_correlation_ds_hadron::IsOrigin);
 
 // table for selection of collisions with at least one Ds meson
 namespace hf_sel_collision_ds

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1266,14 +1266,14 @@ DECLARE_SOA_TABLE(DHadronRecoInfo, "AOD", "DHADRONRECOINFO",
 // definition of columns and tables for Ds-Hadron correlation pairs
 namespace hf_correlation_ds_hadron
 {
-DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);            //! DeltaPhi between Ds and Hadrons
-DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);            //! DeltaEta between Ds and Hadrons
-DECLARE_SOA_COLUMN(PtD, ptD, float);                      //! Transverse momentum of Ds
-DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);            //! Transverse momentum of Hadron
-DECLARE_SOA_COLUMN(MD, mD, float);                        //! Invariant mass of Ds
-DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                //! Pool Bin for the MixedEvent
-DECLARE_SOA_COLUMN(IsSignalStatus, isSignalStatus, bool); //! Used in MC-Rec, Ds Signal
-DECLARE_SOA_COLUMN(IsOrigin, isOrigin, bool);             //! Used in MC-Rec, Ds Origin Prompt or Non-Prompt
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float); //! DeltaPhi between Ds and Hadrons
+DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float); //! DeltaEta between Ds and Hadrons
+DECLARE_SOA_COLUMN(PtD, ptD, float);           //! Transverse momentum of Ds
+DECLARE_SOA_COLUMN(PtHadron, ptHadron, float); //! Transverse momentum of Hadron
+DECLARE_SOA_COLUMN(MD, mD, float);             //! Invariant mass of Ds
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);     //! Pool Bin for the MixedEvent
+DECLARE_SOA_COLUMN(IsSignal, isSignal, bool);  //! Used in MC-Rec, Ds Signal
+DECLARE_SOA_COLUMN(IsPrompt, isPrompt, bool);  //! Used in MC-Rec, Ds Prompt or Non-Prompt
 } // namespace hf_correlation_ds_hadron
 DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informations
                   aod::hf_correlation_ds_hadron::DeltaPhi,
@@ -1284,10 +1284,10 @@ DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informati
 
 DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_ds_hadron::MD,
-                  aod::hf_correlation_ds_hadron::IsSignalStatus);
+                  aod::hf_correlation_ds_hadron::IsSignal);
 
 DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
-                  aod::hf_correlation_ds_hadron::IsOrigin);
+                  aod::hf_correlation_ds_hadron::IsPrompt);
 
 // table for selection of collisions with at least one Ds meson
 namespace hf_sel_collision_ds

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -491,7 +491,6 @@ struct HfCorrelatorDsHadrons {
         }
         auto prong0McPart = candidate.prong0_as<myTracksMc>().mcParticle_as<candDsMcGen>();
         auto indexMother = RecoDecay::getMother(particlesMc, prong0McPart, pdg::Code::kDS, true);
-        auto particleMother = particlesMc.iteratorAt(indexMother);
         if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
           fillHistoMcRecSig(candidate, multiplicityV0M);
           // KKPi

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -466,15 +466,15 @@ struct HfCorrelatorDsHadrons {
       auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
 
       // MC reco level
-      bool flagDsPrompt;
-      bool flagDsSignal;
+      bool isDsPrompt = false;
+      bool isDsSignal = false;
       float multiplicityV0M = collision.multFV0M();
       for (const auto& candidate : candidates) {
         auto prong0McPart = candidate.prong0_as<MyTracksMc>().mcParticle_as<CandDsMcGen>();
         // prompt and non-prompt division
-        flagDsPrompt = candidate.originMcRec() == RecoDecay::OriginType::Prompt;
+        isDsPrompt = candidate.originMcRec() == RecoDecay::OriginType::Prompt;
         // Ds Signal
-        flagDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
+        isDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
 
         if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
           continue;
@@ -489,7 +489,7 @@ struct HfCorrelatorDsHadrons {
         if (applyEfficiency) {
           efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate.pt()));
         }
-        if (flagDsSignal) {
+        if (isDsSignal) {
           fillHistoMcRecSig(candidate, multiplicityV0M);
           // DsToKKPi and DsToPiKK division
           if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
@@ -533,16 +533,16 @@ struct HfCorrelatorDsHadrons {
                               candidate.pt(),
                               track.pt(),
                               poolBin);
-            entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal);
-            entryDsHadronGenInfo(flagDsPrompt);
+            entryDsHadronRecoInfo(invMassDsToKKPi(candidate), isDsSignal);
+            entryDsHadronGenInfo(isDsPrompt);
           } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
             entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
                               track.eta() - candidate.eta(),
                               candidate.pt(),
                               track.pt(),
                               poolBin);
-            entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal);
-            entryDsHadronGenInfo(flagDsPrompt);
+            entryDsHadronRecoInfo(invMassDsToPiKK(candidate), isDsSignal);
+            entryDsHadronGenInfo(isDsPrompt);
           }
         }
       }
@@ -568,7 +568,7 @@ struct HfCorrelatorDsHadrons {
     using BinningTypeMcGen = FlexibleBinningPolicy<std::tuple<decltype(getTracksSize)>, aod::mccollision::PosZ, decltype(getTracksSize)>;
     BinningTypeMcGen corrBinningMcGen{{getTracksSize}, {zBins, multBinsMcGen}, true};
     int poolBin = corrBinningMcGen.getBin(std::make_tuple(mccollision.posZ(), getTracksSize(mccollision)));
-    bool flagDsPrompt;
+    bool isDsPrompt = false;
 
     // MC gen level
     for (auto const& particle : particlesMc) {
@@ -587,7 +587,7 @@ struct HfCorrelatorDsHadrons {
         fillHistoMcGen(particle, yD);
         counterDsHadron++;
         // prompt and non-prompt division
-        flagDsPrompt = particle.originMcGen() == RecoDecay::OriginType::Prompt;
+        isDsPrompt = particle.originMcGen() == RecoDecay::OriginType::Prompt;
 
         // Ds Hadron correlation dedicated section
         for (auto const& particleAssoc : particlesMc) {
@@ -608,7 +608,7 @@ struct HfCorrelatorDsHadrons {
                             particleAssoc.pt(),
                             poolBin);
           entryDsHadronRecoInfo(1.968, true);
-          entryDsHadronGenInfo(flagDsPrompt);
+          entryDsHadronGenInfo(isDsPrompt);
         }
       }
     }
@@ -660,16 +660,16 @@ struct HfCorrelatorDsHadrons {
     auto tracksTuple = std::make_tuple(candidates, tracks);
     Pair<SelCollisionsWithDs, CandDsMcReco, MyTracksMc, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple, &cache};
 
-    bool flagDsPrompt;
-    bool flagDsSignal;
+    bool isDsPrompt = false;
+    bool isDsSignal = false;
     for (auto& [c1, tracks1, c2, tracks2] : pairMcRec) {
       int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
       for (auto& [candidate, pAssoc] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
         auto prong0McPart = candidate.prong0_as<MyTracksMc>().mcParticle_as<CandDsMcGen>();
         // prompt and non-prompt division
-        flagDsPrompt = candidate.originMcRec() == RecoDecay::OriginType::Prompt;
+        isDsPrompt = candidate.originMcRec() == RecoDecay::OriginType::Prompt;
         // Ds Signal
-        flagDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
+        isDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
 
         if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
           continue;
@@ -681,16 +681,16 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal);
-          entryDsHadronGenInfo(flagDsPrompt);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), isDsSignal);
+          entryDsHadronGenInfo(isDsPrompt);
         } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
                             candidate.eta() - pAssoc.eta(),
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal);
-          entryDsHadronGenInfo(flagDsPrompt);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), isDsSignal);
+          entryDsHadronGenInfo(isDsPrompt);
         }
       }
     }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -165,15 +165,15 @@ struct HfCorrelatorDsHadrons {
 
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<int> applyEfficiency{"applyEfficiency", 1, "Flag for applying D-meson efficiency weights"};
-  Configurable<double> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
-  Configurable<double> etaTrackMax{"etaTrackMax", 0.8, "max. eta of tracks"};
-  Configurable<double> dcaXYTrackMax{"dcaXYTrackMax", 1., "max. DCA_xy of tracks"};
-  Configurable<double> dcaZTrackMax{"dcaZTrackMax", 1., "max. DCA_z of tracks"};
-  Configurable<double> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
-  Configurable<double> ptTrackMin{"ptTrackMin", 0.3, "min. track pT"};
-  Configurable<double> ptTrackMax{"ptTrackMax", 50., "max. track pT"};
-  Configurable<double> multMin{"multMin", 0., "minimum multiplicity accepted"};
-  Configurable<double> multMax{"multMax", 10000., "maximum multiplicity accepted"};
+  Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. eta of tracks"};
+  Configurable<float> dcaXYTrackMax{"dcaXYTrackMax", 1., "max. DCA_xy of tracks"};
+  Configurable<float> dcaZTrackMax{"dcaZTrackMax", 1., "max. DCA_z of tracks"};
+  Configurable<float> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
+  Configurable<float> ptTrackMin{"ptTrackMin", 0.3, "min. track pT"};
+  Configurable<float> ptTrackMax{"ptTrackMax", 50., "max. track pT"};
+  Configurable<float> multMin{"multMin", 0., "minimum multiplicity accepted"};
+  Configurable<float> multMax{"multMax", 10000., "maximum multiplicity accepted"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", std::vector<double>{vecEfficiencyDmeson}, "Efficiency values for Ds meson"};
 
@@ -186,9 +186,8 @@ struct HfCorrelatorDsHadrons {
   using candDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;
   using candDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
 
-  Filter trackFilter = (aod::track::eta > static_cast<float>(-etaTrackMax)) && (aod::track::eta< static_cast<float>(etaTrackMax)) && (aod::track::pt > static_cast<float>(ptTrackMin)) 
-                       && (aod::track::dcaXY > static_cast<float>(-dcaXYTrackMax)) && (aod::track::dcaXY< static_cast<float>(dcaXYTrackMax)) && 
-                       (aod::track::dcaZ > static_cast<float>(-dcaZTrackMax)) && (aod::track::dcaZ< static_cast<float>(dcaZTrackMax));
+  Filter trackFilter = (aod::track::eta < std::abs(etaTrackMax)) && (aod::track::pt > ptTrackMin) 
+                       && (aod::track::dcaXY < std::abs(dcaXYTrackMax)) && (aod::track::dcaZ < std::abs(dcaZTrackMax));
   using myTracksData = soa::Filtered<soa::Join<aod::Tracks, aod::TracksDCA>>;
   using myTracksMc = soa::Filtered<soa::Join<aod::BigTracksMC, aod::TracksDCA>>;
   

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -167,7 +167,7 @@ struct HfCorrelatorDsHadrons {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", std::vector<double>{vecEfficiencyDmeson}, "Efficiency values for Ds meson"};
 
-  Filter collisionFilter = aod::hf_ds_sel_collision::dsFound == true;
+  Filter collisionFilter = aod::hf_sel_collision_ds::dsFound == true;
   Filter flagDsFilter = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << DecayType::DsToKKPi)) != static_cast<uint8_t>(0);
   Filter trackFilter = (aod::track::eta < std::abs(etaTrackMax)) && (aod::track::pt > ptTrackMin) && (aod::track::dcaXY < std::abs(dcaXYTrackMax)) && (aod::track::dcaZ < std::abs(dcaZTrackMax));
 

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -484,12 +484,8 @@ struct HfCorrelatorDsHadrons {
       }
       registry.fill(HIST("hMultiplicity"), nTracks);
 
-<<<<<<< Updated upstream
-      auto selectedDsCandidatesGroupedMC = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
-=======
       auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
        
->>>>>>> Stashed changes
       // MC reco level
       bool flagDsPrompt = false;
       float multiplicityV0M = collision.multFV0M();

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -64,7 +64,7 @@ BinningType corrBinning{{zBins, multBins}, true};
 
 struct HfDsSelectionCollision {
   SliceCache cache;
-  Produces<aod::DsSelCollision> collisionsWithSelDs; 
+  Produces<aod::DsSelCollision> collisionsWithSelDs;
 
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
@@ -78,7 +78,7 @@ struct HfDsSelectionCollision {
 
   Partition<candDsData> selectedDsAllCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
   Partition<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfCand3ProngMcRec>> recoFlagDsCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
-     
+
   void processDsSelCollisionsData(aod::Collision const& collision, candDsData const& candidates)
   {
     bool isDsFound = false;
@@ -99,7 +99,7 @@ struct HfDsSelectionCollision {
   }
   PROCESS_SWITCH(HfDsSelectionCollision, processDsSelCollisionsData, "Process Ds Collision Selection Data", true);
 
- void processDsSelCollisionsMcRec(aod::Collision const& collision, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfCand3ProngMcRec> const& candidates)
+  void processDsSelCollisionsMcRec(aod::Collision const& collision, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfCand3ProngMcRec> const& candidates)
   {
     bool isDsFound = false;
     if (recoFlagDsCandidates.size() > 0) {
@@ -171,14 +171,14 @@ struct HfCorrelatorDsHadrons {
   Filter flagDsFilter = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << DecayType::DsToKKPi)) != static_cast<uint8_t>(0);
   Filter trackFilter = (aod::track::eta < std::abs(etaTrackMax)) && (aod::track::pt > ptTrackMin) && (aod::track::dcaXY < std::abs(dcaXYTrackMax)) && (aod::track::dcaZ < std::abs(dcaZTrackMax));
 
-  using selCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::DsSelCollision>>; // collisionFilter applied
-  using selCollisionsWithDsMc = soa::Join<aod::McCollisions, aod::Mults, aod::DsSelCollision>; // collisionFilter applied
-  using candDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>; // flagDsFilter applied
+  using selCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::DsSelCollision>>;       // collisionFilter applied
+  using selCollisionsWithDsMc = soa::Join<aod::McCollisions, aod::Mults, aod::DsSelCollision>;                  // collisionFilter applied
+  using candDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>;                           // flagDsFilter applied
   using candDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>; // flagDsFilter applied
-  using candDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>; // flagDsFilter applied
-  using myTracksData = soa::Filtered<soa::Join<aod::Tracks, aod::TracksDCA>>; // trackFilter applied
-  using myTracksMc = soa::Filtered<soa::Join<aod::BigTracksMC, aod::TracksDCA>>; // trackFilter applied
-  
+  using candDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;                                      // flagDsFilter applied
+  using myTracksData = soa::Filtered<soa::Join<aod::Tracks, aod::TracksDCA>>;                                   // trackFilter applied
+  using myTracksMc = soa::Filtered<soa::Join<aod::BigTracksMC, aod::TracksDCA>>;                                // trackFilter applied
+
   Partition<candDsData> selectedDsAllCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
   Partition<candDsData> selectedDsToKKPiCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs;
   Partition<candDsData> selectedDsToPiKKCand = aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
@@ -282,7 +282,7 @@ struct HfCorrelatorDsHadrons {
     return;
   }
 
-  /// Fill histograms of quantities for the Ds signal for MC reco-level 
+  /// Fill histograms of quantities for the Ds signal for MC reco-level
   /// \param candidate is candidate
   /// \param multiplicityV0M is the multiplicity
   template <typename T1>
@@ -311,7 +311,7 @@ struct HfCorrelatorDsHadrons {
     return;
   }
 
-  /// Fill histograms of quantities for the Ds backgroung for MC reco-level 
+  /// Fill histograms of quantities for the Ds backgroung for MC reco-level
   /// \param candidate is candidate
   template <typename T1>
   void fillHistoMcRecBkg(const T1& candidate)
@@ -326,7 +326,7 @@ struct HfCorrelatorDsHadrons {
     return;
   }
 
-  /// Fill histograms of quantities for the Ds signal for MC reco-level 
+  /// Fill histograms of quantities for the Ds signal for MC reco-level
   /// \param particle is particle, Ds
   /// \param yD is the Ds rapidity
   template <typename T1>
@@ -375,7 +375,7 @@ struct HfCorrelatorDsHadrons {
 
       auto selectedDsToKKPiCandGrouped = selectedDsToKKPiCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
       auto selectedDsToPiKKCandGrouped = selectedDsToPiKKCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
-      
+
       // Ds fill histograms and Ds-Hadron correlation for DsToKKPi
       for (const auto& candidate : selectedDsToKKPiCandGrouped) {
         if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
@@ -471,7 +471,7 @@ struct HfCorrelatorDsHadrons {
       registry.fill(HIST("hMultiplicity"), nTracks);
 
       auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
-       
+
       // MC reco level
       bool flagDsPrompt = false;
       float multiplicityV0M = collision.multFV0M();
@@ -510,11 +510,11 @@ struct HfCorrelatorDsHadrons {
           }
           // prompt
           if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
-          flagDsPrompt = true;
+            flagDsPrompt = true;
           }
           // non-prompt
           if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
-          flagDsPrompt = false;
+            flagDsPrompt = false;
           }
         } else {
           fillHistoMcRecBkg(candidate);
@@ -591,7 +591,7 @@ struct HfCorrelatorDsHadrons {
       if (std::abs(particle.pdgCode()) != pdg::Code::kDS) {
         continue;
       }
-      if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi){ 
+      if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi) {
         double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
@@ -637,34 +637,34 @@ struct HfCorrelatorDsHadrons {
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcGen, "Process MC Gen mode", false);
 
   // Event Mixing
-   void processDataME(selCollisionsWithDs& collisions, candDsData& candidates, myTracksData& tracks)
-    {
-      auto tracksTuple = std::make_tuple(candidates,tracks);
-      Pair<selCollisionsWithDs, candDsData, myTracksData, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple, &cache};
-   
+  void processDataME(selCollisionsWithDs& collisions, candDsData& candidates, myTracksData& tracks)
+  {
+    auto tracksTuple = std::make_tuple(candidates, tracks);
+    Pair<selCollisionsWithDs, candDsData, myTracksData, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple, &cache};
+
     for (auto& [c1, tracks1, c2, tracks2] : pairData) {
-       LOGF(info, "Mixed event collisions: Index = (%d, %d), tracks Size: (%d, %d), Z Vertex: (%f, %f), Pool Bin: (%d, %d)", c1.globalIndex(), c2.globalIndex(), tracks1.size(), tracks2.size(), c1.posZ(), c2.posZ(), corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFV0M())),corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M())));
+      LOGF(info, "Mixed event collisions: Index = (%d, %d), tracks Size: (%d, %d), Z Vertex: (%f, %f), Pool Bin: (%d, %d)", c1.globalIndex(), c2.globalIndex(), tracks1.size(), tracks2.size(), c1.posZ(), c2.posZ(), corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFV0M())), corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M())));
       int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
-      for (auto& [candidate, pAssoc] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) { 
-          
+      for (auto& [candidate, pAssoc] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+
         if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
           continue;
         }
         // KKPi
-        if (candidate.isSelDsToKKPi() == selectionFlagDs){
-          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index()); 
-          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()), 
-                            candidate.eta() - pAssoc.eta(), 
+        if (candidate.isSelDsToKKPi() == selectionFlagDs) {
+          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index());
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
+                            candidate.eta() - pAssoc.eta(),
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
           entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
         }
         // PiKK
-        else if (candidate.isSelDsToPiKK() == selectionFlagDs){
-          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index()); 
-          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()), 
-                            candidate.eta() - pAssoc.eta(), 
+        else if (candidate.isSelDsToPiKK() == selectionFlagDs) {
+          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index());
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
+                            candidate.eta() - pAssoc.eta(),
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
@@ -679,8 +679,8 @@ struct HfCorrelatorDsHadrons {
   {
     auto tracksTuple = std::make_tuple(candidates, tracks);
     Pair<selCollisionsWithDs, candDsMcReco, myTracksMc, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple, &cache};
-    
-    //bool flagDsSignal = false;
+
+    // bool flagDsSignal = false;
     bool flagDsPrompt = false;
     for (auto& [c1, tracks1, c2, tracks2] : pairMcRec) {
       int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
@@ -701,19 +701,19 @@ struct HfCorrelatorDsHadrons {
         // KKPi
         if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
-                          candidate.eta() - pAssoc.eta(),
-                          candidate.pt(),
-                          pAssoc.pt(),
-                          poolBin);
+                            candidate.eta() - pAssoc.eta(),
+                            candidate.pt(),
+                            pAssoc.pt(),
+                            poolBin);
           entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal, flagDsPrompt);
         }
         // PiKK
         if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
-                          candidate.eta() - pAssoc.eta(),
-                          candidate.pt(),
-                          pAssoc.pt(),
-                          poolBin);
+                            candidate.eta() - pAssoc.eta(),
+                            candidate.pt(),
+                            pAssoc.pt(),
+                            poolBin);
           entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal, flagDsPrompt);
         }
       }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -93,7 +93,7 @@ struct HfDsSelectionCollision {
   {
     bool isDsFound = false;
     if (selectedDsAllCand.size() > 0) {
-      auto selectedDsAllCandGrouped = selectedDsAllCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      auto selectedDsAllCandGrouped = selectedDsAllCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
       for (auto const& candidate : selectedDsAllCandGrouped) {
         if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
           continue;
@@ -113,7 +113,7 @@ struct HfDsSelectionCollision {
   {
     bool isDsFound = false;
     if (recoFlagDsCandidates.size() > 0) {
-      auto selectedDsCandidatesGroupedMc = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      auto selectedDsCandidatesGroupedMc = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
       for (auto const& candidate : selectedDsCandidatesGroupedMc) {
         // check decay channel flag for candidate
         if (!(candidate.hfflag() & 1 << DecayType::DplusToPiKPi)) {
@@ -386,8 +386,8 @@ struct HfCorrelatorDsHadrons {
       }
       registry.fill(HIST("hMultiplicity"), nTracks);
 
-      auto selectedDsToKKPiCandGrouped = selectedDsToKKPiCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
-      auto selectedDsToPiKKCandGrouped = selectedDsToPiKKCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      auto selectedDsToKKPiCandGrouped = selectedDsToKKPiCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+      auto selectedDsToPiKKCandGrouped = selectedDsToPiKKCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
       
       // Ds fill histograms and Ds-Hadron correlation for DsToKKPi
       for (const auto& candidate : selectedDsToKKPiCandGrouped) {
@@ -483,7 +483,7 @@ struct HfCorrelatorDsHadrons {
       }
       registry.fill(HIST("hMultiplicity"), nTracks);
 
-      auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
        
       // MC reco level
       bool flagDsPrompt = false;
@@ -653,7 +653,7 @@ struct HfCorrelatorDsHadrons {
    void processDataME(selCollisionsWithDs& collisions, candDsData& candidates, myTracksData& tracks)
     {
       auto tracksTuple = std::make_tuple(candidates,tracks);
-      Pair<selCollisionsWithDs, candDsData, myTracksData, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple};
+      Pair<selCollisionsWithDs, candDsData, myTracksData, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple, &cache};
    
     for (auto& [c1, tracks1, c2, tracks2] : pairData) {
        LOGF(info, "Mixed event collisions: Index = (%d, %d), tracks Size: (%d, %d), Z Vertex: (%f, %f), Pool Bin: (%d, %d)", c1.globalIndex(), c2.globalIndex(), tracks1.size(), tracks2.size(), c1.posZ(), c2.posZ(), corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFV0M())),corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M())));
@@ -696,7 +696,7 @@ struct HfCorrelatorDsHadrons {
   void processMcRecME(selCollisionsWithDs& collisions, candDsMcReco& candidates, candDsMcGen const& particlesMc, myTracksMc& tracks)
   {
     auto tracksTuple = std::make_tuple(candidates, tracks);
-    Pair<selCollisionsWithDs, candDsMcReco, myTracksMc, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple};
+    Pair<selCollisionsWithDs, candDsMcReco, myTracksMc, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple, &cache};
     
     //bool flagDsSignal = false;
     bool flagDsPrompt = false;

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -200,36 +200,36 @@ struct HfCorrelatorDsHadrons {
      {"hEta", "Ds,Hadron candidates", {HistType::kTH1F, {axisEta}}},
      {"hPhi", "Ds,Hadron candidates", {HistType::kTH1F, {axisPhi}}},
      {"hY", "Ds,Hadron candidates", {HistType::kTH1F, {axisY}}},
-     {"hPtCandMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
-     {"hPtCandMCRecSigPrompt", "Ds,Hadron candidates Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
-     {"hPtCandMCRecSigNonPrompt", "Ds,Hadron candidates Non Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng0MCRecSig", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
-     {"hPtProng1MCRecSig", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
-     {"hPtProng2MCRecSig", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
-     {"hPtCandMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng0MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
-     {"hPtProng1MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
-     {"hPtProng2MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
-     {"hSelectionStatusMCRec", "Ds,Hadron candidates - MC Reco;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
-     {"hEtaMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
-     {"hPhiMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
-     {"hYMCRecSig", "Ds,Hadron candidates - MC Reco;;entries", {HistType::kTH1F, {axisY}}},
-     {"hEtaMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
-     {"hPhiMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
-     {"hYMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisY}}},
-     {"hMCEvtCount", "Event counter - MC Gen", {HistType::kTH1F, {{1, -0.5, 0.5}}}},
-     {"hPtCandMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPtD}}},
-     {"hPtCandMCGenPrompt", "Ds,Hadron particles - MC Gen Prompt", {HistType::kTH1F, {axisPtD}}},
-     {"hPtCandMCGenNonPrompt", "Ds,Hadron particles - MC Gen Non Prompt", {HistType::kTH1F, {axisPtD}}},
-     {"hEtaMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisEta}}},
-     {"hPhiMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPhi}}},
-     {"hYMCGen", "Ds,Hadron candidates - MC Gen", {HistType::kTH1F, {axisY}}},
+     {"hPtCandMcRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMcRecSigPrompt", "Ds,Hadron candidates Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMcRecSigNonPrompt", "Ds,Hadron candidates Non Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtProng0McRecSig", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
+     {"hPtProng1McRecSig", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
+     {"hPtProng2McRecSig", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
+     {"hPtCandMcRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtProng0McRecBkg", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
+     {"hPtProng1McRecBkg", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
+     {"hPtProng2McRecBkg", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
+     {"hSelectionStatusMcRec", "Ds,Hadron candidates - MC Reco;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hEtaMcRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMcRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
+     {"hYMcRecSig", "Ds,Hadron candidates - MC Reco;;entries", {HistType::kTH1F, {axisY}}},
+     {"hEtaMcRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMcRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
+     {"hYMcRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisY}}},
+     {"hMcEvtCount", "Event counter - MC Gen", {HistType::kTH1F, {{1, -0.5, 0.5}}}},
+     {"hPtCandMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMcGenPrompt", "Ds,Hadron particles - MC Gen Prompt", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMcGenNonPrompt", "Ds,Hadron particles - MC Gen Non Prompt", {HistType::kTH1F, {axisPtD}}},
+     {"hEtaMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPhi}}},
+     {"hYMcGen", "Ds,Hadron candidates - MC Gen", {HistType::kTH1F, {axisY}}},
      {"hCountDsHadronPerEvent", "Ds,Hadron particles - MC Gen;Number per event;entries", {HistType::kTH1F, {{21, -0.5, 20.5}}}},
      {"hMultiplicityPreSelection", "Multiplicity prior to selection;multiplicity;entries", {HistType::kTH1F, {axisMultiplicity}}},
-     {"hPtVsMultiplicityMCRecPrompt", "Multiplicity V0M - MC Rec Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
-     {"hPtVsMultiplicityMCRecNonPrompt", "Multiplicity V0M - MC Rec Non Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
-     {"hPtVsMultiplicityMCGenPrompt", "Multiplicity V0M - MC Gen Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
-     {"hPtVsMultiplicityMCGenNonPrompt", "Multiplicity V0M - MC Gen Non Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
+     {"hPtVsMultiplicityMcRecPrompt", "Multiplicity V0M - MC Rec Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
+     {"hPtVsMultiplicityMcRecNonPrompt", "Multiplicity V0M - MC Rec Non Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
+     {"hPtVsMultiplicityMcGenPrompt", "Multiplicity V0M - MC Gen Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
+     {"hPtVsMultiplicityMcGenNonPrompt", "Multiplicity V0M - MC Gen Non Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultiplicity}}}},
      {"hMultiplicity", "Multiplicity", {HistType::kTH1F, {axisMultiplicity}}},
      {"hMultV0M", "multiplicity;multiplicity;entries", {HistType::kTH1F, {axisMultiplicity}}},
      {"hZVtx", "z vertex;z vertex;entries", {HistType::kTH1F, {{200, -20., 20.}}}},
@@ -290,21 +290,21 @@ struct HfCorrelatorDsHadrons {
   template <typename T1>
   void fillHistoMcRecSig(const T1& candidate, float multiplicityV0M)
   {
-    registry.fill(HIST("hPtCandMCRecSig"), candidate.pt());
-    registry.fill(HIST("hPtProng0MCRecSig"), candidate.ptProng0());
-    registry.fill(HIST("hPtProng1MCRecSig"), candidate.ptProng1());
-    registry.fill(HIST("hPtProng2MCRecSig"), candidate.ptProng2());
-    registry.fill(HIST("hEtaMCRecSig"), candidate.eta());
-    registry.fill(HIST("hPhiMCRecSig"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
-    registry.fill(HIST("hYMCRecSig"), yDs(candidate));
+    registry.fill(HIST("hPtCandMcRecSig"), candidate.pt());
+    registry.fill(HIST("hPtProng0McRecSig"), candidate.ptProng0());
+    registry.fill(HIST("hPtProng1McRecSig"), candidate.ptProng1());
+    registry.fill(HIST("hPtProng2McRecSig"), candidate.ptProng2());
+    registry.fill(HIST("hEtaMcRecSig"), candidate.eta());
+    registry.fill(HIST("hPhiMcRecSig"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMcRecSig"), yDs(candidate));
 
     // prompt and non-prompt division
     if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
-      registry.fill(HIST("hPtCandMCRecSigPrompt"), candidate.pt());
-      registry.fill(HIST("hPtVsMultiplicityMCRecPrompt"), candidate.pt(), multiplicityV0M);
+      registry.fill(HIST("hPtCandMcRecSigPrompt"), candidate.pt());
+      registry.fill(HIST("hPtVsMultiplicityMcRecPrompt"), candidate.pt(), multiplicityV0M);
     } else if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
-      registry.fill(HIST("hPtCandMCRecSigNonPrompt"), candidate.pt());
-      registry.fill(HIST("hPtVsMultiplicityMCRecNonPrompt"), candidate.pt(), multiplicityV0M);
+      registry.fill(HIST("hPtCandMcRecSigNonPrompt"), candidate.pt());
+      registry.fill(HIST("hPtVsMultiplicityMcRecNonPrompt"), candidate.pt(), multiplicityV0M);
     }
   }
 
@@ -313,13 +313,13 @@ struct HfCorrelatorDsHadrons {
   template <typename T1>
   void fillHistoMcRecBkg(const T1& candidate)
   {
-    registry.fill(HIST("hPtCandMCRecBkg"), candidate.pt());
-    registry.fill(HIST("hPtProng0MCRecBkg"), candidate.ptProng0());
-    registry.fill(HIST("hPtProng1MCRecBkg"), candidate.ptProng1());
-    registry.fill(HIST("hPtProng2MCRecBkg"), candidate.ptProng2());
-    registry.fill(HIST("hEtaMCRecBkg"), candidate.eta());
-    registry.fill(HIST("hPhiMCRecBkg"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
-    registry.fill(HIST("hYMCRecBkg"), yDs(candidate));
+    registry.fill(HIST("hPtCandMcRecBkg"), candidate.pt());
+    registry.fill(HIST("hPtProng0McRecBkg"), candidate.ptProng0());
+    registry.fill(HIST("hPtProng1McRecBkg"), candidate.ptProng1());
+    registry.fill(HIST("hPtProng2McRecBkg"), candidate.ptProng2());
+    registry.fill(HIST("hEtaMcRecBkg"), candidate.eta());
+    registry.fill(HIST("hPhiMcRecBkg"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMcRecBkg"), yDs(candidate));
   }
 
   /// Fill histograms of quantities for the Ds signal for MC reco-level
@@ -328,17 +328,17 @@ struct HfCorrelatorDsHadrons {
   template <typename T1>
   void fillHistoMcGen(const T1& particle, double yD)
   {
-    registry.fill(HIST("hPtCandMCGen"), particle.pt());
-    registry.fill(HIST("hEtaMCGen"), particle.eta());
-    registry.fill(HIST("hPhiMCGen"), RecoDecay::constrainAngle(particle.phi(), -o2::constants::math::PIHalf));
-    registry.fill(HIST("hYMCGen"), yD);
+    registry.fill(HIST("hPtCandMcGen"), particle.pt());
+    registry.fill(HIST("hEtaMcGen"), particle.eta());
+    registry.fill(HIST("hPhiMcGen"), RecoDecay::constrainAngle(particle.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMcGen"), yD);
     registry.fill(HIST("hCountDstriggersMCGen"), 0, particle.pt()); // to count trigger Ds for normalisation
 
     // prompt and non-prompt division
     if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
-      registry.fill(HIST("hPtCandMCGenPrompt"), particle.pt());
+      registry.fill(HIST("hPtCandMcGenPrompt"), particle.pt());
     } else if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
-      registry.fill(HIST("hPtCandMCGenNonPrompt"), particle.pt());
+      registry.fill(HIST("hPtCandMcGenNonPrompt"), particle.pt());
     }
   }
 
@@ -496,12 +496,12 @@ struct HfCorrelatorDsHadrons {
             registry.fill(HIST("hMassDsMCRec"), invMassDsToKKPi(candidate), efficiencyWeight);
             registry.fill(HIST("hMassDsMCRecSig"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
             registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
-            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToKKPi());
+            registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelDsToKKPi());
           } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
             registry.fill(HIST("hMassDsMCRec"), invMassDsToPiKK(candidate), efficiencyWeight);
             registry.fill(HIST("hMassDsMCRecSig"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
             registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
-            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToPiKK());
+            registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelDsToPiKK());
           }
         } else {
           fillHistoMcRecBkg(candidate);
@@ -510,12 +510,12 @@ struct HfCorrelatorDsHadrons {
             registry.fill(HIST("hMassDsMCRec"), invMassDsToKKPi(candidate), efficiencyWeight);
             registry.fill(HIST("hMassDsMCRecBkg"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
             registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
-            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToKKPi());
+            registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelDsToKKPi());
           } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
             registry.fill(HIST("hMassDsMCRec"), invMassDsToPiKK(candidate), efficiencyWeight);
             registry.fill(HIST("hMassDsMCRecBkg"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
             registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
-            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToPiKK());
+            registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelDsToPiKK());
           }
         }
 
@@ -554,7 +554,7 @@ struct HfCorrelatorDsHadrons {
   void processMcGen(SelCollisionsWithDsMc::iterator const& mccollision, CandDsMcGen const& particlesMc)
   {
     int counterDsHadron = 0;
-    registry.fill(HIST("hMCEvtCount"), 0);
+    registry.fill(HIST("hMcEvtCount"), 0);
 
     auto getTracksSize = [&particlesMc](SelCollisionsWithDsMc::iterator const& mccollision) {
       int nTracks = 0;

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -74,6 +74,7 @@ using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFV0
 BinningType corrBinning{{zBins, multBins}, true};
 
 struct HfDsSelectionCollision {
+  SliceCache cache;
   Produces<aod::DsSelCollision> collisionSelDs; 
 
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
@@ -684,9 +685,6 @@ struct HfCorrelatorDsHadrons {
                             pAssoc.pt(),
                             poolBin);
           entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false, false);
-        }
-        else {
-          LOGF(info, "**** PROBLEM IN THE DS SELECTION OR IN THE FLAG USED ****");
         }
       }
     }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -607,7 +607,7 @@ struct HfCorrelatorDsHadrons {
                             particle.pt(),
                             particleAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(1.968, true);
+          entryDsHadronRecoInfo(RecoDecay::getMassPDG(particle.pdgCode()), true);
           entryDsHadronGenInfo(isDsPrompt);
         }
       }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -18,6 +18,9 @@
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
 #include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -30,6 +33,18 @@ using namespace o2::aod::hf_correlation_ds_hadron;
 using namespace o2::analysis::hf_cuts_ds_to_k_k_pi;
 using namespace o2::constants::math;
 
+namespace o2::aod
+{
+namespace ds_sel_collision
+{
+DECLARE_SOA_COLUMN(DsFound, dsFound, bool);
+} // namespace hash
+DECLARE_SOA_TABLE(DsSelCollision, "AOD", "DSCOLL", ds_sel_collision::DsFound);
+using It = DsSelCollision::iterator;
+} // namespace o2::aod
+
+using namespace o2::aod::ds_sel_collision;
+
 /// Returns deltaPhi value in range [-pi/2., 3.*pi/2], typically used for correlation studies
 double getDeltaPhi(double phiD, double phiHadron)
 {
@@ -41,14 +56,104 @@ const int nBinsPtMassAndEfficiency = o2::analysis::hf_cuts_ds_to_k_k_pi::nBinsPt
 const double efficiencyDmesonDefault[nBinsPtMassAndEfficiency] = {};
 auto vecEfficiencyDmeson = std::vector<double>{efficiencyDmesonDefault, efficiencyDmesonDefault + nBinsPtMassAndEfficiency};
 
-// histogram axes definition
-AxisSpec axisMassD = {300, 1.7, 2.2, ""};
-AxisSpec axisPhi = {128, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf, ""};
-AxisSpec axisEta = {100, -2., 2., ""};
-AxisSpec axisY = {100, -2., 2., ""};
-AxisSpec axisPtD = {180, 0., 36., ""};
+// histograms axes definition
+AxisSpec axisMassD = {200, 1.75, 2.13, "inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2})"};
+AxisSpec axisPhi = {128, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf, "#it{#varphi}"};
+AxisSpec axisEta = {100, -2., 2., "#it{#eta}"};
+AxisSpec axisY = {100, -2., 2., "#it{#y}"};
+AxisSpec axisPtD = {180, 0., 36., "#it{p}_{T}Ds (GeV/#it{c})"};
+AxisSpec axisPtProng0 = {180, 0., 36., "#it{p}_{T} prong0 (GeV/#it{c})"};
+AxisSpec axisPtProng1 = {180, 0., 36., "#it{p}_{T} prong1 (GeV/#it{c})"};
+AxisSpec axisPtProng2 = {180, 0., 36., "#it{p}_{T} prong2 (GeV/#it{c})"};
 
-using MCParticlesPlus3Prong = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
+// binning type
+std::vector<double> zBins{VARIABLE_WIDTH, -10.0, -2.5, 2.5, 10.0};
+std::vector<double> multBins{VARIABLE_WIDTH, 0., 200., 500.0, 5000.};
+std::vector<double> multBinsMcGen{VARIABLE_WIDTH, 0., 20., 50.0, 500.}; // In MCGen multiplicity is defined by counting primaries
+using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFV0M<aod::mult::MultFV0A, aod::mult::MultFV0C>>;
+BinningType corrBinning{{zBins, multBins}, true};
+
+struct HfDsSelectionCollision {
+  Produces<aod::DsSelCollision> collisionSelDs; 
+
+  Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
+  Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
+
+  Filter dsFlagFilter = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << DecayType::DsToKKPi)) != static_cast<uint8_t>(0); // filter in HfCand3Prong
+
+  using candDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>;
+  using candDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;
+  using candDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
+
+  Partition<candDsData> selectedDsAllCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
+  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfCand3ProngMcRec>> recoFlagDsCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
+     
+  void processDsSelCollisionsData(aod::Collision const& collision, candDsData const& candidates)
+  {
+    bool isDsFound = false;
+    if (selectedDsAllCand.size() > 0) {
+      auto selectedDsAllCandGrouped = selectedDsAllCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      for (auto const& candidate : selectedDsAllCandGrouped) {
+        if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        isDsFound = true;
+        break;
+      }
+    }
+    collisionSelDs(isDsFound);
+  }
+  PROCESS_SWITCH(HfDsSelectionCollision, processDsSelCollisionsData, "Process Ds Collision Selection Data", true);
+
+ void processDsSelCollisionsMcRec(aod::Collision const& collision, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfCand3ProngMcRec> const& candidates)
+  {
+    bool isDsFound = false;
+    if (recoFlagDsCandidates.size() > 0) {
+      auto selectedDsCandidatesGroupedMc = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      for (auto const& candidate : selectedDsCandidatesGroupedMc) {
+        // check decay channel flag for candidate
+        if (!(candidate.hfflag() & 1 << DecayType::DplusToPiKPi)) {
+          continue;
+        }
+        if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        isDsFound = true;
+        break;
+      }
+    }
+    collisionSelDs(isDsFound);
+  }
+  PROCESS_SWITCH(HfDsSelectionCollision, processDsSelCollisionsMcRec, "Process Ds Collision Selection MCRec", false);
+
+  void processDsSelCollisionsMcGen(aod::McCollision const& mccollision, candDsMcGen const& particlesMc)
+  {
+    bool isDsFound = false;
+    for (auto const& particle : particlesMc) {
+      if (std::abs(particle.pdgCode()) != pdg::Code::kDS) {
+        continue;
+      }
+      double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+      if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
+        continue;
+      }
+      if (ptCandMin >= 0. && particle.pt() < ptCandMin) {
+        continue;
+      }
+      isDsFound = true;
+      break;
+    }
+    collisionSelDs(isDsFound);
+  }
+  PROCESS_SWITCH(HfDsSelectionCollision, processDsSelCollisionsMcGen, "Process Ds Collision Selection MCGen", false);
+};
 
 /// Ds-Hadron correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
 struct HfCorrelatorDsHadrons {
@@ -56,6 +161,7 @@ struct HfCorrelatorDsHadrons {
   Preslice<aod::HfCand3Prong> perCol = aod::hf_cand::collisionId;
   Produces<aod::DsHadronPair> entryDsHadronPair;
   Produces<aod::DsHadronRecoInfo> entryDsHadronRecoInfo;
+  Produces<aod::DsHadronGenInfo> entryDsHadronGenInfo;
 
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<int> applyEfficiency{"applyEfficiency", 1, "Flag for applying D-meson efficiency weights"};
@@ -71,273 +177,578 @@ struct HfCorrelatorDsHadrons {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", std::vector<double>{vecEfficiencyDmeson}, "Efficiency values for Ds meson"};
 
-  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>> selectedDsCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
-  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>> recoFlagDsCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
+  Filter collisionFilter = aod::ds_sel_collision::dsFound == true;
+  using selCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::DsSelCollision>>;
+  using selCollisionsWithDsMc = soa::Join<aod::McCollisions, aod::Mults, aod::DsSelCollision>;
+
+  Filter flagDsFilter = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << DecayType::DsToKKPi)) != static_cast<uint8_t>(0);
+  using candDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>;
+  using candDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;
+  using candDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
+
+  Filter trackFilter = (aod::track::eta > static_cast<float>(-etaTrackMax)) && (aod::track::eta< static_cast<float>(etaTrackMax)) && (aod::track::pt > static_cast<float>(ptTrackMin)) 
+                       && (aod::track::dcaXY > static_cast<float>(-dcaXYTrackMax)) && (aod::track::dcaXY< static_cast<float>(dcaXYTrackMax)) && 
+                       (aod::track::dcaZ > static_cast<float>(-dcaZTrackMax)) && (aod::track::dcaZ< static_cast<float>(dcaZTrackMax));
+  using myTracksData = soa::Filtered<soa::Join<aod::Tracks, aod::TracksDCA>>;
+  using myTracksMc = soa::Filtered<soa::Join<aod::BigTracksMC, aod::TracksDCA>>;
+  
+  Partition<candDsData> selectedDsAllCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
+  Partition<candDsData> selectedDsToKKPiCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs;
+  Partition<candDsData> selectedDsToPiKKCand = aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
+  Partition<candDsMcReco> selectedDsMcRecoCand = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
 
   HistogramRegistry registry{
     "registry",
-    {{"hPtCand", "Ds,Hadron candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng0", "Ds,Hadron candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng1", "Ds,Hadron candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng2", "Ds,Hadron candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hSelectionStatus", "Ds,Hadron candidates;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
-     {"hEta", "Ds,Hadron candidates;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}}},
-     {"hPhi", "Ds,Hadron candidates;candidate #it{#varphi};entries", {HistType::kTH1F, {axisPhi}}},
-     {"hY", "Ds,Hadron candidates;candidate #it{#y};entries", {HistType::kTH1F, {axisY}}},
-     {"hPtCandMCRec", "Ds,Hadron candidates - MC reco;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng0MCRec", "Ds,Hadron candidates - MC reco;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng1MCRec", "Ds,Hadron candidates - MC reco;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hPtProng2MCRec", "Ds,Hadron candidates - MC reco;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hSelectionStatusMCRec", "Ds,Hadron candidates - MC reco;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
-     {"hEtaMCRec", "Ds,Hadron candidates - MC reco;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}}},
-     {"hPhiMCRec", "Ds,Hadron candidates - MC reco;candidate #it{#varphi};entries", {HistType::kTH1F, {axisPhi}}},
-     {"hYMCRec", "Ds,Hadron candidates - MC reco;candidate #it{#y};entries", {HistType::kTH1F, {axisY}}},
-     {"hMCEvtCount", "Event counter - MC gen;;entries", {HistType::kTH1F, {{1, -0.5, 0.5}}}},
-     {"hPtCandMCGen", "Ds,Hadron particles - MC gen;particle #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPtD}}},
-     {"hEtaMCGen", "Ds,Hadron particles - MC gen;particle #it{#eta};entries", {HistType::kTH1F, {axisEta}}},
-     {"hPhiMCGen", "Ds,Hadron particles - MC gen;particle #it{#varphi};entries", {HistType::kTH1F, {axisPhi}}},
-     {"hYMCGen", "Ds,Hadron candidates - MC gen;candidate #it{#y};entries", {HistType::kTH1F, {axisY}}},
-     {"hcountDsHadronPerEvent", "Ds,Hadron particles - MC gen;Number per event;entries", {HistType::kTH1F, {{20, 0., 20.}}}},
-     {"hMultiplicityPreSelection", "multiplicity prior to selection;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
-     {"hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}}}};
+    {{"hPtCand", "Ds,Hadron candidates", {HistType::kTH1F, {axisPtD}}},
+     {"hPtProng0", "Ds,Hadron candidates - prong 0", {HistType::kTH1F, {axisPtProng0}}},
+     {"hPtProng1", "Ds,Hadron candidates - prong 1", {HistType::kTH1F, {axisPtProng1}}},
+     {"hPtProng2", "Ds,Hadron candidates - prong 2", {HistType::kTH1F, {axisPtProng2}}},
+     {"hSelectionStatusDsToKKPi", "Ds,Hadron candidates;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hSelectionStatusDsToPiKK", "Ds,Hadron candidates;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hEta", "Ds,Hadron candidates", {HistType::kTH1F, {axisEta}}},
+     {"hPhi", "Ds,Hadron candidates", {HistType::kTH1F, {axisPhi}}},
+     {"hY", "Ds,Hadron candidates", {HistType::kTH1F, {axisY}}},
+     {"hPtCandMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMCRecSigPrompt", "Ds,Hadron candidates Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMCRecSigNonPrompt", "Ds,Hadron candidates Non Prompt - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtProng0MCRecSig", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
+     {"hPtProng1MCRecSig", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
+     {"hPtProng2MCRecSig", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
+     {"hPtCandMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPtD}}},
+     {"hPtProng0MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 0", {HistType::kTH1F, {axisPtProng0}}},
+     {"hPtProng1MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 1", {HistType::kTH1F, {axisPtProng1}}},
+     {"hPtProng2MCRecBkg", "Ds,Hadron candidates - MC Reco - prong 2", {HistType::kTH1F, {axisPtProng2}}},
+     {"hSelectionStatusMCRec", "Ds,Hadron candidates - MC Reco;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hEtaMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMCRecSig", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
+     {"hYMCRecSig", "Ds,Hadron candidates - MC Reco;;entries", {HistType::kTH1F, {axisY}}},
+     {"hEtaMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisPhi}}},
+     {"hYMCRecBkg", "Ds,Hadron candidates - MC Reco", {HistType::kTH1F, {axisY}}},
+     {"hMCEvtCount", "Event counter - MC Gen", {HistType::kTH1F, {{1, -0.5, 0.5}}}},
+     {"hPtCandMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMCGenPrompt", "Ds,Hadron particles - MC Gen Prompt", {HistType::kTH1F, {axisPtD}}},
+     {"hPtCandMCGenNonPrompt", "Ds,Hadron particles - MC Gen Non Prompt", {HistType::kTH1F, {axisPtD}}},
+     {"hEtaMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisEta}}},
+     {"hPhiMCGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPhi}}},
+     {"hYMCGen", "Ds,Hadron candidates - MC Gen", {HistType::kTH1F, {axisY}}},
+     {"hcountDsHadronPerEvent", "Ds,Hadron particles - MC Gen;Number per event;entries", {HistType::kTH1F, {{21, -0.5, 20.5}}}},
+     {"hMultiplicityPreSelection", "Multiplicity prior to selection;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"hPtVsMultiplicityMCRecPrompt", "Multiplicity V0M - MC Rec Prompt", {HistType::kTH2F, {{axisPtD}, {1000, 0., 10000.}}}},
+     {"hPtVsMultiplicityMCRecNonPrompt", "Multiplicity V0M - MC Rec Non Prompt", {HistType::kTH2F, {{axisPtD}, {1000, 0., 10000.}}}},
+     {"hPtVsMultiplicityMCGenPrompt", "Multiplicity V0M - MC Gen Prompt", {HistType::kTH2F, {{axisPtD}, {1000, 0., 10000.}}}},
+     {"hPtVsMultiplicityMCGenNonPrompt", "Multiplicity V0M - MC Gen Non Prompt", {HistType::kTH2F, {{axisPtD}, {1000, 0., 10000.}}}},
+     {"hMultiplicity", "Multiplicity", {HistType::kTH1F, {{10000, 0., 10000., "multiplicity"}}}},
+     {"hMultV0M", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"hZvtx", "z vertex;z vertex;entries", {HistType::kTH1F, {{200, -20., 20.}}}},
+     {"hDsPoolBin", "Ds selected in pool Bin;pool Bin;entries", {HistType::kTH1F, {{9, 0., 9.}}}},
+     {"hTracksPoolBin", "Tracks selected in pool Bin;pool Bin;entries", {HistType::kTH1F, {{9, 0., 9.}}}}}};
 
   void init(o2::framework::InitContext&)
   {
     auto vbins = (std::vector<double>)binsPt;
-    registry.add("hMassDs2D", "Ds candidates;inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hMassDsData", "Ds candidates;inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassD}});
-    registry.add("hMassDsMCRec", "Ds candidates;inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassD}});
-    registry.add("hMassDsMCRecSig", "Ds signal candidates - MC reco;inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hMassDsMCRecBkg", "Ds background candidates - MC reco;inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hcountDstriggersMCGen", "Ds trigger particles - MC gen;;N of trigger Ds", {HistType::kTH2F, {{1, -0.5, 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassDs2D", "Ds candidates", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassDsData", "Ds candidates", {HistType::kTH1F, {axisMassD}});
+    registry.add("hMassDsMCRec", "Ds candidates", {HistType::kTH1F, {axisMassD}});
+    registry.add("hMassDsVsPtMCRec", "Ds signal candidates - MC Reco", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassDsMCRecSig", "Ds signal candidates - MC Reco", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassDsMCRecBkg", "Ds background candidates - MC Reco", {HistType::kTH2F, {{axisMassD}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hcountDstriggersMCGen", "Ds trigger particles - MC Gen", {HistType::kTH2F, {{1, -0.5, 0.5, "number of Ds triggers"}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+  }
+
+  /// Fill histograms of quantities independent from the daugther-mass hypothesis for data
+  /// \param candidate is candidate
+  template <typename T1>
+  void fillHisto(const T1& candidate)
+  {
+    registry.fill(HIST("hPtCand"), candidate.pt());
+    registry.fill(HIST("hPtProng0"), candidate.ptProng0());
+    registry.fill(HIST("hPtProng1"), candidate.ptProng1());
+    registry.fill(HIST("hPtProng2"), candidate.ptProng2());
+    registry.fill(HIST("hEta"), candidate.eta());
+    registry.fill(HIST("hPhi"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hY"), yDs(candidate));
+    return;
+  }
+
+  /// Fill histograms of quantities for the KKPi daugther-mass hypothesis for data
+  /// \param candidate is candidate
+  /// \param efficiencyWeight is the efficiency correction
+  template <typename T1>
+  void fillHistoKKPi(const T1& candidate, double efficiencyWeight)
+  {
+    registry.fill(HIST("hMassDs2D"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
+    registry.fill(HIST("hMassDsData"), invMassDsToKKPi(candidate), efficiencyWeight);
+    registry.fill(HIST("hSelectionStatusDsToKKPi"), candidate.isSelDsToKKPi());
+    return;
+  }
+
+  /// Fill histograms of quantities for the PiKK daugther-mass hypothesis for data
+  /// \param candidate is candidate
+  /// \param efficiencyWeight is the efficiency correction
+  template <typename T1>
+  void fillHistoPiKK(const T1& candidate, double efficiencyWeight)
+  {
+    registry.fill(HIST("hMassDs2D"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
+    registry.fill(HIST("hMassDsData"), invMassDsToPiKK(candidate), efficiencyWeight);
+    registry.fill(HIST("hSelectionStatusDsToPiKK"), candidate.isSelDsToPiKK());
+    return;
+  }
+
+  /// Fill histograms of quantities for the Ds signal for MC reco-level 
+  /// \param candidate is candidate
+  /// \param multiplicityV0M is the multiplicity
+  template <typename T1>
+  void fillHistoMcRecSig(const T1& candidate, float multiplicityV0M)
+  {
+    registry.fill(HIST("hPtCandMCRecSig"), candidate.pt());
+    registry.fill(HIST("hPtProng0MCRecSig"), candidate.ptProng0());
+    registry.fill(HIST("hPtProng1MCRecSig"), candidate.ptProng1());
+    registry.fill(HIST("hPtProng2MCRecSig"), candidate.ptProng2());
+    registry.fill(HIST("hEtaMCRecSig"), candidate.eta());
+    registry.fill(HIST("hPhiMCRecSig"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMCRecSig"), yDs(candidate));
+
+    // prompt
+    if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
+      registry.fill(HIST("hPtCandMCRecSigPrompt"), candidate.pt());
+      //std::cout <<"Multiplicity when Prompt: "<< multiplicityV0M << std::endl;
+      registry.fill(HIST("hPtVsMultiplicityMCRecPrompt"), candidate.pt(), multiplicityV0M);
+    }
+
+    // non-prompt
+    if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
+      registry.fill(HIST("hPtCandMCRecSigNonPrompt"), candidate.pt());
+      registry.fill(HIST("hPtVsMultiplicityMCRecNonPrompt"), candidate.pt(), multiplicityV0M);
+    }
+
+    return;
+  }
+
+  /// Fill histograms of quantities for the Ds backgroung for MC reco-level 
+  /// \param candidate is candidate
+  template <typename T1>
+  void fillHistoMcRecBkg(const T1& candidate)
+  {
+    registry.fill(HIST("hPtCandMCRecBkg"), candidate.pt());
+    registry.fill(HIST("hPtProng0MCRecBkg"), candidate.ptProng0());
+    registry.fill(HIST("hPtProng1MCRecBkg"), candidate.ptProng1());
+    registry.fill(HIST("hPtProng2MCRecBkg"), candidate.ptProng2());
+    registry.fill(HIST("hEtaMCRecBkg"), candidate.eta());
+    registry.fill(HIST("hPhiMCRecBkg"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMCRecBkg"), yDs(candidate));
+    return;
+  }
+
+  /// Fill histograms of quantities for the Ds signal for MC reco-level 
+  /// \param particle is particle, Ds
+  /// \param yD is the Ds rapidity
+  template <typename T1>
+  void fillHistoMcGen(const T1& particle, double yD)
+  {
+    registry.fill(HIST("hPtCandMCGen"), particle.pt());
+    registry.fill(HIST("hEtaMCGen"), particle.eta());
+    registry.fill(HIST("hPhiMCGen"), RecoDecay::constrainAngle(particle.phi(), -o2::constants::math::PIHalf));
+    registry.fill(HIST("hYMCGen"), yD);
+    registry.fill(HIST("hcountDstriggersMCGen"), 0, particle.pt()); // to count trigger Ds for normalisation
+
+    // prompt
+    if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
+      registry.fill(HIST("hPtCandMCGenPrompt"), particle.pt());
+    }
+
+    // non-prompt
+    if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
+      registry.fill(HIST("hPtCandMCGenNonPrompt"), particle.pt());
+    }
+
+    return;
   }
 
   /// Ds-hadron correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
-  void processData(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi> const& candidates)
+  void processData(selCollisionsWithDs::iterator const& collision, candDsData const& candidates, myTracksData const& tracks)
   {
-    // number of tracks
-    if (selectedDsCandidates.size() > 0) {
+    if (selectedDsAllCand.size() > 0) {
+      registry.fill(HIST("hZvtx"), collision.posZ());
+      registry.fill(HIST("hMultV0M"), collision.multFV0M());
+      int poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.multFV0M()));
       int nTracks = 0;
       if (collision.numContrib() > 1) {
         for (const auto& track : tracks) {
-          if (std::abs(track.eta()) > etaTrackMax) {
-            continue;
-          }
-          if (std::abs(track.dcaXY()) > dcaXYTrackMax || std::abs(track.dcaZ()) > dcaZTrackMax) {
+          if (std::abs(track.eta()) > etaTrackMax) { // se tolgo da errore perche track e' unused variable
             continue;
           }
           nTracks++;
+          registry.fill(HIST("hTracksPoolBin"), poolBin);
         }
       }
-
-      auto selectedDsCandidatesGrouped = selectedDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
-
-      for (const auto& candidate1 : selectedDsCandidatesGrouped) {
-        if (yCandMax >= 0. && std::abs(yDs(candidate1)) > yCandMax) {
-          continue;
-        }
-        if (ptCandMin >= 0. && candidate1.pt() < ptCandMin) {
-          continue;
-        }
-        if (candidate1.pt() > ptTrackMax) {
-          continue;
-        }
-        // check decay channel flag for candidate1
-        if (!(candidate1.hfflag() & 1 << DecayType::DsToKKPi)) {
-          continue;
-        }
-        double efficiencyWeight = 1.;
-        if (applyEfficiency) {
-          efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate1.pt()));
-        }
-
-        // fill invariant mass plots and generic info from all Ds candidates
-        registry.fill(HIST("hMassDs2D"), invMassDsToKKPi(candidate1), candidate1.pt(), efficiencyWeight);
-        registry.fill(HIST("hMassDsData"), invMassDsToKKPi(candidate1), efficiencyWeight);
-        registry.fill(HIST("hPtCand"), candidate1.pt());
-        registry.fill(HIST("hPtProng0"), candidate1.ptProng0());
-        registry.fill(HIST("hPtProng1"), candidate1.ptProng1());
-        registry.fill(HIST("hPtProng2"), candidate1.ptProng2());
-        registry.fill(HIST("hEta"), candidate1.eta());
-        registry.fill(HIST("hPhi"), RecoDecay::constrainAngle(candidate1.phi(), -o2::constants::math::PIHalf));
-        registry.fill(HIST("hY"), yDs(candidate1));
-        registry.fill(HIST("hSelectionStatus"), candidate1.isSelDsToKKPi());
-
-        // Ds-Hadron correlation dedicated section
-        // if the candidate is a Ds, search for Hadrons and evaluate correlations
-        for (const auto& track : tracks) {
-          if (std::abs(track.eta()) > etaTrackMax) {
-            continue;
-          }
-          if (track.pt() < ptTrackMin) {
-            continue;
-          }
-          // Remove secondary tracks
-          if (std::abs(track.dcaXY()) >= dcaXYTrackMax || std::abs(track.dcaZ()) >= dcaZTrackMax) {
-            continue;
-          }
-          // Removing Ds daughters by checking track indices
-          if ((candidate1.prong0Id() == track.globalIndex()) || (candidate1.prong1Id() == track.globalIndex()) || (candidate1.prong2Id() == track.globalIndex())) {
-            continue;
-          }
-          entryDsHadronPair(getDeltaPhi(track.phi(), candidate1.phi()),
-                            track.eta() - candidate1.eta(),
-                            candidate1.pt(),
-                            track.pt());
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate1), false);
-        } // Hadron Tracks loop
-      }   // end outer Ds loop
-    }
-  }
-  PROCESS_SWITCH(HfCorrelatorDsHadrons, processData, "Process data", true);
-
-  /// Ds-Hadron correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
-  void processMcRec(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec> const& candidates)
-  {
-    if (recoFlagDsCandidates.size() > 0) {
-      int nTracks = 0;
-      if (collision.numContrib() > 1) {
-        for (const auto& track : tracks) {
-          if (std::abs(track.eta()) > etaTrackMax) {
-            continue;
-          }
-          if (std::abs(track.dcaXY()) > dcaXYTrackMax || std::abs(track.dcaZ()) > dcaZTrackMax) {
-            continue;
-          }
-          nTracks++;
-        }
-      }
-      registry.fill(HIST("hMultiplicityPreSelection"), nTracks);
       if (nTracks < multMin || nTracks > multMax) {
         return;
       }
       registry.fill(HIST("hMultiplicity"), nTracks);
 
-      auto selectedDsCandidatesGroupedMC = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
-      // MC reco level
-      bool flagDsSignal = false;
-      for (const auto& candidate1 : selectedDsCandidatesGroupedMC) {
-        // check decay channel flag for candidate1
-        if (!(candidate1.hfflag() & 1 << DecayType::DsToKKPi)) {
+      auto selectedDsToKKPiCandGrouped = selectedDsToKKPiCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      auto selectedDsToPiKKCandGrouped = selectedDsToPiKKCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+      
+      // Ds fill histograms and Ds-Hadron correlation for DsToKKPi
+      for (const auto& candidate : selectedDsToKKPiCandGrouped) {
+        if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
           continue;
         }
-        if (yCandMax >= 0. && std::abs(yDs(candidate1)) > yCandMax) {
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
           continue;
         }
-        if (ptCandMin >= 0. && candidate1.pt() < ptCandMin) {
-          continue;
-        }
-        if (candidate1.pt() >= ptTrackMax) {
+        if (candidate.pt() > ptTrackMax) {
           continue;
         }
         double efficiencyWeight = 1.;
         if (applyEfficiency) {
-          efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate1.pt()));
+          efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate.pt()));
         }
-
-        if (std::abs(candidate1.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
-          // fill per-candidate distributions from Ds true candidates
-          registry.fill(HIST("hPtCandMCRec"), candidate1.pt());
-          registry.fill(HIST("hPtProng0MCRec"), candidate1.ptProng0());
-          registry.fill(HIST("hPtProng1MCRec"), candidate1.ptProng1());
-          registry.fill(HIST("hPtProng2MCRec"), candidate1.ptProng2());
-          registry.fill(HIST("hEtaMCRec"), candidate1.eta());
-          registry.fill(HIST("hPhiMCRec"), RecoDecay::constrainAngle(candidate1.phi(), -o2::constants::math::PIHalf));
-          registry.fill(HIST("hYMCRec"), yDs(candidate1));
-          registry.fill(HIST("hSelectionStatusMCRec"), candidate1.isSelDsToKKPi());
-        }
-        // fill invariant mass plots from Ds signal and background candidates
-        registry.fill(HIST("hMassDsMCRec"), invMassDsToKKPi(candidate1), efficiencyWeight);
-        if (candidate1.flagMcMatchRec() == 1 << DecayType::DsToKKPi) { // also matched as Ds
-          registry.fill(HIST("hMassDsMCRecSig"), invMassDsToKKPi(candidate1), candidate1.pt(), efficiencyWeight);
-        } else {
-          registry.fill(HIST("hMassDsMCRecBkg"), invMassDsToKKPi(candidate1), candidate1.pt(), efficiencyWeight);
-        }
+        fillHisto(candidate);
+        fillHistoKKPi(candidate, efficiencyWeight);
 
         // Ds-Hadron correlation dedicated section
-        // if the candidate is selected as Ds, search for Hadron and evaluate correlations
-        flagDsSignal = candidate1.flagMcMatchRec() == 1 << DecayType::DsToKKPi;
+        for (const auto& track : tracks) {
+          // Removing Ds daughters by checking track indices
+          if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
+            continue;
+          }
+          entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
+        }
+      }
+
+      // Ds fill histograms and Ds-Hadron correlation for DsToPiKK
+      for (const auto& candidate : selectedDsToPiKKCandGrouped) {
+        if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        if (candidate.pt() > ptTrackMax) {
+          continue;
+        }
+        double efficiencyWeight = 1.;
+        if (applyEfficiency) {
+          efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate.pt()));
+        }
+        fillHisto(candidate);
+        fillHistoPiKK(candidate, efficiencyWeight);
+
+        // Ds-Hadron correlation dedicated section
+        for (const auto& track : tracks) {
+          // Removing Ds daughters by checking track indices
+          if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
+            continue;
+          }
+          entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false, false);
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorDsHadrons, processData, "Process data", true);
+
+  /// Ds-Hadron correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
+  void processMcRec(selCollisionsWithDs::iterator const& collision, candDsMcReco const& candidates, candDsMcGen const& particlesMc, myTracksMc const& tracks)
+  {
+    if (selectedDsMcRecoCand.size() > 0) {
+      registry.fill(HIST("hZvtx"), collision.posZ());
+      registry.fill(HIST("hMultV0M"), collision.multFV0M());
+      int poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.multFV0M()));
+      int nTracks = 0;
+      if (collision.numContrib() > 1) {
         for (const auto& track : tracks) {
           if (std::abs(track.eta()) > etaTrackMax) {
             continue;
           }
-          if (track.pt() < ptTrackMin) {
+          if (std::abs(track.dcaXY()) > dcaXYTrackMax || std::abs(track.dcaZ()) > dcaZTrackMax) {
             continue;
           }
-          // Removing Ds daughters by checking track indices
-          if ((candidate1.prong0Id() == track.globalIndex()) || (candidate1.prong1Id() == track.globalIndex()) || (candidate1.prong2Id() == track.globalIndex())) {
-            continue;
-          }
-          if (std::abs(track.dcaXY()) >= dcaXYTrackMax || std::abs(track.dcaZ()) >= dcaZTrackMax) {
-            continue; // Remove secondary tracks
-          }
-          entryDsHadronPair(getDeltaPhi(track.phi(), candidate1.phi()),
-                            track.eta() - candidate1.eta(),
-                            candidate1.pt(),
-                            track.pt());
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate1), flagDsSignal);
-        } // end inner loop (Tracks)
+          nTracks++;
+        }
+      }
+      //registry.fill(HIST("hMultiplicityPreSelection"), nTracks);
+      if (nTracks < multMin || nTracks > multMax) {
+        return;
+      }
+      registry.fill(HIST("hMultiplicity"), nTracks);
 
-      } // end outer Ds loop
+<<<<<<< Updated upstream
+      auto selectedDsCandidatesGroupedMC = recoFlagDsCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+=======
+      auto selectedDsMcRecoCandGrouped = selectedDsMcRecoCand->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex());
+       
+>>>>>>> Stashed changes
+      // MC reco level
+      bool flagDsPrompt = false;
+      float multiplicityV0M = collision.multFV0M();
+      for (const auto& candidate : candidates) {
+        if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        if (candidate.pt() >= ptTrackMax) {
+          continue;
+        }
+        double efficiencyWeight = 1.;
+        if (applyEfficiency) {
+          efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate.pt()));
+        }
+        auto prong0McPart = candidate.prong0_as<myTracksMc>().mcParticle_as<candDsMcGen>();
+        auto indexMother = RecoDecay::getMother(particlesMc, prong0McPart, pdg::Code::kDS, true);
+        auto particleMother = particlesMc.iteratorAt(indexMother);
+        if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
+          fillHistoMcRecSig(candidate, multiplicityV0M);
+          // KKPi
+          if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
+            registry.fill(HIST("hMassDsMCRec"), invMassDsToKKPi(candidate), efficiencyWeight);
+            registry.fill(HIST("hMassDsMCRecSig"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToKKPi());
+          }
+          // PiKK
+          if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
+            registry.fill(HIST("hMassDsMCRec"), invMassDsToPiKK(candidate), efficiencyWeight);
+            registry.fill(HIST("hMassDsMCRecSig"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToPiKK());
+          }
+          // prompt
+          if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
+          flagDsPrompt = true;
+          }
+          // non-prompt
+          if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
+          flagDsPrompt = false;
+          }
+        } else {
+          fillHistoMcRecBkg(candidate);
+          // KKPi
+          if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
+            registry.fill(HIST("hMassDsMCRec"), invMassDsToKKPi(candidate), efficiencyWeight);
+            registry.fill(HIST("hMassDsMCRecBkg"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToKKPi());
+          }
+          // PiKK
+          if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
+            registry.fill(HIST("hMassDsMCRec"), invMassDsToPiKK(candidate), efficiencyWeight);
+            registry.fill(HIST("hMassDsMCRecBkg"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hMassDsVsPtMCRec"), invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeight);
+            registry.fill(HIST("hSelectionStatusMCRec"), candidate.isSelDsToPiKK());
+          }
+        }
+
+        // Ds-Hadron correlation dedicated section
+        // if the candidate is selected as Ds, search for Hadron and evaluate correlations
+        bool flagDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
+        for (const auto& track : tracks) {
+          // Removing Ds daughters by checking track indices
+          if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
+            continue;
+          }
+          // KKPi
+          if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
+            entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                              track.eta() - candidate.eta(),
+                              candidate.pt(),
+                              track.pt(),
+                              poolBin);
+            entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal, flagDsPrompt);
+          }
+          // PiKK
+          if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
+            entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                              track.eta() - candidate.eta(),
+                              candidate.pt(),
+                              track.pt(),
+                              poolBin);
+            entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal, flagDsPrompt);
+          }
+        }
+      }
     }
   }
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcRec, "Process MC Reco mode", false);
 
   /// Ds-Hadron correlation pair builder - for MC gen-level analysis (no filter/selection, only true signal)
-  void processMcGen(aod::McCollision const&, MCParticlesPlus3Prong const& particlesMc)
+  void processMcGen(selCollisionsWithDsMc::iterator const& mccollision, candDsMcGen const& particlesMc)
   {
     int counterDsHadron = 0;
     registry.fill(HIST("hMCEvtCount"), 0);
+
+    auto getTracksSize = [&particlesMc](selCollisionsWithDsMc::iterator const& mccollision) {
+      int nTracks = 0;
+      for (auto& track : particlesMc) {
+        if (track.isPhysicalPrimary() && std::abs(track.eta()) < 1.0) {
+          nTracks++;
+        }
+      }
+      return nTracks;
+    };
+    using BinningTypeMcGen = FlexibleBinningPolicy<std::tuple<decltype(getTracksSize)>, aod::mccollision::PosZ, decltype(getTracksSize)>;
+    BinningTypeMcGen corrBinningMcGen{{getTracksSize}, {zBins, multBinsMcGen}, true};
+    int poolBin = corrBinningMcGen.getBin(std::make_tuple(mccollision.posZ(), getTracksSize(mccollision)));
+
     // MC gen level
-    for (auto const& particle1 : particlesMc) {
-      // check if the particle is Ds  (for general plot filling and selection, so both cases are fine) - NOTE: decay channel is not probed!
-      if (std::abs(particle1.pdgCode()) != pdg::Code::kDS) {
+    for (auto const& particle : particlesMc) {
+      // check if the particle is Ds
+      if (std::abs(particle.pdgCode()) != pdg::Code::kDS) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
-      if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
-        continue;
-      }
-      if (ptCandMin >= 0. && particle1.pt() < ptCandMin) {
-        continue;
-      }
-      registry.fill(HIST("hPtCandMCGen"), particle1.pt());
-      registry.fill(HIST("hEtaMCGen"), particle1.eta());
-      registry.fill(HIST("hPhiMCGen"), RecoDecay::constrainAngle(particle1.phi(), -o2::constants::math::PIHalf));
-      registry.fill(HIST("hYMCGen"), yD);
-      counterDsHadron++;
-      // Ds Hadron correlation dedicated section
-      // if it's a Ds particle, search for Hadron and evaluate correlations
-      if (std::abs(particle1.pdgCode()) != pdg::Code::kDS) { // just checking the particle PDG, not the decay channel (differently from Reco: you have a BR factor btw such levels!)
-        continue;
-      }
-      registry.fill(HIST("hcountDstriggersMCGen"), 0, particle1.pt()); // to count trigger Ds for normalisation
-
-      for (auto const& particle2 : particlesMc) {
-        if (std::abs(particle2.eta()) > etaTrackMax) {
+      if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi){ 
+        double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }
-        if (particle2.pt() < ptTrackMin) {
+        if (ptCandMin >= 0. && particle.pt() < ptCandMin) {
           continue;
         }
-
-        if ((std::abs(particle2.pdgCode()) != kElectron) && (std::abs(particle2.pdgCode()) != kMuonMinus) && (std::abs(particle2.pdgCode()) != kPiPlus) && (std::abs(particle2.pdgCode()) != kKPlus) && (std::abs(particle2.pdgCode()) != kProton)) {
-          continue;
+        fillHistoMcGen(particle, yD);
+        counterDsHadron++;
+        bool flagDsPrompt = false;
+        // prompt
+        if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
+          flagDsPrompt = true;
         }
+        // non-prompt
+        if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
+          flagDsPrompt = false;
+        }
+        // Ds Hadron correlation dedicated section
+        for (auto const& particleAssoc : particlesMc) {
+          if (std::abs(particleAssoc.eta()) > etaTrackMax) {
+            continue;
+          }
+          if (particleAssoc.pt() < ptTrackMin) {
+            continue;
+          }
 
-        entryDsHadronPair(getDeltaPhi(particle2.phi(), particle1.phi()),
-                          particle2.eta() - particle1.eta(),
-                          particle1.pt(),
-                          particle2.pt());
+          if ((std::abs(particleAssoc.pdgCode()) != kElectron) && (std::abs(particleAssoc.pdgCode()) != kMuonMinus) && (std::abs(particleAssoc.pdgCode()) != kPiPlus) && (std::abs(particleAssoc.pdgCode()) != kKPlus) && (std::abs(particleAssoc.pdgCode()) != kProton)) {
+            continue;
+          }
 
-      } // end inner loop
-    }   // end outer loop
+          entryDsHadronPair(getDeltaPhi(particleAssoc.phi(), particle.phi()),
+                            particleAssoc.eta() - particle.eta(),
+                            particle.pt(),
+                            particleAssoc.pt(),
+                            poolBin);
+          entryDsHadronGenInfo(flagDsPrompt);
+        }
+      }
+    }
     registry.fill(HIST("hcountDsHadronPerEvent"), counterDsHadron);
   }
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcGen, "Process MC Gen mode", false);
+
+  // Event Mixing
+   void processDataME(selCollisionsWithDs& collisions, candDsData& candidates, myTracksData& tracks)
+    {
+      auto tracksTuple = std::make_tuple(candidates,tracks);
+      Pair<selCollisionsWithDs, candDsData, myTracksData, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple};
+   
+    for (auto& [c1, tracks1, c2, tracks2] : pairData) {
+       LOGF(info, "Mixed event collisions: Index = (%d, %d), tracks Size: (%d, %d), Z Vertex: (%f, %f), Pool Bin: (%d, %d)", c1.globalIndex(), c2.globalIndex(), tracks1.size(), tracks2.size(), c1.posZ(), c2.posZ(), corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFV0M())),corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M())));
+      int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
+      for (auto& [candidate, pAssoc] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) { 
+          
+        if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+          continue;
+        }
+        std::cout << "candidate.isSelDsToKKPi() = " << candidate.isSelDsToKKPi() << std::endl;
+        std::cout << "candidate.isSelDsToPiKK() = " << candidate.isSelDsToPiKK() << std::endl;
+        // KKPi
+        if (candidate.isSelDsToKKPi() == selectionFlagDs){
+          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index()); 
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()), 
+                            candidate.eta() - pAssoc.eta(), 
+                            candidate.pt(),
+                            pAssoc.pt(),
+                            poolBin);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
+        }
+        // PiKK
+        else if (candidate.isSelDsToPiKK() == selectionFlagDs){
+          LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index()); 
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()), 
+                            candidate.eta() - pAssoc.eta(), 
+                            candidate.pt(),
+                            pAssoc.pt(),
+                            poolBin);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false, false);
+        }
+        else {
+          LOGF(info, "**** PROBLEM IN THE DS SELECTION OR IN THE FLAG USED ****");
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorDsHadrons, processDataME, "Process Mixed Event Data", false);
+
+  void processMcRecME(selCollisionsWithDs& collisions, candDsMcReco& candidates, candDsMcGen const& particlesMc, myTracksMc& tracks)
+  {
+    auto tracksTuple = std::make_tuple(candidates, tracks);
+    Pair<selCollisionsWithDs, candDsMcReco, myTracksMc, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple};
+    
+    //bool flagDsSignal = false;
+    bool flagDsPrompt = false;
+    for (auto& [c1, tracks1, c2, tracks2] : pairMcRec) {
+      int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
+      for (auto& [candidate, pAssoc] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+        if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
+          continue;
+        }
+        auto prong0McPart = candidate.prong0_as<myTracksMc>().mcParticle_as<candDsMcGen>();
+        bool flagDsSignal = std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi;
+        // prompt
+        if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
+          flagDsPrompt = true;
+        }
+        // non-prompt
+        if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
+          flagDsPrompt = false;
+        }
+        // KKPi
+        if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
+                          candidate.eta() - pAssoc.eta(),
+                          candidate.pt(),
+                          pAssoc.pt(),
+                          poolBin);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal, flagDsPrompt);
+        }
+        // PiKK
+        if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
+          entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
+                          candidate.eta() - pAssoc.eta(),
+                          candidate.pt(),
+                          pAssoc.pt(),
+                          poolBin);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal, flagDsPrompt);
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcRecME, "Process Mixed Event MCRec", false);
+
+  // Event Mixing for the MCGen Mode (To do later)
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<HfCorrelatorDsHadrons>(cfgc)};
+  return WorkflowSpec{adaptAnalysisTask<HfDsSelectionCollision>(cfgc),
+                      adaptAnalysisTask<HfCorrelatorDsHadrons>(cfgc)};
 }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -396,7 +396,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             track.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false);
+          entryDsHadronGenInfo(false);
         }
       }
 
@@ -429,7 +430,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             track.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false, false);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false);
+          entryDsHadronGenInfo(false);
         }
       }
     }
@@ -531,14 +533,16 @@ struct HfCorrelatorDsHadrons {
                               candidate.pt(),
                               track.pt(),
                               poolBin);
-            entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal, flagDsPrompt);
+            entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal);
+            entryDsHadronGenInfo(flagDsPrompt);
           } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
             entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
                               track.eta() - candidate.eta(),
                               candidate.pt(),
                               track.pt(),
                               poolBin);
-            entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal, flagDsPrompt);
+            entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal);
+            entryDsHadronGenInfo(flagDsPrompt);
           }
         }
       }
@@ -603,6 +607,7 @@ struct HfCorrelatorDsHadrons {
                             particle.pt(),
                             particleAssoc.pt(),
                             poolBin);
+          entryDsHadronRecoInfo(1.968, true);
           entryDsHadronGenInfo(flagDsPrompt);
         }
       }
@@ -633,7 +638,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false);
+          entryDsHadronGenInfo(false);
         } else if (candidate.isSelDsToPiKK() == selectionFlagDs) {
           LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index());
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
@@ -641,7 +647,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false, false);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), false);
+          entryDsHadronGenInfo(false);
         }
       }
     }
@@ -674,14 +681,16 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal, flagDsPrompt);
+          entryDsHadronRecoInfo(invMassDsToKKPi(candidate), flagDsSignal);
+          entryDsHadronGenInfo(flagDsPrompt);
         } else if (std::abs(prong0McPart.pdgCode()) == kPiPlus) {
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
                             candidate.eta() - pAssoc.eta(),
                             candidate.pt(),
                             pAssoc.pt(),
                             poolBin);
-          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal, flagDsPrompt);
+          entryDsHadronRecoInfo(invMassDsToPiKK(candidate), flagDsSignal);
+          entryDsHadronGenInfo(flagDsPrompt);
         }
       }
     }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -490,7 +490,6 @@ struct HfCorrelatorDsHadrons {
           efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate.pt()));
         }
         auto prong0McPart = candidate.prong0_as<myTracksMc>().mcParticle_as<candDsMcGen>();
-        auto indexMother = RecoDecay::getMother(particlesMc, prong0McPart, pdg::Code::kDS, true);
         if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
           fillHistoMcRecSig(candidate, multiplicityV0M);
           // KKPi

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -54,6 +54,7 @@ AxisSpec axisPtD = {180, 0., 36., "#it{p}_{T}Ds (GeV/#it{c})"};
 AxisSpec axisPtProng0 = {180, 0., 36., "#it{p}_{T} prong0 (GeV/#it{c})"};
 AxisSpec axisPtProng1 = {180, 0., 36., "#it{p}_{T} prong1 (GeV/#it{c})"};
 AxisSpec axisPtProng2 = {180, 0., 36., "#it{p}_{T} prong2 (GeV/#it{c})"};
+AxisSpec axisPtHadron = {11, 0., 11., "#it{p}_{T} Hadron (GeV/#it{c})"};
 AxisSpec axisMultiplicity = {1000, 0., 10000., "Multiplicity"};
 
 // binning type
@@ -221,6 +222,8 @@ struct HfCorrelatorDsHadrons {
      {"hPtCandMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPtD}}},
      {"hPtCandMcGenPrompt", "Ds,Hadron particles - MC Gen Prompt", {HistType::kTH1F, {axisPtD}}},
      {"hPtCandMcGenNonPrompt", "Ds,Hadron particles - MC Gen Non Prompt", {HistType::kTH1F, {axisPtD}}},
+     {"hPtParticleAssocMcRec", "Associated Particle - MC Rec", {HistType::kTH1F, {axisPtHadron}}},
+     {"hPtParticleAssocMcGen", "Associated Particle - MC Gen", {HistType::kTH1F, {axisPtHadron}}},
      {"hEtaMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisEta}}},
      {"hPhiMcGen", "Ds,Hadron particles - MC Gen", {HistType::kTH1F, {axisPhi}}},
      {"hYMcGen", "Ds,Hadron candidates - MC Gen", {HistType::kTH1F, {axisY}}},
@@ -526,6 +529,7 @@ struct HfCorrelatorDsHadrons {
           if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
             continue;
           }
+          registry.fill(HIST("hPtParticleAssocMcRec"), track.pt());
           // DsToKKPi and DsToPiKK division
           if (std::abs(prong0McPart.pdgCode()) == kKPlus) {
             entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
@@ -601,7 +605,7 @@ struct HfCorrelatorDsHadrons {
           if ((std::abs(particleAssoc.pdgCode()) != kElectron) && (std::abs(particleAssoc.pdgCode()) != kMuonMinus) && (std::abs(particleAssoc.pdgCode()) != kPiPlus) && (std::abs(particleAssoc.pdgCode()) != kKPlus) && (std::abs(particleAssoc.pdgCode()) != kProton)) {
             continue;
           }
-
+          registry.fill(HIST("hPtParticleAssocMcGen"), particleAssoc.pt());
           entryDsHadronPair(getDeltaPhi(particleAssoc.phi(), particle.phi()),
                             particleAssoc.eta() - particle.eta(),
                             particle.pt(),

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -661,7 +661,7 @@ struct HfCorrelatorDsHadrons {
           entryDsHadronRecoInfo(invMassDsToKKPi(candidate), false, false);
         }
         // PiKK
-        else if (candidate.isSelDsToPiKK() == selectionFlagDs) {
+        if (candidate.isSelDsToPiKK() == selectionFlagDs) {
           LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", candidate.index(), pAssoc.index(), c1.index(), c2.index(), candidate.collision().index(), pAssoc.collision().index());
           entryDsHadronPair(getDeltaPhi(candidate.phi(), pAssoc.phi()),
                             candidate.eta() - pAssoc.eta(),

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -111,8 +111,8 @@ struct HfTaskCorrelationDsHadrons {
       {"hDeltaPhiPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hDeltaEtaPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hCorrel2DPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-      {"hCorrel2DVsPtSignalRegionMCRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
+      {"hCorrel2DVsPtSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+      {"hCorrel2DVsPtSignalRegionMcRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
       {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
       {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
       {"hDeltaPhiPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
@@ -134,9 +134,9 @@ struct HfTaskCorrelationDsHadrons {
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebands"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegion"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebands"))->Sumw2();
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMCRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMCRec"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMCRec"))->Sumw2();
@@ -217,13 +217,13 @@ struct HfTaskCorrelationDsHadrons {
       }
       // in signal region
       if (massD > signalRegionInner->at(pTBinD) && massD < signalRegionOuter->at(pTBinD)) {
-        registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hCorrel2DPtIntSignalRegionMCRec"), deltaPhi, deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSignalRegionMCRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMCRec"), deltaPhi, efficiencyWeight);
         // prompt and non-prompt division
         if (pairEntry.signalStatus()) {
-          registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
+          registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
         }
       }
       // in sideband region

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -82,7 +82,7 @@ auto vecEfficiencyDmeson = std::vector<double>{efficiencyDmesonDefault, efficien
 
 /// Ds-Hadron correlation pair filling task, from pair tables - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
 struct HfTaskCorrelationDsHadrons {
-  Configurable<int> applyEfficiency{"applyEfficiency", 1, "Flag for applying efficiency weights"};
+  Configurable<bool> applyEfficiency{"applyEfficiency", true, "Flag for applying efficiency weights"};
   // pT ranges for correlation plots: the default values are those embedded in hf_cuts_ds_to_k_k_pi (i.e. the mass pT bins), but can be redefined via json files
   Configurable<std::vector<double>> binsPtCorrelations{"binsPtCorrelations", std::vector<double>{vecBinsPtCorrelations}, "pT bin limits for correlation plots"};
   Configurable<std::vector<double>> binsPtEfficiency{"binsPtEfficiency", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for efficiency"};

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -213,7 +213,7 @@ struct HfTaskCorrelationDsHadrons {
       if (pairEntry.signalStatus()) {
         registry.fill(HIST("hCorrel2DVsPtSignalMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       } else {
-        registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin,efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       }
       // in signal region
       if (massD > signalRegionInner->at(pTBinD) && massD < signalRegionOuter->at(pTBinD)) {
@@ -223,7 +223,7 @@ struct HfTaskCorrelationDsHadrons {
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMCRec"), deltaPhi, efficiencyWeight);
         // prompt and non-prompt division
         if (pairEntry.signalStatus()) {
-        registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
+          registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
         }
       }
       // in sideband region

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -106,20 +106,20 @@ struct HfTaskCorrelationDsHadrons {
      {"hDeltaPhiPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
      {"hCorrel2DPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
      {"hCorrel2DVsPtSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
-     {"hDeltaEtaPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-     {"hDeltaPhiPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-     {"hDeltaEtaPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-     {"hCorrel2DPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hDeltaEtaPtIntSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hDeltaEtaPtIntSidebandsMcRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hCorrel2DPtIntSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
      {"hCorrel2DVsPtSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
      {"hCorrel2DVsPtSignalRegionMcRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
-     {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-     {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-     {"hDeltaPhiPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-     {"hCorrel2DPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-     {"hCorrel2DVsPtSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-     {"hDeltaEtaPtIntMCGen", stringMCParticles + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-     {"hDeltaPhiPtIntMCGen", stringMCParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-     {"hCorrel2DPtIntMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSignalMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hCorrel2DVsPtBkgMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hDeltaPhiPtIntSidebandsMcRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntSidebandsMcRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSidebandsMcRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hDeltaEtaPtIntMcGen", stringMCParticles + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntMcGen", stringMCParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntMcGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
      {"hCorrel2DVsPtMcGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
      {"hCorrel2DVsPtMcGenPromptDivision", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}}}};
 
@@ -134,13 +134,13 @@ struct HfTaskCorrelationDsHadrons {
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegion"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebands"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->Sumw2();
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMCRec"))->Sumw2();
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMCRec"))->Sumw2();
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMCRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMcRec"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->Sumw2();
   }
@@ -210,16 +210,16 @@ struct HfTaskCorrelationDsHadrons {
       }
       // fill correlation plots for signal/bagkground correlations
       if (pairEntry.isSignalStatus()) {
-        registry.fill(HIST("hCorrel2DVsPtSignalMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSignalMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       } else {
-        registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtBkgMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       }
       // in signal region
       if (massD > signalRegionInner->at(pTBinD) && massD < signalRegionOuter->at(pTBinD)) {
         registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
-        registry.fill(HIST("hCorrel2DPtIntSignalRegionMCRec"), deltaPhi, deltaEta, efficiencyWeight);
-        registry.fill(HIST("hDeltaEtaPtIntSignalRegionMCRec"), deltaEta, efficiencyWeight);
-        registry.fill(HIST("hDeltaPhiPtIntSignalRegionMCRec"), deltaPhi, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSignalRegionMcRec"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSignalRegionMcRec"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSignalRegionMcRec"), deltaPhi, efficiencyWeight);
         // prompt and non-prompt division
         if (pairEntry.isSignalStatus()) {
           registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
@@ -228,10 +228,10 @@ struct HfTaskCorrelationDsHadrons {
       // in sideband region
       if (((massD > sidebandLeftOuter->at(pTBinD)) && (massD < sidebandLeftInner->at(pTBinD))) ||
           ((massD > sidebandRightInner->at(pTBinD) && massD < sidebandRightOuter->at(pTBinD)))) {
-        registry.fill(HIST("hCorrel2DVsPtSidebandsMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
-        registry.fill(HIST("hCorrel2DPtIntSidebandsMCRec"), deltaPhi, deltaEta, efficiencyWeight);
-        registry.fill(HIST("hDeltaEtaPtIntSidebandsMCRec"), deltaEta, efficiencyWeight);
-        registry.fill(HIST("hDeltaPhiPtIntSidebandsMCRec"), deltaPhi, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSidebandsMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSidebandsMcRec"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSidebandsMcRec"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSidebandsMcRec"), deltaPhi, efficiencyWeight);
       }
     }
   }
@@ -255,9 +255,9 @@ struct HfTaskCorrelationDsHadrons {
 
       registry.fill(HIST("hCorrel2DVsPtMcGen"), deltaPhi, deltaEta, ptD, ptHadron, poolBin);
       registry.fill(HIST("hCorrel2DVsPtMcGenPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin);
-      registry.fill(HIST("hCorrel2DPtIntMCGen"), deltaPhi, deltaEta);
-      registry.fill(HIST("hDeltaEtaPtIntMCGen"), deltaEta);
-      registry.fill(HIST("hDeltaPhiPtIntMCGen"), deltaPhi);
+      registry.fill(HIST("hCorrel2DPtIntMcGen"), deltaPhi, deltaEta);
+      registry.fill(HIST("hDeltaEtaPtIntMcGen"), deltaEta);
+      registry.fill(HIST("hDeltaPhiPtIntMcGen"), deltaPhi);
     }
   }
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processMcGen, "Process MC Gen mode", false);

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -11,8 +11,8 @@
 
 /// \file taskCorrelationDsHadrons.cxx
 /// \brief Ds-Hadrons azimuthal correlations analysis task - data-like, MC-reco and MC-Gen analyses
-/// \author Grazia Luparello <Grazia.Luparello@cern.ch>
-/// \author Samuele Cattaruzzi <Samuele.Cattaruzzi@cern.ch>
+/// \author Grazia Luparello <grazia.luparello@cern.ch>
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
@@ -21,17 +21,13 @@
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
 using namespace o2;
+//using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::aod::hf_cand_3prong;
 using namespace o2::aod::hf_correlation_ds_hadron;
 using namespace o2::analysis::hf_cuts_ds_to_k_k_pi;
 using namespace o2::constants::math;
-
-namespace o2::aod
-{
-using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo>;
-}
 
 /// Returns deltaPhi value in range [-pi/2., 3.*pi/2], typically used for correlation studies
 double getDeltaPhi(double phiD, double phiHadron)
@@ -48,8 +44,10 @@ double evaluatePhiByVertex(double xVertex1, double xVertex2, double yVertex1, do
 // string definitions, used for histogram axis labels
 const TString stringPtD = "#it{p}_{T}^{D} (GeV/#it{c});";
 const TString stringPtHadron = "#it{p}_{T}^{Hadron} (GeV/#it{c});";
+const TString stringPoolBin = "poolBin;";
 const TString stringDeltaEta = "#it{#eta}^{Hadron}-#it{#eta}^{D};";
 const TString stringDeltaPhi = "#it{#varphi}^{Hadron}-#it{#varphi}^{D} (rad);";
+const TString stringDsPrompt = "Prompt Ds;";
 const TString stringDHadron = "D,Hadron candidates ";
 const TString stringSignal = "signal region;";
 const TString stringSideband = "sidebands;";
@@ -61,6 +59,8 @@ AxisSpec axisDetlaEta = {200, -4., 4., ""};
 AxisSpec axisDetlaPhi = {64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf, ""};
 AxisSpec axisPtD = {10, 0., 10., ""};
 AxisSpec axisPtHadron = {11, 0., 11., ""};
+AxisSpec axisDsPrompt = {2, -0.5, 1.5, ""};
+AxisSpec axisPoolBin = {9, 0., 9., ""};
 
 const int nBinsPtCorrelations = 8;
 const double pTBinsCorrelations[nBinsPtCorrelations + 1] = {0., 2., 4., 6., 8., 12., 16., 24., 99.};
@@ -87,7 +87,6 @@ struct HfTaskCorrelationDsHadrons {
   // pT ranges for correlation plots: the default values are those embedded in hf_cuts_ds_to_k_k_pi (i.e. the mass pT bins), but can be redefined via json files
   Configurable<std::vector<double>> binsPtCorrelations{"binsPtCorrelations", std::vector<double>{vecBinsPtCorrelations}, "pT bin limits for correlation plots"};
   Configurable<std::vector<double>> binsPtEfficiency{"binsPtEfficiency", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for efficiency"};
-  // signal and sideband region edges, to be defined via json file (initialised to empty)
   Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>{vecSignalRegionInner}, "Inner values of signal region vs pT"};
   Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>{vecSignalRegionOuter}, "Outer values of signal region vs pT"};
   Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>{vecSidebandLeftInner}, "Inner values of left sideband vs pT"};
@@ -96,31 +95,34 @@ struct HfTaskCorrelationDsHadrons {
   Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>{vecSidebandRightOuter}, "Outer values of right sideband vs pT"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", std::vector<double>{vecEfficiencyDmeson}, "Efficiency values for D meson specie under study"};
 
+  using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo>;
+
   HistogramRegistry registry{
     "registry",
     {
       {"hDeltaEtaPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hDeltaPhiPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hCorrel2DPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+      {"hCorrel2DVsPtSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
       {"hDeltaEtaPtIntSidebands", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hDeltaPhiPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hCorrel2DPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+      {"hCorrel2DVsPtSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
       {"hDeltaEtaPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hDeltaPhiPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hDeltaEtaPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hCorrel2DPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}},
-      {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}},
-      {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}},
+      {"hCorrel2DVsPtSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+      {"hCorrel2DVsPtSignalRegionMCRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
+      {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+      {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
       {"hDeltaPhiPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hCorrel2DPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}},
+      {"hCorrel2DVsPtSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
       {"hDeltaEtaPtIntMCGen", stringMCParticles + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
       {"hDeltaPhiPtIntMCGen", stringMCParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
       {"hCorrel2DPtIntMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+      {"hCorrel2DVsPtMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
     }};
 
   void init(o2::framework::InitContext&)
@@ -145,7 +147,7 @@ struct HfTaskCorrelationDsHadrons {
     registry.get<THnSparse>(HIST("hCorrel2DVsPtMCGen"))->Sumw2();
   }
 
-  void processData(aod::DsHadronPairFull const& pairEntries)
+  void processData(DsHadronPairFull const& pairEntries)
   {
     for (auto const& pairEntry : pairEntries) {
       // define variables for widely used quantities
@@ -153,6 +155,7 @@ struct HfTaskCorrelationDsHadrons {
       double deltaEta = pairEntry.deltaEta();
       double ptD = pairEntry.ptD();
       double ptHadron = pairEntry.ptHadron();
+      int poolBin = pairEntry.poolBin();
       double massD = pairEntry.mD();
       int effBinD = o2::analysis::findBin(binsPtEfficiency, ptD);
       int pTBinD = o2::analysis::findBin(binsPtCorrelations, ptD);
@@ -161,34 +164,31 @@ struct HfTaskCorrelationDsHadrons {
         continue;
       }
       double efficiencyWeight = 1.;
-      double efficiencyHadron = 1.; // Note: To be implemented later on ??
+      double efficiencyHadron = 1.; // Note: To be implemented later on
       if (applyEfficiency) {
         efficiencyWeight = 1. / (efficiencyD->at(effBinD) * efficiencyHadron);
       }
-
-      // check if correlation entry belongs to signal region, sidebands or is outside both, and fill correlation plots
+      // in signal region
       if (massD > signalRegionInner->at(pTBinD) && massD < signalRegionOuter->at(pTBinD)) {
-        // in signal region
-        registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hCorrel2DPtIntSignalRegion"), deltaPhi, deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSignalRegion"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegion"), deltaPhi, efficiencyWeight);
       }
-
+      // in sideband region
       if ((massD > sidebandLeftOuter->at(pTBinD) && massD < sidebandLeftInner->at(pTBinD)) ||
           (massD > sidebandRightInner->at(pTBinD) && massD < sidebandRightOuter->at(pTBinD))) {
-        // in sideband region
-        registry.fill(HIST("hCorrel2DVsPtSidebands"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSidebands"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hCorrel2DPtIntSidebands"), deltaPhi, deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSidebands"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSidebands"), deltaPhi, efficiencyWeight);
       }
-    } // end loop
+    }
   }
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processData, "Process data", true);
 
   /// D-Hadron correlation pair filling task, from pair tables - for MC reco-level analysis (candidates matched to true signal only, but also bkg sources are studied)
-  void processMcRec(aod::DsHadronPairFull const& pairEntries)
+  void processMcRec(DsHadronPairFull const& pairEntries)
   {
     for (auto const& pairEntry : pairEntries) {
       // define variables for widely used quantities
@@ -196,9 +196,12 @@ struct HfTaskCorrelationDsHadrons {
       double deltaEta = pairEntry.deltaEta();
       double ptD = pairEntry.ptD();
       double ptHadron = pairEntry.ptHadron();
+      int poolBin = pairEntry.poolBin();
       double massD = pairEntry.mD();
+      int statusDsPrompt = int(pairEntry.promptStatus());
       int effBinD = o2::analysis::findBin(binsPtEfficiency, ptD);
       int pTBinD = o2::analysis::findBin(binsPtCorrelations, ptD);
+      // reject entries outside pT ranges of interest
       if (pTBinD < 0 || effBinD < 0) {
         continue;
       }
@@ -209,30 +212,30 @@ struct HfTaskCorrelationDsHadrons {
       }
       // fill correlation plots for signal/bagkground correlations
       if (pairEntry.signalStatus()) {
-        registry.fill(HIST("hCorrel2DVsPtSignalMCRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSignalMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       } else {
-        registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin,efficiencyWeight);
       }
-      // reject entries outside pT ranges of interest
-
-      // check if correlation entry belongs to signal region, sidebands or is outside both, and fill correlation plots
+      // in signal region
       if (massD > signalRegionInner->at(pTBinD) && massD < signalRegionOuter->at(pTBinD)) {
-        // in signal region
-        registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hCorrel2DPtIntSignalRegionMCRec"), deltaPhi, deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSignalRegionMCRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMCRec"), deltaPhi, efficiencyWeight);
+        // prompt and non-prompt division
+        if (pairEntry.signalStatus()) {
+        registry.fill(HIST("hCorrel2DVsPtSignalRegionMCRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
+        }
       }
-
+      // in sideband region
       if (((massD > sidebandLeftOuter->at(pTBinD)) && (massD < sidebandLeftInner->at(pTBinD))) ||
           ((massD > sidebandRightInner->at(pTBinD) && massD < sidebandRightOuter->at(pTBinD)))) {
-        // in sideband region
-        registry.fill(HIST("hCorrel2DVsPtSidebandsMCRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DVsPtSidebandsMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hCorrel2DPtIntSidebandsMCRec"), deltaPhi, deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSidebandsMCRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSidebandsMCRec"), deltaPhi, efficiencyWeight);
       }
-    } // end loop
+    }
   }
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processMcRec, "Process MC Reco mode", false);
 
@@ -245,16 +248,17 @@ struct HfTaskCorrelationDsHadrons {
       double deltaEta = pairEntry.deltaEta();
       double ptD = pairEntry.ptD();
       double ptHadron = pairEntry.ptHadron();
+      int poolBin = pairEntry.poolBin();
       // reject entries outside pT ranges of interest
       if (o2::analysis::findBin(binsPtCorrelations, ptD) < 0) {
         continue;
       }
 
-      registry.fill(HIST("hCorrel2DVsPtMCGen"), deltaPhi, deltaEta, ptD, ptHadron);
+      registry.fill(HIST("hCorrel2DVsPtMCGen"), deltaPhi, deltaEta, ptD, ptHadron, poolBin);
       registry.fill(HIST("hCorrel2DPtIntMCGen"), deltaPhi, deltaEta);
       registry.fill(HIST("hDeltaEtaPtIntMCGen"), deltaEta);
       registry.fill(HIST("hDeltaPhiPtIntMCGen"), deltaPhi);
-    } // end loop
+    }
   }
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processMcGen, "Process MC Gen mode", false);
 };

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -197,7 +197,7 @@ struct HfTaskCorrelationDsHadrons {
       double ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
       double massD = pairEntry.mD();
-      int statusDsPrompt = int(pairEntry.promptStatus());
+      int statusDsPrompt = static_cast<int>(pairEntry.promptStatus());
       int effBinD = o2::analysis::findBin(binsPtEfficiency, ptD);
       int pTBinD = o2::analysis::findBin(binsPtCorrelations, ptD);
       // reject entries outside pT ranges of interest

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -21,7 +21,6 @@
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
 using namespace o2;
-//using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::aod::hf_cand_3prong;

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -94,35 +94,34 @@ struct HfTaskCorrelationDsHadrons {
   Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>{vecSidebandRightOuter}, "Outer values of right sideband vs pT"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", std::vector<double>{vecEfficiencyDmeson}, "Efficiency values for D meson specie under study"};
 
-  using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo>;
+  using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo>;
 
   HistogramRegistry registry{
     "registry",
-    {
-      {"hDeltaEtaPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-      {"hDeltaPhiPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-      {"hCorrel2DPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
-      {"hDeltaEtaPtIntSidebands", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-      {"hDeltaPhiPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-      {"hCorrel2DPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
-      {"hDeltaEtaPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-      {"hDeltaPhiPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-      {"hDeltaEtaPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-      {"hCorrel2DPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-      {"hCorrel2DVsPtSignalRegionMcRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
-      {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-      {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-      {"hDeltaPhiPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-      {"hCorrel2DPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
-      {"hDeltaEtaPtIntMCGen", stringMCParticles + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
-      {"hDeltaPhiPtIntMCGen", stringMCParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
-      {"hCorrel2DPtIntMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
-      {"hCorrel2DVsPtMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
-    }};
+    {{"hDeltaEtaPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSignalRegion", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+     {"hDeltaEtaPtIntSidebands", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSidebands", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+     {"hDeltaEtaPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hDeltaEtaPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hCorrel2DPtIntSignalRegionMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSignalRegionMcRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hCorrel2DVsPtSignalRegionMcRecPromptDivision", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}},
+     {"hCorrel2DVsPtSignalMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hCorrel2DVsPtBkgMCRec", stringDHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hDeltaPhiPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtSidebandsMCRec", stringDHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}},
+     {"hDeltaEtaPtIntMCGen", stringMCParticles + stringDeltaEta + "entries", {HistType::kTH1F, {axisDetlaEta}}},
+     {"hDeltaPhiPtIntMCGen", stringMCParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {axisDetlaPhi}}},
+     {"hCorrel2DPtIntMCGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{axisDetlaPhi}, {axisDetlaEta}}}},
+     {"hCorrel2DVsPtMcGen", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}}}, // note: axes 3 and 4 (the pT) are updated in the init()
+     {"hCorrel2DVsPtMcGenPromptDivision", stringMCParticles + stringDeltaPhi + stringDeltaEta + stringPtD + stringPtHadron + stringDsPrompt + stringPoolBin + "entries", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisDsPrompt}, {axisPoolBin}}}}}};
 
   void init(o2::framework::InitContext&)
   {
@@ -142,8 +141,8 @@ struct HfTaskCorrelationDsHadrons {
     registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMCRec"))->Sumw2();
     registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMCRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
     registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMCRec"))->Sumw2();
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtMCGen"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
-    registry.get<THnSparse>(HIST("hCorrel2DVsPtMCGen"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->Sumw2();
   }
 
   void processData(DsHadronPairFull const& pairEntries)
@@ -197,7 +196,7 @@ struct HfTaskCorrelationDsHadrons {
       double ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
       double massD = pairEntry.mD();
-      int statusDsPrompt = static_cast<int>(pairEntry.promptStatus());
+      int statusDsPrompt = static_cast<int>(pairEntry.isOrigin());
       int effBinD = o2::analysis::findBin(binsPtEfficiency, ptD);
       int pTBinD = o2::analysis::findBin(binsPtCorrelations, ptD);
       // reject entries outside pT ranges of interest
@@ -210,7 +209,7 @@ struct HfTaskCorrelationDsHadrons {
         efficiencyWeight = 1. / (efficiencyD->at(effBinD) * efficiencyHadron);
       }
       // fill correlation plots for signal/bagkground correlations
-      if (pairEntry.signalStatus()) {
+      if (pairEntry.isSignalStatus()) {
         registry.fill(HIST("hCorrel2DVsPtSignalMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       } else {
         registry.fill(HIST("hCorrel2DVsPtBkgMCRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
@@ -222,7 +221,7 @@ struct HfTaskCorrelationDsHadrons {
         registry.fill(HIST("hDeltaEtaPtIntSignalRegionMCRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMCRec"), deltaPhi, efficiencyWeight);
         // prompt and non-prompt division
-        if (pairEntry.signalStatus()) {
+        if (pairEntry.isSignalStatus()) {
           registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
         }
       }
@@ -239,7 +238,7 @@ struct HfTaskCorrelationDsHadrons {
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processMcRec, "Process MC Reco mode", false);
 
   /// D-Hadron correlation pair filling task, from pair tables - for MC gen-level analysis (no filter/selection, only true signal)
-  void processMcGen(aod::DsHadronPair const& pairEntries)
+  void processMcGen(DsHadronPairFull const& pairEntries)
   {
     for (auto const& pairEntry : pairEntries) {
       // define variables for widely used quantities
@@ -248,12 +247,14 @@ struct HfTaskCorrelationDsHadrons {
       double ptD = pairEntry.ptD();
       double ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
+      int statusDsPrompt = static_cast<int>(pairEntry.isOrigin());
       // reject entries outside pT ranges of interest
       if (o2::analysis::findBin(binsPtCorrelations, ptD) < 0) {
         continue;
       }
 
-      registry.fill(HIST("hCorrel2DVsPtMCGen"), deltaPhi, deltaEta, ptD, ptHadron, poolBin);
+      registry.fill(HIST("hCorrel2DVsPtMcGen"), deltaPhi, deltaEta, ptD, ptHadron, poolBin);
+      registry.fill(HIST("hCorrel2DVsPtMcGenPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin);
       registry.fill(HIST("hCorrel2DPtIntMCGen"), deltaPhi, deltaEta);
       registry.fill(HIST("hDeltaEtaPtIntMCGen"), deltaEta);
       registry.fill(HIST("hDeltaPhiPtIntMCGen"), deltaPhi);

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -196,7 +196,7 @@ struct HfTaskCorrelationDsHadrons {
       double ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
       double massD = pairEntry.mD();
-      int statusDsPrompt = static_cast<int>(pairEntry.isOrigin());
+      int statusDsPrompt = static_cast<int>(pairEntry.isPrompt());
       int effBinD = o2::analysis::findBin(binsPtEfficiency, ptD);
       int pTBinD = o2::analysis::findBin(binsPtCorrelations, ptD);
       // reject entries outside pT ranges of interest
@@ -209,7 +209,7 @@ struct HfTaskCorrelationDsHadrons {
         efficiencyWeight = 1. / (efficiencyD->at(effBinD) * efficiencyHadron);
       }
       // fill correlation plots for signal/bagkground correlations
-      if (pairEntry.isSignalStatus()) {
+      if (pairEntry.isSignal()) {
         registry.fill(HIST("hCorrel2DVsPtSignalMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
       } else {
         registry.fill(HIST("hCorrel2DVsPtBkgMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
@@ -221,7 +221,7 @@ struct HfTaskCorrelationDsHadrons {
         registry.fill(HIST("hDeltaEtaPtIntSignalRegionMcRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMcRec"), deltaPhi, efficiencyWeight);
         // prompt and non-prompt division
-        if (pairEntry.isSignalStatus()) {
+        if (pairEntry.isSignal()) {
           registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
         }
       }
@@ -247,7 +247,7 @@ struct HfTaskCorrelationDsHadrons {
       double ptD = pairEntry.ptD();
       double ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
-      int statusDsPrompt = static_cast<int>(pairEntry.isOrigin());
+      int statusDsPrompt = static_cast<int>(pairEntry.isPrompt());
       // reject entries outside pT ranges of interest
       if (o2::analysis::findBin(binsPtCorrelations, ptD) < 0) {
         continue;


### PR DESCRIPTION
Dear all,
I have implemented the event mixing for Ds-hadron correlations in Data and MCRec mode following the same done for the Dplus.
I see the commit "Implementation of Event Mixing for D+-hadron correlations" and I have already updated my code implementing some suggestions made on that commit. Let me know if there is something to change so this pull request can go ahead quickly.

Thanks in advance,
Best regards,
Samuele
