### PR TITLE
[EMCAL-903] Proper selector for cluster iteration in FullJetTriggerQA

### DIFF
--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -444,7 +444,7 @@ struct JetTriggerQA {
 
       // auto clustersInJet = jetClusterConstituents.sliceBy(perJetClusterConstituents, jet.globalIndex());
       // for (const auto& clusterList : clustersInJet) {
-      for (auto& cluster : jet.tracks_as<selectedClusters>()) {
+      for (auto& cluster : jet.clusters_as<selectedClusters>()) {
         auto clusterPt = cluster.energy() / std::cosh(cluster.eta());
         neutralEnergyFraction += cluster.energy();
         auto z = clusterPt / jetPt;


### PR DESCRIPTION
Simple copy&paste error applying selector for track constituents to cluster constituents