### PR TITLE
Add metadata handling for TPCResponse CCDB objects

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -83,6 +83,7 @@ struct tpcPid {
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if empty the parametrization is not taken from file"};
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC/Response", "Path of the TPC parametrization on the CCDB"};
+  Configurable<std::string> recoPass{"recoPass", "", "Reconstruction pass name for CCDB query (automatically takes latest object for timestamp if blank)"};
   Configurable<int64_t> ccdbTimestamp{"ccdb-timestamp", 0, "timestamp of the object used to query in CCDB the detector response. Exceptions: -1 gets the latest object, 0 gets the run dependent timestamp"};
   // Parameters for loading network from a file / downloading the file
   Configurable<bool> useNetworkCorrection{"useNetworkCorrection", 0, "(bool) Wether or not to use the network correction for the TPC dE/dx signal"};
@@ -121,6 +122,14 @@ struct tpcPid {
     enableFlag("He", pidHe);
     enableFlag("Al", pidAl);
 
+    // Initialise metadata object for CCDB calls
+    if (recoPass.value == "") {
+      LOGP(info, "Reco pass not specified; CCDB will take latest available object");
+    } else {
+      LOGP(info, "CCDB object will be requested for reconstruction pass {}", recoPass.value);
+      metadata["RecoPassName"] = recoPass.value;
+    }
+
     /// TPC PID Response
     const TString fname = paramfile.value;
     if (fname != "") { // Loading the parametrization from file
@@ -132,6 +141,7 @@ struct tpcPid {
       } catch (...) {
         LOGF(fatal, "Loading the TPC PID Response from file {} failed!", fname);
       }
+      response.PrintAll();
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
@@ -142,13 +152,11 @@ struct tpcPid {
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
       if (time != 0) {
-        LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
+        LOGP(info, "Initialising TPC PID response for fixed timestamp {} and reco pass {}:", time, recoPass.value);
         ccdb->setTimestamp(time);
-        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      } else {
-        LOGP(info, "Initialising default TPC PID response:");
+        response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(path, time, metadata));
+        response.PrintAll();
       }
-      response.PrintAll();
     }
 
     /// Neural network init for TPC PID
@@ -284,10 +292,16 @@ struct tpcPid {
 
     for (auto const& trk : tracks) {
       // Loop on Tracks
-      if (useCCDBParam && ccdbTimestamp.value == 0 && trk.has_collision() && trk.collisionId() != lastCollisionId) { // Updating parametrization only if the initial timestamp is 0
-        lastCollisionId = trk.collisionId();
-        const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
-        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp()));
+      const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
+      if (useCCDBParam && ccdbTimestamp.value == 0 && trk.has_collision() && !ccdb->isCachedObjectValid(ccdbPath.value, bc.timestamp())) { // Updating parametrization only if the initial timestamp is 0
+
+        if (recoPass.value == "") {
+          LOGP(info, "Retrieving latest TPC response object for timestamp {}:", bc.timestamp());
+        } else {
+          LOGP(info, "Retrieving TPC Response for timestamp {} and recoPass {}:", bc.timestamp(), recoPass.value);
+        }
+        response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata));
+        response.PrintAll();
       }
       // Check and fill enabled tables
       auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracks_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -287,7 +287,6 @@ struct tpcPid {
       LOG(debug) << "Neural Network for the TPC PID response correction: Time per track (eval + overhead): " << std::chrono::duration<float, std::ratio<1, 1000000000>>(stop_network_total - start_network_total).count() / (tracks_size * 9) << "ns ; Total time (eval + overhead): " << std::chrono::duration<float, std::ratio<1, 1000000000>>(stop_network_total - start_network_total).count() / 1000000000 << " s";
     }
 
-    int lastCollisionId = -1; // Last collision ID analysed
     uint64_t count_tracks = 0;
 
     for (auto const& trk : tracks) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -156,8 +156,7 @@ struct tpcPidFull {
         ccdb->setTimestamp(time);
         response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(path, time, metadata));
         response.PrintAll();
-      } 
-      
+      }
     }
 
     /// Neural network init for TPC PID
@@ -300,8 +299,8 @@ struct tpcPidFull {
         }
         response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata));
         response.PrintAll();
-        
       }
+
       // Check and fill enabled tables
       auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracks_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {
         if (flag.value != 1) {

--- a/Common/TableProducer/PID/pidTPCFull.cxx
+++ b/Common/TableProducer/PID/pidTPCFull.cxx
@@ -83,6 +83,7 @@ struct tpcPidFull {
   Configurable<std::string> paramfile{"param-file", "", "Path to the parametrization object, if empty the parametrization is not taken from file"};
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPath{"ccdbPath", "Analysis/PID/TPC/Response", "Path of the TPC parametrization on the CCDB"};
+  Configurable<std::string> recoPass{"recoPass", "", "Reconstruction pass name for CCDB query (automatically takes latest object for timestamp if blank)"};
   Configurable<int64_t> ccdbTimestamp{"ccdb-timestamp", 0, "timestamp of the object used to query in CCDB the detector response. Exceptions: -1 gets the latest object, 0 gets the run dependent timestamp"};
   // Parameters for loading network from a file / downloading the file
   Configurable<bool> useNetworkCorrection{"useNetworkCorrection", 0, "(bool) Wether or not to use the network correction for the TPC dE/dx signal"};
@@ -121,6 +122,14 @@ struct tpcPidFull {
     enableFlag("He", pidHe);
     enableFlag("Al", pidAl);
 
+    // Initialise metadata object for CCDB calls
+    if (recoPass.value == "") {
+      LOGP(info, "Reco pass not specified; CCDB will take latest available object");
+    } else {
+      LOGP(info, "CCDB object will be requested for reconstruction pass {}", recoPass.value);
+      metadata["RecoPassName"] = recoPass.value;
+    }
+
     /// TPC PID Response
     const TString fname = paramfile.value;
     if (fname != "") { // Loading the parametrization from file
@@ -132,6 +141,7 @@ struct tpcPidFull {
       } catch (...) {
         LOGF(fatal, "Loading the TPC PID Response from file {} failed!", fname);
       }
+      response.PrintAll();
     } else {
       useCCDBParam = true;
       const std::string path = ccdbPath.value;
@@ -142,13 +152,12 @@ struct tpcPidFull {
       ccdb->setLocalObjectValidityChecking();
       ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
       if (time != 0) {
-        LOGP(info, "Initialising TPC PID response for fixed timestamp {}:", time);
+        LOGP(info, "Initialising TPC PID response for fixed timestamp {} and reco pass {}:", time, recoPass.value);
         ccdb->setTimestamp(time);
-        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(path, time));
-      } else {
-        LOGP(info, "Initialising default TPC PID response:");
-      }
-      response.PrintAll();
+        response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(path, time, metadata));
+        response.PrintAll();
+      } 
+      
     }
 
     /// Neural network init for TPC PID
@@ -277,15 +286,21 @@ struct tpcPidFull {
       LOG(debug) << "Neural Network for the TPC PID response correction: Time per track (eval + overhead): " << std::chrono::duration<float, std::ratio<1, 1000000000>>(stop_network_total - start_network_total).count() / (tracks_size * 9) << "ns ; Total time (eval + overhead): " << std::chrono::duration<float, std::ratio<1, 1000000000>>(stop_network_total - start_network_total).count() / 1000000000 << " s";
     }
 
-    int lastCollisionId = -1; // Last collision ID analysed
     uint64_t count_tracks = 0;
 
     for (auto const& trk : tracks) {
       // Loop on Tracks
-      if (useCCDBParam && ccdbTimestamp.value == 0 && trk.has_collision() && trk.collisionId() != lastCollisionId) { // Updating parametrization only if the initial timestamp is 0
-        lastCollisionId = trk.collisionId();
-        const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
-        response.SetParameters(ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp()));
+      const auto& bc = collisions.iteratorAt(trk.collisionId()).bc_as<aod::BCsWithTimestamps>();
+      if (useCCDBParam && ccdbTimestamp.value == 0 && trk.has_collision() && !ccdb->isCachedObjectValid(ccdbPath.value, bc.timestamp())) { // Updating parametrization only if the initial timestamp is 0
+
+        if (recoPass.value == "") {
+          LOGP(info, "Retrieving latest TPC response object for timestamp {}:", bc.timestamp());
+        } else {
+          LOGP(info, "Retrieving TPC Response for timestamp {} and recoPass {}:", bc.timestamp(), recoPass.value);
+        }
+        response.SetParameters(ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata));
+        response.PrintAll();
+        
       }
       // Check and fill enabled tables
       auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracks_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -32,9 +32,9 @@ bpo::variables_map arguments;             // Command line arguments
 o2::ccdb::CcdbApi api;                    // Global CCDB api
 unsigned int minRunNumber = 0;            // Starting run validity
 unsigned int maxRunNumber = minRunNumber; // Ending run validity
-long ccdbTimestamp = 0;                   // Timestamp used for the retrieval
-long validityStart = 0;                   // Initial validity for the object
-long validityStop = 0;                    // End validity for the object
+int64_t ccdbTimestamp = 0;                   // Timestamp used for the retrieval
+int64_t validityStart = 0;                   // Initial validity for the object
+int64_t validityStop = 0;                    // End validity for the object
 
 std::string timeStampToHReadble(time_t rawtime)
 {
@@ -66,9 +66,9 @@ void setStandardOpt(bpo::options_description& options)
     "dryrun,D", bpo::value<int>()->default_value(1), "Dryrun mode")(
     "url,u", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL of the CCDB database e.g. http://ccdb-test.cern.ch:8080 or http://alice-ccdb.cern.ch")(
     "rct-path", bpo::value<std::string>()->default_value("RCT/Info/RunInformation"), "path to the ccdb RCT objects for the SOR/EOR timestamps")(
-    "start,s", bpo::value<long>()->default_value(0), "Start timestamp of object validity. If 0 and min-runnumber != 0 it will be set to the run SOR")(
-    "stop,S", bpo::value<long>()->default_value(0), "Stop timestamp of object validity. If 0 and max-runnumber != 0 it will be set to the run EOR")(
-    "timestamp,T", bpo::value<long>()->default_value(-1), "Timestamp of the object to retrieve, used in alternative to the run number")(
+    "start,s", bpo::value<int64_t>()->default_value(0), "Start timestamp of object validity. If 0 and min-runnumber != 0 it will be set to the run SOR")(
+    "stop,S", bpo::value<int64_t>()->default_value(0), "Stop timestamp of object validity. If 0 and max-runnumber != 0 it will be set to the run EOR")(
+    "timestamp,T", bpo::value<int64_t>()->default_value(-1), "Timestamp of the object to retrieve, used in alternative to the run number")(
     "min-runnumber,r", bpo::value<unsigned int>()->default_value(0), "Starting run number validity (included) corresponding to the parametrization")(
     "max-runnumber,R", bpo::value<unsigned int>()->default_value(0), "Ending run number validity (included) corresponding to the parametrization. If not specified coincides with min-runnumber")(
     "delete-previous,delete_previous,d", bpo::value<int>()->default_value(0), "Flag to delete previous versions of converter objects in the CCDB before uploading the new one so as to avoid proliferation on CCDB")(
@@ -80,7 +80,7 @@ void setStandardOpt(bpo::options_description& options)
 
 template <typename T>
 T* retrieveFromCCDB(const std::string path,
-                    const long timestamp,
+                    const int64_t timestamp,
                     std::map<std::string, std::string> metadata)
 {
   std::map<std::string, std::string> headers;
@@ -96,12 +96,11 @@ T* retrieveFromCCDB(const std::string path,
     LOG(fatal) << "Could not get from CCDB for path " << path << " and timestamp " << timestamp << " -> " << timeStampToHReadble(timestamp);
   }
   return obj;
-
 }
 
 template <typename T>
 T* retrieveFromCCDB(const std::string path,
-                    const long timestamp)
+                    const int64_t timestamp)
 {
   std::map<std::string, std::string> metadata;
   return retrieveFromCCDB<T>(path, timestamp, metadata);
@@ -110,8 +109,8 @@ T* retrieveFromCCDB(const std::string path,
 template <typename T>
 void storeOnCCDB(const std::string& path,
                  const std::map<std::string, std::string>& metadata,
-                 const long& start,
-                 const long& stop,
+                 const int64_t& start,
+                 const int64_t& stop,
                  const T* obj)
 {
   const auto dryrun = arguments["dryrun"].as<int>();
@@ -126,13 +125,13 @@ void storeOnCCDB(const std::string& path,
   }
 }
 
-void setupTimestamps(long& timestamp,
-                     long& start,
-                     long& stop)
+void setupTimestamps(int64_t& timestamp,
+                     int64_t& start,
+                     int64_t& stop)
 {
-  ccdbTimestamp = arguments["timestamp"].as<long>();
-  validityStart = arguments["start"].as<long>();
-  validityStop = arguments["stop"].as<long>();
+  ccdbTimestamp = arguments["timestamp"].as<int64_t>();
+  validityStart = arguments["start"].as<int64_t>();
+  validityStop = arguments["stop"].as<int64_t>();
   minRunNumber = arguments["min-runnumber"].as<unsigned int>();
   auto mrun = arguments["max-runnumber"].as<unsigned int>();
   maxRunNumber = mrun > 0 ? mrun : minRunNumber;
@@ -140,7 +139,7 @@ void setupTimestamps(long& timestamp,
     LOG(fatal) << "Cannot have `min-runnumber` " << minRunNumber << " > `max-runnumber`" << maxRunNumber;
   }
 
-  auto getSOREOR = [&](const unsigned int runnumber, long& sor, long& eor) {
+  auto getSOREOR = [&](const unsigned int runnumber, int64_t& sor, int64_t& eor) {
     std::map<std::string, std::string> metadata, headers;
     const auto rct_path = arguments["rct-path"].as<std::string>();
     const std::string run_path = Form("%s/%i", rct_path.data(), runnumber);
@@ -159,7 +158,7 @@ void setupTimestamps(long& timestamp,
   };
 
   if (minRunNumber != 0) {
-    long SOR = 0, EOR = 0;
+    int64_t SOR = 0, EOR = 0;
     getSOREOR(minRunNumber, SOR, EOR);
     timestamp = SOR; // timestamp of the SOR in ms
     LOG(info) << "Setting timestamp of object from run number " << minRunNumber << ": " << validityStart << " -> " << timeStampToHReadble(validityStart);

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -32,9 +32,9 @@ bpo::variables_map arguments;             // Command line arguments
 o2::ccdb::CcdbApi api;                    // Global CCDB api
 unsigned int minRunNumber = 0;            // Starting run validity
 unsigned int maxRunNumber = minRunNumber; // Ending run validity
-int64_t ccdbTimestamp = 0;                   // Timestamp used for the retrieval
-int64_t validityStart = 0;                   // Initial validity for the object
-int64_t validityStop = 0;                    // End validity for the object
+int64_t ccdbTimestamp = 0;                // Timestamp used for the retrieval
+int64_t validityStart = 0;                // Initial validity for the object
+int64_t validityStop = 0;                 // End validity for the object
 
 std::string timeStampToHReadble(time_t rawtime)
 {
@@ -44,7 +44,7 @@ std::string timeStampToHReadble(time_t rawtime)
   struct tm* dt;
   char buffer[30];
   rawtime /= 1000;
-  dt = localtime_r(&rawtime);
+  localtime_r(&rawtime, dt);
   strftime(buffer, sizeof(buffer), "%H:%M %d-%m %Y", dt);
   return std::string(buffer);
 }
@@ -182,4 +182,4 @@ void setupTimestamps(int64_t& timestamp,
   }
 }
 
-#endif
+#endif  // COMMON_TOOLS_HANDLEPARAMBASE_H_

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -182,4 +182,4 @@ void setupTimestamps(int64_t& timestamp,
   }
 }
 
-#endif  // COMMON_TOOLS_HANDLEPARAMBASE_H_
+#endif // COMMON_TOOLS_HANDLEPARAMBASE_H_

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -41,7 +41,7 @@ std::string timeStampToHReadble(time_t rawtime)
   if (rawtime < 0) {
     return std::string(" latest");
   }
-  struct tm* dt;
+  struct tm* dt = new tm();
   char buffer[30];
   rawtime /= 1000;
   localtime_r(&rawtime, dt);

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -100,10 +100,7 @@ T* retrieveFromCCDB(const std::string path,
 {
   std::map<std::string, std::string> metadata;
   return retrieveFromCCDB<T>(path,timestamp,metadata);
-  
 }
-
-
 
 template <typename T>
 void storeOnCCDB(const std::string& path,

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -75,9 +75,10 @@ void setStandardOpt(bpo::options_description& options)
 
 template <typename T>
 T* retrieveFromCCDB(const std::string path,
-                    const long timestamp)
+                    const long timestamp,
+                    std::map<std::string, std::string> metadata)
 {
-  std::map<std::string, std::string> metadata, headers;
+  std::map<std::string, std::string> headers;
   LOG(info) << "Object " << path << " for timestamp " << timestamp << " -> " << timeStampToHReadble(timestamp);
   headers = api.retrieveHeaders(path, metadata, timestamp);
   LOG(info) << headers.size() << " HEADERS:";
@@ -90,7 +91,19 @@ T* retrieveFromCCDB(const std::string path,
     LOG(fatal) << "Could not get from CCDB for path " << path << " and timestamp " << timestamp << " -> " << timeStampToHReadble(timestamp);
   }
   return obj;
+
 }
+
+template <typename T>
+T* retrieveFromCCDB(const std::string path,
+                    const long timestamp)
+{
+  std::map<std::string, std::string> metadata;
+  return retrieveFromCCDB<T>(path,timestamp,metadata);
+  
+}
+
+
 
 template <typename T>
 void storeOnCCDB(const std::string& path,

--- a/Common/Tools/handleParamBase.h
+++ b/Common/Tools/handleParamBase.h
@@ -16,6 +16,11 @@
 /// \brief  Header file with utilities for handling PID parametrization on CCDB
 ///
 
+#ifndef COMMON_TOOLS_HANDLEPARAMBASE_H_
+#define COMMON_TOOLS_HANDLEPARAMBASE_H_
+
+#include <map>
+#include <string>
 #include "CCDB/CcdbApi.h"
 #include <boost/program_options.hpp>
 #include "Framework/Logger.h"
@@ -39,7 +44,7 @@ std::string timeStampToHReadble(time_t rawtime)
   struct tm* dt;
   char buffer[30];
   rawtime /= 1000;
-  dt = localtime(&rawtime);
+  dt = localtime_r(&rawtime);
   strftime(buffer, sizeof(buffer), "%H:%M %d-%m %Y", dt);
   return std::string(buffer);
 }
@@ -99,7 +104,7 @@ T* retrieveFromCCDB(const std::string path,
                     const long timestamp)
 {
   std::map<std::string, std::string> metadata;
-  return retrieveFromCCDB<T>(path,timestamp,metadata);
+  return retrieveFromCCDB<T>(path, timestamp, metadata);
 }
 
 template <typename T>
@@ -177,3 +182,5 @@ void setupTimestamps(long& timestamp,
     validityStop = 4108971600000;
   }
 }
+
+#endif

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -91,7 +91,6 @@ int main(int argc, char* argv[])
   const std::string jiraticket = arguments["jiraticket"].as<std::string>();
   const std::string comment = arguments["comment"].as<std::string>();
 
-
   const float bb0 = arguments["bb0"].as<float>();
   const float bb1 = arguments["bb1"].as<float>();
   const float bb2 = arguments["bb2"].as<float>();
@@ -212,7 +211,7 @@ int main(int argc, char* argv[])
       std::map<std::string, std::string> metadata;
 
       // Sanity check: Request confirmation if any of recoPass, period name, comment, jira not specified
-      int missingPass=0, missingPeriod=0, missingComment=0, missingJira=0;
+      int missingPass = 0, missingPeriod = 0, missingComment = 0, missingJira = 0;
       if (recopass.empty()) {
         missingPass = 1;
       } else {
@@ -226,7 +225,7 @@ int main(int argc, char* argv[])
       }
 
       if (comment.empty()) {
-        missingComment = 1; 
+        missingComment = 1;
       } else {
         metadata["Comment"] = comment;
       }
@@ -246,12 +245,12 @@ int main(int argc, char* argv[])
           LOG(info) << "\t- Comment";
         if (missingJira)
           LOG(info) << "\t- JIRA ticket";
-        
-        //Request interactive confirmation to upload
+
+        // Request interactive confirmation to upload
         LOG(info) << "Continue with object upload anyway? (Y/n)";
         std::string confirm;
         cin >> confirm;
-        if (boost::iequals(confirm.substr(0, 1),"y")) {
+        if (boost::iequals(confirm.substr(0, 1), "y")) {
           LOG(info) << "Continuing with object upload";
         } else {
           LOG(info) << "Aborting upload";
@@ -259,14 +258,11 @@ int main(int argc, char* argv[])
         }
       }
 
-
-
       // Fill metadata map for start/end run number
       if (minRunNumber != 0) {
         metadata["min-runnumber"] = Form("%i", minRunNumber);
         metadata["max-runnumber"] = Form("%i", maxRunNumber);
       }
-
 
       storeOnCCDB(pathCCDB + "/" + objname, metadata, validityStart, validityStop, tpc);
     }

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -31,8 +31,8 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "objname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be stored in file")(
     "inobjname", bpo::value<std::string>()->default_value("Response"), "Object name to be read from file in 'push' mode")(
     "recopass", bpo::value<std::string>()->default_value(""), "Reconstruction pass name")(
-    "period", bpo::value<std::string>()->default_value(""), "Period name" )(
-    "jiraticket", bpo::value<std::string>()->default_value(""),"JIRA ticket")(
+    "period", bpo::value<std::string>()->default_value(""), "Period name")(
+    "jiraticket", bpo::value<std::string>()->default_value(""), "JIRA ticket")(
     "comment", bpo::value<std::string>()->default_value(""), "Comment for metadata")(
     "bb0", bpo::value<float>()->default_value(0.03209809958934784f), "Bethe-Bloch parameter 0")(
     "bb1", bpo::value<float>()->default_value(19.9768009185791f), "Bethe-Bloch parameter 1")(
@@ -213,31 +213,49 @@ int main(int argc, char* argv[])
 
       // Sanity check: Request confirmation if any of recoPass, period name, comment, jira not specified
       int missingPass=0, missingPeriod=0, missingComment=0, missingJira=0;
-      if (recopass.empty()) {missingPass = 1;}
-        else {metadata["RecoPassName"] = recopass;}
+      if (recopass.empty()) {
+        missingPass = 1;
+      } else {
+        metadata["RecoPassName"] = recopass;
+      }
 
-      if (periodname.empty()) missingPeriod = 1;
-        else {metadata["LPMProductionTag"] = periodname;}
+      if (periodname.empty()) {
+        missingPeriod = 1;
+      } else {
+        metadata["LPMProductionTag"] = periodname;
+      }
 
-      if (comment.empty()) missingComment = 1;
-        else {metadata["Comment"] = comment;}
-      if (jiraticket.empty()) missingJira = 1;
-        else {metadata["JIRA"] = jiraticket;}
+      if (comment.empty()) {
+        missingComment = 1; 
+      } else {
+        metadata["Comment"] = comment;
+      }
+      if (jiraticket.empty()) {
+        missingJira = 1;
+      } else {
+        metadata["JIRA"] = jiraticket;
+      }
 
       if (missingPass || missingPeriod || missingComment || missingJira) {
         LOG(info) << "WARNING: Attempting to push an object with missing metadata elements:";
-        if (missingPass) LOG(info) << "\t- Pass name";
-        if (missingPeriod) LOG(info) << "\t- Period name";
-        if (missingComment) LOG(info) << "\t- Comment";
-        if (missingJira) LOG(info) << "\t- JIRA ticket";
+        if (missingPass)
+          LOG(info) << "\t- Pass name";
+        if (missingPeriod)
+          LOG(info) << "\t- Period name";
+        if (missingComment)
+          LOG(info) << "\t- Comment";
+        if (missingJira)
+          LOG(info) << "\t- JIRA ticket";
+        
+        //Request interactive confirmation to upload
         LOG(info) << "Continue with object upload anyway? (Y/n)";
         std::string confirm;
         cin >> confirm;
-        if (boost::iequals(confirm.substr(0,1),"y")) {
-           LOG(info) << "Continuing with object upload";
+        if (boost::iequals(confirm.substr(0, 1),"y")) {
+          LOG(info) << "Continuing with object upload";
         } else {
-           LOG(info) << "Aborting upload";
-           return 1;
+          LOG(info) << "Aborting upload";
+          return 1;
         }
       }
 

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -17,6 +17,7 @@
 #include <array>
 #include <fstream>
 #include <sstream>
+#include <boost/algorithm/string.hpp>
 #include "TFile.h"
 #include "Common/Core/PID/TPCPIDResponse.h"
 #include "handleParamBase.h"
@@ -29,6 +30,10 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "ccdb-path,c", bpo::value<std::string>()->default_value("Analysis/PID/TPC"), "CCDB path for storage/retrieval")(
     "objname,n", bpo::value<std::string>()->default_value("Response"), "Object name to be stored in file")(
     "inobjname", bpo::value<std::string>()->default_value("Response"), "Object name to be read from file in 'push' mode")(
+    "recopass", bpo::value<std::string>()->default_value(""), "Reconstruction pass name")(
+    "period", bpo::value<std::string>()->default_value(""), "Period name" )(
+    "jiraticket", bpo::value<std::string>()->default_value(""),"JIRA ticket")(
+    "comment", bpo::value<std::string>()->default_value(""), "Comment for metadata")(
     "bb0", bpo::value<float>()->default_value(0.03209809958934784f), "Bethe-Bloch parameter 0")(
     "bb1", bpo::value<float>()->default_value(19.9768009185791f), "Bethe-Bloch parameter 1")(
     "bb2", bpo::value<float>()->default_value(2.5266601063857674e-16f), "Bethe-Bloch parameter 2")(
@@ -81,6 +86,11 @@ int main(int argc, char* argv[])
   const std::string inFilename = arguments["read-from-file"].as<std::string>();
   const std::string objname = arguments["objname"].as<std::string>();
   const std::string inobjname = arguments["inobjname"].as<std::string>();
+  const std::string recopass = arguments["recopass"].as<std::string>();
+  const std::string periodname = arguments["period"].as<std::string>();
+  const std::string jiraticket = arguments["jiraticket"].as<std::string>();
+  const std::string comment = arguments["comment"].as<std::string>();
+  
 
   const float bb0 = arguments["bb0"].as<float>();
   const float bb1 = arguments["bb1"].as<float>();
@@ -199,20 +209,63 @@ int main(int argc, char* argv[])
 
     if (optMode.compare("push") == 0) {
       LOG(info) << "Attempting to push object to CCDB";
-
       std::map<std::string, std::string> metadata;
+
+      // Sanity check: Request confirmation if any of recoPass, period name, comment, jira not specified
+      int missingPass=0, missingPeriod=0, missingComment=0, missingJira=0;
+      if (recopass.empty()) {missingPass = 1;}
+        else {metadata["RecoPassName"] = recopass;}
+      
+      if (periodname.empty()) missingPeriod = 1;
+        else {metadata["LPMProductionTag"] = periodname;}
+      
+      if (comment.empty()) missingComment = 1;
+        else {metadata["Comment"] = comment;}
+      if (jiraticket.empty()) missingJira = 1;
+        else {metadata["JIRA"] = jiraticket;}
+
+      if (missingPass || missingPeriod || missingComment || missingJira) {
+        LOG(info) << "WARNING: Attempting to push an object with missing metadata elements:";
+        if (missingPass) LOG(info) << "\t- Pass name";
+        if (missingPeriod) LOG(info) << "\t- Period name";
+        if (missingComment) LOG(info) << "\t- Comment";
+        if (missingJira) LOG(info) << "\t- JIRA ticket";
+        LOG(info) << "Continue with object upload anyway? (Y/n)";
+        std::string confirm;
+        cin >> confirm;
+        if (boost::iequals(confirm.substr(0,1),"y")) {
+           LOG(info) << "Continuing with object upload";
+        } else {
+           LOG(info) << "Aborting upload";
+           return 1;
+        }
+      }
+
+
+
+      // Fill metadata map for start/end run number
       if (minRunNumber != 0) {
         metadata["min-runnumber"] = Form("%i", minRunNumber);
         metadata["max-runnumber"] = Form("%i", maxRunNumber);
       }
+
+
       storeOnCCDB(pathCCDB + "/" + objname, metadata, validityStart, validityStop, tpc);
     }
   }
 
   else if (optMode.compare("pull") == 0) { // pull existing from CCDB; write out to file if requested
-    LOG(info) << "Attempting to pull object from CCDB (" << urlCCDB << "): " << pathCCDB << "/" << objname;
-    tpc = retrieveFromCCDB<Response>(pathCCDB + "/" + objname, ccdbTimestamp);
-
+    LOG(info) << "Attempting to pull object from CCDB (" << urlCCDB << "): " << pathCCDB << "/" << objname << (recopass.empty() ? "" : "/recoPass=" + recopass);
+    std::map<std::string, std::string> metadata;
+    if (!recopass.empty()) {
+      metadata["RecoPassName"] = recopass;
+    }
+    
+    tpc = retrieveFromCCDB<Response>(pathCCDB + "/" + objname, ccdbTimestamp, metadata);
+    if (!tpc) {
+      LOG(error) << "No CCDB object found with requested parameters";
+      return 1;
+    }
     tpc->PrintAll();
 
     if (!outFilename.empty()) {

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
   const std::string periodname = arguments["period"].as<std::string>();
   const std::string jiraticket = arguments["jiraticket"].as<std::string>();
   const std::string comment = arguments["comment"].as<std::string>();
-  
+
 
   const float bb0 = arguments["bb0"].as<float>();
   const float bb1 = arguments["bb1"].as<float>();
@@ -215,10 +215,10 @@ int main(int argc, char* argv[])
       int missingPass=0, missingPeriod=0, missingComment=0, missingJira=0;
       if (recopass.empty()) {missingPass = 1;}
         else {metadata["RecoPassName"] = recopass;}
-      
+
       if (periodname.empty()) missingPeriod = 1;
         else {metadata["LPMProductionTag"] = periodname;}
-      
+
       if (comment.empty()) missingComment = 1;
         else {metadata["Comment"] = comment;}
       if (jiraticket.empty()) missingJira = 1;
@@ -260,7 +260,7 @@ int main(int argc, char* argv[])
     if (!recopass.empty()) {
       metadata["RecoPassName"] = recopass;
     }
-    
+
     tpc = retrieveFromCCDB<Response>(pathCCDB + "/" + objname, ccdbTimestamp, metadata);
     if (!tpc) {
       LOG(error) << "No CCDB object found with requested parameters";

--- a/Common/Tools/handleParamTPCResponse.cxx
+++ b/Common/Tools/handleParamTPCResponse.cxx
@@ -156,10 +156,9 @@ int main(int argc, char* argv[])
     LOG(info) << "Reading existing TPCPIDResponse object " << objname << " from " << inFilename << ":";
     tpc->PrintAll();
     return 0;
-  }
 
-  else if (optMode.compare("write") == 0 || optMode.compare("push") == 0) // Create new object to write to local file or push to CCDB
-  {
+  } else if (optMode.compare("write") == 0 || optMode.compare("push") == 0) { // Create new object to write to local file or push to CCDB
+
     if (!inFilename.empty()) { // Read from existing file to push to CCDB
       LOG(info) << "Reading from existing file to write to CCDB:";
       TFile fin(inFilename.data(), "READ");
@@ -167,11 +166,13 @@ int main(int argc, char* argv[])
         LOG(error) << "Input file " << inFilename << " could not be read";
         return 1;
       }
+
       tpc = fin.Get<Response>(inobjname.c_str());
       if (!tpc) {
         LOG(error) << "Object with name " << objname << " could not be found in file " << inFilename;
         return 1;
       }
+
       tpc->PrintAll();
     } else { // Create new object if file not specified
       LOG(info) << "Creating new TPCPIDResponse object with defined parameters:";
@@ -187,6 +188,7 @@ int main(int argc, char* argv[])
       tpc->SetUseDefaultResolutionParam(useDefaultParam);
       tpc->PrintAll();
     }
+
     if (optMode.compare("write") == 0) {
       if (outFilename.empty()) {
         LOG(error) << "'write' mode specified, but no output filename. Quitting";
@@ -266,9 +268,7 @@ int main(int argc, char* argv[])
 
       storeOnCCDB(pathCCDB + "/" + objname, metadata, validityStart, validityStop, tpc);
     }
-  }
-
-  else if (optMode.compare("pull") == 0) { // pull existing from CCDB; write out to file if requested
+  } else if (optMode.compare("pull") == 0) { // pull existing from CCDB; write out to file if requested
     LOG(info) << "Attempting to pull object from CCDB (" << urlCCDB << "): " << pathCCDB << "/" << objname << (recopass.empty() ? "" : "/recoPass=" + recopass);
     std::map<std::string, std::string> metadata;
     if (!recopass.empty()) {
@@ -295,9 +295,7 @@ int main(int argc, char* argv[])
       LOG(info) << "File successfully written";
     }
     return 0;
-  }
-
-  else {
+  } else {
     LOG(error) << "Invalid mode specified! (must be 'read', 'write', 'pull' or 'push')";
     return 1;
   }


### PR DESCRIPTION
Adding support for TPC parameter handler + response tasks to save/request specific pass number for multiple objects with same name.

New features:
- Task will now correctly print the used parameters after loading the object from CCDB (previously: would only report the parameters from the default object)
- Able to load specific object with different pass name for same path + timestamp (default behaviour unchanged: will load the latest uploaded object for the timestamp if "passname" configurable unspecified)

Plan to change default behaviour in future to automatically determine pass name, when pulling from AO2D metadata is available