### PR TITLE
PWGHF: fix logic for D0 PID

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -241,9 +241,7 @@ struct HfCandidateSelectorD0 {
           pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted) {
         pidD0 = 1; // accept D0
       } else if (pidTrackPosPion == TrackSelectorPID::Status::PIDRejected ||
-                 pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected ||
-                 pidTrackNegPion == TrackSelectorPID::Status::PIDAccepted ||
-                 pidTrackPosKaon == TrackSelectorPID::Status::PIDAccepted) {
+                 pidTrackNegKaon == TrackSelectorPID::Status::PIDRejected) {
         pidD0 = 0; // exclude D0
       }
 
@@ -251,9 +249,7 @@ struct HfCandidateSelectorD0 {
           pidTrackPosKaon == TrackSelectorPID::Status::PIDAccepted) {
         pidD0bar = 1; // accept D0bar
       } else if (pidTrackPosPion == TrackSelectorPID::Status::PIDAccepted ||
-                 pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted ||
-                 pidTrackNegPion == TrackSelectorPID::Status::PIDRejected ||
-                 pidTrackPosKaon == TrackSelectorPID::Status::PIDRejected) {
+                 pidTrackNegKaon == TrackSelectorPID::Status::PIDAccepted) {
         pidD0bar = 0; // exclude D0bar
       }
 


### PR DESCRIPTION
This PR fixes the issue with the max pT set for PID in the D0 selection, see e.g. selection efficiency (red) obtained by setting max pT=5 GeV/c:

<img width="650" alt="image" src="https://github.com/AliceO2Group/O2Physics/assets/19532765/9fb4f4fe-d090-4f7e-ba6e-50da19eea7f0">

In fact, in the previous version whenever one of the two track had pT > pTmax, the PID selection relied on the other track only. For example if it was supposed to be a kaon it was sufficient to be compatible with the pion hypothesis to be rejected, even if compatible with the kaon hypothesis. However, most of the kaons are compatible with pions and viceversa, especially if at high pT.
In general, the rejection of a kaon(pion) only based on the compatibility with pion(kaon) should be avoided, because it leads to drastic loss of efficiency (because pions and kaons are mostly overlapping, except for very low pT).
