### PR TITLE
PWGHF: adding option to select only background candidates on D0 data analysis

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -170,7 +170,7 @@ struct HfCandidateSelectorD0 {
     }
 
     // in case only sideband candidates have to be stored, additional invariant-mass cut
-    if(keepOnlySidebandCandidates) {
+    if (keepOnlySidebandCandidates) {
       if (trackPion.sign() > 0) {
         if (std::abs(invMassD0ToPiK(candidate) - RecoDecay::getMassPDG(pdg::Code::kD0)) < distanceFromD0MassForSidebands) {
           return false;

--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -44,6 +44,9 @@ struct HfCandidateSelectorD0 {
   Configurable<double> nSigmaTofCombinedMax{"nSigmaTofCombinedMax", 5., "Nsigma cut on TOF combined with TPC"};
   // AND logic for TOF+TPC PID (as in Run2)
   Configurable<bool> usePidTpcAndTof{"usePidTpcAndTof", false, "Use AND logic for TPC and TOF PID"};
+  // selecting only background candidates
+  Configurable<bool> keepOnlySidebandCandidates{"keepOnlySidebandCandidates", false, "Select only sideband candidates, for studying background cut variable distributions"};
+  Configurable<double> distanceFromD0MassForSidebands{"distanceFromD0MassForSidebands", 0.15, "Minimum distance from nominal D0 mass value for sideband region"};
   // topological cuts
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_d0_to_pi_k::cuts[0], nBinsPt, nCutVars, labelsPt, labelsCutVar}, "D0 candidate selection per pT bin"};
@@ -163,6 +166,19 @@ struct HfCandidateSelectorD0 {
     } else {
       if (std::abs(cosThetaStarD0bar(candidate)) > cuts->get(pTBin, "cos theta*")) {
         return false;
+      }
+    }
+
+    // in case only sideband candidates have to be stored, additional invariant-mass cut
+    if(keepOnlySidebandCandidates) {
+      if (trackPion.sign() > 0) {
+        if (std::abs(invMassD0ToPiK(candidate) - RecoDecay::getMassPDG(pdg::Code::kD0)) < distanceFromD0MassForSidebands) {
+          return false;
+        }
+      } else {
+        if (std::abs(invMassD0barToKPi(candidate) - RecoDecay::getMassPDG(pdg::Code::kD0)) < distanceFromD0MassForSidebands) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
Useful to produce cut variable distributions for background, only exploiting candidates in the sideband region, in view of studying the optimal selection values.
Option activated via a dedicated configurable in the D0 selector, kept as false in the default configuration to preserve backward compatibility