### PR TITLE
Correct usage of time configurables - i/oTOF

### DIFF
--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -236,7 +236,7 @@ struct OnTheFlyTOFPID {
 
       // Smear with expected resolutions
       float measuredTimeInnerTOF = pRandomNumberGenerator.Gaus(expectedTimeInnerTOF, innerTOFTimeReso);
-      float measuredTimeOuterTOF = pRandomNumberGenerator.Gaus(expectedTimeOuterTOF, innerTOFTimeReso);
+      float measuredTimeOuterTOF = pRandomNumberGenerator.Gaus(expectedTimeOuterTOF, outerTOFTimeReso);
 
       // Now we calculate the expected arrival time following certain mass hypotheses
       // and the (imperfect!) reconstructed track parametrizations


### PR DESCRIPTION
* corrects a minor bug in which the inner TOF time resolution is used for the outer TOF resolution.  @hscheid this can't be why the outer TOF isn't great but it's still a bug...