### PR TITLE
Adding code for Hyperhelium-4 study 

### DIFF
--- a/PWGLF/DataModel/LFHyperhelium4Tables.h
+++ b/PWGLF/DataModel/LFHyperhelium4Tables.h
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef PWGLF_DATAMODEL_LFHYHEFOURTABLES_H_
+#define PWGLF_DATAMODEL_LFHYHEFOURTABLES_H_
+
+#include <cmath>
+#include "Framework/AnalysisDataModel.h"
+#include "Common/Core/RecoDecay.h"
+#include "CommonConstants/PhysicsConstants.h"
+
+namespace o2::aod
+{
+// helper for building
+namespace hyhe4tag
+{
+// Global bool
+DECLARE_SOA_COLUMN(IsInteresting, isInteresting, bool); //! will this be built or not?
+
+// MC association bools
+DECLARE_SOA_COLUMN(IsTrueHyHe4, isTrueHyHe4, bool);                     //! PDG checked correctly in MC
+DECLARE_SOA_COLUMN(IsTrueAntiHyHe4, isTrueAntiHyHe4, bool);                 //! PDG checked correctly in MC
+// dE/dx compatibility bools
+DECLARE_SOA_COLUMN(IsHyHe4Candidate, isHyHe4Candidate, bool);                     //! compatible with dE/dx hypotheses
+DECLARE_SOA_COLUMN(IsAntiHyHe4Candidate, isAntiHyHe4Candidate, bool);                 //! compatible with dE/dx hypotheses
+}
+DECLARE_SOA_TABLE(HyHe4Tags, "AOD", "HYHE4TAGS",
+                  hyhe4tag::IsInteresting,
+                  hyhe4tag::IsTrueHyHe4,
+                  hyhe4tag::IsTrueAntiHyHe4,
+                  hyhe4tag::IsHyHe4Candidate,
+                  hyhe4tag::IsAntiHyHe4Candidate);
+} // namespace o2::aod
+
+
+#endif // PWGLF_DATAMODEL_LFHYHEFOURTABLES_H_

--- a/PWGLF/DataModel/LFHyperhelium4Tables.h
+++ b/PWGLF/DataModel/LFHyperhelium4Tables.h
@@ -16,28 +16,116 @@
 #include "Common/Core/RecoDecay.h"
 #include "CommonConstants/PhysicsConstants.h"
 
+//===========================================================================
+// For aiding in building: tag those candidates that are interesting
 namespace o2::aod
 {
-// helper for building
 namespace hyhe4tag
 {
-// Global bool
 DECLARE_SOA_COLUMN(IsInteresting, isInteresting, bool); //! will this be built or not?
-
 // MC association bools
-DECLARE_SOA_COLUMN(IsTrueHyHe4, isTrueHyHe4, bool);                     //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueAntiHyHe4, isTrueAntiHyHe4, bool);                 //! PDG checked correctly in MC
+DECLARE_SOA_COLUMN(IsTrueHyHe4, isTrueHyHe4, bool);         //! PDG checked correctly in MC
+DECLARE_SOA_COLUMN(IsTrueAntiHyHe4, isTrueAntiHyHe4, bool); //! PDG checked correctly in MC
 // dE/dx compatibility bools
-DECLARE_SOA_COLUMN(IsHyHe4Candidate, isHyHe4Candidate, bool);                     //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsAntiHyHe4Candidate, isAntiHyHe4Candidate, bool);                 //! compatible with dE/dx hypotheses
-}
+DECLARE_SOA_COLUMN(IsHyHe4Candidate, isHyHe4Candidate, bool);         //! compatible with dE/dx hypotheses
+DECLARE_SOA_COLUMN(IsAntiHyHe4Candidate, isAntiHyHe4Candidate, bool); //! compatible with dE/dx hypotheses
+} // namespace hyhe4tag
 DECLARE_SOA_TABLE(HyHe4Tags, "AOD", "HYHE4TAGS",
                   hyhe4tag::IsInteresting,
                   hyhe4tag::IsTrueHyHe4,
                   hyhe4tag::IsTrueAntiHyHe4,
                   hyhe4tag::IsHyHe4Candidate,
                   hyhe4tag::IsAntiHyHe4Candidate);
+
+//===========================================================================
+// The actual analysis data model for hyperhelium4
+namespace hyhe4data
+{
+// Needed to have shorter table that does not rely on existing one (filtering!)
+DECLARE_SOA_INDEX_COLUMN_FULL(Helium3Track, prong0Track, int, Tracks, "_Helium3"); //!
+DECLARE_SOA_INDEX_COLUMN_FULL(ProtonTrack, prong1Track, int, Tracks, "_Proton");   //!
+DECLARE_SOA_INDEX_COLUMN_FULL(PionTrack, prong2Track, int, Tracks, "_Pion");       //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                                    //!
+DECLARE_SOA_INDEX_COLUMN(Decay3Body, decay3Bodys);                                 //!
+
+// General V0 properties: position, momentum
+DECLARE_SOA_COLUMN(Sign, sign, int);             //! sign (positive = matter)
+DECLARE_SOA_COLUMN(Helium3X, helium3X, float);   //! prong0 track X at min
+DECLARE_SOA_COLUMN(ProtonX, protonX, float);     //! prong1 track X at min
+DECLARE_SOA_COLUMN(PionX, pionX, float);         //! prong2 track X at min
+DECLARE_SOA_COLUMN(PxHelium3, pxHelium3, float); //! prong 0 track px at min; NB already charge-corrected! Not rigidity anymore!
+DECLARE_SOA_COLUMN(PyHelium3, pyHelium3, float); //! prong 0 track py at min; NB already charge-corrected! Not rigidity anymore!
+DECLARE_SOA_COLUMN(PzHelium3, pzHelium3, float); //! prong 0 track pz at min; NB already charge-corrected! Not rigidity anymore!
+DECLARE_SOA_COLUMN(PxProton, pxProton, float);   //! prong 1 track px at min
+DECLARE_SOA_COLUMN(PyProton, pyProton, float);   //! prong 1 track py at min
+DECLARE_SOA_COLUMN(PzProton, pzProton, float);   //! prong 1 track pz at min
+DECLARE_SOA_COLUMN(PxPion, pxPion, float);       //! prong 1 track px at min
+DECLARE_SOA_COLUMN(PyPion, pyPion, float);       //! prong 1 track py at min
+DECLARE_SOA_COLUMN(PzPion, pzPion, float);       //! prong 1 track pz at min
+DECLARE_SOA_COLUMN(X, x, float);                 //! decay position X
+DECLARE_SOA_COLUMN(Y, y, float);                 //! decay position Y
+DECLARE_SOA_COLUMN(Z, z, float);                 //! decay position Z
+
+// Saved from finding: DCAs
+DECLARE_SOA_COLUMN(DCADaughters, dcaDaughters, float);     //! DCA between V0 daughters
+DECLARE_SOA_COLUMN(DCAHelium3ToPV, dcaHelium3ToPV, float); //! DCA positive prong to PV
+DECLARE_SOA_COLUMN(DCAProtonToPV, dcaProtonToPV, float);   //! DCA positive prong to PV
+DECLARE_SOA_COLUMN(DCAPionToPV, dcaPionToPV, float);       //! DCA positive prong to PV
+
+// DCA to primary vertex
+DECLARE_SOA_COLUMN(DCAxyHyHe4ToPV, dcaxyHyHe4ToPV, float); //! DCAxy
+DECLARE_SOA_COLUMN(DCAzHyHe4ToPV, dcazHyHe4ToPV, float);   //! DCAz
+
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! pT
+                           [](float pxp0, float pyp0, float pxp1, float pyp1, float pxp2, float pyp2) -> float { return RecoDecay::sqrtSumOfSquares(pxp0 + pxp1 + pxp2, pyp0 + pyp1 + pyp2); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtHelium3, ptHelium3, //! pT of prong 0 (identified as Helium-3)
+                           [](float px, float py) -> float { return RecoDecay::sqrtSumOfSquares(px, py); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtProton, ptProton, //! pT of prong 0 (identified as proton)
+                           [](float px, float py) -> float { return RecoDecay::sqrtSumOfSquares(px, py); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtPion, ptPion, //! pT of prong 0 (identified as proton)
+                           [](float px, float py) -> float { return RecoDecay::sqrtSumOfSquares(px, py); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(DecayRadius, decayRadius, //! decay radius (2D, centered at zero)
+                           [](float x, float y) -> float { return RecoDecay::sqrtSumOfSquares(x, y); });
+DECLARE_SOA_DYNAMIC_COLUMN(M, m, //! mass under hyperhelium-4 hypo
+                           [](float pxp0, float pyp0, float pzp0, float pxp1, float pyp1, float pzp1, float pxp2, float pyp2, float pzp2) -> float { return RecoDecay::m(array{array{pxp0, pyp0, pzp0}, array{pxp1, pyp1, pzp1}, array{pxp2, pyp2, pzp2}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged}); });
+DECLARE_SOA_DYNAMIC_COLUMN(YHyHe4, yHyHe4, //! y -> FIXME add Hyperhelium4 mass to physics constants
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, 3.929); });
+
+// Standard expression columns - note correct momentum for the He3 daughter
+DECLARE_SOA_EXPRESSION_COLUMN(Px, px, //! px
+                              float, 1.f * aod::hyhe4data::pxHelium3 + 1.f * aod::hyhe4data::pxProton + 1.f * aod::hyhe4data::pxPion);
+DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //! py
+                              float, 1.f * aod::hyhe4data::pyHelium3 + 1.f * aod::hyhe4data::pyProton + 1.f * aod::hyhe4data::pyPion);
+DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //! pz
+                              float, 1.f * aod::hyhe4data::pzHelium3 + 1.f * aod::hyhe4data::pzProton + 1.f * aod::hyhe4data::pzPion);
+} // namespace hyhe4data
+DECLARE_SOA_TABLE_FULL(StoredHyHe4Datas, "HyHe4Datas", "AOD", "HYHE4DATA", //!
+                       o2::soa::Index<>, hyhe4data::Helium3TrackId, hyhe4data::ProtonTrackId, hyhe4data::PionTrackId,
+                       hyhe4data::CollisionId, hyhe4data::Decay3BodyId, hyhe4data::Sign,
+                       hyhe4data::Helium3X, hyhe4data::ProtonX, hyhe4data::PionX,
+                       hyhe4data::PxHelium3, hyhe4data::PyHelium3, hyhe4data::PzHelium3,
+                       hyhe4data::PxProton, hyhe4data::PyProton, hyhe4data::PzProton,
+                       hyhe4data::PxPion, hyhe4data::PyPion, hyhe4data::PzPion,
+                       hyhe4data::X, hyhe4data::Y, hyhe4data::Z,
+                       hyhe4data::DCADaughters, hyhe4data::DCAHelium3ToPV, hyhe4data::DCAProtonToPV, hyhe4data::DCAPionToPV,
+                       hyhe4data::DCAxyHyHe4ToPV, hyhe4data::DCAzHyHe4ToPV,
+
+                       // dynamic columns
+                       hyhe4data::Pt<hyhe4data::PxHelium3, hyhe4data::PyHelium3, hyhe4data::PxProton, hyhe4data::PyProton, hyhe4data::PxPion, hyhe4data::PyPion>,
+                       hyhe4data::PtHelium3<hyhe4data::PxHelium3, hyhe4data::PyHelium3>,
+                       hyhe4data::PtProton<hyhe4data::PxProton, hyhe4data::PyProton>,
+                       hyhe4data::PtPion<hyhe4data::PxPion, hyhe4data::PyPion>,
+                       hyhe4data::DecayRadius<hyhe4data::X, hyhe4data::Y>,
+                       hyhe4data::M<hyhe4data::PxHelium3, hyhe4data::PyHelium3, hyhe4data::PzHelium3, hyhe4data::PxProton, hyhe4data::PyProton, hyhe4data::PzProton, hyhe4data::PxPion, hyhe4data::PyPion, hyhe4data::PzPion>,
+                       hyhe4data::YHyHe4<hyhe4data::Px, hyhe4data::Py, hyhe4data::Pz>);
+
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(HyHe4Datas, StoredHyHe4Datas, "HYHE4DATAEXT", //!
+                                hyhe4data::Px, hyhe4data::Py, hyhe4data::Pz); // the table name has here to be the one with EXT which is not nice and under study
+
+// iterator
+using HyHe4Data = HyHe4Datas::iterator;
+
 } // namespace o2::aod
-
-
 #endif // PWGLF_DATAMODEL_LFHYHEFOURTABLES_H_

--- a/PWGLF/TableProducer/CMakeLists.txt
+++ b/PWGLF/TableProducer/CMakeLists.txt
@@ -83,6 +83,11 @@ o2physics_add_dpl_workflow(hypertriton-reco-task
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(hyhefour-builder
+                    SOURCES hyhe4builder.cxx
+                    PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 # Resonances
 o2physics_add_dpl_workflow(reso2initializer
                     SOURCES LFResonanceInitializer.cxx

--- a/PWGLF/TableProducer/CMakeLists.txt
+++ b/PWGLF/TableProducer/CMakeLists.txt
@@ -88,6 +88,11 @@ o2physics_add_dpl_workflow(hyhefour-builder
                     PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(threebodymcfinder
+                    SOURCES threebodymcfinder.cxx
+                    PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 # Resonances
 o2physics_add_dpl_workflow(reso2initializer
                     SOURCES LFResonanceInitializer.cxx

--- a/PWGLF/TableProducer/hyhe4builder.cxx
+++ b/PWGLF/TableProducer/hyhe4builder.cxx
@@ -1,0 +1,477 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+//  *+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+//  3-body Hyperhelium 4 builder
+//  *+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+
+#include <cmath>
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <iterator>
+#include <utility>
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "PWGLF/DataModel/LFParticleIdentification.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "PWGLF/DataModel/LFHyperhelium4Tables.h"
+
+using namespace std;
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+// use parameters + cov mat non-propagated, aux info + (extension propagated)
+using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
+using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU>;
+using TracksWithExtra = soa::Join<aod::Tracks, aod::TracksExtra>;
+
+// For dE/dx association in pre-selection
+//using TracksExtraWithPID = soa::Join<aod::TracksExtra, aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTPCFullHe>;
+
+// For MC and dE/dx association
+using TracksExtraWithPIDandLabels = soa::Join<aod::TracksExtra, aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTPCFullHe, aod::McTrackLabels>;
+
+// Pre-selected Decay3Bodys
+using TaggedHyHe4Candidates = soa::Join<aod::Decay3Bodys, aod::HyHe4Tags>;
+
+// For MC association in pre-selection
+using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
+
+struct hyhefourbuilder {
+  //  Produces<aod::CascData> hyp4data;	//Declaring the table that created by this task
+  
+  Service<o2::ccdb::BasicCCDBManager> ccdb; // <-- for CCDB access
+  
+  Configurable<int> tpcrefit{"tpcrefit", 0, "demand TPC refit"};
+  Preslice<aod::Decay3Bodys> perCollision = o2::aod::decay3body::collisionId;	//used for grouping, here we use the collisionID
+  
+  // Operation and minimisation criteria
+  Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
+  Configurable<bool> d_UseAbsDCA{"d_UseAbsDCA", true, "Use Abs DCAs"};
+  Configurable<bool> d_UseWeightedPCA{"d_UseWeightedPCA", false, "Vertices use cov matrices"};
+  Configurable<int> useMatCorrType{"useMatCorrType", 2, "0: none, 1: TGeo, 2: LUT"};
+  
+  // CCDB options
+  Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> grpPath{"grpPath", "GLO/GRP/GRP", "Path of the grp file"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
+  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  
+  // Basic selection criteria
+  Configurable<float> hyhe4daudca{"hyhe4daudca", 1, "DCA between HyHe4 daughters"};
+
+  // Filter out HyHe4 that are interesting!
+  Filter taggedFilter = aod::hyhe4tag::isInteresting == true;
+  
+  // bookkeeping propagation / run number / magnetic field
+  int mRunNumber;
+  float d_bz;
+  float maxSnp;  // max sine phi for propagation
+  float maxStep; // max step size (cm) for propagation
+  o2::base::MatLayerCylSet* lut = nullptr; // lut pointer
+  
+  // storing output
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  
+  // Define o2 fitter, 3-prong, active memory (no need to redefine per event)
+  o2::vertexing::DCAFitterN<3> fitter;
+  
+  void init(InitContext& context)
+  {
+    const AxisSpec axispionmass{(int)100, 0.0f, 0.3f, "pion Mass Distribution  (GeV/c^{2})"};
+    const AxisSpec axisprotonmass{(int)100, 0.5f, 1.5f, "proton Mass Distribution (GeV/c^{2})"};
+    const AxisSpec axishelium3{(int)100, 2.5f, 3.5f, "Helium3 Mass Distribution (GeV/c^{2})"};
+    const AxisSpec axisHyHe4{(int)1000, 3.5f, 4.5f, "Hyperhelium4 Mass Distribution (GeV/c^{2})"};
+    
+    const AxisSpec hEventCounter{(int)1, 0.0f, 1.0f, "Number of events"};
+    const AxisSpec Helium3pT{(int)100, 0.0f, 10.0f, "Helium3 pT distribution"};
+    const AxisSpec protonpT{(int)100, 0.0f, 10.0f, "proton pT distribution"};
+    const AxisSpec pionpT{(int)100, 0.0f, 0.5f, "pion pT distribution"};
+    
+    
+    const AxisSpec dcaDaughters{(int)200, 0.0f, 10.0f, "DCA"};
+    
+    const AxisSpec axisNCandidates{(int)100, 0.0f, 100.0f, "Number of 3 body candidates"};
+    histos.add("hNCandidates", "hNCandidates", kTH1F, {axisNCandidates});
+    histos.add("hNEvents", "hNEvents", kTH1F, {hEventCounter});
+    
+    histos.add("hHe3pT", "hHe3pT", kTH1F, {Helium3pT});
+    histos.add("hprotonpT", "hprotonpT", kTH1F, {protonpT});
+    histos.add("hpionpT", "hpionpT", kTH1F, {pionpT});
+    
+    histos.add("helium3mass", "helium3mass", kTH1F, {axishelium3});
+    histos.add("protonmass", "protonmass", kTH1F, {axisprotonmass});
+    histos.add("pionmass", "pionmass", kTH1F, {axispionmass});
+    
+    histos.add("hyhe4mass", "hyhe4mass", kTH1F, {axisHyHe4});
+    histos.add("hyhe4daudcaHisto", "hyhe4daudcaHisto", kTH1F, {dcaDaughters});
+//    histos.add("hyhe4daudcaHistobefore", "hyhe4daudcaHisto", kTH1F, {dcaDaughters});
+   
+    ccdb->setURL(ccdburl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    ccdb->setFatalWhenNull(false);
+    
+    if (useMatCorrType == 1) {
+      LOGF(info, "TGeo correction requested, loading geometry");
+      if (!o2::base::GeometryManager::isGeometryLoaded()) {
+        ccdb->get<TGeoManager>(geoPath);
+      }
+    }
+    if (useMatCorrType == 2) {
+      LOGF(info, "LUT correction requested, loading LUT");
+      lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
+    }
+    
+    //initialize O2 3-prong fitter (only once)
+    fitter.setPropagateToPCA(true);
+    fitter.setMaxR(200.);
+    fitter.setMinParamChange(1e-3);
+    fitter.setMinRelChi2Change(0.9);
+    fitter.setMaxDZIni(1e9);
+    fitter.setMaxChi2(1e9);
+    fitter.setUseAbsDCA(d_UseAbsDCA);
+    fitter.setWeightedFinalPCA(d_UseWeightedPCA);
+    
+    // Material correction in the DCA fitter
+    o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+    if (useMatCorrType == 1)
+      matCorr = o2::base::Propagator::MatCorrType::USEMatCorrTGeo;
+    if (useMatCorrType == 2)
+      matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+    fitter.setMatCorrType(matCorr);
+  }
+  
+  // Helper struct to pass HyHe4 information
+  struct {
+    float track3HeX;
+    float trackProtonX;
+    float trackPionX;
+    std::array<float, 3> pos;
+    std::array<float, 3> mom3He;
+    std::array<float, 3> momProton;
+    std::array<float, 3> momPion;
+    float dcaHyHe4dau;
+    float dcaXY3He;
+    float dcaXYProton;
+    float dcaXYPion;
+    float dcaXY;
+    float dcaZ;
+    float decayRadius;
+    float hyHe4Mass;
+    float hyHe4BarMass;
+  } hyHe4Candidate;
+
+//ccdb to fetch the magnetic fieldd  
+  void initCCDB(aod::BCsWithTimestamps::iterator const& bc)
+  {
+    if (mRunNumber == bc.runNumber()) {
+      return;
+    }
+
+    // In case override, don't proceed, please - no CCDB access required
+    if (d_bz_input > -990) {
+      d_bz = d_bz_input;
+      fitter.setBz(d_bz);
+      o2::parameters::GRPMagField grpmag;
+      if (fabs(d_bz) > 1e-5) {
+        grpmag.setL3Current(30000.f / (d_bz / 5.0f));
+      }
+      o2::base::Propagator::initFieldFromGRP(&grpmag);
+      mRunNumber = bc.runNumber();
+      return;
+    }
+
+    auto run3grp_timestamp = bc.timestamp();
+    o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
+    o2::parameters::GRPMagField* grpmag = 0x0;
+    if (grpo) {
+      o2::base::Propagator::initFieldFromGRP(grpo);
+      // Fetch magnetic field from ccdb for current collision
+      d_bz = grpo->getNominalL3Field();
+      LOG(info) << "Retrieved GRP for timestamp " << run3grp_timestamp << " with magnetic field of " << d_bz << " kZG";
+    } else {
+      grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, run3grp_timestamp);
+      if (!grpmag) {
+        LOG(fatal) << "Got nullptr from CCDB for path " << grpmagPath << " of object GRPMagField and " << grpPath << " of object GRPObject for timestamp " << run3grp_timestamp;
+      }
+      o2::base::Propagator::initFieldFromGRP(grpmag);
+      // Fetch magnetic field from ccdb for current collision
+      d_bz = std::lround(5.f * grpmag->getL3Current() / 30000.f);
+      LOG(info) << "Retrieved GRP for timestamp " << run3grp_timestamp << " with magnetic field of " << d_bz << " kZG";
+    }
+    mRunNumber = bc.runNumber();
+    // Set magnetic field value once known
+    fitter.setBz(d_bz);
+
+    if (useMatCorrType == 2) {
+      // setMatLUT only after magfield has been initalized
+      // (setMatLUT has implicit and problematic init field call if not)
+      o2::base::Propagator::Instance()->setMatLUT(lut);
+    }
+  }
+  
+  //wirte something to verify whether the selected particles are the he3, proton or pion somehow with pdg code
+  //function to check pdg associations:
+  //  template <class TTrackTo, typename TCascadeObject>
+  //  void checkPDG(TCascadeObject const& lCascadeCandidate, bool& lIsInteresting, bool& lIsXiMinus, bool& lIsXiPlus, bool& lIsOmegaMinus, bool& lIsOmegaPlus)
+  //  {
+  //  }
+  template <class TTrackTo, typename TTrack>
+  bool buildHyHe4Candidate(TTrack const& Helium3, TTrack const& proton, TTrack const& pion)
+  {
+    //          histos.fill(HIST("helium3mass"), RecoDecay::m(array{Helium3.px(), Helium3.py(), Helium3.pz()},Helium3.energy()));
+    //          histos.fill(HIST("protonmass"), RecoDecay::m(array{proton.px(), proton.py(), proton.pz()},proton.energy()));
+    //    histos.fill(HIST("pionmass"), RecoDecay::m(array{pion.px(), pion.py(), pion.pz()},RecoDecay::e(array{pion.px(), pion.py(), pion.pz()},o2::constants::physics::MassPionCharged)));
+    //    histos.fill(HIST("helium3mass"), RecoDecay::m(array{Helium3.px(), Helium3.py(), Helium3.pz()},RecoDecay::e(array{Helium3.px(), Helium3.py(), Helium3.pz()},o2::constants::physics::MassHelium3)));
+    //    histos.fill(HIST("protonmass"), RecoDecay::m(array{proton.px(), proton.py(), proton.pz()},RecoDecay::e(array{proton.px(), proton.py(), proton.pz()},o2::constants::physics::MassProton)));
+    //
+    
+    // Step 0: check DCAxy / z to primary vertex for each of those tracks
+    
+    
+    // Step 1: try distance minimization with 3-body DCA fitter
+    
+    auto lHelium3Track = getTrackParCov(Helium3);
+    auto lProtonTrack = getTrackParCov(proton);
+    auto lPionTrack = getTrackParCov(pion);
+    
+    //---/---/---/
+    // Move close to minima
+    int nCand = 0;
+    try {
+      nCand = fitter.process(lHelium3Track, lProtonTrack, lPionTrack);
+    } catch (...) {
+      LOG(error) << "Exception caught in DCA fitter process call!";
+      return false;
+    }
+    if (nCand == 0) {
+      return false;
+    }
+//    cout<<"Hey beautiful peoples I am going to print the momemtum of 3He before filling "<<Helium3.px()<<"\n\n\n\n" <<endl; 
+
+    fitter.getTrack(0).getPxPyPzGlo(hyHe4Candidate.mom3He);
+
+//    cout<<"Hey beautiful peoples I am going to print the momemtum of 3He "<<hyHe4Candidate.mom3He[0]<<"\n\n\n\n" <<endl; 
+    fitter.getTrack(1).getPxPyPzGlo(hyHe4Candidate.momProton);
+    fitter.getTrack(2).getPxPyPzGlo(hyHe4Candidate.momPion);
+    
+    // get decay vertex coordinates
+    const auto& vtx = fitter.getPCACandidate();
+    for (int i = 0; i < 3; i++) {
+      hyHe4Candidate.pos[i] = vtx[i];
+    }
+    
+    hyHe4Candidate.dcaHyHe4dau = TMath::Sqrt(fitter.getChi2AtPCACandidate());
+    
+    histos.fill(HIST("hyhe4daudcaHisto"), hyHe4Candidate.dcaHyHe4dau);
+    if( hyHe4Candidate.dcaHyHe4dau > hyhe4daudca ) return false;
+    
+    auto lHyHe4m = RecoDecay::m(array{array{hyHe4Candidate.mom3He[0], hyHe4Candidate.mom3He[1], hyHe4Candidate.mom3He[2]}, array{hyHe4Candidate.momProton[0], hyHe4Candidate.momProton[1], hyHe4Candidate.momProton[2]}, array{hyHe4Candidate.momPion[0], hyHe4Candidate.momPion[1], hyHe4Candidate.momPion[2]}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
+
+    histos.fill(HIST("hyhe4mass"), lHyHe4m); 
+    //		cout<<"The collision id of Helim3 is "<< Helium3.pt()<<endl;
+    
+    return true;
+  }
+  
+  
+  template <class TTrackTo, typename T3BodyTable>
+  void buildHyHe4Tables(T3BodyTable const& d3Bodys)
+  {
+    for (const auto& d3body : d3Bodys) {
+      auto const& trackProng0 = d3body.template track0_as<TTrackTo>();
+      auto const& trackProng1 = d3body.template track1_as<TTrackTo>();
+      auto const& trackProng2 = d3body.template track2_as<TTrackTo>();
+      
+      //sign -> if positive, matter; if negative, antimatter
+      int sign = trackProng0.sign() + trackProng1.sign() + trackProng2.sign();
+      
+      if( trackProng0.sign() != sign ){ //prong 0 = pion
+        if( trackProng1.tpcSignal() < trackProng2.tpcSignal() ){ //0 = pi, 1 = p, 2 = 3He
+          buildHyHe4Candidate<FullTracksExtIU>(trackProng2, trackProng1, trackProng0);
+        }
+      }
+      if( trackProng1.sign() != sign ){ //prong 1 = pion
+        if( trackProng0.tpcSignal() > trackProng2.tpcSignal() ){ //0 = 3He, 1 = pi, 2 = p
+          buildHyHe4Candidate<FullTracksExtIU>(trackProng0, trackProng2, trackProng1);
+        }
+        if( trackProng0.tpcSignal() < trackProng2.tpcSignal() ){ //0 = p, 1 = pi, 2 = 3He
+          buildHyHe4Candidate<FullTracksExtIU>(trackProng2, trackProng0, trackProng1);
+        }
+      }
+      if( trackProng2.sign() != sign ){ //prong 2 = pion
+        if( trackProng0.tpcSignal() > trackProng1.tpcSignal() ){ //0 = 3He, 1 = p, 2 = pi
+          buildHyHe4Candidate<FullTracksExtIU>(trackProng0, trackProng1, trackProng2);
+        }
+        if( trackProng0.tpcSignal() < trackProng1.tpcSignal() ){ //0 = p, 1 = 3He, 2 = pi
+          buildHyHe4Candidate<FullTracksExtIU>(trackProng1, trackProng0, trackProng2);
+        }
+      }
+
+      // Fill the table
+    }
+  }
+  
+  void process(aod::Collisions const& collisions, soa::Filtered<TaggedHyHe4Candidates> const& d3bodys, FullTracksExtIU const&, aod::BCsWithTimestamps const&)
+  {
+    long eventCounter=0;
+    for (const auto& collision : collisions) {
+      eventCounter++;
+      //      bool lIsInteresting = false;
+      //      bool lIsQualityInteresting = false;
+      //      bool lIsTrueHelium3 = false;
+      //      bool lIsTrueProton = false;
+      //      bool lIsTruePion = false;
+      // Fire up CCDB
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      initCCDB(bc);
+      // Do analysis with collision-grouped V0s, retain full collision information
+      const uint64_t collIdx = collision.globalIndex();
+      auto d3Bodys_thisCollision = d3bodys.sliceBy(perCollision, collIdx);	//To access the 3body decays only collisons or I can say the collision with contain the 3body decay
+      
+      histos.fill(HIST("hNCandidates"), d3Bodys_thisCollision.size());
+      
+      // Do the building
+      buildHyHe4Tables<FullTracksExtIU>(d3Bodys_thisCollision);
+    }
+    histos.fill(HIST("hNEvents"), 0.0, eventCounter);
+    
+  }
+};
+
+
+//*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+struct hyHe4Preselector 
+{
+  Produces<aod::HyHe4Tags> hyhetags; // MC tags
+  Preslice<aod::Decay3Bodys> perCollision = o2::aod::decay3body::collisionId;
+  //  Configurable<bool> dIfMCgenerateHelium3{"dIfMCgenerateHelium3", true, "if MC, generate MC true Helium3 (yes/no)"};
+  Configurable<bool> dIfMCgeneratehyHe4{"dIfMCgeneratehyHe4", true, "if MC, generate MC true hyHe4 (yes/no)"};
+  Configurable<bool> dIfMCgenerateAntihyHe4{"dIfMCgenerateAntihyHe4", true, "if MC, generate MC true AntihyHe4 (yes/no)"};
+
+  Configurable<bool> ddEdxPreSelecthyHe4{"ddEdxPreSelhyHe4", true, "pre-select dE/dx compatibility with hyHe4 (yes/no)"};
+  Configurable<bool> ddEdxPreSelectAntihyHe4{"ddEdxPreSelectAntihyHe4", true, "pre-select dE/dx compatibility with AntihyHe4 (yes/no)"};
+
+  // dEdx pre-selection compatibility
+  Configurable<float> ddEdxPreSelectionWindow{"ddEdxPreSelectionWindow", 7, "Nsigma window for dE/dx preselection"};
+
+  // tpc quality pre-selection
+  Configurable<int> dTPCNCrossedRows{"dTPCNCrossedRows", 50, "Minimum TPC crossed rows"};
+
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// function to check track quality
+  template <class TTrackTo, typename T3Body>
+  void checkTrackQuality(T3Body const& d3body, bool& lIsInteresting)
+  {
+      lIsInteresting = false;
+      auto const& trackProng0 = d3body.template track0_as<TTrackTo>();
+      auto const& trackProng1 = d3body.template track1_as<TTrackTo>();
+      auto const& trackProng2 = d3body.template track2_as<TTrackTo>();
+      //	cout<<"The number of TPC clusters are "<<trackProng1.tpcNClsCrossedRows() <<endl;
+      if ((trackProng0.tpcNClsCrossedRows() >= dTPCNCrossedRows) && (trackProng1.tpcNClsCrossedRows() >= dTPCNCrossedRows) && (trackProng2.tpcNClsCrossedRows() >= dTPCNCrossedRows) ){
+        lIsInteresting = true;
+      } 
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// function to check PDG code 
+  template <class TTrackTo, typename T3Body>
+  void checkPDG(T3Body const& d3body, bool& lIsInteresting,  bool& lIsTrueHyHelium4, bool& lIsTrueAntiHyHelium4)
+  {
+    int lPDG = -1;
+    lIsInteresting = false;
+    auto const& trackProng0 = d3body.template track0_as<TTrackTo>();
+    auto const& trackProng1 = d3body.template track1_as<TTrackTo>();
+    auto const& trackProng2 = d3body.template track2_as<TTrackTo>();
+
+    // Association check
+    // Lets do something to identify the PID of particles 
+    if (trackProng0.has_mcParticle() && trackProng1.has_mcParticle() && trackProng2.has_mcParticle() ) {
+      auto lMCtrackProng0 = trackProng0.template mcParticle_as<aod::McParticles>();
+      auto lMCtrackProng1 = trackProng1.template mcParticle_as<aod::McParticles>();
+      auto lMCtrackProng2 = trackProng2.template mcParticle_as<aod::McParticles>();
+      if (lMCtrackProng0.has_mothers() && lMCtrackProng1.has_mothers() && lMCtrackProng2.has_mothers()) {
+        for (auto& lProng0Mother : lMCtrackProng0.template mothers_as<aod::McParticles>()) {
+          for (auto& lProng1Mother : lMCtrackProng1.template mothers_as<aod::McParticles>()) {
+            for (auto& lProng2Mother : lMCtrackProng2.template mothers_as<aod::McParticles>()) {
+              if ((lProng0Mother.globalIndex() == lProng1Mother.globalIndex()) && (lProng0Mother.globalIndex() == lProng2Mother.globalIndex())) {
+                lPDG = lProng0Mother.pdgCode();
+              }
+            }
+          }
+        }
+      }
+    } // end association check
+
+    if (lPDG == -1010020040 && dIfMCgenerateAntihyHe4) {
+      lIsTrueAntiHyHelium4 = true;
+      lIsInteresting = true;
+    }
+    if (lPDG == 1010020040 && dIfMCgeneratehyHe4) {
+      lIsTrueHyHelium4 = true;
+      lIsInteresting = true;
+    }
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// This process function ensures that all 3 body candidates are built. It will simply tag everything as true.
+  void processBuildAll(aod::Collisions const& collisions, aod::Decay3Bodys const& d3bodys, aod::TracksExtra const&){
+    long eventCounter=0;
+    for (const auto& d3body : d3bodys) {
+      eventCounter++;
+      bool lIsQualityInteresting = false;
+      checkTrackQuality<aod::TracksExtra>(d3body, lIsQualityInteresting);
+      hyhetags( lIsQualityInteresting, true, true, true, true );
+    }
+
+  }
+  PROCESS_SWITCH(hyHe4Preselector , processBuildAll, "Switch to build all V0s", false);
+
+   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  void processBuildMCAssociated(aod::Collisions const& collisions, aod::Decay3Bodys const& d3bodys, LabeledTracksExtra const&, aod::McParticles const& particlesMC)
+  {
+	  for (const auto& d3body : d3bodys) {
+		  bool lIsInteresting = false;
+      bool lIsQualityInteresting = false;
+      bool lIsTrueHyHelium4 = false;
+      bool lIsTrueAntiHyHelium4 = false;
+      checkPDG<LabeledTracksExtra>(d3body, lIsInteresting,  lIsTrueHyHelium4, lIsTrueAntiHyHelium4);
+      checkTrackQuality<LabeledTracksExtra>(d3body, lIsQualityInteresting);
+      hyhetags( lIsQualityInteresting, lIsTrueHyHelium4, lIsTrueAntiHyHelium4, true, true );
+    }
+  }
+  PROCESS_SWITCH(hyHe4Preselector, processBuildMCAssociated, "Switch to build MC-associated V0s", true);
+};
+ 
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<hyhefourbuilder>(cfgc),
+    adaptAnalysisTask<hyHe4Preselector>(cfgc)};
+}

--- a/PWGLF/TableProducer/hyhe4builder.cxx
+++ b/PWGLF/TableProducer/hyhe4builder.cxx
@@ -371,6 +371,9 @@ struct hyhefourbuilder {
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 struct hyHe4Preselector 
 {
+  // storing output
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
   Produces<aod::HyHe4Tags> hyhetags; // MC tags
   Preslice<aod::Decay3Bodys> perCollision = o2::aod::decay3body::collisionId;
   //  Configurable<bool> dIfMCgenerateHelium3{"dIfMCgenerateHelium3", true, "if MC, generate MC true Helium3 (yes/no)"};
@@ -385,6 +388,12 @@ struct hyHe4Preselector
 
   // tpc quality pre-selection
   Configurable<int> dTPCNCrossedRows{"dTPCNCrossedRows", 50, "Minimum TPC crossed rows"};
+
+  void init(InitContext& context)
+  {
+    const AxisSpec hEventCounter{(int)1, 0.0f, 1.0f, "Number of events"};
+    histos.add("hNEvents", "hNEvents", kTH1F, {hEventCounter});
+  }
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check track quality
@@ -405,6 +414,8 @@ struct hyHe4Preselector
   template <class TTrackTo, typename T3Body>
   void checkPDG(T3Body const& d3body, bool& lIsInteresting,  bool& lIsTrueHyHelium4, bool& lIsTrueAntiHyHelium4)
   {
+    lIsTrueHyHelium4 = false; 
+    lIsTrueAntiHyHelium4 = false; 
     int lPDG = -1;
     lIsInteresting = false;
     auto const& trackProng0 = d3body.template track0_as<TTrackTo>();

--- a/PWGLF/TableProducer/hyhe4builder.cxx
+++ b/PWGLF/TableProducer/hyhe4builder.cxx
@@ -409,7 +409,6 @@ struct hyHe4Preselector {
     auto const& trackProng0 = d3body.template track0_as<TTrackTo>();
     auto const& trackProng1 = d3body.template track1_as<TTrackTo>();
     auto const& trackProng2 = d3body.template track2_as<TTrackTo>();
-    //	cout<<"The number of TPC clusters are "<<trackProng1.tpcNClsCrossedRows() <<endl;
     if ((trackProng0.tpcNClsCrossedRows() >= dTPCNCrossedRows) && (trackProng1.tpcNClsCrossedRows() >= dTPCNCrossedRows) && (trackProng2.tpcNClsCrossedRows() >= dTPCNCrossedRows)) {
       lIsInteresting = true;
     }

--- a/PWGLF/TableProducer/threebodymcfinder.cxx
+++ b/PWGLF/TableProducer/threebodymcfinder.cxx
@@ -12,10 +12,10 @@
 // 3-body MC finder task
 // -----------------
 //
-//    This task allows for the re-creation of the Decay3Body table with 
-//    perfect MC information. It is meant to be used to understand 
-//    baseline svertexer efficiency and to allow for tuning 
-//    of the 3-body decay reconstruction using MC. 
+//    This task allows for the re-creation of the Decay3Body table with
+//    perfect MC information. It is meant to be used to understand
+//    baseline svertexer efficiency and to allow for tuning
+//    of the 3-body decay reconstruction using MC.
 //
 //    Nota bene: special attention could still be dedicated to the PV
 //               reconstruction efficiency.
@@ -91,23 +91,23 @@ struct threebodymcfinder {
 
     histos.add("hNTimesCollRecoed", "hNTimesCollRecoed", kTH1F, {axisNTimesCollRecoed});
 
-    histos.add("hPtLambdaGenerated", "hPtLambdaGenerated", kTH1F, {axisPt});
-    histos.add("hPtAntiLambdaGenerated", "hPtAntiLambdaGenerated", kTH1F, {axisPt});
+    histos.add("hPtHyHe4Generated", "hPtHyHe4Generated", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4Generated", "hPtAntiHyHe4Generated", kTH1F, {axisPt});
     histos.add("hPtHypertritonGenerated", "hPtHypertritonGenerated", kTH1F, {axisPt});
     histos.add("hPtAntiHypertritonGenerated", "hPtAntiHypertritonGenerated", kTH1F, {axisPt});
 
-    histos.add("hPtLambdaReconstructed", "hPtLambdaReconstructed", kTH1F, {axisPt});
-    histos.add("hPtAntiLambdaReconstructed", "hPtAntiLambdaReconstructed", kTH1F, {axisPt});
+    histos.add("hPtHyHe4Reconstructed", "hPtHyHe4Reconstructed", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4Reconstructed", "hPtAntiHyHe4Reconstructed", kTH1F, {axisPt});
     histos.add("hPtHypertritonReconstructed", "hPtHypertritonReconstructed", kTH1F, {axisPt});
     histos.add("hPtAntiHypertritonReconstructed", "hPtAntiHypertritonReconstructed", kTH1F, {axisPt});
 
-    histos.add("hPtLambdaGlobal", "hPtLambdaGlobal", kTH1F, {axisPt});
-    histos.add("hPtAntiLambdaGlobal", "hPtAntiLambdaGlobal", kTH1F, {axisPt});
+    histos.add("hPtHyHe4Global", "hPtHyHe4Global", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4Global", "hPtAntiHyHe4Global", kTH1F, {axisPt});
     histos.add("hPtHypertritonGlobal", "hPtHypertritonGlobal", kTH1F, {axisPt});
     histos.add("hPtAntiHypertritonGlobal", "hPtAntiHypertritonGlobal", kTH1F, {axisPt});
 
-    histos.add("hPtLambdaGlobalWithPV", "hPtLambdaGlobalWithPV", kTH1F, {axisPt});
-    histos.add("hPtAntiLambdaGlobalWithPV", "hPtAntiLambdaGlobalWithPV", kTH1F, {axisPt});
+    histos.add("hPtHyHe4GlobalWithPV", "hPtHyHe4GlobalWithPV", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4GlobalWithPV", "hPtAntiHyHe4GlobalWithPV", kTH1F, {axisPt});
     histos.add("hPtHypertritonGlobalWithPV", "hPtHypertritonGlobalWithPV", kTH1F, {axisPt});
     histos.add("hPtAntiHypertritonGlobalWithPV", "hPtAntiHypertritonGlobalWithPV", kTH1F, {axisPt});
   }
@@ -127,36 +127,36 @@ struct threebodymcfinder {
   bool ProcessThreeBody(TmcParticle const& mcParticle, TTrackList const& trackList, int bestCollisionIndex, bool& prong0ITS, bool& prong1ITS, bool& prong2ITS, bool& prong0TPC, bool& prong1TPC, bool& prong2TPC)
   {
     bool reconstructed = false;
-    prong0ITS = false; 
-    prong1ITS = false; 
+    prong0ITS = false;
+    prong1ITS = false;
     prong2ITS = false;
-    prong0TPC = false; 
-    prong1TPC = false; 
+    prong0TPC = false;
+    prong1TPC = false;
     prong2TPC = false;
     int trackIndexProng0 = -1, trackIndexProng1 = -1, trackIndexProng2 = -1;
     int prong0pdg = -1, prong1pdg = -1, prong2pdg = -1;
 
-    //expected daughter pdgs 
-    if(mcParticle.pdgCode() == +1010020040){
+    // expected daughter pdgs
+    if (mcParticle.pdgCode() == +1010020040) {
       prong0pdg = +1000020030;
       prong1pdg = +2212;
       prong2pdg = -211;
     }
-    if(mcParticle.pdgCode() == -1010020040){
+    if (mcParticle.pdgCode() == -1010020040) {
       prong0pdg = -1000020030;
       prong1pdg = -2212;
       prong2pdg = +211;
     }
-    if(mcParticle.pdgCode() == +1010010030){
+    if (mcParticle.pdgCode() == +1010010030) {
       prong0pdg = +1000010020;
       prong1pdg = +2212;
       prong2pdg = -211;
     }
-    if(mcParticle.pdgCode() == -1010010030){
+    if (mcParticle.pdgCode() == -1010010030) {
       prong0pdg = -1000010020;
       prong1pdg = -2212;
       prong2pdg = +211;
-    }      
+    }
 
     if (mcParticle.has_daughters()) {
       auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
@@ -165,30 +165,30 @@ struct threebodymcfinder {
           for (auto const& track : trackList) {
             if (track.mcParticleId() == daughter.globalIndex()) {
               // determine which charge this particle has
-              if (daughter.pdgCode() == prong0pdg ) {
+              if (daughter.pdgCode() == prong0pdg) {
                 trackIndexProng0 = track.globalIndex();
                 if (track.hasITS())
                   prong0ITS = true;
                 if (track.hasTPC())
                   prong0TPC = true;
               }
-              if (daughter.pdgCode() == prong1pdg ) {
+              if (daughter.pdgCode() == prong1pdg) {
                 trackIndexProng1 = track.globalIndex();
                 if (track.hasITS())
                   prong1ITS = true;
                 if (track.hasTPC())
                   prong1TPC = true;
               }
-              if (daughter.pdgCode() == prong2pdg ) {
+              if (daughter.pdgCode() == prong2pdg) {
                 trackIndexProng2 = track.globalIndex();
                 if (track.hasITS())
                   prong2ITS = true;
                 if (track.hasTPC())
                   prong2TPC = true;
               }
-              if(trackIndexProng0 >= 0 && trackIndexProng1 >= 0 && trackIndexProng2 >= 0) 
+              if (trackIndexProng0 >= 0 && trackIndexProng1 >= 0 && trackIndexProng2 >= 0)
                 break; // all found
-              }
+            }
           }
         }
       }
@@ -236,7 +236,7 @@ struct threebodymcfinder {
         if (mcParticle.pdgCode() == -1010020040 && findHyHe4) {
           reconstructed = ProcessThreeBody(mcParticle, tracks, bestCollisionIndex, prong0ITS, prong1ITS, prong2ITS, prong0TPC, prong1TPC, prong2TPC);
           if (fabs(mcParticle.y()) < 0.5) {
-            histos.fill(HIST("hPtHyAntiHe4Generated"), mcParticle.pt());
+            histos.fill(HIST("hPtAntiHyHe4Generated"), mcParticle.pt());
             if (reconstructed)
               histos.fill(HIST("hPtAntiHyHe4Reconstructed"), mcParticle.pt());
             if (reconstructed && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)

--- a/PWGLF/TableProducer/threebodymcfinder.cxx
+++ b/PWGLF/TableProducer/threebodymcfinder.cxx
@@ -1,0 +1,291 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// 3-body MC finder task
+// -----------------
+//
+//    This task allows for the re-creation of the Decay3Body table with 
+//    perfect MC information. It is meant to be used to understand 
+//    baseline svertexer efficiency and to allow for tuning 
+//    of the 3-body decay reconstruction using MC. 
+//
+//    Nota bene: special attention could still be dedicated to the PV
+//               reconstruction efficiency.
+//
+//    Comments, questions, complaints, suggestions?
+//    Please write to:
+//    david.dobrigkeit.chinellato@cern.ch
+//
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "PWGLF/DataModel/LFQATables.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "CCDB/BasicCCDBManager.h"
+
+#include <TFile.h>
+#include <TLorentzVector.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <Math/Vector4D.h>
+#include <TPDGCode.h>
+#include <TDatabasePDG.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+using namespace ROOT::Math;
+
+using LabeledTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels>;
+
+struct threebodymcfinder {
+  Produces<aod::Decay3Bodys> d3b;
+
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  // Configurables for selecting which particles to generate
+  Configurable<bool> findHyHe4{"findHyHe4", true, "findHyHe4"};
+  Configurable<bool> findHypertriton{"findHypertriton", false, "findHypertriton"};
+
+  Configurable<bool> requireITS{"requireITS", false, "require ITS information used in tracks"};
+
+  Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+
+  std::vector<int> d3bcollisionId;
+  std::vector<int> d3bprong0Index;
+  std::vector<int> d3bprong1Index;
+  std::vector<int> d3bprong2Index;
+
+  void init(InitContext& context)
+  {
+    // initialize histograms
+    const AxisSpec axisNTimesCollRecoed{(int)10, -0.5f, +9.5f, ""};
+    const AxisSpec axisPt{(int)100, +0.0f, +10.0f, "p_{T} (GeV/c)"};
+
+    histos.add("hNTimesCollRecoed", "hNTimesCollRecoed", kTH1F, {axisNTimesCollRecoed});
+
+    histos.add("hPtLambdaGenerated", "hPtLambdaGenerated", kTH1F, {axisPt});
+    histos.add("hPtAntiLambdaGenerated", "hPtAntiLambdaGenerated", kTH1F, {axisPt});
+    histos.add("hPtHypertritonGenerated", "hPtHypertritonGenerated", kTH1F, {axisPt});
+    histos.add("hPtAntiHypertritonGenerated", "hPtAntiHypertritonGenerated", kTH1F, {axisPt});
+
+    histos.add("hPtLambdaReconstructed", "hPtLambdaReconstructed", kTH1F, {axisPt});
+    histos.add("hPtAntiLambdaReconstructed", "hPtAntiLambdaReconstructed", kTH1F, {axisPt});
+    histos.add("hPtHypertritonReconstructed", "hPtHypertritonReconstructed", kTH1F, {axisPt});
+    histos.add("hPtAntiHypertritonReconstructed", "hPtAntiHypertritonReconstructed", kTH1F, {axisPt});
+
+    histos.add("hPtLambdaGlobal", "hPtLambdaGlobal", kTH1F, {axisPt});
+    histos.add("hPtAntiLambdaGlobal", "hPtAntiLambdaGlobal", kTH1F, {axisPt});
+    histos.add("hPtHypertritonGlobal", "hPtHypertritonGlobal", kTH1F, {axisPt});
+    histos.add("hPtAntiHypertritonGlobal", "hPtAntiHypertritonGlobal", kTH1F, {axisPt});
+
+    histos.add("hPtLambdaGlobalWithPV", "hPtLambdaGlobalWithPV", kTH1F, {axisPt});
+    histos.add("hPtAntiLambdaGlobalWithPV", "hPtAntiLambdaGlobalWithPV", kTH1F, {axisPt});
+    histos.add("hPtHypertritonGlobalWithPV", "hPtHypertritonGlobalWithPV", kTH1F, {axisPt});
+    histos.add("hPtAntiHypertritonGlobalWithPV", "hPtAntiHypertritonGlobalWithPV", kTH1F, {axisPt});
+  }
+
+  // for sorting
+  template <typename T>
+  std::vector<std::size_t> sort_indices(const std::vector<T>& v)
+  {
+    std::vector<std::size_t> idx(v.size());
+    std::iota(idx.begin(), idx.end(), 0);
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&v](std::size_t i1, std::size_t i2) { return v[i1] < v[i2]; });
+    return idx;
+  }
+
+  template <typename TmcParticle, typename TTrackList>
+  bool ProcessThreeBody(TmcParticle const& mcParticle, TTrackList const& trackList, int bestCollisionIndex, bool& prong0ITS, bool& prong1ITS, bool& prong2ITS, bool& prong0TPC, bool& prong1TPC, bool& prong2TPC)
+  {
+    bool reconstructed = false;
+    prong0ITS = false; 
+    prong1ITS = false; 
+    prong2ITS = false;
+    prong0TPC = false; 
+    prong1TPC = false; 
+    prong2TPC = false;
+    int trackIndexProng0 = -1, trackIndexProng1 = -1, trackIndexProng2 = -1;
+    int prong0pdg = -1, prong1pdg = -1, prong2pdg = -1;
+
+    //expected daughter pdgs 
+    if(mcParticle.pdgCode() == +1010020040){
+      prong0pdg = +1000020030;
+      prong1pdg = +2212;
+      prong2pdg = -211;
+    }
+    if(mcParticle.pdgCode() == -1010020040){
+      prong0pdg = -1000020030;
+      prong1pdg = -2212;
+      prong2pdg = +211;
+    }
+    if(mcParticle.pdgCode() == +1010010030){
+      prong0pdg = +1000010020;
+      prong1pdg = +2212;
+      prong2pdg = -211;
+    }
+    if(mcParticle.pdgCode() == -1010010030){
+      prong0pdg = -1000010020;
+      prong1pdg = -2212;
+      prong2pdg = +211;
+    }      
+
+    if (mcParticle.has_daughters()) {
+      auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
+      if (daughters.size() == 3) {
+        for (auto const& daughter : daughters) { // might be better ways of doing this but ok
+          for (auto const& track : trackList) {
+            if (track.mcParticleId() == daughter.globalIndex()) {
+              // determine which charge this particle has
+              if (daughter.pdgCode() == prong0pdg ) {
+                trackIndexProng0 = track.globalIndex();
+                if (track.hasITS())
+                  prong0ITS = true;
+                if (track.hasTPC())
+                  prong0TPC = true;
+              }
+              if (daughter.pdgCode() == prong1pdg ) {
+                trackIndexProng1 = track.globalIndex();
+                if (track.hasITS())
+                  prong1ITS = true;
+                if (track.hasTPC())
+                  prong1TPC = true;
+              }
+              if (daughter.pdgCode() == prong2pdg ) {
+                trackIndexProng2 = track.globalIndex();
+                if (track.hasITS())
+                  prong2ITS = true;
+                if (track.hasTPC())
+                  prong2TPC = true;
+              }
+              if(trackIndexProng0 >= 0 && trackIndexProng1 >= 0 && trackIndexProng2 >= 0) 
+                break; // all found
+              }
+          }
+        }
+      }
+    }
+    if (trackIndexProng0 >= 0 && trackIndexProng1 >= 0 && trackIndexProng2 >= 0 && (!requireITS || (requireITS && prong0ITS && prong1ITS && prong2ITS))) {
+      reconstructed = true;
+      d3bcollisionId.emplace_back(bestCollisionIndex);
+      d3bprong0Index.emplace_back(trackIndexProng0);
+      d3bprong1Index.emplace_back(trackIndexProng1);
+      d3bprong2Index.emplace_back(trackIndexProng2);
+    }
+    return reconstructed;
+  }
+
+  void process(soa::Join<aod::McCollisions, aod::McCollsExtra> const& mcCollisions, LabeledTracks const& tracks, aod::McParticles const& allMcParticles)
+  {
+    d3bcollisionId.clear();
+    d3bprong0Index.clear();
+    d3bprong1Index.clear();
+    d3bprong2Index.clear();
+
+    // Step 1: sweep over all mcCollisions and find all relevant candidates
+    for (auto const& mcCollision : mcCollisions) {
+      histos.fill(HIST("hNTimesCollRecoed"), mcCollision.hasRecoCollision());
+      int bestCollisionIndex = mcCollision.bestCollisionIndex();
+
+      auto mcParticles = allMcParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
+
+      bool prong0ITS = false, prong1ITS = false, prong2ITS = false;
+      bool prong0TPC = false, prong1TPC = false, prong2TPC = false;
+      bool reconstructed = false;
+      for (auto& mcParticle : mcParticles) {
+        if (mcParticle.pdgCode() == 1010020040 && findHyHe4) {
+          reconstructed = ProcessThreeBody(mcParticle, tracks, bestCollisionIndex, prong0ITS, prong1ITS, prong2ITS, prong0TPC, prong1TPC, prong2TPC);
+          if (fabs(mcParticle.y()) < 0.5) {
+            histos.fill(HIST("hPtHyHe4Generated"), mcParticle.pt());
+            if (reconstructed)
+              histos.fill(HIST("hPtHyHe4Reconstructed"), mcParticle.pt());
+            if (reconstructed && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtHyHe4Global"), mcParticle.pt());
+            if (reconstructed && bestCollisionIndex >= 0 && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtHyHe4GlobalWithPV"), mcParticle.pt());
+          }
+        }
+        if (mcParticle.pdgCode() == -1010020040 && findHyHe4) {
+          reconstructed = ProcessThreeBody(mcParticle, tracks, bestCollisionIndex, prong0ITS, prong1ITS, prong2ITS, prong0TPC, prong1TPC, prong2TPC);
+          if (fabs(mcParticle.y()) < 0.5) {
+            histos.fill(HIST("hPtHyAntiHe4Generated"), mcParticle.pt());
+            if (reconstructed)
+              histos.fill(HIST("hPtAntiHyHe4Reconstructed"), mcParticle.pt());
+            if (reconstructed && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtAntiHyHe4Global"), mcParticle.pt());
+            if (reconstructed && bestCollisionIndex >= 0 && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtAntiHyHe4GlobalWithPV"), mcParticle.pt());
+          }
+        }
+        if (mcParticle.pdgCode() == 1010010030 && findHypertriton) {
+          reconstructed = ProcessThreeBody(mcParticle, tracks, bestCollisionIndex, prong0ITS, prong1ITS, prong2ITS, prong0TPC, prong1TPC, prong2TPC);
+          if (fabs(mcParticle.y()) < 0.5) {
+            histos.fill(HIST("hPtHyperTritonGenerated"), mcParticle.pt());
+            if (reconstructed)
+              histos.fill(HIST("hPtHyperTritonReconstructed"), mcParticle.pt());
+            if (reconstructed && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtHyperTritonGlobal"), mcParticle.pt());
+            if (reconstructed && bestCollisionIndex >= 0 && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtHyperTritonGlobalWithPV"), mcParticle.pt());
+          }
+        }
+        if (mcParticle.pdgCode() == -1010010030 && findHypertriton) {
+          reconstructed = ProcessThreeBody(mcParticle, tracks, bestCollisionIndex, prong0ITS, prong1ITS, prong2ITS, prong0TPC, prong1TPC, prong2TPC);
+          if (fabs(mcParticle.y()) < 0.5) {
+            histos.fill(HIST("hPtAntiHyperTritonGenerated"), mcParticle.pt());
+            if (reconstructed)
+              histos.fill(HIST("hPtAntiHyperTritonReconstructed"), mcParticle.pt());
+            if (reconstructed && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtAntiHyperTritonGlobal"), mcParticle.pt());
+            if (reconstructed && bestCollisionIndex >= 0 && prong0ITS && prong1ITS && prong2ITS && prong0TPC && prong1TPC && prong2TPC)
+              histos.fill(HIST("hPtAntiHyperTritonGlobalWithPV"), mcParticle.pt());
+          }
+        }
+      }
+    }
+
+    // sort according to collision ID
+    auto sortedIndices = sort_indices(d3bcollisionId);
+
+    // V0 list established, populate
+    for (auto ic : sortedIndices) {
+      if (d3bcollisionId[ic] >= 0) {
+        d3b(d3bcollisionId[ic], d3bprong0Index[ic], d3bprong1Index[ic], d3bprong2Index[ic]);
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<threebodymcfinder>(cfgc, TaskName{"lf-threebodymcfinder"})};
+}

--- a/PWGLF/Tasks/CMakeLists.txt
+++ b/PWGLF/Tasks/CMakeLists.txt
@@ -140,3 +140,8 @@ o2physics_add_dpl_workflow(stqa
                     SOURCES stqa.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::ReconstructionDataFormats O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(hyhefour-analysis
+                    SOURCES hyhe4analysis.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)

--- a/PWGLF/Tasks/hyhe4analysis.cxx
+++ b/PWGLF/Tasks/hyhe4analysis.cxx
@@ -1,0 +1,149 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+//  *+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+//  3-body Hyperhelium 4 analysis
+//  *+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+
+#include <cmath>
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <iterator>
+#include <utility>
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "PWGLF/DataModel/LFParticleIdentification.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "PWGLF/DataModel/LFHyperhelium4Tables.h"
+
+using namespace std;
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+// use parameters + cov mat non-propagated, aux info + (extension propagated)
+using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
+using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU>;
+using TracksWithExtra = soa::Join<aod::Tracks, aod::TracksExtra>;
+
+// For MC and dE/dx association
+using TracksExtraWithPIDandLabels = soa::Join<aod::TracksExtra, aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTPCFullHe, aod::McTrackLabels>;
+
+// For MC association in pre-selection
+using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
+
+struct hyhefouranalysis {
+  // Basic selection criteria
+  Configurable<float> selHyHe4daudca{"selHyHe4daudca", 1, "DCA between HyHe4 daughters"};
+
+  // storing output
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext& context)
+  {
+    const AxisSpec axisMassHyHe4{(int)400, 3.7f, 4.1f, "Hyperhelium4 Mass Distribution (GeV/c^{2})"};
+    const AxisSpec axisNCandidates{(int)100, -0.5f, 99.5f, "Number of 3-body candidates"};
+
+    const AxisSpec axisEventCounter{(int)1, 0.0f, 1.0f, "Number of events"};
+    const AxisSpec axisPt{(int)1000, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
+    const AxisSpec axisDCADaughters{(int)1000, 0.0f, 10.0f, "DCA Daughters (cm)"};
+    const AxisSpec axisDCAtoPV{(int)1000, -10.0f, 10.0f, "DCA to PV (cm)"};
+
+    // Base counters
+    histos.add("hNEvents", "hNEvents", kTH1F, {axisEventCounter});
+    histos.add("hNCandidates", "hNCandidates", kTH1F, {axisNCandidates});
+
+    // Kinematics
+    histos.add("hPtHyHe4_Helium3", "hPtHyHe4_Helium3", kTH1F, {axisPt});
+    histos.add("hPtHyHe4_Proton", "hPtHyHe4_Proton", kTH1F, {axisPt});
+    histos.add("hPtHyHe4_Pion", "hPtHyHe4_Pion", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4_Helium3", "hPtAntiHyHe4_Helium3", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4_Proton", "hPtAntiHyHe4_Proton", kTH1F, {axisPt});
+    histos.add("hPtAntiHyHe4_Pion", "hPtAntiHyHe4_Pion", kTH1F, {axisPt});
+
+    // Topological variables
+    histos.add("hPtHyHe4_DCADaughters", "hPtHyHe4_DCADaughters", kTH1F, {axisDCADaughters});
+    histos.add("hPtHyHe4_DCAxy", "hPtHyHe4_DCAxy", kTH1F, {axisDCAtoPV});
+    histos.add("hPtHyHe4_DCAz", "hPtHyHe4_DCAz", kTH1F, {axisDCAtoPV});
+    histos.add("hPtHyHe4_Helium3_DCA", "hPtHyHe4_Helium3_DCA", kTH1F, {axisDCAtoPV});
+    histos.add("hPtHyHe4_Proton_DCA", "hPtHyHe4_Proton_DCA", kTH1F, {axisDCAtoPV});
+    histos.add("hPtHyHe4_Pion_DCA", "hPtHyHe4_Pion_DCA", kTH1F, {axisDCAtoPV});
+    histos.add("hPtAntiHyHe4_DCADaughters", "hPtAntiHyHe4_DCADaughters", kTH1F, {axisDCADaughters});
+    histos.add("hPtAntiHyHe4_DCAxy", "hPtAntiHyHe4_DCAxy", kTH1F, {axisDCAtoPV});
+    histos.add("hPtAntiHyHe4_DCAz", "hPtAntiHyHe4_DCAz", kTH1F, {axisDCAtoPV});
+    histos.add("hPtAntiHyHe4_Helium3_DCA", "hPtAntiHyHe4_Helium3_DCA", kTH1F, {axisDCAtoPV});
+    histos.add("hPtAntiHyHe4_Proton_DCA", "hPtAntiHyHe4_Proton_DCA", kTH1F, {axisDCAtoPV});
+    histos.add("hPtAntiHyHe4_Pion_DCA", "hPtAntiHyHe4_Pion_DCA", kTH1F, {axisDCAtoPV});
+
+    // Base mass
+    histos.add("hMassVsPtHyHe4", "hMassVsPtHyHe4", kTH2F, {axisPt, axisMassHyHe4});
+    histos.add("hMassVsPtAntiHyHe4", "hMassVsPtAntiHyHe4", kTH2F, {axisPt, axisMassHyHe4});
+  }
+
+  void process(aod::Collision const& collision, aod::HyHe4Datas const& hyhe4candidates, FullTracksExtIU const&, aod::BCsWithTimestamps const&)
+  {
+    histos.fill(HIST("hNEvents"), 0.5);
+    histos.fill(HIST("hNCandidates"), hyhe4candidates.size());
+    for (auto const& hyhe4cand : hyhe4candidates) {
+      // process this particular candidate with existing data model
+      if (hyhe4cand.sign() > 0) {
+        histos.fill(HIST("hMassVsPtHyHe4"), hyhe4cand.pt(), hyhe4cand.m());
+        histos.fill(HIST("hPtHyHe4_Helium3"), hyhe4cand.ptHelium3());
+        histos.fill(HIST("hPtHyHe4_Proton"), hyhe4cand.ptProton());
+        histos.fill(HIST("hPtHyHe4_Pion"), hyhe4cand.ptPion());
+
+        histos.fill(HIST("hPtHyHe4_DCADaughters"), hyhe4cand.dcaDaughters());
+        histos.fill(HIST("hPtHyHe4_DCAxy"), hyhe4cand.dcaxyHyHe4ToPV());
+        histos.fill(HIST("hPtHyHe4_DCAz"), hyhe4cand.dcazHyHe4ToPV());
+        histos.fill(HIST("hPtHyHe4_Helium3_DCA"), hyhe4cand.dcaHelium3ToPV());
+        histos.fill(HIST("hPtHyHe4_Proton_DCA"), hyhe4cand.dcaProtonToPV());
+        histos.fill(HIST("hPtHyHe4_Pion_DCA"), hyhe4cand.dcaPionToPV());
+      }
+
+      if (hyhe4cand.sign() < 0) {
+        histos.fill(HIST("hMassVsPtAntiHyHe4"), hyhe4cand.pt(), hyhe4cand.m());
+        histos.fill(HIST("hPtAntiHyHe4_Helium3"), hyhe4cand.ptHelium3());
+        histos.fill(HIST("hPtAntiHyHe4_Proton"), hyhe4cand.ptProton());
+        histos.fill(HIST("hPtAntiHyHe4_Pion"), hyhe4cand.ptPion());
+
+        histos.fill(HIST("hPtAntiHyHe4_DCADaughters"), hyhe4cand.dcaDaughters());
+        histos.fill(HIST("hPtAntiHyHe4_DCAxy"), hyhe4cand.dcaxyHyHe4ToPV());
+        histos.fill(HIST("hPtAntiHyHe4_DCAz"), hyhe4cand.dcazHyHe4ToPV());
+        histos.fill(HIST("hPtAntiHyHe4_Helium3_DCA"), hyhe4cand.dcaHelium3ToPV());
+        histos.fill(HIST("hPtAntiHyHe4_Proton_DCA"), hyhe4cand.dcaProtonToPV());
+        histos.fill(HIST("hPtAntiHyHe4_Pion_DCA"), hyhe4cand.dcaPionToPV());
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<hyhefouranalysis>(cfgc)};
+}


### PR DESCRIPTION
This PR adds work from Navneet Kumar, Natasha Sharma, Lokesh Kumar, and myself, who are studying the possibility of measuring double-hypernuclei going into hyperhelium-4 and then hyperhelium-4 into helium-3, proton and pion (see [PAG talk](https://indico.cern.ch/event/1187403/contributions/5025252/attachments/2506230/4306417/Double_HyperNuclei.pdf) as reference). The first step is to check for the 3-body decay of the hyperhelium-4, which is what the first tools provided here do. Having that in mind, this PR: 

- adds a three-body decay MC-based finder `threebodymcfinder` that, similarly to [what has been presented last week at the AOT Tracks](https://indico.cern.ch/event/1281698/contributions/5387798/attachments/2640630/4569917/Strangeness-Reco-04.pdf), re-creates the Decay3Body table with perfect MC candidates of Hyperhelium-4. This allows for a very fast and effective turnaround for tuning the svertexer for this specific 3-body decay, with the actual study still following. It also supports the hypertriton 3-body decay (untested) in case anybody wants to try that our in the future. 
- adds a hyperhelium-4 builder task `hyhe4builder` that spawns an analysis table for hyperhelium-4 candidates. It mirrors the functioning of the existing `lambdakzerobuilder` but for hyperhelium-4. 
- adds the corresponding hyperhelium-4 data model into `PWGLF/DataModel`. 
- adds a sample analysis task for hyperhelium-4 

Still missing: more dE/dx-based selections, both at analysis time and at building time. More to follow. Navneet will present an update in one of the coming PAG meetings about this work. 