### PR TITLE
PWGHF: split configurable for generated and reconstructed rapidity cut

### DIFF
--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -35,7 +35,8 @@ using namespace o2::framework::expressions;
 /// B0 analysis task
 struct HfTaskB0 {
   Configurable<int> selectionFlagB0{"selectionFlagB0", 1, "Selection Flag for B0"};
-  Configurable<double> yCandMax{"yCandMax", 1.44, "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. track pseudo-rapidity"};
   Configurable<float> ptTrackMin{"ptTrackMin", 0.1, "min. track transverse momentum"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
@@ -154,7 +155,7 @@ struct HfTaskB0 {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yB0(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -194,7 +195,7 @@ struct HfTaskB0 {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yB0(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -267,7 +268,7 @@ struct HfTaskB0 {
 
         auto ptParticle = particle.pt();
         auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
-        if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
 
@@ -288,9 +289,6 @@ struct HfTaskB0 {
         registry.fill(HIST("hYProng1Gen"), yProngs[1], ptParticle);
         registry.fill(HIST("hEtaProng0Gen"), etaProngs[0], ptParticle);
         registry.fill(HIST("hEtaProng1Gen"), etaProngs[1], ptParticle);
-
-        //  if (yCandMax >= 0. && (std::abs(yProngs[0]) > yCandMax || std::abs(yProngs[1]) > yCandMax))
-        //    continue;
 
         registry.fill(HIST("hPtGen"), ptParticle);
         registry.fill(HIST("hYGen"), yParticle, ptParticle);

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -33,7 +33,8 @@ using namespace o2::aod::hf_cand_b0; // from CandidateReconstructionTables.h
 /// B0 analysis task
 struct HfTaskB0Reduced {
   Configurable<int> selectionFlagB0{"selectionFlagB0", 1, "Selection Flag for B0"};
-  Configurable<double> yCandMax{"yCandMax", -1, "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. track pseudo-rapidity"};
   Configurable<float> ptTrackMin{"ptTrackMin", 0.1, "min. track transverse momentum"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
@@ -132,7 +133,7 @@ struct HfTaskB0Reduced {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yB0(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -169,7 +170,7 @@ struct HfTaskB0Reduced {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yB0(candidate)) > yCandMax) {
+      if (yCandGenMax >= 0. && std::abs(yB0(candidate)) > yCandGenMax) {
         continue;
       }
 
@@ -222,7 +223,7 @@ struct HfTaskB0Reduced {
       auto ptParticle = particle.ptTrack();
       auto yParticle = particle.yTrack();
       auto etaParticle = particle.etaTrack();
-      if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+      if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
         continue;
       }
 

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -170,7 +170,7 @@ struct HfTaskB0Reduced {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         continue;
       }
-      if (yCandGenMax >= 0. && std::abs(yB0(candidate)) > yCandGenMax) {
+      if (yCandRecoMax >= 0. && std::abs(yB0(candidate)) > yCandRecoMax) {
         continue;
       }
 

--- a/PWGHF/D2H/Tasks/taskBplus.cxx
+++ b/PWGHF/D2H/Tasks/taskBplus.cxx
@@ -46,7 +46,8 @@ const TString mcParticleMatched = "MC particles (matched);";
 /// B± analysis task
 struct HfTaskBplus {
   Configurable<int> selectionFlagBplus{"selectionFlagBplus", 1, "Selection Flag for B+"};
-  Configurable<double> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_bplus_to_d0_pi::vecBinsPt}, "pT bin limits"};
 
   Partition<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> selectedBPlusCandidates = aod::hf_sel_candidate_bplus::isSelBplusToD0Pi >= selectionFlagBplus;
@@ -141,7 +142,7 @@ struct HfTaskBplus {
       if (!TESTBIT(candidate.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yBplus(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -183,7 +184,7 @@ struct HfTaskBplus {
       if (!TESTBIT(candidate.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yBplus(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
@@ -233,7 +234,7 @@ struct HfTaskBplus {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
 
         auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBPlus));
-        if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
 

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -32,7 +32,8 @@ using namespace o2::analysis::hf_cuts_d0_to_pi_k;
 struct HfTaskD0 {
   Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
   Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
-  Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<int> selectionFlagHf{"selectionFlagHf", 1, "Selection Flag for HF flagged candidates"};
   Configurable<int> selectionTopol{"selectionTopol", 1, "Selection Flag for topologically selected candidates"};
   Configurable<int> selectionCand{"selectionCand", 1, "Selection Flag for conj. topol. selected candidates"};
@@ -166,7 +167,7 @@ struct HfTaskD0 {
       if (!(candidate.hfflag() & 1 << DecayType::D0ToPiK)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yD0(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yD0(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -224,7 +225,7 @@ struct HfTaskD0 {
       if (!(candidate.hfflag() & 1 << DecayType::D0ToPiK)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yD0(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yD0(candidate)) > yCandRecoMax) {
         continue;
       }
       auto massD0 = invMassD0ToPiK(candidate);
@@ -381,7 +382,7 @@ struct HfTaskD0 {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::D0ToPiK) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandGenMax) {
           continue;
         }
         auto ptGen = particle.pt();

--- a/PWGHF/D2H/Tasks/taskDplus.cxx
+++ b/PWGHF/D2H/Tasks/taskDplus.cxx
@@ -31,7 +31,8 @@ using namespace o2::aod::hf_cand_3prong;
 /// D± analysis task
 struct HfTaskDplus {
   Configurable<int> selectionFlagDplus{"selectionFlagDplus", 7, "Selection Flag for DPlus"}; // 7 corresponds to topo+PID cuts
-  Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_dplus_to_pi_k_pi::vecBinsPt}, "pT bin limits"};
 
   Partition<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>> selectedDPlusCandidates = aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
@@ -98,7 +99,7 @@ struct HfTaskDplus {
       if (!(candidate.hfflag() & 1 << DecayType::DplusToPiKPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yDplus(candidate)) > yCandRecoMax) {
         continue;
       }
       registry.fill(HIST("hMass"), invMassDplusToPiKPi(candidate), candidate.pt());
@@ -137,7 +138,7 @@ struct HfTaskDplus {
       if (!(candidate.hfflag() & 1 << DecayType::DplusToPiKPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yDplus(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yDplus(candidate)) > yCandRecoMax) {
         continue;
       }
       if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DplusToPiKPi) {
@@ -194,7 +195,7 @@ struct HfTaskDplus {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DplusToPiKPi) {
         auto ptGen = particle.pt();
         auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
-        if (yCandMax >= 0. && std::abs(yGen) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), ptGen);

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -32,7 +32,8 @@ using namespace o2::aod::hf_cand_3prong;
 struct HfTaskDs {
   Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
-  Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits"};
 
   Filter dsFlagFilter = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << DecayType::DsToKKPi)) != static_cast<uint8_t>(0);
@@ -209,7 +210,7 @@ struct HfTaskDs {
   void process(candDsData const& candidates)
   {
     for (auto& candidate : selectedDsToKKPiCand) {
-      if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yDs(candidate)) > yCandRecoMax) {
         continue;
       }
       fillHisto(candidate);
@@ -217,7 +218,7 @@ struct HfTaskDs {
     }
 
     for (auto& candidate : selectedDsToPiKKCand) {
-      if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yDs(candidate)) > yCandRecoMax) {
         continue;
       }
       fillHisto(candidate);
@@ -229,7 +230,7 @@ struct HfTaskDs {
   {
     // MC rec.
     for (auto& candidate : candidates) {
-      if (yCandMax >= 0. && std::abs(yDs(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yDs(candidate)) > yCandRecoMax) {
         continue;
       }
       if (std::abs(candidate.flagMcMatchRec()) == 1 << DecayType::DsToKKPi) {
@@ -267,7 +268,7 @@ struct HfTaskDs {
         }
         auto pt = particle.pt();
         auto y = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
-        if (yCandMax >= 0. && std::abs(y) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(y) > yCandGenMax) {
           continue;
         }
 

--- a/PWGHF/D2H/Tasks/taskLb.cxx
+++ b/PWGHF/D2H/Tasks/taskLb.cxx
@@ -43,7 +43,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 /// Λb0 analysis task
 struct HfTaskLb {
   Configurable<int> selectionFlagLb{"selectionFlagLb", 1, "Selection Flag for Lb"};
-  Configurable<double> yCandMax{"yCandMax", 1.44, "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lb_to_lc_pi::vecBinsPt}, "pT bin limits"};
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_lb::isSelLbToLcPi >= selectionFlagLb);
@@ -81,7 +82,7 @@ struct HfTaskLb {
       if (!(candidate.hfflag() & 1 << hf_cand_lb::DecayType::LbToLcPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yLb(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yLb(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -114,7 +115,8 @@ struct HfTaskLb {
 /// Lb MC analysis and fill histograms
 struct HfTaskLbMc {
   Configurable<int> selectionFlagLb{"selectionFlagLb", 1, "Selection Flag for Lb"};
-  Configurable<double> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lb_to_lc_pi::vecBinsPt}, "pT bin limits"};
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_lb::isSelLbToLcPi >= selectionFlagLb);
@@ -183,7 +185,7 @@ struct HfTaskLbMc {
       if (!(candidate.hfflag() & 1 << hf_cand_lb::DecayType::LbToLcPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yLb(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yLb(candidate)) > yCandRecoMax) {
         continue;
       }
       auto candLc = candidate.prong0_as<aod::HfCand3Prong>();
@@ -238,7 +240,7 @@ struct HfTaskLbMc {
       if (std::abs(particle.flagMcMatchGen()) == 1 << hf_cand_lb::DecayType::LbToLcPi) {
 
         auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kLambdaB0));
-        if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -35,7 +35,8 @@ using namespace o2::analysis::hf_cuts_lc_to_p_k_pi;
 /// Λc± → p± K∓ π± analysis task
 struct HfTaskLc {
   Configurable<int> selectionFlagLc{"selectionFlagLc", 1, "Selection Flag for Lc"};
-  Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lc_to_p_k_pi::vecBinsPt}, "pT bin limits"};
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc);
@@ -255,7 +256,7 @@ struct HfTaskLc {
       if (!(candidate.hfflag() & 1 << DecayType::LcToPKPi)) {
         continue;
       }
-      if (yCandMax >= 0. && std::abs(yLc(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yLc(candidate)) > yCandRecoMax) {
         continue;
       }
       auto pt = candidate.pt();
@@ -314,7 +315,7 @@ struct HfTaskLc {
         continue;
       }
       /// rapidity selection
-      if (yCandMax >= 0. && std::abs(yLc(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yLc(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -454,7 +455,7 @@ struct HfTaskLc {
     for (auto const& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::LcToPKPi) {
         auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
-        if (yCandMax >= 0. && std::abs(yGen) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }
         auto ptGen = particle.pt();

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -36,7 +36,8 @@ using namespace o2::analysis::hf_cuts_xic_to_p_k_pi;
 
 struct HfTaskXic {
   Configurable<int> selectionFlagXic{"selectionFlagXic", 1, "Selection Flag for Xic"};
-  Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<float> etaTrackMax{"etaTrackMax", 4.0, "max. track eta"};
   Configurable<float> dcaXYTrackMax{"dcaXYTrackMax", 0.0025, "max. DCAxy for track"};
   Configurable<float> dcaZTrackMax{"dcaZTrackMax", 0.0025, "max. DCAz for track"};
@@ -203,7 +204,7 @@ struct HfTaskXic {
         continue;
       }
 
-      if (yCandMax >= 0. && std::abs(yXic(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yXic(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -286,7 +287,7 @@ struct HfTaskXic {
       if (!(candidate.hfflag() & 1 << DecayType::XicToPKPi)) {
         continue;
       } // rapidity selection
-      if (yCandMax >= 0. && std::abs(yXic(candidate)) > yCandMax) {
+      if (yCandRecoMax >= 0. && std::abs(yXic(candidate)) > yCandRecoMax) {
         continue;
       }
 
@@ -363,7 +364,7 @@ struct HfTaskXic {
     for (auto const& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::XicToPKPi) {
         auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
-        if (yCandMax >= 0. && std::abs(yParticle) > yCandMax) {
+        if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
         auto ptParticle = particle.pt();


### PR DESCRIPTION
In general, the cut on generated and reconstructed rapidity might be different for efficiency calculation. In particular, if `-1` is set (no cut) it has a much different (and maybe undesired) effect on reconstructed (limited by acceptance anyway) and generated (limited by the MC settings)