### PR TITLE
PWGHF: candidateCreatorCascade: fix McGen

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -266,7 +266,7 @@ struct HfCandidateCreatorCascadeMc {
     int indexRec = -1;
     std::vector<int> arrDaughLcIndex;
     std::array<int, 3> arrDaughLcPDG;
-    std::array<int, 3> arrDaughLcPDGRef = {2212, 211, -211};
+    std::array<int, 3> arrDaughLcPDGRef = {+kProton, +kPiPlus, -kPiPlus};
 
     // Match reconstructed candidates.
     rowCandidateCasc->bindExternalIndices(&tracks);

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -295,7 +295,7 @@ struct HfCandidateCreatorCascadeMc {
       MY_DEBUG_MSG(isK0SfromLc, LOG(info) << "correct K0S in the Lc daughters: posTrack --> " << indexV0DaughPos << ", negTrack --> " << indexV0DaughNeg);
 
       // if (isLc) {
-      RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersV0, kK0Short, array{+kPiPlus, -kPiPlus}, true, &sign, 1); // does it matter the "acceptAntiParticle" in the K0s case? In principle, there is no anti-K0s
+      RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersV0, kK0Short, array{+kPiPlus, -kPiPlus}, false, &sign, 1);
 
       if (sign != 0) { // we have already positively checked the K0s
         // then we check the Lc
@@ -319,7 +319,11 @@ struct HfCandidateCreatorCascadeMc {
     for (const auto& particle : particlesMC) {
       origin = 0;
       // checking if I have a Lc --> K0S + p
-      RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, array{+kProton, +kK0Short}, true, &sign, 2);
+      RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, array{+kProton, +kK0Short}, false, &sign, 2);
+      if (sign == 0) { // now check for anti-Lc
+        RecoDecay::isMatchedMCGen(particlesMC, particle, -pdg::Code::kLambdaCPlus, array{-kProton, +kK0Short}, false, &sign, 2);
+        sign = -sign;
+      }
       if (sign != 0) {
         MY_DEBUG_MSG(sign, LOG(info) << "Lc in K0S p");
         arrDaughLcIndex.clear();
@@ -330,7 +334,7 @@ struct HfCandidateCreatorCascadeMc {
             auto daughI = particlesMC.rawIteratorAt(arrDaughLcIndex[iProng]);
             arrDaughLcPDG[iProng] = daughI.pdgCode();
           }
-          if (!(arrDaughLcPDG[0] == arrDaughLcPDGRef[0] && arrDaughLcPDG[1] == arrDaughLcPDGRef[1] && arrDaughLcPDG[2] == arrDaughLcPDGRef[2])) { // this should be the condition, first bach, then v0
+          if (!(arrDaughLcPDG[0] == sign * arrDaughLcPDGRef[0] && arrDaughLcPDG[1] == arrDaughLcPDGRef[1] && arrDaughLcPDG[2] == arrDaughLcPDGRef[2])) { // this should be the condition, first bach, then v0
             sign = 0;
           } else {
             LOG(debug) << "Lc --> K0S+p found in MC table";


### PR DESCRIPTION
Bug fix for finding generated $\Lambda_c^+\to pK^0_S$ and $\Lambda_c^- \to \bar{p}K^0_S$.  Currently $\Lambda_c^-$ are missed because the flag `acceptAntiParticles` in `RecoDecay::isMatchedMCGen` does not work for the $K^0_S$ (does not have an antiparticle, so the PDG code -310 that `RecoDecay::isMatchedMCGen` is looking for in that case does not exist, such that no $\Lambda_c^-$ is ever accepted)