### PR TITLE
Reserve memory in mult/cent

### DIFF
--- a/Common/TableProducer/centralityTable.cxx
+++ b/Common/TableProducer/centralityTable.cxx
@@ -316,105 +316,126 @@ struct CentralityTable {
 
   using BCsWithTimestamps = soa::Join<aod::BCs, aod::Timestamps>;
 
-  void processRun3(soa::Join<aod::Collisions, aod::Mults, aod::MultZeqs>::iterator const& collision, BCsWithTimestamps const&)
+  void processRun3(soa::Join<aod::Collisions, aod::Mults, aod::MultZeqs> const& collisions, BCsWithTimestamps const&)
   {
-    /* check the previous run number */
-    auto bc = collision.bc_as<BCsWithTimestamps>();
-    if (bc.runNumber() != mRunNumber) {
-      LOGF(info, "timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
-      TList* callst = ccdb->getForTimeStamp<TList>(ccdbPath, bc.timestamp());
-
-      FV0AInfo.mCalibrationStored = false;
-      FT0MInfo.mCalibrationStored = false;
-      FT0AInfo.mCalibrationStored = false;
-      FT0CInfo.mCalibrationStored = false;
-      FDDMInfo.mCalibrationStored = false;
-      NTPVInfo.mCalibrationStored = false;
-      if (callst != nullptr) {
-        LOGF(info, "Getting new histograms with %d run number for %d run number", mRunNumber, bc.runNumber());
-        auto getccdb = [callst, bc](struct calibrationInfo& estimator, const Configurable<std::string> generatorName) { // TODO: to consider the name inside the estimator structure
-          estimator.mhMultSelCalib = (TH1*)callst->FindObject(TString::Format("hCalibZeq%s", estimator.name.c_str()).Data());
-          estimator.mMCScale = (TFormula*)callst->FindObject(TString::Format("%s-%s", generatorName->c_str(), estimator.name.c_str()).Data());
-          if (estimator.mhMultSelCalib != nullptr) {
-            if (generatorName->length() != 0) {
-              if (estimator.mMCScale != nullptr) {
-                for (int ixpar = 0; ixpar < 6; ++ixpar) {
-                  estimator.mMCScalePars[ixpar] = estimator.mMCScale->GetParameter(ixpar);
-                }
-              } else {
-                LOGF(warning, "MC Scale information from %s for run %d not available", estimator.name.c_str(), bc.runNumber());
-              }
-            }
-            estimator.mCalibrationStored = true;
-          } else {
-            LOGF(error, "Calibration information from %s for run %d not available", estimator.name.c_str(), bc.runNumber());
-          }
-        };
-        if (estFV0A == 1) {
-          getccdb(FV0AInfo, genName);
-        }
-        if (estFT0M == 1) {
-          getccdb(FT0MInfo, genName);
-        }
-        if (estFT0A == 1) {
-          getccdb(FT0AInfo, genName);
-        }
-        if (estFT0C == 1) {
-          getccdb(FT0CInfo, genName);
-        }
-        if (estFDDM == 1) {
-          getccdb(FDDMInfo, genName);
-        }
-        if (estNTPV == 1) {
-          getccdb(NTPVInfo, genName);
-        }
-        mRunNumber = bc.runNumber();
-      } else {
-        if (!doNotCrashOnNull) { // default behaviour: crash
-          LOGF(fatal, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
-        } else { // only if asked: continue filling with non-valid values (105)
-          LOGF(info, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu, will fill tables with dummy values", bc.runNumber(), bc.timestamp());
-          mRunNumber = bc.runNumber();
-        }
-      }
-    }
-
-    auto populateTable = [](auto& table, struct calibrationInfo& estimator, float multiplicity) {
-      auto scaleMC = [](float x, float pars[6]) {
-        return pow(((pars[0] + pars[1] * pow(x, pars[2])) - pars[3]) / pars[4], 1.0f / pars[5]);
-      };
-
-      float percentile = 105.0f;
-      float scaledMultiplicity = multiplicity;
-      if (estimator.mCalibrationStored) {
-        if (estimator.mMCScale != nullptr) {
-          scaledMultiplicity = scaleMC(multiplicity, estimator.mMCScalePars);
-          LOGF(debug, "Unscaled %s multiplicity: %f, scaled %s multiplicity: %f", estimator.name.c_str(), multiplicity, estimator.name.c_str(), scaledMultiplicity);
-        }
-        percentile = estimator.mhMultSelCalib->GetBinContent(estimator.mhMultSelCalib->FindFixBin(scaledMultiplicity));
-      }
-      LOGF(debug, "%s centrality/multiplicity percentile = %.0f for a zvtx eq %s value %.0f", estimator.name.c_str(), percentile, estimator.name.c_str(), scaledMultiplicity);
-      table(percentile);
-    };
-
+    // do memory reservation for the relevant tables only, please
     if (estFV0A == 1) {
-      populateTable(centFV0A, FV0AInfo, collision.multZeqFV0A());
+      centFV0A.reserve(collisions.size());
     }
     if (estFT0M == 1) {
-      populateTable(centFT0M, FT0MInfo, collision.multZeqFT0A() + collision.multZeqFT0C());
+      centFT0M.reserve(collisions.size());
     }
     if (estFT0A == 1) {
-      populateTable(centFT0A, FT0AInfo, collision.multZeqFT0A());
+      centFT0A.reserve(collisions.size());
     }
     if (estFT0C == 1) {
-      populateTable(centFT0C, FT0CInfo, collision.multZeqFT0C());
+      centFT0C.reserve(collisions.size());
     }
     if (estFDDM == 1) {
-      populateTable(centFDDM, FDDMInfo, collision.multZeqFDDA() + collision.multZeqFDDC());
+      centFDDM.reserve(collisions.size());
     }
     if (estNTPV == 1) {
-      populateTable(centNTPV, NTPVInfo, collision.multZeqNTracksPV());
+      centNTPV.reserve(collisions.size());
     }
+    for (auto const& collision : collisions) {
+      /* check the previous run number */
+      auto bc = collision.bc_as<BCsWithTimestamps>();
+      if (bc.runNumber() != mRunNumber) {
+        LOGF(info, "timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
+        TList* callst = ccdb->getForTimeStamp<TList>(ccdbPath, bc.timestamp());
+
+        FV0AInfo.mCalibrationStored = false;
+        FT0MInfo.mCalibrationStored = false;
+        FT0AInfo.mCalibrationStored = false;
+        FT0CInfo.mCalibrationStored = false;
+        FDDMInfo.mCalibrationStored = false;
+        NTPVInfo.mCalibrationStored = false;
+        if (callst != nullptr) {
+          LOGF(info, "Getting new histograms with %d run number for %d run number", mRunNumber, bc.runNumber());
+          auto getccdb = [callst, bc](struct calibrationInfo& estimator, const Configurable<std::string> generatorName) { // TODO: to consider the name inside the estimator structure
+            estimator.mhMultSelCalib = (TH1*)callst->FindObject(TString::Format("hCalibZeq%s", estimator.name.c_str()).Data());
+            estimator.mMCScale = (TFormula*)callst->FindObject(TString::Format("%s-%s", generatorName->c_str(), estimator.name.c_str()).Data());
+            if (estimator.mhMultSelCalib != nullptr) {
+              if (generatorName->length() != 0) {
+                if (estimator.mMCScale != nullptr) {
+                  for (int ixpar = 0; ixpar < 6; ++ixpar) {
+                    estimator.mMCScalePars[ixpar] = estimator.mMCScale->GetParameter(ixpar);
+                  }
+                } else {
+                  LOGF(warning, "MC Scale information from %s for run %d not available", estimator.name.c_str(), bc.runNumber());
+                }
+              }
+              estimator.mCalibrationStored = true;
+            } else {
+              LOGF(error, "Calibration information from %s for run %d not available", estimator.name.c_str(), bc.runNumber());
+            }
+          };
+          if (estFV0A == 1) {
+            getccdb(FV0AInfo, genName);
+          }
+          if (estFT0M == 1) {
+            getccdb(FT0MInfo, genName);
+          }
+          if (estFT0A == 1) {
+            getccdb(FT0AInfo, genName);
+          }
+          if (estFT0C == 1) {
+            getccdb(FT0CInfo, genName);
+          }
+          if (estFDDM == 1) {
+            getccdb(FDDMInfo, genName);
+          }
+          if (estNTPV == 1) {
+            getccdb(NTPVInfo, genName);
+          }
+          mRunNumber = bc.runNumber();
+        } else {
+          if (!doNotCrashOnNull) { // default behaviour: crash
+            LOGF(fatal, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+          } else { // only if asked: continue filling with non-valid values (105)
+            LOGF(info, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu, will fill tables with dummy values", bc.runNumber(), bc.timestamp());
+            mRunNumber = bc.runNumber();
+          }
+        }
+      }
+
+      auto populateTable = [](auto& table, struct calibrationInfo& estimator, float multiplicity) {
+        auto scaleMC = [](float x, float pars[6]) {
+          return pow(((pars[0] + pars[1] * pow(x, pars[2])) - pars[3]) / pars[4], 1.0f / pars[5]);
+        };
+
+        float percentile = 105.0f;
+        float scaledMultiplicity = multiplicity;
+        if (estimator.mCalibrationStored) {
+          if (estimator.mMCScale != nullptr) {
+            scaledMultiplicity = scaleMC(multiplicity, estimator.mMCScalePars);
+            LOGF(debug, "Unscaled %s multiplicity: %f, scaled %s multiplicity: %f", estimator.name.c_str(), multiplicity, estimator.name.c_str(), scaledMultiplicity);
+          }
+          percentile = estimator.mhMultSelCalib->GetBinContent(estimator.mhMultSelCalib->FindFixBin(scaledMultiplicity));
+        }
+        LOGF(debug, "%s centrality/multiplicity percentile = %.0f for a zvtx eq %s value %.0f", estimator.name.c_str(), percentile, estimator.name.c_str(), scaledMultiplicity);
+        table(percentile);
+      };
+
+      if (estFV0A == 1) {
+        populateTable(centFV0A, FV0AInfo, collision.multZeqFV0A());
+      }
+      if (estFT0M == 1) {
+        populateTable(centFT0M, FT0MInfo, collision.multZeqFT0A() + collision.multZeqFT0C());
+      }
+      if (estFT0A == 1) {
+        populateTable(centFT0A, FT0AInfo, collision.multZeqFT0A());
+      }
+      if (estFT0C == 1) {
+        populateTable(centFT0C, FT0CInfo, collision.multZeqFT0C());
+      }
+      if (estFDDM == 1) {
+        populateTable(centFDDM, FDDMInfo, collision.multZeqFDDA() + collision.multZeqFDDC());
+      }
+      if (estNTPV == 1) {
+        populateTable(centNTPV, NTPVInfo, collision.multZeqNTracksPV());
+      }
+      }
   }
   PROCESS_SWITCH(CentralityTable, processRun3, "Provide Run3 calibrated centrality/multiplicity percentiles tables", false);
 };

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -132,102 +132,107 @@ struct MultiplicityTableTaskIndexed {
   Partition<Run3Tracks> tracksIUWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
   Partition<Run3Tracks> pvContribTracksIU = (nabs(aod::track::eta) < 0.8f) && ((aod::track::flags & (uint32_t)o2::aod::track::PVContributor) == (uint32_t)o2::aod::track::PVContributor);
   Partition<Run3Tracks> pvContribTracksIUEta1 = (nabs(aod::track::eta) < 1.0f) && ((aod::track::flags & (uint32_t)o2::aod::track::PVContributor) == (uint32_t)o2::aod::track::PVContributor);
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision,
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
                    Run3Tracks const& tracksExtra,
                    soa::Join<aod::BCs, aod::Timestamps> const& bcs,
                    aod::Zdcs const& zdcs,
                    aod::FV0As const& fv0as,
                    aod::FT0s const& ft0s,
                    aod::FDDs const& fdds)
-  {
-    float multFV0A = 0.f;
-    float multFV0C = 0.f;
-    float multFT0A = 0.f;
-    float multFT0C = 0.f;
-    float multFDDA = 0.f;
-    float multFDDC = 0.f;
-    float multZNA = 0.f;
-    float multZNC = 0.f;
-    int multTracklets = 0;
+  {    
+    // reserve memory
+    mult.reserve(collisions.size());
+    multzeq.reserve(collisions.size());
+    for (auto const& collision : collisions) {
+      float multFV0A = 0.f;
+      float multFV0C = 0.f;
+      float multFT0A = 0.f;
+      float multFT0C = 0.f;
+      float multFDDA = 0.f;
+      float multFDDC = 0.f;
+      float multZNA = 0.f;
+      float multZNC = 0.f;
+      int multTracklets = 0;
 
-    float multZeqFV0A = 0.f;
-    float multZeqFT0A = 0.f;
-    float multZeqFT0C = 0.f;
-    float multZeqFDDA = 0.f;
-    float multZeqFDDC = 0.f;
-    float multZeqNContribs = 0.f;
+      float multZeqFV0A = 0.f;
+      float multZeqFT0A = 0.f;
+      float multZeqFT0C = 0.f;
+      float multZeqFDDA = 0.f;
+      float multZeqFDDC = 0.f;
+      float multZeqNContribs = 0.f;
 
-    auto tracksGrouped = tracksIUWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    auto pvContribsGrouped = pvContribTracksIU->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    auto pvContribsEta1Grouped = pvContribTracksIUEta1->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    int multTPC = tracksGrouped.size();
-    int multNContribs = pvContribsGrouped.size();
-    int multNContribsEta1 = pvContribsEta1Grouped.size();
+      auto tracksGrouped = tracksIUWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+      auto pvContribsGrouped = pvContribTracksIU->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+      auto pvContribsEta1Grouped = pvContribTracksIUEta1->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+      int multTPC = tracksGrouped.size();
+      int multNContribs = pvContribsGrouped.size();
+      int multNContribsEta1 = pvContribsEta1Grouped.size();
 
-    /* check the previous run number */
-    auto bc = collision.bc_as<soa::Join<aod::BCs, aod::Timestamps>>();
-    if (doVertexZeq > 0) {
-      if (bc.runNumber() != mRunNumber) {
-        mRunNumber = bc.runNumber(); // mark this run as at least tried
-        lCalibObjects = ccdb->getForTimeStamp<TList>("Centrality/Calibration", bc.timestamp());
-        if (lCalibObjects) {
-          hVtxZFV0A = (TProfile*)lCalibObjects->FindObject("hVtxZFV0A");
-          hVtxZFT0A = (TProfile*)lCalibObjects->FindObject("hVtxZFT0A");
-          hVtxZFT0C = (TProfile*)lCalibObjects->FindObject("hVtxZFT0C");
-          hVtxZFDDA = (TProfile*)lCalibObjects->FindObject("hVtxZFDDA");
-          hVtxZFDDC = (TProfile*)lCalibObjects->FindObject("hVtxZFDDC");
-          hVtxZNTracks = (TProfile*)lCalibObjects->FindObject("hVtxZNTracksPV");
-          lCalibLoaded = true;
-          // Capture error
-          if (!hVtxZFV0A || !hVtxZFT0A || !hVtxZFT0C || !hVtxZFDDA || !hVtxZFDDC || !hVtxZNTracks) {
-            LOGF(error, "Problem loading CCDB objects! Please check");
+      /* check the previous run number */
+      auto bc = collision.bc_as<soa::Join<aod::BCs, aod::Timestamps>>();
+      if (doVertexZeq > 0) {
+        if (bc.runNumber() != mRunNumber) {
+          mRunNumber = bc.runNumber(); // mark this run as at least tried
+          lCalibObjects = ccdb->getForTimeStamp<TList>("Centrality/Calibration", bc.timestamp());
+          if (lCalibObjects) {
+            hVtxZFV0A = (TProfile*)lCalibObjects->FindObject("hVtxZFV0A");
+            hVtxZFT0A = (TProfile*)lCalibObjects->FindObject("hVtxZFT0A");
+            hVtxZFT0C = (TProfile*)lCalibObjects->FindObject("hVtxZFT0C");
+            hVtxZFDDA = (TProfile*)lCalibObjects->FindObject("hVtxZFDDA");
+            hVtxZFDDC = (TProfile*)lCalibObjects->FindObject("hVtxZFDDC");
+            hVtxZNTracks = (TProfile*)lCalibObjects->FindObject("hVtxZNTracksPV");
+            lCalibLoaded = true;
+            // Capture error
+            if (!hVtxZFV0A || !hVtxZFT0A || !hVtxZFT0C || !hVtxZFDDA || !hVtxZFDDC || !hVtxZNTracks) {
+              LOGF(error, "Problem loading CCDB objects! Please check");
+              lCalibLoaded = false;
+            }
+          } else {
+            LOGF(error, "Problem loading CCDB object! Please check");
             lCalibLoaded = false;
           }
-        } else {
-          LOGF(error, "Problem loading CCDB object! Please check");
-          lCalibLoaded = false;
         }
       }
-    }
-    // using FT0 row index from event selection task
-    if (collision.has_foundFT0()) {
-      auto ft0 = collision.foundFT0();
-      for (auto amplitude : ft0.amplitudeA()) {
-        multFT0A += amplitude;
+      // using FT0 row index from event selection task
+      if (collision.has_foundFT0()) {
+        auto ft0 = collision.foundFT0();
+        for (auto amplitude : ft0.amplitudeA()) {
+          multFT0A += amplitude;
+        }
+        for (auto amplitude : ft0.amplitudeC()) {
+          multFT0C += amplitude;
+        }
       }
-      for (auto amplitude : ft0.amplitudeC()) {
-        multFT0C += amplitude;
+      // using FDD row index from event selection task
+      if (collision.has_foundFDD()) {
+        auto fdd = collision.foundFDD();
+        for (auto amplitude : fdd.chargeA()) {
+          multFDDA += amplitude;
+        }
+        for (auto amplitude : fdd.chargeC()) {
+          multFDDC += amplitude;
+        }
       }
-    }
-    // using FDD row index from event selection task
-    if (collision.has_foundFDD()) {
-      auto fdd = collision.foundFDD();
-      for (auto amplitude : fdd.chargeA()) {
-        multFDDA += amplitude;
+      // using FV0 row index from event selection task
+      if (collision.has_foundFV0()) {
+        auto fv0 = collision.foundFV0();
+        for (auto amplitude : fv0.amplitude()) {
+          multFV0A += amplitude;
+        }
       }
-      for (auto amplitude : fdd.chargeC()) {
-        multFDDC += amplitude;
+      if (fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
+        multZeqFV0A = hVtxZFV0A->Interpolate(0.0) * multFV0A / hVtxZFV0A->Interpolate(collision.posZ());
+        multZeqFT0A = hVtxZFT0A->Interpolate(0.0) * multFT0A / hVtxZFT0A->Interpolate(collision.posZ());
+        multZeqFT0C = hVtxZFT0C->Interpolate(0.0) * multFT0C / hVtxZFT0C->Interpolate(collision.posZ());
+        multZeqFDDA = hVtxZFDDA->Interpolate(0.0) * multFDDA / hVtxZFDDA->Interpolate(collision.posZ());
+        multZeqFDDC = hVtxZFDDC->Interpolate(0.0) * multFDDC / hVtxZFDDC->Interpolate(collision.posZ());
+        multZeqNContribs = hVtxZNTracks->Interpolate(0.0) * multNContribs / hVtxZNTracks->Interpolate(collision.posZ());
       }
-    }
-    // using FV0 row index from event selection task
-    if (collision.has_foundFV0()) {
-      auto fv0 = collision.foundFV0();
-      for (auto amplitude : fv0.amplitude()) {
-        multFV0A += amplitude;
-      }
-    }
-    if (fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
-      multZeqFV0A = hVtxZFV0A->Interpolate(0.0) * multFV0A / hVtxZFV0A->Interpolate(collision.posZ());
-      multZeqFT0A = hVtxZFT0A->Interpolate(0.0) * multFT0A / hVtxZFT0A->Interpolate(collision.posZ());
-      multZeqFT0C = hVtxZFT0C->Interpolate(0.0) * multFT0C / hVtxZFT0C->Interpolate(collision.posZ());
-      multZeqFDDA = hVtxZFDDA->Interpolate(0.0) * multFDDA / hVtxZFDDA->Interpolate(collision.posZ());
-      multZeqFDDC = hVtxZFDDC->Interpolate(0.0) * multFDDC / hVtxZFDDC->Interpolate(collision.posZ());
-      multZeqNContribs = hVtxZNTracks->Interpolate(0.0) * multNContribs / hVtxZNTracks->Interpolate(collision.posZ());
-    }
 
-    LOGF(debug, "multFV0A=%5.0f multFV0C=%5.0f multFT0A=%5.0f multFT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
-    mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs, multNContribsEta1);
-    multzeq(multZeqFV0A, multZeqFT0A, multZeqFT0C, multZeqFDDA, multZeqFDDC, multZeqNContribs);
+      LOGF(debug, "multFV0A=%5.0f multFV0C=%5.0f multFT0A=%5.0f multFT0C=%5.0f multFDDA=%5.0f multFDDC=%5.0f multZNA=%6.0f multZNC=%6.0f multTracklets=%i multTPC=%i", multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC);
+      mult(multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTPC, multNContribs, multNContribsEta1);
+      multzeq(multZeqFV0A, multZeqFT0A, multZeqFT0C, multZeqFDDA, multZeqFDDC, multZeqNContribs);
+    }
   }
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", false);
 };


### PR DESCRIPTION
* switches for a for-loop inside process rather than iterator; pre-reserves memory for collision-associated tables (multiplicity and centrality) 