### PR TITLE
PWGEM/DQ: Include pdgInHistory into previous checkSignal, enable the …

### DIFF
--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -24,14 +24,14 @@ MCProng::MCProng() : fNGenerations(0),
                      fSourceBits({}),
                      fExcludeSource({}),
                      fUseANDonSourceBitMap({}),
-                     fPDGInHistory(0),
-                     fCheckGenerationsInTime(0)
+                     fCheckGenerationsInTime(0),
+                     fPDGInHistory({}),
+                     fExcludePDGInHistory({})
 {
 }
 
 //________________________________________________________________________________________________________________
 MCProng::MCProng(int n) : fNGenerations(n),
-                          fPDGInHistory(0),
                           fCheckGenerationsInTime(0)
 {
   fPDGcodes.reserve(n);
@@ -51,17 +51,45 @@ MCProng::MCProng(int n) : fNGenerations(n),
 }
 
 //________________________________________________________________________________________________________________
+MCProng::MCProng(int n, int m) : fNGenerations(n),
+                                 fCheckGenerationsInTime(0)
+{
+  fPDGcodes.reserve(n);
+  fCheckBothCharges.reserve(n);
+  fExcludePDG.reserve(n);
+  fSourceBits.reserve(n);
+  fExcludeSource.reserve(n);
+  fUseANDonSourceBitMap.reserve(n);
+  fPDGInHistory.reserve(m);
+  fExcludePDGInHistory.reserve(m);
+  for (int i = 0; i < n; i++) {
+    fPDGcodes.push_back(kPDGCodeNotAssigned);
+    fCheckBothCharges.push_back(false);
+    fExcludePDG.push_back(false);
+    fSourceBits.push_back(0);
+    fExcludeSource.push_back(0);
+    fUseANDonSourceBitMap.push_back(true);
+  }
+  for (int j = 0; j < m; j++) {
+    fPDGInHistory.push_back(0);
+    fExcludePDGInHistory.push_back(0);
+  }
+}
+
+//________________________________________________________________________________________________________________
 MCProng::MCProng(int n, const std::vector<int> pdgs, const std::vector<bool> checkBothCharges, const std::vector<bool> excludePDG,
                  const std::vector<uint64_t> sourceBits, const std::vector<uint64_t> excludeSource,
-                 const std::vector<bool> useANDonSourceBitMap, bool checkIfPDGInHistory, bool checkGenerationsInTime) : fNGenerations(n),
-                                                                                                                        fPDGcodes(pdgs),
-                                                                                                                        fCheckBothCharges(checkBothCharges),
-                                                                                                                        fExcludePDG(excludePDG),
-                                                                                                                        fSourceBits(sourceBits),
-                                                                                                                        fExcludeSource(excludeSource),
-                                                                                                                        fUseANDonSourceBitMap(useANDonSourceBitMap),
-                                                                                                                        fPDGInHistory(checkIfPDGInHistory),
-                                                                                                                        fCheckGenerationsInTime(checkGenerationsInTime) {}
+                 const std::vector<bool> useANDonSourceBitMap, bool checkGenerationsInTime,
+                 const std::vector<int> checkIfPDGInHistory, const std::vector<bool> excludePDGInHistory) : fNGenerations(n),
+                                                                                                            fPDGcodes(pdgs),
+                                                                                                            fCheckBothCharges(checkBothCharges),
+                                                                                                            fExcludePDG(excludePDG),
+                                                                                                            fSourceBits(sourceBits),
+                                                                                                            fExcludeSource(excludeSource),
+                                                                                                            fUseANDonSourceBitMap(useANDonSourceBitMap),
+                                                                                                            fCheckGenerationsInTime(checkGenerationsInTime),
+                                                                                                            fPDGInHistory(checkIfPDGInHistory),
+                                                                                                            fExcludePDGInHistory(excludePDGInHistory) {}
 
 //________________________________________________________________________________________________________________
 void MCProng::SetPDGcode(int generation, int code, bool checkBothCharges /*= false*/, bool exclude /*= false*/)
@@ -118,7 +146,7 @@ void MCProng::Print() const
   for (int i = 0; i < fNGenerations; i++) {
     std::cout << "Generation #" << i << " PDGcode(" << fPDGcodes[i] << ") CheckBothCharges(" << fCheckBothCharges[i]
               << ") ExcludePDG(" << fExcludePDG[i] << ")  SourceBits(" << fSourceBits[i] << ") ExcludeSource(" << fExcludeSource[i]
-              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ") PDGInHistory(" << fPDGInHistory << ") CheckGenerationsInTime(" << fCheckGenerationsInTime << ")" << std::endl;
+              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ") CheckGenerationsInTime(" << fCheckGenerationsInTime << ") PDGInHistory(" << fPDGInHistory[i] << ") ExcludePDGInHistory(" << fExcludePDGInHistory[i] << ")" << std::endl;
   }
 }
 

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -78,8 +78,10 @@ class MCProng
 
   MCProng();
   MCProng(int n);
+  MCProng(int n, int m);
   MCProng(int n, std::vector<int> pdgs, std::vector<bool> checkBothCharges, std::vector<bool> excludePDG,
-          std::vector<uint64_t> sourceBits, std::vector<uint64_t> excludeSource, std::vector<bool> useANDonSourceBitMap, bool fPDGInHistory = false, bool fCheckGenerationsInTime = false);
+          std::vector<uint64_t> sourceBits, std::vector<uint64_t> excludeSource, std::vector<bool> useANDonSourceBitMap,
+          bool checkGenerationsInTime = false, std::vector<int> checkIfPDGInHistory = {}, std::vector<bool> excludePDGInHistory = {});
   MCProng(const MCProng& c) = default;
   virtual ~MCProng() = default;
 
@@ -99,8 +101,9 @@ class MCProng
   std::vector<uint64_t> fSourceBits;
   std::vector<uint64_t> fExcludeSource;
   std::vector<bool> fUseANDonSourceBitMap;
-  bool fPDGInHistory;
   bool fCheckGenerationsInTime;
+  std::vector<int> fPDGInHistory;
+  std::vector<bool> fExcludePDGInHistory;
 
   ClassDef(MCProng, 2);
 };

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -130,80 +130,6 @@ bool MCSignal::CheckProng(int i, bool checkSources, const T& track)
   using P = typename T::parent_t;
   auto currentMCParticle = track;
 
-  // check if mother pdg is in history
-  if (fProngs[i].fPDGInHistory) {
-    std::vector<bool> pdgInHistory;
-    // check the PDG code of currentMCParticle
-    if (!fProngs[i].TestPDG(0, currentMCParticle.pdgCode())) {
-      return false;
-    }
-
-    if (checkSources && fProngs[i].fSourceBits[0]) {
-      // check source of first prong
-      uint64_t sourcesDecision = 0;
-      // Check kPhysicalPrimary
-      if (fProngs[i].fSourceBits[0] & (uint64_t(1) << MCProng::kPhysicalPrimary)) {
-        if ((fProngs[i].fExcludeSource[0] & (uint64_t(1) << MCProng::kPhysicalPrimary)) != currentMCParticle.isPhysicalPrimary()) {
-          sourcesDecision |= (uint64_t(1) << MCProng::kPhysicalPrimary);
-        }
-      }
-      // Check kProducedInTransport
-      if (fProngs[i].fSourceBits[0] & (uint64_t(1) << MCProng::kProducedInTransport)) {
-        if ((fProngs[i].fExcludeSource[0] & (uint64_t(1) << MCProng::kProducedInTransport)) != (!currentMCParticle.producedByGenerator())) {
-          sourcesDecision |= (uint64_t(1) << MCProng::kProducedInTransport);
-        }
-      }
-      // Check kProducedByGenerator
-      if (fProngs[i].fSourceBits[0] & (uint64_t(1) << MCProng::kProducedByGenerator)) {
-        if ((fProngs[i].fExcludeSource[0] & (uint64_t(1) << MCProng::kProducedByGenerator)) != currentMCParticle.producedByGenerator()) {
-          sourcesDecision |= (uint64_t(1) << MCProng::kProducedByGenerator);
-        }
-      }
-      // Check kFromBackgroundEvent
-      if (fProngs[i].fSourceBits[0] & (uint64_t(1) << MCProng::kFromBackgroundEvent)) {
-        if ((fProngs[i].fExcludeSource[0] & (uint64_t(1) << MCProng::kFromBackgroundEvent)) != currentMCParticle.fromBackgroundEvent()) {
-          sourcesDecision |= (uint64_t(1) << MCProng::kFromBackgroundEvent);
-        }
-      }
-      // no source bit is fulfilled
-      if (!sourcesDecision) {
-        return false;
-      }
-      // if fUseANDonSourceBitMap is on, request all bits
-      if (fProngs[i].fUseANDonSourceBitMap[0] && (sourcesDecision != fProngs[i].fSourceBits[0])) {
-        return false;
-      }
-    }
-
-    // while find mothers, check if they have provided PDG codes
-    int nIncludedPDG = 0;
-    for (int k = 1; k < fProngs[i].fPDGcodes.size(); k++) {
-      currentMCParticle = track;
-      if (!fProngs[i].fExcludePDG[k])
-        nIncludedPDG++;
-      int ith = 0;
-      while (currentMCParticle.has_mothers()) {
-        auto mother = currentMCParticle.template mothers_first_as<P>();
-        if (!fProngs[i].fExcludePDG[k] && fProngs[i].TestPDG(k, mother.pdgCode())) {
-          pdgInHistory.emplace_back(true);
-          break;
-        }
-        if (fProngs[i].fExcludePDG[k] && !fProngs[i].TestPDG(k, mother.pdgCode())) {
-          return false;
-        }
-        ith++;
-        currentMCParticle = mother;
-        if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
-          break;
-        }
-      }
-    }
-    if (pdgInHistory.size() == nIncludedPDG) { // vector has as many entries as mothers defined for prong
-      return true;
-    } else
-      return false;
-  }
-
   // loop over the generations specified for this prong
   for (int j = 0; j < fProngs[i].fNGenerations; j++) {
     // check the PDG code
@@ -318,6 +244,38 @@ bool MCSignal::CheckProng(int i, bool checkSources, const T& track)
         }
       }
     }
+  }
+
+  if (fProngs[i].fPDGInHistory.size() == 0)
+    return true;
+  else { // check if mother pdg is in history
+    std::vector<int> pdgInHistory;
+
+    // while find mothers, check if the provided PDG codes are included or excluded in the particle decay history
+    int nIncludedPDG = 0;
+    for (int k = 0; k < fProngs[i].fPDGInHistory.size(); k++) {
+      currentMCParticle = track;
+      if (!fProngs[i].fExcludePDGInHistory[k])
+        nIncludedPDG++;
+      int ith = 0;
+      while (currentMCParticle.has_mothers()) {
+        auto mother = currentMCParticle.template mothers_first_as<P>();
+        if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+          pdgInHistory.emplace_back(true);
+          break;
+        }
+        if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+          return false;
+        }
+        ith++;
+        currentMCParticle = mother;
+        if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
+          break;
+        }
+      }
+    }
+    if (pdgInHistory.size() != nIncludedPDG) // vector has as many entries as mothers defined for prong
+      return false;
   }
 
   return true;

--- a/PWGDQ/Core/MCSignalLibrary.cxx
+++ b/PWGDQ/Core/MCSignalLibrary.cxx
@@ -349,13 +349,18 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Electrons from open charmed hadron decays", {prong}, {-1});
     return signal;
   }
+  if (!nameStr.compare("eFromAnyHc")) {
+    MCProng prong(1, {11}, {true}, {false}, {0}, {0}, {false}, false, {402}, {false});
+    signal = new MCSignal(name, "Electrons from open charm hadron decays", {prong}, {-1});
+    return signal;
+  }
   if (!nameStr.compare("eFromHb")) {
     MCProng prong(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "Electrons from open beauty hadron decays", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("eFromAnyHb")) {
-    MCProng prong(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, true);
+    MCProng prong(1, {11}, {true}, {false}, {0}, {0}, {false}, false, {502}, {false});
     signal = new MCSignal(name, "Electrons from open beauty hadron decays", {prong}, {-1});
     return signal;
   }
@@ -385,13 +390,13 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
   if (!nameStr.compare("eFromPromptHc")) {
-    MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);
+    MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {true});
     signal = new MCSignal(name, "Electrons from open charmed hadron decays", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("eFromHbtoHc")) {
-    MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);
-    signal = new MCSignal(name, "Electrons from open charmed hadron decays from b hadron decays", {prong}, {-1});
+    MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false});
+    signal = new MCSignal(name, "Electrons from open charmed hadron decays with b hadron in decay history", {prong}, {-1});
     return signal;
   }
 
@@ -560,13 +565,6 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
 
   // LMEE pair signals for HF
-  // Any c in history -> e
-  if (!nameStr.compare("eeFromAnyCandAnyC")) {
-    MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, true); // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any charm in decay chain", {prong, prong}, {-1, -1}); // signal at pair level
-    return signal;
-  }
-
   // c->e and c->e (no check)
   if (!nameStr.compare("eeFromCCNoCheck")) {
     MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
@@ -583,54 +581,31 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
 
   // Any c in history but no b -> c -> e
   if (!nameStr.compare("eeFromPromptCandPromptC")) {
-    MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any charm but no beauty in decay chain", {prong, prong}, {-1, -1});                 // signal at pair level
-    return signal;
-  }
-
-  // Any b in history -> e
-  if (!nameStr.compare("eeFromAnyBandAnyB")) {
-    MCProng prong(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, true);  // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any beauty in decay chain", {prong, prong}, {-1, -1}); // signal at pair level
+    MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {true}); // check if mother pdg code is in history
+    signal = new MCSignal(name, "ee pairs with any charm but no beauty in decay chain", {prong, prong}, {-1, -1});   // signal at pair level
     return signal;
   }
 
   // Any b to any c in history b -> c -> e
   if (!nameStr.compare("eeFromBtoCandBtoC")) {
-    MCProng prong(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any beauty to charm in decay chain", {prong, prong}, {-1, -1});                      // signal at pair level
-    return signal;
-  }
-
-  // Any c from b and any c in history b -> c -> e  and c -> e
-  if (!nameStr.compare("eeFromBtoCandPromptC")) {
-    MCProng prongB(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    MCProng prongC(3, {11, 402, 502}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);  // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any charm crossterms in decay chain", {prongB, prongC}, {-1, -1});                    // signal at pair level
-    return signal;
-  }
-
-  // Any c from b and any c in history b -> c -> e  and c -> e
-  if (!nameStr.compare("eeFromBtoCandPromptCBis")) {
-    MCProng prongB(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    MCProng prongC(3, {11, 402, 502}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);  // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs with any charm crossterms in decay chain", {prongC, prongB}, {-1, -1});                    // signal at pair level
+    MCProng prong(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
+    signal = new MCSignal(name, "ee pairs with any beauty to charm in decay chain", {prong, prong}, {-1, -1});        // signal at pair level
     return signal;
   }
 
   // Any b->e and Any b->c->e
   if (!nameStr.compare("eeFromBandBtoC")) {
-    MCProng prongB(3, {11, 402, 502}, {true, true, true}, {false, true, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);     // check if mother pdg code is in history
-    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs from b->e and b->c->e", {prongB, prongBtoC}, {-1, -1});                                       // signal at pair level
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});                           // check if mother pdg code is in history
+    MCProng prongBtoC(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
+    signal = new MCSignal(name, "ee pairs from b->e and b->c->e", {prongB, prongBtoC}, {-1, -1});                         // signal at pair level
     return signal;
   }
 
   // Any b->e and Any b->c->e
   if (!nameStr.compare("eeFromBandBtoCBis")) {
-    MCProng prongB(3, {11, 402, 502}, {true, true, true}, {false, true, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true);     // check if mother pdg code is in history
-    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, true); // check if mother pdg code is in history
-    signal = new MCSignal(name, "ee pairs from b->e and b->c->e", {prongBtoC, prongB}, {-1, -1});                                       // signal at pair level
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});                           // check if mother pdg code is in history
+    MCProng prongBtoC(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
+    signal = new MCSignal(name, "ee pairs from b->e and b->c->e", {prongBtoC, prongB}, {-1, -1});                         // signal at pair level
     return signal;
   }
 


### PR DESCRIPTION
…use of both, adapt MCSignals

Change order of initialisation for MCProng. 
Move checkGenerationsInTime in front of new defined vectors:
"checkIfPDGInHistory" (vector of pdgCoded that should be checked)
"excludePDGInHistory" (vector of booleans checking if provided pdgCode should be excluded)

Include pdgInHistory into the existing version of checkSignal, so both can be used in addition.
Enables to check if Prong has a pdg as direct mother & has (not) a certain pdgCode somewhere else in the decay chain.  
