### PR TITLE
PWGHF: Add TPC/TOF nSig hist in Xic task

### DIFF
--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -21,8 +21,6 @@
 #include "Framework/HistogramRegistry.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
-#include "TTree.h"
-#include "Common/DataModel/PIDResponse.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -34,48 +32,11 @@ using namespace o2::analysis::hf_cuts_xic_to_p_k_pi;
 
 /// Ξc± analysis task
 
-struct XicTTree {
-  float fMass;
-  float fPt;
-  float fEta;
-  float fCpa;
-  float fCpaXY;
-  float fDecayLength;
-  float fDecayLengthErr;
-  float fChi2PCA;
-
-  float fPidTpcNsigPrProng0;
-  float fPidTpcNsigPiProng0;
-  float fPidTpcNsigKProng0;
-  float fPidTpcNsigPrProng1;
-  float fPidTpcNsigPiProng1;
-  float fPidTpcNsigKProng1;
-  float fPidTpcNsigPrProng2;
-  float fPidTpcNsigPiProng2;
-  float fPidTpcNsigKProng2;
-
-  float fPidTofNsigPrProng0;
-  float fPidTofNsigPiProng0;
-  float fPidTofNsigKProng0;
-  float fPidTofNsigPrProng1;
-  float fPidTofNsigPiProng1;
-  float fPidTofNsigKProng1;
-  float fPidTofNsigPrProng2;
-  float fPidTofNsigPiProng2;
-  float fPidTofNsigKProng2;
-};
-
 struct HfTaskXic {
-
-  OutputObj<TTree> tree{"XicTTree"};
-  XicTTree xictreeObj;
 
   Configurable<int> selectionFlagXic{"selectionFlagXic", 1, "Selection Flag for Xic"};
   Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_xic_to_p_k_pi::vecBinsPt}, "pT bin limits"};
-  Configurable<bool> fConfigWriteTTree{"cfgWriteTTree", false, "write tree output"};
-  Configurable<bool> fFillTOFnSigma{"fFillTOFnSigma", false, "write TOF nSigma info to tree"};
-  Configurable<bool> fFillTPCnSigma{"fFillTPCnSigma", false, "write TPC nSigma info to tree"};
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic);
 
@@ -84,23 +45,22 @@ struct HfTaskXic {
   HistogramRegistry registry{
     "registry", // histo not in pt bins
     {
-      {"Data/hPt", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},                                       // pt Xic
-      {"MC/reconstructed/signal/hPtRecCand", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},             // pt Xic
-      {"Data/hEta", "3-prong candidates;candidate #it{eta};entries", {HistType::kTH1F, {{100, -5., 5.}}}},                                                     // eta Xic
-      {"Data/hPhi", "3-prong candidates;candidate #varphi;entries", {HistType::kTH1F, {{72, 0., 2. * constants::math::PI}}}},                                  // phi Xic
-      {"Data/hMass", "3-prong candidates; inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}},                                      // mass Xic
-      {"MC/reconstructed/hMassRecCand", "3-prong candidates (matched, prompt); inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}}, // mass Xic
-      {"MC/reconstructed/hPtRecSig", "3-prong candidates (matched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"MC/reconstructed/hPtRecBg", "3-prong candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"MC/generated/hPtGen", "MC particles (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"MC/generated/hPtGenSig", "3-prong candidates (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}}, ///
-      {"Data/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{1000, 0., 1000.}}}}}};
+      {"Data/hPt", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},      // pt Xic
+      {"Data/hEta", "3-prong candidates;candidate #it{eta};entries", {HistType::kTH1F, {{100, -5., 5.}}}},                    // eta Xic
+      {"Data/hPhi", "3-prong candidates;candidate #varphi;entries", {HistType::kTH1F, {{72, 0., 2. * constants::math::PI}}}}, // phi Xic
+      {"Data/hMass", "3-prong candidates; inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}},     // mass Xic
+      {"Data/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{1000, 0., 1000.}}}},
+
+      {"MC/reconstructed/signal/hMassRecCand", "3-prong candidates (matched, prompt); inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}}, // mass Xic
+      {"MC/reconstructed/signal/hPtRecCand", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},                    // pt Xic
+      {"MC/reconstructed/signal/hPtRecSig", "3-prong candidates (matched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/reconstructed/background/hPtRecBg", "3-prong candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/generated/signal/hPtGen", "MC particles (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/generated/signal/hPtGenSig", "3-prong candidates (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}} ///
+    }};
 
   void init(o2::framework::InitContext&)
   {
-    if (fConfigWriteTTree) {
-      SetTree();
-    }
 
     AxisSpec axisPidP = {100, 0.f, 10.0f, "#it{p} (GeV/#it{c})"};
     AxisSpec axisNSigmaPr = {100, -6.f, 6.f, "n#it{#sigma}_{p}"};
@@ -153,35 +113,36 @@ struct HfTaskXic {
     registry.add("Data/hPVsTOFNSigmaKa_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
 
     registry.add("MC/reconstructed/signal/hMassSig", "Invariant mass (matched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hMassBg", "Invariant mass (unmatched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/generated/hEtaGen", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hMassBg", "Invariant mass (unmatched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/generated/signal/hEtaGen", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
-    registry.add("MC/reconstructed/hDecLengthRecSig", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong0RecSig", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong1RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong2RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hCtRecSig", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hCPARecSig", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hEtaRecSig", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng0RecSig", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng1RecSig", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng2RecSig", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hDecLengthRecSig", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hd0Prong0RecSig", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hd0Prong1RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hd0Prong2RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hCtRecSig", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hCPARecSig", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hEtaRecSig", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hPtProng0RecSig", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hPtProng1RecSig", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/signal/hPtProng2RecSig", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
-    registry.add("MC/reconstructed/hDecLengthRecBg", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong0RecBg", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong1RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hd0Prong2RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hCtRecBg", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hCPARecBg", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hEtaRecBg", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng0RecBg", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng1RecBg", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("MC/reconstructed/hPtProng2RecBg", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hDecLengthRecBg", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hd0Prong0RecBg", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hd0Prong1RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hd0Prong2RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hCtRecBg", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hCPARecBg", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hEtaRecBg", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hPtProng0RecBg", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hPtProng1RecBg", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/background/hPtProng2RecBg", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
   }
 
   void process(const o2::aod::Collision& collision, const soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi>> const& candidates, aod::BigTracksPID const&)
   {
     int nTracks = 0;
+
     if (collision.numContrib() > 1) {
       for (auto const& track : tracks) {
         if (std::abs(track.eta()) > 4.0) { // hard coded cut TO BE REFINED
@@ -196,6 +157,7 @@ struct HfTaskXic {
 
     registry.fill(HIST("Data/hMultiplicity"), nTracks); // filling the histo for multiplicity
     for (auto const& candidate : candidates) {
+      auto candidatePt = candidate.pt();
       if (!(candidate.hfflag() & 1 << DecayType::XicToPKPi)) {
         continue;
       }
@@ -205,106 +167,67 @@ struct HfTaskXic {
       }
 
       if (candidate.isSelXicToPKPi() >= selectionFlagXic) { // pKpi
-        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPKPi(candidate), candidate.pt());
+        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPKPi(candidate), candidatePt);
         registry.fill(HIST("Data/hMass"), invMassXicToPKPi(candidate));
-        xictreeObj.fMass = invMassXicToPKPi(candidate);
       }
       if (candidate.isSelXicToPiKP() >= selectionFlagXic) { // piKp
-        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPiKP(candidate), candidate.pt());
+        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPiKP(candidate), candidatePt);
         registry.fill(HIST("Data/hMass"), invMassXicToPiKP(candidate));
-        xictreeObj.fMass = invMassXicToPiKP(candidate);
       }
-      registry.fill(HIST("Data/hPt"), candidate.pt());
+      registry.fill(HIST("Data/hPt"), candidatePt);
       registry.fill(HIST("Data/hEta"), candidate.eta());
       registry.fill(HIST("Data/hPhi"), candidate.phi());
-      registry.fill(HIST("Data/hPtProng0VsPt"), candidate.ptProng0(), candidate.pt());
-      registry.fill(HIST("Data/hPtProng1VsPt"), candidate.ptProng1(), candidate.pt());
-      registry.fill(HIST("Data/hPtProng2VsPt"), candidate.ptProng2(), candidate.pt());
-      registry.fill(HIST("Data/hDecLengthVsPt"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("Data/hd0Prong0VsPt"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/hd0Prong1VsPt"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/hd0Prong2VsPt"), candidate.impactParameter2(), candidate.pt());
-      registry.fill(HIST("Data/hCtVsPt"), ctXic(candidate), candidate.pt());
-      registry.fill(HIST("Data/hCPAVsPt"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("Data/hEtaVsPt"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPKPi(), candidate.pt());
-      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPiKP(), candidate.pt());
-      registry.fill(HIST("Data/hImpParErr0VsPt"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/hImpParErr1VsPt"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/hImpParErr2VsPt"), candidate.errorImpactParameter2(), candidate.pt());
-      registry.fill(HIST("Data/hDecLenErrVsPt"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("Data/hChi2PCAVsPt"), candidate.chi2PCA(), candidate.pt());
+      registry.fill(HIST("Data/hPtProng0VsPt"), candidate.ptProng0(), candidatePt);
+      registry.fill(HIST("Data/hPtProng1VsPt"), candidate.ptProng1(), candidatePt);
+      registry.fill(HIST("Data/hPtProng2VsPt"), candidate.ptProng2(), candidatePt);
+      registry.fill(HIST("Data/hDecLengthVsPt"), candidate.decayLength(), candidatePt);
+      registry.fill(HIST("Data/hd0Prong0VsPt"), candidate.impactParameter0(), candidatePt);
+      registry.fill(HIST("Data/hd0Prong1VsPt"), candidate.impactParameter1(), candidatePt);
+      registry.fill(HIST("Data/hd0Prong2VsPt"), candidate.impactParameter2(), candidatePt);
+      registry.fill(HIST("Data/hCtVsPt"), ctXic(candidate), candidatePt);
+      registry.fill(HIST("Data/hCPAVsPt"), candidate.cpa(), candidatePt);
+      registry.fill(HIST("Data/hEtaVsPt"), candidate.eta(), candidatePt);
+      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPKPi(), candidatePt);
+      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPiKP(), candidatePt);
+      registry.fill(HIST("Data/hImpParErr0VsPt"), candidate.errorImpactParameter0(), candidatePt);
+      registry.fill(HIST("Data/hImpParErr1VsPt"), candidate.errorImpactParameter1(), candidatePt);
+      registry.fill(HIST("Data/hImpParErr2VsPt"), candidate.errorImpactParameter2(), candidatePt);
+      registry.fill(HIST("Data/hDecLenErrVsPt"), candidate.errorDecayLength(), candidatePt);
+      registry.fill(HIST("Data/hChi2PCAVsPt"), candidate.chi2PCA(), candidatePt);
 
       const auto& trackProng0 = candidate.prong0_as<aod::BigTracksPID>(); // bachelor track
       const auto& trackProng1 = candidate.prong1_as<aod::BigTracksPID>(); // bachelor track
       const auto& trackProng2 = candidate.prong2_as<aod::BigTracksPID>(); // bachelor track
 
+      auto prong0_P = trackProng0.p();
+      auto prong1_P = trackProng1.p();
+      auto prong2_P = trackProng2.p();
+
       // TPC nSigma histograms
-      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaPr());
-      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaPi());
-      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaKa());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong0"), prong0_P, trackProng0.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong0"), prong0_P, trackProng0.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong0"), prong0_P, trackProng0.tpcNSigmaKa());
 
-      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaPr());
-      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaPi());
-      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaKa());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong1"), prong1_P, trackProng1.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong1"), prong1_P, trackProng1.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong1"), prong1_P, trackProng1.tpcNSigmaKa());
 
-      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaPr());
-      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaPi());
-      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaKa());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong2"), prong2_P, trackProng2.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong2"), prong2_P, trackProng2.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong2"), prong2_P, trackProng2.tpcNSigmaKa());
 
       // TOF nSigma histograms
-      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong0"), trackProng0.p(), trackProng0.tofNSigmaPr());
-      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong0"), trackProng0.p(), trackProng0.tofNSigmaPi());
-      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong0"), trackProng0.p(), trackProng0.tofNSigmaKa());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong0"), prong0_P, trackProng0.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong0"), prong0_P, trackProng0.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong0"), prong0_P, trackProng0.tofNSigmaKa());
 
-      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong1"), trackProng1.p(), trackProng1.tofNSigmaPr());
-      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong1"), trackProng1.p(), trackProng1.tofNSigmaPi());
-      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong1"), trackProng1.p(), trackProng1.tofNSigmaKa());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong1"), prong1_P, trackProng1.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong1"), prong1_P, trackProng1.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong1"), prong1_P, trackProng1.tofNSigmaKa());
 
-      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong2"), trackProng2.p(), trackProng2.tofNSigmaPr());
-      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong2"), trackProng2.p(), trackProng2.tofNSigmaPi());
-      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong2"), trackProng2.p(), trackProng2.tofNSigmaKa());
-
-      // fill TTree varaibles
-      xictreeObj.fPt = candidate.pt();
-      xictreeObj.fCpa = candidate.cpa();
-      xictreeObj.fCpaXY = candidate.cpaXY();
-      xictreeObj.fDecayLength = candidate.decayLength();
-      xictreeObj.fDecayLengthErr = candidate.errorDecayLength();
-      xictreeObj.fChi2PCA = candidate.chi2PCA();
-
-      if (fFillTOFnSigma) {
-        xictreeObj.fPidTofNsigPrProng0 = trackProng0.tofNSigmaPr();
-        xictreeObj.fPidTofNsigPiProng0 = trackProng0.tofNSigmaPi();
-        xictreeObj.fPidTofNsigKProng0 = trackProng0.tofNSigmaKa();
-
-        xictreeObj.fPidTofNsigPrProng1 = trackProng1.tofNSigmaPr();
-        xictreeObj.fPidTofNsigPiProng1 = trackProng1.tofNSigmaPi();
-        xictreeObj.fPidTofNsigKProng1 = trackProng1.tofNSigmaKa();
-
-        xictreeObj.fPidTofNsigPrProng2 = trackProng2.tofNSigmaPr();
-        xictreeObj.fPidTofNsigPiProng2 = trackProng2.tofNSigmaPi();
-        xictreeObj.fPidTofNsigKProng2 = trackProng2.tofNSigmaKa();
-      }
-
-      if (fFillTPCnSigma) {
-        xictreeObj.fPidTpcNsigPrProng0 = trackProng0.tpcNSigmaPr();
-        xictreeObj.fPidTpcNsigPiProng0 = trackProng0.tpcNSigmaPi();
-        xictreeObj.fPidTpcNsigKProng0 = trackProng0.tpcNSigmaKa();
-
-        xictreeObj.fPidTpcNsigPrProng1 = trackProng1.tpcNSigmaPr();
-        xictreeObj.fPidTpcNsigPiProng1 = trackProng1.tpcNSigmaPi();
-        xictreeObj.fPidTpcNsigKProng1 = trackProng1.tpcNSigmaKa();
-
-        xictreeObj.fPidTpcNsigPrProng2 = trackProng2.tpcNSigmaPr();
-        xictreeObj.fPidTpcNsigPiProng2 = trackProng2.tpcNSigmaPi();
-        xictreeObj.fPidTpcNsigKProng2 = trackProng2.tpcNSigmaKa();
-      }
-
-      // fill TTree
-      if (fConfigWriteTTree) { // many parameters not set for photons: d1DCA,fd2DCA, fdectyp,fdau3pdg,fwMultpT,fwMultpT2,fwMultmT2
-        tree->Fill();
-      }
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong2"), prong2_P, trackProng2.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong2"), prong2_P, trackProng2.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong2"), prong2_P, trackProng2.tofNSigmaKa());
     }
   }
   // Fill MC histograms
@@ -324,6 +247,7 @@ struct HfTaskXic {
 
       auto mass = 0.;
       auto massC = 0.;
+      auto candidatePt = candidate.pt();
 
       if (candidate.isSelXicToPKPi() >= selectionFlagXic) {
         mass = invMassXicToPKPi(candidate);
@@ -338,46 +262,46 @@ struct HfTaskXic {
         auto particleMother = particlesMC.rawIteratorAt(indexMother);
 
         registry.fill(HIST("MC/generated/signal/hPtGenSig"), particleMother.pt()); // gen. level pT
-        registry.fill(HIST("MC/reconstructed/signal/hPtRecSig"), candidate.pt());  // rec. level pT
+        registry.fill(HIST("MC/reconstructed/signal/hPtRecSig"), candidatePt);     // rec. level pT
 
         if (mass != 0.) {
-          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), mass, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), mass, candidatePt);
         }
         if (massC != 0.) {
-          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), massC, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), massC, candidatePt);
         }
 
-        registry.fill(HIST("MC/reconstructed/signal/hDecLengthRecSig"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hPtProng0RecSig"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hPtProng1RecSig"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hPtProng2RecSig"), candidate.ptProng2(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hd0Prong0RecSig"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hd0Prong1RecSig"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hd0Prong2RecSig"), candidate.impactParameter2(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hCtRecSig"), ctXic(candidate), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hCPARecSig"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/signal/hEtaRecSig"), candidate.eta(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hDecLengthRecSig"), candidate.decayLength(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng0RecSig"), candidate.ptProng0(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng1RecSig"), candidate.ptProng1(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng2RecSig"), candidate.ptProng2(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong0RecSig"), candidate.impactParameter0(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong1RecSig"), candidate.impactParameter1(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong2RecSig"), candidate.impactParameter2(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hCtRecSig"), ctXic(candidate), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hCPARecSig"), candidate.cpa(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/signal/hEtaRecSig"), candidate.eta(), candidatePt);
       } else {
         // Background
-        registry.fill(HIST("MC/reconstructed/bakground/hPtRecBg"), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/background/hPtRecBg"), candidatePt);
 
         if (mass != 0.) {
-          registry.fill(HIST("MC/reconstructed/bakground/hMassBg"), mass, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/background/hMassBg"), mass, candidatePt);
         }
         if (massC != 0.) {
-          registry.fill(HIST("MC/reconstructed/bakground/hMassBg"), massC, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/background/hMassBg"), massC, candidatePt);
         }
 
-        registry.fill(HIST("MC/reconstructed/bakground/hDecLengthRecBg"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hPtProng0RecBg"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hPtProng1RecBg"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hPtProng2RecBg"), candidate.ptProng2(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong0RecBg"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong1RecBg"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong2RecBg"), candidate.impactParameter2(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hCtRecBg"), ctXic(candidate), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hCPARecBg"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("MC/reconstructed/bakground/hEtaRecBg"), candidate.eta(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/background/hDecLengthRecBg"), candidate.decayLength(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hPtProng0RecBg"), candidate.ptProng0(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hPtProng1RecBg"), candidate.ptProng1(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hPtProng2RecBg"), candidate.ptProng2(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hd0Prong0RecBg"), candidate.impactParameter0(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hd0Prong1RecBg"), candidate.impactParameter1(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hd0Prong2RecBg"), candidate.impactParameter2(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hCtRecBg"), ctXic(candidate), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hCPARecBg"), candidate.cpa(), candidatePt);
+        registry.fill(HIST("MC/reconstructed/background/hEtaRecBg"), candidate.eta(), candidatePt);
       }
     }
     // MC gen.
@@ -386,49 +310,10 @@ struct HfTaskXic {
         if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
           continue;
         }
-        registry.fill(HIST("MC/genearated/signal/hPtGen"), particle.pt());
-        registry.fill(HIST("MC/genearated/signal/hEtaGen"), particle.eta(), particle.pt());
+        registry.fill(HIST("MC/generated/signal/hPtGen"), particle.pt());
+        registry.fill(HIST("MC/generated/signal/hEtaGen"), particle.eta(), particle.pt());
       }
     }
-  }
-
-  void SetTree()
-  {
-    tree.setObject(new TTree("XicTTree", "XicTTree"));
-
-    tree->Branch("fPt", &xictreeObj.fPt, "fPt/F");
-    tree->Branch("fMass", &xictreeObj.fMass, "fMass/F");
-    tree->Branch("fDecayLength", &xictreeObj.fDecayLength, "fDecayLength/F");
-    tree->Branch("fDecayLengthErr", &xictreeObj.fDecayLengthErr, "fDecayLengthErr/F");
-    tree->Branch("fCpa", &xictreeObj.fCpa, "fCpa/F");
-    tree->Branch("fCpaXY", &xictreeObj.fCpaXY, "fCpaXY/F");
-    tree->Branch("fChi2PCA", &xictreeObj.fChi2PCA, "fChi2PCA/F");
-
-    //---tpc nSigma for all prongs and Pi, K, Pr hypothesis
-    tree->Branch("fPidTpcNsigPrProng0", &xictreeObj.fPidTpcNsigPrProng0, "fPidTpcNsigPrProng0/F");
-    tree->Branch("fPidTpcNsigKProng0", &xictreeObj.fPidTpcNsigKProng0, "fPidTpcNsigKProng0/F");
-    tree->Branch("fPidTpcNsigPiProng0", &xictreeObj.fPidTpcNsigPiProng0, "fPidTpcNsigPiProng0/F");
-
-    tree->Branch("fPidTpcNsigPrProng1", &xictreeObj.fPidTpcNsigPrProng1, "fPidTpcNsigPrProng1/F");
-    tree->Branch("fPidTpcNsigKProng1", &xictreeObj.fPidTpcNsigKProng1, "fPidTpcNsigKProng1/F");
-    tree->Branch("fPidTpcNsigPiProng1", &xictreeObj.fPidTpcNsigPiProng1, "fPidTpcNsigPiProng1/F");
-
-    tree->Branch("fPidTpcNsigPrProng2", &xictreeObj.fPidTpcNsigPrProng2, "fPidTpcNsigPrProng2/F");
-    tree->Branch("fPidTpcNsigKProng2", &xictreeObj.fPidTpcNsigKProng2, "fPidTpcNsigKProng2/F");
-    tree->Branch("fPidTpcNsigPiProng2", &xictreeObj.fPidTpcNsigPiProng2, "fPidTpcNsigPiProng2/F");
-
-    //---tof nSigma for all prongs and Pi, K, Pr hypothesis
-    tree->Branch("fPidTofNsigPrProng0", &xictreeObj.fPidTofNsigPrProng0, "fPidTofNsigPrProng0/F");
-    tree->Branch("fPidTofNsigKProng0", &xictreeObj.fPidTofNsigKProng0, "fPidTofNsigKProng0/F");
-    tree->Branch("fPidTofNsigPiProng0", &xictreeObj.fPidTofNsigPiProng0, "fPidTofNsigPiProng0/F");
-
-    tree->Branch("fPidTofNsigPrProng1", &xictreeObj.fPidTofNsigPrProng1, "fPidTofNsigPrProng1/F");
-    tree->Branch("fPidTofNsigKProng1", &xictreeObj.fPidTofNsigKProng1, "fPidTofNsigKProng1/F");
-    tree->Branch("fPidTofNsigPiProng1", &xictreeObj.fPidTofNsigPiProng1, "fPidTofNsigPiProng1/F");
-
-    tree->Branch("fPidTofNsigPrProng2", &xictreeObj.fPidTofNsigPrProng2, "fPidTofNsigPrProng2/F");
-    tree->Branch("fPidTofNsigKProng2", &xictreeObj.fPidTofNsigKProng2, "fPidTofNsigKProng2/F");
-    tree->Branch("fPidTofNsigPiProng2", &xictreeObj.fPidTofNsigPiProng2, "fPidTofNsigPiProng2/F");
   }
 
   PROCESS_SWITCH(HfTaskXic, processMc, "Process MC", false);

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -11,7 +11,7 @@
 
 /// \file taskXic.cxx
 /// \brief Ξc± analysis task
-/// \note Inspired from taskLc.cxx
+/// \note Inspired from taskLc.cxx and SigmaC.cxx
 ///
 /// \author Mattia Faggin <mattia.faggin@cern.ch>, University and INFN PADOVA
 /// \author Anton Alkin <anton.alkin@cern.ch>, CERN
@@ -21,6 +21,8 @@
 #include "Framework/HistogramRegistry.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "TTree.h"
+#include "Common/DataModel/PIDResponse.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -31,115 +33,291 @@ using namespace o2::analysis::hf_cuts_xic_to_p_k_pi;
 #include "Framework/runDataProcessing.h"
 
 /// Ξc± analysis task
+
+struct XicTTree {
+  float fMass;
+  float fPt;
+  float fEta;
+  float fCpa;
+  float fCpaXY;
+  float fDecayLength;
+  float fDecayLengthErr;
+  float fChi2PCA;
+
+  float fPidTpcNsigPrProng0;
+  float fPidTpcNsigPiProng0;
+  float fPidTpcNsigKProng0;
+  float fPidTpcNsigPrProng1;
+  float fPidTpcNsigPiProng1;
+  float fPidTpcNsigKProng1;
+  float fPidTpcNsigPrProng2;
+  float fPidTpcNsigPiProng2;
+  float fPidTpcNsigKProng2;
+
+  float fPidTofNsigPrProng0;
+  float fPidTofNsigPiProng0;
+  float fPidTofNsigKProng0;
+  float fPidTofNsigPrProng1;
+  float fPidTofNsigPiProng1;
+  float fPidTofNsigKProng1;
+  float fPidTofNsigPrProng2;
+  float fPidTofNsigPiProng2;
+  float fPidTofNsigKProng2;
+};
+
 struct HfTaskXic {
+
+  OutputObj<TTree> tree{"XicTTree"};
+  XicTTree xictreeObj;
+
   Configurable<int> selectionFlagXic{"selectionFlagXic", 1, "Selection Flag for Xic"};
   Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_xic_to_p_k_pi::vecBinsPt}, "pT bin limits"};
+  Configurable<bool> fConfigWriteTTree{"cfgWriteTTree", false, "write tree output"};
+  Configurable<bool> fFillTOFnSigma{"fFillTOFnSigma", false, "write TOF nSigma info to tree"};
+  Configurable<bool> fFillTPCnSigma{"fFillTPCnSigma", false, "write TPC nSigma info to tree"};
 
-  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi>> selectedXicCandidates = aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic;
+  Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic);
+
   Partition<soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi, aod::HfCand3ProngMcRec>> selectedMCXicCandidates = (aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic);
 
   HistogramRegistry registry{
-    "registry",
+    "registry", // histo not in pt bins
     {
-      {"hPtCand", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"hPtRecSig", "3-prong candidates (matched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"hPtRecBg", "3-prong candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"hPtGen", "MC particles (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
-      {"hPtGenSig", "3-prong candidates (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}} ///
-    }};
+      {"Data/hPt", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},                                       // pt Xic
+      {"MC/reconstructed/signal/hPtRecCand", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},             // pt Xic
+      {"Data/hEta", "3-prong candidates;candidate #it{eta};entries", {HistType::kTH1F, {{100, -5., 5.}}}},                                                     // eta Xic
+      {"Data/hPhi", "3-prong candidates;candidate #varphi;entries", {HistType::kTH1F, {{72, 0., 2. * constants::math::PI}}}},                                  // phi Xic
+      {"Data/hMass", "3-prong candidates; inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}},                                      // mass Xic
+      {"MC/reconstructed/hMassRecCand", "3-prong candidates (matched, prompt); inv. mass (p K #pi) (GeV/#it{c}^{2})", {HistType::kTH1F, {{600, 2.18, 2.58}}}}, // mass Xic
+      {"MC/reconstructed/hPtRecSig", "3-prong candidates (matched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/reconstructed/hPtRecBg", "3-prong candidates (unmatched);#it{p}_{T}^{rec.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/generated/hPtGen", "MC particles (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}},
+      {"MC/generated/hPtGenSig", "3-prong candidates (matched);#it{p}_{T}^{gen.} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0., 10.}}}}, ///
+      {"Data/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{1000, 0., 1000.}}}}}};
 
   void init(o2::framework::InitContext&)
   {
-    auto vbins = (std::vector<double>)binsPt;
-    registry.add("hMass", "3-prong candidates;inv. mass (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hDecLength", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong2", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCt", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCPA", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEta", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hSelectionStatus", "3-prong candidates;selection status;;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hImpParErr", "3-prong candidates;impact parameter error (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hDecLenErr", "3-prong candidates;decay length error (cm);;entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng0", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng1", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng2", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    if (fConfigWriteTTree) {
+      SetTree();
+    }
 
-    registry.add("hMassSig", "Invariant mass (matched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hMassBg", "Invariant mass (unmatched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaGen", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    AxisSpec axisPidP = {100, 0.f, 10.0f, "#it{p} (GeV/#it{c})"};
+    AxisSpec axisNSigmaPr = {100, -6.f, 6.f, "n#it{#sigma}_{p}"};
+    AxisSpec axisNSigmaPi = {100, -6.f, 6.f, "n#it{#sigma}_{#pi}"};
+    AxisSpec axisNSigmaKa = {100, -6.f, 6.f, "n#it{#sigma}_{K}"};
 
-    registry.add("hDecLengthRecSig", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong0RecSig", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong1RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong2RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCtRecSig", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCPARecSig", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaRecSig", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng0RecSig", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng1RecSig", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng2RecSig", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    auto vbins = (std::vector<double>)binsPt; // histo in pt bins
+    registry.add("Data/hMassVsPt", "3-prong candidates;inv. mass (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 2., 3.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hDecLengthVsPt", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{800, 0., 4.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hd0Prong0VsPt", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hd0Prong1VsPt", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hd0Prong2VsPt", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hCtVsPt", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hCPAVsPt", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hEtaVsPt", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hSelectionStatusVsPt", "3-prong candidates;selection status;;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hImpParErr0VsPt", "3-prong candidates;impact parameter error prong 0 (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hImpParErr1VsPt", "3-prong candidates;impact parameter error prong 1 (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hImpParErr2VsPt", "3-prong candidates;impact parameter error prong 2 (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hDecLenErrVsPt", "3-prong candidates;decay length error (cm);;entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hPtProng0VsPt", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hPtProng1VsPt", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hPtProng2VsPt", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/hChi2PCAVsPt", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);;entries", {HistType::kTH2F, {{100, 0, 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
-    registry.add("hDecLengthRecBg", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong0RecBg", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong1RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hd0Prong2RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCtRecBg", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hCPARecBg", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hEtaRecBg", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng0RecBg", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng1RecBg", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hPtProng2RecBg", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    // TPC nSigma histograms
+    registry.add("Data/hPVsTPCNSigmaPr_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTPCNSigmaPi_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTPCNSigmaKa_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    registry.add("Data/hPVsTPCNSigmaPr_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTPCNSigmaPi_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTPCNSigmaKa_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    registry.add("Data/hPVsTPCNSigmaPr_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTPCNSigmaPi_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTPCNSigmaKa_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TPC", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    // TOF nSigma histograms
+    registry.add("Data/hPVsTOFNSigmaPr_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTOFNSigmaPi_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTOFNSigmaKa_Prong0", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    registry.add("Data/hPVsTOFNSigmaPr_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTOFNSigmaPi_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTOFNSigmaKa_Prong1", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    registry.add("Data/hPVsTOFNSigmaPr_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPr}});
+    registry.add("Data/hPVsTOFNSigmaPi_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{#pi} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaPi}});
+    registry.add("Data/hPVsTOFNSigmaKa_Prong2", "3-prong candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{K} TOF", {HistType::kTH2F, {axisPidP, axisNSigmaKa}});
+
+    registry.add("MC/reconstructed/signal/hMassSig", "Invariant mass (matched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hMassBg", "Invariant mass (unmatched);m (p K #pi) (GeV/#it{c}^{2});;entries", {HistType::kTH2F, {{500, 1.6, 3.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/generated/hEtaGen", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("MC/reconstructed/hDecLengthRecSig", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong0RecSig", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong1RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong2RecSig", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hCtRecSig", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hCPARecSig", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hEtaRecSig", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng0RecSig", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng1RecSig", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng2RecSig", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+
+    registry.add("MC/reconstructed/hDecLengthRecBg", "3-prong candidates;decay length (cm);;entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong0RecBg", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong1RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hd0Prong2RecBg", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);;entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hCtRecBg", "3-prong candidates;proper lifetime (#Xi_{c}) * #it{c} (cm);;entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hCPARecBg", "3-prong candidates;cosine of pointing angle;;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hEtaRecBg", "3-prong candidates;candidate #it{#eta};;entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng0RecBg", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng1RecBg", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("MC/reconstructed/hPtProng2RecBg", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});;entries", {HistType::kTH2F, {{100, 0., 10.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
   }
 
-  void process(soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi> const& candidates)
+  void process(const o2::aod::Collision& collision, const soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi>> const& candidates, aod::BigTracksPID const&)
   {
-    for (auto& candidate : selectedXicCandidates) {
+    int nTracks = 0;
+    if (collision.numContrib() > 1) {
+      for (auto const& track : tracks) {
+        if (std::abs(track.eta()) > 4.0) { // hard coded cut TO BE REFINED
+          continue;
+        }
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) { // hardcoded cut TO BE REFINED
+          continue;
+        }
+        nTracks++;
+      }
+    }
+
+    registry.fill(HIST("Data/hMultiplicity"), nTracks); // filling the histo for multiplicity
+    for (auto const& candidate : candidates) {
       if (!(candidate.hfflag() & 1 << DecayType::XicToPKPi)) {
         continue;
       }
+
       if (yCandMax >= 0. && std::abs(yXic(candidate)) > yCandMax) {
         continue;
       }
 
-      if (candidate.isSelXicToPKPi() >= selectionFlagXic) {
-        registry.fill(HIST("hMass"), invMassXicToPKPi(candidate), candidate.pt());
+      if (candidate.isSelXicToPKPi() >= selectionFlagXic) { // pKpi
+        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPKPi(candidate), candidate.pt());
+        registry.fill(HIST("Data/hMass"), invMassXicToPKPi(candidate));
+        xictreeObj.fMass = invMassXicToPKPi(candidate);
       }
-      if (candidate.isSelXicToPiKP() >= selectionFlagXic) {
-        registry.fill(HIST("hMass"), invMassXicToPiKP(candidate), candidate.pt());
+      if (candidate.isSelXicToPiKP() >= selectionFlagXic) { // piKp
+        registry.fill(HIST("Data/hMassVsPt"), invMassXicToPiKP(candidate), candidate.pt());
+        registry.fill(HIST("Data/hMass"), invMassXicToPiKP(candidate));
+        xictreeObj.fMass = invMassXicToPiKP(candidate);
+      }
+      registry.fill(HIST("Data/hPt"), candidate.pt());
+      registry.fill(HIST("Data/hEta"), candidate.eta());
+      registry.fill(HIST("Data/hPhi"), candidate.phi());
+      registry.fill(HIST("Data/hPtProng0VsPt"), candidate.ptProng0(), candidate.pt());
+      registry.fill(HIST("Data/hPtProng1VsPt"), candidate.ptProng1(), candidate.pt());
+      registry.fill(HIST("Data/hPtProng2VsPt"), candidate.ptProng2(), candidate.pt());
+      registry.fill(HIST("Data/hDecLengthVsPt"), candidate.decayLength(), candidate.pt());
+      registry.fill(HIST("Data/hd0Prong0VsPt"), candidate.impactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/hd0Prong1VsPt"), candidate.impactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/hd0Prong2VsPt"), candidate.impactParameter2(), candidate.pt());
+      registry.fill(HIST("Data/hCtVsPt"), ctXic(candidate), candidate.pt());
+      registry.fill(HIST("Data/hCPAVsPt"), candidate.cpa(), candidate.pt());
+      registry.fill(HIST("Data/hEtaVsPt"), candidate.eta(), candidate.pt());
+      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPKPi(), candidate.pt());
+      registry.fill(HIST("Data/hSelectionStatusVsPt"), candidate.isSelXicToPiKP(), candidate.pt());
+      registry.fill(HIST("Data/hImpParErr0VsPt"), candidate.errorImpactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/hImpParErr1VsPt"), candidate.errorImpactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/hImpParErr2VsPt"), candidate.errorImpactParameter2(), candidate.pt());
+      registry.fill(HIST("Data/hDecLenErrVsPt"), candidate.errorDecayLength(), candidate.pt());
+      registry.fill(HIST("Data/hChi2PCAVsPt"), candidate.chi2PCA(), candidate.pt());
+
+      const auto& trackProng0 = candidate.prong0_as<aod::BigTracksPID>(); // bachelor track
+      const auto& trackProng1 = candidate.prong1_as<aod::BigTracksPID>(); // bachelor track
+      const auto& trackProng2 = candidate.prong2_as<aod::BigTracksPID>(); // bachelor track
+
+      // TPC nSigma histograms
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong0"), trackProng0.p(), trackProng0.tpcNSigmaKa());
+
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong1"), trackProng1.p(), trackProng1.tpcNSigmaKa());
+
+      registry.fill(HIST("Data/hPVsTPCNSigmaPr_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaPr());
+      registry.fill(HIST("Data/hPVsTPCNSigmaPi_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaPi());
+      registry.fill(HIST("Data/hPVsTPCNSigmaKa_Prong2"), trackProng2.p(), trackProng2.tpcNSigmaKa());
+
+      // TOF nSigma histograms
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong0"), trackProng0.p(), trackProng0.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong0"), trackProng0.p(), trackProng0.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong0"), trackProng0.p(), trackProng0.tofNSigmaKa());
+
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong1"), trackProng1.p(), trackProng1.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong1"), trackProng1.p(), trackProng1.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong1"), trackProng1.p(), trackProng1.tofNSigmaKa());
+
+      registry.fill(HIST("Data/hPVsTOFNSigmaPr_Prong2"), trackProng2.p(), trackProng2.tofNSigmaPr());
+      registry.fill(HIST("Data/hPVsTOFNSigmaPi_Prong2"), trackProng2.p(), trackProng2.tofNSigmaPi());
+      registry.fill(HIST("Data/hPVsTOFNSigmaKa_Prong2"), trackProng2.p(), trackProng2.tofNSigmaKa());
+
+      // fill TTree varaibles
+      xictreeObj.fPt = candidate.pt();
+      xictreeObj.fCpa = candidate.cpa();
+      xictreeObj.fCpaXY = candidate.cpaXY();
+      xictreeObj.fDecayLength = candidate.decayLength();
+      xictreeObj.fDecayLengthErr = candidate.errorDecayLength();
+      xictreeObj.fChi2PCA = candidate.chi2PCA();
+
+      if (fFillTOFnSigma) {
+        xictreeObj.fPidTofNsigPrProng0 = trackProng0.tofNSigmaPr();
+        xictreeObj.fPidTofNsigPiProng0 = trackProng0.tofNSigmaPi();
+        xictreeObj.fPidTofNsigKProng0 = trackProng0.tofNSigmaKa();
+
+        xictreeObj.fPidTofNsigPrProng1 = trackProng1.tofNSigmaPr();
+        xictreeObj.fPidTofNsigPiProng1 = trackProng1.tofNSigmaPi();
+        xictreeObj.fPidTofNsigKProng1 = trackProng1.tofNSigmaKa();
+
+        xictreeObj.fPidTofNsigPrProng2 = trackProng2.tofNSigmaPr();
+        xictreeObj.fPidTofNsigPiProng2 = trackProng2.tofNSigmaPi();
+        xictreeObj.fPidTofNsigKProng2 = trackProng2.tofNSigmaKa();
       }
 
-      registry.fill(HIST("hPtCand"), candidate.pt());
-      registry.fill(HIST("hPtProng0"), candidate.ptProng0(), candidate.pt());
-      registry.fill(HIST("hPtProng1"), candidate.ptProng1(), candidate.pt());
-      registry.fill(HIST("hPtProng2"), candidate.ptProng2(), candidate.pt());
-      registry.fill(HIST("hDecLength"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("hd0Prong0"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("hd0Prong1"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("hd0Prong2"), candidate.impactParameter2(), candidate.pt());
-      registry.fill(HIST("hCt"), ctXic(candidate), candidate.pt());
-      registry.fill(HIST("hCPA"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("hEta"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("hSelectionStatus"), candidate.isSelXicToPKPi(), candidate.pt());
-      registry.fill(HIST("hSelectionStatus"), candidate.isSelXicToPiKP(), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter2(), candidate.pt());
-      registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("hDecLenErr"), candidate.chi2PCA(), candidate.pt());
+      if (fFillTPCnSigma) {
+        xictreeObj.fPidTpcNsigPrProng0 = trackProng0.tpcNSigmaPr();
+        xictreeObj.fPidTpcNsigPiProng0 = trackProng0.tpcNSigmaPi();
+        xictreeObj.fPidTpcNsigKProng0 = trackProng0.tpcNSigmaKa();
+
+        xictreeObj.fPidTpcNsigPrProng1 = trackProng1.tpcNSigmaPr();
+        xictreeObj.fPidTpcNsigPiProng1 = trackProng1.tpcNSigmaPi();
+        xictreeObj.fPidTpcNsigKProng1 = trackProng1.tpcNSigmaKa();
+
+        xictreeObj.fPidTpcNsigPrProng2 = trackProng2.tpcNSigmaPr();
+        xictreeObj.fPidTpcNsigPiProng2 = trackProng2.tpcNSigmaPi();
+        xictreeObj.fPidTpcNsigKProng2 = trackProng2.tpcNSigmaKa();
+      }
+
+      // fill TTree
+      if (fConfigWriteTTree) { // many parameters not set for photons: d1DCA,fd2DCA, fdectyp,fdau3pdg,fwMultpT,fwMultpT2,fwMultmT2
+        tree->Fill();
+      }
     }
   }
-
-  void processMc(soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi, aod::HfCand3ProngMcRec> const& candidates,
-                 soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particlesMC, aod::BigTracksMC const&)
+  // Fill MC histograms
+  void processMc(soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelXicToPKPi, aod::HfCand3ProngMcRec>> const& candidates,
+                 soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particlesMC, aod::BigTracksMC const& /*tracks*/)
   {
+
     // MC rec.
-    for (auto& candidate : selectedMCXicCandidates) {
+    for (auto& candidate : candidates) {
+      // Selected Xic
       if (!(candidate.hfflag() & 1 << DecayType::XicToPKPi)) {
         continue;
-      }
+      } // rapidity selection
       if (yCandMax >= 0. && std::abs(yXic(candidate)) > yCandMax) {
         continue;
       }
@@ -151,7 +329,7 @@ struct HfTaskXic {
         mass = invMassXicToPKPi(candidate);
       }
       if (candidate.isSelXicToPiKP() >= selectionFlagXic) {
-        massC = invMassXicToPiKP(candidate);
+        massC = invMassXicToPiKP(candidate); // mass conjiugated
       }
 
       if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::XicToPKPi) {
@@ -159,47 +337,47 @@ struct HfTaskXic {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong0_as<aod::BigTracksMC>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>(), pdg::Code::kXiCPlus, true);
         auto particleMother = particlesMC.rawIteratorAt(indexMother);
 
-        registry.fill(HIST("hPtGenSig"), particleMother.pt()); // gen. level pT
-        registry.fill(HIST("hPtRecSig"), candidate.pt());      // rec. level pT
+        registry.fill(HIST("MC/generated/signal/hPtGenSig"), particleMother.pt()); // gen. level pT
+        registry.fill(HIST("MC/reconstructed/signal/hPtRecSig"), candidate.pt());  // rec. level pT
 
         if (mass != 0.) {
-          registry.fill(HIST("hMassSig"), mass, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), mass, candidate.pt());
         }
         if (massC != 0.) {
-          registry.fill(HIST("hMassSig"), massC, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/signal/hMassSig"), massC, candidate.pt());
         }
 
-        registry.fill(HIST("hDecLengthRecSig"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("hPtProng0RecSig"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("hPtProng1RecSig"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("hPtProng2RecSig"), candidate.ptProng2(), candidate.pt());
-        registry.fill(HIST("hd0Prong0RecSig"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("hd0Prong1RecSig"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("hd0Prong2RecSig"), candidate.impactParameter2(), candidate.pt());
-        registry.fill(HIST("hCtRecSig"), ctXic(candidate), candidate.pt());
-        registry.fill(HIST("hCPARecSig"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hEtaRecSig"), candidate.eta(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hDecLengthRecSig"), candidate.decayLength(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng0RecSig"), candidate.ptProng0(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng1RecSig"), candidate.ptProng1(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hPtProng2RecSig"), candidate.ptProng2(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong0RecSig"), candidate.impactParameter0(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong1RecSig"), candidate.impactParameter1(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hd0Prong2RecSig"), candidate.impactParameter2(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hCtRecSig"), ctXic(candidate), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hCPARecSig"), candidate.cpa(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/signal/hEtaRecSig"), candidate.eta(), candidate.pt());
       } else {
         // Background
-        registry.fill(HIST("hPtRecBg"), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hPtRecBg"), candidate.pt());
 
         if (mass != 0.) {
-          registry.fill(HIST("hMassBg"), mass, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/bakground/hMassBg"), mass, candidate.pt());
         }
         if (massC != 0.) {
-          registry.fill(HIST("hMassBg"), massC, candidate.pt());
+          registry.fill(HIST("MC/reconstructed/bakground/hMassBg"), massC, candidate.pt());
         }
 
-        registry.fill(HIST("hDecLengthRecBg"), candidate.decayLength(), candidate.pt());
-        registry.fill(HIST("hPtProng0RecBg"), candidate.ptProng0(), candidate.pt());
-        registry.fill(HIST("hPtProng1RecBg"), candidate.ptProng1(), candidate.pt());
-        registry.fill(HIST("hPtProng2RecBg"), candidate.ptProng2(), candidate.pt());
-        registry.fill(HIST("hd0Prong0RecBg"), candidate.impactParameter0(), candidate.pt());
-        registry.fill(HIST("hd0Prong1RecBg"), candidate.impactParameter1(), candidate.pt());
-        registry.fill(HIST("hd0Prong2RecBg"), candidate.impactParameter2(), candidate.pt());
-        registry.fill(HIST("hCtRecBg"), ctXic(candidate), candidate.pt());
-        registry.fill(HIST("hCPARecBg"), candidate.cpa(), candidate.pt());
-        registry.fill(HIST("hEtaRecBg"), candidate.eta(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hDecLengthRecBg"), candidate.decayLength(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hPtProng0RecBg"), candidate.ptProng0(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hPtProng1RecBg"), candidate.ptProng1(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hPtProng2RecBg"), candidate.ptProng2(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong0RecBg"), candidate.impactParameter0(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong1RecBg"), candidate.impactParameter1(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hd0Prong2RecBg"), candidate.impactParameter2(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hCtRecBg"), ctXic(candidate), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hCPARecBg"), candidate.cpa(), candidate.pt());
+        registry.fill(HIST("MC/reconstructed/bakground/hEtaRecBg"), candidate.eta(), candidate.pt());
       }
     }
     // MC gen.
@@ -208,10 +386,49 @@ struct HfTaskXic {
         if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
           continue;
         }
-        registry.fill(HIST("hPtGen"), particle.pt());
-        registry.fill(HIST("hEtaGen"), particle.eta(), particle.pt());
+        registry.fill(HIST("MC/genearated/signal/hPtGen"), particle.pt());
+        registry.fill(HIST("MC/genearated/signal/hEtaGen"), particle.eta(), particle.pt());
       }
     }
+  }
+
+  void SetTree()
+  {
+    tree.setObject(new TTree("XicTTree", "XicTTree"));
+
+    tree->Branch("fPt", &xictreeObj.fPt, "fPt/F");
+    tree->Branch("fMass", &xictreeObj.fMass, "fMass/F");
+    tree->Branch("fDecayLength", &xictreeObj.fDecayLength, "fDecayLength/F");
+    tree->Branch("fDecayLengthErr", &xictreeObj.fDecayLengthErr, "fDecayLengthErr/F");
+    tree->Branch("fCpa", &xictreeObj.fCpa, "fCpa/F");
+    tree->Branch("fCpaXY", &xictreeObj.fCpaXY, "fCpaXY/F");
+    tree->Branch("fChi2PCA", &xictreeObj.fChi2PCA, "fChi2PCA/F");
+
+    //---tpc nSigma for all prongs and Pi, K, Pr hypothesis
+    tree->Branch("fPidTpcNsigPrProng0", &xictreeObj.fPidTpcNsigPrProng0, "fPidTpcNsigPrProng0/F");
+    tree->Branch("fPidTpcNsigKProng0", &xictreeObj.fPidTpcNsigKProng0, "fPidTpcNsigKProng0/F");
+    tree->Branch("fPidTpcNsigPiProng0", &xictreeObj.fPidTpcNsigPiProng0, "fPidTpcNsigPiProng0/F");
+
+    tree->Branch("fPidTpcNsigPrProng1", &xictreeObj.fPidTpcNsigPrProng1, "fPidTpcNsigPrProng1/F");
+    tree->Branch("fPidTpcNsigKProng1", &xictreeObj.fPidTpcNsigKProng1, "fPidTpcNsigKProng1/F");
+    tree->Branch("fPidTpcNsigPiProng1", &xictreeObj.fPidTpcNsigPiProng1, "fPidTpcNsigPiProng1/F");
+
+    tree->Branch("fPidTpcNsigPrProng2", &xictreeObj.fPidTpcNsigPrProng2, "fPidTpcNsigPrProng2/F");
+    tree->Branch("fPidTpcNsigKProng2", &xictreeObj.fPidTpcNsigKProng2, "fPidTpcNsigKProng2/F");
+    tree->Branch("fPidTpcNsigPiProng2", &xictreeObj.fPidTpcNsigPiProng2, "fPidTpcNsigPiProng2/F");
+
+    //---tof nSigma for all prongs and Pi, K, Pr hypothesis
+    tree->Branch("fPidTofNsigPrProng0", &xictreeObj.fPidTofNsigPrProng0, "fPidTofNsigPrProng0/F");
+    tree->Branch("fPidTofNsigKProng0", &xictreeObj.fPidTofNsigKProng0, "fPidTofNsigKProng0/F");
+    tree->Branch("fPidTofNsigPiProng0", &xictreeObj.fPidTofNsigPiProng0, "fPidTofNsigPiProng0/F");
+
+    tree->Branch("fPidTofNsigPrProng1", &xictreeObj.fPidTofNsigPrProng1, "fPidTofNsigPrProng1/F");
+    tree->Branch("fPidTofNsigKProng1", &xictreeObj.fPidTofNsigKProng1, "fPidTofNsigKProng1/F");
+    tree->Branch("fPidTofNsigPiProng1", &xictreeObj.fPidTofNsigPiProng1, "fPidTofNsigPiProng1/F");
+
+    tree->Branch("fPidTofNsigPrProng2", &xictreeObj.fPidTofNsigPrProng2, "fPidTofNsigPrProng2/F");
+    tree->Branch("fPidTofNsigKProng2", &xictreeObj.fPidTofNsigKProng2, "fPidTofNsigKProng2/F");
+    tree->Branch("fPidTofNsigPiProng2", &xictreeObj.fPidTofNsigPiProng2, "fPidTofNsigPiProng2/F");
   }
 
   PROCESS_SWITCH(HfTaskXic, processMc, "Process MC", false);


### PR DESCRIPTION
- These modifications in `taskXic.cxx` will enable to produce TH2F for TPC/TOF nSig vs P for Xic prongs
- A small tree is also added in order to see cut variation effects. This option, to write or not a TTree, is configurable. 