### PR TITLE
PWGCF: Remove unnecessary logging in FemtoDream

### DIFF
--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -59,11 +59,7 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
   bool pidSelection = true;
   int iNsigma = getPIDselection(nSigma, vNsigma);
   for (auto iSpecies : vSpecies) {
-    //\todo we also need the possibility to specify whether the bit is
-    // true/false ->std>>vector<std::pair<int, int>>
-    // if (!((pidcut >> it.first) & it.second)) {
     int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + iSpecies * kDetector::kNdetectors + iDet;
-    LOG(info) << "Check bit: " << bit_to_check;
     if (!(pidcut & (1UL << bit_to_check))) {
       pidSelection = false;
     }

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -467,7 +467,6 @@ struct femtoDreamProducerTask {
                     childIDs,
                     0,
                     0);
-        LOG(info) << "PosChild: " << cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID);
         const int rowOfPosTrack = outputParts.lastIndex();
         if constexpr (isMC) {
           fillMCParticle(postrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);
@@ -488,7 +487,6 @@ struct femtoDreamProducerTask {
                     childIDs,
                     0,
                     0);
-        LOG(info) << "NegChild: " << cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID);
         const int rowOfNegTrack = outputParts.lastIndex();
         if constexpr (isMC) {
           fillMCParticle(negtrack, o2::aod::femtodreamparticle::ParticleType::kV0Child);


### PR DESCRIPTION
Remove unnecessary LOG calls in FemtoDreamProducer and FemtoUtils. Depending on the dataset, they can trigger a warning that the log file is too large.