### PR TITLE
EventFiltering: add charm-baryon triggers and reorganise configurables

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -17,6 +17,7 @@
 /// \author Marcel Lesch <marcel.lesch@tum.de>, TUM
 /// \author Alexandre Bigot <alexandre.bigot@cern.ch>, Strasbourg University
 /// \author Biao Zhang <biao.zhang@cern.ch>, CCNU
+/// \author Federica Zanone <federica.zanone@cern.ch>, GSI
 
 #include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
 
@@ -52,45 +53,31 @@ struct HfFilter { // Main struct for HF triggers
   Configurable<int> activateQA{"activateQA", 0, "flag to enable QA histos (0 no QA, 1 basic QA, 2 extended QA, 3 very extended QA)"};
 
   // parameters for all triggers
-  Configurable<float> maxNsigmaPrLc{"maxNsigmaPrLc", 3., "Maximum value for TPC/TOF PID proton Nsigma for Lc candidates"};
-  Configurable<float> maxNsigmaPiKaDzero{"maxNsigmaPiKaDzero", 4., "Maximum value for TOF PID pion/kaon Nsigma for D0 candidates"};
-  Configurable<float> maxNsigmaKa3Prong{"maxNsigmaKa3Prong", 4., "Maximum value for TPC/TOF PID kaon Nsigma for all 3-prongs candidates"};
+  // nsigma PID (except for V0 and cascades)
+  Configurable<LabeledArray<float>> nSigmaPidCuts{"nSigmaPidCuts", {cutsNsigma[0], 2, 5, labelsRowsNsigma, labelsColumnsNsigma}, "Nsigma cuts for TPC/TOF PID (except for V0 and cascades)"};
+  // min pts for tracks and bachelors (except for V0 and cascades)
+  Configurable<LabeledArray<float>> minPtCuts{"minPtCuts", {cutsMinPt[0], 1, 4, labelsEmpty, labelsColumnsMinPt}, "minimum pT for bachelor tracks (except for V0 and cascades)"};
 
   // parameters for high-pT triggers
-  Configurable<float> pTThreshold2Prong{"pTThreshold2Prong", 8., "pT treshold for high pT 2-prong candidates for kHighPt triggers in GeV/c"};
-  Configurable<float> pTThreshold3Prong{"pTThreshold3Prong", 8., "pT treshold for high pT 3-prong candidates for kHighPt triggers in GeV/c"};
+  Configurable<LabeledArray<float>> ptThresholds{"ptThresholds", {cutsHighPtThresholds[0], 1, 2, labelsEmpty, labelsColumnsHighPtThresholds}, "pT treshold for high pT charm hadron candidates for kHighPt triggers in GeV/c"};
 
   // parameters for beauty triggers
-  Configurable<float> deltaMassBPlus{"deltaMassBPlus", 0.3, "invariant-mass delta with respect to the B+ mass"};
-  Configurable<float> deltaMassB0{"deltaMassB0", 0.3, "invariant-mass delta with respect to the B0 mass"};
-  Configurable<float> deltaMassBs{"deltaMassBs", 0.3, "invariant-mass delta with respect to the Bs mass"};
-  Configurable<float> deltaMassCharmHadronForBeauty{"deltaMassCharmHadronForBeauty", 0.04, "invariant-mass delta for charm"};
-  Configurable<float> deltaMassLb{"deltaMassLb", 0.3, "invariant-mass delta with respect to the Lb mass"};
-  Configurable<float> deltaMassXib{"deltaMassXib", 0.3, "invariant-mass delta with respect to the Lb mass"};
-  Configurable<float> deltaMassDStar{"deltaMassDStar", 0.01, "invariant-mass delta with respect to the D* mass for B0 -> D*pi"};
-  Configurable<float> pTMinBeautyBachelor{"pTMinBeautyBachelor", 0.5, "minimum pT for bachelor pion track used to build b-hadron candidates"};
-  Configurable<float> pTMinSoftPion{"pTMinSoftPion", 0.1, "minimum pT for soft pion track used to build D* mesons in the b-hadron decay chain"};
+  Configurable<LabeledArray<float>> deltaMassBeauty{"deltaMassBeauty", {cutsDeltaMassB[0], 1, kNBeautyParticles + 1, labelsEmpty, labelsColumnsDeltaMassB}, "invariant-mass delta with respect to the b-hadron masses in GeV/c2"};
   Configurable<std::vector<double>> pTBinsTrack{"pTBinsTrack", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for DCAXY pT-dependent cut"};
   Configurable<LabeledArray<double>> cutsTrackBeauty3Prong{"cutsTrackBeauty3Prong", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 3-prong beauty candidates"};
   Configurable<LabeledArray<double>> cutsTrackBeauty4Prong{"cutsTrackBeauty4Prong", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 4-prong beauty candidates"};
   std::array<LabeledArray<double>, 2> cutsSingleTrackBeauty;
-  static constexpr double cutsTrackDummy[hf_cuts_single_track::nBinsPtTrack][hf_cuts_single_track::nCutVarsTrack] = {{0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}};
-  LabeledArray<double> cutsSingleTrackDummy{cutsTrackDummy[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack};
 
   // parameters for femto triggers
   Configurable<float> femtoMaxRelativeMomentum{"femtoMaxRelativeMomentum", 2., "Maximal allowed value for relative momentum between charm-proton pairs in GeV/c"};
-  Configurable<float> femtoMinProtonPt{"femtoMinProtonPt", 0.5, "Minimal required transverse momentum for proton in GeV/c"};
-  Configurable<bool> femtoProtonOnlyTOF{"femtoProtonOnlyTOF", false, "Use only TOF information for proton identification if true"};
-  Configurable<float> femtoMaxNsigmaProton{"femtoMaxNsigmaProton", 3., "Maximum value for PID proton Nsigma for femto triggers"};
 
-  // parameters for V0 triggers
-  Configurable<float> minCosPaGamma{"minCosPaGamma", 0.85, "Minimal required cosine of pointing angle for photons"};
-  Configurable<float> minCosPaV0{"minCosPaV0", 0.95, "Minimal required cosine of pointing angle for K0S and Lambdas"};
-  Configurable<float> minV0Radius{"minV0Radius", 0.1, "Minimal required V0 radius for K0S and Lambdas"};
-  Configurable<float> maxNsigmaPrForLambda{"maxNsigmaPrForLambda", 5., "Maximum allowed nSigma TPC/TOF for protons in Lambda decays"};
-  Configurable<float> maxMassDstarToGamma{"maxMassDstarToGamma", 0.4, "Maximum invariant mass delta for D* -> D gamma"};
-  Configurable<float> maxMassDs12{"maxMassDs12", 0.88, "Maximum invariant mass delta for Ds1+ and Ds2*+"};
-  Configurable<float> maxMassXicStar{"maxMassXicStar", 1.4, "Maximum invariant mass delta for Xic(3055) and Xic(3080)"};
+  // parameters for V0 + charm triggers
+  Configurable<LabeledArray<float>> cutsGammaK0sLambda{"cutsGammaK0sLambda", {cutsV0s[0], 1, 6, labelsEmpty, labelsColumnsV0s}, "Selections for V0s (gamma, K0s, Lambda) for D+V0 triggers"};
+  Configurable<LabeledArray<float>> maxDeltaMassCharmReso{"maxDeltaMassCharmReso", {cutsMassCharmReso[0], 1, 6, labelsEmpty, labelsColumnsDeltaMasseCharmReso}, "maximum invariant-mass delta for charm hadron resonances in GeV/c2"};
+
+  // parameters for charm baryons to Xi bachelor
+  Configurable<LabeledArray<float>> cutsXiCascades{"cutsXiCascades", {cutsCascades[0], 1, 4, labelsEmpty, labelsColumnsCascades}, "Selections for cascades (Xi) for Xi+bachelor triggers"};
+  Configurable<float> minPtCharmBaryon{"minPtCharmBaryon", 3.f, "minimum pT for Xic and Omegac baryons decaying into Xi pi/K"};
 
   // parameters for ML application with ONNX
   Configurable<bool> applyML{"applyML", false, "Flag to enable or disable ML application"};
@@ -98,16 +85,12 @@ struct HfFilter { // Main struct for HF triggers
 
   Configurable<std::string> onnxFileD0ToKPiConf{"onnxFileD0ToKPiConf", "XGBoostModel.onnx", "ONNX file for ML model for D0 candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreD0ToKPi{"thresholdBDTScoreD0ToKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D0 candidates"};
-
   Configurable<std::string> onnxFileDPlusToPiKPiConf{"onnxFileDPlusToPiKPiConf", "", "ONNX file for ML model for D+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDPlusToPiKPi{"thresholdBDTScoreDPlusToPiKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D+ candidates"};
-
   Configurable<std::string> onnxFileDSToPiKKConf{"onnxFileDSToPiKKConf", "", "ONNX file for ML model for Ds+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDSToPiKK{"thresholdBDTScoreDSToPiKK", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Ds+ candidates"};
-
   Configurable<std::string> onnxFileLcToPiKPConf{"onnxFileLcToPiKPConf", "", "ONNX file for ML model for Lc+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreLcToPiKP{"thresholdBDTScoreLcToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Lc+ candidates"};
-
   Configurable<std::string> onnxFileXicToPiKPConf{"onnxFileXicToPiKPConf", "", "ONNX file for ML model for Xic+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreXicToPiKP{"thresholdBDTScoreXicToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Xic+ candidates"};
 
@@ -145,7 +128,7 @@ struct HfFilter { // Main struct for HF triggers
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hCharmHighPt{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hCharmProtonKstarDistr{};
   std::array<std::shared_ptr<TH2>, kNBeautyParticles> hMassVsPtB{};
-  std::array<std::shared_ptr<TH2>, kNCharmParticles + 6> hMassVsPtC{}; // +6 for resonances (D*+, D*0, Ds*+, Ds1+, Ds2*+, Xic*)
+  std::array<std::shared_ptr<TH2>, kNCharmParticles + 8> hMassVsPtC{}; // +6 for resonances (D*+, D*0, Ds*+, Ds1+, Ds2*+, Xic*) +2 for charm baryons (Xi+Pi, Xi+Ka)
   std::shared_ptr<TH2> hProtonTPCPID, hProtonTOFPID;
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hBDTScoreBkg{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hBDTScorePrompt{};
@@ -172,6 +155,8 @@ struct HfFilter { // Main struct for HF triggers
   std::array<int, kNCharmParticles> dataTypeML{};
 
   // material correction for track propagation
+  o2::base::MatLayerCylSet* lut;
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
   o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
 
   void init(o2::framework::InitContext&)
@@ -196,12 +181,16 @@ struct HfFilter { // Main struct for HF triggers
           hBDTScoreNonPrompt[iCharmPart] = registry.add<TH1>(Form("f%sBDTScoreNonPromptDistr", charmParticleNames[iCharmPart].data()), Form("BDT nonprompt score distribution for %s;BDT nonprompt score;counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {bdtAxis});
         }
       }
+      // charm resonances
       hMassVsPtC[kNCharmParticles] = registry.add<TH2>("fMassVsPtDStarPlus", "#it{M} vs. #it{p}_{T} distribution of triggered DStarPlus candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles]});
       hMassVsPtC[kNCharmParticles + 1] = registry.add<TH2>("fMassVsPtDStarZero", "#it{M} vs. #it{p}_{T} distribution of triggered DStarZero candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 1]});
       hMassVsPtC[kNCharmParticles + 2] = registry.add<TH2>("fMassVsPtDStarS", "#it{M} vs. #it{p}_{T} distribution of triggered DStarS candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 2]});
       hMassVsPtC[kNCharmParticles + 3] = registry.add<TH2>("fMassVsPtDs1Plus", "#it{M} vs. #it{p}_{T} distribution of triggered Ds1Plus candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 3]});
       hMassVsPtC[kNCharmParticles + 4] = registry.add<TH2>("fMassVsPtDs2StarPlus", "#it{M} vs. #it{p}_{T} distribution of triggered Ds2StarPlus candidates;#it{p}_{T} (GeV/#Delta#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 4]});
       hMassVsPtC[kNCharmParticles + 5] = registry.add<TH2>("fMassVsPtXicStar", "#it{M} vs. #it{p}_{T} distribution of triggered XicStar candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 5]});
+      // charm baryons to LF cascades
+      hMassVsPtC[kNCharmParticles + 6] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+#pi candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 6]});
+      hMassVsPtC[kNCharmParticles + 7] = registry.add<TH2>("fMassVsPtCharmBaryonToXiKa", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+K candidates;#it{p}_{T} (GeV/#it{c});#Delta#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2F, {ptAxis, massAxisC[kNCharmParticles + 7]});
       for (int iBeautyPart{0}; iBeautyPart < kNBeautyParticles; ++iBeautyPart) {
         hMassVsPtB[iBeautyPart] = registry.add<TH2>(Form("fMassVsPt%s", beautyParticleNames[iBeautyPart].data()), Form("#it{M} vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", beautyParticleNames[iBeautyPart].data()), HistType::kTH2F, {ptAxis, massAxisB[iBeautyPart]});
       }
@@ -234,6 +223,7 @@ struct HfFilter { // Main struct for HF triggers
     ccdb->setLocalObjectValidityChecking();
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
     ccdbApi.init(url);
+    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>("GLO/Param/MatLUT"));
 
     thresholdBDTScores = {
       thresholdBDTScoreD0ToKPi,
@@ -264,18 +254,19 @@ struct HfFilter { // Main struct for HF triggers
   }
 
   using BigTracksMCPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::McTrackLabels>;
-
-  Filter trackFilter = requireGlobalTrackWoDCAInFilter();
-  using BigTracksPID = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr>>;
+  using BigTracksPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr>;
 
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::V0Datas> v0sPerCollision = aod::v0data::collisionId;
   Preslice<aod::Hf2Prongs> hf2ProngPerCollision = aod::track_association::collisionId;
   Preslice<aod::Hf3Prongs> hf3ProngPerCollision = aod::track_association::collisionId;
+  Preslice<aod::CascDatas> cascPerCollision = aod::cascdata::collisionId;
 
   void process(aod::Collisions const& collisions,
                aod::BCsWithTimestamps const&,
                aod::V0Datas const& theV0s,
+               aod::V0sLinked const& v0Links,
+               aod::CascDatas const& cascades,
                aod::Hf2Prongs const& cand2Prongs,
                aod::Hf3Prongs const& cand3Prongs,
                aod::TrackAssoc const& trackIndices,
@@ -348,7 +339,7 @@ struct HfFilter { // Main struct for HF triggers
         auto trackPos = cand2Prong.prong0_as<BigTracksPID>(); // positive daughter
         auto trackNeg = cand2Prong.prong1_as<BigTracksPID>(); // negative daughter
 
-        auto preselD0 = isDzeroPreselected(trackPos, trackNeg, maxNsigmaPiKaDzero, maxNsigmaPiKaDzero, setTPCCalib, hMapPion, hBBPion, hBBKaon);
+        auto preselD0 = isDzeroPreselected(trackPos, trackNeg, nSigmaPidCuts->get(0u, 1u), nSigmaPidCuts->get(1u, 1u), setTPCCalib, hMapPion, hBBPion, hBBKaon);
         if (!preselD0) {
           continue;
         }
@@ -419,9 +410,9 @@ struct HfFilter { // Main struct for HF triggers
           optimisationTreeCharm(thisCollId, pdg::Code::kD0, pt2Prong, scoresToFill[0], scoresToFill[1], scoresToFill[2]);
         }
 
-        auto selD0 = isSelectedD0InMassRange(pVecPos, pVecNeg, pt2Prong, phi2Prong, preselD0, deltaMassCharmHadronForBeauty, activateQA, hMassVsPtC[kD0]);
+        auto selD0 = isSelectedD0InMassRange(pVecPos, pVecNeg, pt2Prong, phi2Prong, preselD0, deltaMassBeauty->get(0u, kNBeautyParticles), activateQA, hMassVsPtC[kD0]);
 
-        if (pt2Prong >= pTThreshold2Prong) {
+        if (pt2Prong >= ptThresholds->get(0u, 0u)) {
           keepEvent[kHighPt2P] = true;
           if (activateQA) {
             hCharmHighPt[kD0]->Fill(pt2Prong);
@@ -453,12 +444,12 @@ struct HfFilter { // Main struct for HF triggers
           }
 
           if (!keepEvent[kBeauty3P] && isBeautyTagged) {
-            int isTrackSelected = isSelectedTrackForSoftPionOrBeauty(trackParThird, dcaThird, pTMinSoftPion, pTMinBeautyBachelor, pTBinsTrack, cutsSingleTrackBeauty[kBeauty3P - 2]);
+            int isTrackSelected = isSelectedTrackForSoftPionOrBeauty(track, trackParThird, dcaThird, minPtCuts->get(0u, 1u), minPtCuts->get(0u, 0u), pTBinsTrack, cutsSingleTrackBeauty[kBeauty3P - 2]);
             if (isTrackSelected && ((TESTBIT(selD0, 0) && track.sign() < 0) || (TESTBIT(selD0, 1) && track.sign() > 0))) {
               auto massCand = RecoDecay::m(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi});
               auto pVecBeauty3Prong = RecoDecay::pVec(pVec2Prong, pVecThird);
               auto ptCand = RecoDecay::pt(pVecBeauty3Prong);
-              if (isTrackSelected == kRegular && std::fabs(massCand - massBPlus) <= deltaMassBPlus) {
+              if (isTrackSelected == kForBeauty && std::fabs(massCand - massBPlus) <= deltaMassBeauty->get(0u, 0u)) {
                 keepEvent[kBeauty3P] = true;
                 // fill optimisation tree for D0
                 if (applyOptimisation) {
@@ -478,7 +469,7 @@ struct HfFilter { // Main struct for HF triggers
                 auto massDstarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, pVecThird}, std::array{massDausD0[0], massDausD0[1], massPi});
                 auto massDiffDstar = massDstarCand - massD0dau;
 
-                if (std::fabs(massDiffDstar - (massDStar - massD0)) <= deltaMassDStar) { // additional check for B0->D*pi polarization studies
+                if (std::fabs(massDiffDstar - (massDStar - massD0)) <= maxDeltaMassCharmReso->get(0u, 0u)) { // additional check for B0->D*pi polarization studies
                   if (activateQA) {
                     hMassVsPtC[kNCharmParticles]->Fill(ptCand, massDiffDstar);
                   }
@@ -495,9 +486,9 @@ struct HfFilter { // Main struct for HF triggers
                       getPxPyPz(trackParFourth, pVecFourth);
                     }
 
-                    if (track.sign() * trackB.sign() < 0 && isSelectedTrackForSoftPionOrBeauty(trackParFourth, dcaFourth, pTMinSoftPion, pTMinBeautyBachelor, pTBinsTrack, cutsSingleTrackBeauty[kBeauty3P - 2]) == kRegular) {
+                    if (track.sign() * trackB.sign() < 0 && isSelectedTrackForSoftPionOrBeauty(trackB, trackParFourth, dcaFourth, minPtCuts->get(0u, 1u), minPtCuts->get(0u, 0u), pTBinsTrack, cutsSingleTrackBeauty[kBeauty3P - 2]) == kForBeauty) {
                       auto massCandB0 = RecoDecay::m(std::array{pVecBeauty3Prong, pVecFourth}, std::array{massDStar, massPi});
-                      if (std::fabs(massCandB0 - massB0) <= deltaMassB0) {
+                      if (std::fabs(massCandB0 - massB0) <= deltaMassBeauty->get(0u, 2u)) {
                         keepEvent[kBeauty3P] = true;
                         // fill optimisation tree for D0
                         if (applyOptimisation) {
@@ -518,7 +509,7 @@ struct HfFilter { // Main struct for HF triggers
 
           // 2-prong femto
           if (!keepEvent[kFemto2P] && isCharmTagged && track.collisionId() == thisCollId) {
-            bool isProton = isSelectedProton4Femto(track, trackParThird, femtoMinProtonPt, femtoMaxNsigmaProton, femtoProtonOnlyTOF, setTPCCalib, hMapProton, hBBProton, activateQA, hProtonTPCPID, hProtonTOFPID);
+            bool isProton = isSelectedProton4Femto(track, trackParThird, minPtCuts->get(0u, 2u), nSigmaPidCuts->get(0u, 3u), setTPCCalib, hMapProton, hBBProton, activateQA, hProtonTPCPID, hProtonTOFPID);
             if (isProton) {
               float relativeMomentum = computeRelativeMomentum(pVecThird, pVec2Prong, massD0);
               if (applyOptimisation) {
@@ -542,9 +533,14 @@ struct HfFilter { // Main struct for HF triggers
             float v0CosinePa = v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ());
             auto posTrack = v0.posTrack_as<BigTracksPID>();
             auto negTrack = v0.negTrack_as<BigTracksPID>();
-            auto selV0 = isSelectedV0(v0, std::array{posTrack, negTrack}, v0CosinePa, minCosPaGamma, minCosPaV0, minV0Radius, maxNsigmaPrForLambda, setTPCCalib, hMapProton, hBBProton, activateQA, hV0Selected, hArmPod);
+            auto selV0 = isSelectedV0(v0, std::array{posTrack, negTrack}, v0CosinePa, cutsGammaK0sLambda->get(0u, 0u), cutsGammaK0sLambda->get(0u, 1u), cutsGammaK0sLambda->get(0u, 2u), cutsGammaK0sLambda->get(0u, 3u), cutsGammaK0sLambda->get(0u, 4u), cutsGammaK0sLambda->get(0u, 5u), setTPCCalib, hMapProton, hBBProton, activateQA, hV0Selected, hArmPod);
             if (selV0) {
+              // propagate to PV
+              gpu::gpustd::array<float, 2> dcaInfo;
               std::array<float, 3> pVecV0 = {v0.px(), v0.py(), v0.pz()};
+              auto trackParV0 = o2::track::TrackPar(std::array{v0.x(), v0.y(), v0.z()}, pVecV0, 0, true);
+              o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParV0, 2.f, matCorr, &dcaInfo);
+              getPxPyPz(trackParV0, pVecV0);
               if (TESTBIT(selV0, kPhoton)) {
                 float massDStarCand{-1.}, massDStarBarCand{999.};
                 float massDiffDstar{-1.}, massDiffDstarBar{999.};
@@ -556,8 +552,8 @@ struct HfFilter { // Main struct for HF triggers
                   massDStarBarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, pVecV0}, std::array{massK, massPi, massGamma});
                   massDiffDstarBar = massDStarBarCand - massD0BarCand;
                 }
-                bool isGoodDstar = (massDiffDstar < maxMassDstarToGamma);
-                bool isGoodDstarBar = (massDiffDstarBar < maxMassDstarToGamma);
+                bool isGoodDstar = (massDiffDstar < maxDeltaMassCharmReso->get(0u, 1u));
+                bool isGoodDstarBar = (massDiffDstarBar < maxDeltaMassCharmReso->get(0u, 1u));
 
                 if (isGoodDstar || isGoodDstarBar) {
                   keepEvent[kV0Charm2P] = true;
@@ -590,7 +586,7 @@ struct HfFilter { // Main struct for HF triggers
                     getPxPyPz(trackParBachelor, pVecBachelor);
                   }
 
-                  int isTrackSelected = isSelectedTrackForSoftPionOrBeauty(trackParBachelor, dcaBachelor, pTMinSoftPion, pTMinBeautyBachelor, pTBinsTrack, cutsSingleTrackDummy);
+                  int isTrackSelected = isSelectedTrackForSoftPionOrBeauty(trackBachelor, trackParBachelor, dcaBachelor, minPtCuts->get(0u, 1u), minPtCuts->get(0u, 0u), pTBinsTrack, cutsSingleTrackDummy);
                   if (isTrackSelected && ((TESTBIT(selD0, 0) && trackBachelor.sign() < 0) || (TESTBIT(selD0, 1) && trackBachelor.sign() > 0))) {
                     std::array<float, 2> massDausD0{massPi, massK};
                     auto massD0dau = massD0Cand;
@@ -603,13 +599,13 @@ struct HfFilter { // Main struct for HF triggers
                     auto massDiffDstar = massDStarCand - massD0dau;
                     auto pVecDStarCand = RecoDecay::pVec(pVec2Prong, pVecBachelor);
                     auto ptDStarCand = RecoDecay::pt(pVecDStarCand);
-                    if (std::fabs(massDiffDstar - (massDStar - massD0)) <= deltaMassDStar) {
+                    if (std::fabs(massDiffDstar - (massDStar - massD0)) <= maxDeltaMassCharmReso->get(0u, 0u)) {
                       if (activateQA) {
                         hMassVsPtC[kNCharmParticles]->Fill(ptDStarCand, massDiffDstar);
                       }
                       auto massDStarK0S = RecoDecay::m(std::array{pVecPos, pVecNeg, pVecBachelor, pVecV0}, std::array{massDausD0[0], massDausD0[1], massPi, massK0S});
                       auto massDiffDsReso = massDStarK0S - massDStarCand;
-                      if (massDiffDsReso < maxMassDs12) {
+                      if (massDiffDsReso < maxDeltaMassCharmReso->get(0u, 3u)) {
                         if (activateQA) {
                           auto pVecReso2Prong = RecoDecay::pVec(pVecDStarCand, pVecV0);
                           auto ptCand = RecoDecay::pt(pVecReso2Prong);
@@ -623,7 +619,7 @@ struct HfFilter { // Main struct for HF triggers
               }
             }
           }
-        } // end gamma selection
+        } // end V0 selection
 
       } // end loop over 2-prong candidates
 
@@ -666,13 +662,13 @@ struct HfFilter { // Main struct for HF triggers
         }
 
         if (is3Prong[0]) { // D+ preselections
-          is3Prong[0] = isDplusPreselected(trackSecond, maxNsigmaKa3Prong, maxNsigmaKa3Prong, setTPCCalib, hMapPion, hBBKaon);
+          is3Prong[0] = isDplusPreselected(trackSecond, nSigmaPidCuts->get(0u, 2u), nSigmaPidCuts->get(1u, 2u), setTPCCalib, hMapPion, hBBKaon);
         }
         if (is3Prong[1]) { // Ds preselections
-          is3Prong[1] = isDsPreselected(pVecFirst, pVecThird, pVecSecond, trackSecond, maxNsigmaKa3Prong, maxNsigmaKa3Prong, setTPCCalib, hMapPion, hBBKaon);
+          is3Prong[1] = isDsPreselected(pVecFirst, pVecThird, pVecSecond, trackSecond, nSigmaPidCuts->get(0u, 2u), nSigmaPidCuts->get(1u, 2u), setTPCCalib, hMapPion, hBBKaon);
         }
         if (is3Prong[2] || is3Prong[3]) { // charm baryon preselections
-          auto presel = isCharmBaryonPreselected(trackFirst, trackThird, trackSecond, maxNsigmaPrLc, maxNsigmaPrLc, maxNsigmaKa3Prong, maxNsigmaKa3Prong, setTPCCalib, hMapProton, hBBProton, hMapPion, hBBKaon);
+          auto presel = isCharmBaryonPreselected(trackFirst, trackThird, trackSecond, nSigmaPidCuts->get(0u, 0u), nSigmaPidCuts->get(1u, 0u), nSigmaPidCuts->get(0u, 2u), nSigmaPidCuts->get(1u, 2u), setTPCCalib, hMapProton, hBBProton, hMapPion, hBBKaon);
           if (is3Prong[2]) {
             is3Prong[2] = presel;
           }
@@ -744,31 +740,31 @@ struct HfFilter { // Main struct for HF triggers
 
         std::array<int8_t, kNCharmParticles - 1> is3ProngInMass{0};
         if (is3Prong[0]) {
-          is3ProngInMass[0] = isSelectedDplusInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, deltaMassCharmHadronForBeauty, activateQA, hMassVsPtC[kDplus]);
+          is3ProngInMass[0] = isSelectedDplusInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, deltaMassBeauty->get(0u, kNBeautyParticles), activateQA, hMassVsPtC[kDplus]);
           if (applyOptimisation) {
             optimisationTreeCharm(thisCollId, pdg::Code::kDPlus, pt3Prong, scoresToFill[0][0], scoresToFill[0][1], scoresToFill[0][2]);
           }
         }
         if (is3Prong[1]) {
-          is3ProngInMass[1] = isSelectedDsInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[1], deltaMassCharmHadronForBeauty, activateQA, hMassVsPtC[kDs]);
+          is3ProngInMass[1] = isSelectedDsInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[1], deltaMassBeauty->get(0u, kNBeautyParticles), activateQA, hMassVsPtC[kDs]);
           if (applyOptimisation) {
             optimisationTreeCharm(thisCollId, pdg::Code::kDS, pt3Prong, scoresToFill[1][0], scoresToFill[1][1], scoresToFill[1][2]);
           }
         }
         if (is3Prong[2]) {
-          is3ProngInMass[2] = isSelectedLcInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[2], deltaMassCharmHadronForBeauty, activateQA, hMassVsPtC[kLc]);
+          is3ProngInMass[2] = isSelectedLcInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[2], deltaMassBeauty->get(0u, kNBeautyParticles), activateQA, hMassVsPtC[kLc]);
           if (applyOptimisation) {
             optimisationTreeCharm(thisCollId, pdg::Code::kLambdaCPlus, pt3Prong, scoresToFill[2][0], scoresToFill[2][1], scoresToFill[2][2]);
           }
         }
         if (is3Prong[3]) {
-          is3ProngInMass[3] = isSelectedXicInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[3], deltaMassCharmHadronForBeauty, activateQA, hMassVsPtC[kXic]);
+          is3ProngInMass[3] = isSelectedXicInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, phi3Prong, is3Prong[3], deltaMassBeauty->get(0u, kNBeautyParticles), activateQA, hMassVsPtC[kXic]);
           if (applyOptimisation) {
             optimisationTreeCharm(thisCollId, pdg::Code::kXiCPlus, pt3Prong, scoresToFill[3][0], scoresToFill[3][1], scoresToFill[3][2]);
           }
         }
 
-        if (pt3Prong >= pTThreshold3Prong) {
+        if (pt3Prong >= ptThresholds->get(0u, 1u)) {
           keepEvent[kHighPt3P] = true;
           if (activateQA) {
             for (auto iCharmPart{1}; iCharmPart < kNCharmParticles; ++iCharmPart) {
@@ -799,8 +795,8 @@ struct HfFilter { // Main struct for HF triggers
 
           float massCharmHypos[kNBeautyParticles - 2] = {massDPlus, massDs, massLc, massXic};
           float massBeautyHypos[kNBeautyParticles - 2] = {massB0, massBs, massLb, massXib};
-          float deltaMassHypos[kNBeautyParticles - 2] = {deltaMassB0, deltaMassBs, deltaMassLb, deltaMassXib};
-          if (track.sign() * sign3Prong < 0 && isSelectedTrackForSoftPionOrBeauty(trackParFourth, dcaFourth, pTMinBeautyBachelor, pTMinBeautyBachelor, pTBinsTrack, cutsSingleTrackBeauty[kBeauty4P - 2]) == kRegular) {
+          float deltaMassHypos[kNBeautyParticles - 2] = {deltaMassBeauty->get(0u, 1u), deltaMassBeauty->get(0u, 3u), deltaMassBeauty->get(0u, 4u), deltaMassBeauty->get(0u, 5u)};
+          if (track.sign() * sign3Prong < 0 && isSelectedTrackForSoftPionOrBeauty(track, trackParFourth, dcaFourth, minPtCuts->get(0u, 0u), minPtCuts->get(0u, 0u), pTBinsTrack, cutsSingleTrackBeauty[kBeauty4P - 2]) == kForBeauty) {
             for (int iHypo{0}; iHypo < kNBeautyParticles - 2 && !keepEvent[kBeauty4P]; ++iHypo) {
               if (isBeautyTagged[iHypo] && (TESTBIT(is3ProngInMass[iHypo], 0) || TESTBIT(is3ProngInMass[iHypo], 1))) {
                 auto massCandB = RecoDecay::m(std::array{pVec3Prong, pVecFourth}, std::array{massCharmHypos[iHypo], massPi});
@@ -820,7 +816,7 @@ struct HfFilter { // Main struct for HF triggers
           } // end beauty selection
 
           // 3-prong femto
-          bool isProton = isSelectedProton4Femto(track, trackParFourth, femtoMinProtonPt, femtoMaxNsigmaProton, femtoProtonOnlyTOF, setTPCCalib, hMapProton, hBBProton, activateQA, hProtonTPCPID, hProtonTOFPID);
+          bool isProton = isSelectedProton4Femto(track, trackParFourth, minPtCuts->get(0u, 2u), nSigmaPidCuts->get(0u, 3u), setTPCCalib, hMapProton, hBBProton, activateQA, hProtonTPCPID, hProtonTOFPID);
           if (isProton && track.collisionId() == thisCollId) {
             for (int iHypo{0}; iHypo < kNCharmParticles - 1 && !keepEvent[kFemto3P]; ++iHypo) {
               if (isCharmTagged[iHypo]) {
@@ -853,9 +849,15 @@ struct HfFilter { // Main struct for HF triggers
             float v0CosinePa = v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ());
             auto posTrack = v0.posTrack_as<BigTracksPID>();
             auto negTrack = v0.negTrack_as<BigTracksPID>();
-            auto selV0 = isSelectedV0(v0, std::array{posTrack, negTrack}, v0CosinePa, minCosPaGamma, minCosPaV0, minV0Radius, maxNsigmaPrForLambda, setTPCCalib, hMapProton, hBBProton, activateQA, hV0Selected, hArmPod);
+            auto selV0 = isSelectedV0(v0, std::array{posTrack, negTrack}, v0CosinePa, cutsGammaK0sLambda->get(0u, 0u), cutsGammaK0sLambda->get(0u, 1u), cutsGammaK0sLambda->get(0u, 2u), cutsGammaK0sLambda->get(0u, 3u), cutsGammaK0sLambda->get(0u, 4u), cutsGammaK0sLambda->get(0u, 5u), setTPCCalib, hMapProton, hBBProton, activateQA, hV0Selected, hArmPod);
             if (selV0 > 0) {
+              // propagate to PV
+              gpu::gpustd::array<float, 2> dcaInfo;
               std::array<float, 3> pVecV0 = {v0.px(), v0.py(), v0.pz()};
+              auto trackParV0 = o2::track::TrackPar(std::array{v0.x(), v0.y(), v0.z()}, pVecV0, 0, true);
+              o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParV0, 2.f, matCorr, &dcaInfo);
+              getPxPyPz(trackParV0, pVecV0);
+
               if (!keepEvent[kV0Charm3P] && (isGoodDsToKKPi || isGoodDsToPiKK) && TESTBIT(selV0, kPhoton)) {
                 float massDsStarToKKPiCand{-1.}, massDsStarToPiKKCand{999.};
                 float massDiffDsStarToKKPi{-1.}, massDiffDsStarToPiKK{999.};
@@ -867,8 +869,8 @@ struct HfFilter { // Main struct for HF triggers
                   massDsStarToPiKKCand = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird, pVecV0}, std::array{massPi, massK, massK, massGamma});
                   massDiffDsStarToPiKK = massDsStarToPiKKCand - massDsPiKK;
                 }
-                bool isGoodDsStarToKKPi = (massDiffDsStarToKKPi < maxMassDstarToGamma);
-                bool isGoodDsStarToPiKK = (massDiffDsStarToPiKK < maxMassDstarToGamma);
+                bool isGoodDsStarToKKPi = (massDiffDsStarToKKPi < maxDeltaMassCharmReso->get(0u, 1u));
+                bool isGoodDsStarToPiKK = (massDiffDsStarToPiKK < maxDeltaMassCharmReso->get(0u, 1u));
 
                 if (isGoodDsStarToKKPi || isGoodDsStarToPiKK) {
                   keepEvent[kV0Charm3P] = true;
@@ -888,7 +890,7 @@ struct HfFilter { // Main struct for HF triggers
                 if (TESTBIT(selV0, kK0S)) { // Ds2*
                   auto massDsStarCand = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird, pVecV0}, std::array{massPi, massK, massPi, massK0S});
                   auto massDiffDsStar = massDsStarCand - massDPlusCand;
-                  if (massDiffDsStar < maxMassDs12) {
+                  if (massDiffDsStar < maxDeltaMassCharmReso->get(0u, 4u)) {
                     if (activateQA) {
                       auto pVecReso3Prong = RecoDecay::pVec(pVec3Prong, pVecV0);
                       auto ptCand = RecoDecay::pt(pVecReso3Prong);
@@ -900,7 +902,7 @@ struct HfFilter { // Main struct for HF triggers
                 if ((TESTBIT(selV0, kLambda) && sign3Prong > 0) || (TESTBIT(selV0, kAntiLambda) && sign3Prong < 0)) { // Xic(3055) and Xic(3080)
                   auto massXicStarCand = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird, pVecV0}, std::array{massPi, massK, massPi, massLambda});
                   auto massDiffXicStar = massXicStarCand - massDPlusCand;
-                  if (massDiffXicStar < maxMassXicStar) {
+                  if (massDiffXicStar < maxDeltaMassCharmReso->get(0u, 5u)) {
                     if (activateQA) {
                       auto pVecReso3Prong = RecoDecay::pVec(pVec3Prong, pVecV0);
                       auto ptCand = RecoDecay::pt(pVecReso3Prong);
@@ -916,7 +918,81 @@ struct HfFilter { // Main struct for HF triggers
 
       } // end loop over 3-prong candidates
 
-      // TODO: add loop over lfcascades
+      if (!keepEvent[kCharmBarToXiBach]) {
+        auto cascThisColl = cascades.sliceBy(cascPerCollision, thisCollId);
+        for (auto const& casc : cascThisColl) {
+          if (!casc.v0_as<aod::V0sLinked>().has_v0Data()) { // check that V0 data are stored
+            continue;
+          }
+          auto bachelorCasc = casc.bachelor_as<BigTracksPID>();
+          auto v0 = casc.v0_as<aod::V0sLinked>();
+          auto v0Element = v0.v0Data_as<aod::V0Datas>();
+          auto v0DauPos = v0Element.posTrack_as<BigTracksPID>();
+          auto v0DauNeg = v0Element.negTrack_as<BigTracksPID>();
+          if (!isSelectedCascade(casc, v0Element, std::array{bachelorCasc, v0DauPos, v0DauNeg}, collision, cutsXiCascades->get(0u, 0u), cutsXiCascades->get(0u, 1u), cutsXiCascades->get(0u, 2u), cutsXiCascades->get(0u, 3u), setTPCCalib, hMapPion, hMapProton, hBBPion, hBBProton)) {
+            continue;
+          }
+
+          auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+          for (const auto& trackId : trackIdsThisCollision) { // start loop over tracks
+            auto track = trackId.track_as<BigTracksPID>();
+
+            // ask for opposite sign daughters (omegac daughters)
+            if (track.sign() * bachelorCasc.sign() >= 0) {
+              continue;
+            }
+
+            // check if track is one of the Xi daughters
+            if (track.globalIndex() == bachelorCasc.globalIndex() || track.globalIndex() == v0DauPos.globalIndex() || track.globalIndex() == v0DauNeg.globalIndex()) {
+              continue;
+            }
+
+            auto isSelBachelor = isSelectedBachelorForCharmBaryon(track, minPtCuts->get(0u, 3u), nSigmaPidCuts->get(0u, 4u), setTPCCalib, hMapPion, hBBPion, hBBKaon);
+            if (isSelBachelor == kRejected) {
+              continue;
+            }
+
+            // propagate to PV
+            gpu::gpustd::array<float, 2> dcaInfo;
+            std::array<float, 3> pVecCascade = {casc.px(), casc.py(), casc.pz()};
+            auto trackParCasc = o2::track::TrackPar(std::array{casc.x(), casc.y(), casc.z()}, pVecCascade, bachelorCasc.sign(), true);
+            o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCasc, 2.f, matCorr, &dcaInfo);
+            getPxPyPz(trackParCasc, pVecCascade);
+
+            auto trackParBachelor = getTrackPar(track);
+            std::array<float, 3> pVecBachelor = {track.px(), track.py(), track.pz()};
+            if (track.collisionId() != thisCollId) {
+              o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParBachelor, 2.f, noMatCorr, &dcaInfo);
+              getPxPyPz(trackParBachelor, pVecBachelor);
+            }
+
+            auto ptCharmBaryon = RecoDecay::pt(RecoDecay::pVec(pVecCascade, pVecBachelor));
+            if (ptCharmBaryon < minPtCharmBaryon) {
+              continue;
+            }
+
+            float massLimits[2] = {2.35f, 2.8f};
+            if (TESTBIT(isSelBachelor, kPionForCharmBaryon)) {
+              auto massXiPi = RecoDecay::m(std::array{pVecCascade, pVecBachelor}, std::array{massXi, massPi});
+              if (massXiPi >= massLimits[0] && massXiPi <= massLimits[1]) {
+                keepEvent[kCharmBarToXiBach] = true;
+                if (activateQA) {
+                  hMassVsPtC[kNCharmParticles + 6]->Fill(ptCharmBaryon, massXiPi);
+                }
+              }
+            }
+            if (!keepEvent[kCharmBarToXiBach] && TESTBIT(isSelBachelor, kKaonForCharmBaryon)) {
+              auto massXiKa = RecoDecay::m(std::array{pVecCascade, pVecBachelor}, std::array{massXi, massK});
+              if (massXiKa >= massLimits[0] && massXiKa <= massLimits[1]) {
+                keepEvent[kCharmBarToXiBach] = true;
+                if (activateQA) {
+                  hMassVsPtC[kNCharmParticles + 7]->Fill(ptCharmBaryon, massXiKa);
+                }
+              }
+            }
+          }
+        }
+      }
 
       auto n2Prongs = computeNumberOfCandidates(indicesDau2Prong);
       auto n3Prongs = computeNumberOfCandidates(indicesDau3Prong);
@@ -938,7 +1014,7 @@ struct HfFilter { // Main struct for HF triggers
         keepEvent[kDoubleCharmMix] = true;
       }
 
-      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P]);
+      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach]);
 
       if (!std::accumulate(keepEvent, keepEvent + kNtriggersHF, 0)) {
         hProcessedEvents->Fill(1);

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -17,6 +17,7 @@
 /// \author Marcel Lesch <marcel.lesch@tum.de>, TUM
 /// \author Alexandre Bigot <alexandre.bigot@cern.ch>, Strasbourg University
 /// \author Biao Zhang <biao.zhang@cern.ch>, CCNU
+/// \author Federica Zanone <federica.zanone@cern.ch>, CCNU
 
 #ifndef EVENTFILTERING_PWGHF_HFFILTERHELPERS_H_
 #define EVENTFILTERING_PWGHF_HFFILTERHELPERS_H_
@@ -33,7 +34,7 @@
 #include "Math/Vector3D.h"
 #include "Math/Vector4D.h"
 
-#include "CCDB/CcdbApi.h" // CCDB
+#include "CCDB/CcdbApi.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsTPC/BetheBlochAleph.h"
@@ -70,6 +71,7 @@ enum HfTriggers {
   kDoubleCharmMix,
   kV0Charm2P,
   kV0Charm3P,
+  kCharmBarToXiBach,
   kNtriggersHF
 };
 
@@ -92,10 +94,12 @@ enum beautyParticles {
   kNBeautyParticles
 };
 
-enum beautyTrackSelection {
+enum bachelorTrackSelection {
   kRejected = 0,
   kSoftPion,
-  kRegular
+  kForBeauty,
+  kPionForCharmBaryon,
+  kKaonForCharmBaryon
 };
 
 enum PIDSpecies {
@@ -116,8 +120,8 @@ enum V0Species {
 static const std::array<std::string, kNCharmParticles> charmParticleNames{"D0", "Dplus", "Ds", "Lc", "Xic"};
 static const std::array<std::string, kNBeautyParticles> beautyParticleNames{"Bplus", "B0toDStar", "B0", "Bs", "Lb", "Xib"};
 static const std::array<int, kNCharmParticles> pdgCodesCharm{421, 411, 431, 4122, 4232};
-static const std::array<std::string, kNtriggersHF + 2> eventTitles = {"all", "rejected", "w/ high-#it{p}_{T} 2p charm", "w/ high-#it{p}_{T} 3p charm", "w/ 3p beauty", "w/ 4p beauty", "w/ 2p femto", "w/ 3p femto", "w/ 2p double charm", "w/ 3p double charm", "w/ 2p and 3p double charm", "w/ 2p + V0", "w/ 3p + V0"};
-static const std::array<std::string, kNtriggersHF> hfTriggerNames{"kHighPt2P", "kHighPt3P", "kBeauty3P", "kBeauty4P", "kFemto2P", "kFemto3P", "kDoubleCharm2P", "kDoubleCharm3P", "kDoubleCharmMix", "kV0Charm2P", "kV0Charm3P"};
+static const std::array<std::string, kNtriggersHF + 2> eventTitles = {"all", "rejected", "w/ high-#it{p}_{T} 2p charm", "w/ high-#it{p}_{T} 3p charm", "w/ 3p beauty", "w/ 4p beauty", "w/ 2p femto", "w/ 3p femto", "w/ 2p double charm", "w/ 3p double charm", "w/ 2p and 3p double charm", "w/ 2p + V0", "w/ 3p + V0", "w/ charm baryon"};
+static const std::array<std::string, kNtriggersHF> hfTriggerNames{"kHighPt2P", "kHighPt3P", "kBeauty3P", "kBeauty4P", "kFemto2P", "kFemto3P", "kDoubleCharm2P", "kDoubleCharm3P", "kDoubleCharmMix", "kV0Charm2P", "kV0Charm3P", "kCharmBarToXiBach"};
 static const std::array<std::string, kNV0> v0Labels{"#gamma", "K_{S}^{0}", "#Lambda", "#bar{#Lambda}"};
 static const std::array<std::string, kNV0> v0Names{"Photon", "K0S", "Lambda", "AntiLambda"};
 
@@ -146,6 +150,7 @@ static const float massXib = RecoDecay::getMassPDG(5232);
 static const float massGamma = RecoDecay::getMassPDG(22);
 static const float massK0S = RecoDecay::getMassPDG(310);
 static const float massLambda = RecoDecay::getMassPDG(3122);
+static const float massXi = RecoDecay::getMassPDG(3312);
 
 static const AxisSpec ptAxis{50, 0.f, 50.f};
 static const AxisSpec pAxis{50, 0.f, 10.f};
@@ -156,8 +161,44 @@ static const AxisSpec alphaAxis{100, -1.f, 1.f};
 static const AxisSpec qtAxis{100, 0.f, 0.25f};
 static const AxisSpec bdtAxis{100, 0.f, 1.f};
 static const AxisSpec phiAxis{36, 0., TwoPI};
-static const std::array<AxisSpec, kNCharmParticles + 6> massAxisC = {AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.75f, 2.15f}, AxisSpec{100, 2.05f, 2.45f}, AxisSpec{100, 2.25f, 2.65f}, AxisSpec{100, 0.139f, 0.159f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 1.1f, 1.4f}};
+static const std::array<AxisSpec, kNCharmParticles + 8> massAxisC = {AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.75f, 2.15f}, AxisSpec{100, 2.05f, 2.45f}, AxisSpec{100, 2.25f, 2.65f}, AxisSpec{100, 0.139f, 0.159f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 1.1f, 1.4f}, AxisSpec{100, 2.3f, 2.9f}, AxisSpec{100, 2.3f, 2.9f}};
 static const std::array<AxisSpec, kNBeautyParticles> massAxisB = {AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 5.0f, 6.2f}, AxisSpec{240, 5.0f, 6.2f}};
+
+// default values for configurables
+
+// min pT for all tracks combined  (except for V0 and cascades)
+constexpr float cutsMinPt[1][4] = {{0.5, 0.1, 0.8, 0.5}}; // beauty, D*, femto, charm baryons
+static const std::vector<std::string> labelsColumnsMinPt = {"Beauty", "DstarPlus", "Femto", "CharmBaryon"};
+
+// min pT for all tracks combined  (except for V0 and cascades)
+constexpr float cutsNsigma[2][5] = {{3., 3., 3., 2.5, 3.},  // TPC proton from Lc, pi/K from D0, K from 3-prong, femto, pi/K from Xic/Omegac
+                                    {3., 3., 3., 2.5, 3.}}; // TOF proton from Lc, pi/K from D0, K from 3-prong, femto, pi/K from Xic/Omegac
+static const std::vector<std::string> labelsColumnsNsigma = {"PrFromLc", "PiKaFromDZero", "KaFrom3Prong", "Femto", "PiKaFromCharmBaryon"};
+static const std::vector<std::string> labelsRowsNsigma = {"TPC", "TOF"};
+
+// high pt
+constexpr float cutsHighPtThresholds[1][2] = {{8., 8.}}; // 2-prongs, 3-prongs
+static const std::vector<std::string> labelsColumnsHighPtThresholds = {"2Prongs", "3Prongs"};
+
+// beauty
+constexpr float cutsDeltaMassB[1][kNBeautyParticles + 1] = {{0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.04}}; // B+, B0, B0toDstar, Bs, Lb, Xib, charm daughter
+static const std::vector<std::string> labelsColumnsDeltaMassB = {"Bplus", "BZero", "BZeroToDstar", "Bs", "Lb", "Xib", "CharmDau"};
+
+// charm resonances
+constexpr float cutsMassCharmReso[1][6] = {{0.01, 0.4, 0.4, 0.88, 0.88, 1.4}}; // D*+, D*0, Ds*0, Ds1+, Ds2*+, Xic*
+static const std::vector<std::string> labelsColumnsDeltaMasseCharmReso = {"DstarPlus", "DstarZero", "DsStarZero", "Ds1Plus", "Ds2StarPlus", "XicStar"};
+// V0s for charm resonances
+constexpr float cutsV0s[1][6] = {{0.85, 0.95, 0.1, 4., 0.03, 0.01}}; // cosPaGamma, cosPaK0sLambda, radiusK0sLambda, nSigmaPrLambda, deltaMassK0S, deltaMassLambda
+static const std::vector<std::string> labelsColumnsV0s = {"CosPaGamma", "CosPaK0sLambda", "RadiusK0sLambda", "NSigmaPrLambda", "DeltaMassK0s", "DeltaMassLambda"};
+
+// cascades for Xi + bachelor triggers
+constexpr float cutsCascades[1][4] = {{0.15, 0.01, 0.01, 3.}}; // ptXiBachelor, deltaMassXi, deltaMassLambda, nSigmaPid
+static const std::vector<std::string> labelsColumnsCascades = {"PtBachelor", "deltaMassXi", "deltaMassLambda", "NsigmaPid"};
+
+// dummy array
+static const std::vector<std::string> labelsEmpty{};
+static constexpr double cutsTrackDummy[hf_cuts_single_track::nBinsPtTrack][hf_cuts_single_track::nCutVarsTrack] = {{0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}};
+LabeledArray<double> cutsSingleTrackDummy{cutsTrackDummy[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack};
 
 /// load the TPC spline from the CCDB
 /// \param ccdbApi is Api for CCDB
@@ -198,15 +239,20 @@ double getTPCSplineCalib(const T& track, const float mMassPar, const std::vector
 }
 
 /// Single-track cuts for bachelor track of beauty candidates
+/// \param track is a track parameter
 /// \param trackPar is a track parameter
 /// \param dca is the 2d array with dcaXY and dcaZ of the track
 /// \param pTMinSoftPion min pT for soft pions
 /// \param pTMinBeautyBachelor min pT for beauty bachelor pions
 /// \param cutsSingleTrackBeauty cuts for all tracks
 /// \return 0 if track is rejected, 1 if track is soft pion, 2 if it is regular beauty
-template <typename T1, typename T2, typename T3, typename T4>
-int isSelectedTrackForSoftPionOrBeauty(const T1& trackPar, const T2& dca, const float& pTMinSoftPion, const float& pTMinBeautyBachelor, const T3& pTBinsTrack, const T4& cutsSingleTrackBeauty)
+template <typename T, typename T1, typename T2, typename T3, typename T4>
+int isSelectedTrackForSoftPionOrBeauty(const T track, const T1& trackPar, const T2& dca, const float& pTMinSoftPion, const float& pTMinBeautyBachelor, const T3& pTBinsTrack, const T4& cutsSingleTrackBeauty)
 {
+  if (!track.isGlobalTrackWoDCA()) {
+    return kRejected;
+  }
+
   auto pT = trackPar.getPt();
   auto pTBinTrack = findBin(pTBinsTrack, pT);
   if (pTBinTrack == -1) {
@@ -237,7 +283,7 @@ int isSelectedTrackForSoftPionOrBeauty(const T1& trackPar, const T2& dca, const 
     return kSoftPion;
   }
 
-  return kRegular;
+  return kForBeauty;
 }
 
 /// Basic selection of proton candidates
@@ -245,7 +291,6 @@ int isSelectedTrackForSoftPionOrBeauty(const T1& trackPar, const T2& dca, const 
 /// \param trackPar is a track parameter
 /// \param femtoMinProtonPt min pT for proton candidates
 /// \param femtoMaxNsigmaProton max Nsigma for proton candidates
-/// \param femtoProtonOnlyTOF flag to activate PID selection with TOF only
 /// \param setTPCCalib flag to activate TPC PID postcalibrations
 /// \param hMapProton map of nSigma mean and sigma calibrations for proton
 /// \param hSplineProton spline of proton and anti-proton calibrations
@@ -254,7 +299,7 @@ int isSelectedTrackForSoftPionOrBeauty(const T1& trackPar, const T2& dca, const 
 /// \param hProtonTOFPID histo with NsigmaTOF vs. p
 /// \return true if track passes all cuts
 template <typename T1, typename T2, typename H2, typename H3>
-bool isSelectedProton4Femto(const T1& track, const T2& trackPar, const float& femtoMinProtonPt, const float& femtoMaxNsigmaProton, const bool femtoProtonOnlyTOF, const int setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H2 hProtonTPCPID, H2 hProtonTOFPID)
+bool isSelectedProton4Femto(const T1& track, const T2& trackPar, const float& femtoMinProtonPt, const float& femtoMaxNsigmaProton, const int setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H2 hProtonTPCPID, H2 hProtonTOFPID)
 {
   if (trackPar.getPt() < femtoMinProtonPt) {
     return false;
@@ -264,14 +309,12 @@ bool isSelectedProton4Femto(const T1& track, const T2& trackPar, const float& fe
     return false;
   }
 
-  // FIXME: this is applied to the wrong dca for ambiguous tracks!
-  if (track.isGlobalTrack() != (uint8_t) true) {
+  if (track.isGlobalTrack()) {
     return false; // use only global tracks
   }
 
   float NSigmaTPC = track.tpcNSigmaPr();
   float NSigmaTOF = track.tofNSigmaPr();
-  float NSigma;
 
   if (setTPCCalib == 1) {
     NSigmaTPC = getTPCPostCalib(hMapProton, track, kPr);
@@ -283,11 +326,7 @@ bool isSelectedProton4Femto(const T1& track, const T2& trackPar, const float& fe
     }
   }
 
-  if (femtoProtonOnlyTOF) {
-    NSigma = abs(NSigmaTOF);
-  } else {
-    NSigma = sqrt(NSigmaTPC * NSigmaTPC + NSigmaTOF * NSigmaTOF);
-  }
+  float NSigma = std::sqrt(NSigmaTPC * NSigmaTPC + NSigmaTOF * NSigmaTOF);
 
   if (NSigma > femtoMaxNsigmaProton) {
     return false;
@@ -681,17 +720,19 @@ int8_t isSelectedXicInMassRange(const T& pTrackSameChargeFirst, const T& pTrackS
 /// \param minV0CosinePa is the minimum required cosp of K0S/Lambda
 /// \param minV0Radius is the minimum required K0S/Lambda radius
 /// \param maxNsigmaPrForLambda is the maximum allowed nSigma TPC/TOF for protons in Lambda decays (applied only if PID info available)
+/// \param deltaMassK0s is the maximum allowed delta mass for K0S
+/// \param deltaMassLambda is the maximum allowed delta mass for Lambda
 /// \param setTPCCalib flag to activate TPC PID postcalibrations
 /// \param hMapProton map of nSigma mean and sigma calibrations for proton
 /// \param hSplineProton spline of proton and anti-proton calibrations
 /// \param activateQA flag to fill QA histos
 /// \param hV0Selected is the pointer to the QA histo for selected gammas
 /// \param hArmPod is the pointer to an array of QA histo AP plot before selection
-/// \return true if gamma passes all cuts
+/// \return an integer passes all cuts
 template <typename V0, typename T, typename H, typename H2, typename H3>
-int isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const float& v0CosinePa, const float& minGammaCosinePa, const float& minV0CosinePa, const float& minV0Radius, const float& maxNsigmaPrForLambda, const int& setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H hV0Selected, H2 hArmPod)
+int8_t isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const float& v0CosinePa, const float& minGammaCosinePa, const float& minV0CosinePa, const float& minV0Radius, const float& maxNsigmaPrForLambda, const float& deltaMassK0s, const float& deltaMassLambda, const int& setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H hV0Selected, H2 hArmPod)
 {
-  int isSelected{BIT(kPhoton) | BIT(kK0S) | BIT(kLambda) | BIT(kAntiLambda)};
+  int8_t isSelected{BIT(kPhoton) | BIT(kK0S) | BIT(kLambda) | BIT(kAntiLambda)};
 
   if (activateQA > 1) {
     for (int iV0{kPhoton}; iV0 < kNV0; ++iV0) {
@@ -743,7 +784,7 @@ int isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const float& v0Cosi
 
   // DCA V0 daughters (K0S/Lambda only)
   for (int iV0{kK0S}; iV0 < kNV0; ++iV0) {
-    if (TESTBIT(isSelected, iV0) && v0.dcaV0daughters() > 2.f) {
+    if (TESTBIT(isSelected, iV0) && v0.dcaV0daughters() > 1.f) {
       CLRBIT(isSelected, iV0);
       if (activateQA > 1) {
         hV0Selected->Fill(4., iV0);
@@ -758,19 +799,19 @@ int isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const float& v0Cosi
       hV0Selected->Fill(5., kPhoton);
     }
   }
-  if (TESTBIT(isSelected, kK0S) && std::fabs(v0.mK0Short() - massK0S) > 0.05) {
+  if (TESTBIT(isSelected, kK0S) && std::fabs(v0.mK0Short() - massK0S) > deltaMassK0s) {
     CLRBIT(isSelected, kK0S);
     if (activateQA > 1) {
       hV0Selected->Fill(5., kK0S);
     }
   }
-  if (TESTBIT(isSelected, kLambda) && std::fabs(v0.mLambda() - massLambda) > 0.05) {
+  if (TESTBIT(isSelected, kLambda) && std::fabs(v0.mLambda() - massLambda) > deltaMassLambda) {
     CLRBIT(isSelected, kLambda);
     if (activateQA > 1) {
       hV0Selected->Fill(5., kLambda);
     }
   }
-  if (TESTBIT(isSelected, kAntiLambda) && std::fabs(v0.mAntiLambda() - massLambda) > 0.05) {
+  if (TESTBIT(isSelected, kAntiLambda) && std::fabs(v0.mAntiLambda() - massLambda) > deltaMassLambda) {
     CLRBIT(isSelected, kAntiLambda);
     if (activateQA > 1) {
       hV0Selected->Fill(5., kAntiLambda);
@@ -825,7 +866,174 @@ int isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const float& v0Cosi
   return isSelected;
 }
 
-/// Single-track cuts for bachelor track of beauty candidates
+/// Basic selection of gamma candidates
+/// \param casc is the cascade candidate
+/// \param v0 is the cascade daughter
+/// \param dauTracks is a 3-element array with bachelor, positive and negative V0 daughter tracks
+/// \param collision is the collision
+/// \param minPtXiBachelor is the minimum required pT for the cascade bachelor
+/// \param deltaMassXi is the maximum delta mass for the Xi
+/// \param deltaMassLambda is the maximum delta mass for the Lambda daughter
+/// \param setTPCCalib flag to activate TPC PID postcalibrations
+/// \param hMapProton map of nSigma mean and sigma calibrations for proton
+/// \param hMapPion map of nSigma mean and sigma calibrations for pion
+/// \param hSplineProton spline of proton and anti-proton calibrations
+/// \param hSplinePion spline of pion and anti-pion calibrations
+/// \return true if cascade passes all cuts
+template <typename Casc, typename V0, typename T, typename Coll, typename H3>
+bool isSelectedCascade(const Casc& casc, const V0& v0, const array<T, 3>& dauTracks, const Coll& collision, const float& minPtXiBachelor, const float& deltaMassXi, const float& deltaMassLambda, const float& maxNsigma, const int& setTPCCalib, H3 hMapPion, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplinePion, const std::array<std::vector<double>, 2>& hSplineProton)
+{
+  // eta of daughters
+  if (std::fabs(dauTracks[0].eta()) > 1. || std::fabs(dauTracks[1].eta()) > 1. || std::fabs(dauTracks[2].eta()) > 1.) { // cut all V0 daughters with |eta| > 1.
+    return false;
+  }
+
+  // V0 radius
+  if (v0.v0radius() < 1.2) {
+    return false;
+  }
+
+  // cascade radius
+  if (casc.cascradius() < 0.6) {
+    return false;
+  }
+
+  // V0 cosp
+  if (casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < 0.95) {
+    return false;
+  };
+
+  // cascade cosp
+  if (casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) < 0.95) {
+    return false;
+  };
+
+  // Xi bachelor min pT
+  if (dauTracks[0].pt() < minPtXiBachelor) {
+    return false;
+  };
+
+  // cascade mass
+  if (std::fabs(casc.mXi() - massXi) < deltaMassXi) {
+    return false;
+  };
+
+  // V0 mass
+  if (std::fabs(casc.mLambda() - massLambda) < deltaMassLambda) {
+    return false;
+  };
+
+  // PID
+  float nSigmaPrTpc[3] = {-999., dauTracks[1].tpcNSigmaPr(), dauTracks[2].tpcNSigmaPr()};
+  float nSigmaPrTof[3] = {-999., dauTracks[1].tofNSigmaPr(), dauTracks[2].tofNSigmaPr()};
+  float nSigmaPiTpc[3] = {dauTracks[0].tpcNSigmaPr(), dauTracks[1].tpcNSigmaPr(), dauTracks[2].tpcNSigmaPr()};
+  float nSigmaPiTof[3] = {dauTracks[0].tofNSigmaPr(), dauTracks[1].tofNSigmaPr(), dauTracks[2].tofNSigmaPr()};
+  if (setTPCCalib == 1) {
+    for (int iDau{0}; iDau < 3; ++iDau) {
+      nSigmaPiTpc[iDau] = getTPCPostCalib(hMapPion, dauTracks[iDau], kPi);
+      if (iDau == 0) {
+        return false;
+      }
+      nSigmaPrTpc[iDau - 1] = getTPCPostCalib(hMapProton, dauTracks[iDau], kPr);
+    }
+  } else if (setTPCCalib == 2) {
+    for (int iDau{0}; iDau < 3; ++iDau) {
+      nSigmaPiTpc[iDau] = getTPCSplineCalib(dauTracks[iDau], massPi, (dauTracks[iDau].sign() > 0) ? hSplinePion[0] : hSplinePion[1]);
+      if (iDau == 0) {
+        return false;
+      }
+      nSigmaPrTpc[iDau - 1] = getTPCSplineCalib(dauTracks[iDau], massProton, (dauTracks[iDau].sign() > 0) ? hSplineProton[0] : hSplineProton[1]);
+    }
+  }
+
+  // PID to V0 tracks
+  if (dauTracks[0].sign() < 0) { // Xi-
+    if ((dauTracks[1].hasTPC() && std::fabs(nSigmaPrTpc[1] > maxNsigma)) && (dauTracks[1].hasTOF() && std::fabs(nSigmaPrTof[1] > maxNsigma))) {
+      return false;
+    }
+    if ((dauTracks[2].hasTPC() && std::fabs(nSigmaPiTpc[2] > maxNsigma)) && (dauTracks[2].hasTOF() && std::fabs(nSigmaPiTof[2] > maxNsigma))) {
+      return false;
+    }
+  } else if (dauTracks[0].sign() > 0) { // Xi+
+    if ((dauTracks[2].hasTPC() && std::fabs(nSigmaPrTpc[2] > maxNsigma)) && (dauTracks[2].hasTOF() && std::fabs(nSigmaPrTof[2] > maxNsigma))) {
+      return false;
+    }
+    if ((dauTracks[1].hasTPC() && std::fabs(nSigmaPiTpc[1] > maxNsigma)) && (dauTracks[1].hasTOF() && std::fabs(nSigmaPiTof[1] > maxNsigma))) {
+      return false;
+    }
+  }
+
+  // bachelor PID
+  if ((dauTracks[0].hasTPC() && std::fabs(nSigmaPiTpc[0] > maxNsigma)) && (dauTracks[0].hasTOF() && std::fabs(nSigmaPiTof[0] > maxNsigma))) {
+    return false;
+  }
+
+  // additional track cuts
+  for (auto const& dauTrack : dauTracks) {
+    //  TPC clusters selections
+    if (dauTrack.tpcNClsFound() < 70) { // TODO: put me as a configurable please
+      return false;
+    }
+    if (dauTrack.tpcNClsCrossedRows() < 70) {
+      return false;
+    }
+    if (dauTrack.tpcCrossedRowsOverFindableCls() < 0.8) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/// Single-track cuts for bachelor track of charm baryon candidates
+/// \param track is a track
+/// \param minPt is the minimum pT
+/// \param maxNsigma is the maximum nSigma TPC/TOF for pions and kaons
+/// \param setTPCCalib flag to activate TPC PID postcalibrations
+/// \param hMapPion map of nSigma mean and sigma calibrations for pion
+/// \param hSplinePion spline of pion and anti-pion calibrations
+/// \param hSplineKaon spline of kaon and anti-kaon calibrations
+/// \return 0 if rejected, or a bitmap that contains the information whether it is selected as pion and/or kaon
+template <typename T, typename H3>
+int8_t isSelectedBachelorForCharmBaryon(const T& track, const float& minPt, const float& maxNsigma, const int& setTPCCalib, H3 hMapPion, const std::array<std::vector<double>, 2>& hSplinePion, const std::array<std::vector<double>, 2>& hSplineKaon)
+{
+  int8_t retValue{BIT(kPionForCharmBaryon) | BIT(kKaonForCharmBaryon)};
+
+  if (std::fabs(track.pt()) < minPt) {
+    return kRejected;
+  }
+
+  if (track.tpcNClsFound() < 70) {
+    return kRejected;
+  }
+
+  if (track.itsNCls() < 3) {
+    return kRejected;
+  }
+
+  float nSigmaPiTpc = track.tpcNSigmaPi();
+  float nSigmaKaTpc = track.tpcNSigmaKa();
+  float nSigmaPiTof = track.tofNSigmaPi();
+  float nSigmaKaTof = track.tofNSigmaKa();
+  if (setTPCCalib == 1) {
+    nSigmaPiTpc = getTPCPostCalib(hMapPion, track, kPi);
+    nSigmaKaTpc = getTPCPostCalib(hMapPion, track, kKa);
+  } else if (setTPCCalib == 2) {
+    nSigmaPiTpc = getTPCSplineCalib(track, massPi, (track.sign() > 0) ? hSplinePion[0] : hSplinePion[1]);
+    nSigmaKaTpc = getTPCSplineCalib(track, massK, (track.sign() > 0) ? hSplineKaon[0] : hSplineKaon[1]);
+  }
+
+  if ((track.hasTPC() && std::fabs(nSigmaPiTpc > maxNsigma)) && (track.hasTOF() && std::fabs(nSigmaPiTof > maxNsigma))) {
+    CLRBIT(retValue, kPionForCharmBaryon);
+  }
+  if ((track.hasTPC() && std::fabs(nSigmaKaTpc > maxNsigma)) && (track.hasTOF() && std::fabs(nSigmaKaTof > maxNsigma))) {
+    CLRBIT(retValue, kKaonForCharmBaryon);
+  }
+
+  return retValue;
+}
+
+/// BDT selections
 /// \param scores is a 3-element array with BDT out scores
 /// \param thresholdBDTScores is the LabelledArray containing the BDT cut values
 /// \return 0 if rejected, otherwise bitmap with BIT(RecoDecay::OriginType::Prompt) and/or BIT(RecoDecay::OriginType::NonPrompt) on
@@ -837,13 +1045,13 @@ int8_t isBDTSelected(const T& scores, const U& thresholdBDTScores)
     return retValue;
   }
 
-  if (scores[0] > thresholdBDTScores.get(0u, "BDTbkg")) {
+  if (scores[0] > thresholdBDTScores.get(0u, 0u)) {
     return retValue;
   }
-  if (scores[1] > thresholdBDTScores.get(0u, "BDTprompt")) {
+  if (scores[1] > thresholdBDTScores.get(0u, 1u)) {
     retValue |= BIT(RecoDecay::OriginType::Prompt);
   }
-  if (scores[2] > thresholdBDTScores.get(0u, "BDTnonprompt")) {
+  if (scores[2] > thresholdBDTScores.get(0u, 2u)) {
     retValue |= BIT(RecoDecay::OriginType::NonPrompt);
   }
 
@@ -1028,6 +1236,7 @@ float getTPCPostCalib(const array<H3, 2>& hCalibMap, const T& track, const int p
 
   return (tpcNSigma - mean) / width;
 }
+
 } // namespace hffilters
 
 /// definition of tables

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -901,27 +901,27 @@ bool isSelectedCascade(const Casc& casc, const V0& v0, const array<T, 3>& dauTra
   // V0 cosp
   if (casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) < 0.95) {
     return false;
-  };
+  }
 
   // cascade cosp
   if (casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) < 0.95) {
     return false;
-  };
+  }
 
   // Xi bachelor min pT
   if (dauTracks[0].pt() < minPtXiBachelor) {
     return false;
-  };
+  }
 
   // cascade mass
   if (std::fabs(casc.mXi() - massXi) < deltaMassXi) {
     return false;
-  };
+  }
 
   // V0 mass
   if (std::fabs(casc.mLambda() - massLambda) < deltaMassLambda) {
     return false;
-  };
+  }
 
   // PID
   float nSigmaPrTpc[3] = {-999., dauTracks[1].tpcNSigmaPr(), dauTracks[2].tpcNSigmaPr()};

--- a/EventFiltering/PWGHF/HFFilterQC.cxx
+++ b/EventFiltering/PWGHF/HFFilterQC.cxx
@@ -110,10 +110,11 @@ struct HfFilterQc { // Main struct for HF trigger QC
     bool hasDoubleCharm2P = filterDecision.hasHfDoubleCharm2P();
     bool hasDoubleCharm3P = filterDecision.hasHfDoubleCharm3P();
     bool hasDoubleCharmMix = filterDecision.hasHfDoubleCharmMix();
-    bool hasHfSoftGamma2P = filterDecision.hasHfSoftGamma2P();
-    bool hasHfSoftGamma3P = filterDecision.hasHfSoftGamma3P();
-    bool isTriggered = hasHighPt2P || hasHighPt3P || hasBeauty3P || hasBeauty4P || hasFemto2P || hasFemto3P || hasDoubleCharm2P || hasDoubleCharm3P || hasDoubleCharmMix || hasHfSoftGamma2P || hasHfSoftGamma3P;
-    auto triggerDecision = std::array{isTriggered, hasHighPt2P, hasHighPt3P, hasBeauty3P, hasBeauty4P, hasFemto2P, hasFemto3P, hasDoubleCharm2P, hasDoubleCharm3P, hasDoubleCharmMix, hasHfSoftGamma2P, hasHfSoftGamma3P};
+    bool hasHfV02P = filterDecision.hasHfV0Charm2P();
+    bool hasHfV03P = filterDecision.hasHfV0Charm3P();
+    bool hasCharmBarToXiBach = filterDecision.hasHfCharmBarToXiBach();
+    bool isTriggered = hasHighPt2P || hasHighPt3P || hasBeauty3P || hasBeauty4P || hasFemto2P || hasFemto3P || hasDoubleCharm2P || hasDoubleCharm3P || hasDoubleCharmMix || hasHfV02P || hasHfV03P || hasCharmBarToXiBach;
+    auto triggerDecision = std::array{isTriggered, hasHighPt2P, hasHighPt3P, hasBeauty3P, hasBeauty4P, hasFemto2P, hasFemto3P, hasDoubleCharm2P, hasDoubleCharm3P, hasDoubleCharmMix, hasHfV02P, hasHfV03P, hasCharmBarToXiBach};
 
     std::array<int, kNCharmParticles> nPart{0};
     // Loop over the MC particles

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -38,17 +38,18 @@ DECLARE_SOA_COLUMN(DiElectron, hasDiElectron, bool);     //! dielectron trigger
 DECLARE_SOA_COLUMN(DiMuon, hasDiMuon, bool);             //! dimuon trigger with low pT on muons
 
 // heavy flavours
-DECLARE_SOA_COLUMN(HfHighPt2P, hasHfHighPt2P, bool);             //! high-pT 2-prong charm hadron
-DECLARE_SOA_COLUMN(HfHighPt3P, hasHfHighPt3P, bool);             //! high-pT 3-prong charm hadron
-DECLARE_SOA_COLUMN(HfBeauty3P, hasHfBeauty3P, bool);             //! 3-prong beauty hadron
-DECLARE_SOA_COLUMN(HfBeauty4P, hasHfBeauty4P, bool);             //! 4-prong beauty hadron
-DECLARE_SOA_COLUMN(HfFemto2P, hasHfFemto2P, bool);               //! 2-prong charm-hadron - N pair
-DECLARE_SOA_COLUMN(HfFemto3P, hasHfFemto3P, bool);               //! 3-prong charm-hadron - N pair
-DECLARE_SOA_COLUMN(HfDoubleCharm2P, hasHfDoubleCharm2P, bool);   //! at least two 2-prong charm-hadron candidates
-DECLARE_SOA_COLUMN(HfDoubleCharm3P, hasHfDoubleCharm3P, bool);   //! at least two 3-prong charm-hadron candidates
-DECLARE_SOA_COLUMN(HfDoubleCharmMix, hasHfDoubleCharmMix, bool); //! at least one 2-prong and one 3-prong charm-hadron candidates
-DECLARE_SOA_COLUMN(HfSoftGamma2P, hasHfSoftGamma2P, bool);       //! soft gamma with 2-prong charm hadron
-DECLARE_SOA_COLUMN(HfSoftGamma3P, hasHfSoftGamma3P, bool);       //! soft gamma with 3-prong charm hadron
+DECLARE_SOA_COLUMN(HfHighPt2P, hasHfHighPt2P, bool);                 //! high-pT 2-prong charm hadron
+DECLARE_SOA_COLUMN(HfHighPt3P, hasHfHighPt3P, bool);                 //! high-pT 3-prong charm hadron
+DECLARE_SOA_COLUMN(HfBeauty3P, hasHfBeauty3P, bool);                 //! 3-prong beauty hadron
+DECLARE_SOA_COLUMN(HfBeauty4P, hasHfBeauty4P, bool);                 //! 4-prong beauty hadron
+DECLARE_SOA_COLUMN(HfFemto2P, hasHfFemto2P, bool);                   //! 2-prong charm-hadron - N pair
+DECLARE_SOA_COLUMN(HfFemto3P, hasHfFemto3P, bool);                   //! 3-prong charm-hadron - N pair
+DECLARE_SOA_COLUMN(HfDoubleCharm2P, hasHfDoubleCharm2P, bool);       //! at least two 2-prong charm-hadron candidates
+DECLARE_SOA_COLUMN(HfDoubleCharm3P, hasHfDoubleCharm3P, bool);       //! at least two 3-prong charm-hadron candidates
+DECLARE_SOA_COLUMN(HfDoubleCharmMix, hasHfDoubleCharmMix, bool);     //! at least one 2-prong and one 3-prong charm-hadron candidates
+DECLARE_SOA_COLUMN(HfV0Charm2P, hasHfV0Charm2P, bool);               //! V0 with 2-prong charm hadron
+DECLARE_SOA_COLUMN(HfV0Charm3P, hasHfV0Charm3P, bool);               //! V0 with 3-prong charm hadron
+DECLARE_SOA_COLUMN(HfCharmBarToXiBach, hasHfCharmBarToXiBach, bool); //! Charm baryon to Xi + bachelor
 
 // CF two body triggers
 DECLARE_SOA_COLUMN(PD, hasPD, bool); //! has d-p pair
@@ -142,7 +143,7 @@ using DqFilter = DqFilters::iterator;
 
 // heavy flavours
 DECLARE_SOA_TABLE(HfFilters, "AOD", "HfFilters", //!
-                  filtering::HfHighPt2P, filtering::HfHighPt3P, filtering::HfBeauty3P, filtering::HfBeauty4P, filtering::HfFemto2P, filtering::HfFemto3P, filtering::HfDoubleCharm2P, filtering::HfDoubleCharm3P, filtering::HfDoubleCharmMix, filtering::HfSoftGamma2P, filtering::HfSoftGamma3P);
+                  filtering::HfHighPt2P, filtering::HfHighPt3P, filtering::HfBeauty3P, filtering::HfBeauty4P, filtering::HfFemto2P, filtering::HfFemto3P, filtering::HfDoubleCharm2P, filtering::HfDoubleCharm3P, filtering::HfDoubleCharmMix, filtering::HfV0Charm2P, filtering::HfV0Charm3P, filtering::HfCharmBarToXiBach);
 
 using HfFilter = HfFilters::iterator;
 


### PR DESCRIPTION
This PR was implemented with @ZFederica. It adds:
- triggers for charm baryon --> Xi + Pi/K
- reorganisation of configurables to avoid hitting the limit of data members