### PR TITLE
Make O2DatabasePDG service class unambiguous

### DIFF
--- a/ALICE3/TableProducer/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/onTheFlyTOFPID.cxx
@@ -55,7 +55,7 @@ struct OnTheFlyTOFPID {
   Produces<aod::UpgradeTof> upgradeTof;
 
   // necessary for particle charges
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   // these are the settings governing the TOF layers to be used
   // note that there are two layers foreseen for now: inner and outer TOF

--- a/ALICE3/TableProducer/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/onTheFlyTracker.cxx
@@ -122,7 +122,7 @@ struct OnTheFlyTracker {
   };
 
   // necessary for particle charges
-  Service<O2DatabasePDG> pdgDB;
+  Service<o2::framework::O2DatabasePDG> pdgDB;
 
   // for handling basic QA histograms if requested
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/ALICE3/Tasks/alice3-qa-singleparticle.cxx
+++ b/ALICE3/Tasks/alice3-qa-singleparticle.cxx
@@ -27,7 +27,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 struct Alice3SingleParticle {
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   Configurable<int> PDG{"PDG", 2212, "PDG code of the particle of interest"};
   Configurable<int> IsStable{"IsStable", 0, "Flag to check stable particles"};
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/Common/Tasks/multiplicityQa.cxx
+++ b/Common/Tasks/multiplicityQa.cxx
@@ -61,7 +61,7 @@ struct MultiplicityQa {
   Configurable<bool> useZeqInProfiles{"useZeqInProfiles", true, "use Z-equalized signals in midrap Nch profiles"};
 
   // necessary for particle charges
-  Service<O2DatabasePDG> pdgDB;
+  Service<o2::framework::O2DatabasePDG> pdgDB;
 
   SliceCache cache;
 

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -44,7 +44,7 @@ using CFMultiplicity = CFMultiplicities::iterator;
 } // namespace o2::aod
 
 struct FilterCF {
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   // Configuration
   O2_DEFINE_CONFIGURABLE(cfgCutVertex, float, 7.0f, "Accepted z-vertex range")

--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -65,7 +65,7 @@ struct JetFinderTask {
   Configurable<bool> DoRhoAreaSub{"DoRhoAreaSub", false, "do rho area subtraction"};
   Configurable<bool> DoConstSub{"DoConstSub", false, "do constituent subtraction"};
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   std::string trackSelection;
   std::string eventSelection;
 

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -91,7 +91,7 @@ struct JetFinderHFTask {
   Configurable<bool> DoRhoAreaSub{"DoRhoAreaSub", false, "do rho area subtraction"};
   Configurable<bool> DoConstSub{"DoConstSub", false, "do constituent subtraction"};
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   std::string trackSelection;
   std::string eventSelection;
 

--- a/PWGJE/Tasks/jetsubstructurehf.cxx
+++ b/PWGJE/Tasks/jetsubstructurehf.cxx
@@ -54,7 +54,7 @@ struct JetSubstructureHFTask {
   Configurable<float> zCut{"zCut", 0.1, "soft drop z cut"};
   Configurable<float> beta{"beta", 0.0, "soft drop beta"};
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   int candPDG;
 
   std::vector<fastjet::PseudoJet> jetConstituents;

--- a/PWGLF/TableProducer/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/cascqaanalysis.cxx
@@ -66,7 +66,7 @@ struct cascqaanalysis {
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
 
   // Necessary for particle charges
-  Service<O2DatabasePDG> pdgDB;
+  Service<o2::framework::O2DatabasePDG> pdgDB;
 
   SliceCache cache;
 

--- a/PWGLF/Tasks/spectraCharged.cxx
+++ b/PWGLF/Tasks/spectraCharged.cxx
@@ -33,7 +33,7 @@ using namespace o2::framework;
 struct chargedSpectra {
 
   HistogramRegistry histos;
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   // task settings that can be steered via hyperloop
   Configurable<bool> isRun3{"isRun3", true, "is Run3 dataset"};

--- a/PWGMM/Mult/Tasks/dndeta-hi.cxx
+++ b/PWGMM/Mult/Tasks/dndeta-hi.cxx
@@ -159,7 +159,7 @@ struct MultiplicityCounter {
   SliceCache cache;
   Preslice<aod::McParticles> perMCCol = aod::mcparticle::mcCollisionId;
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Configurable<float> estimatorEta{"estimatorEta", 2.0, "eta range for INEL>0 sample definition"};
   Configurable<bool> useEvSel{"useEvSel", true, "use event selection"};

--- a/PWGMM/Mult/Tasks/dndeta-mft.cxx
+++ b/PWGMM/Mult/Tasks/dndeta-mft.cxx
@@ -72,7 +72,7 @@ struct PseudorapidityDensityMFT {
   Preslice<aod::McParticles> perMcCol = aod::mcparticle::mcCollisionId;
   Preslice<aod::Tracks> perColCentral = aod::track::collisionId;
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Configurable<float> estimatorEta{"estimatorEta", 1.0, "eta range for INEL>0 sample definition"};
 

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -75,7 +75,7 @@ struct MultiplicityCounter {
   Preslice<aod::McParticles> perMCCol = aod::mcparticle::mcCollisionId;
   PresliceUnsorted<ReTracks> perColU = aod::track::bestCollisionId;
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Configurable<float> estimatorEta{"estimatorEta", 1.0, "eta range for INEL>0 sample definition"};
   Configurable<bool> useEvSel{"useEvSel", true, "use event selection"};

--- a/PWGMM/Mult/Tasks/effpt-mft.cxx
+++ b/PWGMM/Mult/Tasks/effpt-mft.cxx
@@ -42,7 +42,7 @@ struct EffPtMFT {
   SliceCache cache;
   Preslice<aod::McParticles> perMCCol = aod::mcparticle::mcCollisionId;
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Configurable<bool> useEvSel{"useEvSel", true, "use event selection"};
   ConfigurableAxis PtAxis{"PtAxis", {1001, -0.0005, 1.0005}, "pt axis for histograms"};

--- a/PWGMM/Mult/Tasks/run2dndeta.cxx
+++ b/PWGMM/Mult/Tasks/run2dndeta.cxx
@@ -36,7 +36,7 @@ struct PseudorapidityDensity {
   Preslice<aod::Tracks> perCol = aod::track::collisionId;
   Preslice<aod::McParticles> perMCCol = aod::mcparticle::mcCollisionId;
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   Configurable<float> estimatorEta{"estimatorEta", 1.0, "eta range for INEL>0 sample definition"};
   Configurable<bool> useEvSel{"useEvSel", true, "use event selection"};

--- a/PWGMM/UE/Tasks/uecharged.cxx
+++ b/PWGMM/UE/Tasks/uecharged.cxx
@@ -45,7 +45,7 @@ struct ueCharged {
 
   TrackSelection myTrackSelection();
 
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   float DeltaPhi(float phia, float phib, float rangeMin, float rangeMax);
   Configurable<bool> isRun3{"isRun3", true, "is Run3 dataset"};
   // acceptance cuts

--- a/Tutorials/src/mcHistograms.cxx
+++ b/Tutorials/src/mcHistograms.cxx
@@ -42,7 +42,7 @@ struct VertexDistribution {
 // Simple analysis of PhysicalPrimary particles
 struct PhysicalPrimaryCharge {
   OutputObj<TH1F> charge{TH1F("charge_prim", "charge_prim", 100, -5, 5)};
-  Service<O2DatabasePDG> pdgDB;
+  Service<o2::framework::O2DatabasePDG> pdgDB;
 
   void process(aod::McParticles const& mcParticles)
   {

--- a/Tutorials/src/usingPDGService.cxx
+++ b/Tutorials/src/usingPDGService.cxx
@@ -18,7 +18,7 @@ using namespace o2;
 using namespace o2::framework;
 
 struct UsePdgDatabase {
-  Service<O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg;
   OutputObj<TH1F> particleCharges{TH1F("charges", ";charge;entries", 201, -10.1, 10.1)};
 
   void process(aod::McCollision const&, aod::McParticles const& particles)


### PR DESCRIPTION
This is a preparation for including the `o2::O2DatabasePDG::Mass` function in the `o2::framework::O2DatabasePDG` service.
It has to be merged first, to avoid the `template argument 1 is invalid` error.