### PR TITLE
EMCAL-911

### DIFF
--- a/EventFiltering/PWGJE/fullJetFilter.cxx
+++ b/EventFiltering/PWGJE/fullJetFilter.cxx
@@ -15,8 +15,11 @@
 #include <array>
 #include <cmath>
 #include <string>
+#include <string_view>
 #include <TMath.h>
 
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsCTP/Configuration.h"
 #include "EMCALBase/Geometry.h"
 #include "ReconstructionDataFormats/Track.h"
 #include "Framework/runDataProcessing.h"
@@ -43,6 +46,7 @@ using namespace o2::framework::expressions;
 
 struct fullJetFilter {
   using collisionInfo = soa::Join<aod::Collisions, aod::EvSels>::iterator;
+  using BCsWithBcSelsRun3 = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
   using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
   using filteredFullJets = o2::soa::Filtered<o2::aod::FullJets>;
   using filteredNeutralJets = o2::soa::Filtered<o2::aod::NeutralJets>;
@@ -63,6 +67,12 @@ struct fullJetFilter {
   enum class ThresholdType_t {
     HIGH_THRESHOLD,
     LOW_THRESHOLD
+  };
+
+  enum class EMCALHWTriggerConfiguration {
+    MB_ONLY,
+    EMC_TRIGGERD,
+    UNKNOWN
   };
 
   Produces<aod::FullJetFilters> tags;
@@ -92,6 +102,8 @@ struct fullJetFilter {
   // Configurables
   Configurable<float> f_jetPtMin{"f_jetPtMin", 0.0, "minimum jet pT cut"};
   Configurable<float> f_jetPtMinLow{"f_jetPtMinLow", 0.0, "minimum jet pT cut (low threshold)"};
+  Configurable<float> f_jetPtMinMB{"f_jetPtMinMB", 0.0, "minimum jet pT cut (MB-only runs)"};
+  Configurable<float> f_jetPtMinLowMB{"f_jetPtMinLowMB", 0.0, "minimum jet pT cut (low threshold, MB-only runs)"};
   Configurable<float> f_clusterPtMin{"f_clusterPtMin", 0.0, "minimum cluster pT cut"};
   Configurable<int> f_jetR{"f_jetR", 20, "jet R * 100 to trigger on"};
   Configurable<int> f_ObservalbeGammaTrigger{"fObservableGammaTrigger", 0, "Observable for the gamma trigger (0 - Energy, 1 - pt)"};
@@ -101,6 +113,10 @@ struct fullJetFilter {
   Configurable<float> f_gammaPtMinEMCALLow{"f_gammaPtMinEMCALLow", 1.5, "minimum gamma pT cut in EMCAL low threshold"};
   Configurable<float> f_gammaPtMinDCALHigh{"f_gammaPtMinDCALHigh", 4.0, "minimum gamma pT cut in DCAL high threshold"};
   Configurable<float> f_gammaPtMinDCALLow{"f_gammaPtMinDCALLow", 1.5, "minimum gamma pT cut in DCAL low threshold"};
+  Configurable<float> f_gammaPtMinEMCALHighMB{"f_gammaPtMinEMCALHighMB", 4.0, "minimum gamma pT cut in EMCAL high threshold (MB-only runs)"};
+  Configurable<float> f_gammaPtMinEMCALLowMB{"f_gammaPtMinEMCALLowMB", 1.5, "minimum gamma pT cut in EMCAL low threshold (MB-only runs)"};
+  Configurable<float> f_gammaPtMinDCALHighMB{"f_gammaPtMinDCALHighMB", 4.0, "minimum gamma pT cut in DCAL high threshold (MB-only runs)"};
+  Configurable<float> f_gammaPtMinDCALLowMB{"f_gammaPtMinDCALLowMB", 1.5, "minimum gamma pT cut in DCAL low threshold (MB-only runs)"};
   Configurable<float> f_minClusterTime{"f_minClusterTime", -999, "Min. cluster time for gamma trigger (ns)"};
   Configurable<float> f_maxClusterTime{"f_maxClusterTime", 999, "Max. cluster time for gamma trigger (ns)"};
   Configurable<float> f_PhiEmcalOrDcal{"f_PhiEmcalOrDcal", 4, "if cluster phi is less than this value, count it to be EMCAL"};
@@ -111,6 +127,11 @@ struct fullJetFilter {
   Configurable<bool> b_IgnoreEmcalFlag{"b_IgnoreEmcalFlag", false, "ignore the EMCAL live flag check"};
   Configurable<bool> b_DoFiducialCut{"b_DoFiducialCut", false, "do a fiducial cut on jets to check if they are in the emcal"};
   Configurable<bool> b_RejectExoticClusters{"b_RejectExoticClusters", true, "Reject exotic clusters"};
+
+  int lastRun = -1;
+  EMCALHWTriggerConfiguration mHardwareTriggerConfig = EMCALHWTriggerConfiguration::UNKNOWN;
+
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
 
   void init(o2::framework::InitContext&)
   {
@@ -177,16 +198,110 @@ struct fullJetFilter {
     return false;
   }
 
-  Bool_t isEvtSelectedJet(double const& jetpt, ThresholdType_t thresholdt)
+  EMCALHWTriggerConfiguration getHWTriggerConfiguration(o2::ctp::CTPConfiguration& ctpconfig)
+  {
+    EMCALHWTriggerConfiguration result = EMCALHWTriggerConfiguration::UNKNOWN;
+    bool hasMinBias = false, hasL0 = false;
+    for (auto& cls : ctpconfig.getCTPClasses()) {
+      std::string_view trgclsname = cls.name;
+      if (trgclsname.find("-EMC") == std::string::npos) {
+        // Not an EMCAL trigger class
+        continue;
+      }
+      std::vector<std::string> tokens;
+      std::stringstream tokenizer(trgclsname.data());
+      std::string buf;
+      while (std::getline(tokenizer, buf, '-')) {
+        tokens.emplace_back(buf);
+      }
+      if (tokens[1] != "B") {
+        // Not bucket in both beams
+        continue;
+      }
+      std::cout << "Found trigger class: " << trgclsname << std::endl;
+      if (tokens[0] == "C0TVX") {
+        hasMinBias = true;
+      }
+      if (tokens[0] == "CTVXEMC" || tokens[0] == "CTVXDMC") {
+        hasL0 = true;
+      }
+    }
+    if (hasL0) {
+      result = EMCALHWTriggerConfiguration::EMC_TRIGGERD;
+    } else if (hasMinBias) {
+      result = EMCALHWTriggerConfiguration::MB_ONLY;
+    }
+    return result;
+  }
+
+  float getGammaThreshold(o2::emcal::AcceptanceType_t subdet, ThresholdType_t thresholdt, bool mblike)
+  {
+    float threshold = 0;
+    switch (subdet) {
+      case o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE: {
+        switch (thresholdt) {
+          case ThresholdType_t::HIGH_THRESHOLD: {
+            threshold = mblike ? f_gammaPtMinEMCALHighMB : f_gammaPtMinEMCALHigh;
+            break;
+          }
+          case ThresholdType_t::LOW_THRESHOLD: {
+            threshold = mblike ? f_gammaPtMinEMCALLowMB : f_gammaPtMinEMCALLow;
+            break;
+          }
+        }
+        break;
+      }
+      case o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE: {
+        switch (thresholdt) {
+          case ThresholdType_t::HIGH_THRESHOLD: {
+            threshold = mblike ? f_gammaPtMinDCALHighMB : f_gammaPtMinDCALHigh;
+            break;
+          }
+          case ThresholdType_t::LOW_THRESHOLD: {
+            threshold = mblike ? f_gammaPtMinDCALLowMB : f_gammaPtMinDCALLow;
+            break;
+          }
+        }
+        break;
+      }
+      case o2::emcal::AcceptanceType_t::NON_ACCEPTANCE: {
+        threshold = FLT_MAX;
+        break;
+      }
+    }
+    return threshold;
+  }
+
+  double getJetThreshold(ThresholdType_t thresholdt, bool mblike)
   {
     float threshold = 0.;
     switch (thresholdt) {
       case ThresholdType_t::HIGH_THRESHOLD:
-        threshold = f_jetPtMin;
+        threshold = mblike ? f_jetPtMinMB : f_jetPtMin;
         break;
       case ThresholdType_t::LOW_THRESHOLD:
-        threshold = f_jetPtMinLow;
+        threshold = mblike ? f_jetPtMinLowMB : f_jetPtMinLow;
         break;
+    }
+    return threshold;
+  }
+
+  Bool_t isEvtSelectedJet(double const& jetpt, ThresholdType_t thresholdt)
+  {
+    float threshold = 0;
+    switch (mHardwareTriggerConfig) {
+      case EMCALHWTriggerConfiguration::EMC_TRIGGERD: {
+        threshold = getJetThreshold(thresholdt, false);
+        break;
+      }
+      case EMCALHWTriggerConfiguration::MB_ONLY: {
+        threshold = getJetThreshold(thresholdt, true);
+        break;
+      }
+      case EMCALHWTriggerConfiguration::UNKNOWN: {
+        // No EMCAL trigger present in run - cannot select thresholds
+        return false;
+      }
     }
     if (jetpt > threshold) {
       return true;
@@ -197,35 +312,19 @@ struct fullJetFilter {
   Bool_t isEvtSelectedGamma(double const& gammapt, o2::emcal::AcceptanceType_t subdet, ThresholdType_t thresholdt)
   {
     float threshold = 0;
-    switch (subdet) {
-      case o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE: {
-        switch (thresholdt) {
-          case ThresholdType_t::HIGH_THRESHOLD: {
-            threshold = f_gammaPtMinEMCALHigh;
-            break;
-          }
-          case ThresholdType_t::LOW_THRESHOLD: {
-            threshold = f_gammaPtMinEMCALLow;
-            break;
-          }
-        }
+    switch (mHardwareTriggerConfig) {
+      case EMCALHWTriggerConfiguration::EMC_TRIGGERD: {
+        threshold = getGammaThreshold(subdet, thresholdt, false);
         break;
       }
-      case o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE: {
-        switch (thresholdt) {
-          case ThresholdType_t::HIGH_THRESHOLD: {
-            threshold = f_gammaPtMinDCALHigh;
-            break;
-          }
-          case ThresholdType_t::LOW_THRESHOLD: {
-            threshold = f_gammaPtMinDCALLow;
-            break;
-          }
-        }
+      case EMCALHWTriggerConfiguration::MB_ONLY: {
+        threshold = getGammaThreshold(subdet, thresholdt, true);
         break;
       }
-      case o2::emcal::AcceptanceType_t::NON_ACCEPTANCE:
+      case EMCALHWTriggerConfiguration::UNKNOWN: {
+        // No EMCAL trigger present in run - cannot select thresholds
         return false;
+      }
     }
     if (gammapt > threshold) {
       return true;
@@ -378,8 +477,30 @@ struct fullJetFilter {
   }
 
   template <typename JetCollection>
-  void runTrigger(collisionInfo const& collision, JetCollection const& jets, selectedClusters const& clusters)
+  void runTrigger(collisionInfo const& collision, JetCollection const& jets, selectedClusters const& clusters, BCsWithBcSelsRun3 const& bcs)
   {
+    int run = bcs.iteratorAt(0).runNumber();
+    // extract bc pattern from CCDB for data or anchored MC only
+    if (run != lastRun && run >= 500000) {
+      lastRun = run;
+      int64_t ts = bcs.iteratorAt(0).timestamp();
+      mHardwareTriggerConfig = getHWTriggerConfiguration(*(ccdb->getForTimeStamp<o2::ctp::CTPConfiguration>("CTP/CTP/Config", ts)));
+      switch (mHardwareTriggerConfig) {
+        case EMCALHWTriggerConfiguration::MB_ONLY: {
+          std::cout << "Found hardware trigger configuration Min. bias only" << std::endl;
+          break;
+        }
+        case EMCALHWTriggerConfiguration::EMC_TRIGGERD: {
+          std::cout << "Found hardware trigger configuration L0-triggered" << std::endl;
+          break;
+        }
+        case EMCALHWTriggerConfiguration::UNKNOWN: {
+          std::cout << "No EMCAL trigger class found for run, event selection will not be possible" << std::endl;
+          break;
+        }
+      }
+    }
+
     std::array<bool, kCategories> keepEvent;
     std::fill(keepEvent.begin(), keepEvent.end(), false);
 
@@ -408,17 +529,17 @@ struct fullJetFilter {
     tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8]);
   }
 
-  void processFullJetTrigger(collisionInfo const& collision, filteredFullJets const& jets, selectedClusters const& clusters)
+  void processFullJetTrigger(collisionInfo const& collision, filteredFullJets const& jets, selectedClusters const& clusters, BCsWithBcSelsRun3 const& bcs)
   {
     // Trigger selection (full jet case)
-    runTrigger(collision, jets, clusters);
+    runTrigger(collision, jets, clusters, bcs);
   }
   PROCESS_SWITCH(fullJetFilter, processFullJetTrigger, "run full jet triggere code", true);
 
-  void processNeutralJetTrigger(collisionInfo const& collision, filteredNeutralJets const& jets, selectedClusters const& clusters)
+  void processNeutralJetTrigger(collisionInfo const& collision, filteredNeutralJets const& jets, selectedClusters const& clusters, BCsWithBcSelsRun3 const& bcs)
   {
     // Trigger selection (neutral jet case)
-    runTrigger(collision, jets, clusters);
+    runTrigger(collision, jets, clusters, bcs);
   }
   PROCESS_SWITCH(fullJetFilter, processNeutralJetTrigger, "run neutral jet triggere code", false);
 };

--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -40,6 +40,7 @@ struct JetTriggerQA {
   using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
   using fullJetInfos = soa::Join<aod::FullJets, aod::FullJetConstituents>;
   using neutralJetInfos = soa::Join<aod::NeutralJets, aod::NeutralJetConstituents>;
+  using collisionWithTrigger = soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator;
 
   enum TriggerType_t {
     kMinBias,
@@ -319,7 +320,7 @@ struct JetTriggerQA {
     return false;
   }
 
-  bool hasEMCAL(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision) const
+  bool hasEMCAL(collisionWithTrigger const& collision) const
   {
     std::array<triggerAliases, 11> selectAliases = {{triggerAliases::kTVXinEMC, triggerAliases::kEMC7, triggerAliases::kDMC7, triggerAliases::kEG1, triggerAliases::kEG2, triggerAliases::kDG1, triggerAliases::kDG2, triggerAliases::kEJ1, triggerAliases::kEJ2, triggerAliases::kDJ1, triggerAliases::kDJ2}};
     bool found = false;
@@ -584,7 +585,7 @@ struct JetTriggerQA {
   }
 
   template <typename JetCollection>
-  void runQA(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+  void runQA(collisionWithTrigger const& collision,
              JetCollection const& jets,
              aod::Tracks const& tracks,
              selectedClusters const& clusters)
@@ -676,7 +677,7 @@ struct JetTriggerQA {
     // Discard collisions without EMCAL if it is not respecifically required to discard the the EMCAL flag
     // If ignore is true, we don't check for the flag and accept all events
     if (!b_IgnoreEmcalFlag) {
-      if (isTrigger(TriggerType_t::kEmcalAny)) {
+      if (!isTrigger(TriggerType_t::kEmcalAny)) {
         return; // Only consider events where EMCAL is live
       }
     }
@@ -721,7 +722,7 @@ struct JetTriggerQA {
 
   } // process
 
-  void processFullJets(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+  void processFullJets(collisionWithTrigger const& collision,
                        fullJetInfos const& jets,
                        aod::Tracks const& tracks,
                        selectedClusters const& clusters)
@@ -730,7 +731,7 @@ struct JetTriggerQA {
   }
   PROCESS_SWITCH(JetTriggerQA, processFullJets, "Run QA for full jets", true);
 
-  void processNeutralJets(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
+  void processNeutralJets(collisionWithTrigger const& collision,
                           neutralJetInfos const& jets,
                           aod::Tracks const& tracks,
                           selectedClusters const& clusters)


### PR DESCRIPTION
Filtering runs either on datasets which have
MB-triggered or L0-triggered input data. Thresholds
for L0 input need to be higher since the data is biased
to high-pt, while the same thresholds for min. bias
input will reject most of the data. Determination
whether the run is trigger- or MB-like is done based
on the CTP configuration for the run containing
EMCAL rare trigger classes or just the min. bias
trigger classes with EMCAL readout.