### PR TITLE
Fix in the filterPPWithassociation + More Cuts in the Library

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -1025,6 +1025,18 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("muonHighPt5")) {
+    cut->AddCut(GetAnalysisCut("muonHighPt5"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+
+  if (!nameStr.compare("muonHighPt6")) {
+    cut->AddCut(GetAnalysisCut("muonHighPt6"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+
   if (!nameStr.compare("muonHighPtMatchingOnly2")) {
     cut->AddCut(GetAnalysisCut("muonHighPt2"));
     cut->AddCut(GetAnalysisCut("muonQualityCutsMatchingOnly"));
@@ -2064,6 +2076,16 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
   }
 
   if (!nameStr.compare("muonHighPt4")) {
+    cut->AddCut(VarManager::kPt, 8.0, 1000.0);
+    return cut;
+  }
+
+  if (!nameStr.compare("muonHighPt5")) {
+    cut->AddCut(VarManager::kPt, 10.0, 1000.0);
+    return cut;
+  }
+
+  if (!nameStr.compare("muonHighPt6")) {
     cut->AddCut(VarManager::kPt, 20.0, 1000.0);
     return cut;
   }

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -314,7 +314,7 @@ struct DQBarrelTrackSelection {
           trackTime = track.trackTime();
           trackTimeRes = track.trackTimeRes();
         }
-        const float deltaTime = trackTime - collTime + bcOffset * 25.f;
+        const float deltaTime = trackTime - collTime + bcOffset * constants::lhc::LHCBunchSpacingNS;
         float sigmaTimeRes2 = collTimeRes2 + trackTimeRes * trackTimeRes;
 
         // optimization to avoid looping over all collisions in the TF (loop just for +/- bOffsetMax around the track)
@@ -612,7 +612,9 @@ struct DQMuonsSelection {
   }
 
   template <uint32_t TMuonFillMap, typename TMuons>
-  void runMuonSelection(TMuons const& muons)
+  void runMuonSelection(Collisions const& collisions,
+                        TMuons const& muons,
+                        BCs const& bcs)
   {
     fSelectedMuons.clear();
 
@@ -642,11 +644,11 @@ struct DQMuonsSelection {
     } // end loop over muons
   }
 
-  void runCollisionMap(Collisions const& collisions, aod::BCsWithTimestamps const& bcs)
+  void runCollisionMap(Collisions const& collisions, aod::BCs const& bcs)
   {
     // association of time brackets to each collision
     for (auto& collision : collisions) {
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+      auto bc = collision.template bc_as<aod::BCs>();
       double t0 = bc.globalBC() * o2::constants::lhc::LHCBunchSpacingNS - collision.collisionTime();
       double err = collision.collisionTimeRes() * fSigmaVtx + fTimeMarginVtx;
       std::pair<double, double> timeBracket = {t0 - err, t0 + err};
@@ -739,8 +741,8 @@ struct DQMuonsSelection {
       return;
     }
 
-    std::map<int64_t, std::vector<int64_t>> collTrackIds;   // map to keep all collision-track associations (ordered based on the key by construction)
-    std::map<uint64_t, uint64_t> collBCmap;                 // map to hold collision - BC associations
+    std::map<int64_t, std::vector<int64_t>> collTrackIds; // map to keep all collision-track associations (ordered based on the key by construction)
+    std::map<uint64_t, uint64_t> collBCmap;               // map to hold collision - BC associations
 
     // first lets associate all the non-orphan muons to their primary collision Id
     for (auto const& [muonIdx, filterMap] : fSelectedMuons) {
@@ -845,7 +847,7 @@ struct DQMuonsSelection {
   template <typename TMuons>
   void associateMuonsToCollisionsAllTracks(Collisions const& collisions,
                                            TMuons const& muons,
-                                           BCsWithTimestamps const& bcs,
+                                           BCs const& bcs,
                                            AmbiguousFwdTracks const& ambiTracksFwd)
   {
     // first processing tracks registered in the ambigous tracks table
@@ -910,7 +912,7 @@ struct DQMuonsSelection {
       registry.fill(HIST("Association/AssociationTrackStatus"), 2);
       std::vector<int> vtxList;
       auto collision = collisions.rawIteratorAt(muon.collisionId() - collisions.offset());
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+      auto bc = collision.template bc_as<aod::BCs>();
       double t0 = muon.trackTime() + bc.globalBC() * o2::constants::lhc::LHCBunchSpacingNS - collision.collisionTime() + fTimeBias; // computing track time relative to associated collisino time
       double err = muon.trackTimeRes() * fSigmaTrack + fTimeMarginTrack;
       double tmin = t0 - err;
@@ -948,14 +950,13 @@ struct DQMuonsSelection {
   }
 
   void processSelection(Collisions const& collisions,
-                        BCsWithTimestamps const& bcstimestamp,
                         BCs const& bcs,
                         MyMuons const& muons,
                         soa::Filtered<MyMuons> const& filteredMuons,
                         AmbiguousFwdTracks const& ambFwdTracks)
   {
-    runMuonSelection<gkMuonFillMap>(filteredMuons);
-    runCollisionMap(collisions, bcstimestamp);
+    runMuonSelection<gkMuonFillMap>(collisions, filteredMuons, bcs);
+    runCollisionMap(collisions, bcs);
     if (fConfigCollisionMuonAssoc.value == 0) {
       associateMuonsToCollisionsStandard(collisions, muons);
     } else if (fConfigCollisionMuonAssoc.value == 1) {
@@ -963,7 +964,7 @@ struct DQMuonsSelection {
     } else if (fConfigCollisionMuonAssoc.value == 2) {
       associateMuonsToCollisionsAmbigous(collisions, muons, bcs, ambFwdTracks);
     } else {
-      associateMuonsToCollisionsAllTracks(collisions, muons, bcstimestamp, ambFwdTracks);
+      associateMuonsToCollisionsAllTracks(collisions, muons, bcs, ambFwdTracks);
       isMuonReassigned.clear();
       vtxOrdBrack.clear();
     }
@@ -1377,7 +1378,8 @@ struct DQFilterPPTask {
       } else {
         totalEventsTriggered++;
         for (int i = 0; i < fNBarrelCuts + fNMuonCuts; i++) {
-          fStats->Fill(static_cast<float>(i));
+          if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i))
+            fStats->Fill(static_cast<float>(i));
         }
         eventFilter(fFiltersMap[collision.globalIndex()]);
         auto dqDecisions = fCEFPfilters[collision.globalIndex()];

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -739,8 +739,8 @@ struct DQMuonsSelection {
       return;
     }
 
-    std::map<int64_t, std::vector<int64_t>> collTrackIds;   // map to keep all collision-track associations (ordered based on the key by construction)
-    std::map<uint64_t, uint64_t> collBCmap;                 // map to hold collision - BC associations
+    std::map<int64_t, std::vector<int64_t>> collTrackIds; // map to keep all collision-track associations (ordered based on the key by construction)
+    std::map<uint64_t, uint64_t> collBCmap;               // map to hold collision - BC associations
 
     // first lets associate all the non-orphan muons to their primary collision Id
     for (auto const& [muonIdx, filterMap] : fSelectedMuons) {
@@ -1377,7 +1377,8 @@ struct DQFilterPPTask {
       } else {
         totalEventsTriggered++;
         for (int i = 0; i < fNBarrelCuts + fNMuonCuts; i++) {
-            if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i)) fStats->Fill(static_cast<float>(i));
+          if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i))
+            fStats->Fill(static_cast<float>(i));
         }
         eventFilter(fFiltersMap[collision.globalIndex()]);
         auto dqDecisions = fCEFPfilters[collision.globalIndex()];


### PR DESCRIPTION
Fix in filterPPwithassociation :
 -Fill Histograms correctly
 -Replace BCsWithtimastamps with BCs to avoid segmentation fault breaks

Adding more Hight pT cuts for muons : 
 - pT >8 Gev/c & pT>10 GeV/C added as muonHighPt4 and muonHighPt5 repectively
 - pT > 20 GeV/c renamed as muonHighPt6