### PR TITLE
Bugfix, improvements

### DIFF
--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -84,7 +84,7 @@ struct correlateStrangeness {
 
   uint8_t doCorrelation;
 
-  std::vector<std::vector<float>> axisRanges; 
+  std::vector<std::vector<float>> axisRanges;
 
   /// Function to aid in calculating delta-phi
   /// \param phi1 first phi value
@@ -124,12 +124,12 @@ struct correlateStrangeness {
         float ptassoc = assoc.pt();
 
         // skip if basic ranges not met
-        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
-          continue; 
-        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
-          continue; 
-        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
-          continue; 
+        if (deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1])
+          continue;
+        if (deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1])
+          continue;
+        if (ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1])
+          continue;
 
         static_for<0, 2>([&](auto i) {
           constexpr int index = i.value;
@@ -182,12 +182,12 @@ struct correlateStrangeness {
         float ptassoc = assoc.pt();
 
         // skip if basic ranges not met
-        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
-          continue; 
-        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
-          continue; 
-        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
-          continue; 
+        if (deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1])
+          continue;
+        if (deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1])
+          continue;
+        if (ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1])
+          continue;
 
         static_for<0, 3>([&](auto i) {
           constexpr int index = i.value;
@@ -230,12 +230,12 @@ struct correlateStrangeness {
         float ptassoc = assoc.pt();
 
         // skip if basic ranges not met
-        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
-          continue; 
-        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
-          continue; 
-        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
-          continue; 
+        if (deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1])
+          continue;
+        if (deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1])
+          continue;
+        if (ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1])
+          continue;
 
         if (!mixing)
           histos.fill(HIST("sameEvent/Pion"), deltaphi, deltaeta, ptassoc, pvz, mult);
@@ -273,43 +273,43 @@ struct correlateStrangeness {
     const AxisSpec preAxisVtxZ{axisVtxZ, "vertex Z (cm)"};
     const AxisSpec preAxisMult{axisMult, "mult percentile"};
 
-    std::vector<double> edgesDeltaPhi = preAxisDeltaPhi.binEdges; 
-    std::vector<double> edgesDeltaEta = preAxisDeltaEta.binEdges; 
-    std::vector<double> edgesPtAssoc = preAxisPtAssoc.binEdges; 
-    std::vector<double> edgesVtxZ = preAxisVtxZ.binEdges; 
-    std::vector<double> edgesMult = preAxisMult.binEdges; 
+    std::vector<double> edgesDeltaPhi = preAxisDeltaPhi.binEdges;
+    std::vector<double> edgesDeltaEta = preAxisDeltaEta.binEdges;
+    std::vector<double> edgesPtAssoc = preAxisPtAssoc.binEdges;
+    std::vector<double> edgesVtxZ = preAxisVtxZ.binEdges;
+    std::vector<double> edgesMult = preAxisMult.binEdges;
 
-    // Store axis ranges to prevent spurious filling 
-    // axis status: 
-    // --- Delta-phi is safe -> math forbids insanity  
-    // --- Delta-eta depends on pre-filter -> check 
-    // --- pT assoc depends on binning -> check 
-    // --- vertex Z is safe -> skipped at evsel level 
-    // --- multiplicity -> check 
+    // Store axis ranges to prevent spurious filling
+    // axis status:
+    // --- Delta-phi is safe -> math forbids insanity
+    // --- Delta-eta depends on pre-filter -> check
+    // --- pT assoc depends on binning -> check
+    // --- vertex Z is safe -> skipped at evsel level
+    // --- multiplicity -> check
 
-    std::vector<float> rangesDeltaPhi = {edgesDeltaPhi[0], edgesDeltaPhi[edgesDeltaPhi.size()-1]};
-    std::vector<float> rangesDeltaEta = {edgesDeltaEta[0], edgesDeltaEta[edgesDeltaEta.size()-1]};
-    std::vector<float> rangesPtAssoc = {edgesPtAssoc[0], edgesPtAssoc[edgesPtAssoc.size()-1]};
-    std::vector<float> rangesVtxZ = {edgesVtxZ[0], edgesVtxZ[edgesVtxZ.size()-1]};
-    std::vector<float> rangesMult = {edgesMult[0], edgesMult[edgesMult.size()-1]};
+    std::vector<float> rangesDeltaPhi = {edgesDeltaPhi[0], edgesDeltaPhi[edgesDeltaPhi.size() - 1]};
+    std::vector<float> rangesDeltaEta = {edgesDeltaEta[0], edgesDeltaEta[edgesDeltaEta.size() - 1]};
+    std::vector<float> rangesPtAssoc = {edgesPtAssoc[0], edgesPtAssoc[edgesPtAssoc.size() - 1]};
+    std::vector<float> rangesVtxZ = {edgesVtxZ[0], edgesVtxZ[edgesVtxZ.size() - 1]};
+    std::vector<float> rangesMult = {edgesMult[0], edgesMult[edgesMult.size() - 1]};
 
-    axisRanges.emplace_back(rangesDeltaPhi); 
-    axisRanges.emplace_back(rangesDeltaEta); 
-    axisRanges.emplace_back(rangesPtAssoc); 
-    axisRanges.emplace_back(rangesVtxZ); 
-    axisRanges.emplace_back(rangesMult); 
+    axisRanges.emplace_back(rangesDeltaPhi);
+    axisRanges.emplace_back(rangesDeltaEta);
+    axisRanges.emplace_back(rangesPtAssoc);
+    axisRanges.emplace_back(rangesVtxZ);
+    axisRanges.emplace_back(rangesMult);
 
     // check if U/O-flow skip is on
-    if( skipUnderOverflowInTHn ){ 
+    if (skipUnderOverflowInTHn) {
       // v--- skipUnderOverflowInTHn ---v
-      // 
+      //
       // if enabled, this will change the axes such that they will solely cover the interval from
-      // edge[1] to edge[n-1]; this will mean that the bin 1 and bin N will be stored in 
-      // under / overflow bins and will have to be manually unpacked. Do not forget to do the manual 
-      // unpacking a posteriori! 
-      // 
-      // this feature is meant to save memory conveniently. 
-      // it should actually be implemented centrally in ROOT but ok, this will do it for now. 
+      // edge[1] to edge[n-1]; this will mean that the bin 1 and bin N will be stored in
+      // under / overflow bins and will have to be manually unpacked. Do not forget to do the manual
+      // unpacking a posteriori!
+      //
+      // this feature is meant to save memory conveniently.
+      // it should actually be implemented centrally in ROOT but ok, this will do it for now.
       edgesDeltaPhi.erase(edgesDeltaPhi.begin());
       edgesDeltaPhi.erase(edgesDeltaPhi.end());
       edgesDeltaEta.erase(edgesDeltaPhi.begin());
@@ -521,9 +521,9 @@ struct correlateStrangeness {
         continue;
       if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
         continue;
-      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0])
         continue;
-      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0])
         continue;
 
       if (!doprocessMixedEventHCascades) {
@@ -554,9 +554,9 @@ struct correlateStrangeness {
         continue;
       if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
         continue;
-      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0])
         continue;
-      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0])
         continue;
 
       if (collision1.globalIndex() == collision2.globalIndex()) {
@@ -586,9 +586,9 @@ struct correlateStrangeness {
         continue;
       if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
         continue;
-      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0])
         continue;
-      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0])
         continue;
 
       if (collision1.globalIndex() == collision2.globalIndex()) {

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -287,11 +287,11 @@ struct correlateStrangeness {
     // --- vertex Z is safe -> skipped at evsel level
     // --- multiplicity -> check
 
-    std::vector<float> rangesDeltaPhi = {edgesDeltaPhi[0], edgesDeltaPhi[edgesDeltaPhi.size() - 1]};
-    std::vector<float> rangesDeltaEta = {edgesDeltaEta[0], edgesDeltaEta[edgesDeltaEta.size() - 1]};
-    std::vector<float> rangesPtAssoc = {edgesPtAssoc[0], edgesPtAssoc[edgesPtAssoc.size() - 1]};
-    std::vector<float> rangesVtxZ = {edgesVtxZ[0], edgesVtxZ[edgesVtxZ.size() - 1]};
-    std::vector<float> rangesMult = {edgesMult[0], edgesMult[edgesMult.size() - 1]};
+    std::vector<float> rangesDeltaPhi = {static_cast<float>(edgesDeltaPhi[0]), static_cast<float>(edgesDeltaPhi[edgesDeltaPhi.size() - 1])};
+    std::vector<float> rangesDeltaEta = {static_cast<float>(edgesDeltaEta[0]), static_cast<float>(edgesDeltaEta[edgesDeltaEta.size() - 1])};
+    std::vector<float> rangesPtAssoc = {static_cast<float>(edgesPtAssoc[0]), static_cast<float>(edgesPtAssoc[edgesPtAssoc.size() - 1])};
+    std::vector<float> rangesVtxZ = {static_cast<float>(edgesVtxZ[0]), static_cast<float>(edgesVtxZ[edgesVtxZ.size() - 1])};
+    std::vector<float> rangesMult = {static_cast<float>(edgesMult[0]), static_cast<float>(edgesMult[edgesMult.size() - 1])};
 
     axisRanges.emplace_back(rangesDeltaPhi);
     axisRanges.emplace_back(rangesDeltaEta);

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -350,7 +350,7 @@ struct correlateStrangeness {
     }
     if (bitcheck(doCorrelation, 5)) {
       histos.add("h2dMassOmegaMinus", "h2dMassOmegaMinus", kTH3F, {axisPtQA, axisOmegaMass, axisMult});
-      histos.add("sameEvent/Signal/OmegaMinus", "OmegaMinus", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("sameEvent/Signal/OmegaMinus", "OmegaMinus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 6)) {
       histos.add("h2dMassOmegaPlus", "h2dMassOmegaPlus", kTH3F, {axisPtQA, axisOmegaMass, axisMult});

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -54,6 +54,7 @@ struct correlateStrangeness {
   Configurable<bool> doCorrelationOmegaPlus{"doCorrelationOmegaPlus", false, "do OmegaPlus correlation"};
   Configurable<bool> doCorrelationPion{"doCorrelationPion", false, "do Pion correlation"};
   Configurable<int> zVertexCut{"zVertexCut", 10, "Cut on PV position"};
+  Configurable<bool> skipUnderOverflowInTHn{"skipUnderOverflowInTHn", true, "skip under/overflow in THns"};
 
   // Axes - configurable for smaller sizes
   ConfigurableAxis axisMult{"axisMult", {VARIABLE_WIDTH, 0.0f, 0.01f, 1.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 70.0f, 100.0f}, "Mixing bins - multiplicity"};
@@ -82,6 +83,8 @@ struct correlateStrangeness {
   static constexpr std::string_view cascadenames[] = {"XiMinus", "XiPlus", "OmegaMinus", "OmegaPlus"};
 
   uint8_t doCorrelation;
+
+  std::vector<std::vector<float>> axisRanges; 
 
   /// Function to aid in calculating delta-phi
   /// \param phi1 first phi value
@@ -119,6 +122,15 @@ struct correlateStrangeness {
         float deltaphi = ComputeDeltaPhi(trigg.phi(), assoc.phi());
         float deltaeta = trigg.eta() - assoc.eta();
         float ptassoc = assoc.pt();
+
+        // skip if basic ranges not met
+        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
+          continue; 
+        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
+          continue; 
+        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
+          continue; 
+
         static_for<0, 2>([&](auto i) {
           constexpr int index = i.value;
           if (bitcheck(doCorrelation, index)) {
@@ -168,6 +180,15 @@ struct correlateStrangeness {
         float deltaphi = ComputeDeltaPhi(trigg.phi(), assoc.phi());
         float deltaeta = trigg.eta() - assoc.eta();
         float ptassoc = assoc.pt();
+
+        // skip if basic ranges not met
+        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
+          continue; 
+        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
+          continue; 
+        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
+          continue; 
+
         static_for<0, 3>([&](auto i) {
           constexpr int index = i.value;
           if (bitcheck(doCorrelation, index + 3)) {
@@ -207,6 +228,15 @@ struct correlateStrangeness {
         float deltaphi = ComputeDeltaPhi(trigg.phi(), assoc.phi());
         float deltaeta = trigg.eta() - assoc.eta();
         float ptassoc = assoc.pt();
+
+        // skip if basic ranges not met
+        if ( deltaphi < axisRanges[0][0] || deltaphi > axisRanges[0][1] ) 
+          continue; 
+        if ( deltaeta < axisRanges[1][0] || deltaeta > axisRanges[1][1] ) 
+          continue; 
+        if ( ptassoc < axisRanges[2][0] || ptassoc > axisRanges[2][1] ) 
+          continue; 
+
         if (!mixing)
           histos.fill(HIST("sameEvent/Pion"), deltaphi, deltaeta, ptassoc, pvz, mult);
         else
@@ -236,36 +266,99 @@ struct correlateStrangeness {
     if (doCorrelationPion)
       bitset(doCorrelation, 7);
 
+    // grab axis edge from ConfigurableAxes
+    const AxisSpec preAxisDeltaPhi{axisDeltaPhi, "#Delta#varphi"};
+    const AxisSpec preAxisDeltaEta{axisDeltaEta, "#Delta#eta"};
+    const AxisSpec preAxisPtAssoc{axisPtAssoc, "#it{p}_{T}^{assoc} (GeV/c)"};
+    const AxisSpec preAxisVtxZ{axisVtxZ, "vertex Z (cm)"};
+    const AxisSpec preAxisMult{axisMult, "mult percentile"};
+
+    std::vector<double> edgesDeltaPhi = preAxisDeltaPhi.binEdges; 
+    std::vector<double> edgesDeltaEta = preAxisDeltaEta.binEdges; 
+    std::vector<double> edgesPtAssoc = preAxisPtAssoc.binEdges; 
+    std::vector<double> edgesVtxZ = preAxisVtxZ.binEdges; 
+    std::vector<double> edgesMult = preAxisMult.binEdges; 
+
+    // Store axis ranges to prevent spurious filling 
+    // axis status: 
+    // --- Delta-phi is safe -> math forbids insanity  
+    // --- Delta-eta depends on pre-filter -> check 
+    // --- pT assoc depends on binning -> check 
+    // --- vertex Z is safe -> skipped at evsel level 
+    // --- multiplicity -> check 
+
+    std::vector<float> rangesDeltaPhi = {edgesDeltaPhi[0], edgesDeltaPhi[edgesDeltaPhi.size()-1]};
+    std::vector<float> rangesDeltaEta = {edgesDeltaEta[0], edgesDeltaEta[edgesDeltaEta.size()-1]};
+    std::vector<float> rangesPtAssoc = {edgesPtAssoc[0], edgesPtAssoc[edgesPtAssoc.size()-1]};
+    std::vector<float> rangesVtxZ = {edgesVtxZ[0], edgesVtxZ[edgesVtxZ.size()-1]};
+    std::vector<float> rangesMult = {edgesMult[0], edgesMult[edgesMult.size()-1]};
+
+    axisRanges.emplace_back(rangesDeltaPhi); 
+    axisRanges.emplace_back(rangesDeltaEta); 
+    axisRanges.emplace_back(rangesPtAssoc); 
+    axisRanges.emplace_back(rangesVtxZ); 
+    axisRanges.emplace_back(rangesMult); 
+
+    // check if U/O-flow skip is on
+    if( skipUnderOverflowInTHn ){ 
+      // v--- skipUnderOverflowInTHn ---v
+      // 
+      // if enabled, this will change the axes such that they will solely cover the interval from
+      // edge[1] to edge[n-1]; this will mean that the bin 1 and bin N will be stored in 
+      // under / overflow bins and will have to be manually unpacked. Do not forget to do the manual 
+      // unpacking a posteriori! 
+      // 
+      // this feature is meant to save memory conveniently. 
+      // it should actually be implemented centrally in ROOT but ok, this will do it for now. 
+      edgesDeltaPhi.erase(edgesDeltaPhi.begin());
+      edgesDeltaPhi.erase(edgesDeltaPhi.end());
+      edgesDeltaEta.erase(edgesDeltaPhi.begin());
+      edgesDeltaEta.erase(edgesDeltaPhi.end());
+      edgesPtAssoc.erase(edgesDeltaPhi.begin());
+      edgesPtAssoc.erase(edgesDeltaPhi.end());
+      edgesVtxZ.erase(edgesDeltaPhi.begin());
+      edgesVtxZ.erase(edgesDeltaPhi.end());
+      edgesMult.erase(edgesDeltaPhi.begin());
+      edgesMult.erase(edgesDeltaPhi.end());
+    }
+
+    const AxisSpec axisDeltaPhiNDim{edgesDeltaPhi, "#Delta#varphi"};
+    const AxisSpec axisDeltaEtaNDim{edgesDeltaEta, "#Delta#eta"};
+    const AxisSpec axisPtAssocNDim{edgesPtAssoc, "#it{p}_{T}^{assoc} (GeV/c)"};
+    const AxisSpec axisVtxZNDim{edgesVtxZ, "vertex Z (cm)"};
+    const AxisSpec axisMultNDim{edgesMult, "mult percentile"};
+
     if (bitcheck(doCorrelation, 0)) {
-      histos.add("h2dMassK0Short", "h2dMassK0Short", kTH2F, {axisPtQA, axisK0ShortMass, axisMult});
-      histos.add("sameEvent/Signal/K0Short", "K0Short", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassK0Short", "h2dMassK0Short", kTH3F, {axisPtQA, axisK0ShortMass, axisMult});
+      histos.add("sameEvent/Signal/K0Short", "K0Short", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 1)) {
-      histos.add("h2dMassLambda", "h2dMassLambda", kTH2F, {axisPtQA, axisLambdaMass, axisMult});
-      histos.add("sameEvent/Signal/Lambda", "Lambda", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassLambda", "h2dMassLambda", kTH3F, {axisPtQA, axisLambdaMass, axisMult});
+      histos.add("sameEvent/Signal/Lambda", "Lambda", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 2)) {
-      histos.add("h2dMassAntiLambda", "h2dMassAntiLambda", kTH2F, {axisPtQA, axisLambdaMass, axisMult});
-      histos.add("sameEvent/Signal/AntiLambda", "AntiLambda", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassAntiLambda", "h2dMassAntiLambda", kTH3F, {axisPtQA, axisLambdaMass, axisMult});
+      histos.add("sameEvent/Signal/AntiLambda", "AntiLambda", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 3)) {
-      histos.add("h2dMassXiMinus", "h2dMassXiMinus", kTH2F, {axisPtQA, axisXiMass, axisMult});
-      histos.add("sameEvent/Signal/XiMinus", "XiMinus", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassXiMinus", "h2dMassXiMinus", kTH3F, {axisPtQA, axisXiMass, axisMult});
+      histos.add("sameEvent/Signal/XiMinus", "XiMinus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 4)) {
-      histos.add("h2dMassXiPlus", "h2dMassXiPlus", kTH2F, {axisPtQA, axisXiMass, axisMult});
-      histos.add("sameEvent/Signal/XiPlus", "XiPlus", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassXiPlus", "h2dMassXiPlus", kTH3F, {axisPtQA, axisXiMass, axisMult});
+      histos.add("sameEvent/Signal/XiPlus", "XiPlus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 5)) {
-      histos.add("h2dMassOmegaMinus", "h2dMassOmegaMinus", kTH2F, {axisPtQA, axisOmegaMass, axisMult});
+      histos.add("h2dMassOmegaMinus", "h2dMassOmegaMinus", kTH3F, {axisPtQA, axisOmegaMass, axisMult});
       histos.add("sameEvent/Signal/OmegaMinus", "OmegaMinus", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
     }
     if (bitcheck(doCorrelation, 6)) {
-      histos.add("h2dMassOmegaPlus", "h2dMassOmegaPlus", kTH2F, {axisPtQA, axisOmegaMass, axisMult});
-      histos.add("sameEvent/Signal/OmegaPlus", "OmegaPlus", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+      histos.add("h2dMassOmegaPlus", "h2dMassOmegaPlus", kTH3F, {axisPtQA, axisOmegaMass, axisMult});
+      histos.add("sameEvent/Signal/OmegaPlus", "OmegaPlus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
-    if (doCorrelationPion)
-      histos.add("sameEvent/Pion", "Pion", kTHnF, {axisDeltaPhi, axisDeltaEta, axisPtAssoc, axisVtxZ, axisMult});
+    if (bitcheck(doCorrelation, 7)) {
+      histos.add("sameEvent/Pion", "Pion", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
+    }
 
     if (doCorrelationK0Short || doCorrelationLambda || doCorrelationAntiLambda || doCorrelationXiMinus || doCorrelationXiPlus || doCorrelationOmegaMinus || doCorrelationOmegaPlus) {
       histos.addClone("sameEvent/Signal/", "sameEvent/LeftBg/");
@@ -311,6 +404,9 @@ struct correlateStrangeness {
     if (TMath::Abs(collision.posZ()) > zVertexCut) {
       return;
     }
+    if (collision.centFT0M() > axisRanges[4][1] || collision.centFT0M() < axisRanges[4][0]) {
+      return;
+    }
     // ________________________________________________
     if (!doprocessSameEventHCascades) {
       histos.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({collision.posZ(), collision.centFT0M()}));
@@ -338,6 +434,7 @@ struct correlateStrangeness {
     // Do hadron - V0 correlations
     fillCorrelationsV0(triggerTracks, associatedV0s, false, collision.posZ(), collision.centFT0M());
   }
+
   void processSameEventHCascades(soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>::iterator const& collision,
                                  aod::AssocV0s const& associatedV0s, aod::AssocCascades const& associatedCascades, aod::TriggerTracks const& triggerTracks,
                                  aod::V0Datas const&, aod::V0sLinked const&, aod::CascDatas const&, TracksComplete const&)
@@ -348,6 +445,9 @@ struct correlateStrangeness {
       return;
     }
     if (TMath::Abs(collision.posZ()) > zVertexCut) {
+      return;
+    }
+    if (collision.centFT0M() > axisRanges[4][1] || collision.centFT0M() < axisRanges[4][0]) {
       return;
     }
     // ________________________________________________
@@ -385,6 +485,9 @@ struct correlateStrangeness {
     if (TMath::Abs(collision.posZ()) > zVertexCut) {
       return;
     }
+    if (collision.centFT0M() > axisRanges[4][1] || collision.centFT0M() < axisRanges[4][0]) {
+      return;
+    }
     // ________________________________________________
     if (!doprocessSameEventHCascades && !doprocessSameEventHV0s) {
       histos.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({collision.posZ(), collision.centFT0M()}));
@@ -416,6 +519,13 @@ struct correlateStrangeness {
       // Perform basic event selection on both collisions
       if (!collision1.sel8() || !collision2.sel8())
         continue;
+      if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
+        continue;
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+        continue;
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
+        continue;
+
       if (!doprocessMixedEventHCascades) {
         if (collision1.globalIndex() == collision2.globalIndex()) {
           histos.fill(HIST("MixingQA/hMixingQA"), 0.0f); // same-collision pair counting
@@ -442,6 +552,12 @@ struct correlateStrangeness {
       // Perform basic event selection on both collisions
       if (!collision1.sel8() || !collision2.sel8())
         continue;
+      if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
+        continue;
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+        continue;
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
+        continue;
 
       if (collision1.globalIndex() == collision2.globalIndex()) {
         histos.fill(HIST("MixingQA/hMixingQA"), 0.0f); // same-collision pair counting
@@ -467,6 +583,12 @@ struct correlateStrangeness {
       // ________________________________________________
       // Perform basic event selection on both collisions
       if (!collision1.sel8() || !collision2.sel8())
+        continue;
+      if (TMath::Abs(collision1.posZ()) > zVertexCut || TMath::Abs(collision2.posZ()) > zVertexCut)
+        continue;
+      if (collision1.centFT0M() > axisRanges[4][1] || collision1.centFT0M() < axisRanges[4][0]) 
+        continue;
+      if (collision2.centFT0M() > axisRanges[4][1] || collision2.centFT0M() < axisRanges[4][0]) 
         continue;
 
       if (collision1.globalIndex() == collision2.globalIndex()) {


### PR DESCRIPTION
* fixes `kTH2F` -> `kTH3F` bug 
* adds a switch that allows for the `THnF` objects to not store under and overflow. Estimated reduction in memory consumption is of about a factor 2. This is a hack, and it should actually be implemented as a bool option in the main `THn` implementation in ROOT. But in the meantime, this should do the trick...  