### PR TITLE
PWGHF: Factor out common functions used in B0 selectors

### DIFF
--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -88,101 +88,6 @@ struct HfCandidateSelectorB0ToDPiReduced {
     }
   }
 
-  /// Apply topological cuts as defined in SelectorCuts.h
-  /// \param hfCandB0 is the B0 candidate
-  /// \param hfCandD is prong1 of B0 candidate
-  /// \param trackPi is prong1 of B0 candidate
-  /// \return true if candidate passes all selections
-  template <typename T>
-  bool selectionTopol(const T& hfCandB0)
-  {
-    auto candpT = hfCandB0.pt();
-    auto ptD = RecoDecay::pt(hfCandB0.pxProng0(), hfCandB0.pyProng0());
-    auto ptPi = RecoDecay::pt(hfCandB0.pxProng1(), hfCandB0.pyProng1());
-
-    int pTBin = findBin(binsPt, candpT);
-    if (pTBin == -1) {
-      // LOGF(info, "B0 topol selection failed at getpTBin");
-      return false;
-    }
-
-    // // check that the candidate pT is within the analysis range
-    // if (candpT < ptCandMin || candpT >= ptCandMax) {
-    //   return false;
-    // }
-
-    // B0 mass cut
-    if (std::abs(invMassB0ToDPi(hfCandB0) - RecoDecay::getMassPDG(pdg::Code::kB0)) > cuts->get(pTBin, "m")) {
-      // Printf("B0 topol selection failed at mass diff check");
-      return false;
-    }
-
-    // pion pt
-    if (ptPi < cuts->get(pTBin, "pT Pi")) {
-      return false;
-    }
-
-    // D- pt
-    if (ptD < cuts->get(pTBin, "pT D")) {
-      return false;
-    }
-
-    /*
-    // D mass cut | already applied in candidateSelectorDplusToPiKPi.cxx
-    if (std::abs(hf_cand_3prong::invMassDplusToPiKPi(hfCandD) - RecoDecay::getMassPDG(pdg::Code::kDMinus)) > cuts->get(pTBin, "DeltaMD")) {
-      return false;
-    }
-    */
-
-    // B0 Decay length
-    if (hfCandB0.decayLength() < cuts->get(pTBin, "B0 decLen")) {
-      return false;
-    }
-
-    // B0 Decay length XY
-    if (hfCandB0.decayLengthXY() < cuts->get(pTBin, "B0 decLenXY")) {
-      return false;
-    }
-
-    // B0 chi2PCA cut
-    if (hfCandB0.chi2PCA() > cuts->get(pTBin, "Chi2PCA")) {
-      return false;
-    }
-
-    // B0 CPA cut
-    if (hfCandB0.cpa() < cuts->get(pTBin, "CPA")) {
-      return false;
-    }
-
-    // d0 of pi
-    if (std::abs(hfCandB0.impactParameter1()) < cuts->get(pTBin, "d0 Pi")) {
-      return false;
-    }
-
-    // d0 of D
-    if (std::abs(hfCandB0.impactParameter0()) < cuts->get(pTBin, "d0 D")) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /// Apply PID selection
-  /// \param pidTrackPi is the PID status of trackPi (prong1 of B0 candidate)
-  /// \return true if prong1 of B0 candidate passes all selections
-  template <typename T = int>
-  bool selectionPID(const T& pidTrackPi)
-  {
-    if (!acceptPIDNotApplicable && pidTrackPi != TrackSelectorPID::Status::PIDAccepted) {
-      return false;
-    }
-    if (acceptPIDNotApplicable && pidTrackPi == TrackSelectorPID::Status::PIDRejected) {
-      return false;
-    }
-
-    return true;
-  }
-
   void process(HfCandB0 const& hfCandsB0,
                HfTracksPidReduced const&,
                HfCandB0Config const& configs)
@@ -220,7 +125,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
       }
 
       // topological cuts
-      if (!selectionTopol(hfCandB0)) {
+      if (!hf_sel_candidate_b0::selectionTopol(hfCandB0, cuts, binsPt)) {
         hfSelB0ToDPiCandidate(statusB0ToDPi);
         // LOGF(info, "B0 candidate selection failed at topology selection");
         continue;
@@ -236,10 +141,10 @@ struct HfCandidateSelectorB0ToDPiReduced {
         continue;
       }
       // track-level PID selection
-      auto trackPi = hfCandB0.prong1_as<HfTracksPidReduced>();
       if (usePid) {
+        auto trackPi = hfCandB0.prong1_as<HfTracksPidReduced>();
         int pidTrackPi = selectorPion.getStatusTrackPIDTpcAndTof(trackPi);
-        if (!selectionPID(pidTrackPi)) {
+        if (!hf_sel_candidate_b0::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B0 candidate selection failed at PID selection");
           hfSelB0ToDPiCandidate(statusB0ToDPi);
           continue;

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -15,6 +15,11 @@
 #ifndef PWGHF_DATAMODEL_CANDIDATESELECTIONTABLES_H_
 #define PWGHF_DATAMODEL_CANDIDATESELECTIONTABLES_H_
 
+#include "Common/Core/TrackSelectorPID.h"
+#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/SelectorCuts.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+
 namespace o2::aod
 {
 // selection steps
@@ -183,6 +188,103 @@ DECLARE_SOA_TABLE(HfSelLcToK0sP, "AOD", "HFSELLCK0SP", //!
 namespace hf_sel_candidate_b0
 {
 DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int); //!
+
+/// Apply topological cuts as defined in SelectorCuts.h
+/// \param candB0 B0 candidate
+/// \param cuts B0 candidate selection per pT bin"
+/// \param binsPt pT bin limits
+/// \return true if candidate passes all selections
+template <typename T1, typename T2, typename T3>
+bool selectionTopol(const T1& candB0, const T2& cuts, const T3& binsPt)
+{
+  auto ptCandB0 = candB0.pt();
+  auto ptD = RecoDecay::pt(candB0.pxProng0(), candB0.pyProng0());
+  auto ptPi = RecoDecay::pt(candB0.pxProng1(), candB0.pyProng1());
+
+  int pTBin = findBin(binsPt, ptCandB0);
+  if (pTBin == -1) {
+    // LOGF(info, "B0 topol selection failed at getpTBin");
+    return false;
+  }
+
+  // // check that the candidate pT is within the analysis range
+  // if (ptCandB0 < ptCandMin || ptCandB0 >= ptCandMax) {
+  //   return false;
+  // }
+
+  // B0 mass cut
+  if (std::abs(o2::aod::hf_cand_b0::invMassB0ToDPi(candB0) - RecoDecay::getMassPDG(o2::analysis::pdg::Code::kB0)) > cuts->get(pTBin, "m")) {
+    // Printf("B0 topol selection failed at mass diff check");
+    return false;
+  }
+
+  // pion pt
+  if (ptPi < cuts->get(pTBin, "pT Pi")) {
+    return false;
+  }
+
+  // D- pt
+  if (ptD < cuts->get(pTBin, "pT D")) {
+    return false;
+  }
+
+  /*
+  // D mass cut | already applied in candidateSelectorDplusToPiKPi.cxx
+  if (std::abs(o2::aod::hf_cand_3prong::invMassDplusToPiKPi(hfCandD) - RecoDecay::getMassPDG(o2::analysis::pdg::Code::kDMinus)) > cuts->get(pTBin, "DeltaMD")) {
+    return false;
+  }
+  */
+
+  // B0 Decay length
+  if (candB0.decayLength() < cuts->get(pTBin, "B0 decLen")) {
+    return false;
+  }
+
+  // B0 Decay length XY
+  if (candB0.decayLengthXY() < cuts->get(pTBin, "B0 decLenXY")) {
+    return false;
+  }
+
+  // B0 chi2PCA cut
+  if (candB0.chi2PCA() > cuts->get(pTBin, "Chi2PCA")) {
+    return false;
+  }
+
+  // B0 CPA cut
+  if (candB0.cpa() < cuts->get(pTBin, "CPA")) {
+    return false;
+  }
+
+  // d0 of pi
+  if (std::abs(candB0.impactParameter1()) < cuts->get(pTBin, "d0 Pi")) {
+    return false;
+  }
+
+  // d0 of D
+  if (std::abs(candB0.impactParameter0()) < cuts->get(pTBin, "d0 D")) {
+    return false;
+  }
+
+  return true;
+}
+
+/// Apply PID selection
+/// \param pidTrackPi PID status of trackPi (prong1 of B0 candidate)
+/// \param acceptPIDNotApplicable switch to accept Status::PIDNotApplicable
+/// \return true if prong1 of B0 candidate passes all selections
+template <typename T1 = int, typename T2 = bool>
+bool selectionPID(const T1& pidTrackPi, const T2& acceptPIDNotApplicable)
+{
+  if (!acceptPIDNotApplicable && pidTrackPi != TrackSelectorPID::Status::PIDAccepted) {
+    return false;
+  }
+  if (acceptPIDNotApplicable && pidTrackPi == TrackSelectorPID::Status::PIDRejected) {
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace hf_sel_candidate_b0
 DECLARE_SOA_TABLE(HfSelB0ToDPi, "AOD", "HFSELB0", //!
                   hf_sel_candidate_b0::IsSelB0ToDPi);

--- a/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorB0ToDPi.cxx
@@ -126,99 +126,8 @@ struct HfCandidateSelectorB0ToDPi {
     }*/
   }
 
-  /// Apply topological cuts as defined in SelectorCuts.h
-  /// \param hfCandB0 is the B0 candidate
-  /// \param hfCandD is prong1 of B0 candidate
-  /// \param trackPi is prong1 of B0 candidate
-  /// \return true if candidate passes all selections
-  template <typename T1, typename T2, typename T3>
-  bool selectionTopol(const T1& hfCandB0, const T2& hfCandD, const T3& trackPi)
-  {
-    auto candpT = hfCandB0.pt();
-    int pTBin = findBin(binsPt, candpT);
-    if (pTBin == -1) {
-      // LOGF(info, "B0 topol selection failed at getpTBin");
-      return false;
-    }
-
-    // check that the candidate pT is within the analysis range
-    if (candpT < ptCandMin || candpT >= ptCandMax) {
-      return false;
-    }
-
-    // B0 mass cut
-    if (std::abs(invMassB0ToDPi(hfCandB0) - RecoDecay::getMassPDG(pdg::Code::kB0)) > cuts->get(pTBin, "m")) {
-      // Printf("B0 topol selection failed at mass diff check");
-      return false;
-    }
-
-    // pion pt
-    if (trackPi.pt() < cuts->get(pTBin, "pT Pi")) {
-      return false;
-    }
-
-    // D- pt
-    if (hfCandD.pt() < cuts->get(pTBin, "pT D")) {
-      return false;
-    }
-
-    /*
-    // D mass cut | already applied in candidateSelectorDplusToPiKPi.cxx
-    if (std::abs(hf_cand_3prong::invMassDplusToPiKPi(hfCandD) - RecoDecay::getMassPDG(pdg::Code::kDMinus)) > cuts->get(pTBin, "DeltaMD")) {
-      return false;
-    }
-    */
-
-    // B0 Decay length
-    if (hfCandB0.decayLength() < cuts->get(pTBin, "B0 decLen")) {
-      return false;
-    }
-
-    // B0 Decay length XY
-    if (hfCandB0.decayLengthXY() < cuts->get(pTBin, "B0 decLenXY")) {
-      return false;
-    }
-
-    // B0 chi2PCA cut
-    if (hfCandB0.chi2PCA() > cuts->get(pTBin, "Chi2PCA")) {
-      return false;
-    }
-
-    // B0 CPA cut
-    if (hfCandB0.cpa() < cuts->get(pTBin, "CPA")) {
-      return false;
-    }
-
-    // d0 of pi
-    if (std::abs(hfCandB0.impactParameter1()) < cuts->get(pTBin, "d0 Pi")) {
-      return false;
-    }
-
-    // d0 of D
-    if (std::abs(hfCandB0.impactParameter0()) < cuts->get(pTBin, "d0 D")) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /// Apply PID selection
-  /// \param pidTrackPi is the PID status of trackPi (prong1 of B0 candidate)
-  /// \return true if prong1 of B0 candidate passes all selections
-  template <typename T = int>
-  bool selectionPID(const T& pidTrackPi)
-  {
-    if (!acceptPIDNotApplicable && pidTrackPi != TrackSelectorPID::Status::PIDAccepted) {
-      return false;
-    }
-    if (acceptPIDNotApplicable && pidTrackPi == TrackSelectorPID::Status::PIDRejected) {
-      return false;
-    }
-
-    return true;
-  }
-
-  void process(aod::HfCandB0 const& hfCandsB0, soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi> const&, TracksPIDWithSel const&,
+  void process(aod::HfCandB0 const& hfCandsB0,
+               TracksPIDWithSel const&,
                HfCandB0Config const& configs)
   {
     // FIXME: get B0 creator configurable (until https://alice.its.cern.ch/jira/browse/O2-3582 solved)
@@ -253,11 +162,8 @@ struct HfCandidateSelectorB0ToDPi {
         registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoSkims, ptCandB0);
       }
 
-      auto candD = hfCandB0.prong0_as<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>();
-      auto trackPi = hfCandB0.prong1_as<TracksPIDWithSel>();
-
       // topological cuts
-      if (!selectionTopol(hfCandB0, candD, trackPi)) {
+      if (!hf_sel_candidate_b0::selectionTopol(hfCandB0, cuts, binsPt)) {
         hfSelB0ToDPiCandidate(statusB0ToDPi);
         // LOGF(info, "B0 candidate selection failed at topology selection");
         continue;
@@ -274,8 +180,9 @@ struct HfCandidateSelectorB0ToDPi {
       }
       // track-level PID selection
       if (usePid) {
+        auto trackPi = hfCandB0.prong1_as<TracksPIDWithSel>();
         int pidTrackPi = selectorPion.getStatusTrackPIDTpcAndTof(trackPi);
-        if (!selectionPID(pidTrackPi)) {
+        if (!hf_sel_candidate_b0::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B0 candidate selection failed at PID selection");
           hfSelB0ToDPiCandidate(statusB0ToDPi);
           continue;


### PR DESCRIPTION
Hi @vkucera, I put the selection functions in `CandidateSelectionTables.h` (the same way the reconstruction functions are implemented in `CandidateReconstructionTables.h`).

Following issue #2594 .

------------------
Modifications applied:
- move `selectionTopol` and `selectionPID` to `CandidateSelectionTables.h` under `hf_sel_candidate_b0` namespace and add the required headers
- add arguments for the configurables of the tasks
- specific issue linked to `acceptPIDNotApplicable`. This is a boolean configurable, so the operators `!` and `&&` lead to compilation errors. Solution proposed: use `acceptPIDNotApplicable.value` of type `bool` as argument of `selectionPID`
- modify the code in `candidateSelectorB0ToDPi.cxx` to adapt it to the latest version (similar to the one of `candidateSelectorB0ToDPiReduced.cxx`):
  - no need to create an instance of D candidate as all the information we need is stored in B0 candidate table --> no need to subscribe to `HfCand3Prong` anymore
  - instead of passing `hfCandB0`, `candD` and `trackPi` in `selectionTopol`, only pass `hfCandB0` and use it to build `ptD`, `ptPi` 