### PR TITLE
PWGCF: adding analysis of pairs of pions of the same charge

### DIFF
--- a/PWGCF/FemtoWorld/Core/FemtoWorldPionContainer.h
+++ b/PWGCF/FemtoWorld/Core/FemtoWorldPionContainer.h
@@ -1,0 +1,186 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file FemtoWorldPionContainer.h
+/// \brief Definition of the FemtoWorldPionContainer
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Valentina Mantovani Sarti, valentina.mantovani-sarti@tum.de
+/// \author Zuzanna Chochulska, WUT Warsaw, zchochul@cern.ch NOWE
+
+#ifndef PWGCF_FEMTOWORLD_CORE_FEMTOWORLDPIONCONTAINER_H_
+#define PWGCF_FEMTOWORLD_CORE_FEMTOWORLDPIONCONTAINER_H_
+
+#include <vector>
+#include <string>
+#include "Framework/HistogramRegistry.h"
+#include "PWGCF/FemtoWorld/Core/FemtoWorldMath.h"
+
+#include "Math/Vector4D.h"
+#include "TMath.h"
+#include "TDatabasePDG.h"
+
+#include "TLorentzVector.h"
+#include "CommonConstants/MathConstants.h"
+#include "TRandom.h"
+
+using namespace o2::framework;
+using namespace o2::constants::math;
+
+namespace o2::analysis::femtoWorld
+{
+
+namespace femtoWorldPionContainer
+{
+/// Femtoscopic observable to be computed
+enum Observable { kstar ///< kstar
+};
+
+/// Type of the event processind
+enum EventType { samePM,  ///< Pair with the opposite charge from same event
+                 mixedPM, ///< Pair with the opposite charge from mixed event
+                 samePP,  ///< Pair with the same, positive charge from same event
+                 mixedPP, ///< Pair with the same, positive charge from mixed event
+                 sameMM,  ///< Pair with the same, negative charge from same event
+                 mixedMM, ///< Pair with the same, negative charge from mixed event
+};
+}; // namespace femtoWorldPionContainer
+
+/// \class FemtoWorldPionContainer
+/// \brief Container for all histogramming related to the correlation function. The two
+/// particles of the pair are passed here, and the correlation function and QA histograms
+/// are filled according to the specified observable
+/// \tparam eventType Type of the event (same/mixed)
+/// \tparam obs Observable to be computed (k*/Q_inv/...)
+template <femtoWorldPionContainer::EventType eventType, femtoWorldPionContainer::Observable obs>
+class FemtoWorldPionContainer
+{
+ public:
+  /// Destructor
+  virtual ~FemtoWorldPionContainer() = default;
+
+  /// Initializes histograms for the task
+  /// \tparam T Type of the configurable for the axis configuration
+  /// \param registry Histogram registry to be passed
+  /// \param kstarBins k* binning for the histograms
+  /// \param multBins multiplicity binning for the histograms
+  /// \param kTBins kT binning for the histograms
+  /// \param mTBins mT binning for the histograms
+  /// \param etaBins eta binning for the histograms
+  /// \param phiBins phi binning for the histograms
+  /// \param mInvBins invariant mass binning for the histograms
+
+  template <typename T1, typename T2>
+  void init(HistogramRegistry* registry, T1& kstarBins, T1& multBins, T1& kTBins, T1& mTBins, T2& phiBins, T2& etaBins, T2& mInvBins)
+  {
+    mHistogramRegistry = registry;
+    std::string femtoObs;
+    if constexpr (mFemtoObs == femtoWorldPionContainer::Observable::kstar) {
+      femtoObs = "#it{k*} (GeV/#it{c})";
+    }
+    std::vector<double> tmpVecMult = multBins;
+    framework::AxisSpec multAxis = {tmpVecMult, "Multiplicity"};
+    framework::AxisSpec femtoObsAxis = {kstarBins, femtoObs.c_str()};
+    framework::AxisSpec kTAxis = {kTBins, "#it{k}_{T} (GeV/#it{c})"};
+    framework::AxisSpec mTAxis = {mTBins, "#it{m}_{T} (GeV/#it{c}^{2})"};
+
+    mPhiLow = (-static_cast<int>(phiBins / 4) + 0.5) * 2. * PI / phiBins;
+    mPhiHigh = 2 * PI + (-static_cast<int>(phiBins / 4) + 0.5) * 2. * PI / phiBins;
+
+    framework::AxisSpec phiAxis = {phiBins, mPhiLow, mPhiHigh};
+    framework::AxisSpec etaAxis = {etaBins, -2.0, 2.0};
+    framework::AxisSpec mInvAxis = {mInvBins, 0.0, 10.0};
+
+    std::string folderName = static_cast<std::string>(mFolderSuffix[mEventType]);
+    mHistogramRegistry->add((folderName + "relPairDist").c_str(), ("; " + femtoObs + "; Entries").c_str(), kTH1F, {femtoObsAxis});
+    mHistogramRegistry->add((folderName + "relPairkT").c_str(), "; #it{k}_{T} (GeV/#it{c}); Entries", kTH1F, {kTAxis});
+    mHistogramRegistry->add((folderName + "relPairkstarkT").c_str(), ("; " + femtoObs + "; #it{k}_{T} (GeV/#it{c})").c_str(), kTH2F, {femtoObsAxis, kTAxis});
+    mHistogramRegistry->add((folderName + "relPairkstarmT").c_str(), ("; " + femtoObs + "; #it{m}_{T} (GeV/#it{c}^{2})").c_str(), kTH2F, {femtoObsAxis, mTAxis});
+    mHistogramRegistry->add((folderName + "relPairkstarMult").c_str(), ("; " + femtoObs + "; Multiplicity").c_str(), kTH2F, {femtoObsAxis, multAxis});
+    mHistogramRegistry->add((folderName + "kstarPtPart1").c_str(), ("; " + femtoObs + "; #it{p} _{T} Particle 1 (GeV/#it{c})").c_str(), kTH2F, {femtoObsAxis, {375, 0., 7.5}});
+    mHistogramRegistry->add((folderName + "kstarPtPart2").c_str(), ("; " + femtoObs + "; #it{p} _{T} Particle 2 (GeV/#it{c})").c_str(), kTH2F, {femtoObsAxis, {375, 0., 7.5}});
+    mHistogramRegistry->add((folderName + "MultPtPart1").c_str(), "; #it{p} _{T} Particle 1 (GeV/#it{c}); Multiplicity", kTH2F, {{375, 0., 7.5}, multAxis});
+    mHistogramRegistry->add((folderName + "MultPtPart2").c_str(), "; #it{p} _{T} Particle 2 (GeV/#it{c}); Multiplicity", kTH2F, {{375, 0., 7.5}, multAxis});
+    mHistogramRegistry->add((folderName + "PtPart1PtPart2").c_str(), "; #it{p} _{T} Particle 1 (GeV/#it{c}); #it{p} _{T} Particle 2 (GeV/#it{c})", kTH2F, {{375, 0., 7.5}, {375, 0., 7.5}});
+    mHistogramRegistry->add((folderName + "relPairDetaDphi").c_str(), ";  #Delta#varphi (rad); #Delta#eta", kTH2D, {phiAxis, etaAxis});
+    mHistogramRegistry->add((folderName + "relPairInvariantMass").c_str(), ";M_{K^{+}K^{-}} (GeV/#it{c}^{2});", kTH1D, {mInvAxis});
+  }
+
+  /// Set the PDG codes of the two particles involved
+  /// \param pdg1 PDG code of particle one
+  /// \param pdg2 PDG code of particle two
+  void setPDGCodes(const int pdg1, const int pdg2)
+  {
+    mMassOne = TDatabasePDG::Instance()->GetParticle(pdg1)->Mass();
+    mMassTwo = TDatabasePDG::Instance()->GetParticle(pdg2)->Mass();
+  }
+
+  /// Pass a pair to the container and compute all the relevant observables
+  /// \tparam T type of the femtoworldparticle
+  /// \param part1 Particle one
+  /// \param part2 Particle two
+  /// \param mult Multiplicity of the event
+  template <typename T>
+  void setPair(T const& part1, T const& part2, const int mult)
+  {
+    float femtoObs;
+    if constexpr (mFemtoObs == femtoWorldPionContainer::Observable::kstar) {
+      femtoObs = FemtoWorldMath::getkstar(part1, mMassOne, part2, mMassTwo);
+    }
+    const float kT = FemtoWorldMath::getkT(part1, mMassOne, part2, mMassTwo);
+    const float mT = FemtoWorldMath::getmT(part1, mMassOne, part2, mMassTwo);
+
+    double delta_eta = part1.eta() - part2.eta();
+    double delta_phi = part1.phi() - part2.phi();
+
+    while (delta_phi < mPhiLow) {
+      delta_phi += TwoPI;
+    }
+    while (delta_phi > mPhiHigh) {
+      delta_phi -= TwoPI;
+    }
+    TLorentzVector part1Vec;
+    part1Vec.SetPtEtaPhiM(part1.pt(), part1.eta(), part1.phi(), mMassOne);
+    TLorentzVector part2Vec;
+    part2Vec.SetPtEtaPhiM(part2.pt(), part2.eta(), part2.phi(), mMassTwo);
+
+    TLorentzVector sumVec(part1Vec);
+    sumVec += part2Vec;
+
+    if (mHistogramRegistry) {
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairDist"), femtoObs);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairkT"), kT);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairkstarkT"), femtoObs, kT);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairkstarmT"), femtoObs, mT);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairkstarMult"), femtoObs, mult);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("kstarPtPart1"), femtoObs, part1.pt());
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("kstarPtPart2"), femtoObs, part2.pt());
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("MultPtPart1"), part1.pt(), mult);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("MultPtPart2"), part2.pt(), mult);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("PtPart1PtPart2"), part1.pt(), part2.pt());
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairDetaDphi"), delta_phi, delta_eta);
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST("relPairInvariantMass"), sumVec.M());
+    }
+  }
+
+ protected:
+  HistogramRegistry* mHistogramRegistry = nullptr;                                                                                                                                                    ///< For QA output
+  static constexpr std::string_view mFolderSuffix[6] = {"SameEventPlusMinus/", "MixedEventPlusMinus/", "SameEventPlusPlus/", "MixedEventPlusPlus/", "SameEventMinusMinus/", "MixedEventMinusMinus/"}; ///< Folder naming for the output according to mEventType
+  static constexpr femtoWorldPionContainer::Observable mFemtoObs = obs;                                                                                                                               ///< Femtoscopic observable to be computed (according to femtoWorldPionContainer::Observable)
+  static constexpr int mEventType = eventType;                                                                                                                                                        ///< Type of the event (same/mixed, according to femtoWorldPionContainer::EventType)
+  float mMassOne = 0.f;                                                                                                                                                                               ///< PDG mass of particle 1
+  float mMassTwo = 0.f;                                                                                                                                                                               ///< PDG mass of particle 2
+  double mPhiLow;
+  double mPhiHigh;
+};
+
+} // namespace o2::analysis::femtoWorld
+
+#endif // PWGCF_FEMTOWORLD_CORE_FEMTOWORLDPIONCONTAINER_H_

--- a/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskPionPion.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskPionPion.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks - pions
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 /// \author Zuzanna Chochulska, WUT Warsaw, zchochul@cern.ch
+/// \author Alicja Plachta, WUT Warsaw
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
@@ -25,7 +26,7 @@
 #include "PWGCF/FemtoWorld/Core/FemtoWorldParticleHisto.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldEventHisto.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldPairCleaner.h"
-#include "PWGCF/FemtoWorld/Core/FemtoWorldContainer.h"
+#include "PWGCF/FemtoWorld/Core/FemtoWorldPionContainer.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldDetaDphiStar.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldUtils.h"
 
@@ -42,8 +43,10 @@ using FemtoWorldParticleMerged = FemtoWorldParticlesMerged::iterator;
 } // namespace o2::aod
 
 struct femtoWorldPairTaskPionPion {
+
   SliceCache cache;
   Preslice<aod::FemtoWorldParticlesMerged> perCol = aod::femtoworldparticle::femtoWorldCollisionId;
+
   /// Particle selection part
 
   Configurable<float> ConfNsigmaTPCPion{"ConfNsigmaTPCPion", 3.0, "TPC Pion Sigma for momentum < 0.5"};
@@ -152,14 +155,25 @@ struct femtoWorldPairTaskPionPion {
   Configurable<int> ConfEtaBins{"ConfEtaBins", 15, "Number of eta bins in deta dphi"};
   Configurable<int> ConfMInvBins{"ConfMInvBins", 1000, "Number of bins in mInv distribution"};
 
-  FemtoWorldContainer<femtoWorldContainer::EventType::same, femtoWorldContainer::Observable::kstar> sameEventCont;
-  FemtoWorldContainer<femtoWorldContainer::EventType::mixed, femtoWorldContainer::Observable::kstar> mixedEventCont;
+  Configurable<bool> ConfPlusMinus{"ConfPlusMinus", true, "Process pi+pi- pions pairs"};
+  Configurable<bool> ConfPlusPlus{"ConfPlusPlus", true, "Process pi+pi+ pion pairs"};
+  Configurable<bool> ConfMinusMinus{"ConfMinusMinus", true, "Process pi-pi- pion pairs"};
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::samePM, femtoWorldPionContainer::Observable::kstar> sameEventPlusMinCont;
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::samePP, femtoWorldPionContainer::Observable::kstar> sameEventPlusPlusCont;
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::sameMM, femtoWorldPionContainer::Observable::kstar> sameEventMinMinCont;
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::mixedPM, femtoWorldPionContainer::Observable::kstar> mixedEventPlusMinCont;
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::mixedPP, femtoWorldPionContainer::Observable::kstar> mixedEventPlusPlusCont;
+  FemtoWorldPionContainer<femtoWorldPionContainer::EventType::mixedMM, femtoWorldPionContainer::Observable::kstar> mixedEventMinMinCont;
+
   FemtoWorldPairCleaner<aod::femtoworldparticle::ParticleType::kTrack, aod::femtoworldparticle::ParticleType::kTrack> pairCleaner;
   FemtoWorldDetaDphiStar<aod::femtoworldparticle::ParticleType::kTrack, aod::femtoworldparticle::ParticleType::kTrack> pairCloseRejection;
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   // HistogramRegistry qaRegistryFail{"TrackQAFailed", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry resultRegistryPlusMin{"CorrelationsPlusMin", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry resultRegistryPlusPlus{"CorrelationsPlusPlus", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry resultRegistryMinMin{"CorrelationsMinMin", {}, OutputObjHandlingPolicy::AnalysisObject};
+
   HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
@@ -175,13 +189,36 @@ struct femtoWorldPairTaskPionPion {
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
-    sameEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
-    sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
-    mixedEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
-    mixedEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    if (ConfPlusMinus)
+      sameEventPlusMinCont.init(&resultRegistryPlusMin, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    if (ConfPlusMinus)
+      sameEventPlusMinCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    if (ConfPlusPlus)
+      sameEventPlusPlusCont.init(&resultRegistryPlusPlus, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    if (ConfPlusPlus)
+      sameEventPlusPlusCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    sameEventMinMinCont.init(&resultRegistryMinMin, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    sameEventMinMinCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+
+    if (ConfPlusMinus)
+      mixedEventPlusMinCont.init(&resultRegistryPlusMin, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    if (ConfPlusMinus)
+      mixedEventPlusMinCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    if (ConfPlusPlus)
+      mixedEventPlusPlusCont.init(&resultRegistryPlusPlus, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    if (ConfPlusPlus)
+      mixedEventPlusPlusCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    if (ConfMinusMinus)
+      mixedEventMinMinCont.init(&resultRegistryMinMin, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
+    if (ConfMinusMinus)
+      mixedEventMinMinCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+
     pairCleaner.init(&qaRegistry);
+
     if (ConfIsCPR) {
-      pairCloseRejection.init(&resultRegistry, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii); /// \todo add config for Δη and ΔΦ cut values
+      pairCloseRejection.init(&resultRegistryPlusMin, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii); /// \todo add config for Δη and ΔΦ cut values
+      pairCloseRejection.init(&resultRegistryPlusPlus, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii);
+      pairCloseRejection.init(&resultRegistryMinMin, &qaRegistry, 0.01, 0.01, ConfCPRPlotPerRadii);
     }
 
     vPIDPartOne = ConfPIDPartOne;
@@ -216,8 +253,31 @@ struct femtoWorldPairTaskPionPion {
     return false;
   }
 
+  // Function to build combinations
+  template <typename T1, typename T2, typename T3, typename T4>
+  void CombineParticles(T1 groupPartsOne, T1 groupPartsTwo, T2 cont, T3 parts, T4 magFieldTesla, int multCol)
+  {
+    for (auto& [p1, p2] : combinations(groupPartsOne, groupPartsTwo)) {
+      if (!(IsPionNSigma(p1.p(), p1.tpcNSigmaPi(), p1.tofNSigmaPi()))) {
+        continue;
+      }
+      if (!(IsPionNSigma(p2.p(), p2.tpcNSigmaPi(), p2.tofNSigmaPi()))) {
+        continue;
+      }
+      if (ConfIsCPR) {
+        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+          continue;
+        }
+      }
+      // track cleaning
+      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+        continue;
+      }
+      cont.setPair(p1, p2, multCol);
+    }
+  }
+
   /// This function processes the same event and takes care of all the histogramming
-  /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
   void processSameEvent(o2::aod::FemtoWorldCollision& col,
                         o2::aod::FemtoWorldParticlesMerged& parts)
   {
@@ -253,31 +313,18 @@ struct femtoWorldPairTaskPionPion {
         trackHistoPartTwoFailed.fillQA(part);
       }
     }
-    /// Now build the combinations
-    for (auto& [p1, p2] : combinations(groupPartsOne, groupPartsTwo)) {
-      if (!(IsPionNSigma(p1.p(), p1.tpcNSigmaPi(), p1.tofNSigmaPi()))) {
-        continue;
-      }
-      if (!(IsPionNSigma(p2.p(), p2.tpcNSigmaPi(), p2.tofNSigmaPi()))) {
-        continue;
-      }
-      if (ConfIsCPR) {
-        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
-          continue;
-        }
-      }
-      // track cleaning
-      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-        continue;
-      }
-      sameEventCont.setPair(p1, p2, multCol);
-    }
+    /// Build the combinations
+    if (ConfPlusMinus)
+      CombineParticles(groupPartsOne, groupPartsTwo, sameEventPlusMinCont, parts, magFieldTesla, multCol);
+    if (ConfPlusPlus)
+      CombineParticles(groupPartsOne, groupPartsOne, sameEventPlusPlusCont, parts, magFieldTesla, multCol);
+    if (ConfMinusMinus)
+      CombineParticles(groupPartsTwo, groupPartsTwo, sameEventMinMinCont, parts, magFieldTesla, multCol);
   }
 
   PROCESS_SWITCH(femtoWorldPairTaskPionPion, processSameEvent, "Enable processing same event", true);
 
   /// This function processes the mixed event
-  /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
   void processMixedEvent(o2::aod::FemtoWorldCollisions& cols,
                          o2::aod::FemtoWorldParticlesMerged& parts)
   {
@@ -296,23 +343,17 @@ struct femtoWorldPairTaskPionPion {
         continue;
       }
 
+      const int multCol1 = collision1.multV0M();
+
       /// \todo before mixing we should check whether both collisions contain a pair of particles!
       // if (partsOne.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTwo.size() == 0 ) continue;
 
-      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-        if (!(IsPionNSigma(p1.p(), p1.tpcNSigmaPi(), p1.tofNSigmaPi()))) {
-          continue;
-        }
-        if (!(IsPionNSigma(p2.p(), p2.tpcNSigmaPi(), p2.tofNSigmaPi()))) {
-          continue;
-        }
-        if (ConfIsCPR) {
-          if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla1)) {
-            continue;
-          }
-        }
-        mixedEventCont.setPair(p1, p2, collision1.multV0M());
-      }
+      if (ConfPlusMinus)
+        CombineParticles(groupPartsOne, groupPartsTwo, mixedEventPlusMinCont, parts, magFieldTesla1, multCol1);
+      if (ConfPlusPlus)
+        CombineParticles(groupPartsOne, groupPartsOne, mixedEventPlusPlusCont, parts, magFieldTesla1, multCol1);
+      if (ConfMinusMinus)
+        CombineParticles(groupPartsTwo, groupPartsTwo, mixedEventMinMinCont, parts, magFieldTesla1, multCol1);
     }
   }
 


### PR DESCRIPTION
femtoWorldPairTaskPionPionPion.cxx is changed, so that it not only works for pions of opposite charge, but also the same. Output is put in folders named according to event type and charges.