### PR TITLE
PWGHF: set appropriately default configurables for PV refit and add protection

### DIFF
--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -77,7 +77,7 @@ struct HfCandidateCreator2Prong {
 
   void init(InitContext const&)
   {
-    if (doprocessPvRefit && doProcessNoPvRefit) {
+    if (doprocessPvRefit && doprocessNoPvRefit) {
       LOGP(fatal, "Only one process function between processPvRefit and processNoPvRefit can be enabled at a time.");
     }
 

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -77,6 +77,10 @@ struct HfCandidateCreator2Prong {
 
   void init(InitContext const&)
   {
+    if (doprocessPvRefit && doProcessNoPvRefit) {
+      LOGP(fatal, "Only one process function between processPvRefit and processNoPvRefit can be enabled at a time.");
+    }
+
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
@@ -215,7 +219,7 @@ struct HfCandidateCreator2Prong {
     runCreator2Prong<true>(collisions, rowsTrackIndexProng2, tracks, bcWithTimeStamps);
   }
 
-  PROCESS_SWITCH(HfCandidateCreator2Prong, processPvRefit, "Run candidate creator with PV refit", true);
+  PROCESS_SWITCH(HfCandidateCreator2Prong, processPvRefit, "Run candidate creator with PV refit", false);
 
   void processNoPvRefit(aod::Collisions const& collisions,
                         aod::Hf2Prongs const& rowsTrackIndexProng2,

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -80,7 +80,6 @@ struct HfCandidateCreator2Prong {
     if (doprocessPvRefit && doprocessNoPvRefit) {
       LOGP(fatal, "Only one process function between processPvRefit and processNoPvRefit can be enabled at a time.");
     }
-
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -76,6 +76,10 @@ struct HfCandidateCreator3Prong {
 
   void init(InitContext const&)
   {
+    if (doprocessPvRefit && doProcessNoPvRefit) {
+      LOGP(fatal, "Only one process function between processPvRefit and processNoPvRefit can be enabled at a time.");
+    }
+
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
@@ -222,7 +226,7 @@ struct HfCandidateCreator3Prong {
     runCreator3Prong<true>(collisions, rowsTrackIndexProng3, tracks, bcWithTimeStamps);
   }
 
-  PROCESS_SWITCH(HfCandidateCreator3Prong, processPvRefit, "Run candidate creator with PV refit", true);
+  PROCESS_SWITCH(HfCandidateCreator3Prong, processPvRefit, "Run candidate creator with PV refit", false);
 
   void processNoPvRefit(aod::Collisions const& collisions,
                         aod::Hf3Prongs const& rowsTrackIndexProng3,

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -76,7 +76,7 @@ struct HfCandidateCreator3Prong {
 
   void init(InitContext const&)
   {
-    if (doprocessPvRefit && doProcessNoPvRefit) {
+    if (doprocessPvRefit && doprocessNoPvRefit) {
       LOGP(fatal, "Only one process function between processPvRefit and processNoPvRefit can be enabled at a time.");
     }
 


### PR DESCRIPTION
@vkucera I unfortunately noticed only now that the default values of the `PROCESS_SWITCH` were not properly set in my previous PR https://github.com/AliceO2Group/O2Physics/pull/2878. It's not a big issue since they are anyway configurables, but it would be good to have the correct default values to avoid to cause troubles to users.