### PR TITLE
PWGHF: change indexes in toXiPi tasks

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -256,7 +256,7 @@ struct HfCandidateCreatorToXiPi {
           }
 
           // check not to take the same particle twice in the decay chain
-          if (trackPion.globalIndex() == trackXiDauCharged.globalIndex() || trackPion.globalIndex() == trackV0Dau0.globalIndex() || trackPion.globalIndex() == trackV0Dau1.globalIndex() || trackPion.globalIndex() == casc.globalIndex()) {
+          if (trackPion.globalIndex() == trackXiDauCharged.globalIndex() || trackPion.globalIndex() == trackV0Dau0.globalIndex() || trackPion.globalIndex() == trackV0Dau1.globalIndex()) {
             continue;
           }
 

--- a/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
@@ -49,7 +49,7 @@ struct HfCandidateSelectorToXiPi {
   Configurable<double> invMassOmegacMax{"invMassOmegacMax", 3.1, "Upper limit invariant mass spectrum charm baryon"};
 
   // kinematic selections
-  Configurable<double> etaTrackMax{"etaTrackMax", 1.0, "Max absolute value of eta"};
+  Configurable<double> etaTrackMax{"etaTrackMax", 0.8, "Max absolute value of eta"};
   Configurable<double> ptPiFromCascMin{"ptPiFromCascMin", 0.15, "Min pT pi <- casc"};
   Configurable<double> ptPiFromOmeMin{"ptPiFromOmeMin", 0.2, "Min pT pi <- omegac"};
 

--- a/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
@@ -49,7 +49,7 @@ struct HfCandidateSelectorToXiPi {
   Configurable<double> invMassOmegacMax{"invMassOmegacMax", 3.1, "Upper limit invariant mass spectrum charm baryon"};
 
   // kinematic selections
-  Configurable<double> etaTrackMax{"etaTrackMax", 0.8, "Max absolute value of eta"};
+  Configurable<double> etaTrackMax{"etaTrackMax", 1.0, "Max absolute value of eta"};
   Configurable<double> ptPiFromCascMin{"ptPiFromCascMin", 0.15, "Min pT pi <- casc"};
   Configurable<double> ptPiFromOmeMin{"ptPiFromOmeMin", 0.2, "Min pT pi <- omegac"};
 

--- a/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPi.cxx
@@ -549,7 +549,7 @@ struct HfCandidateSelectorToXiPi {
 
         if (candidate.collisionId() != collId) {
           hNEventsSaved->Fill(0.5);
-          collId = trackPiFromCasc.collisionId();
+          collId = candidate.collisionId();
         }
       }
     }


### PR DESCRIPTION
- remove comparison index cascade-index track pi <- charm (wrong) in creator
- implement check on different index when filling saved events histogram (selector)