### PR TITLE
PWGHF: avoid production and subscription of PVrefit tables if not enabled

### DIFF
--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -84,7 +84,7 @@ struct HfCandidateCreator2Prong {
     runNumber = 0;
   }
 
-  template<bool doPvRefit = false, typename Cand>
+  template <bool doPvRefit = false, typename Cand>
   void runCreator2Prong(aod::Collisions const& collisions, Cand const& rowsTrackIndexProng2, aod::BigTracks const& tracks, aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 2-prong vertex fitter
@@ -223,7 +223,6 @@ struct HfCandidateCreator2Prong {
   }
 
   PROCESS_SWITCH(HfCandidateCreator2Prong, processNoPvRefit, "Run candidate creator without PV refit", true);
-
 };
 
 /// Extends the base table with expression columns.

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -85,7 +85,10 @@ struct HfCandidateCreator2Prong {
   }
 
   template <bool doPvRefit = false, typename Cand>
-  void runCreator2Prong(aod::Collisions const& collisions, Cand const& rowsTrackIndexProng2, aod::BigTracks const& tracks, aod::BCsWithTimestamps const& bcWithTimeStamps)
+  void runCreator2Prong(aod::Collisions const& collisions,
+                        Cand const& rowsTrackIndexProng2,
+                        aod::BigTracks const& tracks,
+                        aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df;

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -35,8 +35,6 @@ struct HfCandidateCreator2Prong {
   Produces<aod::HfCand2ProngBase> rowCandidateBase;
 
   // vertexing
-  Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the candidate daughters, if contributors"};
-  // Configurable<double> bz{"bz", 5., "magnetic field"};
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
   Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
   Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
@@ -86,10 +84,8 @@ struct HfCandidateCreator2Prong {
     runNumber = 0;
   }
 
-  void process(aod::Collisions const& collisions,
-               soa::Join<aod::Hf2Prongs, aod::HfPvRefit2Prong> const& rowsTrackIndexProng2,
-               aod::BigTracks const& tracks,
-               aod::BCsWithTimestamps const& bcWithTimeStamps)
+  template<bool doPvRefit = false, typename Cand>
+  void runCreator2Prong(aod::Collisions const& collisions, Cand const& rowsTrackIndexProng2, aod::BigTracks const& tracks, aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 2-prong vertex fitter
     o2::vertexing::DCAFitterN<2> df;
@@ -104,8 +100,8 @@ struct HfCandidateCreator2Prong {
 
     // loop over pairs of track indices
     for (const auto& rowTrackIndexProng2 : rowsTrackIndexProng2) {
-      auto track0 = rowTrackIndexProng2.prong0_as<aod::BigTracks>();
-      auto track1 = rowTrackIndexProng2.prong1_as<aod::BigTracks>();
+      auto track0 = rowTrackIndexProng2.template prong0_as<aod::BigTracks>();
+      auto track1 = rowTrackIndexProng2.template prong1_as<aod::BigTracks>();
       auto trackParVarPos1 = getTrackParCov(track0);
       auto trackParVarNeg1 = getTrackParCov(track1);
       auto collision = rowTrackIndexProng2.collision();
@@ -113,7 +109,7 @@ struct HfCandidateCreator2Prong {
       /// Set the magnetic field from ccdb.
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
       /// but this is not true when running on Run2 data/MC already converted into AO2Ds.
-      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
       if (runNumber != bc.runNumber()) {
         LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
         initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
@@ -148,7 +144,7 @@ struct HfCandidateCreator2Prong {
       // This modifies track momenta!
       auto primaryVertex = getPrimaryVertex(collision);
       auto covMatrixPV = primaryVertex.getCov();
-      if (doPvRefit) {
+      if constexpr (doPvRefit) {
         /// use PV refit
         /// Using it in the rowCandidateBase all dynamic columns shall take it into account
         // coordinates
@@ -207,6 +203,27 @@ struct HfCandidateCreator2Prong {
       }
     }
   }
+
+  void processPvRefit(aod::Collisions const& collisions,
+                      soa::Join<aod::Hf2Prongs, aod::HfPvRefit2Prong> const& rowsTrackIndexProng2,
+                      aod::BigTracks const& tracks,
+                      aod::BCsWithTimestamps const& bcWithTimeStamps)
+  {
+    runCreator2Prong<true>(collisions, rowsTrackIndexProng2, tracks, bcWithTimeStamps);
+  }
+
+  PROCESS_SWITCH(HfCandidateCreator2Prong, processPvRefit, "Run candidate creator with PV refit", true);
+
+  void processNoPvRefit(aod::Collisions const& collisions,
+                        aod::Hf2Prongs const& rowsTrackIndexProng2,
+                        aod::BigTracks const& tracks,
+                        aod::BCsWithTimestamps const& bcWithTimeStamps)
+  {
+    runCreator2Prong(collisions, rowsTrackIndexProng2, tracks, bcWithTimeStamps);
+  }
+
+  PROCESS_SWITCH(HfCandidateCreator2Prong, processNoPvRefit, "Run candidate creator without PV refit", true);
+
 };
 
 /// Extends the base table with expression columns.

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -84,7 +84,10 @@ struct HfCandidateCreator3Prong {
   }
 
   template <bool doPvRefit = false, typename Cand>
-  void runCreator3Prong(aod::Collisions const& collisions, Cand const& rowsTrackIndexProng3, aod::BigTracks const& tracks, aod::BCsWithTimestamps const& bcWithTimeStamps)
+  void runCreator3Prong(aod::Collisions const& collisions,
+                        Cand const& rowsTrackIndexProng3,
+                        aod::BigTracks const& tracks,
+                        aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 3-prong vertex fitter
     o2::vertexing::DCAFitterN<3> df;

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -83,7 +83,7 @@ struct HfCandidateCreator3Prong {
     runNumber = 0;
   }
 
-  template<bool doPvRefit = false, typename Cand>
+  template <bool doPvRefit = false, typename Cand>
   void runCreator3Prong(aod::Collisions const& collisions, Cand const& rowsTrackIndexProng3, aod::BigTracks const& tracks, aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 3-prong vertex fitter
@@ -230,7 +230,6 @@ struct HfCandidateCreator3Prong {
   }
 
   PROCESS_SWITCH(HfCandidateCreator3Prong, processNoPvRefit, "Run candidate creator without PV refit", true);
-
 };
 
 /// Extends the base table with expression columns.
@@ -255,9 +254,9 @@ struct HfCandidateCreator3ProngExpressions {
     int8_t channel = 0;
     std::vector<int> arrDaughIndex;
     std::array<int, 2> arrPDGDaugh;
-    std::array<int, 2> arrPDGResonant1 = {kProton, 313};  // Λc± → p± K*
-    std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};  // Λc± → Δ(1232)±± K∓
-    std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus}; // Λc± → Λ(1520) π±
+    std::array<int, 2> arrPDGResonant1 = {kProton, 313};       // Λc± → p± K*
+    std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};       // Λc± → Δ(1232)±± K∓
+    std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus};      // Λc± → Λ(1520) π±
     std::array<int, 2> arrPDGResonantDsPhiPi = {333, kPiPlus}; // Ds± → Phi π±
     std::array<int, 2> arrPDGResonantDsKstarK = {313, kKPlus}; // Ds± → K*(892)0bar K±
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1736,9 +1736,12 @@ struct HfTrackIndexSkimCreator {
               if (isSelected2ProngCand > 0) {
                 // fill table row
                 rowTrackIndexProng2(thisCollId, trackPos1.globalIndex(), trackNeg1.globalIndex(), isSelected2ProngCand);
-                // fill table row with coordinates of PV refit
-                rowProng2PVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
-                                 pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+
+                if (doPvRefit) {
+                  // fill table row with coordinates of PV refit
+                  rowProng2PVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
+                                  pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+                }
 
                 if (debug) {
                   int Prong2CutStatus[kN2ProngDecays];
@@ -1953,9 +1956,11 @@ struct HfTrackIndexSkimCreator {
 
               // fill table row
               rowTrackIndexProng3(thisCollId, trackPos1.globalIndex(), trackNeg1.globalIndex(), trackPos2.globalIndex(), isSelected3ProngCand);
-              // fill table row of coordinates of PV refit
-              rowProng3PVrefit(pvRefitCoord3Prong2Pos1Neg[0], pvRefitCoord3Prong2Pos1Neg[1], pvRefitCoord3Prong2Pos1Neg[2],
-                               pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
+              if (doPvRefit) {
+                // fill table row of coordinates of PV refit
+                rowProng3PVrefit(pvRefitCoord3Prong2Pos1Neg[0], pvRefitCoord3Prong2Pos1Neg[1], pvRefitCoord3Prong2Pos1Neg[2],
+                                pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
+              }
 
               if (debug) {
                 int Prong3CutStatus[kN3ProngDecays];

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -135,9 +135,9 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
       }
       // primary vertex histograms
       registry.add("hNContributors", "Number of PV contributors;entries", {HistType::kTH1F, {axisNumContributors}});
-      registry.add("hPrimVtxX", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -0.5, 0.5}}});
-      registry.add("hPrimVtxY", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -0.5, 0.5}}});
-      registry.add("hPrimVtxZ", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{400, -20., 20.}}});
+      registry.add("hPrimVtxX", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -0.5, 0.5}}});
+      registry.add("hPrimVtxY", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -0.5, 0.5}}});
+      registry.add("hPrimVtxZ", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -20., 20.}}});
     }
   }
 
@@ -363,9 +363,9 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         AxisSpec axisCollisionX{100, -20.f, 20.f, "X (cm)"};
         AxisSpec axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
         AxisSpec axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
-        AxisSpec axisCollisionXOriginal{1000, -20.f, 20.f, "X original PV (cm)"};
-        AxisSpec axisCollisionYOriginal{1000, -20.f, 20.f, "Y original PV (cm)"};
-        AxisSpec axisCollisionZOriginal{1000, -20.f, 20.f, "Z original PV (cm)"};
+        AxisSpec axisCollisionXOriginal{100, -2.f, 2.f, "X original PV (cm)"};
+        AxisSpec axisCollisionYOriginal{100, -2.f, 2.f, "Y original PV (cm)"};
+        AxisSpec axisCollisionZOriginal{100, -2.f, 2.f, "Z original PV (cm)"};
         AxisSpec axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
         AxisSpec axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
         AxisSpec axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
@@ -791,6 +791,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 #endif
   )
   {
+    rowSelectedTrack.reserve(tracks.size());
 
     // prepare vectors to cache quantities needed for PV refit
     std::vector<std::array<float, 2>> pvRefitDcaPerTrack{};
@@ -804,6 +805,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         LOG(info) << ">>> number of tracks: " << tracks.size();
         LOG(info) << ">>> number of collisions: " << collisions.size();
       }
+      tabPvRefitTrack.reserve(tracks.size());
     }
 
     for (const auto& collision : collisions) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -973,6 +973,7 @@ struct HfTrackIndexSkimCreator {
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using TracksWithDCA = soa::Join<aod::BigTracks, aod::TracksDCA>;
   using TracksWithPVRefitAndDCA = soa::Join<aod::BigTracks, aod::TracksDCA, aod::HfPvRefitTrack>;
+  using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
 
   // filter collisions
   Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == 0);
@@ -982,7 +983,6 @@ struct HfTrackIndexSkimCreator {
 
   // filter track indices
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng > 0);
-  using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
   Preslice<FilteredTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId;
 
   // FIXME
@@ -1482,7 +1482,10 @@ struct HfTrackIndexSkimCreator {
   } /// end of performPvRefitCandProngs function
 
   template <bool doPvRefit = false, typename TTracks>
-  void run2And3Prongs(SelectedCollisions const& collisions, aod::BCsWithTimestamps const& bcWithTimeStamps, FilteredTrackAssocSel const& trackIndices, TTracks const& tracks)
+  void run2And3Prongs(SelectedCollisions const& collisions,
+                      aod::BCsWithTimestamps const& bcWithTimeStamps,
+                      FilteredTrackAssocSel const& trackIndices,
+                      TTracks const& tracks)
   {
 
     // can be added to run over limited collisions per file - for tesing purposes
@@ -2409,7 +2412,7 @@ struct HfTrackIndexSkimCreatorCascades {
   {
     // set the magnetic field from CCDB
     for (const auto& collision : collisions) {
-      auto bc = collision.template bc_as<o2::aod::BCsWithTimestamps>();
+      auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
       initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
 
       // Define o2 fitter, 2-prong

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -28,8 +28,8 @@
 #include "DataFormatsParameters/GRPMagField.h" // for PV refit
 #include "DataFormatsParameters/GRPObject.h"   // for PV refit
 #include "DCAFitter/DCAFitterN.h"
-#include "DetectorsBase/Propagator.h"      // for PV refit
-#include "DetectorsVertexing/PVertexer.h"  // for PV refit
+#include "DetectorsBase/Propagator.h"     // for PV refit
+#include "DetectorsVertexing/PVertexer.h" // for PV refit
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
@@ -1482,7 +1482,7 @@ struct HfTrackIndexSkimCreator {
     return;
   } /// end of performPvRefitCandProngs function
 
-  template<bool doPvRefit = false, typename TTracks>
+  template <bool doPvRefit = false, typename TTracks>
   void run2And3Prongs(SelectedCollisions const& collisions, aod::BCsWithTimestamps const& bcWithTimeStamps, FilteredTrackAssocSel const& trackIndices, TTracks const& tracks)
   {
 
@@ -1736,7 +1736,7 @@ struct HfTrackIndexSkimCreator {
                 if constexpr (doPvRefit) {
                   // fill table row with coordinates of PV refit
                   rowProng2PVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
-                                  pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+                                   pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
                 }
 
                 if (debug) {
@@ -1955,7 +1955,7 @@ struct HfTrackIndexSkimCreator {
               if constexpr (doPvRefit) {
                 // fill table row of coordinates of PV refit
                 rowProng3PVrefit(pvRefitCoord3Prong2Pos1Neg[0], pvRefitCoord3Prong2Pos1Neg[1], pvRefitCoord3Prong2Pos1Neg[2],
-                                pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
+                                 pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
               }
 
               if (debug) {


### PR DESCRIPTION
This PR allows us to not fill and to not process the tables filled with the PV refit information if the feature is not enabled. This implies a reduction of the memory used and it avoids to process these tables in the 2-prong and 3-prong creators (and consequently it is not needed to write the PV refit tables on disk if the derived AO2Ds containing the track-index-skim-creator tables are produced), if the PV refit is not enabled. 

To achieve it, I had to templatise the process functions of the track-index-skim and the 2-prong and 3-prong creators. This means that the current `doPvRefit` configurable will be replaced by several `PROCESS_SWITCH` (i.e. `processPvRefit` and `processNoPvRefit`).

I still have to complete the tests, but @mfaggin and @vkucera @fcolamar @ginnocen you can start having a look at the implementation if you want.

@vkucera minor note: in principle also this task https://github.com/AliceO2Group/O2Physics/blob/master/PWGHF/TableProducer/refitPvDummy.cxx will not be needed anymore for the filling of the PV refit dummy tables (it will be sufficient to run the 2-prong and 3-prong creators with `processNoPvRefit` once this PR will be merged). The conversion from `001` to `000` table versions though it will still be needed. I would suggest therefore to remove the part where the dummy PVrefit tables are filled and rename the task to have a more meaningful name. Let me know if you want me to include the changes in this PR, or you prefer to do it in a second step.