### PR TITLE
PWGEM/PhotonMeson: update on 2 photon analyses

### DIFF
--- a/PWGEM/PhotonMeson/Core/CutsLibrary.cxx
+++ b/PWGEM/PhotonMeson/Core/CutsLibrary.cxx
@@ -36,6 +36,24 @@ V0PhotonCut* o2::aod::pcmcuts::GetCut(const char* cutName)
     cut->SetMaxMeePsiPairDep([](float psipair) { return psipair < 0.4 ? 0.06 : 0.015; });
     return cut;
   }
+  if (!nameStr.compare("analysis_eta12")) {
+    // for track
+    cut->SetTrackPtRange(0.01f, 1e10f);
+    cut->SetTrackEtaRange(-1.2, +1.2);
+    cut->SetMinNCrossedRowsTPC(20);
+    cut->SetMinNCrossedRowsOverFindableClustersTPC(0.6);
+    cut->SetMaxChi2PerClusterTPC(4.0);
+    cut->SetTPCNsigmaElRange(-3, +3);
+    cut->SetIsWithinBeamPipe(true);
+    // for v0
+    cut->SetV0PtRange(0.01f, 1e10f);
+    cut->SetV0EtaRange(-1.2, +1.2);
+    cut->SetMinCosPA(0.998);
+    cut->SetMaxPCA(0.5);
+    cut->SetRxyRange(1, 90);
+    cut->SetMaxMeePsiPairDep([](float psipair) { return psipair < 0.4 ? 0.06 : 0.015; });
+    return cut;
+  }
   if (!nameStr.compare("analysis_wo_mee")) {
     // for track
     cut->SetTrackPtRange(0.01f, 1e10f);
@@ -53,6 +71,23 @@ V0PhotonCut* o2::aod::pcmcuts::GetCut(const char* cutName)
     cut->SetRxyRange(1, 90);
     return cut;
   }
+  if (!nameStr.compare("analysis_wo_mee_eta12")) {
+    // for track
+    cut->SetTrackPtRange(0.01f, 1e10f);
+    cut->SetTrackEtaRange(-1.2, +1.2);
+    cut->SetMinNCrossedRowsTPC(20);
+    cut->SetMinNCrossedRowsOverFindableClustersTPC(0.6);
+    cut->SetMaxChi2PerClusterTPC(4.0);
+    cut->SetTPCNsigmaElRange(-3, +3);
+    cut->SetIsWithinBeamPipe(true);
+    // for v0
+    cut->SetV0PtRange(0.01f, 1e10f);
+    cut->SetV0EtaRange(-1.2, +1.2);
+    cut->SetMinCosPA(0.998);
+    cut->SetMaxPCA(0.5);
+    cut->SetRxyRange(1, 90);
+    return cut;
+  }
   if (!nameStr.compare("qc")) {
     // for track
     cut->SetTrackPtRange(0.01f, 1e10f);
@@ -65,6 +100,24 @@ V0PhotonCut* o2::aod::pcmcuts::GetCut(const char* cutName)
     // for v0
     cut->SetV0PtRange(0.01f, 1e10f);
     cut->SetV0EtaRange(-0.9, +0.9);
+    cut->SetMinCosPA(0.99);
+    cut->SetMaxPCA(1.5);
+    cut->SetRxyRange(1, 180);
+    cut->SetMaxMeePsiPairDep([](float psipair) { return psipair < 0.4 ? 0.06 : 0.015; });
+    return cut;
+  }
+  if (!nameStr.compare("qc_eta12")) {
+    // for track
+    cut->SetTrackPtRange(0.01f, 1e10f);
+    cut->SetTrackEtaRange(-1.2, +1.2);
+    cut->SetMinNCrossedRowsTPC(20);
+    cut->SetMinNCrossedRowsOverFindableClustersTPC(0.6);
+    cut->SetMaxChi2PerClusterTPC(4.0);
+    cut->SetTPCNsigmaElRange(-3, +3);
+    cut->SetIsWithinBeamPipe(true);
+    // for v0
+    cut->SetV0PtRange(0.01f, 1e10f);
+    cut->SetV0EtaRange(-1.2, +1.2);
     cut->SetMinCosPA(0.99);
     cut->SetMaxPCA(1.5);
     cut->SetRxyRange(1, 180);

--- a/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
+++ b/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
@@ -137,6 +137,14 @@ void o2::aod::emphotonhistograms::DefineHistograms(THashList* list, const char* 
     reinterpret_cast<TH2F*>(list->FindObject("hMggPt_Same"))->Sumw2();
     reinterpret_cast<TH2F*>(list->FindObject("hMggPt_Mixed"))->Sumw2();
 
+    if (TString(subGroup) == "PCMPHOS" || TString(subGroup) == "PCMEMC") {
+      list->Add(new TH2F("hdEtadPhi", "#Delta#eta vs. #Delta#varphi;#Delta#varphi (rad.);#Delta#eta", 200, -TMath::Pi(), +TMath::Pi(), 400, -2, +2));
+      list->Add(new TH2F("hdEtaPt", "#Delta#eta vs. p_{T}^{leg};p_{T}^{leg} (GeV/c);#Delta#eta", 100, 0, 10, 400, -2, +2));
+      list->Add(new TH2F("hdPhiPt", "#Delta#varphi vs. p_{T}^{leg};p_{T}^{leg} (GeV/c);#Delta#varphi", 100, 0, 10, 200, -TMath::Pi(), +TMath::Pi()));
+      list->Add(new TH2F("hdRPt", "#DeltaR vs. p_{T}^{leg};p_{T}^{leg} (GeV/c);#DeltaR", 100, 0, 10, 400, 0, 4));
+      list->Add(new TH2F("hEp_E", "E/p vs. matched E_{cluster};E_{cluster} (GeV);E/p", 100, 0, 10, 200, 0, 2));
+    }
+
     if (TString(subGroup) == "EMCEMC") {
       list->Add(new TH2F("hMggPt_Same_RotatedBkg", "m_{#gamma#gamma} vs. p_{T};m_{#gamma#gamma} (GeV/c^{2});p_{T,#gamma#gamma} (GeV/c)", nmgg - 1, mgg, npTgg - 1, pTgg));
       reinterpret_cast<TH2F*>(list->FindObject("hMggPt_Same_RotatedBkg"))->Sumw2();

--- a/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
+++ b/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
@@ -218,6 +218,13 @@ struct PhotonHBT {
             if (!IsSelectedPair<pairtype>(g1, g2, cut, cut)) {
               continue;
             }
+            if constexpr (pairtype == PairType::kPCMPHOS) {
+              auto pos = g1.template posTrack_as<aod::V0Legs>();
+              auto ele = g1.template negTrack_as<aod::V0Legs>();
+              if (o2::aod::photonpair::DoesV0LegMatchWithCluster<pairtype>(pos, g2) || o2::aod::photonpair::DoesV0LegMatchWithCluster<pairtype>(ele, g2)) {
+                continue;
+              }
+            }
             // longitudinally co-moving system (LCMS)
             ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.);
             ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.);
@@ -242,6 +249,13 @@ struct PhotonHBT {
             for (auto& [g1, g2] : combinations(CombinationsFullIndexPolicy(photons1_coll, photons2_coll))) {
               if (!IsSelectedPair<pairtype>(g1, g2, cut1, cut2)) {
                 continue;
+              }
+              if constexpr (pairtype == PairType::kPCMPHOS) {
+                auto pos = g1.template posTrack_as<aod::V0Legs>();
+                auto ele = g1.template negTrack_as<aod::V0Legs>();
+                if (o2::aod::photonpair::DoesV0LegMatchWithCluster(pos, g2, 0.4) || o2::aod::photonpair::DoesV0LegMatchWithCluster(ele, g2, 0.4)) {
+                  continue;
+                }
               }
               ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.);
               ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.);

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMC.cxx
@@ -307,6 +307,13 @@ struct Pi0EtaToGammaGammaMC {
               if (!IsSelectedPair<pairtype>(g1, g2, cut1, cut2)) {
                 continue;
               }
+              if constexpr (pairtype == PairType::kPCMPHOS || pairtype == PairType::kPCMEMC) {
+                auto pos = g1.template posTrack_as<MyMCV0Legs>();
+                auto ele = g1.template negTrack_as<MyMCV0Legs>();
+                if (o2::aod::photonpair::DoesV0LegMatchWithCluster(pos, g2, 0.4) || o2::aod::photonpair::DoesV0LegMatchWithCluster(ele, g2, 0.4)) {
+                  continue;
+                }
+              }
 
               ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.);
               ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.);

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
@@ -272,6 +272,13 @@ struct TaggingPi0 {
             if (!IsSelectedPair<pairtype>(g1, g2, cut1, cut2)) {
               continue;
             }
+            if constexpr (pairtype == PairType::kPCMPHOS || pairtype == PairType::kPCMEMC) {
+              auto pos = g1.template posTrack_as<aod::V0Legs>();
+              auto ele = g1.template negTrack_as<aod::V0Legs>();
+              if (o2::aod::photonpair::DoesV0LegMatchWithCluster(pos, g2, 0.4) || o2::aod::photonpair::DoesV0LegMatchWithCluster(ele, g2, 0.4)) {
+                continue;
+              }
+            }
             ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.); // pcm
             ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.); // phos or emc
             ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
@@ -273,6 +273,13 @@ struct TaggingPi0MC {
             if (!IsSelectedPair<pairtype>(g1, g2, cut1, cut2)) {
               continue;
             }
+            if constexpr (pairtype == PairType::kPCMPHOS || pairtype == PairType::kPCMEMC) {
+              auto pos = g1.template posTrack_as<MyMCV0Legs>();
+              auto ele = g1.template negTrack_as<MyMCV0Legs>();
+              if (o2::aod::photonpair::DoesV0LegMatchWithCluster(pos, g2, 0.4) || o2::aod::photonpair::DoesV0LegMatchWithCluster(ele, g2, 0.4)) {
+                continue;
+              }
+            }
             ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.); // pcm
             ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.); // phos or emc
             ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;

--- a/PWGEM/PhotonMeson/Utils/PairUtilities.h
+++ b/PWGEM/PhotonMeson/Utils/PairUtilities.h
@@ -15,6 +15,7 @@
 #ifndef PWGEM_PHOTONMESON_UTILS_PAIRUTILITIES_H_
 #define PWGEM_PHOTONMESON_UTILS_PAIRUTILITIES_H_
 
+#include <TVector2.h>
 #include "Framework/AnalysisTask.h"
 
 //_______________________________________________________________________
@@ -40,9 +41,19 @@ bool IsSelectedPair(TG1 const& g1, TG2 const& g2, TCut1 const& cut1, TCut2 const
   is_g2_selected = cut2.template IsSelected<U2>(g2);
   return (is_g1_selected & is_g2_selected);
 }
+//_______________________________________________________________________
+template <typename TV0Leg, typename TCluster>
+bool DoesV0LegMatchWithCluster(TV0Leg const& v0leg, TCluster const& cluster, const float maxR)
+{
+  float deta = v0leg.eta() - cluster.eta();
+  float dphi = TVector2::Phi_mpi_pi(TVector2::Phi_0_2pi(v0leg.phi()) - TVector2::Phi_0_2pi(cluster.phi()));
+  float dR = sqrt(deta * deta + dphi * dphi);
+  float Ep = cluster.e() / v0leg.p();
+  return (dR < maxR) & (abs(Ep - 1) < 0.5);
+}
+//_______________________________________________________________________
 } // namespace photonpair
 } // namespace o2::aod
-
 //_______________________________________________________________________
 //_______________________________________________________________________
 //_______________________________________________________________________


### PR DESCRIPTION
This PR contains following commits:
PWGEM/PhotonMeson: re-activate EMC track matching veto
PWGEM/PhotonMeson: add v0leg-cluster matching
PWGEM/PhotonMeson: add cuts for PCM
