### PR TITLE
PWGCF: Fix V0 selection in FemtoDream

### DIFF
--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -1135,7 +1135,7 @@ struct CFFilterQA {
     bool keepEvent2N[CFTrigger::kNTwoBodyTriggers] = {false, false};
     int lowKstarPairs[CFTrigger::kNTwoBodyTriggers] = {0, 0};
 
-    int childIDs[2] = {0, 0};
+    std::vector<int> childIDs = {0, 0};
 
     // keep track of proton indices
     std::vector<int> ProtonIndex = {};

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -71,16 +71,16 @@ enum TrackType {
 static constexpr std::string_view TrackTypeName[kNTrackTypes] = {"Trk", "Pos", "Neg"}; //! Naming of the different particle types
 
 DECLARE_SOA_INDEX_COLUMN(FemtoDreamCollision, femtoDreamCollision);
-DECLARE_SOA_COLUMN(Pt, pt, float);                    //! p_T (GeV/c)
-DECLARE_SOA_COLUMN(Eta, eta, float);                  //! Eta
-DECLARE_SOA_COLUMN(Phi, phi, float);                  //! Phi
-DECLARE_SOA_COLUMN(PartType, partType, uint8_t);      //! Type of the particle, according to femtodreamparticle::ParticleType
-DECLARE_SOA_COLUMN(Cut, cut, cutContainerType);       //! Bit-wise container for the different selection criteria
-DECLARE_SOA_COLUMN(PIDCut, pidcut, cutContainerType); //! Bit-wise container for the different PID selection criteria \todo since bit-masking cannot be done yet with filters we use a second field for the PID
-DECLARE_SOA_COLUMN(TempFitVar, tempFitVar, float);    //! Observable for the template fitting (Track: DCA_xy, V0: CPA)
-DECLARE_SOA_COLUMN(Indices, indices, int[2]);         //! Field for the track indices to remove auto-correlations
-DECLARE_SOA_COLUMN(MLambda, mLambda, float);          //! The invariant mass of V0 candidate, assuming lambda
-DECLARE_SOA_COLUMN(MAntiLambda, mAntiLambda, float);  //! The invariant mass of V0 candidate, assuming antilambda
+DECLARE_SOA_COLUMN(Pt, pt, float);                       //! p_T (GeV/c)
+DECLARE_SOA_COLUMN(Eta, eta, float);                     //! Eta
+DECLARE_SOA_COLUMN(Phi, phi, float);                     //! Phi
+DECLARE_SOA_COLUMN(PartType, partType, uint8_t);         //! Type of the particle, according to femtodreamparticle::ParticleType
+DECLARE_SOA_COLUMN(Cut, cut, cutContainerType);          //! Bit-wise container for the different selection criteria
+DECLARE_SOA_COLUMN(PIDCut, pidcut, cutContainerType);    //! Bit-wise container for the different PID selection criteria \todo since bit-masking cannot be done yet with filters we use a second field for the PID
+DECLARE_SOA_COLUMN(TempFitVar, tempFitVar, float);       //! Observable for the template fitting (Track: DCA_xy, V0: CPA)
+DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN(Children, children); //! Field for the track indices to remove auto-correlations
+DECLARE_SOA_COLUMN(MLambda, mLambda, float);             //! The invariant mass of V0 candidate, assuming lambda
+DECLARE_SOA_COLUMN(MAntiLambda, mAntiLambda, float);     //! The invariant mass of V0 candidate, assuming antilambda
 
 DECLARE_SOA_DYNAMIC_COLUMN(Theta, theta, //! Compute the theta of the track
                            [](float eta) -> float {
@@ -130,7 +130,7 @@ DECLARE_SOA_TABLE(FemtoDreamParticles, "AOD", "FEMTODREAMPARTS",
                   femtodreamparticle::Cut,
                   femtodreamparticle::PIDCut,
                   femtodreamparticle::TempFitVar,
-                  femtodreamparticle::Indices,
+                  femtodreamparticle::ChildrenIds,
                   femtodreamparticle::MLambda,
                   femtodreamparticle::MAntiLambda,
                   femtodreamparticle::Theta<femtodreamparticle::Eta>,

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,48 +10,47 @@
 // or submit itself to any jurisdiction.
 
 /// \file FemtoDreamCutculator.h
-/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and
-/// actual physics cuts \author Andi Mathis, TU München,
-/// andreas.mathis@ph.tum.de \author Luca Barioglio, TU München,
-/// luca.barioglio@cern.ch
+/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and actual physics cuts
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 #define PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 
-#include "FemtoDreamSelection.h"
-#include "FemtoDreamTrackSelection.h"
-#include "FemtoDreamV0Selection.h"
-#include <bitset>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <iostream>
 #include <string>
 #include <vector>
+#include <bitset>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include "FemtoDreamSelection.h"
+#include "FemtoDreamTrackSelection.h"
+#include "FemtoDreamV0Selection.h"
 
-namespace o2::analysis::femtoDream {
+namespace o2::analysis::femtoDream
+{
 
 /// \class FemtoDreamCutculator
 /// \brief Small class to match bit-wise encoding and actual physics cuts
-class FemtoDreamCutculator {
-public:
+class FemtoDreamCutculator
+{
+ public:
   /// Initializes boost ptree
-  /// \param configFile Path to the dpl-config.json file from the
-  /// femtodream-producer task
-  void init(const char *configFile) {
+  /// \param configFile Path to the dpl-config.json file from the femtodream-producer task
+  void init(const char* configFile)
+  {
     LOG(info) << "Welcome to the CutCulator!";
 
     boost::property_tree::ptree root;
     try {
       boost::property_tree::read_json(configFile, root);
-    } catch (const boost::property_tree::ptree_error &e) {
-      LOG(fatal) << "Failed to read JSON config file " << configFile << " ("
-                 << e.what() << ")";
+    } catch (const boost::property_tree::ptree_error& e) {
+      LOG(fatal) << "Failed to read JSON config file " << configFile << " (" << e.what() << ")";
     }
 
     // check the config file for all known producer task
-    std::vector<const char *> ProducerTasks = {
-        "femto-dream-producer-task", "femto-dream-producer-reduced-task"};
-    for (auto &Producer : ProducerTasks) {
+    std::vector<const char*> ProducerTasks = {"femto-dream-producer-task", "femto-dream-producer-reduced-task"};
+    for (auto& Producer : ProducerTasks) {
       if (root.count(Producer) > 0) {
         mConfigTree = root.get_child(Producer);
         LOG(info) << "Found " << Producer << " in " << configFile;
@@ -60,23 +59,21 @@ public:
     }
   };
 
-  /// Generic function that retrieves a given selection from the boost ptree and
-  /// returns an std::vector in the proper format \param name Name of the
-  /// selection in the dpl-config.json \return std::vector that can be directly
-  /// passed to the FemtoDreamTrack/V0/../Selection
-  std::vector<float> setSelection(std::string name) {
+  /// Generic function that retrieves a given selection from the boost ptree and returns an std::vector in the proper format
+  /// \param name Name of the selection in the dpl-config.json
+  /// \return std::vector that can be directly passed to the FemtoDreamTrack/V0/../Selection
+  std::vector<float> setSelection(std::string name)
+  {
     try {
-      boost::property_tree::ptree &selections = mConfigTree.get_child(name);
-      boost::property_tree::ptree &selectionsValues =
-          selections.get_child("values");
+      boost::property_tree::ptree& selections = mConfigTree.get_child(name);
+      boost::property_tree::ptree& selectionsValues = selections.get_child("values");
       std::vector<float> tmpVec;
-      for (boost::property_tree::ptree::value_type &val : selectionsValues) {
+      for (boost::property_tree::ptree::value_type& val : selectionsValues) {
         tmpVec.push_back(std::stof(val.second.data()));
       }
       return tmpVec;
-    } catch (const boost::property_tree::ptree_error &e) {
-      LOG(warning) << "Selection " << name << " not available (" << e.what()
-                   << ")";
+    } catch (const boost::property_tree::ptree_error& e) {
+      LOG(warning) << "Selection " << name << " not available (" << e.what() << ")";
       return {};
     }
   }
@@ -87,11 +84,9 @@ public:
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs,
-                         femtoDreamSelection::SelectionType type,
-                         const char *prefix) {
-    auto tmpVec =
-        setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
+  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs, femtoDreamSelection::SelectionType type, const char* prefix)
+  {
+    auto tmpVec = setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mTrackSel.setSelection(tmpVec, obs, type);
     }
@@ -99,13 +94,13 @@ public:
 
   /// Automatically retrieves track selections from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setTrackSelectionFromFile(const char *prefix) {
-    for (const auto &sel : mConfigTree) {
+  void setTrackSelectionFromFile(const char* prefix)
+  {
+    for (const auto& sel : mConfigTree) {
       std::string sel_name = sel.first;
       femtoDreamTrackSelection::TrackSel obs;
       if (sel_name.find(prefix) != std::string::npos) {
-        int index = FemtoDreamTrackSelection::findSelectionIndex(
-            std::string_view(sel_name), prefix);
+        int index = FemtoDreamTrackSelection::findSelectionIndex(std::string_view(sel_name), prefix);
         if (index >= 0) {
           obs = femtoDreamTrackSelection::TrackSel(index);
         } else {
@@ -113,24 +108,23 @@ public:
         }
         if (obs == femtoDreamTrackSelection::TrackSel::kPIDnSigmaMax)
           continue; // kPIDnSigmaMax is a special case
-        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs),
-                          prefix);
+        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs), prefix);
       }
     }
   }
 
   /// Automatically retrieves track PID from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setPIDSelectionFromFile(const char *prefix) {
+  void setPIDSelectionFromFile(const char* prefix)
+  {
     std::string PIDnodeName = std::string(prefix) + "species";
     try {
-      boost::property_tree::ptree &pidNode = mConfigTree.get_child(PIDnodeName);
-      boost::property_tree::ptree &pidValues = pidNode.get_child("values");
-      for (auto &val : pidValues) {
-        mPIDspecies.push_back(
-            static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
+      boost::property_tree::ptree& pidNode = mConfigTree.get_child(PIDnodeName);
+      boost::property_tree::ptree& pidValues = pidNode.get_child("values");
+      for (auto& val : pidValues) {
+        mPIDspecies.push_back(static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
       }
-    } catch (const boost::property_tree::ptree_error &e) {
+    } catch (const boost::property_tree::ptree_error& e) {
       LOG(info) << "PID selection not avalible for these skimmed data.";
     }
   }
@@ -141,11 +135,9 @@ public:
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setV0Selection(femtoDreamV0Selection::V0Sel obs,
-                      femtoDreamSelection::SelectionType type,
-                      const char *prefix) {
-    auto tmpVec =
-        setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
+  void setV0Selection(femtoDreamV0Selection::V0Sel obs, femtoDreamSelection::SelectionType type, const char* prefix)
+  {
+    auto tmpVec = setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mV0Sel.setSelection(tmpVec, obs, type);
     }
@@ -153,41 +145,35 @@ public:
 
   /// Automatically retrieves V0 selections from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setV0SelectionFromFile(const char *prefixV0, const char *prefixChild) {
-    for (const auto &sel : mConfigTree) {
+  void setV0SelectionFromFile(const char* prefix)
+  {
+    for (const auto& sel : mConfigTree) {
       std::string sel_name = sel.first;
       femtoDreamV0Selection::V0Sel obs;
-      if (sel_name.find(prefixV0) != std::string::npos) {
-        int index = FemtoDreamV0Selection::findSelectionIndex(
-            std::string_view(sel_name), prefixV0);
+      if (sel_name.find(prefix) != std::string::npos) {
+        int index = FemtoDreamV0Selection::findSelectionIndex(std::string_view(sel_name), prefix);
         if (index >= 0) {
           obs = femtoDreamV0Selection::V0Sel(index);
         } else {
           continue;
         }
-        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs),
-                       prefixV0);
+        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs), prefix);
       }
     }
-    setTrackSelectionFromFile(prefixChild);
   }
 
-  /// This function investigates a given selection criterion. The available
-  /// options are displayed in the terminal and the bit-wise container is put
-  /// together according to the user input \tparam T1 Selection class under
-  /// investigation \param T2  Selection type under investigation \param output
-  /// Bit-wise container for the systematic variations \param counter Current
-  /// position in the bit-wise container to modify \tparam objectSelection
-  /// Selection class under investigation (FemtoDreamTrack/V0/../Selection)
-  /// \param selectionType Selection type under investigation, as defined in the
-  /// selection class
+  /// This function investigates a given selection criterion. The available options are displayed in the terminal and the bit-wise container is put together according to the user input
+  /// \tparam T1 Selection class under investigation
+  /// \param T2  Selection type under investigation
+  /// \param output Bit-wise container for the systematic variations
+  /// \param counter Current position in the bit-wise container to modify
+  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
+  /// \param selectionType Selection type under investigation, as defined in the selection class
   template <typename T1, typename T2>
-  void checkForSelection(aod::femtodreamparticle::cutContainerType &output,
-                         size_t &counter, T1 objectSelection,
-                         T2 selectionType) {
+  void checkForSelection(aod::femtodreamparticle::cutContainerType& output, size_t& counter, T1 objectSelection, T2 selectionType)
+  {
     /// Output of the available selections and user input
-    std::cout << "Selection: "
-              << objectSelection.getSelectionHelper(selectionType) << " - (";
+    std::cout << "Selection: " << objectSelection.getSelectionHelper(selectionType) << " - (";
     auto selVec = objectSelection.getSelections(selectionType);
     for (auto selIt : selVec) {
       std::cout << selIt.getSelectionValue() << " ";
@@ -197,12 +183,10 @@ public:
     std::cin >> in;
     const float input = std::stof(in);
 
-    /// First we check whether the input is actually contained within the
-    /// options
+    /// First we check whether the input is actually contained within the options
     bool inputSane = false;
     for (auto sel : selVec) {
-      if (std::abs(sel.getSelectionValue() - input) <=
-          std::abs(1.e-6 * input)) {
+      if (std::abs(sel.getSelectionValue() - input) <= std::abs(1.e-6 * input)) {
         inputSane = true;
       }
     }
@@ -213,21 +197,20 @@ public:
       for (auto sel : selVec) {
         double signOffset;
         switch (sel.getSelectionType()) {
-        case femtoDreamSelection::SelectionType::kEqual:
-          signOffset = 0.;
-          break;
-        case (femtoDreamSelection::SelectionType::kLowerLimit):
-        case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
-          signOffset = 1.;
-          break;
-        case (femtoDreamSelection::SelectionType::kUpperLimit):
-        case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
-          signOffset = -1.;
-          break;
+          case femtoDreamSelection::SelectionType::kEqual:
+            signOffset = 0.;
+            break;
+          case (femtoDreamSelection::SelectionType::kLowerLimit):
+          case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
+            signOffset = 1.;
+            break;
+          case (femtoDreamSelection::SelectionType::kUpperLimit):
+          case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
+            signOffset = -1.;
+            break;
         }
 
-        /// for upper and lower limit we have to subtract/add an epsilon so that
-        /// the cut is actually fulfilled
+        /// for upper and lower limit we have to subtract/add an epsilon so that the cut is actually fulfilled
         if (sel.isSelected(input + signOffset * 1.e-6 * input)) {
           output |= 1UL << counter;
           for (int i = internal_index; i > 0; i--) {
@@ -243,15 +226,13 @@ public:
     }
   }
 
-  /// This function iterates over all selection types of a given class and puts
-  /// together the bit-wise container \tparam T1 Selection class under
-  /// investigation \tparam objectSelection Selection class under investigation
-  /// (FemtoDreamTrack/V0/../Selection) \return the full selection bit-wise
-  /// container that will be put to the user task incorporating the user choice
-  /// of selections
+  /// This function iterates over all selection types of a given class and puts together the bit-wise container
+  /// \tparam T1 Selection class under investigation
+  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
+  /// \return the full selection bit-wise container that will be put to the user task incorporating the user choice of selections
   template <typename T>
-  aod::femtodreamparticle::cutContainerType
-  iterateSelection(T objectSelection) {
+  aod::femtodreamparticle::cutContainerType iterateSelection(T objectSelection)
+  {
     aod::femtodreamparticle::cutContainerType output = 0;
     size_t counter = 0;
     auto selectionVariables = objectSelection.getSelectionVariables();
@@ -261,27 +242,19 @@ public:
     return output;
   }
 
-  /// This is the function called by the executable that then outputs the full
-  /// selection bit-wise container incorporating the user choice of selections
-  void analyseCuts() {
-    std::cout << "Do you want to work with tracks/v0/cascade (T/V/C)?\n";
-    std::cout << " > ";
-    std::string in;
-    std::cin >> in;
+  /// This is the function called by the executable that then outputs the full selection bit-wise container incorporating the user choice of selections
+  void analyseCuts(std::string choice)
+  {
     aod::femtodreamparticle::cutContainerType output = -1;
-    if (in.compare("T") == 0) {
+    if (choice == std::string("T")) {
       output = iterateSelection(mTrackSel);
-    } else if (in.compare("V") == 0) {
+    } else if (choice == std::string("V")) {
       output = iterateSelection(mV0Sel);
-    } else if (in.compare("C") == 0) {
-      // output =  iterateSelection(mCascadeSel);
     } else {
-      std::cout << "Option " << in
-                << " not recognized - available options are (T/V/C) \n";
-      analyseCuts();
+      LOG(info) << "Option " << choice << " not recognized - available options are (T/V)";
+      return;
     }
-    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)>
-        bitOutput = output;
+    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)> bitOutput = output;
     std::cout << "+++++++++++++++++++++++++++++++++\n";
     std::cout << "CutCulator has spoken - your selection bit is\n";
     std::cout << bitOutput << " (bitwise)\n";
@@ -293,15 +266,11 @@ public:
     }
   }
 
-private:
-  boost::property_tree::ptree
-      mConfigTree; ///< the dpl-config.json buffered into a ptree
-  FemtoDreamTrackSelection
-      mTrackSel; ///< for setting up the bit-wise selection container for tracks
-  FemtoDreamV0Selection
-      mV0Sel; ///< for setting up the bit-wise selection container for V0s
-  std::vector<o2::track::PID::ID>
-      mPIDspecies; ///< list of particle species for which PID is stored
+ private:
+  boost::property_tree::ptree mConfigTree;     ///< the dpl-config.json buffered into a ptree
+  FemtoDreamTrackSelection mTrackSel;          ///< for setting up the bit-wise selection container for tracks
+  FemtoDreamV0Selection mV0Sel;                ///< for setting up the bit-wise selection container for V0s
+  std::vector<o2::track::PID::ID> mPIDspecies; ///< list of particle species for which PID is stored
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,47 +10,48 @@
 // or submit itself to any jurisdiction.
 
 /// \file FemtoDreamCutculator.h
-/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and actual physics cuts
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
-/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and
+/// actual physics cuts \author Andi Mathis, TU München,
+/// andreas.mathis@ph.tum.de \author Luca Barioglio, TU München,
+/// luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 #define PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include <bitset>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
+#include <bitset>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
 
-namespace o2::analysis::femtoDream
-{
+namespace o2::analysis::femtoDream {
 
 /// \class FemtoDreamCutculator
 /// \brief Small class to match bit-wise encoding and actual physics cuts
-class FemtoDreamCutculator
-{
- public:
+class FemtoDreamCutculator {
+public:
   /// Initializes boost ptree
-  /// \param configFile Path to the dpl-config.json file from the femtodream-producer task
-  void init(const char* configFile)
-  {
+  /// \param configFile Path to the dpl-config.json file from the
+  /// femtodream-producer task
+  void init(const char *configFile) {
     LOG(info) << "Welcome to the CutCulator!";
 
     boost::property_tree::ptree root;
     try {
       boost::property_tree::read_json(configFile, root);
-    } catch (const boost::property_tree::ptree_error& e) {
-      LOG(fatal) << "Failed to read JSON config file " << configFile << " (" << e.what() << ")";
+    } catch (const boost::property_tree::ptree_error &e) {
+      LOG(fatal) << "Failed to read JSON config file " << configFile << " ("
+                 << e.what() << ")";
     }
 
     // check the config file for all known producer task
-    std::vector<const char*> ProducerTasks = {"femto-dream-producer-task", "femto-dream-producer-reduced-task"};
-    for (auto& Producer : ProducerTasks) {
+    std::vector<const char *> ProducerTasks = {
+        "femto-dream-producer-task", "femto-dream-producer-reduced-task"};
+    for (auto &Producer : ProducerTasks) {
       if (root.count(Producer) > 0) {
         mConfigTree = root.get_child(Producer);
         LOG(info) << "Found " << Producer << " in " << configFile;
@@ -59,21 +60,23 @@ class FemtoDreamCutculator
     }
   };
 
-  /// Generic function that retrieves a given selection from the boost ptree and returns an std::vector in the proper format
-  /// \param name Name of the selection in the dpl-config.json
-  /// \return std::vector that can be directly passed to the FemtoDreamTrack/V0/../Selection
-  std::vector<float> setSelection(std::string name)
-  {
+  /// Generic function that retrieves a given selection from the boost ptree and
+  /// returns an std::vector in the proper format \param name Name of the
+  /// selection in the dpl-config.json \return std::vector that can be directly
+  /// passed to the FemtoDreamTrack/V0/../Selection
+  std::vector<float> setSelection(std::string name) {
     try {
-      boost::property_tree::ptree& selections = mConfigTree.get_child(name);
-      boost::property_tree::ptree& selectionsValues = selections.get_child("values");
+      boost::property_tree::ptree &selections = mConfigTree.get_child(name);
+      boost::property_tree::ptree &selectionsValues =
+          selections.get_child("values");
       std::vector<float> tmpVec;
-      for (boost::property_tree::ptree::value_type& val : selectionsValues) {
+      for (boost::property_tree::ptree::value_type &val : selectionsValues) {
         tmpVec.push_back(std::stof(val.second.data()));
       }
       return tmpVec;
-    } catch (const boost::property_tree::ptree_error& e) {
-      LOG(warning) << "Selection " << name << " not available (" << e.what() << ")";
+    } catch (const boost::property_tree::ptree_error &e) {
+      LOG(warning) << "Selection " << name << " not available (" << e.what()
+                   << ")";
       return {};
     }
   }
@@ -84,9 +87,11 @@ class FemtoDreamCutculator
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs, femtoDreamSelection::SelectionType type, const char* prefix)
-  {
-    auto tmpVec = setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
+  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs,
+                         femtoDreamSelection::SelectionType type,
+                         const char *prefix) {
+    auto tmpVec =
+        setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mTrackSel.setSelection(tmpVec, obs, type);
     }
@@ -94,13 +99,13 @@ class FemtoDreamCutculator
 
   /// Automatically retrieves track selections from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setTrackSelectionFromFile(const char* prefix)
-  {
-    for (const auto& sel : mConfigTree) {
+  void setTrackSelectionFromFile(const char *prefix) {
+    for (const auto &sel : mConfigTree) {
       std::string sel_name = sel.first;
       femtoDreamTrackSelection::TrackSel obs;
       if (sel_name.find(prefix) != std::string::npos) {
-        int index = FemtoDreamTrackSelection::findSelectionIndex(std::string_view(sel_name), prefix);
+        int index = FemtoDreamTrackSelection::findSelectionIndex(
+            std::string_view(sel_name), prefix);
         if (index >= 0) {
           obs = femtoDreamTrackSelection::TrackSel(index);
         } else {
@@ -108,23 +113,24 @@ class FemtoDreamCutculator
         }
         if (obs == femtoDreamTrackSelection::TrackSel::kPIDnSigmaMax)
           continue; // kPIDnSigmaMax is a special case
-        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs), prefix);
+        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs),
+                          prefix);
       }
     }
   }
 
   /// Automatically retrieves track PID from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setPIDSelectionFromFile(const char* prefix)
-  {
+  void setPIDSelectionFromFile(const char *prefix) {
     std::string PIDnodeName = std::string(prefix) + "species";
     try {
-      boost::property_tree::ptree& pidNode = mConfigTree.get_child(PIDnodeName);
-      boost::property_tree::ptree& pidValues = pidNode.get_child("values");
-      for (auto& val : pidValues) {
-        mPIDspecies.push_back(static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
+      boost::property_tree::ptree &pidNode = mConfigTree.get_child(PIDnodeName);
+      boost::property_tree::ptree &pidValues = pidNode.get_child("values");
+      for (auto &val : pidValues) {
+        mPIDspecies.push_back(
+            static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
       }
-    } catch (const boost::property_tree::ptree_error& e) {
+    } catch (const boost::property_tree::ptree_error &e) {
       LOG(info) << "PID selection not avalible for these skimmed data.";
     }
   }
@@ -135,9 +141,11 @@ class FemtoDreamCutculator
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setV0Selection(femtoDreamV0Selection::V0Sel obs, femtoDreamSelection::SelectionType type, const char* prefix)
-  {
-    auto tmpVec = setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
+  void setV0Selection(femtoDreamV0Selection::V0Sel obs,
+                      femtoDreamSelection::SelectionType type,
+                      const char *prefix) {
+    auto tmpVec =
+        setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mV0Sel.setSelection(tmpVec, obs, type);
     }
@@ -145,35 +153,41 @@ class FemtoDreamCutculator
 
   /// Automatically retrieves V0 selections from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setV0SelectionFromFile(const char* prefix)
-  {
-    for (const auto& sel : mConfigTree) {
+  void setV0SelectionFromFile(const char *prefixV0, const char *prefixChild) {
+    for (const auto &sel : mConfigTree) {
       std::string sel_name = sel.first;
       femtoDreamV0Selection::V0Sel obs;
-      if (sel_name.find(prefix) != std::string::npos) {
-        int index = FemtoDreamV0Selection::findSelectionIndex(std::string_view(sel_name), prefix);
+      if (sel_name.find(prefixV0) != std::string::npos) {
+        int index = FemtoDreamV0Selection::findSelectionIndex(
+            std::string_view(sel_name), prefixV0);
         if (index >= 0) {
           obs = femtoDreamV0Selection::V0Sel(index);
         } else {
           continue;
         }
-        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs), prefix);
+        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs),
+                       prefixV0);
       }
     }
+    setTrackSelectionFromFile(prefixChild);
   }
 
-  /// This function investigates a given selection criterion. The available options are displayed in the terminal and the bit-wise container is put together according to the user input
-  /// \tparam T1 Selection class under investigation
-  /// \param T2  Selection type under investigation
-  /// \param output Bit-wise container for the systematic variations
-  /// \param counter Current position in the bit-wise container to modify
-  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
-  /// \param selectionType Selection type under investigation, as defined in the selection class
+  /// This function investigates a given selection criterion. The available
+  /// options are displayed in the terminal and the bit-wise container is put
+  /// together according to the user input \tparam T1 Selection class under
+  /// investigation \param T2  Selection type under investigation \param output
+  /// Bit-wise container for the systematic variations \param counter Current
+  /// position in the bit-wise container to modify \tparam objectSelection
+  /// Selection class under investigation (FemtoDreamTrack/V0/../Selection)
+  /// \param selectionType Selection type under investigation, as defined in the
+  /// selection class
   template <typename T1, typename T2>
-  void checkForSelection(aod::femtodreamparticle::cutContainerType& output, size_t& counter, T1 objectSelection, T2 selectionType)
-  {
+  void checkForSelection(aod::femtodreamparticle::cutContainerType &output,
+                         size_t &counter, T1 objectSelection,
+                         T2 selectionType) {
     /// Output of the available selections and user input
-    std::cout << "Selection: " << objectSelection.getSelectionHelper(selectionType) << " - (";
+    std::cout << "Selection: "
+              << objectSelection.getSelectionHelper(selectionType) << " - (";
     auto selVec = objectSelection.getSelections(selectionType);
     for (auto selIt : selVec) {
       std::cout << selIt.getSelectionValue() << " ";
@@ -183,10 +197,12 @@ class FemtoDreamCutculator
     std::cin >> in;
     const float input = std::stof(in);
 
-    /// First we check whether the input is actually contained within the options
+    /// First we check whether the input is actually contained within the
+    /// options
     bool inputSane = false;
     for (auto sel : selVec) {
-      if (std::abs(sel.getSelectionValue() - input) <= std::abs(1.e-6 * input)) {
+      if (std::abs(sel.getSelectionValue() - input) <=
+          std::abs(1.e-6 * input)) {
         inputSane = true;
       }
     }
@@ -197,20 +213,21 @@ class FemtoDreamCutculator
       for (auto sel : selVec) {
         double signOffset;
         switch (sel.getSelectionType()) {
-          case femtoDreamSelection::SelectionType::kEqual:
-            signOffset = 0.;
-            break;
-          case (femtoDreamSelection::SelectionType::kLowerLimit):
-          case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
-            signOffset = 1.;
-            break;
-          case (femtoDreamSelection::SelectionType::kUpperLimit):
-          case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
-            signOffset = -1.;
-            break;
+        case femtoDreamSelection::SelectionType::kEqual:
+          signOffset = 0.;
+          break;
+        case (femtoDreamSelection::SelectionType::kLowerLimit):
+        case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
+          signOffset = 1.;
+          break;
+        case (femtoDreamSelection::SelectionType::kUpperLimit):
+        case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
+          signOffset = -1.;
+          break;
         }
 
-        /// for upper and lower limit we have to subtract/add an epsilon so that the cut is actually fulfilled
+        /// for upper and lower limit we have to subtract/add an epsilon so that
+        /// the cut is actually fulfilled
         if (sel.isSelected(input + signOffset * 1.e-6 * input)) {
           output |= 1UL << counter;
           for (int i = internal_index; i > 0; i--) {
@@ -226,13 +243,15 @@ class FemtoDreamCutculator
     }
   }
 
-  /// This function iterates over all selection types of a given class and puts together the bit-wise container
-  /// \tparam T1 Selection class under investigation
-  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
-  /// \return the full selection bit-wise container that will be put to the user task incorporating the user choice of selections
+  /// This function iterates over all selection types of a given class and puts
+  /// together the bit-wise container \tparam T1 Selection class under
+  /// investigation \tparam objectSelection Selection class under investigation
+  /// (FemtoDreamTrack/V0/../Selection) \return the full selection bit-wise
+  /// container that will be put to the user task incorporating the user choice
+  /// of selections
   template <typename T>
-  aod::femtodreamparticle::cutContainerType iterateSelection(T objectSelection)
-  {
+  aod::femtodreamparticle::cutContainerType
+  iterateSelection(T objectSelection) {
     aod::femtodreamparticle::cutContainerType output = 0;
     size_t counter = 0;
     auto selectionVariables = objectSelection.getSelectionVariables();
@@ -242,9 +261,9 @@ class FemtoDreamCutculator
     return output;
   }
 
-  /// This is the function called by the executable that then outputs the full selection bit-wise container incorporating the user choice of selections
-  void analyseCuts()
-  {
+  /// This is the function called by the executable that then outputs the full
+  /// selection bit-wise container incorporating the user choice of selections
+  void analyseCuts() {
     std::cout << "Do you want to work with tracks/v0/cascade (T/V/C)?\n";
     std::cout << " > ";
     std::string in;
@@ -257,10 +276,12 @@ class FemtoDreamCutculator
     } else if (in.compare("C") == 0) {
       // output =  iterateSelection(mCascadeSel);
     } else {
-      std::cout << "Option " << in << " not recognized - available options are (T/V/C) \n";
+      std::cout << "Option " << in
+                << " not recognized - available options are (T/V/C) \n";
       analyseCuts();
     }
-    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)> bitOutput = output;
+    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)>
+        bitOutput = output;
     std::cout << "+++++++++++++++++++++++++++++++++\n";
     std::cout << "CutCulator has spoken - your selection bit is\n";
     std::cout << bitOutput << " (bitwise)\n";
@@ -272,11 +293,15 @@ class FemtoDreamCutculator
     }
   }
 
- private:
-  boost::property_tree::ptree mConfigTree;     ///< the dpl-config.json buffered into a ptree
-  FemtoDreamTrackSelection mTrackSel;          ///< for setting up the bit-wise selection container for tracks
-  FemtoDreamV0Selection mV0Sel;                ///< for setting up the bit-wise selection container for V0s
-  std::vector<o2::track::PID::ID> mPIDspecies; ///< list of particle species for which PID is stored
+private:
+  boost::property_tree::ptree
+      mConfigTree; ///< the dpl-config.json buffered into a ptree
+  FemtoDreamTrackSelection
+      mTrackSel; ///< for setting up the bit-wise selection container for tracks
+  FemtoDreamV0Selection
+      mV0Sel; ///< for setting up the bit-wise selection container for V0s
+  std::vector<o2::track::PID::ID>
+      mPIDspecies; ///< list of particle species for which PID is stored
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -68,14 +68,11 @@ class FemtoDreamPairCleaner
         LOG(fatal) << "FemtoDreamPairCleaner: passed arguments don't agree with FemtoDreamPairCleaner instantiation! Please provide second argument kV0 candidate.";
         return false;
       }
-      // TODO fix pair cleaner
-      // uint64_t id1 = part2.index() - 2;
-      // uint64_t id2 = part2.index() - 1;
-      // auto daughter1 = particles.begin() + id1;
-      // auto daughter2 = particles.begin() + id2;
-      // if ((*daughter1).indices()[0] <= 0 && (*daughter1).indices()[1] <= 0 && (*daughter2).indices()[0] <= 0 && (*daughter2).indices()[1] <= 0) {
-      //   return true;
-      // }
+      const auto& posChild = particles.iteratorAt(part2.index() - 2);
+      const auto& negChild = particles.iteratorAt(part2.index() - 1);
+      if (part1.globalIndex() != posChild.globalIndex() || part2.globalIndex() != negChild.globalIndex()) {
+        return true;
+      }
       return false;
     } else {
       LOG(fatal) << "FemtoDreamPairCleaner: Combination of objects not defined - quitting!";

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -68,13 +68,14 @@ class FemtoDreamPairCleaner
         LOG(fatal) << "FemtoDreamPairCleaner: passed arguments don't agree with FemtoDreamPairCleaner instantiation! Please provide second argument kV0 candidate.";
         return false;
       }
-      uint64_t id1 = part2.index() - 2;
-      uint64_t id2 = part2.index() - 1;
-      auto daughter1 = particles.begin() + id1;
-      auto daughter2 = particles.begin() + id2;
-      if ((*daughter1).indices()[0] <= 0 && (*daughter1).indices()[1] <= 0 && (*daughter2).indices()[0] <= 0 && (*daughter2).indices()[1] <= 0) {
-        return true;
-      }
+      // TODO fix pair cleaner
+      // uint64_t id1 = part2.index() - 2;
+      // uint64_t id2 = part2.index() - 1;
+      // auto daughter1 = particles.begin() + id1;
+      // auto daughter2 = particles.begin() + id2;
+      // if ((*daughter1).indices()[0] <= 0 && (*daughter1).indices()[1] <= 0 && (*daughter2).indices()[0] <= 0 && (*daughter2).indices()[1] <= 0) {
+      //   return true;
+      // }
       return false;
     } else {
       LOG(fatal) << "FemtoDreamPairCleaner: Combination of objects not defined - quitting!";

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -61,6 +61,40 @@ class FemtoDreamParticleHisto
     }
   }
 
+  // comment
+  template <o2::aod::femtodreamMCparticle::MCType mc>
+  void init_debug(std::string folderName)
+  {
+    std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[mc]).c_str();
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedOverFindable").c_str(), "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedRows").c_str(), "; TPC crossed rows; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindableVsCrossed").c_str(), ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{20, 0.5, 4.05}, {500, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+  }
+
   /// Initializes specialized Monte Carlo particle histograms
   /// internal function called by init only in case of Monte Carlo truth
   /// \tparam T type of the axis Object
@@ -71,20 +105,28 @@ class FemtoDreamParticleHisto
   template <typename T>
   void init_MC(std::string folderName, std::string tempFitVarAxisTitle, T& tempFitVarpTAxis, T& tempFitVarAxis)
   {
-
     /// Particle-type specific histograms
+    std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str();
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
       /// Track histograms
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_Material").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_Fake").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_DaughterLambda").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_DaughterSigmaplus").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_Primary").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str() + "/hDCAxy_Daughter").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hPt_MC").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hEta_MC").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hPhi_MC").c_str(), "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
+      mHistogramRegistry->add((folderName + folderSuffix + "FullTrackQA_MC/hPDG").c_str(), "; PDG; Entries", kTH1I, {{6001, -3000, 3000}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{8, 0, 7}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hNoMCtruthCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Material").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Fake").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterLambda").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterSigmaplus").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Primary").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Daughter").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
     } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
       /// V0 histograms
+      ///  to be implemented
     } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       /// Cascade histograms
+      /// to be implemented
     } else {
       LOG(fatal) << "FemtoDreamParticleHisto: Histogramming for requested object not defined - quitting!";
     }
@@ -99,7 +141,7 @@ class FemtoDreamParticleHisto
   /// \param tempFitVarBins binning of the tempFitVar (DCA_xy in case of tracks, CPA in case of V0s, etc.)
   /// \param isMC add Monte Carlo truth histograms to the output file
   template <typename T>
-  void init(HistogramRegistry* registry, T& tempFitVarpTBins, T& tempFitVarBins, bool isMC)
+  void init(HistogramRegistry* registry, T& tempFitVarpTBins, T& tempFitVarBins, bool isMC, bool isDebug = false)
   {
     if (registry) {
       mHistogramRegistry = registry;
@@ -125,6 +167,9 @@ class FemtoDreamParticleHisto
 
       // Fill here the actual histogramms by calling init_base and init_MC
       init_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, tempFitVarAxisTitle, tempFitVarpTAxis, tempFitVarAxis);
+      if (isDebug) {
+        init_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName);
+      }
       if (isMC) {
         init_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(folderName, tempFitVarAxisTitle, tempFitVarpTAxis, tempFitVarAxis);
         init_MC(folderName, tempFitVarAxisTitle, tempFitVarpTAxis, tempFitVarAxis);
@@ -150,6 +195,38 @@ class FemtoDreamParticleHisto
     }
   }
 
+  template <o2::aod::femtodreamMCparticle::MCType mc, typename T>
+  void fillQA_debug(T const& part)
+  {
+    // Histograms holding further debug information
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedOverFindable"), part.tpcCrossedRowsOverFindableCls());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedRows"), part.tpcNClsCrossedRows());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindableVsCrossed"), part.tpcNClsFindable(), part.tpcNClsCrossedRows());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCshared"), part.tpcNClsShared());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclusters"), part.itsNCls());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclustersIB"), part.itsNClsInnerBarrel());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCAz"), part.pt(), part.dcaZ());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCA"), part.pt(), std::sqrt(std::pow(part.dcaXY(), 2.) + std::pow(part.dcaZ(), 2.)));
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCdEdX"), part.p(), part.tpcSignal());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_pi"), part.p(), part.tpcNSigmaPi());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_K"), part.p(), part.tpcNSigmaKa());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_p"), part.p(), part.tpcNSigmaPr());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_d"), part.p(), part.tpcNSigmaDe());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_el"), part.p(), part.tofNSigmaEl());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_pi"), part.p(), part.tofNSigmaPi());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_K"), part.p(), part.tofNSigmaKa());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_p"), part.p(), part.tofNSigmaPr());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_d"), part.p(), part.tofNSigmaDe());
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_el"), part.p(), std::sqrt(part.tpcNSigmaEl() * part.tpcNSigmaEl() + part.tofNSigmaEl() * part.tofNSigmaEl()));
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_pi"), part.p(), std::sqrt(part.tpcNSigmaPi() * part.tpcNSigmaPi() + part.tofNSigmaPi() * part.tofNSigmaPi()));
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_K"), part.p(), std::sqrt(part.tpcNSigmaKa() * part.tpcNSigmaKa() + part.tofNSigmaKa() * part.tofNSigmaKa()));
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_p"), part.p(), std::sqrt(part.tpcNSigmaPr() * part.tpcNSigmaPr() + part.tofNSigmaPr() * part.tofNSigmaPr()));
+    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_d"), part.p(), std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
+  }
+
   /// Filling specialized histograms for Monte Carlo truth
   /// internal function called by init only in case of Monte Carlo truth
   /// \tparam T Data type of the particle
@@ -159,7 +236,6 @@ class FemtoDreamParticleHisto
   void fillQA_MC(T const& part, int mctruthorigin)
   {
     if (mHistogramRegistry) {
-
       if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
         /// Track histograms
         switch (mctruthorigin) {
@@ -210,17 +286,21 @@ class FemtoDreamParticleHisto
   /// \tparam T particle type
   /// \tparam isMC fills the additional histograms for Monte Carlo truth
   /// \param part particle for which the histograms should be filled
-  template <bool isMC, typename T>
+  template <bool isMC, bool isDebug, typename T>
   void fillQA(T const& part)
   {
     std::string tempFitVarName;
     if (mHistogramRegistry) {
-
       fillQA_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(part);
+      if constexpr (isDebug) {
+        fillQA_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(part);
+      }
       if constexpr (isMC) {
         if (part.has_femtoDreamMCParticle()) {
           fillQA_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(part.femtoDreamMCParticle());
           fillQA_MC(part, (part.femtoDreamMCParticle()).partOriginMCTruth());
+        } else {
+          mHistogramRegistry->fill(HIST("Tracks/hNoMCtruthCounter"), 1);
         }
       }
     }

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -66,33 +66,47 @@ class FemtoDreamParticleHisto
   void init_debug(std::string folderName)
   {
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[mc]).c_str();
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedOverFindable").c_str(), "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedRows").c_str(), "; TPC crossed rows; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindableVsCrossed").c_str(), ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{20, 0.5, 4.05}, {500, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+      mHistogramRegistry->add((folderName + folderSuffix + "/hCharge").c_str(), "; Charge; Entries", kTH1F, {{5, -2.5, 2.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedOverFindable").c_str(), "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCcrossedRows").c_str(), "; TPC crossed rows; Entries", kTH1F, {{163, -0.5, 162.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindableVsCrossed").c_str(), ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{20, 0.5, 4.05}, {500, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, 0, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, 0, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, 0, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, 0, 5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, 0, 5}});
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDaughDCA").c_str(), "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTransRadius").c_str(), "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hCPA").c_str(), "; #it{cos #theta_{p}}; Entries", kTH1F, {{1000, 0.9, 1.}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hCPAvsPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}", kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {{600, 0.f, 3.f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {{600, 0.f, 3.f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {{600, 0.f, 3.f}, {600, 0.f, 3.f}});
+    }
   }
 
   /// Initializes specialized Monte Carlo particle histograms
@@ -107,7 +121,7 @@ class FemtoDreamParticleHisto
   {
     /// Particle-type specific histograms
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str();
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
       /// Track histograms
       mHistogramRegistry->add((folderName + folderSuffix + "/hPt_MC").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hEta_MC").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
@@ -147,7 +161,7 @@ class FemtoDreamParticleHisto
       mHistogramRegistry = registry;
       /// The folder names are defined by the type of the object and the suffix (if applicable)
       std::string tempFitVarAxisTitle;
-      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
+      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
         /// Track histograms
         tempFitVarAxisTitle = "DCA_{xy} (cm)";
       } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
@@ -199,32 +213,46 @@ class FemtoDreamParticleHisto
   void fillQA_debug(T const& part)
   {
     // Histograms holding further debug information
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedOverFindable"), part.tpcCrossedRowsOverFindableCls());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedRows"), part.tpcNClsCrossedRows());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindableVsCrossed"), part.tpcNClsFindable(), part.tpcNClsCrossedRows());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCshared"), part.tpcNClsShared());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclusters"), part.itsNCls());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclustersIB"), part.itsNClsInnerBarrel());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCAz"), part.pt(), part.dcaZ());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCA"), part.pt(), std::sqrt(std::pow(part.dcaXY(), 2.) + std::pow(part.dcaZ(), 2.)));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCdEdX"), part.p(), part.tpcSignal());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_pi"), part.p(), part.tpcNSigmaPi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_K"), part.p(), part.tpcNSigmaKa());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_p"), part.p(), part.tpcNSigmaPr());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_d"), part.p(), part.tpcNSigmaDe());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_el"), part.p(), part.tofNSigmaEl());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_pi"), part.p(), part.tofNSigmaPi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_K"), part.p(), part.tofNSigmaKa());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_p"), part.p(), part.tofNSigmaPr());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_d"), part.p(), part.tofNSigmaDe());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_el"), part.p(), std::sqrt(part.tpcNSigmaEl() * part.tpcNSigmaEl() + part.tofNSigmaEl() * part.tofNSigmaEl()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_pi"), part.p(), std::sqrt(part.tpcNSigmaPi() * part.tpcNSigmaPi() + part.tofNSigmaPi() * part.tofNSigmaPi()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_K"), part.p(), std::sqrt(part.tpcNSigmaKa() * part.tpcNSigmaKa() + part.tofNSigmaKa() * part.tofNSigmaKa()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_p"), part.p(), std::sqrt(part.tpcNSigmaPr() * part.tpcNSigmaPr() + part.tofNSigmaPr() * part.tofNSigmaPr()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_d"), part.p(), std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCharge"), part.sign());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedOverFindable"), part.tpcCrossedRowsOverFindableCls());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCcrossedRows"), part.tpcNClsCrossedRows());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindableVsCrossed"), part.tpcNClsFindable(), part.tpcNClsCrossedRows());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCshared"), part.tpcNClsShared());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclusters"), part.itsNCls());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hITSclustersIB"), part.itsNClsInnerBarrel());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCAz"), part.pt(), part.dcaZ());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDCA"), part.pt(), std::sqrt(std::pow(part.dcaXY(), 2.) + std::pow(part.dcaZ(), 2.)));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCdEdX"), part.p(), part.tpcSignal());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_pi"), part.p(), part.tpcNSigmaPi());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_K"), part.p(), part.tpcNSigmaKa());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_p"), part.p(), part.tpcNSigmaPr());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTPC_d"), part.p(), part.tpcNSigmaDe());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_el"), part.p(), part.tofNSigmaEl());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_pi"), part.p(), part.tofNSigmaPi());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_K"), part.p(), part.tofNSigmaKa());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_p"), part.p(), part.tofNSigmaPr());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaTOF_d"), part.p(), part.tofNSigmaDe());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_el"), part.p(), std::sqrt(part.tpcNSigmaEl() * part.tpcNSigmaEl() + part.tofNSigmaEl() * part.tofNSigmaEl()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_pi"), part.p(), std::sqrt(part.tpcNSigmaPi() * part.tpcNSigmaPi() + part.tofNSigmaPi() * part.tofNSigmaPi()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_K"), part.p(), std::sqrt(part.tpcNSigmaKa() * part.tpcNSigmaKa() + part.tofNSigmaKa() * part.tofNSigmaKa()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_p"), part.p(), std::sqrt(part.tpcNSigmaPr() * part.tpcNSigmaPr() + part.tofNSigmaPr() * part.tofNSigmaPr()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_d"), part.p(), std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDaughDCA"), part.daughDCA());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTransRadius"), part.transRadius());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxX"), part.decayVtxX());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxY"), part.decayVtxY());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxZ"), part.decayVtxZ());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCPA"), part.tempFitVar());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCPAvsPt"), part.pt(), part.tempFitVar());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambda"), part.mLambda());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassAntiLambda"), part.mAntiLambda());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
+    }
   }
 
   /// Filling specialized histograms for Monte Carlo truth
@@ -236,7 +264,7 @@ class FemtoDreamParticleHisto
   void fillQA_MC(T const& part, int mctruthorigin)
   {
     if (mHistogramRegistry) {
-      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
+      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
         /// Track histograms
         switch (mctruthorigin) {
           case (o2::aod::femtodreamMCparticle::kPrimary):
@@ -299,18 +327,16 @@ class FemtoDreamParticleHisto
         if (part.has_femtoDreamMCParticle()) {
           fillQA_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(part.femtoDreamMCParticle());
           fillQA_MC(part, (part.femtoDreamMCParticle()).partOriginMCTruth());
-        } else {
-          mHistogramRegistry->fill(HIST("Tracks/hNoMCtruthCounter"), 1);
         }
       }
     }
   }
 
  private:
-  HistogramRegistry* mHistogramRegistry;                                                   ///< For QA output
-  static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType; ///< Type of the particle under analysis
-  static constexpr int mFolderSuffixType = suffixType;                                     ///< Counter for the folder suffix specified below
-  static constexpr std::string_view mFolderSuffix[3] = {"", "_one", "_two"};               ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
+  HistogramRegistry* mHistogramRegistry;                                                     ///< For QA output
+  static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType;   ///< Type of the particle under analysis
+  static constexpr int mFolderSuffixType = suffixType;                                       ///< Counter for the folder suffix specified below
+  static constexpr std::string_view mFolderSuffix[5] = {"", "_one", "_two", "_pos", "_neg"}; ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -27,7 +27,6 @@
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/TrackSelectionDefaults.h"
 #include "FemtoDreamObjectSelection.h"
-
 #include "ReconstructionDataFormats/PID.h"
 #include "Framework/HistogramRegistry.h"
 

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -116,11 +116,10 @@ class FemtoDreamV0Selection
     }
   }
 
-  /// Helper function to obtain the name of a given selection criterion for
-  /// consistent naming of the configurables \param iSel Track selection
-  /// variable to be examined \param prefix Additional prefix for the name of
-  /// the configurable \param suffix Additional suffix for the name of the
-  /// configurable
+  /// Helper function to obtain the name of a given selection criterion for consistent naming of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the name of the configurable
+  /// \param suffix Additional suffix for the name of the configurable
   static std::string getSelectionName(femtoDreamV0Selection::V0Sel iSel,
                                       std::string_view prefix = "",
                                       std::string_view suffix = "")
@@ -131,10 +130,9 @@ class FemtoDreamV0Selection
     return outString;
   }
 
-  /// Helper function to obtain the index of a given selection variable for
-  /// consistent naming of the configurables \param obs V0 selection variable
-  /// (together with prefix) got from file \param prefix Additional prefix for
-  /// the output of the configurable
+  /// Helper function to obtain the index of a given selection variable for consistent naming of the configurables
+  /// \param obs V0 selection variable (together with prefix) got from file
+  /// \param prefix Additional prefix for the output of the configurable
   static int findSelectionIndex(const std::string_view& obs,
                                 std::string_view prefix = "")
   {
@@ -149,9 +147,8 @@ class FemtoDreamV0Selection
     return -1;
   }
 
-  /// Helper function to obtain the type of a given selection variable for
-  /// consistent naming of the configurables \param iSel V0 selection variable
-  /// whose type is returned
+  /// Helper function to obtain the type of a given selection variable for consistent naming of the configurables
+  /// \param iSel V0 selection variable whose type is returned
   static femtoDreamSelection::SelectionType
     getSelectionType(femtoDreamV0Selection::V0Sel iSel)
   {
@@ -159,9 +156,9 @@ class FemtoDreamV0Selection
   }
 
   /// Helper function to obtain the helper string of a given selection criterion
-  /// for consistent description of the configurables \param iSel Track
-  /// selection variable to be examined \param prefix Additional prefix for the
-  /// output of the configurable
+  /// for consistent description of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the output of the configurable
   static std::string getSelectionHelper(femtoDreamV0Selection::V0Sel iSel,
                                         std::string_view prefix = "")
   {
@@ -195,8 +192,7 @@ class FemtoDreamV0Selection
   }
 
   void
-    setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child,
-                                      bool reject)
+    setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child, bool reject)
   {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setRejectNotPropagatedTracks(reject);
@@ -205,8 +201,7 @@ class FemtoDreamV0Selection
     }
   }
 
-  void setChildnSigmaPIDOffset(femtoDreamV0Selection::ChildTrackType child,
-                               float offsetTPC, float offsetTOF)
+  void setChildnSigmaPIDOffset(femtoDreamV0Selection::ChildTrackType child, float offsetTPC, float offsetTOF)
   {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setnSigmaPIDOffset(offsetTPC, offsetTOF);

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -11,10 +11,9 @@
 
 /// \file FemtoDreamV0Selection.h
 /// \brief Definition of the FemtoDreamV0Selection
-/// \author Valentina Mantovani Sarti, TU München
-/// valentina.mantovani-sarti@tum.de \author Andi Mathis, TU München,
-/// andreas.mathis@ph.tum.de \author Luca Barioglio, TU München,
-/// luca.barioglio@cern.ch
+/// \author Valentina Mantovani Sarti, TU München valentina.mantovani-sarti@tum.de
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTODREAMV0SELECTION_H_
 #define PWGCF_FEMTODREAM_FEMTODREAMV0SELECTION_H_

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -33,8 +33,10 @@
 
 using namespace o2::framework;
 
-namespace o2::analysis::femtoDream {
-namespace femtoDreamV0Selection {
+namespace o2::analysis::femtoDream
+{
+namespace femtoDreamV0Selection
+{
 /// The different selections this task is capable of doing
 enum V0Sel {
   kV0Sign, ///< +1 particle, -1 antiparticle
@@ -47,7 +49,8 @@ enum V0Sel {
   kV0DecVtxMax
 };
 
-enum ChildTrackType { kPosTrack, kNegTrack };
+enum ChildTrackType { kPosTrack,
+                      kNegTrack };
 
 enum V0ContainerPosition {
   kV0,
@@ -62,45 +65,41 @@ enum V0ContainerPosition {
 /// \class FemtoDreamV0Selection
 /// \brief Cut class to contain and execute all cuts applied to V0s
 class FemtoDreamV0Selection
-    : public FemtoDreamObjectSelection<float, femtoDreamV0Selection::V0Sel> {
-public:
+  : public FemtoDreamObjectSelection<float, femtoDreamV0Selection::V0Sel>
+{
+ public:
   FemtoDreamV0Selection()
-      : nPtV0MinSel(0), nPtV0MaxSel(0), nDCAV0DaughMax(0), nCPAV0Min(0),
-        nTranRadV0Min(0), nTranRadV0Max(0), nDecVtxMax(0), pTV0Min(9999999.),
-        pTV0Max(-9999999.), DCAV0DaughMax(-9999999.), CPAV0Min(9999999.),
-        TranRadV0Min(9999999.), TranRadV0Max(-9999999.), DecVtxMax(-9999999.),
-        fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false),
-        fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515),
-        nSigmaPIDOffsetTPC(0.) {}
+    : nPtV0MinSel(0), nPtV0MaxSel(0), nDCAV0DaughMax(0), nCPAV0Min(0), nTranRadV0Min(0), nTranRadV0Max(0), nDecVtxMax(0), pTV0Min(9999999.), pTV0Max(-9999999.), DCAV0DaughMax(-9999999.), CPAV0Min(9999999.), TranRadV0Min(9999999.), TranRadV0Max(-9999999.), DecVtxMax(-9999999.), fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false), fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515), nSigmaPIDOffsetTPC(0.) {}
   /// Initializes histograms for the task
   template <o2::aod::femtodreamparticle::ParticleType part,
             o2::aod::femtodreamparticle::ParticleType daugh,
             typename cutContainerType>
-  void init(HistogramRegistry *registry);
+  void init(HistogramRegistry* registry);
 
   template <typename C, typename V, typename T>
-  bool isSelectedMinimal(C const &col, V const &v0, T const &posTrack,
-                         T const &negTrack);
+  bool isSelectedMinimal(C const& col, V const& v0, T const& posTrack,
+                         T const& negTrack);
 
   template <typename C, typename V, typename T>
-  void fillLambdaQA(C const &col, V const &v0, T const &posTrack,
-                    T const &negTrack);
+  void fillLambdaQA(C const& col, V const& v0, T const& posTrack,
+                    T const& negTrack);
 
   /// \todo for the moment the PID of the tracks is factored out into a separate
   /// field, hence 5 values in total \\ASK: what does it mean?
   template <typename cutContainerType, typename C, typename V, typename T>
-  std::array<cutContainerType, 5> getCutContainer(C const &col, V const &v0,
-                                                  T const &posTrack,
-                                                  T const &negTrack);
+  std::array<cutContainerType, 5> getCutContainer(C const& col, V const& v0,
+                                                  T const& posTrack,
+                                                  T const& negTrack);
 
   template <o2::aod::femtodreamparticle::ParticleType part,
             o2::aod::femtodreamparticle::ParticleType daugh, typename C,
             typename V, typename T>
-  void fillQA(C const &col, V const &v0, T const &posTrack, T const &negTrack);
+  void fillQA(C const& col, V const& v0, T const& posTrack, T const& negTrack);
 
   template <typename T1, typename T2>
   void setChildCuts(femtoDreamV0Selection::ChildTrackType child, T1 selVal,
-                    T2 selVar, femtoDreamSelection::SelectionType selType) {
+                    T2 selVar, femtoDreamSelection::SelectionType selType)
+  {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setSelection(selVal, selVar, selType);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -109,7 +108,8 @@ public:
   }
   template <typename T>
   void setChildPIDSpecies(femtoDreamV0Selection::ChildTrackType child,
-                          T &pids) {
+                          T& pids)
+  {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setPIDSpecies(pids);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -124,7 +124,8 @@ public:
   /// configurable
   static std::string getSelectionName(femtoDreamV0Selection::V0Sel iSel,
                                       std::string_view prefix = "",
-                                      std::string_view suffix = "") {
+                                      std::string_view suffix = "")
+  {
     std::string outString = static_cast<std::string>(prefix);
     outString += static_cast<std::string>(mSelectionNames[iSel]);
     outString += suffix;
@@ -135,8 +136,9 @@ public:
   /// consistent naming of the configurables \param obs V0 selection variable
   /// (together with prefix) got from file \param prefix Additional prefix for
   /// the output of the configurable
-  static int findSelectionIndex(const std::string_view &obs,
-                                std::string_view prefix = "") {
+  static int findSelectionIndex(const std::string_view& obs,
+                                std::string_view prefix = "")
+  {
     for (int index = 0; index < kNv0Selection; index++) {
       std::string comp = static_cast<std::string>(prefix) +
                          static_cast<std::string>(mSelectionNames[index]);
@@ -152,7 +154,8 @@ public:
   /// consistent naming of the configurables \param iSel V0 selection variable
   /// whose type is returned
   static femtoDreamSelection::SelectionType
-  getSelectionType(femtoDreamV0Selection::V0Sel iSel) {
+    getSelectionType(femtoDreamV0Selection::V0Sel iSel)
+  {
     return mSelectionTypes[iSel];
   }
 
@@ -161,7 +164,8 @@ public:
   /// selection variable to be examined \param prefix Additional prefix for the
   /// output of the configurable
   static std::string getSelectionHelper(femtoDreamV0Selection::V0Sel iSel,
-                                        std::string_view prefix = "") {
+                                        std::string_view prefix = "")
+  {
     std::string outString = static_cast<std::string>(prefix);
     outString += static_cast<std::string>(mSelectionHelper[iSel]);
     return outString;
@@ -170,7 +174,8 @@ public:
   /// Set limit for the selection on the invariant mass
   /// \param lowLimit Lower limit for the invariant mass distribution
   /// \param upLimit Upper limit for the invariant mass distribution
-  void setInvMassLimits(float lowLimit, float upLimit) {
+  void setInvMassLimits(float lowLimit, float upLimit)
+  {
     fInvMassLowLimit = lowLimit;
     fInvMassUpLimit = upLimit;
   }
@@ -178,19 +183,22 @@ public:
   /// Set limit for the kaon rejection on the invariant mass
   /// \param lowLimit Lower limit for the invariant mass distribution
   /// \param upLimit Upper limit for the invariant mass distribution
-  void setKaonInvMassLimits(float lowLimit, float upLimit) {
+  void setKaonInvMassLimits(float lowLimit, float upLimit)
+  {
     fRejectKaon = true;
     fInvMassKaonLowLimit = lowLimit;
     fInvMassKaonUpLimit = upLimit;
   }
 
-  void setnSigmaPIDOffsetTPC(float offsetTPC) {
+  void setnSigmaPIDOffsetTPC(float offsetTPC)
+  {
     nSigmaPIDOffsetTPC = offsetTPC;
   }
 
   void
-  setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child,
-                                    bool reject) {
+    setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child,
+                                      bool reject)
+  {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setRejectNotPropagatedTracks(reject);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -199,7 +207,8 @@ public:
   }
 
   void setChildnSigmaPIDOffset(femtoDreamV0Selection::ChildTrackType child,
-                               float offsetTPC, float offsetTOF) {
+                               float offsetTPC, float offsetTOF)
+  {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setnSigmaPIDOffset(offsetTPC, offsetTOF);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -207,7 +216,7 @@ public:
     }
   }
 
-private:
+ private:
   int nPtV0MinSel;
   int nPtV0MaxSel;
   int nDCAV0DaughMax;
@@ -238,39 +247,40 @@ private:
   static constexpr int kNv0Selection = 8;
 
   static constexpr std::string_view mSelectionNames[kNv0Selection] = {
-      "Sign",       "PtMin",      "PtMax",    "DCAdaughMax", "CPAMin",
-      "TranRadMin", "TranRadMax", "DecVecMax"}; ///< Name of the different
-                                                ///< selections
+    "Sign", "PtMin", "PtMax", "DCAdaughMax", "CPAMin",
+    "TranRadMin", "TranRadMax", "DecVecMax"}; ///< Name of the different
+                                              ///< selections
 
   static constexpr femtoDreamSelection::SelectionType
-      mSelectionTypes[kNv0Selection]{
-          femtoDreamSelection::kEqual,
-          femtoDreamSelection::kLowerLimit,
-          femtoDreamSelection::kUpperLimit,
-          femtoDreamSelection::kUpperLimit,
-          femtoDreamSelection::kLowerLimit,
-          femtoDreamSelection::kLowerLimit,
-          femtoDreamSelection::kUpperLimit,
-          femtoDreamSelection::kUpperLimit}; ///< Map to match a variable with
-                                             ///< its type
+    mSelectionTypes[kNv0Selection]{
+      femtoDreamSelection::kEqual,
+      femtoDreamSelection::kLowerLimit,
+      femtoDreamSelection::kUpperLimit,
+      femtoDreamSelection::kUpperLimit,
+      femtoDreamSelection::kLowerLimit,
+      femtoDreamSelection::kLowerLimit,
+      femtoDreamSelection::kUpperLimit,
+      femtoDreamSelection::kUpperLimit}; ///< Map to match a variable with
+                                         ///< its type
 
   static constexpr std::string_view mSelectionHelper[kNv0Selection] = {
-      "+1 for lambda, -1 for antilambda",
-      "Minimum pT (GeV/c)",
-      "Maximum pT (GeV/c)",
-      "Maximum DCA between daughters (cm)",
-      "Minimum Cosine of Pointing Angle",
-      "Minimum transverse radius (cm)",
-      "Maximum transverse radius (cm)",
-      "Maximum distance from primary vertex"}; ///< Helper information for the
-                                               ///< different selections
+    "+1 for lambda, -1 for antilambda",
+    "Minimum pT (GeV/c)",
+    "Maximum pT (GeV/c)",
+    "Maximum DCA between daughters (cm)",
+    "Minimum Cosine of Pointing Angle",
+    "Minimum transverse radius (cm)",
+    "Maximum transverse radius (cm)",
+    "Maximum distance from primary vertex"}; ///< Helper information for the
+                                             ///< different selections
 
 }; // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part,
           o2::aod::femtodreamparticle::ParticleType daugh,
           typename cutContainerType>
-void FemtoDreamV0Selection::init(HistogramRegistry *registry) {
+void FemtoDreamV0Selection::init(HistogramRegistry* registry)
+{
   if (registry) {
     mHistogramRegistry = registry;
     fillSelectionHistogram<part>();
@@ -288,7 +298,7 @@ void FemtoDreamV0Selection::init(HistogramRegistry *registry) {
                     "container - quitting!";
     }
     std::string folderName = static_cast<std::string>(
-        o2::aod::femtodreamparticle::ParticleTypeName[part]);
+      o2::aod::femtodreamparticle::ParticleTypeName[part]);
     /// \todo initialize histograms for children tracks of v0s
     mHistogramRegistry->add((folderName + "/hPt").c_str(),
                             "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
@@ -328,11 +338,11 @@ void FemtoDreamV0Selection::init(HistogramRegistry *registry) {
     PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
                        aod::femtodreamparticle::TrackType::kPosChild,
                        aod::femtodreamparticle::cutContainerType>(
-        mHistogramRegistry);
+      mHistogramRegistry);
     NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
                        aod::femtodreamparticle::TrackType::kNegChild,
                        aod::femtodreamparticle::cutContainerType>(
-        mHistogramRegistry);
+      mHistogramRegistry);
 
     mHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F,
                             {massAxisLambda});
@@ -383,9 +393,10 @@ void FemtoDreamV0Selection::init(HistogramRegistry *registry) {
 }
 
 template <typename C, typename V, typename T>
-bool FemtoDreamV0Selection::isSelectedMinimal(C const &col, V const &v0,
-                                              T const &posTrack,
-                                              T const &negTrack) {
+bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0,
+                                              T const& posTrack,
+                                              T const& negTrack)
+{
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
@@ -462,8 +473,9 @@ bool FemtoDreamV0Selection::isSelectedMinimal(C const &col, V const &v0,
 }
 
 template <typename C, typename V, typename T>
-void FemtoDreamV0Selection::fillLambdaQA(C const &col, V const &v0,
-                                         T const &posTrack, T const &negTrack) {
+void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0,
+                                         T const& posTrack, T const& negTrack)
+{
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
@@ -522,12 +534,13 @@ void FemtoDreamV0Selection::fillLambdaQA(C const &col, V const &v0,
 /// to pass the collsion as well
 template <typename cutContainerType, typename C, typename V, typename T>
 std::array<cutContainerType, 5>
-FemtoDreamV0Selection::getCutContainer(C const &col, V const &v0,
-                                       T const &posTrack, T const &negTrack) {
+  FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0,
+                                         T const& posTrack, T const& negTrack)
+{
   auto outputPosTrack =
-      PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
+    PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
   auto outputNegTrack =
-      NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
+    NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
   cutContainerType output = 0;
   size_t counter = 0;
 
@@ -570,7 +583,7 @@ FemtoDreamV0Selection::getCutContainer(C const &col, V const &v0,
   const std::vector<float> decVtx = {v0.x(), v0.y(), v0.z()};
 
   float observable = 0.;
-  for (auto &sel : mSelections) {
+  for (auto& sel : mSelections) {
     const auto selVariable = sel.getSelectionVariable();
 
     if (selVariable == femtoDreamV0Selection::kV0DecVtxMax) {
@@ -580,102 +593,103 @@ FemtoDreamV0Selection::getCutContainer(C const &col, V const &v0,
       }
     } else {
       switch (selVariable) {
-      case (femtoDreamV0Selection::kV0Sign):
-        observable = sign;
-        break;
-      case (femtoDreamV0Selection::kV0pTMin):
-        observable = pT;
-        break;
-      case (femtoDreamV0Selection::kV0pTMax):
-        observable = pT;
-        break;
-      case (femtoDreamV0Selection::kV0DCADaughMax):
-        observable = dcaDaughv0;
-        break;
-      case (femtoDreamV0Selection::kV0CPAMin):
-        observable = cpav0;
-        break;
-      case (femtoDreamV0Selection::kV0TranRadMin):
-        observable = tranRad;
-        break;
-      case (femtoDreamV0Selection::kV0TranRadMax):
-        observable = tranRad;
-        break;
-      case (femtoDreamV0Selection::kV0DecVtxMax):
-        break;
+        case (femtoDreamV0Selection::kV0Sign):
+          observable = sign;
+          break;
+        case (femtoDreamV0Selection::kV0pTMin):
+          observable = pT;
+          break;
+        case (femtoDreamV0Selection::kV0pTMax):
+          observable = pT;
+          break;
+        case (femtoDreamV0Selection::kV0DCADaughMax):
+          observable = dcaDaughv0;
+          break;
+        case (femtoDreamV0Selection::kV0CPAMin):
+          observable = cpav0;
+          break;
+        case (femtoDreamV0Selection::kV0TranRadMin):
+          observable = tranRad;
+          break;
+        case (femtoDreamV0Selection::kV0TranRadMax):
+          observable = tranRad;
+          break;
+        case (femtoDreamV0Selection::kV0DecVtxMax):
+          break;
       }
       sel.checkSelectionSetBit(observable, output, counter);
     }
   }
   return {
-      output,
-      outputPosTrack.at(
-          femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-      outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
-      outputNegTrack.at(
-          femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-      outputNegTrack.at(
-          femtoDreamTrackSelection::TrackContainerPosition::kPID)};
+    output,
+    outputPosTrack.at(
+      femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
+    outputNegTrack.at(
+      femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputNegTrack.at(
+      femtoDreamTrackSelection::TrackContainerPosition::kPID)};
 }
 
 template <o2::aod::femtodreamparticle::ParticleType part,
           o2::aod::femtodreamparticle::ParticleType daugh, typename C,
           typename V, typename T>
-void FemtoDreamV0Selection::fillQA(C const &col, V const &v0, T const &posTrack,
-                                   T const &negTrack) {
+void FemtoDreamV0Selection::fillQA(C const& col, V const& v0, T const& posTrack,
+                                   T const& negTrack)
+{
   if (mHistogramRegistry) {
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hPt"),
-        v0.pt());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hPt"),
+      v0.pt());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hEta"),
-        v0.eta());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hEta"),
+      v0.eta());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hPhi"),
-        v0.phi());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hPhi"),
+      v0.phi());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hDaughDCA"),
-        v0.dcaV0daughters());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hDaughDCA"),
+      v0.dcaV0daughters());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hTransRadius"),
-        v0.v0radius());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hTransRadius"),
+      v0.v0radius());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hDecayVtxX"),
-        v0.x());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hDecayVtxX"),
+      v0.x());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hDecayVtxY"),
-        v0.y());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hDecayVtxY"),
+      v0.y());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hDecayVtxZ"),
-        v0.z());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hDecayVtxZ"),
+      v0.z());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hCPA"),
-        v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hCPA"),
+      v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hCPAvsPt"),
-        v0.pt(), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hCPAvsPt"),
+      v0.pt(), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hInvMassLambda"),
-        v0.mLambda());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hInvMassLambda"),
+      v0.mLambda());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hInvMassAntiLambda"),
-        v0.mAntiLambda());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hInvMassAntiLambda"),
+      v0.mAntiLambda());
     mHistogramRegistry->fill(
-        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-            HIST("/hInvMassLambdaAntiLambda"),
-        v0.mLambda(), v0.mAntiLambda());
+      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+        HIST("/hInvMassLambdaAntiLambda"),
+      v0.mLambda(), v0.mAntiLambda());
   }
 
   PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -11,9 +11,10 @@
 
 /// \file FemtoDreamV0Selection.h
 /// \brief Definition of the FemtoDreamV0Selection
-/// \author Valentina Mantovani Sarti, TU München valentina.mantovani-sarti@tum.de
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
-/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \author Valentina Mantovani Sarti, TU München
+/// valentina.mantovani-sarti@tum.de \author Andi Mathis, TU München,
+/// andreas.mathis@ph.tum.de \author Luca Barioglio, TU München,
+/// luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTODREAMV0SELECTION_H_
 #define PWGCF_FEMTODREAM_FEMTODREAMV0SELECTION_H_
@@ -23,31 +24,30 @@
 #include <vector>
 
 #include "FemtoDreamObjectSelection.h"
-#include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamSelection.h"
+#include "FemtoDreamTrackSelection.h"
 
-#include "ReconstructionDataFormats/PID.h"
 #include "Common/Core/RecoDecay.h"
 #include "Framework/HistogramRegistry.h"
+#include "ReconstructionDataFormats/PID.h"
 
 using namespace o2::framework;
 
-namespace o2::analysis::femtoDream
-{
-namespace femtoDreamV0Selection
-{
+namespace o2::analysis::femtoDream {
+namespace femtoDreamV0Selection {
 /// The different selections this task is capable of doing
-enum V0Sel { kV0Sign, ///< +1 particle, -1 antiparticle
-             kpTV0Min,
-             kpTV0Max,
-             kDCAV0DaughMax,
-             kCPAV0Min,
-             kTranRadV0Min,
-             kTranRadV0Max,
-             kDecVtxMax };
+enum V0Sel {
+  kV0Sign, ///< +1 particle, -1 antiparticle
+  kV0pTMin,
+  kV0pTMax,
+  kV0DCADaughMax,
+  kV0CPAMin,
+  kV0TranRadMin,
+  kV0TranRadMax,
+  kV0DecVtxMax
+};
 
-enum ChildTrackType { kPosTrack,
-                      kNegTrack };
+enum ChildTrackType { kPosTrack, kNegTrack };
 
 enum V0ContainerPosition {
   kV0,
@@ -61,49 +61,46 @@ enum V0ContainerPosition {
 
 /// \class FemtoDreamV0Selection
 /// \brief Cut class to contain and execute all cuts applied to V0s
-class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDreamV0Selection::V0Sel>
-{
- public:
-  FemtoDreamV0Selection() : nPtV0MinSel(0),
-                            nPtV0MaxSel(0),
-                            nDCAV0DaughMax(0),
-                            nCPAV0Min(0),
-                            nTranRadV0Min(0),
-                            nTranRadV0Max(0),
-                            nDecVtxMax(0),
-                            pTV0Min(9999999.),
-                            pTV0Max(-9999999.),
-                            DCAV0DaughMax(-9999999.),
-                            CPAV0Min(9999999.),
-                            TranRadV0Min(9999999.),
-                            TranRadV0Max(-9999999.),
-                            DecVtxMax(-9999999.),
-                            fInvMassLowLimit(1.05),
-                            fInvMassUpLimit(1.3),
-                            fRejectKaon(false),
-                            fInvMassKaonLowLimit(0.48),
-                            fInvMassKaonUpLimit(0.515),
-                            nSigmaPIDOffsetTPC(0.) {}
+class FemtoDreamV0Selection
+    : public FemtoDreamObjectSelection<float, femtoDreamV0Selection::V0Sel> {
+public:
+  FemtoDreamV0Selection()
+      : nPtV0MinSel(0), nPtV0MaxSel(0), nDCAV0DaughMax(0), nCPAV0Min(0),
+        nTranRadV0Min(0), nTranRadV0Max(0), nDecVtxMax(0), pTV0Min(9999999.),
+        pTV0Max(-9999999.), DCAV0DaughMax(-9999999.), CPAV0Min(9999999.),
+        TranRadV0Min(9999999.), TranRadV0Max(-9999999.), DecVtxMax(-9999999.),
+        fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false),
+        fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515),
+        nSigmaPIDOffsetTPC(0.) {}
   /// Initializes histograms for the task
-  template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, typename cutContainerType>
-  void init(HistogramRegistry* registry);
+  template <o2::aod::femtodreamparticle::ParticleType part,
+            o2::aod::femtodreamparticle::ParticleType daugh,
+            typename cutContainerType>
+  void init(HistogramRegistry *registry);
 
   template <typename C, typename V, typename T>
-  bool isSelectedMinimal(C const& col, V const& v0, T const& posTrack, T const& negTrack);
+  bool isSelectedMinimal(C const &col, V const &v0, T const &posTrack,
+                         T const &negTrack);
 
   template <typename C, typename V, typename T>
-  void fillLambdaQA(C const& col, V const& v0, T const& posTrack, T const& negTrack);
+  void fillLambdaQA(C const &col, V const &v0, T const &posTrack,
+                    T const &negTrack);
 
-  /// \todo for the moment the PID of the tracks is factored out into a separate field, hence 5 values in total \\ASK: what does it mean?
+  /// \todo for the moment the PID of the tracks is factored out into a separate
+  /// field, hence 5 values in total \\ASK: what does it mean?
   template <typename cutContainerType, typename C, typename V, typename T>
-  std::array<cutContainerType, 5> getCutContainer(C const& col, V const& v0, T const& posTrack, T const& negTrack);
+  std::array<cutContainerType, 5> getCutContainer(C const &col, V const &v0,
+                                                  T const &posTrack,
+                                                  T const &negTrack);
 
-  template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, typename C, typename V, typename T>
-  void fillQA(C const& col, V const& v0, T const& posTrack, T const& negTrack);
+  template <o2::aod::femtodreamparticle::ParticleType part,
+            o2::aod::femtodreamparticle::ParticleType daugh, typename C,
+            typename V, typename T>
+  void fillQA(C const &col, V const &v0, T const &posTrack, T const &negTrack);
 
   template <typename T1, typename T2>
-  void setChildCuts(femtoDreamV0Selection::ChildTrackType child, T1 selVal, T2 selVar, femtoDreamSelection::SelectionType selType)
-  {
+  void setChildCuts(femtoDreamV0Selection::ChildTrackType child, T1 selVal,
+                    T2 selVar, femtoDreamSelection::SelectionType selType) {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setSelection(selVal, selVar, selType);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -111,8 +108,8 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
     }
   }
   template <typename T>
-  void setChildPIDSpecies(femtoDreamV0Selection::ChildTrackType child, T& pids)
-  {
+  void setChildPIDSpecies(femtoDreamV0Selection::ChildTrackType child,
+                          T &pids) {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setPIDSpecies(pids);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -120,25 +117,29 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
     }
   }
 
-  /// Helper function to obtain the name of a given selection criterion for consistent naming of the configurables
-  /// \param iSel Track selection variable to be examined
-  /// \param prefix Additional prefix for the name of the configurable
-  /// \param suffix Additional suffix for the name of the configurable
-  static std::string getSelectionName(femtoDreamV0Selection::V0Sel iSel, std::string_view prefix = "", std::string_view suffix = "")
-  {
+  /// Helper function to obtain the name of a given selection criterion for
+  /// consistent naming of the configurables \param iSel Track selection
+  /// variable to be examined \param prefix Additional prefix for the name of
+  /// the configurable \param suffix Additional suffix for the name of the
+  /// configurable
+  static std::string getSelectionName(femtoDreamV0Selection::V0Sel iSel,
+                                      std::string_view prefix = "",
+                                      std::string_view suffix = "") {
     std::string outString = static_cast<std::string>(prefix);
     outString += static_cast<std::string>(mSelectionNames[iSel]);
     outString += suffix;
     return outString;
   }
 
-  /// Helper function to obtain the index of a given selection variable for consistent naming of the configurables
-  /// \param obs V0 selection variable (together with prefix) got from file
-  /// \param prefix Additional prefix for the output of the configurable
-  static int findSelectionIndex(const std::string_view& obs, std::string_view prefix = "")
-  {
+  /// Helper function to obtain the index of a given selection variable for
+  /// consistent naming of the configurables \param obs V0 selection variable
+  /// (together with prefix) got from file \param prefix Additional prefix for
+  /// the output of the configurable
+  static int findSelectionIndex(const std::string_view &obs,
+                                std::string_view prefix = "") {
     for (int index = 0; index < kNv0Selection; index++) {
-      std::string comp = static_cast<std::string>(prefix) + static_cast<std::string>(mSelectionNames[index]);
+      std::string comp = static_cast<std::string>(prefix) +
+                         static_cast<std::string>(mSelectionNames[index]);
       std::string_view cmp{comp};
       if (obs.compare(cmp) == 0)
         return index;
@@ -147,18 +148,20 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
     return -1;
   }
 
-  /// Helper function to obtain the type of a given selection variable for consistent naming of the configurables
-  /// \param iSel V0 selection variable whose type is returned
-  static femtoDreamSelection::SelectionType getSelectionType(femtoDreamV0Selection::V0Sel iSel)
-  {
+  /// Helper function to obtain the type of a given selection variable for
+  /// consistent naming of the configurables \param iSel V0 selection variable
+  /// whose type is returned
+  static femtoDreamSelection::SelectionType
+  getSelectionType(femtoDreamV0Selection::V0Sel iSel) {
     return mSelectionTypes[iSel];
   }
 
-  /// Helper function to obtain the helper string of a given selection criterion for consistent description of the configurables
-  /// \param iSel Track selection variable to be examined
-  /// \param prefix Additional prefix for the output of the configurable
-  static std::string getSelectionHelper(femtoDreamV0Selection::V0Sel iSel, std::string_view prefix = "")
-  {
+  /// Helper function to obtain the helper string of a given selection criterion
+  /// for consistent description of the configurables \param iSel Track
+  /// selection variable to be examined \param prefix Additional prefix for the
+  /// output of the configurable
+  static std::string getSelectionHelper(femtoDreamV0Selection::V0Sel iSel,
+                                        std::string_view prefix = "") {
     std::string outString = static_cast<std::string>(prefix);
     outString += static_cast<std::string>(mSelectionHelper[iSel]);
     return outString;
@@ -167,8 +170,7 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
   /// Set limit for the selection on the invariant mass
   /// \param lowLimit Lower limit for the invariant mass distribution
   /// \param upLimit Upper limit for the invariant mass distribution
-  void setInvMassLimits(float lowLimit, float upLimit)
-  {
+  void setInvMassLimits(float lowLimit, float upLimit) {
     fInvMassLowLimit = lowLimit;
     fInvMassUpLimit = upLimit;
   }
@@ -176,20 +178,19 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
   /// Set limit for the kaon rejection on the invariant mass
   /// \param lowLimit Lower limit for the invariant mass distribution
   /// \param upLimit Upper limit for the invariant mass distribution
-  void setKaonInvMassLimits(float lowLimit, float upLimit)
-  {
+  void setKaonInvMassLimits(float lowLimit, float upLimit) {
     fRejectKaon = true;
     fInvMassKaonLowLimit = lowLimit;
     fInvMassKaonUpLimit = upLimit;
   }
 
-  void setnSigmaPIDOffsetTPC(float offsetTPC)
-  {
+  void setnSigmaPIDOffsetTPC(float offsetTPC) {
     nSigmaPIDOffsetTPC = offsetTPC;
   }
 
-  void setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child, bool reject)
-  {
+  void
+  setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child,
+                                    bool reject) {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setRejectNotPropagatedTracks(reject);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -197,8 +198,8 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
     }
   }
 
-  void setChildnSigmaPIDOffset(femtoDreamV0Selection::ChildTrackType child, float offsetTPC, float offsetTOF)
-  {
+  void setChildnSigmaPIDOffset(femtoDreamV0Selection::ChildTrackType child,
+                               float offsetTPC, float offsetTOF) {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setnSigmaPIDOffset(offsetTPC, offsetTOF);
     } else if (child == femtoDreamV0Selection::kNegTrack) {
@@ -206,7 +207,7 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
     }
   }
 
- private:
+private:
   int nPtV0MinSel;
   int nPtV0MaxSel;
   int nDCAV0DaughMax;
@@ -237,103 +238,154 @@ class FemtoDreamV0Selection : public FemtoDreamObjectSelection<float, femtoDream
   static constexpr int kNv0Selection = 8;
 
   static constexpr std::string_view mSelectionNames[kNv0Selection] = {
-    "Sign",
-    "PtMin",
-    "PtMax",
-    "DCAdaughMax",
-    "CPAMin",
-    "TranRadMin",
-    "TranRadMax",
-    "DecVecMax"}; ///< Name of the different selections
+      "Sign",       "PtMin",      "PtMax",    "DCAdaughMax", "CPAMin",
+      "TranRadMin", "TranRadMax", "DecVecMax"}; ///< Name of the different
+                                                ///< selections
 
-  static constexpr femtoDreamSelection::SelectionType mSelectionTypes[kNv0Selection]{
-    femtoDreamSelection::kEqual,
-    femtoDreamSelection::kLowerLimit,
-    femtoDreamSelection::kUpperLimit,
-    femtoDreamSelection::kUpperLimit,
-    femtoDreamSelection::kLowerLimit,
-    femtoDreamSelection::kLowerLimit,
-    femtoDreamSelection::kLowerLimit,
-    femtoDreamSelection::kUpperLimit}; ///< Map to match a variable with its type
+  static constexpr femtoDreamSelection::SelectionType
+      mSelectionTypes[kNv0Selection]{
+          femtoDreamSelection::kEqual,
+          femtoDreamSelection::kLowerLimit,
+          femtoDreamSelection::kUpperLimit,
+          femtoDreamSelection::kUpperLimit,
+          femtoDreamSelection::kLowerLimit,
+          femtoDreamSelection::kLowerLimit,
+          femtoDreamSelection::kUpperLimit,
+          femtoDreamSelection::kUpperLimit}; ///< Map to match a variable with
+                                             ///< its type
 
   static constexpr std::string_view mSelectionHelper[kNv0Selection] = {
-    "+1 for lambda, -1 for antilambda",
-    "Minimum pT (GeV/c)",
-    "Maximum pT (GeV/c)",
-    "Maximum DCA between daughters (cm)",
-    "Minimum Cosine of Pointing Angle",
-    "Minimum transverse radius (cm)",
-    "Maximum transverse radius (cm)",
-    "Maximum distance from primary vertex"}; ///< Helper information for the different selections
+      "+1 for lambda, -1 for antilambda",
+      "Minimum pT (GeV/c)",
+      "Maximum pT (GeV/c)",
+      "Maximum DCA between daughters (cm)",
+      "Minimum Cosine of Pointing Angle",
+      "Minimum transverse radius (cm)",
+      "Maximum transverse radius (cm)",
+      "Maximum distance from primary vertex"}; ///< Helper information for the
+                                               ///< different selections
 
 }; // namespace femtoDream
 
-template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, typename cutContainerType>
-void FemtoDreamV0Selection::init(HistogramRegistry* registry)
-{
+template <o2::aod::femtodreamparticle::ParticleType part,
+          o2::aod::femtodreamparticle::ParticleType daugh,
+          typename cutContainerType>
+void FemtoDreamV0Selection::init(HistogramRegistry *registry) {
   if (registry) {
     mHistogramRegistry = registry;
     fillSelectionHistogram<part>();
     fillSelectionHistogram<daugh>();
 
     AxisSpec massAxisLambda = {600, 0.0f, 3.0f, "m_{#Lambda} (GeV/#it{c}^{2})"};
-    AxisSpec massAxisAntiLambda = {600, 0.0f, 3.0f, "m_{#bar{#Lambda}} (GeV/#it{c}^{2})"};
+    AxisSpec massAxisAntiLambda = {600, 0.0f, 3.0f,
+                                   "m_{#bar{#Lambda}} (GeV/#it{c}^{2})"};
 
-    /// \todo this should be an automatic check in the parent class, and the return type should be templated
+    /// \todo this should be an automatic check in the parent class, and the
+    /// return type should be templated
     size_t nSelections = getNSelections();
     if (nSelections > 8 * sizeof(cutContainerType)) {
-      LOG(fatal) << "FemtoDreamV0Cuts: Number of selections to large for your container - quitting!";
+      LOG(fatal) << "FemtoDreamV0Cuts: Number of selections to large for your "
+                    "container - quitting!";
     }
-    std::string folderName = static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[part]);
+    std::string folderName = static_cast<std::string>(
+        o2::aod::femtodreamparticle::ParticleTypeName[part]);
     /// \todo initialize histograms for children tracks of v0s
-    mHistogramRegistry->add((folderName + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{1000, 0, 10}});
-    mHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries", kTH1F, {{1000, -1, 1}});
-    mHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries", kTH1F, {{1000, 0, 2. * M_PI}});
-    mHistogramRegistry->add((folderName + "/hDaughDCA").c_str(), "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
-    mHistogramRegistry->add((folderName + "/hTransRadius").c_str(), "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hCPA").c_str(), "; #it{cos #theta_{p}}; Entries", kTH1F, {{1000, 0.9, 1.}});
-    mHistogramRegistry->add((folderName + "/hCPAvsPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}", kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
-    mHistogramRegistry->add((folderName + "/hInvMassLambda").c_str(), "", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add((folderName + "/hInvMassAntiLambda").c_str(), "", kTH1F, {massAxisAntiLambda});
-    mHistogramRegistry->add((folderName + "/hInvMassLambdaAntiLambda").c_str(), "", kTH2F, {massAxisLambda, massAxisAntiLambda});
+    mHistogramRegistry->add((folderName + "/hPt").c_str(),
+                            "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
+                            {{1000, 0, 10}});
+    mHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries",
+                            kTH1F, {{1000, -1, 1}});
+    mHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries",
+                            kTH1F, {{1000, 0, 2. * M_PI}});
+    mHistogramRegistry->add((folderName + "/hDaughDCA").c_str(),
+                            "; DCA^{daugh} (cm); Entries", kTH1F,
+                            {{1000, 0, 10}});
+    mHistogramRegistry->add((folderName + "/hTransRadius").c_str(),
+                            "; #it{r}_{xy} (cm); Entries", kTH1F,
+                            {{1500, 0, 150}});
+    mHistogramRegistry->add((folderName + "/hDecayVtxX").c_str(),
+                            "; #it{Vtx}_{x} (cm); Entries", kTH1F,
+                            {{2000, 0, 200}});
+    mHistogramRegistry->add((folderName + "/hDecayVtxY").c_str(),
+                            "; #it{Vtx}_{y} (cm)); Entries", kTH1F,
+                            {{2000, 0, 200}});
+    mHistogramRegistry->add((folderName + "/hDecayVtxZ").c_str(),
+                            "; #it{Vtx}_{z} (cm); Entries", kTH1F,
+                            {{2000, 0, 200}});
+    mHistogramRegistry->add((folderName + "/hCPA").c_str(),
+                            "; #it{cos #theta_{p}}; Entries", kTH1F,
+                            {{1000, 0.9, 1.}});
+    mHistogramRegistry->add((folderName + "/hCPAvsPt").c_str(),
+                            "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}",
+                            kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
+    mHistogramRegistry->add((folderName + "/hInvMassLambda").c_str(), "", kTH1F,
+                            {massAxisLambda});
+    mHistogramRegistry->add((folderName + "/hInvMassAntiLambda").c_str(), "",
+                            kTH1F, {massAxisAntiLambda});
+    mHistogramRegistry->add((folderName + "/hInvMassLambdaAntiLambda").c_str(),
+                            "", kTH2F, {massAxisLambda, massAxisAntiLambda});
 
-    PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::TrackType::kPosChild, aod::femtodreamparticle::cutContainerType>(mHistogramRegistry);
-    NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::TrackType::kNegChild, aod::femtodreamparticle::cutContainerType>(mHistogramRegistry);
+    PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kPosChild,
+                       aod::femtodreamparticle::cutContainerType>(
+        mHistogramRegistry);
+    NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kNegChild,
+                       aod::femtodreamparticle::cutContainerType>(
+        mHistogramRegistry);
 
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaInvMassCut", "Invariant mass cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMin", "Minimum Pt cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAV0Daugh", "V0-daughters DCA cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMin", "Minimum transverse radius cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMax", "Maximum transverse radius cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDecVtxMax", "Maximum distance on  decay vertex cut", kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F,
+                            {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaInvMassCut",
+                            "Invariant mass cut", kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMin", "Minimum Pt cut",
+                            kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut",
+                            kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAV0Daugh",
+                            "V0-daughters DCA cut", kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F,
+                            {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMin",
+                            "Minimum transverse radius cut", kTH1F,
+                            {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMax",
+                            "Maximum transverse radius cut", kTH1F,
+                            {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDecVtxMax",
+                            "Maximum distance on  decay vertex cut", kTH1F,
+                            {massAxisLambda});
   }
-  /// check whether the most open cuts are fulfilled - most of this should have already be done by the filters
-  nPtV0MinSel = getNSelections(femtoDreamV0Selection::kpTV0Min);
-  nPtV0MaxSel = getNSelections(femtoDreamV0Selection::kpTV0Max);
-  nDCAV0DaughMax = getNSelections(femtoDreamV0Selection::kDCAV0DaughMax);
-  nCPAV0Min = getNSelections(femtoDreamV0Selection::kCPAV0Min);
-  nTranRadV0Min = getNSelections(femtoDreamV0Selection::kTranRadV0Min);
-  nTranRadV0Max = getNSelections(femtoDreamV0Selection::kTranRadV0Max);
-  nDecVtxMax = getNSelections(femtoDreamV0Selection::kDecVtxMax);
+  /// check whether the most open cuts are fulfilled - most of this should have
+  /// already be done by the filters
+  nPtV0MinSel = getNSelections(femtoDreamV0Selection::kV0pTMin);
+  nPtV0MaxSel = getNSelections(femtoDreamV0Selection::kV0pTMax);
+  nDCAV0DaughMax = getNSelections(femtoDreamV0Selection::kV0DCADaughMax);
+  nCPAV0Min = getNSelections(femtoDreamV0Selection::kV0CPAMin);
+  nTranRadV0Min = getNSelections(femtoDreamV0Selection::kV0TranRadMin);
+  nTranRadV0Max = getNSelections(femtoDreamV0Selection::kV0TranRadMax);
+  nDecVtxMax = getNSelections(femtoDreamV0Selection::kV0DecVtxMax);
 
-  pTV0Min = getMinimalSelection(femtoDreamV0Selection::kpTV0Min, femtoDreamSelection::kLowerLimit);
-  pTV0Max = getMinimalSelection(femtoDreamV0Selection::kpTV0Max, femtoDreamSelection::kUpperLimit);
-  DCAV0DaughMax = getMinimalSelection(femtoDreamV0Selection::kDCAV0DaughMax, femtoDreamSelection::kUpperLimit);
-  CPAV0Min = getMinimalSelection(femtoDreamV0Selection::kCPAV0Min, femtoDreamSelection::kLowerLimit);
-  TranRadV0Min = getMinimalSelection(femtoDreamV0Selection::kTranRadV0Min, femtoDreamSelection::kLowerLimit);
-  TranRadV0Max = getMinimalSelection(femtoDreamV0Selection::kTranRadV0Max, femtoDreamSelection::kUpperLimit);
-  DecVtxMax = getMinimalSelection(femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
+  pTV0Min = getMinimalSelection(femtoDreamV0Selection::kV0pTMin,
+                                femtoDreamSelection::kLowerLimit);
+  pTV0Max = getMinimalSelection(femtoDreamV0Selection::kV0pTMax,
+                                femtoDreamSelection::kUpperLimit);
+  DCAV0DaughMax = getMinimalSelection(femtoDreamV0Selection::kV0DCADaughMax,
+                                      femtoDreamSelection::kUpperLimit);
+  CPAV0Min = getMinimalSelection(femtoDreamV0Selection::kV0CPAMin,
+                                 femtoDreamSelection::kLowerLimit);
+  TranRadV0Min = getMinimalSelection(femtoDreamV0Selection::kV0TranRadMin,
+                                     femtoDreamSelection::kLowerLimit);
+  TranRadV0Max = getMinimalSelection(femtoDreamV0Selection::kV0TranRadMax,
+                                     femtoDreamSelection::kUpperLimit);
+  DecVtxMax = getMinimalSelection(femtoDreamV0Selection::kV0DecVtxMax,
+                                  femtoDreamSelection::kAbsUpperLimit);
 }
 
 template <typename C, typename V, typename T>
-bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0, T const& posTrack, T const& negTrack)
-{
+bool FemtoDreamV0Selection::isSelectedMinimal(C const &col, V const &v0,
+                                              T const &posTrack,
+                                              T const &negTrack) {
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
@@ -349,12 +401,15 @@ bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0, T const
   const float invMassLambda = v0.mLambda();
   const float invMassAntiLambda = v0.mAntiLambda();
 
-  if ((invMassLambda < fInvMassLowLimit || invMassLambda > fInvMassUpLimit) && (invMassAntiLambda < fInvMassLowLimit || invMassAntiLambda > fInvMassUpLimit)) {
+  if ((invMassLambda < fInvMassLowLimit || invMassLambda > fInvMassUpLimit) &&
+      (invMassAntiLambda < fInvMassLowLimit ||
+       invMassAntiLambda > fInvMassUpLimit)) {
     return false;
   }
   if (fRejectKaon) {
     const float invMassKaon = v0.mK0Short();
-    if (invMassKaon > fInvMassKaonLowLimit && invMassKaon < fInvMassKaonUpLimit) {
+    if (invMassKaon > fInvMassKaonLowLimit &&
+        invMassKaon < fInvMassKaonUpLimit) {
       return false;
     }
   }
@@ -407,8 +462,8 @@ bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0, T const
 }
 
 template <typename C, typename V, typename T>
-void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0, T const& posTrack, T const& negTrack)
-{
+void FemtoDreamV0Selection::fillLambdaQA(C const &col, V const &v0,
+                                         T const &posTrack, T const &negTrack) {
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
@@ -426,42 +481,53 @@ void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0, T const& pos
   mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaNoCuts"), v0.mLambda());
 
   if (invMassLambda > fInvMassLowLimit && invMassLambda < fInvMassUpLimit) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaInvMassCut"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaInvMassCut"),
+                             v0.mLambda());
   }
 
   if (pT > pTV0Min) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMin"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMin"),
+                             v0.mLambda());
   }
   if (pT < pTV0Max) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"),
+                             v0.mLambda());
   }
   if (dcaDaughv0 < DCAV0DaughMax) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDCAV0Daugh"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDCAV0Daugh"),
+                             v0.mLambda());
   }
   if (cpav0 > CPAV0Min) {
     mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaCPA"), v0.mLambda());
   }
   if (tranRad > TranRadV0Min) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMin"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMin"),
+                             v0.mLambda());
   }
   if (tranRad < TranRadV0Max) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMax"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMax"),
+                             v0.mLambda());
   }
   bool write = true;
   for (size_t i = 0; i < decVtx.size(); i++) {
     write = write && (decVtx.at(i) < DecVtxMax);
   }
   if (write) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDecVtxMax"), v0.mLambda());
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDecVtxMax"),
+                             v0.mLambda());
   }
 }
 
-/// the CosPA of V0 needs as argument the posXYZ of collisions vertex so we need to pass the collsion as well
+/// the CosPA of V0 needs as argument the posXYZ of collisions vertex so we need
+/// to pass the collsion as well
 template <typename cutContainerType, typename C, typename V, typename T>
-std::array<cutContainerType, 5> FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0, T const& posTrack, T const& negTrack)
-{
-  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
-  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
+std::array<cutContainerType, 5>
+FemtoDreamV0Selection::getCutContainer(C const &col, V const &v0,
+                                       T const &posTrack, T const &negTrack) {
+  auto outputPosTrack =
+      PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
+  auto outputNegTrack =
+      NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
   cutContainerType output = 0;
   size_t counter = 0;
 
@@ -478,15 +544,21 @@ std::array<cutContainerType, 5> FemtoDreamV0Selection::getCutContainer(C const& 
   auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
   auto nSigmaPrPos = posTrack.tpcNSigmaPr();
   // check the mass and the PID of daughters
-  if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda > diffLambda) {
+  if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+      abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+      diffAntiLambda > diffLambda) {
     sign = -1.;
-  } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda < diffLambda) {
+  } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+             abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+             diffAntiLambda < diffLambda) {
     sign = 1.;
   } else {
     // if it happens that none of these are true, ignore the invariant mass
-    if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+    if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+        abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
       sign = -1.;
-    } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+    } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+               abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
       sign = 1.;
     }
   }
@@ -498,66 +570,118 @@ std::array<cutContainerType, 5> FemtoDreamV0Selection::getCutContainer(C const& 
   const std::vector<float> decVtx = {v0.x(), v0.y(), v0.z()};
 
   float observable = 0.;
-  for (auto& sel : mSelections) {
+  for (auto &sel : mSelections) {
     const auto selVariable = sel.getSelectionVariable();
 
-    if (selVariable == femtoDreamV0Selection::kDecVtxMax) {
+    if (selVariable == femtoDreamV0Selection::kV0DecVtxMax) {
       for (size_t i = 0; i < decVtx.size(); ++i) {
         auto decVtxValue = decVtx.at(i);
         sel.checkSelectionSetBit(decVtxValue, output, counter);
       }
     } else {
       switch (selVariable) {
-        case (femtoDreamV0Selection::kV0Sign):
-          observable = sign;
-          break;
-        case (femtoDreamV0Selection::kpTV0Min):
-        case (femtoDreamV0Selection::kpTV0Max):
-          observable = pT;
-          break;
-        case (femtoDreamV0Selection::kDCAV0DaughMax):
-          observable = dcaDaughv0;
-          break;
-        case (femtoDreamV0Selection::kCPAV0Min):
-          observable = cpav0;
-          break;
-        case (femtoDreamV0Selection::kTranRadV0Min):
-        case (femtoDreamV0Selection::kTranRadV0Max):
-          observable = tranRad;
-          break;
-        case (femtoDreamV0Selection::kDecVtxMax):
-          break;
+      case (femtoDreamV0Selection::kV0Sign):
+        observable = sign;
+        break;
+      case (femtoDreamV0Selection::kV0pTMin):
+        observable = pT;
+        break;
+      case (femtoDreamV0Selection::kV0pTMax):
+        observable = pT;
+        break;
+      case (femtoDreamV0Selection::kV0DCADaughMax):
+        observable = dcaDaughv0;
+        break;
+      case (femtoDreamV0Selection::kV0CPAMin):
+        observable = cpav0;
+        break;
+      case (femtoDreamV0Selection::kV0TranRadMin):
+        observable = tranRad;
+        break;
+      case (femtoDreamV0Selection::kV0TranRadMax):
+        observable = tranRad;
+        break;
+      case (femtoDreamV0Selection::kV0DecVtxMax):
+        break;
       }
       sel.checkSelectionSetBit(observable, output, counter);
     }
   }
-  return {output, outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-          outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
-          outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-          outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID)};
+  return {
+      output,
+      outputPosTrack.at(
+          femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+      outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
+      outputNegTrack.at(
+          femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+      outputNegTrack.at(
+          femtoDreamTrackSelection::TrackContainerPosition::kPID)};
 }
 
-template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, typename C, typename V, typename T>
-void FemtoDreamV0Selection::fillQA(C const& col, V const& v0, T const& posTrack, T const& negTrack)
-{
+template <o2::aod::femtodreamparticle::ParticleType part,
+          o2::aod::femtodreamparticle::ParticleType daugh, typename C,
+          typename V, typename T>
+void FemtoDreamV0Selection::fillQA(C const &col, V const &v0, T const &posTrack,
+                                   T const &negTrack) {
   if (mHistogramRegistry) {
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hPt"), v0.pt());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hEta"), v0.eta());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hPhi"), v0.phi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDaughDCA"), v0.dcaV0daughters());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hTransRadius"), v0.v0radius());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecayVtxX"), v0.x());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecayVtxY"), v0.y());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecayVtxZ"), v0.z());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hCPA"), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hCPAvsPt"), v0.pt(), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hInvMassLambda"), v0.mLambda());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hInvMassAntiLambda"), v0.mAntiLambda());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hInvMassLambdaAntiLambda"), v0.mLambda(), v0.mAntiLambda());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hPt"),
+        v0.pt());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hEta"),
+        v0.eta());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hPhi"),
+        v0.phi());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hDaughDCA"),
+        v0.dcaV0daughters());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hTransRadius"),
+        v0.v0radius());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hDecayVtxX"),
+        v0.x());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hDecayVtxY"),
+        v0.y());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hDecayVtxZ"),
+        v0.z());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hCPA"),
+        v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hCPAvsPt"),
+        v0.pt(), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hInvMassLambda"),
+        v0.mLambda());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hInvMassAntiLambda"),
+        v0.mAntiLambda());
+    mHistogramRegistry->fill(
+        HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
+            HIST("/hInvMassLambdaAntiLambda"),
+        v0.mLambda(), v0.mAntiLambda());
   }
 
-  PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
-  NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
+  PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
+  NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
 }
 
 } // namespace o2::analysis::femtoDream

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -23,15 +23,19 @@
 #include <fairlogger/Logger.h>
 #include <vector>
 
-namespace o2::analysis::femtoDream {
+namespace o2::analysis::femtoDream
+{
 
-enum kDetector { kTPC = 0, kTPCTOF = 1, kNdetectors = 2 };
+enum kDetector { kTPC = 0,
+                 kTPCTOF = 1,
+                 kNdetectors = 2 };
 
 /// internal function that returns the kPIDselection element corresponding to a
 /// specifica n-sigma value \param nSigma number of sigmas for PID \param
 /// vNsigma vector with the number of sigmas of interest \return kPIDselection
 /// corresponding to n-sigma
-int getPIDselection(const float nSigma, const std::vector<float> &vNsigma) {
+int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
+{
   for (std::size_t i = 0; i < vNsigma.size(); i++) {
     if (abs(nSigma - vNsigma[i]) < 1e-3) {
       return static_cast<int>(i);
@@ -44,17 +48,23 @@ int getPIDselection(const float nSigma, const std::vector<float> &vNsigma) {
 }
 
 /// function that checks whether the PID selection specified in the vectors is
-/// fulfilled \param pidcut Bit-wise container for the PID \param vSpecies
+/// fulfilled
+/// \param pidcut Bit-wise container for the PID \param vSpecies
 /// vector with ID corresponding to the selected species (output from
-/// cutculator) \param nSpecies number of available selected species (output
-/// from cutculator) \param nSigma number of sigma selection fo PID \param
-/// vNsigma vector with available n-sigma selections for PID \param kDetector
-/// enum corresponding to the PID technique \return Whether the PID selection
+/// cutculator)
+/// \param nSpecies number of available selected species (output
+/// from cutculator)
+/// \param nSigma number of sigma selection fo PID \param
+/// vNsigma vector with available n-sigma selections for PID
+/// \param kDetector
+/// enum corresponding to the PID technique
+/// \return Whether the PID selection
 /// specified in the vectors is fulfilled
-bool isPIDSelected(aod::femtodreamparticle::cutContainerType const &pidcut,
-                   std::vector<int> const &vSpecies, int nSpecies, float nSigma,
-                   const std::vector<float> &vNsigma,
-                   const kDetector iDet = kDetector::kTPC) {
+bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
+                   std::vector<int> const& vSpecies, int nSpecies, float nSigma,
+                   const std::vector<float>& vNsigma,
+                   const kDetector iDet = kDetector::kTPC)
+{
   bool pidSelection = true;
   int iNsigma = getPIDselection(nSigma, vNsigma);
   for (auto iSpecies : vSpecies) {
@@ -70,20 +80,22 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const &pidcut,
   return pidSelection;
 };
 
-/// function that checks whether the PID selection specified in the vectors is
-/// fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted \param
-/// pidcut Bit-wise container for the PID \param momentum Momentum of the track
+/// function that checks whether the PID selection specified in the vectors is fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted
+/// \param pidcut Bit-wise container for the PID
+/// \param momentum Momentum of the track
 /// \param pidThresh Momentum threshold that separates between TPC and TPC+TOF
-/// PID \param vSpecies Vector with the species of interest (number returned by
-/// the CutCulator) \param nSpecies number of available selected species (output
-/// from cutculator) \param nSigmaTPC Number of TPC sigmas for selection \param
-/// nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
+/// PID
+/// \param vSpecies Vector with the species of interest (number returned by the CutCulator)
+/// \param nSpecies number of available selected species (output from cutculator)
+/// \param nSigmaTPC Number of TPC sigmas for selection
+/// \param nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
 /// \return Whether the PID selection is fulfilled
-bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const &pidCut,
+bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut,
                        float const momentum, float const pidThresh,
-                       std::vector<int> const &vSpecies, int nSpecies,
-                       const std::vector<float> &vNsigma, const float nSigmaTPC,
-                       const float nSigmaTPCTOF) {
+                       std::vector<int> const& vSpecies, int nSpecies,
+                       const std::vector<float>& vNsigma, const float nSigmaTPC,
+                       const float nSigmaTPCTOF)
+{
   bool pidSelection = true;
   if (momentum < pidThresh) {
     /// TPC PID only

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -9,9 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file CFFilter.cxx
+/// \file FemtoUtils.h
 /// \brief Utilities for the FemtoDream framework
-///
 /// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTOUTILS_H_

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -17,11 +17,9 @@
 #ifndef PWGCF_FEMTODREAM_FEMTOUTILS_H_
 #define PWGCF_FEMTODREAM_FEMTOUTILS_H_
 
+#include <vector>
 #include "Framework/ASoAHelpers.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
-#include <CCDB/BasicCCDBManager.h>
-#include <fairlogger/Logger.h>
-#include <vector>
 
 namespace o2::analysis::femtoDream
 {
@@ -41,7 +39,7 @@ int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
       return static_cast<int>(i);
     }
   }
-  LOG(info) << "Invalid value of nSigma: " << nSigma
+  LOG(warn) << "Invalid value of nSigma: " << nSigma
             << ". Return the first value of the vector: " << vNsigma[0]
             << std::endl;
   return 0;
@@ -99,12 +97,10 @@ bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut,
   bool pidSelection = true;
   if (momentum < pidThresh) {
     /// TPC PID only
-    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPC, vNsigma,
-                                 kDetector::kTPC);
+    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPC, vNsigma, kDetector::kTPC);
   } else {
     /// TPC + TOF PID
-    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPCTOF,
-                                 vNsigma, kDetector::kTPCTOF);
+    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPCTOF, vNsigma, kDetector::kTPCTOF);
   }
   return pidSelection;
 };

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -17,51 +17,52 @@
 #ifndef PWGCF_FEMTODREAM_FEMTOUTILS_H_
 #define PWGCF_FEMTODREAM_FEMTOUTILS_H_
 
-#include <CCDB/BasicCCDBManager.h>
-#include <vector>
 #include "Framework/ASoAHelpers.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
+#include <CCDB/BasicCCDBManager.h>
+#include <fairlogger/Logger.h>
+#include <vector>
 
-namespace o2::analysis::femtoDream
-{
+namespace o2::analysis::femtoDream {
 
-enum kDetector {
-  kTPC = 0,
-  kTPCTOF = 1,
-  kNdetectors = 2
-};
+enum kDetector { kTPC = 0, kTPCTOF = 1, kNdetectors = 2 };
 
-/// internal function that returns the kPIDselection element corresponding to a specifica n-sigma value
-/// \param nSigma number of sigmas for PID
-/// \param vNsigma vector with the number of sigmas of interest
-/// \return kPIDselection corresponding to n-sigma
-int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
-{
+/// internal function that returns the kPIDselection element corresponding to a
+/// specifica n-sigma value \param nSigma number of sigmas for PID \param
+/// vNsigma vector with the number of sigmas of interest \return kPIDselection
+/// corresponding to n-sigma
+int getPIDselection(const float nSigma, const std::vector<float> &vNsigma) {
   for (std::size_t i = 0; i < vNsigma.size(); i++) {
     if (abs(nSigma - vNsigma[i]) < 1e-3) {
       return static_cast<int>(i);
     }
   }
-  LOG(info) << "Invalid value of nSigma: " << nSigma << ". Return the first value of the vector: " << vNsigma[0] << std::endl;
+  LOG(info) << "Invalid value of nSigma: " << nSigma
+            << ". Return the first value of the vector: " << vNsigma[0]
+            << std::endl;
   return 0;
 }
 
-/// function that checks whether the PID selection specified in the vectors is fulfilled
-/// \param pidcut Bit-wise container for the PID
-/// \param vSpecies vector with ID corresponding to the selected species (output from cutculator)
-/// \param nSpecies number of available selected species (output from cutculator)
-/// \param nSigma number of sigma selection fo PID
-/// \param vNsigma vector with available n-sigma selections for PID
-/// \param kDetector enum corresponding to the PID technique
-/// \return Whether the PID selection specified in the vectors is fulfilled
-bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut, std::vector<int> const& vSpecies, int nSpecies, float nSigma, const std::vector<float>& vNsigma, const kDetector iDet = kDetector::kTPC)
-{
+/// function that checks whether the PID selection specified in the vectors is
+/// fulfilled \param pidcut Bit-wise container for the PID \param vSpecies
+/// vector with ID corresponding to the selected species (output from
+/// cutculator) \param nSpecies number of available selected species (output
+/// from cutculator) \param nSigma number of sigma selection fo PID \param
+/// vNsigma vector with available n-sigma selections for PID \param kDetector
+/// enum corresponding to the PID technique \return Whether the PID selection
+/// specified in the vectors is fulfilled
+bool isPIDSelected(aod::femtodreamparticle::cutContainerType const &pidcut,
+                   std::vector<int> const &vSpecies, int nSpecies, float nSigma,
+                   const std::vector<float> &vNsigma,
+                   const kDetector iDet = kDetector::kTPC) {
   bool pidSelection = true;
   int iNsigma = getPIDselection(nSigma, vNsigma);
   for (auto iSpecies : vSpecies) {
-    //\todo we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
+    //\todo we also need the possibility to specify whether the bit is
+    // true/false ->std>>vector<std::pair<int, int>>
     // if (!((pidcut >> it.first) & it.second)) {
-    int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + iSpecies * kDetector::kNdetectors + iDet;
+    int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma +
+                       iSpecies * kDetector::kNdetectors + iDet;
     if (!(pidcut & (1UL << bit_to_check))) {
       pidSelection = false;
     }
@@ -69,24 +70,29 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut, std:
   return pidSelection;
 };
 
-/// function that checks whether the PID selection specified in the vectors is fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted
-/// \param pidcut Bit-wise container for the PID
-/// \param momentum Momentum of the track
-/// \param pidThresh Momentum threshold that separates between TPC and TPC+TOF PID
-/// \param vSpecies Vector with the species of interest (number returned by the CutCulator)
-/// \param nSpecies number of available selected species (output from cutculator)
-/// \param nSigmaTPC Number of TPC sigmas for selection
-/// \param nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
+/// function that checks whether the PID selection specified in the vectors is
+/// fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted \param
+/// pidcut Bit-wise container for the PID \param momentum Momentum of the track
+/// \param pidThresh Momentum threshold that separates between TPC and TPC+TOF
+/// PID \param vSpecies Vector with the species of interest (number returned by
+/// the CutCulator) \param nSpecies number of available selected species (output
+/// from cutculator) \param nSigmaTPC Number of TPC sigmas for selection \param
+/// nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
 /// \return Whether the PID selection is fulfilled
-bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut, float const momentum, float const pidThresh, std::vector<int> const& vSpecies, int nSpecies, const std::vector<float>& vNsigma, const float nSigmaTPC, const float nSigmaTPCTOF)
-{
+bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const &pidCut,
+                       float const momentum, float const pidThresh,
+                       std::vector<int> const &vSpecies, int nSpecies,
+                       const std::vector<float> &vNsigma, const float nSigmaTPC,
+                       const float nSigmaTPCTOF) {
   bool pidSelection = true;
   if (momentum < pidThresh) {
     /// TPC PID only
-    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPC, vNsigma, kDetector::kTPC);
+    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPC, vNsigma,
+                                 kDetector::kTPC);
   } else {
     /// TPC + TOF PID
-    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPCTOF, vNsigma, kDetector::kTPCTOF);
+    pidSelection = isPIDSelected(pidCut, vSpecies, nSpecies, nSigmaTPCTOF,
+                                 vNsigma, kDetector::kTPCTOF);
   }
   return pidSelection;
 };

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -28,9 +28,9 @@ enum kDetector { kTPC = 0,
                  kNdetectors = 2 };
 
 /// internal function that returns the kPIDselection element corresponding to a
-/// specifica n-sigma value \param nSigma number of sigmas for PID \param
-/// vNsigma vector with the number of sigmas of interest \return kPIDselection
-/// corresponding to n-sigma
+/// specifica n-sigma value \param nSigma number of sigmas for PID
+/// \param vNsigma vector with the number of sigmas of interest
+/// \return kPIDselection corresponding to n-sigma
 int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
 {
   for (std::size_t i = 0; i < vNsigma.size(); i++) {
@@ -46,17 +46,13 @@ int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
 
 /// function that checks whether the PID selection specified in the vectors is
 /// fulfilled
-/// \param pidcut Bit-wise container for the PID \param vSpecies
-/// vector with ID corresponding to the selected species (output from
-/// cutculator)
-/// \param nSpecies number of available selected species (output
-/// from cutculator)
-/// \param nSigma number of sigma selection fo PID \param
-/// vNsigma vector with available n-sigma selections for PID
-/// \param kDetector
-/// enum corresponding to the PID technique
-/// \return Whether the PID selection
-/// specified in the vectors is fulfilled
+/// \param pidcut Bit-wise container for the PID
+/// \param vSpecies vector with ID corresponding to the selected species (output from cutculator)
+/// \param nSpecies number of available selected species (output from cutculator)
+/// \param nSigma number of sigma selection fo PID
+/// \param vNsigma vector with available n-sigma selections for PID
+/// \param kDetector enum corresponding to the PID technique
+/// \return Whether the PID selection specified in the vectors is fulfilled
 bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
                    std::vector<int> const& vSpecies, int nSpecies, float nSigma,
                    const std::vector<float>& vNsigma,
@@ -80,8 +76,7 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
 /// function that checks whether the PID selection specified in the vectors is fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted
 /// \param pidcut Bit-wise container for the PID
 /// \param momentum Momentum of the track
-/// \param pidThresh Momentum threshold that separates between TPC and TPC+TOF
-/// PID
+/// \param pidThresh Momentum threshold that separates between TPC and TPC+TOF PID
 /// \param vSpecies Vector with the species of interest (number returned by the CutCulator)
 /// \param nSpecies number of available selected species (output from cutculator)
 /// \param nSigmaTPC Number of TPC sigmas for selection

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -25,21 +25,38 @@ using namespace o2::analysis::femtoDream;
 /// The function takes the path to the dpl-config.json as a argument and the
 /// does a Q&A session for the user to find the appropriate selection criteria
 /// for the analysis task
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[])
+{
   std::string configFileName(argv[1]);
   std::filesystem::path configFile{configFileName};
 
   if (std::filesystem::exists(configFile)) {
     FemtoDreamCutculator cut;
     cut.init(argv[1]);
-    cut.setTrackSelectionFromFile("ConfTrk");
-    cut.setPIDSelectionFromFile("ConfPID");
-    cut.setV0SelectionFromFile("ConfV0", "ConfChild");
+
+    LOG(info) << "Do you want to work with tracks or V0s (T/V)?";
+    std::string choice;
+    std::cin >> choice;
+
+    if (choice == std::string("T")) {
+      cut.setTrackSelectionFromFile("ConfTrk");
+      cut.setPIDSelectionFromFile("ConfPIDTrk");
+    } else if (choice == std::string("V")) {
+      LOG(info) << "Do you want to select V0s or one of its children (V/T)?";
+      std::cin >> choice;
+      cut.setV0SelectionFromFile("ConfV0");
+      cut.setTrackSelectionFromFile("ConfChild");
+      cut.setPIDSelectionFromFile("ConfPIDChild");
+    } else {
+      LOG(info) << "Option not recognized. Break...";
+      return 1;
+    }
 
     /// \todo factor out the pid here
     // cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax,
     // femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
-    cut.analyseCuts();
+    cut.analyseCuts(choice);
+
   } else {
     LOG(info) << "The configuration file " << configFileName
               << " could not be found.";

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,21 +10,22 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamCutCulator.cxx
-/// \brief Executable that encodes physical selection criteria in a bit-wise selection
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \brief Executable that encodes physical selection criteria in a bit-wise
+/// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#include <iostream>
-#include <filesystem>
-#include "PWGCF/DataModel/FemtoDerived.h"
+#include "FemtoDreamCutculator.h"
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
-#include "FemtoDreamCutculator.h"
+#include "PWGCF/DataModel/FemtoDerived.h"
+#include <filesystem>
+#include <iostream>
 
 using namespace o2::analysis::femtoDream;
 
-/// The function takes the path to the dpl-config.json as a argument and the does a Q&A session for the user to find the appropriate selection criteria for the analysis task
-int main(int argc, char* argv[])
-{
+/// The function takes the path to the dpl-config.json as a argument and the
+/// does a Q&A session for the user to find the appropriate selection criteria
+/// for the analysis task
+int main(int argc, char *argv[]) {
   std::string configFileName(argv[1]);
   std::filesystem::path configFile{configFileName};
 
@@ -33,12 +34,14 @@ int main(int argc, char* argv[])
     cut.init(argv[1]);
     cut.setTrackSelectionFromFile("ConfTrk");
     cut.setPIDSelectionFromFile("ConfPID");
-    cut.setV0SelectionFromFile("ConfV0");
+    cut.setV0SelectionFromFile("ConfV0", "ConfChild");
 
     /// \todo factor out the pid here
-    // cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
+    // cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax,
+    // femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
     cut.analyseCuts();
   } else {
-    LOG(info) << "The configuration file " << configFileName << " could not be found.";
+    LOG(info) << "The configuration file " << configFileName
+              << " could not be found.";
   }
 }

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,8 +10,8 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamCutCulator.cxx
-/// \brief Executable that encodes physical selection criteria in a bit-wise
-/// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \brief Executable that encodes physical selection criteria in a bit-wise selection
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include <filesystem>
 #include <iostream>

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -13,12 +13,12 @@
 /// \brief Executable that encodes physical selection criteria in a bit-wise
 /// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
+#include <filesystem>
+#include <iostream>
 #include "FemtoDreamCutculator.h"
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
-#include <filesystem>
-#include <iostream>
 
 using namespace o2::analysis::femtoDream;
 

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,8 +10,8 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamDebugTrack.cxx
-/// \brief Tasks that reads the particle tables and fills QA histograms for
-/// tracks \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \brief Tasks that reads the particle tables and fills QA histograms for tracks
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
 #include "DataFormatsParameters/GRPObject.h"
 #include "Framework/ASoAHelpers.h"

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,21 +10,21 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamDebugTrack.cxx
-/// \brief Tasks that reads the particle tables and fills QA histograms for tracks
-/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \brief Tasks that reads the particle tables and fills QA histograms for
+/// tracks \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
-#include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/HistogramRegistry.h"
+#include "DataFormatsParameters/GRPObject.h"
 #include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/StepTHn.h"
-#include "DataFormatsParameters/GRPObject.h"
+#include "Framework/runDataProcessing.h"
 
-#include "PWGCF/DataModel/FemtoDerived.h"
-#include "FemtoDreamParticleHisto.h"
 #include "FemtoDreamEventHisto.h"
+#include "FemtoDreamParticleHisto.h"
 #include "FemtoUtils.h"
+#include "PWGCF/DataModel/FemtoDerived.h"
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -35,7 +35,8 @@ using namespace o2::soa;
 namespace
 {
 static constexpr int nCuts = 5;
-static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
+static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC",
+                                               "nSigmaTPCTOF", "MaxP"};
 static const float cutsTable[1][nCuts] = {{4.05f, 0.75f, 3.5f, 3.5f, 100.f}};
 
 } // namespace
@@ -47,7 +48,6 @@ struct femtoDreamDebugTrack {
   Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
 
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
-
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
   Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
@@ -56,15 +56,13 @@ struct femtoDreamDebugTrack {
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
 
-  using FemtoFullParticlesMC = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles, aod::FemtoDreamMCLabels>;
-  Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
-
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
 
   /// The configurables need to be passed to an std::vector
   std::vector<int> vPIDPartOne;
   std::vector<float> kNsigma;
+
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry FullQaRegistry{"FullTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -74,36 +72,91 @@ struct femtoDreamDebugTrack {
   {
     eventHisto.init(&qaRegistry);
 
-    FullQaRegistry.add("FullTrackQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
-    FullQaRegistry.add("FullTrackQA/hEta", "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
-    FullQaRegistry.add("FullTrackQA/hPhi", "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
-    FullQaRegistry.add("FullTrackQA/hTPCfindable", "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCfound", "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCcrossedOverFindalbe", "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCcrossedRows", "; TPC crossed rows; Entries", kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCfindableVsCrossed", ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCshared", "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hITSclusters", "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullTrackQA/hITSclustersIB", "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullTrackQA/hDCAxy", "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{20, 0.5, 4.05}, {500, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/hDCAz", "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/hDCA", "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCdEdX", "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_el", "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_pi", "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_K", "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_p", "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_d", "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_el", "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_pi", "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_K", "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_p", "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_d", "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_el", "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_pi", "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_K", "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_p", "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_d", "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
+                       kTH1F, {{240, 0, 6}});
+    FullQaRegistry.add("FullTrackQA/hEta", "; #eta; Entries", kTH1F,
+                       {{200, -1.5, 1.5}});
+    FullQaRegistry.add("FullTrackQA/hPhi", "; #phi; Entries", kTH1F,
+                       {{200, 0, 2. * M_PI}});
+    FullQaRegistry.add("FullTrackQA/hTPCfindable",
+                       "; TPC findable clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCfound", "; TPC found clusters; Entries",
+                       kTH1F, {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCcrossedOverFindalbe",
+                       "; TPC ratio findable; Entries", kTH1F,
+                       {{100, 0.5, 1.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCcrossedRows",
+                       "; TPC crossed rows; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCfindableVsCrossed",
+                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
+                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCshared",
+                       "; TPC shared clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullTrackQA/hITSclusters", "; ITS clusters; Entries",
+                       kTH1F, {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullTrackQA/hITSclustersIB",
+                       "; ITS clusters in IB; Entries", kTH1F,
+                       {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullTrackQA/hDCAxy",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
+                       {{20, 0.5, 4.05}, {500, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/hDCAz",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
+                       {{100, 0, 10}, {500, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/hDCA",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
+                       {{100, 0, 10}, {301, 0., 1.5}});
+    FullQaRegistry.add("FullTrackQA/hTPCdEdX",
+                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
+                       {{100, 0, 10}, {1000, 0, 1000}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTPC_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTPC_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTPC_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTPC_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTPC_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTOF_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTOF_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTOF_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTOF_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaTOF_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaComb_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaComb_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaComb_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaComb_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullTrackQA/nSigmaComb_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
 
     if (ConfIsMC) {
       FullQaRegistry.add("FullTrackQA_MC/hPt_MC", "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
@@ -121,37 +174,52 @@ struct femtoDreamDebugTrack {
   template <bool isMC, typename PartitionType>
   void FillDebugHistos(o2::aod::FemtoDreamCollision& col, PartitionType& groupPartsOne)
   {
-
     eventHisto.fillQA(col);
 
     for (auto& part : groupPartsOne) {
-      if (part.p() > cfgCutTable->get("MaxP") || part.pt() > cfgCutTable->get("MaxPt")) {
+      if (part.p() > cfgCutTable->get("MaxP") ||
+          part.pt() > cfgCutTable->get("MaxPt")) {
         continue;
       }
-      if (!isFullPIDSelected(part.pidcut(),
-                             part.p(),
-                             cfgCutTable->get("PIDthr"),
-                             vPIDPartOne,
-                             cfgNspecies,
-                             kNsigma,
-                             cfgCutTable->get("nSigmaTPC"),
-                             cfgCutTable->get("nSigmaTPCTOF"))) {
+      if (!isFullPIDSelected(
+            part.pidcut(), part.p(), cfgCutTable->get("PIDthr"), vPIDPartOne,
+            cfgNspecies, kNsigma, cfgCutTable->get("nSigmaTPC"),
+            cfgCutTable->get("nSigmaTPCTOF"))) {
         continue;
       }
 
       FullQaRegistry.fill(HIST("FullTrackQA/hPt"), part.pt());
       FullQaRegistry.fill(HIST("FullTrackQA/hEta"), part.eta());
       FullQaRegistry.fill(HIST("FullTrackQA/hPhi"), part.phi());
-      FullQaRegistry.fill(HIST("FullTrackQA/hDCAxy"), part.pt(), part.tempFitVar());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindable"), part.tpcNClsFindable());
+      FullQaRegistry.fill(HIST("FullTrackQA/hDCAxy"), part.pt(),
+                          part.tempFitVar());
+      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindable"),
+                          part.tpcNClsFindable());
       FullQaRegistry.fill(HIST("FullTrackQA/hTPCfound"), part.tpcNClsFound());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedOverFindalbe"), part.tpcCrossedRowsOverFindableCls());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedRows"), part.tpcNClsCrossedRows());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindableVsCrossed"), part.tpcNClsFindable(), part.tpcNClsCrossedRows());
+      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedOverFindalbe"),
+                          part.tpcCrossedRowsOverFindableCls());
+      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedRows"),
+                          part.tpcNClsCrossedRows());
+      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindableVsCrossed"),
+                          part.tpcNClsFindable(), part.tpcNClsCrossedRows());
       FullQaRegistry.fill(HIST("FullTrackQA/hTPCshared"), part.tpcNClsShared());
       FullQaRegistry.fill(HIST("FullTrackQA/hITSclusters"), part.itsNCls());
-      FullQaRegistry.fill(HIST("FullTrackQA/hITSclustersIB"), part.itsNClsInnerBarrel());
+      FullQaRegistry.fill(HIST("FullTrackQA/hITSclustersIB"),
+                          part.itsNClsInnerBarrel());
       FullQaRegistry.fill(HIST("FullTrackQA/hDCAz"), part.pt(), part.dcaZ());
+
+      if constexpr (isMC) {
+        if (part.has_femtoDreamMCParticle()) {
+          auto partMC = part.template femtoDreamMCParticle_as<o2::aod::FemtoDreamMCParticles>();
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPt_MC"), partMC.pt());
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hEta_MC"), partMC.eta());
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPhi_MC"), partMC.phi());
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPDG"), partMC.pdgMCTruth());
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hOrigin_MC"), partMC.partOriginMCTruth());
+        } else {
+          FullQaRegistry.fill(HIST("FullTrackQA_MC/hNoMCtruthCounter"), 1);
+        }
+      }
       FullQaRegistry.fill(HIST("FullTrackQA/hDCA"), part.pt(), std::sqrt(pow(part.dcaXY(), 2.) + pow(part.dcaZ(), 2.)));
       FullQaRegistry.fill(HIST("FullTrackQA/hTPCdEdX"), part.p(), part.tpcSignal());
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
@@ -169,19 +237,6 @@ struct femtoDreamDebugTrack {
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_K"), part.p(), std::sqrt(part.tpcNSigmaKa() * part.tpcNSigmaKa() + part.tofNSigmaKa() * part.tofNSigmaKa()));
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_p"), part.p(), std::sqrt(part.tpcNSigmaPr() * part.tpcNSigmaPr() + part.tofNSigmaPr() * part.tofNSigmaPr()));
       FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_d"), part.p(), std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
-
-      if constexpr (isMC) {
-        if (part.has_femtoDreamMCParticle()) {
-          auto partMC = part.template femtoDreamMCParticle_as<o2::aod::FemtoDreamMCParticles>();
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPt_MC"), partMC.pt());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hEta_MC"), partMC.eta());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPhi_MC"), partMC.phi());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPDG"), partMC.pdgMCTruth());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hOrigin_MC"), partMC.partOriginMCTruth());
-        } else {
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hNoMCtruthCounter"), 1);
-        }
-      }
     }
   }
 

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -51,10 +51,17 @@ struct femtoDreamDebugTrack {
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
   Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
-  Configurable<std::vector<float>> ConfPIDnSigmaMax{"ConfPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f},
+                                                       "This configurable needs to be the same as the one used in the producer "
+                                                       "task"};
 
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+
+  using FemtoFullParticlesMC = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles, aod::FemtoDreamMCLabels>;
+  Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+
+  // Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
@@ -167,7 +174,7 @@ struct femtoDreamDebugTrack {
       FullQaRegistry.add("FullTrackQA_MC/hNoMCtruthCounter", "; Counter; Entries", kTH1I, {{1, 0, 1}});
     }
     vPIDPartOne = ConfPIDPartOne.value;
-    kNsigma = ConfPIDnSigmaMax.value;
+    kNsigma = ConfTrkPIDnSigmaMax.value;
   }
 
   /// Porduce QA plots for sigle track selection in FemtoDream framework

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -46,25 +46,26 @@ struct femtoDreamDebugTrack {
 
   Configurable<LabeledArray<float>> cfgCutTable{"cfgCutTable", {cutsTable[0], nCuts, cutNames}, "Particle selections"};
   Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
-
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
   Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f},
-                                                       "This configurable needs to be the same as the one used in the producer "
-                                                       "task"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
+  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::femtoDreamCollisionId;
 
   using FemtoFullParticlesMC = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles, aod::FemtoDreamMCLabels>;
   Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
-
-  // Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<FemtoFullParticlesMC> perColGen = aod::femtodreamparticle::femtoDreamCollisionId;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
+
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack> trackHisto;
 
   /// The configurables need to be passed to an std::vector
   std::vector<int> vPIDPartOne;
@@ -73,106 +74,11 @@ struct femtoDreamDebugTrack {
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry FullQaRegistry{"FullTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry FullQaRegistryMC{"FullTrackQA_MC", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-
-    FullQaRegistry.add("FullTrackQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
-                       kTH1F, {{240, 0, 6}});
-    FullQaRegistry.add("FullTrackQA/hEta", "; #eta; Entries", kTH1F,
-                       {{200, -1.5, 1.5}});
-    FullQaRegistry.add("FullTrackQA/hPhi", "; #phi; Entries", kTH1F,
-                       {{200, 0, 2. * M_PI}});
-    FullQaRegistry.add("FullTrackQA/hTPCfindable",
-                       "; TPC findable clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCfound", "; TPC found clusters; Entries",
-                       kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCcrossedOverFindalbe",
-                       "; TPC ratio findable; Entries", kTH1F,
-                       {{100, 0.5, 1.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCcrossedRows",
-                       "; TPC crossed rows; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCfindableVsCrossed",
-                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
-                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCshared",
-                       "; TPC shared clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullTrackQA/hITSclusters", "; ITS clusters; Entries",
-                       kTH1F, {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullTrackQA/hITSclustersIB",
-                       "; ITS clusters in IB; Entries", kTH1F,
-                       {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullTrackQA/hDCAxy",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
-                       {{20, 0.5, 4.05}, {500, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/hDCAz",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
-                       {{100, 0, 10}, {500, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/hDCA",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
-                       {{100, 0, 10}, {301, 0., 1.5}});
-    FullQaRegistry.add("FullTrackQA/hTPCdEdX",
-                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
-                       {{100, 0, 10}, {1000, 0, 1000}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTPC_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaTOF_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullTrackQA/nSigmaComb_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-
-    if (ConfIsMC) {
-      FullQaRegistry.add("FullTrackQA_MC/hPt_MC", "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
-      FullQaRegistry.add("FullTrackQA_MC/hEta_MC", "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
-      FullQaRegistry.add("FullTrackQA_MC/hPhi_MC", "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
-      FullQaRegistry.add("FullTrackQA_MC/hPDG", "; PDG; Entries", kTH1I, {{6001, -3000, 3000}});
-      FullQaRegistry.add("FullTrackQA_MC/hOrigin_MC", "; Origin; Entries", kTH1I, {{8, 0, 7}});
-      FullQaRegistry.add("FullTrackQA_MC/hNoMCtruthCounter", "; Counter; Entries", kTH1I, {{1, 0, 1}});
-    }
+    trackHisto.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC, true);
     vPIDPartOne = ConfPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }
@@ -182,73 +88,28 @@ struct femtoDreamDebugTrack {
   void FillDebugHistos(o2::aod::FemtoDreamCollision& col, PartitionType& groupPartsOne)
   {
     eventHisto.fillQA(col);
-
     for (auto& part : groupPartsOne) {
       if (part.p() > cfgCutTable->get("MaxP") ||
           part.pt() > cfgCutTable->get("MaxPt")) {
         continue;
       }
-      if (!isFullPIDSelected(
-            part.pidcut(), part.p(), cfgCutTable->get("PIDthr"), vPIDPartOne,
-            cfgNspecies, kNsigma, cfgCutTable->get("nSigmaTPC"),
-            cfgCutTable->get("nSigmaTPCTOF"))) {
+      if (!isFullPIDSelected(part.pidcut(), part.p(), cfgCutTable->get("PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("nSigmaTPC"), cfgCutTable->get("nSigmaTPCTOF"))) {
         continue;
       }
-
-      FullQaRegistry.fill(HIST("FullTrackQA/hPt"), part.pt());
-      FullQaRegistry.fill(HIST("FullTrackQA/hEta"), part.eta());
-      FullQaRegistry.fill(HIST("FullTrackQA/hPhi"), part.phi());
-      FullQaRegistry.fill(HIST("FullTrackQA/hDCAxy"), part.pt(),
-                          part.tempFitVar());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindable"),
-                          part.tpcNClsFindable());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfound"), part.tpcNClsFound());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedOverFindalbe"),
-                          part.tpcCrossedRowsOverFindableCls());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCcrossedRows"),
-                          part.tpcNClsCrossedRows());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCfindableVsCrossed"),
-                          part.tpcNClsFindable(), part.tpcNClsCrossedRows());
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCshared"), part.tpcNClsShared());
-      FullQaRegistry.fill(HIST("FullTrackQA/hITSclusters"), part.itsNCls());
-      FullQaRegistry.fill(HIST("FullTrackQA/hITSclustersIB"),
-                          part.itsNClsInnerBarrel());
-      FullQaRegistry.fill(HIST("FullTrackQA/hDCAz"), part.pt(), part.dcaZ());
-
-      if constexpr (isMC) {
-        if (part.has_femtoDreamMCParticle()) {
-          auto partMC = part.template femtoDreamMCParticle_as<o2::aod::FemtoDreamMCParticles>();
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPt_MC"), partMC.pt());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hEta_MC"), partMC.eta());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPhi_MC"), partMC.phi());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hPDG"), partMC.pdgMCTruth());
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hOrigin_MC"), partMC.partOriginMCTruth());
-        } else {
-          FullQaRegistry.fill(HIST("FullTrackQA_MC/hNoMCtruthCounter"), 1);
-        }
-      }
-      FullQaRegistry.fill(HIST("FullTrackQA/hDCA"), part.pt(), std::sqrt(pow(part.dcaXY(), 2.) + pow(part.dcaZ(), 2.)));
-      FullQaRegistry.fill(HIST("FullTrackQA/hTPCdEdX"), part.p(), part.tpcSignal());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_el"), part.p(), part.tpcNSigmaEl());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_pi"), part.p(), part.tpcNSigmaPi());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_K"), part.p(), part.tpcNSigmaKa());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_p"), part.p(), part.tpcNSigmaPr());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTPC_d"), part.p(), part.tpcNSigmaDe());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_el"), part.p(), part.tofNSigmaEl());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_pi"), part.p(), part.tofNSigmaPi());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_K"), part.p(), part.tofNSigmaKa());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_p"), part.p(), part.tofNSigmaPr());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaTOF_d"), part.p(), part.tofNSigmaDe());
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_el"), part.p(), std::sqrt(part.tpcNSigmaEl() * part.tpcNSigmaEl() + part.tofNSigmaEl() * part.tofNSigmaEl()));
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_pi"), part.p(), std::sqrt(part.tpcNSigmaPi() * part.tpcNSigmaPi() + part.tofNSigmaPi() * part.tofNSigmaPi()));
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_K"), part.p(), std::sqrt(part.tpcNSigmaKa() * part.tpcNSigmaKa() + part.tofNSigmaKa() * part.tofNSigmaKa()));
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_p"), part.p(), std::sqrt(part.tpcNSigmaPr() * part.tpcNSigmaPr() + part.tofNSigmaPr() * part.tofNSigmaPr()));
-      FullQaRegistry.fill(HIST("FullTrackQA/nSigmaComb_d"), part.p(), std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
+      trackHisto.fillQA<isMC, true>(part);
+      // if constexpr (isMC) {
+      // if (part.has_femtoDreamMCParticle()) {
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_MC"), part.pt());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hEta_MC"), part.eta());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPhi_MC"), part.phi());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPDG"), part.pdgMCTruth());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hOrigin_MC"), part.partOriginMCTruth());
+      // } else {
+      // FullQaRegistry.fill(HIST("FullTrackQA_MC/hNoMCtruthCounter"), 1);
+      // }
+      // }
     }
   }
-
-  /// Porduce QA plots for sigle track selection in FemtoDream framework
-  ///
 
   /// process function when runnning over data/ Monte Carlo reconstructed only
   /// \param col subscribe to FemtoDreamCollision table
@@ -264,7 +125,7 @@ struct femtoDreamDebugTrack {
 
   /// \param col subscribe to FemtoDreamCollision table
   /// \param parts subscribe to the joined table of FemtoDreamParticles and FemtoDreamMCLabels table
-  /// @param FemtoDramMCParticles subscribe to the table containing the Monte Carlo Truth information
+  /// \param FemtoDramMCParticles subscribe to the table containing the Monte Carlo Truth information
   void processMC(o2::aod::FemtoDreamCollision& col, FemtoFullParticlesMC& parts, o2::aod::FemtoDreamMCParticles&)
   {
     auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -96,17 +96,6 @@ struct femtoDreamDebugTrack {
         continue;
       }
       trackHisto.fillQA<isMC, true>(part);
-      // if constexpr (isMC) {
-      // if (part.has_femtoDreamMCParticle()) {
-      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_MC"), part.pt());
-      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hEta_MC"), part.eta());
-      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPhi_MC"), part.phi());
-      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPDG"), part.pdgMCTruth());
-      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hOrigin_MC"), part.partOriginMCTruth());
-      // } else {
-      // FullQaRegistry.fill(HIST("FullTrackQA_MC/hNoMCtruthCounter"), 1);
-      // }
-      // }
     }
   }
 

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -37,22 +37,22 @@ namespace
 static constexpr int nCuts = 5;
 static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC",
                                                "nSigmaTPCTOF", "MaxP"};
-static const float cutsTable[1][nCuts] = {{4.05f, 0.75f, 3.5f, 3.5f, 100.f}};
+static const float cutsTable[1][nCuts] = {{4.05f, 0.75f, 3.f, 3.f, 100.f}};
 
 } // namespace
 
 struct femtoDreamDebugTrack {
   SliceCache cache;
 
-  Configurable<LabeledArray<float>> cfgCutTable{"cfgCutTable", {cutsTable[0], nCuts, cutNames}, "Particle selections"};
-  Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
+  Configurable<LabeledArray<float>> ConfCutTable{"ConfCutTable", {cutsTable[0], nCuts, cutNames}, "Particle selections"};
+  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
-  Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
+  Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{1}, "Particle 1 - Read from cutCulator"};
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
-  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
@@ -78,7 +78,7 @@ struct femtoDreamDebugTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHisto.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC, true);
+    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, true);
     vPIDPartOne = ConfPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }
@@ -89,11 +89,10 @@ struct femtoDreamDebugTrack {
   {
     eventHisto.fillQA(col);
     for (auto& part : groupPartsOne) {
-      if (part.p() > cfgCutTable->get("MaxP") ||
-          part.pt() > cfgCutTable->get("MaxPt")) {
+      if (part.p() > ConfCutTable->get("MaxP") || part.pt() > ConfCutTable->get("MaxPt")) {
         continue;
       }
-      if (!isFullPIDSelected(part.pidcut(), part.p(), cfgCutTable->get("PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("nSigmaTPC"), cfgCutTable->get("nSigmaTPCTOF"))) {
+      if (!isFullPIDSelected(part.pidcut(), part.p(), ConfCutTable->get("PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfCutTable->get("nSigmaTPC"), ConfCutTable->get("nSigmaTPCTOF"))) {
         continue;
       }
       trackHisto.fillQA<isMC, true>(part);

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -13,6 +13,10 @@
 /// \brief Tasks that reads the particle tables and fills QA histograms for V0s
 /// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
+#include <fairlogger/Logger.h>
+#include <cstdint>
+#include <iostream>
+#include <vector>
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
@@ -36,15 +40,26 @@ struct femtoDreamDebugV0 {
   SliceCache cache;
 
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 3122, "Particle 1 - PDG code"};
-  Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 338, "Particle 1 - Selection bit from cutCulator"};
+  Configurable<uint32_t> ConfCutV0{"ConfCutV0", 338, "V0 - Selection bit from cutCulator"};
+
+  Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
+  Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
+
+  Configurable<float> ConfChildPosPidnSigmaMax{"ConfChildPosPidnSigmaMax", 3.f, "Positive Child of V0 - Selection bit from cutCulator"};
+  Configurable<float> ConfChildNegPidnSigmaMax{"ConfChildNegPidnSigmaMax", 3.f, "Negative Child of V0 - Selection bit from cutCulator"};
+  Configurable<int> ConfChildPosPos{"ConfChildPosPos", 1, "Positive Child of V0 - Selection bit from cutCulator"};
+  Configurable<int> ConfChildNegPos{"ConfChildNegPos", 0, "Negative Child of V0 - Selection bit from cutCulator"};
+
+  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{
+    "ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f},
+    "V0 Child sel: Max. PID nSigma TPC"};
+  Configurable<int> cfgNspecies{"ccfgNspecies", 2, "Number of particle spieces (for V0 children) with PID info"};
 
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
 
-  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
-                                           // (aod::femtodreamparticle::pt < cfgCutTable->get("MaxPt")) &&
-                                           ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutV0) == ConfCutV0);
 
-  Preslice<aod::FemtoDreamParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
@@ -76,10 +91,186 @@ struct femtoDreamDebugV0 {
     FullQaRegistry.add("FullV0QA/hInvMassLambda", "", kTH1F, {massAxisLambda});
     FullQaRegistry.add("FullV0QA/hInvMassAntiLambda", "", kTH1F, {massAxisAntiLambda});
     FullQaRegistry.add("FullV0QA/hInvMassLambdaAntiLambda", "", kTH2F, {massAxisLambda, massAxisAntiLambda});
+
+    FullQaRegistry.add("FullDaughterPosQA/hCharge", "; Q (e); Entries",
+                       kTH1F, {{5, -2.5, 2.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
+                       kTH1F, {{240, 0, 6}});
+    FullQaRegistry.add("FullDaughterPosQA/hEta", "; #eta; Entries", kTH1F,
+                       {{200, -1.5, 1.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hPhi", "; #phi; Entries", kTH1F,
+                       {{200, 0, 2. * M_PI}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCfindable",
+                       "; TPC findable clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCfound", "; TPC found clusters; Entries",
+                       kTH1F, {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCcrossedOverFindalbe",
+                       "; TPC ratio findable; Entries", kTH1F,
+                       {{100, 0.5, 1.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCcrossedRows",
+                       "; TPC crossed rows; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCfindableVsCrossed",
+                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
+                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCshared",
+                       "; TPC shared clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hITSclusters", "; ITS clusters; Entries",
+                       kTH1F, {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hITSclustersIB",
+                       "; ITS clusters in IB; Entries", kTH1F,
+                       {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hDCAxy",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
+                       {{20, 0.5, 4.05}, {500, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/hDCAz",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
+                       {{100, 0, 10}, {500, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/hDCA",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
+                       {{100, 0, 10}, {301, 0., 1.5}});
+    FullQaRegistry.add("FullDaughterPosQA/hTPCdEdX",
+                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
+                       {{100, 0, 10}, {1000, 0, 1000}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+
+    FullQaRegistry.add("FullDaughterNegQA/hCharge", "; Q (e); Entries",
+                       kTH1F, {{5, -2.5, 2.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
+                       kTH1F, {{240, 0, 6}});
+    FullQaRegistry.add("FullDaughterNegQA/hEta", "; #eta; Entries", kTH1F,
+                       {{200, -1.5, 1.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hPhi", "; #phi; Entries", kTH1F,
+                       {{200, 0, 2. * M_PI}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCfindable",
+                       "; TPC findable clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCfound", "; TPC found clusters; Entries",
+                       kTH1F, {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCcrossedOverFindalbe",
+                       "; TPC ratio findable; Entries", kTH1F,
+                       {{100, 0.5, 1.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCcrossedRows",
+                       "; TPC crossed rows; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCfindableVsCrossed",
+                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
+                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCshared",
+                       "; TPC shared clusters; Entries", kTH1F,
+                       {{163, -0.5, 162.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hITSclusters", "; ITS clusters; Entries",
+                       kTH1F, {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hITSclustersIB",
+                       "; ITS clusters in IB; Entries", kTH1F,
+                       {{10, -0.5, 9.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hDCAxy",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
+                       {{20, 0.5, 4.05}, {500, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/hDCAz",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
+                       {{100, 0, 10}, {500, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/hDCA",
+                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
+                       {{100, 0, 10}, {301, 0., 1.5}});
+    FullQaRegistry.add("FullDaughterNegQA/hTPCdEdX",
+                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
+                       {{100, 0, 10}, {1000, 0, 1000}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_el",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_pi",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_K",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_p",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
+    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_d",
+                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
+                       {{100, 0, 10}, {100, -5, 5}});
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
-  void process(o2::aod::FemtoDreamCollision& col, FemtoFullParticles& parts)
+  void process(o2::aod::FemtoDreamCollision const& col, FemtoFullParticles const& parts)
   {
     auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
 
@@ -87,24 +278,205 @@ struct femtoDreamDebugV0 {
 
     for (auto& part : groupPartsOne) {
 
-      FullQaRegistry.fill(HIST("FullV0QA/hPt"), part.pt());
-      FullQaRegistry.fill(HIST("FullV0QA/hEta"), part.eta());
-      FullQaRegistry.fill(HIST("FullV0QA/hPhi"), part.phi());
-      FullQaRegistry.fill(HIST("FullV0QA/hDaughDCA"), part.daughDCA());
-      FullQaRegistry.fill(HIST("FullV0QA/hTransRadius"), part.transRadius());
-      FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxX"), part.decayVtxX());
-      FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxY"), part.decayVtxY());
-      FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxZ"), part.decayVtxZ());
-      FullQaRegistry.fill(HIST("FullV0QA/hCPA"), part.tempFitVar());
-      FullQaRegistry.fill(HIST("FullV0QA/hCPAvsPt"), part.pt(), part.tempFitVar());
-      FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambda"), part.mLambda());
-      FullQaRegistry.fill(HIST("FullV0QA/hInvMassAntiLambda"), part.mAntiLambda());
-      FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
+      if (!part.has_children()) {
+        continue;
+      }
+
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
+
+      if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
+        LOG(warn) << "Indices of V0 children do not match";
+        LOG(info) << posChild.globalIndex();
+        LOG(info) << part.childrenIds()[0];
+        continue;
+      }
+
+      // check cuts on V0 children
+      if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
+          (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg)) {
+
+        if (!isPIDSelected(posChild.pidcut(),
+                           std::vector<int>(ConfChildPosPos.value),
+                           cfgNspecies.value,
+                           ConfChildPosPidnSigmaMax.value,
+                           ConfChildPIDnSigmaMax.value,
+                           o2::analysis::femtoDream::kDetector::kTPC) ||
+            !isPIDSelected(negChild.pidcut(),
+                           std::vector<int>(ConfChildNegPos.value),
+                           cfgNspecies.value,
+                           ConfChildNegPidnSigmaMax.value,
+                           ConfChildPIDnSigmaMax.value,
+                           o2::analysis::femtoDream::kDetector::kTPC)) {
+          continue;
+        }
+
+        FullQaRegistry.fill(HIST("FullV0QA/hPt"), part.pt());
+        FullQaRegistry.fill(HIST("FullV0QA/hEta"), part.eta());
+        FullQaRegistry.fill(HIST("FullV0QA/hPhi"), part.phi());
+        FullQaRegistry.fill(HIST("FullV0QA/hDaughDCA"), part.daughDCA());
+        FullQaRegistry.fill(HIST("FullV0QA/hTransRadius"), part.transRadius());
+        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxX"), part.decayVtxX());
+        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxY"), part.decayVtxY());
+        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxZ"), part.decayVtxZ());
+        FullQaRegistry.fill(HIST("FullV0QA/hCPA"), part.tempFitVar());
+        FullQaRegistry.fill(HIST("FullV0QA/hCPAvsPt"), part.pt(), part.tempFitVar());
+        FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambda"), part.mLambda());
+        FullQaRegistry.fill(HIST("FullV0QA/hInvMassAntiLambda"), part.mAntiLambda());
+        FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
+
+        // asdf
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hCharge"), posChild.sign());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hPt"), posChild.pt());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hEta"), posChild.eta());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hPhi"), posChild.phi());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hDCAxy"), posChild.pt(),
+                            posChild.tempFitVar());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfindable"),
+                            posChild.tpcNClsFindable());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfound"), posChild.tpcNClsFound());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCcrossedOverFindalbe"),
+                            posChild.tpcCrossedRowsOverFindableCls());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCcrossedRows"),
+                            posChild.tpcNClsCrossedRows());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfindableVsCrossed"),
+                            posChild.tpcNClsFindable(), posChild.tpcNClsCrossedRows());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCshared"), posChild.tpcNClsShared());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hITSclusters"), posChild.itsNCls());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hITSclustersIB"),
+                            posChild.itsNClsInnerBarrel());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hDCAz"), posChild.pt(), posChild.dcaZ());
+        FullQaRegistry.fill(
+          HIST("FullDaughterPosQA/hDCA"), posChild.pt(),
+          std::sqrt(pow(posChild.dcaXY(), 2.) + pow(posChild.dcaZ(), 2.)));
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCdEdX"), posChild.p(),
+                            posChild.tpcSignal());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_el"), posChild.p(),
+                            posChild.tpcNSigmaEl());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_pi"), posChild.p(),
+                            posChild.tpcNSigmaPi());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_K"), posChild.p(),
+                            posChild.tpcNSigmaKa());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_p"), posChild.p(),
+                            posChild.tpcNSigmaPr());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_d"), posChild.p(),
+                            posChild.tpcNSigmaDe());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_el"), posChild.p(),
+                            posChild.tofNSigmaEl());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_pi"), posChild.p(),
+                            posChild.tofNSigmaPi());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_K"), posChild.p(),
+                            posChild.tofNSigmaKa());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_p"), posChild.p(),
+                            posChild.tofNSigmaPr());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_d"), posChild.p(),
+                            posChild.tofNSigmaDe());
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_el"), posChild.p(),
+                            std::sqrt(posChild.tpcNSigmaEl() * posChild.tpcNSigmaEl() +
+                                      posChild.tofNSigmaEl() * posChild.tofNSigmaEl()));
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_pi"), posChild.p(),
+                            std::sqrt(posChild.tpcNSigmaPi() * posChild.tpcNSigmaPi() +
+                                      posChild.tofNSigmaPi() * posChild.tofNSigmaPi()));
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_K"), posChild.p(),
+                            std::sqrt(posChild.tpcNSigmaKa() * posChild.tpcNSigmaKa() +
+                                      posChild.tofNSigmaKa() * posChild.tofNSigmaKa()));
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_p"), posChild.p(),
+                            std::sqrt(posChild.tpcNSigmaPr() * posChild.tpcNSigmaPr() +
+                                      posChild.tofNSigmaPr() * posChild.tofNSigmaPr()));
+        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_d"), posChild.p(),
+                            std::sqrt(posChild.tpcNSigmaDe() * posChild.tpcNSigmaDe() +
+                                      posChild.tofNSigmaDe() * posChild.tofNSigmaDe()));
+
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hCharge"), negChild.sign());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hPt"), negChild.pt());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hEta"), negChild.eta());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hPhi"), negChild.phi());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hDCAxy"), negChild.pt(),
+                            negChild.tempFitVar());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfindable"),
+                            negChild.tpcNClsFindable());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfound"), negChild.tpcNClsFound());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCcrossedOverFindalbe"),
+                            negChild.tpcCrossedRowsOverFindableCls());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCcrossedRows"),
+                            negChild.tpcNClsCrossedRows());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfindableVsCrossed"),
+                            negChild.tpcNClsFindable(), negChild.tpcNClsCrossedRows());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCshared"), negChild.tpcNClsShared());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hITSclusters"), negChild.itsNCls());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hITSclustersIB"),
+                            negChild.itsNClsInnerBarrel());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hDCAz"), negChild.pt(), negChild.dcaZ());
+        FullQaRegistry.fill(
+          HIST("FullDaughterNegQA/hDCA"), negChild.pt(),
+          std::sqrt(pow(negChild.dcaXY(), 2.) + pow(negChild.dcaZ(), 2.)));
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCdEdX"), negChild.p(),
+                            negChild.tpcSignal());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_el"), negChild.p(),
+                            negChild.tpcNSigmaEl());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_pi"), negChild.p(),
+                            negChild.tpcNSigmaPi());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_K"), negChild.p(),
+                            negChild.tpcNSigmaKa());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_p"), negChild.p(),
+                            negChild.tpcNSigmaPr());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_d"), negChild.p(),
+                            negChild.tpcNSigmaDe());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_el"), negChild.p(),
+                            negChild.tofNSigmaEl());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_pi"), negChild.p(),
+                            negChild.tofNSigmaPi());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_K"), negChild.p(),
+                            negChild.tofNSigmaKa());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_p"), negChild.p(),
+                            negChild.tofNSigmaPr());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_d"), negChild.p(),
+                            negChild.tofNSigmaDe());
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_el"), negChild.p(),
+                            std::sqrt(negChild.tpcNSigmaEl() * negChild.tpcNSigmaEl() +
+                                      negChild.tofNSigmaEl() * negChild.tofNSigmaEl()));
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_pi"), negChild.p(),
+                            std::sqrt(negChild.tpcNSigmaPi() * negChild.tpcNSigmaPi() +
+                                      negChild.tofNSigmaPi() * negChild.tofNSigmaPi()));
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_K"), negChild.p(),
+                            std::sqrt(negChild.tpcNSigmaKa() * negChild.tpcNSigmaKa() +
+                                      negChild.tofNSigmaKa() * negChild.tofNSigmaKa()));
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_p"), negChild.p(),
+                            std::sqrt(negChild.tpcNSigmaPr() * negChild.tpcNSigmaPr() +
+                                      negChild.tofNSigmaPr() * negChild.tofNSigmaPr()));
+        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_d"), negChild.p(),
+                            std::sqrt(negChild.tpcNSigmaDe() * negChild.tpcNSigmaDe() +
+                                      negChild.tofNSigmaDe() * negChild.tofNSigmaDe()));
+      }
     }
+
+    // for(auto& p: parts){}
+    // LOG(info) << "MotherIndex: " << part.index();
+    // LOG(info) << "MotherGlobalIndex: " << part.globalIndex();
+    // uint64_t id1 = static_cast<uint64_t>(part.childrenIds()[0]);
+    // uint64_t id2 = static_cast<uint64_t>(part.childrenIds()[1]);
+    //
+    // LOG(info) << "Index from mother: " << id1;
+    // LOG(info) << "Index from mother: " << id2;
+    //
+    // uint64_t begin = static_cast<uint64_t>(parts.begin().index());
+    // LOG(info) << "StartIndex: " << begin;
+    //
+    // LOG(info) << "New Index from mother: " << id1 - begin;
+    // LOG(info) << "New Index from mother: " << id2 - begin;
+    //
+    // for (const auto& child : part.children_as<o2::aod::FemtoDreamParticles>()) {
+    //   LOG(info) << "ChildIndex: " << static_cast<uint64_t>(child.index());
+    //   LOG(info) << "New ChildIndex from mother: " << child.index() - begin;
+    //   LOG(info) << "ChildGlobalIndex: " << static_cast<uint64_t>(child.globalIndex());
+    //   LOG(info) << "New ChildGlobalIndex: " << child.globalIndex() - begin;
+    // LOG(info) << allParts.pt();
+    // }
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+WorkflowSpec
+  defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
     adaptAnalysisTask<femtoDreamDebugV0>(cfgc),

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -55,6 +55,9 @@ struct femtoDreamDebugV0 {
     "V0 Child sel: Max. PID nSigma TPC"};
   Configurable<int> cfgNspecies{"ccfgNspecies", 2, "Number of particle spieces (for V0 children) with PID info"};
 
+  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
 
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutV0) == ConfCutV0);
@@ -64,16 +67,25 @@ struct femtoDreamDebugV0 {
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
 
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child> posChildHisto;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child> negChildHisto;
+
   /// The configurables need to be passed to an std::vector
   std::vector<int> vPIDPartOne;
 
   /// Histogram output
-  HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry qaRegistry{"Event", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry qaRegistryPos{"PosTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry qaRegistryNeg{"NegTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry FullQaRegistry{"FullV0QA", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
+    LOG(warn) << "Init start";
+    // posChildHisto.init(&qaRegistryPos, CfgTempFitVarpTBins, CfgTempFitVarBins, false, true);
+    // negChildHisto.init(&qaRegistryNeg, CfgTempFitVarpTBins, CfgTempFitVarBins, false, true);
+    LOG(warn) << "Init done";
 
     AxisSpec massAxisLambda = {600, 0.0f, 3.0f, "m_{#Lambda} (GeV/#it{c}^{2})"};
     AxisSpec massAxisAntiLambda = {600, 0.0f, 3.0f, "m_{#bar{#Lambda}} (GeV/#it{c}^{2})"};

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -41,449 +41,67 @@ struct femtoDreamDebugV0 {
 
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 3122, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutV0{"ConfCutV0", 338, "V0 - Selection bit from cutCulator"};
+  ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
 
   Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
-
   Configurable<float> ConfChildPosPidnSigmaMax{"ConfChildPosPidnSigmaMax", 3.f, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<float> ConfChildNegPidnSigmaMax{"ConfChildNegPidnSigmaMax", 3.f, "Negative Child of V0 - Selection bit from cutCulator"};
-  Configurable<int> ConfChildPosPos{"ConfChildPosPos", 1, "Positive Child of V0 - Selection bit from cutCulator"};
-  Configurable<int> ConfChildNegPos{"ConfChildNegPos", 0, "Negative Child of V0 - Selection bit from cutCulator"};
-
-  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{
-    "ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f},
-    "V0 Child sel: Max. PID nSigma TPC"};
-  Configurable<int> cfgNspecies{"ccfgNspecies", 2, "Number of particle spieces (for V0 children) with PID info"};
-
-  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  Configurable<int> ConfChildPosIndex{"ConfChildPosIndex", 1, "Positive Child of V0 - Index from cutCulator"};
+  Configurable<int> ConfChildNegIndex{"ConfChildNegIndex", 0, "Negative Child of V0 - Index from cutCulator"};
+  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f}, "V0 child sel: Max. PID nSigma TPC"};
+  Configurable<int> ConfChildnSpecies{"ConfChildnSpecies", 2, "Number of particle spieces (for V0 children) with PID info"};
+  ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
-
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutV0) == ConfCutV0);
-
   Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
-  /// Histogramming for Event
+  /// Histogramming
   FemtoDreamEventHisto eventHisto;
-
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child> posChildHisto;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child> negChildHisto;
-
-  /// The configurables need to be passed to an std::vector
-  std::vector<int> vPIDPartOne;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0> V0Histos;
 
   /// Histogram output
-  HistogramRegistry qaRegistry{"Event", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry qaRegistryPos{"PosTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry qaRegistryNeg{"NegTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry FullQaRegistry{"FullV0QA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry EventRegistry{"Event", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry V0Registry{"FullV0QA", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {
-    eventHisto.init(&qaRegistry);
-    LOG(warn) << "Init start";
-    // posChildHisto.init(&qaRegistryPos, CfgTempFitVarpTBins, CfgTempFitVarBins, false, true);
-    // negChildHisto.init(&qaRegistryNeg, CfgTempFitVarpTBins, CfgTempFitVarBins, false, true);
-    LOG(warn) << "Init done";
-
-    AxisSpec massAxisLambda = {600, 0.0f, 3.0f, "m_{#Lambda} (GeV/#it{c}^{2})"};
-    AxisSpec massAxisAntiLambda = {600, 0.0f, 3.0f, "m_{#bar{#Lambda}} (GeV/#it{c}^{2})"};
-
-    FullQaRegistry.add("FullV0QA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
-    FullQaRegistry.add("FullV0QA/hEta", "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
-    FullQaRegistry.add("FullV0QA/hPhi", "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
-    FullQaRegistry.add("FullV0QA/hDaughDCA", "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
-    FullQaRegistry.add("FullV0QA/hTransRadius", "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
-    FullQaRegistry.add("FullV0QA/hDecayVtxX", "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
-    FullQaRegistry.add("FullV0QA/hDecayVtxY", "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
-    FullQaRegistry.add("FullV0QA/hDecayVtxZ", "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
-    FullQaRegistry.add("FullV0QA/hCPA", "; #it{cos #theta_{p}}; Entries", kTH1F, {{1000, 0.9, 1.}});
-    FullQaRegistry.add("FullV0QA/hCPAvsPt", "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}", kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
-    FullQaRegistry.add("FullV0QA/hInvMassLambda", "", kTH1F, {massAxisLambda});
-    FullQaRegistry.add("FullV0QA/hInvMassAntiLambda", "", kTH1F, {massAxisAntiLambda});
-    FullQaRegistry.add("FullV0QA/hInvMassLambdaAntiLambda", "", kTH2F, {massAxisLambda, massAxisAntiLambda});
-
-    FullQaRegistry.add("FullDaughterPosQA/hCharge", "; Q (e); Entries",
-                       kTH1F, {{5, -2.5, 2.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
-                       kTH1F, {{240, 0, 6}});
-    FullQaRegistry.add("FullDaughterPosQA/hEta", "; #eta; Entries", kTH1F,
-                       {{200, -1.5, 1.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hPhi", "; #phi; Entries", kTH1F,
-                       {{200, 0, 2. * M_PI}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCfindable",
-                       "; TPC findable clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCfound", "; TPC found clusters; Entries",
-                       kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCcrossedOverFindalbe",
-                       "; TPC ratio findable; Entries", kTH1F,
-                       {{100, 0.5, 1.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCcrossedRows",
-                       "; TPC crossed rows; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCfindableVsCrossed",
-                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
-                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCshared",
-                       "; TPC shared clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hITSclusters", "; ITS clusters; Entries",
-                       kTH1F, {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hITSclustersIB",
-                       "; ITS clusters in IB; Entries", kTH1F,
-                       {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hDCAxy",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
-                       {{20, 0.5, 4.05}, {500, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/hDCAz",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
-                       {{100, 0, 10}, {500, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/hDCA",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
-                       {{100, 0, 10}, {301, 0., 1.5}});
-    FullQaRegistry.add("FullDaughterPosQA/hTPCdEdX",
-                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
-                       {{100, 0, 10}, {1000, 0, 1000}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTPC_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaTOF_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterPosQA/nSigmaComb_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-
-    FullQaRegistry.add("FullDaughterNegQA/hCharge", "; Q (e); Entries",
-                       kTH1F, {{5, -2.5, 2.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hPt", "; #it{p}_{T} (GeV/#it{c}); Entries",
-                       kTH1F, {{240, 0, 6}});
-    FullQaRegistry.add("FullDaughterNegQA/hEta", "; #eta; Entries", kTH1F,
-                       {{200, -1.5, 1.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hPhi", "; #phi; Entries", kTH1F,
-                       {{200, 0, 2. * M_PI}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCfindable",
-                       "; TPC findable clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCfound", "; TPC found clusters; Entries",
-                       kTH1F, {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCcrossedOverFindalbe",
-                       "; TPC ratio findable; Entries", kTH1F,
-                       {{100, 0.5, 1.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCcrossedRows",
-                       "; TPC crossed rows; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCfindableVsCrossed",
-                       ";TPC findable clusters ; TPC crossed rows;", kTH2F,
-                       {{163, -0.5, 162.5}, {163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCshared",
-                       "; TPC shared clusters; Entries", kTH1F,
-                       {{163, -0.5, 162.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hITSclusters", "; ITS clusters; Entries",
-                       kTH1F, {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hITSclustersIB",
-                       "; ITS clusters in IB; Entries", kTH1F,
-                       {{10, -0.5, 9.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hDCAxy",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F,
-                       {{20, 0.5, 4.05}, {500, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/hDCAz",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F,
-                       {{100, 0, 10}, {500, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/hDCA",
-                       "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F,
-                       {{100, 0, 10}, {301, 0., 1.5}});
-    FullQaRegistry.add("FullDaughterNegQA/hTPCdEdX",
-                       "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F,
-                       {{100, 0, 10}, {1000, 0, 1000}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTPC_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaTOF_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_el",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_pi",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_K",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_p",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
-    FullQaRegistry.add("FullDaughterNegQA/nSigmaComb_d",
-                       "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F,
-                       {{100, 0, 10}, {100, -5, 5}});
+    eventHisto.init(&EventRegistry);
+    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, true);
+    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, true);
+    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, false, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
   void process(o2::aod::FemtoDreamCollision const& col, FemtoFullParticles const& parts)
   {
     auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
-
     eventHisto.fillQA(col);
-
     for (auto& part : groupPartsOne) {
-
       if (!part.has_children()) {
         continue;
       }
-
       const auto& posChild = parts.iteratorAt(part.index() - 2);
       const auto& negChild = parts.iteratorAt(part.index() - 1);
-
       if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
         LOG(warn) << "Indices of V0 children do not match";
-        LOG(info) << posChild.globalIndex();
-        LOG(info) << part.childrenIds()[0];
         continue;
       }
-
       // check cuts on V0 children
       if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
-          (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg)) {
-
-        if (!isPIDSelected(posChild.pidcut(),
-                           std::vector<int>(ConfChildPosPos.value),
-                           cfgNspecies.value,
-                           ConfChildPosPidnSigmaMax.value,
-                           ConfChildPIDnSigmaMax.value,
-                           o2::analysis::femtoDream::kDetector::kTPC) ||
-            !isPIDSelected(negChild.pidcut(),
-                           std::vector<int>(ConfChildNegPos.value),
-                           cfgNspecies.value,
-                           ConfChildNegPidnSigmaMax.value,
-                           ConfChildPIDnSigmaMax.value,
-                           o2::analysis::femtoDream::kDetector::kTPC)) {
-          continue;
-        }
-
-        FullQaRegistry.fill(HIST("FullV0QA/hPt"), part.pt());
-        FullQaRegistry.fill(HIST("FullV0QA/hEta"), part.eta());
-        FullQaRegistry.fill(HIST("FullV0QA/hPhi"), part.phi());
-        FullQaRegistry.fill(HIST("FullV0QA/hDaughDCA"), part.daughDCA());
-        FullQaRegistry.fill(HIST("FullV0QA/hTransRadius"), part.transRadius());
-        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxX"), part.decayVtxX());
-        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxY"), part.decayVtxY());
-        FullQaRegistry.fill(HIST("FullV0QA/hDecayVtxZ"), part.decayVtxZ());
-        FullQaRegistry.fill(HIST("FullV0QA/hCPA"), part.tempFitVar());
-        FullQaRegistry.fill(HIST("FullV0QA/hCPAvsPt"), part.pt(), part.tempFitVar());
-        FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambda"), part.mLambda());
-        FullQaRegistry.fill(HIST("FullV0QA/hInvMassAntiLambda"), part.mAntiLambda());
-        FullQaRegistry.fill(HIST("FullV0QA/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
-
-        // asdf
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hCharge"), posChild.sign());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hPt"), posChild.pt());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hEta"), posChild.eta());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hPhi"), posChild.phi());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hDCAxy"), posChild.pt(),
-                            posChild.tempFitVar());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfindable"),
-                            posChild.tpcNClsFindable());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfound"), posChild.tpcNClsFound());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCcrossedOverFindalbe"),
-                            posChild.tpcCrossedRowsOverFindableCls());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCcrossedRows"),
-                            posChild.tpcNClsCrossedRows());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCfindableVsCrossed"),
-                            posChild.tpcNClsFindable(), posChild.tpcNClsCrossedRows());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCshared"), posChild.tpcNClsShared());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hITSclusters"), posChild.itsNCls());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hITSclustersIB"),
-                            posChild.itsNClsInnerBarrel());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hDCAz"), posChild.pt(), posChild.dcaZ());
-        FullQaRegistry.fill(
-          HIST("FullDaughterPosQA/hDCA"), posChild.pt(),
-          std::sqrt(pow(posChild.dcaXY(), 2.) + pow(posChild.dcaZ(), 2.)));
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/hTPCdEdX"), posChild.p(),
-                            posChild.tpcSignal());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_el"), posChild.p(),
-                            posChild.tpcNSigmaEl());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_pi"), posChild.p(),
-                            posChild.tpcNSigmaPi());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_K"), posChild.p(),
-                            posChild.tpcNSigmaKa());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_p"), posChild.p(),
-                            posChild.tpcNSigmaPr());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTPC_d"), posChild.p(),
-                            posChild.tpcNSigmaDe());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_el"), posChild.p(),
-                            posChild.tofNSigmaEl());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_pi"), posChild.p(),
-                            posChild.tofNSigmaPi());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_K"), posChild.p(),
-                            posChild.tofNSigmaKa());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_p"), posChild.p(),
-                            posChild.tofNSigmaPr());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaTOF_d"), posChild.p(),
-                            posChild.tofNSigmaDe());
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_el"), posChild.p(),
-                            std::sqrt(posChild.tpcNSigmaEl() * posChild.tpcNSigmaEl() +
-                                      posChild.tofNSigmaEl() * posChild.tofNSigmaEl()));
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_pi"), posChild.p(),
-                            std::sqrt(posChild.tpcNSigmaPi() * posChild.tpcNSigmaPi() +
-                                      posChild.tofNSigmaPi() * posChild.tofNSigmaPi()));
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_K"), posChild.p(),
-                            std::sqrt(posChild.tpcNSigmaKa() * posChild.tpcNSigmaKa() +
-                                      posChild.tofNSigmaKa() * posChild.tofNSigmaKa()));
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_p"), posChild.p(),
-                            std::sqrt(posChild.tpcNSigmaPr() * posChild.tpcNSigmaPr() +
-                                      posChild.tofNSigmaPr() * posChild.tofNSigmaPr()));
-        FullQaRegistry.fill(HIST("FullDaughterPosQA/nSigmaComb_d"), posChild.p(),
-                            std::sqrt(posChild.tpcNSigmaDe() * posChild.tpcNSigmaDe() +
-                                      posChild.tofNSigmaDe() * posChild.tofNSigmaDe()));
-
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hCharge"), negChild.sign());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hPt"), negChild.pt());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hEta"), negChild.eta());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hPhi"), negChild.phi());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hDCAxy"), negChild.pt(),
-                            negChild.tempFitVar());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfindable"),
-                            negChild.tpcNClsFindable());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfound"), negChild.tpcNClsFound());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCcrossedOverFindalbe"),
-                            negChild.tpcCrossedRowsOverFindableCls());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCcrossedRows"),
-                            negChild.tpcNClsCrossedRows());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCfindableVsCrossed"),
-                            negChild.tpcNClsFindable(), negChild.tpcNClsCrossedRows());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCshared"), negChild.tpcNClsShared());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hITSclusters"), negChild.itsNCls());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hITSclustersIB"),
-                            negChild.itsNClsInnerBarrel());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hDCAz"), negChild.pt(), negChild.dcaZ());
-        FullQaRegistry.fill(
-          HIST("FullDaughterNegQA/hDCA"), negChild.pt(),
-          std::sqrt(pow(negChild.dcaXY(), 2.) + pow(negChild.dcaZ(), 2.)));
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/hTPCdEdX"), negChild.p(),
-                            negChild.tpcSignal());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_el"), negChild.p(),
-                            negChild.tpcNSigmaEl());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_pi"), negChild.p(),
-                            negChild.tpcNSigmaPi());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_K"), negChild.p(),
-                            negChild.tpcNSigmaKa());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_p"), negChild.p(),
-                            negChild.tpcNSigmaPr());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTPC_d"), negChild.p(),
-                            negChild.tpcNSigmaDe());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_el"), negChild.p(),
-                            negChild.tofNSigmaEl());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_pi"), negChild.p(),
-                            negChild.tofNSigmaPi());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_K"), negChild.p(),
-                            negChild.tofNSigmaKa());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_p"), negChild.p(),
-                            negChild.tofNSigmaPr());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaTOF_d"), negChild.p(),
-                            negChild.tofNSigmaDe());
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_el"), negChild.p(),
-                            std::sqrt(negChild.tpcNSigmaEl() * negChild.tpcNSigmaEl() +
-                                      negChild.tofNSigmaEl() * negChild.tofNSigmaEl()));
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_pi"), negChild.p(),
-                            std::sqrt(negChild.tpcNSigmaPi() * negChild.tpcNSigmaPi() +
-                                      negChild.tofNSigmaPi() * negChild.tofNSigmaPi()));
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_K"), negChild.p(),
-                            std::sqrt(negChild.tpcNSigmaKa() * negChild.tpcNSigmaKa() +
-                                      negChild.tofNSigmaKa() * negChild.tofNSigmaKa()));
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_p"), negChild.p(),
-                            std::sqrt(negChild.tpcNSigmaPr() * negChild.tpcNSigmaPr() +
-                                      negChild.tofNSigmaPr() * negChild.tofNSigmaPr()));
-        FullQaRegistry.fill(HIST("FullDaughterNegQA/nSigmaComb_d"), negChild.p(),
-                            std::sqrt(negChild.tpcNSigmaDe() * negChild.tpcNSigmaDe() +
-                                      negChild.tofNSigmaDe() * negChild.tofNSigmaDe()));
+          (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) &&
+          isFullPIDSelected(posChild.pidcut(), 0.f, 1.f, std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
+          isFullPIDSelected(negChild.pidcut(), 0.f, 1.f, std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
+        V0Histos.fillQA<false, true>(part);
+        posChildHistos.fillQA<false, true>(posChild);
+        negChildHistos.fillQA<false, true>(negChild);
       }
     }
-
-    // for(auto& p: parts){}
-    // LOG(info) << "MotherIndex: " << part.index();
-    // LOG(info) << "MotherGlobalIndex: " << part.globalIndex();
-    // uint64_t id1 = static_cast<uint64_t>(part.childrenIds()[0]);
-    // uint64_t id2 = static_cast<uint64_t>(part.childrenIds()[1]);
-    //
-    // LOG(info) << "Index from mother: " << id1;
-    // LOG(info) << "Index from mother: " << id2;
-    //
-    // uint64_t begin = static_cast<uint64_t>(parts.begin().index());
-    // LOG(info) << "StartIndex: " << begin;
-    //
-    // LOG(info) << "New Index from mother: " << id1 - begin;
-    // LOG(info) << "New Index from mother: " << id2 - begin;
-    //
-    // for (const auto& child : part.children_as<o2::aod::FemtoDreamParticles>()) {
-    //   LOG(info) << "ChildIndex: " << static_cast<uint64_t>(child.index());
-    //   LOG(info) << "New ChildIndex from mother: " << child.index() - begin;
-    //   LOG(info) << "ChildGlobalIndex: " << static_cast<uint64_t>(child.globalIndex());
-    //   LOG(info) << "New ChildGlobalIndex: " << child.globalIndex() - begin;
-    // LOG(info) << allParts.pt();
-    // }
   }
 };
 

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -60,8 +60,8 @@ struct femtoDreamPairTaskTrackTrack {
   /// Table for both particles
   Configurable<LabeledArray<float>> cfgCutTable{"cfgCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
   Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
-  Configurable<std::vector<float>> ConfPIDnSigmaMax{"ConfPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
 
   /// Particle 1
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
@@ -147,7 +147,7 @@ struct femtoDreamPairTaskTrackTrack {
 
     vPIDPartOne = ConfPIDPartOne;
     vPIDPartTwo = ConfPIDPartTwo;
-    kNsigma = ConfPIDnSigmaMax;
+    kNsigma = ConfTrkPIDnSigmaMax;
   }
 
   template <typename CollisionType>

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -51,17 +51,16 @@ static const float cutsTable[nPart][nCuts]{
 } // namespace
 
 struct femtoDreamPairTaskTrackTrack {
-  Service<O2DatabasePDG> pdg;
   SliceCache cache;
   Preslice<aod::FemtoDreamDebugParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
   /// Particle selection part
 
   /// Table for both particles
-  Configurable<LabeledArray<float>> cfgCutTable{"cfgCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
-  Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
+  Configurable<LabeledArray<float>> ConfCutTable{"ConfCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
+  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
 
   /// Particle 1
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
@@ -99,22 +98,24 @@ struct femtoDreamPairTaskTrackTrack {
   std::vector<float> kNsigma;
 
   /// particle part
-  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   /// Correlation part
-  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
+  ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
   // ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
-  ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
+  ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
 
-  ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinning{{CfgVtxBins, CfgMultBins}, true};
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
 
-  ConfigurableAxis CfgkstarBins{"CfgkstarBins", {1500, 0., 6.}, "binning kstar"};
-  ConfigurableAxis CfgkTBins{"CfgkTBins", {150, 0., 9.}, "binning kT"};
-  ConfigurableAxis CfgmTBins{"CfgmTBins", {225, 0., 7.5}, "binning mT"};
+  ConfigurableAxis ConfkstarBins{"ConfkstarBins", {1500, 0., 6.}, "binning kstar"};
+  ConfigurableAxis ConfkTBins{"ConfkTBins", {150, 0., 9.}, "binning kT"};
+  ConfigurableAxis ConfmTBins{"ConfmTBins", {225, 0., 7.5}, "binning mT"};
   Configurable<int> ConfNEventsMix{"ConfNEventsMix", 5, "Number of events for mixing"};
   Configurable<bool> ConfIsCPR{"ConfIsCPR", true, "Close Pair Rejection"};
   Configurable<bool> ConfCPRPlotPerRadii{"ConfCPRPlotPerRadii", false, "Plot CPR per radii"};
+  Configurable<float> ConfCPRdeltaPhiMax{"ConfCPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+  Configurable<float> ConfCPRdeltaEtaMax{"ConfCPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
 
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
@@ -128,21 +129,21 @@ struct femtoDreamPairTaskTrackTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC);
     if (!ConfIsSame) {
-      trackHistoPartTwo.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC);
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
-    sameEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfIsMC);
-    mixedEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfIsMC);
+    sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfIsMC);
+    mixedEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfIsMC);
     sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
     mixedEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
     pairCleaner.init(&qaRegistry);
-    if (ConfIsCPR) {
-      pairCloseRejection.init(&resultRegistry, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii); /// \todo add config for Δη and ΔΦ cut values
+    if (ConfIsCPR.value) {
+      pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
 
     vPIDPartOne = ConfPIDPartOne;
@@ -173,17 +174,17 @@ struct femtoDreamPairTaskTrackTrack {
 
     /// Histogramming same event
     for (auto& part : groupPartsOne) {
-      if (part.p() > cfgCutTable->get("PartOne", "MaxP") || part.pt() > cfgCutTable->get("PartOne", "MaxPt")) {
+      if (part.p() > ConfCutTable->get("PartOne", "MaxP") || part.pt() > ConfCutTable->get("PartOne", "MaxPt")) {
         continue;
       }
       if (!isFullPIDSelected(part.pidcut(),
                              part.p(),
-                             cfgCutTable->get("PartOne", "PIDthr"),
+                             ConfCutTable->get("PartOne", "PIDthr"),
                              vPIDPartOne,
-                             cfgNspecies,
+                             ConfNspecies,
                              kNsigma,
-                             cfgCutTable->get("PartOne", "nSigmaTPC"),
-                             cfgCutTable->get("PartOne", "nSigmaTPCTOF"))) {
+                             ConfCutTable->get("PartOne", "nSigmaTPC"),
+                             ConfCutTable->get("PartOne", "nSigmaTPCTOF"))) {
         continue;
       }
 
@@ -192,17 +193,17 @@ struct femtoDreamPairTaskTrackTrack {
 
     if (!ConfIsSame) {
       for (auto& part : groupPartsTwo) {
-        if (part.p() > cfgCutTable->get("PartTwo", "MaxP") || part.pt() > cfgCutTable->get("PartTwo", "MaxPt")) {
+        if (part.p() > ConfCutTable->get("PartTwo", "MaxP") || part.pt() > ConfCutTable->get("PartTwo", "MaxPt")) {
           continue;
         }
         if (!isFullPIDSelected(part.pidcut(),
                                part.p(),
-                               cfgCutTable->get("PartTwo", "PIDthr"),
+                               ConfCutTable->get("PartTwo", "PIDthr"),
                                vPIDPartTwo,
-                               cfgNspecies,
+                               ConfNspecies,
                                kNsigma,
-                               cfgCutTable->get("PartTwo", "nSigmaTPC"),
-                               cfgCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+                               ConfCutTable->get("PartTwo", "nSigmaTPC"),
+                               ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
           continue;
         }
         trackHistoPartTwo.fillQA<isMC, false>(part);
@@ -210,29 +211,29 @@ struct femtoDreamPairTaskTrackTrack {
     }
     /// Now build the combinations
     for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      if (p1.p() > cfgCutTable->get("PartOne", "MaxP") || p1.pt() > cfgCutTable->get("PartOne", "MaxPt") || p2.p() > cfgCutTable->get("PartTwo", "MaxP") || p2.pt() > cfgCutTable->get("PartTwo", "MaxPt")) {
+      if (p1.p() > ConfCutTable->get("PartOne", "MaxP") || p1.pt() > ConfCutTable->get("PartOne", "MaxPt") || p2.p() > ConfCutTable->get("PartTwo", "MaxP") || p2.pt() > ConfCutTable->get("PartTwo", "MaxPt")) {
         continue;
       }
       if (!isFullPIDSelected(p1.pidcut(),
                              p1.p(),
-                             cfgCutTable->get("PartOne", "PIDthr"),
+                             ConfCutTable->get("PartOne", "PIDthr"),
                              vPIDPartOne,
-                             cfgNspecies,
+                             ConfNspecies,
                              kNsigma,
-                             cfgCutTable->get("PartOne", "nSigmaTPC"),
-                             cfgCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+                             ConfCutTable->get("PartOne", "nSigmaTPC"),
+                             ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
           !isFullPIDSelected(p2.pidcut(),
                              p2.p(),
-                             cfgCutTable->get("PartTwo", "PIDthr"),
+                             ConfCutTable->get("PartTwo", "PIDthr"),
                              vPIDPartTwo,
-                             cfgNspecies,
+                             ConfNspecies,
                              kNsigma,
-                             cfgCutTable->get("PartTwo", "nSigmaTPC"),
-                             cfgCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+                             ConfCutTable->get("PartTwo", "nSigmaTPC"),
+                             ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
         continue;
       }
 
-      if (ConfIsCPR) {
+      if (ConfIsCPR.value) {
         if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
           continue;
         }
@@ -293,29 +294,29 @@ struct femtoDreamPairTaskTrackTrack {
   {
 
     for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      if (p1.p() > cfgCutTable->get("PartOne", "MaxP") || p1.pt() > cfgCutTable->get("PartOne", "MaxPt") || p2.p() > cfgCutTable->get("PartTwo", "MaxP") || p2.pt() > cfgCutTable->get("PartTwo", "MaxPt")) {
+      if (p1.p() > ConfCutTable->get("PartOne", "MaxP") || p1.pt() > ConfCutTable->get("PartOne", "MaxPt") || p2.p() > ConfCutTable->get("PartTwo", "MaxP") || p2.pt() > ConfCutTable->get("PartTwo", "MaxPt")) {
         continue;
       }
       if (!isFullPIDSelected(p1.pidcut(),
                              p1.p(),
-                             cfgCutTable->get("PartOne", "PIDthr"),
+                             ConfCutTable->get("PartOne", "PIDthr"),
                              vPIDPartOne,
-                             cfgNspecies,
+                             ConfNspecies,
                              kNsigma,
-                             cfgCutTable->get("PartOne", "nSigmaTPC"),
-                             cfgCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+                             ConfCutTable->get("PartOne", "nSigmaTPC"),
+                             ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
           !isFullPIDSelected(p2.pidcut(),
                              p2.p(),
-                             cfgCutTable->get("PartTwo", "PIDthr"),
+                             ConfCutTable->get("PartTwo", "PIDthr"),
                              vPIDPartTwo,
-                             cfgNspecies,
+                             ConfNspecies,
                              kNsigma,
-                             cfgCutTable->get("PartTwo", "nSigmaTPC"),
-                             cfgCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+                             ConfCutTable->get("PartTwo", "nSigmaTPC"),
+                             ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
         continue;
       }
 
-      if (ConfIsCPR) {
+      if (ConfIsCPR.value) {
         if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
           continue;
         }

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -187,7 +187,7 @@ struct femtoDreamPairTaskTrackTrack {
         continue;
       }
 
-      trackHistoPartOne.fillQA<isMC>(part);
+      trackHistoPartOne.fillQA<isMC, false>(part);
     }
 
     if (!ConfIsSame) {
@@ -205,7 +205,7 @@ struct femtoDreamPairTaskTrackTrack {
                                cfgCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
           continue;
         }
-        trackHistoPartTwo.fillQA<isMC>(part);
+        trackHistoPartTwo.fillQA<isMC, false>(part);
       }
     }
     /// Now build the combinations

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -54,16 +54,13 @@ struct femtoDreamPairTaskTrackV0 {
   SliceCache cache;
   Preslice<aod::FemtoDreamParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
-  /// Particle selection part
-  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
-  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
-
   /// Particle 1 (track)
   Configurable<LabeledArray<float>> ConfTrkCutTable{"ConfTrkCutTable", {cutsTableTrack[0], nTrack, nCuts, TrackName, cutNames}, "Particle selections"};
   Configurable<int> ConfTrkPDGCodePartOne{"ConfTrkPDGCodePartOne", 2212, "Particle 1 (Track) - PDG code"};
   Configurable<uint32_t> ConfTrkCutPartOne{"ConfTrkCutPartOne", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
   Configurable<std::vector<int>> ConfTrkPIDPartOne{"ConfTrkPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
+  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
   ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTrkTempFitVarpTBins{"ConfTrkTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
@@ -105,6 +102,7 @@ struct femtoDreamPairTaskTrackV0 {
   std::vector<float> kNsigma;
 
   /// Correlation part
+  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
   ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
   ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
   ConfigurableAxis ConfkstarBins{"ConfkstarBins", {1500, 0., 6.}, "binning kstar"};
@@ -140,7 +138,6 @@ struct femtoDreamPairTaskTrackV0 {
     if (ConfIsCPR.value) {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
-
     vPIDPartOne = ConfTrkPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -147,10 +147,10 @@ struct femtoDreamPairTaskTrackV0 {
       if (!isFullPIDSelected(part.pidcut(), part.p(), cfgCutTable->get("PartOne", "PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("PartOne", "nSigmaTPC"), cfgCutTable->get("PartOne", "nSigmaTPCTOF"))) {
         continue;
       }
-      trackHistoPartOne.fillQA<false>(part);
+      trackHistoPartOne.fillQA<false, false>(part);
     }
     for (auto& part : groupPartsTwo) {
-      trackHistoPartTwo.fillQA<false>(part);
+      trackHistoPartTwo.fillQA<false, false>(part);
     }
     /// Now build the combinations
     for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -43,8 +43,7 @@ static constexpr int nCuts = 5;
 static const std::vector<std::string> TrackName{"Track"};
 static const std::vector<std::string> V0ChildrenName{"PosChild", "NegChild"};
 static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
-static const float cutsTableTrack[nTrack][nCuts]{
-  {4.05f, 0.75f, 3.f, 3.f, 100.f}};
+static const float cutsTableTrack[nTrack][nCuts]{{4.05f, 0.75f, 3.f, 3.f, 100.f}};
 static const float cutsTableV0Children[nV0Children][nCuts]{
   {90.f, 99.f, 5.f, 5.f, 100.f},
   {90.f, 99.f, 5.f, 5.f, 100.f}};

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
+#include <vector>
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
@@ -29,23 +30,24 @@
 #include "FemtoUtils.h"
 
 using namespace o2;
-using namespace o2::analysis::femtoDream;
+using namespace o2::soa;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::soa;
+using namespace o2::analysis::femtoDream;
 
 namespace
 {
-static constexpr int nPart = 2;
+static constexpr int nTrack = 1;
+static constexpr int nV0Children = 2;
 static constexpr int nCuts = 5;
-static const std::vector<std::string> partNames{"PartOne", "PartTwo"};
+static const std::vector<std::string> TrackName{"Track"};
+static const std::vector<std::string> V0ChildrenName{"PosChild", "NegChild"};
 static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
-static const float cutsTable[nPart][nCuts]{
-  {4.05f, 1.f, 3.f, 3.f, 100.f},
-  {4.05f, 1.f, 5.f, 5.f, 100.f}};
-
-static const std::vector<float> kNsigma = {3.5f, 3.f, 2.5f};
-
+static const float cutsTableTrack[nTrack][nCuts]{
+  {4.05f, 0.75f, 3.f, 3.f, 100.f}};
+static const float cutsTableV0Children[nV0Children][nCuts]{
+  {90.f, 99.f, 5.f, 5.f, 100.f},
+  {90.f, 99.f, 5.f, 5.f, 100.f}};
 } // namespace
 
 struct femtoDreamPairTaskTrackV0 {
@@ -53,52 +55,66 @@ struct femtoDreamPairTaskTrackV0 {
   Preslice<aod::FemtoDreamParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
 
   /// Particle selection part
-
-  /// Table for both particles
-  Configurable<LabeledArray<float>> cfgCutTable{"cfgCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
-  Configurable<int> cfgNspecies{"ccfgNspecies", 4, "Number of particle spieces with PID info"};
+  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
 
   /// Particle 1 (track)
-  Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
-  Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
-  Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
+  Configurable<LabeledArray<float>> ConfTrkCutTable{"ConfTrkCutTable", {cutsTableTrack[0], nTrack, nCuts, TrackName, cutNames}, "Particle selections"};
+  Configurable<int> ConfTrkPDGCodePartOne{"ConfTrkPDGCodePartOne", 2212, "Particle 1 (Track) - PDG code"};
+  Configurable<uint32_t> ConfTrkCutPartOne{"ConfTrkCutPartOne", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
+  Configurable<std::vector<int>> ConfTrkPIDPartOne{"ConfTrkPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
+  ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTrkTempFitVarpTBins{"ConfTrkTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   /// Partition for particle 1
-  Partition<aod::FemtoDreamParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Partition<aod::FemtoDreamParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfTrkCutPartOne) == ConfTrkCutPartOne);
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
 
   /// Particle 2 (V0)
-  Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 3122, "Particle 1 - PDG code"};
-  Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 338, "Particle 2 - Selection bit"};
+  Configurable<LabeledArray<float>> ConfV0ChildrenCutTable{"ConfV0ChildrenCutTable", {cutsTableV0Children[0], nV0Children, nCuts, V0ChildrenName, cutNames}, "V0 Children selections"};
+  Configurable<int> ConfV0PDGCodePartTwo{"ConfV0PDGCodePartTwo", 3122, "Particle 2 (V0) - PDG code"};
+  Configurable<uint32_t> ConfV0CutPartTwo{"ConfV0CutPartTwo", 338, "Particle 2 (V0) - Selection bit"};
+  ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
+
+  Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
+  Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
+  Configurable<int> ConfChildPosIndex{"ConfChildPosIndex", 1, "Positive Child of V0 - Index from cutCulator"};
+  Configurable<int> ConfChildNegIndex{"ConfChildNegIndex", 0, "Negative Child of V0 - Index from cutCulator"};
+  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f}, "V0 child sel: Max. PID nSigma TPC"};
+  Configurable<int> ConfChildnSpecies{"ConfChildnSpecies", 2, "Number of particle spieces (for V0 children) with PID info"};
+  ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   /// Partition for particle 2
-  Partition<aod::FemtoDreamParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo);
+  Partition<aod::FemtoDreamParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV0CutPartTwo) == ConfV0CutPartTwo);
 
   /// Histogramming for particle 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
 
   /// The configurables need to be passed to an std::vector
   std::vector<int> vPIDPartOne;
-
-  /// particle part
-  ConfigurableAxis CfgTempFitVarBins{"CfgDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis CfgTempFitVarpTBins{"CfgTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  std::vector<float> kNsigma;
 
   /// Correlation part
-  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
-  ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
-  ConfigurableAxis CfgkstarBins{"CfgkstarBins", {1500, 0., 6.}, "binning kstar"};
-  ConfigurableAxis CfgkTBins{"CfgkTBins", {150, 0., 9.}, "binning kT"};
-  ConfigurableAxis CfgmTBins{"CfgmTBins", {225, 0., 7.5}, "binning mT"};
+  ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
+  ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
+  ConfigurableAxis ConfkstarBins{"ConfkstarBins", {1500, 0., 6.}, "binning kstar"};
+  ConfigurableAxis ConfkTBins{"ConfkTBins", {150, 0., 9.}, "binning kT"};
+  ConfigurableAxis ConfmTBins{"ConfmTBins", {225, 0., 7.5}, "binning mT"};
   Configurable<int> ConfNEventsMix{"ConfNEventsMix", 5, "Number of events for mixing"};
   Configurable<bool> ConfIsCPR{"ConfIsCPR", true, "Close Pair Rejection"};
   Configurable<bool> ConfCPRPlotPerRadii{"ConfCPRPlotPerRadii", false, "Plot CPR per radii"};
+  Configurable<float> ConfCPRdeltaPhiMax{"ConfCPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+  Configurable<float> ConfCPRdeltaEtaMax{"ConfCPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
 
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
@@ -111,25 +127,27 @@ struct femtoDreamPairTaskTrackV0 {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC);
-    trackHistoPartTwo.init(&qaRegistry, CfgTempFitVarpTBins, CfgTempFitVarBins, ConfIsMC);
+    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfIsMC);
+    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfIsMC);
+    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
+    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
 
-    sameEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfIsMC);
-    sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
-    mixedEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfIsMC);
-    mixedEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfIsMC);
+    sameEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);
+    mixedEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfIsMC);
+    mixedEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);
     pairCleaner.init(&qaRegistry);
-    if (ConfIsCPR) {
-      pairCloseRejection.init(&resultRegistry, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii); /// \todo add config for Δη and ΔΦ cut values
+    if (ConfIsCPR.value) {
+      pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
 
-    vPIDPartOne = ConfPIDPartOne;
+    vPIDPartOne = ConfTrkPIDPartOne.value;
+    kNsigma = ConfTrkPIDnSigmaMax.value;
   }
 
   /// This function processes the same event and takes care of all the histogramming
   /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
-  void processSameEvent(o2::aod::FemtoDreamCollision& col,
-                        o2::aod::FemtoDreamParticles& parts)
+  void processSameEvent(o2::aod::FemtoDreamCollision& col, o2::aod::FemtoDreamParticles& parts)
   {
     const auto& magFieldTesla = col.magField();
 
@@ -141,32 +159,46 @@ struct femtoDreamPairTaskTrackV0 {
 
     /// Histogramming same event
     for (auto& part : groupPartsOne) {
-      if (part.p() > cfgCutTable->get("PartOne", "MaxP") || part.pt() > cfgCutTable->get("PartOne", "MaxPt")) {
-        continue;
-      }
-      if (!isFullPIDSelected(part.pidcut(), part.p(), cfgCutTable->get("PartOne", "PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("PartOne", "nSigmaTPC"), cfgCutTable->get("PartOne", "nSigmaTPCTOF"))) {
+      if (part.p() > ConfTrkCutTable->get("Track", "MaxP") || part.pt() > ConfTrkCutTable->get("Track", "MaxPt") ||
+          !isFullPIDSelected(part.pidcut(), part.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
         continue;
       }
       trackHistoPartOne.fillQA<false, false>(part);
     }
+
     for (auto& part : groupPartsTwo) {
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
+      // check cuts on V0 children
+      if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
+          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
+        continue;
+      }
       trackHistoPartTwo.fillQA<false, false>(part);
+      posChildHistos.fillQA<false, false>(posChild);
+      negChildHistos.fillQA<false, false>(negChild);
     }
+
     /// Now build the combinations
     for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      if (p1.p() > cfgCutTable->get("PartOne", "MaxP") || p1.pt() > cfgCutTable->get("PartOne", "MaxPt")) {
+      if (p1.p() > ConfTrkCutTable->get("Track", "MaxP") || p1.pt() > ConfTrkCutTable->get("Track", "MaxPt") ||
+          !isFullPIDSelected(p1.pidcut(), p1.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
         continue;
       }
-      if (!isFullPIDSelected(p1.pidcut(), p1.p(), cfgCutTable->get("PartOne", "PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("PartOne", "nSigmaTPC"), cfgCutTable->get("PartOne", "nSigmaTPCTOF"))) {
+      const auto& posChild = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild = parts.iteratorAt(p2.index() - 1);
+      // check cuts on V0 children
+      if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
+          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
         continue;
       }
-
-      if (ConfIsCPR) {
+      if (ConfIsCPR.value) {
         if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
           continue;
         }
       }
-
       // track cleaning
       if (!pairCleaner.isCleanPair(p1, p2, parts)) {
         continue;
@@ -179,10 +211,9 @@ struct femtoDreamPairTaskTrackV0 {
 
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
-  void processMixedEvent(o2::aod::FemtoDreamCollisions& cols,
-                         o2::aod::FemtoDreamParticles& parts)
+  void processMixedEvent(o2::aod::FemtoDreamCollisions& cols, o2::aod::FemtoDreamParticles& parts)
   {
-    ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinning{{CfgVtxBins, CfgMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
 
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
 
@@ -199,16 +230,26 @@ struct femtoDreamPairTaskTrackV0 {
       }
 
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-        if (p1.p() > cfgCutTable->get("PartOne", "MaxP") || p1.pt() > cfgCutTable->get("PartOne", "MaxPt")) {
+        if (p1.p() > ConfTrkCutTable->get("Track", "MaxP") || p1.pt() > ConfTrkCutTable->get("Track", "MaxPt") ||
+            !isFullPIDSelected(p1.pidcut(), p1.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
           continue;
         }
-        if (!isFullPIDSelected(p1.pidcut(), p1.p(), cfgCutTable->get("PartOne", "PIDthr"), vPIDPartOne, cfgNspecies, kNsigma, cfgCutTable->get("PartOne", "nSigmaTPC"), cfgCutTable->get("PartOne", "nSigmaTPCTOF"))) {
+        const auto& posChild = parts.iteratorAt(p2.index() - 2);
+        const auto& negChild = parts.iteratorAt(p2.index() - 1);
+        // check cuts on V0 children
+        if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
+            !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+            !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
           continue;
         }
-        if (ConfIsCPR) {
+        if (ConfIsCPR.value) {
           if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla1)) {
             continue;
           }
+        }
+        // track cleaning
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          continue;
         }
         mixedEventCont.setPair<false>(p1, p2, multCol);
       }

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -258,7 +258,7 @@ struct femtoDreamProducerReducedTask {
 
     // these IDs are necessary to keep track of the children
     // since this producer only produces the tables for tracks, there are no children
-    int childIDs[2] = {0, 0};
+    std::vector<int> childIDs = {0, 0};
     for (auto& track : tracks) {
       /// if the most open selection criteria are not fulfilled there is no point looking further at the track
       if (!trackCuts.isSelectedMinimal(track)) {

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -129,170 +129,44 @@ struct femtoDreamProducerTask {
 
   Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "PDG code of the selected track for Monte Carlo truth"};
   FemtoDreamTrackSelection trackCuts;
-  Configurable<std::vector<float>> ConfTrkCharge{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kSign, "ConfTrk"),
-    std::vector<float>{-1, 1},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kSign, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmin{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kpTMin, "ConfTrk"),
-    std::vector<float>{0.4f, 0.6f, 0.5f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kpTMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkCharge{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kSign, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkPtmin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMin, "ConfTrk"), std::vector<float>{0.4f, 0.6f, 0.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMin, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkPtmax{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kpTMax, "ConfTrk"),
-    std::vector<float>{5.4f, 5.6f, 5.5f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kpTMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkEta{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kEtaMax, "ConfTrk"),
-    std::vector<float>{0.8f, 0.7f, 0.9f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kEtaMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCnclsMin{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kTPCnClsMin, "ConfTrk"),
-    std::vector<float>{80.f, 70.f, 60.f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kTPCnClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCfCls{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kTPCfClsMin, "ConfTrk"),
-    std::vector<float>{0.7f, 0.83f, 0.9f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kTPCfClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCcRowsMin{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kTPCcRowsMin, "ConfTrk"),
-    std::vector<float>{70.f, 60.f, 80.f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kTPCcRowsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCsCls{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kTPCsClsMax, "ConfTrk"),
-    std::vector<float>{0.1f, 160.f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kTPCsClsMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkITSnclsMin{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"),
-    std::vector<float>{-1.f, 2.f, 4.f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkITSnclsIbMin{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"),
-    std::vector<float>{-1.f, 1.f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkDCAxyMax{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"),
-    std::vector<float>{0.1f, 3.5f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kDCAxyMax,
-      "Track selection: ")}; /// here we need an open cut to do the DCA fits
-                             /// later on!
-  Configurable<std::vector<float>> ConfTrkDCAzMax{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kDCAzMax, "ConfTrk"),
-    std::vector<float>{0.2f, 3.5f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};
-  /// \todo Reintegrate PID to the general selection container
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{
-    FemtoDreamTrackSelection::getSelectionName(
-      femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"),
-    std::vector<float>{3.5f, 3.f, 2.5f},
-    FemtoDreamTrackSelection::getSelectionHelper(
-      femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
-  Configurable<float> ConfPIDnSigmaOffsetTPC{
-    "ConfPIDnSigmaOffsetTPC", 0.,
-    "Offset for TPC nSigma because of bad calibration"};
-  Configurable<float> ConfPIDnSigmaOffsetTOF{
-    "ConfPIDnSigmaOffsetTOF", 0.,
-    "Offset for TOF nSigma because of bad calibration"};
-  Configurable<std::vector<int>> ConfPIDspecies{
-    "ConfPIDspecies",
-    std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon,
-                     o2::track::PID::Proton, o2::track::PID::Deuteron},
-    "Trk sel: Particles species for PID"};
+    FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMax, "ConfTrk"), std::vector<float>{5.4f, 5.6f, 5.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkEta{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kEtaMax, "ConfTrk"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kEtaMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCnClsMin, "ConfTrk"), std::vector<float>{80.f, 70.f, 60.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCnClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCfCls{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCfClsMin, "ConfTrk"), std::vector<float>{0.7f, 0.83f, 0.9f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCfClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCcRowsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCcRowsMin, "ConfTrk"), std::vector<float>{70.f, 60.f, 80.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCcRowsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCsCls{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCsClsMax, "ConfTrk"), std::vector<float>{0.1f, 160.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCsClsMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkITSnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"), std::vector<float>{-1.f, 2.f, 4.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkITSnclsIbMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"), std::vector<float>{-1.f, 1.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")}; /// here we need an open cut to do the DCA fits
+                                                                                                                                                                                                                                                                                        /// later on!
+  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};    /// \todo Reintegrate PID to the general selection container
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"), std::vector<float>{3.5f, 3.f, 2.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
+  Configurable<float> ConfPIDnSigmaOffsetTPC{"ConfPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
+  Configurable<float> ConfPIDnSigmaOffsetTOF{"ConfPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
+  Configurable<std::vector<int>> ConfPIDTrkspecies{"ConfPIDTrkspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
 
   FemtoDreamV0Selection v0Cuts;
   // TrackSelection *o2PhysicsTrackSelection;
   /// \todo Labeled array (see Track-Track task)
 
-  Configurable<std::vector<float>> ConfV0Sign{
-    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign,
-                                            "ConfV0"),
-    std::vector<float>{-1, 1},
-    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign,
-                                              "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0PtMin{
-    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin,
-                                            "ConfV0"),
-    std::vector<float>{0.3f, 0.4f, 0.5f},
-    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
-                                              "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0PtMax{
-    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax,
-                                            "ConfV0"),
-    std::vector<float>{3.3f, 3.4f, 3.5f},
-    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax,
-                                              "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0DCADaughMax{
-    FemtoDreamV0Selection::getSelectionName(
-      femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
-    std::vector<float>{1.2f, 1.5f},
-    FemtoDreamV0Selection::getSelectionHelper(
-      femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0CPAMin{
-    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin,
-                                            "ConfV0"),
-    std::vector<float>{0.99f, 0.995f},
-    FemtoDreamV0Selection::getSelectionHelper(
-      femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0Sign{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin, "ConfV0"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax, "ConfV0"), std::vector<float>{3.3f, 3.4f, 3.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0DCADaughMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"), std::vector<float>{1.2f, 1.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0CPAMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin, "ConfV0"), std::vector<float>{0.99f, 0.995f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0TranRadMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0TranRadMin, "ConfV0"), std::vector<float>{0.2f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0TranRadMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0TranRadMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0DecVtxMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
 
-  Configurable<std::vector<float>> ConfV0TranRadMin{
-    FemtoDreamV0Selection::getSelectionName(
-      femtoDreamV0Selection::kV0TranRadMin, "ConfV0"),
-    std::vector<float>{0.2f},
-    FemtoDreamV0Selection::getSelectionHelper(
-      femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0TranRadMax{
-    FemtoDreamV0Selection::getSelectionName(
-      femtoDreamV0Selection::kV0TranRadMax, "ConfV0"),
-    std::vector<float>{100.f},
-    FemtoDreamV0Selection::getSelectionHelper(
-      femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0DecVtxMax{
-    FemtoDreamV0Selection::getSelectionName(
-      femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"),
-    std::vector<float>{100.f},
-    FemtoDreamV0Selection::getSelectionHelper(
-      femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
-
-  Configurable<std::vector<float>> ConfChildCharge{
-    "ConfChildSign", std::vector<float>{-1, 1}, "V0 Child sel: Charge"};
-  Configurable<std::vector<float>> ConfChildEtaMax{
-    "ConfChildEtaMax", std::vector<float>{0.8f}, "V0 Child sel: max eta"};
-  Configurable<std::vector<float>> ConfChildTPCnClsMin{
-    "ConfChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f},
-    "V0 Child sel: Min. nCls TPC"};
-  Configurable<std::vector<float>> ConfChildDCAMin{
-    "ConfChildDCAMin", std::vector<float>{0.05f, 0.06f},
-    "V0 Child sel:  Max. DCA Daugh to PV (cm)"};
-  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{
-    "ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f},
-    "V0 Child sel: Max. PID nSigma TPC"};
-  Configurable<std::vector<int>> ConfChildPIDspecies{
-    "ConfChildPIDspecies",
-    std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton},
-    "V0 Child sel: Particles species for PID"};
+  Configurable<std::vector<float>> ConfChildCharge{"ConfChildSign", std::vector<float>{-1, 1}, "V0 Child sel: Charge"};
+  Configurable<std::vector<float>> ConfChildEtaMax{"ConfChildEtaMax", std::vector<float>{0.8f}, "V0 Child sel: max eta"};
+  Configurable<std::vector<float>> ConfChildTPCnClsMin{"ConfChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "V0 Child sel: Min. nCls TPC"};
+  Configurable<std::vector<float>> ConfChildDCAMin{"ConfChildDCAMin", std::vector<float>{0.05f, 0.06f}, "V0 Child sel:  Max. DCA Daugh to PV (cm)"};
+  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "V0 Child sel: Max. PID nSigma TPC"};
+  Configurable<std::vector<int>> ConfPIDChildspecies{"ConfPIDChildspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
 
   Configurable<float> ConfV0InvMassLowLimit{
     "ConfInvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
@@ -353,8 +227,9 @@ struct femtoDreamProducerTask {
     trackCuts.setSelection(ConfTrkDCAxyMax, femtoDreamTrackSelection::kDCAxyMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkDCAzMax, femtoDreamTrackSelection::kDCAzMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-    trackCuts.setPIDSpecies(ConfPIDspecies);
-    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
+    trackCuts.setPIDSpecies(ConfPIDTrkspecies);
+    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC,
+                                 ConfPIDnSigmaOffsetTOF);
     trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
 
     /// \todo fix how to pass array to setSelection, getRow() passing a
@@ -415,9 +290,9 @@ struct femtoDreamProducerTask {
                           femtoDreamTrackSelection::kPIDnSigmaMax,
                           femtoDreamSelection::kAbsUpperLimit);
       v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack,
-                                ConfChildPIDspecies);
+                                ConfPIDChildspecies);
       v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack,
-                                ConfChildPIDspecies);
+                                ConfPIDChildspecies);
       v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0,
                   aod::femtodreamparticle::ParticleType::kV0Child,
                   aod::femtodreamparticle::cutContainerType>(&qaRegistry);
@@ -600,11 +475,8 @@ struct femtoDreamProducerTask {
     colCuts.fillQA(col);
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
-    int childIDs[2] = {
-      0, 0}; // these IDs are necessary to keep track of the children
-    std::vector<int>
-      tmpIDtrack; // this vector keeps track of the matching of the primary
-                  // track table row <-> aod::track table global index
+    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
 
     for (auto& track : tracks) {
       /// if the most open selection criteria are not fulfilled there is no
@@ -640,9 +512,9 @@ struct femtoDreamProducerTask {
     if (ConfStoreV0) {
       for (auto& v0 : fullV0s) {
         auto postrack = v0.template posTrack_as<TrackType>();
-        auto negtrack = v0.template negTrack_as<
-          TrackType>(); ///\tocheck funnily enough if we apply the filter the
-                        /// sign of Pos and Neg track is always negative
+        auto negtrack = v0.template negTrack_as<TrackType>();
+        ///\tocheck funnily enough if we apply the filter the
+        /// sign of Pos and Neg track is always negative
         // const auto dcaXYpos = postrack.dcaXY();
         // const auto dcaZpos = postrack.dcaZ();
         // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
@@ -707,7 +579,7 @@ struct femtoDreamProducerTask {
           if constexpr (isMC) {
             fillMCParticle(negtrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
           }
-          int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
+          std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
           // LOG(info) << cutContainerV0.at(
           //     femtoDreamV0Selection::V0ContainerPosition::kV0);
           outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(),

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Laura Serksnyte, TU München, laura.serksnyte@tum.de
 
+#include <CCDB/BasicCCDBManager.h>
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -34,8 +35,6 @@
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "TMath.h"
-#include <CCDB/BasicCCDBManager.h>
-#include <cstdint>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -105,24 +104,15 @@ struct femtoDreamProducerTask {
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfUseTPCmult{
-    "ConfUseTPCmult", false,
-    "Use multiplicity based on the number of tracks with TPC information"};
-  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f,
-                                  "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true,
-                                         "Evt sel: check for trigger"};
-  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7,
-                                      "Evt sel: trigger"};
-  Configurable<bool> ConfEvtOfflineCheck{
-    "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
-
+  Configurable<bool> ConfUseTPCmult{"ConfUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
+  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
+  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
+  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
+  Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
   Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
   // just sanity check to make sure in case there are problems in conversion or
   // MC production it does not affect results
-  Configurable<bool> ConfRejectNotPropagatedTracks{
-    "ConfRejectNotPropagatedTracks", false,
-    "True: reject not propagated tracks"};
+  Configurable<bool> ConfRejectNotPropagatedTracks{"ConfRejectNotPropagatedTracks", false, "True: reject not propagated tracks"};
   // Configurable<bool> ConfRejectITSHitandTOFMissing{
   //     "ConfRejectITSHitandTOFMissing", false,
   //     "True: reject if neither ITS hit nor TOF timing satisfied"};
@@ -140,9 +130,8 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfTrkTPCsCls{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCsClsMax, "ConfTrk"), std::vector<float>{0.1f, 160.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCsClsMax, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkITSnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"), std::vector<float>{-1.f, 2.f, 4.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkITSnclsIbMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"), std::vector<float>{-1.f, 1.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")}; /// here we need an open cut to do the DCA fits
-                                                                                                                                                                                                                                                                                        /// later on!
-  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};    /// \todo Reintegrate PID to the general selection container
+  Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")}; /// \todo Reintegrate PID to the general selection container
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"), std::vector<float>{3.5f, 3.f, 2.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
   Configurable<float> ConfPIDnSigmaOffsetTPC{"ConfPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
   Configurable<float> ConfPIDnSigmaOffsetTOF{"ConfPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
@@ -168,19 +157,12 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "V0 Child sel: Max. PID nSigma TPC"};
   Configurable<std::vector<int>> ConfPIDChildspecies{"ConfPIDChildspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
 
-  Configurable<float> ConfV0InvMassLowLimit{
-    "ConfInvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
-  Configurable<float> ConfV0InvMassUpLimit{
-    "ConfInvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassLowLimit{"ConfInvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassUpLimit{"ConfInvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
 
-  Configurable<bool> ConfV0RejectKaons{"ConfRejectKaons", false,
-                                       "Switch to reject kaons"};
-  Configurable<float> ConfV0InvKaonMassLowLimit{
-    "ConfInvKaonMassLowLimit", 0.48,
-    "Lower limit of the V0 invariant mass for Kaon rejection"};
-  Configurable<float> ConfV0InvKaonMassUpLimit{
-    "ConfInvKaonMassUpLimit", 0.515,
-    "Upper limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<bool> ConfV0RejectKaons{"ConfRejectKaons", false, "Switch to reject kaons"};
+  Configurable<float> ConfV0InvKaonMassLowLimit{"ConfInvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<float> ConfV0InvKaonMassUpLimit{"ConfInvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
@@ -189,10 +171,7 @@ struct femtoDreamProducerTask {
   // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working
   // for now do not know why
 
-  HistogramRegistry qaRegistry{
-    "QAHistos",
-    {},
-    OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
 
   int mRunNumber;
   float mMagField;
@@ -201,8 +180,7 @@ struct femtoDreamProducerTask {
   void init(InitContext&)
   {
     if (doprocessData == false && doprocessMC == false) {
-      LOGF(fatal,
-           "Neither processData nor processMC enabled. Please choose one.");
+      LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
     if (doprocessData == true && doprocessMC == true) {
       LOGF(fatal,
@@ -210,8 +188,7 @@ struct femtoDreamProducerTask {
            "Please choose one.");
     }
 
-    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel,
-                    ConfEvtOfflineCheck, ConfIsRun3);
+    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
 
     trackCuts.setSelection(ConfTrkCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
@@ -228,8 +205,7 @@ struct femtoDreamProducerTask {
     trackCuts.setSelection(ConfTrkDCAzMax, femtoDreamTrackSelection::kDCAzMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setPIDSpecies(ConfPIDTrkspecies);
-    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC,
-                                 ConfPIDnSigmaOffsetTOF);
+    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
     trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
 
     /// \todo fix how to pass array to setSelection, getRow() passing a
@@ -237,83 +213,38 @@ struct femtoDreamProducerTask {
     // v0Cuts.setSelection(ConfV0Selection->getRow(0),
     // femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
     if (ConfStoreV0) {
-      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign,
-                          femtoDreamSelection::kEqual);
-      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin,
-                          femtoDreamSelection::kLowerLimit);
-      v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax,
-                          femtoDreamSelection::kUpperLimit);
-      v0Cuts.setSelection(ConfV0DCADaughMax,
-                          femtoDreamV0Selection::kV0DCADaughMax,
-                          femtoDreamSelection::kUpperLimit);
-      v0Cuts.setSelection(ConfV0CPAMin, femtoDreamV0Selection::kV0CPAMin,
-                          femtoDreamSelection::kLowerLimit);
-      v0Cuts.setSelection(ConfV0TranRadMin,
-                          femtoDreamV0Selection::kV0TranRadMin,
-                          femtoDreamSelection::kLowerLimit);
-      v0Cuts.setSelection(ConfV0TranRadMax,
-                          femtoDreamV0Selection::kV0TranRadMax,
-                          femtoDreamSelection::kUpperLimit);
-      v0Cuts.setSelection(ConfV0DecVtxMax, femtoDreamV0Selection::kV0DecVtxMax,
-                          femtoDreamSelection::kUpperLimit);
-
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildCharge,
-                          femtoDreamTrackSelection::kSign,
-                          femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildEtaMax,
-                          femtoDreamTrackSelection::kEtaMax,
-                          femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildTPCnClsMin,
-                          femtoDreamTrackSelection::kTPCnClsMin,
-                          femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildDCAMin,
-                          femtoDreamTrackSelection::kDCAMin,
-                          femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack,
-                          ConfChildPIDnSigmaMax,
-                          femtoDreamTrackSelection::kPIDnSigmaMax,
-                          femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildCharge,
-                          femtoDreamTrackSelection::kSign,
-                          femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildEtaMax,
-                          femtoDreamTrackSelection::kEtaMax,
-                          femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin,
-                          femtoDreamTrackSelection::kTPCnClsMin,
-                          femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildDCAMin,
-                          femtoDreamTrackSelection::kDCAMin,
-                          femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack,
-                          ConfChildPIDnSigmaMax,
-                          femtoDreamTrackSelection::kPIDnSigmaMax,
-                          femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack,
-                                ConfPIDChildspecies);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack,
-                                ConfPIDChildspecies);
-      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0,
-                  aod::femtodreamparticle::ParticleType::kV0Child,
-                  aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign, femtoDreamSelection::kEqual);
+      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax, femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0DCADaughMax, femtoDreamV0Selection::kV0DCADaughMax, femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0CPAMin, femtoDreamV0Selection::kV0CPAMin, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0TranRadMin, femtoDreamV0Selection::kV0TranRadMin, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0TranRadMax, femtoDreamV0Selection::kV0TranRadMax, femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0DecVtxMax, femtoDreamV0Selection::kV0DecVtxMax, femtoDreamSelection::kUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfPIDChildspecies);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfPIDChildspecies);
+      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
       v0Cuts.setInvMassLimits(ConfV0InvMassLowLimit, ConfV0InvMassUpLimit);
 
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack,
-                                               ConfRejectNotPropagatedTracks);
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack,
-                                               ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack, ConfRejectNotPropagatedTracks);
 
       v0Cuts.setnSigmaPIDOffsetTPC(ConfPIDnSigmaOffsetTPC);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack,
-                                     ConfPIDnSigmaOffsetTPC,
-                                     ConfPIDnSigmaOffsetTOF);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack,
-                                     ConfPIDnSigmaOffsetTPC,
-                                     ConfPIDnSigmaOffsetTOF);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack, ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack, ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
 
       if (ConfV0RejectKaons) {
-        v0Cuts.setKaonInvMassLimits(ConfV0InvKaonMassLowLimit,
-                                    ConfV0InvKaonMassUpLimit);
+        v0Cuts.setKaonInvMassLimits(ConfV0InvKaonMassLowLimit, ConfV0InvKaonMassUpLimit);
       }
       // if (ConfRejectITSHitandTOFMissing) {
       //   o2PhysicsTrackSelection = new
@@ -329,9 +260,7 @@ struct femtoDreamProducerTask {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    std::chrono::system_clock::now().time_since_epoch())
-                    .count();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
   }
 
@@ -439,9 +368,7 @@ struct femtoDreamProducerTask {
 
   template <bool isMC, typename V0Type, typename TrackType,
             typename CollisionType>
-  void fillCollisionsAndTracksAndV0(CollisionType const& col,
-                                    TrackType const& tracks,
-                                    V0Type const& fullV0s)
+  void fillCollisionsAndTracksAndV0(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
   {
 
     const auto vtxZ = col.posZ();
@@ -487,9 +414,7 @@ struct femtoDreamProducerTask {
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack,
                        aod::femtodreamparticle::TrackType::kNoChild>(track);
       // the bit-wise container of the systematic variations is obtained
-      auto cutContainer =
-        trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
-          track);
+      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track);
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -13,29 +13,29 @@
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Laura Serksnyte, TU München, laura.serksnyte@tum.de
 
-#include <CCDB/BasicCCDBManager.h>
-#include <cstdint>
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/ASoAHelpers.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
-#include "Common/Core/trackUtilities.h"
-#include "DataFormatsParameters/GRPObject.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 #include "DataFormatsParameters/GRPMagField.h"
-#include "PWGLF/DataModel/LFStrangenessTables.h"
-#include "PWGCF/DataModel/FemtoDerived.h"
-#include "ReconstructionDataFormats/Track.h"
-#include "Math/Vector4D.h"
-#include "TMath.h"
+#include "DataFormatsParameters/GRPObject.h"
 #include "FemtoDreamCollisionSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
 #include "FemtoUtils.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "Math/Vector4D.h"
+#include "PWGCF/DataModel/FemtoDerived.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "TMath.h"
+#include <CCDB/BasicCCDBManager.h>
+#include <cstdint>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -45,28 +45,28 @@ using namespace o2::framework::expressions;
 namespace o2::aod
 {
 
-using FemtoFullCollision = soa::Join<aod::Collisions,
-                                     aod::EvSels,
-                                     aod::Mults>::iterator;
-using FemtoFullCollisionMC = soa::Join<aod::Collisions,
-                                       aod::EvSels,
-                                       aod::Mults,
+using FemtoFullCollision =
+  soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
+using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults,
                                        aod::McCollisionLabels>::iterator;
 
-using FemtoFullTracks = soa::Join<aod::FullTracks,
-                                  aod::TracksDCA, aod::TOFSignal,
-                                  aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
-                                  aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
-                                  aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
-                                  aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+using FemtoFullTracks =
+  soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
+            aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
+            aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
+            aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
 
-// using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s> to be used when we add v0Filter
+// using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
+// table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
+// to be used when we add v0Filter
 } // namespace o2::aod
 
-/// \todo fix how to pass array to setSelection, getRow() passing a different type!
-// static constexpr float arrayV0Sel[3][3] = {{100.f, 100.f, 100.f}, {0.2f, 0.2f, 0.2f}, {100.f, 100.f, 100.f}};
-// unsigned int rows = sizeof(arrayV0Sel) / sizeof(arrayV0Sel[0]);
-// unsigned int columns = sizeof(arrayV0Sel[0]) / sizeof(arrayV0Sel[0][0]);
+/// \todo fix how to pass array to setSelection, getRow() passing a different
+/// type!
+// static constexpr float arrayV0Sel[3][3] = {{100.f, 100.f, 100.f}, {0.2f,
+// 0.2f, 0.2f}, {100.f, 100.f, 100.f}}; unsigned int rows = sizeof(arrayV0Sel) /
+// sizeof(arrayV0Sel[0]); unsigned int columns = sizeof(arrayV0Sel[0]) /
+// sizeof(arrayV0Sel[0][0]);
 
 template <typename T>
 int getRowDaughters(int daughID, T const& vecID)
@@ -94,80 +94,231 @@ struct femtoDreamProducerTask {
 
   // Choose if filtering or skimming version is run
 
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
+  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false,
+                                   "Store all collisions"};
 
   // Choose if running on converted data or Run3  / Pilot
-  Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
-  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
+  Configurable<bool> ConfIsRun3{"ConfIsRun3", false,
+                                "Running on Run3 or pilot"};
+  Configurable<bool> ConfIsMC{"ConfIsMC", false,
+                              "Running on MC; implemented only for Run3"};
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfUseTPCmult{"ConfUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
-  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
-  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
-  Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+  Configurable<bool> ConfUseTPCmult{
+    "ConfUseTPCmult", false,
+    "Use multiplicity based on the number of tracks with TPC information"};
+  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f,
+                                  "Evt sel: Max. z-Vertex (cm)"};
+  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true,
+                                         "Evt sel: check for trigger"};
+  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7,
+                                      "Evt sel: trigger"};
+  Configurable<bool> ConfEvtOfflineCheck{
+    "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
 
   Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
-  // just sanity check to make sure in case there are problems in conversion or MC production it does not affect results
-  Configurable<bool> ConfRejectNotPropagatedTracks{"ConfRejectNotPropagatedTracks", false, "True: reject not propagated tracks"};
-  Configurable<bool> ConfRejectITSHitandTOFMissing{"ConfRejectITSHitandTOFMissing", false, "True: reject if neither ITS hit nor TOF timing satisfied"};
+  // just sanity check to make sure in case there are problems in conversion or
+  // MC production it does not affect results
+  Configurable<bool> ConfRejectNotPropagatedTracks{
+    "ConfRejectNotPropagatedTracks", false,
+    "True: reject not propagated tracks"};
+  // Configurable<bool> ConfRejectITSHitandTOFMissing{
+  //     "ConfRejectITSHitandTOFMissing", false,
+  //     "True: reject if neither ITS hit nor TOF timing satisfied"};
 
   Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "PDG code of the selected track for Monte Carlo truth"};
   FemtoDreamTrackSelection trackCuts;
-  Configurable<std::vector<float>> ConfTrkCharge{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kSign, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMin, "ConfTrk"), std::vector<float>{0.4f, 0.6f, 0.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMax, "ConfTrk"), std::vector<float>{5.4f, 5.6f, 5.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkEta{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kEtaMax, "ConfTrk"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kEtaMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCnClsMin, "ConfTrk"), std::vector<float>{80.f, 70.f, 60.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCnClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCfCls{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCfClsMin, "ConfTrk"), std::vector<float>{0.7f, 0.83f, 0.9f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCfClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCcRowsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCcRowsMin, "ConfTrk"), std::vector<float>{70.f, 60.f, 80.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCcRowsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkTPCsCls{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kTPCsClsMax, "ConfTrk"), std::vector<float>{0.1f, 160.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kTPCsClsMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkITSnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"), std::vector<float>{-1.f, 2.f, 4.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkITSnclsIbMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"), std::vector<float>{-1.f, 1.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")}; /// here we need an open cut to do the DCA fits later on!
-  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkCharge{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kSign, "ConfTrk"),
+    std::vector<float>{-1, 1},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kSign, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkPtmin{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kpTMin, "ConfTrk"),
+    std::vector<float>{0.4f, 0.6f, 0.5f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kpTMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkPtmax{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kpTMax, "ConfTrk"),
+    std::vector<float>{5.4f, 5.6f, 5.5f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kpTMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkEta{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kEtaMax, "ConfTrk"),
+    std::vector<float>{0.8f, 0.7f, 0.9f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kEtaMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCnclsMin{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kTPCnClsMin, "ConfTrk"),
+    std::vector<float>{80.f, 70.f, 60.f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kTPCnClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCfCls{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kTPCfClsMin, "ConfTrk"),
+    std::vector<float>{0.7f, 0.83f, 0.9f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kTPCfClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCcRowsMin{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kTPCcRowsMin, "ConfTrk"),
+    std::vector<float>{70.f, 60.f, 80.f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kTPCcRowsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkTPCsCls{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kTPCsClsMax, "ConfTrk"),
+    std::vector<float>{0.1f, 160.f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kTPCsClsMax, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkITSnclsMin{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"),
+    std::vector<float>{-1.f, 2.f, 4.f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkITSnclsIbMin{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"),
+    std::vector<float>{-1.f, 1.f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkDCAxyMax{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"),
+    std::vector<float>{0.1f, 3.5f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kDCAxyMax,
+      "Track selection: ")}; /// here we need an open cut to do the DCA fits
+                             /// later on!
+  Configurable<std::vector<float>> ConfTrkDCAzMax{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kDCAzMax, "ConfTrk"),
+    std::vector<float>{0.2f, 3.5f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};
   /// \todo Reintegrate PID to the general selection container
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"), std::vector<float>{3.5f, 3.f, 2.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
-  Configurable<float> ConfTrkPIDnSigmaOffsetTPC{"ConfTrkPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
-  Configurable<float> ConfTrkPIDnSigmaOffsetTOF{"ConfTrkPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
-  Configurable<std::vector<int>> ConfTrkTPIDspecies{"ConfTrkTPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
+  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{
+    FemtoDreamTrackSelection::getSelectionName(
+      femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"),
+    std::vector<float>{3.5f, 3.f, 2.5f},
+    FemtoDreamTrackSelection::getSelectionHelper(
+      femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
+  Configurable<float> ConfPIDnSigmaOffsetTPC{
+    "ConfPIDnSigmaOffsetTPC", 0.,
+    "Offset for TPC nSigma because of bad calibration"};
+  Configurable<float> ConfPIDnSigmaOffsetTOF{
+    "ConfPIDnSigmaOffsetTOF", 0.,
+    "Offset for TOF nSigma because of bad calibration"};
+  Configurable<std::vector<int>> ConfPIDspecies{
+    "ConfPIDspecies",
+    std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon,
+                     o2::track::PID::Proton, o2::track::PID::Deuteron},
+    "Trk sel: Particles species for PID"};
 
   FemtoDreamV0Selection v0Cuts;
-  TrackSelection* o2PhysicsTrackSelection;
+  // TrackSelection *o2PhysicsTrackSelection;
   /// \todo Labeled array (see Track-Track task)
 
-  Configurable<std::vector<float>> ConfV0Sign{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0PtMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kpTV0Min, "ConfV0"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kpTV0Min, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfDCAV0DaughMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kDCAV0DaughMax, "ConfV0"), std::vector<float>{1.2f, 1.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kDCAV0DaughMax, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfCPAV0Min{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kCPAV0Min, "ConfV0"), std::vector<float>{0.99f, 0.995f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kCPAV0Min, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0Sign{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign,
+                                            "ConfV0"),
+    std::vector<float>{-1, 1},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign,
+                                              "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMin{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin,
+                                            "ConfV0"),
+    std::vector<float>{0.3f, 0.4f, 0.5f},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
+                                              "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMax{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax,
+                                            "ConfV0"),
+    std::vector<float>{3.3f, 3.4f, 3.5f},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax,
+                                              "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0DCADaughMax{
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
+    std::vector<float>{1.2f, 1.5f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0CPAMin{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin,
+                                            "ConfV0"),
+    std::vector<float>{0.99f, 0.995f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
 
-  Configurable<std::vector<float>> V0TranRadV0Min{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kTranRadV0Min, "ConfV0"), std::vector<float>{0.2f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kTranRadV0Min, "V0 selection: ")};
-  Configurable<std::vector<float>> V0TranRadV0Max{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kTranRadV0Max, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kTranRadV0Max, "V0 selection: ")};
-  Configurable<std::vector<float>> V0DecVtxMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kDecVtxMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kDecVtxMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0TranRadMin{
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0TranRadMin, "ConfV0"),
+    std::vector<float>{0.2f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0TranRadMax{
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0TranRadMax, "ConfV0"),
+    std::vector<float>{100.f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0DecVtxMax{
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"),
+    std::vector<float>{100.f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
 
-  Configurable<std::vector<float>> ConfV0DaughCharge{"ConfV0DaughCharge", std::vector<float>{-1, 1}, "V0 Daugh sel: Charge"};
-  Configurable<std::vector<float>> ConfDaughEta{"ConfDaughEta", std::vector<float>{0.8f}, "V0 Daugh sel: max eta"};
-  Configurable<std::vector<float>> ConfV0DaughTPCnclsMin{"ConfV0DaughTPCnclsMin", std::vector<float>{80.f, 70.f, 60.f}, "V0 Daugh sel: Min. nCls TPC"};
-  Configurable<std::vector<float>> ConfV0DaughDCAMin{"ConfV0DaughDCAMin", std::vector<float>{0.05f, 0.06f}, "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"};
-  Configurable<std::vector<float>> ConfV0DaughPIDnSigmaMax{"ConfV0DaughPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "V0 Daugh sel: Max. PID nSigma TPC"};
+  Configurable<std::vector<float>> ConfChildCharge{
+    "ConfChildSign", std::vector<float>{-1, 1}, "V0 Child sel: Charge"};
+  Configurable<std::vector<float>> ConfChildEtaMax{
+    "ConfChildEtaMax", std::vector<float>{0.8f}, "V0 Child sel: max eta"};
+  Configurable<std::vector<float>> ConfChildTPCnClsMin{
+    "ConfChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f},
+    "V0 Child sel: Min. nCls TPC"};
+  Configurable<std::vector<float>> ConfChildDCAMin{
+    "ConfChildDCAMin", std::vector<float>{0.05f, 0.06f},
+    "V0 Child sel:  Max. DCA Daugh to PV (cm)"};
+  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{
+    "ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f},
+    "V0 Child sel: Max. PID nSigma TPC"};
+  Configurable<std::vector<int>> ConfChildPIDspecies{
+    "ConfChildPIDspecies",
+    std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton},
+    "V0 Child sel: Particles species for PID"};
 
-  Configurable<std::vector<int>> ConfV0DaughTPIDspecies{"ConfV0DaughTPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Daugh sel: Particles species for PID"};
+  Configurable<float> ConfV0InvMassLowLimit{
+    "ConfInvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassUpLimit{
+    "ConfInvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
 
-  Configurable<float> ConfInvMassLowLimit{"ConfInvMassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
-  Configurable<float> ConfInvMassUpLimit{"ConfInvMassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
-
-  Configurable<bool> ConfRejectKaons{"ConfRejectKaons", false, "Switch to reject kaons"};
-  Configurable<float> ConfInvKaonMassLowLimit{"ConfInvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
-  Configurable<float> ConfInvKaonMassUpLimit{"ConfInvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<bool> ConfV0RejectKaons{"ConfRejectKaons", false,
+                                       "Switch to reject kaons"};
+  Configurable<float> ConfV0InvKaonMassLowLimit{
+    "ConfInvKaonMassLowLimit", 0.48,
+    "Lower limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<float> ConfV0InvKaonMassUpLimit{
+    "ConfInvKaonMassUpLimit", 0.515,
+    "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
                     (nabs(aod::v0data::y) < V0DecVtxMax.value) &&
                     (nabs(aod::v0data::z) < V0DecVtxMax.value);*/
-  // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working for now do not know why
+  // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working
+  // for now do not know why
 
-  HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry qaRegistry{
+    "QAHistos",
+    {},
+    OutputObjHandlingPolicy::QAObject};
 
   int mRunNumber;
   float mMagField;
@@ -176,16 +327,19 @@ struct femtoDreamProducerTask {
   void init(InitContext&)
   {
     if (doprocessData == false && doprocessMC == false) {
-      LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
+      LOGF(fatal,
+           "Neither processData nor processMC enabled. Please choose one.");
     }
     if (doprocessData == true && doprocessMC == true) {
-      LOGF(fatal, "Cannot enable processData and processMC at the same time. Please choose one.");
+      LOGF(fatal,
+           "Cannot enable processData and processMC at the same time. "
+           "Please choose one.");
     }
 
-    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
+    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel,
+                    ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
 
-    Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "PDG code of the selected track for Monte Carlo truth"};
     trackCuts.setSelection(ConfTrkCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
     trackCuts.setSelection(ConfTrkPtmin, femtoDreamTrackSelection::kpTMin, femtoDreamSelection::kLowerLimit);
     trackCuts.setSelection(ConfTrkPtmax, femtoDreamTrackSelection::kpTMax, femtoDreamSelection::kUpperLimit);
@@ -199,47 +353,98 @@ struct femtoDreamProducerTask {
     trackCuts.setSelection(ConfTrkDCAxyMax, femtoDreamTrackSelection::kDCAxyMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkDCAzMax, femtoDreamTrackSelection::kDCAzMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-    trackCuts.setPIDSpecies(ConfTrkTPIDspecies);
-    trackCuts.setnSigmaPIDOffset(ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
+    trackCuts.setPIDSpecies(ConfPIDspecies);
+    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
     trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
 
-    /// \todo fix how to pass array to setSelection, getRow() passing a different type!
-    // v0Cuts.setSelection(ConfV0Selection->getRow(0), femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
+    /// \todo fix how to pass array to setSelection, getRow() passing a
+    /// different type!
+    // v0Cuts.setSelection(ConfV0Selection->getRow(0),
+    // femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
     if (ConfStoreV0) {
-      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign, femtoDreamSelection::kEqual);
-      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kpTV0Min, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setSelection(ConfDCAV0DaughMax, femtoDreamV0Selection::kDCAV0DaughMax, femtoDreamSelection::kUpperLimit);
-      v0Cuts.setSelection(ConfCPAV0Min, femtoDreamV0Selection::kCPAV0Min, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax,
+                          femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0DCADaughMax,
+                          femtoDreamV0Selection::kV0DCADaughMax,
+                          femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0CPAMin, femtoDreamV0Selection::kV0CPAMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0TranRadMin,
+                          femtoDreamV0Selection::kV0TranRadMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0TranRadMax,
+                          femtoDreamV0Selection::kV0TranRadMax,
+                          femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0DecVtxMax, femtoDreamV0Selection::kV0DecVtxMax,
+                          femtoDreamSelection::kUpperLimit);
 
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfDaughEta, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughTPCnclsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfDaughEta, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughTPCnclsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfV0DaughTPIDspecies);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfV0DaughTPIDspecies);
-      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
-      v0Cuts.setInvMassLimits(ConfInvMassLowLimit, ConfInvMassUpLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildCharge,
+                          femtoDreamTrackSelection::kSign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildEtaMax,
+                          femtoDreamTrackSelection::kEtaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildTPCnClsMin,
+                          femtoDreamTrackSelection::kTPCnClsMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildDCAMin,
+                          femtoDreamTrackSelection::kDCAMin,
+                          femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack,
+                          ConfChildPIDnSigmaMax,
+                          femtoDreamTrackSelection::kPIDnSigmaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildCharge,
+                          femtoDreamTrackSelection::kSign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildEtaMax,
+                          femtoDreamTrackSelection::kEtaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin,
+                          femtoDreamTrackSelection::kTPCnClsMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildDCAMin,
+                          femtoDreamTrackSelection::kDCAMin,
+                          femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack,
+                          ConfChildPIDnSigmaMax,
+                          femtoDreamTrackSelection::kPIDnSigmaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack,
+                                ConfChildPIDspecies);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack,
+                                ConfChildPIDspecies);
+      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0,
+                  aod::femtodreamparticle::ParticleType::kV0Child,
+                  aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+      v0Cuts.setInvMassLimits(ConfV0InvMassLowLimit, ConfV0InvMassUpLimit);
 
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfRejectNotPropagatedTracks);
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack, ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack,
+                                               ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack,
+                                               ConfRejectNotPropagatedTracks);
 
-      v0Cuts.setnSigmaPIDOffsetTPC(ConfTrkPIDnSigmaOffsetTPC);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack, ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack, ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
+      v0Cuts.setnSigmaPIDOffsetTPC(ConfPIDnSigmaOffsetTPC);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack,
+                                     ConfPIDnSigmaOffsetTPC,
+                                     ConfPIDnSigmaOffsetTOF);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack,
+                                     ConfPIDnSigmaOffsetTPC,
+                                     ConfPIDnSigmaOffsetTOF);
 
-      if (ConfRejectKaons) {
-        v0Cuts.setKaonInvMassLimits(ConfInvKaonMassLowLimit, ConfInvKaonMassUpLimit);
+      if (ConfV0RejectKaons) {
+        v0Cuts.setKaonInvMassLimits(ConfV0InvKaonMassLowLimit,
+                                    ConfV0InvKaonMassUpLimit);
       }
-      if (ConfRejectITSHitandTOFMissing) {
-        o2PhysicsTrackSelection = new TrackSelection(getGlobalTrackSelection());
-        o2PhysicsTrackSelection->SetRequireHitsInITSLayers(1, {0, 1, 2, 3});
-      }
+      // if (ConfRejectITSHitandTOFMissing) {
+      //   o2PhysicsTrackSelection = new
+      //   TrackSelection(getGlobalTrackSelection());
+      //   o2PhysicsTrackSelection->SetRequireHitsInITSLayers(1, {0, 1, 2, 3});
+      // }
     }
 
     mRunNumber = 0;
@@ -249,15 +454,18 @@ struct femtoDreamProducerTask {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count();
     ccdb->setCreatedNotAfter(now);
   }
 
-  /// Function to retrieve the nominal mgnetic field in kG (0.1T) and convert it directly to T
+  /// Function to retrieve the nominal mgnetic field in kG (0.1T) and convert it
+  /// directly to T
   void getMagneticFieldTesla(aod::BCsWithTimestamps::iterator bc)
   {
-    // TODO done only once (and not per run). Will be replaced by CCDBConfigurable
-    // get magnetic field for run
+    // TODO done only once (and not per run). Will be replaced by
+    // CCDBConfigurable get magnetic field for run
     if (mRunNumber == bc.runNumber())
       return;
     auto timestamp = bc.timestamp();
@@ -266,14 +474,18 @@ struct femtoDreamProducerTask {
     if (ConfIsRun3 && !ConfIsMC) {
       static o2::parameters::GRPMagField* grpo = nullptr;
       if (grpo == nullptr) {
-        grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", timestamp);
+        grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(
+          "GLO/Config/GRPMagField", timestamp);
         if (grpo == nullptr) {
           LOGF(fatal, "GRP object not found for timestamp %llu", timestamp);
           return;
         }
-        LOGF(info, "Retrieved GRP for timestamp %llu with L3 ", timestamp, grpo->getL3Current());
+        LOGF(info, "Retrieved GRP for timestamp %llu with L3 ", timestamp,
+             grpo->getL3Current());
       }
-      // taken from GRP onject definition of getNominalL3Field; update later to something smarter (mNominalL3Field = std::lround(5.f * mL3Current / 30000.f);)
+      // taken from GRP onject definition of getNominalL3Field; update later to
+      // something smarter (mNominalL3Field = std::lround(5.f * mL3Current /
+      // 30000.f);)
       auto NominalL3Field = std::lround(5.f * grpo->getL3Current() / 30000.f);
       output = 0.1 * (NominalL3Field);
     }
@@ -281,12 +493,15 @@ struct femtoDreamProducerTask {
     if (!ConfIsRun3 || (ConfIsRun3 && ConfIsMC)) {
       static o2::parameters::GRPObject* grpo = nullptr;
       if (grpo == nullptr) {
-        grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>("GLO/GRP/GRP", timestamp);
+        grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>("GLO/GRP/GRP",
+                                                                timestamp);
         if (grpo == nullptr) {
           LOGF(fatal, "GRP object not found for timestamp %llu", timestamp);
           return;
         }
-        LOGF(info, "Retrieved GRP for timestamp %llu with magnetic field of %d kG", timestamp, grpo->getNominalL3Field());
+        LOGF(info,
+             "Retrieved GRP for timestamp %llu with magnetic field of %d kG",
+             timestamp, grpo->getNominalL3Field());
       }
       output = 0.1 * (grpo->getNominalL3Field());
     }
@@ -298,37 +513,24 @@ struct femtoDreamProducerTask {
   void fillDebugParticle(ParticleType const& particle)
   {
     if constexpr (isTrackOrV0) {
-      outputDebugParts(particle.sign(),
-                       (uint8_t)particle.tpcNClsFound(),
+      outputDebugParts(particle.sign(), (uint8_t)particle.tpcNClsFound(),
                        particle.tpcNClsFindable(),
                        (uint8_t)particle.tpcNClsCrossedRows(),
-                       particle.tpcNClsShared(),
-                       particle.tpcInnerParam(),
-                       particle.itsNCls(),
-                       particle.itsNClsInnerBarrel(),
-                       particle.dcaXY(),
-                       particle.dcaZ(),
-                       particle.tpcSignal(),
-                       particle.tpcNSigmaStoreEl(),
-                       particle.tpcNSigmaStorePi(),
-                       particle.tpcNSigmaStoreKa(),
-                       particle.tpcNSigmaStorePr(),
-                       particle.tpcNSigmaStoreDe(),
-                       particle.tofNSigmaStoreEl(),
-                       particle.tofNSigmaStorePi(),
-                       particle.tofNSigmaStoreKa(),
-                       particle.tofNSigmaStorePr(),
-                       particle.tofNSigmaStoreDe(),
+                       particle.tpcNClsShared(), particle.tpcInnerParam(),
+                       particle.itsNCls(), particle.itsNClsInnerBarrel(),
+                       particle.dcaXY(), particle.dcaZ(), particle.tpcSignal(),
+                       particle.tpcNSigmaStoreEl(), particle.tpcNSigmaStorePi(),
+                       particle.tpcNSigmaStoreKa(), particle.tpcNSigmaStorePr(),
+                       particle.tpcNSigmaStoreDe(), particle.tofNSigmaStoreEl(),
+                       particle.tofNSigmaStorePi(), particle.tofNSigmaStoreKa(),
+                       particle.tofNSigmaStorePr(), particle.tofNSigmaStoreDe(),
                        -999., -999., -999., -999., -999., -999.);
     } else {
-      outputDebugParts(-999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999., -999., -999.,
-                       particle.dcaV0daughters(),
-                       particle.v0radius(),
-                       particle.x(),
-                       particle.y(),
-                       particle.z(),
+      outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       particle.dcaV0daughters(), particle.v0radius(),
+                       particle.x(), particle.y(), particle.z(),
                        particle.mK0Short()); // QA for v0
     }
   }
@@ -340,12 +542,9 @@ struct femtoDreamProducerTask {
       // get corresponding MC particle and its info
       auto particleMC = particle.mcParticle();
       auto pdgCode = particleMC.pdgCode();
-
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
-
       if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
-
         if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
         } else if (motherparticleMC.producedByGenerator()) {
@@ -353,9 +552,7 @@ struct femtoDreamProducerTask {
         } else {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
         }
-
       } else {
-
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
       }
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
@@ -365,8 +562,11 @@ struct femtoDreamProducerTask {
     }
   }
 
-  template <bool isMC, typename V0Type, typename TrackType, typename CollisionType>
-  void fillCollisionsAndTracksAndV0(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
+  template <bool isMC, typename V0Type, typename TrackType,
+            typename CollisionType>
+  void fillCollisionsAndTracksAndV0(CollisionType const& col,
+                                    TrackType const& tracks,
+                                    V0Type const& fullV0s)
   {
 
     const auto vtxZ = col.posZ();
@@ -377,7 +577,8 @@ struct femtoDreamProducerTask {
       mult = col.multFV0M();
       multNtr = col.multNTracksPV();
     } else {
-      mult = 0.5 * (col.multFV0M()); /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
+      mult = 0.5 * (col.multFV0M()); /// For benchmarking on Run 2, V0M in
+                                     /// FemtoDreamRun2 is defined V0M/2
       multNtr = col.multTracklets();
     }
     if (ConfUseTPCmult) {
@@ -387,7 +588,8 @@ struct femtoDreamProducerTask {
     // check whether the basic event selection criteria are fulfilled
     // if the basic selection is NOT fulfilled:
     // in case of skimming run - don't store such collisions
-    // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
+    // in case of trigger run - store such collisions but don't store any
+    // particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
         outputCollision(vtxZ, mult, multNtr, spher, mMagField);
@@ -398,28 +600,33 @@ struct femtoDreamProducerTask {
     colCuts.fillQA(col);
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
-    int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    int childIDs[2] = {
+      0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int>
+      tmpIDtrack; // this vector keeps track of the matching of the primary
+                  // track table row <-> aod::track table global index
 
     for (auto& track : tracks) {
-      /// if the most open selection criteria are not fulfilled there is no point looking further at the track
+      /// if the most open selection criteria are not fulfilled there is no
+      /// point looking further at the track
       if (!trackCuts.isSelectedMinimal(track)) {
         continue;
       }
-      trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
+      trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack,
+                       aod::femtodreamparticle::TrackType::kNoChild>(track);
       // the bit-wise container of the systematic variations is obtained
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track);
+      auto cutContainer =
+        trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
+          track);
 
       // now the table is filled
-      outputParts(outputCollision.lastIndex(),
-                  track.pt(),
-                  track.eta(),
-                  track.phi(),
-                  aod::femtodreamparticle::ParticleType::kTrack,
-                  cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-                  cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
-                  track.dcaXY(),
-                  childIDs, 0, 0);
+      outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),
+                  track.phi(), aod::femtodreamparticle::ParticleType::kTrack,
+                  cutContainer.at(
+                    femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+                  cutContainer.at(
+                    femtoDreamTrackSelection::TrackContainerPosition::kPID),
+                  track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
       if (ConfDebugOutput) {
         fillDebugParticle<true>(track);
@@ -433,7 +640,9 @@ struct femtoDreamProducerTask {
     if (ConfStoreV0) {
       for (auto& v0 : fullV0s) {
         auto postrack = v0.template posTrack_as<TrackType>();
-        auto negtrack = v0.template negTrack_as<TrackType>(); ///\tocheck funnily enough if we apply the filter the sign of Pos and Neg track is always negative
+        auto negtrack = v0.template negTrack_as<
+          TrackType>(); ///\tocheck funnily enough if we apply the filter the
+                        /// sign of Pos and Neg track is always negative
         // const auto dcaXYpos = postrack.dcaXY();
         // const auto dcaZpos = postrack.dcaZ();
         // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
@@ -443,22 +652,40 @@ struct femtoDreamProducerTask {
           continue;
         }
 
-        if (ConfRejectITSHitandTOFMissing) {
-          // Uncomment only when TOF timing is solved
-          // bool itsHit = o2PhysicsTrackSelection->IsSelected(postrack, TrackSelection::TrackCuts::kITSHits);
-          // bool itsHit = o2PhysicsTrackSelection->IsSelected(negtrack, TrackSelection::TrackCuts::kITSHits);
-        }
+        // if (ConfRejectITSHitandTOFMissing) {
+        // Uncomment only when TOF timing is solved
+        // bool itsHit = o2PhysicsTrackSelection->IsSelected(postrack,
+        // TrackSelection::TrackCuts::kITSHits); bool itsHit =
+        // o2PhysicsTrackSelection->IsSelected(negtrack,
+        // TrackSelection::TrackCuts::kITSHits);
+        // }
 
-        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
-        auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, v0, postrack, negtrack);
+        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0,
+                      aod::femtodreamparticle::ParticleType::kV0Child>(
+          col, v0, postrack, negtrack); ///\todo fill QA also for daughters
+        auto cutContainerV0 =
+          v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
+            col, v0, postrack, negtrack);
 
-        if ((cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) && (cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) && (cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
+        if ((cutContainerV0.at(
+               femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) &&
+            (cutContainerV0.at(
+               femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) &&
+            (cutContainerV0.at(
+               femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
           int postrackID = v0.posTrackId();
           int rowInPrimaryTrackTablePos = -1;
           rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
           childIDs[0] = rowInPrimaryTrackTablePos;
           childIDs[1] = 0;
-          outputParts(outputCollision.lastIndex(), v0.positivept(), v0.positiveeta(), v0.positivephi(), aod::femtodreamparticle::ParticleType::kV0Child, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts), cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID), 0., childIDs, 0, 0);
+          outputParts(outputCollision.lastIndex(), v0.positivept(),
+                      v0.positiveeta(), v0.positivephi(),
+                      aod::femtodreamparticle::ParticleType::kV0Child,
+                      cutContainerV0.at(
+                        femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
+                      cutContainerV0.at(
+                        femtoDreamV0Selection::V0ContainerPosition::kPosPID),
+                      0., childIDs, 0, 0);
           const int rowOfPosTrack = outputParts.lastIndex();
           if constexpr (isMC) {
             fillMCParticle(postrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
@@ -468,13 +695,27 @@ struct femtoDreamProducerTask {
           rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
           childIDs[0] = 0;
           childIDs[1] = rowInPrimaryTrackTableNeg;
-          outputParts(outputCollision.lastIndex(), v0.negativept(), v0.negativeeta(), v0.negativephi(), aod::femtodreamparticle::ParticleType::kV0Child, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts), cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID), 0., childIDs, 0, 0);
+          outputParts(outputCollision.lastIndex(), v0.negativept(),
+                      v0.negativeeta(), v0.negativephi(),
+                      aod::femtodreamparticle::ParticleType::kV0Child,
+                      cutContainerV0.at(
+                        femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
+                      cutContainerV0.at(
+                        femtoDreamV0Selection::V0ContainerPosition::kNegPID),
+                      0., childIDs, 0, 0);
           const int rowOfNegTrack = outputParts.lastIndex();
           if constexpr (isMC) {
             fillMCParticle(negtrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
           }
           int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
-          outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(), aod::femtodreamparticle::ParticleType::kV0, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kV0), 0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()), indexChildID, v0.mLambda(), v0.mAntiLambda());
+          // LOG(info) << cutContainerV0.at(
+          //     femtoDreamV0Selection::V0ContainerPosition::kV0);
+          outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(),
+                      aod::femtodreamparticle::ParticleType::kV0,
+                      cutContainerV0.at(
+                        femtoDreamV0Selection::V0ContainerPosition::kV0),
+                      0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                      indexChildID, v0.mLambda(), v0.mAntiLambda());
           if (ConfDebugOutput) {
             fillDebugParticle<true>(postrack); // QA for positive daughter
             fillDebugParticle<true>(negtrack); // QA for negative daughter
@@ -488,21 +729,27 @@ struct femtoDreamProducerTask {
     }
   }
 
-  void processData(aod::FemtoFullCollision const& col, aod::BCsWithTimestamps const&, aod::FemtoFullTracks const& tracks,
-                   o2::aod::V0Datas const& fullV0s) /// \todo with FilteredFullV0s
+  void
+    processData(aod::FemtoFullCollision const& col,
+                aod::BCsWithTimestamps const&,
+                aod::FemtoFullTracks const& tracks,
+                o2::aod::V0Datas const& fullV0s) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
     fillCollisionsAndTracksAndV0<false>(col, tracks, fullV0s);
   }
-  PROCESS_SWITCH(femtoDreamProducerTask, processData, "Provide experimental data", true);
+  PROCESS_SWITCH(femtoDreamProducerTask, processData,
+                 "Provide experimental data", true);
 
-  void processMC(aod::FemtoFullCollisionMC const& col,
-                 aod::BCsWithTimestamps const&,
-                 soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                 aod::McCollisions const& mcCollisions, aod::McParticles const& mcParticles,
-                 soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
+  void
+    processMC(aod::FemtoFullCollisionMC const& col,
+              aod::BCsWithTimestamps const&,
+              soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+              aod::McCollisions const& mcCollisions,
+              aod::McParticles const& mcParticles,
+              soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
+#include <CCDB/BasicCCDBManager.h>
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -33,7 +34,6 @@
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "TMath.h"
-#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
@@ -85,35 +85,24 @@ struct femtoDreamProducerTaskV0Only {
 
   // Choose if filtering or skimming version is run
 
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false,
-                                   "Store all collisions"};
+  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
 
   // Choose if running on converted data or Run3  / Pilot
-  Configurable<bool> ConfIsRun3{"ConfIsRun3", false,
-                                "Running on Run3 or pilot"};
-  Configurable<bool> ConfIsMC{"ConfIsMC", false,
-                              "Running on MC; implemented only for Run3"};
+  Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
+  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfUseTPCmult{
-    "ConfUseTPCmult", false,
-    "Use multiplicity based on the number of tracks with TPC information"};
-  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f,
-                                  "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true,
-                                         "Evt sel: check for trigger"};
-  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7,
-                                      "Evt sel: trigger"};
-  Configurable<bool> ConfEvtOfflineCheck{
-    "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+  Configurable<bool> ConfUseTPCmult{"ConfUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
+  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
+  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
+  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
+  Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
 
   Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
   // just sanity check to make sure in case there are problems in conversion or
   // MC production it does not affect results
-  Configurable<bool> ConfRejectNotPropagatedTracks{
-    "ConfRejectNotPropagatedTracks", false,
-    "True: reject not propagated tracks"};
+  Configurable<bool> ConfRejectNotPropagatedTracks{"ConfRejectNotPropagatedTracks", false, "True: reject not propagated tracks"};
   FemtoDreamV0Selection v0Cuts;
   /// \todo Labeled array (see Track-Track task)
 

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -8,7 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
 /// \file femtoDreamProducerTaskV0Only.cxx
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -40,15 +40,16 @@ using namespace o2::analysis::femtoDream;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-namespace o2::aod {
+namespace o2::aod
+{
 
 using FemtoFullCollision =
-    soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
+  soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
 using FemtoFullTracks =
-    soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
-              aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
-              aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
-              aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+  soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
+            aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
+            aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
+            aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
 // to be used when we add v0Filter
@@ -61,7 +62,9 @@ using FemtoFullTracks =
 // sizeof(arrayV0Sel[0]); unsigned int columns = sizeof(arrayV0Sel[0]) /
 // sizeof(arrayV0Sel[0][0]);
 
-template <typename T> int getRowDaughters(int daughID, T const &vecID) {
+template <typename T>
+int getRowDaughters(int daughID, T const& vecID)
+{
   int rowInPrimaryTrackTableDaugh = -1;
   for (size_t i = 0; i < vecID.size(); i++) {
     if (vecID.at(i) == daughID) {
@@ -94,8 +97,8 @@ struct femtoDreamProducerTaskV0Only {
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
   Configurable<bool> ConfUseTPCmult{
-      "ConfUseTPCmult", false,
-      "Use multiplicity based on the number of tracks with TPC information"};
+    "ConfUseTPCmult", false,
+    "Use multiplicity based on the number of tracks with TPC information"};
   Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f,
                                   "Evt sel: Max. z-Vertex (cm)"};
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true,
@@ -103,94 +106,94 @@ struct femtoDreamProducerTaskV0Only {
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7,
                                       "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{
-      "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+    "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
 
   Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
   // just sanity check to make sure in case there are problems in conversion or
   // MC production it does not affect results
   Configurable<bool> ConfRejectNotPropagatedTracks{
-      "ConfRejectNotPropagatedTracks", false,
-      "True: reject not propagated tracks"};
+    "ConfRejectNotPropagatedTracks", false,
+    "True: reject not propagated tracks"};
   FemtoDreamV0Selection v0Cuts;
   /// \todo Labeled array (see Track-Track task)
 
   Configurable<std::vector<float>> ConfV0Sign{
-      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign,
-                                              "ConfV0"),
-      std::vector<float>{-1, 1},
-      FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign,
-                                                "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign,
+                                            "ConfV0"),
+    std::vector<float>{-1, 1},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign,
+                                              "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMin{
-      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin,
-                                              "ConfV0"),
-      std::vector<float>{0.3f},
-      FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
-                                                "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin,
+                                            "ConfV0"),
+    std::vector<float>{0.3f},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
+                                              "V0 selection: ")};
   Configurable<std::vector<float>> ConfDCAV0DaughMax{
-      FemtoDreamV0Selection::getSelectionName(
-          femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
-      std::vector<float>{1.5f},
-      FemtoDreamV0Selection::getSelectionHelper(
-          femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
+    std::vector<float>{1.5f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
   Configurable<std::vector<float>> ConfCPAV0Min{
-      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin,
-                                              "ConfV0"),
-      std::vector<float>{0.99f},
-      FemtoDreamV0Selection::getSelectionHelper(
-          femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin,
+                                            "ConfV0"),
+    std::vector<float>{0.99f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
 
   Configurable<std::vector<float>> V0TranRadV0Min{
-      FemtoDreamV0Selection::getSelectionName(
-          femtoDreamV0Selection::kV0TranRadMin, "ConfV0"),
-      std::vector<float>{0.2f},
-      FemtoDreamV0Selection::getSelectionHelper(
-          femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0TranRadMin, "ConfV0"),
+    std::vector<float>{0.2f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
   Configurable<std::vector<float>> V0TranRadV0Max{
-      FemtoDreamV0Selection::getSelectionName(
-          femtoDreamV0Selection::kV0TranRadMax, "ConfV0"),
-      std::vector<float>{100.f},
-      FemtoDreamV0Selection::getSelectionHelper(
-          femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0TranRadMax, "ConfV0"),
+    std::vector<float>{100.f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
   Configurable<std::vector<float>> V0DecVtxMax{
-      FemtoDreamV0Selection::getSelectionName(
-          femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"),
-      std::vector<float>{100.f},
-      FemtoDreamV0Selection::getSelectionHelper(
-          femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
+    FemtoDreamV0Selection::getSelectionName(
+      femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"),
+    std::vector<float>{100.f},
+    FemtoDreamV0Selection::getSelectionHelper(
+      femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
 
   Configurable<std::vector<float>> ConfV0DaughCharge{
-      "ConfV0DaughCharge", std::vector<float>{-1, 1}, "V0 Daugh sel: Charge"};
+    "ConfV0DaughCharge", std::vector<float>{-1, 1}, "V0 Daugh sel: Charge"};
   Configurable<std::vector<float>> ConfDaughEta{
-      "ConfDaughEta", std::vector<float>{0.8f}, "V0 Daugh sel: max eta"};
+    "ConfDaughEta", std::vector<float>{0.8f}, "V0 Daugh sel: max eta"};
   Configurable<std::vector<float>> ConfV0DaughTPCnclsMin{
-      "ConfV0DaughTPCnclsMin", std::vector<float>{70.f},
-      "V0 Daugh sel: Min. nCls TPC"};
+    "ConfV0DaughTPCnclsMin", std::vector<float>{70.f},
+    "V0 Daugh sel: Min. nCls TPC"};
   Configurable<std::vector<float>> ConfV0DaughDCAMin{
-      "ConfV0DaughDCAMin", std::vector<float>{0.05f},
-      "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"};
+    "ConfV0DaughDCAMin", std::vector<float>{0.05f},
+    "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"};
   Configurable<std::vector<float>> ConfV0DaughPIDnSigmaMax{
-      "ConfV0DaughPIDnSigmaMax", std::vector<float>{5.f},
-      "V0 Daugh sel: Max. PID nSigma TPC"};
+    "ConfV0DaughPIDnSigmaMax", std::vector<float>{5.f},
+    "V0 Daugh sel: Max. PID nSigma TPC"};
 
   Configurable<std::vector<int>> ConfV0DaughTPIDspecies{
-      "ConfV0DaughTPIDspecies",
-      std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon,
-                       o2::track::PID::Proton},
-      "V0 Daugh sel: Particles species for PID"};
+    "ConfV0DaughTPIDspecies",
+    std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon,
+                     o2::track::PID::Proton},
+    "V0 Daugh sel: Particles species for PID"};
 
   Configurable<float> ConfInvMassLowLimit{
-      "ConfInvMassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+    "ConfInvMassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
   Configurable<float> ConfInvMassUpLimit{
-      "ConfInvMassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
+    "ConfInvMassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
 
   Configurable<bool> ConfRejectKaons{"ConfRejectKaons", false,
                                      "Switch to reject kaons"};
   Configurable<float> ConfInvKaonMassLowLimit{
-      "ConfInvKaonMassLowLimit", 0.48,
-      "Lower limit of the V0 invariant mass for Kaon rejection"};
+    "ConfInvKaonMassLowLimit", 0.48,
+    "Lower limit of the V0 invariant mass for Kaon rejection"};
   Configurable<float> ConfInvKaonMassUpLimit{
-      "ConfInvKaonMassUpLimit", 0.515,
-      "Upper limit of the V0 invariant mass for Kaon rejection"};
+    "ConfInvKaonMassUpLimit", 0.515,
+    "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
@@ -200,13 +203,16 @@ struct femtoDreamProducerTaskV0Only {
   // for now do not know why
 
   HistogramRegistry qaRegistry{
-      "QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+    "QAHistos",
+    {},
+    OutputObjHandlingPolicy::QAObject};
 
   int mRunNumber;
   float mMagField;
   Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
 
-  void init(InitContext &) {
+  void init(InitContext&)
+  {
     colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel,
                     ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
@@ -285,23 +291,24 @@ struct femtoDreamProducerTaskV0Only {
     ccdb->setLocalObjectValidityChecking();
 
     int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::system_clock::now().time_since_epoch())
-                      .count();
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count();
     ccdb->setCreatedNotAfter(now);
   }
 
   /// Function to retrieve the nominal mgnetic field in kG (0.1T) and convert it
   /// directly to T
-  float getMagneticFieldTesla(uint64_t timestamp) {
+  float getMagneticFieldTesla(uint64_t timestamp)
+  {
     // TODO done only once (and not per run). Will be replaced by
     // CCDBConfigurable
     float output = -999;
 
     if (ConfIsRun3 && !ConfIsMC) {
-      static o2::parameters::GRPMagField *grpo = nullptr;
+      static o2::parameters::GRPMagField* grpo = nullptr;
       if (grpo == nullptr) {
         grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(
-            "GLO/Config/GRPMagField", timestamp);
+          "GLO/Config/GRPMagField", timestamp);
         if (grpo == nullptr) {
           LOGF(fatal, "GRP object not found for timestamp %llu", timestamp);
           return 0;
@@ -317,7 +324,7 @@ struct femtoDreamProducerTaskV0Only {
     }
 
     if (!ConfIsRun3 || (ConfIsRun3 && ConfIsMC)) {
-      static o2::parameters::GRPObject *grpo = nullptr;
+      static o2::parameters::GRPObject* grpo = nullptr;
       if (grpo == nullptr) {
         grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>("GLO/GRP/GRP",
                                                                 timestamp);
@@ -334,10 +341,10 @@ struct femtoDreamProducerTaskV0Only {
     return output;
   }
 
-  void process(aod::FemtoFullCollision const &col,
-               aod::BCsWithTimestamps const &,
-               aod::FemtoFullTracks const &tracks,
-               o2::aod::V0Datas const &fullV0s) /// \todo with FilteredFullV0s
+  void process(aod::FemtoFullCollision const& col,
+               aod::BCsWithTimestamps const&,
+               aod::FemtoFullTracks const& tracks,
+               o2::aod::V0Datas const& fullV0s) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
     auto bc = col.bc_as<aod::BCsWithTimestamps>();
@@ -380,20 +387,19 @@ struct femtoDreamProducerTaskV0Only {
     // now the table is filled
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
-    int childIDs[2] = {
-        0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int>
-        tmpIDtrack; // this vector keeps track of the matching of the primary
-                    // track table row <-> aod::track table global index
+      tmpIDtrack; // this vector keeps track of the matching of the primary
+                  // track table row <-> aod::track table global index
 
     if (ConfStoreV0) {
-      for (auto &v0 : fullV0s) {
+      for (auto& v0 : fullV0s) {
         auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
         auto negtrack =
-            v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough
-                                                    /// if we apply the filter
-                                                    /// the sign of Pos and Neg
-                                                    /// track is always negative
+          v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough
+                                                  /// if we apply the filter
+                                                  /// the sign of Pos and Neg
+                                                  /// track is always negative
         // const auto dcaXYpos = postrack.dcaXY();
         // const auto dcaZpos = postrack.dcaZ();
         // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
@@ -404,17 +410,17 @@ struct femtoDreamProducerTaskV0Only {
         }
         v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0,
                       aod::femtodreamparticle::ParticleType::kV0Child>(
-            col, v0, postrack, negtrack); ///\todo fill QA also for daughters
+          col, v0, postrack, negtrack); ///\todo fill QA also for daughters
         auto cutContainerV0 =
-            v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
-                col, v0, postrack, negtrack);
+          v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
+            col, v0, postrack, negtrack);
 
         if ((cutContainerV0.at(
-                 femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) &&
+               femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) &&
             (cutContainerV0.at(
-                 femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) &&
+               femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) &&
             (cutContainerV0.at(
-                 femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
+               femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
           int postrackID = v0.posTrackId();
           int rowInPrimaryTrackTablePos = -1;
           rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
@@ -424,9 +430,9 @@ struct femtoDreamProducerTaskV0Only {
                       v0.positiveeta(), v0.positivephi(),
                       aod::femtodreamparticle::ParticleType::kV0Child,
                       cutContainerV0.at(
-                          femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
+                        femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
                       cutContainerV0.at(
-                          femtoDreamV0Selection::V0ContainerPosition::kPosPID),
+                        femtoDreamV0Selection::V0ContainerPosition::kPosPID),
                       0., childIDs, 0, 0);
           const int rowOfPosTrack = outputParts.lastIndex();
           int negtrackID = v0.negTrackId();
@@ -438,47 +444,47 @@ struct femtoDreamProducerTaskV0Only {
                       v0.negativeeta(), v0.negativephi(),
                       aod::femtodreamparticle::ParticleType::kV0Child,
                       cutContainerV0.at(
-                          femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
+                        femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
                       cutContainerV0.at(
-                          femtoDreamV0Selection::V0ContainerPosition::kNegPID),
+                        femtoDreamV0Selection::V0ContainerPosition::kNegPID),
                       0., childIDs, 0, 0);
           const int rowOfNegTrack = outputParts.lastIndex();
-          int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
+          std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
           outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(),
                       aod::femtodreamparticle::ParticleType::kV0,
                       cutContainerV0.at(
-                          femtoDreamV0Selection::V0ContainerPosition::kV0),
+                        femtoDreamV0Selection::V0ContainerPosition::kV0),
                       0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
                       indexChildID, v0.mLambda(), v0.mAntiLambda());
           if (ConfDebugOutput) {
             outputDebugParts(
-                postrack.sign(), (uint8_t)postrack.tpcNClsFound(),
-                postrack.tpcNClsFindable(),
-                (uint8_t)postrack.tpcNClsCrossedRows(),
-                postrack.tpcNClsShared(), postrack.tpcInnerParam(),
-                postrack.itsNCls(), postrack.itsNClsInnerBarrel(),
-                postrack.dcaXY(), postrack.dcaZ(), postrack.tpcSignal(),
-                postrack.tpcNSigmaStoreEl(), postrack.tpcNSigmaStorePi(),
-                postrack.tpcNSigmaStoreKa(), postrack.tpcNSigmaStorePr(),
-                postrack.tpcNSigmaStoreDe(), postrack.tofNSigmaStoreEl(),
-                postrack.tofNSigmaStorePi(), postrack.tofNSigmaStoreKa(),
-                postrack.tofNSigmaStorePr(), postrack.tofNSigmaStoreDe(), -999.,
-                -999., -999., -999., -999.,
-                -999.); // QA for positive daughter
+              postrack.sign(), (uint8_t)postrack.tpcNClsFound(),
+              postrack.tpcNClsFindable(),
+              (uint8_t)postrack.tpcNClsCrossedRows(),
+              postrack.tpcNClsShared(), postrack.tpcInnerParam(),
+              postrack.itsNCls(), postrack.itsNClsInnerBarrel(),
+              postrack.dcaXY(), postrack.dcaZ(), postrack.tpcSignal(),
+              postrack.tpcNSigmaStoreEl(), postrack.tpcNSigmaStorePi(),
+              postrack.tpcNSigmaStoreKa(), postrack.tpcNSigmaStorePr(),
+              postrack.tpcNSigmaStoreDe(), postrack.tofNSigmaStoreEl(),
+              postrack.tofNSigmaStorePi(), postrack.tofNSigmaStoreKa(),
+              postrack.tofNSigmaStorePr(), postrack.tofNSigmaStoreDe(), -999.,
+              -999., -999., -999., -999.,
+              -999.); // QA for positive daughter
             outputDebugParts(
-                negtrack.sign(), (uint8_t)negtrack.tpcNClsFound(),
-                negtrack.tpcNClsFindable(),
-                (uint8_t)negtrack.tpcNClsCrossedRows(),
-                negtrack.tpcNClsShared(), negtrack.tpcInnerParam(),
-                negtrack.itsNCls(), negtrack.itsNClsInnerBarrel(),
-                negtrack.dcaXY(), negtrack.dcaZ(), negtrack.tpcSignal(),
-                negtrack.tpcNSigmaStoreEl(), negtrack.tpcNSigmaStorePi(),
-                negtrack.tpcNSigmaStoreKa(), negtrack.tpcNSigmaStorePr(),
-                negtrack.tpcNSigmaStoreDe(), negtrack.tofNSigmaStoreEl(),
-                negtrack.tofNSigmaStorePi(), negtrack.tofNSigmaStoreKa(),
-                negtrack.tofNSigmaStorePr(), negtrack.tofNSigmaStoreDe(), -999.,
-                -999., -999., -999., -999.,
-                -999.); // QA for negative daughter
+              negtrack.sign(), (uint8_t)negtrack.tpcNClsFound(),
+              negtrack.tpcNClsFindable(),
+              (uint8_t)negtrack.tpcNClsCrossedRows(),
+              negtrack.tpcNClsShared(), negtrack.tpcInnerParam(),
+              negtrack.itsNCls(), negtrack.itsNClsInnerBarrel(),
+              negtrack.dcaXY(), negtrack.dcaZ(), negtrack.tpcSignal(),
+              negtrack.tpcNSigmaStoreEl(), negtrack.tpcNSigmaStorePi(),
+              negtrack.tpcNSigmaStoreKa(), negtrack.tpcNSigmaStorePr(),
+              negtrack.tpcNSigmaStoreDe(), negtrack.tofNSigmaStoreEl(),
+              negtrack.tofNSigmaStorePi(), negtrack.tofNSigmaStoreKa(),
+              negtrack.tofNSigmaStorePr(), negtrack.tofNSigmaStoreDe(), -999.,
+              -999., -999., -999., -999.,
+              -999.); // QA for negative daughter
             outputDebugParts(-999., -999., -999., -999., -999., -999., -999.,
                              -999., -999., -999., -999., -999., -999., -999.,
                              -999., -999., -999., -999., -999., -999., -999.,
@@ -492,7 +498,8 @@ struct femtoDreamProducerTaskV0Only {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const &cfgc) {
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
   WorkflowSpec workflow{adaptAnalysisTask<femtoDreamProducerTaskV0Only>(cfgc)};
   return workflow;
 }

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -13,56 +13,55 @@
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#include <CCDB/BasicCCDBManager.h>
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
 #include "FemtoDreamCollisionSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
-#include "PWGCF/DataModel/FemtoDerived.h"
+#include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
-#include "Framework/ASoAHelpers.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/Multiplicity.h"
-#include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/trackUtilities.h"
-#include "PWGLF/DataModel/LFStrangenessTables.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "DataFormatsParameters/GRPMagField.h"
+#include "Framework/runDataProcessing.h"
 #include "Math/Vector4D.h"
+#include "PWGCF/DataModel/FemtoDerived.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "ReconstructionDataFormats/Track.h"
 #include "TMath.h"
+#include <CCDB/BasicCCDBManager.h>
 
 using namespace o2;
 using namespace o2::analysis::femtoDream;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-namespace o2::aod
-{
+namespace o2::aod {
 
-using FemtoFullCollision = soa::Join<aod::Collisions,
-                                     aod::EvSels,
-                                     aod::Mults>::iterator;
-using FemtoFullTracks = soa::Join<aod::FullTracks,
-                                  aod::TracksDCA, aod::TOFSignal,
-                                  aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
-                                  aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
-                                  aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
-                                  aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
-// using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s> to be used when we add v0Filter
+using FemtoFullCollision =
+    soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
+using FemtoFullTracks =
+    soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
+              aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
+              aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
+              aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+// using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
+// table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
+// to be used when we add v0Filter
 } // namespace o2::aod
 
-/// \todo fix how to pass array to setSelection, getRow() passing a different type!
-// static constexpr float arrayV0Sel[3][3] = {{100.f, 100.f, 100.f}, {0.2f, 0.2f, 0.2f}, {100.f, 100.f, 100.f}};
-// unsigned int rows = sizeof(arrayV0Sel) / sizeof(arrayV0Sel[0]);
-// unsigned int columns = sizeof(arrayV0Sel[0]) / sizeof(arrayV0Sel[0][0]);
+/// \todo fix how to pass array to setSelection, getRow() passing a different
+/// type!
+// static constexpr float arrayV0Sel[3][3] = {{100.f, 100.f, 100.f}, {0.2f,
+// 0.2f, 0.2f}, {100.f, 100.f, 100.f}}; unsigned int rows = sizeof(arrayV0Sel) /
+// sizeof(arrayV0Sel[0]); unsigned int columns = sizeof(arrayV0Sel[0]) /
+// sizeof(arrayV0Sel[0][0]);
 
-template <typename T>
-int getRowDaughters(int daughID, T const& vecID)
-{
+template <typename T> int getRowDaughters(int daughID, T const &vecID) {
   int rowInPrimaryTrackTableDaugh = -1;
   for (size_t i = 0; i < vecID.size(); i++) {
     if (vecID.at(i) == daughID) {
@@ -83,93 +82,199 @@ struct femtoDreamProducerTaskV0Only {
 
   // Choose if filtering or skimming version is run
 
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
+  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false,
+                                   "Store all collisions"};
 
   // Choose if running on converted data or Run3  / Pilot
-  Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
-  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
+  Configurable<bool> ConfIsRun3{"ConfIsRun3", false,
+                                "Running on Run3 or pilot"};
+  Configurable<bool> ConfIsMC{"ConfIsMC", false,
+                              "Running on MC; implemented only for Run3"};
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfUseTPCmult{"ConfUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
-  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
-  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
-  Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+  Configurable<bool> ConfUseTPCmult{
+      "ConfUseTPCmult", false,
+      "Use multiplicity based on the number of tracks with TPC information"};
+  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f,
+                                  "Evt sel: Max. z-Vertex (cm)"};
+  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true,
+                                         "Evt sel: check for trigger"};
+  Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7,
+                                      "Evt sel: trigger"};
+  Configurable<bool> ConfEvtOfflineCheck{
+      "ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
 
   Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
-  // just sanity check to make sure in case there are problems in conversion or MC production it does not affect results
-  Configurable<bool> ConfRejectNotPropagatedTracks{"ConfRejectNotPropagatedTracks", false, "True: reject not propagated tracks"};
+  // just sanity check to make sure in case there are problems in conversion or
+  // MC production it does not affect results
+  Configurable<bool> ConfRejectNotPropagatedTracks{
+      "ConfRejectNotPropagatedTracks", false,
+      "True: reject not propagated tracks"};
   FemtoDreamV0Selection v0Cuts;
   /// \todo Labeled array (see Track-Track task)
 
-  Configurable<std::vector<float>> ConfV0Sign{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfV0PtMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kpTV0Min, "ConfV0"), std::vector<float>{0.3f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kpTV0Min, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfDCAV0DaughMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kDCAV0DaughMax, "ConfV0"), std::vector<float>{1.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kDCAV0DaughMax, "V0 selection: ")};
-  Configurable<std::vector<float>> ConfCPAV0Min{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kCPAV0Min, "ConfV0"), std::vector<float>{0.99f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kCPAV0Min, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0Sign{
+      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign,
+                                              "ConfV0"),
+      std::vector<float>{-1, 1},
+      FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign,
+                                                "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMin{
+      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin,
+                                              "ConfV0"),
+      std::vector<float>{0.3f},
+      FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
+                                                "V0 selection: ")};
+  Configurable<std::vector<float>> ConfDCAV0DaughMax{
+      FemtoDreamV0Selection::getSelectionName(
+          femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
+      std::vector<float>{1.5f},
+      FemtoDreamV0Selection::getSelectionHelper(
+          femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfCPAV0Min{
+      FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin,
+                                              "ConfV0"),
+      std::vector<float>{0.99f},
+      FemtoDreamV0Selection::getSelectionHelper(
+          femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
 
-  Configurable<std::vector<float>> V0TranRadV0Min{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kTranRadV0Min, "ConfV0"), std::vector<float>{0.2f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kTranRadV0Min, "V0 selection: ")};
-  Configurable<std::vector<float>> V0TranRadV0Max{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kTranRadV0Max, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kTranRadV0Max, "V0 selection: ")};
-  Configurable<std::vector<float>> V0DecVtxMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kDecVtxMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kDecVtxMax, "V0 selection: ")};
+  Configurable<std::vector<float>> V0TranRadV0Min{
+      FemtoDreamV0Selection::getSelectionName(
+          femtoDreamV0Selection::kV0TranRadMin, "ConfV0"),
+      std::vector<float>{0.2f},
+      FemtoDreamV0Selection::getSelectionHelper(
+          femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
+  Configurable<std::vector<float>> V0TranRadV0Max{
+      FemtoDreamV0Selection::getSelectionName(
+          femtoDreamV0Selection::kV0TranRadMax, "ConfV0"),
+      std::vector<float>{100.f},
+      FemtoDreamV0Selection::getSelectionHelper(
+          femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
+  Configurable<std::vector<float>> V0DecVtxMax{
+      FemtoDreamV0Selection::getSelectionName(
+          femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"),
+      std::vector<float>{100.f},
+      FemtoDreamV0Selection::getSelectionHelper(
+          femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
 
-  Configurable<std::vector<float>> ConfV0DaughCharge{"ConfV0DaughCharge", std::vector<float>{-1, 1}, "V0 Daugh sel: Charge"};
-  Configurable<std::vector<float>> ConfDaughEta{"ConfDaughEta", std::vector<float>{0.8f}, "V0 Daugh sel: max eta"};
-  Configurable<std::vector<float>> ConfV0DaughTPCnclsMin{"ConfV0DaughTPCnclsMin", std::vector<float>{70.f}, "V0 Daugh sel: Min. nCls TPC"};
-  Configurable<std::vector<float>> ConfV0DaughDCAMin{"ConfV0DaughDCAMin", std::vector<float>{0.05f}, "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"};
-  Configurable<std::vector<float>> ConfV0DaughPIDnSigmaMax{"ConfV0DaughPIDnSigmaMax", std::vector<float>{5.f}, "V0 Daugh sel: Max. PID nSigma TPC"};
+  Configurable<std::vector<float>> ConfV0DaughCharge{
+      "ConfV0DaughCharge", std::vector<float>{-1, 1}, "V0 Daugh sel: Charge"};
+  Configurable<std::vector<float>> ConfDaughEta{
+      "ConfDaughEta", std::vector<float>{0.8f}, "V0 Daugh sel: max eta"};
+  Configurable<std::vector<float>> ConfV0DaughTPCnclsMin{
+      "ConfV0DaughTPCnclsMin", std::vector<float>{70.f},
+      "V0 Daugh sel: Min. nCls TPC"};
+  Configurable<std::vector<float>> ConfV0DaughDCAMin{
+      "ConfV0DaughDCAMin", std::vector<float>{0.05f},
+      "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"};
+  Configurable<std::vector<float>> ConfV0DaughPIDnSigmaMax{
+      "ConfV0DaughPIDnSigmaMax", std::vector<float>{5.f},
+      "V0 Daugh sel: Max. PID nSigma TPC"};
 
-  Configurable<std::vector<int>> ConfV0DaughTPIDspecies{"ConfV0DaughTPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton}, "V0 Daugh sel: Particles species for PID"};
+  Configurable<std::vector<int>> ConfV0DaughTPIDspecies{
+      "ConfV0DaughTPIDspecies",
+      std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon,
+                       o2::track::PID::Proton},
+      "V0 Daugh sel: Particles species for PID"};
 
-  Configurable<float> ConfInvMassLowLimit{"ConfInvMassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
-  Configurable<float> ConfInvMassUpLimit{"ConfInvMassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
+  Configurable<float> ConfInvMassLowLimit{
+      "ConfInvMassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+  Configurable<float> ConfInvMassUpLimit{
+      "ConfInvMassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
 
-  Configurable<bool> ConfRejectKaons{"ConfRejectKaons", false, "Switch to reject kaons"};
-  Configurable<float> ConfInvKaonMassLowLimit{"ConfInvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
-  Configurable<float> ConfInvKaonMassUpLimit{"ConfInvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<bool> ConfRejectKaons{"ConfRejectKaons", false,
+                                     "Switch to reject kaons"};
+  Configurable<float> ConfInvKaonMassLowLimit{
+      "ConfInvKaonMassLowLimit", 0.48,
+      "Lower limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<float> ConfInvKaonMassUpLimit{
+      "ConfInvKaonMassUpLimit", 0.515,
+      "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
                     (nabs(aod::v0data::y) < V0DecVtxMax.value) &&
                     (nabs(aod::v0data::z) < V0DecVtxMax.value);*/
-  // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working for now do not know why
+  // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working
+  // for now do not know why
 
-  HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry qaRegistry{
+      "QAHistos", {}, OutputObjHandlingPolicy::QAObject};
 
   int mRunNumber;
   float mMagField;
   Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
 
-  void init(InitContext&)
-  {
-    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
+  void init(InitContext &) {
+    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel,
+                    ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
 
-    /// \todo fix how to pass array to setSelection, getRow() passing a different type!
-    // v0Cuts.setSelection(ConfV0Selection->getRow(0), femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
+    /// \todo fix how to pass array to setSelection, getRow() passing a
+    /// different type!
+    // v0Cuts.setSelection(ConfV0Selection->getRow(0),
+    // femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
     if (ConfStoreV0) {
-      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign, femtoDreamSelection::kEqual);
-      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kpTV0Min, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setSelection(ConfDCAV0DaughMax, femtoDreamV0Selection::kDCAV0DaughMax, femtoDreamSelection::kUpperLimit);
-      v0Cuts.setSelection(ConfCPAV0Min, femtoDreamV0Selection::kCPAV0Min, femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfDCAV0DaughMax,
+                          femtoDreamV0Selection::kV0DCADaughMax,
+                          femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfCPAV0Min, femtoDreamV0Selection::kV0CPAMin,
+                          femtoDreamSelection::kLowerLimit);
 
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfDaughEta, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughTPCnclsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfDaughEta, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughTPCnclsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
-      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfV0DaughTPIDspecies);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfV0DaughTPIDspecies);
-      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughCharge,
+                          femtoDreamTrackSelection::kSign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfDaughEta,
+                          femtoDreamTrackSelection::kEtaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack,
+                          ConfV0DaughTPCnclsMin,
+                          femtoDreamTrackSelection::kTPCnClsMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfV0DaughDCAMin,
+                          femtoDreamTrackSelection::kDCAMin,
+                          femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack,
+                          ConfV0DaughPIDnSigmaMax,
+                          femtoDreamTrackSelection::kPIDnSigmaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughCharge,
+                          femtoDreamTrackSelection::kSign,
+                          femtoDreamSelection::kEqual);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfDaughEta,
+                          femtoDreamTrackSelection::kEtaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack,
+                          ConfV0DaughTPCnclsMin,
+                          femtoDreamTrackSelection::kTPCnClsMin,
+                          femtoDreamSelection::kLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfV0DaughDCAMin,
+                          femtoDreamTrackSelection::kDCAMin,
+                          femtoDreamSelection::kAbsLowerLimit);
+      v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack,
+                          ConfV0DaughPIDnSigmaMax,
+                          femtoDreamTrackSelection::kPIDnSigmaMax,
+                          femtoDreamSelection::kAbsUpperLimit);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack,
+                                ConfV0DaughTPIDspecies);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack,
+                                ConfV0DaughTPIDspecies);
+      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0,
+                  aod::femtodreamparticle::ParticleType::kV0Child,
+                  aod::femtodreamparticle::cutContainerType>(&qaRegistry);
       v0Cuts.setInvMassLimits(ConfInvMassLowLimit, ConfInvMassUpLimit);
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfRejectNotPropagatedTracks);
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack, ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack,
+                                               ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack,
+                                               ConfRejectNotPropagatedTracks);
       if (ConfRejectKaons) {
-        v0Cuts.setKaonInvMassLimits(ConfInvKaonMassLowLimit, ConfInvKaonMassUpLimit);
+        v0Cuts.setKaonInvMassLimits(ConfInvKaonMassLowLimit,
+                                    ConfInvKaonMassUpLimit);
       }
     }
     mRunNumber = 0;
@@ -179,48 +284,60 @@ struct femtoDreamProducerTaskV0Only {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count();
     ccdb->setCreatedNotAfter(now);
   }
 
-  /// Function to retrieve the nominal mgnetic field in kG (0.1T) and convert it directly to T
-  float getMagneticFieldTesla(uint64_t timestamp)
-  {
-    // TODO done only once (and not per run). Will be replaced by CCDBConfigurable
+  /// Function to retrieve the nominal mgnetic field in kG (0.1T) and convert it
+  /// directly to T
+  float getMagneticFieldTesla(uint64_t timestamp) {
+    // TODO done only once (and not per run). Will be replaced by
+    // CCDBConfigurable
     float output = -999;
 
     if (ConfIsRun3 && !ConfIsMC) {
-      static o2::parameters::GRPMagField* grpo = nullptr;
+      static o2::parameters::GRPMagField *grpo = nullptr;
       if (grpo == nullptr) {
-        grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", timestamp);
+        grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(
+            "GLO/Config/GRPMagField", timestamp);
         if (grpo == nullptr) {
           LOGF(fatal, "GRP object not found for timestamp %llu", timestamp);
           return 0;
         }
-        LOGF(info, "Retrieved GRP for timestamp %llu with L3 ", timestamp, grpo->getL3Current());
+        LOGF(info, "Retrieved GRP for timestamp %llu with L3 ", timestamp,
+             grpo->getL3Current());
       }
-      // taken from GRP onject definition of getNominalL3Field; update later to something smarter (mNominalL3Field = std::lround(5.f * mL3Current / 30000.f);)
+      // taken from GRP onject definition of getNominalL3Field; update later to
+      // something smarter (mNominalL3Field = std::lround(5.f * mL3Current /
+      // 30000.f);)
       auto NominalL3Field = std::lround(5.f * grpo->getL3Current() / 30000.f);
       output = 0.1 * (NominalL3Field);
     }
 
     if (!ConfIsRun3 || (ConfIsRun3 && ConfIsMC)) {
-      static o2::parameters::GRPObject* grpo = nullptr;
+      static o2::parameters::GRPObject *grpo = nullptr;
       if (grpo == nullptr) {
-        grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>("GLO/GRP/GRP", timestamp);
+        grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>("GLO/GRP/GRP",
+                                                                timestamp);
         if (grpo == nullptr) {
           LOGF(fatal, "GRP object not found for timestamp %llu", timestamp);
           return 0;
         }
-        LOGF(info, "Retrieved GRP for timestamp %llu with magnetic field of %d kG", timestamp, grpo->getNominalL3Field());
+        LOGF(info,
+             "Retrieved GRP for timestamp %llu with magnetic field of %d kG",
+             timestamp, grpo->getNominalL3Field());
       }
       output = 0.1 * (grpo->getNominalL3Field());
     }
     return output;
   }
 
-  void process(aod::FemtoFullCollision const& col, aod::BCsWithTimestamps const&, aod::FemtoFullTracks const& tracks,
-               o2::aod::V0Datas const& fullV0s) /// \todo with FilteredFullV0s
+  void process(aod::FemtoFullCollision const &col,
+               aod::BCsWithTimestamps const &,
+               aod::FemtoFullTracks const &tracks,
+               o2::aod::V0Datas const &fullV0s) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
     auto bc = col.bc_as<aod::BCsWithTimestamps>();
@@ -238,17 +355,20 @@ struct femtoDreamProducerTaskV0Only {
       mult = col.multFV0M();
       multNtr = col.multNTracksPV();
     } else {
-      mult = 0.5 * (col.multFV0M()); /// For benchmarking on Run 2, V0M in FemtoDreamRun2 is defined V0M/2
+      mult = 0.5 * (col.multFV0M()); /// For benchmarking on Run 2, V0M in
+                                     /// FemtoDreamRun2 is defined V0M/2
       multNtr = col.multTracklets();
     }
     if (ConfUseTPCmult) {
       multNtr = col.multTPC();
     }
 
-    /// First thing to do is to check whether the basic event selection criteria are fulfilled
+    /// First thing to do is to check whether the basic event selection criteria
+    /// are fulfilled
     // If the basic selection is NOT fulfilled:
     // in case of skimming run - don't store such collisions
-    // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
+    // in case of trigger run - store such collisions but don't store any
+    // particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       if (ConfIsTrigger) {
         outputCollision(vtxZ, mult, multNtr, spher, mMagField);
@@ -260,13 +380,20 @@ struct femtoDreamProducerTaskV0Only {
     // now the table is filled
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
-    int childIDs[2] = {0, 0};    // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack; // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    int childIDs[2] = {
+        0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int>
+        tmpIDtrack; // this vector keeps track of the matching of the primary
+                    // track table row <-> aod::track table global index
 
     if (ConfStoreV0) {
-      for (auto& v0 : fullV0s) {
+      for (auto &v0 : fullV0s) {
         auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
-        auto negtrack = v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough if we apply the filter the sign of Pos and Neg track is always negative
+        auto negtrack =
+            v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough
+                                                    /// if we apply the filter
+                                                    /// the sign of Pos and Neg
+                                                    /// track is always negative
         // const auto dcaXYpos = postrack.dcaXY();
         // const auto dcaZpos = postrack.dcaZ();
         // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
@@ -275,106 +402,87 @@ struct femtoDreamProducerTaskV0Only {
         if (!v0Cuts.isSelectedMinimal(col, v0, postrack, negtrack)) {
           continue;
         }
-        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
-        auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, v0, postrack, negtrack);
+        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0,
+                      aod::femtodreamparticle::ParticleType::kV0Child>(
+            col, v0, postrack, negtrack); ///\todo fill QA also for daughters
+        auto cutContainerV0 =
+            v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
+                col, v0, postrack, negtrack);
 
-        if ((cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) && (cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) && (cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
+        if ((cutContainerV0.at(
+                 femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) &&
+            (cutContainerV0.at(
+                 femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) &&
+            (cutContainerV0.at(
+                 femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
           int postrackID = v0.posTrackId();
           int rowInPrimaryTrackTablePos = -1;
           rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
           childIDs[0] = rowInPrimaryTrackTablePos;
           childIDs[1] = 0;
-          outputParts(outputCollision.lastIndex(), v0.positivept(), v0.positiveeta(), v0.positivephi(), aod::femtodreamparticle::ParticleType::kV0Child, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts), cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID), 0., childIDs, 0, 0);
+          outputParts(outputCollision.lastIndex(), v0.positivept(),
+                      v0.positiveeta(), v0.positivephi(),
+                      aod::femtodreamparticle::ParticleType::kV0Child,
+                      cutContainerV0.at(
+                          femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
+                      cutContainerV0.at(
+                          femtoDreamV0Selection::V0ContainerPosition::kPosPID),
+                      0., childIDs, 0, 0);
           const int rowOfPosTrack = outputParts.lastIndex();
           int negtrackID = v0.negTrackId();
           int rowInPrimaryTrackTableNeg = -1;
           rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
           childIDs[0] = 0;
           childIDs[1] = rowInPrimaryTrackTableNeg;
-          outputParts(outputCollision.lastIndex(), v0.negativept(), v0.negativeeta(), v0.negativephi(), aod::femtodreamparticle::ParticleType::kV0Child, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts), cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID), 0., childIDs, 0, 0);
+          outputParts(outputCollision.lastIndex(), v0.negativept(),
+                      v0.negativeeta(), v0.negativephi(),
+                      aod::femtodreamparticle::ParticleType::kV0Child,
+                      cutContainerV0.at(
+                          femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
+                      cutContainerV0.at(
+                          femtoDreamV0Selection::V0ContainerPosition::kNegPID),
+                      0., childIDs, 0, 0);
           const int rowOfNegTrack = outputParts.lastIndex();
           int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
-          outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(), aod::femtodreamparticle::ParticleType::kV0, cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kV0), 0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()), indexChildID, v0.mLambda(), v0.mAntiLambda());
+          outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(),
+                      aod::femtodreamparticle::ParticleType::kV0,
+                      cutContainerV0.at(
+                          femtoDreamV0Selection::V0ContainerPosition::kV0),
+                      0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                      indexChildID, v0.mLambda(), v0.mAntiLambda());
           if (ConfDebugOutput) {
-            outputDebugParts(postrack.sign(),
-                             (uint8_t)postrack.tpcNClsFound(),
-                             postrack.tpcNClsFindable(),
-                             (uint8_t)postrack.tpcNClsCrossedRows(),
-                             postrack.tpcNClsShared(),
-                             postrack.tpcInnerParam(),
-                             postrack.itsNCls(),
-                             postrack.itsNClsInnerBarrel(),
-                             postrack.dcaXY(),
-                             postrack.dcaZ(),
-                             postrack.tpcSignal(),
-                             postrack.tpcNSigmaStoreEl(),
-                             postrack.tpcNSigmaStorePi(),
-                             postrack.tpcNSigmaStoreKa(),
-                             postrack.tpcNSigmaStorePr(),
-                             postrack.tpcNSigmaStoreDe(),
-                             postrack.tofNSigmaStoreEl(),
-                             postrack.tofNSigmaStorePi(),
-                             postrack.tofNSigmaStoreKa(),
-                             postrack.tofNSigmaStorePr(),
-                             postrack.tofNSigmaStoreDe(),
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.); // QA for positive daughter
-            outputDebugParts(negtrack.sign(),
-                             (uint8_t)negtrack.tpcNClsFound(),
-                             negtrack.tpcNClsFindable(),
-                             (uint8_t)negtrack.tpcNClsCrossedRows(),
-                             negtrack.tpcNClsShared(),
-                             negtrack.tpcInnerParam(),
-                             negtrack.itsNCls(),
-                             negtrack.itsNClsInnerBarrel(),
-                             negtrack.dcaXY(),
-                             negtrack.dcaZ(),
-                             negtrack.tpcSignal(),
-                             negtrack.tpcNSigmaStoreEl(),
-                             negtrack.tpcNSigmaStorePi(),
-                             negtrack.tpcNSigmaStoreKa(),
-                             negtrack.tpcNSigmaStorePr(),
-                             negtrack.tpcNSigmaStoreDe(),
-                             negtrack.tofNSigmaStoreEl(),
-                             negtrack.tofNSigmaStorePi(),
-                             negtrack.tofNSigmaStoreKa(),
-                             negtrack.tofNSigmaStorePr(),
-                             negtrack.tofNSigmaStoreDe(),
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.); // QA for negative daughter
-            outputDebugParts(-999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             -999.,
-                             v0.dcaV0daughters(),
-                             v0.v0radius(),
-                             v0.x(),
-                             v0.y(),
+            outputDebugParts(
+                postrack.sign(), (uint8_t)postrack.tpcNClsFound(),
+                postrack.tpcNClsFindable(),
+                (uint8_t)postrack.tpcNClsCrossedRows(),
+                postrack.tpcNClsShared(), postrack.tpcInnerParam(),
+                postrack.itsNCls(), postrack.itsNClsInnerBarrel(),
+                postrack.dcaXY(), postrack.dcaZ(), postrack.tpcSignal(),
+                postrack.tpcNSigmaStoreEl(), postrack.tpcNSigmaStorePi(),
+                postrack.tpcNSigmaStoreKa(), postrack.tpcNSigmaStorePr(),
+                postrack.tpcNSigmaStoreDe(), postrack.tofNSigmaStoreEl(),
+                postrack.tofNSigmaStorePi(), postrack.tofNSigmaStoreKa(),
+                postrack.tofNSigmaStorePr(), postrack.tofNSigmaStoreDe(), -999.,
+                -999., -999., -999., -999.,
+                -999.); // QA for positive daughter
+            outputDebugParts(
+                negtrack.sign(), (uint8_t)negtrack.tpcNClsFound(),
+                negtrack.tpcNClsFindable(),
+                (uint8_t)negtrack.tpcNClsCrossedRows(),
+                negtrack.tpcNClsShared(), negtrack.tpcInnerParam(),
+                negtrack.itsNCls(), negtrack.itsNClsInnerBarrel(),
+                negtrack.dcaXY(), negtrack.dcaZ(), negtrack.tpcSignal(),
+                negtrack.tpcNSigmaStoreEl(), negtrack.tpcNSigmaStorePi(),
+                negtrack.tpcNSigmaStoreKa(), negtrack.tpcNSigmaStorePr(),
+                negtrack.tpcNSigmaStoreDe(), negtrack.tofNSigmaStoreEl(),
+                negtrack.tofNSigmaStorePi(), negtrack.tofNSigmaStoreKa(),
+                negtrack.tofNSigmaStorePr(), negtrack.tofNSigmaStoreDe(), -999.,
+                -999., -999., -999., -999.,
+                -999.); // QA for negative daughter
+            outputDebugParts(-999., -999., -999., -999., -999., -999., -999.,
+                             -999., -999., -999., -999., -999., -999., -999.,
+                             -999., -999., -999., -999., -999., -999., -999.,
+                             v0.dcaV0daughters(), v0.v0radius(), v0.x(), v0.y(),
                              v0.z(),
                              v0.mK0Short()); // QA for V0
           }
@@ -384,8 +492,7 @@ struct femtoDreamProducerTaskV0Only {
   }
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
-{
+WorkflowSpec defineDataProcessing(ConfigContext const &cfgc) {
   WorkflowSpec workflow{adaptAnalysisTask<femtoDreamProducerTaskV0Only>(cfgc)};
   return workflow;
 }


### PR DESCRIPTION
This PR will fix the V0 selection for the pairTrackV0 task in FemtoDream. In particular,

- CutBit for the V0 itself is now functioning properly and
- the CutBit can now also be applied to the children of the V0 as well as PID cuts.

The selection of the V0s still needs a bit of work to allow for the systematic variations of the PID cuts. These will follow in a future PR. For now analysis can be performed with standard cuts on the PID of the V0 children.

This PR also contains clean-ups for the debug task and abstracts the creation of debug histograms into the designated class. Further cleanup will also follow in the future (espcially for configurables) as well as the merging of tasks. There are a several tasks that have a lot of copy-paste code that can be more elegantly handled with process switches.

Adding @gmantzar to discussion.