### PR TITLE
[PWGJE Validation]: Implement configurable for hybrid trackselection, extension for run3 data and run2,run3 MC 

### DIFF
--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -12,8 +12,36 @@
 //  \author
 //  Johanna Lömker
 //  \since Dec 2022
-// The goal would be to set up the jet, track and event/collision QA's for the validation framework
-// Staring with the hybrid tracks
+// Examples for configurations and run macros (https://github.com/jloemker/PWGJE/tree/master/O2Physics/config_run)
+// 1)Configuration for run2 validation on ESD:
+//  Use run2ESD.sh with configRun2ESD.json    
+// 2)Configuration for run3 validation on AOD: NOT YET WORKING - see comment in run3AOD.sh
+//  Use run3AOD.sh with configRun3AOD.json
+// 3)Configuration for MC validation on converted run2 AOD:
+//  Use runMC2.sh with configMC2Jet.json  
+// 4) Configuration for MC validation on run3 AOD:  
+// Use runMC3.sh with configMC3Jet.json 
+
+  ////////////////=============================================////////////////
+  //                              TODO's: 
+  //============== 1)template in mcJetTrackCollisionQa to validate JetMatching !
+  // look at matching https://github.com/AliceO2Group/O2Physics/blob/723d78931b446e7b5f6e0673c0345fcef584e796/Tutorials/src/mcHistograms.cxx#L154
+  // loop over matched jets
+  // make additional TH2F's for matched jets in pt, phi, eta (just what i did for the ones for tracks and collisions)
+  //        i) with mcrec vs mcpart 
+  //        ii)with (mcrec-mcpart)/mcpart as function of mcpart
+  //
+  //============== 2) Add processes for:
+  //                i) processRun3AOD, process ESD: Full (doesn't work yet) and Neutral Jets
+  //                ii)processMcRun3, processMcRun2: Full (doesn't work yet) and Neutral Jets
+  //
+  //============== 3) prepare plotting macros for Run3 and MCrun2, MCrun3 !
+  //
+  //============== 4) add logarithmic x-axis for pt plots and improve overall binning via arrays - also in AliPhysics !
+  // look here https://github.com/AliceO2Group/QualityControl/blob/17798501ac1cbc9a9f25797ed15c68244c0a36f0/Modules/MUON/MCH/src/RofsTask.cxx#L58
+  //
+  //============== 3) add explicit filters for collision and tracks (?)
+  ////////////////=============================================////////////////
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -22,6 +50,7 @@
 #include "Framework/HistogramRegistry.h"
 
 #include "PWGJE/DataModel/Jet.h"
+#include "PWGJE/TableProducer/jetfinder.h"
 
 #include "Common/DataModel/EventSelection.h"
 #include "Common/Core/TrackSelection.h"
@@ -31,8 +60,12 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
+// tracks for 1) validation on ESD 2) Run2 MC validatio on AO2D's 3) Run2 MC validation on AO2D's
 using TracksJE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>;
+using MCTracksRun3JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;
+using MCTracksRun2JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;// for now the same
 
+// struct for jetfinder validation on run2 ESD's and run3 data
 struct jetTrackCollisionQa {
 
   HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
@@ -40,31 +73,16 @@ struct jetTrackCollisionQa {
   Configurable<int> nBinsPt{"nBinsPt", 200, "N bins in pT histos"};
   Configurable<int> nBinsEta{"nBinsEta", 200, "N bins in Eta histos"};
   Configurable<int> nBinsPhi{"nBinsPhi", 200, "N bins in Phi histos"};
+  Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
 
-  TrackSelection validationTracks;
+  std::string trackSelection;
 
   void init(InitContext const&)
   {
-    /*set trackselections - initial idea for now on hold
-    //we should not touch the getJEGlobalTrackSelectionRun2 anymore, but here we are free to modify the defaults
-    validationTracks = getJEGlobalTrackSelectionRun2();
-    validationTracks.SetTrackType(o2::aod::track::Run2Track); // Run 2 track asked by default
-    validationTracks.SetMinNCrossedRowsTPC(70);
-    validationTracks.SetMinNCrossedRowsOverFindableClustersTPC(0.8f);
-    validationTracks.SetMaxChi2PerClusterTPC(4.f);
-    validationTracks.SetRequireTPCRefit(true);
-    validationTracks.SetRequireITSRefit(true);
-    validationTracks.SetRequireHitsInITSLayers(1, {0, 1}); // one hit in any SPD layer
-    validationTracks.SetMaxChi2PerClusterITS(36.f);
-    validationTracks.SetPtRange(0.15f, 1e10f); // the 0.15 is the original hybrid cuts
-    validationTracks.SetEtaRange(-0.9f, 0.9f);
-    validationTracks.SetMaxDcaXY(2.4f);
-    validationTracks.SetMaxDcaZ(3.2f);
-    validationTracks.print();*/
-    validationTracks = getGlobalTrackSelection(); // using global tracks instead
-
+    //set trackselections 
+    trackSelection = static_cast<std::string>(trackSelections);
     // histograms
-    // 1)Jetvalidation from data
+    // 1)Jetvalidation on data
     mHistManager.add("collisionVtxZ", "control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
     // process jet qa
     mHistManager.add("jetPt", "inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
@@ -91,95 +109,396 @@ struct jetTrackCollisionQa {
     mHistManager.add("leadTrackPt", "leading selected track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("leadTrackPhi", "leading selected track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("leadTrackEta", "leading selected track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-
-    // 2)Jetvalidation from MC
-    mHistManager.add("MCcollisionVtxZ", "MC control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
-    // process jet qa
-    mHistManager.add("MCjetPt", "MC inclusive jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
-    mHistManager.add("MCjetPhi", "MC inclusive jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
-    mHistManager.add("MCjetEta", "MC inclusive jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    // process jet constituent qa - constituents as tracks
-    mHistManager.add("MCjetConstTrackPt", "MC inclusive jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
-    mHistManager.add("MCjetConstTrackPhi", "MC inclusive jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
-    mHistManager.add("MCjetConstTrackEta", "MC inclusive jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    // cross check the cuts from Run2Hybrid selection
-    mHistManager.add("MCselectedTrackPt", "MC hybrid track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
-    mHistManager.add("MCselectedTrackPhi", "MC hybrid track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
-    mHistManager.add("MCselectedTrackEta", "MC hybrid track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
   }
-  // add another process for MC studies !
-  void processData(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
-  {
-    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
 
-    double leadingJetPt = -1;
-    double leadingJetPhi = -1;
-    double leadingJetEta = -1;
-    // jet QA hists per jet in this collision
-    for (const auto& j : jets) {
-      mHistManager.fill(HIST("jetPt"), j.pt());
-      mHistManager.fill(HIST("jetPhi"), j.phi());
-      mHistManager.fill(HIST("jetEta"), j.eta());
-      if (j.pt() > leadingJetPt) {
-        leadingJetPt = j.pt();
-        leadingJetPhi = j.phi();
-        leadingJetEta = j.eta();
-      }
+  template <typename validationTracks>
+  void fillTrackQA(validationTracks const& track)
+  { 
+    if (!selectTrack(track, trackSelection)) {
+      return;
+    }
+    mHistManager.fill(HIST("selectedTrackPt"), track.pt());
+    mHistManager.fill(HIST("selectedTrackPhi"), track.phi());
+    mHistManager.fill(HIST("selectedTrackEta"), track.eta());
+  }// end of fillTrackQA template
 
-      double leadingConstTrackPt = -1;
-      double leadingConstTrackPhi = -1;
-      double leadingConstTrackEta = -1;
-      // access jet constituents as tracks
-      for (auto& jct : j.tracks_as<TracksJE>()) {
-        mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
-        mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
-        mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
-        if (jct.pt() > leadingConstTrackPt) {
-          leadingConstTrackPt = jct.pt();
-          leadingConstTrackPhi = jct.phi();
-          leadingConstTrackEta = jct.eta();
-        }
-      } // end of jet constituent loop
+  //template <typename validationTracks>
+  void fillLeadingTrackQA(double leadingTrackPt, double leadingTrackPhi, double leadingTrackEta)
+  { 
+    mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
+    mHistManager.fill(HIST("leadTrackPhi"), leadingTrackPhi);
+    mHistManager.fill(HIST("leadTrackEta"), leadingTrackEta);
+  }// end of fillLeadingTrackQA template
 
-      // fill leading jet constituent qa
-      mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
-      mHistManager.fill(HIST("leadJetConstPhi"), leadingConstTrackPhi);
-      mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
-    } // end of jet loop
+  template <typename dataJet>
+  void fillJetQA(dataJet const& jet)
+  { 
+    mHistManager.fill(HIST("jetPt"), jet.pt());
+    mHistManager.fill(HIST("jetPhi"), jet.phi());
+    mHistManager.fill(HIST("jetEta"), jet.eta());
+  }// end of fillJetQA template
 
-    // fill leading jet qa
+  //template <typename validationTracks>
+  void fillLeadingJetQA(double leadingJetPt, double leadingJetPhi, double leadingJetEta)
+  { 
     mHistManager.fill(HIST("leadJetPt"), leadingJetPt);
     mHistManager.fill(HIST("leadJetPhi"), leadingJetPhi);
     mHistManager.fill(HIST("leadJetEta"), leadingJetEta);
+  }// end of fillLeadingJetQA template
+
+  template <typename dataJetConstituent>
+  void fillJetConstituentQA(dataJetConstituent const& jct)
+  {
+    mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
+    mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
+    mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
+  }// end of mcDetJetConstituent template
+
+  //template <typename validationTracks>
+  void fillLeadingJetConstQA(double leadingConstTrackPt, double leadingConstTrackPhi, double leadingConstTrackEta)
+  { 
+    mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
+    mHistManager.fill(HIST("leadJetConstPhi"), leadingConstTrackPhi);
+    mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
+  }// end of fillLeadingJetConstQA template
+
+  void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
+  {
+    if (!collision.sel7() || abs(collision.posZ()) > 10) {
+      return;
+    }
+    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
 
     double leadingTrackPt = -1;
     double leadingTrackPhi = -1;
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      if (!validationTracks.IsSelected(t)) {
-        continue;
-      } // check if this is really a global track - maybe adding hists for rejected tracks ?
-      mHistManager.fill(HIST("selectedTrackPt"), t.pt());
-      mHistManager.fill(HIST("selectedTrackPhi"), t.phi());
-      mHistManager.fill(HIST("selectedTrackEta"), t.eta());
+      fillTrackQA(t);
       if (t.pt() > leadingTrackPt) {
         leadingTrackPt = t.pt();
         leadingTrackPhi = t.phi();
         leadingTrackEta = t.eta();
       }
     } // end of tracks loop
+    //fill leading track  
+    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi,leadingTrackEta);
 
-    // fill leading selected track qa
-    mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
-    mHistManager.fill(HIST("leadTrackPhi"), leadingTrackPhi);
-    mHistManager.fill(HIST("leadTrackEta"), leadingTrackEta);
+    double leadingJetPt = -1;
+    double leadingJetPhi = -1;
+    double leadingJetEta = -1;
+    // jet QA hists per jet in this collision
+    for (const auto& j : jets) {
+      fillJetQA(j);
+      if (j.pt() > leadingJetPt) {
+        leadingJetPt = j.pt();
+        leadingJetPhi = j.phi();
+        leadingJetEta = j.eta();
+      }
+      double leadingConstTrackPt = -1;
+      double leadingConstTrackPhi = -1;
+      double leadingConstTrackEta = -1;
+      // access jet constituents as tracks
+      for (auto& jct : j.tracks_as<TracksJE>()) {
+        fillJetConstituentQA(jct);
+        if (jct.pt() > leadingConstTrackPt) {
+          leadingConstTrackPt = jct.pt();
+          leadingConstTrackPhi = jct.phi();
+          leadingConstTrackEta = jct.eta();
+        }
+      } // end of jet constituent loop
+      // fill leading jet constituent qa
+      fillLeadingJetConstQA(leadingConstTrackPt, leadingConstTrackPhi, leadingConstTrackEta);
+    } // end of jet loop
+    // fill leading jet qa
+    fillLeadingJetQA(leadingJetPt, leadingJetPhi, leadingJetEta);
   } // end process
-  PROCESS_SWITCH(jetTrackCollisionQa, processData, "process jets from jet-finder output", true);
+  PROCESS_SWITCH(jetTrackCollisionQa, processESD, "validate jet-finder output on run2 ESD", true);
+
+  // process for run3 AOD's
+  void processRun3AOD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
+  {
+    if (!collision.sel8() || abs(collision.posZ()) > 10) {
+      return;
+    }
+    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
+    double leadingTrackPt = -1;
+    double leadingTrackPhi = -1;
+    double leadingTrackEta = -1;
+    // qa histograms for selected tracks in collision
+    for (const auto& t : tracks) {
+      fillTrackQA(t);
+      if (t.pt() > leadingTrackPt) {
+        leadingTrackPt = t.pt();
+        leadingTrackPhi = t.phi();
+        leadingTrackEta = t.eta();
+      }
+    } // end of tracks loop
+    //fill leading track  
+    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi,leadingTrackEta);
+
+    double leadingJetPt = -1;
+    double leadingJetPhi = -1;
+    double leadingJetEta = -1;
+    // jet QA hists per jet in this collision
+    for (const auto& j : jets) {
+      fillJetQA(j);
+      if (j.pt() > leadingJetPt) {
+        leadingJetPt = j.pt();
+        leadingJetPhi = j.phi();
+        leadingJetEta = j.eta();
+      }
+      double leadingConstTrackPt = -1;
+      double leadingConstTrackPhi = -1;
+      double leadingConstTrackEta = -1;
+      // access jet constituents as tracks
+      for (auto& jct : j.tracks_as<TracksJE>()) {
+        fillJetConstituentQA(jct);
+        if (jct.pt() > leadingConstTrackPt) {
+          leadingConstTrackPt = jct.pt();
+          leadingConstTrackPhi = jct.phi();
+          leadingConstTrackEta = jct.eta();
+        }
+      } // end of jet constituent loop
+      // fill leading jet constituent qa
+      fillLeadingJetConstQA(leadingConstTrackPt, leadingConstTrackPhi, leadingConstTrackEta);
+    } // end of jet loop
+    // fill leading jet qa
+    fillLeadingJetQA(leadingJetPt, leadingJetPhi, leadingJetEta);
+  }
+  PROCESS_SWITCH(jetTrackCollisionQa, processRun3AOD, "validate jet-finder output on run3 AOD", false);
+
+  // dummy process to run jetfinder validation code on ESD, but MC validation for run3 on hyperloop
+  void processDummy(aod::Collisions const& collision)
+  {
+  }
+  PROCESS_SWITCH(jetTrackCollisionQa, processDummy, "Dummy process function turned on by default", false);
+};
+
+// MC validation for run2 and run3 on AO2D's
+struct mcJetTrackCollisionQa {
+
+  HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
+  Configurable<int> nBins{"nBins", 200, "N bins in histos"};
+  Configurable<int> nBinsPt{"nBinsPt", 200, "N bins in pT histos"};
+  Configurable<int> nBinsEta{"nBinsEta", 200, "N bins in Eta histos"};
+  Configurable<int> nBinsPhi{"nBinsPhi", 200, "N bins in Phi histos"};
+  Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
+
+  std::string trackSelection;
+
+  void init(InitContext const&)
+  {
+    // set trackselection
+    trackSelection = static_cast<std::string>(trackSelections);
+
+    // histograms
+    // 2)Jetvalidation on MC: generator = particle = mcTruth and reconstruction = detector (=tracks) 
+    mHistManager.add("collisionVtxZ", "Control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
+    mHistManager.add("genMCcollisionVtxZ", "MC control gen.collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
+    mHistManager.add("recMCcollisionVtxZ", "MC control rec.collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
+    // 2D for reco vs. truth level
+    mHistManager.add("collMatchPosZ","MC reco vs truth; MC truth posZ (cm); MC reco posZ (cm)", {HistType::kTH2F, {{nBins, -15, 15}, {nBins, -15, 15}}});
+    // 2D for 'relative resolution figure'
+    mHistManager.add("collResolutionPt","Collision reso #Delta posZ = (MC reco - MC truth)/ MC truth; MC truth posZ (cm); #Delta posZ (cm)", {HistType::kTH2F, {{nBinsPt, -15, 15}, {nBins, -5, 5}}});
+
+    // process jet qa
+    mHistManager.add("genMCjetPt", "MC inclusive gen jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("genMCjetPhi", "MC inclusive gen jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
+    mHistManager.add("genMCjetEta", "MC inclusive gen jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    mHistManager.add("recMCjetPt", "MC inclusive rec jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("recMCjetPhi", "MC inclusive rec jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
+    mHistManager.add("recMCjetEta", "MC inclusive rec jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    // process mc matching from particle to det
+    mHistManager.add("genRecMCjetPt", "MC rec to part jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("genRecMCjetPhi", "MC reco to part jet #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, -3.2, 6.4}});
+    mHistManager.add("genRecMCjetEta", "MC rec to part jet #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    // process jet constituent qa - constituents as tracks
+    mHistManager.add("genMCjetConstTrackPt", "MC inclusive part jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("genMCjetConstTrackPhi", "MC inclusive part jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("genMCjetConstTrackEta", "MC inclusive part jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    mHistManager.add("recMCjetConstTrackPt", "MC inclusive reco jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("recMCjetConstTrackPhi", "MC inclusive reco jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("recMCjetConstTrackEta", "MC inclusive reco jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    // process mc matching from partice to detector - needs matching from nime / aimeric has something for it 
+    mHistManager.add("genRecMCjetConstTrackPt", "MC rec to part jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("genRecMCjetConstTrackPhi", "MC rec to part inclusive part jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("genRecMCjetConstTrackEta", "MC rec to part part jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}}); 
+
+    // cross check the cuts from Run2Hybrid selection
+    mHistManager.add("genMCselectedTrackPt", "MC track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("genMCselectedTrackPhi", "MC track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("genMCselectedTrackEta", "MC track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    mHistManager.add("recMCselectedTrackPt", "reconstructed MC track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("recMCselectedTrackPhi", "reconstructed MC track #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("recMCselectedTrackEta", "reconstructed MC track #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    // tracks from mc data not mc associated
+    mHistManager.add("selectedTrackPt", "selected collission tracks Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
+    mHistManager.add("selectedTrackPhi", "selected collission tracks #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
+    mHistManager.add("selectedTrackEta", "selected collission tracks #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
+    // 2D for reco vs. truth level - we want this for jets too, but first we need proper matching there !
+    mHistManager.add("trackMatchPt","MC reco vs truth; MC truth p_{T} (GeV/#it{c}); MC reco p_{T} (GeV/#it{c})", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBinsPt, 0, 20}}});
+    mHistManager.add("trackMatchEta","MC reco vs truth; MC truth #eta; MC reco  #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -0.9, 0.9}}});
+    mHistManager.add("trackMatchPhi","MC reco vs truth; MC truth #phi; MC reco #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, 0, 6.32}}});
+    // 2D for 'relative resolution figure'
+    mHistManager.add("trackResolutionPt","Track reso #Delta p_{T} = (MC reco - MC truth)/ MC truth; MC truth p_{T} (GeV/#it{c}); #Delta p_{T}", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBins, -3, 3}}});
+    mHistManager.add("trackResolutionEta","Track reso #Delta #eta = (MC reco - MC truth)/ MC truth; MC truth #Delta #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -1, 1}}});
+    mHistManager.add("trackResolutionPhi","Track reso #Delta #phi = (MC reco - MC truth)/ MC truth; MC truth #phi (GeV/#it{c}); #Delta #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, -5, 5}}});
+  }
+
+  // fill collision qa histograms
+  template <class mcCollisions>
+  void fillMcCollisionHistos(mcCollisions const& collision)
+  {
+    mHistManager.fill(HIST("genMCcollisionVtxZ"), collision.mcCollision().posZ());
+    mHistManager.fill(HIST("recMCcollisionVtxZ"), collision.posZ());
+    mHistManager.fill(HIST("collMatchPosZ"), collision.mcCollision().posZ(), collision.posZ());
+    // 2D for 'relative resolution figure'
+    mHistManager.fill(HIST("collResolutionPt"), collision.mcCollision().posZ(), (collision.posZ() - collision.mcCollision().posZ())/collision.mcCollision().posZ());
+  }// end of collision template
+
+  // fill qa histograms for selected tracks in collision - bool for if .has_mcCollision()
+  template <class ValidationTracks> 
+  void fillMcTrackHistos(ValidationTracks const& mct, bool mc)//could give collision as argument for additional association
+  {  
+    for (const auto& track : mct) {
+      if (!selectTrack(track, trackSelection)) {
+        return;
+      }
+      if(mc == true){
+        if(track.has_mcParticle()){
+          auto mcParticle =  track.mcParticle();//t.mcParticle_as<aod::McParticles>();
+          mHistManager.fill(HIST("genMCselectedTrackPt"), mcParticle.pt());
+          mHistManager.fill(HIST("genMCselectedTrackPhi"), mcParticle.phi());
+          mHistManager.fill(HIST("genMCselectedTrackEta"), mcParticle.eta());
+          // 2D reco vs. gen
+          mHistManager.fill(HIST("trackMatchPt"), mcParticle.pt(), track.pt());
+          mHistManager.fill(HIST("trackMatchEta"), mcParticle.eta(), track.eta());
+          mHistManager.fill(HIST("trackMatchPhi"), mcParticle.phi(), track.phi());
+          // 2D for 'relative resolution figure'
+          mHistManager.fill(HIST("trackResolutionPt"), mcParticle.pt(), (track.pt() - mcParticle.pt())/mcParticle.pt());
+          mHistManager.fill(HIST("trackResolutionEta"),mcParticle.eta(), (track.eta() - mcParticle.eta())/mcParticle.eta());
+          mHistManager.fill(HIST("trackResolutionPhi"), mcParticle.phi(), (track.phi() - mcParticle.phi())/mcParticle.phi());
+        }// end of track.has_mcParticle
+        // fill histos for all reconstructed particles from mc associated collision (includes mcParticles)
+        mHistManager.fill(HIST("recMCselectedTrackPt"), track.pt());
+        mHistManager.fill(HIST("recMCselectedTrackPhi"), track.phi());
+        mHistManager.fill(HIST("recMCselectedTrackEta"), track.eta()); 
+      }//end of if mc
+      if(mc == false){
+        mHistManager.fill(HIST("selectedTrackPt"), track.pt());
+        mHistManager.fill(HIST("selectedTrackPhi"), track.phi());
+        mHistManager.fill(HIST("selectedTrackEta"), track.eta()); 
+      } 
+    }// end of tracks loop
+  }//end of mcTrack template
+
+  template <typename detectorJet>
+  void fillMcDetJets(detectorJet const& mcdJet)
+  { 
+    mHistManager.fill(HIST("recMCjetPt"), mcdJet.pt());
+    mHistManager.fill(HIST("recMCjetPhi"), mcdJet.phi());
+    mHistManager.fill(HIST("recMCjetEta"), mcdJet.eta());
+  }// end of mcDetJet template
+
+  template <typename particleJet>
+  void fillMcPartJets(particleJet const& mcpJet)
+  { 
+    mHistManager.fill(HIST("genMCjetPt"), mcpJet.pt());
+    mHistManager.fill(HIST("genMCjetPhi"), mcpJet.phi());
+    mHistManager.fill(HIST("genMCjetEta"), mcpJet.eta());
+  }// end of mcPartJet template
+
+  template <typename detectorJetConstituent>
+  void fillMcDetJetConstituents(detectorJetConstituent const& mcdJConst)
+  {
+    mHistManager.fill(HIST("recMCjetConstTrackPt"), mcdJConst.pt());
+    mHistManager.fill(HIST("recMCjetConstTrackPhi"), mcdJConst.phi());
+    mHistManager.fill(HIST("recMCjetConstTrackEta"), mcdJConst.eta());
+  }// end of mcDetJetConstituent template
+
+  template <typename particleJetConstituent>
+  void fillMcPartJetConstituents(particleJetConstituent const& mcpJConst)
+  {
+    mHistManager.fill(HIST("genMCjetConstTrackPt"), mcpJConst.pt());
+    mHistManager.fill(HIST("genMCjetConstTrackPhi"), mcpJConst.phi());
+    mHistManager.fill(HIST("genMCjetConstTrackEta"), mcpJConst.eta());
+  }// end of mcPartJetConstituent template
+
+  void processMcRun2(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision, 
+                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets, 
+                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets, 
+                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
+                      MCTracksRun2JE const& tracks)
+  {
+    if (abs(collision.posZ()) > 10) {//sel7 for run2: !collision.sel7()
+      return;
+    }
+    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
+    if(collision.has_mcCollision()){
+      fillMcCollisionHistos(collision);
+      fillMcTrackHistos(tracks, true);
+    } // end if has mc collision
+    fillMcTrackHistos(tracks, false);
+
+    for(const auto& detJet : mcDetJets){
+      fillMcDetJets(detJet);
+      for (auto& detConst : detJet.tracks_as<MCTracksRun2JE>()) {
+        fillMcDetJetConstituents(detConst);
+      }// end of loop detector level constituents
+    }// end of loop detector level jets
+
+    for(const auto& genJet : mcPartJets ){
+      fillMcPartJets(genJet);
+      for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
+        fillMcPartJetConstituents(mcParticle);
+      } // end of jet constituent loop 
+    } // end of loop particle level jets 
+  } // end processMcRun2
+  PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun2, "validate jet-finder output on converted run2 mc AOD's", false);
+
+  void processMcRun3(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision, 
+                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets, 
+                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets, 
+                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
+                      MCTracksRun3JE const& tracks)
+  { 
+    if (abs(collision.posZ()) > 10) {//sel8 for run3: !collision.sel8() -> only on run3 data with EvSels in process function !
+      return;
+    }
+    mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
+    if(collision.has_mcCollision()){
+      fillMcCollisionHistos(collision);
+      fillMcTrackHistos(tracks, true);
+    } // end of loop if mc collision
+    fillMcTrackHistos(tracks, false);
+
+    for(const auto& detJet : mcDetJets){
+      fillMcDetJets(detJet);
+      for (auto& detConst : detJet.tracks_as<MCTracksRun3JE>()) {
+        fillMcDetJetConstituents(detConst);
+      }// end of loop detector level constituents
+    }// end of loop detector level jets
+
+    for(const auto& genJet : mcPartJets ){
+      fillMcPartJets(genJet);
+      for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
+        fillMcPartJetConstituents(mcParticle);
+      } // end of jet constituent loop 
+    } // end of loop particle level jets 
+  } // end processMcRun3
+  PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun3, "validate jet-finder output on run3 mc AOD's", false);
+
+  // dummy process to run jetfinder validation code on AO2D's, but MC validation for run3 on hyperloop
+  void processDummy(aod::Collisions const& collision)
+  {
+  }
+  PROCESS_SWITCH(mcJetTrackCollisionQa, processDummy, "Dummy process function turned off by default", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"})};
+  return WorkflowSpec{ 
+    adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"}),
+    adaptAnalysisTask<mcJetTrackCollisionQa>(cfgc, TaskName{"mc-jet-validation-track-collision-qa"})};
 }

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -14,34 +14,34 @@
 //  \since Dec 2022
 // Examples for configurations and run macros (https://github.com/jloemker/PWGJE/tree/master/O2Physics/config_run)
 // 1)Configuration for run2 validation on ESD:
-//  Use run2ESD.sh with configRun2ESD.json    
+//  Use run2ESD.sh with configRun2ESD.json
 // 2)Configuration for run3 validation on AOD: NOT YET WORKING - see comment in run3AOD.sh
 //  Use run3AOD.sh with configRun3AOD.json
 // 3)Configuration for MC validation on converted run2 AOD:
-//  Use runMC2.sh with configMC2Jet.json  
-// 4) Configuration for MC validation on run3 AOD:  
-// Use runMC3.sh with configMC3Jet.json 
+//  Use runMC2.sh with configMC2Jet.json
+// 4) Configuration for MC validation on run3 AOD:
+// Use runMC3.sh with configMC3Jet.json
 
-  ////////////////=============================================////////////////
-  //                              TODO's: 
-  //============== 1)template in mcJetTrackCollisionQa to validate JetMatching !
-  // look at matching https://github.com/AliceO2Group/O2Physics/blob/723d78931b446e7b5f6e0673c0345fcef584e796/Tutorials/src/mcHistograms.cxx#L154
-  // loop over matched jets
-  // make additional TH2F's for matched jets in pt, phi, eta (just what i did for the ones for tracks and collisions)
-  //        i) with mcrec vs mcpart 
-  //        ii)with (mcrec-mcpart)/mcpart as function of mcpart
-  //
-  //============== 2) Add processes for:
-  //                i) processRun3AOD, process ESD: Full (doesn't work yet) and Neutral Jets
-  //                ii)processMcRun3, processMcRun2: Full (doesn't work yet) and Neutral Jets
-  //
-  //============== 3) prepare plotting macros for Run3 and MCrun2, MCrun3 !
-  //
-  //============== 4) add logarithmic x-axis for pt plots and improve overall binning via arrays - also in AliPhysics !
-  // look here https://github.com/AliceO2Group/QualityControl/blob/17798501ac1cbc9a9f25797ed15c68244c0a36f0/Modules/MUON/MCH/src/RofsTask.cxx#L58
-  //
-  //============== 3) add explicit filters for collision and tracks (?)
-  ////////////////=============================================////////////////
+////////////////=============================================////////////////
+//                              TODO's:
+//============== 1)template in mcJetTrackCollisionQa to validate JetMatching !
+// look at matching https://github.com/AliceO2Group/O2Physics/blob/723d78931b446e7b5f6e0673c0345fcef584e796/Tutorials/src/mcHistograms.cxx#L154
+// loop over matched jets
+// make additional TH2F's for matched jets in pt, phi, eta (just what i did for the ones for tracks and collisions)
+//        i) with mcrec vs mcpart
+//        ii)with (mcrec-mcpart)/mcpart as function of mcpart
+//
+//============== 2) Add processes for:
+//                i) processRun3AOD, process ESD: Full (doesn't work yet) and Neutral Jets
+//                ii)processMcRun3, processMcRun2: Full (doesn't work yet) and Neutral Jets
+//
+//============== 3) prepare plotting macros for Run3 and MCrun2, MCrun3 !
+//
+//============== 4) add logarithmic x-axis for pt plots and improve overall binning via arrays - also in AliPhysics !
+// look here https://github.com/AliceO2Group/QualityControl/blob/17798501ac1cbc9a9f25797ed15c68244c0a36f0/Modules/MUON/MCH/src/RofsTask.cxx#L58
+//
+//============== 3) add explicit filters for collision and tracks (?)
+////////////////=============================================////////////////
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -63,7 +63,7 @@ using namespace o2::framework::expressions;
 // tracks for 1) validation on ESD 2) Run2 MC validatio on AO2D's 3) Run2 MC validation on AO2D's
 using TracksJE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>;
 using MCTracksRun3JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;
-using MCTracksRun2JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;// for now the same
+using MCTracksRun2JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>; // for now the same
 
 // struct for jetfinder validation on run2 ESD's and run3 data
 struct jetTrackCollisionQa {
@@ -79,7 +79,7 @@ struct jetTrackCollisionQa {
 
   void init(InitContext const&)
   {
-    //set trackselections 
+    // set trackselections
     trackSelection = static_cast<std::string>(trackSelections);
     // histograms
     // 1)Jetvalidation on data
@@ -113,38 +113,38 @@ struct jetTrackCollisionQa {
 
   template <typename validationTracks>
   void fillTrackQA(validationTracks const& track)
-  { 
+  {
     if (!selectTrack(track, trackSelection)) {
       return;
     }
     mHistManager.fill(HIST("selectedTrackPt"), track.pt());
     mHistManager.fill(HIST("selectedTrackPhi"), track.phi());
     mHistManager.fill(HIST("selectedTrackEta"), track.eta());
-  }// end of fillTrackQA template
+  } // end of fillTrackQA template
 
-  //template <typename validationTracks>
+  // template <typename validationTracks>
   void fillLeadingTrackQA(double leadingTrackPt, double leadingTrackPhi, double leadingTrackEta)
-  { 
+  {
     mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
     mHistManager.fill(HIST("leadTrackPhi"), leadingTrackPhi);
     mHistManager.fill(HIST("leadTrackEta"), leadingTrackEta);
-  }// end of fillLeadingTrackQA template
+  } // end of fillLeadingTrackQA template
 
   template <typename dataJet>
   void fillJetQA(dataJet const& jet)
-  { 
+  {
     mHistManager.fill(HIST("jetPt"), jet.pt());
     mHistManager.fill(HIST("jetPhi"), jet.phi());
     mHistManager.fill(HIST("jetEta"), jet.eta());
-  }// end of fillJetQA template
+  } // end of fillJetQA template
 
-  //template <typename validationTracks>
+  // template <typename validationTracks>
   void fillLeadingJetQA(double leadingJetPt, double leadingJetPhi, double leadingJetEta)
-  { 
+  {
     mHistManager.fill(HIST("leadJetPt"), leadingJetPt);
     mHistManager.fill(HIST("leadJetPhi"), leadingJetPhi);
     mHistManager.fill(HIST("leadJetEta"), leadingJetEta);
-  }// end of fillLeadingJetQA template
+  } // end of fillLeadingJetQA template
 
   template <typename dataJetConstituent>
   void fillJetConstituentQA(dataJetConstituent const& jct)
@@ -152,15 +152,15 @@ struct jetTrackCollisionQa {
     mHistManager.fill(HIST("jetConstTrackPt"), jct.pt());
     mHistManager.fill(HIST("jetConstTrackPhi"), jct.phi());
     mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
-  }// end of mcDetJetConstituent template
+  } // end of mcDetJetConstituent template
 
-  //template <typename validationTracks>
+  // template <typename validationTracks>
   void fillLeadingJetConstQA(double leadingConstTrackPt, double leadingConstTrackPhi, double leadingConstTrackEta)
-  { 
+  {
     mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
     mHistManager.fill(HIST("leadJetConstPhi"), leadingConstTrackPhi);
     mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
-  }// end of fillLeadingJetConstQA template
+  } // end of fillLeadingJetConstQA template
 
   void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
@@ -181,8 +181,8 @@ struct jetTrackCollisionQa {
         leadingTrackEta = t.eta();
       }
     } // end of tracks loop
-    //fill leading track  
-    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi,leadingTrackEta);
+    // fill leading track
+    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi, leadingTrackEta);
 
     double leadingJetPt = -1;
     double leadingJetPhi = -1;
@@ -234,8 +234,8 @@ struct jetTrackCollisionQa {
         leadingTrackEta = t.eta();
       }
     } // end of tracks loop
-    //fill leading track  
-    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi,leadingTrackEta);
+    // fill leading track
+    fillLeadingTrackQA(leadingTrackPt, leadingTrackPhi, leadingTrackEta);
 
     double leadingJetPt = -1;
     double leadingJetPhi = -1;
@@ -293,14 +293,14 @@ struct mcJetTrackCollisionQa {
     trackSelection = static_cast<std::string>(trackSelections);
 
     // histograms
-    // 2)Jetvalidation on MC: generator = particle = mcTruth and reconstruction = detector (=tracks) 
+    // 2)Jetvalidation on MC: generator = particle = mcTruth and reconstruction = detector (=tracks)
     mHistManager.add("collisionVtxZ", "Control collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
     mHistManager.add("genMCcollisionVtxZ", "MC control gen.collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
     mHistManager.add("recMCcollisionVtxZ", "MC control rec.collsion VtxZ ; z [cm]", HistType::kTH1F, {{nBins, -15, 15}});
     // 2D for reco vs. truth level
-    mHistManager.add("collMatchPosZ","MC reco vs truth; MC truth posZ (cm); MC reco posZ (cm)", {HistType::kTH2F, {{nBins, -15, 15}, {nBins, -15, 15}}});
+    mHistManager.add("collMatchPosZ", "MC reco vs truth; MC truth posZ (cm); MC reco posZ (cm)", {HistType::kTH2F, {{nBins, -15, 15}, {nBins, -15, 15}}});
     // 2D for 'relative resolution figure'
-    mHistManager.add("collResolutionPt","Collision reso #Delta posZ = (MC reco - MC truth)/ MC truth; MC truth posZ (cm); #Delta posZ (cm)", {HistType::kTH2F, {{nBinsPt, -15, 15}, {nBins, -5, 5}}});
+    mHistManager.add("collResolutionPt", "Collision reso #Delta posZ = (MC reco - MC truth)/ MC truth; MC truth posZ (cm); #Delta posZ (cm)", {HistType::kTH2F, {{nBinsPt, -15, 15}, {nBins, -5, 5}}});
 
     // process jet qa
     mHistManager.add("genMCjetPt", "MC inclusive gen jetPt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
@@ -320,10 +320,10 @@ struct mcJetTrackCollisionQa {
     mHistManager.add("recMCjetConstTrackPt", "MC inclusive reco jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("recMCjetConstTrackPhi", "MC inclusive reco jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("recMCjetConstTrackEta", "MC inclusive reco jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
-    // process mc matching from partice to detector - needs matching from nime / aimeric has something for it 
+    // process mc matching from partice to detector - needs matching from nime / aimeric has something for it
     mHistManager.add("genRecMCjetConstTrackPt", "MC rec to part jet constituent Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
     mHistManager.add("genRecMCjetConstTrackPhi", "MC rec to part inclusive part jet constituent #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
-    mHistManager.add("genRecMCjetConstTrackEta", "MC rec to part part jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}}); 
+    mHistManager.add("genRecMCjetConstTrackEta", "MC rec to part part jet constituent #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
 
     // cross check the cuts from Run2Hybrid selection
     mHistManager.add("genMCselectedTrackPt", "MC track Pt ; p_{T} (GeV/#it{c})", HistType::kTH1F, {{nBinsPt, 0, 100}});
@@ -337,13 +337,13 @@ struct mcJetTrackCollisionQa {
     mHistManager.add("selectedTrackPhi", "selected collission tracks #phi ; #phi ", HistType::kTH1F, {{nBinsPhi, 0, 6.4}});
     mHistManager.add("selectedTrackEta", "selected collission tracks #eta ; #eta ", HistType::kTH1F, {{nBinsEta, -0.9, 0.9}});
     // 2D for reco vs. truth level - we want this for jets too, but first we need proper matching there !
-    mHistManager.add("trackMatchPt","MC reco vs truth; MC truth p_{T} (GeV/#it{c}); MC reco p_{T} (GeV/#it{c})", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBinsPt, 0, 20}}});
-    mHistManager.add("trackMatchEta","MC reco vs truth; MC truth #eta; MC reco  #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -0.9, 0.9}}});
-    mHistManager.add("trackMatchPhi","MC reco vs truth; MC truth #phi; MC reco #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, 0, 6.32}}});
+    mHistManager.add("trackMatchPt", "MC reco vs truth; MC truth p_{T} (GeV/#it{c}); MC reco p_{T} (GeV/#it{c})", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBinsPt, 0, 20}}});
+    mHistManager.add("trackMatchEta", "MC reco vs truth; MC truth #eta; MC reco  #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -0.9, 0.9}}});
+    mHistManager.add("trackMatchPhi", "MC reco vs truth; MC truth #phi; MC reco #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, 0, 6.32}}});
     // 2D for 'relative resolution figure'
-    mHistManager.add("trackResolutionPt","Track reso #Delta p_{T} = (MC reco - MC truth)/ MC truth; MC truth p_{T} (GeV/#it{c}); #Delta p_{T}", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBins, -3, 3}}});
-    mHistManager.add("trackResolutionEta","Track reso #Delta #eta = (MC reco - MC truth)/ MC truth; MC truth #Delta #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -1, 1}}});
-    mHistManager.add("trackResolutionPhi","Track reso #Delta #phi = (MC reco - MC truth)/ MC truth; MC truth #phi (GeV/#it{c}); #Delta #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, -5, 5}}});
+    mHistManager.add("trackResolutionPt", "Track reso #Delta p_{T} = (MC reco - MC truth)/ MC truth; MC truth p_{T} (GeV/#it{c}); #Delta p_{T}", {HistType::kTH2F, {{nBinsPt, 0, 20}, {nBins, -3, 3}}});
+    mHistManager.add("trackResolutionEta", "Track reso #Delta #eta = (MC reco - MC truth)/ MC truth; MC truth #Delta #eta", {HistType::kTH2F, {{nBinsPt, -0.9, 0.9}, {nBins, -1, 1}}});
+    mHistManager.add("trackResolutionPhi", "Track reso #Delta #phi = (MC reco - MC truth)/ MC truth; MC truth #phi (GeV/#it{c}); #Delta #phi", {HistType::kTH2F, {{nBinsPt, 0, 6.32}, {nBins, -5, 5}}});
   }
 
   // fill collision qa histograms
@@ -354,20 +354,20 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("recMCcollisionVtxZ"), collision.posZ());
     mHistManager.fill(HIST("collMatchPosZ"), collision.mcCollision().posZ(), collision.posZ());
     // 2D for 'relative resolution figure'
-    mHistManager.fill(HIST("collResolutionPt"), collision.mcCollision().posZ(), (collision.posZ() - collision.mcCollision().posZ())/collision.mcCollision().posZ());
-  }// end of collision template
+    mHistManager.fill(HIST("collResolutionPt"), collision.mcCollision().posZ(), (collision.posZ() - collision.mcCollision().posZ()) / collision.mcCollision().posZ());
+  } // end of collision template
 
   // fill qa histograms for selected tracks in collision - bool for if .has_mcCollision()
-  template <class ValidationTracks> 
-  void fillMcTrackHistos(ValidationTracks const& mct, bool mc)//could give collision as argument for additional association
-  {  
+  template <class ValidationTracks>
+  void fillMcTrackHistos(ValidationTracks const& mct, bool mc) // could give collision as argument for additional association
+  {
     for (const auto& track : mct) {
       if (!selectTrack(track, trackSelection)) {
         return;
       }
-      if(mc == true){
-        if(track.has_mcParticle()){
-          auto mcParticle =  track.mcParticle();//t.mcParticle_as<aod::McParticles>();
+      if (mc == true) {
+        if (track.has_mcParticle()) {
+          auto mcParticle = track.mcParticle(); // t.mcParticle_as<aod::McParticles>();
           mHistManager.fill(HIST("genMCselectedTrackPt"), mcParticle.pt());
           mHistManager.fill(HIST("genMCselectedTrackPhi"), mcParticle.phi());
           mHistManager.fill(HIST("genMCselectedTrackEta"), mcParticle.eta());
@@ -376,38 +376,38 @@ struct mcJetTrackCollisionQa {
           mHistManager.fill(HIST("trackMatchEta"), mcParticle.eta(), track.eta());
           mHistManager.fill(HIST("trackMatchPhi"), mcParticle.phi(), track.phi());
           // 2D for 'relative resolution figure'
-          mHistManager.fill(HIST("trackResolutionPt"), mcParticle.pt(), (track.pt() - mcParticle.pt())/mcParticle.pt());
-          mHistManager.fill(HIST("trackResolutionEta"),mcParticle.eta(), (track.eta() - mcParticle.eta())/mcParticle.eta());
-          mHistManager.fill(HIST("trackResolutionPhi"), mcParticle.phi(), (track.phi() - mcParticle.phi())/mcParticle.phi());
-        }// end of track.has_mcParticle
+          mHistManager.fill(HIST("trackResolutionPt"), mcParticle.pt(), (track.pt() - mcParticle.pt()) / mcParticle.pt());
+          mHistManager.fill(HIST("trackResolutionEta"), mcParticle.eta(), (track.eta() - mcParticle.eta()) / mcParticle.eta());
+          mHistManager.fill(HIST("trackResolutionPhi"), mcParticle.phi(), (track.phi() - mcParticle.phi()) / mcParticle.phi());
+        } // end of track.has_mcParticle
         // fill histos for all reconstructed particles from mc associated collision (includes mcParticles)
         mHistManager.fill(HIST("recMCselectedTrackPt"), track.pt());
         mHistManager.fill(HIST("recMCselectedTrackPhi"), track.phi());
-        mHistManager.fill(HIST("recMCselectedTrackEta"), track.eta()); 
-      }//end of if mc
-      if(mc == false){
+        mHistManager.fill(HIST("recMCselectedTrackEta"), track.eta());
+      } // end of if mc
+      if (mc == false) {
         mHistManager.fill(HIST("selectedTrackPt"), track.pt());
         mHistManager.fill(HIST("selectedTrackPhi"), track.phi());
-        mHistManager.fill(HIST("selectedTrackEta"), track.eta()); 
-      } 
-    }// end of tracks loop
-  }//end of mcTrack template
+        mHistManager.fill(HIST("selectedTrackEta"), track.eta());
+      }
+    } // end of tracks loop
+  }   // end of mcTrack template
 
   template <typename detectorJet>
   void fillMcDetJets(detectorJet const& mcdJet)
-  { 
+  {
     mHistManager.fill(HIST("recMCjetPt"), mcdJet.pt());
     mHistManager.fill(HIST("recMCjetPhi"), mcdJet.phi());
     mHistManager.fill(HIST("recMCjetEta"), mcdJet.eta());
-  }// end of mcDetJet template
+  } // end of mcDetJet template
 
   template <typename particleJet>
   void fillMcPartJets(particleJet const& mcpJet)
-  { 
+  {
     mHistManager.fill(HIST("genMCjetPt"), mcpJet.pt());
     mHistManager.fill(HIST("genMCjetPhi"), mcpJet.phi());
     mHistManager.fill(HIST("genMCjetEta"), mcpJet.eta());
-  }// end of mcPartJet template
+  } // end of mcPartJet template
 
   template <typename detectorJetConstituent>
   void fillMcDetJetConstituents(detectorJetConstituent const& mcdJConst)
@@ -415,7 +415,7 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("recMCjetConstTrackPt"), mcdJConst.pt());
     mHistManager.fill(HIST("recMCjetConstTrackPhi"), mcdJConst.phi());
     mHistManager.fill(HIST("recMCjetConstTrackEta"), mcdJConst.eta());
-  }// end of mcDetJetConstituent template
+  } // end of mcDetJetConstituent template
 
   template <typename particleJetConstituent>
   void fillMcPartJetConstituents(particleJetConstituent const& mcpJConst)
@@ -423,70 +423,70 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("genMCjetConstTrackPt"), mcpJConst.pt());
     mHistManager.fill(HIST("genMCjetConstTrackPhi"), mcpJConst.phi());
     mHistManager.fill(HIST("genMCjetConstTrackEta"), mcpJConst.eta());
-  }// end of mcPartJetConstituent template
+  } // end of mcPartJetConstituent template
 
-  void processMcRun2(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision, 
-                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets, 
-                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets, 
-                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
-                      MCTracksRun2JE const& tracks)
+  void processMcRun2(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision,
+                     soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets,
+                     soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets,
+                     aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
+                     MCTracksRun2JE const& tracks)
   {
-    if (abs(collision.posZ()) > 10) {//sel7 for run2: !collision.sel7()
+    if (abs(collision.posZ()) > 10) { // sel7 for run2: !collision.sel7()
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
-    if(collision.has_mcCollision()){
+    if (collision.has_mcCollision()) {
       fillMcCollisionHistos(collision);
       fillMcTrackHistos(tracks, true);
     } // end if has mc collision
     fillMcTrackHistos(tracks, false);
 
-    for(const auto& detJet : mcDetJets){
+    for (const auto& detJet : mcDetJets) {
       fillMcDetJets(detJet);
       for (auto& detConst : detJet.tracks_as<MCTracksRun2JE>()) {
         fillMcDetJetConstituents(detConst);
-      }// end of loop detector level constituents
-    }// end of loop detector level jets
+      } // end of loop detector level constituents
+    }   // end of loop detector level jets
 
-    for(const auto& genJet : mcPartJets ){
+    for (const auto& genJet : mcPartJets) {
       fillMcPartJets(genJet);
       for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
         fillMcPartJetConstituents(mcParticle);
-      } // end of jet constituent loop 
-    } // end of loop particle level jets 
-  } // end processMcRun2
+      } // end of jet constituent loop
+    }   // end of loop particle level jets
+  }     // end processMcRun2
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun2, "validate jet-finder output on converted run2 mc AOD's", false);
 
-  void processMcRun3(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision, 
-                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets, 
-                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets, 
-                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
-                      MCTracksRun3JE const& tracks)
-  { 
-    if (abs(collision.posZ()) > 10) {//sel8 for run3: !collision.sel8() -> only on run3 data with EvSels in process function !
+  void processMcRun3(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision,
+                     soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets,
+                     soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets,
+                     aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
+                     MCTracksRun3JE const& tracks)
+  {
+    if (abs(collision.posZ()) > 10) { // sel8 for run3: !collision.sel8() -> only on run3 data with EvSels in process function !
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
-    if(collision.has_mcCollision()){
+    if (collision.has_mcCollision()) {
       fillMcCollisionHistos(collision);
       fillMcTrackHistos(tracks, true);
     } // end of loop if mc collision
     fillMcTrackHistos(tracks, false);
 
-    for(const auto& detJet : mcDetJets){
+    for (const auto& detJet : mcDetJets) {
       fillMcDetJets(detJet);
       for (auto& detConst : detJet.tracks_as<MCTracksRun3JE>()) {
         fillMcDetJetConstituents(detConst);
-      }// end of loop detector level constituents
-    }// end of loop detector level jets
+      } // end of loop detector level constituents
+    }   // end of loop detector level jets
 
-    for(const auto& genJet : mcPartJets ){
+    for (const auto& genJet : mcPartJets) {
       fillMcPartJets(genJet);
       for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
         fillMcPartJetConstituents(mcParticle);
-      } // end of jet constituent loop 
-    } // end of loop particle level jets 
-  } // end processMcRun3
+      } // end of jet constituent loop
+    }   // end of loop particle level jets
+  }     // end processMcRun3
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun3, "validate jet-finder output on run3 mc AOD's", false);
 
   // dummy process to run jetfinder validation code on AO2D's, but MC validation for run3 on hyperloop
@@ -498,7 +498,7 @@ struct mcJetTrackCollisionQa {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{ 
+  return WorkflowSpec{
     adaptAnalysisTask<jetTrackCollisionQa>(cfgc, TaskName{"jet-validation-track-collision-qa"}),
     adaptAnalysisTask<mcJetTrackCollisionQa>(cfgc, TaskName{"mc-jet-validation-track-collision-qa"})};
 }


### PR DESCRIPTION
Hi @nzardosh , @fkrizek , @aimeric-landou (I could not tag the others),

here we have the updated jetvalidation.cxx with two structures that will allow us to split the work for the mc and data processes easily such that we can perform the validation on ESD's very independent of the ongoing developments for the mc analysis. We can also merge them in the future.

* The trackselection works just like for the jetfinder (we call the function from jetfinder.h for it) but please make sure to configure the hybridTracksJE for the jetfinder **and** jetvalidation when running on ESD's. Please avoid using them for processes that run on hyperloop (for now).
* There is a link for example configurables and run macros to help others getting started
* There is a long todo list from simple task to more complicated ones for the next weeks.

Many thanks for approving !

Cheerio,
Johanna