### PR TITLE
[EMCAL-903] Updates of the full jet trigger task for hardware trigger…

### DIFF
--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -67,7 +67,9 @@ DECLARE_SOA_COLUMN(JetChHighPt, hasJetChHighPt, bool); //! high-pT charged jet
 // full jets
 DECLARE_SOA_COLUMN(EMCALReadout, hasEMCALinReadout, bool);       //! EMCAL readout
 DECLARE_SOA_COLUMN(JetFullHighPt, hasJetFullHighPt, bool);       //! high-pT full jet
+DECLARE_SOA_COLUMN(JetFullLowPt, hasJetFullLowPt, bool);         //! low-pT full jet
 DECLARE_SOA_COLUMN(JetNeutralHighPt, hasJetNeutralHighPt, bool); //! high-pT neutral jet
+DECLARE_SOA_COLUMN(JetNeutralLowPt, hasJetNeutralLowPt, bool);   //! low-pT neutral jet
 DECLARE_SOA_COLUMN(GammaHighPtEMCAL, hasGammaHighPtEMCAL, bool); //! Photon trigger in EMCAL, high threshold
 DECLARE_SOA_COLUMN(GammaHighPtDCAL, hasGammaHighPtDCAL, bool);   //! Photon trigger in DCAL, high threshold
 DECLARE_SOA_COLUMN(GammaLowPtEMCAL, hasGammaLowPtEMCAL, bool);   //! Photon trigger in EMCAL, low threshold
@@ -158,7 +160,7 @@ DECLARE_SOA_TABLE(JetFilters, "AOD", "JetFilters", //!
 using JetFilter = JetFilters::iterator;
 
 DECLARE_SOA_TABLE(FullJetFilters, "AOD", "FullJetFilters", //!
-                  filtering::EMCALReadout, filtering::JetFullHighPt, filtering::JetNeutralHighPt, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL, filtering::GammaLowPtEMCAL, filtering::GammaLowPtDCAL);
+                  filtering::EMCALReadout, filtering::JetFullHighPt, filtering::JetFullLowPt, filtering::JetNeutralHighPt, filtering::JetNeutralLowPt, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL, filtering::GammaLowPtEMCAL, filtering::GammaLowPtDCAL);
 
 using FullJetFilter = FullJetFilters::iterator;
 

--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -14,6 +14,7 @@
 // Author: Gijs van Weelden
 //
 #include <bitset>
+#include <utility>
 
 #include "TH1F.h"
 #include "TTree.h"
@@ -34,15 +35,19 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
 
 struct JetTriggerQA {
+  using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
+  using fullJetInfos = soa::Join<aod::FullJets, aod::FullJetConstituents>;
+  using neutralJetInfos = soa::Join<aod::NeutralJets, aod::NeutralJetConstituents>;
 
   enum TriggerType_t {
     kMinBias,
     kEmcal,
     kEmcalJetFull,
+    kEmcalJetFullLow,
     kEmcalJetNeutral,
+    kEmcalJetNeutralLow,
     kEmcalGammaHigh,
     kDcalGammaHigh,
     kEmcalGammaLow,
@@ -122,24 +127,26 @@ struct JetTriggerQA {
     registry.add("jetRPtEtaPhiNoFiducial", "JetRPtEtaPhiNoFiducial", hJetRPtEtaPhiNoFiducial);
     registry.add("jetRMaxPtEtaPhiNoFiducial", "JetRMaxPtEtaPhiNoFiducial", hJetRMaxPtEtaPhiNoFiducial);
 
-    registry.add("hProcessedEvents", "Processed events", HistType::kTH1I, {{14, -0.5, 13.5, "Trigger type"}});
+    registry.add("hProcessedEvents", "Processed events", HistType::kTH1D, {{16, -0.5, 15.5, "Trigger type"}});
     auto histProcessed = registry.get<TH1>(HIST("hProcessedEvents"));
     histProcessed->GetXaxis()->SetBinLabel(1, "MB");
     histProcessed->GetXaxis()->SetBinLabel(2, "EMC");
-    histProcessed->GetXaxis()->SetBinLabel(3, "Selected Full Jet");
-    histProcessed->GetXaxis()->SetBinLabel(4, "Selected Neutral Jet");
-    histProcessed->GetXaxis()->SetBinLabel(5, "Selected Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(6, "Selected Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(7, "Selected Gamma low EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(8, "Selected Gamma low DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(9, "Selected full jet and Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(10, "Selected full jet and Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(11, "Selected neutral jet and Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(12, "Selected neutral jet and Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(13, "Selected Gamma high EMCAL and high Gamma DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(14, "Selected full jet and neutral jet");
+    histProcessed->GetXaxis()->SetBinLabel(3, "Selected Full Jet high");
+    histProcessed->GetXaxis()->SetBinLabel(4, "Selected Full Jet low");
+    histProcessed->GetXaxis()->SetBinLabel(5, "Selected Neutral Jet high");
+    histProcessed->GetXaxis()->SetBinLabel(6, "Selected Neutral Jet low");
+    histProcessed->GetXaxis()->SetBinLabel(7, "Selected Gamma high EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(8, "Selected Gamma high DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(9, "Selected Gamma low EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(10, "Selected Gamma low DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(11, "Selected full jet high and Gamma high EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(12, "Selected full jet high and Gamma high DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(13, "Selected neutral jet high and Gamma high EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(14, "Selected neutral jet high and Gamma high DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(15, "Selected Gamma high EMCAL and high Gamma DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(16, "Selected full jet high and neutral jet high");
 
-    std::array<std::string, TriggerType_t::kNTriggers> triggerlabels = {{"MB", "EMC", "EMC jet full", "EMC jet neutral", "EMC gamma high", "DCL gamma high", "EMC gamma low", "DCL gamma low"}};
+    std::array<std::string, TriggerType_t::kNTriggers> triggerlabels = {{"MB", "EMC", "EMC jet full high", "EMC jet full low", "EMC jet neutral high", "EMC jet neutral low", "EMC gamma high", "DCL gamma high", "EMC gamma low", "DCL gamma low"}};
     registry.add("hTriggerCorrelation", "Correlation between EMCAL triggers", HistType::kTH2D, {{TriggerType_t::kNTriggers, -0.5, TriggerType_t::kNTriggers - 0.5, "Main trigger"}, {TriggerType_t::kNTriggers, -0.5, TriggerType_t::kNTriggers - 0.5, "Associated trigger"}});
     auto triggerCorrelation = registry.get<TH2>(HIST("hTriggerCorrelation"));
     for (std::size_t triggertype = 0; triggertype < TriggerType_t::kNTriggers; triggertype++) {
@@ -170,16 +177,18 @@ struct JetTriggerQA {
     registry.add("hJetRMaxPtClusterMaxPt", "Leading jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
 
     // Histograms for triggered events
-    registry.add("hSelectedJetRPtEta", "Selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hSelectedJetRPtPhi", "Selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hSelectedJetRMaxPtPhi", "Leading selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
     registry.add("hSelectedClusterPtEta", Form("Selected Cluster %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedClusterPtPhi", Form("Selected Cluster %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedClusterPtEtaPhi", Form("Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedClusterMaxPtEtaPhi", Form("Leading Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedClusterMaxPtEta", Form("Leading selected clusters %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedClusterMaxPtPhi", Form("Leading selected clusters %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
+
+    // Jet high trigger
+    registry.add("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+    registry.add("hSelectedJetRMaxPtPhi", "Leading selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    registry.add("hSelectedJetRPtEta", "Selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+    registry.add("hSelectedJetRPtPhi", "Selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
     registry.add("hSelectedJetRPtTrackPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
     registry.add("hSelectedJetRPtClusterPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
     registry.add("hSelectedJetRPtPtd", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
@@ -188,26 +197,46 @@ struct JetTriggerQA {
     registry.add("hSelectedJetRPtZTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
     registry.add("hSelectedJetRPtZSqTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
     registry.add("hSelectedJetRPtZThetaSq", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+
+    // Jet low trigger
+    registry.add("hSelectedJetLowRPtEta", "Selected jets (low threshold) #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+    registry.add("hSelectedJetLowRPtPhi", "Selected jets (low threshold) #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    registry.add("hSelectedJetLowRPtTrackPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
+    registry.add("hSelectedJetLowRPtClusterPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
+    registry.add("hSelectedJetLowRPtPtd", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
+    registry.add("hSelectedJetLowRPtChargeFrag", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
+    registry.add("hSelectedJetLowRPtNEF", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
+    registry.add("hSelectedJetLowRPtZTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
+    registry.add("hSelectedJetLowRPtZSqTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
+    registry.add("hSelectedJetLowRPtZThetaSq", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+
+    // EG1 trigger
     registry.add("hSelectedGammaEMCALPtEta", Form("Selected Gamma %s and #eta (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaEMCALPtPhi", Form("Selected Gamma %s and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
-    registry.add("hSelectedGammaDCALPtEta", Form("Selected Gamma %s and #eta (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALPtPhi", Form("Selected Gamma %s and #phi (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaEMCALPtEtaPhi", Form("Selected Gamma %s, #eta and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (EMCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEta", Form("Leading selected gamma %s and #eta (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaEMCALMaxPtPhi", Form("Leading selected gamma %s and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
+
+    // DG1 trigger
+    registry.add("hSelectedGammaDCALPtEta", Form("Selected Gamma %s and #eta (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
+    registry.add("hSelectedGammaDCALPtPhi", Form("Selected Gamma %s and #phi (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALMaxPtEta", Form("Leading selected gamma %s and #eta (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaDCALMaxPtPhi", Form("Leading selected gamma %s and #phi (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALPtEtaPhi", Form("Selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaDCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
+    // EG2 trigger
     registry.add("hSelectedGammaEMCALPtEtaLow", Form("Selected Gamma %s and #eta (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaEMCALPtPhiLow", Form("Selected Gamma %s and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
-    registry.add("hSelectedGammaDCALPtEtaLow", Form("Selected Gamma %s and #eta (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALPtPhiLow", Form("Selected Gamma %s and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaEMCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEtaLow", Form("Leading selected gamma %s and #eta (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaEMCALMaxPtPhiLow", Form("Leading selected gamma %s and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
+
+    // DG2 trigger
+    registry.add("hSelectedGammaDCALPtEtaLow", Form("Selected Gamma %s and #eta (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
+    registry.add("hSelectedGammaDCALPtPhiLow", Form("Selected Gamma %s and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALMaxPtEtaLow", Form("Leading selected gamma %s and #eta (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
     registry.add("hSelectedGammaDCALMaxPtPhiLow", Form("Leading selected gamma %s and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
@@ -244,6 +273,18 @@ struct JetTriggerQA {
       registry.get<TH3>(HIST("hSelectedJetRPtZTheta"))->SetTitle("Selected jets (in emcal only)");
       registry.get<TH3>(HIST("hSelectedJetRPtZSqTheta"))->SetTitle("Selected jets (in emcal only)");
       registry.get<TH3>(HIST("hSelectedJetRPtZThetaSq"))->SetTitle("Selected jets (in emcal only)");
+
+      registry.get<TH3>(HIST("hSelectedJetLowRPtEta"))->SetTitle("Selected jets (low threshold, in emcal only) #it{p}_{T} and #eta");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtPhi"))->SetTitle("Selected jets (low threshold, in emcal only) #it{p}_{T} and #phi");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtTrackPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtClusterPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtPtd"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtChargeFrag"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtNEF"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtZTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtZSqTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      registry.get<TH3>(HIST("hSelectedJetLowRPtZThetaSq"))->SetTitle("Selected jets (low threshold, in emcal only)");
+
       registry.get<TH3>(HIST("hSelectedJetRMaxPtEta"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #eta");
       registry.get<TH3>(HIST("hSelectedJetRMaxPtPhi"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #phi");
       registry.get<TH3>(HIST("hSelectedJetRMaxPtClusterMaxPt"))->SetTitle("Leading selected jets (in emcal only) and clusters");
@@ -311,177 +352,14 @@ struct JetTriggerQA {
     registry.fill(HIST("hTriggerCorrelation"), mainTrigger, assocTrigger);
   }
 
-  void process(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
-               soa::Join<aod::FullJets, aod::FullJetConstituents> const& jets,
-               aod::Tracks const& tracks,
-               selectedClusters const& clusters)
+  std::pair<double, double> fillGammaQA(const selectedClusters& clusters, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
   {
-    std::bitset<TriggerType_t::kNTriggers> triggerstatus;
     auto isTrigger = [&triggerstatus](TriggerType_t triggertype) -> bool {
       return triggerstatus.test(triggertype);
     };
-    auto setTrigger = [&triggerstatus](TriggerType_t triggertype) {
-      triggerstatus.set(triggertype, true);
-    };
-
-    fillEventSelectionCounter(0);
-    setTrigger(TriggerType_t::kMinBias);
-
-    // fill event counters and correlation matrix without constraint on the EMCAL trigger flag
-    if (collision.alias_bit(kTVXinEMC)) {
-      fillEventSelectionCounter(1);
-      setTrigger(TriggerType_t::kEmcal);
-    }
-
-    bool isEvtSelected = false, isEventSelectedNeutralJet = false, isEvtSelectedGammaEMCAL = false, isEvtSelectedGammaDCAL = false, isEvtSelectedGammaLowEMCAL = false, isEvtSelectedGammaLowDCAL = false;
-    if (collision.hasJetFullHighPt()) {
-      isEvtSelected = true;
-      fillEventSelectionCounter(2);
-      setTrigger(TriggerType_t::kEmcalJetFull);
-    }
-    if (collision.hasJetNeutralHighPt()) {
-      isEventSelectedNeutralJet = true;
-      fillEventSelectionCounter(3);
-      setTrigger(TriggerType_t::kEmcalJetNeutral);
-    }
-    if (collision.hasGammaHighPtEMCAL()) {
-      isEvtSelectedGammaEMCAL = true;
-      fillEventSelectionCounter(4);
-      setTrigger(TriggerType_t::kEmcalGammaHigh);
-    }
-    if (collision.hasGammaHighPtDCAL()) {
-      isEvtSelectedGammaDCAL = true;
-      fillEventSelectionCounter(5);
-      setTrigger(TriggerType_t::kDcalGammaHigh);
-    }
-    if (collision.hasGammaLowPtEMCAL()) {
-      isEvtSelectedGammaLowEMCAL = true;
-      fillEventSelectionCounter(6);
-      setTrigger(TriggerType_t::kEmcalGammaLow);
-    }
-    if (collision.hasGammaLowPtDCAL()) {
-      isEvtSelectedGammaLowDCAL = true;
-      fillEventSelectionCounter(7);
-      setTrigger(TriggerType_t::kDcalGammaLow);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtEMCAL()) {
-      fillEventSelectionCounter(8);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(9);
-    }
-    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtEMCAL()) {
-      fillEventSelectionCounter(10);
-    }
-    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(11);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasJetNeutralHighPt()) {
-      fillEventSelectionCounter(12);
-    }
-    if (collision.hasGammaHighPtEMCAL() && collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(13);
-    }
-
-    // Create correlationMatrix
-    for (std::size_t maintriggertype = 0; maintriggertype < TriggerType_t::kNTriggers; maintriggertype++) {
-      if (isTrigger(static_cast<TriggerType_t>(maintriggertype))) {
-        for (std::size_t assoctriggertype = 0; assoctriggertype < TriggerType_t::kNTriggers; assoctriggertype++) {
-          if (isTrigger(static_cast<TriggerType_t>(assoctriggertype))) {
-            fillCorrelationMatrix(static_cast<TriggerType_t>(maintriggertype), static_cast<TriggerType_t>(assoctriggertype));
-          }
-        }
-      }
-    }
-
-    // Discard collisions without EMCAL if it is not respecifically required to discard the the EMCAL flag
-    // If ignore is true, we don't check for the flag and accept all events
-    if (!b_IgnoreEmcalFlag) {
-      if (!collision.alias_bit(kTVXinEMC)) {
-        return; // Only consider events where EMCAL is live
-      }
-    }
 
     double maxClusterObservableEMCAL = -1., maxClusterObservableDCAL = -1.;
     selectedClusters::iterator maxClusterEMCAL, maxClusterDCAL;
-    std::vector<soa::Join<aod::FullJets, aod::FullJetConstituents>::iterator> vecMaxJet;
-    std::vector<soa::Join<aod::FullJets, aod::FullJetConstituents>::iterator> vecMaxJetNoFiducial;
-
-    for (const auto& jet : jets) {
-      double jetPt = jet.pt(), jetR = jet.r() * 1e-2;
-      registry.get<THn>(HIST("jetRPtEtaPhiNoFiducial"))->Fill(jetR, jetPt, jet.eta(), jet.phi());
-      check_maxJetPt(jet, vecMaxJetNoFiducial);
-      if (b_JetsInEmcalOnly && !isJetInEmcal(jet)) {
-        continue;
-      }
-      float neutralEnergyFraction = 0., ptD = 0.;
-      float zTheta = 0., zSqTheta = 0., zThetaSq = 0; // Jet angularities (1,1), (1,2), (2,1)
-      check_maxJetPt(jet, vecMaxJet);
-
-      // Slice JetTrackConstituents table to obtain a list of trackId belonging to this jet only (and the same for clusters)
-      // This gives us access to all jet substructure information
-      // auto tracksInJet = jetTrackConstituents.sliceBy(perJetTrackConstituents, jet.globalIndex());
-      // for (const auto& trackList : tracksInJet) {
-      for (auto& track : jet.tracks_as<aod::Tracks>()) {
-        auto trackPt = track.pt();
-        auto chargeFrag = track.px() * jet.px() + track.py() * jet.py() + track.pz() * jet.pz();
-        chargeFrag /= (jet.p() * jet.p());
-        auto z = trackPt / jetPt;
-        auto dphi = jet.phi() - track.phi();
-        dphi = check_dphi(dphi);
-        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - track.eta(), 2));
-        zTheta += z * dR / jetR;
-        zSqTheta += z * z * dR / jetR;
-        zThetaSq += z * dR * dR / (jetR * jetR);
-        ptD += z * z;
-        registry.fill(HIST("hJetRPtTrackPt"), jetR, jetPt, trackPt);
-        registry.fill(HIST("hJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
-        if (isEvtSelected || isEventSelectedNeutralJet) {
-          registry.fill(HIST("hSelectedJetRPtTrackPt"), jetR, jetPt, trackPt);
-          registry.fill(HIST("hSelectedJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
-        }
-      } // for tracks in jet
-
-      // auto clustersInJet = jetClusterConstituents.sliceBy(perJetClusterConstituents, jet.globalIndex());
-      // for (const auto& clusterList : clustersInJet) {
-      for (auto& cluster : jet.clusters_as<selectedClusters>()) {
-        auto clusterPt = cluster.energy() / std::cosh(cluster.eta());
-        neutralEnergyFraction += cluster.energy();
-        auto z = clusterPt / jetPt;
-        auto dphi = jet.phi() - cluster.phi();
-        dphi = check_dphi(dphi);
-        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - cluster.eta(), 2));
-        zTheta += z * dR / jetR;
-        zSqTheta += z * z * dR / jetR;
-        zThetaSq += z * dR * dR / (jetR * jetR);
-        ptD += z * z;
-        registry.fill(HIST("hJetRPtClusterPt"), jetR, jetPt, clusterPt);
-        if (isEvtSelected || isEventSelectedNeutralJet) {
-          registry.fill(HIST("hSelectedJetRPtClusterPt"), jetR, jetPt, clusterPt);
-        }
-      } // for clusters in jet
-      neutralEnergyFraction /= jet.energy();
-      ptD = TMath::Sqrt(ptD);
-
-      // Fillng histograms
-      registry.fill(HIST("hJetRPtEta"), jetR, jetPt, jet.eta());
-      registry.fill(HIST("hJetRPtPhi"), jetR, jetPt, jet.phi());
-      registry.fill(HIST("hJetRPtPtd"), jetR, jetPt, ptD);
-      registry.fill(HIST("hJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
-      registry.fill(HIST("hJetRPtZTheta"), jetR, jetPt, zTheta);
-      registry.fill(HIST("hJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
-      registry.fill(HIST("hJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
-      registry.get<THn>(HIST("jetRPtEtaPhi"))->Fill(jetR, jetPt, jet.eta(), jet.phi());
-      if (isEvtSelected || isEventSelectedNeutralJet) {
-        registry.fill(HIST("hSelectedJetRPtEta"), jetR, jetPt, jet.eta());
-        registry.fill(HIST("hSelectedJetRPtPhi"), jetR, jetPt, jet.phi());
-        registry.fill(HIST("hSelectedJetRPtPtd"), jetR, jetPt, ptD);
-        registry.fill(HIST("hSelectedJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
-        registry.fill(HIST("hSelectedJetRPtZTheta"), jetR, jetPt, zTheta);
-        registry.fill(HIST("hSelectedJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
-        registry.fill(HIST("hSelectedJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
-      }
-    } // for jets
 
     struct ClusterData {
       float mTriggerObservable;
@@ -513,27 +391,27 @@ struct JetTriggerQA {
       registry.fill(HIST("hClusterPtEta"), clusterObservable, cluster.eta());
       registry.fill(HIST("hClusterPtPhi"), clusterObservable, cluster.phi());
       registry.fill(HIST("hClusterPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
-      if (isEvtSelected || isEventSelectedNeutralJet) {
+      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
         registry.fill(HIST("hSelectedClusterPtEta"), clusterObservable, cluster.eta());
         registry.fill(HIST("hSelectedClusterPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedClusterPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
-      if (isEvtSelectedGammaEMCAL && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
+      if (isTrigger(TriggerType_t::kEmcalGammaHigh) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
         registry.fill(HIST("hSelectedGammaEMCALPtEta"), clusterObservable, cluster.eta());
         registry.fill(HIST("hSelectedGammaEMCALPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaEMCALPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
-      if (isEvtSelectedGammaDCAL && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
+      if (isTrigger(TriggerType_t::kDcalGammaHigh) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
         registry.fill(HIST("hSelectedGammaDCALPtEta"), clusterObservable, cluster.eta());
         registry.fill(HIST("hSelectedGammaDCALPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaDCALPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
-      if (isEvtSelectedGammaLowEMCAL && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
+      if (isTrigger(TriggerType_t::kEmcalGammaLow) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
         registry.fill(HIST("hSelectedGammaEMCALPtEtaLow"), clusterObservable, cluster.eta());
         registry.fill(HIST("hSelectedGammaEMCALPtPhiLow"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaEMCALPtEtaPhiLow"), clusterObservable, cluster.eta(), cluster.phi());
       }
-      if (isEvtSelectedGammaLowDCAL && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
+      if (isTrigger(TriggerType_t::kDcalGammaLow) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
         registry.fill(HIST("hSelectedGammaDCALPtEtaLow"), clusterObservable, cluster.eta());
         registry.fill(HIST("hSelectedGammaDCALPtPhiLow"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaDCALPtEtaPhiLow"), clusterObservable, cluster.eta(), cluster.phi());
@@ -549,17 +427,17 @@ struct JetTriggerQA {
           registry.fill(HIST("hClusterEMCALMaxPtClusterEMCALPt"), maxClusterObservableEMCAL, cluster.mTriggerObservable);
         }
       }
-      if (isEvtSelected) {
+      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
         registry.fill(HIST("hSelectedClusterMaxPtEta"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
         registry.fill(HIST("hSelectedClusterMaxPtPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedClusterMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
-      if (isEvtSelectedGammaEMCAL) {
+      if (isTrigger(TriggerType_t::kEmcalGammaHigh)) {
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEta"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
-      if (isEvtSelectedGammaLowEMCAL) {
+      if (isTrigger(TriggerType_t::kEmcalGammaLow)) {
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
@@ -572,17 +450,219 @@ struct JetTriggerQA {
           registry.fill(HIST("hClusterDCALMaxPtClusterDCALPt"), maxClusterObservableDCAL, cluster.mTriggerObservable);
         }
       }
-      if (isEvtSelectedGammaDCAL) {
+      if (isTrigger(TriggerType_t::kDcalGammaHigh)) {
         registry.fill(HIST("hSelectedGammaDCALMaxPtEta"), maxClusterObservableDCAL, maxClusterDCAL.eta());
         registry.fill(HIST("hSelectedGammaDCALMaxPtPhi"), maxClusterObservableDCAL, maxClusterDCAL.phi());
         registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
       }
-      if (isEvtSelectedGammaLowDCAL) {
+      if (isTrigger(TriggerType_t::kDcalGammaLow)) {
         registry.fill(HIST("hSelectedGammaDCALMaxPtEtaLow"), maxClusterObservableDCAL, maxClusterDCAL.eta());
         registry.fill(HIST("hSelectedGammaDCALMaxPtPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.phi());
         registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
       }
     }
+    return std::make_pair(maxClusterObservableEMCAL, maxClusterObservableDCAL);
+  }
+
+  template <typename JetCollection>
+  std::pair<std::vector<typename JetCollection::iterator>, std::vector<typename JetCollection::iterator>> fillJetQA(const JetCollection& jets, aod::Tracks const& tracks, selectedClusters const& clusters, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
+  {
+    auto isTrigger = [&triggerstatus](TriggerType_t triggertype) -> bool {
+      return triggerstatus.test(triggertype);
+    };
+
+    std::vector<typename JetCollection::iterator> vecMaxJet;
+    std::vector<typename JetCollection::iterator> vecMaxJetNoFiducial;
+
+    for (const auto& jet : jets) {
+      double jetPt = jet.pt(), jetR = jet.r() * 1e-2;
+      registry.get<THn>(HIST("jetRPtEtaPhiNoFiducial"))->Fill(jetR, jetPt, jet.eta(), jet.phi());
+      check_maxJetPt(jet, vecMaxJetNoFiducial);
+      if (b_JetsInEmcalOnly && !isJetInEmcal(jet)) {
+        continue;
+      }
+      float neutralEnergyFraction = 0., ptD = 0.;
+      float zTheta = 0., zSqTheta = 0., zThetaSq = 0; // Jet angularities (1,1), (1,2), (2,1)
+      check_maxJetPt(jet, vecMaxJet);
+
+      // Slice JetTrackConstituents table to obtain a list of trackId belonging to this jet only (and the same for clusters)
+      // This gives us access to all jet substructure information
+      // auto tracksInJet = jetTrackConstituents.sliceBy(perJetTrackConstituents, jet.globalIndex());
+      // for (const auto& trackList : tracksInJet) {
+      for (auto& track : jet.template tracks_as<aod::Tracks>()) {
+        auto trackPt = track.pt();
+        auto chargeFrag = track.px() * jet.px() + track.py() * jet.py() + track.pz() * jet.pz();
+        chargeFrag /= (jet.p() * jet.p());
+        auto z = trackPt / jetPt;
+        auto dphi = jet.phi() - track.phi();
+        dphi = check_dphi(dphi);
+        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - track.eta(), 2));
+        zTheta += z * dR / jetR;
+        zSqTheta += z * z * dR / jetR;
+        zThetaSq += z * dR * dR / (jetR * jetR);
+        ptD += z * z;
+        registry.fill(HIST("hJetRPtTrackPt"), jetR, jetPt, trackPt);
+        registry.fill(HIST("hJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
+        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+          registry.fill(HIST("hSelectedJetRPtTrackPt"), jetR, jetPt, trackPt);
+          registry.fill(HIST("hSelectedJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
+        }
+        if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+          registry.fill(HIST("hSelectedJetLowRPtTrackPt"), jetR, jetPt, trackPt);
+          registry.fill(HIST("hSelectedJetLowRPtChargeFrag"), jetR, jetPt, chargeFrag);
+        }
+      } // for tracks in jet
+
+      // auto clustersInJet = jetClusterConstituents.sliceBy(perJetClusterConstituents, jet.globalIndex());
+      // for (const auto& clusterList : clustersInJet) {
+      for (auto& cluster : jet.template clusters_as<selectedClusters>()) {
+        auto clusterPt = cluster.energy() / std::cosh(cluster.eta());
+        neutralEnergyFraction += cluster.energy();
+        auto z = clusterPt / jetPt;
+        auto dphi = jet.phi() - cluster.phi();
+        dphi = check_dphi(dphi);
+        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - cluster.eta(), 2));
+        zTheta += z * dR / jetR;
+        zSqTheta += z * z * dR / jetR;
+        zThetaSq += z * dR * dR / (jetR * jetR);
+        ptD += z * z;
+        registry.fill(HIST("hJetRPtClusterPt"), jetR, jetPt, clusterPt);
+        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+          registry.fill(HIST("hSelectedJetRPtClusterPt"), jetR, jetPt, clusterPt);
+        }
+        if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+          registry.fill(HIST("hSelectedJetLowRPtClusterPt"), jetR, jetPt, clusterPt);
+        }
+      } // for clusters in jet
+      neutralEnergyFraction /= jet.energy();
+      ptD = TMath::Sqrt(ptD);
+
+      // Fillng histograms
+      registry.fill(HIST("hJetRPtEta"), jetR, jetPt, jet.eta());
+      registry.fill(HIST("hJetRPtPhi"), jetR, jetPt, jet.phi());
+      registry.fill(HIST("hJetRPtPtd"), jetR, jetPt, ptD);
+      registry.fill(HIST("hJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+      registry.fill(HIST("hJetRPtZTheta"), jetR, jetPt, zTheta);
+      registry.fill(HIST("hJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
+      registry.fill(HIST("hJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+      registry.get<THn>(HIST("jetRPtEtaPhi"))->Fill(jetR, jetPt, jet.eta(), jet.phi());
+      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+        registry.fill(HIST("hSelectedJetRPtEta"), jetR, jetPt, jet.eta());
+        registry.fill(HIST("hSelectedJetRPtPhi"), jetR, jetPt, jet.phi());
+        registry.fill(HIST("hSelectedJetRPtPtd"), jetR, jetPt, ptD);
+        registry.fill(HIST("hSelectedJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+        registry.fill(HIST("hSelectedJetRPtZTheta"), jetR, jetPt, zTheta);
+        registry.fill(HIST("hSelectedJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
+        registry.fill(HIST("hSelectedJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+      }
+      if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+        registry.fill(HIST("hSelectedJetLowRPtEta"), jetR, jetPt, jet.eta());
+        registry.fill(HIST("hSelectedJetLowRPtPhi"), jetR, jetPt, jet.phi());
+        registry.fill(HIST("hSelectedJetLowRPtPtd"), jetR, jetPt, ptD);
+        registry.fill(HIST("hSelectedJetLowRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+        registry.fill(HIST("hSelectedJetLowRPtZTheta"), jetR, jetPt, zTheta);
+        registry.fill(HIST("hSelectedJetLowRPtZSqTheta"), jetR, jetPt, zSqTheta);
+        registry.fill(HIST("hSelectedJetLowRPtZThetaSq"), jetR, jetPt, zThetaSq);
+      }
+    } // for jets
+    return std::make_pair(vecMaxJet, vecMaxJetNoFiducial);
+  }
+
+  template <typename JetCollection>
+  void runQA(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+             JetCollection const& jets,
+             aod::Tracks const& tracks,
+             selectedClusters const& clusters)
+  {
+    std::bitset<TriggerType_t::kNTriggers> triggerstatus;
+    auto isTrigger = [&triggerstatus](TriggerType_t triggertype) -> bool {
+      return triggerstatus.test(triggertype);
+    };
+    auto setTrigger = [&triggerstatus](TriggerType_t triggertype) {
+      triggerstatus.set(triggertype, true);
+    };
+
+    fillEventSelectionCounter(0);
+    setTrigger(TriggerType_t::kMinBias);
+
+    // fill event counters and correlation matrix without constraint on the EMCAL trigger flag
+    if (collision.alias_bit(kTVXinEMC)) {
+      fillEventSelectionCounter(1);
+      setTrigger(TriggerType_t::kEmcal);
+    }
+
+    if (collision.hasJetFullHighPt()) {
+      fillEventSelectionCounter(2);
+      setTrigger(TriggerType_t::kEmcalJetFull);
+    }
+    if (collision.hasJetFullLowPt()) {
+      fillEventSelectionCounter(3);
+      setTrigger(TriggerType_t::kEmcalJetFullLow);
+    }
+    if (collision.hasJetNeutralHighPt()) {
+      fillEventSelectionCounter(4);
+      setTrigger(TriggerType_t::kEmcalJetNeutral);
+    }
+    if (collision.hasJetNeutralLowPt()) {
+      fillEventSelectionCounter(5);
+      setTrigger(TriggerType_t::kEmcalJetNeutralLow);
+    }
+    if (collision.hasGammaHighPtEMCAL()) {
+      fillEventSelectionCounter(6);
+      setTrigger(TriggerType_t::kEmcalGammaHigh);
+    }
+    if (collision.hasGammaHighPtDCAL()) {
+      fillEventSelectionCounter(7);
+      setTrigger(TriggerType_t::kDcalGammaHigh);
+    }
+    if (collision.hasGammaLowPtEMCAL()) {
+      fillEventSelectionCounter(8);
+      setTrigger(TriggerType_t::kEmcalGammaLow);
+    }
+    if (collision.hasGammaLowPtDCAL()) {
+      fillEventSelectionCounter(9);
+      setTrigger(TriggerType_t::kDcalGammaLow);
+    }
+    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtEMCAL()) {
+      fillEventSelectionCounter(10);
+    }
+    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtDCAL()) {
+      fillEventSelectionCounter(11);
+    }
+    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtEMCAL()) {
+      fillEventSelectionCounter(12);
+    }
+    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtDCAL()) {
+      fillEventSelectionCounter(13);
+    }
+    if (collision.hasJetFullHighPt() && collision.hasJetNeutralHighPt()) {
+      fillEventSelectionCounter(14);
+    }
+    if (collision.hasGammaHighPtEMCAL() && collision.hasGammaHighPtDCAL()) {
+      fillEventSelectionCounter(15);
+    }
+
+    // Create correlationMatrix
+    for (std::size_t maintriggertype = 0; maintriggertype < TriggerType_t::kNTriggers; maintriggertype++) {
+      if (isTrigger(static_cast<TriggerType_t>(maintriggertype))) {
+        for (std::size_t assoctriggertype = 0; assoctriggertype < TriggerType_t::kNTriggers; assoctriggertype++) {
+          if (isTrigger(static_cast<TriggerType_t>(assoctriggertype))) {
+            fillCorrelationMatrix(static_cast<TriggerType_t>(maintriggertype), static_cast<TriggerType_t>(assoctriggertype));
+          }
+        }
+      }
+    }
+
+    // Discard collisions without EMCAL if it is not respecifically required to discard the the EMCAL flag
+    // If ignore is true, we don't check for the flag and accept all events
+    if (!b_IgnoreEmcalFlag) {
+      if (!collision.alias_bit(kTVXinEMC)) {
+        return; // Only consider events where EMCAL is live
+      }
+    }
+
+    auto [maxClusterObservableEMCAL, maxClusterObservableDCAL] = fillGammaQA(clusters, triggerstatus);
+    auto [vecMaxJet, vecMaxJetNoFiducial] = fillJetQA(jets, tracks, clusters, triggerstatus);
 
     for (auto maxJet : vecMaxJet) {
       double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
@@ -590,13 +670,13 @@ struct JetTriggerQA {
       registry.fill(HIST("hJetRMaxPtPhi"), jetR, jetPt, jetPhi);
       // hJetRMaxPtEtaPhi->Fill(jetR, jetPt, jetEta, jetPhi);
       registry.get<THn>(HIST("jetRMaxPtEtaPhi"))->Fill(jetR, jetPt, jetEta, jetPhi);
-      if (isEvtSelected) {
+      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
         registry.fill(HIST("hSelectedJetRMaxPtEta"), jetR, jetPt, jetEta);
         registry.fill(HIST("hSelectedJetRMaxPtPhi"), jetR, jetPt, jetPhi);
       }
       if (maxClusterObservableEMCAL > 0) {
         registry.fill(HIST("hJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
-        if (isEvtSelected) {
+        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
           registry.fill(HIST("hSelectedJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
         }
       } // if maxClusterPt
@@ -618,8 +698,28 @@ struct JetTriggerQA {
         } // for jets
       }   // if maxJet.r() == std::round(f_jetR * 100)
     }     // for maxjet no fiducial
-  }       // process
+
+  } // process
+
+  void processFullJets(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+                       fullJetInfos const& jets,
+                       aod::Tracks const& tracks,
+                       selectedClusters const& clusters)
+  {
+    runQA(collision, jets, tracks, clusters);
+  }
+  PROCESS_SWITCH(JetTriggerQA, processFullJets, "Run QA for full jets", true);
+
+  void processNeutralJets(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+                          neutralJetInfos const& jets,
+                          aod::Tracks const& tracks,
+                          selectedClusters const& clusters)
+  {
+    runQA(collision, jets, tracks, clusters);
+  }
+  PROCESS_SWITCH(JetTriggerQA, processNeutralJets, "Run QA for neutral jets", false);
 };
+
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{


### PR DESCRIPTION
…ed mode

- Accept all EMCAL hardware trigger + readout trigger
- Add low threshold trigger class for jet trigger
- Restructure functions in order to switch between jet types
  + Extract gamma / jet trigger logics to dedicated functions
  + Template jet trigger function to be able to run on full/neutral jet collection
  + Extract process code to templated run function
  + Create process functions (and PROCESS_SWITCH) for full / neutral jet input
- Users must specify the jet type for the jet trigger via PROCESS_SWITCH, the jet type configurable is removed as the information is redundant