### PR TITLE
PWGCF: Update Femtodream

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -112,14 +112,24 @@ DECLARE_SOA_DYNAMIC_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFind
                            [](uint8_t tpcNClsFindable, uint8_t tpcNClsCrossedRows) -> float {
                              return (float)tpcNClsCrossedRows / (float)tpcNClsFindable;
                            });
+DECLARE_SOA_COLUMN(TPCNSigmaEl, tpcNSigmaEl, float);
+DECLARE_SOA_COLUMN(TPCNSigmaPi, tpcNSigmaPi, float);
+DECLARE_SOA_COLUMN(TPCNSigmaKa, tpcNSigmaKa, float);
+DECLARE_SOA_COLUMN(TPCNSigmaPr, tpcNSigmaPr, float);
+DECLARE_SOA_COLUMN(TPCNSigmaDe, tpcNSigmaDe, float);
+DECLARE_SOA_COLUMN(TOFNSigmaEl, tofNSigmaEl, float);
+DECLARE_SOA_COLUMN(TOFNSigmaPi, tofNSigmaPi, float);
+DECLARE_SOA_COLUMN(TOFNSigmaKa, tofNSigmaKa, float);
+DECLARE_SOA_COLUMN(TOFNSigmaPr, tofNSigmaPr, float);
+DECLARE_SOA_COLUMN(TOFNSigmaDe, tofNSigmaDe, float);
 DECLARE_SOA_COLUMN(DaughDCA, daughDCA, float);       //! DCA between daughters
 DECLARE_SOA_COLUMN(TransRadius, transRadius, float); //! Transverse radius of the decay vertex
 DECLARE_SOA_COLUMN(DecayVtxX, decayVtxX, float);     //! X position of the decay vertex
 DECLARE_SOA_COLUMN(DecayVtxY, decayVtxY, float);     //! Y position of the decay vertex
 DECLARE_SOA_COLUMN(DecayVtxZ, decayVtxZ, float);     //! Z position of the decay vertex
 DECLARE_SOA_COLUMN(MKaon, mKaon, float);             //! The invariant mass of V0 candidate, assuming kaon
-
 } // namespace femtodreamparticle
+
 DECLARE_SOA_TABLE(FDParticles, "AOD", "FDPARTICLE",
                   o2::soa::Index<>,
                   femtodreamparticle::FDCollisionId,
@@ -152,33 +162,23 @@ DECLARE_SOA_TABLE(FDExtParticles, "AOD", "FDEXTPARTICLE",
                   track::DcaXY,
                   track::DcaZ,
                   track::TPCSignal,
-                  pidtpc_tiny::TPCNSigmaStoreEl,
-                  pidtpc_tiny::TPCNSigmaStorePi,
-                  pidtpc_tiny::TPCNSigmaStoreKa,
-                  pidtpc_tiny::TPCNSigmaStorePr,
-                  pidtpc_tiny::TPCNSigmaStoreDe,
-                  pidtof_tiny::TOFNSigmaStoreEl,
-                  pidtof_tiny::TOFNSigmaStorePi,
-                  pidtof_tiny::TOFNSigmaStoreKa,
-                  pidtof_tiny::TOFNSigmaStorePr,
-                  pidtof_tiny::TOFNSigmaStoreDe,
+                  femtodreamparticle::TPCNSigmaEl,
+                  femtodreamparticle::TPCNSigmaPi,
+                  femtodreamparticle::TPCNSigmaKa,
+                  femtodreamparticle::TPCNSigmaPr,
+                  femtodreamparticle::TPCNSigmaDe,
+                  femtodreamparticle::TOFNSigmaEl,
+                  femtodreamparticle::TOFNSigmaPi,
+                  femtodreamparticle::TOFNSigmaKa,
+                  femtodreamparticle::TOFNSigmaPr,
+                  femtodreamparticle::TOFNSigmaDe,
                   femtodreamparticle::DaughDCA,
                   femtodreamparticle::TransRadius,
                   femtodreamparticle::DecayVtxX,
                   femtodreamparticle::DecayVtxY,
                   femtodreamparticle::DecayVtxZ,
                   femtodreamparticle::MKaon,
-                  femtodreamparticle::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, femtodreamparticle::TPCNClsCrossedRows>,
-                  pidtpc_tiny::TPCNSigmaEl<pidtpc_tiny::TPCNSigmaStoreEl>,
-                  pidtpc_tiny::TPCNSigmaPi<pidtpc_tiny::TPCNSigmaStorePi>,
-                  pidtpc_tiny::TPCNSigmaKa<pidtpc_tiny::TPCNSigmaStoreKa>,
-                  pidtpc_tiny::TPCNSigmaPr<pidtpc_tiny::TPCNSigmaStorePr>,
-                  pidtpc_tiny::TPCNSigmaDe<pidtpc_tiny::TPCNSigmaStoreDe>,
-                  pidtof_tiny::TOFNSigmaEl<pidtof_tiny::TOFNSigmaStoreEl>,
-                  pidtof_tiny::TOFNSigmaPi<pidtof_tiny::TOFNSigmaStorePi>,
-                  pidtof_tiny::TOFNSigmaKa<pidtof_tiny::TOFNSigmaStoreKa>,
-                  pidtof_tiny::TOFNSigmaPr<pidtof_tiny::TOFNSigmaStorePr>,
-                  pidtof_tiny::TOFNSigmaDe<pidtof_tiny::TOFNSigmaStoreDe>);
+                  femtodreamparticle::TPCCrossedRowsOverFindableCls<track::TPCNClsFindable, femtodreamparticle::TPCNClsCrossedRows>)
 using FDFullParticle = FDExtParticles::iterator;
 
 /// FemtoDreamTrackMC

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -81,7 +81,7 @@ class FemtoDreamCollisionSelection
   /// \param col Collision
   /// \return whether or not the collisions fulfills the specified selections
   template <typename C>
-  bool isSelectedCollision_base(C const& col)
+  bool isSelectedCollision(C const& col)
   {
     if (std::abs(col.posZ()) > mZvtxMax) {
       return false;
@@ -102,42 +102,29 @@ class FemtoDreamCollisionSelection
   }
 
   template <typename C, typename T, typename TC>
-  bool isSelectedCollision(C const& col, T const& tracks, TC& trackCuts)
+  bool isEmptyCollision(C const& col, T const& tracks, TC& trackCuts)
   {
-    if (!isSelectedCollision_base(col)) {
-      return false;
-    }
-
-    // check if there is at least one selected track in the collision
-    bool keepCollision = false;
+    // check if there is no selected track
     for (auto const& track : tracks) {
       if (trackCuts.isSelectedMinimal(track)) {
-        keepCollision = true;
-        break;
+        return false;
       }
     }
-    return keepCollision;
+    return true;
   }
 
   template <typename C, typename V, typename VC, typename T>
-  bool isSelectedCollision(C const& col, V const& V0s, VC& V0Cuts, T const& Tracks)
+  bool isEmptyCollision(C const& col, V const& V0s, VC& V0Cuts, T const& Tracks)
   {
-    if (!isSelectedCollision_base(col)) {
-      return false;
-    }
-    // check if there is at least one selected V0 in the collision
-    bool keepCollision = false;
+    // check if there is no selected V0
     for (auto const& V0 : V0s) {
-      const auto postrack = V0.template posTrack_as<T>();
-      const auto negtrack = V0.template negTrack_as<T>();
+      auto postrack = V0.template posTrack_as<T>();
+      auto negtrack = V0.template negTrack_as<T>();
       if (V0Cuts.isSelectedMinimal(col, V0, postrack, negtrack)) {
-        keepCollision = true;
-        break;
+        return false;
       }
     }
-    // if no track has been found, return false
-    // otherwise true
-    return keepCollision;
+    return true;
   }
 
   /// Some basic QA of the event

--- a/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamCollisionSelection.h
@@ -80,8 +80,8 @@ class FemtoDreamCollisionSelection
   /// \tparam T type of the collision
   /// \param col Collision
   /// \return whether or not the collisions fulfills the specified selections
-  template <typename T>
-  bool isSelected(T const& col)
+  template <typename C>
+  bool isSelectedCollision_base(C const& col)
   {
     if (std::abs(col.posZ()) > mZvtxMax) {
       return false;
@@ -99,6 +99,45 @@ class FemtoDreamCollisionSelection
       }
     }
     return true;
+  }
+
+  template <typename C, typename T, typename TC>
+  bool isSelectedCollision(C const& col, T const& tracks, TC& trackCuts)
+  {
+    if (!isSelectedCollision_base(col)) {
+      return false;
+    }
+
+    // check if there is at least one selected track in the collision
+    bool keepCollision = false;
+    for (auto const& track : tracks) {
+      if (trackCuts.isSelectedMinimal(track)) {
+        keepCollision = true;
+        break;
+      }
+    }
+    return keepCollision;
+  }
+
+  template <typename C, typename V, typename VC, typename T>
+  bool isSelectedCollision(C const& col, V const& V0s, VC& V0Cuts, T const& Tracks)
+  {
+    if (!isSelectedCollision_base(col)) {
+      return false;
+    }
+    // check if there is at least one selected V0 in the collision
+    bool keepCollision = false;
+    for (auto const& V0 : V0s) {
+      const auto postrack = V0.template posTrack_as<T>();
+      const auto negtrack = V0.template negTrack_as<T>();
+      if (V0Cuts.isSelectedMinimal(col, V0, postrack, negtrack)) {
+        keepCollision = true;
+        break;
+      }
+    }
+    // if no track has been found, return false
+    // otherwise true
+    return keepCollision;
   }
 
   /// Some basic QA of the event

--- a/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamObjectSelection.h
@@ -51,8 +51,8 @@ class FemtoDreamObjectSelection
   void fillSelectionHistogram()
   {
     int nBins = mSelections.size();
-    mHistogramRegistry->add((static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[part]) + "/cuthist").c_str(), "; Cut; Value", kTH1F, {{nBins, 0, static_cast<double>(nBins)}});
-    auto hist = mHistogramRegistry->get<TH1>(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/cuthist"));
+    mQAHistogramRegistry->add((static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[part]) + "/cuthist").c_str(), "; Cut; Value", kTH1F, {{nBins, 0, static_cast<double>(nBins)}});
+    auto hist = mQAHistogramRegistry->get<TH1>(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/cuthist"));
     for (size_t i = 0; i < mSelections.size(); ++i) {
       hist->GetXaxis()->SetBinLabel(i + 1, Form("%u", mSelections.at(i).getSelectionVariable()));
       hist->SetBinContent(i + 1, mSelections.at(i).getSelectionValue());
@@ -187,7 +187,8 @@ class FemtoDreamObjectSelection
   }
 
  protected:
-  HistogramRegistry* mHistogramRegistry;                                     ///< For QA output
+  HistogramRegistry* mHistogramRegistry;                                     ///< For Analysis QA output
+  HistogramRegistry* mQAHistogramRegistry;                                   ///< For QA output
   std::vector<FemtoDreamSelection<selValDataType, selVariable>> mSelections; ///< Vector containing all selections
 };
 

--- a/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/FemtoDreamParticleHisto.h
@@ -63,7 +63,7 @@ class FemtoDreamParticleHisto
 
   // comment
   template <o2::aod::femtodreamMCparticle::MCType mc, typename T>
-  void init_debug(std::string folderName, T& tempFitVarpAxis, T& tempFitVarNsigmaTPCAxis, T& tempFitVarNsigmaTOFAxis)
+  void init_debug(std::string folderName, T& tempFitVarpTAxis, T& tempFitVarInvMassAxis, T& tempFitVarpAxis, T& tempFitVarNsigmaTPCAxis, T& tempFitVarNsigmaTOFAxis, T& tempFitVarNsigmaTPCTOFAxis)
   {
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[mc]).c_str();
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
@@ -79,31 +79,32 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
-      // mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_el").c_str(), "n#sigma_{TPC}^{e}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCAxis});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{600, 0, 6}, {130, -6.5, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{600, 0, 6}, {65, 0, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{600, 0, 6}, {65, 0, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{600, 0, 6}, {100, 0, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{600, 0, 6}, {100, 0, 6.5}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{600, 0, 6}, {100, 0, 6.5}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_pi").c_str(), "n#sigma_{TPC}^{#pi}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_K").c_str(), "n#sigma_{TPC}^{K}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_p").c_str(), "n#sigma_{TPC}^{p}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTPC_d").c_str(), "n#sigma_{TPC}^{d}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_el").c_str(), "n#sigma_{TOF}^{e}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_pi").c_str(), "n#sigma_{TOF}^{#pi}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_K").c_str(), "n#sigma_{TOF}^{K}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_p").c_str(), "n#sigma_{TOF}^{p}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaTOF_d").c_str(), "n#sigma_{TOF}^{d}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_el").c_str(), "n#sigma_{comb}^{e}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_pi").c_str(), "n#sigma_{comb}^{#pi}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_K").c_str(), "n#sigma_{comb}^{K}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_p").c_str(), "n#sigma_{comb}^{p}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "n#sigma_{comb}^{d}", kTH2F, {tempFitVarpAxis, tempFitVarNsigmaTPCTOFAxis});
     } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hDaughDCA").c_str(), "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTransRadius").c_str(), "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {{5000, 1.f, 1.5f}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {{5000, 1.f, 1.5f}});
-      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {{500, 1.f, 1.5f}, {500, 1.f, 1.5f}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {tempFitVarInvMassAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassLambda").c_str(), "; p_{T} (GeV/#it{c{}); M_{#Lambda}", kTH2F, {tempFitVarpTAxis, tempFitVarInvMassAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {tempFitVarInvMassAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH2F, {tempFitVarpTAxis, tempFitVarInvMassAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {tempFitVarInvMassAxis, tempFitVarInvMassAxis});
     }
   }
 
@@ -155,8 +156,8 @@ class FemtoDreamParticleHisto
   /// \param isMC add Monte Carlo truth histograms to the output file
   template <typename T>
   void init(HistogramRegistry* registry,
-            T& tempFitVarpTBins, T& tempFitVarBins,
-            T& tempFitVarpBins, T& tempFitVarNsigmaTPCBins, T& tempFitVarNsigmaTOFBins,
+            T& tempFitVarpTBins, T& tempFitVarBins, T& tempFitVarInvMassBins,
+            T& tempFitVarpBins, T& tempFitVarNsigmaTPCBins, T& tempFitVarNsigmaTOFBins, T& tempFitVarNsigmaTPCTOFBins,
             bool isMC, int pdgCode, bool isDebug = false)
   {
     mPDG = pdgCode;
@@ -179,17 +180,19 @@ class FemtoDreamParticleHisto
 
       framework::AxisSpec tempFitVarpTAxis = {tempFitVarpTBins, "#it{p}_{T} (GeV/#it{c})"};
       framework::AxisSpec tempFitVarAxis = {tempFitVarBins, tempFitVarAxisTitle};
+      framework::AxisSpec tempFitVarInvMassAxis = {tempFitVarInvMassBins, "M_{inv} (GeV/#it{c}^{2})"};
 
       framework::AxisSpec tempFitVarpAxis = {tempFitVarpBins, "#it{p}_{reco} (GeV/#it{c})"};
       framework::AxisSpec tempFitVarNsigmaTPCAxis = {tempFitVarNsigmaTPCBins, "n#sigma_{TPC}"};
       framework::AxisSpec tempFitVarNsigmaTOFAxis = {tempFitVarNsigmaTOFBins, "n#sigma_{TOF}"};
+      framework::AxisSpec tempFitVarNsigmaTPCTOFAxis = {tempFitVarNsigmaTPCTOFBins, "n#sigma_{TPC+TOF}"};
 
       std::string folderName = (static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]).c_str() + static_cast<std::string>(mFolderSuffix[mFolderSuffixType])).c_str();
 
       // Fill here the actual histogramms by calling init_base and init_MC
       init_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, tempFitVarAxisTitle, tempFitVarpTAxis, tempFitVarAxis);
       if (isDebug) {
-        init_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, tempFitVarpAxis, tempFitVarNsigmaTPCAxis, tempFitVarNsigmaTOFAxis);
+        init_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, tempFitVarpTAxis, tempFitVarInvMassAxis, tempFitVarpAxis, tempFitVarNsigmaTPCAxis, tempFitVarNsigmaTOFAxis, tempFitVarNsigmaTPCTOFAxis);
       }
       if (isMC) {
         init_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(folderName, tempFitVarAxisTitle, tempFitVarpTAxis, tempFitVarAxis);
@@ -255,7 +258,9 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxY"), part.decayVtxY());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxZ"), part.decayVtxZ());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambda"), part.mLambda());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassLambda"), part.pt(), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassAntiLambda"), part.mAntiLambda());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassAntiLambda"), part.pt(), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
     }
   }

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -17,6 +17,11 @@
 #define PWGCF_FEMTODREAM_FEMTODREAMSELECTION_H_
 
 #include <cmath>
+#include "Framework/HistogramRegistry.h"
+#include "PWGCF/DataModel/FemtoDerived.h"
+
+using namespace o2;
+using namespace o2::framework;
 
 namespace o2::analysis::femtoDream
 {
@@ -100,25 +105,35 @@ class FemtoDreamSelection
   /// \param cutContainer Bit-wise container for the systematic variations
   /// \param counter Position in the bit-wise container for the systematic variations to be modified
   template <typename T>
-  void checkSelectionSetBit(selValDataType observable, T& cutContainer, size_t& counter)
+  void checkSelectionSetBit(selValDataType observable, T& cutContainer, size_t& counter, HistogramRegistry* registry)
   {
     /// If the selection is fulfilled the bit at the specified position (counter) within the bit-wise container is set to 1
     if (isSelected(observable)) {
       cutContainer |= 1UL << counter;
+      if (registry) {
+        registry->fill(HIST("AnalysisQA/CutCounter"), 1 + sizeof(o2::aod::femtodreamparticle::cutContainerType));
+      }
+    } else {
+      if (registry) {
+        registry->fill(HIST("AnalysisQA/CutCounter"), counter);
+      }
     }
     ++counter;
   }
 
   template <typename T>
-  void checkSelectionSetBitPID(selValDataType observable, T& cutContainer)
+  void checkSelectionSetBitPID(selValDataType observable, T& cutContainer, std::size_t& counter, HistogramRegistry* registry)
   {
     /// If the selection is fulfilled the bit at the specified position (counter) within the bit-wise container is set to 1
     if (isSelected(observable)) {
-      cutContainer |= 1UL;
+      cutContainer |= 1UL << counter;
+      if (registry) {
+        registry->fill(HIST("AnalysisQA/PIDCutCounter"), 1 + sizeof(o2::aod::femtodreamparticle::cutContainerType));
+      }
     } else {
-      cutContainer |= 0UL;
+      registry->fill(HIST("AnalysisQA/PIDCutCounter"), counter);
     }
-    cutContainer <<= 1;
+    ++counter;
   }
 
  private:

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -111,7 +111,7 @@ class FemtoDreamSelection
     if (isSelected(observable)) {
       cutContainer |= 1UL << counter;
       if (registry) {
-        registry->fill(HIST("AnalysisQA/CutCounter"), 1 + sizeof(o2::aod::femtodreamparticle::cutContainerType));
+        registry->fill(HIST("AnalysisQA/CutCounter"), sizeof(o2::aod::femtodreamparticle::cutContainerType));
       }
     } else {
       if (registry) {
@@ -122,18 +122,15 @@ class FemtoDreamSelection
   }
 
   template <typename T>
-  void checkSelectionSetBitPID(selValDataType observable, T& cutContainer, std::size_t& counter, HistogramRegistry* registry)
+  void checkSelectionSetBitPID(selValDataType observable, T& cutContainer)
   {
     /// If the selection is fulfilled the bit at the specified position (counter) within the bit-wise container is set to 1
     if (isSelected(observable)) {
-      cutContainer |= 1UL << counter;
-      if (registry) {
-        registry->fill(HIST("AnalysisQA/PIDCutCounter"), 1 + sizeof(o2::aod::femtodreamparticle::cutContainerType));
-      }
+      cutContainer |= 1UL;
     } else {
-      registry->fill(HIST("AnalysisQA/PIDCutCounter"), counter);
+      cutContainer |= 0UL;
     }
-    ++counter;
+    cutContainer <<= 1;
   }
 
  private:

--- a/PWGCF/FemtoDream/FemtoDreamSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamSelection.h
@@ -111,7 +111,7 @@ class FemtoDreamSelection
     if (isSelected(observable)) {
       cutContainer |= 1UL << counter;
       if (registry) {
-        registry->fill(HIST("AnalysisQA/CutCounter"), sizeof(o2::aod::femtodreamparticle::cutContainerType));
+        registry->fill(HIST("AnalysisQA/CutCounter"), 8 * sizeof(o2::aod::femtodreamparticle::cutContainerType));
       }
     } else {
       if (registry) {

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -367,7 +367,20 @@ void FemtoDreamTrackSelection::init(HistogramRegistry* QAregistry, HistogramRegi
 template <typename T>
 auto FemtoDreamTrackSelection::getNsigmaTPC(T const& track, o2::track::PID pid)
 {
-  return o2::aod::pidutils::tpcNSigma(pid, track);
+  if (pid == o2::track::PID::Electron)
+    return track.tpcNSigmaEl();
+  else if (pid == o2::track::PID::Muon)
+    return track.tpcNSigmaMu();
+  else if (pid == o2::track::PID::Pion)
+    return track.tpcNSigmaPi();
+  else if (pid == o2::track::PID::Kaon)
+    return track.tpcNSigmaKa();
+  else if (pid == o2::track::PID::Proton)
+    return track.tpcNSigmaPr();
+  else if (pid == o2::track::PID::Deuteron)
+    return track.tpcNSigmaDe();
+  else
+    return 999.f;
 }
 
 template <typename T>
@@ -377,8 +390,21 @@ auto FemtoDreamTrackSelection::getNsigmaTOF(T const& track, o2::track::PID pid)
   if (!track.hasTOF()) {
     return 999.f;
   }
-
-  return o2::aod::pidutils::tofNSigma(pid, track);
+  if (pid == o2::track::PID::Electron)
+    return track.tofNSigmaEl();
+  else if (pid == o2::track::PID::Muon)
+    return track.tofNSigmaMu();
+  else if (pid == o2::track::PID::Pion)
+    return track.tofNSigmaPi();
+  else if (pid == o2::track::PID::Kaon)
+    return track.tofNSigmaKa();
+  else if (pid == o2::track::PID::Proton)
+    return track.tofNSigmaPr();
+  else if (pid == o2::track::PID::Deuteron)
+    return track.tofNSigmaDe();
+  else
+    LOG(info) << "what";
+  return 999.f;
 }
 
 template <typename T>
@@ -463,7 +489,6 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
   cutContainerType output = 0;
   size_t counter = 0;
   cutContainerType outputPID = 0;
-  size_t counterPID = 0;
   const auto sign = track.sign();
   const auto pT = track.pt();
   const auto eta = track.eta();
@@ -492,10 +517,9 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
         auto pidTPCVal = pidTPC.at(i) - nSigmaPIDOffsetTPC;
         auto pidTOFVal = pidTOF.at(i) - nSigmaPIDOffsetTOF;
         auto pidComb = std::sqrt(pidTPCVal * pidTPCVal + pidTOFVal * pidTOFVal);
-        sel.checkSelectionSetBitPID(pidTPCVal, outputPID, counterPID, mHistogramRegistry);
-        sel.checkSelectionSetBitPID(pidComb, outputPID, counterPID, mHistogramRegistry);
+        sel.checkSelectionSetBitPID(pidTPCVal, outputPID);
+        sel.checkSelectionSetBitPID(pidComb, outputPID);
       }
-
     } else {
       /// for the rest it's all the same
       switch (selVariable) {

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -369,8 +369,6 @@ auto FemtoDreamTrackSelection::getNsigmaTPC(T const& track, o2::track::PID pid)
 {
   if (pid == o2::track::PID::Electron)
     return track.tpcNSigmaEl();
-  else if (pid == o2::track::PID::Muon)
-    return track.tpcNSigmaMu();
   else if (pid == o2::track::PID::Pion)
     return track.tpcNSigmaPi();
   else if (pid == o2::track::PID::Kaon)
@@ -392,8 +390,6 @@ auto FemtoDreamTrackSelection::getNsigmaTOF(T const& track, o2::track::PID pid)
   }
   if (pid == o2::track::PID::Electron)
     return track.tofNSigmaEl();
-  else if (pid == o2::track::PID::Muon)
-    return track.tofNSigmaMu();
   else if (pid == o2::track::PID::Pion)
     return track.tofNSigmaPi();
   else if (pid == o2::track::PID::Kaon)
@@ -403,8 +399,7 @@ auto FemtoDreamTrackSelection::getNsigmaTOF(T const& track, o2::track::PID pid)
   else if (pid == o2::track::PID::Deuteron)
     return track.tofNSigmaDe();
   else
-    LOG(info) << "what";
-  return 999.f;
+    return 999.f;
 }
 
 template <typename T>

--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -99,7 +99,7 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
   /// \tparam cutContainerType Data type of the bit-wise container for the selections
   /// \param registry HistogramRegistry for QA output
   template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::TrackType tracktype, typename cutContainerType>
-  void init(HistogramRegistry* registry);
+  void init(HistogramRegistry* QAregistry, HistogramRegistry* Registry);
 
   /// Passes the species to the task for which PID needs to be stored
   /// \tparam T Data type of the configurable passed to the functions
@@ -290,10 +290,11 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
 };                                                                                                 // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::TrackType tracktype, typename cutContainerType>
-void FemtoDreamTrackSelection::init(HistogramRegistry* registry)
+void FemtoDreamTrackSelection::init(HistogramRegistry* QAregistry, HistogramRegistry* Registry)
 {
-  if (registry) {
-    mHistogramRegistry = registry;
+  if (QAregistry && Registry) {
+    mHistogramRegistry = Registry;
+    mQAHistogramRegistry = QAregistry;
     std::string folderName = static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[part]) + "/" + static_cast<std::string>(o2::aod::femtodreamparticle::TrackTypeName[tracktype]);
 
     /// check whether the number of selection exceeds the bitmap size
@@ -301,38 +302,38 @@ void FemtoDreamTrackSelection::init(HistogramRegistry* registry)
     if (nSelections > 8 * sizeof(cutContainerType)) {
       LOG(fatal) << "FemtoDreamTrackCuts: Number of selections too large for your container - quitting!";
     }
-
-    mHistogramRegistry->add((folderName + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
-    mHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
-    mHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
-    mHistogramRegistry->add((folderName + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + "/hTPCcrossedOverFindalbe").c_str(), "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
-    mHistogramRegistry->add((folderName + "/hTPCcrossedRows").c_str(), "; TPC crossed rows; Entries", kTH1F, {{163, 0, 163}});
-    mHistogramRegistry->add((folderName + "/hTPCfindableVsCrossed").c_str(), ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, 0, 163}, {163, 0, 163}});
-    mHistogramRegistry->add((folderName + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
-    mHistogramRegistry->add((folderName + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
-    mHistogramRegistry->add((folderName + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
-    mHistogramRegistry->add((folderName + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
-    mHistogramRegistry->add((folderName + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
-    mHistogramRegistry->add((folderName + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
-    mHistogramRegistry->add((folderName + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
-    mHistogramRegistry->add((folderName + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
-    mHistogramRegistry->add((folderName + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
+    mQAHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
+    mQAHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
+    mQAHistogramRegistry->add((folderName + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mQAHistogramRegistry->add((folderName + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mQAHistogramRegistry->add((folderName + "/hTPCcrossedOverFindalbe").c_str(), "; TPC ratio findable; Entries", kTH1F, {{100, 0.5, 1.5}});
+    mQAHistogramRegistry->add((folderName + "/hTPCcrossedRows").c_str(), "; TPC crossed rows; Entries", kTH1F, {{163, 0, 163}});
+    mQAHistogramRegistry->add((folderName + "/hTPCfindableVsCrossed").c_str(), ";TPC findable clusters ; TPC crossed rows;", kTH2F, {{163, 0, 163}, {163, 0, 163}});
+    mQAHistogramRegistry->add((folderName + "/hTPCshared").c_str(), "; TPC shared clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
+    mQAHistogramRegistry->add((folderName + "/hITSclusters").c_str(), "; ITS clusters; Entries", kTH1F, {{10, -0.5, 9.5}});
+    mQAHistogramRegistry->add((folderName + "/hITSclustersIB").c_str(), "; ITS clusters in IB; Entries", kTH1F, {{10, -0.5, 9.5}});
+    mQAHistogramRegistry->add((folderName + "/hDCAxy").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{xy} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/hDCAz").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA_{z} (cm)", kTH2F, {{100, 0, 10}, {500, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/hDCA").c_str(), "; #it{p}_{T} (GeV/#it{c}); DCA (cm)", kTH2F, {{100, 0, 10}, {301, 0., 1.5}});
+    mQAHistogramRegistry->add((folderName + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTPC_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTPC_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTPC_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTPC_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTPC_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TPC}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTOF_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTOF_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTOF_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTOF_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaTOF_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{TOF}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaComb_el").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{e}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaComb_pi").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{#pi}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaComb_K").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{K}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaComb_p").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{p}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
+    mQAHistogramRegistry->add((folderName + "/nSigmaComb_d").c_str(), "; #it{p} (GeV/#it{c}); n#sigma_{comb}^{d}", kTH2F, {{100, 0, 10}, {100, -5, 5}});
   }
+
   /// set cuts
   nPtMinSel = getNSelections(femtoDreamTrackSelection::kpTMin);
   nPtMaxSel = getNSelections(femtoDreamTrackSelection::kpTMax);
@@ -462,6 +463,7 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
   cutContainerType output = 0;
   size_t counter = 0;
   cutContainerType outputPID = 0;
+  size_t counterPID = 0;
   const auto sign = track.sign();
   const auto pT = track.pt();
   const auto eta = track.eta();
@@ -490,8 +492,8 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
         auto pidTPCVal = pidTPC.at(i) - nSigmaPIDOffsetTPC;
         auto pidTOFVal = pidTOF.at(i) - nSigmaPIDOffsetTOF;
         auto pidComb = std::sqrt(pidTPCVal * pidTPCVal + pidTOFVal * pidTOFVal);
-        sel.checkSelectionSetBitPID(pidTPCVal, outputPID);
-        sel.checkSelectionSetBitPID(pidComb, outputPID);
+        sel.checkSelectionSetBitPID(pidTPCVal, outputPID, counterPID, mHistogramRegistry);
+        sel.checkSelectionSetBitPID(pidComb, outputPID, counterPID, mHistogramRegistry);
       }
 
     } else {
@@ -537,7 +539,7 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
         case (femtoDreamTrackSelection::kPIDnSigmaMax):
           break;
       }
-      sel.checkSelectionSetBit(observable, output, counter);
+      sel.checkSelectionSetBit(observable, output, counter, mHistogramRegistry);
     }
   }
   return {output, outputPID};
@@ -546,37 +548,37 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
 template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::TrackType tracktype, typename T>
 void FemtoDreamTrackSelection::fillQA(T const& track)
 {
-  if (mHistogramRegistry) {
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hPt"), track.pt());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hEta"), track.eta());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hPhi"), track.phi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfindable"), track.tpcNClsFindable());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfound"), track.tpcNClsFound());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCcrossedOverFindalbe"), track.tpcCrossedRowsOverFindableCls());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCcrossedRows"), track.tpcNClsCrossedRows());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfindableVsCrossed"), track.tpcNClsFindable(), track.tpcNClsCrossedRows());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCshared"), track.tpcNClsShared());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hITSclusters"), track.itsNCls());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hITSclustersIB"), track.itsNClsInnerBarrel());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCAxy"), track.pt(), track.dcaXY());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCAz"), track.pt(), track.dcaZ());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCA"), track.pt(), std::sqrt(pow(track.dcaXY(), 2.) + pow(track.dcaZ(), 2.)));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCdEdX"), track.p(), track.tpcSignal());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_el"), track.p(), track.tpcNSigmaEl());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_pi"), track.p(), track.tpcNSigmaPi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_K"), track.p(), track.tpcNSigmaKa());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_p"), track.p(), track.tpcNSigmaPr());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_d"), track.p(), track.tpcNSigmaDe());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_el"), track.p(), track.tofNSigmaEl());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_pi"), track.p(), track.tofNSigmaPi());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_K"), track.p(), track.tofNSigmaKa());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_p"), track.p(), track.tofNSigmaPr());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_d"), track.p(), track.tofNSigmaDe());
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_el"), track.p(), std::sqrt(track.tpcNSigmaEl() * track.tpcNSigmaEl() + track.tofNSigmaEl() * track.tofNSigmaEl()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_pi"), track.p(), std::sqrt(track.tpcNSigmaPi() * track.tpcNSigmaPi() + track.tofNSigmaPi() * track.tofNSigmaPi()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_K"), track.p(), std::sqrt(track.tpcNSigmaKa() * track.tpcNSigmaKa() + track.tofNSigmaKa() * track.tofNSigmaKa()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_p"), track.p(), std::sqrt(track.tpcNSigmaPr() * track.tpcNSigmaPr() + track.tofNSigmaPr() * track.tofNSigmaPr()));
-    mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_d"), track.p(), std::sqrt(track.tpcNSigmaDe() * track.tpcNSigmaDe() + track.tofNSigmaDe() * track.tofNSigmaDe()));
+  if (mQAHistogramRegistry) {
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hPt"), track.pt());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hEta"), track.eta());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hPhi"), track.phi());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfindable"), track.tpcNClsFindable());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfound"), track.tpcNClsFound());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCcrossedOverFindalbe"), track.tpcCrossedRowsOverFindableCls());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCcrossedRows"), track.tpcNClsCrossedRows());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCfindableVsCrossed"), track.tpcNClsFindable(), track.tpcNClsCrossedRows());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCshared"), track.tpcNClsShared());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hITSclusters"), track.itsNCls());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hITSclustersIB"), track.itsNClsInnerBarrel());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCAxy"), track.pt(), track.dcaXY());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCAz"), track.pt(), track.dcaZ());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hDCA"), track.pt(), std::sqrt(pow(track.dcaXY(), 2.) + pow(track.dcaZ(), 2.)));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/hTPCdEdX"), track.p(), track.tpcSignal());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_el"), track.p(), track.tpcNSigmaEl());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_pi"), track.p(), track.tpcNSigmaPi());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_K"), track.p(), track.tpcNSigmaKa());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_p"), track.p(), track.tpcNSigmaPr());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTPC_d"), track.p(), track.tpcNSigmaDe());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_el"), track.p(), track.tofNSigmaEl());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_pi"), track.p(), track.tofNSigmaPi());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_K"), track.p(), track.tofNSigmaKa());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_p"), track.p(), track.tofNSigmaPr());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaTOF_d"), track.p(), track.tofNSigmaDe());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_el"), track.p(), std::sqrt(track.tpcNSigmaEl() * track.tpcNSigmaEl() + track.tofNSigmaEl() * track.tofNSigmaEl()));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_pi"), track.p(), std::sqrt(track.tpcNSigmaPi() * track.tpcNSigmaPi() + track.tofNSigmaPi() * track.tofNSigmaPi()));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_K"), track.p(), std::sqrt(track.tpcNSigmaKa() * track.tpcNSigmaKa() + track.tofNSigmaKa() * track.tofNSigmaKa()));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_p"), track.p(), std::sqrt(track.tpcNSigmaPr() * track.tpcNSigmaPr() + track.tofNSigmaPr() * track.tofNSigmaPr()));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/") + HIST(o2::aod::femtodreamparticle::TrackTypeName[tracktype]) + HIST("/nSigmaComb_d"), track.p(), std::sqrt(track.tpcNSigmaDe() * track.tpcNSigmaDe() + track.tofNSigmaDe() * track.tofNSigmaDe()));
   }
 }
 

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -74,7 +74,7 @@ class FemtoDreamV0Selection
   template <o2::aod::femtodreamparticle::ParticleType part,
             o2::aod::femtodreamparticle::ParticleType daugh,
             typename cutContainerType>
-  void init(HistogramRegistry* registry);
+  void init(HistogramRegistry* QAregistry, HistogramRegistry* Registry);
 
   template <typename C, typename V, typename T>
   bool isSelectedMinimal(C const& col, V const& v0, T const& posTrack,
@@ -277,10 +277,11 @@ class FemtoDreamV0Selection
 template <o2::aod::femtodreamparticle::ParticleType part,
           o2::aod::femtodreamparticle::ParticleType daugh,
           typename cutContainerType>
-void FemtoDreamV0Selection::init(HistogramRegistry* registry)
+void FemtoDreamV0Selection::init(HistogramRegistry* QAregistry, HistogramRegistry* Registry)
 {
-  if (registry) {
-    mHistogramRegistry = registry;
+  if (QAregistry && Registry) {
+    mHistogramRegistry = Registry;
+    mQAHistogramRegistry = QAregistry;
     fillSelectionHistogram<part>();
     fillSelectionHistogram<daugh>();
 
@@ -298,73 +299,73 @@ void FemtoDreamV0Selection::init(HistogramRegistry* registry)
     std::string folderName = static_cast<std::string>(
       o2::aod::femtodreamparticle::ParticleTypeName[part]);
     /// \todo initialize histograms for children tracks of v0s
-    mHistogramRegistry->add((folderName + "/hPt").c_str(),
-                            "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
-                            {{1000, 0, 10}});
-    mHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries",
-                            kTH1F, {{1000, -1, 1}});
-    mHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries",
-                            kTH1F, {{1000, 0, 2. * M_PI}});
-    mHistogramRegistry->add((folderName + "/hDaughDCA").c_str(),
-                            "; DCA^{daugh} (cm); Entries", kTH1F,
-                            {{1000, 0, 10}});
-    mHistogramRegistry->add((folderName + "/hTransRadius").c_str(),
-                            "; #it{r}_{xy} (cm); Entries", kTH1F,
-                            {{1500, 0, 150}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxX").c_str(),
-                            "; #it{Vtx}_{x} (cm); Entries", kTH1F,
-                            {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxY").c_str(),
-                            "; #it{Vtx}_{y} (cm)); Entries", kTH1F,
-                            {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hDecayVtxZ").c_str(),
-                            "; #it{Vtx}_{z} (cm); Entries", kTH1F,
-                            {{2000, 0, 200}});
-    mHistogramRegistry->add((folderName + "/hCPA").c_str(),
-                            "; #it{cos #theta_{p}}; Entries", kTH1F,
-                            {{1000, 0.9, 1.}});
-    mHistogramRegistry->add((folderName + "/hCPAvsPt").c_str(),
-                            "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}",
-                            kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
-    mHistogramRegistry->add((folderName + "/hInvMassLambda").c_str(), "", kTH1F,
-                            {massAxisLambda});
-    mHistogramRegistry->add((folderName + "/hInvMassAntiLambda").c_str(), "",
-                            kTH1F, {massAxisAntiLambda});
-    mHistogramRegistry->add((folderName + "/hInvMassLambdaAntiLambda").c_str(),
-                            "", kTH2F, {massAxisLambda, massAxisAntiLambda});
+    mQAHistogramRegistry->add((folderName + "/hPt").c_str(),
+                              "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
+                              {{1000, 0, 10}});
+    mQAHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries",
+                              kTH1F, {{1000, -1, 1}});
+    mQAHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries",
+                              kTH1F, {{1000, 0, 2. * M_PI}});
+    mQAHistogramRegistry->add((folderName + "/hDaughDCA").c_str(),
+                              "; DCA^{daugh} (cm); Entries", kTH1F,
+                              {{1000, 0, 10}});
+    mQAHistogramRegistry->add((folderName + "/hTransRadius").c_str(),
+                              "; #it{r}_{xy} (cm); Entries", kTH1F,
+                              {{1500, 0, 150}});
+    mQAHistogramRegistry->add((folderName + "/hDecayVtxX").c_str(),
+                              "; #it{Vtx}_{x} (cm); Entries", kTH1F,
+                              {{2000, 0, 200}});
+    mQAHistogramRegistry->add((folderName + "/hDecayVtxY").c_str(),
+                              "; #it{Vtx}_{y} (cm)); Entries", kTH1F,
+                              {{2000, 0, 200}});
+    mQAHistogramRegistry->add((folderName + "/hDecayVtxZ").c_str(),
+                              "; #it{Vtx}_{z} (cm); Entries", kTH1F,
+                              {{2000, 0, 200}});
+    mQAHistogramRegistry->add((folderName + "/hCPA").c_str(),
+                              "; #it{cos #theta_{p}}; Entries", kTH1F,
+                              {{1000, 0.9, 1.}});
+    mQAHistogramRegistry->add((folderName + "/hCPAvsPt").c_str(),
+                              "; #it{p}_{T} (GeV/#it{c}); #it{cos #theta_{p}}",
+                              kTH2F, {{8, 0.3, 4.3}, {1000, 0.9, 1.}});
+    mQAHistogramRegistry->add((folderName + "/hInvMassLambda").c_str(), "", kTH1F,
+                              {massAxisLambda});
+    mQAHistogramRegistry->add((folderName + "/hInvMassAntiLambda").c_str(), "",
+                              kTH1F, {massAxisAntiLambda});
+    mQAHistogramRegistry->add((folderName + "/hInvMassLambdaAntiLambda").c_str(),
+                              "", kTH2F, {massAxisLambda, massAxisAntiLambda});
 
     PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
                        aod::femtodreamparticle::TrackType::kPosChild,
                        aod::femtodreamparticle::cutContainerType>(
-      mHistogramRegistry);
+      mQAHistogramRegistry, mHistogramRegistry);
     NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
                        aod::femtodreamparticle::TrackType::kNegChild,
                        aod::femtodreamparticle::cutContainerType>(
-      mHistogramRegistry);
+      mQAHistogramRegistry, mHistogramRegistry);
 
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F,
-                            {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaInvMassCut",
-                            "Invariant mass cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMin", "Minimum Pt cut",
-                            kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut",
-                            kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaEtaMax", "Maximum Eta cut",
-                            kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAV0Daugh",
-                            "V0-daughters DCA cut", kTH1F, {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F,
-                            {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMin",
-                            "Minimum transverse radius cut", kTH1F,
-                            {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMax",
-                            "Maximum transverse radius cut", kTH1F,
-                            {massAxisLambda});
-    mHistogramRegistry->add("LambdaQA/hInvMassLambdaDecVtxMax",
-                            "Maximum distance on  decay vertex cut", kTH1F,
-                            {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F,
+                              {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaInvMassCut",
+                              "Invariant mass cut", kTH1F, {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMin", "Minimum Pt cut",
+                              kTH1F, {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut",
+                              kTH1F, {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaEtaMax", "Maximum Eta cut",
+                              kTH1F, {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAV0Daugh",
+                              "V0-daughters DCA cut", kTH1F, {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F,
+                              {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMin",
+                              "Minimum transverse radius cut", kTH1F,
+                              {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMax",
+                              "Maximum transverse radius cut", kTH1F,
+                              {massAxisLambda});
+    mQAHistogramRegistry->add("LambdaQA/hInvMassLambdaDecVtxMax",
+                              "Maximum distance on  decay vertex cut", kTH1F,
+                              {massAxisLambda});
   }
   /// check whether the most open cuts are fulfilled - most of this should have
   /// already be done by the filters
@@ -499,47 +500,47 @@ void FemtoDreamV0Selection::fillLambdaQA(C const& col, V const& v0,
 
   const float invMassLambda = v0.mLambda();
 
-  mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaNoCuts"), v0.mLambda());
+  mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaNoCuts"), v0.mLambda());
 
   if (invMassLambda > fInvMassLowLimit && invMassLambda < fInvMassUpLimit) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaInvMassCut"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaInvMassCut"),
+                               v0.mLambda());
   }
 
   if (pT > pTV0Min) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMin"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMin"),
+                               v0.mLambda());
   }
   if (pT < pTV0Max) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"),
+                               v0.mLambda());
   }
   if (std::abs(eta) < etaV0Max) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaEtaMax"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaEtaMax"),
+                               v0.mLambda());
   }
   if (dcaDaughv0 < DCAV0DaughMax) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDCAV0Daugh"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDCAV0Daugh"),
+                               v0.mLambda());
   }
   if (cpav0 > CPAV0Min) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaCPA"), v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaCPA"), v0.mLambda());
   }
   if (tranRad > TranRadV0Min) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMin"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMin"),
+                               v0.mLambda());
   }
   if (tranRad < TranRadV0Max) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMax"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMax"),
+                               v0.mLambda());
   }
   bool write = true;
   for (size_t i = 0; i < decVtx.size(); i++) {
     write = write && (decVtx.at(i) < DecVtxMax);
   }
   if (write) {
-    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDecVtxMax"),
-                             v0.mLambda());
+    mQAHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDecVtxMax"),
+                               v0.mLambda());
   }
 }
 
@@ -593,7 +594,7 @@ std::array<cutContainerType, 5>
     if (selVariable == femtoDreamV0Selection::kV0DecVtxMax) {
       for (size_t i = 0; i < decVtx.size(); ++i) {
         auto decVtxValue = decVtx.at(i);
-        sel.checkSelectionSetBit(decVtxValue, output, counter);
+        sel.checkSelectionSetBit(decVtxValue, output, counter, nullptr);
       }
     } else {
       switch (selVariable) {
@@ -624,7 +625,7 @@ std::array<cutContainerType, 5>
         case (femtoDreamV0Selection::kV0DecVtxMax):
           break;
       }
-      sel.checkSelectionSetBit(observable, output, counter);
+      sel.checkSelectionSetBit(observable, output, counter, nullptr);
     }
   }
   return {
@@ -641,56 +642,56 @@ template <o2::aod::femtodreamparticle::ParticleType part,
 void FemtoDreamV0Selection::fillQA(C const& col, V const& v0, T const& posTrack,
                                    T const& negTrack)
 {
-  if (mHistogramRegistry) {
-    mHistogramRegistry->fill(
+  if (mQAHistogramRegistry) {
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hPt"),
       v0.pt());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hEta"),
       v0.eta());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hPhi"),
       v0.phi());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hDaughDCA"),
       v0.dcaV0daughters());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hTransRadius"),
       v0.v0radius());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hDecayVtxX"),
       v0.x());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hDecayVtxY"),
       v0.y());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hDecayVtxZ"),
       v0.z());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hCPA"),
       v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hCPAvsPt"),
       v0.pt(), v0.v0cosPA(col.posX(), col.posY(), col.posZ()));
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hInvMassLambda"),
       v0.mLambda());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hInvMassAntiLambda"),
       v0.mAntiLambda());
-    mHistogramRegistry->fill(
+    mQAHistogramRegistry->fill(
       HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
         HIST("/hInvMassLambdaAntiLambda"),
       v0.mLambda(), v0.mAntiLambda());

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -38,7 +38,8 @@ int getPIDselection(float nSigma, std::vector<float> vNsigma)
   std::sort(vNsigma.begin(), vNsigma.end(), std::greater<>());
   auto it = std::find(vNsigma.begin(), vNsigma.end(), nSigma);
   if (it == vNsigma.end()) {
-    LOG(warn) << "Invalid value of nSigma: " << nSigma << ". Return the largest value of the vector: " << *it;
+    it = vNsigma.begin() + 1;
+    LOG(warn) << "Invalid value of nSigma: " << nSigma << ". Return the first value of the vector: " << *(it);
   }
   return std::distance(vNsigma.begin(), it);
 }

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -61,7 +61,7 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType pidcut,
 {
   int iNsigma = getPIDselection(nSigma, vNsigma);
   int nDet = static_cast<int>(kDetector::kNdetectors);
-  int bit_to_check = 1 + (vNsigma.size() - (iNsigma + 1)) * nDet * nSpecies + (nSpecies - (vSpecies + 1)) * nSpecies + (nDet - 1 - iDet);
+  int bit_to_check = (vNsigma.size() - (iNsigma + 1)) * nDet * nSpecies + (nSpecies - (vSpecies + 1)) * nSpecies + (nDet - 1 - iDet);
   return ((pidcut >> (bit_to_check)) & 1) == 1;
 };
 

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -61,7 +61,7 @@ bool isPIDSelected(aod::femtodreamparticle::cutContainerType pidcut,
 {
   int iNsigma = getPIDselection(nSigma, vNsigma);
   int nDet = static_cast<int>(kDetector::kNdetectors);
-  int bit_to_check = (vNsigma.size() - (iNsigma + 1)) * nDet * nSpecies + (nSpecies - (vSpecies + 1)) * nSpecies + (nDet - 1 - iDet);
+  int bit_to_check = 1 + (vNsigma.size() - (iNsigma + 1)) * nDet * nSpecies + (nSpecies - (vSpecies + 1)) * nSpecies + (nDet - 1 - iDet);
   return ((pidcut >> (bit_to_check)) & 1) == 1;
 };
 

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -53,6 +53,10 @@ struct femtoDreamDebugTrack {
   ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
+  ConfigurableAxis ConfTempFitVarpBins{"ConfTempFitVarpBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
+  ConfigurableAxis ConfTempFitVarNsigmaTPCBins{"ConfTempFitVarNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
+  ConfigurableAxis ConfTempFitVarNsigmaTOFBins{"ConfTempFitVarNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
   Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::fdCollisionId;
@@ -76,7 +80,7 @@ struct femtoDreamDebugTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartOne.value, true);
+    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, ConfIsMC, ConfPDGCodePartOne.value, true);
     vPIDPartOne = ConfPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -56,6 +56,8 @@ struct femtoDreamDebugTrack {
   ConfigurableAxis ConfTempFitVarpBins{"ConfTempFitVarpBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
   ConfigurableAxis ConfTempFitVarNsigmaTPCBins{"ConfTempFitVarNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
   ConfigurableAxis ConfTempFitVarNsigmaTOFBins{"ConfTempFitVarNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+  ConfigurableAxis ConfTempFitVarNsigmaTPCTOFBins{"ConfTempFitVarNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
+  ConfigurableAxis ConfTempFitVarDummy{"ConfTempFitVarDummy", {1, 0, 1}, "Dummy axis for inv mass"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
@@ -80,7 +82,7 @@ struct femtoDreamDebugTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, ConfIsMC, ConfPDGCodePartOne.value, true);
+    trackHisto.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfTempFitVarDummy, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, ConfTempFitVarNsigmaTPCTOFBins, ConfIsMC, ConfPDGCodePartOne.value, true);
     vPIDPartOne = ConfPIDPartOne.value;
     kNsigma = ConfTrkPIDnSigmaMax.value;
   }

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -46,6 +46,10 @@ struct femtoDreamDebugV0 {
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
 
+  ConfigurableAxis ConfTempFitVarpBins{"ConfTempFitVarpBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
+  ConfigurableAxis ConfTempFitVarNsigmaTPCBins{"ConfTempFitVarNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
+  ConfigurableAxis ConfTempFitVarNsigmaTOFBins{"ConfTempFitVarNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+
   Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
   Configurable<float> ConfChildPosPidnSigmaMax{"ConfChildPosPidnSigmaMax", 3.f, "Positive Child of V0 - Selection bit from cutCulator"};
@@ -74,9 +78,9 @@ struct femtoDreamDebugV0 {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry);
-    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, ConfPDGCodeChildPos.value, true);
-    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, ConfPDGCodeChildNeg, true);
-    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, false, ConfPDGCodeV0.value, true);
+    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeChildPos.value, true);
+    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeChildNeg, true);
+    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeV0.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -45,10 +45,12 @@ struct femtoDreamDebugV0 {
   Configurable<uint32_t> ConfCutV0{"ConfCutV0", 338, "V0 - Selection bit from cutCulator"};
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0TempFitVarInvMassBins{"ConfV0TempFitVarInvMassBins", {200, 1, 1.2}, "V0: InvMass binning"};
 
-  ConfigurableAxis ConfTempFitVarpBins{"ConfTempFitVarpBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
-  ConfigurableAxis ConfTempFitVarNsigmaTPCBins{"ConfTempFitVarNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
-  ConfigurableAxis ConfTempFitVarNsigmaTOFBins{"ConfTempFitVarNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+  ConfigurableAxis ConfChildTempFitVarpBins{"ConfChildTempFitVarpBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
+  ConfigurableAxis ConfChildTempFitVarNsigmaTPCBins{"ConfChildTempFitVarNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
+  ConfigurableAxis ConfChildTempFitVarNsigmaTOFBins{"ConfChildTempFitVarNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+  ConfigurableAxis ConfChildTempFitVarNsigmaTPCTOFBins{"ConfChildTempFitVarNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
 
   Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
@@ -78,9 +80,9 @@ struct femtoDreamDebugV0 {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry);
-    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeChildPos.value, true);
-    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeChildNeg, true);
-    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfTempFitVarpBins, ConfTempFitVarNsigmaTPCBins, ConfTempFitVarNsigmaTOFBins, false, ConfPDGCodeV0.value, true);
+    posChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfV0TempFitVarInvMassBins, ConfChildTempFitVarpBins, ConfChildTempFitVarNsigmaTPCBins, ConfChildTempFitVarNsigmaTOFBins, ConfChildTempFitVarNsigmaTPCTOFBins, false, ConfPDGCodeChildPos.value, true);
+    negChildHistos.init(&V0Registry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfV0TempFitVarInvMassBins, ConfChildTempFitVarpBins, ConfChildTempFitVarNsigmaTPCBins, ConfChildTempFitVarNsigmaTOFBins, ConfChildTempFitVarNsigmaTPCTOFBins, false, ConfPDGCodeChildNeg, true);
+    V0Histos.init(&V0Registry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfV0TempFitVarInvMassBins, ConfChildTempFitVarpBins, ConfChildTempFitVarNsigmaTPCBins, ConfChildTempFitVarNsigmaTOFBins, ConfChildTempFitVarNsigmaTPCTOFBins, false, ConfPDGCodeV0.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
@@ -101,8 +103,7 @@ struct femtoDreamDebugV0 {
       // check cuts on V0 children
       if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
           (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) &&
-          isFullPIDSelected(posChild.pidcut(), posChild.p(), 999.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) &&
-          isFullPIDSelected(negChild.pidcut(), negChild.p(), 999.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
+          isFullPIDSelected(posChild.pidcut(), posChild.p(), 999.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) && isFullPIDSelected(negChild.pidcut(), negChild.p(), 999.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
         V0Histos.fillQA<false, true>(part);
         posChildHistos.fillQA<false, true>(posChild);
         negChildHistos.fillQA<false, true>(negChild);

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -135,9 +135,9 @@ struct femtoDreamPairTaskTrackTrack {
   {
 
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartOne);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartOne);
     if (!ConfIsSame) {
-      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartTwo);
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartTwo);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -120,6 +120,7 @@ struct femtoDreamPairTaskTrackTrack {
   Configurable<bool> ConfCPRPlotPerRadii{"ConfCPRPlotPerRadii", false, "Plot CPR per radii"};
   Configurable<float> ConfCPRdeltaPhiMax{"ConfCPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
   Configurable<float> ConfCPRdeltaEtaMax{"ConfCPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+  ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis"};
 
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
@@ -132,10 +133,11 @@ struct femtoDreamPairTaskTrackTrack {
 
   void init(InitContext&)
   {
+
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartOne);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartOne);
     if (!ConfIsSame) {
-      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfIsMC, ConfPDGCodePartTwo);
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePartTwo);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -75,6 +75,7 @@ struct femtoDreamPairTaskTrackV0 {
   Configurable<uint32_t> ConfV0CutPartTwo{"ConfV0CutPartTwo", 338, "Particle 2 (V0) - Selection bit"};
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0TempFitVarInvMassBins{"ConfV0TempFitVarInvMassBins", {200, 1, 1.2}, "V0: InvMass binning"};
 
   Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
@@ -128,10 +129,10 @@ struct femtoDreamPairTaskTrackV0 {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrkPDGCodePartOne);
-    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfV0PDGCodePartTwo);
-    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, false, false);
-    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, false, false);
+    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrkPDGCodePartOne);
+    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfV0TempFitVarInvMassBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfV0PDGCodePartTwo);
+    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
+    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
 
     sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D);
     sameEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -115,6 +115,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   ConfigurableAxis ConfmTBins3D{"ConfmTBins3D", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfUse3D>> to true in order to use)"};
   ConfigurableAxis ConfmultBins3D{"ConfMultBins3D", {VARIABLE_WIDTH, 0.0f, 20.0f, 30.0f, 40.0f, 99999.0f}, "multiplicity Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfUse3D>> to true in order to use)"};
+  ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis"};
 
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
@@ -127,10 +128,10 @@ struct femtoDreamPairTaskTrackV0 {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfIsMC, ConfTrkPDGCodePartOne);
-    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfIsMC, ConfV0PDGCodePartTwo);
-    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
-    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, false);
+    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrkPDGCodePartOne);
+    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfV0PDGCodePartTwo);
+    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, false, false);
+    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, false, false);
 
     sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D);
     sameEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -243,7 +243,7 @@ struct femtoDreamProducerReducedTask {
     // If the basic selection is NOT fulfilled:
     // in case of skimming run - don't store such collisions
     // in case of trigger run - store such collisions but don't store any particle candidates for such collisions
-    if (!colCuts.isSelected(col)) {
+    if (!colCuts.isSelectedCollision(col, tracks, trackCuts)) {
       if (ConfIsTrigger) {
         outputCollision(vtxZ, mult, multNtr, colCuts.computeSphericity(col, tracks), mMagField);
       }

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -280,7 +280,6 @@ struct femtoDreamProducerReducedTask {
                   cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
                   cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
                   track.dcaXY(), childIDs, 0, 0);
-
       if constexpr (isMC) {
         fillMCParticle(track, o2::aod::femtodreamparticle::ParticleType::kTrack);
       }

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -116,6 +116,10 @@ struct femtoDreamProducerReducedTask {
 
   void init(InitContext&)
   {
+
+    int CutBits = 8 * sizeof(o2::aod::femtodreamparticle::cutContainerType);
+    Registry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
+
     colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
 

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -54,10 +54,10 @@ using FemtoFullCollisionMC = soa::Join<aod::Collisions,
                                        aod::McCollisionLabels>::iterator;
 
 using FemtoFullTracks = soa::Join<aod::FullTracks, aod::TracksDCA,
-                                  aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi,
-                                  aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
-                                  aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
-                                  aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+                                  aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                  aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe>;
 } // namespace o2::aod
 
 struct femtoDreamProducerReducedTask {
@@ -293,16 +293,16 @@ struct femtoDreamProducerReducedTask {
                          track.dcaXY(),
                          track.dcaZ(),
                          track.tpcSignal(),
-                         track.tpcNSigmaStoreEl(),
-                         track.tpcNSigmaStorePi(),
-                         track.tpcNSigmaStoreKa(),
-                         track.tpcNSigmaStorePr(),
-                         track.tpcNSigmaStoreDe(),
-                         track.tofNSigmaStoreEl(),
-                         track.tofNSigmaStorePi(),
-                         track.tofNSigmaStoreKa(),
-                         track.tofNSigmaStorePr(),
-                         track.tofNSigmaStoreDe(),
+                         track.tpcNSigmaEl(),
+                         track.tpcNSigmaPi(),
+                         track.tpcNSigmaKa(),
+                         track.tpcNSigmaPr(),
+                         track.tpcNSigmaDe(),
+                         track.tofNSigmaEl(),
+                         track.tofNSigmaPi(),
+                         track.tofNSigmaKa(),
+                         track.tofNSigmaPr(),
+                         track.tofNSigmaDe(),
                          -999.,
                          -999.,
                          -999.,

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -108,6 +108,7 @@ struct femtoDreamProducerReducedTask {
   Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
 
   HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry Registry{"Tracks", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   int mRunNumber;
   float mMagField;
@@ -135,7 +136,7 @@ struct femtoDreamProducerReducedTask {
     trackCuts.setnSigmaPIDOffset(ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
     trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack,
                    aod::femtodreamparticle::TrackType::kNoChild,
-                   aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+                   aod::femtodreamparticle::cutContainerType>(&qaRegistry, &Registry);
     mRunNumber = 0;
     mMagField = 0.0;
     /// Initializing CCDB

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -168,6 +168,8 @@ struct femtoDreamProducerTask {
   // for now do not know why
 
   HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry TrackRegistry{"Tracks", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry V0Registry{"V0", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   int mRunNumber;
   float mMagField;
@@ -183,6 +185,12 @@ struct femtoDreamProducerTask {
            "Cannot enable processData and processMC at the same time. "
            "Please choose one.");
     }
+
+    int CutBits = 8 * sizeof(o2::aod::femtodreamparticle::cutContainerType);
+    TrackRegistry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
+    TrackRegistry.add("AnalysisQA/PIDCutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
+    V0Registry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
+    V0Registry.add("AnalysisQA/PIDCutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
 
     colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
     colCuts.init(&qaRegistry);
@@ -202,7 +210,7 @@ struct femtoDreamProducerTask {
     trackCuts.setSelection(ConfTrkPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
     trackCuts.setPIDSpecies(ConfTrkPIDspecies);
     trackCuts.setnSigmaPIDOffset(ConfTrkPIDnSigmaOffsetTPC, ConfTrkPIDnSigmaOffsetTOF);
-    trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+    trackCuts.init<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, aod::femtodreamparticle::cutContainerType>(&qaRegistry, &TrackRegistry);
 
     /// \todo fix how to pass array to setSelection, getRow() passing a
     /// different type!
@@ -230,7 +238,7 @@ struct femtoDreamProducerTask {
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kPosTrack, ConfChildPIDspecies);
       v0Cuts.setChildPIDSpecies(femtoDreamV0Selection::kNegTrack, ConfChildPIDspecies);
-      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+      v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0, aod::femtodreamparticle::ParticleType::kV0Child, aod::femtodreamparticle::cutContainerType>(&qaRegistry, &V0Registry);
       v0Cuts.setInvMassLimits(ConfV0InvMassLowLimit, ConfV0InvMassUpLimit);
 
       v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack, ConfTrkRejectNotPropagated);

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -93,13 +93,9 @@ struct femtoDreamProducerTask {
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
   Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtodream tables"};
-  // just sanity check to make sure in case there are problems in conversion or
-  // MC production it does not affect results
-  Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
-  // Configurable<bool> ConfRejectITSHitandTOFMissing{
-  //     "ConfRejectITSHitandTOFMissing", false,
-  //     "True: reject if neither ITS hit nor TOF timing satisfied"};
 
+  Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
+  // Configurable<bool> ConfRejectITSHitandTOFMissing{ "ConfRejectITSHitandTOFMissing", false, "True: reject if neither ITS hit nor TOF timing satisfied"};
   Configurable<int> ConfTrkPDGCode{"ConfTrkPDGCode", 2212, "PDG code of the selected track for Monte Carlo truth"};
   FemtoDreamTrackSelection trackCuts;
   Configurable<std::vector<float>> ConfTrkCharge{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kSign, "Track selection: ")};
@@ -114,16 +110,13 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfTrkITSnclsMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsMin, "ConfTrk"), std::vector<float>{-1.f, 2.f, 4.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsMin, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkITSnclsIbMin{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kITSnClsIbMin, "ConfTrk"), std::vector<float>{-1.f, 1.f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kITSnClsIbMin, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkDCAxyMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAxyMax, "ConfTrk"), std::vector<float>{0.1f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAxyMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")}; /// \todo Reintegrate PID to the general selection container
+  Configurable<std::vector<float>> ConfTrkDCAzMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kDCAzMax, "ConfTrk"), std::vector<float>{0.2f, 3.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kDCAzMax, "Track selection: ")};
   Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{FemtoDreamTrackSelection::getSelectionName(femtoDreamTrackSelection::kPIDnSigmaMax, "ConfTrk"), std::vector<float>{3.5f, 3.f, 2.5f}, FemtoDreamTrackSelection::getSelectionHelper(femtoDreamTrackSelection::kPIDnSigmaMax, "Track selection: ")};
   Configurable<float> ConfTrkPIDnSigmaOffsetTPC{"ConfTrkPIDnSigmaOffsetTPC", 0., "Offset for TPC nSigma because of bad calibration"};
   Configurable<float> ConfTrkPIDnSigmaOffsetTOF{"ConfTrkPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
   Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
 
   FemtoDreamV0Selection v0Cuts;
-  // TrackSelection *o2PhysicsTrackSelection;
-  /// \todo Labeled array (see Track-Track task)
-
   Configurable<std::vector<float>> ConfV0Sign{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0Sign, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMin{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMin, "ConfV0"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMin, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0pTMax, "ConfV0"), std::vector<float>{3.3f, 3.4f, 3.5f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0pTMax, "V0 selection: ")};
@@ -134,19 +127,18 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<float>> ConfV0TranRadMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0TranRadMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0TranRadMax, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0DecVtxMax{FemtoDreamV0Selection::getSelectionName(femtoDreamV0Selection::kV0DecVtxMax, "ConfV0"), std::vector<float>{100.f}, FemtoDreamV0Selection::getSelectionHelper(femtoDreamV0Selection::kV0DecVtxMax, "V0 selection: ")};
 
+  Configurable<float> ConfV0InvMassLowLimit{"ConfV0InvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
+  Configurable<float> ConfV0InvMassUpLimit{"ConfV0InvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
+  Configurable<bool> ConfV0RejectKaons{"ConfV0RejectKaons", false, "Switch to reject kaons"};
+  Configurable<float> ConfV0InvKaonMassLowLimit{"ConfV0InvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
+  Configurable<float> ConfV0InvKaonMassUpLimit{"ConfV0InvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
+
   Configurable<std::vector<float>> ConfChildCharge{"ConfChildSign", std::vector<float>{-1, 1}, "V0 Child sel: Charge"};
   Configurable<std::vector<float>> ConfChildEtaMax{"ConfChildEtaMax", std::vector<float>{0.8f}, "V0 Child sel: max eta"};
   Configurable<std::vector<float>> ConfChildTPCnClsMin{"ConfChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "V0 Child sel: Min. nCls TPC"};
   Configurable<std::vector<float>> ConfChildDCAMin{"ConfChildDCAMin", std::vector<float>{0.05f, 0.06f}, "V0 Child sel:  Max. DCA Daugh to PV (cm)"};
   Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "V0 Child sel: Max. PID nSigma TPC"};
   Configurable<std::vector<int>> ConfChildPIDspecies{"ConfChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
-
-  Configurable<float> ConfV0InvMassLowLimit{"ConfV0InvV0MassLowLimit", 1.05, "Lower limit of the V0 invariant mass"};
-  Configurable<float> ConfV0InvMassUpLimit{"ConfV0InvV0MassUpLimit", 1.30, "Upper limit of the V0 invariant mass"};
-
-  Configurable<bool> ConfV0RejectKaons{"ConfV0RejectKaons", false, "Switch to reject kaons"};
-  Configurable<float> ConfV0InvKaonMassLowLimit{"ConfV0InvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
-  Configurable<float> ConfV0InvKaonMassUpLimit{"ConfV0InvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
@@ -375,13 +367,15 @@ struct femtoDreamProducerTask {
       if (colCuts.isSelectedCollision(col, tracks, trackCuts) || colCuts.isSelectedCollision(col, fullV0s, v0Cuts, tracks)) {
         keepCollsion = true;
       }
-    } else if (colCuts.isSelectedCollision(col, tracks, trackCuts)) {
-      keepCollsion = true;
+    } else {
+      if (colCuts.isSelectedCollision(col, tracks, trackCuts)) {
+        keepCollsion = true;
+      }
     }
     // if the basic selection is NOT fulfilled
     // in case of trigger store the collision even though there are no particles
     if (!keepCollsion) {
-      if (ConfIsTrigger) {
+      if (ConfIsTrigger.value) {
         outputCollision(vtxZ, mult, multNtr, spher, mMagField);
       }
       return;
@@ -399,21 +393,21 @@ struct femtoDreamProducerTask {
       if (!trackCuts.isSelectedMinimal(track)) {
         continue;
       }
-      trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack,
-                       aod::femtodreamparticle::TrackType::kNoChild>(track);
+      trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // the bit-wise container of the systematic variations is obtained
       auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track);
 
       // now the table is filled
-      outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),
-                  track.phi(), aod::femtodreamparticle::ParticleType::kTrack,
-                  cutContainer.at(
-                    femtoDreamTrackSelection::TrackContainerPosition::kCuts),
-                  cutContainer.at(
-                    femtoDreamTrackSelection::TrackContainerPosition::kPID),
+      outputParts(outputCollision.lastIndex(),
+                  track.pt(),
+                  track.eta(),
+                  track.phi(),
+                  aod::femtodreamparticle::ParticleType::kTrack,
+                  cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+                  cutContainer.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
                   track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
-      if (ConfIsDebug) {
+      if (ConfIsDebug.value) {
         fillDebugParticle<true>(track);
       }
 
@@ -422,7 +416,7 @@ struct femtoDreamProducerTask {
       }
     }
 
-    if (ConfIsActivateV0) {
+    if (ConfIsActivateV0.value) {
       for (auto& v0 : fullV0s) {
         auto postrack = v0.template posTrack_as<TrackType>();
         auto negtrack = v0.template negTrack_as<TrackType>();

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -49,10 +49,10 @@ using FemtoFullCollision =
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 
 using FemtoFullTracks =
-  soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::pidTPCEl,
-            aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
-            aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
-            aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+  soa::Join<aod::FullTracks, aod::TracksDCA, aod::pidTPCFullEl,
+            aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
+            aod::pidTPCFullDe, aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+            aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe>;
 
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
@@ -316,11 +316,11 @@ struct femtoDreamProducerTask {
                        particle.tpcNClsShared(), particle.tpcInnerParam(),
                        particle.itsNCls(), particle.itsNClsInnerBarrel(),
                        particle.dcaXY(), particle.dcaZ(), particle.tpcSignal(),
-                       particle.tpcNSigmaStoreEl(), particle.tpcNSigmaStorePi(),
-                       particle.tpcNSigmaStoreKa(), particle.tpcNSigmaStorePr(),
-                       particle.tpcNSigmaStoreDe(), particle.tofNSigmaStoreEl(),
-                       particle.tofNSigmaStorePi(), particle.tofNSigmaStoreKa(),
-                       particle.tofNSigmaStorePr(), particle.tofNSigmaStoreDe(),
+                       particle.tpcNSigmaEl(), particle.tpcNSigmaPi(),
+                       particle.tpcNSigmaKa(), particle.tpcNSigmaPr(),
+                       particle.tpcNSigmaDe(), particle.tofNSigmaEl(),
+                       particle.tofNSigmaPi(), particle.tofNSigmaKa(),
+                       particle.tofNSigmaPr(), particle.tofNSigmaDe(),
                        -999., -999., -999., -999., -999., -999.);
     } else {
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -378,7 +378,7 @@ struct femtoDreamProducerTaskV0Only {
     // in case of skimming run - don't store such collisions
     // in case of trigger run - store such collisions but don't store any
     // particle candidates for such collisions
-    if (!colCuts.isSelected(col)) {
+    if (!colCuts.isSelectedCollision(col, fullV0s, v0Cuts, tracks)) {
       if (ConfIsTrigger) {
         outputCollision(vtxZ, mult, multNtr, spher, mMagField);
       }
@@ -395,13 +395,9 @@ struct femtoDreamProducerTaskV0Only {
                   // track table row <-> aod::track table global index
 
     if (ConfStoreV0) {
-      for (auto& v0 : fullV0s) {
-        auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
-        auto negtrack =
-          v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough
-                                                  /// if we apply the filter
-                                                  /// the sign of Pos and Neg
-                                                  /// track is always negative
+      for (auto const& v0 : fullV0s) {
+        const auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
+        const auto negtrack = v0.negTrack_as<aod::FemtoFullTracks>();
         // const auto dcaXYpos = postrack.dcaXY();
         // const auto dcaZpos = postrack.dcaZ();
         // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -81,12 +81,6 @@ struct femtoDreamProducerTaskV0Only {
   Produces<aod::FDExtParticles> outputDebugParts;
 
   Configurable<bool> ConfDebugOutput{"ConfDebugOutput", true, "Debug output"};
-
-  // Choose if filtering or skimming version is run
-
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
-
-  // Choose if running on converted data or Run3  / Pilot
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
 
@@ -372,16 +366,12 @@ struct femtoDreamProducerTaskV0Only {
       multNtr = col.multTPC();
     }
 
-    /// First thing to do is to check whether the basic event selection criteria
-    /// are fulfilled
-    // If the basic selection is NOT fulfilled:
-    // in case of skimming run - don't store such collisions
-    // in case of trigger run - store such collisions but don't store any
-    // particle candidates for such collisions
-    if (!colCuts.isSelectedCollision(col, fullV0s, v0Cuts, tracks)) {
-      if (ConfIsTrigger) {
-        outputCollision(vtxZ, mult, multNtr, spher, mMagField);
-      }
+    /// First thing to do is to check whether the basic event selection criteria are fullfilled
+    /// that includes checking if there is at least one usable V0 in the collision
+    if (!colCuts.isSelectedCollision(col)) {
+      return;
+    }
+    if (colCuts.isEmptyCollision(col, fullV0s, v0Cuts, tracks)) {
       return;
     }
 

--- a/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTaskV0Only.cxx
@@ -202,10 +202,8 @@ struct femtoDreamProducerTaskV0Only {
   // (aod::v0data::v0radius > V0TranRadV0Min.value); to be added, not working
   // for now do not know why
 
-  HistogramRegistry qaRegistry{
-    "QAHistos",
-    {},
-    OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
+  HistogramRegistry Registry{"Producer", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   int mRunNumber;
   float mMagField;
@@ -276,7 +274,7 @@ struct femtoDreamProducerTaskV0Only {
                                 ConfV0DaughTPIDspecies);
       v0Cuts.init<aod::femtodreamparticle::ParticleType::kV0,
                   aod::femtodreamparticle::ParticleType::kV0Child,
-                  aod::femtodreamparticle::cutContainerType>(&qaRegistry);
+                  aod::femtodreamparticle::cutContainerType>(&qaRegistry, &Registry);
       v0Cuts.setInvMassLimits(ConfInvMassLowLimit, ConfInvMassUpLimit);
       v0Cuts.setChildRejectNotPropagatedTracks(femtoDreamV0Selection::kPosTrack,
                                                ConfRejectNotPropagatedTracks);


### PR DESCRIPTION
Changes in this PR:
- Add a cutcounter to the FemtoDreamProducer task that keeps track of the number of particles cut by each specified cut as well as its variations
- Add several configurables to the DebugTasks to change the binning of histograms used for a data-driven purity estimation
- Change the subscription of the FemtoDreamProducerTask to the full PID helper tasks for TPC and TOF. With the normal helper task, only nSigma values of up to +/- 6.35 were given. With the full helper task arbitrarily large values can be computed, which is necessary for the data-driven estimation of purities.
- Change the behavior of the FemtoDreamProducerTask to not store collision in which there are no tracks/V0 that do not fulfill the loosest configuration of the specified cuts.