### PR TITLE
[PWGEM-8] Change skimmed EMCal data table to include vector of matched tracks

### DIFF
--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <vector>
+
 #include "Framework/AnalysisDataModel.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
@@ -339,14 +341,18 @@ DECLARE_SOA_COLUMN(CoreEnergy, coreEnergy, float);                              
 DECLARE_SOA_COLUMN(Time, time, float);                                                                                        //! cluster time (ns)
 DECLARE_SOA_COLUMN(IsExotic, isExotic, bool);                                                                                 //! flag to mark cluster as exotic
 DECLARE_SOA_COLUMN(Definition, definition, int);                                                                              //! cluster definition, see EMCALClusterDefinition.h
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Track, track);                                                                                 //! TrackIds
+DECLARE_SOA_COLUMN(TrackEta, tracketa, std::vector<float>);                                                                   //! eta values of the matched tracks
+DECLARE_SOA_COLUMN(TrackPhi, trackphi, std::vector<float>);                                                                   //! phi values of the matched tracks
+DECLARE_SOA_COLUMN(TrackP, trackp, std::vector<float>);                                                                       //! momentum values of the matched tracks
+DECLARE_SOA_COLUMN(TrackPt, trackpt, std::vector<float>);                                                                     //! pt values of the matched tracks
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float e, float eta, float m = 0) -> float { return sqrt(e * e - m * m) / cosh(eta); }); //! cluster pt, mass to be given as argument when getter is called!
-// DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! transverse momentum of a photon candidate
-//                               (emccluster::energy * 2.f) / (nexp(emccluster::eta) + nexp(emccluster::eta * -1.f)));
 } // namespace emccluster
 DECLARE_SOA_TABLE(SkimEMCClusters, "AOD", "SKIMEMCCLUSTERS", //! table of skimmed EMCal clusters
                   o2::soa::Index<>, skimmedcluster::CollisionId, skimmedcluster::BCId, skimmedcluster::E, emccluster::CoreEnergy,
                   skimmedcluster::Eta, skimmedcluster::Phi, skimmedcluster::M02, skimmedcluster::M20, skimmedcluster::NCells, skimmedcluster::Time,
                   emccluster::IsExotic, skimmedcluster::DistanceToBadChannel, skimmedcluster::NLM, emccluster::Definition,
+                  emccluster::TrackIds, emccluster::TrackEta, emccluster::TrackPhi, emccluster::TrackP, emccluster::TrackPt,
                   // dynamic column
                   emccluster::Pt<skimmedcluster::E, skimmedcluster::Eta>);
 using SkimEMCCluster = SkimEMCClusters::iterator;

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -91,14 +91,34 @@ struct skimmerGammaCalo {
       }
 
       // Skimmed matched tracks table
+      std::vector<int32_t> vTrackIds;
+      std::vector<float> vEta;
+      std::vector<float> vPhi;
+      std::vector<float> vP;
+      std::vector<float> vPt;
       auto groupedMTs = emcmatchedtracks.sliceBy(MTperCluster, emccluster.globalIndex());
+      vTrackIds.reserve(groupedMTs.size());
+      vEta.reserve(groupedMTs.size());
+      vPhi.reserve(groupedMTs.size());
+      vP.reserve(groupedMTs.size());
+      vPt.reserve(groupedMTs.size());
       for (const auto& emcmatchedtrack : groupedMTs) {
         if (hasPropagatedTracks) { // only temporarily while not every data has the tracks propagated to EMCal/PHOS
           historeg.fill(HIST("hMTEtaPhi"), emccluster.eta() - emcmatchedtrack.track_as<aod::FullTracks>().trackEtaEmcal(), emccluster.phi() - emcmatchedtrack.track_as<aod::FullTracks>().trackPhiEmcal());
+          vTrackIds.emplace_back(emcmatchedtrack.trackId());
+          vEta.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().trackEtaEmcal());
+          vPhi.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().trackPhiEmcal());
+          vP.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().p());
+          vPt.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().pt());
           tableTrackEMCReco(emcmatchedtrack.emcalclusterId(), emcmatchedtrack.track_as<aod::FullTracks>().trackEtaEmcal(), emcmatchedtrack.track_as<aod::FullTracks>().trackPhiEmcal(),
                             emcmatchedtrack.track_as<aod::FullTracks>().p(), emcmatchedtrack.track_as<aod::FullTracks>().pt());
         } else {
           historeg.fill(HIST("hMTEtaPhi"), emccluster.eta() - emcmatchedtrack.track_as<aod::FullTracks>().eta(), emccluster.phi() - emcmatchedtrack.track_as<aod::FullTracks>().phi());
+          vTrackIds.emplace_back(emcmatchedtrack.trackId());
+          vEta.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().eta());
+          vPhi.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().phi());
+          vP.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().p());
+          vPt.emplace_back(emcmatchedtrack.track_as<aod::FullTracks>().pt());
           tableTrackEMCReco(emcmatchedtrack.emcalclusterId(), emcmatchedtrack.track_as<aod::FullTracks>().eta(), emcmatchedtrack.track_as<aod::FullTracks>().phi(),
                             emcmatchedtrack.track_as<aod::FullTracks>().p(), emcmatchedtrack.track_as<aod::FullTracks>().pt());
         }
@@ -110,7 +130,7 @@ struct skimmerGammaCalo {
       tableGammaEMCReco(emccluster.collisionId(), emccluster.id(),
                         emccluster.energy(), emccluster.coreEnergy(), emccluster.eta(), emccluster.phi(), emccluster.m02(),
                         emccluster.m20(), emccluster.nCells(), emccluster.time(), emccluster.isExotic(), emccluster.distanceToBadChannel(), emccluster.nlm(),
-                        emccluster.definition());
+                        emccluster.definition(), vTrackIds, vEta, vPhi, vP, vPt);
     }
   }
   PROCESS_SWITCH(skimmerGammaCalo, processRec, "process only reconstructed info", true);


### PR DESCRIPTION
- skimmed EMCal cluster table now includes variable sized array of track index and their eta, phi, p and pT values for track matching. The index can be used to comapre with V0 daughters and the other values were previously stored in an extra table. So with this change we can reduce the number of tables and need less sliceBy, Preslice stuff.