### PR TITLE
PWGHF: fill only signal or background (fraction) in D+ tree creator

### DIFF
--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -206,7 +206,16 @@ struct HfTreeCreatorDplusToPiKPi {
   Configurable<int> selectionFlagDplus{"selectionFlagDplus", 1, "Selection Flag for Dplus"};
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};
 
+  // parameters for production of training samples
+  Configurable<bool> fillOnlySignal{"fillOnlySignal", false, "Flag to fill derived tables with signal for ML trainings"};
+  Configurable<bool> fillOnlyBackground{"fillOnlyBackground", false, "Flag to fill derived tables with background for ML trainings"};
+  Configurable<float> donwSampleBkgFactor{"donwSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
+
   Filter filterSelectCandidates = aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
+  using selectedCandidatesMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec, aod::HfSelDplusToPiKPi>>;
+
+  Partition<selectedCandidatesMc> recSig = (aod::hf_cand_3prong::flagMcMatchRec == (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi)) || (aod::hf_cand_3prong::flagMcMatchRec == -(int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
+  Partition<selectedCandidatesMc> recBg = (aod::hf_cand_3prong::flagMcMatchRec != (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi)) && (aod::hf_cand_3prong::flagMcMatchRec != -(int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
 
   void init(InitContext const&)
   {
@@ -357,6 +366,12 @@ struct HfTreeCreatorDplusToPiKPi {
       rowCandidateLite.reserve(candidates.size());
     }
     for (auto const& candidate : candidates) {
+      if (fillOnlyBackground) {
+        float pseudoRndm = candidate.ptProng0() * 1000. - (int64_t)(candidate.ptProng0() * 1000);
+        if (pseudoRndm >= donwSampleBkgFactor) {
+          continue;
+        }
+      }
       auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
       auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
       auto prong2 = candidate.prong2_as<aod::BigTracksPID>();
@@ -368,7 +383,7 @@ struct HfTreeCreatorDplusToPiKPi {
 
   void processMc(aod::Collisions const& collisions,
                  aod::McCollisions const&,
-                 soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec, aod::HfSelDplusToPiKPi>> const& candidates,
+                 selectedCandidatesMc const& candidates,
                  soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                  aod::BigTracksPID const&)
   {
@@ -379,15 +394,43 @@ struct HfTreeCreatorDplusToPiKPi {
     }
 
     // Filling candidate properties
-    rowCandidateFull.reserve(candidates.size());
-    if (fillCandidateLiteTable) {
-      rowCandidateLite.reserve(candidates.size());
-    }
-    for (auto const& candidate : candidates) {
-      auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
-      auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
-      auto prong2 = candidate.prong2_as<aod::BigTracksPID>();
-      fillCandidateTable<true>(candidate, prong0, prong1, prong2);
+    if (fillOnlySignal) {
+      rowCandidateFull.reserve(recSig.size());
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(recSig.size());
+      }
+      for (const auto& candidate : recSig) {
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
+        auto prong2 = candidate.prong2_as<aod::BigTracksPID>();
+        fillCandidateTable<true>(candidate, prong0, prong1, prong2);
+      }
+    } else if (fillOnlyBackground) {
+      rowCandidateFull.reserve(recBg.size());
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(recBg.size());
+      }
+      for (const auto& candidate : recBg) {
+        float pseudoRndm = candidate.ptProng0() * 1000. - (int64_t)(candidate.ptProng0() * 1000);
+        if (pseudoRndm >= donwSampleBkgFactor) {
+          continue;
+        }
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
+        auto prong2 = candidate.prong2_as<aod::BigTracksPID>();
+        fillCandidateTable<true>(candidate, prong0, prong1, prong2);
+      }
+    } else {
+      rowCandidateFull.reserve(candidates.size());
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(candidates.size());
+      }
+      for (const auto& candidate : candidates) {
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
+        auto prong2 = candidate.prong2_as<aod::BigTracksPID>();
+        fillCandidateTable<true>(candidate, prong0, prong1, prong2);
+      }
     }
 
     // Filling particle properties

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -212,10 +212,10 @@ struct HfTreeCreatorDplusToPiKPi {
   Configurable<float> donwSampleBkgFactor{"donwSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
 
   Filter filterSelectCandidates = aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
-  using selectedCandidatesMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec, aod::HfSelDplusToPiKPi>>;
+  using SelectedCandidatesMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec, aod::HfSelDplusToPiKPi>>;
 
-  Partition<selectedCandidatesMc> recSig = (aod::hf_cand_3prong::flagMcMatchRec == (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi)) || (aod::hf_cand_3prong::flagMcMatchRec == -(int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
-  Partition<selectedCandidatesMc> recBg = (aod::hf_cand_3prong::flagMcMatchRec != (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi)) && (aod::hf_cand_3prong::flagMcMatchRec != -(int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
+  Partition<SelectedCandidatesMc> recSig = nabs(aod::hf_cand_3prong::flagMcMatchRec) == (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi);
+  Partition<SelectedCandidatesMc> recBg = nabs(aod::hf_cand_3prong::flagMcMatchRec) != (int8_t)BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi);
 
   void init(InitContext const&)
   {
@@ -383,7 +383,7 @@ struct HfTreeCreatorDplusToPiKPi {
 
   void processMc(aod::Collisions const& collisions,
                  aod::McCollisions const&,
-                 selectedCandidatesMc const& candidates,
+                 SelectedCandidatesMc const& candidates,
                  soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                  aod::BigTracksPID const&)
   {


### PR DESCRIPTION
Hi @fgrosa !

I added configurables to fill only signal or only (a fraction of) background.

For the MC part, I defined `Partition`s allowing to apply the `if` condition (`if (fillOnlySignal)` or `if (fillOnlyBackground)`) outside the loop over candidates.