### PR TITLE
Mult QA: add process function for event studies at low mult

### DIFF
--- a/Common/Tasks/multiplicityQa.cxx
+++ b/Common/Tasks/multiplicityQa.cxx
@@ -94,7 +94,7 @@ struct MultiplicityQa {
     histos.add("multiplicityQa/hVtxZNTracksPV", "Av NTracks vs vertex Z", kTProfile, {axisVertexZ});
 
     // two-dimensional histograms
-    if( do2Dplots ){
+    if (do2Dplots) {
       histos.add("multiplicityQa/h2dNchVsFV0", "FV0", kTH2F, {axisMultFV0, axisMultNTracks});
       histos.add("multiplicityQa/h2dNchVsFT0", "FT0", kTH2F, {axisMultFT0, axisMultNTracks});
       histos.add("multiplicityQa/h2dNchVsFT0A", "FT0A", kTH2F, {axisMultFT0A, axisMultNTracks});
@@ -164,7 +164,7 @@ struct MultiplicityQa {
     histos.fill(HIST("multiplicityQa/hZeqNTracksPV"), col.multZeqNTracksPV());
 
     // Profiles
-    if (useZeqInProfiles && do2Dplots ) {
+    if (useZeqInProfiles && do2Dplots) {
       histos.fill(HIST("multiplicityQa/h2dNchVsFV0"), col.multZeqFV0A(), col.multZeqNTracksPV());
       histos.fill(HIST("multiplicityQa/h2dNchVsFT0"), col.multZeqFT0A() + col.multZeqFT0C(), col.multZeqNTracksPV());
       histos.fill(HIST("multiplicityQa/h2dNchVsFT0A"), col.multZeqFT0A(), col.multZeqNTracksPV());
@@ -276,9 +276,9 @@ struct MultiplicityQa {
 
     // verify that PV has collision
     if (!col.has_mcCollision())
-      return; 
-    
-    auto mcCollision = col.mcCollision_as<soa::Join<aod::McCollisions, aod::McCollsExtra>>(); 
+      return;
+
+    auto mcCollision = col.mcCollision_as<soa::Join<aod::McCollisions, aod::McCollsExtra>>();
     if (mcCollision.hasRecoCollision() < 1)
       return; // total paranoia mode: on
 

--- a/Common/Tasks/multiplicityQa.cxx
+++ b/Common/Tasks/multiplicityQa.cxx
@@ -27,6 +27,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/EventSelection.h"
+#include "PWGLF/DataModel/LFQATables.h"
 #include "TH1F.h"
 #include "TH2F.h"
 
@@ -41,56 +42,29 @@ struct MultiplicityQa {
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Configurable<int> selection{"sel", 7, "trigger: 7 - sel7, 8 - sel8"};
   Configurable<float> vtxZsel{"vtxZsel", 10, "max vertex Z (cm)"};
-  Configurable<bool> INELgtZERO{"INELgtZERO", 1, "0 - no, 1 - yes"};
+  Configurable<bool> INELgtZERO{"INELgtZERO", true, "0 - no, 1 - yes"};
+  Configurable<bool> do2Dplots{"do2Dplots", false, "0 - no, 1 - yes"};
 
-  Configurable<int> NBinsMultFV0{"NBinsMultFV0", 1000, "N bins FV0"};
-  Configurable<int> NBinsMultFT0{"NBinsMultFT0", 1000, "N bins FT0"};
-  Configurable<int> NBinsMultFT0A{"NBinsMultFT0A", 1000, "N bins FT0A"};
-  Configurable<int> NBinsMultFT0C{"NBinsMultFT0C", 1000, "N bins FT0C"};
-  Configurable<int> NBinsMultFDD{"NBinsMultFDD", 1000, "N bins FDD"};
-  Configurable<int> NBinsMultNTracks{"NBinsMultNTracks", 1000, "N bins Ntracks"};
+  ConfigurableAxis axisMultFV0{"axisMultFV0", {10000, 0, 500000}, "FV0 amplitude"};
+  ConfigurableAxis axisMultFT0{"axisMultFT0", {10000, 0, 40000}, "FT0 amplitude"};
+  ConfigurableAxis axisMultFT0A{"axisMultFT0A", {10000, 0, 30000}, "FT0A amplitude"};
+  ConfigurableAxis axisMultFT0C{"axisMultFT0C", {10000, 0, 10000}, "FT0C amplitude"};
+  ConfigurableAxis axisMultFDD{"axisMultFDD", {1000, 0, 4000}, "FDD amplitude"};
+  ConfigurableAxis axisMultNTracks{"axisMultNTracks", {500, 0, 500}, "N_{tracks}"};
+  ConfigurableAxis axisVertexZ{"axisVertexZ", {60, -15, 15}, "Vertex z (cm)"};
 
-  Configurable<int> NBinsMultFV02d{"NBinsMultFV02d", 100, "N bins FV0 in 2D"};
-  Configurable<int> NBinsMultFT02d{"NBinsMultFT02d", 100, "N bins FT0 in 2D"};
-  Configurable<int> NBinsMultFT0A2d{"NBinsMultFT0A2d", 100, "N bins FT0A in 2D"};
-  Configurable<int> NBinsMultFT0C2d{"NBinsMultFT0C2d", 100, "N bins FT0C in 2D"};
-  Configurable<int> NBinsMultFDD2d{"NBinsMultFDD2d", 100, "N bins FDD in 2D"};
-  Configurable<int> NBinsMultNTracks2d{"NBinsMultNTracks2d", 100, "N bins Ntracks in 2D"};
-  Configurable<int> NBinsNContributors{"NBinsNContributors", 100, "N bins Ntracks in 2D"};
+  ConfigurableAxis axisContributors{"axisContributors", {100, -0.5f, 99.5f}, "Vertex z (cm)"};
+  ConfigurableAxis axisNumberOfPVs{"axisNumberOfPVs", {10, -0.5f, 9.5f}, "Number of reconstructed PVs"};
 
-  Configurable<float> MaxMultFV0{"MaxMultFV0", 20000, "Max FV0 signal"};
-  Configurable<float> MaxMultFT0{"MaxMultFT0", 10000, "Max FT0 signal"};
-  Configurable<float> MaxMultFT0A{"MaxMultFT0A", 10000, "Max FT0A signal"};
-  Configurable<float> MaxMultFT0C{"MaxMultFT0C", 10000, "Max FT0C signal"};
-  Configurable<float> MaxMultFDD{"MaxMultFDD", 10000, "Max FDD signal"};
-  Configurable<float> MaxMultNTracks{"MaxMultNTracks", 1000, "Max Ntracks"};
-  Configurable<float> MaxNContributors{"MaxNContributors", 200, "Max NContributors"};
-  Configurable<int> NBinsVertexZ{"NBinsVertexZ", 400, "max vertex Z (cm)"};
   Configurable<bool> useZeqInProfiles{"useZeqInProfiles", true, "use Z-equalized signals in midrap Nch profiles"};
 
   void init(InitContext&)
   {
     const AxisSpec axisEvent{10, 0, 10, "Event counter"};
-    const AxisSpec axisMultFV0{(int)NBinsMultFV0, 0, MaxMultFV0, "FV0 total amplitude"};
-    const AxisSpec axisMultFT0{(int)NBinsMultFT0, 0, MaxMultFT0, "FT0 total amplitude"};
-    const AxisSpec axisMultFT0A{(int)NBinsMultFT0A, 0, MaxMultFT0A, "FT0A total amplitude"};
-    const AxisSpec axisMultFT0C{(int)NBinsMultFT0C, 0, MaxMultFT0C, "FT0C total amplitude"};
-    const AxisSpec axisMultFDD{(int)NBinsMultFDD, 0, MaxMultFDD, "FDD total amplitude"};
-    const AxisSpec axisMultNTracks{(int)NBinsMultNTracks, 0, MaxMultNTracks, "Track counter"};
-
-    const AxisSpec axisMultFV02d{(int)NBinsMultFV02d, 0, MaxMultFV0, "FV0 total amplitude"};
-    const AxisSpec axisMultFT02d{(int)NBinsMultFT02d, 0, MaxMultFT0, "FT0 total amplitude"};
-    const AxisSpec axisMultFT0A2d{(int)NBinsMultFT0A2d, 0, MaxMultFT0A, "FT0A total amplitude"};
-    const AxisSpec axisMultFT0C2d{(int)NBinsMultFT0C2d, 0, MaxMultFT0C, "FT0C total amplitude"};
-    const AxisSpec axisMultFDD2d{(int)NBinsMultFDD2d, 0, MaxMultFDD, "FDD total amplitude"};
-    const AxisSpec axisMultNTracks2d{(int)NBinsMultNTracks2d, 0, MaxMultNTracks, "Track counter"};
-
-    const AxisSpec axisVertexZ{(int)NBinsVertexZ, -20, 20, "Vertex Z (cm)"};
-    const AxisSpec axisContributorsTRD{(int)NBinsNContributors, -0.5f, MaxNContributors - 0.5f, "N_{contribs}^{TRD}"};
-    const AxisSpec axisContributorsTOF{(int)NBinsNContributors, -0.5f, MaxNContributors - 0.5f, "N_{contribs}^{TOF}"};
 
     //Base histograms
     histos.add("multiplicityQa/hEventCounter", "Event counter", kTH1D, {axisEvent});
+
     histos.add("multiplicityQa/hRawFV0", "Raw FV0", kTH1D, {axisMultFV0});
     histos.add("multiplicityQa/hRawFT0", "Raw FT0", kTH1D, {axisMultFT0});
     histos.add("multiplicityQa/hRawFT0A", "Raw FT0A", kTH1D, {axisMultFT0A});
@@ -119,15 +93,23 @@ struct MultiplicityQa {
     histos.add("multiplicityQa/hVtxZFDDC", "Av FDDC vs vertex Z", kTProfile, {axisVertexZ});
     histos.add("multiplicityQa/hVtxZNTracksPV", "Av NTracks vs vertex Z", kTProfile, {axisVertexZ});
 
-    // profiles of track contributors
-    histos.add("multiplicityQa/hNchProfileFV0", "FV0", kTH2F, {axisMultFV02d, axisMultNTracks2d});
-    histos.add("multiplicityQa/hNchProfileFT0", "FT0", kTH2F, {axisMultFT02d, axisMultNTracks2d});
-    histos.add("multiplicityQa/hNchProfileFT0A", "FT0A", kTH2F, {axisMultFT0A2d, axisMultNTracks2d});
-    histos.add("multiplicityQa/hNchProfileFT0C", "FT0C", kTH2F, {axisMultFT0C2d, axisMultNTracks2d});
-    histos.add("multiplicityQa/hNchProfileFDD", "FDD", kTH2F, {axisMultFDD2d, axisMultNTracks2d});
+    // two-dimensional histograms
+    if( do2Dplots ){
+      histos.add("multiplicityQa/h2dNchVsFV0", "FV0", kTH2F, {axisMultFV0, axisMultNTracks});
+      histos.add("multiplicityQa/h2dNchVsFT0", "FT0", kTH2F, {axisMultFT0, axisMultNTracks});
+      histos.add("multiplicityQa/h2dNchVsFT0A", "FT0A", kTH2F, {axisMultFT0A, axisMultNTracks});
+      histos.add("multiplicityQa/h2dNchVsFT0C", "FT0C", kTH2F, {axisMultFT0C, axisMultNTracks});
+      histos.add("multiplicityQa/h2dNchVsFDD", "FDD", kTH2F, {axisMultFDD, axisMultNTracks});
+
+      histos.add("multiplicityQa/h2dPVsVsFV0", "FV0", kTH2F, {axisMultFV0, axisNumberOfPVs});
+      histos.add("multiplicityQa/h2dPVsVsFT0", "FT0", kTH2F, {axisMultFT0, axisNumberOfPVs});
+      histos.add("multiplicityQa/h2dPVsVsFT0A", "FT0A", kTH2F, {axisMultFT0A, axisNumberOfPVs});
+      histos.add("multiplicityQa/h2dPVsVsFT0C", "FT0C", kTH2F, {axisMultFT0C, axisNumberOfPVs});
+      histos.add("multiplicityQa/h2dPVsVsFDD", "FDD", kTH2F, {axisMultFDD, axisNumberOfPVs});
+    }
 
     // Contributors correlation
-    histos.add("h2dNContribCorrAll", "h2dNContribCorrAll", kTH2D, {axisContributorsTRD, axisContributorsTOF});
+    histos.add("h2dNContribCorrAll", "h2dNContribCorrAll", kTH2D, {axisContributors, axisContributors});
   }
 
   void processCollisions(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::MultZeqs>::iterator const& col)
@@ -182,21 +164,20 @@ struct MultiplicityQa {
     histos.fill(HIST("multiplicityQa/hZeqNTracksPV"), col.multZeqNTracksPV());
 
     // Profiles
-    if (useZeqInProfiles) {
-      histos.fill(HIST("multiplicityQa/hNchProfileFV0"), col.multZeqFV0A(), col.multZeqNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0"), col.multZeqFT0A() + col.multZeqFT0C(), col.multZeqNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0A"), col.multZeqFT0A(), col.multZeqNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0C"), col.multZeqFT0C(), col.multZeqNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFDD"), col.multZeqFDDA() + col.multZeqFDDC(), col.multZeqNTracksPV());
+    if (useZeqInProfiles && do2Dplots ) {
+      histos.fill(HIST("multiplicityQa/h2dNchVsFV0"), col.multZeqFV0A(), col.multZeqNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0"), col.multZeqFT0A() + col.multZeqFT0C(), col.multZeqNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0A"), col.multZeqFT0A(), col.multZeqNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0C"), col.multZeqFT0C(), col.multZeqNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFDD"), col.multZeqFDDA() + col.multZeqFDDC(), col.multZeqNTracksPV());
     } else {
-      histos.fill(HIST("multiplicityQa/hNchProfileFV0"), col.multFV0A(), col.multNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0"), col.multFT0A() + col.multFT0C(), col.multNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0A"), col.multFT0A(), col.multNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFT0C"), col.multFT0C(), col.multNTracksPV());
-      histos.fill(HIST("multiplicityQa/hNchProfileFDD"), col.multFDDA() + col.multFDDC(), col.multNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFV0"), col.multFV0A(), col.multNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0"), col.multFT0A() + col.multFT0C(), col.multNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0A"), col.multFT0A(), col.multNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFT0C"), col.multFT0C(), col.multNTracksPV());
+      histos.fill(HIST("multiplicityQa/h2dNchVsFDD"), col.multFDDA() + col.multFDDC(), col.multNTracksPV());
     }
   }
-  PROCESS_SWITCH(MultiplicityQa, processCollisions, "per-collision analysis", true);
 
   void processBCs(BCsWithRun3Matchings::iterator const& bc,
                   aod::FV0As const&,
@@ -243,7 +224,6 @@ struct MultiplicityQa {
     histos.fill(HIST("multiplicityQa/hPerBCRawFT0C"), multFT0C);
     histos.fill(HIST("multiplicityQa/hPerBCRawFDD"), multFDDA + multFDDC);
   }
-  PROCESS_SWITCH(MultiplicityQa, processBCs, "per-BC analysis", true);
 
   void processCollisionsPVChecks(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::MultZeqs>::iterator const& col, soa::Join<aod::TracksIU, aod::TracksExtra> const& tracks)
   {
@@ -277,7 +257,50 @@ struct MultiplicityQa {
     }
     histos.fill(HIST("h2dNContribCorrAll"), NcontribsTRD, NcontribsTOF);
   }
-  PROCESS_SWITCH(MultiplicityQa, processCollisionsPVChecks, "do PV contributors check", true);
+
+  void processMCCollisions(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::MultZeqs, aod::McCollisionLabels>::iterator const& col, soa::Join<aod::McCollisions, aod::McCollsExtra> const& mcCollisions)
+  {
+    if (selection == 7 && !col.sel7()) {
+      return;
+    }
+
+    if (selection == 8 && !col.sel8()) {
+      return;
+    }
+    if (INELgtZERO && col.multNTracksPVeta1() < 1) {
+      return;
+    }
+    if (fabs(col.posZ()) > vtxZsel) {
+      return;
+    }
+
+    // verify that PV has collision
+    if (!col.has_mcCollision())
+      return; 
+    
+    auto mcCollision = col.mcCollision_as<soa::Join<aod::McCollisions, aod::McCollsExtra>>(); 
+    if (mcCollision.hasRecoCollision() < 1)
+      return; // total paranoia mode: on
+
+    // Profiles
+    if (useZeqInProfiles && do2Dplots) {
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFV0"), col.multZeqFV0A(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0"), col.multZeqFT0A() + col.multZeqFT0C(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0A"), col.multZeqFT0A(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0C"), col.multZeqFT0C(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFDD"), col.multZeqFDDA() + col.multZeqFDDC(), mcCollision.hasRecoCollision());
+    } else {
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFV0"), col.multFV0A(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0"), col.multFT0A() + col.multFT0C(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0A"), col.multFT0A(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFT0C"), col.multFT0C(), mcCollision.hasRecoCollision());
+      histos.fill(HIST("multiplicityQa/h2dPVsVsFDD"), col.multFDDA() + col.multFDDC(), mcCollision.hasRecoCollision());
+    }
+  }
+  PROCESS_SWITCH(MultiplicityQa, processCollisions, "per-collision analysis", true);
+  PROCESS_SWITCH(MultiplicityQa, processBCs, "per-BC analysis", false);
+  PROCESS_SWITCH(MultiplicityQa, processCollisionsPVChecks, "do PV contributors check", false);
+  PROCESS_SWITCH(MultiplicityQa, processMCCollisions, "verify mc collisions", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
* adds a number of QA plots and better configurability to the multiplicity QA task
* allows for checking number of reconstructed PVs vs multiplicity in MC 
* allows for switching the check from equalized to non-equalized quantities 