### PR TITLE
Monte Carlo: fixes and additional Histogramms

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -190,7 +190,6 @@ enum ParticleOriginMCTruth {
   kDaughter,          //! Particle from a decay
   kMaterial,          //! Particle from a material
   kNotPrimary,        //! Not primary particles (kept for compatibility reasons with the FullProducer task. will be removed, since we look at "non primaries" more differentially now)
-  // kFake,              //! particle, that has NOT the PDG code of the current analysed particle
   kDaughterLambda,    //! Daughter from a Lambda decay
   kDaughterSigmaplus, //! Daughter from a Sigma^plus decay
   kNOriginMCTruthTypes
@@ -202,7 +201,6 @@ static constexpr std::string_view ParticleOriginMCTruthName[kNOriginMCTruthTypes
   "_Daughter",
   "_Material",
   "_NotPrimary",
-  //"_Fake",
   "_DaughterLambda",
   "DaughterSigmaPlus"};
 

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -57,7 +57,7 @@ enum ParticleType {
 };
 
 static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeBachelor"}; //! Naming of the different particle types
-static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/DCAxy", "/CPA", "/DCAxy", "/CPA", "/DCAxy"};
+static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy"};
 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 
@@ -190,7 +190,7 @@ enum ParticleOriginMCTruth {
   kDaughter,          //! Particle from a decay
   kMaterial,          //! Particle from a material
   kNotPrimary,        //! Not primary particles (kept for compatibility reasons with the FullProducer task. will be removed, since we look at "non primaries" more differentially now)
-  kFake,              //! particle, that has NOT the PDG code of the current analysed particle
+  // kFake,              //! particle, that has NOT the PDG code of the current analysed particle
   kDaughterLambda,    //! Daughter from a Lambda decay
   kDaughterSigmaplus, //! Daughter from a Sigma^plus decay
   kNOriginMCTruthTypes
@@ -202,7 +202,7 @@ static constexpr std::string_view ParticleOriginMCTruthName[kNOriginMCTruthTypes
   "_Daughter",
   "_Material",
   "_NotPrimary",
-  "_Fake",
+  //"_Fake",
   "_DaughterLambda",
   "DaughterSigmaPlus"};
 

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -120,6 +120,7 @@ class FemtoDreamParticleHisto
   void init_MC(std::string folderName, std::string tempFitVarAxisTitle, T& tempFitVarpTAxis, T& tempFitVarAxis)
   {
     /// Particle-type specific histograms
+    // TODO Continue here: mHistogramRegistry->add((folderName + folderSuffix + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str();
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
       /// Track histograms
@@ -130,7 +131,7 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{8, 0, 7}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hNoMCtruthCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Material").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Fake").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
+      //mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Fake").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterLambda").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterSigmaplus").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Primary").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
@@ -283,10 +284,10 @@ class FemtoDreamParticleHisto
             mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_NotPrimary"),
                                      part.pt(), part.tempFitVar());
             break;
-          case (o2::aod::femtodreamMCparticle::kFake):
-            mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_Fake"),
-                                     part.pt(), part.tempFitVar());
-            break;
+          //case (o2::aod::femtodreamMCparticle::kFake):
+          //  mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_Fake"),
+          //                           part.pt(), part.tempFitVar());
+          // break;
           case (o2::aod::femtodreamMCparticle::kDaughterLambda):
             mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_DaughterLambda"),
                                      part.pt(), part.tempFitVar());

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -122,19 +122,15 @@ class FemtoDreamParticleHisto
     /// Particle-type specific histograms
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]).c_str();
     
-    mHistogramRegistry->add((folderName + folderSuffix + "/hPt_NoFake").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hPt_ReconNoFake").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
    
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
       /// Track histograms
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hPt_MC").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hEta_MC").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hPhi_MC").c_str(), "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hPDG").c_str(), "; PDG; Entries", kTH1I, {{6001, -3000, 3000}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{8, 0, 7}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{7, 0, 7}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hNoMCtruthCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
       //DCA plots 
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Material").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Fake").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterLambda").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_DaughterSigmaplus").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy_Primary").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {tempFitVarpTAxis, tempFitVarAxis});
@@ -265,24 +261,22 @@ class FemtoDreamParticleHisto
   /// \tparam T Data type of the particle
   /// \tparam TMC Data typ of the Monte Carlo Particle
   /// \param part Particle
-  /// \param partMC Monte Carlo Particle
   /// \param mctruthorigin Origin of the associated mc Truth particle
-  template <typename T, typename TMC>
-  //void fillQA_MC(T const& part, int mctruthorigin, int pdgcode)
-  void fillQA_MC(T const& part, TMC const& partMC)
+  /// \param pdgcode PDG of the associated mc Truth particle associated to the reconstructed particle part
+  template <typename T>
+  void fillQA_MC(T const& part, int mctruthorigin, int pdgcode)
   {
     if (mHistogramRegistry) {
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hPDG").c_str(), "; PDG; Entries", kTH1I, {{6001, -3000, 3000}});
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{8, 0, 7}});
-      //mHistogramRegistry->add((folderName + folderSuffix + "/hNoMCtruthCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
-      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPDG"), partMC.pdgMCTruth());
-      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hOrigin_MC"), partMC.partOriginMCTruth());
-      if(abs(partMC.pdgMCTruth()) == mPDG){
-        mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_NoFake"), part.pt());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPDG"), pdgcode);
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hOrigin_MC"), mctruthorigin);
+      
+      if(abs(pdgcode) == mPDG){ //fill this histogramm only for TRUE protons (independently of their origin) for the track purity estimation
+        mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_ReconNoFake"), part.pt());
       }
+
       if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
         /// Track histograms
-        switch (partMC.partOriginMCTruth()) {
+        switch (mctruthorigin) {
           case (o2::aod::femtodreamMCparticle::kPrimary):
             mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_Primary"),
                                      part.pt(), part.tempFitVar());
@@ -299,10 +293,6 @@ class FemtoDreamParticleHisto
             mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_NotPrimary"),
                                      part.pt(), part.tempFitVar());
             break;
-          //case (o2::aod::femtodreamMCparticle::kFake):
-          //  mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_Fake"),
-          //                           part.pt(), part.tempFitVar());
-          // break;
           case (o2::aod::femtodreamMCparticle::kDaughterLambda):
             mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hDCAxy_DaughterLambda"),
                                      part.pt(), part.tempFitVar());
@@ -342,8 +332,7 @@ class FemtoDreamParticleHisto
       if constexpr (isMC) {
         if (part.has_femtoDreamMCParticle()) {
           fillQA_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(part.femtoDreamMCParticle());
-          //fillQA_MC(part, (part.femtoDreamMCParticle()).partOriginMCTruth(), (part.femtoDreamMCParticle()).pdgMCTruth());
-          fillQA_MC(part, part.femtoDreamMCParticle());
+          fillQA_MC(part, (part.femtoDreamMCParticle()).partOriginMCTruth(), (part.femtoDreamMCParticle()).pdgMCTruth());
         }else{
           mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hNoMCtruthCounter"), 0);
         }
@@ -356,7 +345,7 @@ class FemtoDreamParticleHisto
   static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType;   ///< Type of the particle under analysis
   static constexpr int mFolderSuffixType = suffixType;                                       ///< Counter for the folder suffix specified below
   static constexpr std::string_view mFolderSuffix[5] = {"", "_one", "_two", "_pos", "_neg"}; ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
-  int mPDG = 0;
+  int mPDG = 0;                                                                              ///< PDG code of the selected particle
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -129,9 +129,9 @@ struct femtoDreamPairTaskTrackTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartOne);
     if (!ConfIsSame) {
-      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC);
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartTwo);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -124,8 +124,8 @@ struct femtoDreamPairTaskTrackV0 {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfIsMC);
-    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfIsMC);
+    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfIsMC, ConfTrkPDGCodePartOne);
+    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfIsMC, ConfV0PDGCodePartTwo);
     posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
     negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
 

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -199,20 +199,20 @@ struct femtoDreamProducerReducedTask {
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
-      if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
+      // if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
 
-        if (particleMC.isPhysicalPrimary()) {
-          particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
-        } else if (motherparticleMC.producedByGenerator()) {
-          particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
-        } else {
-          particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
-        }
-
+      if (particleMC.isPhysicalPrimary()) {
+        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
+      } else if (motherparticleMC.producedByGenerator()) {
+        particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
       } else {
-
-        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
+        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
       }
+
+      // } else {
+
+      //  particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
+      // }
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
     } else {

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -199,8 +199,6 @@ struct femtoDreamProducerReducedTask {
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
-      // if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
-
       if (particleMC.isPhysicalPrimary()) {
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
       } else if (motherparticleMC.producedByGenerator()) {
@@ -209,10 +207,6 @@ struct femtoDreamProducerReducedTask {
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
       }
 
-      // } else {
-
-      //  particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
-      // }
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
     } else {

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -348,17 +348,19 @@ struct femtoDreamProducerTask {
       auto pdgCode = particleMC.pdgCode();
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
-      if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
-        if (particleMC.isPhysicalPrimary()) {
-          particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
-        } else if (motherparticleMC.producedByGenerator()) {
-          particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
-        } else {
-          particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
-        }
+      //if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
+      
+      if (particleMC.isPhysicalPrimary()) {
+        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
+      } else if (motherparticleMC.producedByGenerator()) {
+        particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
       } else {
-        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
+        particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
       }
+
+      //} else {
+      //  particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
+      //}
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
     } else {

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -348,7 +348,6 @@ struct femtoDreamProducerTask {
       auto pdgCode = particleMC.pdgCode();
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
-      //if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
       
       if (particleMC.isPhysicalPrimary()) {
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
@@ -358,9 +357,6 @@ struct femtoDreamProducerTask {
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
       }
 
-      //} else {
-      //  particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
-      //}
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
     } else {


### PR DESCRIPTION
**Fixes:**
- We removed the entry `kFake` in the enum `ParticleOriginMCTruth` since we can distinguish fake and real candidates in Monte Carlo directly via their PDG code.
- The TempFitVar plots (for tracks the DCA) are filled only in cathegories according to their origin and not according to their species (i.e. if they are fake or not)

**New histogramms:**
In order to estimate the purity in a pT and kstar dependent way, we added the histogramms with the suffix `_NoFakeCandidates`. They are filled with the same values as the histogramms with Monte Carlo reconstructed, but only if the track candidate (or both candidates in the kstar plots) have the correct PDG code.

**Some rearrangements** in the `SetPair` functions in `FemtoDreamContainer` in order to calculate values only once and passing them where they are needed to fill the histogramm instead of recalculating every time.