### PR TITLE
PWGHF: adding flag to select Ds decay channel in candidateCreator3Prong

### DIFF
--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -29,6 +29,7 @@ using namespace o2::aod::hf_cand_3prong;
 
 /// Ds± analysis task
 struct HfTaskDs {
+  Configurable<int> DsChannelCase{"DsChannelCase", 1, "Int to consider the decay channel: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits"};
@@ -231,6 +232,9 @@ struct HfTaskDs {
         continue;
       }
       if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
+        if (candidate.flagMcDecayChanRec() != DsChannelCase) {
+          continue;
+        }
         auto prong0McPart = candidate.prong0_as<aod::BigTracksMC>().mcParticle_as<candDsMcGen>();
         auto indexMother = RecoDecay::getMother(particlesMC, prong0McPart, pdg::Code::kDS, true);
         auto particleMother = particlesMC.iteratorAt(indexMother);
@@ -257,6 +261,9 @@ struct HfTaskDs {
     // MC gen.
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi) {
+        if (particle.flagMcDecayChanGen() != DsChannelCase) {
+          continue;
+        }
         auto pt = particle.pt();
         auto y = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandMax >= 0. && std::abs(y) > yCandMax) {

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -29,7 +29,7 @@ using namespace o2::aod::hf_cand_3prong;
 
 /// Ds± analysis task
 struct HfTaskDs {
-  Configurable<int> DsChannelCase{"DsChannelCase", 1, "Int to consider the decay channel: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};
+  Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits"};
@@ -232,7 +232,7 @@ struct HfTaskDs {
         continue;
       }
       if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
-        if (candidate.flagMcDecayChanRec() != DsChannelCase) {
+        if (candidate.flagMcDecayChanRec() != decayChannel) {
           continue;
         }
         auto prong0McPart = candidate.prong0_as<aod::BigTracksMC>().mcParticle_as<candDsMcGen>();
@@ -261,7 +261,7 @@ struct HfTaskDs {
     // MC gen.
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi) {
-        if (particle.flagMcDecayChanGen() != DsChannelCase) {
+        if (particle.flagMcDecayChanGen() != decayChannel) {
           continue;
         }
         auto pt = particle.pt();

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -800,7 +800,7 @@ auto invMassDplusToPiKPi(const T& candidate)
 
 enum DecayChannelDs {
   PhiPi = 1,
-  K0stK
+  K0starK
 };
 
 template <typename T>

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -798,6 +798,11 @@ auto invMassDplusToPiKPi(const T& candidate)
 
 // Ds± → K± K∓ π±
 
+enum DecayChannelDs {
+  PhiPi = 1,
+  K0stK
+};
+
 template <typename T>
 auto ctDs(const T& candidate)
 {

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -250,6 +250,8 @@ struct HfCandidateCreator3ProngExpressions {
     std::array<int, 2> arrPDGResonant1 = {kProton, 313};  // Λc± → p± K*
     std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};  // Λc± → Δ(1232)±± K∓
     std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus}; // Λc± → Λ(1520) π±
+    std::array<int, 2> arrPDGResonantDsPhiPi = {333, kPiPlus}; // Ds± → Phi π±
+    std::array<int, 2> arrPDGResonantDsKstK = {313, kKPlus}; // Ds± → K*(892)0bar K±
 
     // Match reconstructed candidates.
     // Spawned table can be used directly
@@ -275,6 +277,21 @@ struct HfCandidateCreator3ProngExpressions {
         indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDS, array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           flag = sign * (1 << DecayType::DsToKKPi);
+          if (arrayDaughters[0].has_mcParticle()) {
+            swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
+          }
+          RecoDecay::getDaughters(particlesMC.rawIteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
+          if (arrDaughIndex.size() == 2) {
+            for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
+              auto daughI = particlesMC.rawIteratorAt(arrDaughIndex[iProng]);
+              arrPDGDaugh[iProng] = std::abs(daughI.pdgCode());
+            }
+            if ((arrPDGDaugh[0] == arrPDGResonantDsPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDsPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[0])) {
+              channel = DecayChannelDs::PhiPi;
+            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstK[0])) {
+              channel = DecayChannelDs::K0stK;
+            }
+          } 
         }
       }
 
@@ -343,6 +360,18 @@ struct HfCandidateCreator3ProngExpressions {
         // Printf("Checking Ds± → K± K∓ π±");
         if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kDS, array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           flag = sign * (1 << DecayType::DsToKKPi);
+          RecoDecay::getDaughters(particle, &arrDaughIndex, array{0}, 1);
+          if (arrDaughIndex.size() == 2) {
+            for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
+              auto daughJ = particlesMC.rawIteratorAt(arrDaughIndex[jProng]);
+              arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
+            }
+            if ((arrPDGDaugh[0] == arrPDGResonantDsPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDsPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[0])) {
+              channel = DecayChannelDs::PhiPi;
+            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstK[0])) {
+              channel = DecayChannelDs::K0stK;
+            }
+          }
         }
       }
 

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -251,7 +251,7 @@ struct HfCandidateCreator3ProngExpressions {
     std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};  // Λc± → Δ(1232)±± K∓
     std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus}; // Λc± → Λ(1520) π±
     std::array<int, 2> arrPDGResonantDsPhiPi = {333, kPiPlus}; // Ds± → Phi π±
-    std::array<int, 2> arrPDGResonantDsKstK = {313, kKPlus}; // Ds± → K*(892)0bar K±
+    std::array<int, 2> arrPDGResonantDsKstarK = {313, kKPlus};   // Ds± → K*(892)0bar K±
 
     // Match reconstructed candidates.
     // Spawned table can be used directly
@@ -288,8 +288,8 @@ struct HfCandidateCreator3ProngExpressions {
             }
             if ((arrPDGDaugh[0] == arrPDGResonantDsPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDsPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[0])) {
               channel = DecayChannelDs::PhiPi;
-            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstK[0])) {
-              channel = DecayChannelDs::K0stK;
+            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstarK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstarK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstarK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstarK[0])) {
+              channel = DecayChannelDs::K0starK;
             }
           } 
         }
@@ -368,8 +368,8 @@ struct HfCandidateCreator3ProngExpressions {
             }
             if ((arrPDGDaugh[0] == arrPDGResonantDsPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDsPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDsPhiPi[0])) {
               channel = DecayChannelDs::PhiPi;
-            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstK[0])) {
-              channel = DecayChannelDs::K0stK;
+            } else if ((arrPDGDaugh[0] == arrPDGResonantDsKstarK[0] && arrPDGDaugh[1] == arrPDGResonantDsKstarK[1]) || (arrPDGDaugh[0] == arrPDGResonantDsKstarK[1] && arrPDGDaugh[1] == arrPDGResonantDsKstarK[0])) {
+              channel = DecayChannelDs::K0starK;
             }
           }
         }


### PR DESCRIPTION
This PR contains a flag to select Ds decay channel to be considered in 3Prongs MC Gen matching to be consistent with AliPhysics.
Three possible options available: 

1. flag = 0 -> Ds->PhiPi->KKPi, default (fig1)
2. flag = 1 -> Ds->K*0barK->KKPi (fig2)
3. flag = 2 -> Both (fig3)

[Flag_0.pdf](https://github.com/AliceO2Group/O2Physics/files/11488424/Flag_0.pdf) fig1
[Flag_1.pdf](https://github.com/AliceO2Group/O2Physics/files/11488426/Flag_1.pdf) fig2
[Flag_2.pdf](https://github.com/AliceO2Group/O2Physics/files/11488428/Flag_2.pdf) fig3