### PR TITLE
PWGHF: Enabling AND logic for TPC+TOF PID for D0 selection

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -42,6 +42,8 @@ struct HfCandidateSelectorD0 {
   Configurable<double> ptPidTofMax{"ptPidTofMax", 5., "Upper bound of track pT for TOF PID"};
   Configurable<double> nSigmaTofMax{"nSigmaTofMax", 3., "Nsigma cut on TOF only"};
   Configurable<double> nSigmaTofCombinedMax{"nSigmaTofCombinedMax", 5., "Nsigma cut on TOF combined with TPC"};
+  // AND logic for TOF+TPC PID (as in Run2)
+  Configurable<bool> useAndLogicForPid{"useAndLogicForPid", false, "Use AND logic for TPC and TOF PID"};
   // topological cuts
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_d0_to_pi_k::cuts[0], nBinsPt, nCutVars, labelsPt, labelsCutVar}, "D0 candidate selection per pT bin"};
@@ -229,10 +231,22 @@ struct HfCandidateSelectorD0 {
       statusCand = 1;
 
       // track-level PID selection
-      int pidTrackPosKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackPos);
-      int pidTrackPosPion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos);
-      int pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
-      int pidTrackNegPion = selectorPion.getStatusTrackPIDTpcOrTof(trackNeg);
+      int pidTrackPosKaon = -1;
+      int pidTrackPosPion = -1;
+      int pidTrackNegKaon = -1;
+      int pidTrackNegPion = -1;
+
+      if (useAndLogicForPid) {
+        pidTrackPosKaon = selectorKaon.getStatusTrackPIDTpcAndTof(trackPos);
+        pidTrackPosPion = selectorPion.getStatusTrackPIDTpcAndTof(trackPos);
+        pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcAndTof(trackNeg);
+        pidTrackNegPion = selectorPion.getStatusTrackPIDTpcAndTof(trackNeg);
+      } else {
+        pidTrackPosKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackPos);
+        pidTrackPosPion = selectorPion.getStatusTrackPIDTpcOrTof(trackPos);
+        pidTrackNegKaon = selectorKaon.getStatusTrackPIDTpcOrTof(trackNeg);
+        pidTrackNegPion = selectorPion.getStatusTrackPIDTpcOrTof(trackNeg);
+      }
 
       int pidD0 = -1;
       int pidD0bar = -1;


### PR DESCRIPTION
Activates the possibility of using TPC and TOF approach, as done in Run2, following the general implementation introduced in [https://github.com/AliceO2Group/O2Physics/pull/2109](PR#2109).
Option enabled via a dedicated configurable, set to false as defaults to preserve backward compatibility