### PR TITLE
PWGHF: B+ creator, fix UseAbsDCA flags in vertexers

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -137,7 +137,7 @@ struct HfCandidateCreatorBplus {
     dfB.setMaxR(maxR);
     dfB.setMinParamChange(minParamChange);
     dfB.setMinRelChi2Change(minRelChi2Change);
-    dfB.setUseAbsDCA(useAbsDCA);
+    dfB.setUseAbsDCA(true);
     dfB.setWeightedFinalPCA(useWeightedFinalPCA);
 
     // Initial fitter to redo D-vertex to get extrapolated daughter tracks


### PR DESCRIPTION
Different options "UseAbsDCA" for the two vertexers:
B+  : set to true by default, false not compatible with V0 track
D0  : configurable