### PR TITLE
Declarative filter for mc finder speed

### DIFF
--- a/PWGLF/TableProducer/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/lambdakzeromcfinder.cxx
@@ -87,8 +87,8 @@ struct lambdakzeromcfinder {
   Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
 
   // declarative filtering for particles of interest
-  // pre-filter on PDG and on very broad rapidity window 
-  Filter mcParticleFilter = nabs(o2::aod::mcparticle::y)<yPreFilter && (nabs(o2::aod::mcparticle::pdgCode) == 1010010030 || nabs(o2::aod::mcparticle::pdgCode) == 3122 || o2::aod::mcparticle::pdgCode == 310 || o2::aod::mcparticle::pdgCode == 22);
+  // pre-filter on PDG and on very broad rapidity window
+  Filter mcParticleFilter = nabs(o2::aod::mcparticle::y) < yPreFilter && (nabs(o2::aod::mcparticle::pdgCode) == 1010010030 || nabs(o2::aod::mcparticle::pdgCode) == 3122 || o2::aod::mcparticle::pdgCode == 310 || o2::aod::mcparticle::pdgCode == 22);
 
   std::vector<int> v0collisionId;
   std::vector<int> v0positiveIndex;

--- a/PWGLF/TableProducer/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/lambdakzeromcfinder.cxx
@@ -81,9 +81,14 @@ struct lambdakzeromcfinder {
   Configurable<bool> doUnassociatedV0s{"doUnassociatedV0s", true, "generate also unassociated V0s (for cascades!)"};
   Configurable<bool> doQA{"doQA", true, "do qa plots"};
   Configurable<int> qaNbins{"qaNbins", 200, "qa plots: binning"};
+  Configurable<float> yPreFilter{"yPreFilter", 2.5, "broad y pre-filter for speed"};
   ConfigurableAxis axisPtQA{"axisPtQA", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
 
   Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+
+  // declarative filtering for particles of interest
+  // pre-filter on PDG and on very broad rapidity window 
+  Filter mcParticleFilter = nabs(o2::aod::mcparticle::y)<yPreFilter && (nabs(o2::aod::mcparticle::pdgCode) == 1010010030 || nabs(o2::aod::mcparticle::pdgCode) == 3122 || o2::aod::mcparticle::pdgCode == 310 || o2::aod::mcparticle::pdgCode == 22);
 
   std::vector<int> v0collisionId;
   std::vector<int> v0positiveIndex;
@@ -243,7 +248,7 @@ struct lambdakzeromcfinder {
     return reconstructed;
   }
 
-  void process(soa::Join<aod::McCollisions, aod::McCollsExtra> const& mcCollisions, LabeledTracks const& tracks, aod::McParticles const& allMcParticles)
+  void process(soa::Join<aod::McCollisions, aod::McCollsExtra> const& mcCollisions, LabeledTracks const& tracks, soa::Filtered<aod::McParticles> const& allMcParticles)
   {
     v0collisionId.clear();
     v0positiveIndex.clear();


### PR DESCRIPTION
* adds a broad `y` preselection + a pdg code preselection to MC-finder for better CPU efficiency. Both selections done declaratively with arrow `Filter` declarations. 