### PR TITLE
PWGCF: FemtoWorld - D0 analysis - corrected producer

### DIFF
--- a/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
+++ b/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
@@ -211,8 +211,8 @@ struct femtoWorldProducerTask {
 
   // PHI Candidates
   FemtoWorldPhiSelection PhiCuts;
-  //Configurable<std::vector<float>> ConfPhiSign{FemtoWorldPhiSelection::getSelectionName(femtoWorldPhiSelection::kPhiSign, "ConfPhi"), std::vector<float>{-1, 1}, FemtoWorldPhiSelection::getSelectionHelper(femtoWorldPhiSelection::kPhiSign, "Phi selection: ")};
-  //Configurable<std::vector<float>> ConfPhiPtMin{FemtoWorldPhiSelection::getSelectionName(femtoWorldPhiSelection::kpTPhiMin, "ConfPhi"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoWorldPhiSelection::getSelectionHelper(femtoWorldPhiSelection::kpTPhiMin, "Phi selection: ")};
+  // Configurable<std::vector<float>> ConfPhiSign{FemtoWorldPhiSelection::getSelectionName(femtoWorldPhiSelection::kPhiSign, "ConfPhi"), std::vector<float>{-1, 1}, FemtoWorldPhiSelection::getSelectionHelper(femtoWorldPhiSelection::kPhiSign, "Phi selection: ")};
+  // Configurable<std::vector<float>> ConfPhiPtMin{FemtoWorldPhiSelection::getSelectionName(femtoWorldPhiSelection::kpTPhiMin, "ConfPhi"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoWorldPhiSelection::getSelectionHelper(femtoWorldPhiSelection::kpTPhiMin, "Phi selection: ")};
 
   HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
 
@@ -456,7 +456,7 @@ struct femtoWorldProducerTask {
   PROCESS_SWITCH(femtoWorldProducerTask, processProdTrackRun2, "Produce Femto tables", true);
 
   void processProdTrackV0Run2(aod::FemtoFullCollisionRun2 const& col, aod::BCsWithTimestamps const&, aod::FemtoFullTracks const& tracks,
-                       o2::aod::V0Datas const& fullV0s)
+                              o2::aod::V0Datas const& fullV0s)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
@@ -543,192 +543,192 @@ struct femtoWorldProducerTask {
     }
 
     for (auto& v0 : fullV0s) {
-        auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
-        auto negtrack = v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough if we apply the filter the sign of Pos and Neg track is always negative
-        // const auto dcaXYpos = postrack.dcaXY();
-        // const auto dcaZpos = postrack.dcaZ();
-        // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
-        v0Cuts.fillLambdaQA(col, v0, postrack, negtrack);
+      auto postrack = v0.posTrack_as<aod::FemtoFullTracks>();
+      auto negtrack = v0.negTrack_as<aod::FemtoFullTracks>(); ///\tocheck funnily enough if we apply the filter the sign of Pos and Neg track is always negative
+      // const auto dcaXYpos = postrack.dcaXY();
+      // const auto dcaZpos = postrack.dcaZ();
+      // const auto dcapos = std::sqrt(pow(dcaXYpos, 2.) + pow(dcaZpos, 2.));
+      v0Cuts.fillLambdaQA(col, v0, postrack, negtrack);
 
-        if (!v0Cuts.isSelectedMinimal(col, v0, postrack, negtrack)) {
-          continue;
-        }
-
-        if (ConfRejectITSHitandTOFMissing) {
-          // Uncomment only when TOF timing is solved
-          // bool itsHit = o2PhysicsTrackSelection->IsSelected(postrack, TrackSelection::TrackCuts::kITSHits);
-          // bool itsHit = o2PhysicsTrackSelection->IsSelected(negtrack, TrackSelection::TrackCuts::kITSHits);
-        }
-
-        v0Cuts.fillQA<aod::femtoworldparticle::ParticleType::kV0, aod::femtoworldparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
-        auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtoworldparticle::cutContainerType>(col, v0, postrack, negtrack);
-
-        if ((cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kV0) > 0) && (cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosCuts) > 0) && (cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
-          int postrackID = v0.posTrackId();
-          int rowInPrimaryTrackTablePos = -1;
-          rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
-          childIDs[0] = rowInPrimaryTrackTablePos;
-          childIDs[1] = 0;
-          outputParts(outputCollision.lastIndex(),
-                      v0.positivept(),
-                      v0.positiveeta(),
-                      v0.positivephi(),
-                      0,     // v0.p(),
-                      0,     // mass
-                      -999., // D0mass
-                      -999., // D0bar mass
-                      -999., // D0 flag
-                      -999., // D0bar flag
-                      aod::femtoworldparticle::ParticleType::kV0Child,
-                      cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosCuts),
-                      cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosPID),
-                      0.,
-                      childIDs,
-                      0,
-                      0,
-                      postrack.sign(),
-                      postrack.beta(),
-                      postrack.itsChi2NCl(),
-                      postrack.tpcChi2NCl(),
-                      postrack.tpcNSigmaKa(),
-                      postrack.tofNSigmaKa(),
-                      (uint8_t)postrack.tpcNClsFound(),
-                      postrack.tpcNClsFindable(),
-                      (uint8_t)postrack.tpcNClsCrossedRows(),
-                      postrack.tpcNClsShared(),
-                      postrack.tpcInnerParam(),
-                      postrack.itsNCls(),
-                      postrack.itsNClsInnerBarrel(),
-                      postrack.dcaXY(),
-                      postrack.dcaZ(),
-                      postrack.tpcSignal(),
-                      postrack.tpcNSigmaStoreEl(),
-                      postrack.tpcNSigmaStorePi(),
-                      postrack.tpcNSigmaStoreKa(),
-                      postrack.tpcNSigmaStorePr(),
-                      postrack.tpcNSigmaStoreDe(),
-                      postrack.tofNSigmaStoreEl(),
-                      postrack.tofNSigmaStorePi(),
-                      postrack.tofNSigmaStoreKa(),
-                      postrack.tofNSigmaStorePr(),
-                      postrack.tofNSigmaStoreDe(),
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.);
-          const int rowOfPosTrack = outputParts.lastIndex();
-          int negtrackID = v0.negTrackId();
-          int rowInPrimaryTrackTableNeg = -1;
-          rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
-          childIDs[0] = 0;
-          childIDs[1] = rowInPrimaryTrackTableNeg;
-          outputParts(outputCollision.lastIndex(),
-                      v0.negativept(),
-                      v0.negativeeta(),
-                      v0.negativephi(),
-                      0,     // momentum
-                      0,     // mass
-                      -999., // D0mass
-                      -999., // D0bar mass
-                      -999., // D0 flag
-                      -999., // D0bar flag
-                      aod::femtoworldparticle::ParticleType::kV0Child,
-                      cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegCuts),
-                      cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegPID),
-                      0.,
-                      childIDs,
-                      0,
-                      0,
-                      negtrack.sign(),
-                      negtrack.beta(),
-                      negtrack.itsChi2NCl(),
-                      negtrack.tpcChi2NCl(),
-                      negtrack.tpcNSigmaKa(),
-                      negtrack.tofNSigmaKa(),
-                      (uint8_t)negtrack.tpcNClsFound(),
-                      negtrack.tpcNClsFindable(),
-                      (uint8_t)negtrack.tpcNClsCrossedRows(),
-                      negtrack.tpcNClsShared(),
-                      negtrack.tpcInnerParam(),
-                      negtrack.itsNCls(),
-                      negtrack.itsNClsInnerBarrel(),
-                      negtrack.dcaXY(),
-                      negtrack.dcaZ(),
-                      negtrack.tpcSignal(),
-                      negtrack.tpcNSigmaStoreEl(),
-                      negtrack.tpcNSigmaStorePi(),
-                      negtrack.tpcNSigmaStoreKa(),
-                      negtrack.tpcNSigmaStorePr(),
-                      negtrack.tpcNSigmaStoreDe(),
-                      negtrack.tofNSigmaStoreEl(),
-                      negtrack.tofNSigmaStorePi(),
-                      negtrack.tofNSigmaStoreKa(),
-                      negtrack.tofNSigmaStorePr(),
-                      negtrack.tofNSigmaStoreDe(),
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.);
-          const int rowOfNegTrack = outputParts.lastIndex();
-          int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
-          outputParts(outputCollision.lastIndex(),
-                      v0.pt(),
-                      v0.eta(),
-                      v0.phi(),
-                      0,     // momentum
-                      0,     // mass
-                      -999., // D0mass
-                      -999., // D0bar mass
-                      -999., // D0 flag
-                      -999., // D0bar flag
-                      aod::femtoworldparticle::ParticleType::kV0,
-                      cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kV0),
-                      0,
-                      v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
-                      indexChildID,
-                      v0.mLambda(),
-                      v0.mAntiLambda(),
-                      postrack.sign(),
-                      postrack.beta(),
-                      postrack.itsChi2NCl(),
-                      postrack.tpcChi2NCl(),
-                      postrack.tpcNSigmaKa(),
-                      postrack.tofNSigmaKa(),
-                      (uint8_t)postrack.tpcNClsFound(),
-                      postrack.tpcNClsFindable(),
-                      (uint8_t)postrack.tpcNClsCrossedRows(),
-                      postrack.tpcNClsShared(),
-                      postrack.tpcInnerParam(),
-                      postrack.itsNCls(),
-                      postrack.itsNClsInnerBarrel(),
-                      postrack.dcaXY(),
-                      postrack.dcaZ(),
-                      postrack.tpcSignal(),
-                      postrack.tpcNSigmaStoreEl(),
-                      postrack.tpcNSigmaStorePi(),
-                      postrack.tpcNSigmaStoreKa(),
-                      postrack.tpcNSigmaStorePr(),
-                      postrack.tpcNSigmaStoreDe(),
-                      postrack.tofNSigmaStoreEl(),
-                      postrack.tofNSigmaStorePi(),
-                      postrack.tofNSigmaStoreKa(),
-                      postrack.tofNSigmaStorePr(),
-                      postrack.tofNSigmaStoreDe(),
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.,
-                      -999.);
-        }
+      if (!v0Cuts.isSelectedMinimal(col, v0, postrack, negtrack)) {
+        continue;
       }
+
+      if (ConfRejectITSHitandTOFMissing) {
+        // Uncomment only when TOF timing is solved
+        // bool itsHit = o2PhysicsTrackSelection->IsSelected(postrack, TrackSelection::TrackCuts::kITSHits);
+        // bool itsHit = o2PhysicsTrackSelection->IsSelected(negtrack, TrackSelection::TrackCuts::kITSHits);
+      }
+
+      v0Cuts.fillQA<aod::femtoworldparticle::ParticleType::kV0, aod::femtoworldparticle::ParticleType::kV0Child>(col, v0, postrack, negtrack); ///\todo fill QA also for daughters
+      auto cutContainerV0 = v0Cuts.getCutContainer<aod::femtoworldparticle::cutContainerType>(col, v0, postrack, negtrack);
+
+      if ((cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kV0) > 0) && (cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosCuts) > 0) && (cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegCuts) > 0)) {
+        int postrackID = v0.posTrackId();
+        int rowInPrimaryTrackTablePos = -1;
+        rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+        childIDs[0] = rowInPrimaryTrackTablePos;
+        childIDs[1] = 0;
+        outputParts(outputCollision.lastIndex(),
+                    v0.positivept(),
+                    v0.positiveeta(),
+                    v0.positivephi(),
+                    0,     // v0.p(),
+                    0,     // mass
+                    -999., // D0mass
+                    -999., // D0bar mass
+                    -999., // D0 flag
+                    -999., // D0bar flag
+                    aod::femtoworldparticle::ParticleType::kV0Child,
+                    cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosCuts),
+                    cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kPosPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0,
+                    postrack.sign(),
+                    postrack.beta(),
+                    postrack.itsChi2NCl(),
+                    postrack.tpcChi2NCl(),
+                    postrack.tpcNSigmaKa(),
+                    postrack.tofNSigmaKa(),
+                    (uint8_t)postrack.tpcNClsFound(),
+                    postrack.tpcNClsFindable(),
+                    (uint8_t)postrack.tpcNClsCrossedRows(),
+                    postrack.tpcNClsShared(),
+                    postrack.tpcInnerParam(),
+                    postrack.itsNCls(),
+                    postrack.itsNClsInnerBarrel(),
+                    postrack.dcaXY(),
+                    postrack.dcaZ(),
+                    postrack.tpcSignal(),
+                    postrack.tpcNSigmaStoreEl(),
+                    postrack.tpcNSigmaStorePi(),
+                    postrack.tpcNSigmaStoreKa(),
+                    postrack.tpcNSigmaStorePr(),
+                    postrack.tpcNSigmaStoreDe(),
+                    postrack.tofNSigmaStoreEl(),
+                    postrack.tofNSigmaStorePi(),
+                    postrack.tofNSigmaStoreKa(),
+                    postrack.tofNSigmaStorePr(),
+                    postrack.tofNSigmaStoreDe(),
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.);
+        const int rowOfPosTrack = outputParts.lastIndex();
+        int negtrackID = v0.negTrackId();
+        int rowInPrimaryTrackTableNeg = -1;
+        rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+        childIDs[0] = 0;
+        childIDs[1] = rowInPrimaryTrackTableNeg;
+        outputParts(outputCollision.lastIndex(),
+                    v0.negativept(),
+                    v0.negativeeta(),
+                    v0.negativephi(),
+                    0,     // momentum
+                    0,     // mass
+                    -999., // D0mass
+                    -999., // D0bar mass
+                    -999., // D0 flag
+                    -999., // D0bar flag
+                    aod::femtoworldparticle::ParticleType::kV0Child,
+                    cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegCuts),
+                    cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kNegPID),
+                    0.,
+                    childIDs,
+                    0,
+                    0,
+                    negtrack.sign(),
+                    negtrack.beta(),
+                    negtrack.itsChi2NCl(),
+                    negtrack.tpcChi2NCl(),
+                    negtrack.tpcNSigmaKa(),
+                    negtrack.tofNSigmaKa(),
+                    (uint8_t)negtrack.tpcNClsFound(),
+                    negtrack.tpcNClsFindable(),
+                    (uint8_t)negtrack.tpcNClsCrossedRows(),
+                    negtrack.tpcNClsShared(),
+                    negtrack.tpcInnerParam(),
+                    negtrack.itsNCls(),
+                    negtrack.itsNClsInnerBarrel(),
+                    negtrack.dcaXY(),
+                    negtrack.dcaZ(),
+                    negtrack.tpcSignal(),
+                    negtrack.tpcNSigmaStoreEl(),
+                    negtrack.tpcNSigmaStorePi(),
+                    negtrack.tpcNSigmaStoreKa(),
+                    negtrack.tpcNSigmaStorePr(),
+                    negtrack.tpcNSigmaStoreDe(),
+                    negtrack.tofNSigmaStoreEl(),
+                    negtrack.tofNSigmaStorePi(),
+                    negtrack.tofNSigmaStoreKa(),
+                    negtrack.tofNSigmaStorePr(),
+                    negtrack.tofNSigmaStoreDe(),
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.);
+        const int rowOfNegTrack = outputParts.lastIndex();
+        int indexChildID[2] = {rowOfPosTrack, rowOfNegTrack};
+        outputParts(outputCollision.lastIndex(),
+                    v0.pt(),
+                    v0.eta(),
+                    v0.phi(),
+                    0,     // momentum
+                    0,     // mass
+                    -999., // D0mass
+                    -999., // D0bar mass
+                    -999., // D0 flag
+                    -999., // D0bar flag
+                    aod::femtoworldparticle::ParticleType::kV0,
+                    cutContainerV0.at(femtoWorldV0Selection::V0ContainerPosition::kV0),
+                    0,
+                    v0.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                    indexChildID,
+                    v0.mLambda(),
+                    v0.mAntiLambda(),
+                    postrack.sign(),
+                    postrack.beta(),
+                    postrack.itsChi2NCl(),
+                    postrack.tpcChi2NCl(),
+                    postrack.tpcNSigmaKa(),
+                    postrack.tofNSigmaKa(),
+                    (uint8_t)postrack.tpcNClsFound(),
+                    postrack.tpcNClsFindable(),
+                    (uint8_t)postrack.tpcNClsCrossedRows(),
+                    postrack.tpcNClsShared(),
+                    postrack.tpcInnerParam(),
+                    postrack.itsNCls(),
+                    postrack.itsNClsInnerBarrel(),
+                    postrack.dcaXY(),
+                    postrack.dcaZ(),
+                    postrack.tpcSignal(),
+                    postrack.tpcNSigmaStoreEl(),
+                    postrack.tpcNSigmaStorePi(),
+                    postrack.tpcNSigmaStoreKa(),
+                    postrack.tpcNSigmaStorePr(),
+                    postrack.tpcNSigmaStoreDe(),
+                    postrack.tofNSigmaStoreEl(),
+                    postrack.tofNSigmaStorePi(),
+                    postrack.tofNSigmaStoreKa(),
+                    postrack.tofNSigmaStorePr(),
+                    postrack.tofNSigmaStoreDe(),
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.,
+                    -999.);
+      }
+    }
   }
   PROCESS_SWITCH(femtoWorldProducerTask, processProdTrackV0Run2, "Produce Femto tables", true);
 
@@ -1414,7 +1414,7 @@ struct femtoWorldProducerTask {
   PROCESS_SWITCH(femtoWorldProducerTask, processProdTrackRun3, "Produce Femto tables", true);
 
   void processProdTrackV0Run3(aod::FemtoFullCollisionRun3 const& col, aod::BCsWithTimestamps const&, aod::FemtoFullTracks const& tracks,
-                       o2::aod::V0Datas const& fullV0s)
+                              o2::aod::V0Datas const& fullV0s)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
@@ -2003,7 +2003,7 @@ struct femtoWorldProducerTask {
   void processProdTrackD0Run3(aod::FemtoFullCollisionRun3 const& col, aod::BCsWithTimestamps const&, aod::FemtoFullTracks const& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
   // void processCharmMesons(aod::Collision const& collision, soa::Join<aod::Tracks, aod::TracksDCA>& tracks, soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
   {
-    
+
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
 
@@ -2017,7 +2017,6 @@ struct femtoWorldProducerTask {
       }
       return;
     }
-
 
     const auto vtxZ = col.posZ();
     // const auto mult = collision.multFV0M();

--- a/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskTrackD0.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskTrackD0.cxx
@@ -112,7 +112,7 @@ struct femtoWorldPairTaskTrackD0 {
   Partition<aod::FemtoWorldParticles> partsD0D0barDaughters = (aod::femtoworldparticle::partType == uint8_t(aod::femtoworldparticle::ParticleType::kD0D0barChild));
 
   // HIstogramin for particle 2
-  //FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kD0D0bar, 0> trackHistoPartThree;
+  // FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kD0D0bar, 0> trackHistoPartThree;
 
   /// Histogramming for Event
   FemtoWorldEventHisto eventHisto;
@@ -264,7 +264,7 @@ struct femtoWorldPairTaskTrackD0 {
   {
     eventHisto.init(&qaRegistry);
     trackHistoPartOne.init(&qaRegistry);
-    //trackHistoPartThree.init(&qaRegistry);
+    // trackHistoPartThree.init(&qaRegistry);
 
     sameEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
     sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);

--- a/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskTrackD0.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoWorldPairTaskTrackD0.cxx
@@ -99,30 +99,20 @@ struct femtoWorldPairTaskTrackD0 {
   /// Histogramming for particle 1
   FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kTrack, 0> trackHistoPartOne;
 
-  /// Particle 2 (Phi)
-  Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 333, "Particle 1 - PDG code"}; // phi meson (333)
-  Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 338, "Particle 2 - Selection bit"};
+  /// Particle 2 (D0/D0bar)
+  Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 421, "Particle 1 - PDG code"}; // phi meson (333)
+  Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 421, "Particle 2 - Selection bit"};
   Configurable<float> cfgPtLowPart2{"cfgPtLowPart2", 0.14, "Lower limit for Pt for the second particle"};
   Configurable<float> cfgPtHighPart2{"cfgPtHighPart2", 5.0, "Higher limit for Pt for the second particle"};
   Configurable<float> cfgEtaLowPart2{"cfgEtaLowPart2", -0.8, "Lower limit for Eta for the second particle"};
   Configurable<float> cfgEtaHighPart2{"cfgEtaHighPart2", 0.8, "Higher limit for Eta for the second particle"};
 
-  /// Partition for particle 2
-  Partition<aod::FemtoWorldParticles> partsTwo = (aod::femtoworldparticle::partType == uint8_t(aod::femtoworldparticle::ParticleType::kPhi)) && (aod::femtoworldparticle::pt < cfgPtHighPart2) && (aod::femtoworldparticle::pt > cfgPtLowPart2) // pT cuts
-                                                 && (aod::femtoworldparticle::eta < cfgEtaHighPart2) && (aod::femtoworldparticle::eta > cfgEtaLowPart2);                                                                                        // Eta cuts
-
-  /// Histogramming for particle 2
-  FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kPhi, 0> trackHistoPartTwo;
-
-  // Partition for particle 3 (Phi daughters (K+ K-))
-  Partition<aod::FemtoWorldParticles> partsThree = (aod::femtoworldparticle::partType == uint8_t(aod::femtoworldparticle::ParticleType::kPhiChild));
-
-  /// Histogramming for particle 3
-  FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kPhiChild, 0> trackHistoPartThree;
-
   // Partition for D0/D0bar mesons
   Partition<aod::FemtoWorldParticles> partsD0D0barMesons = (aod::femtoworldparticle::partType == uint8_t(aod::femtoworldparticle::ParticleType::kD0D0bar));
   Partition<aod::FemtoWorldParticles> partsD0D0barDaughters = (aod::femtoworldparticle::partType == uint8_t(aod::femtoworldparticle::ParticleType::kD0D0barChild));
+
+  // HIstogramin for particle 2
+  //FemtoWorldParticleHisto<aod::femtoworldparticle::ParticleType::kD0D0bar, 0> trackHistoPartThree;
 
   /// Histogramming for Event
   FemtoWorldEventHisto eventHisto;
@@ -274,8 +264,7 @@ struct femtoWorldPairTaskTrackD0 {
   {
     eventHisto.init(&qaRegistry);
     trackHistoPartOne.init(&qaRegistry);
-    trackHistoPartTwo.init(&qaRegistry);
-    trackHistoPartThree.init(&qaRegistry);
+    //trackHistoPartThree.init(&qaRegistry);
 
     sameEventCont.init(&resultRegistry, CfgkstarBins, CfgMultBins, CfgkTBins, CfgmTBins, ConfPhiBins, ConfEtaBins, ConfMInvBins);
     sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
@@ -343,8 +332,6 @@ struct femtoWorldPairTaskTrackD0 {
   {
     // const auto& magFieldTesla = col.magField();
     auto groupPartsOne = partsOne->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
-    auto groupPartsTwo = partsTwo->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
-    auto groupPartsThree = partsThree->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
     auto groupPartsD0D0bar = partsD0D0barMesons->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
 
     const int multCol = col.multV0M();
@@ -357,34 +344,11 @@ struct femtoWorldPairTaskTrackD0 {
       }
       trackHistoPartOne.fillQA(part);
     }
-    for (auto& part : groupPartsTwo) {
-      trackHistoPartTwo.fillQAMult(part, multCol);
-    }
-    for (auto& part : groupPartsThree) {
+    /*for (auto& part : groupPartsD0D0bar) {
       trackHistoPartThree.fillQA(part);
-    }
+    }*/
 
     /// Now build the combinations
-    for (auto& [p1, p2] : combinations(groupPartsOne, groupPartsTwo)) {
-      if (!(IsParticleNSigma(p1.p(), p1.tpcNSigmaPr(), p1.tofNSigmaPr(), p1.tpcNSigmaPi(), p1.tofNSigmaPi(), p1.tpcNSigmaKa(), p1.tofNSigmaKa()))) {
-        continue;
-      }
-      // TODO: Include pairCloseRejection and pairCleaner
-      /*
-      if (ConfIsCPR) {
-        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
-          continue;
-        }
-      }
-      */
-      // track cleaning
-      /*if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-        continue;
-      }*/
-
-      sameEventCont.setPair(p1, p2, multCol);
-    }
-    /// Now build the combinations track-D0/D0bar
     for (auto& [p1, p2] : combinations(groupPartsOne, groupPartsD0D0bar)) {
       if (!(IsParticleNSigma(p1.p(), p1.tpcNSigmaPr(), p1.tofNSigmaPr(), p1.tpcNSigmaPi(), p1.tofNSigmaPi(), p1.tpcNSigmaKa(), p1.tofNSigmaKa()))) {
         continue;
@@ -405,6 +369,7 @@ struct femtoWorldPairTaskTrackD0 {
       sameEventCont.setPair(p1, p2, multCol);
     }
   }
+
   PROCESS_SWITCH(femtoWorldPairTaskTrackD0, processSameEvent, "Enable processing same event", false);
 
   /// This function processes the mixed event
@@ -417,8 +382,6 @@ struct femtoWorldPairTaskTrackD0 {
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, ConfNEventsMix, -1, cols, cols)) {
 
       auto groupPartsOne = partsOne->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, collision2.globalIndex(), cache);
-      auto groupPartsThree = partsThree->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, collision2.globalIndex(), cache);
       auto groupPartsD0D0bar = partsD0D0barMesons->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
@@ -428,7 +391,7 @@ struct femtoWorldPairTaskTrackD0 {
         continue;
       }
 
-      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
+      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsD0D0bar))) {
         if (!(IsParticleNSigma(p1.p(), p1.tpcNSigmaPr(), p1.tofNSigmaPr(), p1.tpcNSigmaPi(), p1.tofNSigmaPi(), p1.tpcNSigmaKa(), p1.tofNSigmaKa()))) {
           continue;
         }
@@ -443,6 +406,7 @@ struct femtoWorldPairTaskTrackD0 {
       }
     }
   }
+
   PROCESS_SWITCH(femtoWorldPairTaskTrackD0, processMixedEvent, "Enable processing mixed events", false);
 };
 


### PR DESCRIPTION
Changes in the femtoWorldProducerTask.cxx and femtoWorldPairTaskTrackD0.cxx.
Functionalities in the producer: one can store only tracks, track and V0s, tracks and phi mesons or tracks and D0 mesons.
Functionalities about centrality kept: one can choose to run over Run2 or Run3 data.