### PR TITLE
Analytical length calculator added

### DIFF
--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -127,60 +127,59 @@ struct OnTheFlyTOFPID {
   {
     // don't make use of the track parametrization
     float length = -100;
-    
+
     o2::math_utils::CircleXYf_t trcCircle;
     float sna, csa;
-    track.getCircleParams(magneticField, trcCircle, sna, csa );
-    
+    track.getCircleParams(magneticField, trcCircle, sna, csa);
+
     // distance between circle centers (one circle is at origin -> easy)
     float centerDistance = std::hypot(trcCircle.xC, trcCircle.yC);
-    
+
     // condition of circles touching - if not satisfied returned length will be -100
-    if(centerDistance < trcCircle.rC + radius && centerDistance > fabs(trcCircle.rC - radius)){
+    if (centerDistance < trcCircle.rC + radius && centerDistance > fabs(trcCircle.rC - radius)) {
       length = 0.0f;
-      
+
       // base radical direction
-      float ux = trcCircle.xC/centerDistance;
-      float uy = trcCircle.yC/centerDistance;
+      float ux = trcCircle.xC / centerDistance;
+      float uy = trcCircle.yC / centerDistance;
       // calculate perpendicular vector (normalized) for +/- displacement
       float vx = -uy;
       float vy = +ux;
       // calculate coordinate for radical line
-      float radical = (centerDistance*centerDistance - trcCircle.rC*trcCircle.rC + radius*radius) / (2.0f*centerDistance);
+      float radical = (centerDistance * centerDistance - trcCircle.rC * trcCircle.rC + radius * radius) / (2.0f * centerDistance);
       // calculate absolute displacement from center-to-center axis
-      float displace = (0.5f/centerDistance) * TMath::Sqrt(
-                                                          (-centerDistance + trcCircle.rC - radius) *
-                                                          (-centerDistance - trcCircle.rC + radius) *
-                                                          (-centerDistance + trcCircle.rC + radius) *
-                                                          ( centerDistance + trcCircle.rC + radius)
-                                                          );
-      
+      float displace = (0.5f / centerDistance) * TMath::Sqrt(
+                                                   (-centerDistance + trcCircle.rC - radius) *
+                                                   (-centerDistance - trcCircle.rC + radius) *
+                                                   (-centerDistance + trcCircle.rC + radius) *
+                                                   (centerDistance + trcCircle.rC + radius));
+
       // possible intercept points of track and TOF layer in 2D plane
-      float point1[2] = {radical*ux + displace*vx, radical*uy + displace*vy};
-      float point2[2] = {radical*ux - displace*vx, radical*uy - displace*vy};
-      
+      float point1[2] = {radical * ux + displace * vx, radical * uy + displace * vy};
+      float point2[2] = {radical * ux - displace * vx, radical * uy - displace * vy};
+
       // decide on correct intercept point
       std::array<float, 3> mom;
       track.getPxPyPzGlo(mom);
-      float scalarProduct1 = point1[0]*mom[0] + point1[1]*mom[1];
-      float scalarProduct2 = point2[0]*mom[0] + point2[1]*mom[1];
-      
+      float scalarProduct1 = point1[0] * mom[0] + point1[1] * mom[1];
+      float scalarProduct2 = point2[0] * mom[0] + point2[1] * mom[1];
+
       // get start point
       std::array<float, 3> startPoint;
       track.getXYZGlo(startPoint);
-      
+
       float cosAngle = -1000, modulus = -1000;
-      
-      if(scalarProduct1>scalarProduct2){
+
+      if (scalarProduct1 > scalarProduct2) {
         modulus = std::hypot(point1[0] - trcCircle.xC, point1[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
-        cosAngle =(point1[0] - trcCircle.xC)*(startPoint[0]-trcCircle.xC) + (point1[1] - trcCircle.yC)*(startPoint[0]-trcCircle.yC);
-      }else{
+        cosAngle = (point1[0] - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (point1[1] - trcCircle.yC) * (startPoint[0] - trcCircle.yC);
+      } else {
         modulus = std::hypot(point2[0] - trcCircle.xC, point2[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
-        cosAngle =(point2[0] - trcCircle.xC)*(startPoint[0]-trcCircle.xC) + (point2[1] - trcCircle.yC)*(startPoint[0]-trcCircle.yC);
+        cosAngle = (point2[0] - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (point2[1] - trcCircle.yC) * (startPoint[0] - trcCircle.yC);
       }
-      cosAngle/=modulus;
-      length = trcCircle.rC*TMath::ACos(cosAngle);
-      length*=sqrt(1.0f + track.getTgl()*track.getTgl());
+      cosAngle /= modulus;
+      length = trcCircle.rC * TMath::ACos(cosAngle);
+      length *= sqrt(1.0f + track.getTgl() * track.getTgl());
     }
     return length;
   }
@@ -222,7 +221,7 @@ struct OnTheFlyTOFPID {
       float xPv = -100, trackLengthInnerTOF = -1, trackLengthOuterTOF = -1;
       if (o2track.propagateToDCA(mcPvVtx, dBz))
         xPv = o2track.getX();
-      if (xPv > -99. ){
+      if (xPv > -99.) {
         trackLengthInnerTOF = trackLength(o2track, innerTOFRadius, dBz);
         trackLengthOuterTOF = trackLength(o2track, outerTOFRadius, dBz);
       }
@@ -245,7 +244,7 @@ struct OnTheFlyTOFPID {
       auto recoTrack = getTrackParCov(track);
       if (recoTrack.propagateToDCA(pvVtx, dBz))
         xPv = recoTrack.getX();
-      if (xPv > -99. ){
+      if (xPv > -99.) {
         trackLengthRecoInnerTOF = trackLength(recoTrack, innerTOFRadius, dBz);
         trackLengthRecoOuterTOF = trackLength(recoTrack, outerTOFRadius, dBz);
       }

--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -34,6 +34,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "TRandom3.h"
 #include "ALICE3/DataModel/OTFTOF.h"
+#include "DetectorsVertexing/HelixHelper.h"
 
 /// \file onTheFlyTOFPID.cxx
 ///
@@ -118,23 +119,68 @@ struct OnTheFlyTOFPID {
     new (&o2track)(o2::track::TrackParCov)(x, particle.phi(), params, covm);
   }
 
-  /// function to calculate track length
+  /// function to calculate track length of this track up to a certain radius
   /// \param track the input track
-  /// \param x0 the initial position
-  /// \param x1 the final position
+  /// \param radius the radius of the layer you're calculating the length to
   /// \param magneticField the magnetic field to use when propagating
-  float trackLength(o2::track::TrackParCov track, float x0, float x1, float magneticField)
+  float trackLength(o2::track::TrackParCov track, float radius, float magneticField)
   {
-    std::array<float, 3> pointN;
-    std::array<float, 3> pointNplus;
-    float length = 0.0;
-    track.propagateTo(x0, magneticField);
-    for (int iStep = 1; iStep < nStepsLIntegrator; iStep++) {
-      track.getXYZGlo(pointN);
-      float position = x0 + (x1 - x0) * (static_cast<float>(iStep)) / (static_cast<float>(nStepsLIntegrator - 1));
-      track.propagateTo(position, magneticField);
-      track.getXYZGlo(pointNplus);
-      length += std::hypot(pointNplus[0] - pointN[0], pointNplus[1] - pointN[1], pointNplus[2] - pointN[2]);
+    // don't make use of the track parametrization
+    float length = -100;
+    
+    o2::math_utils::CircleXYf_t trcCircle;
+    float sna, csa;
+    track.getCircleParams(magneticField, trcCircle, sna, csa );
+    
+    // distance between circle centers (one circle is at origin -> easy)
+    float centerDistance = std::hypot(trcCircle.xC, trcCircle.yC);
+    
+    // condition of circles touching - if not satisfied returned length will be -100
+    if(centerDistance < trcCircle.rC + radius && centerDistance > fabs(trcCircle.rC - radius)){
+      length = 0.0f;
+      
+      // base radical direction
+      float ux = trcCircle.xC/centerDistance;
+      float uy = trcCircle.yC/centerDistance;
+      // calculate perpendicular vector (normalized) for +/- displacement
+      float vx = -uy;
+      float vy = +ux;
+      // calculate coordinate for radical line
+      float radical = (centerDistance*centerDistance - trcCircle.rC*trcCircle.rC + radius*radius) / (2.0f*centerDistance);
+      // calculate absolute displacement from center-to-center axis
+      float displace = (0.5f/centerDistance) * TMath::Sqrt(
+                                                          (-centerDistance + trcCircle.rC - radius) *
+                                                          (-centerDistance - trcCircle.rC + radius) *
+                                                          (-centerDistance + trcCircle.rC + radius) *
+                                                          ( centerDistance + trcCircle.rC + radius)
+                                                          );
+      
+      // possible intercept points of track and TOF layer in 2D plane
+      float point1[2] = {radical*ux + displace*vx, radical*uy + displace*vy};
+      float point2[2] = {radical*ux - displace*vx, radical*uy - displace*vy};
+      
+      // decide on correct intercept point
+      std::array<float, 3> mom;
+      track.getPxPyPzGlo(mom);
+      float scalarProduct1 = point1[0]*mom[0] + point1[1]*mom[1];
+      float scalarProduct2 = point2[0]*mom[0] + point2[1]*mom[1];
+      
+      // get start point
+      std::array<float, 3> startPoint;
+      track.getXYZGlo(startPoint);
+      
+      float cosAngle = -1000, modulus = -1000;
+      
+      if(scalarProduct1>scalarProduct2){
+        modulus = std::hypot(point1[0] - trcCircle.xC, point1[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
+        cosAngle =(point1[0] - trcCircle.xC)*(startPoint[0]-trcCircle.xC) + (point1[1] - trcCircle.yC)*(startPoint[0]-trcCircle.yC);
+      }else{
+        modulus = std::hypot(point2[0] - trcCircle.xC, point2[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
+        cosAngle =(point2[0] - trcCircle.xC)*(startPoint[0]-trcCircle.xC) + (point2[1] - trcCircle.yC)*(startPoint[0]-trcCircle.yC);
+      }
+      cosAngle/=modulus;
+      length = trcCircle.rC*TMath::ACos(cosAngle);
+      length*=sqrt(1.0f + track.getTgl()*track.getTgl());
     }
     return length;
   }
@@ -173,17 +219,13 @@ struct OnTheFlyTOFPID {
       auto mcParticle = track.mcParticle();
       convertMCParticleToO2Track(mcParticle, o2track);
 
-      float xPv = -100, xInnerTOF = -100, xOuterTOF = -100, trackLengthInnerTOF = -1, trackLengthOuterTOF = -1;
+      float xPv = -100, trackLengthInnerTOF = -1, trackLengthOuterTOF = -1;
       if (o2track.propagateToDCA(mcPvVtx, dBz))
         xPv = o2track.getX();
-      if (!o2track.getXatLabR(innerTOFRadius, xInnerTOF, dBz, o2::track::DirOutward))
-        xInnerTOF = -100;
-      if (!o2track.getXatLabR(outerTOFRadius, xOuterTOF, dBz, o2::track::DirOutward))
-        xOuterTOF = -100;
-      if (xPv > -99. && xInnerTOF > -99.)
-        trackLengthInnerTOF = trackLength(o2track, xPv, xInnerTOF, dBz);
-      if (xPv > -99. && xOuterTOF > -99.)
-        trackLengthOuterTOF = trackLength(o2track, xPv, xOuterTOF, dBz);
+      if (xPv > -99. ){
+        trackLengthInnerTOF = trackLength(o2track, innerTOFRadius, dBz);
+        trackLengthOuterTOF = trackLength(o2track, outerTOFRadius, dBz);
+      }
 
       // get mass to calculate velocity
       auto pdgInfo = pdg->GetParticle(mcParticle.pdgCode());
@@ -203,14 +245,10 @@ struct OnTheFlyTOFPID {
       auto recoTrack = getTrackParCov(track);
       if (recoTrack.propagateToDCA(pvVtx, dBz))
         xPv = recoTrack.getX();
-      if (!recoTrack.getXatLabR(innerTOFRadius, xInnerTOF, dBz, o2::track::DirOutward))
-        xInnerTOF = -100;
-      if (!recoTrack.getXatLabR(outerTOFRadius, xOuterTOF, dBz, o2::track::DirOutward))
-        xOuterTOF = -100;
-      if (xPv > -99. && xInnerTOF > -99.)
-        trackLengthRecoInnerTOF = trackLength(recoTrack, xPv, xInnerTOF, dBz);
-      if (xPv > -99. && xOuterTOF > -99.)
-        trackLengthRecoOuterTOF = trackLength(recoTrack, xPv, xOuterTOF, dBz);
+      if (xPv > -99. ){
+        trackLengthRecoInnerTOF = trackLength(recoTrack, innerTOFRadius, dBz);
+        trackLengthRecoOuterTOF = trackLength(recoTrack, outerTOFRadius, dBz);
+      }
 
       // Straight to Nsigma
       float deltaTimeInnerTOF[5], nSigmaInnerTOF[5];
@@ -241,9 +279,9 @@ struct OnTheFlyTOFPID {
         // Fixme: assumes dominant resolution effect is the TOF resolution
         // and not the tracking itself. It's *probably* a fair assumption
         // but it should be tested further!
-        if (trackLengthInnerTOF > 0 && trackLengthRecoInnerTOF)
+        if (trackLengthInnerTOF > 0 && trackLengthRecoInnerTOF > 0)
           nSigmaInnerTOF[ii] = deltaTimeInnerTOF[ii] / innerTOFTimeReso;
-        if (trackLengthOuterTOF > 0 && trackLengthRecoOuterTOF)
+        if (trackLengthOuterTOF > 0 && trackLengthRecoOuterTOF > 0)
           nSigmaOuterTOF[ii] = deltaTimeOuterTOF[ii] / outerTOFTimeReso;
       }
 


### PR DESCRIPTION
* this adds a calculation of analytical track length to a TOF layer, solving a problem that appears due to the ALICE track parametrization and leading to the following comparison between numerical (previous) and analytical values of track lengths (given here as an example for B = 2T and rTOF = 1m): 
```
Pt:	0.000	Length:	0.000000,	 analytical: -100.000000,	delta = -100.0000000000
Pt:	0.100	Length:	28.060884,	 analytical: -100.000000,	delta = -128.0608825684
Pt:	0.200	Length:	58.917965,	 analytical: -100.000000,	delta = -158.9179687500
Pt:	0.300	Length:	90.278923,	 analytical: 171.579880,	delta = 81.3009567261
Pt:	0.400	Length:	81.894432,	 analytical: 126.392189,	delta = 44.4977569580
Pt:	0.500	Length:	119.894913,	 analytical: 119.895638,	delta = 0.0007247925
Pt:	0.600	Length:	117.071625,	 analytical: 117.071938,	delta = 0.0003128052
Pt:	0.700	Length:	115.538307,	 analytical: 115.538567,	delta = 0.0002593994
Pt:	0.800	Length:	114.600685,	 analytical: 114.600822,	delta = 0.0001373291
Pt:	0.900	Length:	113.981468,	 analytical: 113.981583,	delta = 0.0001144409
Pt:	1.000	Length:	113.549644,	 analytical: 113.549706,	delta = 0.0000610352
```
* notably, the numerical values below 100cm for the numerical length - the first column - have to be wrong as they are shorter than the TOF radius; they were a result of spurious results of the `getXatLabR` function when the necessary angle traveled in the track helix is above pi/2. 
* the calculation is such that it should also operate correctly in case a track doesn't reach the TOF layer - in which case no TOF signal will be generated, which was not necessarily the case before due to the `getXatLabR` finding an incorrect X. 
* For the future, something like this could be used as a preparatory stage in a `getXatLabR` improvement, too. 