### PR TITLE
PWGCF: FemtoUniverse - adding phi to the producer and creating a track-phi task

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h
@@ -52,6 +52,7 @@ class FemtoUniverseObjectSelection
   void fillSelectionHistogram()
   {
     int nBins = mSelections.size();
+    LOGF(info, "%s", (static_cast<std::string>(o2::aod::femtouniverseparticle::ParticleTypeName[part]) + "/cuthist").c_str());
     mHistogramRegistry->add((static_cast<std::string>(o2::aod::femtouniverseparticle::ParticleTypeName[part]) + "/cuthist").c_str(), "; Cut; Value", kTH1F, {{nBins, 0, static_cast<double>(nBins)}});
     auto hist = mHistogramRegistry->get<TH1>(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[part]) + HIST("/cuthist"));
     for (size_t i = 0; i < mSelections.size(); ++i) {

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
@@ -30,7 +30,7 @@ namespace o2::analysis::femtoUniverse
 
 /// \class FemtoUniverseParticleHisto
 /// \brief Class for histogramming particle properties
-/// \tparam particleType Type of the particle (Track/V0/Cascade/...)
+/// \tparam particleType Type of the particle (Track/V0/Cascade/Phi/...)
 /// \tparam suffixType (optional) Takes care of the suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
 template <o2::aod::femtouniverseparticle::ParticleType particleType, int suffixType = 0>
 class FemtoUniverseParticleHisto
@@ -55,7 +55,6 @@ class FemtoUniverseParticleHisto
     mHistogramRegistry->add((folderName + folderSuffix + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hEta").c_str(), "; #eta; Entries", kTH1F, {{200, -1.5, 1.5}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hPhi").c_str(), "; #phi; Entries", kTH1F, {{200, 0, 2. * M_PI}});
-    // mHistogramRegistry->add((folderName + folderSuffix + "/hTPCdEdX").c_str(), "; #it{p} (GeV/#it{c}); TPC Signal", kTH2F, {{100, 0, 10}, {1000, 0, 1000}});
 
     /// particle specific histogramms for the TempFitVar column in FemtoUniverseParticles
     if constexpr (o2::aod::femtouniverseMCparticle::MCType::kRecon == mc) {
@@ -203,7 +202,6 @@ class FemtoUniverseParticleHisto
     mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hPt"), part.pt());
     mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hEta"), part.eta());
     mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hPhi"), part.phi());
-    // mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hTPCdEdX"), part.pt(), part.tpcSignal());
 
     /// particle specific histogramms for the TempFitVar column in FemtoUniverseParticles
     if constexpr (mc == o2::aod::femtouniverseMCparticle::MCType::kRecon) {

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
@@ -1,0 +1,667 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file FemtoUniversePhiSelection.h
+/// \brief Definition of the FemtoUniversePhiSelection
+/// \author Valentina Mantovani Sarti, TU München valentina.mantovani-sarti@tum.de
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
+
+#ifndef PWGCF_FEMTOUNIVERSE_CORE_FEMTOUNIVERSEPHISELECTION_H_
+#define PWGCF_FEMTOUNIVERSE_CORE_FEMTOUNIVERSEPHISELECTION_H_
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseSelection.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
+
+#include "Common/Core/RecoDecay.h"
+#include "Framework/HistogramRegistry.h"
+#include "ReconstructionDataFormats/PID.h"
+#include "TLorentzVector.h"
+
+using namespace o2::framework;
+
+namespace o2::analysis::femtoUniverse
+{
+namespace femtoUniversePhiSelection
+{
+/// The different selections this task is capable of doing
+enum PhiSel {
+  kPhiSign, ///< +1 particle, -1 antiparticle
+  kPhipTMin,
+  kPhipTMax,
+  kPhietaMax,
+  kPhiDCADaughMax,
+  kPhiCPAMin,
+  kPhiTranRadMin,
+  kPhiTranRadMax,
+  kPhiDecVtxMax
+};
+
+enum ChildTrackType { kPosTrack,
+                      kNegTrack };
+
+enum PhiContainerPosition {
+  kPhi,
+  kPosCuts,
+  kPosPID,
+  kNegCuts,
+  kNegPID,
+}; /// Position in the full VO cut container
+
+} // namespace femtoUniversePhiSelection
+
+/// \class FemtoUniversePhiSelection
+/// \brief Cut class to contain and execute all cuts applied to Phis
+class FemtoUniversePhiSelection
+  : public FemtoUniverseObjectSelection<float, femtoUniversePhiSelection::PhiSel>
+{
+ public:
+  FemtoUniversePhiSelection()
+    : nPtPhiMinSel(0), nPtPhiMaxSel(0), nEtaPhiMaxSel(0), nDCAPhiDaughMax(0), nCPAPhiMin(0), nTranRadPhiMin(0), nTranRadPhiMax(0), nDecVtxMax(0), pTPhiMin(9999999.), pTPhiMax(-9999999.), etaPhiMax(-9999999.), DCAPhiDaughMax(-9999999.), CPAPhiMin(9999999.), TranRadPhiMin(9999999.), TranRadPhiMax(-9999999.), DecVtxMax(-9999999.), fInvMassLowLimit(1.05), fInvMassUpLimit(1.3), fRejectKaon(false), fInvMassKaonLowLimit(0.48), fInvMassKaonUpLimit(0.515), nSigmaPIDOffsetTPC(0.) {}
+  /// Initializes histograms for the task
+  template <o2::aod::femtouniverseparticle::ParticleType part,
+            o2::aod::femtouniverseparticle::ParticleType daugh,
+            typename cutContainerType>
+  void init(HistogramRegistry* registry);
+
+  template <typename C, typename V, typename T>
+  bool isSelectedMinimal(C const& col, V const& phi, T const& posTrack,
+                         T const& negTrack);
+
+  template <typename C, typename V, typename T>
+  void fillLambdaQA(C const& col, V const& phi, T const& posTrack,
+                    T const& negTrack);
+
+  /// \todo for the moment the PID of the tracks is factored out into a separate
+  /// field, hence 5 values in total \\ASK: what does it mean?
+  template <typename cutContainerType, typename C, typename V, typename T>
+  std::array<cutContainerType, 5> getCutContainer(C const& col, V const& phi,
+                                                  T const& posTrack,
+                                                  T const& negTrack);
+
+  template <o2::aod::femtouniverseparticle::ParticleType part,
+            o2::aod::femtouniverseparticle::ParticleType daugh, typename C,
+            typename V, typename T, typename Q>
+  void fillQA(C const& col, V const& phi, T const& posTrack, T const& negTrack, Q const& posPID, Q const& negPID);
+
+  template <typename T1, typename T2>
+  void setChildCuts(femtoUniversePhiSelection::ChildTrackType child, T1 selVal,
+                    T2 selVar, femtoUniverseSelection::SelectionType selType)
+  {
+    if (child == femtoUniversePhiSelection::kPosTrack) {
+      PosDaughTrack.setSelection(selVal, selVar, selType);
+    } else if (child == femtoUniversePhiSelection::kNegTrack) {
+      NegDaughTrack.setSelection(selVal, selVar, selType);
+    }
+  }
+  template <typename T>
+  void setChildPIDSpecies(femtoUniversePhiSelection::ChildTrackType child,
+                          T& pids)
+  {
+    if (child == femtoUniversePhiSelection::kPosTrack) {
+      PosDaughTrack.setPIDSpecies(pids);
+    } else if (child == femtoUniversePhiSelection::kNegTrack) {
+      NegDaughTrack.setPIDSpecies(pids);
+    }
+  }
+
+  /// Helper function to obtain the name of a given selection criterion for consistent naming of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the name of the configurable
+  /// \param suffix Additional suffix for the name of the configurable
+  static std::string getSelectionName(femtoUniversePhiSelection::PhiSel iSel,
+                                      std::string_view prefix = "",
+                                      std::string_view suffix = "")
+  {
+    std::string outString = static_cast<std::string>(prefix);
+    outString += static_cast<std::string>(mSelectionNames[iSel]);
+    outString += suffix;
+    return outString;
+  }
+
+  /// Helper function to obtain the index of a given selection variable for consistent naming of the configurables
+  /// \param obs Phi selection variable (together with prefix) got from file
+  /// \param prefix Additional prefix for the output of the configurable
+  static int findSelectionIndex(const std::string_view& obs,
+                                std::string_view prefix = "")
+  {
+    for (int index = 0; index < kNphiSelection; index++) {
+      std::string comp = static_cast<std::string>(prefix) +
+                         static_cast<std::string>(mSelectionNames[index]);
+      std::string_view cmp{comp};
+      if (obs.compare(cmp) == 0)
+        return index;
+    }
+    LOGF(info, "Variable %s not found", obs);
+    return -1;
+  }
+
+  /// Helper function to obtain the type of a given selection variable for consistent naming of the configurables
+  /// \param iSel Phi selection variable whose type is returned
+  static femtoUniverseSelection::SelectionType
+    getSelectionType(femtoUniversePhiSelection::PhiSel iSel)
+  {
+    return mSelectionTypes[iSel];
+  }
+
+  /// Helper function to obtain the helper string of a given selection criterion
+  /// for consistent description of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the output of the configurable
+  static std::string getSelectionHelper(femtoUniversePhiSelection::PhiSel iSel,
+                                        std::string_view prefix = "")
+  {
+    std::string outString = static_cast<std::string>(prefix);
+    outString += static_cast<std::string>(mSelectionHelper[iSel]);
+    return outString;
+  }
+
+  /// Set limit for the selection on the invariant mass
+  /// \param lowLimit Lower limit for the invariant mass distribution
+  /// \param upLimit Upper limit for the invariant mass distribution
+  void setInvMassLimits(float lowLimit, float upLimit)
+  {
+    fInvMassLowLimit = lowLimit;
+    fInvMassUpLimit = upLimit;
+  }
+
+  /// Set limit for the kaon rejection on the invariant mass
+  /// \param lowLimit Lower limit for the invariant mass distribution
+  /// \param upLimit Upper limit for the invariant mass distribution
+  void setKaonInvMassLimits(float lowLimit, float upLimit)
+  {
+    fRejectKaon = true;
+    fInvMassKaonLowLimit = lowLimit;
+    fInvMassKaonUpLimit = upLimit;
+  }
+
+  void setnSigmaPIDOffsetTPC(float offsetTPC)
+  {
+    nSigmaPIDOffsetTPC = offsetTPC;
+  }
+
+  void setChildRejectNotPropagatedTracks(femtoUniversePhiSelection::ChildTrackType child, bool reject)
+  {
+    if (child == femtoUniversePhiSelection::kPosTrack) {
+      PosDaughTrack.setRejectNotPropagatedTracks(reject);
+    } else if (child == femtoUniversePhiSelection::kNegTrack) {
+      NegDaughTrack.setRejectNotPropagatedTracks(reject);
+    }
+  }
+
+  void setChildnSigmaPIDOffset(femtoUniversePhiSelection::ChildTrackType child, float offsetTPC, float offsetTOF)
+  {
+    if (child == femtoUniversePhiSelection::kPosTrack) {
+      PosDaughTrack.setnSigmaPIDOffset(offsetTPC, offsetTOF);
+    } else if (child == femtoUniversePhiSelection::kNegTrack) {
+      NegDaughTrack.setnSigmaPIDOffset(offsetTPC, offsetTOF);
+    }
+  }
+
+ private:
+  int nPtPhiMinSel;
+  int nPtPhiMaxSel;
+  int nEtaPhiMaxSel;
+  int nDCAPhiDaughMax;
+  int nCPAPhiMin;
+  int nTranRadPhiMin;
+  int nTranRadPhiMax;
+  int nDecVtxMax;
+  float pTPhiMin;
+  float pTPhiMax;
+  float etaPhiMax;
+  float DCAPhiDaughMax;
+  float CPAPhiMin;
+  float TranRadPhiMin;
+  float TranRadPhiMax;
+  float DecVtxMax;
+
+  float fInvMassLowLimit;
+  float fInvMassUpLimit;
+
+  bool fRejectKaon;
+  float fInvMassKaonLowLimit;
+  float fInvMassKaonUpLimit;
+
+  float nSigmaPIDOffsetTPC;
+
+  FemtoUniverseTrackSelection PosDaughTrack;
+  FemtoUniverseTrackSelection NegDaughTrack;
+
+  static constexpr int kNphiSelection = 9;
+
+  static constexpr std::string_view mSelectionNames[kNphiSelection] = {
+    "Sign", "PtMin", "PtMax", "EtaMax", "DCAdaughMax", "CPAMin",
+    "TranRadMin", "TranRadMax", "DecVecMax"}; ///< Name of the different
+                                              ///< selections
+
+  static constexpr femtoUniverseSelection::SelectionType
+    mSelectionTypes[kNphiSelection]{
+      femtoUniverseSelection::kEqual,
+      femtoUniverseSelection::kLowerLimit,
+      femtoUniverseSelection::kUpperLimit,
+      femtoUniverseSelection::kUpperLimit,
+      femtoUniverseSelection::kUpperLimit,
+      femtoUniverseSelection::kLowerLimit,
+      femtoUniverseSelection::kLowerLimit,
+      femtoUniverseSelection::kUpperLimit,
+      femtoUniverseSelection::kUpperLimit}; ///< Map to match a variable with
+                                            ///< its type
+
+  static constexpr std::string_view mSelectionHelper[kNphiSelection] = {
+    "+1 for lambda, -1 for antilambda",
+    "Minimum pT (GeV/c)",
+    "Maximum pT (GeV/c)",
+    "Maximum |Eta|",
+    "Maximum DCA between daughters (cm)",
+    "Minimum Cosine of Pointing Angle",
+    "Minimum transverse radius (cm)",
+    "Maximum transverse radius (cm)",
+    "Maximum distance from primary vertex"}; ///< Helper information for the
+                                             ///< different selections
+
+}; // namespace femtoUniverse
+
+template <o2::aod::femtouniverseparticle::ParticleType part,
+          o2::aod::femtouniverseparticle::ParticleType daugh,
+          typename cutContainerType>
+void FemtoUniversePhiSelection::init(HistogramRegistry* registry)
+{
+
+  if (registry) {
+    mHistogramRegistry = registry;
+    fillSelectionHistogram<part>();
+    fillSelectionHistogram<daugh>();
+
+    AxisSpec massAxisPhi = {600, 0.0f, 3.0f, "m_{#Phi} (GeV/#it{c}^{2})"};
+    AxisSpec massAxisLambda = {600, 0.0f, 3.0f, "m_{#Lambda} (GeV/#it{c}^{2})"};
+    AxisSpec massAxisAntiLambda = {600, 0.0f, 3.0f,
+                                   "m_{#bar{#Lambda}} (GeV/#it{c}^{2})"};
+
+    /// \todo this should be an automatic check in the parent class, and the
+    /// return type should be templated
+    size_t nSelections = getNSelections();
+    if (nSelections > 8 * sizeof(cutContainerType)) {
+      LOG(fatal) << "FemtoUniversePhiCuts: Number of selections to large for your "
+                    "container - quitting!";
+    }
+    std::string folderName = static_cast<std::string>(
+      o2::aod::femtouniverseparticle::ParticleTypeName[part]);
+    /// \todo initialize histograms for children tracks of phis
+    mHistogramRegistry->add((folderName + "/hPt").c_str(),
+                            "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
+                            {{1000, 0, 10}});
+    mHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries",
+                            kTH1F, {{1000, -1, 1}});
+    mHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries",
+                            kTH1F, {{1000, 0, 2. * M_PI}});
+    mHistogramRegistry->add((folderName + "/hInvMassPhi").c_str(), "", kTH1F,
+                            {massAxisPhi});
+
+    PosDaughTrack.init<aod::femtouniverseparticle::ParticleType::kPhiChild,
+                       aod::femtouniverseparticle::TrackType::kPosChild,
+                       aod::femtouniverseparticle::cutContainerType>(
+      mHistogramRegistry);
+    NegDaughTrack.init<aod::femtouniverseparticle::ParticleType::kPhiChild,
+                       aod::femtouniverseparticle::TrackType::kNegChild,
+                       aod::femtouniverseparticle::cutContainerType>(
+      mHistogramRegistry);
+
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaNoCuts", "No cuts", kTH1F,
+    //                         {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaInvMassCut",
+    //                         "Invariant mass cut", kTH1F, {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMin", "Minimum Pt cut",
+    //                         kTH1F, {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaPtMax", "Maximum Pt cut",
+    //                         kTH1F, {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaEtaMax", "Maximum Eta cut",
+    //                         kTH1F, {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaDCAPhiDaugh",
+    //                         "Phi-daughters DCA cut", kTH1F, {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaCPA", "CPA cut", kTH1F,
+    //                         {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMin",
+    //                         "Minimum transverse radius cut", kTH1F,
+    //                         {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaTranRadMax",
+    //                         "Maximum transverse radius cut", kTH1F,
+    //                         {massAxisLambda});
+    // mHistogramRegistry->add("LambdaQA/hInvMassLambdaDecVtxMax",
+    //                         "Maximum distance on  decay vertex cut", kTH1F,
+    //                         {massAxisLambda});
+  }
+  /// check whether the most open cuts are fulfilled - most of this should have
+  /// already be done by the filters
+  nPtPhiMinSel = getNSelections(femtoUniversePhiSelection::kPhipTMin);
+  nPtPhiMaxSel = getNSelections(femtoUniversePhiSelection::kPhipTMax);
+  nEtaPhiMaxSel = getNSelections(femtoUniversePhiSelection::kPhietaMax);
+  nDCAPhiDaughMax = getNSelections(femtoUniversePhiSelection::kPhiDCADaughMax);
+  nCPAPhiMin = getNSelections(femtoUniversePhiSelection::kPhiCPAMin);
+  nTranRadPhiMin = getNSelections(femtoUniversePhiSelection::kPhiTranRadMin);
+  nTranRadPhiMax = getNSelections(femtoUniversePhiSelection::kPhiTranRadMax);
+  nDecVtxMax = getNSelections(femtoUniversePhiSelection::kPhiDecVtxMax);
+
+  pTPhiMin = getMinimalSelection(femtoUniversePhiSelection::kPhipTMin,
+                                 femtoUniverseSelection::kLowerLimit);
+  pTPhiMax = getMinimalSelection(femtoUniversePhiSelection::kPhipTMax,
+                                 femtoUniverseSelection::kUpperLimit);
+  etaPhiMax = getMinimalSelection(femtoUniversePhiSelection::kPhietaMax,
+                                  femtoUniverseSelection::kAbsUpperLimit);
+  DCAPhiDaughMax = getMinimalSelection(femtoUniversePhiSelection::kPhiDCADaughMax,
+                                       femtoUniverseSelection::kUpperLimit);
+  CPAPhiMin = getMinimalSelection(femtoUniversePhiSelection::kPhiCPAMin,
+                                  femtoUniverseSelection::kLowerLimit);
+  TranRadPhiMin = getMinimalSelection(femtoUniversePhiSelection::kPhiTranRadMin,
+                                      femtoUniverseSelection::kLowerLimit);
+  TranRadPhiMax = getMinimalSelection(femtoUniversePhiSelection::kPhiTranRadMax,
+                                      femtoUniverseSelection::kUpperLimit);
+  DecVtxMax = getMinimalSelection(femtoUniversePhiSelection::kPhiDecVtxMax,
+                                  femtoUniverseSelection::kAbsUpperLimit);
+}
+
+template <typename C, typename V, typename T>
+bool FemtoUniversePhiSelection::isSelectedMinimal(C const& col, V const& phi,
+                                                  T const& posTrack,
+                                                  T const& negTrack)
+{
+  const auto signPos = posTrack.sign();
+  const auto signNeg = negTrack.sign();
+  if (signPos < 0 || signNeg > 0) {
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for Phi daughters";
+  }
+  // asfaf
+  const float pT = phi.pt();
+  const float eta = phi.eta();
+  const std::vector<float> decVtx = {phi.x(), phi.y(), phi.z()};
+  const float tranRad = phi.phiradius();
+  const float dcaDaughphi = phi.dcaPhidaughters();
+  const float cpaphi = phi.phicosPA(col.posX(), col.posY(), col.posZ());
+
+  const float invMassLambda = phi.mLambda();
+  const float invMassAntiLambda = phi.mAntiLambda();
+
+  if ((invMassLambda < fInvMassLowLimit || invMassLambda > fInvMassUpLimit) &&
+      (invMassAntiLambda < fInvMassLowLimit ||
+       invMassAntiLambda > fInvMassUpLimit)) {
+    return false;
+  }
+  if (fRejectKaon) {
+    const float invMassKaon = phi.mK0Short();
+    if (invMassKaon > fInvMassKaonLowLimit &&
+        invMassKaon < fInvMassKaonUpLimit) {
+      return false;
+    }
+  }
+  if (nPtPhiMinSel > 0 && pT < pTPhiMin) {
+    return false;
+  }
+  if (nPtPhiMaxSel > 0 && pT > pTPhiMax) {
+    return false;
+  }
+  if (nEtaPhiMaxSel > 0 && std::abs(eta) > etaPhiMax) {
+    return false;
+  }
+  if (nDCAPhiDaughMax > 0 && dcaDaughphi > DCAPhiDaughMax) {
+    return false;
+  }
+  if (nCPAPhiMin > 0 && cpaphi < CPAPhiMin) {
+    return false;
+  }
+  if (nTranRadPhiMin > 0 && tranRad < TranRadPhiMin) {
+    return false;
+  }
+  if (nTranRadPhiMax > 0 && tranRad > TranRadPhiMax) {
+    return false;
+  }
+  for (size_t i = 0; i < decVtx.size(); i++) {
+    if (nDecVtxMax > 0 && decVtx.at(i) > DecVtxMax) {
+      return false;
+    }
+  }
+  if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
+    return false;
+  }
+  if (!NegDaughTrack.isSelectedMinimal(negTrack)) {
+    return false;
+  }
+
+  // check that track combinations for Phi or antiPhi would be fulfilling PID
+  int nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
+  // antiPhi
+  auto nSigmaPrNeg = negTrack.tpcNSigmaPr();
+  auto nSigmaPiPos = posTrack.tpcNSigmaPi();
+  // phi
+  auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
+  auto nSigmaPrPos = posTrack.tpcNSigmaPr();
+  if (!(abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+        abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) &&
+      !(abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+        abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax)) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename C, typename V, typename T>
+void FemtoUniversePhiSelection::fillLambdaQA(C const& col, V const& phi,
+                                             T const& posTrack, T const& negTrack)
+{
+  const auto signPos = posTrack.sign();
+  const auto signNeg = negTrack.sign();
+  if (signPos < 0 || signNeg > 0) {
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for Phi daughters";
+  }
+  const float pT = phi.pt();
+  const float eta = phi.eta();
+  const std::vector<float> decVtx = {phi.x(), phi.y(), phi.z()};
+  const float tranRad = phi.phiradius();
+  const float dcaDaughphi = phi.dcaPhidaughters();
+  const float cpaphi = phi.phicosPA(col.posX(), col.posY(), col.posZ());
+
+  const float invMassLambda = phi.mLambda();
+
+  mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaNoCuts"), phi.mLambda());
+
+  if (invMassLambda > fInvMassLowLimit && invMassLambda < fInvMassUpLimit) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaInvMassCut"),
+                             phi.mLambda());
+  }
+
+  if (pT > pTPhiMin) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMin"),
+                             phi.mLambda());
+  }
+  if (pT < pTPhiMax) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaPtMax"),
+                             phi.mLambda());
+  }
+  if (std::abs(eta) < etaPhiMax) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaEtaMax"),
+                             phi.mLambda());
+  }
+  if (dcaDaughphi < DCAPhiDaughMax) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDCAPhiDaugh"),
+                             phi.mLambda());
+  }
+  if (cpaphi > CPAPhiMin) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaCPA"), phi.mLambda());
+  }
+  if (tranRad > TranRadPhiMin) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMin"),
+                             phi.mLambda());
+  }
+  if (tranRad < TranRadPhiMax) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaTranRadMax"),
+                             phi.mLambda());
+  }
+  bool write = true;
+  for (size_t i = 0; i < decVtx.size(); i++) {
+    write = write && (decVtx.at(i) < DecVtxMax);
+  }
+  if (write) {
+    mHistogramRegistry->fill(HIST("LambdaQA/hInvMassLambdaDecVtxMax"),
+                             phi.mLambda());
+  }
+}
+
+/// the CosPA of Phi needs as argument the posXYZ of collisions vertex so we need
+/// to pass the collsion as well
+template <typename cutContainerType, typename C, typename V, typename T>
+std::array<cutContainerType, 5>
+  FemtoUniversePhiSelection::getCutContainer(C const& col, V const& phi, T const& posTrack, T const& negTrack)
+{
+  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
+  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
+  cutContainerType output = 0;
+  size_t counter = 0;
+
+  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+  auto lambdaMassHypothesis = phi.mLambda();
+  auto antiLambdaMassHypothesis = phi.mAntiLambda();
+  auto diffLambda = abs(lambdaMassNominal - lambdaMassHypothesis);
+  auto diffAntiLambda = abs(antiLambdaMassHypothesis - lambdaMassHypothesis);
+
+  float sign = 0.;
+  int nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
+  auto nSigmaPrNeg = negTrack.tpcNSigmaPr();
+  auto nSigmaPiPos = posTrack.tpcNSigmaPi();
+  auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
+  auto nSigmaPrPos = posTrack.tpcNSigmaPr();
+  // check the mass and the PID of daughters
+  if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda > diffLambda) {
+    sign = -1.;
+  } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && diffAntiLambda < diffLambda) {
+    sign = 1.;
+  } else {
+    // if it happens that none of these are true, ignore the invariant mass
+    if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+      sign = -1.;
+    } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
+      sign = 1.;
+    }
+  }
+
+  const auto pT = phi.pt();
+  const auto eta = phi.eta();
+  const auto tranRad = phi.phiradius();
+  const auto dcaDaughphi = phi.dcaPhidaughters();
+  const auto cpaphi = phi.phicosPA(col.posX(), col.posY(), col.posZ());
+  const std::vector<float> decVtx = {phi.x(), phi.y(), phi.z()};
+
+  float observable = 0.;
+  for (auto& sel : mSelections) {
+    const auto selVariable = sel.getSelectionVariable();
+    if (selVariable == femtoUniversePhiSelection::kPhiDecVtxMax) {
+      for (size_t i = 0; i < decVtx.size(); ++i) {
+        auto decVtxValue = decVtx.at(i);
+        sel.checkSelectionSetBit(decVtxValue, output, counter);
+      }
+    } else {
+      switch (selVariable) {
+        case (femtoUniversePhiSelection::kPhiSign):
+          observable = sign;
+          break;
+        case (femtoUniversePhiSelection::kPhipTMin):
+          observable = pT;
+          break;
+        case (femtoUniversePhiSelection::kPhipTMax):
+          observable = pT;
+          break;
+        case (femtoUniversePhiSelection::kPhietaMax):
+          observable = eta;
+          break;
+        case (femtoUniversePhiSelection::kPhiDCADaughMax):
+          observable = dcaDaughphi;
+          break;
+        case (femtoUniversePhiSelection::kPhiCPAMin):
+          observable = cpaphi;
+          break;
+        case (femtoUniversePhiSelection::kPhiTranRadMin):
+          observable = tranRad;
+          break;
+        case (femtoUniversePhiSelection::kPhiTranRadMax):
+          observable = tranRad;
+          break;
+        case (femtoUniversePhiSelection::kPhiDecVtxMax):
+          break;
+      }
+      sel.checkSelectionSetBit(observable, output, counter);
+    }
+  }
+  return {
+    output,
+    outputPosTrack.at(femtoUniverseTrackSelection::TrackContainerPosition::kCuts),
+    outputPosTrack.at(femtoUniverseTrackSelection::TrackContainerPosition::kPID),
+    outputNegTrack.at(femtoUniverseTrackSelection::TrackContainerPosition::kCuts),
+    outputNegTrack.at(femtoUniverseTrackSelection::TrackContainerPosition::kPID)};
+}
+
+template <o2::aod::femtouniverseparticle::ParticleType part,
+          o2::aod::femtouniverseparticle::ParticleType daugh, typename C,
+          typename V, typename T, typename Q>
+void FemtoUniversePhiSelection::fillQA(C const& col, V const& phi, T const& posTrack,
+                                       T const& negTrack, Q const& posPID, Q const& negPID)
+{
+  if (mHistogramRegistry) {
+    TLorentzVector part1Vec;
+    TLorentzVector part2Vec;
+    float mMassOne = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+    float mMassTwo = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+
+    part1Vec.SetPtEtaPhiM(posTrack.pt(), posTrack.eta(), posTrack.phi(), mMassOne);
+    part2Vec.SetPtEtaPhiM(negTrack.pt(), negTrack.eta(), negTrack.phi(), mMassTwo);
+
+    TLorentzVector sumVec(part1Vec);
+    sumVec += part2Vec;
+    float phiEta = sumVec.Eta();
+    float phiPt = sumVec.Pt();
+    // float phiP = sumVec.P();
+    float phiPhi = sumVec.Phi();
+    float phiM = sumVec.M();
+
+    mHistogramRegistry->fill(
+      HIST(o2::aod::femtouniverseparticle::ParticleTypeName[part]) +
+        HIST("/hPt"),
+      phiPt);
+    mHistogramRegistry->fill(
+      HIST(o2::aod::femtouniverseparticle::ParticleTypeName[part]) +
+        HIST("/hEta"),
+      phiEta);
+    mHistogramRegistry->fill(
+      HIST(o2::aod::femtouniverseparticle::ParticleTypeName[part]) +
+        HIST("/hPhi"),
+      phiPhi);
+
+    mHistogramRegistry->fill(
+      HIST(o2::aod::femtouniverseparticle::ParticleTypeName[part]) +
+        HIST("/hInvMassPhi"),
+      phiM);
+  }
+
+  PosDaughTrack.fillQA<aod::femtouniverseparticle::ParticleType::kPhiChild,
+                       aod::femtouniverseparticle::TrackType::kPosChild>(posTrack);
+  NegDaughTrack.fillQA<aod::femtouniverseparticle::ParticleType::kPhiChild,
+                       aod::femtouniverseparticle::TrackType::kNegChild>(negTrack);
+}
+
+} // namespace o2::analysis::femtoUniverse
+
+#endif // PWGCF_FEMTOUNIVERSE_CORE_FEMTOUNIVERSEPHISELECTION_H_

--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -53,10 +53,12 @@ enum ParticleType {
   kV0Child,         //! Child track of a V0
   kCascade,         //! Cascade
   kCascadeBachelor, //! Bachelor track of a cascade
+  kPhi,             //! Phi meson
+  kPhiChild,        //! Child track of a Phi meson
   kNParticleTypes   //! Number of particle types
 };
 
-static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeBachelor"}; //! Naming of the different particle types
+static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeBachelor", "kPhi", "kPhiChild"}; //! Naming of the different particle types
 static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy"};
 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -643,7 +643,12 @@ struct femtoUniverseProducerTask {
         float phiPt = sumVec.Pt();
         // float phiP = sumVec.P();
         float phiPhi = sumVec.Phi();
-        // float phiM = sumVec.M(); //mass of the reconstructed Phi meson
+        if (sumVec.Phi() < 0) {
+          phiPhi = sumVec.Phi() + 2 * o2::constants::math::PI;
+        } else if (sumVec.Phi() >= 0) {
+          phiPhi = sumVec.Phi();
+        }
+        float phiM = sumVec.M(); // mass of the reconstructed Phi meson
 
         // this cut probably is not doing anything, check it
         //  if (((phiM < ConfPhiCommon.ConfInvMassLowLimitPhi) || (phiM > ConfPhiCommon.ConfInvMassUpLimitPhi))) {
@@ -701,7 +706,7 @@ struct femtoUniverseProducerTask {
                     0,
                     -999, // v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
                     indexChildID,
-                    -999,  // v0.mLambda(),
+                    phiM,  // phi.mLambda(), //for now it will have a mLambda getter, maybe we will change it in the future so it's more logical
                     -999); // v0.mAntiLambda()
 
         if (ConfIsDebug) {

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -701,9 +701,9 @@ struct femtoUniverseProducerTask {
                     0,
                     -999, // v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
                     indexChildID,
-                    -999, // v0.mLambda(),
-                    -999  // v0.mAntiLambda()
-        );
+                    -999,  // v0.mLambda(),
+                    -999); // v0.mAntiLambda()
+
         if (ConfIsDebug) {
           fillDebugParticle<true, false>(p1); // QA for positive daughter
           fillDebugParticle<true, false>(p2); // QA for negative daughter

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -25,6 +25,7 @@
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseCollisionSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUtils.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
@@ -36,6 +37,7 @@
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "TMath.h"
+#include "TLorentzVector.h"
 
 using namespace o2;
 using namespace o2::analysis::femtoUniverse;
@@ -106,6 +108,7 @@ struct femtoUniverseProducerTask {
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
   Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtouniverse tables"};
+  Configurable<bool> ConfIsActivatePhi{"ConfIsActivatePhi", true, "Activate filling of Phi into femtouniverse tables"};
   // just sanity check to make sure in case there are problems in conversion or
   // MC production it does not affect results
   Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
@@ -133,10 +136,11 @@ struct femtoUniverseProducerTask {
   Configurable<float> ConfTrkPIDnSigmaOffsetTOF{"ConfTrkPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
   Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
 
-  FemtoUniverseV0Selection v0Cuts;
   // TrackSelection *o2PhysicsTrackSelection;
   /// \todo Labeled array (see Track-Track task)
 
+  // V0
+  FemtoUniverseV0Selection v0Cuts;
   Configurable<std::vector<float>> ConfV0Sign{FemtoUniverseV0Selection::getSelectionName(femtoUniverseV0Selection::kV0Sign, "ConfV0"), std::vector<float>{-1, 1}, FemtoUniverseV0Selection::getSelectionHelper(femtoUniverseV0Selection::kV0Sign, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMin{FemtoUniverseV0Selection::getSelectionName(femtoUniverseV0Selection::kV0pTMin, "ConfV0"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoUniverseV0Selection::getSelectionHelper(femtoUniverseV0Selection::kV0pTMin, "V0 selection: ")};
   Configurable<std::vector<float>> ConfV0PtMax{FemtoUniverseV0Selection::getSelectionName(femtoUniverseV0Selection::kV0pTMax, "ConfV0"), std::vector<float>{3.3f, 3.4f, 3.5f}, FemtoUniverseV0Selection::getSelectionHelper(femtoUniverseV0Selection::kV0pTMax, "V0 selection: ")};
@@ -160,6 +164,72 @@ struct femtoUniverseProducerTask {
   Configurable<bool> ConfV0RejectKaons{"ConfV0RejectKaons", false, "Switch to reject kaons"};
   Configurable<float> ConfV0InvKaonMassLowLimit{"ConfV0InvKaonMassLowLimit", 0.48, "Lower limit of the V0 invariant mass for Kaon rejection"};
   Configurable<float> ConfV0InvKaonMassUpLimit{"ConfV0InvKaonMassUpLimit", 0.515, "Upper limit of the V0 invariant mass for Kaon rejection"};
+
+  // PHI
+  FemtoUniversePhiSelection phiCuts;
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<std::vector<float>> ConfPhiSign{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiSign, "ConfPhi"), std::vector<float>{-1, 1}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiSign, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiPtMin{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhipTMin, "ConfPhi"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhipTMin, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiPtMax{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhipTMax, "ConfPhi"), std::vector<float>{3.3f, 3.4f, 3.5f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhipTMax, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiEtaMax{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhietaMax, "ConfPhi"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhietaMax, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiDCADaughMax{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiDCADaughMax, "ConfPhi"), std::vector<float>{1.2f, 1.5f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiDCADaughMax, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiCPAMin{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiCPAMin, "ConfPhi"), std::vector<float>{0.99f, 0.995f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiCPAMin, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiTranRadMin{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiTranRadMin, "ConfPhi"), std::vector<float>{0.2f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiTranRadMin, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiTranRadMax{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiTranRadMax, "ConfPhi"), std::vector<float>{100.f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiTranRadMax, "Phi selection: ")};
+    Configurable<std::vector<float>> ConfPhiDecVtxMax{FemtoUniversePhiSelection::getSelectionName(femtoUniversePhiSelection::kPhiDecVtxMax, "ConfPhi"), std::vector<float>{100.f}, FemtoUniversePhiSelection::getSelectionHelper(femtoUniversePhiSelection::kPhiDecVtxMax, "Phi selection: ")};
+  } ConfPhiSelection;
+
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<std::vector<float>> ConfPhiChildCharge{"ConfPhiChildSign", std::vector<float>{-1, 1}, "Phi Child sel: Charge"};
+    Configurable<std::vector<float>> ConfPhiChildEtaMax{"ConfPhiChildEtaMax", std::vector<float>{0.8f}, "Phi Child sel: max eta"};
+    Configurable<std::vector<float>> ConfPhiChildTPCnClsMin{"ConfPhiChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "Phi Child sel: Min. nCls TPC"};
+    Configurable<std::vector<float>> ConfPhiChildDCAMin{"ConfPhiChildDCAMin", std::vector<float>{0.05f, 0.06f}, "Phi Child sel:  Max. DCA Daugh to PV (cm)"};
+    Configurable<std::vector<float>> ConfPhiChildPIDnSigmaMax{"ConfPhiChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "Phi Child sel: Max. PID nSigma TPC"};
+    Configurable<std::vector<int>> ConfPhiChildPIDspecies{"ConfPhiChildPIDspecies", std::vector<int>{o2::track::PID::Kaon, o2::track::PID::Kaon}, "Phi Child sel: Particles species for PID"};
+  } ConfPhiChildSelection;
+
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<float> ConfNsigmaCombinedKaon{"ConfNsigmaCombinedKaon", 3.0, "TPC and TOF Kaon Sigma (combined) for momentum > 0.4"};
+    Configurable<float> ConfNsigmaTPCKaon{"ConfNsigmaTPCKaon", 3.0, "TPC Kaon Sigma for momentum < 0.4"};
+    Configurable<bool> ConfNsigmaTPCTOFKaon{"ConfNsigmaTPCTOFKaon", true, "Use TPC and TOF for PID of Kaons"};
+    Configurable<float> ConfInvMassLowLimitPhi{"ConfInvMassLowLimitPhi", 1.011, "Lower limit of the Phi invariant mass"}; // change that to do invariant mass cut
+    Configurable<float> ConfInvMassUpLimitPhi{"ConfInvMassUpLimitPhi", 1.027, "Upper limit of the Phi invariant mass"};
+  } ConfPhiCommon;
+  // PHI child one
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 321, "Particle 1 - PDG code"};
+  } ConfPhiChildOne;
+  // PHI child two
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 321, "Particle 2 - PDG code"};
+  } ConfPhiChildTwo;
+
+  bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    //|nsigma_TPC| < 5 for p < 0.4 GeV/c
+    //|nsigma_combined| < 5 for p > 0.4
+
+    // using configurables:
+    // ConfNsigmaTPCTOFKaon -> are we doing TPC TOF PID for Kaons? (boolean)
+    // ConfNsigmaTPCKaon -> TPC Kaon Sigma for momentum < 0.4
+    // ConfNsigmaCombinedKaon -> TPC and TOF Kaon Sigma (combined) for momentum > 0.4
+    if (ConfPhiCommon.ConfNsigmaTPCTOFKaon) {
+      if (mom < 0.4) {
+        if (TMath::Abs(nsigmaTPCK) < ConfPhiCommon.ConfNsigmaTPCKaon) {
+          return true;
+        } else {
+          return false;
+        }
+      } else if (mom > 0.4) {
+        if (TMath::Hypot(nsigmaTOFK, nsigmaTPCK) < ConfPhiCommon.ConfNsigmaCombinedKaon) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
 
   /// \todo should we add filter on min value pT/eta of V0 and daughters?
   /*Filter v0Filter = (nabs(aod::v0data::x) < V0DecVtxMax.value) &&
@@ -210,6 +280,7 @@ struct femtoUniverseProducerTask {
     // v0Cuts.setSelection(ConfV0Selection->getRow(0),
     // femtoUniverseV0Selection::kDecVtxMax, femtoUniverseSelection::kAbsUpperLimit);
     if (ConfIsActivateV0) {
+      // initializing for V0
       v0Cuts.setSelection(ConfV0Sign, femtoUniverseV0Selection::kV0Sign, femtoUniverseSelection::kEqual);
       v0Cuts.setSelection(ConfV0PtMin, femtoUniverseV0Selection::kV0pTMin, femtoUniverseSelection::kLowerLimit);
       v0Cuts.setSelection(ConfV0PtMax, femtoUniverseV0Selection::kV0pTMax, femtoUniverseSelection::kUpperLimit);
@@ -249,6 +320,33 @@ struct femtoUniverseProducerTask {
       //   TrackSelection(getGlobalTrackSelection());
       //   o2PhysicsTrackSelection->SetRequireHitsInITSLayers(1, {0, 1, 2, 3});
       // }
+    }
+
+    if (ConfIsActivatePhi) {
+      // selection for Phi meson
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiSign, femtoUniversePhiSelection::kPhiSign, femtoUniverseSelection::kEqual);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiPtMin, femtoUniversePhiSelection::kPhipTMin, femtoUniverseSelection::kLowerLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiPtMax, femtoUniversePhiSelection::kPhipTMax, femtoUniverseSelection::kUpperLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiEtaMax, femtoUniversePhiSelection::kPhietaMax, femtoUniverseSelection::kAbsUpperLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiDCADaughMax, femtoUniversePhiSelection::kPhiDCADaughMax, femtoUniverseSelection::kUpperLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiCPAMin, femtoUniversePhiSelection::kPhiCPAMin, femtoUniverseSelection::kLowerLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiTranRadMin, femtoUniversePhiSelection::kPhiTranRadMin, femtoUniverseSelection::kLowerLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiTranRadMax, femtoUniversePhiSelection::kPhiTranRadMax, femtoUniverseSelection::kUpperLimit);
+      phiCuts.setSelection(ConfPhiSelection.ConfPhiDecVtxMax, femtoUniversePhiSelection::kPhiDecVtxMax, femtoUniverseSelection::kUpperLimit);
+
+      // selection for Phi meson daughters
+      phiCuts.setChildCuts(femtoUniversePhiSelection::kPosTrack, ConfPhiChildSelection.ConfPhiChildCharge, femtoUniverseTrackSelection::kSign, femtoUniverseSelection::kEqual);
+      phiCuts.setChildCuts(femtoUniversePhiSelection::kPosTrack, ConfPhiChildSelection.ConfPhiChildEtaMax, femtoUniverseTrackSelection::kEtaMax, femtoUniverseSelection::kAbsUpperLimit);
+      phiCuts.setChildCuts(femtoUniversePhiSelection::kPosTrack, ConfPhiChildSelection.ConfPhiChildTPCnClsMin, femtoUniverseTrackSelection::kTPCnClsMin, femtoUniverseSelection::kLowerLimit);
+      phiCuts.setChildCuts(femtoUniversePhiSelection::kPosTrack, ConfPhiChildSelection.ConfPhiChildDCAMin, femtoUniverseTrackSelection::kDCAMin, femtoUniverseSelection::kAbsLowerLimit);
+      phiCuts.setChildCuts(femtoUniversePhiSelection::kPosTrack, ConfPhiChildSelection.ConfPhiChildPIDnSigmaMax, femtoUniverseTrackSelection::kPIDnSigmaMax, femtoUniverseSelection::kAbsUpperLimit);
+
+      // initializing for Phi meson
+      LOGF(info, "DEBUG: before phicuts.init");
+      phiCuts.init<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild, aod::femtouniverseparticle::cutContainerType>(&qaRegistry);
+
+      // phiCuts setting and initializing
+      phiCuts.setInvMassLimits(ConfPhiCommon.ConfInvMassLowLimitPhi, ConfPhiCommon.ConfInvMassUpLimitPhi);
     }
 
     mRunNumber = 0;
@@ -299,7 +397,7 @@ struct femtoUniverseProducerTask {
     mRunNumber = bc.runNumber();
   }
 
-  template <bool isTrackOrV0, typename ParticleType>
+  template <bool isTrackOrV0, bool isPhi, typename ParticleType>
   void fillDebugParticle(ParticleType const& particle)
   {
     if constexpr (isTrackOrV0) {
@@ -315,7 +413,15 @@ struct femtoUniverseProducerTask {
                        particle.tofNSigmaStorePi(), particle.tofNSigmaStoreKa(),
                        particle.tofNSigmaStorePr(), particle.tofNSigmaStoreDe(),
                        -999., -999., -999., -999., -999., -999.);
+    } else if constexpr (isPhi) {
+      outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       -999., -999.,
+                       -999., -999., -999.,
+                       -999.); // QA for phi
     } else {
+      LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhi);
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999.,
@@ -356,7 +462,7 @@ struct femtoUniverseProducerTask {
 
   template <bool isMC, typename V0Type, typename TrackType,
             typename CollisionType>
-  void fillCollisionsAndTracksAndV0(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
+  void fillCollisionsAndTracksAndV0AndPhi(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
   {
 
     const auto vtxZ = col.posZ();
@@ -414,7 +520,7 @@ struct femtoUniverseProducerTask {
                   track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
       if (ConfIsDebug) {
-        fillDebugParticle<true>(track);
+        fillDebugParticle<true, false>(track);
       }
 
       if constexpr (isMC) {
@@ -499,13 +605,113 @@ struct femtoUniverseProducerTask {
                     v0.mLambda(),
                     v0.mAntiLambda());
         if (ConfIsDebug) {
-          fillDebugParticle<true>(postrack); // QA for positive daughter
-          fillDebugParticle<true>(negtrack); // QA for negative daughter
-          fillDebugParticle<false>(v0);      // QA for v0
+          fillDebugParticle<true, false>(postrack); // QA for positive daughter
+          fillDebugParticle<true, false>(negtrack); // QA for negative daughter
+          fillDebugParticle<false, false>(v0);      // QA for v0
         }
         if constexpr (isMC) {
           fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);
         }
+      }
+    }
+
+    if (ConfIsActivatePhi) {
+      // lorentz vectors and filling the tables
+      for (auto& [p1, p2] : combinations(soa::CombinationsStrictlyUpperIndexPolicy(tracks, tracks))) {
+        // implementing cuts for phi children
+        if (!(IsKaonNSigma(p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon)))) {
+          continue;
+        }
+        if (!(IsKaonNSigma(p2.p(), trackCuts.getNsigmaTPC(p2, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p2, o2::track::PID::Kaon)))) {
+          continue;
+        }
+
+        TLorentzVector part1Vec;
+        TLorentzVector part2Vec;
+
+        // getting particle mass
+        float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPhiChildOne.ConfPDGCodePartOne)->Mass();
+        float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPhiChildTwo.ConfPDGCodePartTwo)->Mass();
+
+        part1Vec.SetPtEtaPhiM(p1.pt(), p1.eta(), p1.phi(), mMassOne);
+        part2Vec.SetPtEtaPhiM(p2.pt(), p2.eta(), p2.phi(), mMassTwo);
+
+        TLorentzVector sumVec(part1Vec);
+        sumVec += part2Vec;
+
+        float phiEta = sumVec.Eta();
+        float phiPt = sumVec.Pt();
+        // float phiP = sumVec.P();
+        float phiPhi = sumVec.Phi();
+        // float phiM = sumVec.M(); //mass of the reconstructed Phi meson
+
+        // this cut probably is not doing anything, check it
+        //  if (((phiM < ConfPhiCommon.ConfInvMassLowLimitPhi) || (phiM > ConfPhiCommon.ConfInvMassUpLimitPhi))) {
+        //    continue;
+        //  }
+
+        phiCuts.fillQA<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild>(col, p1, p1, p2, ConfPhiChildOne.ConfPDGCodePartOne, ConfPhiChildTwo.ConfPDGCodePartTwo); ///\todo fill QA also for daughters
+
+        int postrackID = p1.globalIndex();
+        int rowInPrimaryTrackTablePos = -1; // does it do anything?
+        rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+        childIDs[0] = rowInPrimaryTrackTablePos;
+        childIDs[1] = 0;
+
+        outputParts(outputCollision.lastIndex(), p1.pt(),
+                    p1.eta(), p1.phi(),
+                    aod::femtouniverseparticle::ParticleType::kPhiChild,
+                    -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
+                    -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0);
+        const int rowOfPosTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(p1, o2::aod::femtouniverseparticle::ParticleType::kPhiChild);
+        }
+        int negtrackID = p2.globalIndex();
+        int rowInPrimaryTrackTableNeg = -1;
+        rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+        childIDs[0] = 0;
+        childIDs[1] = rowInPrimaryTrackTableNeg;
+        outputParts(outputCollision.lastIndex(),
+                    p2.pt(),
+                    p2.eta(),
+                    p2.phi(),
+                    aod::femtouniverseparticle::ParticleType::kPhiChild,
+                    -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
+                    -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0);
+        const int rowOfNegTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(p2, o2::aod::femtouniverseparticle::ParticleType::kPhiChild);
+        }
+        std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
+        outputParts(outputCollision.lastIndex(),
+                    phiPt,
+                    phiEta,
+                    phiPhi,
+                    aod::femtouniverseparticle::ParticleType::kPhi,
+                    -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kV0),
+                    0,
+                    -999, // v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                    indexChildID,
+                    -999, // v0.mLambda(),
+                    -999  // v0.mAntiLambda()
+        );
+        if (ConfIsDebug) {
+          fillDebugParticle<true, false>(p1); // QA for positive daughter
+          fillDebugParticle<true, false>(p2); // QA for negative daughter
+          fillDebugParticle<false, true>(p1); // QA for phi
+        }
+        // if constexpr (isMC) {
+        //   fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);
+        // }
       }
     }
   }
@@ -519,7 +725,7 @@ struct femtoUniverseProducerTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracksAndV0<false>(col, tracks, fullV0s);
+    fillCollisionsAndTracksAndV0AndPhi<false>(col, tracks, fullV0s);
   }
   PROCESS_SWITCH(femtoUniverseProducerTask, processData,
                  "Provide experimental data", true);
@@ -535,7 +741,7 @@ struct femtoUniverseProducerTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracksAndV0<true>(col, tracks, fullV0s);
+    fillCollisionsAndTracksAndV0AndPhi<true>(col, tracks, fullV0s);
   }
   PROCESS_SWITCH(femtoUniverseProducerTask, processMC, "Provide MC data", false);
 };

--- a/PWGCF/FemtoUniverse/Tasks/CMakeLists.txt
+++ b/PWGCF/FemtoUniverse/Tasks/CMakeLists.txt
@@ -24,6 +24,11 @@ o2physics_add_dpl_workflow(femtouniverse-pair-track-v0
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femtouniverse-pair-track-phi
+          SOURCES femtoUniversePairTaskTrackPhi.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtouniverse-debug-v0
           SOURCES femtoUniverseDebugV0.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
@@ -78,10 +78,10 @@ struct femtoUniversePairTaskTrackPhi {
     Configurable<bool> ConfUse3D{"ConfUse3D", false, "Enable three dimensional histogramms (to be used only for analysis with high statistics): k* vs mT vs multiplicity"};
   } twotracksconfigs;
 
-  /// Particle 1
+  /// Particle 1 --- PHI MESON
   struct : o2::framework::ConfigurableGroup {
-    Configurable<int> ConfTrackChoicePartOne{"ConfTrackChoicePartOne", 0, "Type of particle (track1): {0:Proton, 1:Pion, 2:Kaon}"};
-    Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
+    Configurable<int> ConfTrackChoicePartOne{"ConfTrackChoicePartOne", 3, "Type of particle (track1): {0:Proton, 1:Pion, 2:Kaon, 3:DIFFERENT}"};
+    Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 333, "Particle 1 - PDG code"};
     // Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
     Configurable<int> ConfPIDPartOne{"ConfPIDPartOne", 2, "Particle 1 - Read from cutCulator"};           // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
     Configurable<float> cfgPtLowPart1{"cfgPtLowPart1", 0.5, "Lower limit for Pt for the first particle"}; // change according to wrzesa cuts
@@ -93,9 +93,9 @@ struct femtoUniversePairTaskTrackPhi {
   Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsOneMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kPhi));
 
   /// Histogramming for particle 1
-  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> trackHistoPartOne;
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 0> trackHistoPartOne;
 
-  /// Particle 2
+  /// Particle 2 --- IDENTIFIED HADRON
   Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
   struct : o2::framework::ConfigurableGroup {
     Configurable<int> ConfTrackChoicePartTwo{"ConfTrackChoicePartTwo", 0, "Type of particle (track1): {0:Proton, 1:Pion, 2:Kaon}"};
@@ -315,24 +315,8 @@ struct femtoUniversePairTaskTrackPhi {
   {
 
     /// Histogramming same event
+    // part one is Phi meson
     for (auto& part : groupPartsOne) {
-      // if (part.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || part.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt")) {
-      //   continue;
-      // }
-      // if (!isFullPIDSelected(part.pidcut(),
-      //                        part.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
-      //                        vPIDPartOne,
-      //                        twotracksconfigs.ConfNspecies,
-      //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF"))) {
-      //   continue;
-      // }
-      if (!IsParticleNSigma((int8_t)1, part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
-        continue;
-      }
-
       trackHistoPartOne.fillQA<isMC, false>(part);
     }
 
@@ -380,25 +364,20 @@ struct femtoUniversePairTaskTrackPhi {
       //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
       //   continue;
       // }
-
-      if (!IsParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
-        continue;
-      }
-
       if (!IsParticleNSigma((int8_t)2, p2.p(), trackCuts.getNsigmaTPC(p2, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p2, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p2, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p2, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p2, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p2, o2::track::PID::Kaon))) {
         continue;
       }
 
-      if (ConfIsCPR.value) {
-        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
-          continue;
-        }
-      }
+      // if (ConfIsCPR.value) {
+      //   if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+      //     continue;
+      //   }
+      // }
 
       // track cleaning
-      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-        continue;
-      }
+      // if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+      //   continue;
+      // }
       sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.ConfUse3D);
     }
   }
@@ -471,19 +450,16 @@ struct femtoUniversePairTaskTrackPhi {
       //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
       //   continue;
       // }
-      if (!IsParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
-        continue;
-      }
 
       if (!IsParticleNSigma((int8_t)2, p2.p(), trackCuts.getNsigmaTPC(p2, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p2, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p2, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p2, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p2, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p2, o2::track::PID::Kaon))) {
         continue;
       }
 
-      if (ConfIsCPR.value) {
-        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
-          continue;
-        }
-      }
+      // if (ConfIsCPR.value) {
+      //   if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+      //     continue;
+      //   }
+      // }
 
       mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.ConfUse3D);
     }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
@@ -1,0 +1,557 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoUniversePairTaskTrackPhi.cxx
+/// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Georgios Mantzaridis, TU München, georgios.mantzaridis@tum.de
+/// \author Anton Riedel, TU München, anton.riedel@tum.de
+/// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
+
+#include <vector>
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/StepTHn.h"
+#include "Framework/O2DatabasePDGPlugin.h"
+#include "TDatabasePDG.h"
+#include "ReconstructionDataFormats/PID.h"
+#include "Common/DataModel/PIDResponse.h"
+
+#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUtils.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
+
+using namespace o2;
+using namespace o2::analysis::femtoUniverse;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::soa;
+
+namespace
+{
+static constexpr int nPart = 2;
+static constexpr int nCuts = 5;
+static const std::vector<std::string> partNames{"PartOne", "PartTwo"};
+static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
+static const float cutsTable[nPart][nCuts]{
+  {4.05f, 1.f, 3.f, 3.f, 100.f},
+  {4.05f, 1.f, 3.f, 3.f, 100.f}};
+} // namespace
+
+struct femtoUniversePairTaskTrackPhi {
+
+  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
+  SliceCache cache;
+  Preslice<FemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
+
+  /// Particle selection part
+
+  /// Table for both particles
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<float> ConfNsigmaCombinedKaon{"ConfNsigmaCombinedKaon", 3.0, "TPC and TOF Kaon Sigma (combined) for momentum > 0.4"};
+    Configurable<float> ConfNsigmaTPCKaon{"ConfNsigmaTPCKaon", 3.0, "TPC Kaon Sigma for momentum < 0.4"};
+    Configurable<float> ConfNsigmaCombinedProton{"ConfNsigmaCombinedProton", 3.0, "TPC and TOF Proton Sigma (combined) for momentum > 0.5"};
+    Configurable<float> ConfNsigmaTPCProton{"ConfNsigmaTPCProton", 3.0, "TPC Proton Sigma for momentum < 0.5"};
+    Configurable<float> ConfNsigmaCombinedPion{"ConfNsigmaCombinedPion", 3.0, "TPC and TOF Pion Sigma (combined) for momentum > 0.5"};
+    Configurable<float> ConfNsigmaTPCPion{"ConfNsigmaTPCPion", 3.0, "TPC Pion Sigma for momentum < 0.5"};
+
+    Configurable<LabeledArray<float>> ConfCutTable{"ConfCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
+    Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
+    Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+    Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
+    Configurable<bool> ConfUse3D{"ConfUse3D", false, "Enable three dimensional histogramms (to be used only for analysis with high statistics): k* vs mT vs multiplicity"};
+  } twotracksconfigs;
+
+  /// Particle 1
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> ConfTrackChoicePartOne{"ConfTrackChoicePartOne", 0, "Type of particle (track1): {0:Proton, 1:Pion, 2:Kaon}"};
+    Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
+    // Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
+    Configurable<int> ConfPIDPartOne{"ConfPIDPartOne", 2, "Particle 1 - Read from cutCulator"};           // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
+    Configurable<float> cfgPtLowPart1{"cfgPtLowPart1", 0.5, "Lower limit for Pt for the first particle"}; // change according to wrzesa cuts
+    Configurable<float> cfgPtHighPart1{"cfgPtHighPart1", 1.5, "Higher limit for Pt for the first particle"};
+  } trackonefilter;
+
+  /// Partition for particle 1
+  Partition<FemtoFullParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kPhi));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsOneMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kPhi));
+
+  /// Histogramming for particle 1
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> trackHistoPartOne;
+
+  /// Particle 2
+  Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> ConfTrackChoicePartTwo{"ConfTrackChoicePartTwo", 0, "Type of particle (track1): {0:Proton, 1:Pion, 2:Kaon}"};
+    Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 2212, "Particle 2 - PDG code"};
+    // Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 5542474, "Particle 2 - Selection bit"};
+    Configurable<int> ConfPIDPartTwo{"ConfPIDPartTwo", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
+  } tracktwofilter;
+  /// Partition for particle 2
+  Partition<FemtoFullParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::pt > trackonefilter.cfgPtLowPart1) && (aod::femtouniverseparticle::pt < trackonefilter.cfgPtHighPart1);
+
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsTwoMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
+
+  /// Histogramming for particle 2
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartTwo;
+
+  /// Histogramming for Event
+  FemtoUniverseEventHisto eventHisto;
+
+  /// The configurables need to be passed to an std::vector
+  int vPIDPartOne, vPIDPartTwo;
+  std::vector<float> kNsigma;
+
+  /// particle part
+  ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+
+  /// Correlation part
+  ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
+  // ConfigurableAxis ConfMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
+  ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
+
+  ConfigurableAxis ConfmTBins3D{"ConfmTBins3D", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<twotracksconfigs.ConfUse3D>> to true in order to use)"};
+  ConfigurableAxis ConfmultBins3D{"ConfmultBins3D", {VARIABLE_WIDTH, 0.0f, 20.0f, 30.0f, 40.0f, 99999.0f}, "multiplicity Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<twotracksconfigs.ConfUse3D>> to true in order to use)"};
+
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+
+  ConfigurableAxis ConfkstarBins{"ConfkstarBins", {1500, 0., 6.}, "binning kstar"};
+  ConfigurableAxis ConfkTBins{"ConfkTBins", {150, 0., 9.}, "binning kT"};
+  ConfigurableAxis ConfmTBins{"ConfmTBins", {225, 0., 7.5}, "binning mT"};
+  Configurable<int> ConfNEventsMix{"ConfNEventsMix", 5, "Number of events for mixing"};
+  Configurable<bool> ConfIsCPR{"ConfIsCPR", true, "Close Pair Rejection"};
+  Configurable<bool> ConfCPRPlotPerRadii{"ConfCPRPlotPerRadii", false, "Plot CPR per radii"};
+  Configurable<float> ConfCPRdeltaPhiMax{"ConfCPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+  Configurable<float> ConfCPRdeltaEtaMax{"ConfCPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+
+  FemtoUniverseContainer<femtoUniverseContainer::EventType::same, femtoUniverseContainer::Observable::kstar> sameEventCont;
+  FemtoUniverseContainer<femtoUniverseContainer::EventType::mixed, femtoUniverseContainer::Observable::kstar> mixedEventCont;
+  FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCleaner;
+  FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCloseRejection;
+  FemtoUniverseTrackSelection trackCuts;
+  /// Histogram output
+  HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  // PID for protons
+  bool IsProtonNSigma(float mom, float nsigmaTPCPr, float nsigmaTOFPr) // previous version from: https://github.com/alisw/AliPhysics/blob/master/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.cxx
+  {
+    //|nsigma_TPC| < 3 for p < 0.5 GeV/c
+    //|nsigma_combined| < 3 for p > 0.5
+
+    // using configurables:
+    // ConfNsigmaTPCProton -> TPC Kaon Sigma for momentum < 0.5
+    // ConfNsigmaCombinedProton -> TPC and TOF Kaon Sigma (combined) for momentum > 0.5
+
+    if (mom < 0.5) {
+      if (TMath::Abs(nsigmaTPCPr) < twotracksconfigs.ConfNsigmaTPCProton) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom > 0.4) {
+      if (TMath::Hypot(nsigmaTOFPr, nsigmaTPCPr) < twotracksconfigs.ConfNsigmaCombinedProton) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    //|nsigma_TPC| < 3 for p < 0.5 GeV/c
+    //|nsigma_combined| < 3 for p > 0.5
+
+    // using configurables:
+    // ConfNsigmaTPCTOFKaon -> are we doing TPC TOF PID for Kaons? (boolean)
+    // ConfNsigmaTPCKaon -> TPC Kaon Sigma for momentum < 0.5
+    // ConfNsigmaCombinedKaon -> TPC and TOF Kaon Sigma (combined) for momentum > 0.5
+    if (true) {
+      if (mom < 0.5) {
+        if (TMath::Abs(nsigmaTPCK) < twotracksconfigs.ConfNsigmaTPCKaon) {
+          return true;
+        } else {
+          return false;
+        }
+      } else if (mom > 0.5) {
+        if (TMath::Hypot(nsigmaTOFK, nsigmaTPCK) < twotracksconfigs.ConfNsigmaCombinedKaon) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IsPionNSigma(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
+  {
+    //|nsigma_TPC| < 3 for p < 0.5 GeV/c
+    //|nsigma_combined| < 3 for p > 0.5
+
+    // using configurables:
+    // ConfNsigmaTPCPion -> TPC Kaon Sigma for momentum < 0.5
+    // ConfNsigmaCombinedPion -> TPC and TOF Pion Sigma (combined) for momentum > 0.5
+    if (true) {
+      if (mom < 0.5) {
+        if (TMath::Abs(nsigmaTPCPi) < twotracksconfigs.ConfNsigmaTPCPion) {
+          return true;
+        } else {
+          return false;
+        }
+      } else if (mom > 0.5) {
+        if (TMath::Hypot(nsigmaTOFPi, nsigmaTPCPi) < twotracksconfigs.ConfNsigmaCombinedPion) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IsParticleNSigma(int8_t particle_number, float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    if (particle_number == 1) {
+      switch (trackonefilter.ConfTrackChoicePartOne) {
+        case 0: // Proton
+          return IsProtonNSigma(mom, nsigmaTPCPr, nsigmaTOFPr);
+          break;
+        case 1: // Pion
+          return IsPionNSigma(mom, nsigmaTPCPi, nsigmaTOFPi);
+          break;
+        case 2: // Kaon
+          return IsKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+          break;
+        default:
+          return false;
+      }
+      return false;
+    } else if (particle_number == 2) {
+      switch (tracktwofilter.ConfTrackChoicePartTwo) {
+        case 0: // Proton
+          return IsProtonNSigma(mom, nsigmaTPCPr, nsigmaTOFPr);
+          break;
+        case 1: // Pion
+          return IsPionNSigma(mom, nsigmaTPCPi, nsigmaTOFPi);
+          break;
+        case 2: // Kaon
+          return IsKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+          break;
+        default:
+          return false;
+      }
+      return false;
+    } else {
+      LOGF(fatal, "Wrong number of particle chosen! It should be 1 or 2. It is -> %d", particle_number);
+    }
+    return false;
+  }
+
+  void init(InitContext&)
+  {
+    eventHisto.init(&qaRegistry);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, twotracksconfigs.ConfIsMC, trackonefilter.ConfPDGCodePartOne);
+    if (!ConfIsSame) {
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, twotracksconfigs.ConfIsMC, tracktwofilter.ConfPDGCodePartTwo);
+    }
+
+    MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+
+    sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
+    mixedEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
+    sameEventCont.setPDGCodes(trackonefilter.ConfPDGCodePartOne, tracktwofilter.ConfPDGCodePartTwo);
+    mixedEventCont.setPDGCodes(trackonefilter.ConfPDGCodePartOne, tracktwofilter.ConfPDGCodePartTwo);
+    pairCleaner.init(&qaRegistry);
+    if (ConfIsCPR.value) {
+      pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
+    }
+
+    vPIDPartOne = trackonefilter.ConfPIDPartOne.value;
+    vPIDPartTwo = tracktwofilter.ConfPIDPartTwo.value;
+    kNsigma = twotracksconfigs.ConfTrkPIDnSigmaMax.value;
+  }
+
+  template <typename CollisionType>
+  void fillCollision(CollisionType col)
+  {
+    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtr()}));
+    eventHisto.fillQA(col);
+  }
+
+  /// This function processes the same event and takes care of all the histogramming
+  /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
+  /// @tparam PartitionType
+  /// @tparam PartType
+  /// @tparam isMC: enables Monte Carlo truth specific histograms
+  /// @param groupPartsOne partition for the first particle passed by the process function
+  /// @param groupPartsTwo partition for the second particle passed by the process function
+  /// @param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
+  /// @param magFieldTesla magnetic field of the collision
+  /// @param multCol multiplicity of the collision
+  template <bool isMC, typename PartitionType, typename PartType>
+  void doSameEvent(PartitionType groupPartsOne, PartitionType groupPartsTwo, PartType parts, float magFieldTesla, int multCol)
+  {
+
+    /// Histogramming same event
+    for (auto& part : groupPartsOne) {
+      // if (part.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || part.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt")) {
+      //   continue;
+      // }
+      // if (!isFullPIDSelected(part.pidcut(),
+      //                        part.p(),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
+      //                        vPIDPartOne,
+      //                        twotracksconfigs.ConfNspecies,
+      //                        kNsigma,
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF"))) {
+      //   continue;
+      // }
+      if (!IsParticleNSigma((int8_t)1, part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+        continue;
+      }
+
+      trackHistoPartOne.fillQA<isMC, false>(part);
+    }
+
+    if (!ConfIsSame) {
+      for (auto& part : groupPartsTwo) {
+        // if (part.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || part.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+        //   continue;
+        // }
+        // if (!isFullPIDSelected(part.pidcut(),
+        //                        part.p(),
+        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
+        //                        vPIDPartTwo,
+        //                        twotracksconfigs.ConfNspecies,
+        //                        kNsigma,
+        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
+        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+        //   continue;
+        // }
+        if (!IsParticleNSigma((int8_t)2, part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+          continue;
+        }
+        trackHistoPartTwo.fillQA<isMC, false>(part);
+      }
+    }
+    /// Now build the combinations
+    for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
+      // if (p1.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || p1.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt") || p2.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || p2.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+      //   continue;
+      // }
+      // if (!isFullPIDSelected(p1.pidcut(),
+      //                        p1.p(),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
+      //                        vPIDPartOne,
+      //                        twotracksconfigs.ConfNspecies,
+      //                        kNsigma,
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+      //     !isFullPIDSelected(p2.pidcut(),
+      //                        p2.p(),
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
+      //                        vPIDPartTwo,
+      //                        twotracksconfigs.ConfNspecies,
+      //                        kNsigma,
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+      //   continue;
+      // }
+
+      if (!IsParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
+        continue;
+      }
+
+      if (!IsParticleNSigma((int8_t)2, p2.p(), trackCuts.getNsigmaTPC(p2, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p2, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p2, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p2, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p2, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p2, o2::track::PID::Kaon))) {
+        continue;
+      }
+
+      if (ConfIsCPR.value) {
+        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+          continue;
+        }
+      }
+
+      // track cleaning
+      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+        continue;
+      }
+      sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.ConfUse3D);
+    }
+  }
+
+  /// process function for to call doSameEvent with Data
+  /// \param col subscribe to the collision table (Data)
+  /// \param parts subscribe to the femtoUniverseParticleTable
+  void processSameEvent(o2::aod::FDCollision& col,
+                        FemtoFullParticles& parts)
+  {
+    fillCollision(col);
+
+    auto thegroupPartsOne = partsOne->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    doSameEvent<false>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processSameEvent, "Enable processing same event", true);
+
+  /// process function for to call doSameEvent with Monte Carlo
+  /// \param col subscribe to the collision table (Monte Carlo Reconstructed reconstructed)
+  /// \param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
+  /// \param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
+  void processSameEventMC(o2::aod::FDCollision& col,
+                          soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                          o2::aod::FDMCParticles&)
+  {
+    fillCollision(col);
+
+    auto thegroupPartsOne = partsOneMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTwo = partsTwoMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    doSameEvent<true>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processSameEventMC, "Enable processing same event for Monte Carlo", false);
+
+  /// This function processes the mixed event
+  /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
+  /// \tparam PartitionType
+  /// \tparam PartType
+  /// \tparam isMC: enables Monte Carlo truth specific histograms
+  /// \param groupPartsOne partition for the first particle passed by the process function
+  /// \param groupPartsTwo partition for the second particle passed by the process function
+  /// \param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
+  /// \param magFieldTesla magnetic field of the collision
+  /// \param multCol multiplicity of the collision
+  template <bool isMC, typename PartitionType, typename PartType>
+  void doMixedEvent(PartitionType groupPartsOne, PartitionType groupPartsTwo, PartType parts, float magFieldTesla, int multCol)
+  {
+
+    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
+      // if (p1.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || p1.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt") || p2.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || p2.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+      //   continue;
+      // }
+      // if (!isFullPIDSelected(p1.pidcut(),
+      //                        p1.p(),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
+      //                        vPIDPartOne,
+      //                        twotracksconfigs.ConfNspecies,
+      //                        kNsigma,
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+      //     !isFullPIDSelected(p2.pidcut(),
+      //                        p2.p(),
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
+      //                        vPIDPartTwo,
+      //                        twotracksconfigs.ConfNspecies,
+      //                        kNsigma,
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+      //   continue;
+      // }
+      if (!IsParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
+        continue;
+      }
+
+      if (!IsParticleNSigma((int8_t)2, p2.p(), trackCuts.getNsigmaTPC(p2, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p2, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p2, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p2, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p2, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p2, o2::track::PID::Kaon))) {
+        continue;
+      }
+
+      if (ConfIsCPR.value) {
+        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+          continue;
+        }
+      }
+
+      mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.ConfUse3D);
+    }
+  }
+
+  /// process function for to call doMixedEvent with Data
+  /// @param cols subscribe to the collisions table (Data)
+  /// @param parts subscribe to the femtoUniverseParticleTable
+  void processMixedEvent(o2::aod::FDCollisions& cols,
+                         FemtoFullParticles& parts)
+  {
+    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
+
+      const int multiplicityCol = collision1.multNtr();
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
+
+      auto groupPartsOne = partsOne->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+
+      const auto& magFieldTesla1 = collision1.magField();
+      const auto& magFieldTesla2 = collision2.magField();
+
+      if (magFieldTesla1 != magFieldTesla2) {
+        continue;
+      }
+      /// \todo before mixing we should check whether both collisions contain a pair of particles!
+      // if (partsOne.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTwo.size() == 0 ) continue;
+
+      doMixedEvent<false>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
+    }
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processMixedEvent, "Enable processing mixed events", true);
+
+  /// brief process function for to call doMixedEvent with Monte Carlo
+  /// @param cols subscribe to the collisions table (Monte Carlo Reconstructed reconstructed)
+  /// @param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
+  /// @param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
+  void processMixedEventMC(o2::aod::FDCollisions& cols,
+                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                           o2::aod::FDMCParticles&)
+  {
+    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
+
+      const int multiplicityCol = collision1.multNtr();
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
+
+      auto groupPartsOne = partsOneMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto groupPartsTwo = partsTwoMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+
+      const auto& magFieldTesla1 = collision1.magField();
+      const auto& magFieldTesla2 = collision2.magField();
+
+      if (magFieldTesla1 != magFieldTesla2) {
+        continue;
+      }
+      /// \todo before mixing we should check whether both collisions contain a pair of particles!
+      // if (partsOne.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTwo.size() == 0 ) continue;
+
+      doMixedEvent<true>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
+    }
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processMixedEventMC, "Enable processing mixed events MC", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<femtoUniversePairTaskTrackPhi>(cfgc),
+  };
+  return workflow;
+}


### PR DESCRIPTION
* Adding the option to store Phi mesons in the FemtoAOD.root data for the FemtoUniverse. 
* Adding the track-phi task for FemtoUniverse.

In the next PR:  
* enable storage of Phi will be in the process switch (because not everyone will need them, so we don't want to save them),
* check selection for the tracks, now only PID is working, I would like to use setSelection (like in the FemtoUniverse).