### PR TITLE
PWGCF: Bugfix Femtodream

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -131,10 +131,10 @@ class FemtoDreamCutculator
 
   /// Automatically retrieves track PID from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
-  void setPIDSelectionFromFile(const char* prefixPID, const char* prefixTrack)
+  void setPIDSelectionFromFile(const char* prefix)
   {
-    std::string PIDnodeName = std::string(prefixPID) + "species";
-    std::string PIDNsigmaNodeName = std::string(prefixTrack) + "PIDnSigmaMax";
+    std::string PIDnodeName = std::string(prefix) + "PIDspecies";
+    std::string PIDNsigmaNodeName = std::string(prefix) + "PIDnSigmaMax";
     try {
       boost::property_tree::ptree& pidNode = mConfigTree.get_child(PIDnodeName);
       boost::property_tree::ptree& pidValues = pidNode.get_child("values");
@@ -233,7 +233,7 @@ class FemtoDreamCutculator
         std::cout << input << std::endl;
       }
     } else {
-      if (selVec.size() == 0) {
+      if (selVec.size() == 1) {
         input = selVec[0].getSelectionValue();
         std::cout << input << std::endl;
       } else {

--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -97,7 +97,7 @@ class FemtoDreamObjectSelection
     }
 
     /// Then, the sorted selections are added to the overall container of cuts
-    for (const auto& sel : sels) {
+    for (auto& sel : sels) {
       mSelections.push_back(sel);
     }
   }

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -100,9 +100,9 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {{600, 0.f, 3.f}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {{600, 0.f, 3.f}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {{600, 0.f, 3.f}, {600, 0.f, 3.f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {{2000, 1.f, 3.f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {{2000, 1.f, 3.f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {{2000, 1.f, 3.f}, {2000, 1.f, 3.f}});
     }
   }
 

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -109,6 +109,18 @@ class FemtoDreamSelection
     ++counter;
   }
 
+  template <typename T>
+  void checkSelectionSetBitPID(selValDataType observable, T& cutContainer)
+  {
+    /// If the selection is fulfilled the bit at the specified position (counter) within the bit-wise container is set to 1
+    if (isSelected(observable)) {
+      cutContainer |= 1UL;
+    } else {
+      cutContainer |= 0UL;
+    }
+    cutContainer <<= 1;
+  }
+
  private:
   selValDataType mSelVal{0.f};                 ///< Value used for the selection
   selVariableDataType mSelVar;                 ///< Variable used for the selection

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -462,7 +462,6 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
   cutContainerType output = 0;
   size_t counter = 0;
   cutContainerType outputPID = 0;
-  size_t counterPID = 0;
   const auto sign = track.sign();
   const auto pT = track.pt();
   const auto eta = track.eta();
@@ -487,12 +486,12 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
     const auto selVariable = sel.getSelectionVariable();
     if (selVariable == femtoDreamTrackSelection::kPIDnSigmaMax) {
       /// PID needs to be handled a bit differently since we may need more than one species
-      for (size_t i = 0; i < pidTPC.size(); ++i) {
+      for (size_t i = 0; i < mPIDspecies.size(); ++i) {
         auto pidTPCVal = pidTPC.at(i) - nSigmaPIDOffsetTPC;
         auto pidTOFVal = pidTOF.at(i) - nSigmaPIDOffsetTOF;
-        sel.checkSelectionSetBit(pidTPCVal, outputPID, counterPID);
         auto pidComb = std::sqrt(pidTPCVal * pidTPCVal + pidTOFVal * pidTOFVal);
-        sel.checkSelectionSetBit(pidComb, outputPID, counterPID);
+        sel.checkSelectionSetBitPID(pidTPCVal, outputPID);
+        sel.checkSelectionSetBitPID(pidComb, outputPID);
       }
 
     } else {

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -176,7 +176,6 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
       if (obs.compare(cmp) == 0)
         return index;
     }
-    LOGF(info, "Variable %s not found", obs);
     return -1;
   }
 

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -17,6 +17,7 @@
 #define PWGCF_FEMTODREAM_FEMTOUTILS_H_
 
 #include <vector>
+#include <algorithm>
 #include "Framework/ASoAHelpers.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
 
@@ -33,8 +34,11 @@ enum kDetector { kTPC = 0,
 /// \return kPIDselection corresponding to n-sigma
 int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
 {
-  for (std::size_t i = 0; i < vNsigma.size(); i++) {
-    if (abs(nSigma - vNsigma[i]) < 1e-3) {
+  // asdf
+  std::vector<float> sNsigma(vNsigma);
+  std::reverse(sNsigma.begin(), sNsigma.end());
+  for (std::size_t i = 0; i < sNsigma.size(); i++) {
+    if (abs(nSigma - vNsigma[i]) < 1e-2) {
       return static_cast<int>(i);
     }
   }
@@ -52,17 +56,17 @@ int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
 /// \param kDetector enum corresponding to the PID technique
 /// \return Whether the PID selection specified in the vectors is fulfilled
 bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
-                   std::vector<int> const& vSpecies, int nSpecies, float nSigma,
+                   int vSpecies,
+                   int nSpecies,
+                   float nSigma,
                    const std::vector<float>& vNsigma,
                    const kDetector iDet = kDetector::kTPC)
 {
   bool pidSelection = true;
   int iNsigma = getPIDselection(nSigma, vNsigma);
-  for (auto iSpecies : vSpecies) {
-    int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + iSpecies * kDetector::kNdetectors + iDet;
-    if (!(pidcut & (1UL << bit_to_check))) {
-      pidSelection = false;
-    }
+  int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + vSpecies * kDetector::kNdetectors + iDet;
+  if (!(pidcut & (1UL << bit_to_check))) {
+    pidSelection = false;
   }
   return pidSelection;
 };
@@ -77,9 +81,12 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
 /// \param nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
 /// \return Whether the PID selection is fulfilled
 bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut,
-                       float const momentum, float const pidThresh,
-                       std::vector<int> const& vSpecies, int nSpecies,
-                       const std::vector<float>& vNsigma, const float nSigmaTPC,
+                       float const momentum,
+                       float const pidThresh,
+                       int vSpecies,
+                       int nSpecies,
+                       const std::vector<float>& vNsigma,
+                       const float nSigmaTPC,
                        const float nSigmaTPCTOF)
 {
   bool pidSelection = true;

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -17,6 +17,7 @@
 #define PWGCF_FEMTODREAM_FEMTOUTILS_H_
 
 #include <vector>
+#include <functional>
 #include <algorithm>
 #include "Framework/ASoAHelpers.h"
 #include "PWGCF/DataModel/FemtoDerived.h"

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -24,26 +24,22 @@
 namespace o2::analysis::femtoDream
 {
 
-enum kDetector { kTPC = 0,
-                 kTPCTOF = 1,
-                 kNdetectors = 2 };
+enum kDetector { kTPC,
+                 kTPCTOF,
+                 kNdetectors };
 
 /// internal function that returns the kPIDselection element corresponding to a
 /// specifica n-sigma value \param nSigma number of sigmas for PID
 /// \param vNsigma vector with the number of sigmas of interest
 /// \return kPIDselection corresponding to n-sigma
-int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
+int getPIDselection(float nSigma, std::vector<float> vNsigma)
 {
-  // asdf
-  std::vector<float> sNsigma(vNsigma);
-  std::reverse(sNsigma.begin(), sNsigma.end());
-  for (std::size_t i = 0; i < sNsigma.size(); i++) {
-    if (abs(nSigma - vNsigma[i]) < 1e-2) {
-      return static_cast<int>(i);
-    }
+  std::sort(vNsigma.begin(), vNsigma.end(), std::greater<>());
+  auto it = std::find(vNsigma.begin(), vNsigma.end(), nSigma);
+  if (it == vNsigma.end()) {
+    LOG(warn) << "Invalid value of nSigma: " << nSigma << ". Return the largest value of the vector: " << *it;
   }
-  LOG(warn) << "Invalid value of nSigma: " << nSigma << ". Return the first value of the vector: " << vNsigma[0];
-  return 0;
+  return std::distance(vNsigma.begin(), it);
 }
 
 /// function that checks whether the PID selection specified in the vectors is
@@ -55,20 +51,17 @@ int getPIDselection(const float nSigma, const std::vector<float>& vNsigma)
 /// \param vNsigma vector with available n-sigma selections for PID
 /// \param kDetector enum corresponding to the PID technique
 /// \return Whether the PID selection specified in the vectors is fulfilled
-bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
+bool isPIDSelected(aod::femtodreamparticle::cutContainerType pidcut,
                    int vSpecies,
                    int nSpecies,
                    float nSigma,
-                   const std::vector<float>& vNsigma,
-                   const kDetector iDet = kDetector::kTPC)
+                   std::vector<float> vNsigma,
+                   kDetector iDet)
 {
-  bool pidSelection = true;
   int iNsigma = getPIDselection(nSigma, vNsigma);
-  int bit_to_check = nSpecies * kDetector::kNdetectors * iNsigma + vSpecies * kDetector::kNdetectors + iDet;
-  if (!(pidcut & (1UL << bit_to_check))) {
-    pidSelection = false;
-  }
-  return pidSelection;
+  int nDet = static_cast<int>(kDetector::kNdetectors);
+  int bit_to_check = 1 + (vNsigma.size() - (iNsigma + 1)) * nDet * nSpecies + (nSpecies - (vSpecies + 1)) * nSpecies + (nDet - 1 - iDet);
+  return ((pidcut >> (bit_to_check)) & 1) == 1;
 };
 
 /// function that checks whether the PID selection specified in the vectors is fulfilled, depending on the momentum TPC or TPC+TOF PID is conducted
@@ -81,13 +74,13 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType const& pidcut,
 /// \param nSigmaTPCTOF Number of TPC+TOF sigmas for selection (circular selection)
 /// \return Whether the PID selection is fulfilled
 bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut,
-                       float const momentum,
-                       float const pidThresh,
+                       float momentum,
+                       float pidThresh,
                        int vSpecies,
                        int nSpecies,
-                       const std::vector<float>& vNsigma,
-                       const float nSigmaTPC,
-                       const float nSigmaTPCTOF)
+                       std::vector<float> vNsigma,
+                       float nSigmaTPC,
+                       float nSigmaTPCTOF)
 {
   bool pidSelection = true;
   if (momentum < pidThresh) {

--- a/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCutCulator.cxx
@@ -36,19 +36,19 @@ int main(int argc, char* argv[])
     cut.init(argv[1]);
 
     std::cout
-      << "Do you want to work with tracks or V0s (T/V)?";
+      << "Do you want to work with tracks or V0s (T/V)? >";
     std::string choice;
     std::cin >> choice;
 
     if (choice == std::string("T")) {
       cut.setTrackSelectionFromFile("ConfTrk");
-      cut.setPIDSelectionFromFile("ConfPIDTrk", "ConfTrk");
+      cut.setPIDSelectionFromFile("ConfTrk");
     } else if (choice == std::string("V")) {
-      std::cout << "Do you want to select V0s or one of its children (V/T)?";
+      std::cout << "Do you want to select V0s or one of its children (V/T)? >";
       std::cin >> choice;
       cut.setV0SelectionFromFile("ConfV0");
       cut.setTrackSelectionFromFile("ConfChild");
-      cut.setPIDSelectionFromFile("ConfPIDChild", "ConfChild");
+      cut.setPIDSelectionFromFile("ConfChild");
     } else {
       std::cout << "Option not recognized. Break...";
       return 2;
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
     /// femtoDreamSelection::kAbsUpperLimit, "ConfTrk");
 
     std::cout << "Do you want to manually select cuts or create systematic "
-                 "variations(M/V)?";
+                 "variations(M/V)? >";
     std::string manual;
     std::cin >> manual;
 

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -48,7 +48,7 @@ struct femtoDreamDebugTrack {
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
-  Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{1}, "Particle 1 - Read from cutCulator"};
+  Configurable<int> ConfPIDPartOne{"ConfPIDPartOne", 1, "Particle 1 - Read from cutCulator"};
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
   ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
@@ -67,7 +67,7 @@ struct femtoDreamDebugTrack {
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack> trackHisto;
 
   /// The configurables need to be passed to an std::vector
-  std::vector<int> vPIDPartOne;
+  int vPIDPartOne;
   std::vector<float> kNsigma;
 
   /// Histogram output

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -97,8 +97,8 @@ struct femtoDreamDebugV0 {
       // check cuts on V0 children
       if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
           (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) &&
-          isFullPIDSelected(posChild.pidcut(), 0.f, 1.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
-          isFullPIDSelected(negChild.pidcut(), 0.f, 1.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
+          isFullPIDSelected(posChild.pidcut(), posChild.p(), 999.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
+          isFullPIDSelected(negChild.pidcut(), negChild.p(), 999.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
         V0Histos.fillQA<false, true>(part);
         posChildHistos.fillQA<false, true>(posChild);
         negChildHistos.fillQA<false, true>(negChild);

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -97,8 +97,8 @@ struct femtoDreamDebugV0 {
       // check cuts on V0 children
       if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
           (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) &&
-          isFullPIDSelected(posChild.pidcut(), 0.f, 1.f, std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
-          isFullPIDSelected(negChild.pidcut(), 0.f, 1.f, std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
+          isFullPIDSelected(posChild.pidcut(), 0.f, 1.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
+          isFullPIDSelected(negChild.pidcut(), 0.f, 1.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
         V0Histos.fillQA<false, true>(part);
         posChildHistos.fillQA<false, true>(posChild);
         negChildHistos.fillQA<false, true>(negChild);

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -66,7 +66,7 @@ struct femtoDreamPairTaskTrackTrack {
   /// Particle 1
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
-  Configurable<std::vector<int>> ConfPIDPartOne{"ConfPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
+  Configurable<int> ConfPIDPartOne{"ConfPIDPartOne", 2, "Particle 1 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
 
   /// Partition for particle 1
   Partition<aod::FDParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
@@ -79,7 +79,7 @@ struct femtoDreamPairTaskTrackTrack {
   Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
   Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 2212, "Particle 2 - PDG code"};
   Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 5542474, "Particle 2 - Selection bit"};
-  Configurable<std::vector<int>> ConfPIDPartTwo{"ConfPIDPartTwo", std::vector<int>{2}, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
+  Configurable<int> ConfPIDPartTwo{"ConfPIDPartTwo", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
 
   /// Partition for particle 2
   Partition<aod::FDParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
@@ -95,7 +95,7 @@ struct femtoDreamPairTaskTrackTrack {
   FemtoDreamEventHisto eventHisto;
 
   /// The configurables need to be passed to an std::vector
-  std::vector<int> vPIDPartOne, vPIDPartTwo;
+  int vPIDPartOne, vPIDPartTwo;
   std::vector<float> kNsigma;
 
   /// particle part
@@ -150,9 +150,9 @@ struct femtoDreamPairTaskTrackTrack {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
 
-    vPIDPartOne = ConfPIDPartOne;
-    vPIDPartTwo = ConfPIDPartTwo;
-    kNsigma = ConfTrkPIDnSigmaMax;
+    vPIDPartOne = ConfPIDPartOne.value;
+    vPIDPartTwo = ConfPIDPartTwo.value;
+    kNsigma = ConfTrkPIDnSigmaMax.value;
   }
 
   template <typename CollisionType>

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -57,7 +57,7 @@ struct femtoDreamPairTaskTrackV0 {
   Configurable<LabeledArray<float>> ConfTrkCutTable{"ConfTrkCutTable", {cutsTableTrack[0], nTrack, nCuts, TrackName, cutNames}, "Particle selections"};
   Configurable<int> ConfTrkPDGCodePartOne{"ConfTrkPDGCodePartOne", 2212, "Particle 1 (Track) - PDG code"};
   Configurable<uint32_t> ConfTrkCutPartOne{"ConfTrkCutPartOne", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
-  Configurable<std::vector<int>> ConfTrkPIDPartOne{"ConfTrkPIDPartOne", std::vector<int>{2}, "Particle 1 - Read from cutCulator"};
+  Configurable<int> ConfTrkPIDPartOne{"ConfTrkPIDPartOne", 2, "Particle 1 - Read from cutCulator"};
   Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
   ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
@@ -96,8 +96,7 @@ struct femtoDreamPairTaskTrackV0 {
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
 
-  /// The configurables need to be passed to an std::vector
-  std::vector<int> vPIDPartOne;
+  int vPIDPartOne;
   std::vector<float> kNsigma;
 
   /// Correlation part
@@ -171,8 +170,8 @@ struct femtoDreamPairTaskTrackV0 {
       const auto& negChild = parts.iteratorAt(part.index() - 1);
       // check cuts on V0 children
       if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
+          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
         continue;
       }
       trackHistoPartTwo.fillQA<false, false>(part);
@@ -190,8 +189,8 @@ struct femtoDreamPairTaskTrackV0 {
       const auto& negChild = parts.iteratorAt(p2.index() - 1);
       // check cuts on V0 children
       if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
+          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
         continue;
       }
       if (ConfIsCPR.value) {
@@ -238,8 +237,8 @@ struct femtoDreamPairTaskTrackV0 {
         const auto& negChild = parts.iteratorAt(p2.index() - 1);
         // check cuts on V0 children
         if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-            !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildPosIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-            !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), std::vector<int>(ConfChildNegIndex.value), ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
+            !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
+            !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
           continue;
         }
         if (ConfIsCPR.value) {

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -88,40 +88,34 @@ struct femtoDreamProducerTask {
   Produces<aod::FDMCLabels> outputPartsMCLabels;
   Produces<aod::FDExtMCParticles> outputDebugPartsMC;
 
-  Configurable<bool> ConfDebugOutput{"ConfDebugOutput", true, "Debug output"};
-
+  Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   // Choose if filtering or skimming version is run
-
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false,
-                                   "Store all collisions"};
-
+  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
   // Choose if running on converted data or Run3  / Pilot
-  Configurable<bool> ConfIsRun3{"ConfIsRun3", false,
-                                "Running on Run3 or pilot"};
-  Configurable<bool> ConfIsMC{"ConfIsMC", false,
-                              "Running on MC; implemented only for Run3"};
+  Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
+  Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
 
-  Configurable<bool> ConfForceGRP{"ConfForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
+  Configurable<bool> ConfIsForceGRP{"ConfIsForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfUseTPCmult{"ConfUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
+  Configurable<bool> ConfEvtUseTPCmult{"ConfEvtUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
   Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
-  Configurable<bool> ConfStoreV0{"ConfStoreV0", true, "True: store V0 table"};
+  Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtodream tables"};
   // just sanity check to make sure in case there are problems in conversion or
   // MC production it does not affect results
-  Configurable<bool> ConfRejectNotPropagatedTracks{"ConfRejectNotPropagatedTracks", false, "True: reject not propagated tracks"};
+  Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
   // Configurable<bool> ConfRejectITSHitandTOFMissing{
   //     "ConfRejectITSHitandTOFMissing", false,
   //     "True: reject if neither ITS hit nor TOF timing satisfied"};
 
-  Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "PDG code of the selected track for Monte Carlo truth"};
+  Configurable<int> ConfTrkPDGCode{"ConfTrkPDGCode", 2212, "PDG code of the selected track for Monte Carlo truth"};
   FemtoDreamTrackSelection trackCuts;
   Configurable<std::vector<float>> ConfTrkCharge{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kSign, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMin, "ConfTrk"), std::vector<float>{0.4f, 0.6f, 0.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMin, "Track selection: ")};
+  Configurable<std::vector<float>> ConfTrkPtmin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMin, "ConfTrk"), std::vector<float>{0.5f, 0.4f, 0.6f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMin, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkPtmax{
     FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kpTMax, "ConfTrk"), std::vector<float>{5.4f, 5.6f, 5.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kpTMax, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkEta{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kEtaMax, "ConfTrk"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kEtaMax, "Track selection: ")};
@@ -134,9 +128,9 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")}; /// \todo Reintegrate PID to the general selection container
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"), std::vector<float>{3.5f, 3.f, 2.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
-  Configurable<float> ConfPIDnSigmaOffsetTPC{"ConfPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
-  Configurable<float> ConfPIDnSigmaOffsetTOF{"ConfPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
-  Configurable<std::vector<int>> ConfPIDTrkspecies{"ConfPIDTrkspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
+  Configurable<float> ConfTrkPIDnSigmaOffsetTPC{"ConfTrkPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
+  Configurable<float> ConfTrkPIDnSigmaOffsetTOF{"ConfTrkPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
+  Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
 
   FemtoDreamV0Selection v0Cuts;
   // TrackSelection *o2PhysicsTrackSelection;
@@ -157,14 +151,14 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfChildTPCnClsMin{"ConfChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "V0 Child sel: Min. nCls TPC"};
   Configurable<std::vector<float>> ConfChildDCAMin{"ConfChildDCAMin", std::vector<float>{0.05f, 0.06f}, "V0 Child sel:  Max. DCA Daugh to PV (cm)"};
   Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "V0 Child sel: Max. PID nSigma TPC"};
-  Configurable<std::vector<int>> ConfPIDChildspecies{"ConfPIDChildspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
+  Configurable<std::vector<int>> ConfChildPIDspecies{"ConfChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
 
-  Configurable<float> ConfV0InvMassLowLimit{"ConfInvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
-  Configurable<float> ConfV0InvMassUpLimit{"ConfInvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassLowLimit{"ConfV0InvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassUpLimit{"ConfV0InvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
 
-  Configurable<bool> ConfV0RejectKaons{"ConfRejectKaons", false, "Switch to reject kaons"};
-  Configurable<float> ConfV0InvKaonMassLowLimit{"ConfInvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
-  Configurable<float> ConfV0InvKaonMassUpLimit{"ConfInvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<bool> ConfV0RejectKaons{"ConfV0RejectKaons", false, "Switch to reject kaons"};
+  Configurable<float> ConfV0InvKaonMassLowLimit{"ConfV0InvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<float> ConfV0InvKaonMassUpLimit{"ConfV0InvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
@@ -206,15 +200,15 @@ struct femtoDreamProducerTask {
     trackCuts.setSelection(ConfTrkDCAxyMax, femtoDreamTrackSelection::kDCAxyMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkDCAzMax, femtoDreamTrackSelection::kDCAzMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setSelection(ConfTrkPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-    trackCuts.setPIDSpecies(ConfPIDTrkspecies);
-    trackCuts.setnSigmaPIDOffset(ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
+    trackCuts.setPIDSpecies(ConfTrkPIDspecies);
+    trackCuts.setnSigmaPIDOffset(ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
     trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
 
     /// \todo fix how to pass array to setSelection, getRow() passing a
     /// different type!
     // v0Cuts.setSelection(ConfV0Selection->getRow(0),
     // femtoDreamV0Selection::kDecVtxMax, femtoDreamSelection::kAbsUpperLimit);
-    if (ConfStoreV0) {
+    if (ConfIsActivateV0) {
       v0Cuts.setSelection(ConfV0Sign, femtoDreamV0Selection::kV0Sign, femtoDreamSelection::kEqual);
       v0Cuts.setSelection(ConfV0PtMin, femtoDreamV0Selection::kV0pTMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setSelection(ConfV0PtMax, femtoDreamV0Selection::kV0pTMax, femtoDreamSelection::kUpperLimit);
@@ -234,17 +228,17 @@ struct femtoDreamProducerTask {
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfPIDChildspecies);
-      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfPIDChildspecies);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfChildPIDspecies);
+      v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfChildPIDspecies);
       v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
       v0Cuts.setInvMassLimits(ConfV0InvMassLowLimit, ConfV0InvMassUpLimit);
 
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfRejectNotPropagatedTracks);
-      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack, ConfRejectNotPropagatedTracks);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfTrkRejectNotPropagated);
+      v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kNegTrack, ConfTrkRejectNotPropagated);
 
-      v0Cuts.setnSigmaPIDOffsetTPC(ConfPIDnSigmaOffsetTPC);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack, ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
-      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack, ConfPIDnSigmaOffsetTPC, ConfPIDnSigmaOffsetTOF);
+      v0Cuts.setnSigmaPIDOffsetTPC(ConfTrkPIDnSigmaOffsetTPC);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kPosTrack, ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
+      v0Cuts.setChildnSigmaPIDOffset(femtoDreamV0Selection::kNegTrack, ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
 
       if (ConfV0RejectKaons) {
         v0Cuts.setKaonInvMassLimits(ConfV0InvKaonMassLowLimit, ConfV0InvKaonMassUpLimit);
@@ -277,7 +271,7 @@ struct femtoDreamProducerTask {
     auto timestamp = bc.timestamp();
     float output = -999;
 
-    if (ConfIsRun3 && !ConfForceGRP) {
+    if (ConfIsRun3 && !ConfIsForceGRP) {
       static o2::parameters::GRPMagField* grpo = nullptr;
       grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", timestamp);
       if (grpo == nullptr) {
@@ -340,7 +334,7 @@ struct femtoDreamProducerTask {
       int particleOrigin = 99;
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
-      if (abs(pdgCode) == abs(ConfPDGCodeTrack.value)) {
+      if (abs(pdgCode) == abs(ConfTrkPDGCode.value)) {
         if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
         } else if (motherparticleMC.producedByGenerator()) {
@@ -376,7 +370,7 @@ struct femtoDreamProducerTask {
                                      /// FemtoDreamRun2 is defined V0M/2
       multNtr = col.multTracklets();
     }
-    if (ConfUseTPCmult) {
+    if (ConfEvtUseTPCmult) {
       multNtr = col.multTPC();
     }
 
@@ -418,7 +412,7 @@ struct femtoDreamProducerTask {
                     femtoDreamTrackSelection::TrackContainerPosition::kPID),
                   track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
-      if (ConfDebugOutput) {
+      if (ConfIsDebug) {
         fillDebugParticle<true>(track);
       }
 
@@ -427,7 +421,7 @@ struct femtoDreamProducerTask {
       }
     }
 
-    if (ConfStoreV0) {
+    if (ConfIsActivateV0) {
       for (auto& v0 : fullV0s) {
         auto postrack = v0.template posTrack_as<TrackType>();
         auto negtrack = v0.template negTrack_as<TrackType>();
@@ -503,7 +497,7 @@ struct femtoDreamProducerTask {
                     indexChildID,
                     v0.mLambda(),
                     v0.mAntiLambda());
-        if (ConfDebugOutput) {
+        if (ConfIsDebug) {
           fillDebugParticle<true>(postrack); // QA for positive daughter
           fillDebugParticle<true>(negtrack); // QA for negative daughter
           fillDebugParticle<false>(v0);      // QA for v0


### PR DESCRIPTION
Fixes contained in this PR:
- Standardized the naming of configurables (i.e. proper namespaces) such that the configurables for certain track types are close to each other in the HY interface
- Systematical variations of PID selections for Tracks are now working regardless of the selected Nsigma values 
- Adjust binning for certain QA histograms