### PR TITLE
Optimizations to builders

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -287,10 +287,11 @@ DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
 namespace cascdata
 {
 // Necessary for full filtering functionality
-DECLARE_SOA_INDEX_COLUMN(V0, v0);                                   //!
-DECLARE_SOA_INDEX_COLUMN(Cascade, cascade);                         //!
-DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, ""); //!
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                     //!
+DECLARE_SOA_INDEX_COLUMN(V0, v0);                                           //!
+DECLARE_SOA_INDEX_COLUMN(Cascade, cascade);                                 //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, "");         //!
+DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrack, strangeTrack, int, Tracks, ""); //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                             //!
 // General cascade properties: position, momentum
 DECLARE_SOA_COLUMN(Sign, sign, int);         //!
 DECLARE_SOA_COLUMN(MXi, mXi, float);         //!
@@ -414,7 +415,7 @@ DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
                   cascdata::Phi<cascdata::Px, cascdata::Py>);
 
 DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
-                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId,
+                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::StrangeTrackId, cascdata::CollisionId,
                   cascdata::Sign, cascdata::MXi, cascdata::MOmega,
                   cascdata::X, cascdata::Y, cascdata::Z,
                   cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda,

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -913,6 +913,7 @@ struct cascadeBuilder {
         trackedcascdata(cascadecandidate.v0Id,
                         cascade.globalIndex(),
                         cascadecandidate.bachelorId,
+                        trackedCascade.trackId(),
                         cascade.collisionId(),
                         cascadecandidate.charge, trackedCascade.xiMass(), trackedCascade.omegaMass(), // <--- stratrack masses
                         trackedCascade.decayX(), trackedCascade.decayY(), trackedCascade.decayZ(),    // <--- stratrack position
@@ -998,17 +999,28 @@ struct cascadePreselector {
   // context-aware selections
   Configurable<bool> dPreselectOnlyBaryons{"dPreselectOnlyBaryons", false, "apply TPC dE/dx and quality only to baryon daughters"};
 
+  std::vector<char> trackQualityMask;
+  std::vector<char> mcLabelMaskXiMinus;
+  std::vector<char> mcLabelMaskXiPlus;
+  std::vector<char> mcLabelMaskOmegaMinus;
+  std::vector<char> mcLabelMaskOmegaPlus;
+  std::vector<char> dEdxMaskXiMinus;
+  std::vector<char> dEdxMaskXiPlus;
+  std::vector<char> dEdxMaskOmegaMinus;
+  std::vector<char> dEdxMaskOmegaPlus;
+  std::vector<char> usedInTrackedCascadeMask;
+
   void init(InitContext const&) {}
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check track quality
   template <class TTrackTo, typename TCascadeObject>
-  void checkTrackQuality(TCascadeObject const& lCascadeCandidate, bool& lIsInteresting, bool lIsXiMinus, bool lIsXiPlus, bool lIsOmegaMinus, bool lIsOmegaPlus)
+  void checkTrackQuality(TCascadeObject const& lCascadeCandidate, char& lIsInteresting, char lIsXiMinus, char lIsXiPlus, char lIsOmegaMinus, char lIsOmegaPlus)
   {
-    lIsInteresting = false;
+    lIsInteresting = 0;
     auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
     if (!(v0.has_v0Data())) {
-      lIsInteresting = false;
+      lIsInteresting = 0;
       return;
     }
     auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
@@ -1019,22 +1031,21 @@ struct cascadePreselector {
     auto lPosTrack = v0data.template posTrack_as<TTrackTo>();
 
     if ((lIsXiMinus || lIsOmegaMinus) && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) && (lBachTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
     if ((lIsXiPlus || lIsOmegaPlus) && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons) && (lBachTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check PDG association
   template <class TTrackTo, typename TCascadeObject>
-  void checkPDG(TCascadeObject const& lCascadeCandidate, bool& lIsInteresting, bool& lIsXiMinus, bool& lIsXiPlus, bool& lIsOmegaMinus, bool& lIsOmegaPlus)
+  void checkPDG(TCascadeObject const& lCascadeCandidate, char& lIsXiMinus, char& lIsXiPlus, char& lIsOmegaMinus, char& lIsOmegaPlus)
   {
     auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
     if (!(v0.has_v0Data())) {
-      lIsInteresting = false;
-      lIsXiMinus = false;
-      lIsXiPlus = false;
-      lIsOmegaMinus = false;
-      lIsOmegaPlus = false;
+      lIsXiMinus = 0;
+      lIsXiPlus = 0;
+      lIsOmegaMinus = 0;
+      lIsOmegaPlus = 0;
       return;
     }
     auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
@@ -1072,35 +1083,26 @@ struct cascadePreselector {
       }   // end conditional of mothers existing
     }     // end association check
     // Construct tag table (note: this will be joinable with CascDatas)
-    if (lPDG == 3312 && dIfMCgenerateXiMinus) {
-      lIsXiMinus = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == -3312 && dIfMCgenerateXiPlus) {
-      lIsXiPlus = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == 3334 && dIfMCgenerateOmegaMinus) {
-      lIsOmegaMinus = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == -3334 && dIfMCgenerateOmegaPlus) {
-      lIsOmegaPlus = true;
-      lIsInteresting = true;
-    }
+    if (lPDG == 3312) 
+      lIsXiMinus = 1;
+    if (lPDG == -3312) 
+      lIsXiPlus = 1;
+    if (lPDG == 3334) 
+      lIsOmegaMinus = 1;
+    if (lPDG == -3334) 
+      lIsOmegaPlus = 1;
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check early dE/dx selection
   template <class TTrackTo, typename TCascadeObject>
-  void checkdEdx(TCascadeObject const& lCascadeCandidate, bool& lIsInteresting, bool& lIsXiMinus, bool& lIsXiPlus, bool& lIsOmegaMinus, bool& lIsOmegaPlus)
+  void checkdEdx(TCascadeObject const& lCascadeCandidate, char& lIsXiMinus, char& lIsXiPlus, char& lIsOmegaMinus, char& lIsOmegaPlus)
   {
     auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
     if (!(v0.has_v0Data())) {
-      lIsInteresting = false;
-      lIsXiMinus = false;
-      lIsXiPlus = false;
-      lIsOmegaMinus = false;
-      lIsOmegaPlus = false;
+      lIsXiMinus = 0;
+      lIsXiPlus = 0;
+      lIsOmegaMinus = 0;
+      lIsOmegaPlus = 0;
       return;
     }
     auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
@@ -1113,111 +1115,147 @@ struct cascadePreselector {
     // dEdx check with LF PID
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
         TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lBachTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectXiMinus) {
+        TMath::Abs(lBachTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow) 
       lIsXiMinus = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
         TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lBachTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectXiPlus) {
+        TMath::Abs(lBachTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow) 
       lIsXiPlus = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
         TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lBachTrack.tpcNSigmaKa()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectOmegaMinus) {
+        TMath::Abs(lBachTrack.tpcNSigmaKa()) < ddEdxPreSelectionWindow) 
       lIsOmegaMinus = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
         TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lBachTrack.tpcNSigmaKa()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectOmegaPlus) {
+        TMath::Abs(lBachTrack.tpcNSigmaKa()) < ddEdxPreSelectionWindow) 
       lIsOmegaPlus = 1;
-      lIsInteresting = 1;
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// Initialization of mask vectors if uninitialized
+  void initializeMasks(int size)
+  {
+    if(trackQualityMask.size()<1){
+      // reserve // FIXME check speed / optimise
+      trackQualityMask.resize(size, 0);
+      mcLabelMaskXiMinus.resize(size, 0);
+      mcLabelMaskXiPlus.resize(size, 0);
+      mcLabelMaskOmegaMinus.resize(size, 0);
+      mcLabelMaskOmegaPlus.resize(size, 0);
+      dEdxMaskXiMinus.resize(size, 0);
+      dEdxMaskXiPlus.resize(size, 0);
+      dEdxMaskOmegaMinus.resize(size, 0);
+      dEdxMaskOmegaPlus.resize(size, 0);
+      usedInTrackedCascadeMask.resize(size, 0);
     }
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// Clear mask vectors
+  void resetMasks()
+  {
+    trackQualityMask.clear();
+    mcLabelMaskXiMinus.clear();
+    mcLabelMaskXiPlus.clear();
+    mcLabelMaskOmegaMinus.clear();
+    mcLabelMaskOmegaPlus.clear();
+    dEdxMaskXiMinus.clear();
+    dEdxMaskXiPlus.clear();
+    dEdxMaskOmegaMinus.clear();
+    dEdxMaskOmegaPlus.clear();
+    usedInTrackedCascadeMask.clear();
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// checks and publishes tags if last 
+  void checkAndFinalize()
+  {
+    // parse + publish tag table now
+    for (int ii = 0; ii < trackQualityMask.size(); ii++){
+      bool validCascade = trackQualityMask[ii]; 
+      if( doprocessBuildMCAssociated || doprocessBuildValiddEdxMCAssociated ) 
+        validCascade = validCascade && (( mcLabelMaskXiMinus[ii] && dIfMCgenerateXiMinus ) ||
+                                        ( mcLabelMaskXiPlus[ii] && dIfMCgenerateXiPlus ) ||
+                                        ( mcLabelMaskOmegaMinus[ii] && dIfMCgenerateOmegaMinus ) ||
+                                        ( mcLabelMaskOmegaPlus[ii] && dIfMCgenerateOmegaPlus )); 
+      if( doprocessBuildValiddEdx || doprocessBuildValiddEdxMCAssociated ) 
+        validCascade = validCascade && (( dEdxMaskXiMinus[ii] && ddEdxPreSelectXiMinus ) ||
+                                        ( dEdxMaskXiPlus[ii] && ddEdxPreSelectXiPlus ) ||
+                                        ( dEdxMaskOmegaMinus[ii] && ddEdxPreSelectOmegaMinus ) ||
+                                        ( dEdxMaskOmegaPlus[ii] && ddEdxPreSelectOmegaPlus )); 
+      if( doprocessSkipCascadesNotUsedInTrackedCascades ) 
+        validCascade = validCascade && usedInTrackedCascadeMask[ii]; 
+      casctags(validCascade,
+             mcLabelMaskXiMinus[ii], mcLabelMaskXiPlus[ii], mcLabelMaskOmegaPlus[ii], mcLabelMaskOmegaPlus[ii],
+             dEdxMaskXiMinus[ii], dEdxMaskXiPlus[ii], dEdxMaskOmegaPlus[ii], dEdxMaskOmegaPlus[ii]);
+    }
+    resetMasks();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all cascades are built. It will simply tag everything as true.
   void processBuildAll(aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, aod::TracksExtra const&)
   {
+    initializeMasks(cascades.size());
     for (auto& casc : cascades) {
-      bool lIsQualityInteresting = false;
-      checkTrackQuality<aod::TracksExtra>(casc, lIsQualityInteresting, true, true, true, true);
-      casctags(lIsQualityInteresting,
-               true, true, true, true,
-               true, true, true, true);
+      checkTrackQuality<aod::TracksExtra>(casc, trackQualityMask[casc.globalIndex()], 1, 1, 1, 1);
     }
+    if( !doprocessSkipCascadesNotUsedInTrackedCascades ) 
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(cascadePreselector, processBuildAll, "Switch to build all cascades", true);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const& v0table, LabeledTracksExtra const&, aod::McParticles const&)
   {
+    initializeMasks(cascades.size());
     for (auto& casc : cascades) {
-      bool lIsInteresting = false;
-      bool lIsQualityInteresting = false;
-      bool lIsTrueXiMinus = false;
-      bool lIsTrueXiPlus = false;
-      bool lIsTrueOmegaMinus = false;
-      bool lIsTrueOmegaPlus = false;
-
-      checkPDG<LabeledTracksExtra>(casc, lIsInteresting, lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus);
-      checkTrackQuality<LabeledTracksExtra>(casc, lIsQualityInteresting, true, true, true, true);
-      casctags(lIsInteresting * lIsQualityInteresting,
-               lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus,
-               true, true, true, true);
+      int cai = casc.globalIndex();
+      checkPDG<LabeledTracksExtra>(casc, mcLabelMaskXiMinus[cai], mcLabelMaskXiPlus[cai], mcLabelMaskOmegaPlus[cai], mcLabelMaskOmegaPlus[cai]);
+      checkTrackQuality<LabeledTracksExtra>(casc, trackQualityMask[casc.globalIndex()], 1, 1, 1, 1);
     } // end cascades loop
+    if( !doprocessSkipCascadesNotUsedInTrackedCascades ) 
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(cascadePreselector, processBuildMCAssociated, "Switch to build MC-associated cascades", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildValiddEdx(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, TracksExtraWithPID const&)
   {
+    initializeMasks(cascades.size());
     for (auto& casc : cascades) {
-      bool lIsInteresting = false;
-      bool lIsQualityInteresting = false;
-      bool lIsdEdxXiMinus = false;
-      bool lIsdEdxXiPlus = false;
-      bool lIsdEdxOmegaMinus = false;
-      bool lIsdEdxOmegaPlus = false;
-
-      checkdEdx<TracksExtraWithPID>(casc, lIsInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      checkTrackQuality<TracksExtraWithPID>(casc, lIsQualityInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      casctags(lIsInteresting * lIsQualityInteresting,
-               true, true, true, true,
-               lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
+      int cai = casc.globalIndex();
+      checkdEdx<TracksExtraWithPID>(casc, dEdxMaskXiMinus[cai], dEdxMaskXiPlus[cai], dEdxMaskOmegaPlus[cai], dEdxMaskOmegaPlus[cai]);
+      checkTrackQuality<TracksExtraWithPID>(casc, trackQualityMask[casc.globalIndex()], dEdxMaskXiMinus[cai], dEdxMaskXiPlus[cai], dEdxMaskOmegaPlus[cai], dEdxMaskOmegaPlus[cai]);
     }
+    if( !doprocessSkipCascadesNotUsedInTrackedCascades ) 
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(cascadePreselector, processBuildValiddEdx, "Switch to build cascades with dE/dx preselection", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildValiddEdxMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, TracksExtraWithPIDandLabels const&)
   {
+    initializeMasks(cascades.size());
     for (auto& casc : cascades) {
-      bool lIsdEdxInteresting = false;
-      bool lIsQualityInteresting = false;
-      bool lIsdEdxXiMinus = false;
-      bool lIsdEdxXiPlus = false;
-      bool lIsdEdxOmegaMinus = false;
-      bool lIsdEdxOmegaPlus = false;
-
-      bool lIsTrueInteresting = false;
-      bool lIsTrueXiMinus = false;
-      bool lIsTrueXiPlus = false;
-      bool lIsTrueOmegaMinus = false;
-      bool lIsTrueOmegaPlus = false;
-
-      checkPDG<TracksExtraWithPIDandLabels>(casc, lIsTrueInteresting, lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus);
-      checkdEdx<TracksExtraWithPIDandLabels>(casc, lIsdEdxInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      checkTrackQuality<TracksExtraWithPIDandLabels>(casc, lIsQualityInteresting, lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
-      casctags(lIsTrueInteresting * lIsdEdxInteresting * lIsQualityInteresting,
-               lIsTrueXiMinus, lIsTrueXiPlus, lIsTrueOmegaMinus, lIsTrueOmegaPlus,
-               lIsdEdxXiMinus, lIsdEdxXiPlus, lIsdEdxOmegaMinus, lIsdEdxOmegaPlus);
+      int cai = casc.globalIndex();
+      checkPDG<TracksExtraWithPIDandLabels>(casc, mcLabelMaskXiMinus[cai], mcLabelMaskXiPlus[cai], mcLabelMaskOmegaPlus[cai], mcLabelMaskOmegaPlus[cai]);
+      checkdEdx<TracksExtraWithPIDandLabels>(casc, dEdxMaskXiMinus[cai], dEdxMaskXiPlus[cai], dEdxMaskOmegaPlus[cai], dEdxMaskOmegaPlus[cai]);
+      checkTrackQuality<TracksExtraWithPIDandLabels>(casc, trackQualityMask[casc.globalIndex()], dEdxMaskXiMinus[cai], dEdxMaskXiPlus[cai], dEdxMaskOmegaPlus[cai], dEdxMaskOmegaPlus[cai]);
     }
+    if( !doprocessSkipCascadesNotUsedInTrackedCascades ) 
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(cascadePreselector, processBuildValiddEdxMCAssociated, "Switch to build MC-associated cascades with dE/dx preselection", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// This process function checks for the use of Cascades in strangeness tracked cascades 
+  /// They are then marked appropriately; the user could then operate
+  /// the cascadebuilder to construct only those Cascades.
+  void processSkipCascadesNotUsedInTrackedCascades(aod::TrackedCascades const& tracasctable, aod::Cascades const& casctable)
+  {
+    for (auto const& tracasc : tracasctable) {
+      usedInTrackedCascadeMask[tracasc.cascadeId()] = true; // tag V0s needed by tracked cascades
+    }
+    checkAndFinalize();
+  }
+  //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<* 
+    /// basic building options (one of them must be chosen)
+  PROCESS_SWITCH(cascadePreselector, processBuildAll, "Switch to build all cascades", true);
+  PROCESS_SWITCH(cascadePreselector, processBuildMCAssociated, "Switch to build MC-associated cascades", false);
+  PROCESS_SWITCH(cascadePreselector, processBuildValiddEdx, "Switch to build cascades with dE/dx preselection", false);
+  PROCESS_SWITCH(cascadePreselector, processBuildValiddEdxMCAssociated, "Switch to build MC-associated cascades with dE/dx preselection", false);
+  /// skipper option (choose in addition to a processBuild if you like)
+  PROCESS_SWITCH(cascadePreselector, processSkipCascadesNotUsedInTrackedCascades, "Switch to skip cascades not used in cascade tracking", false);
+  //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<* 
 };
 
 /// Extends the cascdata table with expression columns

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -707,32 +707,48 @@ struct lambdakzeroPreselector {
   // context-aware selections
   Configurable<bool> dPreselectOnlyBaryons{"dPreselectOnlyBaryons", false, "apply TPC dE/dx and quality only to baryon daughters"};
 
+  std::vector<char> trackQualityMask;
+  std::vector<char> mcLabelMaskGamma;
+  std::vector<char> mcLabelMaskK0Short;
+  std::vector<char> mcLabelMaskLambda;
+  std::vector<char> mcLabelMaskAntiLambda;
+  std::vector<char> mcLabelMaskHypertriton;
+  std::vector<char> mcLabelMaskAntiHypertriton;
+  std::vector<char> dEdxMaskGamma;
+  std::vector<char> dEdxMaskK0Short;
+  std::vector<char> dEdxMaskLambda;
+  std::vector<char> dEdxMaskAntiLambda;
+  std::vector<char> dEdxMaskHypertriton;
+  std::vector<char> dEdxMaskAntiHypertriton;
+  std::vector<char> usedInCascadeMask;
+  std::vector<char> usedInTrackedCascadeMask;
+
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check track quality
   template <class TTrackTo, typename TV0Object>
-  void checkTrackQuality(TV0Object const& lV0Candidate, bool& lIsInteresting, bool lIsGamma, bool lIsK0Short, bool lIsLambda, bool lIsAntiLambda, bool lIsHypertriton, bool lIsAntiHypertriton)
+  void checkTrackQuality(TV0Object const& lV0Candidate, char& lIsInteresting, char lIsGamma, char lIsK0Short, char lIsLambda, char lIsAntiLambda, char lIsHypertriton, char lIsAntiHypertriton)
   {
-    lIsInteresting = false;
+    lIsInteresting = 0;
     auto lNegTrack = lV0Candidate.template negTrack_as<TTrackTo>();
     auto lPosTrack = lV0Candidate.template posTrack_as<TTrackTo>();
 
     // No baryons in decay
     if ((lIsGamma || lIsK0Short) && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows))
-      lIsInteresting = true;
+      lIsInteresting = 1;
     // With baryons in decay
     if (lIsLambda && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
     if (lIsAntiLambda && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
     if (lIsHypertriton && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
     if (lIsHypertriton && (lNegTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows && (lPosTrack.tpcNClsCrossedRows() >= dTPCNCrossedRows || dPreselectOnlyBaryons)))
-      lIsInteresting = true;
+      lIsInteresting = 1;
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// function to check PDG association
   template <class TTrackTo, typename TV0Object>
-  void checkPDG(TV0Object const& lV0Candidate, bool& lIsInteresting, bool& lIsGamma, bool& lIsK0Short, bool& lIsLambda, bool& lIsAntiLambda, bool& lIsHypertriton, bool& lIsAntiHypertriton)
+  void checkPDG(TV0Object const& lV0Candidate, char& lIsGamma, char& lIsK0Short, char& lIsLambda, char& lIsAntiLambda, char& lIsHypertriton, char& lIsAntiHypertriton)
   {
     int lPDG = -1;
     auto lNegTrack = lV0Candidate.template negTrack_as<TTrackTo>();
@@ -754,165 +770,201 @@ struct lambdakzeroPreselector {
         }
       }
     } // end association check
-    if (lPDG == 310 && dIfMCgenerateK0Short) {
-      lIsK0Short = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == 3122 && dIfMCgenerateLambda) {
-      lIsLambda = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == -3122 && dIfMCgenerateAntiLambda) {
-      lIsAntiLambda = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == 22 && dIfMCgenerateGamma) {
-      lIsGamma = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == 1010010030 && dIfMCgenerateHypertriton) {
-      lIsHypertriton = true;
-      lIsInteresting = true;
-    }
-    if (lPDG == -1010010030 && dIfMCgenerateAntiHypertriton) {
-      lIsAntiHypertriton = true;
-      lIsInteresting = true;
-    }
+    if (lPDG == 310) 
+      lIsK0Short = 1;
+    if (lPDG == 3122) 
+      lIsLambda = 1;
+    if (lPDG == -3122) 
+      lIsAntiLambda = 1;
+    if (lPDG == 22) 
+      lIsGamma = 1;
+    if (lPDG == 1010010030) 
+      lIsHypertriton = 1;
+    if (lPDG == -1010010030) 
+      lIsAntiHypertriton = 1;
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   template <class TTrackTo, typename TV0Object>
-  void checkdEdx(TV0Object const& lV0Candidate, bool& lIsInteresting, bool& lIsGamma, bool& lIsK0Short, bool& lIsLambda, bool& lIsAntiLambda, bool& lIsHypertriton, bool& lIsAntiHypertriton)
+  void checkdEdx(TV0Object const& lV0Candidate, char& lIsGamma, char& lIsK0Short, char& lIsLambda, char& lIsAntiLambda, char& lIsHypertriton, char& lIsAntiHypertriton)
   {
     auto lNegTrack = lV0Candidate.template negTrack_as<TTrackTo>();
     auto lPosTrack = lV0Candidate.template posTrack_as<TTrackTo>();
 
     // dEdx check with LF PID
     if (TMath::Abs(lNegTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lPosTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectGamma) {
+        TMath::Abs(lPosTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow)
       lIsGamma = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectK0Short) {
+        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow) 
       lIsK0Short = 1;
-      lIsInteresting = 1;
-    }
     if ((TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons) &&
-        TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectLambda) {
+        TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow) 
       lIsLambda = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow &&
-        (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons) &&
-        ddEdxPreSelectAntiLambda) {
+        (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons)) 
       lIsAntiLambda = 1;
-      lIsInteresting = 1;
-    }
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        (TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons) &&
-        ddEdxPreSelectHypertriton) {
+        (TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons)) 
       lIsHypertriton = 1;
-      lIsInteresting = 1;
-    }
     if ((TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow || dPreselectOnlyBaryons) &&
-        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&
-        ddEdxPreSelectAntiHypertriton) {
+        TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow) 
       lIsAntiHypertriton = 1;
-      lIsInteresting = 1;
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// Initialization of mask vectors if uninitialized
+  void initializeMasks(int size)
+  {
+    if(trackQualityMask.size()<1){
+      // reserve // FIXME check speed / optimise
+      trackQualityMask.resize(size, 0);
+      mcLabelMaskGamma.resize(size, 0);
+      mcLabelMaskK0Short.resize(size, 0);
+      mcLabelMaskLambda.resize(size, 0);
+      mcLabelMaskAntiLambda.resize(size, 0);;
+      mcLabelMaskHypertriton.resize(size, 0);
+      mcLabelMaskAntiHypertriton.resize(size, 0);
+      dEdxMaskGamma.resize(size, 0);
+      dEdxMaskK0Short.resize(size, 0);
+      dEdxMaskLambda.resize(size, 0);
+      dEdxMaskAntiLambda.resize(size, 0);
+      dEdxMaskHypertriton.resize(size, 0);
+      dEdxMaskAntiHypertriton.resize(size, 0);
+      usedInCascadeMask.resize(size, 0);
+      usedInTrackedCascadeMask.resize(size, 0);
     }
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// Clear mask vectors
+  void resetMasks()
+  {
+    trackQualityMask.clear();
+    mcLabelMaskGamma.clear();
+    mcLabelMaskK0Short.clear();
+    mcLabelMaskLambda.clear();
+    mcLabelMaskAntiLambda.clear();
+    mcLabelMaskHypertriton.clear();
+    mcLabelMaskAntiHypertriton.clear();
+    dEdxMaskGamma.clear();
+    dEdxMaskK0Short.clear();
+    dEdxMaskLambda.clear();
+    dEdxMaskAntiLambda.clear();
+    dEdxMaskHypertriton.clear();
+    dEdxMaskAntiHypertriton.clear();
+    usedInCascadeMask.clear();
+    usedInTrackedCascadeMask.clear();
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// checks and publishes tags if last 
+  void checkAndFinalize()
+  {
+    // parse + publish tag table now
+    for (int ii = 0; ii < trackQualityMask.size(); ii++){
+      bool validV0 = trackQualityMask[ii]; 
+      if( doprocessBuildMCAssociated || doprocessBuildValiddEdxMCAssociated ) 
+        validV0 = validV0 && (( mcLabelMaskK0Short[ii] && dIfMCgenerateK0Short ) ||
+                              ( mcLabelMaskLambda[ii] && dIfMCgenerateLambda ) ||
+                              ( mcLabelMaskAntiLambda[ii] && dIfMCgenerateAntiLambda ) ||
+                              ( mcLabelMaskGamma[ii] && dIfMCgenerateGamma ) ||
+                              ( mcLabelMaskHypertriton[ii] && dIfMCgenerateHypertriton ) ||
+                              ( mcLabelMaskAntiHypertriton[ii] && dIfMCgenerateAntiHypertriton )); 
+      if( doprocessBuildValiddEdx || doprocessBuildValiddEdxMCAssociated ) 
+        validV0 = validV0 && (( dEdxMaskK0Short[ii] && ddEdxPreSelectK0Short ) ||
+                              ( dEdxMaskLambda[ii] && ddEdxPreSelectLambda ) ||
+                              ( dEdxMaskAntiLambda[ii] && ddEdxPreSelectAntiLambda ) ||
+                              ( dEdxMaskGamma[ii] && ddEdxPreSelectGamma ) ||
+                              ( dEdxMaskHypertriton[ii] && ddEdxPreSelectHypertriton ) ||
+                              ( dEdxMaskAntiHypertriton[ii] && ddEdxPreSelectAntiHypertriton )); 
+      if( doprocessSkipV0sNotUsedInCascades ) 
+        validV0 = validV0 && usedInCascadeMask[ii]; 
+      if( doprocessSkipV0sNotUsedInTrackedCascades ) 
+        validV0 = validV0 && usedInTrackedCascadeMask[ii]; 
+      v0tags(validV0,
+             mcLabelMaskGamma[ii], mcLabelMaskK0Short[ii], mcLabelMaskLambda[ii], mcLabelMaskAntiLambda[ii], mcLabelMaskHypertriton[ii], mcLabelMaskAntiHypertriton[ii],
+             dEdxMaskGamma[ii], dEdxMaskK0Short[ii], dEdxMaskLambda[ii], dEdxMaskAntiLambda[ii], dEdxMaskHypertriton[ii], dEdxMaskAntiHypertriton[ii]);
+    }
+    resetMasks();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all V0s are built. It will simply tag everything as true.
   void processBuildAll(aod::V0s const& v0table, aod::TracksExtra const&)
   {
-    for (auto& v0 : v0table) {
-      bool lIsQualityInteresting = false;
-      checkTrackQuality<aod::TracksExtra>(v0, lIsQualityInteresting, true, true, true, true, true, true);
-      v0tags(lIsQualityInteresting,
-             true, true, true, true, true, true,
-             true, true, true, true, true, true);
+    initializeMasks(v0table.size());
+    for (auto const& v0 : v0table) {
+      checkTrackQuality<aod::TracksExtra>(v0, trackQualityMask[v0.globalIndex()], 1, 1, 1, 1, 1, 1);
     }
+    if ( !doprocessSkipV0sNotUsedInCascades && !doprocessSkipV0sNotUsedInCascades )
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(lambdakzeroPreselector, processBuildAll, "Switch to build all V0s", true);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildMCAssociated(aod::Collisions const& collisions, aod::V0s const& v0table, LabeledTracksExtra const&, aod::McParticles const& particlesMC)
   {
-    for (auto& v0 : v0table) {
-      bool lIsInteresting = false;
-      bool lIsTrueGamma = false;
-      bool lIsTrueK0Short = false;
-      bool lIsTrueLambda = false;
-      bool lIsTrueAntiLambda = false;
-      bool lIsTrueHypertriton = false;
-      bool lIsTrueAntiHypertriton = false;
-
-      bool lIsQualityInteresting = false;
-
-      checkPDG<LabeledTracksExtra>(v0, lIsInteresting, lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton);
-      checkTrackQuality<LabeledTracksExtra>(v0, lIsQualityInteresting, true, true, true, true, true, true);
-      v0tags(lIsInteresting * lIsQualityInteresting,
-             lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton,
-             true, true, true, true, true, true);
+    initializeMasks(v0table.size());
+    for (auto const& v0 : v0table) {
+      int v0i = v0.globalIndex();
+      checkPDG<LabeledTracksExtra>(v0, mcLabelMaskGamma[v0i], mcLabelMaskK0Short[v0i], mcLabelMaskLambda[v0i], mcLabelMaskAntiLambda[v0i], mcLabelMaskHypertriton[v0i], mcLabelMaskAntiHypertriton[v0i]);
+      checkTrackQuality<LabeledTracksExtra>(v0, trackQualityMask[v0i], 1, 1, 1, 1, 1, 1);
     }
+    if ( !doprocessSkipV0sNotUsedInCascades && !doprocessSkipV0sNotUsedInCascades )
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(lambdakzeroPreselector, processBuildMCAssociated, "Switch to build MC-associated V0s", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildValiddEdx(aod::Collisions const& collisions, aod::V0s const& v0table, TracksExtraWithPID const&)
   {
-    for (auto& v0 : v0table) {
-      bool lIsInteresting = false;
-      bool lIsdEdxGamma = false;
-      bool lIsdEdxK0Short = false;
-      bool lIsdEdxLambda = false;
-      bool lIsdEdxAntiLambda = false;
-      bool lIsdEdxHypertriton = false;
-      bool lIsdEdxAntiHypertriton = false;
-
-      bool lIsQualityInteresting = false;
-
-      checkdEdx<TracksExtraWithPID>(v0, lIsInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      checkTrackQuality<TracksExtraWithPID>(v0, lIsQualityInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      v0tags(lIsInteresting * lIsQualityInteresting,
-             true, true, true, true, true, true,
-             lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
+    initializeMasks(v0table.size());
+    for (auto const& v0 : v0table) {
+      int v0i = v0.globalIndex();
+      checkdEdx<TracksExtraWithPID>(v0, dEdxMaskGamma[v0i], dEdxMaskK0Short[v0i], dEdxMaskLambda[v0i], dEdxMaskAntiLambda[v0i], dEdxMaskHypertriton[v0i], dEdxMaskAntiHypertriton[v0i]);
+      checkTrackQuality<TracksExtraWithPID>(v0, trackQualityMask[v0.globalIndex()], dEdxMaskGamma[v0i], dEdxMaskK0Short[v0i], dEdxMaskLambda[v0i], dEdxMaskAntiLambda[v0i], dEdxMaskHypertriton[v0i], dEdxMaskAntiHypertriton[v0i]);
     }
+    if ( !doprocessSkipV0sNotUsedInCascades && !doprocessSkipV0sNotUsedInCascades )
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdx, "Switch to build V0s with dE/dx preselection", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   void processBuildValiddEdxMCAssociated(aod::Collisions const& collisions, aod::V0s const& v0table, TracksExtraWithPIDandLabels const&)
   {
-    for (auto& v0 : v0table) {
-      bool lIsTrueInteresting = false;
-      bool lIsTrueGamma = false;
-      bool lIsTrueK0Short = false;
-      bool lIsTrueLambda = false;
-      bool lIsTrueAntiLambda = false;
-      bool lIsTrueHypertriton = false;
-      bool lIsTrueAntiHypertriton = false;
-
-      bool lIsdEdxInteresting = false;
-      bool lIsdEdxGamma = false;
-      bool lIsdEdxK0Short = false;
-      bool lIsdEdxLambda = false;
-      bool lIsdEdxAntiLambda = false;
-      bool lIsdEdxHypertriton = false;
-      bool lIsdEdxAntiHypertriton = false;
-
-      bool lIsQualityInteresting = false;
-
-      checkPDG<TracksExtraWithPIDandLabels>(v0, lIsTrueInteresting, lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton);
-      checkdEdx<TracksExtraWithPIDandLabels>(v0, lIsdEdxInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      checkTrackQuality<TracksExtraWithPIDandLabels>(v0, lIsQualityInteresting, lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
-      v0tags(lIsTrueInteresting * lIsdEdxInteresting * lIsQualityInteresting,
-             lIsTrueGamma, lIsTrueK0Short, lIsTrueLambda, lIsTrueAntiLambda, lIsTrueHypertriton, lIsTrueAntiHypertriton,
-             lIsdEdxGamma, lIsdEdxK0Short, lIsdEdxLambda, lIsdEdxAntiLambda, lIsdEdxHypertriton, lIsdEdxAntiHypertriton);
+    initializeMasks(v0table.size());
+    for (auto const& v0 : v0table) {
+      int v0i = v0.globalIndex();
+      checkPDG<TracksExtraWithPIDandLabels>(v0, mcLabelMaskGamma[v0i], mcLabelMaskK0Short[v0i], mcLabelMaskLambda[v0i], mcLabelMaskAntiLambda[v0i], mcLabelMaskHypertriton[v0i], mcLabelMaskAntiHypertriton[v0i]);
+      checkdEdx<TracksExtraWithPIDandLabels>(v0, dEdxMaskGamma[v0i], dEdxMaskK0Short[v0i], dEdxMaskLambda[v0i], dEdxMaskAntiLambda[v0i], dEdxMaskHypertriton[v0i], dEdxMaskAntiHypertriton[v0i]);
+      checkTrackQuality<TracksExtraWithPIDandLabels>(v0, trackQualityMask[v0i], dEdxMaskGamma[v0i], dEdxMaskK0Short[v0i], dEdxMaskLambda[v0i], dEdxMaskAntiLambda[v0i], dEdxMaskHypertriton[v0i], dEdxMaskAntiHypertriton[v0i]);
     }
+    if ( !doprocessSkipV0sNotUsedInCascades && !doprocessSkipV0sNotUsedInCascades )
+      checkAndFinalize();
   }
-  PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdxMCAssociated, "Switch to build MC-associated V0s with dE/dx preselection", false);
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// This process function checks for the use of V0s in cascades
+  /// They are then marked appropriately; the user could then operate
+  /// the lambdakzerobuilder to construct only those V0s.
+  void processSkipV0sNotUsedInCascades(aod::Cascades const& casctable)
+  {
+    for (auto const& casc : casctable) {
+      usedInCascadeMask[casc.v0Id()] = true; // tag V0s needed by cascades
+    }
+    checkAndFinalize();
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// This process function checks for the use of V0s in strangeness tracked cascades 
+  /// They are then marked appropriately; the user could then operate
+  /// the lambdakzerobuilder to construct only those V0s.
+  void processSkipV0sNotUsedInTrackedCascades(aod::TrackedCascades const& tracasctable, aod::Cascades const& casctable)
+  {
+    for (auto const& tracasc : tracasctable) {
+      auto casc = tracasc.cascade();
+      usedInTrackedCascadeMask[casc.v0Id()] = true; // tag V0s needed by tracked cascades
+    }
+    checkAndFinalize();
+  }
+  //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<* 
+  /// basic building options (one of them must be chosen)
+  PROCESS_SWITCH(lambdakzeroPreselector, processBuildAll, "Switch to build all V0s", true);
+  PROCESS_SWITCH(lambdakzeroPreselector, processBuildMCAssociated, "Switch to build MC-associated V0s", false);
+  PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdx, "Switch to build V0s with dE/dx preselection", false);
+  PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdxMCAssociated, "Switch to build MC-associated V0s with dE/dx preselection", false);
+  /// skippers options (choose one in addition to a processBuild if you like)
+  PROCESS_SWITCH(lambdakzeroPreselector, processSkipV0sNotUsedInCascades, "skip all V0s not used in cascades", false);
+  PROCESS_SWITCH(lambdakzeroPreselector, processSkipV0sNotUsedInTrackedCascades, "skip all V0s not used in tracked cascades", false);
+  //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*
 };
 
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*


### PR DESCRIPTION
* generally improved algorithm for preselector checks
* adds flags to the builders that allows for specific populations to be skipped (e.g. V0s that are not from cascades) to improve speed 
