### PR TITLE
[PWGJE Validation] Adding configurable for flexible usage of evSel7,8

### DIFF
--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -38,6 +38,7 @@ struct JetFinderTask {
   Configurable<float> trackPhiMin{"trackPhiMin", -999, "minimum track phi"};
   Configurable<float> trackPhiMax{"trackPhiMax", 999, "maximum track phi"};
   Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
+  Configurable<std::string> evSel{"evSel", "evSel8", "choose event selection"};
 
   // cluster level configurables
   Configurable<std::string> clusterDefinitionS{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
@@ -108,7 +109,7 @@ struct JetFinderTask {
   void processChargedJets(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision,
                           JetTracks const& tracks)
   {
-    if (!selectCollision(collision)) {
+    if (!selectCollision(collision, evSel)) {
       return;
     }
     inputParticles.clear();

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -66,7 +66,7 @@ bool selectTrack(T const& track, std::string trackSelection)
     return false;
   } else if (trackSelection == "QualityTracks" && !track.isQualityTrack()) {
     return false;
-  } else if (trackSelection == "hybridTracksJE" && !track.trackCutFlagFb5()) { // isQualityTrack
+  } else if (trackSelection == "hybridTracksJE" && !track.trackCutFlagFb5()) {
     return false;
   } else {
     return true;
@@ -237,9 +237,12 @@ void analyseParticles(std::vector<fastjet::PseudoJet>& inputParticles, float par
 }
 
 template <typename T>
-bool selectCollision(T const& collision)
+bool selectCollision(T const& collision, std::string evSel)
 {
-  if (!collision.sel8()) {
+  if (evSel == "evSel8" & !collision.sel8()) {
+    return false;
+  }
+  if(evSel == "evSel7" & !collision.sel7()){
     return false;
   }
   return true;

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -245,7 +245,7 @@ bool selectCollision(T const& collision, std::string evSel)
   if (evSel == "evSel7" & !collision.sel7()) {
     return false;
   }
-  if (evSev == "None") {
+  if (evSel == "None") {
     return true;
   }
   return true;

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -245,7 +245,7 @@ bool selectCollision(T const& collision, std::string evSel)
   if (evSel == "evSel7" & !collision.sel7()) {
     return false;
   }
-  if (evSev == "None"){
+  if (evSev == "None") {
     return true;
   }
   return true;

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -245,6 +245,9 @@ bool selectCollision(T const& collision, std::string evSel)
   if (evSel == "evSel7" & !collision.sel7()) {
     return false;
   }
+  if (evSev == "None"){
+    return true;
+  }
   return true;
 }
 

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -242,7 +242,7 @@ bool selectCollision(T const& collision, std::string evSel)
   if (evSel == "evSel8" & !collision.sel8()) {
     return false;
   }
-  if(evSel == "evSel7" & !collision.sel7()){
+  if (evSel == "evSel7" & !collision.sel7()) {
     return false;
   }
   return true;

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -39,6 +39,8 @@ struct JetFinderHFTask {
   Configurable<float> trackPhiMin{"trackPhiMin", -999, "minimum track phi"};
   Configurable<float> trackPhiMax{"trackPhiMax", 999, "maximum track phi"};
   Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
+  Configurable<std::string> evSel{"evSel", "evSel8", "choose event selection"};
+
 
   // cluster level configurables
   Configurable<std::string> clusterDefinitionS{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
@@ -142,7 +144,7 @@ struct JetFinderHFTask {
   template <typename T, typename U, typename M>
   void analyseData(T const& collision, U const& tracks, M const& candidates)
   {
-    if (!selectCollision(collision)) {
+    if (!selectCollision(collision, evSel)) {
       return;
     }
 
@@ -160,7 +162,7 @@ struct JetFinderHFTask {
   template <typename T, typename U, typename M>
   void analyseMCD(T const& collision, U const& tracks, M const& candidates)
   {
-    if (!selectCollision(collision)) {
+    if (!selectCollision(collision, evSel)) {
       return;
     }
 

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -41,7 +41,6 @@ struct JetFinderHFTask {
   Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
   Configurable<std::string> evSel{"evSel", "evSel8", "choose event selection"};
 
-
   // cluster level configurables
   Configurable<std::string> clusterDefinitionS{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
   Configurable<float> clusterEtaMin{"clusterEtaMin", -0.7, "minimum cluster eta"}; // For ECMAL: |eta| < 0.7, phi = 1.40 - 3.26

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -12,20 +12,9 @@
 //  \author
 //  Johanna Lömker
 //  \since Dec 2022
-// Examples for configurations and run macros (https://github.com/jloemker/PWGJE/tree/master/O2Physics/config_run)
-// 1)Configuration for run2 validation on ESD:
-//  Use run2ESD.sh with configRun2ESD.json
-// 2)Configuration for run3 validation on AOD: NOT YET WORKING - see comment in run3AOD.sh
-//  Use run3AOD.sh with configRun3AOD.json
-// 3)Configuration for MC validation on converted run2 AOD:
-//  Use runMC2.sh with configMC2Jet.json
-// 4) Configuration for MC validation on run3 AOD:
-// Use runMC3.sh with configMC3Jet.json
-
 ////////////////=============================================////////////////
 //                              TODO's:
 //============== 1)template in mcJetTrackCollisionQa to validate JetMatching !
-// look at matching https://github.com/AliceO2Group/O2Physics/blob/723d78931b446e7b5f6e0673c0345fcef584e796/Tutorials/src/mcHistograms.cxx#L154
 // loop over matched jets
 // make additional TH2F's for matched jets in pt, phi, eta (just what i did for the ones for tracks and collisions)
 //        i) with mcrec vs mcpart
@@ -37,9 +26,6 @@
 //
 //============== 3) prepare plotting macros for Run3 and MCrun2, MCrun3 !
 //
-//============== 4) improve binning - also in AliPhysics !
-//
-//============== 3) add explicit filters for collision and tracks to mc and make use in run3
 ////////////////=============================================////////////////
 
 #include "Framework/runDataProcessing.h"
@@ -58,10 +44,6 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-
-// tracks for 1) validation on ESD 2) Run2 MC validatio on AO2D's 3) Run2 MC validation on AO2D's
-using MCTracksRun3JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>;
-using MCTracksRun2JE = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>; // for now the same
 
 // struct for jetfinder validation on run2 ESD's and run3 data
 struct jetTrackCollisionQa {
@@ -125,15 +107,11 @@ struct jetTrackCollisionQa {
   template <typename validationTracks>
   void fillTrackQA(validationTracks const& track)
   {
-    if (!selectTrack(track, trackSelection)) {
-      return;
-    }
     mHistManager.fill(HIST("selectedTrackPt"), track.pt());
     mHistManager.fill(HIST("selectedTrackPhi"), track.phi());
     mHistManager.fill(HIST("selectedTrackEta"), track.eta());
   } // end of fillTrackQA template
 
-  // template <typename validationTracks>
   void fillLeadingTrackQA(double leadingTrackPt, double leadingTrackPhi, double leadingTrackEta)
   {
     mHistManager.fill(HIST("leadTrackPt"), leadingTrackPt);
@@ -149,7 +127,6 @@ struct jetTrackCollisionQa {
     mHistManager.fill(HIST("jetEta"), jet.eta());
   } // end of fillJetQA template
 
-  // template <typename validationTracks>
   void fillLeadingJetQA(double leadingJetPt, double leadingJetPhi, double leadingJetEta)
   {
     mHistManager.fill(HIST("leadJetPt"), leadingJetPt);
@@ -165,7 +142,6 @@ struct jetTrackCollisionQa {
     mHistManager.fill(HIST("jetConstTrackEta"), jct.eta());
   } // end of mcDetJetConstituent template
 
-  // template <typename validationTracks>
   void fillLeadingJetConstQA(double leadingConstTrackPt, double leadingConstTrackPhi, double leadingConstTrackEta)
   {
     mHistManager.fill(HIST("leadJetConstPt"), leadingConstTrackPt);
@@ -175,12 +151,11 @@ struct jetTrackCollisionQa {
 
   Filter etafilter = (aod::track::eta < etaup) && (aod::track::eta > etalow);
   Filter ptfilter = (aod::track::pt < ptUp) && (aod::track::pt > ptLow);
-
   using TracksJE = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>>;
-
+  
   void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (!collision.sel7() || abs(collision.posZ()) > 10) {
+    if (!collision.sel7() || fabs(collision.posZ()) > 10) {
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
@@ -189,10 +164,8 @@ struct jetTrackCollisionQa {
     double leadingTrackPhi = -1;
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
-    // Partition<aod::Tracks> groupedTracks = aod::track::collisionId == collision.globalIndex();//could be Tracks instead of TracksJE
-    // groupedTracks.bindTable(tracks);
     for (const auto& t : tracks) {
-      if (t.collisionId() == collision.globalIndex()) {
+      if (t.collisionId() == collision.globalIndex() & selectTrack(t, trackSelection) == true) {
         fillTrackQA(t);
         if (t.pt() > leadingTrackPt) {
           leadingTrackPt = t.pt();
@@ -238,7 +211,7 @@ struct jetTrackCollisionQa {
   // process for run3 AOD's
   void processRun3AOD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (!collision.sel8() || abs(collision.posZ()) > 10) {
+    if (!collision.sel8() || fabs(collision.posZ()) > 10) {
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
@@ -247,11 +220,13 @@ struct jetTrackCollisionQa {
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      fillTrackQA(t);
-      if (t.pt() > leadingTrackPt) {
-        leadingTrackPt = t.pt();
-        leadingTrackPhi = t.phi();
-        leadingTrackEta = t.eta();
+      if (t.collisionId() == collision.globalIndex() & selectTrack(t, trackSelection) == true) {
+        fillTrackQA(t);
+        if (t.pt() > leadingTrackPt) {
+          leadingTrackPt = t.pt();
+          leadingTrackPhi = t.phi();
+          leadingTrackEta = t.eta();
+        }
       }
     } // end of tracks loop
     // fill leading track
@@ -297,6 +272,11 @@ struct jetTrackCollisionQa {
 
 // MC validation for run2 and run3 on AO2D's
 struct mcJetTrackCollisionQa {
+  // Track filter configs
+  Configurable<float> ptLow{"ptLow", 0.15f, "lowest pt"};
+  Configurable<float> ptUp{"ptUp", 10e10f, "highest pt"};
+  Configurable<float> etalow{"etaLow", -0.9f, "lowest eta"};
+  Configurable<float> etaup{"etaUp", 0.9f, "highest eta"};
 
   HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
   Configurable<int> nBins{"nBins", 200, "N bins in histos"}; // keep nBins for vertex and special 2D's
@@ -384,17 +364,17 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("collResolutionPt"), collision.mcCollision().posZ(), (collision.posZ() - collision.mcCollision().posZ()) / collision.mcCollision().posZ());
   } // end of collision template
 
-  // fill qa histograms for selected tracks in collision - bool for if .has_mcCollision()
-  template <class ValidationTracks>
-  void fillMcTrackHistos(ValidationTracks const& mct, bool mc) // could give collision as argument for additional association
+  // fill qa histograms for selected tracks in collision 
+  template <class ValidationTracks, typename coll>
+  void fillMcTrackHistos(ValidationTracks const& mct, coll collision, bool mc) // could give collision as argument for additional association
   {
     for (const auto& track : mct) {
-      if (!selectTrack(track, trackSelection)) {
+      if (!selectTrack(track, trackSelection) || track.collisionId() == collision.globalIndex()) {
         return;
       }
       if (mc == true) {
         if (track.has_mcParticle()) {
-          auto mcParticle = track.mcParticle(); // t.mcParticle_as<aod::McParticles>();
+          auto mcParticle = track.mcParticle(); 
           mHistManager.fill(HIST("genMCselectedTrackPt"), mcParticle.pt());
           mHistManager.fill(HIST("genMCselectedTrackPhi"), mcParticle.phi());
           mHistManager.fill(HIST("genMCselectedTrackEta"), mcParticle.eta());
@@ -452,68 +432,77 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("genMCjetConstTrackEta"), mcpJConst.eta());
   } // end of mcPartJetConstituent template
 
+  Filter etafilter = (aod::track::eta < etaup) && (aod::track::eta > etalow);
+  Filter ptfilter = (aod::track::pt < ptUp) && (aod::track::pt > ptLow);
+  using MCTracksJE = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::McTrackLabels>>;
+
   void processMcRun2(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision,
                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets,
                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets,
                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
-                     MCTracksRun2JE const& tracks)
+                     MCTracksJE const& tracks)
   {
-    if (abs(collision.posZ()) > 10) { // sel7 for run2: !collision.sel7()
+    if (fabs(collision.posZ()) > 10) {
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
     if (collision.has_mcCollision()) {
       fillMcCollisionHistos(collision);
-      fillMcTrackHistos(tracks, true);
+      fillMcTrackHistos(tracks, collision, true);
+      for (const auto& genJet : mcPartJets) {
+        if (genJet.mcCollisionId() == collision.globalIndex()){
+          fillMcPartJets(genJet);
+          for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
+            fillMcPartJetConstituents(mcParticle);
+          }
+        }
+      } // end of loop particle level jets
     } // end if has mc collision
-    fillMcTrackHistos(tracks, false);
-
+    fillMcTrackHistos(tracks, collision, false);
     for (const auto& detJet : mcDetJets) {
-      fillMcDetJets(detJet);
-      for (auto& detConst : detJet.tracks_as<MCTracksRun2JE>()) {
-        fillMcDetJetConstituents(detConst);
-      } // end of loop detector level constituents
-    }   // end of loop detector level jets
-
-    for (const auto& genJet : mcPartJets) {
-      fillMcPartJets(genJet);
-      for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
-        fillMcPartJetConstituents(mcParticle);
-      } // end of jet constituent loop
-    }   // end of loop particle level jets
-  }     // end processMcRun2
+      if (detJet.collisionId() == collision.globalIndex()){
+        fillMcDetJets(detJet);
+        for (auto& detConst : detJet.tracks_as<MCTracksJE>()) {
+          fillMcDetJetConstituents(detConst);
+        } 
+      }
+    }// end of loop detector level jets
+  } // end processMcRun2
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun2, "validate jet-finder output on converted run2 mc AOD's", false);
+
 
   void processMcRun3(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision,
                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets,
                      soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& mcDetJets,
                      aod::McParticles const& mcParticles, aod::McCollisions const& mcCollisions,
-                     MCTracksRun3JE const& tracks)
+                     MCTracksJE const& tracks)
   {
-    if (abs(collision.posZ()) > 10) { // sel8 for run3: !collision.sel8() -> only on run3 data with EvSels in process function !
+    if (fabs(collision.posZ()) > 10) {
       return;
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
     if (collision.has_mcCollision()) {
       fillMcCollisionHistos(collision);
-      fillMcTrackHistos(tracks, true);
+      fillMcTrackHistos(tracks, collision, true);
+      for (const auto& genJet : mcPartJets) {
+        if (genJet.mcCollisionId() == collision.globalIndex()){
+          fillMcPartJets(genJet);
+          for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
+            fillMcPartJetConstituents(mcParticle);
+          }
+        } 
+      }  // end of loop particle level jets
     } // end of loop if mc collision
-    fillMcTrackHistos(tracks, false);
-
+    fillMcTrackHistos(tracks, collision, false);
     for (const auto& detJet : mcDetJets) {
-      fillMcDetJets(detJet);
-      for (auto& detConst : detJet.tracks_as<MCTracksRun3JE>()) {
-        fillMcDetJetConstituents(detConst);
-      } // end of loop detector level constituents
-    }   // end of loop detector level jets
-
-    for (const auto& genJet : mcPartJets) {
-      fillMcPartJets(genJet);
-      for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
-        fillMcPartJetConstituents(mcParticle);
-      } // end of jet constituent loop
-    }   // end of loop particle level jets
-  }     // end processMcRun3
+      if (detJet.collisionId() == collision.globalIndex()){
+        fillMcDetJets(detJet);
+        for (auto& detConst : detJet.tracks_as<MCTracksJE>()) {
+          fillMcDetJetConstituents(detConst);
+        }
+      }
+    } // end of loop detector level jets
+  } // end processMcRun3
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun3, "validate jet-finder output on run3 mc AOD's", false);
 
   // dummy process to run jetfinder validation code on AO2D's, but MC validation for run3 on hyperloop

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -52,6 +52,7 @@ struct jetTrackCollisionQa {
   Configurable<float> ptUp{"ptUp", 10e10f, "highest pt"};
   Configurable<float> etalow{"etaLow", -0.9f, "lowest eta"};
   Configurable<float> etaup{"etaUp", 0.9f, "highest eta"};
+  Configurable<bool> evSel{"evSel", false, "to use event selection 7 for run2 (or 8 for run3)"};
 
   HistogramRegistry mHistManager{"JetCollisionQAHistograms"};
   Configurable<int> nBins{"nBins", 200, "N bins in histos"}; // keep nBins for vertex and special 2D's
@@ -155,9 +156,17 @@ struct jetTrackCollisionQa {
 
   void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (!collision.sel7() || fabs(collision.posZ()) > 10) {
+    if (evSel == true){
+      if (!collision.sel7() || fabs(collision.posZ()) > 10) {
       return;
+      }
     }
+    else{
+      if (fabs(collision.posZ()) > 10) {
+      return;
+      }
+    }
+
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
 
     double leadingTrackPt = -1;
@@ -165,7 +174,7 @@ struct jetTrackCollisionQa {
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      if (t.collisionId() == collision.globalIndex() & selectTrack(t, trackSelection) == true) {
+      if ( (t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true) ) {
         fillTrackQA(t);
         if (t.pt() > leadingTrackPt) {
           leadingTrackPt = t.pt();
@@ -211,8 +220,15 @@ struct jetTrackCollisionQa {
   // process for run3 AOD's
   void processRun3AOD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (!collision.sel8() || fabs(collision.posZ()) > 10) {
+    if (evSel == true){
+      if (!collision.sel8() || fabs(collision.posZ()) > 10) {
       return;
+      }
+    }
+    else{
+      if (fabs(collision.posZ()) > 10) {
+      return;
+      }
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
     double leadingTrackPt = -1;
@@ -220,7 +236,7 @@ struct jetTrackCollisionQa {
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      if (t.collisionId() == collision.globalIndex() & selectTrack(t, trackSelection) == true) {
+      if ( (t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true)) {
         fillTrackQA(t);
         if (t.pt() > leadingTrackPt) {
           leadingTrackPt = t.pt();
@@ -369,7 +385,7 @@ struct mcJetTrackCollisionQa {
   void fillMcTrackHistos(ValidationTracks const& mct, coll collision, bool mc) // could give collision as argument for additional association
   {
     for (const auto& track : mct) {
-      if (!selectTrack(track, trackSelection) || track.collisionId() == collision.globalIndex()) {
+      if ( (!selectTrack(track, trackSelection)) || (track.collisionId() == collision.globalIndex()) ) {
         return;
       }
       if (mc == true) {

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -190,7 +190,7 @@ struct jetTrackCollisionQa {
     double leadingJetEta = -1;
     // jet QA hists per jet in this collision
     for (const auto& j : jets) {
-      if(j.collisionId() != collision.globalIndex()){
+      if (j.collisionId() != collision.globalIndex()) {
         return;
       }
       fillJetQA(j);
@@ -254,7 +254,7 @@ struct jetTrackCollisionQa {
     double leadingJetEta = -1;
     // jet QA hists per jet in this collision
     for (const auto& j : jets) {
-      if(j.collisionId() != collision.globalIndex()){
+      if (j.collisionId() != collision.globalIndex()) {
         return;
       }
       fillJetQA(j);

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -190,6 +190,9 @@ struct jetTrackCollisionQa {
     double leadingJetEta = -1;
     // jet QA hists per jet in this collision
     for (const auto& j : jets) {
+      if(j.collisionId() != collision.globalIndex()){
+        return;
+      }
       fillJetQA(j);
       if (j.pt() > leadingJetPt) {
         leadingJetPt = j.pt();
@@ -251,6 +254,9 @@ struct jetTrackCollisionQa {
     double leadingJetEta = -1;
     // jet QA hists per jet in this collision
     for (const auto& j : jets) {
+      if(j.collisionId() != collision.globalIndex()){
+        return;
+      }
       fillJetQA(j);
       if (j.pt() > leadingJetPt) {
         leadingJetPt = j.pt();

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -152,7 +152,7 @@ struct jetTrackCollisionQa {
   Filter etafilter = (aod::track::eta < etaup) && (aod::track::eta > etalow);
   Filter ptfilter = (aod::track::pt < ptUp) && (aod::track::pt > ptLow);
   using TracksJE = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>>;
-  
+
   void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
     if (!collision.sel7() || fabs(collision.posZ()) > 10) {
@@ -364,7 +364,7 @@ struct mcJetTrackCollisionQa {
     mHistManager.fill(HIST("collResolutionPt"), collision.mcCollision().posZ(), (collision.posZ() - collision.mcCollision().posZ()) / collision.mcCollision().posZ());
   } // end of collision template
 
-  // fill qa histograms for selected tracks in collision 
+  // fill qa histograms for selected tracks in collision
   template <class ValidationTracks, typename coll>
   void fillMcTrackHistos(ValidationTracks const& mct, coll collision, bool mc) // could give collision as argument for additional association
   {
@@ -374,7 +374,7 @@ struct mcJetTrackCollisionQa {
       }
       if (mc == true) {
         if (track.has_mcParticle()) {
-          auto mcParticle = track.mcParticle(); 
+          auto mcParticle = track.mcParticle();
           mHistManager.fill(HIST("genMCselectedTrackPt"), mcParticle.pt());
           mHistManager.fill(HIST("genMCselectedTrackPhi"), mcParticle.phi());
           mHistManager.fill(HIST("genMCselectedTrackEta"), mcParticle.eta());
@@ -450,7 +450,7 @@ struct mcJetTrackCollisionQa {
       fillMcCollisionHistos(collision);
       fillMcTrackHistos(tracks, collision, true);
       for (const auto& genJet : mcPartJets) {
-        if (genJet.mcCollisionId() == collision.globalIndex()){
+        if (genJet.mcCollisionId() == collision.globalIndex()) {
           fillMcPartJets(genJet);
           for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
             fillMcPartJetConstituents(mcParticle);
@@ -460,16 +460,15 @@ struct mcJetTrackCollisionQa {
     } // end if has mc collision
     fillMcTrackHistos(tracks, collision, false);
     for (const auto& detJet : mcDetJets) {
-      if (detJet.collisionId() == collision.globalIndex()){
+      if (detJet.collisionId() == collision.globalIndex()) {
         fillMcDetJets(detJet);
         for (auto& detConst : detJet.tracks_as<MCTracksJE>()) {
           fillMcDetJetConstituents(detConst);
-        } 
+        }
       }
-    }// end of loop detector level jets
-  } // end processMcRun2
+    } // end of loop detector level jets
+  }   // end processMcRun2
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun2, "validate jet-finder output on converted run2 mc AOD's", false);
-
 
   void processMcRun3(soa::Join<aod::Collisions, aod::McCollisionLabels>::iterator const& collision,
                      soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& mcPartJets,
@@ -485,24 +484,24 @@ struct mcJetTrackCollisionQa {
       fillMcCollisionHistos(collision);
       fillMcTrackHistos(tracks, collision, true);
       for (const auto& genJet : mcPartJets) {
-        if (genJet.mcCollisionId() == collision.globalIndex()){
+        if (genJet.mcCollisionId() == collision.globalIndex()) {
           fillMcPartJets(genJet);
           for (auto& mcParticle : genJet.tracks_as<aod::McParticles>()) {
             fillMcPartJetConstituents(mcParticle);
           }
-        } 
-      }  // end of loop particle level jets
+        }
+      } // end of loop particle level jets
     } // end of loop if mc collision
     fillMcTrackHistos(tracks, collision, false);
     for (const auto& detJet : mcDetJets) {
-      if (detJet.collisionId() == collision.globalIndex()){
+      if (detJet.collisionId() == collision.globalIndex()) {
         fillMcDetJets(detJet);
         for (auto& detConst : detJet.tracks_as<MCTracksJE>()) {
           fillMcDetJetConstituents(detConst);
         }
       }
     } // end of loop detector level jets
-  } // end processMcRun3
+  }   // end processMcRun3
   PROCESS_SWITCH(mcJetTrackCollisionQa, processMcRun3, "validate jet-finder output on run3 mc AOD's", false);
 
   // dummy process to run jetfinder validation code on AO2D's, but MC validation for run3 on hyperloop

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -156,14 +156,13 @@ struct jetTrackCollisionQa {
 
   void processESD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (evSel == true){
+    if (evSel == true) {
       if (!collision.sel7() || fabs(collision.posZ()) > 10) {
-      return;
+        return;
       }
-    }
-    else{
+    } else {
       if (fabs(collision.posZ()) > 10) {
-      return;
+        return;
       }
     }
 
@@ -174,7 +173,7 @@ struct jetTrackCollisionQa {
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      if ( (t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true) ) {
+      if ((t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true)) {
         fillTrackQA(t);
         if (t.pt() > leadingTrackPt) {
           leadingTrackPt = t.pt();
@@ -220,14 +219,13 @@ struct jetTrackCollisionQa {
   // process for run3 AOD's
   void processRun3AOD(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets, TracksJE const& tracks)
   {
-    if (evSel == true){
+    if (evSel == true) {
       if (!collision.sel8() || fabs(collision.posZ()) > 10) {
-      return;
+        return;
       }
-    }
-    else{
+    } else {
       if (fabs(collision.posZ()) > 10) {
-      return;
+        return;
       }
     }
     mHistManager.fill(HIST("collisionVtxZ"), collision.posZ());
@@ -236,7 +234,7 @@ struct jetTrackCollisionQa {
     double leadingTrackEta = -1;
     // qa histograms for selected tracks in collision
     for (const auto& t : tracks) {
-      if ( (t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true)) {
+      if ((t.collisionId() == collision.globalIndex()) & (selectTrack(t, trackSelection) == true)) {
         fillTrackQA(t);
         if (t.pt() > leadingTrackPt) {
           leadingTrackPt = t.pt();
@@ -385,7 +383,7 @@ struct mcJetTrackCollisionQa {
   void fillMcTrackHistos(ValidationTracks const& mct, coll collision, bool mc) // could give collision as argument for additional association
   {
     for (const auto& track : mct) {
-      if ( (!selectTrack(track, trackSelection)) || (track.collisionId() == collision.globalIndex()) ) {
+      if ((!selectTrack(track, trackSelection)) || (track.collisionId() == collision.globalIndex())) {
         return;
       }
       if (mc == true) {


### PR DESCRIPTION
Hi @fkrizek, @archita-dash,

in order to get more jets for the comparison to AliPhysics I included a configurable for the event selection 7 (or 8 for run3). 
As we apply a jet-to-collision association we restricted the amount of jets in O2Physics to jets from collisions that passed the evSel7. Knowing that the Jetfinder from O2Physics does not use the evSel7 for run2 we should have the ability to consider collisions (and thus collision associated jets) with and without the sel7.

**Excluding the evSel7 leads to slightly (when tested on one single AOD.root) more jets in the jetvalidation output !** 

Lets hope that this PR gets merged soon such that we can make a proper comparison for the output with and without the evSel7.

Cheerio,
Johanna
 
