### PR TITLE
O2Physics tasks use GRP, so pull in the library

### DIFF
--- a/Common/Core/CMakeLists.txt
+++ b/Common/Core/CMakeLists.txt
@@ -15,7 +15,7 @@ o2physics_add_library(AnalysisCore
                        PID/ParamBase.cxx
                        CollisionAssociation.cxx
                        TrackSelectionDefaults.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework ROOT::EG O2::CCDB ROOT::Physics)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsParameters ROOT::EG O2::CCDB ROOT::Physics)
 
 o2physics_target_root_dictionary(AnalysisCore
               HEADERS   TrackSelection.h


### PR DESCRIPTION
This was working so far only accidentally, since most tasks are pulling in the library via other dependencies, while other tasks were ok with only the header present, which is present in any case from the O2 installation.