### PR TITLE
PWGMM: dndeta: prepare for gen-level centrality

### DIFF
--- a/PWGMM/Mult/TableProducer/particles2tracks.cxx
+++ b/PWGMM/Mult/TableProducer/particles2tracks.cxx
@@ -38,6 +38,16 @@ struct ParticlesToTracks {
   {
   }
 
+  void process(aod::McParticles const& particles)
+  {
+    if (doprocessIndexingCentral) {
+      p2t.reserve(particles.size());
+    }
+    if (doprocessIndexingFwd) {
+      p2tmft.reserve(particles.size());
+    }
+  }
+
   void processIndexingCentral(aod::McParticle const&, soa::SmallGroups<LabeledTracks> const& tracks)
   {
     trackIds.clear();

--- a/PWGMM/Mult/TableProducer/trackPropagation.cxx
+++ b/PWGMM/Mult/TableProducer/trackPropagation.cxx
@@ -35,20 +35,8 @@
 using SMatrix55 = ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
 using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
 
-// The Run 3 AO2D stores the tracks at the point of innermost update. For a
-// track with ITS this is the innermost (or second innermost) ITS layer. For a
-// track without ITS, this is the TPC inner wall or for loopers in the TPC even
-// a radius beyond that. In order to use the track parameters, the tracks have
-// to be propagated to the collision vertex which is done by this task. The task
-// consumes the TracksIU and TracksCovIU tables and produces Tracks and
-// TracksCov to which then the user analysis can subscribe.
-//
-// This task is not needed for Run 2 converted data.
-// There are two versions of the task (see process flags), one producing also
-// the covariance matrix and the other only the tracks table.
-
-// This is an alternative version of the propagation task with special treatment
-// of ambiguous tracks
+// This is a special version of the propagation task chosing the closest vertex
+// among the compatible, which is defined by track-to-collision-associator
 
 using namespace o2;
 using namespace o2::framework;
@@ -240,6 +228,5 @@ struct AmbiguousTrackPropagation {
 //****************************************************************************************
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<AmbiguousTrackPropagation>(cfgc)};
-  return workflow;
+  return {adaptAnalysisTask<AmbiguousTrackPropagation>(cfgc)};
 }

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -57,6 +57,7 @@ struct MultiplicityCounter {
   SliceCache cache;
   Preslice<aod::Tracks> perCol = aod::track::collisionId;
   Preslice<aod::McParticles> perMCCol = aod::mcparticle::mcCollisionId;
+  PresliceUnsorted<aod::ReassignedTracksCore> perColU = aod::track::bestCollisionId;
 
   Service<O2DatabasePDG> pdg;
 
@@ -82,7 +83,7 @@ struct MultiplicityCounter {
     AxisSpec MultAxis = {multBinning, "N_{trk}"};
     AxisSpec CentAxis = {centBinning, "centrality"};
 
-    auto* hstat = registry.get<TH1>(HIST("Events/BCSelection"));
+    auto hstat = registry.get<TH1>(HIST("Events/BCSelection"));
     auto* x = hstat->GetXaxis();
     x->SetBinLabel(1, "Good BCs");
     x->SetBinLabel(2, "BCs with collisions");
@@ -710,11 +711,11 @@ struct MultiplicityCounter {
         auto perCollisionSample = tracks.sliceBy(perCol, collision.globalIndex());
         auto perCollisionASample = atracks.sliceBy(perColU, collision.globalIndex());
         for (auto const& track : perCollisionASample) {
+          auto otrack = track.template track_as<FiTracks>();
           usedTracksIds.emplace_back(track.trackId());
           if (otrack.collisionId() != track.bestCollisionId()) {
             usedTracksIdsDFMC.emplace_back(track.trackId());
           }
-          auto otrack = track.track_as<FiTracks>();
           if (std::abs(otrack.eta()) < estimatorEta) {
             ++Nrec;
           }
@@ -827,9 +828,9 @@ struct MultiplicityCounter {
   void processGen(
     MC::iterator const& mcCollision,
     o2::soa::SmallGroups<soa::Join<ExCols, aod::McCollisionLabels>> const& collisions,
-    Particles const& particles, FiTracks const& tracks)
+    Particles const& particles, FiTracks const& tracks, soa::Filtered<aod::ReassignedTracksCore> const& atracks)
   {
-    processGenGeneral<MC, ExCols>(mcCollision, collisions, particles, tracks);
+    processGenGeneral<MC, ExCols>(mcCollision, collisions, particles, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processGen, "Process generator-level info", false);
@@ -837,9 +838,9 @@ struct MultiplicityCounter {
   void processGenFT0C(
     MC::iterator const& mcCollision,
     o2::soa::SmallGroups<soa::Join<ExColsCentFT0C, aod::McCollisionLabels>> const& collisions,
-    Particles const& particles, FiTracks const& tracks)
+    Particles const& particles, FiTracks const& tracks, soa::Filtered<aod::ReassignedTracksCore> const& atracks)
   {
-    processGenGeneral<MC, ExColsCentFT0C>(mcCollision, collisions, particles, tracks);
+    processGenGeneral<MC, ExColsCentFT0C>(mcCollision, collisions, particles, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processGenFT0C, "Process generator-level info (FT0C centrality)", false);
@@ -847,9 +848,9 @@ struct MultiplicityCounter {
   void processGenFT0M(
     MC::iterator const& mcCollision,
     o2::soa::SmallGroups<soa::Join<ExColsCentFT0M, aod::McCollisionLabels>> const& collisions,
-    Particles const& particles, FiTracks const& tracks)
+    Particles const& particles, FiTracks const& tracks, soa::Filtered<aod::ReassignedTracksCore> const& atracks)
   {
-    processGenGeneral<MC, ExColsCentFT0M>(mcCollision, collisions, particles, tracks);
+    processGenGeneral<MC, ExColsCentFT0M>(mcCollision, collisions, particles, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processGenFT0M, "Process generator-level info (FT0M centrality)", false);
@@ -859,9 +860,9 @@ struct MultiplicityCounter {
   void processGenFT0Chi(
     MChi::iterator const& mcCollision,
     o2::soa::SmallGroups<soa::Join<ExColsCentFT0C, aod::McCollisionLabels>> const& collisions,
-    Particles const& particles, FiTracks const& tracks)
+    Particles const& particles, FiTracks const& tracks, soa::Filtered<aod::ReassignedTracksCore> const& atracks)
   {
-    processGenGeneral<MChi, ExColsCentFT0C>(mcCollision, collisions, particles, tracks);
+    processGenGeneral<MChi, ExColsCentFT0C>(mcCollision, collisions, particles, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processGenFT0Chi, "Process generator-level info (FT0C centrality, HI)", false);
@@ -869,9 +870,9 @@ struct MultiplicityCounter {
   void processGenFT0Mhi(
     MChi::iterator const& mcCollision,
     o2::soa::SmallGroups<soa::Join<ExColsCentFT0M, aod::McCollisionLabels>> const& collisions,
-    Particles const& particles, FiTracks const& tracks)
+    Particles const& particles, FiTracks const& tracks, soa::Filtered<aod::ReassignedTracksCore> const& atracks)
   {
-    processGenGeneral<MChi, ExColsCentFT0M>(mcCollision, collisions, particles, tracks);
+    processGenGeneral<MChi, ExColsCentFT0M>(mcCollision, collisions, particles, tracks, atracks);
   }
 
   PROCESS_SWITCH(MultiplicityCounter, processGenFT0Mhi, "Process generator-level info (FT0M centrality, HI)", false);

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -514,7 +514,7 @@ struct MultiplicityCounter {
   template <typename C, typename MC>
   void processTrackEfficiencyIndexedGeneral(
     typename soa::Join<C, aod::McCollisionLabels>::iterator const& collision,
-    MC const&, ParticlesI const&,
+    MC const&, soa::Filtered<ParticlesI> const& particles,
     FiLTracks const& tracks)
   {
     if (useEvSel && !collision.sel8()) {
@@ -524,10 +524,11 @@ struct MultiplicityCounter {
       return;
     }
     auto mcCollision = collision.mcCollision();
-    auto particlesI = primariesI->sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache);
-    particlesI.bindExternalIndices(&tracks);
+    //    auto particlesI = primariesI->sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache);
+    //    particlesI.bindExternalIndices(&tracks);
+    auto sample = particles.sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache);
 
-    for (auto& particle : particlesI) {
+    for (auto& particle : sample) {
       auto charge = 0.;
       auto p = pdg->GetParticle(particle.pdgCode());
       if (p != nullptr) {
@@ -598,7 +599,7 @@ struct MultiplicityCounter {
 
   void processTrackEfficiencyIndexed(
     soa::Join<ExCols, aod::McCollisionLabels>::iterator const& collision,
-    aod::McCollisions const& mccollisions, ParticlesI const& particles,
+    aod::McCollisions const& mccollisions, soa::Filtered<ParticlesI> const& particles,
     FiLTracks const& tracks)
   {
     processTrackEfficiencyIndexedGeneral<ExCols, aod::McCollisions>(collision, mccollisions, particles, tracks);


### PR DESCRIPTION
* Updates the gen-level counting to be on par with reco-level
* Fixes a bug where the filter on ambiguous tracks was not applied due to missing subscription
* Accounts for splitting/pileup when filling response matrix

Requires https://github.com/AliceO2Group/AliceO2/pull/11292