### PR TITLE
Add PDG-of-mother option + QA

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -845,7 +845,7 @@ struct cascadeBuilder {
 
       // do specific topological variable QA too
       registry.fill(HIST("h2dTopoVarCascPointingAngle"), lPt, TMath::ACos(cascadecandidate.cosPA));
-      registry.fill(HIST("h2dTopoVarCascRAP"), lPt, TMath::ACos(cascadecandidate.cosPA)*cascadecandidate.cascradius);
+      registry.fill(HIST("h2dTopoVarCascRAP"), lPt, TMath::ACos(cascadecandidate.cosPA) * cascadecandidate.cascradius);
       registry.fill(HIST("h2dTopoVarCascRadius"), lPt, cascadecandidate.cascradius);
     }
     return true;
@@ -1245,17 +1245,17 @@ struct cascadePreselector {
                   if (lV0Mother == lBachMother) {
                     lPDG = lV0Mother.pdgCode();
 
-                    // additionally check PDG of the mother particle if requested 
-                    if ( dIfMCselectV0MotherPDG != 0 ){
+                    // additionally check PDG of the mother particle if requested
+                    if (dIfMCselectV0MotherPDG != 0) {
                       lPDG = 0; // this is not the species you're looking for
-                      if(lBachMother.has_mothers()){
+                      if (lBachMother.has_mothers()) {
                         for (auto& lBachGrandMother : lBachMother.template mothers_as<aod::McParticles>()) {
-                          if(lBachGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
+                          if (lBachGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
                             lPDG = lV0Mother.pdgCode();
                         }
                       }
                     }
-                    //end extra PDG of mother check
+                    // end extra PDG of mother check
                   }
                 }
               } // end conditional V0-bach pair

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -148,6 +148,16 @@ struct cascadeBuilder {
   Configurable<float> dQAXiMassWindow{"dQAXiMassWindow", 0.005, "Xi mass window for ITS cluster map QA"};
   Configurable<float> dQAOmegaMassWindow{"dQAOmegaMassWindow", 0.005, "Omega mass window for ITS cluster map QA"};
 
+  ConfigurableAxis axisPtQA{"axisPtQA", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
+
+  // for topo var QA
+  ConfigurableAxis axisTopoVarPointingAngle{"axisTopoVarPointingAngle", {50, 0.0, 1.0}, "pointing angle"};
+  ConfigurableAxis axisTopoVarRAP{"axisTopoVarRAP", {50, 0.0, 1.0}, "radius x pointing angle axis"};
+  ConfigurableAxis axisTopoVarV0Radius{"axisTopoVarV0Radius", {500, 0.0, 100.0}, "V0 decay radius (cm)"};
+  ConfigurableAxis axisTopoVarDCAV0Dau{"axisTopoVarDCAV0Dau", {200, 0.0, 2.0}, "DCA between V0 daughters (cm)"};
+  ConfigurableAxis axisTopoVarDCAToPV{"axisTopoVarDCAToPV", {200, -1, 1.0}, "single track DCA to PV (cm)"};
+  ConfigurableAxis axisTopoVarDCAV0ToPV{"axisTopoVarDCAV0ToPV", {200, 0, 5.0}, "V0 DCA to PV (cm)"};
+
   int mRunNumber;
   float d_bz;
   float maxSnp;  // max sine phi for propagation
@@ -286,6 +296,11 @@ struct cascadeBuilder {
       registry.add("h2dITSCluMap_OmegaPlusPositive", "h2dITSCluMap_OmegaPlusPositive", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_OmegaPlusNegative", "h2dITSCluMap_OmegaPlusNegative", kTH2D, {axisITSCluMap, axisRadius});
       registry.add("h2dITSCluMap_OmegaPlusBachelor", "h2dITSCluMap_OmegaPlusBachelor", kTH2D, {axisITSCluMap, axisRadius});
+
+      // QA plots of topological variables using axisPtQA
+      registry.add("h2dTopoVarCascPointingAngle", "h2dTopoVarCascPointingAngle", kTH2D, {axisPtQA, axisTopoVarPointingAngle});
+      registry.add("h2dTopoVarCascRAP", "h2dTopoVarCascRAP", kTH2D, {axisPtQA, axisTopoVarRAP});
+      registry.add("h2dTopoVarCascRadius", "h2dTopoVarCascRadius", kTH2D, {axisPtQA, axisTopoVarV0Radius});
 
       // if basic strangeness tracking QA is desired, do it here
       // convenience: equivalence between regular cascade and tracked cascade is easy to check here
@@ -827,6 +842,11 @@ struct cascadeBuilder {
         registry.fill(HIST("h2dITSCluMap_OmegaPlusNegative"), (float)negTrack.itsClusterMap(), v0.v0radius());
         registry.fill(HIST("h2dITSCluMap_OmegaPlusBachelor"), (float)bachTrack.itsClusterMap(), cascadecandidate.cascradius);
       }
+
+      // do specific topological variable QA too
+      registry.fill(HIST("h2dTopoVarCascPointingAngle"), lPt, TMath::ACos(cascadecandidate.cosPA));
+      registry.fill(HIST("h2dTopoVarCascRAP"), lPt, TMath::ACos(cascadecandidate.cosPA)*cascadecandidate.cascradius);
+      registry.fill(HIST("h2dTopoVarCascRadius"), lPt, cascadecandidate.cascradius);
     }
     return true;
   }
@@ -1136,6 +1156,7 @@ struct cascadePreselector {
   Configurable<bool> dIfMCgenerateXiPlus{"dIfMCgenerateXiPlus", true, "if MC, generate MC true XiPlus (yes/no)"};
   Configurable<bool> dIfMCgenerateOmegaMinus{"dIfMCgenerateOmegaMinus", true, "if MC, generate MC true OmegaMinus (yes/no)"};
   Configurable<bool> dIfMCgenerateOmegaPlus{"dIfMCgenerateOmegaPlus", true, "if MC, generate MC true OmegaPlus (yes/no)"};
+  Configurable<int> dIfMCselectV0MotherPDG{"dIfMCselectV0MotherPDG", 0, "if MC, selects based on mother particle (zero for no selection)"};
 
   Configurable<bool> ddEdxPreSelectXiMinus{"ddEdxPreSelectXiMinus", true, "pre-select dE/dx compatibility with XiMinus (yes/no)"};
   Configurable<bool> ddEdxPreSelectXiPlus{"ddEdxPreSelectXiPlus", true, "pre-select dE/dx compatibility with XiPlus (yes/no)"};
@@ -1223,6 +1244,18 @@ struct cascadePreselector {
                 for (auto& lBachMother : lMCBachTrack.template mothers_as<aod::McParticles>()) {
                   if (lV0Mother == lBachMother) {
                     lPDG = lV0Mother.pdgCode();
+
+                    // additionally check PDG of the mother particle if requested 
+                    if ( dIfMCselectV0MotherPDG != 0 ){
+                      lPDG = 0; // this is not the species you're looking for
+                      if(lBachMother.has_mothers()){
+                        for (auto& lBachGrandMother : lBachMother.template mothers_as<aod::McParticles>()) {
+                          if(lBachGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
+                            lPDG = lV0Mother.pdgCode();
+                        }
+                      }
+                    }
+                    //end extra PDG of mother check
                   }
                 }
               } // end conditional V0-bach pair

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -648,7 +648,7 @@ struct lambdakzeroBuilder {
       float dcaV0toPV = std::sqrt((std::pow((primaryVertex.getY() - v0candidate.pos[1]) * pz - (primaryVertex.getZ() - v0candidate.pos[2]) * py, 2) + std::pow((primaryVertex.getX() - v0candidate.pos[0]) * pz - (primaryVertex.getZ() - v0candidate.pos[2]) * px, 2) + std::pow((primaryVertex.getX() - v0candidate.pos[0]) * py - (primaryVertex.getY() - v0candidate.pos[1]) * px, 2)) / (px * px + py * py + pz * pz));
 
       registry.fill(HIST("h2dTopoVarPointingAngle"), lPt, TMath::ACos(v0candidate.cosPA));
-      registry.fill(HIST("h2dTopoVarRAP"), lPt, TMath::ACos(v0candidate.cosPA)*v0candidate.V0radius);
+      registry.fill(HIST("h2dTopoVarRAP"), lPt, TMath::ACos(v0candidate.cosPA) * v0candidate.V0radius);
       registry.fill(HIST("h2dTopoVarV0Radius"), lPt, v0candidate.V0radius);
       registry.fill(HIST("h2dTopoVarDCAV0Dau"), lPt, v0candidate.dcaV0dau);
       registry.fill(HIST("h2dTopoVarPosDCAToPV"), lPt, v0candidate.posDCAxy);
@@ -831,17 +831,17 @@ struct lambdakzeroPreselector {
             if (lNegMother.globalIndex() == lPosMother.globalIndex()) {
               lPDG = lNegMother.pdgCode();
 
-              // additionally check PDG of the mother particle if requested 
-              if ( dIfMCselectV0MotherPDG != 0 ){
+              // additionally check PDG of the mother particle if requested
+              if (dIfMCselectV0MotherPDG != 0) {
                 lPDG = 0; // this is not the species you're looking for
-                if(lNegMother.has_mothers()){
+                if (lNegMother.has_mothers()) {
                   for (auto& lNegGrandMother : lNegMother.template mothers_as<aod::McParticles>()) {
-                    if(lNegGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
+                    if (lNegGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
                       lPDG = lNegMother.pdgCode();
                   }
                 }
               }
-              //end extra PDG of mother check
+              // end extra PDG of mother check
             }
           }
         }

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -144,6 +144,7 @@ struct lambdakzeroBuilder {
 
   // for topo var QA
   ConfigurableAxis axisTopoVarPointingAngle{"axisTopoVarPointingAngle", {50, 0.0, 1.0}, "pointing angle"};
+  ConfigurableAxis axisTopoVarRAP{"axisTopoVarRAP", {50, 0.0, 1.0}, "radius x pointing angle axis"};
   ConfigurableAxis axisTopoVarV0Radius{"axisTopoVarV0Radius", {500, 0.0, 100.0}, "V0 decay radius (cm)"};
   ConfigurableAxis axisTopoVarDCAV0Dau{"axisTopoVarDCAV0Dau", {200, 0.0, 2.0}, "DCA between V0 daughters (cm)"};
   ConfigurableAxis axisTopoVarDCAToPV{"axisTopoVarDCAToPV", {200, -1, 1.0}, "single track DCA to PV (cm)"};
@@ -276,6 +277,7 @@ struct lambdakzeroBuilder {
 
       // QA plots of topological variables using axisPtQA
       registry.add("h2dTopoVarPointingAngle", "h2dTopoVarPointingAngle", kTH2D, {axisPtQA, axisTopoVarPointingAngle});
+      registry.add("h2dTopoVarRAP", "h2dTopoVarRAP", kTH2D, {axisPtQA, axisTopoVarRAP});
       registry.add("h2dTopoVarV0Radius", "h2dTopoVarV0Radius", kTH2D, {axisPtQA, axisTopoVarV0Radius});
       registry.add("h2dTopoVarDCAV0Dau", "h2dTopoVarDCAV0Dau", kTH2D, {axisPtQA, axisTopoVarDCAV0Dau});
       registry.add("h2dTopoVarPosDCAToPV", "h2dTopoVarPosDCAToPV", kTH2D, {axisPtQA, axisTopoVarDCAToPV});
@@ -646,6 +648,7 @@ struct lambdakzeroBuilder {
       float dcaV0toPV = std::sqrt((std::pow((primaryVertex.getY() - v0candidate.pos[1]) * pz - (primaryVertex.getZ() - v0candidate.pos[2]) * py, 2) + std::pow((primaryVertex.getX() - v0candidate.pos[0]) * pz - (primaryVertex.getZ() - v0candidate.pos[2]) * px, 2) + std::pow((primaryVertex.getX() - v0candidate.pos[0]) * py - (primaryVertex.getY() - v0candidate.pos[1]) * px, 2)) / (px * px + py * py + pz * pz));
 
       registry.fill(HIST("h2dTopoVarPointingAngle"), lPt, TMath::ACos(v0candidate.cosPA));
+      registry.fill(HIST("h2dTopoVarRAP"), lPt, TMath::ACos(v0candidate.cosPA)*v0candidate.V0radius);
       registry.fill(HIST("h2dTopoVarV0Radius"), lPt, v0candidate.V0radius);
       registry.fill(HIST("h2dTopoVarDCAV0Dau"), lPt, v0candidate.dcaV0dau);
       registry.fill(HIST("h2dTopoVarPosDCAToPV"), lPt, v0candidate.posDCAxy);
@@ -750,6 +753,7 @@ struct lambdakzeroPreselector {
   Configurable<bool> dIfMCgenerateGamma{"dIfMCgenerateGamma", false, "if MC, generate MC true gamma (yes/no)"};
   Configurable<bool> dIfMCgenerateHypertriton{"dIfMCgenerateHypertriton", false, "if MC, generate MC true hypertritons (yes/no)"};
   Configurable<bool> dIfMCgenerateAntiHypertriton{"dIfMCgenerateAntiHypertriton", false, "if MC, generate MC true antihypertritons (yes/no)"};
+  Configurable<int> dIfMCselectV0MotherPDG{"dIfMCselectV0MotherPDG", 0, "if MC, selects based on mother particle (zero for no selection)"};
 
   Configurable<bool> ddEdxPreSelectK0Short{"ddEdxPreSelectK0Short", true, "pre-select dE/dx compatibility with K0Short (yes/no)"};
   Configurable<bool> ddEdxPreSelectLambda{"ddEdxPreSelectLambda", true, "pre-select dE/dx compatibility with Lambda (yes/no)"};
@@ -826,6 +830,18 @@ struct lambdakzeroPreselector {
           for (auto& lPosMother : lMCPosTrack.template mothers_as<aod::McParticles>()) {
             if (lNegMother.globalIndex() == lPosMother.globalIndex()) {
               lPDG = lNegMother.pdgCode();
+
+              // additionally check PDG of the mother particle if requested 
+              if ( dIfMCselectV0MotherPDG != 0 ){
+                lPDG = 0; // this is not the species you're looking for
+                if(lNegMother.has_mothers()){
+                  for (auto& lNegGrandMother : lNegMother.template mothers_as<aod::McParticles>()) {
+                    if(lNegGrandMother.pdgCode() == dIfMCselectV0MotherPDG)
+                      lPDG = lNegMother.pdgCode();
+                  }
+                }
+              }
+              //end extra PDG of mother check
             }
           }
         }


### PR DESCRIPTION
This PR: 
* adds the possibility of selecting on a specific mother PDG for the MC-associated V0 and cascade building. It is potentially useful, for instance, for building only Lambdas that are truly (in the MC assoc sense) from Xi, K0 from a LambdaC decay, Xi/Omega from a XiC/OmegaC decay, and so on. 
* adds some extra QA histograms for both V0s and cascades. 