### PR TITLE
Tools/KFparticle: Fix event selection

### DIFF
--- a/Tools/KFparticle/qaKFEventTrack.cxx
+++ b/Tools/KFparticle/qaKFEventTrack.cxx
@@ -109,6 +109,9 @@ struct qaKFEventTrack {
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
 
+  
+  Filter eventFilter = (o2::aod::evsel::sel8 == true);
+
   using CollisionTableData = soa::Join<aod::Collisions, aod::EvSels, aod::Mults>;
   using TrackTableData = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA, aod::TrackSelection>;
 
@@ -218,16 +221,6 @@ struct qaKFEventTrack {
     hSelectionMC->GetXaxis()->SetBinLabel(hSelectionMC->FindBin(5), "DCA Z > 10cm");
   } /// End init
 
-  /// Function to select collisions
-  template <typename T>
-  bool isSelectedCollision(const T& collision)
-  {
-    /// Trigger selection
-    if (eventSelection && !(isRun3 ? collision.sel8() : collision.sel7())) { // currently only sel8 is defined for run3
-      return false;
-    }
-    return true;
-  }
 
   /// Function for single track selection
   template <typename T>
@@ -294,7 +287,7 @@ struct qaKFEventTrack {
   }
 
   /// Process function for data
-  void processData(CollisionTableData::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
+  void processData(soa::Filtered<CollisionTableData>::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     if (runNumber != bc.runNumber()) {
@@ -312,10 +305,6 @@ struct qaKFEventTrack {
       histos.fill(HIST("Events/covYY"), collision.covYY());
       histos.fill(HIST("Events/covYZ"), collision.covYZ());
       histos.fill(HIST("Events/covZZ"), collision.covZZ());
-    }
-    /// Apply event selection
-    if (!isSelectedCollision(collision)) {
-      return;
     }
     /// set KF primary vertex
     KFPVertex kfpVertex = createKFPVertexFromCollision(collision);
@@ -382,7 +371,7 @@ struct qaKFEventTrack {
   using CollisionTableDataMult = soa::Join<aod::Collisions, aod::Mults, aod::McCollisionLabels>;
   using TrackTableMC = soa::Join<TrackTableData, aod::McTrackLabels>;
   // Preslice<aod::McCollisionLabels> perMcCollision = aod::mccollisionlabel::mcCollisionId;
-  void processMC(CollisionTableMC::iterator const& collision, CollisionTableMC const& collisions, soa::Filtered<TrackTableMC> const& tracks, aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions, aod::BCsWithTimestamps const&)
+  void processMC(soa::Filtered<CollisionTableMC>::iterator const& collision, soa::Filtered<CollisionTableMC> const& collisions, soa::Filtered<TrackTableMC> const& tracks, aod::McParticles const& mcParticles, soa::Filtered<aod::McCollisions> const& mcCollisions, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     if (runNumber != bc.runNumber()) {
@@ -405,11 +394,6 @@ struct qaKFEventTrack {
       histos.fill(HIST("Events/covYY"), collision.covYY());
       histos.fill(HIST("Events/covYZ"), collision.covYZ());
       histos.fill(HIST("Events/covZZ"), collision.covZZ());
-    }
-
-    /// Apply event selection
-    if (!isSelectedCollision(collision)) {
-      return;
     }
     /// set KF primary vertex
     KFPVertex kfpVertex = createKFPVertexFromCollision(collision);

--- a/Tools/KFparticle/qaKFEventTrack.cxx
+++ b/Tools/KFparticle/qaKFEventTrack.cxx
@@ -109,7 +109,6 @@ struct qaKFEventTrack {
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
 
-  
   Filter eventFilter = (o2::aod::evsel::sel8 == true);
 
   using CollisionTableData = soa::Join<aod::Collisions, aod::EvSels, aod::Mults>;
@@ -220,7 +219,6 @@ struct qaKFEventTrack {
     hSelectionMC->GetXaxis()->SetBinLabel(hSelectionMC->FindBin(4), "Wrong PV");
     hSelectionMC->GetXaxis()->SetBinLabel(hSelectionMC->FindBin(5), "DCA Z > 10cm");
   } /// End init
-
 
   /// Function for single track selection
   template <typename T>

--- a/Tools/KFparticle/qaKFParticle.cxx
+++ b/Tools/KFparticle/qaKFParticle.cxx
@@ -144,9 +144,7 @@ struct qaKFParticle {
   Filter trackFilterEta = (nabs(aod::track::eta) < 0.8f);
   Filter trackFilterPTMin = (aod::track::pt > d_pTMin);
 
-
   Filter eventFilter = (o2::aod::evsel::sel8 == true);
-
 
   using CollisionTableData = soa::Join<aod::Collisions, aod::EvSels>;
   using BigTracks = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra>;

--- a/Tools/KFparticle/qaKFParticle.cxx
+++ b/Tools/KFparticle/qaKFParticle.cxx
@@ -81,8 +81,6 @@ struct qaKFParticle {
   /// Histogram Configurables
   ConfigurableAxis binsPt{"binsPt", {VARIABLE_WIDTH, 0.0, 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 24., 36., 50.0}, ""};
 
-  /// option to select good events
-  Configurable<bool> eventSelection{"eventSelection", true, "select good events"}; // currently only sel8 is defined for run3
   /// options to select only specific tracks
   Configurable<int> trackSelection{"trackSelection", 1, "Track selection: 0 -> No Cut, 1 -> kGlobalTrack, 2 -> kGlobalTrackWoPtEta, 3 -> kGlobalTrackWoDCA, 4 -> kQualityTracks, 5 -> kInAcceptanceTracks"};
 
@@ -142,6 +140,13 @@ struct qaKFParticle {
                        ((trackSelection.node() == 3) && requireGlobalTrackWoDCAInFilter()) ||
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
+
+  Filter trackFilterEta = (nabs(aod::track::eta) < 0.8f);
+  Filter trackFilterPTMin = (aod::track::pt > d_pTMin);
+
+
+  Filter eventFilter = (o2::aod::evsel::sel8 == true);
+
 
   using CollisionTableData = soa::Join<aod::Collisions, aod::EvSels>;
   using BigTracks = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra>;
@@ -326,43 +331,10 @@ struct qaKFParticle {
     histos.print();
   } /// End init
 
-  /// Function to select collisions
-  template <typename T>
-  bool isSelectedCollision(const T& collision)
-  {
-    /// Trigger selection
-    if (eventSelection && !(isRun3 ? collision.sel8() : collision.sel7())) { // currently only sel8 is defined for run3
-      return false;
-    }
-    /// Reject collisions with negative covariance matrix elemts on the digonal
-    if (collision.covXX() < 0. || collision.covYY() < 0. || collision.covZZ() < 0.) {
-      histos.fill(HIST("DZeroCandTopo/Selections"), 2.f);
-      return false;
-    }
-    return true;
-  }
-
   /// Function for single track selection
   template <typename T>
   bool isSelectedTracks(const T& track1, const T& track2)
   {
-    if (track1.p() < d_pTMin) {
-      histos.fill(HIST("DZeroCandTopo/Selections"), 4.f);
-      return false;
-    }
-    if (track2.p() < d_pTMin) {
-      histos.fill(HIST("DZeroCandTopo/Selections"), 4.f);
-      return false;
-    }
-    /// Eta range
-    if (abs(track1.eta()) > d_etaRange) {
-      histos.fill(HIST("DZeroCandTopo/Selections"), 5.f);
-      return false;
-    }
-    if (abs(track2.eta()) > d_etaRange) {
-      histos.fill(HIST("DZeroCandTopo/Selections"), 5.f);
-      return false;
-    }
     /// DCA XY of the daughter tracks to the primaty vertex
     if (track1.dcaXY() > d_dcaXYTrackPV) {
       histos.fill(HIST("DZeroCandTopo/Selections"), 6.f);
@@ -679,7 +651,7 @@ struct qaKFParticle {
   }
 
   /// Process function for data
-  void processData(CollisionTableData::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
+  void processData(soa::Filtered<CollisionTableData>::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     if (runNumber != bc.runNumber()) {
@@ -692,10 +664,6 @@ struct qaKFParticle {
     }
 
     histos.fill(HIST("DZeroCandTopo/Selections"), 1.f);
-    /// Apply event selection
-    if (!isSelectedCollision(collision)) {
-      return;
-    }
     /// set KF primary vertex
     KFPVertex kfpVertex = createKFPVertexFromCollision(collision);
     KFParticle KFPV(kfpVertex);
@@ -885,7 +853,7 @@ struct qaKFParticle {
   using CollisionTableDataMult = soa::Join<aod::Collisions, aod::McCollisionLabels>;
   using TrackTableMC = soa::Join<TrackTableData, aod::McTrackLabels>;
   // Preslice<o2::aod::McCollisionLabels> perMcCollision = o2::aod::mccollisionlabel::mcCollisionId;
-  void processMC(CollisionTableMC::iterator const& collision, CollisionTableMC const& collisions, soa::Filtered<TrackTableMC> const& tracks, aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions, aod::BCsWithTimestamps const&)
+  void processMC(soa::Filtered<CollisionTableMC>::iterator const& collision, soa::Filtered<CollisionTableMC> const& collisions, soa::Filtered<TrackTableMC> const& tracks, aod::McParticles const& mcParticles, soa::Filtered<aod::McCollisions> const& mcCollisions, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     if (runNumber != bc.runNumber()) {
@@ -901,10 +869,6 @@ struct qaKFParticle {
       return;
     }
     histos.fill(HIST("DZeroCandTopo/Selections"), 1.f);
-    /// Apply event selection
-    if (!isSelectedCollision(collision)) {
-      return;
-    }
     /// set KF primary vertex
     KFPVertex kfpVertex = createKFPVertexFromCollision(collision);
     KFParticle KFPV(kfpVertex);

--- a/Tools/KFparticle/qaKFParticleLc.cxx
+++ b/Tools/KFparticle/qaKFParticleLc.cxx
@@ -144,6 +144,11 @@ struct qaKFParticleLc {
                        ((trackSelection.node() == 3) && requireGlobalTrackWoDCAInFilter()) ||
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
+  
+  Filter trackFilterEta = (nabs(aod::track::eta) < 0.8f);
+  Filter trackFilterPTMin = (aod::track::pt > d_pTMin);
+
+  Filter eventFilter = (o2::aod::evsel::sel8 == true);
 
   using CollisionTableData = soa::Join<aod::Collisions, aod::EvSels>;
   using BigTracks = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra>;
@@ -195,32 +200,10 @@ struct qaKFParticleLc {
     runNumber = 0;
   } /// End init
 
-  /// Function to select collisions
-  template <typename T>
-  bool isSelectedCollision(const T& collision)
-  {
-    /// Trigger selection
-    if (eventSelection && !(isRun3 ? collision.sel8() : collision.sel7())) { // currently only sel8 is defined for run3
-      return false;
-    }
-    /// Reject collisions with negative covariance matrix elemts on the digonal
-    if (collision.covXX() < 0. || collision.covYY() < 0. || collision.covZZ() < 0.) {
-      return false;
-    }
-    return true;
-  }
-
   /// Function for single track selection
   template <typename T>
   bool isSelectedTracks(const T& track1, const T& track2, const T& track3)
   {
-    if ((track1.p() < d_pTMin) || (track2.p() < d_pTMin) || (track3.p() < d_pTMin)) {
-      return false;
-    }
-    /// Eta range
-    if ((abs(track1.eta()) > d_etaRange) || (abs(track2.eta()) > d_etaRange) || (abs(track3.eta()) > d_etaRange)) {
-      return false;
-    }
     /// DCA XY of the daughter tracks to the primaty vertex
     if ((track1.dcaXY() > d_dcaXYTrackPV) || (track2.dcaXY() > d_dcaXYTrackPV) || (track3.dcaXY() > d_dcaXYTrackPV)) {
       return false;
@@ -486,7 +469,7 @@ struct qaKFParticleLc {
   }
 
   /// Process function for data
-  void processData(CollisionTableData::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
+  void processData(soa::Filtered<CollisionTableData>::iterator const& collision, soa::Filtered<TrackTableData> const& tracks, aod::BCsWithTimestamps const&)
   {
 
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
@@ -497,10 +480,6 @@ struct qaKFParticleLc {
 #ifdef HomogeneousField
       KFParticle::SetField(magneticField);
 #endif
-    }
-    /// Apply event selection
-    if (!isSelectedCollision(collision)) {
-      return;
     }
     /// set KF primary vertex
     KFPVertex kfpVertex = createKFPVertexFromCollision(collision);

--- a/Tools/KFparticle/qaKFParticleLc.cxx
+++ b/Tools/KFparticle/qaKFParticleLc.cxx
@@ -144,7 +144,7 @@ struct qaKFParticleLc {
                        ((trackSelection.node() == 3) && requireGlobalTrackWoDCAInFilter()) ||
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
-  
+
   Filter trackFilterEta = (nabs(aod::track::eta) < 0.8f);
   Filter trackFilterPTMin = (aod::track::pt > d_pTMin);
 


### PR DESCRIPTION
Fix event selection with sel8 trigger as filter:
Previously, the event selection was not working because a retrun was used. In the PR the event selection is replaced by a filter and the filtered events are passed to the process function. Like this, the event selection is always applied properly.
Also, the simple track selections are replaced by a filter.
@lupengzhong, @ddobrigk 