### PR TITLE
PWGHF: update SigmaC creator and track-to-coll. associator.

### DIFF
--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -51,7 +51,8 @@ struct TrackSelectionFlags {
   static constexpr flagtype kDCAz = 1 << 14;
   // Combo masks
   static constexpr flagtype kQualityTracks = kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits;
-  static constexpr flagtype kQualityTracksWoTPCCluster = kTrackType | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits;
+  static constexpr flagtype kQualityTracksITS = kTrackType | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits;
+  static constexpr flagtype kQualityTracksWoTPCCluster = kQualityTracksITS | kTPCChi2NDF | kTPCRefit;
   static constexpr flagtype kPrimaryTracks = kGoldenChi2 | kDCAxy | kDCAz;
   static constexpr flagtype kInAcceptanceTracks = kPtRange | kEtaRange;
   static constexpr flagtype kGlobalTrack = kQualityTracks | kPrimaryTracks | kInAcceptanceTracks;
@@ -73,6 +74,7 @@ struct TrackSelectionFlags {
 
 #define requireTrackCutInFilter(mask) ((aod::track::trackCutFlag & aod::track::mask) == aod::track::mask)
 #define requireQualityTracksInFilter() requireTrackCutInFilter(TrackSelectionFlags::kQualityTracks)
+#define requireQualityTracksITSInFilter() requireTrackCutInFilter(TrackSelectionFlags::kQualityTracksITS)
 #define requirePrimaryTracksInFilter() requireTrackCutInFilter(TrackSelectionFlags::kPrimaryTracks)
 #define requireInAcceptanceTracksInFilter() requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks)
 #define requireGlobalTrackInFilter() requireTrackCutInFilter(TrackSelectionFlags::kGlobalTrack)
@@ -100,6 +102,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(CheckFlag, checkFlag,
                               TrackSelectionFlags::flagtype mask) -> bool { return TrackSelectionFlags::checkFlag(flags, mask); }); //! Checks the single cut
 // Combo selections
 DECLARE_DYN_TRKSEL_COLUMN(IsQualityTrack, isQualityTrack, TrackSelectionFlags::kQualityTracks);                                          //! Passed the combined track cut: kQualityTracks
+DECLARE_DYN_TRKSEL_COLUMN(IsQualityTrackITS, isQualityTrackITS, TrackSelectionFlags::kQualityTracksITS);                                 //! Passed the combined track cut: kQualityTracksITS
 DECLARE_DYN_TRKSEL_COLUMN(IsPrimaryTrack, isPrimaryTrack, TrackSelectionFlags::kPrimaryTracks);                                          //! Passed the combined track cut: kPrimaryTracks
 DECLARE_DYN_TRKSEL_COLUMN(IsInAcceptanceTrack, isInAcceptanceTrack, TrackSelectionFlags::kInAcceptanceTracks);                           //! Passed the combined track cut: kInAcceptanceTracks
 DECLARE_DYN_TRKSEL_COLUMN(IsGlobalTrack, isGlobalTrack, TrackSelectionFlags::kGlobalTrack);                                              //! Passed the combined track cut: kGlobalTrack
@@ -151,6 +154,7 @@ DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on th
                   track::TrackCutFlagFb4,
                   track::TrackCutFlagFb5,
                   track::IsQualityTrack<track::TrackCutFlag>,
+                  track::IsQualityTrackITS<track::TrackCutFlag>,
                   track::IsPrimaryTrack<track::TrackCutFlag>,
                   track::IsInAcceptanceTrack<track::TrackCutFlag>,
                   track::IsGlobalTrack<track::TrackCutFlag>,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -143,7 +143,7 @@ DECLARE_SOA_TABLE(TracksDCA, "AOD", "TRACKDCA", //! DCA information for the trac
                   track::DcaZ);
 DECLARE_SOA_TABLE(TracksDCACov, "AOD", "TRACKDCACOV",
                   track::SigmaDcaXY2,
-                  track::SigmaDcaZ2);                      //! DCA cov. matrix information for the track
+                  track::SigmaDcaZ2); //! DCA cov. matrix information for the track
 
 DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on the track selection decision + split dynamic information
                   track::IsGlobalTrackSDD,

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -143,7 +143,7 @@ DECLARE_SOA_TABLE(TracksDCA, "AOD", "TRACKDCA", //! DCA information for the trac
                   track::DcaZ);
 DECLARE_SOA_TABLE(TracksDCACov, "AOD", "TRACKDCACOV",
                   track::SigmaDcaXY2,
-                  track::SigmaDcaZ2); //! DCA cov. matrix information for the track
+                  track::SigmaDcaZ2);                      //! DCA cov. matrix information for the track
 
 DECLARE_SOA_TABLE(TrackSelection, "AOD", "TRACKSELECTION", //! Information on the track selection decision + split dynamic information
                   track::IsGlobalTrackSDD,

--- a/Common/TableProducer/trackToCollisionAssociator.cxx
+++ b/Common/TableProducer/trackToCollisionAssociator.cxx
@@ -35,12 +35,14 @@ struct TrackToCollisionAssociation {
   Configurable<float> nSigmaForTimeCompat{"nSigmaForTimeCompat", 4.f, "number of sigmas for time compatibility"};
   Configurable<float> timeMargin{"timeMargin", 0.f, "time margin in ns added to uncertainty because of uncalibrated TPC"};
   Configurable<bool> applyMinimalTrackSelForRun2{"applyMinimalTrackSelForRun2", false, "flag to apply minimal track selection for Run 2 in case of standard association"};
-  Configurable<bool> applyIsGlobalTrackWoDCA{"applyIsGlobalTrackWoDCA", true, "flag to apply global track w/o DCA selection"};
+  Configurable<int> setTrackSelections{"setTrackSelections", 1, "flag to apply track selections: 0=none; 1=global track w/o DCA selection; 2=only ITS quality"};
   Configurable<bool> usePVAssociation{"usePVAssociation", true, "if the track is a PV contributor, use the collision time for it"};
   Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
   Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
 
-  Filter trackFilter = (applyIsGlobalTrackWoDCA.node() == false) || requireGlobalTrackWoDCAInFilter();
+  Filter trackFilter = (setTrackSelections.node() == 0) ||
+                       ((setTrackSelections.node() == 1) || requireGlobalTrackWoDCAInFilter()) ||
+                       ((setTrackSelections.node() == 2) || requireQualityTracksITSInFilter());
   using TracksWithSel = soa::Join<Tracks, TracksExtra, TrackSelection>;
   using TracksWithSelFilter = soa::Filtered<TracksWithSel>;
 
@@ -50,8 +52,8 @@ struct TrackToCollisionAssociation {
       LOGP(fatal, "Exactly one process function should be enabled!");
     }
 
-    if (applyIsGlobalTrackWoDCA && applyMinimalTrackSelForRun2) {
-      LOGP(fatal, "You cannot apply simultaneously Run 2 track selections and applyIsGlobalTrackWoDCA!");
+    if (setTrackSelections > 0 && applyMinimalTrackSelForRun2) {
+      LOGP(fatal, "You cannot apply simultaneously Run 2 track selections and Run 3 track selections!");
     }
   }
 
@@ -174,7 +176,7 @@ struct TrackToCollisionAssociation {
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollisions, collision.globalIndex());
       for (const auto& track : tracksThisCollision) {
         bool hasGoodQuality = true;
-        if (applyIsGlobalTrackWoDCA && !track.isGlobalTrackWoDCA()) {
+        if (setTrackSelections==1 && !track.isGlobalTrackWoDCA()) {
           hasGoodQuality = false;
         } else if (applyMinimalTrackSelForRun2) {
           unsigned char itsClusterMap = track.itsClusterMap();

--- a/Common/TableProducer/trackToCollisionAssociator.cxx
+++ b/Common/TableProducer/trackToCollisionAssociator.cxx
@@ -176,7 +176,7 @@ struct TrackToCollisionAssociation {
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollisions, collision.globalIndex());
       for (const auto& track : tracksThisCollision) {
         bool hasGoodQuality = true;
-        if (setTrackSelections==1 && !track.isGlobalTrackWoDCA()) {
+        if (setTrackSelections == 1 && !track.isGlobalTrackWoDCA()) {
           hasGoodQuality = false;
         } else if (applyMinimalTrackSelForRun2) {
           unsigned char itsClusterMap = track.itsClusterMap();

--- a/Common/TableProducer/trackToCollisionAssociator.cxx
+++ b/Common/TableProducer/trackToCollisionAssociator.cxx
@@ -34,15 +34,14 @@ struct TrackToCollisionAssociation {
 
   Configurable<float> nSigmaForTimeCompat{"nSigmaForTimeCompat", 4.f, "number of sigmas for time compatibility"};
   Configurable<float> timeMargin{"timeMargin", 0.f, "time margin in ns added to uncertainty because of uncalibrated TPC"};
-  Configurable<bool> applyMinimalTrackSelForRun2{"applyMinimalTrackSelForRun2", false, "flag to apply minimal track selection for Run 2 in case of standard association"};
-  Configurable<int> setTrackSelections{"setTrackSelections", 1, "flag to apply track selections: 0=none; 1=global track w/o DCA selection; 2=only ITS quality"};
+  Configurable<int> setTrackSelections{"setTrackSelections", 1, "flag to apply track selections: -1=minimal track selection for Run 2 (standard association); 0=none; 1=global track w/o DCA selection; 2=only ITS quality"};
   Configurable<bool> usePVAssociation{"usePVAssociation", true, "if the track is a PV contributor, use the collision time for it"};
   Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
   Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
 
-  Filter trackFilter = (setTrackSelections.node() == 0) ||
-                       ((setTrackSelections.node() == 1) && requireGlobalTrackWoDCAInFilter()) ||
-                       ((setTrackSelections.node() == 2) && requireQualityTracksITSInFilter());
+  Filter trackFilter = (setTrackSelections.node() == 0) ||                                        // no track selections
+                       ((setTrackSelections.node() == 1) && requireGlobalTrackWoDCAInFilter()) || // global track selections w/o dca
+                       ((setTrackSelections.node() == 2) && requireQualityTracksITSInFilter());   // ITS-quality selections only
   using TracksWithSel = soa::Join<Tracks, TracksExtra, TrackSelection>;
   using TracksWithSelFilter = soa::Filtered<TracksWithSel>;
 
@@ -50,10 +49,6 @@ struct TrackToCollisionAssociation {
   {
     if (doprocessAssocWithTime == doprocessStandardAssoc) {
       LOGP(fatal, "Exactly one process function should be enabled!");
-    }
-
-    if (setTrackSelections > 0 && applyMinimalTrackSelForRun2) {
-      LOGP(fatal, "You cannot apply simultaneously Run 2 track selections and Run 3 track selections!");
     }
   }
 
@@ -177,8 +172,13 @@ struct TrackToCollisionAssociation {
       for (const auto& track : tracksThisCollision) {
         bool hasGoodQuality = true;
         if (setTrackSelections == 1 && !track.isGlobalTrackWoDCA()) {
+          // global track selections w/o dca
           hasGoodQuality = false;
-        } else if (applyMinimalTrackSelForRun2) {
+        } else if (setTrackSelections == 2 && !track.isQualityTrackITS()) {
+          // ITS-quality selections only
+          hasGoodQuality = false;
+        } else if (setTrackSelections == -1) {
+          // minimal track selections for Run 2
           unsigned char itsClusterMap = track.itsClusterMap();
           if (!(track.tpcNClsFound() >= 50 && track.flags() & o2::aod::track::ITSrefit && track.flags() & o2::aod::track::TPCrefit && (TESTBIT(itsClusterMap, 0) || TESTBIT(itsClusterMap, 1)))) {
             hasGoodQuality = false;

--- a/Common/TableProducer/trackToCollisionAssociator.cxx
+++ b/Common/TableProducer/trackToCollisionAssociator.cxx
@@ -41,8 +41,8 @@ struct TrackToCollisionAssociation {
   Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
 
   Filter trackFilter = (setTrackSelections.node() == 0) ||
-                       ((setTrackSelections.node() == 1) || requireGlobalTrackWoDCAInFilter()) ||
-                       ((setTrackSelections.node() == 2) || requireQualityTracksITSInFilter());
+                       ((setTrackSelections.node() == 1) && requireGlobalTrackWoDCAInFilter()) ||
+                       ((setTrackSelections.node() == 2) && requireQualityTracksITSInFilter());
   using TracksWithSel = soa::Join<Tracks, TracksExtra, TrackSelection>;
   using TracksWithSelFilter = soa::Filtered<TracksWithSel>;
 

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -244,9 +244,9 @@ struct HfCandidateCreatorSigmac0plusplus {
         } /// end loop over tracks
       }   /// end loop over candidates
 
-    }     /// end loop over collisions
+    } /// end loop over collisions
 
-  }       /// end processWithAmbTracks
+  } /// end processWithAmbTracks
 };
 
 /// Extends the base table with expression columns.

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -245,9 +245,9 @@ struct HfCandidateCreatorSigmac0plusplus {
         } /// end loop over tracks
       }   /// end loop over candidates
 
-    }     /// end loop over collisions
+    } /// end loop over collisions
 
-  }       /// end processWithAmbTracks
+  } /// end processWithAmbTracks
 };
 
 /// Extends the base table with expression columns.

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -66,6 +66,11 @@ struct HfCandidateCreatorSigmac0plusplus {
   /// Filter the candidate Λc+ used for the Σc0,++ creation
   Filter filterSelectCandidateLc = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc);
 
+  /// Prepare the slicing of candidate Λc+ and pions to be used for the Σc0,++ creation
+  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+  // Preslice<CandidatesLc> hf3ProngPerCollision = aod::track_association::collisionId;
+  Preslice<CandidatesLc> hf3ProngPerCollision = aod::hf_cand::collisionId;
+
   /// Cut selection object for soft π-,+
   TrackSelection softPiCuts;
 
@@ -121,10 +126,6 @@ struct HfCandidateCreatorSigmac0plusplus {
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
     runNumber = 0;
   }
-
-  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
-  // Preslice<CandidatesLc> hf3ProngPerCollision = aod::track_association::collisionId;
-  Preslice<CandidatesLc> hf3ProngPerCollision = aod::hf_cand::collisionId;
 
   /// @brief process function for Σc0,++ → Λc+(→pK-π+) π- candidate reconstruction considering also reassigned tracks for soft pions
   /// @param collision is a o2::aod::Collision
@@ -244,9 +245,9 @@ struct HfCandidateCreatorSigmac0plusplus {
         } /// end loop over tracks
       }   /// end loop over candidates
 
-    } /// end loop over collisions
+    }     /// end loop over collisions
 
-  } /// end processWithAmbTracks
+  }       /// end processWithAmbTracks
 };
 
 /// Extends the base table with expression columns.

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -63,6 +63,9 @@ struct HfCandidateCreatorSigmac0plusplus {
 
   HistogramRegistry histos;
 
+  using TracksSigmac = soa::Join<aod::FullTracks, aod::TracksDCA>;
+  using CandidatesLc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
+
   /// Filter the candidate Λc+ used for the Σc0,++ creation
   Filter filterSelectCandidateLc = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc);
 
@@ -73,9 +76,6 @@ struct HfCandidateCreatorSigmac0plusplus {
 
   /// Cut selection object for soft π-,+
   TrackSelection softPiCuts;
-
-  using TracksSigmac = soa::Join<aod::FullTracks, aod::TracksDCA>;
-  using CandidatesLc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
 
   // Needed for dcaXY, dcaZ recalculation of soft pions reassigned to a new collision
   Service<o2::ccdb::BasicCCDBManager> ccdb;

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -15,11 +15,21 @@
 ///
 /// \author Mattia Faggin <mfaggin@cern.ch>, University and INFN PADOVA
 
+#include "CCDB/BasicCCDBManager.h" // for dca recalculation
+#include "Common/DataModel/CollisionAssociation.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/trackUtilities.h"
+#include "DataFormatsParameters/GRPMagField.h" // for dca recalculation
+#include "DataFormatsParameters/GRPObject.h"   // for dca recalculation
+#include "DetectorsBase/GeometryManager.h"     // for dca recalculation
+#include "DetectorsBase/Propagator.h"          // for dca recalculation
+#include "DetectorsVertexing/PVertexer.h"      // for dca recalculation
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
-#include "Common/Core/TrackSelection.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h" // for dca recalculation
+// #include "ReconstructionDataFormats/Vertex.h" // for dca recalculation
 
 using namespace o2;
 using namespace o2::framework;
@@ -44,6 +54,15 @@ struct HfCandidateCreatorSigmac0plusplus {
   Configurable<float> softPiDcaXYMax{"softPiDcaXYMax", 0.065, "Soft pion max dcaXY (cm)"};
   Configurable<float> softPiDcaZMax{"softPiDcaZMax", 0.065, "Soft pion max dcaZ (cm)"};
 
+  // CCDB
+  Configurable<bool> isRun2Ccdb{"isRun2Ccdb", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
+  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
+  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+
+  HistogramRegistry histos;
+
   /// Filter the candidate Λc+ used for the Σc0,++ creation
   Filter filterSelectCandidateLc = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc);
 
@@ -51,20 +70,34 @@ struct HfCandidateCreatorSigmac0plusplus {
   TrackSelection softPiCuts;
 
   using TracksSigmac = soa::Join<aod::FullTracks, aod::TracksDCA>;
+  using CandidatesLc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
+
+  // Needed for dcaXY, dcaZ recalculation of soft pions reassigned to a new collision
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+  int runNumber;
 
   /// @brief init function, to define the soft pion selections and histograms
   /// @param
   void init(InitContext&)
   {
+    auto h = histos.add<TH1>("hCounter", "", kTH1D, {{6, 0.5, 6.5}});
+    h->GetXaxis()->SetBinLabel(1, "collisions");
+    h->GetXaxis()->SetBinLabel(2, "Lc (before cuts)");
+    h->GetXaxis()->SetBinLabel(3, "Lc (after cuts)");
+    h->GetXaxis()->SetBinLabel(4, "Soft #pi (before cuts)");
+    h->GetXaxis()->SetBinLabel(5, "Soft #pi (after cuts)");
+    h->GetXaxis()->SetBinLabel(6, "#Sigma_{c}");
 
     ////////////////////////////////////////
     /// set the selections for soft pion ///
     ////////////////////////////////////////
     // softPiCuts.SetPtRange(0.001, 1000.); // pt
     softPiCuts.SetEtaRange(-softPiEtaMax, softPiEtaMax); // eta
-    softPiCuts.SetMaxDcaXY(softPiDcaXYMax);              // dcaXY
-    softPiCuts.SetMaxDcaZ(softPiDcaZMax);                // dcaZ
-    // ITS hitmap
+    // softPiCuts.SetMaxDcaXY(softPiDcaXYMax);              // dcaXY
+    // softPiCuts.SetMaxDcaZ(softPiDcaZMax);                // dcaZ
+    //  ITS hitmap
     std::set<uint8_t> setSoftPiItsHitMap; // = {};
     for (int idItsLayer = 0; idItsLayer < 7; idItsLayer++) {
       if (TESTBIT(softPiItsHitMap, idItsLayer)) {
@@ -80,94 +113,140 @@ struct HfCandidateCreatorSigmac0plusplus {
     LOG(info) << "############";
     softPiCuts.SetRequireITSRefit();
     softPiCuts.SetRequireHitsInITSLayers(softPiItsHitsMin, setSoftPiItsHitMap);
+
+    /// CCDB for dcaXY, dcaZ recalculation of soft pions reassigned to another collision
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
+    runNumber = 0;
   }
 
-  /// @brief process function for Σc0,++ → Λc+(→pK-π+) π- candidate reconstruction
+  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+  // Preslice<CandidatesLc> hf3ProngPerCollision = aod::track_association::collisionId;
+  Preslice<CandidatesLc> hf3ProngPerCollision = aod::hf_cand::collisionId;
+
+  /// @brief process function for Σc0,++ → Λc+(→pK-π+) π- candidate reconstruction considering also reassigned tracks for soft pions
   /// @param collision is a o2::aod::Collision
   /// @param tracks are the tracks (with dcaXY, dcaZ information) in the collision → soft-pion candidate tracks
   /// @param candidates are 3-prong candidates satisfying the analysis selections for Λc+ → pK-π+ (and charge conj.)
-  void process(const o2::aod::Collision& collision, const TracksSigmac& tracks, soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>> const& candidates)
+  void process(const o2::aod::Collisions& collisions, aod::TrackAssoc const& trackIndices, const TracksSigmac& tracks, CandidatesLc const& candidates, aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
 
-    /// loop over Λc+ → pK-π+ (and charge conj.) candidates
-    for (auto const& candLc : candidates) {
+    for (auto const& collision : collisions) {
+      histos.fill(HIST("hCounter"), 1);
+      auto thisCollId = collision.globalIndex();
 
-      /// keep only the candidates flagged as possible Λc+ (and charge conj.) decaying into a charged pion, kaon and proton
-      /// if not selected, skip it and go to the next one
-      if (!(candLc.hfflag() & 1 << DecayType::LcToPKPi)) {
-        continue;
-      }
-      /// keep only the candidates Λc+ (and charge conj.) within the desired rapidity
-      /// if not selected, skip it and go to the next one
-      if (yCandLcMax >= 0. && std::abs(yLc(candLc)) > yCandLcMax) {
-        continue;
-      }
+      /// loop over Λc+ → pK-π+ (and charge conj.) candidates
+      auto candidatesThisColl = candidates.sliceBy(hf3ProngPerCollision, thisCollId);
+      for (auto const& candLc : candidatesThisColl) {
+        histos.fill(HIST("hCounter"), 2);
 
-      /// selection on the Λc+ inv. mass window we want to consider for Σc0,++ candidate creation
-      auto statusSpreadMinvPKPiFromPDG = 0;
-      auto statusSpreadMinvPiKPFromPDG = 0;
-      if (candLc.isSelLcToPKPi() >= 1 && std::abs(invMassLcToPKPi(candLc) - RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus)) <= mPKPiCandLcMax) {
-        statusSpreadMinvPKPiFromPDG = 1;
-      }
-      if (candLc.isSelLcToPiKP() >= 1 && std::abs(invMassLcToPiKP(candLc) - RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus)) <= mPiKPCandLcMax) {
-        statusSpreadMinvPiKPFromPDG = 1;
-      }
-      if (statusSpreadMinvPKPiFromPDG == 0 && statusSpreadMinvPiKPFromPDG == 0) {
-        /// none of the two possibilities are satisfied, therefore this candidate Lc can be skipped
-        continue;
-      }
-
-      /// loop over tracks
-      for (auto const& trackSoftPi : tracks) {
-
-        /////////////////////////////////////////////////////////////////////////////////
-        ///                       Σc0,++ candidate creation                           ///
-        ///                                                                           ///
-        /// For each candidate Λc, let's loop over all the candidate soft-pion tracks ///
-        /////////////////////////////////////////////////////////////////////////////////
-
-        /// keep only soft-pion candidate tracks
+        /// keep only the candidates flagged as possible Λc+ (and charge conj.) decaying into a charged pion, kaon and proton
         /// if not selected, skip it and go to the next one
-        if (!softPiCuts.IsSelected(trackSoftPi)) {
+        if (!(candLc.hfflag() & 1 << DecayType::LcToPKPi)) {
+          continue;
+        }
+        /// keep only the candidates Λc+ (and charge conj.) within the desired rapidity
+        /// if not selected, skip it and go to the next one
+        if (yCandLcMax >= 0. && std::abs(yLc(candLc)) > yCandLcMax) {
           continue;
         }
 
-        /// Exclude the current candidate soft pion if it corresponds already to a candidate Lc prong
-        int indexProng0 = candLc.prong0_as<aod::Tracks>().globalIndex();
-        int indexProng1 = candLc.prong1_as<aod::Tracks>().globalIndex();
-        int indexProng2 = candLc.prong2_as<aod::Tracks>().globalIndex();
-        int indexSoftPi = trackSoftPi.globalIndex();
-        if (indexSoftPi == indexProng0 || indexSoftPi == indexProng1 || indexSoftPi == indexProng2) {
+        /// selection on the Λc+ inv. mass window we want to consider for Σc0,++ candidate creation
+        auto statusSpreadMinvPKPiFromPDG = 0;
+        auto statusSpreadMinvPiKPFromPDG = 0;
+        if (candLc.isSelLcToPKPi() >= 1 && std::abs(invMassLcToPKPi(candLc) - RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus)) <= mPKPiCandLcMax) {
+          statusSpreadMinvPKPiFromPDG = 1;
+        }
+        if (candLc.isSelLcToPiKP() >= 1 && std::abs(invMassLcToPiKP(candLc) - RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus)) <= mPiKPCandLcMax) {
+          statusSpreadMinvPiKPFromPDG = 1;
+        }
+        if (statusSpreadMinvPKPiFromPDG == 0 && statusSpreadMinvPiKPFromPDG == 0) {
+          /// none of the two possibilities are satisfied, therefore this candidate Lc can be skipped
           continue;
         }
+        histos.fill(HIST("hCounter"), 3);
 
-        /// determine the Σc candidate charge
-        int chargeLc = candLc.prong0_as<TracksSigmac>().sign() + candLc.prong1_as<TracksSigmac>().sign() + candLc.prong2_as<TracksSigmac>().sign();
-        int chargeSoftPi = trackSoftPi.sign();
-        int8_t chargeSigmac = chargeLc + chargeSoftPi;
-        if (std::abs(chargeSigmac) != 0 && std::abs(chargeSigmac) != 2) {
-          /// this shall never happen
-          LOG(fatal) << ">>> Sc candidate with charge +1 built, not possible! Charge Lc: " << chargeLc << ", charge soft pion: " << chargeSoftPi;
-          continue;
-        }
+        /// loop over tracks
+        auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+        for (auto const& trackId : trackIdsThisCollision) {
 
-        /// fill the Σc0,++ candidate table
-        rowScCandidates(/* general columns */
-                        candLc.collisionId(),
-                        /* 2-prong specific columns */
-                        candLc.px(), candLc.py(), candLc.pz(),
-                        trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz(),
-                        candLc.globalIndex(), trackSoftPi.globalIndex(),
-                        candLc.hfflag(),
-                        /* Σc0,++ specific columns */
-                        chargeSigmac,
-                        statusSpreadMinvPKPiFromPDG, statusSpreadMinvPiKPFromPDG);
+          auto trackSoftPi = trackId.track_as<TracksSigmac>();
+          // auto trackSoftPi = tracks.rawIteratorAt(trackId.trackId());
+          histos.fill(HIST("hCounter"), 4);
 
-      } /// end loop over tracks
+          /////////////////////////////////////////////////////////////////////////////////
+          ///                       Σc0,++ candidate creation                           ///
+          ///                                                                           ///
+          /// For each candidate Λc, let's loop over all the candidate soft-pion tracks ///
+          /////////////////////////////////////////////////////////////////////////////////
 
-    } /// end loop over candidtes
+          /// keep only soft-pion candidate tracks
+          /// if not selected, skip it and go to the next one
+          if (!softPiCuts.IsSelected(trackSoftPi)) {
+            continue;
+          }
+          /// dcaXY, dcaZ selections
+          /// To be done separately from the others, because for reassigned tracks the dca must be recalculated
+          /// TODO: to be properly adapted in case of PV refit usage
+          if (trackSoftPi.collisionId() == thisCollId) {
+            /// this is a track originally assigned to the current collision
+            /// therefore, the dcaXY, dcaZ are those already calculated in the track-propagation workflow
+            if (std::abs(trackSoftPi.dcaXY()) > softPiDcaXYMax || std::abs(trackSoftPi.dcaZ()) > softPiDcaZMax) {
+              continue;
+            }
+          } else {
+            /// this is a reassigned track
+            /// therefore we need to calculate the dcaXY, dcaZ with respect to this new primary vertex
+            auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+            initCCDB(bc, runNumber, ccdb, isRun2Ccdb ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2Ccdb);
+            auto trackParSoftPi = getTrackPar(trackSoftPi);
+            o2::gpu::gpustd::array<float, 2> dcaInfo{-999., -999.};
+            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParSoftPi, 2.f, noMatCorr, &dcaInfo);
+            if (std::abs(dcaInfo[0]) > softPiDcaXYMax || std::abs(dcaInfo[1]) > softPiDcaZMax) {
+              continue;
+            }
+          }
 
-  } /// end process
+          /// Exclude the current candidate soft pion if it corresponds already to a candidate Lc prong
+          int indexProng0 = candLc.prong0_as<aod::Tracks>().globalIndex();
+          int indexProng1 = candLc.prong1_as<aod::Tracks>().globalIndex();
+          int indexProng2 = candLc.prong2_as<aod::Tracks>().globalIndex();
+          int indexSoftPi = trackSoftPi.globalIndex();
+          if (indexSoftPi == indexProng0 || indexSoftPi == indexProng1 || indexSoftPi == indexProng2) {
+            continue;
+          }
+          histos.fill(HIST("hCounter"), 5);
+
+          /// determine the Σc candidate charge
+          int chargeLc = candLc.prong0_as<TracksSigmac>().sign() + candLc.prong1_as<TracksSigmac>().sign() + candLc.prong2_as<TracksSigmac>().sign();
+          int chargeSoftPi = trackSoftPi.sign();
+          int8_t chargeSigmac = chargeLc + chargeSoftPi;
+          if (std::abs(chargeSigmac) != 0 && std::abs(chargeSigmac) != 2) {
+            /// this shall never happen
+            LOG(fatal) << ">>> Sc candidate with charge +1 built, not possible! Charge Lc: " << chargeLc << ", charge soft pion: " << chargeSoftPi;
+            continue;
+          }
+          histos.fill(HIST("hCounter"), 6);
+
+          /// fill the Σc0,++ candidate table
+          rowScCandidates(/* general columns */
+                          candLc.collisionId(),
+                          /* 2-prong specific columns */
+                          candLc.px(), candLc.py(), candLc.pz(),
+                          trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz(),
+                          candLc.globalIndex(), trackSoftPi.globalIndex(),
+                          candLc.hfflag(),
+                          /* Σc0,++ specific columns */
+                          chargeSigmac,
+                          statusSpreadMinvPKPiFromPDG, statusSpreadMinvPiKPFromPDG);
+        } /// end loop over tracks
+      }   /// end loop over candidates
+
+    }     /// end loop over collisions
+
+  }       /// end processWithAmbTracks
 };
 
 /// Extends the base table with expression columns.


### PR DESCRIPTION
 1. insert a new mask for Filters with only ITS quality cuts (useful for SigmaC soft pions)
 2. configurable for track-selections in track-to-coll. associator (good also for other developments)
 3. use re-associated tracks for SigmaC soft pions and add recalculation of dcaXY, dcaZ for reassigned tracks