### PR TITLE
Add lambda cospa, add QA spectra

### DIFF
--- a/PWGLF/DataModel/LFHStrangeCorrelationTables.h
+++ b/PWGLF/DataModel/LFHStrangeCorrelationTables.h
@@ -67,7 +67,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Compatible, compatible,                    //! check 
                                return true;
                              return false;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(InMassRegionCheck, inMassRegionCheck,
+DECLARE_SOA_DYNAMIC_COLUMN(InvMassRegionCheck, invMassRegionCheck,
                            [](int rK0Short, int rLambda, int rAntiLambda, int value, int region) -> bool {
                              if (value == 0 && rK0Short == region)
                                return true;
@@ -75,6 +75,16 @@ DECLARE_SOA_DYNAMIC_COLUMN(InMassRegionCheck, inMassRegionCheck,
                                return true;
                              if (value == 2 && rAntiLambda == region)
                                return true;
+                             return false;
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(InvMassRegion, invMassRegion,
+                           [](int rK0Short, int rLambda, int rAntiLambda, int value) -> bool {
+                             if (value == 0)
+                               return rK0Short;
+                             if (value == 1)
+                               return rLambda;
+                             if (value == 2)
+                               return rAntiLambda;
                              return false;
                            });
 } // namespace assocV0s
@@ -87,7 +97,8 @@ DECLARE_SOA_TABLE(AssocV0s, "AOD", "ASSOCV0S", o2::soa::Index<>,
                   assocV0s::MassRegionLambda,
                   assocV0s::MassRegionAntiLambda,
                   assocV0s::Compatible<assocV0s::CompatibleK0Short, assocV0s::CompatibleLambda, assocV0s::CompatibleAntiLambda>,
-                  assocV0s::InMassRegionCheck<assocV0s::MassRegionK0Short, assocV0s::MassRegionLambda, assocV0s::MassRegionAntiLambda>);
+                  assocV0s::InvMassRegionCheck<assocV0s::MassRegionK0Short, assocV0s::MassRegionLambda, assocV0s::MassRegionAntiLambda>,
+                  assocV0s::InvMassRegion<assocV0s::MassRegionK0Short, assocV0s::MassRegionLambda, assocV0s::MassRegionAntiLambda>);
 /// _________________________________________
 /// Table for storing associated casc indices
 namespace assocCascades
@@ -112,8 +123,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(Compatible, compatible,                    //! check 
                                return true;
                              return false;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(InMassRegionCheck, inMassRegionCheck,
-                           [](int rXi, int rOmega, int value, int region) -> bool {
+DECLARE_SOA_DYNAMIC_COLUMN(InvMassRegionCheck, invMassRegionCheck,
+                           [](int rXi, int rOmega, int value, int region) -> int {
                              if (value == 0 && rXi == region)
                                return true;
                              if (value == 1 && rXi == region)
@@ -122,7 +133,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(InMassRegionCheck, inMassRegionCheck,
                                return true;
                              if (value == 3 && rOmega == region)
                                return true;
-                             return false;
+                             return -1;
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(InvMassRegion, invMassRegion,
+                           [](int rXi, int rOmega, int value) -> int {
+                             if (value == 0 || value == 1)
+                               return rXi;
+                             if (value == 2 || value == 3)
+                               return rOmega;
+                             return -1;
                            });
 } // namespace assocCascades
 DECLARE_SOA_TABLE(AssocCascades, "AOD", "ASSOCCASCADES", o2::soa::Index<>, assocCascades::CollisionId, assocCascades::CascDataId,
@@ -133,7 +152,8 @@ DECLARE_SOA_TABLE(AssocCascades, "AOD", "ASSOCCASCADES", o2::soa::Index<>, assoc
                   assocCascades::MassRegionXi,
                   assocCascades::MassRegionOmega,
                   assocCascades::Compatible<assocCascades::CompatibleXiMinus, assocCascades::CompatibleXiPlus, assocCascades::CompatibleOmegaMinus, assocCascades::CompatibleOmegaPlus>,
-                  assocCascades::InMassRegionCheck<assocCascades::MassRegionXi, assocCascades::MassRegionOmega>);
+                  assocCascades::InvMassRegionCheck<assocCascades::MassRegionXi, assocCascades::MassRegionOmega>,
+                  assocCascades::InvMassRegion<assocCascades::MassRegionXi, assocCascades::MassRegionOmega>);
 } // namespace o2::aod
 
 #endif // PWGLF_DATAMODEL_LFHSTRANGECORRELATIONTABLES_H_

--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -69,7 +69,7 @@ struct hstrangecorrelationfilter {
   Configurable<float> v0RadiusMin{"v0radiusmin", 0.5, "v0radius"};
   Configurable<float> v0RadiusMax{"v0radiusmax", 200, "v0radius"};
 
-  // specific selections 
+  // specific selections
   Configurable<double> lambdaCospa{"lambdaCospa", 0.995, "CosPA for lambda"}; // allows for tighter selection for Lambda
 
   // primary particle DCAxy selections
@@ -290,12 +290,12 @@ struct hstrangecorrelationfilter {
         compatibleK0Short = true;
       }
       if (TMath::Abs(posdau.tpcNSigmaPr()) < strangedEdxNSigma && TMath::Abs(negdau.tpcNSigmaPi()) < strangedEdxNSigma) {
-        if(v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa){
+        if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa) {
           compatibleLambda = true;
         }
       }
       if (TMath::Abs(posdau.tpcNSigmaPi()) < strangedEdxNSigma && TMath::Abs(negdau.tpcNSigmaPr()) < strangedEdxNSigma) {
-        if(v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa){
+        if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa) {
           compatibleAntiLambda = true;
         }
       }

--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -69,6 +69,9 @@ struct hstrangecorrelationfilter {
   Configurable<float> v0RadiusMin{"v0radiusmin", 0.5, "v0radius"};
   Configurable<float> v0RadiusMax{"v0radiusmax", 200, "v0radius"};
 
+  // specific selections 
+  Configurable<double> lambdaCospa{"lambdaCospa", 0.995, "CosPA for lambda"}; // allows for tighter selection for Lambda
+
   // primary particle DCAxy selections
   // formula: |DCAxy| <  0.004f + (0.013f / pt)
   Configurable<float> dcaXYconstant{"dcaXYconstant", 0.004, "[0] in |DCAxy| < [0]+[1]/pT"};
@@ -287,10 +290,14 @@ struct hstrangecorrelationfilter {
         compatibleK0Short = true;
       }
       if (TMath::Abs(posdau.tpcNSigmaPr()) < strangedEdxNSigma && TMath::Abs(negdau.tpcNSigmaPi()) < strangedEdxNSigma) {
-        compatibleLambda = true;
+        if(v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa){
+          compatibleLambda = true;
+        }
       }
       if (TMath::Abs(posdau.tpcNSigmaPi()) < strangedEdxNSigma && TMath::Abs(negdau.tpcNSigmaPr()) < strangedEdxNSigma) {
-        compatibleAntiLambda = true;
+        if(v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < lambdaCospa){
+          compatibleAntiLambda = true;
+        }
       }
       // check whether V0s are in the regin
       int massRegK0Short = -1;

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -131,17 +131,17 @@ struct correlateStrangeness {
         static_for<0, 2>([&](auto i) {
           constexpr int index = i.value;
           if (bitcheck(doCorrelation, index)) {
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 1))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 1))
               histos.fill(HIST("sameEvent/LeftBg/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 2))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 2))
               histos.fill(HIST("sameEvent/Signal/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 3))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 3))
               histos.fill(HIST("sameEvent/RightBg/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 1))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 1))
               histos.fill(HIST("mixedEvent/LeftBg/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 2))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 2))
               histos.fill(HIST("mixedEvent/Signal/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 3))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 3))
               histos.fill(HIST("mixedEvent/RightBg/") + HIST(v0names[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
           }
         });
@@ -189,17 +189,17 @@ struct correlateStrangeness {
         static_for<0, 3>([&](auto i) {
           constexpr int index = i.value;
           if (bitcheck(doCorrelation, index + 3)) {
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 1))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 1))
               histos.fill(HIST("sameEvent/LeftBg/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 2))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 2))
               histos.fill(HIST("sameEvent/Signal/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && !mixing && assocCandidate.inMassRegionCheck(index, 3))
+            if (assocCandidate.compatible(index) && !mixing && assocCandidate.invMassRegionCheck(index, 3))
               histos.fill(HIST("sameEvent/RightBg/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 1))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 1))
               histos.fill(HIST("mixedEvent/LeftBg/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 2))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 2))
               histos.fill(HIST("mixedEvent/Signal/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
-            if (assocCandidate.compatible(index) && mixing && assocCandidate.inMassRegionCheck(index, 3))
+            if (assocCandidate.compatible(index) && mixing && assocCandidate.invMassRegionCheck(index, 3))
               histos.fill(HIST("mixedEvent/RightBg/") + HIST(cascadenames[index]), deltaphi, deltaeta, ptassoc, pvz, mult);
           }
         });
@@ -394,24 +394,31 @@ struct correlateStrangeness {
     const AxisSpec axisMultNDim{edgesMult, "mult percentile"};
 
     if (bitcheck(doCorrelation, 0)) {
+      histos.add("h3dK0ShortSpectrum", "h3dK0ShortSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/K0Short", "K0Short", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 1)) {
+      histos.add("h3dLambdaSpectrum", "h3dLambdaSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/Lambda", "Lambda", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 2)) {
+      histos.add("h3dAntiLambdaSpectrum", "h3dAntiLambdaSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/AntiLambda", "AntiLambda", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 3)) {
+      histos.add("h3dXiMinusSpectrum", "h3dXiMinusSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/XiMinus", "XiMinus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 4)) {
+      histos.add("h3dXiPlusSpectrum", "h3dXiPlusSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/XiPlus", "XiPlus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 5)) {
+      histos.add("h3dXiMinusSpectrum", "h3dXiMinusSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/OmegaMinus", "OmegaMinus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 6)) {
+      histos.add("h3dOmegaPlusSpectrum", "h3dOmegaPlusSpectrum", kTH3F, {axisPtQA, axisMult, {3, 0.5f, 3.5f}});
       histos.add("sameEvent/Signal/OmegaPlus", "OmegaPlus", kTHnF, {axisDeltaPhiNDim, axisDeltaEtaNDim, axisPtAssocNDim, axisVtxZNDim, axisMultNDim});
     }
     if (bitcheck(doCorrelation, 7)) {
@@ -476,6 +483,11 @@ struct correlateStrangeness {
     for (auto const& v0 : associatedV0s) {
       auto v0Data = v0.v0Data();
       histos.fill(HIST("hV0EtaVsPtVsPhi"), v0Data.pt(), v0Data.eta(), v0Data.phi());
+      static_for<0, 2>([&](auto i) {
+        constexpr int index = i.value;
+        if (v0.compatible(index) && bitcheck(doCorrelation, index))
+          histos.fill(HIST("h3d") + HIST(v0names[index]) + HIST("Spectrum"), v0Data.pt(), collision.centFT0M(), v0.invMassRegion(index));
+      });
     }
     if (!doprocessSameEventHCascades) {
       for (auto const& triggerTrack : triggerTracks) {
@@ -512,6 +524,11 @@ struct correlateStrangeness {
     for (auto const& casc : associatedCascades) {
       auto cascData = casc.cascData();
       histos.fill(HIST("hCascEtaVsPtVsPhi"), cascData.pt(), cascData.eta(), cascData.phi());
+      static_for<0, 3>([&](auto i) {
+        constexpr int index = i.value;
+        if (casc.compatible(index) && bitcheck(doCorrelation, index + 3))
+          histos.fill(HIST("h3d") + HIST(cascadenames[index]) + HIST("Spectrum"), cascData.pt(), collision.centFT0M(), casc.invMassRegion(index));
+      });
     }
     for (auto const& triggerTrack : triggerTracks) {
       auto track = triggerTrack.track_as<TracksComplete>();


### PR DESCRIPTION
* adds a cospa selection dedicated to lambdas, to make it such that a tighter cut is allowed (Run 2 used 0.995 for lambdas, 0.97 for K0) 
* adds QA plots that will allow for quick'n'dirty spectra extraction (**NOT** a replacement for a full spectrum analysis for sure) but just meant to check if candidates coming in as potential associated are reasonable and consistent with expectations 