### PR TITLE
Reduce evsel and bcsel table contents

### DIFF
--- a/Common/DataModel/EventSelection.h
+++ b/Common/DataModel/EventSelection.h
@@ -43,23 +43,10 @@ enum Run2EventCuts {
   kTRDHEE  // Offline TRD single-electron-in-EMCAL-acceptance trigger decision
 };
 
-// collision-joinable event selection decisions
 namespace evsel
 {
-DECLARE_SOA_BITMAP_COLUMN(Alias, alias, 32);
-DECLARE_SOA_BITMAP_COLUMN(Selection, selection, 64);
-DECLARE_SOA_COLUMN(BBV0A, bbV0A, bool);                                     //! Beam-beam time in V0A
-DECLARE_SOA_COLUMN(BBV0C, bbV0C, bool);                                     //! Beam-beam time in V0C
-DECLARE_SOA_COLUMN(BGV0A, bgV0A, bool);                                     //! Beam-gas time in V0A
-DECLARE_SOA_COLUMN(BGV0C, bgV0C, bool);                                     //! Beam-gas time in V0C
-DECLARE_SOA_COLUMN(BBFDA, bbFDA, bool);                                     //! Beam-beam time in FDA
-DECLARE_SOA_COLUMN(BBFDC, bbFDC, bool);                                     //! Beam-beam time in FDC
-DECLARE_SOA_COLUMN(BGFDA, bgFDA, bool);                                     //! Beam-gas time in FDA
-DECLARE_SOA_COLUMN(BGFDC, bgFDC, bool);                                     //! Beam-gas time in FDC
-DECLARE_SOA_COLUMN(MultRingV0A, multRingV0A, float[5]);                     //! V0A multiplicity per ring (4 rings in run2, 5 rings in run3)
-DECLARE_SOA_COLUMN(MultRingV0C, multRingV0C, float[4]);                     //! V0C multiplicity per ring (4 rings in run2)
-DECLARE_SOA_COLUMN(SpdClusters, spdClusters, uint32_t);                     //! Number of SPD clusters in two layers
-DECLARE_SOA_COLUMN(NTracklets, nTracklets, int);                            //! Tracklet multiplicity
+DECLARE_SOA_BITMAP_COLUMN(Alias, alias, 32);                                //! Bitmask of fired trigger aliases (see TriggerAliases.h for definitions)
+DECLARE_SOA_BITMAP_COLUMN(Selection, selection, 64);                        //! Bitmask of selection flags (see EventSelectionParams.h for definitions)
 DECLARE_SOA_COLUMN(Sel7, sel7, bool);                                       //! Event selection decision based on V0A & V0C
 DECLARE_SOA_COLUMN(Sel8, sel8, bool);                                       //! Event selection decision based on TVX
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundBC, foundBC, int, BCs, "_foundBC");      //! BC entry index in BCs table (-1 if doesn't exist)
@@ -68,20 +55,16 @@ DECLARE_SOA_INDEX_COLUMN_FULL(FoundFV0, foundFV0, int, FV0As, "_foundFV0"); //! 
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundFDD, foundFDD, int, FDDs, "_foundFDD");  //! FDD entry index in FDDs table (-1 if doesn't exist)
 DECLARE_SOA_INDEX_COLUMN_FULL(FoundZDC, foundZDC, int, Zdcs, "_foundZDC");  //! ZDC entry index in ZDCs table (-1 if doesn't exist)
 } // namespace evsel
-DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
-                  evsel::Alias, evsel::Selection,
-                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
-                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets,
-                  evsel::Sel7, evsel::Sel8, evsel::FoundBCId, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId, evsel::FoundZDCId);
-using EvSel = EvSels::iterator;
 
+// bc-joinable event selection decisions
 DECLARE_SOA_TABLE(BcSels, "AOD", "BCSEL", //!
-                  evsel::Alias, evsel::Selection,
-                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
-                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
-                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId, evsel::FoundZDCId);
+                  evsel::Alias, evsel::Selection, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId, evsel::FoundZDCId);
 using BcSel = BcSels::iterator;
+
+// collision-joinable event selection decisions
+DECLARE_SOA_TABLE(EvSels, "AOD", "EVSEL", //!
+                  evsel::Alias, evsel::Selection, evsel::Sel7, evsel::Sel8, evsel::FoundBCId, evsel::FoundFT0Id, evsel::FoundFV0Id, evsel::FoundFDDId, evsel::FoundZDCId);
+using EvSel = EvSels::iterator;
 } // namespace o2::aod
 
 #endif // COMMON_DATAMODEL_EVENTSELECTION_H_

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -368,7 +368,7 @@ struct EventSelectionTask {
     // applying selections depending on the number of tracklets
     auto trackletsGrouped = tracklets->sliceByCached(aod::track::collisionId, col.globalIndex(), cache);
     int nTkl = trackletsGrouped.size();
-    int spdClusters =  bc.spdClustersL0() + bc.spdClustersL1();
+    int spdClusters = bc.spdClustersL0() + bc.spdClustersL1();
 
     selection |= (spdClusters < par->fSPDClsVsTklA + nTkl * par->fSPDClsVsTklB) ? BIT(kNoSPDClsVsTklBG) : 0;
     selection |= !(nTkl < 6 && multV0C012 > par->fV0C012vsTklA + nTkl * par->fV0C012vsTklB) ? BIT(kNoV0C012vsTklBG) : 0;
@@ -433,8 +433,8 @@ struct EventSelectionTask {
     }
 
     // protection against empty FT0 maps
-    if (mapGlobalBcWithTOR.size()==0 || mapGlobalBcWithTVX.size()==0) {
-      LOGP(error,"FT0 table is empty or corrupted. Filling evsel table with dummy values");
+    if (mapGlobalBcWithTOR.size() == 0 || mapGlobalBcWithTVX.size() == 0) {
+      LOGP(error, "FT0 table is empty or corrupted. Filling evsel table with dummy values");
       for (auto& col : cols) {
         auto bc = col.bc_as<BCsWithBcSelsRun3>();
         int32_t foundBC = bc.globalIndex();
@@ -442,7 +442,7 @@ struct EventSelectionTask {
         int32_t foundFV0 = bc.foundFV0Id();
         int32_t foundFDD = bc.foundFDDId();
         int32_t foundZDC = bc.foundZDCId();
-        evsel(bc.alias_raw(),bc.selection_raw(), kFALSE, kFALSE, foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
+        evsel(bc.alias_raw(), bc.selection_raw(), kFALSE, kFALSE, foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
       }
       return;
     }
@@ -479,13 +479,13 @@ struct EventSelectionTask {
       LOGP(debug, "nContrib={} nITStracks={} nTPCtracks={} nTOFtracks={} nTRDtracks={}", col.numContrib(), nITStracks, nTPCtracks, nTOFtracks, nTRDtracks);
 
       if (nTRDtracks > 0) {
-        meanBC += TMath::Nint(timeFromTRDtracks / nTRDtracks / bcNS);      // assign collision bc using TRD-matched tracks
-        deltaBC = 0;                                                       // use precise bc from TRD-matched tracks
+        meanBC += TMath::Nint(timeFromTRDtracks / nTRDtracks / bcNS); // assign collision bc using TRD-matched tracks
+        deltaBC = 0;                                                  // use precise bc from TRD-matched tracks
       } else if (nTOFtracks > 0) {
         meanBC += TMath::FloorNint(timeFromTOFtracks / nTOFtracks / bcNS); // assign collision bc using TOF-matched tracks
         deltaBC = 4;                                                       // use precise bc from TOF tracks with +/-4 bc margin
       } else if (nTPCtracks > 0) {
-        deltaBC += 30;                                                     // extend deltaBC for collisions built with ITS-TPC tracks only
+        deltaBC += 30; // extend deltaBC for collisions built with ITS-TPC tracks only
       }
 
       int64_t minBC = meanBC - deltaBC;
@@ -495,7 +495,7 @@ struct EventSelectionTask {
       int64_t tvxBC = bcs.iteratorAt(indexClosestTVX).globalBC();
       if (tvxBC >= minBC && tvxBC <= maxBC) { // closest TVX within search region
         bc.setCursor(indexClosestTVX);
-      } else {                                // no TVX within search region, searching for TOR = T0A | T0C
+      } else { // no TVX within search region, searching for TOR = T0A | T0C
         int32_t indexClosestTOR = findClosest(meanBC, mapGlobalBcWithTOR);
         int64_t torBC = bcs.iteratorAt(indexClosestTOR).globalBC();
         if (torBC >= minBC && torBC <= maxBC) {

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -29,7 +29,8 @@ using namespace evsel;
 
 using BCsWithRun2InfosTimestampsAndMatches = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps, aod::Run2MatchedToBCSparse>;
 using BCsWithRun3Matchings = soa::Join<aod::BCs, aod::Timestamps, aod::Run3MatchedToBCSparse>;
-using BCsWithBcSels = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
+using BCsWithBcSelsRun2 = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels, aod::Run2BCInfos, aod::Run2MatchedToBCSparse>;
+using BCsWithBcSelsRun3 = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
 using FullTracksIU = soa::Join<aod::TracksIU, aod::TracksExtra>;
 
 struct BcSelectionTask {
@@ -92,35 +93,23 @@ struct BcSelectionTask {
       LOGF(debug, "timeFDA=%f timeFDC=%f", timeFDA, timeFDC);
       LOGF(debug, "timeT0A=%f timeT0C=%f", timeT0A, timeT0C);
 
-      // applying timing selections
-      bool bbV0A = timeV0A > par->fV0ABBlower && timeV0A < par->fV0ABBupper;
-      bool bbV0C = timeV0C > par->fV0CBBlower && timeV0C < par->fV0CBBupper;
-      bool bbFDA = timeFDA > par->fFDABBlower && timeFDA < par->fFDABBupper;
-      bool bbFDC = timeFDC > par->fFDCBBlower && timeFDC < par->fFDCBBupper;
-      bool bgV0A = timeV0A > par->fV0ABGlower && timeV0A < par->fV0ABGupper;
-      bool bgV0C = timeV0C > par->fV0CBGlower && timeV0C < par->fV0CBGupper;
-      bool bgFDA = timeFDA > par->fFDABGlower && timeFDA < par->fFDABGupper;
-      bool bgFDC = timeFDC > par->fFDCBGlower && timeFDC < par->fFDCBGupper;
-      float znSum = timeZNA + timeZNC;
-      float znDif = timeZNA - timeZNC;
-
       // fill time-based selection criteria
       uint64_t selection{0};
-      selection |= bbV0A ? BIT(kIsBBV0A) : 0;
-      selection |= bbV0C ? BIT(kIsBBV0C) : 0;
-      selection |= bbFDA ? BIT(kIsBBFDA) : 0;
-      selection |= bbFDC ? BIT(kIsBBFDC) : 0;
-      selection |= !bgV0A ? BIT(kNoBGV0A) : 0;
-      selection |= !bgV0C ? BIT(kNoBGV0C) : 0;
-      selection |= !bgFDA ? BIT(kNoBGFDA) : 0;
-      selection |= !bgFDC ? BIT(kNoBGFDC) : 0;
+      selection |= timeV0A > par->fV0ABBlower && timeV0A < par->fV0ABBupper ? BIT(kIsBBV0A) : 0;
+      selection |= timeV0C > par->fV0CBBlower && timeV0C < par->fV0CBBupper ? BIT(kIsBBV0C) : 0;
+      selection |= timeFDA > par->fFDABBlower && timeFDA < par->fFDABBupper ? BIT(kIsBBFDA) : 0;
+      selection |= timeFDC > par->fFDCBBlower && timeFDC < par->fFDCBBupper ? BIT(kIsBBFDC) : 0;
+      selection |= !(timeV0A > par->fV0ABGlower && timeV0A < par->fV0ABGupper) ? BIT(kNoBGV0A) : 0;
+      selection |= !(timeV0C > par->fV0CBGlower && timeV0C < par->fV0CBGupper) ? BIT(kNoBGV0C) : 0;
+      selection |= !(timeFDA > par->fFDABGlower && timeFDA < par->fFDABGupper) ? BIT(kNoBGFDA) : 0;
+      selection |= !(timeFDC > par->fFDCBGlower && timeFDC < par->fFDCBGupper) ? BIT(kNoBGFDC) : 0;
       selection |= (timeT0A > par->fT0ABBlower && timeT0A < par->fT0ABBupper) ? BIT(kIsBBT0A) : 0;
       selection |= (timeT0C > par->fT0CBBlower && timeT0C < par->fT0CBBupper) ? BIT(kIsBBT0C) : 0;
       selection |= (timeZNA > par->fZNABBlower && timeZNA < par->fZNABBupper) ? BIT(kIsBBZNA) : 0;
       selection |= (timeZNC > par->fZNCBBlower && timeZNC < par->fZNCBBupper) ? BIT(kIsBBZNC) : 0;
       selection |= !(fabs(timeZNA) > par->fZNABGlower && fabs(timeZNA) < par->fZNABGupper) ? BIT(kNoBGZNA) : 0;
       selection |= !(fabs(timeZNC) > par->fZNCBGlower && fabs(timeZNC) < par->fZNCBGupper) ? BIT(kNoBGZNC) : 0;
-      selection |= (pow((znSum - par->fZNSumMean) / par->fZNSumSigma, 2) + pow((znDif - par->fZNDifMean) / par->fZNDifSigma, 2) < 1) ? BIT(kIsBBZAC) : 0;
+      selection |= (pow((timeZNA + timeZNC - par->fZNSumMean) / par->fZNSumSigma, 2) + pow((timeZNA - timeZNC - par->fZNDifMean) / par->fZNDifSigma, 2) < 1) ? BIT(kIsBBZAC) : 0;
 
       // Calculate V0 multiplicity per ring
       float multRingV0A[5] = {0.};
@@ -142,7 +131,6 @@ struct BcSelectionTask {
           multFV0C += bc.fv0c().amplitude()[i];
         }
       }
-      uint32_t spdClusters = bc.spdClustersL0() + bc.spdClustersL1();
 
       // Calculate pileup and background related selection flags
       // V0A0 excluded from online V0A charge sum => excluding also from offline sum for consistency
@@ -155,10 +143,11 @@ struct BcSelectionTask {
       selection |= (onV0M > par->fV0MOnVsOfA + par->fV0MOnVsOfB * ofV0M) ? BIT(kNoV0MOnVsOfPileup) : 0;
       selection |= (onSPD > par->fSPDOnVsOfA + par->fSPDOnVsOfB * ofSPD) ? BIT(kNoSPDOnVsOfPileup) : 0;
       selection |= (multRingV0C[3] > par->fV0CasymA + par->fV0CasymB * multV0C012) ? BIT(kNoV0Casymmetry) : 0;
+      selection |= (TESTBIT(selection, kIsBBV0A) || TESTBIT(selection, kIsBBV0C) || ofSPD) ? BIT(kIsINT1) : 0;
+      selection |= (bc.has_ft0() ? TESTBIT(bc.ft0().triggerMask(), o2::ft0::Triggers::bitVertex) : 0) ? BIT(kIsTriggerTVX) : 0;
 
       // copy remaining selection decisions from eventCuts
       uint32_t eventCuts = bc.eventCuts();
-
       selection |= (eventCuts & 1 << aod::kTimeRangeCut) ? BIT(kIsGoodTimeRange) : 0;
       selection |= (eventCuts & 1 << aod::kIncompleteDAQ) ? BIT(kNoIncompleteDAQ) : 0;
       selection |= !(eventCuts & 1 << aod::kIsTPCLaserWarmUp) ? BIT(kNoTPCLaserWarmUp) : 0;
@@ -169,8 +158,6 @@ struct BcSelectionTask {
       selection |= (eventCuts & 1 << aod::kPileupInMultBins) ? BIT(kNoPileupInMultBins) : 0;
       selection |= (eventCuts & 1 << aod::kPileUpMV) ? BIT(kNoPileupMV) : 0;
       selection |= (eventCuts & 1 << aod::kTPCPileUp) ? BIT(kNoPileupTPC) : 0;
-      selection |= (bc.has_ft0() ? TESTBIT(bc.ft0().triggerMask(), o2::ft0::Triggers::bitVertex) : 0) ? BIT(kIsTriggerTVX) : 0;
-      selection |= (bbV0A || bbV0C || ofSPD) ? BIT(kIsINT1) : 0;
 
       int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
       int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
@@ -183,10 +170,7 @@ struct BcSelectionTask {
       }
 
       // Fill bc selection columns
-      bcsel(alias, selection,
-            bbV0A, bbV0C, bgV0A, bgV0C,
-            bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0, foundFDD, foundZDC);
+      bcsel(alias, selection, foundFT0, foundFV0, foundFDD, foundZDC);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun2, "Process Run2 event selection", true);
@@ -214,7 +198,7 @@ struct BcSelectionTask {
       EventSelectionParams* par = ccdb->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", bc.timestamp());
       TriggerAliases* aliases = ccdb->getForTimeStamp<TriggerAliases>("EventSelection/TriggerAliases", bc.timestamp());
       uint32_t alias{0};
-      // workaround for pp2022 apass2-apass3 (trigger info is shifted by -294 bcs)
+      // workaround for pp2022 (trigger info is shifted by -294 bcs)
       int32_t triggerBcId = mapGlobalBCtoBcId[bc.globalBC() + triggerBcShift];
       if (triggerBcId) {
         auto triggerBc = bcs.iteratorAt(triggerBcId);
@@ -240,8 +224,6 @@ struct BcSelectionTask {
       float timeT0CBG = -999.f;
       float timeFDABG = -999.f;
       float timeFDCBG = -999.f;
-      float znSum = timeZNA + timeZNC;
-      float znDif = timeZNA - timeZNC;
 
       uint64_t globalBC = bc.globalBC();
       // move to previous bcs to check beam-gas in FT0, FV0 and FDD
@@ -266,51 +248,24 @@ struct BcSelectionTask {
       // move back to initial position
       bc.moveByIndex(backwardMoveCount);
 
-      // applying timing selections
-      bool bbV0A = timeV0A > par->fV0ABBlower && timeV0A < par->fV0ABBupper;
-      bool bbFDA = timeFDA > par->fFDABBlower && timeFDA < par->fFDABBupper;
-      bool bbFDC = timeFDC > par->fFDCBBlower && timeFDC < par->fFDCBBupper;
-      bool bgV0A = timeV0ABG > par->fV0ABGlower && timeV0ABG < par->fV0ABGupper;
-      bool bgFDA = timeFDABG > par->fFDABGlower && timeFDABG < par->fFDABGupper;
-      bool bgFDC = timeFDCBG > par->fFDCBGlower && timeFDCBG < par->fFDCBGupper;
-      bool bgT0A = timeT0ABG > par->fT0ABGlower && timeT0ABG < par->fT0ABGupper;
-      bool bgT0C = timeT0CBG > par->fT0CBGlower && timeT0CBG < par->fT0CBGupper;
-      bool bbV0C = 0;
-      bool bgV0C = 0;
-
       // fill time-based selection criteria
       uint64_t selection{0};
-      selection |= bbV0A ? BIT(kIsBBV0A) : 0;
-      selection |= bbFDA ? BIT(kIsBBFDA) : 0;
-      selection |= bbFDC ? BIT(kIsBBFDC) : 0;
-      selection |= !bgV0A ? BIT(kNoBGV0A) : 0;
-      selection |= !bgFDA ? BIT(kNoBGFDA) : 0;
-      selection |= !bgFDC ? BIT(kNoBGFDC) : 0;
-      selection |= !bgT0A ? BIT(kNoBGT0A) : 0;
-      selection |= !bgT0C ? BIT(kNoBGT0C) : 0;
+      selection |= timeV0A > par->fV0ABBlower && timeV0A < par->fV0ABBupper ? BIT(kIsBBV0A) : 0;
+      selection |= timeFDA > par->fFDABBlower && timeFDA < par->fFDABBupper ? BIT(kIsBBFDA) : 0;
+      selection |= timeFDC > par->fFDCBBlower && timeFDC < par->fFDCBBupper ? BIT(kIsBBFDC) : 0;
+      selection |= !(timeV0ABG > par->fV0ABGlower && timeV0ABG < par->fV0ABGupper) ? BIT(kNoBGV0A) : 0;
+      selection |= !(timeFDABG > par->fFDABGlower && timeFDABG < par->fFDABGupper) ? BIT(kNoBGFDA) : 0;
+      selection |= !(timeFDCBG > par->fFDCBGlower && timeFDCBG < par->fFDCBGupper) ? BIT(kNoBGFDC) : 0;
+      selection |= !(timeT0ABG > par->fT0ABGlower && timeT0ABG < par->fT0ABGupper) ? BIT(kNoBGT0A) : 0;
+      selection |= !(timeT0CBG > par->fT0CBGlower && timeT0CBG < par->fT0CBGupper) ? BIT(kNoBGT0C) : 0;
       selection |= (timeT0A > par->fT0ABBlower && timeT0A < par->fT0ABBupper) ? BIT(kIsBBT0A) : 0;
       selection |= (timeT0C > par->fT0CBBlower && timeT0C < par->fT0CBBupper) ? BIT(kIsBBT0C) : 0;
       selection |= (timeZNA > par->fZNABBlower && timeZNA < par->fZNABBupper) ? BIT(kIsBBZNA) : 0;
       selection |= (timeZNC > par->fZNCBBlower && timeZNC < par->fZNCBBupper) ? BIT(kIsBBZNC) : 0;
-      selection |= (pow((znSum - par->fZNSumMean) / par->fZNSumSigma, 2) + pow((znDif - par->fZNDifMean) / par->fZNDifSigma, 2) < 1) ? BIT(kIsBBZAC) : 0;
+      selection |= (pow((timeZNA + timeZNC - par->fZNSumMean) / par->fZNSumSigma, 2) + pow((timeZNA - timeZNC - par->fZNDifMean) / par->fZNDifSigma, 2) < 1) ? BIT(kIsBBZAC) : 0;
       selection |= !(fabs(timeZNA) > par->fZNABGlower && fabs(timeZNA) < par->fZNABGupper) ? BIT(kNoBGZNA) : 0;
       selection |= !(fabs(timeZNC) > par->fZNCBGlower && fabs(timeZNC) < par->fZNCBGupper) ? BIT(kNoBGZNC) : 0;
       selection |= (bc.has_ft0() ? (bc.ft0().triggerMask() & BIT(o2::ft0::Triggers::bitVertex)) > 0 : 0) ? BIT(kIsTriggerTVX) : 0;
-
-      // Calculate V0 multiplicity per ring
-      float multRingV0A[5] = {0.};
-      float multRingV0C[4] = {0.};
-      if (bc.has_fv0a()) {
-        for (unsigned int i = 0; i < bc.fv0a().amplitude().size(); ++i) {
-          int ring = bc.fv0a().channel()[i] / 8;
-          if (ring == 5) {
-            ring = 4; // Outermost ring has 16 channels
-          }
-          multRingV0A[ring] += bc.fv0a().amplitude()[i];
-        }
-      }
-
-      uint32_t spdClusters = 0;
 
       int32_t foundFT0 = bc.has_ft0() ? bc.ft0().globalIndex() : -1;
       int32_t foundFV0 = bc.has_fv0a() ? bc.fv0a().globalIndex() : -1;
@@ -324,10 +279,7 @@ struct BcSelectionTask {
       }
 
       // Fill bc selection columns
-      bcsel(alias, selection,
-            bbV0A, bbV0C, bgV0A, bgV0C,
-            bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, foundFT0, foundFV0, foundFDD, foundZDC);
+      bcsel(alias, selection, foundFT0, foundFV0, foundFDD, foundZDC);
     }
   }
   PROCESS_SWITCH(BcSelectionTask, processRun3, "Process Run3 event selection", false);
@@ -378,9 +330,9 @@ struct EventSelectionTask {
     evsel.reserve(collisions.size());
   }
 
-  void processRun2(aod::Collision const& col, BCsWithBcSels const& bcs, aod::Tracks const& tracks)
+  void processRun2(aod::Collision const& col, BCsWithBcSelsRun2 const& bcs, aod::Tracks const& tracks)
   {
-    auto bc = col.bc_as<BCsWithBcSels>();
+    auto bc = col.bc_as<BCsWithBcSelsRun2>();
     EventSelectionParams* par = ccdb->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", bc.timestamp());
     bool* applySelection = par->GetSelection(muonSelection);
     if (isMC) {
@@ -403,34 +355,23 @@ struct EventSelectionTask {
     // copy selection decisions from bcsel table
     uint64_t selection = bc.selection_raw();
 
-    // copy multiplicity per ring and calculate V0C012 multiplicity
-    float multRingV0A[5] = {0.};
+    // calculate V0C012 multiplicity
     float multRingV0C[4] = {0.};
-    for (int i = 0; i < 5; i++) {
-      multRingV0A[i] = bc.multRingV0A()[i];
+    if (bc.has_fv0c()) {
+      for (unsigned int i = 0; i < bc.fv0c().amplitude().size(); ++i) {
+        int ring = bc.fv0c().channel()[i] / 8;
+        multRingV0C[ring] += bc.fv0c().amplitude()[i];
+      }
     }
-    for (int i = 0; i < 4; i++) {
-      multRingV0C[i] = bc.multRingV0C()[i];
-    }
-    float multV0C012 = bc.multRingV0C()[0] + bc.multRingV0C()[1] + bc.multRingV0C()[2];
+    float multV0C012 = multRingV0C[0] + multRingV0C[1] + multRingV0C[2];
 
     // applying selections depending on the number of tracklets
     auto trackletsGrouped = tracklets->sliceByCached(aod::track::collisionId, col.globalIndex(), cache);
     int nTkl = trackletsGrouped.size();
+    int spdClusters =  bc.spdClustersL0() + bc.spdClustersL1();
 
-    uint32_t spdClusters = bc.spdClusters();
     selection |= (spdClusters < par->fSPDClsVsTklA + nTkl * par->fSPDClsVsTklB) ? BIT(kNoSPDClsVsTklBG) : 0;
     selection |= !(nTkl < 6 && multV0C012 > par->fV0C012vsTklA + nTkl * par->fV0C012vsTklB) ? BIT(kNoV0C012vsTklBG) : 0;
-
-    // copy beam-beam and beam-gas flags from bcsel table
-    bool bbV0A = bc.bbV0A();
-    bool bbV0C = bc.bbV0C();
-    bool bgV0A = bc.bgV0A();
-    bool bgV0C = bc.bgV0C();
-    bool bbFDA = bc.bbFDA();
-    bool bbFDC = bc.bbFDC();
-    bool bgFDA = bc.bgFDA();
-    bool bgFDC = bc.bgFDC();
 
     // apply int7-like selections
     bool sel7 = 1;
@@ -439,7 +380,7 @@ struct EventSelectionTask {
     }
 
     // TODO introduce array of sel[0]... sel[8] or similar?
-    bool sel8 = bc.selection_bit(kIsBBT0A) & bc.selection_bit(kIsBBT0C); // TODO apply other cuts for sel8
+    bool sel8 = bc.selection_bit(kIsBBT0A) && bc.selection_bit(kIsBBT0C); // TODO apply other cuts for sel8
     bool sel1 = bc.selection_bit(kIsINT1);
     sel1 &= bc.selection_bit(kNoBGV0A);
     sel1 &= bc.selection_bit(kNoBGV0C);
@@ -457,16 +398,12 @@ struct EventSelectionTask {
       }
     }
 
-    evsel(alias, selection,
-          bbV0A, bbV0C, bgV0A, bgV0C,
-          bbFDA, bbFDC, bgFDA, bgFDC,
-          multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-          foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
+    evsel(alias, selection, sel7, sel8, foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
   }
   PROCESS_SWITCH(EventSelectionTask, processRun2, "Process Run2 event selection", true);
 
   Preslice<FullTracksIU> perCollision = aod::track::collisionId;
-  void processRun3(aod::Collisions const& cols, FullTracksIU const& tracks, BCsWithBcSels const& bcs)
+  void processRun3(aod::Collisions const& cols, FullTracksIU const& tracks, BCsWithBcSelsRun3 const& bcs)
   {
     int run = bcs.iteratorAt(0).runNumber();
     // extract bc pattern from CCDB for data or anchored MC only
@@ -495,8 +432,23 @@ struct EventSelectionTask {
       }
     }
 
+    // protection against empty FT0 maps
+    if (mapGlobalBcWithTOR.size()==0 || mapGlobalBcWithTVX.size()==0) {
+      LOGP(error,"FT0 table is empty or corrupted. Filling evsel table with dummy values");
+      for (auto& col : cols) {
+        auto bc = col.bc_as<BCsWithBcSelsRun3>();
+        int32_t foundBC = bc.globalIndex();
+        int32_t foundFT0 = bc.foundFT0Id();
+        int32_t foundFV0 = bc.foundFV0Id();
+        int32_t foundFDD = bc.foundFDDId();
+        int32_t foundZDC = bc.foundZDCId();
+        evsel(bc.alias_raw(),bc.selection_raw(), kFALSE, kFALSE, foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
+      }
+      return;
+    }
+
     for (auto& col : cols) {
-      auto bc = col.bc_as<BCsWithBcSels>();
+      auto bc = col.bc_as<BCsWithBcSelsRun3>();
       int64_t meanBC = bc.globalBC();
       const double bcNS = o2::constants::lhc::LHCBunchSpacingNS;
       int64_t deltaBC = std::ceil(col.collisionTimeRes() / bcNS * 4);
@@ -527,13 +479,13 @@ struct EventSelectionTask {
       LOGP(debug, "nContrib={} nITStracks={} nTPCtracks={} nTOFtracks={} nTRDtracks={}", col.numContrib(), nITStracks, nTPCtracks, nTOFtracks, nTRDtracks);
 
       if (nTRDtracks > 0) {
-        meanBC += TMath::Nint(timeFromTRDtracks / nTRDtracks / bcNS); // assign collision bc using TRD-matched tracks
-        deltaBC = 0;                                                  // use precise bc from TRD-matched tracks
+        meanBC += TMath::Nint(timeFromTRDtracks / nTRDtracks / bcNS);      // assign collision bc using TRD-matched tracks
+        deltaBC = 0;                                                       // use precise bc from TRD-matched tracks
       } else if (nTOFtracks > 0) {
         meanBC += TMath::FloorNint(timeFromTOFtracks / nTOFtracks / bcNS); // assign collision bc using TOF-matched tracks
         deltaBC = 4;                                                       // use precise bc from TOF tracks with +/-4 bc margin
       } else if (nTPCtracks > 0) {
-        deltaBC += 30; // extend deltaBC for collisions built with ITS-TPC tracks only
+        deltaBC += 30;                                                     // extend deltaBC for collisions built with ITS-TPC tracks only
       }
 
       int64_t minBC = meanBC - deltaBC;
@@ -543,7 +495,7 @@ struct EventSelectionTask {
       int64_t tvxBC = bcs.iteratorAt(indexClosestTVX).globalBC();
       if (tvxBC >= minBC && tvxBC <= maxBC) { // closest TVX within search region
         bc.setCursor(indexClosestTVX);
-      } else { // no TVX within search region, searching for TOR = T0A | T0C
+      } else {                                // no TVX within search region, searching for TOR = T0A | T0C
         int32_t indexClosestTOR = findClosest(meanBC, mapGlobalBcWithTOR);
         int64_t torBC = bcs.iteratorAt(indexClosestTOR).globalBC();
         if (torBC >= minBC && torBC <= maxBC) {
@@ -565,26 +517,6 @@ struct EventSelectionTask {
       // copy selection decisions from bcsel table
       uint64_t selection = bc.selection_raw();
 
-      // copy multiplicity per ring
-      float multRingV0A[5] = {0.};
-      float multRingV0C[4] = {0.};
-      for (int i = 0; i < 5; i++) {
-        multRingV0A[i] = bc.multRingV0A()[i];
-      }
-
-      int nTkl = 0;
-      uint32_t spdClusters = 0;
-
-      // copy beam-beam and beam-gas flags from bcsel table
-      bool bbV0A = bc.bbV0A();
-      bool bbV0C = bc.bbV0C();
-      bool bgV0A = bc.bgV0A();
-      bool bgV0C = bc.bgV0C();
-      bool bbFDA = bc.bbFDA();
-      bool bbFDC = bc.bbFDC();
-      bool bgFDA = bc.bgFDA();
-      bool bgFDC = bc.bgFDC();
-
       // apply int7-like selections
       bool sel7 = 0;
 
@@ -599,11 +531,7 @@ struct EventSelectionTask {
         histos.get<TH1>(HIST("hColCounterAcc"))->Fill(Form("%d", bc.runNumber()), 1);
       }
 
-      evsel(alias, selection,
-            bbV0A, bbV0C, bgV0A, bgV0C,
-            bbFDA, bbFDC, bgFDA, bgFDC,
-            multRingV0A, multRingV0C, spdClusters, nTkl, sel7, sel8,
-            foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
+      evsel(alias, selection, sel7, sel8, foundBC, foundFT0, foundFV0, foundFDD, foundZDC);
     }
   }
   PROCESS_SWITCH(EventSelectionTask, processRun3, "Process Run3 event selection", false);

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -386,7 +386,7 @@ struct EventSelectionQaTask {
       float multRingV0C012 = multV0C - multRingV0C3;
       float onV0M = bc.v0TriggerChargeA() + bc.v0TriggerChargeC();
       float ofV0M = multV0A + multV0C - multRingV0A[0];
-      int spdClusters =  bc.spdClustersL0() + bc.spdClustersL1();
+      int spdClusters = bc.spdClustersL0() + bc.spdClustersL1();
 
       auto trackletsGrouped = tracklets->sliceByCached(aod::track::collisionId, col.globalIndex(), cache);
       int nTracklets = trackletsGrouped.size();

--- a/Common/Tasks/eventSelectionQa.cxx
+++ b/Common/Tasks/eventSelectionQa.cxx
@@ -51,6 +51,9 @@ struct EventSelectionQaTask {
   std::bitset<o2::constants::lhc::LHCMaxBunches> bcPatternC;
   std::bitset<o2::constants::lhc::LHCMaxBunches> bcPatternB;
 
+  SliceCache cache;
+  Partition<aod::Tracks> tracklets = (aod::track::trackType == static_cast<uint8_t>(o2::aod::track::TrackTypeEnum::Run2Tracklet));
+
   void init(InitContext&)
   {
     minGlobalBC = uint64_t(minOrbit) * 3564;
@@ -299,7 +302,7 @@ struct EventSelectionQaTask {
 
     // collision-based event selection qa
     for (auto& col : cols) {
-      bool sel1 = col.selection_bit(kIsINT1) & col.selection_bit(kNoBGV0A) & col.selection_bit(kNoBGV0C) & col.selection_bit(kNoTPCLaserWarmUp) & col.selection_bit(kNoTPCHVdip);
+      bool sel1 = col.selection_bit(kIsINT1) && col.selection_bit(kNoBGV0A) && col.selection_bit(kNoBGV0C) && col.selection_bit(kNoTPCLaserWarmUp) && col.selection_bit(kNoTPCHVdip);
 
       for (int iAlias = 0; iAlias < kNaliases; iAlias++) {
         if (!col.alias_bit(iAlias)) {
@@ -345,6 +348,27 @@ struct EventSelectionQaTask {
         histos.fill(HIST("hBcFDD"), localBC);
       }
 
+      // Calculate V0 multiplicity per ring
+      float multRingV0A[5] = {0.};
+      float multRingV0C[4] = {0.};
+      float multV0A = 0;
+      float multV0C = 0;
+      if (bc.has_fv0a()) {
+        for (unsigned int i = 0; i < bc.fv0a().amplitude().size(); ++i) {
+          int ring = bc.fv0a().channel()[i] / 8;
+          multRingV0A[ring] += bc.fv0a().amplitude()[i];
+          multV0A += bc.fv0a().amplitude()[i];
+        }
+      }
+
+      if (bc.has_fv0c()) {
+        for (unsigned int i = 0; i < bc.fv0c().amplitude().size(); ++i) {
+          int ring = bc.fv0c().channel()[i] / 8;
+          multRingV0C[ring] += bc.fv0c().amplitude()[i];
+          multV0C += bc.fv0c().amplitude()[i];
+        }
+      }
+
       float timeZNA = bc.has_zdc() ? bc.zdc().timeZNA() : -999.f;
       float timeZNC = bc.has_zdc() ? bc.zdc().timeZNC() : -999.f;
       float timeV0A = bc.has_fv0a() ? bc.fv0a().time() : -999.f;
@@ -357,15 +381,15 @@ struct EventSelectionQaTask {
       float znDif = timeZNA - timeZNC;
       float ofSPD = bc.spdFiredChipsL0() + bc.spdFiredChipsL1();
       float onSPD = bc.spdFiredFastOrL0() + bc.spdFiredFastOrL1();
-      float multV0A = col.multRingV0A()[0] + col.multRingV0A()[1] + col.multRingV0A()[2] + col.multRingV0A()[3];
-      float multV0C = col.multRingV0C()[0] + col.multRingV0C()[1] + col.multRingV0C()[2] + col.multRingV0C()[3];
       float multV0M = multV0A + multV0C;
-      float multRingV0C3 = col.multRingV0C()[3];
+      float multRingV0C3 = multRingV0C[3];
       float multRingV0C012 = multV0C - multRingV0C3;
       float onV0M = bc.v0TriggerChargeA() + bc.v0TriggerChargeC();
-      float ofV0M = multV0A + multV0C - col.multRingV0A()[0];
-      int nTracklets = col.nTracklets();
-      int spdClusters = col.spdClusters();
+      float ofV0M = multV0A + multV0C - multRingV0A[0];
+      int spdClusters =  bc.spdClustersL0() + bc.spdClustersL1();
+
+      auto trackletsGrouped = tracklets->sliceByCached(aod::track::collisionId, col.globalIndex(), cache);
+      int nTracklets = trackletsGrouped.size();
 
       float multT0A = 0;
       float multT0C = 0;

--- a/PWGUD/Tasks/diffMCDataScanner.cxx
+++ b/PWGUD/Tasks/diffMCDataScanner.cxx
@@ -147,7 +147,6 @@ struct collisionsInfo {
 
     // update histograms with track information
     LOGF(debug, "Number of tracks: Vertex %d, total %d, global %d", collision.numContrib(), cntAll, cntGlobal);
-    LOGF(debug, "Number of SPD cluster: %d", collision.spdClusters());
     registry.get<TH1>(HIST("numberTracks"))->Fill(cntAll);
     registry.get<TH1>(HIST("numberVtxTracks"))->Fill(collision.numContrib());
     registry.get<TH1>(HIST("numberGlobalTracks"))->Fill(cntGlobal);

--- a/PWGUD/Tasks/upcAnalysis.cxx
+++ b/PWGUD/Tasks/upcAnalysis.cxx
@@ -35,11 +35,11 @@ struct UPCAnalysis {
 
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& col, soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection>> const& tracks)
   {
-    bool checkV0 = col.bbV0A() || col.bbV0C() || col.bgV0A() || col.bgV0C();
+    bool checkV0 = col.selection_bit(kIsBBV0A) || col.selection_bit(kIsBBV0C) || !col.selection_bit(kNoBGV0A) || !col.selection_bit(kNoBGV0C);
     if (checkV0) {
       return;
     }
-    bool checkFDD = col.bbFDA() || col.bbFDC() || col.bgFDA() || col.bgFDC();
+    bool checkFDD = col.selection_bit(kIsBBFDA) || col.selection_bit(kIsBBFDC) || !col.selection_bit(kNoBGFDA) || !col.selection_bit(kNoBGFDC);
     if (checkFDD) {
       return;
     }

--- a/PWGUD/Tasks/upcForward.cxx
+++ b/PWGUD/Tasks/upcForward.cxx
@@ -79,9 +79,9 @@ struct UPCForward {
     bool isBeamGasV0C = !bc.selection_bit(kNoBGV0C);
 
     bool isBeamBeamFDA = bc.selection_bit(kIsBBFDA);
-    bool isBeamGasFDA =  !bc.selection_bit(kNoBGFDA);
-    bool isBeamBeamFDC =  bc.selection_bit(kIsBBFDC);
-    bool isBeamGasFDC =  !bc.selection_bit(kNoBGFDC);
+    bool isBeamGasFDA = !bc.selection_bit(kNoBGFDA);
+    bool isBeamBeamFDC = bc.selection_bit(kIsBBFDC);
+    bool isBeamGasFDC = !bc.selection_bit(kNoBGFDC);
 
     // offline V0 and FD selection
     bool isV0Selection = isBeamBeamV0A || isBeamGasV0A || isBeamGasV0C;

--- a/PWGUD/Tasks/upcForward.cxx
+++ b/PWGUD/Tasks/upcForward.cxx
@@ -73,15 +73,15 @@ struct UPCForward {
     bool isnegative = kFALSE;
 
     // V0 and FD information
-    bool isBeamBeamV0A = bc.bbV0A();
-    bool isBeamGasV0A = bc.bgV0A();
-    // bool isBeamBeamV0C = bc.bbV0C();
-    bool isBeamGasV0C = bc.bgV0C();
+    bool isBeamBeamV0A = bc.selection_bit(kIsBBV0A);
+    bool isBeamGasV0A = !bc.selection_bit(kNoBGV0A);
+    // bool isBeamBeamV0C = bc.selection_bit(kIsBBV0C);
+    bool isBeamGasV0C = !bc.selection_bit(kNoBGV0C);
 
-    bool isBeamBeamFDA = bc.bbFDA();
-    bool isBeamGasFDA = bc.bgFDA();
-    bool isBeamBeamFDC = bc.bbFDC();
-    bool isBeamGasFDC = bc.bgFDC();
+    bool isBeamBeamFDA = bc.selection_bit(kIsBBFDA);
+    bool isBeamGasFDA =  !bc.selection_bit(kNoBGFDA);
+    bool isBeamBeamFDC =  bc.selection_bit(kIsBBFDC);
+    bool isBeamGasFDC =  !bc.selection_bit(kNoBGFDC);
 
     // offline V0 and FD selection
     bool isV0Selection = isBeamBeamV0A || isBeamGasV0A || isBeamGasV0C;

--- a/PWGUD/Tasks/upcForward.cxx
+++ b/PWGUD/Tasks/upcForward.cxx
@@ -19,7 +19,6 @@ alien:///alice/data/2015/LHC15o/000246392/pass5_lowIR/PWGZZ/Run3_Conversion/148_
 #include "Framework/AnalysisDataModel.h"
 #include "Common/DataModel/EventSelection.h"
 #include "iostream"
-#include "Common/DataModel/EventSelection.h"
 #include <TH1D.h>
 #include <TH2D.h>
 #include <TString.h>

--- a/Tutorials/Skimming/spectraUPCProvider.cxx
+++ b/Tutorials/Skimming/spectraUPCProvider.cxx
@@ -33,17 +33,17 @@ struct UPCSpectraProviderTask {
 
   Filter trackFilter = (requireGlobalTrackInFilter());
 
-  void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection>> const& tracks)
+  void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& col, soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection>> const& tracks)
   {
-    bool checkV0 = collision.bbV0A() || collision.bbV0C() || collision.bgV0A() || collision.bgV0C();
+    bool checkV0 = col.selection_bit(kIsBBV0A) || col.selection_bit(kIsBBV0C) || !col.selection_bit(kNoBGV0A) || !col.selection_bit(kNoBGV0C);
     if (checkV0) {
       return;
     }
-    bool checkFDD = collision.bbFDA() || collision.bbFDC() || collision.bgFDA() || collision.bgFDC();
+    bool checkFDD = col.selection_bit(kIsBBFDA) || col.selection_bit(kIsBBFDC) || !col.selection_bit(kNoBGFDA) || !col.selection_bit(kNoBGFDC);
     if (checkFDD) {
       return;
     }
-    if (!collision.alias_bit(kCUP9)) {
+    if (!col.alias_bit(kCUP9)) {
       return;
     }
     if (tracks.size() != 2) {

--- a/Tutorials/Skimming/spectraUPCReference.cxx
+++ b/Tutorials/Skimming/spectraUPCReference.cxx
@@ -40,11 +40,11 @@ struct UPCSpectraReferenceTask {
 
   void process(soa::Join<aod::Collisions, aod::EvSels>::iterator const& col, soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection>> const& tracks)
   {
-    bool checkV0 = col.bbV0A() || col.bbV0C() || col.bgV0A() || col.bgV0C();
+    bool checkV0 = col.selection_bit(kIsBBV0A) || col.selection_bit(kIsBBV0C) || !col.selection_bit(kNoBGV0A) || !col.selection_bit(kNoBGV0C);
     if (checkV0) {
       return;
     }
-    bool checkFDD = col.bbFDA() || col.bbFDC() || col.bgFDA() || col.bgFDC();
+    bool checkFDD = col.selection_bit(kIsBBFDA) || col.selection_bit(kIsBBFDC) || !col.selection_bit(kNoBGFDA) || !col.selection_bit(kNoBGFDC);
     if (checkFDD) {
       return;
     }


### PR DESCRIPTION
1. Removed redundant and unused columns from bcsel and evsel tables:
                  evsel::BBV0A, evsel::BBV0C, evsel::BGV0A, evsel::BGV0C,
                  evsel::BBFDA, evsel::BBFDC, evsel::BGFDA, evsel::BGFDC,
                  evsel::MultRingV0A, evsel::MultRingV0C, evsel::SpdClusters, evsel::NTracklets

2. EvselQA and UD-related tasks are updated. Instead of bb and bg flags, using:
bool checkV0 = col.selection_bit(kIsBBV0A) || col.selection_bit(kIsBBV0C) || !col.selection_bit(kNoBGV0A) || !col.selection_bit(kNoBGV0C);
    bool checkFDD = col.selection_bit(kIsBBFDA) || col.selection_bit(kIsBBFDC) || !col.selection_bit(kNoBGFDA) || !col.selection_bit(kNoBGFDC);
    
2. Protection against empty FT0 table
