### PR TITLE
PWGEM/DQ: Add same pdgInHistory functionality for InTime Signal

### DIFF
--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -258,26 +258,44 @@ bool MCSignal::CheckProng(int i, bool checkSources, const T& track)
       if (!fProngs[i].fExcludePDGInHistory[k])
         nIncludedPDG++;
       int ith = 0;
-      while (currentMCParticle.has_mothers()) {
-        auto mother = currentMCParticle.template mothers_first_as<P>();
-        if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
-          pdgInHistory.emplace_back(true);
-          break;
+      if (!fProngs[i].fCheckGenerationsInTime) { // check generation back in time
+        while (currentMCParticle.has_mothers()) {
+          auto mother = currentMCParticle.template mothers_first_as<P>();
+          if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+            pdgInHistory.emplace_back(mother.pdgCode());
+            break;
+          }
+          if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+            return false;
+          }
+          ith++;
+          currentMCParticle = mother;
+          if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
+            break;
+          }
         }
-        if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+      } else { // check generation in time
+        if (!currentMCParticle.has_daughters())
           return false;
-        }
-        ith++;
-        currentMCParticle = mother;
-        if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
-          break;
+        const auto& daughtersSlice = currentMCParticle.template daughters_as<P>();
+        for (auto& d : daughtersSlice) {
+          if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+            pdgInHistory.emplace_back(d.pdgCode());
+            break;
+          }
+          if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+            return false;
+          }
+          ith++;
+          if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
+            break;
+          }
         }
       }
     }
-    if (pdgInHistory.size() != nIncludedPDG) // vector has as many entries as mothers defined for prong
+    if (pdgInHistory.size() != nIncludedPDG) // vector has as many entries as mothers (daughters) defined for prong
       return false;
   }
-
   return true;
 }
 

--- a/PWGDQ/Core/MCSignalLibrary.cxx
+++ b/PWGDQ/Core/MCSignalLibrary.cxx
@@ -351,7 +351,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
   if (!nameStr.compare("eFromAnyHc")) {
     MCProng prong(1, {11}, {true}, {false}, {0}, {0}, {false}, false, {402}, {false});
-    signal = new MCSignal(name, "Electrons from open charm hadron decays", {prong}, {-1});
+    signal = new MCSignal(name, "Electrons from any open charm hadron decays", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("eFromHb")) {
@@ -361,7 +361,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   }
   if (!nameStr.compare("eFromAnyHb")) {
     MCProng prong(1, {11}, {true}, {false}, {0}, {0}, {false}, false, {502}, {false});
-    signal = new MCSignal(name, "Electrons from open beauty hadron decays", {prong}, {-1});
+    signal = new MCSignal(name, "Electrons from any open beauty hadron decays", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("eFromHbc")) {


### PR DESCRIPTION
Implented functionallity to check the Signal also "In Time".
Before only the mother were selected and looped over.
Now also the daughter loop is implemented.