### PR TITLE
PWGHF: Fix use of wrong abs

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
@@ -140,7 +140,7 @@ struct HfCorrelatorD0D0bar {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;
@@ -249,7 +249,7 @@ struct HfCorrelatorD0D0bar {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;

--- a/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
@@ -141,7 +141,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;
@@ -250,7 +250,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;

--- a/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
@@ -141,7 +141,7 @@ struct HfCorrelatorDplusDminus {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;
@@ -249,7 +249,7 @@ struct HfCorrelatorDplusDminus {
         if (track.eta() < -4.0 || track.eta() > 4.0) {
           continue;
         }
-        if (abs(track.dcaXY()) > 0.0025 || abs(track.dcaZ()) > 0.0025) {
+        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
           continue;
         }
         nTracks++;


### PR DESCRIPTION
The default abs function may return int.
Using std::abs should always be safe for any number type.