### PR TITLE
ALICE3: Fix onTheFlyTracker collision time sampling

### DIFF
--- a/ALICE3/TableProducer/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/onTheFlyTracker.cxx
@@ -30,25 +30,16 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/RunningWorkflowInfo.h"
 #include "Framework/HistogramRegistry.h"
+#include <TPDGCode.h>
 #include "Framework/O2DatabasePDGPlugin.h"
-#include "Framework/ASoAHelpers.h"
 #include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/Core/trackUtilities.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "CommonUtils/NameConf.h"
-#include "CCDB/CcdbApi.h"
-#include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPMagField.h"
-#include "DataFormatsCalibration/MeanVertexObject.h"
-#include "CommonConstants/GeomConstants.h"
 #include "DetectorsVertexing/PVertexer.h"
 #include "DetectorsVertexing/PVertexerHelpers.h"
 #include "SimulationDataFormat/InteractionSampler.h"
-#include "TableHelper.h"
 #include "Field/MagneticField.h"
 
 #include "ALICE3/Core/DelphesO2TrackSmearer.h"
@@ -117,7 +108,7 @@ struct OnTheFlyTracker {
     TrackAlice3(const TrackAlice3& src) = default;
     TrackAlice3(const o2::track::TrackParCov& src, const int64_t label, const float t = 0, const float te = 1) : o2::track::TrackParCov(src), mcLabel{label}, timeEst{t, te} {}
     const TimeEst& getTimeMUS() const { return timeEst; }
-    const int64_t mcLabel;
+    int64_t mcLabel;
     TimeEst timeEst; ///< time estimate in ns
   };
 
@@ -161,9 +152,9 @@ struct OnTheFlyTracker {
       mapPdgLut.insert(std::make_pair(2212, lutPrChar));
 
       if (enableNucleiSmearing) {
-        const char* lutDeChar = ((std::string)lutDe).c_str();
-        const char* lutTrChar = ((std::string)lutTr).c_str();
-        const char* lutHe3Char = ((std::string)lutHe3).c_str();
+        const char* lutDeChar = lutDe->c_str();
+        const char* lutTrChar = lutTr->c_str();
+        const char* lutHe3Char = lutHe3->c_str();
         mapPdgLut.insert(std::make_pair(1000010020, lutDeChar));
         mapPdgLut.insert(std::make_pair(1000010030, lutTrChar));
         mapPdgLut.insert(std::make_pair(1000020030, lutHe3Char));
@@ -229,6 +220,7 @@ struct OnTheFlyTracker {
     o2::base::Propagator::Instance()->setMatLUT(lut);
 
     irSampler.setInteractionRate(100);
+    irSampler.setFirstIR(o2::InteractionRecord(0, 0));
     irSampler.init();
 
     vertexer.setValidateWithIR(kFALSE);
@@ -272,7 +264,7 @@ struct OnTheFlyTracker {
     o2::dataformats::VertexBase vtx;
 
     // generate collision time
-    o2::InteractionRecord ir = irSampler.generateCollisionTime();
+    auto ir = irSampler.generateCollisionTime();
 
     // First we compute the number of charged particles in the event
     dNdEta = 0.f;
@@ -359,7 +351,7 @@ struct OnTheFlyTracker {
       }
 
       // populate vector with track if we reco-ed it
-      const float t = (ir.bc2ns() + gRandom->Gaus(0., 100.)) * 1e-3;
+      const float t = (ir.timeInBCNS + gRandom->Gaus(0., 100.)) * 1e-3;
       tracksAlice3.push_back(TrackAlice3{trackParCov, mcParticle.globalIndex(), t, 100.f * 1e-3});
     }
 


### PR DESCRIPTION
+cleanups

@ddobrigk change in line 354 should prevent crashes in vertexing that happened due to track times reaching float upper limit.