### PR TITLE
DCAxy selection, bugfixes

### DIFF
--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -61,8 +61,8 @@ struct hstrangecorrelationfilter {
   Configurable<float> dcaPostopv{"dcapostopv", 0.06, "DCA Pos To PV"};
   Configurable<float> v0RadiusMin{"v0radiusmin", 0.5, "v0radius"};
   Configurable<float> v0RadiusMax{"v0radiusmax", 200, "v0radius"};
-  
-  // primary particle DCAxy selections 
+
+  // primary particle DCAxy selections
   // formula: |DCAxy| <  0.004f + (0.013f / pt)
   Configurable<std::vector<float>> dcaXYpars{"dcaXYpars", {0.004, 0.013}, "pars in |DCAxy| < [0]+[1]/pT"};
   Configurable<float> dcaXYconstant{"dcaXYconstant", 0.004, "[0] in |DCAxy| < [0]+[1]/pT"};
@@ -102,7 +102,7 @@ struct hstrangecorrelationfilter {
   Configurable<float> backgroundNsigma{"backgroundNsigma", 6.0f, "bg region is +/- this many sigmas away (minus peak)"};
 
   // Do declarative selections for DCAs, if possible
-  Filter preFilterTracks = nabs(aod::track::dcaXY) < dcaXYconstant + dcaXYpTdep*nabs(aod::track::signed1Pt);	
+  Filter preFilterTracks = nabs(aod::track::dcaXY) < dcaXYconstant + dcaXYpTdep * nabs(aod::track::signed1Pt);
   Filter preFilterV0 = nabs(aod::v0data::dcapostopv) > dcaPostopv&&
                                                          nabs(aod::v0data::dcanegtopv) > dcaNegtopv&& aod::v0data::dcaV0daughters < dcaV0dau;
   Filter preFilterCascade =

--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -61,6 +61,12 @@ struct hstrangecorrelationfilter {
   Configurable<float> dcaPostopv{"dcapostopv", 0.06, "DCA Pos To PV"};
   Configurable<float> v0RadiusMin{"v0radiusmin", 0.5, "v0radius"};
   Configurable<float> v0RadiusMax{"v0radiusmax", 200, "v0radius"};
+  
+  // primary particle DCAxy selections 
+  // formula: |DCAxy| <  0.004f + (0.013f / pt)
+  Configurable<std::vector<float>> dcaXYpars{"dcaXYpars", {0.004, 0.013}, "pars in |DCAxy| < [0]+[1]/pT"};
+  Configurable<float> dcaXYconstant{"dcaXYconstant", 0.004, "[0] in |DCAxy| < [0]+[1]/pT"};
+  Configurable<float> dcaXYpTdep{"dcaXYpTdep", 0.013, "[1] in |DCAxy| < [0]+[1]/pT"};
 
   // cascade selections
   Configurable<double> cascadesetting_cospa{"cascadesetting_cospa", 0.95, "cascadesetting_cospa"};
@@ -95,7 +101,8 @@ struct hstrangecorrelationfilter {
   Configurable<float> peakNsigma{"peakNsigma", 3.0f, "peak region is +/- this many sigmas away"};
   Configurable<float> backgroundNsigma{"backgroundNsigma", 6.0f, "bg region is +/- this many sigmas away (minus peak)"};
 
-  // Cannot filter on dynamic columns, so we cut on DCA to PV and DCA between daus only!
+  // Do declarative selections for DCAs, if possible
+  Filter preFilterTracks = nabs(aod::track::dcaXY) < dcaXYconstant + dcaXYpTdep*nabs(aod::track::signed1Pt);	
   Filter preFilterV0 = nabs(aod::v0data::dcapostopv) > dcaPostopv&&
                                                          nabs(aod::v0data::dcanegtopv) > dcaNegtopv&& aod::v0data::dcaV0daughters < dcaV0dau;
   Filter preFilterCascade =
@@ -105,9 +112,9 @@ struct hstrangecorrelationfilter {
   HistogramRegistry registry{
     "registry",
     {}};
-  using DauTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr>;
+  using DauTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::TracksDCA>;
   // using IDTracks= soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidBayesPi, aod::pidBayesKa, aod::pidBayesPr, aod::TOFSignal>; // prepared for Bayesian PID
-  using IDTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TOFSignal>;
+  using IDTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::TOFSignal, aod::TracksDCA>;
 
   Produces<aod::TriggerTracks> triggerTrack;
   Produces<aod::AssocPions> assocPion;
@@ -144,7 +151,7 @@ struct hstrangecorrelationfilter {
     fOmegaWidth->SetParameters(omegaWidthAngular, omegaWidthLinear);
   }
 
-  void processTriggers(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, DauTracks const& tracks)
+  void processTriggers(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, soa::Filtered<DauTracks> const& tracks)
   {
     // Perform basic event selection
     if (!collision.sel8()) {
@@ -176,7 +183,7 @@ struct hstrangecorrelationfilter {
         track.globalIndex());
     }
   }
-  void processAssocPions(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, IDTracks const& tracks)
+  void processAssocPions(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, soa::Filtered<IDTracks> const& tracks)
   {
     // Perform basic event selection
     if (!collision.sel8()) {
@@ -242,7 +249,7 @@ struct hstrangecorrelationfilter {
     }
   }
 
-  void processV0s(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, DauTracks const& tracks, soa::Filtered<aod::V0Datas> const& V0s, aod::V0sLinked const&)
+  void processV0s(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, DauTracks const&, soa::Filtered<aod::V0Datas> const& V0s, aod::V0sLinked const&)
   {
     // Perform basic event selection
     if (!collision.sel8()) {
@@ -334,7 +341,7 @@ struct hstrangecorrelationfilter {
       assocV0(v0.collisionId(), v0.globalIndex(), compatibleK0Short, compatibleLambda, compatibleAntiLambda, massRegK0Short, massRegLambda, massRegAntiLambda);
     }
   }
-  void processCascades(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, DauTracks const& tracks, soa::Filtered<aod::V0Datas> const& V0s, soa::Filtered<aod::CascDatas> const& Cascades, aod::V0sLinked const&)
+  void processCascades(soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator const& collision, DauTracks const&, soa::Filtered<aod::V0Datas> const& V0s, soa::Filtered<aod::CascDatas> const& Cascades, aod::V0sLinked const&)
   {
     // Perform basic event selection
     if (!collision.sel8()) {

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -317,71 +317,71 @@ struct correlateStrangeness {
 
     int offset = skipUnderOverflowInTHn ? 1 : 0;
     // ===] delta-phi [===
-    if(!preAxisDeltaPhi.nBins.has_value()){
+    if (!preAxisDeltaPhi.nBins.has_value()) {
       // variable binning, use bins provided
       for (int i = offset; i < static_cast<int>(edgesDeltaPhiOrig.size()) - offset; i++)
         edgesDeltaPhi.emplace_back(edgesDeltaPhiOrig[i]);
-    }else{
+    } else {
       // fixed binning, generate the bin edges on-the-spot
-      double min = edgesDeltaPhiOrig[0]; 
-      double delta = (edgesDeltaPhiOrig[1]-edgesDeltaPhiOrig[0]) / preAxisDeltaPhi.nBins.value(); 
+      double min = edgesDeltaPhiOrig[0];
+      double delta = (edgesDeltaPhiOrig[1] - edgesDeltaPhiOrig[0]) / preAxisDeltaPhi.nBins.value();
       for (int i = offset; i < preAxisDeltaPhi.nBins.value() + 1 - offset; i++)
-        edgesDeltaPhi.emplace_back(min + static_cast<double>(i)*delta);
+        edgesDeltaPhi.emplace_back(min + static_cast<double>(i) * delta);
     }
     // ===] delta-eta [===
-    if(!preAxisDeltaEta.nBins.has_value()){
+    if (!preAxisDeltaEta.nBins.has_value()) {
       // variable binning, use bins provided
       for (int i = offset; i < static_cast<int>(edgesDeltaEtaOrig.size()) - offset; i++)
         edgesDeltaEta.emplace_back(edgesDeltaEtaOrig[i]);
-    }else{
+    } else {
       // fixed binning, generate the bin edges on-the-spot
-      double min = edgesDeltaEtaOrig[0]; 
-      double delta = (edgesDeltaEtaOrig[1]-edgesDeltaEtaOrig[0]) / preAxisDeltaEta.nBins.value(); 
+      double min = edgesDeltaEtaOrig[0];
+      double delta = (edgesDeltaEtaOrig[1] - edgesDeltaEtaOrig[0]) / preAxisDeltaEta.nBins.value();
       for (int i = offset; i < preAxisDeltaEta.nBins.value() + 1 - offset; i++)
-        edgesDeltaEta.emplace_back(min + static_cast<double>(i)*delta);
+        edgesDeltaEta.emplace_back(min + static_cast<double>(i) * delta);
     }
     // ===] pt assoc [===
-    if(!preAxisPtAssoc.nBins.has_value()){
+    if (!preAxisPtAssoc.nBins.has_value()) {
       // variable binning, use bins provided
       for (int i = offset; i < static_cast<int>(edgesPtAssocOrig.size()) - offset; i++)
         edgesPtAssoc.emplace_back(edgesPtAssocOrig[i]);
-    }else{
+    } else {
       // fixed binning, generate the bin edges on-the-spot
-      double min = edgesPtAssocOrig[0]; 
-      double delta = (edgesPtAssocOrig[1]-edgesPtAssocOrig[0]) / preAxisPtAssoc.nBins.value(); 
+      double min = edgesPtAssocOrig[0];
+      double delta = (edgesPtAssocOrig[1] - edgesPtAssocOrig[0]) / preAxisPtAssoc.nBins.value();
       for (int i = offset; i < preAxisVtxZ.nBins.value() + 1 - offset; i++)
-        edgesPtAssoc.emplace_back(min + static_cast<double>(i)*delta);
+        edgesPtAssoc.emplace_back(min + static_cast<double>(i) * delta);
     }
     // ===] vtx Z [===
-    if(!preAxisVtxZ.nBins.has_value()){
+    if (!preAxisVtxZ.nBins.has_value()) {
       // variable binning, use bins provided
       for (int i = offset; i < static_cast<int>(edgesVtxZOrig.size()) - offset; i++)
         edgesVtxZ.emplace_back(edgesVtxZOrig[i]);
-    }else{
+    } else {
       // fixed binning, generate the bin edges on-the-spot
-      double min = edgesVtxZOrig[0]; 
-      double delta = (edgesVtxZOrig[1]-edgesVtxZOrig[0]) / preAxisVtxZ.nBins.value(); 
+      double min = edgesVtxZOrig[0];
+      double delta = (edgesVtxZOrig[1] - edgesVtxZOrig[0]) / preAxisVtxZ.nBins.value();
       for (int i = offset; i < preAxisVtxZ.nBins.value() + 1 - offset; i++)
-        edgesVtxZ.emplace_back(min + static_cast<double>(i)*delta);
+        edgesVtxZ.emplace_back(min + static_cast<double>(i) * delta);
     }
     // ===] mult percentile [===
-    if(!preAxisMult.nBins.has_value()){
+    if (!preAxisMult.nBins.has_value()) {
       // variable binning, use bins provided
       for (int i = offset; i < static_cast<int>(edgesMultOrig.size()) - offset; i++)
         edgesMult.emplace_back(edgesMultOrig[i]);
-    }else{
+    } else {
       // fixed binning, generate the bin edges on-the-spot
-      double min = edgesMultOrig[0]; 
-      double delta = (edgesMultOrig[1]-edgesMultOrig[0]) / preAxisMult.nBins.value(); 
+      double min = edgesMultOrig[0];
+      double delta = (edgesMultOrig[1] - edgesMultOrig[0]) / preAxisMult.nBins.value();
       for (int i = offset; i < preAxisMult.nBins.value() + 1 - offset; i++)
-        edgesMult.emplace_back(min + static_cast<double>(i)*delta);
+        edgesMult.emplace_back(min + static_cast<double>(i) * delta);
     }
 
-    LOGF(info, "Initialized THnF axis delta-phi with %i bins.", edgesDeltaPhi.size()-1); 
-    LOGF(info, "Initialized THnF axis delta-eta with %i bins.", edgesDeltaEta.size()-1); 
-    LOGF(info, "Initialized THnF axis pTassoc with %i bins.", edgesPtAssoc.size()-1); 
-    LOGF(info, "Initialized THnF axis vertex-Z with %i bins.", edgesVtxZ.size()-1); 
-    LOGF(info, "Initialized THnF axis multiplicity with %i bins.", edgesMult.size()-1); 
+    LOGF(info, "Initialized THnF axis delta-phi with %i bins.", edgesDeltaPhi.size() - 1);
+    LOGF(info, "Initialized THnF axis delta-eta with %i bins.", edgesDeltaEta.size() - 1);
+    LOGF(info, "Initialized THnF axis pTassoc with %i bins.", edgesPtAssoc.size() - 1);
+    LOGF(info, "Initialized THnF axis vertex-Z with %i bins.", edgesVtxZ.size() - 1);
+    LOGF(info, "Initialized THnF axis multiplicity with %i bins.", edgesMult.size() - 1);
 
     const AxisSpec axisDeltaPhiNDim{edgesDeltaPhi, "#Delta#varphi"};
     const AxisSpec axisDeltaEtaNDim{edgesDeltaEta, "#Delta#eta"};

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -62,7 +62,7 @@ struct correlateStrangeness {
   ConfigurableAxis axisPhi{"axisPhi", {72, -0.5 * M_PI, 1.5 * M_PI}, "#phi"};
   ConfigurableAxis axisEta{"axisEta", {80, -0.8, +0.8}, "#eta"};
   ConfigurableAxis axisDeltaPhi{"axisDeltaPhi", {72, -PIHalf, PIHalf * 3}, "delta #varphi axis for histograms"};
-  ConfigurableAxis axisDeltaEta{"axisDeltaEta", {50, -2, 2}, "delta eta axis for histograms"};
+  ConfigurableAxis axisDeltaEta{"axisDeltaEta", {50, -1.6, 1.6}, "delta eta axis for histograms"};
   ConfigurableAxis axisPtAssoc{"axisPtAssoc", {VARIABLE_WIDTH, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 10.0}, "pt associated axis for histograms"};
   ConfigurableAxis axisPtQA{"axisPtQA", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
   ConfigurableAxis axisK0ShortMass{"axisK0ShortMass", {200, 0.400f, 0.600f}, "Inv. Mass (GeV/c^{2})"};
@@ -316,16 +316,72 @@ struct correlateStrangeness {
     // it should actually be implemented centrally in ROOT but ok, this will do it for now.
 
     int offset = skipUnderOverflowInTHn ? 1 : 0;
-    for (int i = offset; i < edgesDeltaPhiOrig.size() - offset; i++)
-      edgesDeltaPhi.emplace_back(edgesDeltaPhiOrig[i]);
-    for (int i = offset; i < edgesDeltaEtaOrig.size() - offset; i++)
-      edgesDeltaEta.emplace_back(edgesDeltaEtaOrig[i]);
-    for (int i = offset; i < edgesPtAssocOrig.size() - offset; i++)
-      edgesPtAssoc.emplace_back(edgesPtAssocOrig[i]);
-    for (int i = offset; i < edgesVtxZOrig.size() - offset; i++)
-      edgesVtxZ.emplace_back(edgesVtxZOrig[i]);
-    for (int i = offset; i < edgesMultOrig.size() - offset; i++)
-      edgesMult.emplace_back(edgesMultOrig[i]);
+    // ===] delta-phi [===
+    if(!preAxisDeltaPhi.nBins.has_value()){
+      // variable binning, use bins provided
+      for (int i = offset; i < static_cast<int>(edgesDeltaPhiOrig.size()) - offset; i++)
+        edgesDeltaPhi.emplace_back(edgesDeltaPhiOrig[i]);
+    }else{
+      // fixed binning, generate the bin edges on-the-spot
+      double min = edgesDeltaPhiOrig[0]; 
+      double delta = (edgesDeltaPhiOrig[1]-edgesDeltaPhiOrig[0]) / preAxisDeltaPhi.nBins.value(); 
+      for (int i = offset; i < preAxisDeltaPhi.nBins.value() + 1 - offset; i++)
+        edgesDeltaPhi.emplace_back(min + static_cast<double>(i)*delta);
+    }
+    // ===] delta-eta [===
+    if(!preAxisDeltaEta.nBins.has_value()){
+      // variable binning, use bins provided
+      for (int i = offset; i < static_cast<int>(edgesDeltaEtaOrig.size()) - offset; i++)
+        edgesDeltaEta.emplace_back(edgesDeltaEtaOrig[i]);
+    }else{
+      // fixed binning, generate the bin edges on-the-spot
+      double min = edgesDeltaEtaOrig[0]; 
+      double delta = (edgesDeltaEtaOrig[1]-edgesDeltaEtaOrig[0]) / preAxisDeltaEta.nBins.value(); 
+      for (int i = offset; i < preAxisDeltaEta.nBins.value() + 1 - offset; i++)
+        edgesDeltaEta.emplace_back(min + static_cast<double>(i)*delta);
+    }
+    // ===] pt assoc [===
+    if(!preAxisPtAssoc.nBins.has_value()){
+      // variable binning, use bins provided
+      for (int i = offset; i < static_cast<int>(edgesPtAssocOrig.size()) - offset; i++)
+        edgesPtAssoc.emplace_back(edgesPtAssocOrig[i]);
+    }else{
+      // fixed binning, generate the bin edges on-the-spot
+      double min = edgesPtAssocOrig[0]; 
+      double delta = (edgesPtAssocOrig[1]-edgesPtAssocOrig[0]) / preAxisPtAssoc.nBins.value(); 
+      for (int i = offset; i < preAxisVtxZ.nBins.value() + 1 - offset; i++)
+        edgesPtAssoc.emplace_back(min + static_cast<double>(i)*delta);
+    }
+    // ===] vtx Z [===
+    if(!preAxisVtxZ.nBins.has_value()){
+      // variable binning, use bins provided
+      for (int i = offset; i < static_cast<int>(edgesVtxZOrig.size()) - offset; i++)
+        edgesVtxZ.emplace_back(edgesVtxZOrig[i]);
+    }else{
+      // fixed binning, generate the bin edges on-the-spot
+      double min = edgesVtxZOrig[0]; 
+      double delta = (edgesVtxZOrig[1]-edgesVtxZOrig[0]) / preAxisVtxZ.nBins.value(); 
+      for (int i = offset; i < preAxisVtxZ.nBins.value() + 1 - offset; i++)
+        edgesVtxZ.emplace_back(min + static_cast<double>(i)*delta);
+    }
+    // ===] mult percentile [===
+    if(!preAxisMult.nBins.has_value()){
+      // variable binning, use bins provided
+      for (int i = offset; i < static_cast<int>(edgesMultOrig.size()) - offset; i++)
+        edgesMult.emplace_back(edgesMultOrig[i]);
+    }else{
+      // fixed binning, generate the bin edges on-the-spot
+      double min = edgesMultOrig[0]; 
+      double delta = (edgesMultOrig[1]-edgesMultOrig[0]) / preAxisMult.nBins.value(); 
+      for (int i = offset; i < preAxisMult.nBins.value() + 1 - offset; i++)
+        edgesMult.emplace_back(min + static_cast<double>(i)*delta);
+    }
+
+    LOGF(info, "Initialized THnF axis delta-phi with %i bins.", edgesDeltaPhi.size()-1); 
+    LOGF(info, "Initialized THnF axis delta-eta with %i bins.", edgesDeltaEta.size()-1); 
+    LOGF(info, "Initialized THnF axis pTassoc with %i bins.", edgesPtAssoc.size()-1); 
+    LOGF(info, "Initialized THnF axis vertex-Z with %i bins.", edgesVtxZ.size()-1); 
+    LOGF(info, "Initialized THnF axis multiplicity with %i bins.", edgesMult.size()-1); 
 
     const AxisSpec axisDeltaPhiNDim{edgesDeltaPhi, "#Delta#varphi"};
     const AxisSpec axisDeltaEtaNDim{edgesDeltaEta, "#Delta#eta"};


### PR DESCRIPTION
* fixes a bug in the binning definitions of the THnF objects (in both no-overflow and regular-overflow modes) 
* adds a parametric cut on DCAxy for both trigger and associated pions