### PR TITLE
Add getters for pt/eta res in track smearer

### DIFF
--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -190,9 +190,9 @@ double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt)
 double TrackSmearer::getEtaRes(int pdg, float nch, float eta, float pt)
 {
   auto lutEntry = getLUTEntry(pdg, nch, 0., eta, pt);
-  auto sigmatgl = sqrt(lutEntry->covm[9]); // sigmatgl2
+  auto sigmatgl = sqrt(lutEntry->covm[9]);           // sigmatgl2
   auto etaRes = 1 / (sqrt(1 + sigmatgl * sigmatgl)); // propagate tgl to eta uncertainty
-  etaRes /= lutEntry->eta; // relative uncertainty
+  etaRes /= lutEntry->eta;                           // relative uncertainty
   return etaRes;
 }
 

--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -178,6 +178,15 @@ bool TrackSmearer::smearTrack(O2Track& o2track, int pid, float nch)
 }
 
 /*****************************************************************/
+double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt)
+{
+  // complaints to sebastian
+  auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
+  auto val = sqrt(lutEntry->covm[14]) * lutEntry->pt * 100.;
+  return val;
+}
+
+/*****************************************************************/
 // Only in DelphesO2
 // bool TrackSmearer::smearTrack(Track& track, bool atDCA)
 // {

--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -182,7 +182,15 @@ double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt)
 {
   // complaints to sebastian
   auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
-  auto val = sqrt(lutEntry->covm[14]) * lutEntry->pt * 100.;
+  auto val = sqrt(lutEntry->covm[14]) * lutEntry->pt;
+  return val;
+}
+
+double TrackSmearer::getEtaRes(int pdg, float nch, float eta, float pt)
+{
+  // complaints to sebastian
+  auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
+  auto val = sqrt(lutEntry->covm[9]) / lutEntry->eta;
   return val;
 }
 

--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -163,35 +163,37 @@ bool TrackSmearer::smearTrack(O2Track& o2track, lutEntry_t* lutEntry)
 
 /*****************************************************************/
 
-bool TrackSmearer::smearTrack(O2Track& o2track, int pid, float nch)
+bool TrackSmearer::smearTrack(O2Track& o2track, int pdg, float nch)
 {
 
   auto pt = o2track.getPt();
-  if (abs(pid) == 1000020030) {
+  if (abs(pdg) == 1000020030) {
     pt *= 2.f;
   }
   auto eta = o2track.getEta();
-  auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
+  auto lutEntry = getLUTEntry(pdg, nch, 0., eta, pt);
   if (!lutEntry || !lutEntry->valid)
     return false;
   return smearTrack(o2track, lutEntry);
 }
 
 /*****************************************************************/
+// relative uncertainty on pt
 double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt)
 {
-  // complaints to sebastian
-  auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
+  auto lutEntry = getLUTEntry(pdg, nch, 0., eta, pt);
   auto val = sqrt(lutEntry->covm[14]) * lutEntry->pt;
   return val;
 }
-
+/*****************************************************************/
+// relative uncertainty on eta
 double TrackSmearer::getEtaRes(int pdg, float nch, float eta, float pt)
 {
-  // complaints to sebastian
-  auto lutEntry = getLUTEntry(pid, nch, 0., eta, pt);
-  auto val = sqrt(lutEntry->covm[9]) / lutEntry->eta;
-  return val;
+  auto lutEntry = getLUTEntry(pdg, nch, 0., eta, pt);
+  auto sigmatgl = sqrt(lutEntry->covm[9]); // sigmatgl2
+  auto etaRes = 1 / (sqrt(1 + sigmatgl * sigmatgl)); // propagate tgl to eta uncertainty
+  etaRes /= lutEntry->eta; // relative uncertainty
+  return etaRes;
 }
 
 /*****************************************************************/

--- a/ALICE3/Core/DelphesO2TrackSmearer.h
+++ b/ALICE3/Core/DelphesO2TrackSmearer.h
@@ -170,6 +170,7 @@ class TrackSmearer
   bool smearTrack(O2Track& o2track, int pid, float nch);
   // bool smearTrack(Track& track, bool atDCA = true); // Only in DelphesO2
   double getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
+  double getEtaRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
 
   int getIndexPDG(int pdg)
   {

--- a/ALICE3/Core/DelphesO2TrackSmearer.h
+++ b/ALICE3/Core/DelphesO2TrackSmearer.h
@@ -169,8 +169,8 @@ class TrackSmearer
   bool smearTrack(O2Track& o2track, lutEntry_t* lutEntry);
   bool smearTrack(O2Track& o2track, int pdg, float nch);
   // bool smearTrack(Track& track, bool atDCA = true); // Only in DelphesO2
-  double getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
-  double getEtaRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
+  double getPtRes(int pdg, float nch, float eta, float pt);
+  double getEtaRes(int pdg, float nch, float eta, float pt);
 
   int getIndexPDG(int pdg)
   {

--- a/ALICE3/Core/DelphesO2TrackSmearer.h
+++ b/ALICE3/Core/DelphesO2TrackSmearer.h
@@ -169,6 +169,7 @@ class TrackSmearer
   bool smearTrack(O2Track& o2track, lutEntry_t* lutEntry);
   bool smearTrack(O2Track& o2track, int pid, float nch);
   // bool smearTrack(Track& track, bool atDCA = true); // Only in DelphesO2
+  double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
 
   int getIndexPDG(int pdg)
   {

--- a/ALICE3/Core/DelphesO2TrackSmearer.h
+++ b/ALICE3/Core/DelphesO2TrackSmearer.h
@@ -169,7 +169,7 @@ class TrackSmearer
   bool smearTrack(O2Track& o2track, lutEntry_t* lutEntry);
   bool smearTrack(O2Track& o2track, int pid, float nch);
   // bool smearTrack(Track& track, bool atDCA = true); // Only in DelphesO2
-  double TrackSmearer::getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
+  double getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
 
   int getIndexPDG(int pdg)
   {

--- a/ALICE3/Core/DelphesO2TrackSmearer.h
+++ b/ALICE3/Core/DelphesO2TrackSmearer.h
@@ -167,7 +167,7 @@ class TrackSmearer
   lutEntry_t* getLUTEntry(int pdg, float nch, float radius, float eta, float pt);
 
   bool smearTrack(O2Track& o2track, lutEntry_t* lutEntry);
-  bool smearTrack(O2Track& o2track, int pid, float nch);
+  bool smearTrack(O2Track& o2track, int pdg, float nch);
   // bool smearTrack(Track& track, bool atDCA = true); // Only in DelphesO2
   double getPtRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer
   double getEtaRes(int pdg, float nch, float eta, float pt); // new in DelphesO2TrackSmearer

--- a/ALICE3/DataModel/OTFTOF.h
+++ b/ALICE3/DataModel/OTFTOF.h
@@ -27,22 +27,22 @@ namespace o2::aod
 {
 namespace upgrade_tof
 {
-DECLARE_SOA_COLUMN(NSigmaElectronInnerTOF, nSigmaElectronInnerTOF, float); //! NSigma electron InnerTOF
-DECLARE_SOA_COLUMN(NSigmaMuonInnerTOF, nSigmaMuonInnerTOF, float);         //! NSigma muon InnerTOF
-DECLARE_SOA_COLUMN(NSigmaPionInnerTOF, nSigmaPionInnerTOF, float);         //! NSigma pion InnerTOF
-DECLARE_SOA_COLUMN(NSigmaKaonInnerTOF, nSigmaKaonInnerTOF, float);         //! NSigma kaon InnerTOF
-DECLARE_SOA_COLUMN(NSigmaProtonInnerTOF, nSigmaProtonInnerTOF, float);     //! NSigma proton InnerTOF
-DECLARE_SOA_COLUMN(InnerTOFTrackLength, innerTOFTrackLength, float);       //! track length for calculation of InnerTOF
-DECLARE_SOA_COLUMN(InnerTOFTrackLengthReco, innerTOFTrackLengthReco, float);       //! track length for calculation of InnerTOF
-DECLARE_SOA_COLUMN(DeltaTrackLengthInnerTOF, deltaTrackLengthInnerTOF, float);       //! track length for calculation of InnerTOF
-DECLARE_SOA_COLUMN(NSigmaElectronOuterTOF, nSigmaElectronOuterTOF, float); //! NSigma electron OuterTOF
-DECLARE_SOA_COLUMN(NSigmaMuonOuterTOF, nSigmaMuonOuterTOF, float);         //! NSigma muon OuterTOF
-DECLARE_SOA_COLUMN(NSigmaPionOuterTOF, nSigmaPionOuterTOF, float);         //! NSigma pion OuterTOF
-DECLARE_SOA_COLUMN(NSigmaKaonOuterTOF, nSigmaKaonOuterTOF, float);         //! NSigma kaon OuterTOF
-DECLARE_SOA_COLUMN(NSigmaProtonOuterTOF, nSigmaProtonOuterTOF, float);     //! NSigma proton OuterTOF
-DECLARE_SOA_COLUMN(OuterTOFTrackLength, outerTOFTrackLength, float);       //! track length for calculation of OuterTOF
-DECLARE_SOA_COLUMN(OuterTOFTrackLengthReco, outerTOFTrackLengthReco, float);       //! track length for calculation of OuterTOF
-DECLARE_SOA_COLUMN(DeltaTrackLengthOuterTOF, deltaTrackLengthOuterTOF, float);       //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(NSigmaElectronInnerTOF, nSigmaElectronInnerTOF, float);     //! NSigma electron InnerTOF
+DECLARE_SOA_COLUMN(NSigmaMuonInnerTOF, nSigmaMuonInnerTOF, float);             //! NSigma muon InnerTOF
+DECLARE_SOA_COLUMN(NSigmaPionInnerTOF, nSigmaPionInnerTOF, float);             //! NSigma pion InnerTOF
+DECLARE_SOA_COLUMN(NSigmaKaonInnerTOF, nSigmaKaonInnerTOF, float);             //! NSigma kaon InnerTOF
+DECLARE_SOA_COLUMN(NSigmaProtonInnerTOF, nSigmaProtonInnerTOF, float);         //! NSigma proton InnerTOF
+DECLARE_SOA_COLUMN(InnerTOFTrackLength, innerTOFTrackLength, float);           //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(InnerTOFTrackLengthReco, innerTOFTrackLengthReco, float);   //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(DeltaTrackLengthInnerTOF, deltaTrackLengthInnerTOF, float); //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(NSigmaElectronOuterTOF, nSigmaElectronOuterTOF, float);     //! NSigma electron OuterTOF
+DECLARE_SOA_COLUMN(NSigmaMuonOuterTOF, nSigmaMuonOuterTOF, float);             //! NSigma muon OuterTOF
+DECLARE_SOA_COLUMN(NSigmaPionOuterTOF, nSigmaPionOuterTOF, float);             //! NSigma pion OuterTOF
+DECLARE_SOA_COLUMN(NSigmaKaonOuterTOF, nSigmaKaonOuterTOF, float);             //! NSigma kaon OuterTOF
+DECLARE_SOA_COLUMN(NSigmaProtonOuterTOF, nSigmaProtonOuterTOF, float);         //! NSigma proton OuterTOF
+DECLARE_SOA_COLUMN(OuterTOFTrackLength, outerTOFTrackLength, float);           //! track length for calculation of OuterTOF
+DECLARE_SOA_COLUMN(OuterTOFTrackLengthReco, outerTOFTrackLengthReco, float);   //! track length for calculation of OuterTOF
+DECLARE_SOA_COLUMN(DeltaTrackLengthOuterTOF, deltaTrackLengthOuterTOF, float); //! track length for calculation of InnerTOF
 } // namespace upgrade_tof
 DECLARE_SOA_TABLE(UpgradeTofs, "AOD", "UPGRADETOF",
                   upgrade_tof::NSigmaElectronInnerTOF,

--- a/ALICE3/DataModel/OTFTOF.h
+++ b/ALICE3/DataModel/OTFTOF.h
@@ -33,12 +33,16 @@ DECLARE_SOA_COLUMN(NSigmaPionInnerTOF, nSigmaPionInnerTOF, float);         //! N
 DECLARE_SOA_COLUMN(NSigmaKaonInnerTOF, nSigmaKaonInnerTOF, float);         //! NSigma kaon InnerTOF
 DECLARE_SOA_COLUMN(NSigmaProtonInnerTOF, nSigmaProtonInnerTOF, float);     //! NSigma proton InnerTOF
 DECLARE_SOA_COLUMN(InnerTOFTrackLength, innerTOFTrackLength, float);       //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(InnerTOFTrackLengthReco, innerTOFTrackLengthReco, float);       //! track length for calculation of InnerTOF
+DECLARE_SOA_COLUMN(DeltaTrackLengthInnerTOF, deltaTrackLengthInnerTOF, float);       //! track length for calculation of InnerTOF
 DECLARE_SOA_COLUMN(NSigmaElectronOuterTOF, nSigmaElectronOuterTOF, float); //! NSigma electron OuterTOF
 DECLARE_SOA_COLUMN(NSigmaMuonOuterTOF, nSigmaMuonOuterTOF, float);         //! NSigma muon OuterTOF
 DECLARE_SOA_COLUMN(NSigmaPionOuterTOF, nSigmaPionOuterTOF, float);         //! NSigma pion OuterTOF
 DECLARE_SOA_COLUMN(NSigmaKaonOuterTOF, nSigmaKaonOuterTOF, float);         //! NSigma kaon OuterTOF
 DECLARE_SOA_COLUMN(NSigmaProtonOuterTOF, nSigmaProtonOuterTOF, float);     //! NSigma proton OuterTOF
 DECLARE_SOA_COLUMN(OuterTOFTrackLength, outerTOFTrackLength, float);       //! track length for calculation of OuterTOF
+DECLARE_SOA_COLUMN(OuterTOFTrackLengthReco, outerTOFTrackLengthReco, float);       //! track length for calculation of OuterTOF
+DECLARE_SOA_COLUMN(DeltaTrackLengthOuterTOF, deltaTrackLengthOuterTOF, float);       //! track length for calculation of InnerTOF
 } // namespace upgrade_tof
 DECLARE_SOA_TABLE(UpgradeTofs, "AOD", "UPGRADETOF",
                   upgrade_tof::NSigmaElectronInnerTOF,
@@ -47,12 +51,16 @@ DECLARE_SOA_TABLE(UpgradeTofs, "AOD", "UPGRADETOF",
                   upgrade_tof::NSigmaKaonInnerTOF,
                   upgrade_tof::NSigmaProtonInnerTOF,
                   upgrade_tof::InnerTOFTrackLength,
+                  upgrade_tof::InnerTOFTrackLengthReco,
+                  upgrade_tof::DeltaTrackLengthInnerTOF,
                   upgrade_tof::NSigmaElectronOuterTOF,
                   upgrade_tof::NSigmaMuonOuterTOF,
                   upgrade_tof::NSigmaPionOuterTOF,
                   upgrade_tof::NSigmaKaonOuterTOF,
                   upgrade_tof::NSigmaProtonOuterTOF,
-                  upgrade_tof::OuterTOFTrackLength);
+                  upgrade_tof::OuterTOFTrackLength,
+                  upgrade_tof::OuterTOFTrackLengthReco,
+                  upgrade_tof::DeltaTrackLengthOuterTOF);
 
 using UpgradeTof = UpgradeTofs::iterator;
 

--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -101,7 +101,6 @@ struct OnTheFlyTOFPID {
       histos.add("h2dTrackLengthInnerRecoVsPt", "h2dTrackLengthInnerRecoVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthInner});
       histos.add("h2dTrackLengthOuterRecoVsPt", "h2dTrackLengthOuterRecoVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthOuter});
 
-
       histos.add("h2dDeltaTrackLengthInnerVsPt", "h2dDeltaTrackLengthInnerVsPt", kTH2F, {axisMomentumSmall, axisTrackDeltaLength});
       histos.add("h2dDeltaTrackLengthOuterVsPt", "h2dDeltaTrackLengthOuterVsPt", kTH2F, {axisMomentumSmall, axisTrackDeltaLength});
     }

--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -72,6 +72,7 @@ struct OnTheFlyTOFPID {
   Configurable<int> nBinsP{"nBinsP", 80, "number of bins in momentum"};
   Configurable<int> nBinsTrackLengthInner{"nBinsTrackLengthInner", 300, "number of bins in track length"};
   Configurable<int> nBinsTrackLengthOuter{"nBinsTrackLengthOuter", 300, "number of bins in track length"};
+  Configurable<int> nBinsTrackDeltaLength{"nBinsTrackDeltaLength", 100, "number of bins in delta track length"};
 
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
 
@@ -91,10 +92,18 @@ struct OnTheFlyTOFPID {
       const AxisSpec axisVelocity{static_cast<int>(nBinsBeta), 0.0f, +1.1f, "Measured #beta"};
       const AxisSpec axisTrackLengthInner{static_cast<int>(nBinsTrackLengthInner), 0.0f, 60.0f, "Track length (cm)"};
       const AxisSpec axisTrackLengthOuter{static_cast<int>(nBinsTrackLengthOuter), 0.0f, 300.0f, "Track length (cm)"};
+      const AxisSpec axisTrackDeltaLength{static_cast<int>(nBinsTrackDeltaLength), 0.0f, 30.0f, "Delta Track length (cm)"};
       histos.add("h2dVelocityVsMomentumInner", "h2dVelocityVsMomentumInner", kTH2F, {axisMomentum, axisVelocity});
       histos.add("h2dVelocityVsMomentumOuter", "h2dVelocityVsMomentumOuter", kTH2F, {axisMomentum, axisVelocity});
       histos.add("h2dTrackLengthInnerVsPt", "h2dTrackLengthInnerVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthInner});
       histos.add("h2dTrackLengthOuterVsPt", "h2dTrackLengthOuterVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthOuter});
+
+      histos.add("h2dTrackLengthInnerRecoVsPt", "h2dTrackLengthInnerRecoVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthInner});
+      histos.add("h2dTrackLengthOuterRecoVsPt", "h2dTrackLengthOuterRecoVsPt", kTH2F, {axisMomentumSmall, axisTrackLengthOuter});
+
+
+      histos.add("h2dDeltaTrackLengthInnerVsPt", "h2dDeltaTrackLengthInnerVsPt", kTH2F, {axisMomentumSmall, axisTrackDeltaLength});
+      histos.add("h2dDeltaTrackLengthOuterVsPt", "h2dDeltaTrackLengthOuterVsPt", kTH2F, {axisMomentumSmall, axisTrackDeltaLength});
     }
   }
 
@@ -270,10 +279,12 @@ struct OnTheFlyTOFPID {
         if (trackLengthRecoInnerTOF > 0) {
           histos.fill(HIST("h2dVelocityVsMomentumInner"), momentum, innerBeta);
           histos.fill(HIST("h2dTrackLengthInnerVsPt"), o2track.getPt(), trackLengthInnerTOF);
+          histos.fill(HIST("h2dTrackLengthInnerRecoVsPt"), o2track.getPt(), trackLengthRecoInnerTOF);
         }
         if (trackLengthRecoOuterTOF > 0) {
           histos.fill(HIST("h2dVelocityVsMomentumOuter"), momentum, outerBeta);
           histos.fill(HIST("h2dTrackLengthOuterVsPt"), o2track.getPt(), trackLengthOuterTOF);
+          histos.fill(HIST("h2dTrackLengthOuterRecoVsPt"), o2track.getPt(), trackLengthRecoOuterTOF);
         }
       }
 
@@ -295,9 +306,18 @@ struct OnTheFlyTOFPID {
           nSigmaOuterTOF[ii] = deltaTimeOuterTOF[ii] / outerTOFTimeReso;
       }
 
+      float deltaTrackLengthInnerTOF = abs(trackLengthInnerTOF - trackLengthRecoInnerTOF);
+      if (trackLengthInnerTOF > 0 && trackLengthRecoInnerTOF > 0) {
+        histos.fill(HIST("h2dDeltaTrackLengthInnerVsPt"), o2track.getPt(), deltaTrackLengthInnerTOF);
+      }
+      float deltaTrackLengthOuterTOF = abs(trackLengthOuterTOF - trackLengthRecoOuterTOF);
+      if (trackLengthOuterTOF > 0 && trackLengthRecoOuterTOF > 0) {
+        histos.fill(HIST("h2dDeltaTrackLengthOuterVsPt"), o2track.getPt(), deltaTrackLengthInnerTOF);
+      }
+
       // Sigmas have been fully calculated. Please populate the NSigma helper table (once per track)
-      upgradeTof(nSigmaInnerTOF[0], nSigmaInnerTOF[1], nSigmaInnerTOF[2], nSigmaInnerTOF[3], nSigmaInnerTOF[4], trackLengthInnerTOF,
-                 nSigmaOuterTOF[0], nSigmaOuterTOF[1], nSigmaOuterTOF[2], nSigmaOuterTOF[3], nSigmaOuterTOF[4], trackLengthOuterTOF);
+      upgradeTof(nSigmaInnerTOF[0], nSigmaInnerTOF[1], nSigmaInnerTOF[2], nSigmaInnerTOF[3], nSigmaInnerTOF[4], trackLengthInnerTOF, trackLengthRecoInnerTOF, deltaTrackLengthInnerTOF,
+                 nSigmaOuterTOF[0], nSigmaOuterTOF[1], nSigmaOuterTOF[2], nSigmaOuterTOF[3], nSigmaOuterTOF[4], trackLengthOuterTOF, trackLengthRecoOuterTOF, deltaTrackLengthOuterTOF);
     }
   }
 };

--- a/ALICE3/TableProducer/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/onTheFlyTracker.cxx
@@ -207,6 +207,7 @@ struct OnTheFlyTracker {
       }
       dNdEta += 1.f;
     }
+    dNdEta /= (multEtaRange*2);
 
     for (const auto& mcParticle : mcParticles) {
       if (!mcParticle.isPhysicalPrimary()) {

--- a/ALICE3/TableProducer/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/onTheFlyTracker.cxx
@@ -209,7 +209,6 @@ struct OnTheFlyTracker {
       }
       dNdEta += 1.f;
     }
-    dNdEta /= (multEtaRange*2);
 
     dNdEta /= (multEtaRange * 2.0f);
 

--- a/ALICE3/Tasks/alice3-dilepton.cxx
+++ b/ALICE3/Tasks/alice3-dilepton.cxx
@@ -23,6 +23,8 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Framework/AnalysisDataModel.h"
+#include "ALICE3/DataModel/OTFTOF.h"
+
 
 using namespace o2;
 using namespace o2::aod;
@@ -64,6 +66,8 @@ struct Alice3Dilepton {
 
     const AxisSpec axisM{500, 0, 5, "#it{m}_{ll} (GeV/#it{c}^{2})"};
     const AxisSpec axisPt{1000, 0, 10, "#it{p}_{T} (GeV/#it{c})"};
+    const AxisSpec axisSigmaEl{200, -10, 10, "n#sigma_{El}"};
+    const AxisSpec axisTrackLengthOuterTOF{300,0.,300.,"Track length (cm)"};
     const AxisSpec axisEta{1000, -5, 5, "#it{#eta}"};
     const AxisSpec axisDCAxy{1000, 0, 20, "DCA_{xy,ll} (#sigma)"};
     const AxisSpec axisPhi{360, 0, TMath::TwoPi(), "#it{#varphi} (rad.)"};
@@ -103,6 +107,10 @@ struct Alice3Dilepton {
     registry.add("Reconstructed/Track/Pt", "Track Pt", kTH1F, {axisPt});
     registry.add("Reconstructed/Track/Eta", "Track Eta", kTH1F, {axisEta});
     registry.add("Reconstructed/Track/Phi", "Track Eta", kTH1F, {axisPhi});
+    registry.add("Reconstructed/Track/SigmaOTofvspt", "Track #sigma oTOF", kTH2F, {axisPt, axisSigmaEl});
+    registry.add("Reconstructed/Track/SigmaITofvspt", "Track #sigma iTOF", kTH2F, {axisPt, axisSigmaEl});
+    registry.add("Reconstructed/Track/outerTOFTrackLength", "Track length outer TOF", kTH1F, {axisTrackLengthOuterTOF});
+
     registry.add("Reconstructed/Pair/ULS/Mass", "Pair Mass", kTH1F, {axisM});
     registry.add("Reconstructed/Pair/ULS/Pt", "Pair Pt", kTH1F, {axisPt});
     registry.add("Reconstructed/Pair/ULS/Eta", "Pair Eta", kTH1F, {axisEta});
@@ -493,7 +501,7 @@ struct Alice3Dilepton {
     } // end of mc collision loop
   }   // end of processGen
 
-  using MyTracksMC = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksDCA, aod::McTrackLabels>;
+  using MyTracksMC = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksDCA, aod::McTrackLabels, aod::UpgradeTofs>;
   Filter trackFilter = etaMin < o2::aod::track::eta && o2::aod::track::eta < etaMax && ptMin < o2::aod::track::pt && o2::aod::track::pt < ptMax;
   using MyFilteredTracksMC = soa::Filtered<MyTracksMC>;
   Preslice<MyFilteredTracksMC> perCollision = aod::track::collisionId;
@@ -516,9 +524,11 @@ struct Alice3Dilepton {
         // if (!IsInAcceptance(neg) || !IsInAcceptance(pos)) {
         //   continue;
         // }// filtered already
-        // if (fabs(track.nSigmaElectronOuter())>3 ) {
+
+        // if (fabs(track.nSigmaElectronOuterTOF())<3 ) {
         //   continue;
         // }
+
         if (!track.has_mcParticle()) {
           continue;
         }
@@ -529,6 +539,9 @@ struct Alice3Dilepton {
         if (!mcParticle.isPhysicalPrimary()) {
           continue;
         }
+        registry.fill(HIST("Reconstructed/Track/SigmaOTofvspt"), mcParticle.pt(), track.nSigmaElectronOuterTOF());
+        registry.fill(HIST("Reconstructed/Track/SigmaITofvspt"), mcParticle.pt(), track.nSigmaElectronInnerTOF());
+        registry.fill(HIST("Reconstructed/Track/outerTOFTrackLength"),track.outerTOFTrackLength());
         registry.fill(HIST("Reconstructed/Track/Pt"), track.pt());
         registry.fill(HIST("Reconstructed/Track/Eta"), track.eta());
         registry.fill(HIST("Reconstructed/Track/Phi"), track.phi());

--- a/ALICE3/Tasks/alice3-dilepton.cxx
+++ b/ALICE3/Tasks/alice3-dilepton.cxx
@@ -25,7 +25,6 @@
 #include "Framework/AnalysisDataModel.h"
 #include "ALICE3/DataModel/OTFTOF.h"
 
-
 using namespace o2;
 using namespace o2::aod;
 using namespace o2::soa;
@@ -67,7 +66,7 @@ struct Alice3Dilepton {
     const AxisSpec axisM{500, 0, 5, "#it{m}_{ll} (GeV/#it{c}^{2})"};
     const AxisSpec axisPt{1000, 0, 10, "#it{p}_{T} (GeV/#it{c})"};
     const AxisSpec axisSigmaEl{200, -10, 10, "n#sigma_{El}"};
-    const AxisSpec axisTrackLengthOuterTOF{300,0.,300.,"Track length (cm)"};
+    const AxisSpec axisTrackLengthOuterTOF{300, 0., 300., "Track length (cm)"};
     const AxisSpec axisEta{1000, -5, 5, "#it{#eta}"};
     const AxisSpec axisDCAxy{1000, 0, 20, "DCA_{xy,ll} (#sigma)"};
     const AxisSpec axisPhi{360, 0, TMath::TwoPi(), "#it{#varphi} (rad.)"};
@@ -541,7 +540,7 @@ struct Alice3Dilepton {
         }
         registry.fill(HIST("Reconstructed/Track/SigmaOTofvspt"), mcParticle.pt(), track.nSigmaElectronOuterTOF());
         registry.fill(HIST("Reconstructed/Track/SigmaITofvspt"), mcParticle.pt(), track.nSigmaElectronInnerTOF());
-        registry.fill(HIST("Reconstructed/Track/outerTOFTrackLength"),track.outerTOFTrackLength());
+        registry.fill(HIST("Reconstructed/Track/outerTOFTrackLength"), track.outerTOFTrackLength());
         registry.fill(HIST("Reconstructed/Track/Pt"), track.pt());
         registry.fill(HIST("Reconstructed/Track/Eta"), track.eta());
         registry.fill(HIST("Reconstructed/Track/Phi"), track.phi());


### PR DESCRIPTION
A couple of commits to:
* Get eta and pt resolution from TrackSmearer
* Fix some inconsistencies in variable naming
* Add QA histograms for OTF TOF