### PR TITLE
PWGCF: bug fixes in femtodream

### DIFF
--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -151,8 +151,8 @@ using FemtoFullTracks =
 
 struct CFFilterQA {
 
-  Produces<aod::FemtoDreamCollisions> outputCollision;
-  Produces<aod::FemtoDreamParticles> outputParts;
+  Produces<aod::FDCollisions> outputCollision;
+  Produces<aod::FDParticles> outputParts;
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::ccdb::CcdbApi ccdbApi;

--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -21,7 +21,7 @@
 #include "Framework/Expressions.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/PIDResponse.h"
-
+// asdfasf
 namespace o2::aod
 {
 /// FemtoDreamCollision
@@ -34,14 +34,14 @@ DECLARE_SOA_COLUMN(MagField, magField, float);     //! Magnetic field of the eve
 
 } // namespace femtodreamcollision
 
-DECLARE_SOA_TABLE(FemtoDreamCollisions, "AOD", "FEMTODREAMCOLS",
+DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
                   o2::soa::Index<>,
                   o2::aod::collision::PosZ,
                   femtodreamcollision::MultV0M,
                   femtodreamcollision::MultNtr,
                   femtodreamcollision::Sphericity,
                   femtodreamcollision::MagField);
-using FemtoDreamCollision = FemtoDreamCollisions::iterator;
+using FDCollision = FDCollisions::iterator;
 
 /// FemtoDreamTrack
 namespace femtodreamparticle
@@ -70,7 +70,7 @@ enum TrackType {
 
 static constexpr std::string_view TrackTypeName[kNTrackTypes] = {"Trk", "Pos", "Neg"}; //! Naming of the different particle types
 
-DECLARE_SOA_INDEX_COLUMN(FemtoDreamCollision, femtoDreamCollision);
+DECLARE_SOA_INDEX_COLUMN(FDCollision, fdCollision);
 DECLARE_SOA_COLUMN(Pt, pt, float);                       //! p_T (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                     //! Eta
 DECLARE_SOA_COLUMN(Phi, phi, float);                     //! Phi
@@ -120,9 +120,9 @@ DECLARE_SOA_COLUMN(DecayVtxZ, decayVtxZ, float);     //! Z position of the decay
 DECLARE_SOA_COLUMN(MKaon, mKaon, float);             //! The invariant mass of V0 candidate, assuming kaon
 
 } // namespace femtodreamparticle
-DECLARE_SOA_TABLE(FemtoDreamParticles, "AOD", "FEMTODREAMPARTS",
+DECLARE_SOA_TABLE(FDParticles, "AOD", "FDPARTICLE",
                   o2::soa::Index<>,
-                  femtodreamparticle::FemtoDreamCollisionId,
+                  femtodreamparticle::FDCollisionId,
                   femtodreamparticle::Pt,
                   femtodreamparticle::Eta,
                   femtodreamparticle::Phi,
@@ -138,9 +138,9 @@ DECLARE_SOA_TABLE(FemtoDreamParticles, "AOD", "FEMTODREAMPARTS",
                   femtodreamparticle::Py<femtodreamparticle::Pt, femtodreamparticle::Phi>,
                   femtodreamparticle::Pz<femtodreamparticle::Pt, femtodreamparticle::Eta>,
                   femtodreamparticle::P<femtodreamparticle::Pt, femtodreamparticle::Eta>);
-using FemtoDreamParticle = FemtoDreamParticles::iterator;
+using FDParticle = FDParticles::iterator;
 
-DECLARE_SOA_TABLE(FemtoDreamDebugParticles, "AOD", "FEMTODEBUGPARTS",
+DECLARE_SOA_TABLE(FDExtParticles, "AOD", "FDEXTPARTICLE",
                   femtodreamparticle::Sign,
                   femtodreamparticle::TPCNClsFound,
                   track::TPCNClsFindable,
@@ -179,7 +179,7 @@ DECLARE_SOA_TABLE(FemtoDreamDebugParticles, "AOD", "FEMTODEBUGPARTS",
                   pidtof_tiny::TOFNSigmaKa<pidtof_tiny::TOFNSigmaStoreKa>,
                   pidtof_tiny::TOFNSigmaPr<pidtof_tiny::TOFNSigmaStorePr>,
                   pidtof_tiny::TOFNSigmaDe<pidtof_tiny::TOFNSigmaStoreDe>);
-using FemtoDreamDebugParticle = FemtoDreamDebugParticles::iterator;
+using FDFullParticle = FDExtParticles::iterator;
 
 /// FemtoDreamTrackMC
 namespace femtodreamMCparticle
@@ -215,7 +215,7 @@ enum MCType {
 
 static constexpr std::string_view MCTypeName[kNMCTypes] = {"", "_MC"};
 
-DECLARE_SOA_INDEX_COLUMN(FemtoDreamCollision, femtoDreamCollision);
+// DECLARE_SOA_INDEX_COLUMN(FemtoDreamCollision, femtoDreamCollision);
 DECLARE_SOA_COLUMN(PartOriginMCTruth, partOriginMCTruth, uint8_t); //! Origin of the particle, according to femtodreamparticle::ParticleOriginMCTruth
 DECLARE_SOA_COLUMN(PDGMCTruth, pdgMCTruth, int);                   //! Particle PDG
 
@@ -223,26 +223,26 @@ DECLARE_SOA_COLUMN(PDGMCTruth, pdgMCTruth, int);                   //! Particle 
 DECLARE_SOA_COLUMN(MotherPDG, motherPDG, int); //! Checks mother PDG, where mother is the primary particle for that decay chain
 } // namespace femtodreamMCparticle
 
-DECLARE_SOA_TABLE(FemtoDreamMCParticles, "AOD", "FEMTODREAMMCPS",
+DECLARE_SOA_TABLE(FDMCParticles, "AOD", "FDMCPARTICLE",
                   o2::soa::Index<>,
                   femtodreamMCparticle::PartOriginMCTruth,
                   femtodreamMCparticle::PDGMCTruth,
                   femtodreamparticle::Pt,
                   femtodreamparticle::Eta,
                   femtodreamparticle::Phi);
-using FemtoDreamMCParticle = FemtoDreamMCParticles::iterator;
+using FDMCParticle = FDMCParticles::iterator;
 
-DECLARE_SOA_TABLE(FemtoDreamDebugMCParticles, "AOD", "FEMTODEBUGMCP",
+DECLARE_SOA_TABLE(FDExtMCParticles, "AOD", "FDEXTMCPARTICLE",
                   femtodreamMCparticle::MotherPDG);
-using FemtoDreamDebugMCParticle = FemtoDreamDebugMCParticles::iterator;
+using FDExtMCParticle = FDExtMCParticles::iterator;
 
 namespace mcfdlabel
 {
-DECLARE_SOA_INDEX_COLUMN(FemtoDreamMCParticle, femtoDreamMCParticle); //! MC particle for femtodreamparticle
+DECLARE_SOA_INDEX_COLUMN(FDMCParticle, fdMCParticle); //! MC particle for femtodreamparticle
 } // namespace mcfdlabel
-DECLARE_SOA_TABLE(FemtoDreamMCLabels, "AOD", "FEMTOMCLABELS", //! Table joinable to FemtoDreamParticle containing the MC labels
-                  mcfdlabel::FemtoDreamMCParticleId);
-using FemtoDreamMCLabel = FemtoDreamMCLabels::iterator;
+DECLARE_SOA_TABLE(FDMCLabels, "AOD", "FDMCLabel", //! Table joinable to FemtoDreamParticle containing the MC labels
+                  mcfdlabel::FDMCParticleId);
+// using FDMCLabel = FDMCLabels::iterator;
 
 /// Hash
 namespace hash

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -215,7 +215,6 @@ enum MCType {
 
 static constexpr std::string_view MCTypeName[kNMCTypes] = {"", "_MC"};
 
-// DECLARE_SOA_INDEX_COLUMN(FemtoDreamCollision, femtoDreamCollision);
 DECLARE_SOA_COLUMN(PartOriginMCTruth, partOriginMCTruth, uint8_t); //! Origin of the particle, according to femtodreamparticle::ParticleOriginMCTruth
 DECLARE_SOA_COLUMN(PDGMCTruth, pdgMCTruth, int);                   //! Particle PDG
 
@@ -242,7 +241,6 @@ DECLARE_SOA_INDEX_COLUMN(FDMCParticle, fdMCParticle); //! MC particle for femtod
 } // namespace mcfdlabel
 DECLARE_SOA_TABLE(FDMCLabels, "AOD", "FDMCLabel", //! Table joinable to FemtoDreamParticle containing the MC labels
                   mcfdlabel::FDMCParticleId);
-// using FDMCLabel = FDMCLabels::iterator;
 
 /// Hash
 namespace hash

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -21,7 +21,7 @@
 #include "Framework/Expressions.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/PIDResponse.h"
-// asdfasf
+
 namespace o2::aod
 {
 /// FemtoDreamCollision

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamContainer.h
+++ b/PWGCF/FemtoDream/FemtoDreamContainer.h
@@ -217,15 +217,15 @@ class FemtoDreamContainer
       setPair_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(femtoObs, mT, part1, part2, mult, use3dplots);
 
       if constexpr (isMC) {
-        if (part1.has_femtoDreamMCParticle() && part2.has_femtoDreamMCParticle()) {
+        if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
           // calculate the femto observable and the mT with MC truth information
           if constexpr (mFemtoObs == femtoDreamContainer::Observable::kstar) {
-            femtoObsMC = FemtoDreamMath::getkstar(part1.femtoDreamMCParticle(), mMassOne, part2.femtoDreamMCParticle(), mMassTwo);
+            femtoObsMC = FemtoDreamMath::getkstar(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
           }
-          const float mTMC = FemtoDreamMath::getmT(part1.femtoDreamMCParticle(), mMassOne, part2.femtoDreamMCParticle(), mMassTwo);
+          const float mTMC = FemtoDreamMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
 
-          if (abs(part1.femtoDreamMCParticle().pdgMCTruth()) == mPDGOne && abs(part2.femtoDreamMCParticle().pdgMCTruth()) == mPDGTwo) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
-            setPair_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(femtoObsMC, mTMC, part1.femtoDreamMCParticle(), part2.femtoDreamMCParticle(), mult, use3dplots);
+          if (abs(part1.fdMCParticle().pdgMCTruth()) == mPDGOne && abs(part2.fdMCParticle().pdgMCTruth()) == mPDGTwo) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
+            setPair_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(femtoObsMC, mTMC, part1.fdMCParticle(), part2.fdMCParticle(), mult, use3dplots);
             setPair_MC(femtoObsMC, femtoObs, mT, mult);
           } else {
             mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("/hFakePairsCounter"), 0);

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,6 +1,6 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,22 +10,26 @@
 // or submit itself to any jurisdiction.
 
 /// \file FemtoDreamCutculator.h
-/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and actual physics cuts
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
-/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \brief FemtoDreamCutculator - small class to match bit-wise encoding and
+/// actual physics cuts \author Andi Mathis, TU München,
+/// andreas.mathis@ph.tum.de \author Luca Barioglio, TU München,
+/// luca.barioglio@cern.ch
 
 #ifndef PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 #define PWGCF_FEMTODREAM_FEMTODREAMCUTCULATOR_H_
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include <bitset>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
+#include <bitset>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <iterator>
 
 namespace o2::analysis::femtoDream
 {
@@ -36,44 +40,51 @@ class FemtoDreamCutculator
 {
  public:
   /// Initializes boost ptree
-  /// \param configFile Path to the dpl-config.json file from the femtodream-producer task
+  /// \param configFile Path to the dpl-config.json file from the
+  /// femtodream-producer task
   void init(const char* configFile)
   {
-    LOG(info) << "Welcome to the CutCulator!";
+    std::cout << "Welcome to the CutCulator!" << std::endl;
 
     boost::property_tree::ptree root;
     try {
       boost::property_tree::read_json(configFile, root);
     } catch (const boost::property_tree::ptree_error& e) {
-      LOG(fatal) << "Failed to read JSON config file " << configFile << " (" << e.what() << ")";
+      std::cout
+        << "Failed to read JSON config file " << configFile << " ("
+        << e.what() << ")" << std::endl;
     }
 
     // check the config file for all known producer task
-    std::vector<const char*> ProducerTasks = {"femto-dream-producer-task", "femto-dream-producer-reduced-task"};
+    std::vector<const char*> ProducerTasks = {
+      "femto-dream-producer-task", "femto-dream-producer-reduced-task"};
     for (auto& Producer : ProducerTasks) {
       if (root.count(Producer) > 0) {
         mConfigTree = root.get_child(Producer);
-        LOG(info) << "Found " << Producer << " in " << configFile;
+        std::cout << "Found " << Producer << " in " << configFile << std::endl;
         break;
       }
     }
   };
 
-  /// Generic function that retrieves a given selection from the boost ptree and returns an std::vector in the proper format
-  /// \param name Name of the selection in the dpl-config.json
-  /// \return std::vector that can be directly passed to the FemtoDreamTrack/V0/../Selection
+  /// Generic function that retrieves a given selection from the boost ptree and
+  /// returns an std::vector in the proper format \param name Name of the
+  /// selection in the dpl-config.json \return std::vector that can be directly
+  /// passed to the FemtoDreamTrack/V0/../Selection
   std::vector<float> setSelection(std::string name)
   {
     try {
       boost::property_tree::ptree& selections = mConfigTree.get_child(name);
-      boost::property_tree::ptree& selectionsValues = selections.get_child("values");
+      boost::property_tree::ptree& selectionsValues =
+        selections.get_child("values");
       std::vector<float> tmpVec;
       for (boost::property_tree::ptree::value_type& val : selectionsValues) {
         tmpVec.push_back(std::stof(val.second.data()));
       }
       return tmpVec;
     } catch (const boost::property_tree::ptree_error& e) {
-      LOG(warning) << "Selection " << name << " not available (" << e.what() << ")";
+      std::cout << "Selection " << name << " not available (" << e.what() << ")"
+                << std::endl;
       return {};
     }
   }
@@ -84,9 +95,12 @@ class FemtoDreamCutculator
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs, femtoDreamSelection::SelectionType type, const char* prefix)
+  void setTrackSelection(femtoDreamTrackSelection::TrackSel obs,
+                         femtoDreamSelection::SelectionType type,
+                         const char* prefix)
   {
-    auto tmpVec = setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
+    auto tmpVec =
+      setSelection(FemtoDreamTrackSelection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mTrackSel.setSelection(tmpVec, obs, type);
     }
@@ -100,7 +114,8 @@ class FemtoDreamCutculator
       std::string sel_name = sel.first;
       femtoDreamTrackSelection::TrackSel obs;
       if (sel_name.find(prefix) != std::string::npos) {
-        int index = FemtoDreamTrackSelection::findSelectionIndex(std::string_view(sel_name), prefix);
+        int index = FemtoDreamTrackSelection::findSelectionIndex(
+          std::string_view(sel_name), prefix);
         if (index >= 0) {
           obs = femtoDreamTrackSelection::TrackSel(index);
         } else {
@@ -108,24 +123,33 @@ class FemtoDreamCutculator
         }
         if (obs == femtoDreamTrackSelection::TrackSel::kPIDnSigmaMax)
           continue; // kPIDnSigmaMax is a special case
-        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs), prefix);
+        setTrackSelection(obs, FemtoDreamTrackSelection::getSelectionType(obs),
+                          prefix);
       }
     }
   }
 
   /// Automatically retrieves track PID from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setPIDSelectionFromFile(const char* prefix)
+  void setPIDSelectionFromFile(const char* prefixPID, const char* prefixTrack)
   {
-    std::string PIDnodeName = std::string(prefix) + "species";
+    std::string PIDnodeName = std::string(prefixPID) + "species";
+    std::string PIDNsigmaNodeName = std::string(prefixTrack) + "PIDnSigmaMax";
     try {
       boost::property_tree::ptree& pidNode = mConfigTree.get_child(PIDnodeName);
       boost::property_tree::ptree& pidValues = pidNode.get_child("values");
       for (auto& val : pidValues) {
-        mPIDspecies.push_back(static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
+        mPIDspecies.push_back(
+          static_cast<o2::track::PID::ID>(std::stoi(val.second.data())));
+      }
+      boost::property_tree::ptree& pidNsigmaNode = mConfigTree.get_child(PIDNsigmaNodeName);
+      boost::property_tree::ptree& pidNsigmaValues = pidNsigmaNode.get_child("values");
+      for (auto& val : pidNsigmaValues) {
+        mPIDValues.push_back(std::stof(val.second.data()));
       }
     } catch (const boost::property_tree::ptree_error& e) {
-      LOG(info) << "PID selection not avalible for these skimmed data.";
+      std::cout << "PID selection not avalible for these skimmed data."
+                << std::endl;
     }
   }
 
@@ -135,9 +159,12 @@ class FemtoDreamCutculator
   /// \param obs Observable of the track selection
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setV0Selection(femtoDreamV0Selection::V0Sel obs, femtoDreamSelection::SelectionType type, const char* prefix)
+  void setV0Selection(femtoDreamV0Selection::V0Sel obs,
+                      femtoDreamSelection::SelectionType type,
+                      const char* prefix)
   {
-    auto tmpVec = setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
+    auto tmpVec =
+      setSelection(FemtoDreamV0Selection::getSelectionName(obs, prefix));
     if (tmpVec.size() > 0) {
       mV0Sel.setSelection(tmpVec, obs, type);
     }
@@ -151,42 +178,76 @@ class FemtoDreamCutculator
       std::string sel_name = sel.first;
       femtoDreamV0Selection::V0Sel obs;
       if (sel_name.find(prefix) != std::string::npos) {
-        int index = FemtoDreamV0Selection::findSelectionIndex(std::string_view(sel_name), prefix);
+        int index = FemtoDreamV0Selection::findSelectionIndex(
+          std::string_view(sel_name), prefix);
         if (index >= 0) {
           obs = femtoDreamV0Selection::V0Sel(index);
         } else {
           continue;
         }
-        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs), prefix);
+        setV0Selection(obs, FemtoDreamV0Selection::getSelectionType(obs),
+                       prefix);
       }
     }
   }
 
-  /// This function investigates a given selection criterion. The available options are displayed in the terminal and the bit-wise container is put together according to the user input
-  /// \tparam T1 Selection class under investigation
-  /// \param T2  Selection type under investigation
-  /// \param output Bit-wise container for the systematic variations
-  /// \param counter Current position in the bit-wise container to modify
-  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
-  /// \param selectionType Selection type under investigation, as defined in the selection class
+  /// This function investigates a given selection criterion. The available
+  /// options are displayed in the terminal and the bit-wise container is put
+  /// together according to the user input \tparam T1 Selection class under
+  /// investigation \param T2  Selection type under investigation \param output
+  /// Bit-wise container for the systematic variations \param counter Current
+  /// position in the bit-wise container to modify \tparam objectSelection
+  /// Selection class under investigation (FemtoDreamTrack/V0/../Selection)
+  /// \param selectionType Selection type under investigation, as defined in the
+  /// selection class
   template <typename T1, typename T2>
-  void checkForSelection(aod::femtodreamparticle::cutContainerType& output, size_t& counter, T1 objectSelection, T2 selectionType)
+  void checkForSelection(aod::femtodreamparticle::cutContainerType& output,
+                         size_t& counter, T1 objectSelection, T2 selectionType,
+                         bool SysChecks, float sign)
   {
     /// Output of the available selections and user input
-    std::cout << "Selection: " << objectSelection.getSelectionHelper(selectionType) << " - (";
+    std::cout << "Selection: "
+              << objectSelection.getSelectionHelper(selectionType) << " - (";
     auto selVec = objectSelection.getSelections(selectionType);
     for (auto selIt : selVec) {
       std::cout << selIt.getSelectionValue() << " ";
     }
-    std::cout << ")\n > ";
+    std::cout << ")" << std::endl
+              << " > ";
     std::string in;
-    std::cin >> in;
-    const float input = std::stof(in);
+    std::vector<float> out;
+    float input;
 
-    /// First we check whether the input is actually contained within the options
+    if (SysChecks) {
+      if (objectSelection.getSelectionHelper(selectionType) == std::string("Sign of the track")) {
+        input = sign;
+        std::cout << sign << std::endl;
+      } else {
+        // Seed the random number generator
+        std::random_device rd;
+        std::mt19937 rng(rd());
+        // Select a random element
+        std::uniform_int_distribution<int> uni(0, selVec.size() - 1);
+        int randomIndex = uni(rng);
+        input = selVec[randomIndex].getSelectionValue();
+        std::cout << input << std::endl;
+      }
+    } else {
+      if (selVec.size() == 0) {
+        input = selVec[0].getSelectionValue();
+        std::cout << input << std::endl;
+      } else {
+        std::cin >> in;
+        input = std::stof(in);
+      }
+    }
+
+    /// First we check whether the input is actually contained within the
+    /// options
     bool inputSane = false;
     for (auto sel : selVec) {
-      if (std::abs(sel.getSelectionValue() - input) <= std::abs(1.e-6 * input)) {
+      if (std::abs(sel.getSelectionValue() - input) <=
+          std::abs(1.e-6 * input)) {
         inputSane = true;
       }
     }
@@ -210,7 +271,8 @@ class FemtoDreamCutculator
             break;
         }
 
-        /// for upper and lower limit we have to subtract/add an epsilon so that the cut is actually fulfilled
+        /// for upper and lower limit we have to subtract/add an epsilon so that
+        /// the cut is actually fulfilled
         if (sel.isSelected(input + signOffset * 1.e-6 * input)) {
           output |= 1UL << counter;
           for (int i = internal_index; i > 0; i--) {
@@ -221,56 +283,78 @@ class FemtoDreamCutculator
         ++internal_index;
       }
     } else {
-      std::cout << "Choice " << in << " not recognized - repeating\n";
-      checkForSelection(output, counter, objectSelection, selectionType);
+      std::cout << "Choice " << in << " not recognized - repeating"
+                << std::endl;
+      checkForSelection(output, counter, objectSelection, selectionType, SysChecks, sign);
     }
   }
 
-  /// This function iterates over all selection types of a given class and puts together the bit-wise container
-  /// \tparam T1 Selection class under investigation
-  /// \tparam objectSelection Selection class under investigation (FemtoDreamTrack/V0/../Selection)
-  /// \return the full selection bit-wise container that will be put to the user task incorporating the user choice of selections
+  /// This function iterates over all selection types of a given class and puts
+  /// together the bit-wise container \tparam T1 Selection class under
+  /// investigation \tparam objectSelection Selection class under investigation
+  /// (FemtoDreamTrack/V0/../Selection) \return the full selection bit-wise
+  /// container that will be put to the user task incorporating the user choice
+  /// of selections
   template <typename T>
-  aod::femtodreamparticle::cutContainerType iterateSelection(T objectSelection)
+  aod::femtodreamparticle::cutContainerType iterateSelection(T objectSelection,
+                                                             bool SysChecks, float sign)
   {
     aod::femtodreamparticle::cutContainerType output = 0;
     size_t counter = 0;
     auto selectionVariables = objectSelection.getSelectionVariables();
     for (auto selVarIt : selectionVariables) {
-      checkForSelection(output, counter, objectSelection, selVarIt);
+      checkForSelection(output, counter, objectSelection, selVarIt, SysChecks, sign);
     }
     return output;
   }
 
-  /// This is the function called by the executable that then outputs the full selection bit-wise container incorporating the user choice of selections
-  void analyseCuts(std::string choice)
+  /// This is the function called by the executable that then outputs the full
+  /// selection bit-wise container incorporating the user choice of selections
+  void analyseCuts(std::string choice, bool SysChecks = false, float sign = 1)
   {
     aod::femtodreamparticle::cutContainerType output = -1;
     if (choice == std::string("T")) {
-      output = iterateSelection(mTrackSel);
+      output = iterateSelection(mTrackSel, SysChecks, sign);
     } else if (choice == std::string("V")) {
-      output = iterateSelection(mV0Sel);
+      output = iterateSelection(mV0Sel, SysChecks, sign);
     } else {
-      LOG(info) << "Option " << choice << " not recognized - available options are (T/V)";
+      std::cout << "Option " << choice
+                << " not recognized - available options are (T/V)" << std::endl;
       return;
     }
-    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)> bitOutput = output;
-    std::cout << "+++++++++++++++++++++++++++++++++\n";
-    std::cout << "CutCulator has spoken - your selection bit is\n";
-    std::cout << bitOutput << " (bitwise)\n";
-    std::cout << output << " (number representation)\n";
-    std::cout << "PID for these species is stored:\n";
+    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)>
+      bitOutput = output;
+    std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+    std::cout << "CutCulator has spoken - your selection bit is" << std::endl;
+    std::cout << bitOutput << " (bitwise)" << std::endl;
+    std::cout << output << " (number representation)" << std::endl;
+    std::cout << "PID for these species is stored:" << std::endl;
     int index = 0;
     for (auto id : mPIDspecies) {
       std::cout << o2::track::PID::getName(id) << " : " << index++ << std::endl;
+      if (SysChecks) {
+        // Seed the random number generator
+        std::random_device rd;
+        std::mt19937 rng(rd());
+        // Select a random element
+        std::uniform_int_distribution<int> uni(0, mPIDValues.size() - 1);
+        int randomIndex = uni(rng);
+        std::cout << "Nsigma: " << mPIDValues[randomIndex] << std::endl;
+      }
     }
   }
 
  private:
-  boost::property_tree::ptree mConfigTree;     ///< the dpl-config.json buffered into a ptree
-  FemtoDreamTrackSelection mTrackSel;          ///< for setting up the bit-wise selection container for tracks
-  FemtoDreamV0Selection mV0Sel;                ///< for setting up the bit-wise selection container for V0s
-  std::vector<o2::track::PID::ID> mPIDspecies; ///< list of particle species for which PID is stored
+  boost::property_tree::ptree
+    mConfigTree; ///< the dpl-config.json buffered into a ptree
+  FemtoDreamTrackSelection
+    mTrackSel; ///< for setting up the bit-wise selection container for tracks
+  FemtoDreamV0Selection
+    mV0Sel; ///< for setting up the bit-wise selection container for V0s
+  std::vector<o2::track::PID::ID>
+    mPIDspecies; ///< list of particle species for which PID is stored
+  std::vector<float>
+    mPIDValues; ///< list of nsigma values for which PID is stored
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,9 +1,9 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -22,14 +22,14 @@
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
 #include <bitset>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <iostream>
 #include <random>
 #include <string>
 #include <vector>
 #include <algorithm>
 #include <iterator>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace o2::analysis::femtoDream
 {

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -1,9 +1,9 @@
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/FemtoDreamDetaDphiStar.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamEventHisto.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamEventHisto.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamEventHisto.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamMath.h
+++ b/PWGCF/FemtoDream/FemtoDreamMath.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamMath.h
+++ b/PWGCF/FemtoDream/FemtoDreamMath.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamMath.h
+++ b/PWGCF/FemtoDream/FemtoDreamMath.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/FemtoDreamPairCleaner.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -326,9 +326,9 @@ class FemtoDreamParticleHisto
         fillQA_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(part);
       }
       if constexpr (isMC) {
-        if (part.has_femtoDreamMCParticle()) {
-          fillQA_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(part.femtoDreamMCParticle());
-          fillQA_MC(part, (part.femtoDreamMCParticle()).partOriginMCTruth(), (part.femtoDreamMCParticle()).pdgMCTruth());
+        if (part.has_fdMCParticle()) {
+          fillQA_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(part.fdMCParticle());
+          fillQA_MC(part, (part.fdMCParticle()).partOriginMCTruth(), (part.fdMCParticle()).pdgMCTruth());
         } else {
           mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hNoMCtruthCounter"), 0);
         }

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -76,7 +76,6 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{20, 0.5, 4.05}, {500, -5, 5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
@@ -101,8 +100,6 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hCPA").c_str(), "; #it{cos #theta_{p}}; Entries", kTH1F, {{1000, 0.9, 1.}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hCPAvsPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}", kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {{600, 0.f, 3.f}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {{600, 0.f, 3.f}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {{600, 0.f, 3.f}, {600, 0.f, 3.f}});
@@ -249,8 +246,6 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxX"), part.decayVtxX());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxY"), part.decayVtxY());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxZ"), part.decayVtxZ());
-      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCPA"), part.tempFitVar());
-      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCPAvsPt"), part.pt(), part.tempFitVar());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambda"), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassAntiLambda"), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -547,13 +547,10 @@ void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0,
 /// to pass the collsion as well
 template <typename cutContainerType, typename C, typename V, typename T>
 std::array<cutContainerType, 5>
-  FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0,
-                                         T const& posTrack, T const& negTrack)
+  FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0, T const& posTrack, T const& negTrack)
 {
-  auto outputPosTrack =
-    PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
-  auto outputNegTrack =
-    NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
+  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
+  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
   cutContainerType output = 0;
   size_t counter = 0;
 
@@ -570,21 +567,15 @@ std::array<cutContainerType, 5>
   auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
   auto nSigmaPrPos = posTrack.tpcNSigmaPr();
   // check the mass and the PID of daughters
-  if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-      abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-      diffAntiLambda > diffLambda) {
+  if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda > diffLambda) {
     sign = -1.;
-  } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-             abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-             diffAntiLambda < diffLambda) {
+  } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda < diffLambda) {
     sign = 1.;
   } else {
     // if it happens that none of these are true, ignore the invariant mass
-    if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-        abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+    if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
       sign = -1.;
-    } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-               abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+    } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
       sign = 1.;
     }
   }
@@ -599,7 +590,6 @@ std::array<cutContainerType, 5>
   float observable = 0.;
   for (auto& sel : mSelections) {
     const auto selVariable = sel.getSelectionVariable();
-
     if (selVariable == femtoDreamV0Selection::kV0DecVtxMax) {
       for (size_t i = 0; i < decVtx.size(); ++i) {
         auto decVtxValue = decVtx.at(i);

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -41,6 +41,7 @@ enum V0Sel {
   kV0Sign, ///< +1 particle, -1 antiparticle
   kV0pTMin,
   kV0pTMax,
+  kV0etaMax,
   kV0DCADaughMax,
   kV0CPAMin,
   kV0TranRadMin,
@@ -68,7 +69,7 @@ class FemtoDreamV0Selection
 {
  public:
   FemtoDreamV0Selection()
-    : nPtV0MinSel(0), nPtV0MaxSel(0), nDCAV0DaughMax(0), nCPAV0Min(0), nTranRadV0Min(0), nTranRadV0Max(0), nDecVtxMax(0), pTV0Min(9999999.), pTV0Max(-9999999.), DCAV0DaughMax(-9999999.), CPAV0Min(9999999.), TranRadV0Min(9999999.), TranRadV0Max(-9999999.), DecVtxMax(-9999999.), fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false), fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515), nSigmaPIDOffsetTPC(0.) {}
+    : nPtV0MinSel(0), nPtV0MaxSel(0), nEtaV0MaxSel(0), nDCAV0DaughMax(0), nCPAV0Min(0), nTranRadV0Min(0), nTranRadV0Max(0), nDecVtxMax(0), pTV0Min(9999999.), pTV0Max(-9999999.), etaV0Max(-9999999.), DCAV0DaughMax(-9999999.), CPAV0Min(9999999.), TranRadV0Min(9999999.), TranRadV0Max(-9999999.), DecVtxMax(-9999999.), fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false), fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515), nSigmaPIDOffsetTPC(0.) {}
   /// Initializes histograms for the task
   template <o2::aod::femtodreamparticle::ParticleType part,
             o2::aod::femtodreamparticle::ParticleType daugh,
@@ -191,8 +192,7 @@ class FemtoDreamV0Selection
     nSigmaPIDOffsetTPC = offsetTPC;
   }
 
-  void
-    setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child, bool reject)
+  void setChildRejectNotPropagatedTracks(femtoDreamV0Selection::ChildTrackType child, bool reject)
   {
     if (child == femtoDreamV0Selection::kPosTrack) {
       PosDaughTrack.setRejectNotPropagatedTracks(reject);
@@ -213,6 +213,7 @@ class FemtoDreamV0Selection
  private:
   int nPtV0MinSel;
   int nPtV0MaxSel;
+  int nEtaV0MaxSel;
   int nDCAV0DaughMax;
   int nCPAV0Min;
   int nTranRadV0Min;
@@ -220,6 +221,7 @@ class FemtoDreamV0Selection
   int nDecVtxMax;
   float pTV0Min;
   float pTV0Max;
+  float etaV0Max;
   float DCAV0DaughMax;
   float CPAV0Min;
   float TranRadV0Min;
@@ -238,10 +240,10 @@ class FemtoDreamV0Selection
   FemtoDreamTrackSelection PosDaughTrack;
   FemtoDreamTrackSelection NegDaughTrack;
 
-  static constexpr int kNv0Selection = 8;
+  static constexpr int kNv0Selection = 9;
 
   static constexpr std::string_view mSelectionNames[kNv0Selection] = {
-    "Sign", "PtMin", "PtMax", "DCAdaughMax", "CPAMin",
+    "Sign", "PtMin", "PtMax", "EtaMax", "DCAdaughMax", "CPAMin",
     "TranRadMin", "TranRadMax", "DecVecMax"}; ///< Name of the different
                                               ///< selections
 
@@ -249,6 +251,7 @@ class FemtoDreamV0Selection
     mSelectionTypes[kNv0Selection]{
       femtoDreamSelection::kEqual,
       femtoDreamSelection::kLowerLimit,
+      femtoDreamSelection::kUpperLimit,
       femtoDreamSelection::kUpperLimit,
       femtoDreamSelection::kUpperLimit,
       femtoDreamSelection::kLowerLimit,
@@ -261,6 +264,7 @@ class FemtoDreamV0Selection
     "+1 for lambda, -1 for antilambda",
     "Minimum pT (GeV/c)",
     "Maximum pT (GeV/c)",
+    "Maximum |Eta|",
     "Maximum DCA between daughters (cm)",
     "Minimum Cosine of Pointing Angle",
     "Minimum transverse radius (cm)",
@@ -346,6 +350,8 @@ void FemtoDreamV0Selection::init(HistogramRegistry* registry)
                             kTH1F, {massAxisLambda});
     mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut",
                             kTH1F, {massAxisLambda});
+    mHistogramRegistry->add("LambdaQA/hInvMassLambdaEtaMax", "Maximum Eta cut",
+                            kTH1F, {massAxisLambda});
     mHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAV0Daugh",
                             "V0-daughters DCA cut", kTH1F, {massAxisLambda});
     mHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F,
@@ -364,6 +370,7 @@ void FemtoDreamV0Selection::init(HistogramRegistry* registry)
   /// already be done by the filters
   nPtV0MinSel = getNSelections(femtoDreamV0Selection::kV0pTMin);
   nPtV0MaxSel = getNSelections(femtoDreamV0Selection::kV0pTMax);
+  nEtaV0MaxSel = getNSelections(femtoDreamV0Selection::kV0etaMax);
   nDCAV0DaughMax = getNSelections(femtoDreamV0Selection::kV0DCADaughMax);
   nCPAV0Min = getNSelections(femtoDreamV0Selection::kV0CPAMin);
   nTranRadV0Min = getNSelections(femtoDreamV0Selection::kV0TranRadMin);
@@ -374,6 +381,8 @@ void FemtoDreamV0Selection::init(HistogramRegistry* registry)
                                 femtoDreamSelection::kLowerLimit);
   pTV0Max = getMinimalSelection(femtoDreamV0Selection::kV0pTMax,
                                 femtoDreamSelection::kUpperLimit);
+  etaV0Max = getMinimalSelection(femtoDreamV0Selection::kV0etaMax,
+                                 femtoDreamSelection::kAbsUpperLimit);
   DCAV0DaughMax = getMinimalSelection(femtoDreamV0Selection::kV0DCADaughMax,
                                       femtoDreamSelection::kUpperLimit);
   CPAV0Min = getMinimalSelection(femtoDreamV0Selection::kV0CPAMin,
@@ -394,10 +403,12 @@ bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0,
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
-    printf("-Something wrong in isSelectedMinimal--\n");
-    printf("ERROR - Wrong sign for V0 daughters\n");
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for V0 daughters";
   }
+  // asfaf
   const float pT = v0.pt();
+  const float eta = v0.eta();
   const std::vector<float> decVtx = {v0.x(), v0.y(), v0.z()};
   const float tranRad = v0.v0radius();
   const float dcaDaughv0 = v0.dcaV0daughters();
@@ -422,6 +433,9 @@ bool FemtoDreamV0Selection::isSelectedMinimal(C const& col, V const& v0,
     return false;
   }
   if (nPtV0MaxSel > 0 && pT > pTV0Max) {
+    return false;
+  }
+  if (nEtaV0MaxSel > 0 && std::abs(eta) > etaV0Max) {
     return false;
   }
   if (nDCAV0DaughMax > 0 && dcaDaughv0 > DCAV0DaughMax) {
@@ -473,10 +487,11 @@ void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0,
   const auto signPos = posTrack.sign();
   const auto signNeg = negTrack.sign();
   if (signPos < 0 || signNeg > 0) {
-    printf("-Something wrong in isSelectedMinimal--\n");
-    printf("ERROR - Wrong sign for V0 daughters\n");
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for V0 daughters";
   }
   const float pT = v0.pt();
+  const float eta = v0.eta();
   const std::vector<float> decVtx = {v0.x(), v0.y(), v0.z()};
   const float tranRad = v0.v0radius();
   const float dcaDaughv0 = v0.dcaV0daughters();
@@ -497,6 +512,10 @@ void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0,
   }
   if (pT < pTV0Max) {
     mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"),
+                             v0.mLambda());
+  }
+  if (std::abs(eta) < etaV0Max) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaEtaMax"),
                              v0.mLambda());
   }
   if (dcaDaughv0 < DCAV0DaughMax) {
@@ -571,6 +590,7 @@ std::array<cutContainerType, 5>
   }
 
   const auto pT = v0.pt();
+  const auto eta = v0.eta();
   const auto tranRad = v0.v0radius();
   const auto dcaDaughv0 = v0.dcaV0daughters();
   const auto cpav0 = v0.v0cosPA(col.posX(), col.posY(), col.posZ());
@@ -596,6 +616,9 @@ std::array<cutContainerType, 5>
         case (femtoDreamV0Selection::kV0pTMax):
           observable = pT;
           break;
+        case (femtoDreamV0Selection::kV0etaMax):
+          observable = eta;
+          break;
         case (femtoDreamV0Selection::kV0DCADaughMax):
           observable = dcaDaughv0;
           break;
@@ -616,13 +639,10 @@ std::array<cutContainerType, 5>
   }
   return {
     output,
-    outputPosTrack.at(
-      femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
     outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
-    outputNegTrack.at(
-      femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-    outputNegTrack.at(
-      femtoDreamTrackSelection::TrackContainerPosition::kPID)};
+    outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID)};
 }
 
 template <o2::aod::femtodreamparticle::ParticleType part,

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -38,9 +38,7 @@ int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
       return static_cast<int>(i);
     }
   }
-  LOG(warn) << "Invalid value of nSigma: " << nSigma
-            << ". Return the first value of the vector: " << vNsigma[0]
-            << std::endl;
+  LOG(warn) << "Invalid value of nSigma: " << nSigma << ". Return the first value of the vector: " << vNsigma[0];
   return 0;
 }
 
@@ -64,8 +62,8 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
     //\todo we also need the possibility to specify whether the bit is
     // true/false ->std>>vector<std::pair<int, int>>
     // if (!((pidcut >> it.first) & it.second)) {
-    int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma +
-                       iSpecies * kDetector::kNdetectors + iDet;
+    int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + iSpecies * kDetector::kNdetectors + iDet;
+    LOG(info) << "Check bit: " << bit_to_check;
     if (!(pidcut & (1UL << bit_to_check))) {
       pidSelection = false;
     }

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -13,13 +13,13 @@
 /// \brief Executable that encodes physical selection criteria in a bit-wise
 /// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
+#include <filesystem>
+#include <iostream>
+#include <random>
 #include "FemtoDreamCutculator.h"
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
-#include <filesystem>
-#include <iostream>
-#include <random>
 
 using namespace o2::analysis::femtoDream;
 

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,6 +1,6 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright
-// holders. All rights not expressly granted are reserved.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -1,6 +1,6 @@
 // Copyright 2020-2022 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright
+// holders. All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
 // License v3 (GPL Version 3), copied verbatim in the file "COPYING".
@@ -10,15 +10,16 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamCutCulator.cxx
-/// \brief Executable that encodes physical selection criteria in a bit-wise selection
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \brief Executable that encodes physical selection criteria in a bit-wise
+/// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#include <filesystem>
-#include <iostream>
 #include "FemtoDreamCutculator.h"
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
+#include <filesystem>
+#include <iostream>
+#include <random>
 
 using namespace o2::analysis::femtoDream;
 
@@ -34,31 +35,52 @@ int main(int argc, char* argv[])
     FemtoDreamCutculator cut;
     cut.init(argv[1]);
 
-    LOG(info) << "Do you want to work with tracks or V0s (T/V)?";
+    std::cout
+      << "Do you want to work with tracks or V0s (T/V)?";
     std::string choice;
     std::cin >> choice;
 
     if (choice == std::string("T")) {
       cut.setTrackSelectionFromFile("ConfTrk");
-      cut.setPIDSelectionFromFile("ConfPIDTrk");
+      cut.setPIDSelectionFromFile("ConfPIDTrk", "ConfTrk");
     } else if (choice == std::string("V")) {
-      LOG(info) << "Do you want to select V0s or one of its children (V/T)?";
+      std::cout << "Do you want to select V0s or one of its children (V/T)?";
       std::cin >> choice;
       cut.setV0SelectionFromFile("ConfV0");
       cut.setTrackSelectionFromFile("ConfChild");
-      cut.setPIDSelectionFromFile("ConfPIDChild");
+      cut.setPIDSelectionFromFile("ConfPIDChild", "ConfChild");
     } else {
-      LOG(info) << "Option not recognized. Break...";
-      return 1;
+      std::cout << "Option not recognized. Break...";
+      return 2;
+    }
+    /// \todo factor out the pid here
+    /// cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax,
+    /// femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
+
+    std::cout << "Do you want to manually select cuts or create systematic "
+                 "variations(M/V)?";
+    std::string manual;
+    std::cin >> manual;
+
+    if (manual == std::string("M")) {
+      cut.analyseCuts(choice);
+    } else if (manual == std::string("V")) {
+      std::ofstream out("CutCulator.txt");
+      std::streambuf* coutbuf = std::cout.rdbuf(); // save old buf
+      std::cout.rdbuf(out.rdbuf());                // redirect std::cout to out.txt!
+      for (int i = 0; i < 20; i++) {
+        cut.analyseCuts(choice, true, 1);
+      }
+      std::cout.rdbuf(coutbuf); // reset to standard output again
+    } else {
+      std::cout << "Option not recognized. Break...";
+      return 2;
     }
 
-    /// \todo factor out the pid here
-    // cut.setTrackSelection(femtoDreamTrackSelection::kPIDnSigmaMax,
-    // femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
-    cut.analyseCuts(choice);
-
   } else {
-    LOG(info) << "The configuration file " << configFileName
+    std::cout << "The configuration file " << configFileName
               << " could not be found.";
   }
+
+  return 0;
 }

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -35,8 +35,7 @@ using namespace o2::soa;
 namespace
 {
 static constexpr int nCuts = 5;
-static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC",
-                                               "nSigmaTPCTOF", "MaxP"};
+static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
 static const float cutsTable[1][nCuts] = {{4.05f, 0.75f, 3.f, 3.f, 100.f}};
 
 } // namespace
@@ -77,7 +76,7 @@ struct femtoDreamDebugTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, true);
+    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartOne.value, true);
     vPIDPartOne = ConfPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -73,7 +73,6 @@ struct femtoDreamDebugTrack {
 
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry FullQaRegistry{"FullTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -53,13 +53,13 @@ struct femtoDreamDebugTrack {
   ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
-  using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
+  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
-  Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::fdCollisionId;
 
-  using FemtoFullParticlesMC = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles, aod::FemtoDreamMCLabels>;
+  using FemtoFullParticlesMC = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>;
   Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
-  Preslice<FemtoFullParticlesMC> perColGen = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<FemtoFullParticlesMC> perColGen = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
@@ -83,7 +83,7 @@ struct femtoDreamDebugTrack {
 
   /// Porduce QA plots for sigle track selection in FemtoDream framework
   template <bool isMC, typename PartitionType>
-  void FillDebugHistos(o2::aod::FemtoDreamCollision& col, PartitionType& groupPartsOne)
+  void FillDebugHistos(o2::aod::FDCollision& col, PartitionType& groupPartsOne)
   {
     eventHisto.fillQA(col);
     for (auto& part : groupPartsOne) {
@@ -100,9 +100,9 @@ struct femtoDreamDebugTrack {
   /// process function when runnning over data/ Monte Carlo reconstructed only
   /// \param col subscribe to FemtoDreamCollision table
   /// \param parts subscribe to FemtoDreamParticles table
-  void processData(o2::aod::FemtoDreamCollision& col, FemtoFullParticles& parts)
+  void processData(o2::aod::FDCollision& col, FemtoFullParticles& parts)
   {
-    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     FillDebugHistos<false>(col, groupPartsOne);
   }
   PROCESS_SWITCH(femtoDreamDebugTrack, processData, "Enable Debug processing for Monte Carlo", true);
@@ -112,9 +112,9 @@ struct femtoDreamDebugTrack {
   /// \param col subscribe to FemtoDreamCollision table
   /// \param parts subscribe to the joined table of FemtoDreamParticles and FemtoDreamMCLabels table
   /// \param FemtoDramMCParticles subscribe to the table containing the Monte Carlo Truth information
-  void processMC(o2::aod::FemtoDreamCollision& col, FemtoFullParticlesMC& parts, o2::aod::FemtoDreamMCParticles&)
+  void processMC(o2::aod::FDCollision& col, FemtoFullParticlesMC& parts, o2::aod::FDMCParticles&)
   {
-    auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     FillDebugHistos<true>(col, groupPartsOne);
   }
   PROCESS_SWITCH(femtoDreamDebugTrack, processMC, "Enable Debug processing for Monte Carlo", false);

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -39,7 +39,9 @@ using namespace o2::soa;
 struct femtoDreamDebugV0 {
   SliceCache cache;
 
-  Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 3122, "Particle 1 - PDG code"};
+  Configurable<int> ConfPDGCodeV0{"ConfPDGCodePartOne", 3122, "V0 - PDG code"};
+  Configurable<int> ConfPDGCodeChildPos{"ConfPDGCodeChildPos", 2212, "Positive Child - PDG code"};
+  Configurable<int> ConfPDGCodeChildNeg{"ConfPDGCodeChildNeg", 211, "Negative Child- PDG code"};
   Configurable<uint32_t> ConfCutV0{"ConfCutV0", 338, "V0 - Selection bit from cutCulator"};
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
@@ -72,9 +74,9 @@ struct femtoDreamDebugV0 {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry);
-    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, true);
-    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, true);
-    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, false, true);
+    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, ConfPDGCodeChildPos.value, true);
+    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, ConfPDGCodeChildNeg, true);
+    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, false, ConfPDGCodeV0.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -57,9 +57,9 @@ struct femtoDreamDebugV0 {
   ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
-  using FemtoFullParticles = soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamDebugParticles>;
+  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutV0) == ConfCutV0);
-  Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming
   FemtoDreamEventHisto eventHisto;
@@ -80,9 +80,9 @@ struct femtoDreamDebugV0 {
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
-  void process(o2::aod::FemtoDreamCollision const& col, FemtoFullParticles const& parts)
+  void process(o2::aod::FDCollision const& col, FemtoFullParticles const& parts)
   {
-    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     eventHisto.fillQA(col);
     for (auto& part : groupPartsOne) {
       if (!part.has_children()) {

--- a/PWGCF/FemtoDream/femtoDreamHashTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamHashTask.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamHashTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamHashTask.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamHashTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamHashTask.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamHashTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamHashTask.cxx
@@ -40,7 +40,7 @@ struct femtoDreamPairHashTask {
     CastCfgMultBins = (std::vector<float>)CfgMultBins;
   }
 
-  void process(o2::aod::FemtoDreamCollision const& col)
+  void process(o2::aod::FDCollision const& col)
   {
     /// the hash of the collision is computed and written to table
     hashes(eventmixing::getMixingBin(CastCfgVtxBins, CastCfgMultBins, col.posZ(), col.multV0M()));

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -52,7 +52,7 @@ static const float cutsTable[nPart][nCuts]{
 
 struct femtoDreamPairTaskTrackTrack {
   SliceCache cache;
-  Preslice<aod::FemtoDreamDebugParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Particle selection part
 
@@ -69,8 +69,8 @@ struct femtoDreamPairTaskTrackTrack {
   Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
 
   /// Partition for particle 1
-  Partition<aod::FemtoDreamParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
-  Partition<soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamMCLabels>> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Partition<aod::FDParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
@@ -82,11 +82,11 @@ struct femtoDreamPairTaskTrackTrack {
   Configurable<std::vector<int>> ConfPIDPartTwo{"ConfPIDPartTwo", std::vector<int>{2}, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
 
   /// Partition for particle 2
-  Partition<aod::FemtoDreamParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                 //  (aod::femtodreamparticle::pt < cfgCutTable->get("PartTwo", "MaxPt")) &&
-                                                 ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo);
-  Partition<soa::Join<aod::FemtoDreamParticles, aod::FemtoDreamMCLabels>> partsTwoMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                                                       ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo);
+  Partition<aod::FDParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                         //  (aod::femtodreamparticle::pt < cfgCutTable->get("PartTwo", "MaxPt")) &&
+                                         ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo);
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsTwoMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                                                       ((aod::femtodreamparticle::cut & ConfCutPartTwo) == ConfCutPartTwo);
 
   /// Histogramming for particle 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 2> trackHistoPartTwo;
@@ -254,13 +254,13 @@ struct femtoDreamPairTaskTrackTrack {
   /// process function for to call doSameEvent with Data
   /// \param col subscribe to the collision table (Data)
   /// \param parts subscribe to the femtoDreamParticleTable
-  void processSameEvent(o2::aod::FemtoDreamCollision& col,
-                        o2::aod::FemtoDreamParticles& parts)
+  void processSameEvent(o2::aod::FDCollision& col,
+                        o2::aod::FDParticles& parts)
   {
     fillCollision(col);
 
-    auto thegroupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
 
     doSameEvent<false>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
   }
@@ -270,14 +270,14 @@ struct femtoDreamPairTaskTrackTrack {
   /// \param col subscribe to the collision table (Monte Carlo Reconstructed reconstructed)
   /// \param parts subscribe to joined table FemtoDreamParticles and FemtoDreamMCLables to access Monte Carlo truth
   /// \param FemtoDreamMCParticles subscribe to the Monte Carlo truth table
-  void processSameEventMC(o2::aod::FemtoDreamCollision& col,
-                          soa::Join<o2::aod::FemtoDreamParticles, o2::aod::FemtoDreamMCLabels>& parts,
-                          o2::aod::FemtoDreamMCParticles&)
+  void processSameEventMC(o2::aod::FDCollision& col,
+                          soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                          o2::aod::FDMCParticles&)
   {
     fillCollision(col);
 
-    auto thegroupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
 
     doSameEvent<true>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
   }
@@ -333,16 +333,16 @@ struct femtoDreamPairTaskTrackTrack {
   /// process function for to call doMixedEvent with Data
   /// @param cols subscribe to the collisions table (Data)
   /// @param parts subscribe to the femtoDreamParticleTable
-  void processMixedEvent(o2::aod::FemtoDreamCollisions& cols,
-                         o2::aod::FemtoDreamParticles& parts)
+  void processMixedEvent(o2::aod::FDCollisions& cols,
+                         o2::aod::FDParticles& parts)
   {
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
 
       const int multiplicityCol = collision1.multNtr();
       MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
 
-      auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
       const auto& magFieldTesla2 = collision2.magField();
@@ -362,17 +362,17 @@ struct femtoDreamPairTaskTrackTrack {
   /// @param cols subscribe to the collisions table (Monte Carlo Reconstructed reconstructed)
   /// @param parts subscribe to joined table FemtoDreamParticles and FemtoDreamMCLables to access Monte Carlo truth
   /// @param FemtoDreamMCParticles subscribe to the Monte Carlo truth table
-  void processMixedEventMC(o2::aod::FemtoDreamCollisions& cols,
-                           soa::Join<o2::aod::FemtoDreamParticles, o2::aod::FemtoDreamMCLabels>& parts,
-                           o2::aod::FemtoDreamMCParticles&)
+  void processMixedEventMC(o2::aod::FDCollisions& cols,
+                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                           o2::aod::FDMCParticles&)
   {
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
 
       const int multiplicityCol = collision1.multNtr();
       MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
 
-      auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto groupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
       const auto& magFieldTesla2 = collision2.magField();

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -51,7 +51,7 @@ static const float cutsTableV0Children[nV0Children][nCuts]{
 
 struct femtoDreamPairTaskTrackV0 {
   SliceCache cache;
-  Preslice<aod::FemtoDreamParticles> perCol = aod::femtodreamparticle::femtoDreamCollisionId;
+  Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Particle 1 (track)
   Configurable<LabeledArray<float>> ConfTrkCutTable{"ConfTrkCutTable", {cutsTableTrack[0], nTrack, nCuts, TrackName, cutNames}, "Particle selections"};
@@ -64,7 +64,7 @@ struct femtoDreamPairTaskTrackV0 {
   ConfigurableAxis ConfTrkTempFitVarpTBins{"ConfTrkTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   /// Partition for particle 1
-  Partition<aod::FemtoDreamParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfTrkCutPartOne) == ConfTrkCutPartOne);
+  Partition<aod::FDParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfTrkCutPartOne) == ConfTrkCutPartOne);
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
@@ -86,7 +86,7 @@ struct femtoDreamPairTaskTrackV0 {
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   /// Partition for particle 2
-  Partition<aod::FemtoDreamParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV0CutPartTwo) == ConfV0CutPartTwo);
+  Partition<aod::FDParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV0CutPartTwo) == ConfV0CutPartTwo);
 
   /// Histogramming for particle 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
@@ -147,12 +147,12 @@ struct femtoDreamPairTaskTrackV0 {
 
   /// This function processes the same event and takes care of all the histogramming
   /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
-  void processSameEvent(o2::aod::FemtoDreamCollision& col, o2::aod::FemtoDreamParticles& parts)
+  void processSameEvent(o2::aod::FDCollision& col, o2::aod::FDParticles& parts)
   {
     const auto& magFieldTesla = col.magField();
 
-    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
-    auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, col.globalIndex(), cache);
+    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     const int multCol = col.multNtr();
 
     eventHisto.fillQA(col);
@@ -211,7 +211,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
-  void processMixedEvent(o2::aod::FemtoDreamCollisions& cols, o2::aod::FemtoDreamParticles& parts)
+  void processMixedEvent(o2::aod::FDCollisions& cols, o2::aod::FDParticles& parts)
   {
     ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
 
@@ -219,8 +219,8 @@ struct femtoDreamPairTaskTrackV0 {
 
       const int multCol = collision1.multNtr();
 
-      auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::femtoDreamCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
       const auto& magFieldTesla2 = collision2.magField();

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -3,7 +3,7 @@
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -62,12 +62,12 @@ using FemtoFullTracks = soa::Join<aod::FullTracks, aod::TracksDCA,
 
 struct femtoDreamProducerReducedTask {
 
-  Produces<aod::FemtoDreamCollisions> outputCollision;
-  Produces<aod::FemtoDreamParticles> outputParts;
-  Produces<aod::FemtoDreamMCParticles> outputPartsMC;
-  Produces<aod::FemtoDreamDebugParticles> outputDebugParts;
-  Produces<aod::FemtoDreamMCLabels> outputPartsMCLabels;
-  Produces<aod::FemtoDreamDebugMCParticles> outputDebugPartsMC;
+  Produces<aod::FDCollisions> outputCollision;
+  Produces<aod::FDParticles> outputParts;
+  Produces<aod::FDMCParticles> outputPartsMC;
+  Produces<aod::FDExtParticles> outputDebugParts;
+  Produces<aod::FDMCLabels> outputPartsMCLabels;
+  Produces<aod::FDExtMCParticles> outputDebugPartsMC;
 
   Configurable<bool> ConfDebugOutput{"ConfDebugOutput", true, "Debug output"};
   Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"}; // Choose if filtering or skimming version is run

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -81,12 +81,12 @@ int getRowDaughters(int daughID, T const& vecID)
 
 struct femtoDreamProducerTask {
 
-  Produces<aod::FemtoDreamCollisions> outputCollision;
-  Produces<aod::FemtoDreamParticles> outputParts;
-  Produces<aod::FemtoDreamMCParticles> outputPartsMC;
-  Produces<aod::FemtoDreamDebugParticles> outputDebugParts;
-  Produces<aod::FemtoDreamMCLabels> outputPartsMCLabels;
-  Produces<aod::FemtoDreamDebugMCParticles> outputDebugPartsMC;
+  Produces<aod::FDCollisions> outputCollision;
+  Produces<aod::FDParticles> outputParts;
+  Produces<aod::FDMCParticles> outputPartsMC;
+  Produces<aod::FDExtParticles> outputDebugParts;
+  Produces<aod::FDMCLabels> outputPartsMCLabels;
+  Produces<aod::FDExtMCParticles> outputDebugPartsMC;
 
   Configurable<bool> ConfDebugOutput{"ConfDebugOutput", true, "Debug output"};
 

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -146,6 +146,7 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfV0Sign{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin, "ConfV0"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax, "ConfV0"), std::vector<float>{3.3f, 3.4f, 3.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax, "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0EtaMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0etaMax, "ConfV0"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0etaMax, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0DCADaughMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"), std::vector<float>{1.2f, 1.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0DCADaughMax, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0CPAMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0CPAMin, "ConfV0"), std::vector<float>{0.99f, 0.995f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0CPAMin, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0TranRadMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0TranRadMin, "ConfV0"), std::vector<float>{0.2f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0TranRadMin, "V0 selection: ")};
@@ -218,6 +219,7 @@ struct femtoDreamProducerTask {
       v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign, femtoDreamSelection::kEqual);
       v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax, femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0EtaMax, femtoDreamV0Selection::kV0etaMax, femtoDreamSelection::kAbsUpperLimit);
       v0Cuts.setSelection(ConfV0DCADaughMax, femtoDreamV0Selection::kV0DCADaughMax, femtoDreamSelection::kUpperLimit);
       v0Cuts.setSelection(ConfV0CPAMin, femtoDreamV0Selection::kV0CPAMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setSelection(ConfV0TranRadMin, femtoDreamV0Selection::kV0TranRadMin, femtoDreamSelection::kLowerLimit);

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -46,8 +46,7 @@ namespace o2::aod
 
 using FemtoFullCollision =
   soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
-using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults,
-                                       aod::McCollisionLabels>::iterator;
+using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 
 using FemtoFullTracks =
   soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
@@ -342,7 +341,6 @@ struct femtoDreamProducerTask {
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
       if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
-
         if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
         } else if (motherparticleMC.producedByGenerator()) {
@@ -350,9 +348,7 @@ struct femtoDreamProducerTask {
         } else {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
         }
-
       } else {
-
         particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kFake;
       }
 
@@ -454,70 +450,68 @@ struct femtoDreamProducerTask {
         // TrackSelection::TrackCuts::kITSHits);
         // }
 
-        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0,
-                      aod::femtodreamparticle::ParticleType::kV0Child>(
-          col, v0, postrack, negtrack); ///\todo fill QA also for daughters
-        auto cutContainerV0 =
-          v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(
-            col, v0, postrack, negtrack);
+        v0Cuts.fillQA<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
+        auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, v0, postrack, negtrack);
 
-        if ((cutContainerV0.at(
-               femtoDreamV0Selection::V0ContainerPosition::kV0) > 0) &&
-            (cutContainerV0.at(
-               femtoDreamV0Selection::V0ContainerPosition::kPosCuts) > 0) &&
-            (cutContainerV0.at(
-               femtoDreamV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
-          int postrackID = v0.posTrackId();
-          int rowInPrimaryTrackTablePos = -1;
-          rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
-          childIDs[0] = rowInPrimaryTrackTablePos;
-          childIDs[1] = 0;
-          outputParts(outputCollision.lastIndex(), v0.positivept(),
-                      v0.positiveeta(), v0.positivephi(),
-                      aod::femtodreamparticle::ParticleType::kV0Child,
-                      cutContainerV0.at(
-                        femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
-                      cutContainerV0.at(
-                        femtoDreamV0Selection::V0ContainerPosition::kPosPID),
-                      0., childIDs, 0, 0);
-          const int rowOfPosTrack = outputParts.lastIndex();
-          if constexpr (isMC) {
-            fillMCParticle(postrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
-          }
-          int negtrackID = v0.negTrackId();
-          int rowInPrimaryTrackTableNeg = -1;
-          rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
-          childIDs[0] = 0;
-          childIDs[1] = rowInPrimaryTrackTableNeg;
-          outputParts(outputCollision.lastIndex(), v0.negativept(),
-                      v0.negativeeta(), v0.negativephi(),
-                      aod::femtodreamparticle::ParticleType::kV0Child,
-                      cutContainerV0.at(
-                        femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
-                      cutContainerV0.at(
-                        femtoDreamV0Selection::V0ContainerPosition::kNegPID),
-                      0., childIDs, 0, 0);
-          const int rowOfNegTrack = outputParts.lastIndex();
-          if constexpr (isMC) {
-            fillMCParticle(negtrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
-          }
-          std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
-          // LOG(info) << cutContainerV0.at(
-          //     femtoDreamV0Selection::V0ContainerPosition::kV0);
-          outputParts(outputCollision.lastIndex(), v0.pt(), v0.eta(), v0.phi(),
-                      aod::femtodreamparticle::ParticleType::kV0,
-                      cutContainerV0.at(
-                        femtoDreamV0Selection::V0ContainerPosition::kV0),
-                      0, v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
-                      indexChildID, v0.mLambda(), v0.mAntiLambda());
-          if (ConfDebugOutput) {
-            fillDebugParticle<true>(postrack); // QA for positive daughter
-            fillDebugParticle<true>(negtrack); // QA for negative daughter
-            fillDebugParticle<false>(v0);      // QA for v0
-          }
-          if constexpr (isMC) {
-            fillMCParticle(v0, o2::aod::femtodreamparticle::ParticleType::kV0);
-          }
+        int postrackID = v0.posTrackId();
+        int rowInPrimaryTrackTablePos = -1;
+        rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+        childIDs[0] = rowInPrimaryTrackTablePos;
+        childIDs[1] = 0;
+        outputParts(outputCollision.lastIndex(), v0.positivept(),
+                    v0.positiveeta(), v0.positivephi(),
+                    aod::femtodreamparticle::ParticleType::kV0Child,
+                    cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
+                    cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0);
+        LOG(info) << "PosChild: " << cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID);
+        const int rowOfPosTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(postrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
+        }
+        int negtrackID = v0.negTrackId();
+        int rowInPrimaryTrackTableNeg = -1;
+        rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+        childIDs[0] = 0;
+        childIDs[1] = rowInPrimaryTrackTableNeg;
+        outputParts(outputCollision.lastIndex(),
+                    v0.negativept(),
+                    v0.negativeeta(),
+                    v0.negativephi(),
+                    aod::femtodreamparticle::ParticleType::kV0Child,
+                    cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
+                    cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0);
+        LOG(info) << "NegChild: " << cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID);
+        const int rowOfNegTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(negtrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
+        }
+        std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
+        outputParts(outputCollision.lastIndex(),
+                    v0.pt(),
+                    v0.eta(),
+                    v0.phi(),
+                    aod::femtodreamparticle::ParticleType::kV0,
+                    cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kV0),
+                    0,
+                    v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                    indexChildID,
+                    v0.mLambda(),
+                    v0.mAntiLambda());
+        if (ConfDebugOutput) {
+          fillDebugParticle<true>(postrack); // QA for positive daughter
+          fillDebugParticle<true>(negtrack); // QA for negative daughter
+          fillDebugParticle<false>(v0);      // QA for v0
+        }
+        if constexpr (isMC) {
+          fillMCParticle(v0, o2::aod::femtodreamparticle::ParticleType::kV0);
         }
       }
     }

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -1,9 +1,9 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+// License v3 (GPL Version 3), copied verbatim in the file COPYING.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -117,6 +117,18 @@ struct femtoDreamProducerTaskV0Only {
     std::vector<float>{0.3f},
     FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin,
                                               "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0PtMax{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax,
+                                            "ConfV0"),
+    std::vector<float>{6.f},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax,
+                                              "V0 selection: ")};
+  Configurable<std::vector<float>> ConfV0EtaMax{
+    FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0etaMax,
+                                            "ConfV0"),
+    std::vector<float>{6.f},
+    FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0etaMax,
+                                              "V0 selection: ")};
   Configurable<std::vector<float>> ConfDCAV0DaughMax{
     FemtoDreamV0Selection::getSelectionName(
       femtoDreamV0Selection::kV0DCADaughMax, "ConfV0"),
@@ -214,6 +226,10 @@ struct femtoDreamProducerTaskV0Only {
                           femtoDreamSelection::kEqual);
       v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin,
                           femtoDreamSelection::kLowerLimit);
+      v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax,
+                          femtoDreamSelection::kUpperLimit);
+      v0Cuts.setSelection(ConfV0EtaMax, femtoDreamV0Selection::kV0etaMax,
+                          femtoDreamSelection::kUpperLimit);
       v0Cuts.setSelection(ConfDCAV0DaughMax,
                           femtoDreamV0Selection::kV0DCADaughMax,
                           femtoDreamSelection::kUpperLimit);

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -1,9 +1,9 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
 // This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file COPYING.
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -76,9 +76,9 @@ int getRowDaughters(int daughID, T const& vecID)
 
 struct femtoDreamProducerTaskV0Only {
 
-  Produces<aod::FemtoDreamCollisions> outputCollision;
-  Produces<aod::FemtoDreamParticles> outputParts;
-  Produces<aod::FemtoDreamDebugParticles> outputDebugParts;
+  Produces<aod::FDCollisions> outputCollision;
+  Produces<aod::FDParticles> outputParts;
+  Produces<aod::FDExtParticles> outputDebugParts;
 
   Configurable<bool> ConfDebugOutput{"ConfDebugOutput", true, "Debug output"};
 


### PR DESCRIPTION
This PR contains several bug fixes of the FemtoDream framework:
- add missing |eta| cut on V0s
- replace LOG calls in CutCulator with std::cout. CutCulator is a standalone binary for generating bitmasks used by the tasks in femtodream. Using std::cout makes the output much easier to parse.
- Recent update to the MC code has broken the debug tasks. This will be fixed.
- The o2-aod-merger makes implicit assumptions on the table names since it is a standalone binary not part of the framework. As such all tables within femtodream had to be renamed to conform with o2-aod-merger.