### PR TITLE
Add has_mcParticle check to LUT maker

### DIFF
--- a/ALICE3/Tasks/alice3-lutmaker.cxx
+++ b/ALICE3/Tasks/alice3-lutmaker.cxx
@@ -206,7 +206,7 @@ struct Alice3LutMaker {
     int ntrks = 0;
 
     for (const auto& track : tracks) {
-      if(!track.has_mcParticle()) 
+      if (!track.has_mcParticle())
         continue;
       const auto mcParticle = track.mcParticle_as<aod::McParticles>();
       if (mcParticle.pdgCode() != pdg) {

--- a/ALICE3/Tasks/alice3-lutmaker.cxx
+++ b/ALICE3/Tasks/alice3-lutmaker.cxx
@@ -206,6 +206,8 @@ struct Alice3LutMaker {
     int ntrks = 0;
 
     for (const auto& track : tracks) {
+      if(!track.has_mcParticle()) 
+        continue;
       const auto mcParticle = track.mcParticle_as<aod::McParticles>();
       if (mcParticle.pdgCode() != pdg) {
         continue;


### PR DESCRIPTION
@njacazio this is definitely a minimal change that we need to add for code safety...  but on top of that, maybe for Run 3 LUT stuff, we should do a minimum crossed rows selection and so on? 