### PR TITLE
Working point for a3 otf sim analysis

### DIFF
--- a/ALICE3/DataModel/A3DecayFinderTables.h
+++ b/ALICE3/DataModel/A3DecayFinderTables.h
@@ -38,9 +38,12 @@ enum a3selectionBit : uint32_t { kDCAxy = 0,
                                  kTrueKaPlusFromD,
                                  kTruePiMinusFromD,
                                  kTrueKaMinusFromD,
-                                 kTruePionFromLc,
-                                 kTrueKaonFromLc,
-                                 kTrueProtonFromLc };
+                                 kTruePiPlusFromLc,
+                                 kTrueKaPlusFromLc,
+                                 kTruePrPlusFromLc,
+                                 kTruePiMinusFromLc,
+                                 kTrueKaMinusFromLc,
+                                 kTruePrMinusFromLc };
 
 namespace o2::aod
 {

--- a/ALICE3/TableProducer/alice3-decayfinder.cxx
+++ b/ALICE3/TableProducer/alice3-decayfinder.cxx
@@ -262,28 +262,28 @@ struct alice3decayFinder {
 
   // partitions for D mesons
   Partition<alice3tracks> tracksPiPlusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromD) == trackSelectionPiPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromD) == trackSelectionPiPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksPiMinusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromD) == trackSelectionPiMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromD) == trackSelectionPiMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaPlusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromD) == trackSelectionKaPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromD) == trackSelectionKaPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaMinusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromD) == trackSelectionKaMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromD) == trackSelectionKaMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep* nabs(aod::track::signed1Pt);
 
   // partitions for Lc baryons
   Partition<alice3tracks> tracksPiPlusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromLc) == trackSelectionPiPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromLc) == trackSelectionPiPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaPlusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromLc) == trackSelectionKaPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromLc) == trackSelectionKaPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksPrPlusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionPrPlusFromLc) == trackSelectionPrPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPrPlusFromLc) == trackSelectionPrPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
   // partitions for Lc baryons
   Partition<alice3tracks> tracksPiMinusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromLc) == trackSelectionPiMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromLc) == trackSelectionPiMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaMinusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromLc) == trackSelectionKaMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromLc) == trackSelectionKaMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksPrMinusFromLc =
-    ((aod::a3DecayMap::decayMap & trackSelectionPrMinusFromLc) == trackSelectionPrMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+    ((aod::a3DecayMap::decayMap & trackSelectionPrMinusFromLc) == trackSelectionPrMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep* nabs(aod::track::signed1Pt);
 
   // Helper struct to pass candidate information
   struct {
@@ -471,10 +471,10 @@ struct alice3decayFinder {
         histos.fill(HIST("h2dGenDbar"), mcParticle.pt(), mcParticle.eta());
     }
     if (doprocessFindLcBaryons) {
-        for (auto const& mcParticle : trueLc)
-          histos.fill(HIST("h2dGenLc"), mcParticle.pt(), mcParticle.eta());
-        for (auto const& mcParticle : trueLcbar)
-          histos.fill(HIST("h2dGenLcbar"), mcParticle.pt(), mcParticle.eta());
+      for (auto const& mcParticle : trueLc)
+        histos.fill(HIST("h2dGenLc"), mcParticle.pt(), mcParticle.eta());
+      for (auto const& mcParticle : trueLcbar)
+        histos.fill(HIST("h2dGenLcbar"), mcParticle.pt(), mcParticle.eta());
     }
   }
 
@@ -520,7 +520,6 @@ struct alice3decayFinder {
         histos.fill(HIST("h3dRecDbar"), dmeson.pt, dmeson.eta, dmeson.mass);
       }
     }
-    
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 
@@ -554,10 +553,10 @@ struct alice3decayFinder {
     // Lc+ baryons +4122 -> +2212 -321 +211
     for (auto const& proton : tracksPrPlusFromLcgrouped) {
       for (auto const& pion : tracksPiPlusFromLcgrouped) {
-        if(pion.globalIndex() == proton.globalIndex()) 
-          continue; //avoid self
+        if (pion.globalIndex() == proton.globalIndex())
+          continue; // avoid self
         for (auto const& kaon : tracksKaMinusFromLcgrouped) {
-          if (mcSameMotherCheck && (!checkSameMother(proton, kaon)||!checkSameMother(proton, pion)))
+          if (mcSameMotherCheck && (!checkSameMother(proton, kaon) || !checkSameMother(proton, pion)))
             continue;
           if (!buildDecayCandidateThreeBody(proton, kaon, pion, o2::constants::physics::MassProton, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
             continue;
@@ -569,10 +568,10 @@ struct alice3decayFinder {
     // Lc- baryons -4122 -> -2212 +321 -211
     for (auto const& proton : tracksPrMinusFromLcgrouped) {
       for (auto const& pion : tracksPiMinusFromLcgrouped) {
-        if(pion.globalIndex() == proton.globalIndex()) 
-          continue; //avoid self
+        if (pion.globalIndex() == proton.globalIndex())
+          continue; // avoid self
         for (auto const& kaon : tracksKaPlusFromLcgrouped) {
-          if (mcSameMotherCheck && (!checkSameMother(proton, kaon)||!checkSameMother(proton, pion)))
+          if (mcSameMotherCheck && (!checkSameMother(proton, kaon) || !checkSameMother(proton, pion)))
             continue;
           if (!buildDecayCandidateThreeBody(proton, kaon, pion, o2::constants::physics::MassProton, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
             continue;
@@ -581,7 +580,6 @@ struct alice3decayFinder {
         }
       }
     }
-    
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 

--- a/ALICE3/TableProducer/alice3-decayfinder.cxx
+++ b/ALICE3/TableProducer/alice3-decayfinder.cxx
@@ -63,7 +63,7 @@ using FullTracksExt = soa::Join<aod::Tracks, aod::TracksCov>;
 using labeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 using tofTracks = soa::Join<aod::Tracks, aod::UpgradeTofs>;
 using richTracks = soa::Join<aod::Tracks, aod::RICHs>;
-using alice3tracks = soa::Join<aod::Tracks, aod::TracksCov, aod::Alice3DecayMaps, aod::McTrackLabels>;
+using alice3tracks = soa::Join<aod::Tracks, aod::TracksCov, aod::Alice3DecayMaps, aod::McTrackLabels, aod::TracksDCA>;
 
 struct alice3decayPreselector {
   Produces<aod::Alice3DecayMaps> a3decayMaps;
@@ -103,7 +103,6 @@ struct alice3decayPreselector {
   void init(InitContext& context)
   {
     // future dev if needed
-    histos.add("hToggle", "hToggle", kTH1F, {{10, -0.5f, 9.5f}});
   }
 
   // go declarative: use partitions instead of "if", then just toggle bits to allow for mask selection later
@@ -164,24 +163,29 @@ struct alice3decayPreselector {
   void processFilterOnMonteCarloTruth(labeledTracks const& tracks, aod::McParticles const&)
   {
     for (auto const& track : tracks) {
+      // D mesons
       if (!checkPDG(track, 421, -321)) //+421 -> -321 +211
-      {
         bitoff(selectionMap[track.globalIndex()], kTrueKaMinusFromD);
-        histos.fill(HIST("hToggle"), 0.0);
-      } else {
-        histos.fill(HIST("hToggle"), 1.0);
-      }
       if (!checkPDG(track, -421, +321)) //-421 -> +321 -211
         bitoff(selectionMap[track.globalIndex()], kTrueKaPlusFromD);
       if (!checkPDG(track, 421, +211)) //+421 -> -321 +211
-      {
         bitoff(selectionMap[track.globalIndex()], kTruePiPlusFromD);
-        histos.fill(HIST("hToggle"), 2.0);
-      } else {
-        histos.fill(HIST("hToggle"), 3.0);
-      }
       if (!checkPDG(track, -421, -211)) //-421 -> +321 -211
         bitoff(selectionMap[track.globalIndex()], kTruePiMinusFromD);
+
+      // Lambdac baryons
+      if (!checkPDG(track, +4122, +2212)) //+4122 -> +2212 -321 +211
+        bitoff(selectionMap[track.globalIndex()], kTruePrPlusFromLc);
+      if (!checkPDG(track, +4122, -321)) //+4122 -> +2212 -321 +211
+        bitoff(selectionMap[track.globalIndex()], kTrueKaMinusFromLc);
+      if (!checkPDG(track, +4122, +211)) //+4122 -> +2212 -321 +211
+        bitoff(selectionMap[track.globalIndex()], kTruePiPlusFromLc);
+      if (!checkPDG(track, -4122, -2212)) //-4122 -> -2212 +321 -211
+        bitoff(selectionMap[track.globalIndex()], kTruePrMinusFromLc);
+      if (!checkPDG(track, -4122, +321)) //-4122 -> -2212 +321 -211
+        bitoff(selectionMap[track.globalIndex()], kTrueKaPlusFromLc);
+      if (!checkPDG(track, -4122, -211)) //-4122 -> -2212 +321 -211
+        bitoff(selectionMap[track.globalIndex()], kTruePiMinusFromLc);
     }
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -209,39 +213,77 @@ struct alice3decayFinder {
 
   // Operation and minimisation criteria
   Configurable<float> magneticField{"magneticField", 20.0f, "Magnetic field (in kilogauss)"};
-  Configurable<bool> doDCAplots{"doDCAplots", true, "do daughter prong DCA plots"};
+  Configurable<bool> doDCAplotsD{"doDCAplotsD", true, "do daughter prong DCA plots for D mesons"};
+  Configurable<bool> doDCAplotsLc{"doDCAplotsLc", true, "do daughter prong DCA plots for Lc baryons"};
   Configurable<bool> mcSameMotherCheck{"mcSameMotherCheck", true, "check if tracks come from the same MC mother"};
   Configurable<float> dcaDaughtersSelection{"dcaDaughtersSelection", 1000.0f, "DCA between daughters (cm)"};
+
+  Configurable<float> piFromD_dcaXYconstant{"piFromD_dcaXYconstant", -1.0f, "[0] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> piFromD_dcaXYpTdep{"piFromD_dcaXYpTdep", 0.0, "[1] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> kaFromD_dcaXYconstant{"kaFromD_dcaXYconstant", -1.0f, "[0] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> kaFromD_dcaXYpTdep{"kaFromD_dcaXYpTdep", 0.0, "[1] in |DCAxy| > [0]+[1]/pT"};
+
+  Configurable<float> piFromLc_dcaXYconstant{"piFromLc_dcaXYconstant", -1.0f, "[0] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> piFromLc_dcaXYpTdep{"piFromLc_dcaXYpTdep", 0.0, "[1] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> kaFromLc_dcaXYconstant{"kaFromLc_dcaXYconstant", -1.0f, "[0] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> kaFromLc_dcaXYpTdep{"kaFromLc_dcaXYpTdep", 0.0, "[1] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> prFromLc_dcaXYconstant{"prFromLc_dcaXYconstant", -1.0f, "[0] in |DCAxy| > [0]+[1]/pT"};
+  Configurable<float> prFromLc_dcaXYpTdep{"prFromLc_dcaXYpTdep", 0.0, "[1] in |DCAxy| > [0]+[1]/pT"};
 
   ConfigurableAxis axisEta{"axisEta", {8, -4.0f, +4.0f}, "#eta"};
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
   ConfigurableAxis axisDCA{"axisDCA", {200, -100, 100}, "DCA (#mum)"};
   ConfigurableAxis axisDMass{"axisDMass", {200, 1.765f, 1.965f}, "D Inv Mass (GeV/c^{2})"};
+  ConfigurableAxis axisLcMass{"axisLcMass", {200, 2.186f, 2.386f}, "#Lambda_{c} Inv Mass (GeV/c^{2})"};
 
-  // Define o2 fitter, 2-prong, active memory (no need to redefine per event)
   o2::vertexing::DCAFitterN<2> fitter;
+  o2::vertexing::DCAFitterN<3> fitter3;
 
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   Partition<aod::McParticles> trueD = aod::mcparticle::pdgCode == 421;
   Partition<aod::McParticles> trueDbar = aod::mcparticle::pdgCode == -421;
+  Partition<aod::McParticles> trueLc = aod::mcparticle::pdgCode == 4122;
+  Partition<aod::McParticles> trueLcbar = aod::mcparticle::pdgCode == -4122;
 
+  // filter expressions for D mesons
   static constexpr uint32_t trackSelectionPiPlusFromD = 1 << kInnerTOFPion | 1 << kOuterTOFPion | 1 << kRICHPion | 1 << kTruePiPlusFromD;
   static constexpr uint32_t trackSelectionPiMinusFromD = 1 << kInnerTOFPion | 1 << kOuterTOFPion | 1 << kRICHPion | 1 << kTruePiMinusFromD;
   static constexpr uint32_t trackSelectionKaPlusFromD = 1 << kInnerTOFKaon | 1 << kOuterTOFKaon | 1 << kRICHKaon | 1 << kTrueKaPlusFromD;
   static constexpr uint32_t trackSelectionKaMinusFromD = 1 << kInnerTOFKaon | 1 << kOuterTOFKaon | 1 << kRICHKaon | 1 << kTrueKaMinusFromD;
 
+  // filter expressions for Lambdac baryons
+  static constexpr uint32_t trackSelectionPiPlusFromLc = 1 << kInnerTOFPion | 1 << kOuterTOFPion | 1 << kRICHPion | 1 << kTruePiPlusFromLc;
+  static constexpr uint32_t trackSelectionKaPlusFromLc = 1 << kInnerTOFKaon | 1 << kOuterTOFKaon | 1 << kRICHKaon | 1 << kTrueKaPlusFromLc;
+  static constexpr uint32_t trackSelectionPrPlusFromLc = 1 << kInnerTOFProton | 1 << kOuterTOFProton | 1 << kRICHProton | 1 << kTruePrPlusFromLc;
+  static constexpr uint32_t trackSelectionPiMinusFromLc = 1 << kInnerTOFPion | 1 << kOuterTOFPion | 1 << kRICHPion | 1 << kTruePiMinusFromLc;
+  static constexpr uint32_t trackSelectionKaMinusFromLc = 1 << kInnerTOFKaon | 1 << kOuterTOFKaon | 1 << kRICHKaon | 1 << kTrueKaMinusFromLc;
+  static constexpr uint32_t trackSelectionPrMinusFromLc = 1 << kInnerTOFProton | 1 << kOuterTOFProton | 1 << kRICHProton | 1 << kTruePrMinusFromLc;
+
+  // partitions for D mesons
   Partition<alice3tracks> tracksPiPlusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromD) == trackSelectionPiPlusFromD) && aod::track::signed1Pt > 0.0f;
-
+    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromD) == trackSelectionPiPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksPiMinusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromD) == trackSelectionPiMinusFromD) && aod::track::signed1Pt < 0.0f;
-
+    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromD) == trackSelectionPiMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromD_dcaXYconstant + piFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaPlusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromD) == trackSelectionKaPlusFromD) && aod::track::signed1Pt > 0.0f;
-
+    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromD) == trackSelectionKaPlusFromD) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
   Partition<alice3tracks> tracksKaMinusFromD =
-    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromD) == trackSelectionKaMinusFromD) && aod::track::signed1Pt < 0.0f;
+    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromD) == trackSelectionKaMinusFromD) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromD_dcaXYconstant + kaFromD_dcaXYpTdep * nabs(aod::track::signed1Pt);
+
+  // partitions for Lc baryons
+  Partition<alice3tracks> tracksPiPlusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionPiPlusFromLc) == trackSelectionPiPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+  Partition<alice3tracks> tracksKaPlusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionKaPlusFromLc) == trackSelectionKaPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+  Partition<alice3tracks> tracksPrPlusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionPrPlusFromLc) == trackSelectionPrPlusFromLc) && aod::track::signed1Pt > 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+  // partitions for Lc baryons
+  Partition<alice3tracks> tracksPiMinusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionPiMinusFromLc) == trackSelectionPiMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > piFromLc_dcaXYconstant + piFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+  Partition<alice3tracks> tracksKaMinusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionKaMinusFromLc) == trackSelectionKaMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > kaFromLc_dcaXYconstant + kaFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
+  Partition<alice3tracks> tracksPrMinusFromLc =
+    ((aod::a3DecayMap::decayMap & trackSelectionPrMinusFromLc) == trackSelectionPrMinusFromLc) && aod::track::signed1Pt < 0.0f && nabs(aod::track::dcaXY) > prFromLc_dcaXYconstant + prFromLc_dcaXYpTdep * nabs(aod::track::signed1Pt);
 
   // Helper struct to pass candidate information
   struct {
@@ -250,8 +292,14 @@ struct alice3decayFinder {
     float eta;
   } dmeson;
 
+  struct {
+    float mass;
+    float pt;
+    float eta;
+  } lcbaryon;
+
   template <typename TTrackType>
-  bool buildDecayCandidate(TTrackType const& posTrackRow, TTrackType const& negTrackRow, float posMass, float negMass)
+  bool buildDecayCandidateTwoBody(TTrackType const& posTrackRow, TTrackType const& negTrackRow, float posMass, float negMass)
   {
     o2::track::TrackParCov posTrack = getTrackParCov(posTrackRow);
     o2::track::TrackParCov negTrack = getTrackParCov(negTrackRow);
@@ -284,6 +332,47 @@ struct alice3decayFinder {
     dmeson.mass = RecoDecay::m(array{array{posP[0], posP[1], posP[2]}, array{negP[0], negP[1], negP[2]}}, array{posMass, negMass});
     dmeson.pt = std::hypot(posP[0] + negP[0], posP[1] + negP[1]);
     dmeson.eta = RecoDecay::eta(array{posP[0] + negP[0], posP[1] + negP[1], posP[2] + negP[2]});
+    return true;
+  }
+
+  template <typename TTrackType>
+  bool buildDecayCandidateThreeBody(TTrackType const& prong0, TTrackType const& prong1, TTrackType const& prong2, float p0mass, float p1mass, float p2mass)
+  {
+    o2::track::TrackParCov t0 = getTrackParCov(prong0);
+    o2::track::TrackParCov t1 = getTrackParCov(prong1);
+    o2::track::TrackParCov t2 = getTrackParCov(prong2);
+
+    //}-{}-{}-{}-{}-{}-{}-{}-{}-{}
+    // Move close to minima
+    int nCand = 0;
+    try {
+      nCand = fitter3.process(t0, t1, t2);
+    } catch (...) {
+      return false;
+    }
+    if (nCand == 0) {
+      return false;
+    }
+    //}-{}-{}-{}-{}-{}-{}-{}-{}-{}
+
+    t0 = fitter.getTrack(0);
+    t1 = fitter.getTrack(1);
+    t2 = fitter.getTrack(2);
+    std::array<float, 3> P0;
+    std::array<float, 3> P1;
+    std::array<float, 3> P2;
+    t0.getPxPyPzGlo(P0);
+    t1.getPxPyPzGlo(P1);
+    t2.getPxPyPzGlo(P2);
+
+    float dcaDau = TMath::Sqrt(fitter3.getChi2AtPCACandidate());
+    if (dcaDau > dcaDaughtersSelection)
+      return false;
+
+    // return mass
+    lcbaryon.mass = RecoDecay::m(array{array{P0[0], P0[1], P0[2]}, array{P1[0], P1[1], P1[2]}, array{P2[0], P2[1], P2[2]}}, array{p0mass, p1mass, p2mass});
+    lcbaryon.pt = std::hypot(P0[0] + P1[0] + P2[0], P0[1] + P1[1] + P2[1]);
+    lcbaryon.eta = RecoDecay::eta(array{P0[0] + P1[0] + P2[0], P0[1] + P1[1] + P2[1], P0[2] + P1[2] + P2[2]});
     return true;
   }
 
@@ -324,6 +413,17 @@ struct alice3decayFinder {
     fitter.setBz(magneticField);
     fitter.setMatCorrType(o2::base::Propagator::MatCorrType::USEMatCorrNONE);
 
+    fitter3.setPropagateToPCA(true);
+    fitter3.setMaxR(200.);
+    fitter3.setMinParamChange(1e-3);
+    fitter3.setMinRelChi2Change(0.9);
+    fitter3.setMaxDZIni(1e9);
+    fitter3.setMaxChi2(1e9);
+    fitter3.setUseAbsDCA(true);
+    fitter3.setWeightedFinalPCA(false);
+    fitter3.setBz(magneticField);
+    fitter3.setMatCorrType(o2::base::Propagator::MatCorrType::USEMatCorrNONE);
+
     if (doprocessFindDmesons) {
       histos.add("h2dGenD", "h2dGenD", kTH2F, {axisPt, axisEta});
       histos.add("h2dGenDbar", "h2dGenDbar", kTH2F, {axisPt, axisEta});
@@ -333,35 +433,77 @@ struct alice3decayFinder {
       histos.add("hMassD", "hMassD", kTH1F, {axisDMass});
       histos.add("hMassDbar", "hMassDbar", kTH1F, {axisDMass});
 
-      if (doDCAplots) {
+      if (doDCAplotsD) {
         histos.add("h2dDCAxyVsPtPiPlusFromD", "h2dDCAxyVsPtPiPlusFromD", kTH2F, {axisPt, axisDCA});
         histos.add("h2dDCAxyVsPtPiMinusFromD", "h2dDCAxyVsPtPiMinusFromD", kTH2F, {axisPt, axisDCA});
         histos.add("h2dDCAxyVsPtKaPlusFromD", "h2dDCAxyVsPtKaPlusFromD", kTH2F, {axisPt, axisDCA});
         histos.add("h2dDCAxyVsPtKaMinusFromD", "h2dDCAxyVsPtKaMinusFromD", kTH2F, {axisPt, axisDCA});
       }
     }
+    if (doprocessFindLcBaryons) {
+      histos.add("h2dGenLc", "h2dGenLc", kTH2F, {axisPt, axisEta});
+      histos.add("h2dGenLcbar", "h2dGenLcbar", kTH2F, {axisPt, axisEta});
+      histos.add("h3dRecLc", "h2dRecLc", kTH3F, {axisPt, axisEta, axisLcMass});
+      histos.add("h3dRecLcbar", "h2dRecLcbar", kTH3F, {axisPt, axisEta, axisLcMass});
+
+      histos.add("hMassLc", "hMassLc", kTH1F, {axisLcMass});
+      histos.add("hMassLcbar", "hMassLcbar", kTH1F, {axisLcMass});
+
+      if (doDCAplotsD) {
+        histos.add("h2dDCAxyVsPtPiPlusFromLc", "h2dDCAxyVsPtPiPlusFromLc", kTH2F, {axisPt, axisDCA});
+        histos.add("h2dDCAxyVsPtPiMinusFromLc", "h2dDCAxyVsPtPiMinusFromLc", kTH2F, {axisPt, axisDCA});
+        histos.add("h2dDCAxyVsPtKaPlusFromLc", "h2dDCAxyVsPtKaPlusFromLc", kTH2F, {axisPt, axisDCA});
+        histos.add("h2dDCAxyVsPtKaMinusFromLc", "h2dDCAxyVsPtKaMinusFromLc", kTH2F, {axisPt, axisDCA});
+        histos.add("h2dDCAxyVsPtPrPlusFromLc", "h2dDCAxyVsPtPrPlusFromLc", kTH2F, {axisPt, axisDCA});
+        histos.add("h2dDCAxyVsPtPrMinusFromLc", "h2dDCAxyVsPtPrMinusFromLc", kTH2F, {axisPt, axisDCA});
+      }
+    }
   }
 
-  void processFindDmesons(aod::Collision const& collision, alice3tracks const& tracks, aod::McParticles const& mcParticles)
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  void processGenerated(aod::McParticles const& mcParticles)
   {
     // no grouping for MC particles -> as intended
-    for (auto const& mcParticle : trueD)
-      histos.fill(HIST("h2dGenD"), mcParticle.pt(), mcParticle.eta());
-    for (auto const& mcParticle : trueDbar)
-      histos.fill(HIST("h2dGenDbar"), mcParticle.pt(), mcParticle.eta());
+    if (doprocessFindDmesons) {
+      for (auto const& mcParticle : trueD)
+        histos.fill(HIST("h2dGenD"), mcParticle.pt(), mcParticle.eta());
+      for (auto const& mcParticle : trueDbar)
+        histos.fill(HIST("h2dGenDbar"), mcParticle.pt(), mcParticle.eta());
+    }
+    if (doprocessFindLcBaryons) {
+        for (auto const& mcParticle : trueLc)
+          histos.fill(HIST("h2dGenLc"), mcParticle.pt(), mcParticle.eta());
+        for (auto const& mcParticle : trueLcbar)
+          histos.fill(HIST("h2dGenLcbar"), mcParticle.pt(), mcParticle.eta());
+    }
+  }
 
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  void processFindDmesons(aod::Collision const& collision, alice3tracks const& tracks, aod::McParticles const& mcParticles)
+  {
     // group with this collision
     auto tracksPiPlusFromDgrouped = tracksPiPlusFromD->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto tracksKaMinusFromDgrouped = tracksKaMinusFromD->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto tracksKaPlusFromDgrouped = tracksKaPlusFromD->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto tracksPiMinusFromDgrouped = tracksPiMinusFromD->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
+    if (doDCAplotsD) {
+      for (auto const& track : tracksPiPlusFromDgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPiPlusFromD"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksPiMinusFromDgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPiMinusFromD"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksKaPlusFromDgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtKaPlusFromD"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksKaMinusFromDgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtKaMinusFromD"), track.pt(), track.dcaXY() * 1e+4);
+    }
+
     // D mesons
     for (auto const& posTrackRow : tracksPiPlusFromDgrouped) {
       for (auto const& negTrackRow : tracksKaMinusFromDgrouped) {
         if (mcSameMotherCheck && !checkSameMother(posTrackRow, negTrackRow))
           continue;
-        if (!buildDecayCandidate(posTrackRow, negTrackRow, o2::constants::physics::MassPionCharged, o2::constants::physics::MassKaonCharged))
+        if (!buildDecayCandidateTwoBody(posTrackRow, negTrackRow, o2::constants::physics::MassPionCharged, o2::constants::physics::MassKaonCharged))
           continue;
         histos.fill(HIST("hMassD"), dmeson.mass);
         histos.fill(HIST("h3dRecD"), dmeson.pt, dmeson.eta, dmeson.mass);
@@ -372,17 +514,80 @@ struct alice3decayFinder {
       for (auto const& negTrackRow : tracksPiMinusFromDgrouped) {
         if (mcSameMotherCheck && !checkSameMother(posTrackRow, negTrackRow))
           continue;
-        if (!buildDecayCandidate(posTrackRow, negTrackRow, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
+        if (!buildDecayCandidateTwoBody(posTrackRow, negTrackRow, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
           continue;
         histos.fill(HIST("hMassDbar"), dmeson.mass);
         histos.fill(HIST("h3dRecDbar"), dmeson.pt, dmeson.eta, dmeson.mass);
       }
     }
+    
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  void processFindLcBaryons(aod::Collision const& collision, alice3tracks const& tracks, aod::McParticles const& mcParticles)
+  {
+    // group with this collision
+    auto tracksPiPlusFromLcgrouped = tracksPiPlusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+    auto tracksKaPlusFromLcgrouped = tracksKaPlusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+    auto tracksPrPlusFromLcgrouped = tracksPrPlusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+
+    auto tracksPiMinusFromLcgrouped = tracksPiMinusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+    auto tracksKaMinusFromLcgrouped = tracksKaMinusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+    auto tracksPrMinusFromLcgrouped = tracksPrMinusFromLc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+
+    if (doDCAplotsLc) {
+      for (auto const& track : tracksPiPlusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPiPlusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksPiMinusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPiMinusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksKaPlusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtKaPlusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksKaMinusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtKaMinusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksPrPlusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPrPlusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+      for (auto const& track : tracksPrMinusFromLcgrouped)
+        histos.fill(HIST("h2dDCAxyVsPtPrMinusFromLc"), track.pt(), track.dcaXY() * 1e+4);
+    }
+
+    // Lc+ baryons +4122 -> +2212 -321 +211
+    for (auto const& proton : tracksPrPlusFromLcgrouped) {
+      for (auto const& pion : tracksPiPlusFromLcgrouped) {
+        if(pion.globalIndex() == proton.globalIndex()) 
+          continue; //avoid self
+        for (auto const& kaon : tracksKaMinusFromLcgrouped) {
+          if (mcSameMotherCheck && (!checkSameMother(proton, kaon)||!checkSameMother(proton, pion)))
+            continue;
+          if (!buildDecayCandidateThreeBody(proton, kaon, pion, o2::constants::physics::MassProton, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
+            continue;
+          histos.fill(HIST("hMassLc"), lcbaryon.mass);
+          histos.fill(HIST("h3dRecLc"), lcbaryon.pt, lcbaryon.eta, lcbaryon.mass);
+        }
+      }
+    }
+    // Lc- baryons -4122 -> -2212 +321 -211
+    for (auto const& proton : tracksPrMinusFromLcgrouped) {
+      for (auto const& pion : tracksPiMinusFromLcgrouped) {
+        if(pion.globalIndex() == proton.globalIndex()) 
+          continue; //avoid self
+        for (auto const& kaon : tracksKaPlusFromLcgrouped) {
+          if (mcSameMotherCheck && (!checkSameMother(proton, kaon)||!checkSameMother(proton, pion)))
+            continue;
+          if (!buildDecayCandidateThreeBody(proton, kaon, pion, o2::constants::physics::MassProton, o2::constants::physics::MassKaonCharged, o2::constants::physics::MassPionCharged))
+            continue;
+          histos.fill(HIST("hMassLcbar"), lcbaryon.mass);
+          histos.fill(HIST("h3dRecLcbar"), lcbaryon.pt, lcbaryon.eta, lcbaryon.mass);
+        }
+      }
+    }
+    
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 
   //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*
   PROCESS_SWITCH(alice3decayFinder, processFindDmesons, "find D mesons", true);
+  PROCESS_SWITCH(alice3decayFinder, processFindLcBaryons, "find Lc Baryons", true);
   //*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*>-~-<*
 };
 


### PR DESCRIPTION
End-of-the-week working point for ALICE 3 otf analysis chain. Includes:
* adds a fully customizable, per-prong, pT-dependent DCAxy selection in the decay daughter track preselection device
* adds a second process function to the finder device to look for three-prong decays
* ...more to follow