### PR TITLE
PWGHF: Improve tree creator for D0 mesons and fix table names of tree creators

### DIFF
--- a/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
@@ -62,7 +62,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandChicFull, "AOD", "HFCANDChicFull",
+DECLARE_SOA_TABLE(HfCandChicFulls, "AOD", "HFCANDCHICFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -94,7 +94,7 @@ DECLARE_SOA_TABLE(HfCandChicFull, "AOD", "HFCANDChicFull",
                   full::MCflag,
                   full::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandChicFullEvents, "AOD", "HFCANDChicFullE",
+DECLARE_SOA_TABLE(HfCandChicFullEs, "AOD", "HFCANDCHICFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -103,7 +103,7 @@ DECLARE_SOA_TABLE(HfCandChicFullEvents, "AOD", "HFCANDChicFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandChicFullParticles, "AOD", "HFCANDChicFullP",
+DECLARE_SOA_TABLE(HfCandChicFullPs, "AOD", "HFCANDCHICFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -117,9 +117,9 @@ DECLARE_SOA_TABLE(HfCandChicFullParticles, "AOD", "HFCANDChicFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorChicToJpsiGamma {
-  Produces<o2::aod::HfCandChicFull> rowCandidateFull;
-  Produces<o2::aod::HfCandChicFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandChicFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandChicFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandChicFullEs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandChicFullPs> rowCandidateFullParticles;
 
   void init(InitContext const&)
   {

--- a/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandXFull, "AOD", "HFCANDXFull",
+DECLARE_SOA_TABLE(HfCandXFulls, "AOD", "HFCANDXFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -118,7 +118,7 @@ DECLARE_SOA_TABLE(HfCandXFull, "AOD", "HFCANDXFull",
                   full::MCflag,
                   full::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandXFullEvents, "AOD", "HFCANDXFullE",
+DECLARE_SOA_TABLE(HfCandXFullEvs, "AOD", "HFCANDXFULLEV",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -127,7 +127,7 @@ DECLARE_SOA_TABLE(HfCandXFullEvents, "AOD", "HFCANDXFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandXFullParticles, "AOD", "HFCANDXFullP",
+DECLARE_SOA_TABLE(HfCandXFullPs, "AOD", "HFCANDXFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -140,9 +140,9 @@ DECLARE_SOA_TABLE(HfCandXFullParticles, "AOD", "HFCANDXFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorXToJpsiPiPi {
-  Produces<o2::aod::HfCandXFull> rowCandidateFull;
-  Produces<o2::aod::HfCandXFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandXFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandXFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandXFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandXFullPs> rowCandidateFullParticles;
 
   void init(InitContext const&)
   {

--- a/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
@@ -62,7 +62,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int); //! Event rejection flag
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);         //! Run number
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandB0Lite, "AOD", "HFCANDB0Lite",
+DECLARE_SOA_TABLE(HfCandB0Lites, "AOD", "HFCANDB0LITE",
                   hf_cand::Chi2PCA,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -86,7 +86,7 @@ DECLARE_SOA_TABLE(HfCandB0Lite, "AOD", "HFCANDB0Lite",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandB0Full, "AOD", "HFCANDB0Full",
+DECLARE_SOA_TABLE(HfCandB0Fulls, "AOD", "HFCANDB0FULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -136,7 +136,7 @@ DECLARE_SOA_TABLE(HfCandB0Full, "AOD", "HFCANDB0Full",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandB0FullEvents, "AOD", "HFCANDB0FullE",
+DECLARE_SOA_TABLE(HfCandB0FullEvs, "AOD", "HFCANDB0FULLEV",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -145,7 +145,7 @@ DECLARE_SOA_TABLE(HfCandB0FullEvents, "AOD", "HFCANDB0FullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandB0FullParticles, "AOD", "HFCANDB0FullP",
+DECLARE_SOA_TABLE(HfCandB0FullPs, "AOD", "HFCANDB0FULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -157,10 +157,10 @@ DECLARE_SOA_TABLE(HfCandB0FullParticles, "AOD", "HFCANDB0FullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorB0ToDPi {
-  Produces<o2::aod::HfCandB0Full> rowCandidateFull;
-  Produces<o2::aod::HfCandB0FullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandB0FullParticles> rowCandidateFullParticles;
-  Produces<o2::aod::HfCandB0Lite> rowCandidateLite;
+  Produces<o2::aod::HfCandB0Fulls> rowCandidateFull;
+  Produces<o2::aod::HfCandB0FullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandB0FullPs> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandB0Lites> rowCandidateLite;
 
   Configurable<int> selectionFlagB0{"selectionB0", 1, "Selection Flag for B0"};
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};

--- a/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
+++ b/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
@@ -97,7 +97,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCandBplus, "_0");
 } // namespace full
 
 // put the arguments into the table
-DECLARE_SOA_TABLE(HfCandBplusFull, "AOD", "HFCANDBPFull",
+DECLARE_SOA_TABLE(HfCandBpFulls, "AOD", "HFCANDBPFULL",
                   full::RSecondaryVertex,
                   full::PtProng0,
                   full::PProng0,
@@ -161,7 +161,7 @@ DECLARE_SOA_TABLE(HfCandBplusFull, "AOD", "HFCANDBPFull",
                   full::NSigmaTPCTrk1Ka,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCandBplusFullEvents, "AOD", "HFCANDBPFullE",
+DECLARE_SOA_TABLE(HfCandBpFullEvs, "AOD", "HFCANDBPFULLEV",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -170,7 +170,7 @@ DECLARE_SOA_TABLE(HfCandBplusFullEvents, "AOD", "HFCANDBPFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandBplusFullParticles, "AOD", "HFCANDBPFullP",
+DECLARE_SOA_TABLE(HfCandBpFullPs, "AOD", "HFCANDBPFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -183,9 +183,9 @@ DECLARE_SOA_TABLE(HfCandBplusFullParticles, "AOD", "HFCANDBPFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorBplusToD0Pi {
-  Produces<o2::aod::HfCandBplusFull> rowCandidateFull;
-  Produces<o2::aod::HfCandBplusFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandBplusFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandBpFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandBpFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandBpFullPs> rowCandidateFullParticles;
 
   Configurable<int> isSignal{"isSignal", 1, "save only MC matched candidates"};
 

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -25,6 +25,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::framework::expressions;
 using namespace o2::aod::hf_cand_2prong;
 
 namespace o2::aod
@@ -61,6 +62,7 @@ DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);
 DECLARE_SOA_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, float);
 DECLARE_SOA_COLUMN(Cpa, cpa, float);
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);
+DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);
 DECLARE_SOA_COLUMN(Ct, ct, float);
 DECLARE_SOA_COLUMN(ImpactParameterProduct, impactParameterProduct, float);
 DECLARE_SOA_COLUMN(CosThetaStar, cosThetaStar, float);
@@ -72,6 +74,39 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand2Prong, "_0");
 DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
+
+DECLARE_SOA_TABLE(HfCand2PLite, "AOD", "HFCAND2PLITE",
+                  hf_cand::Chi2PCA,
+                  full::DecayLength,
+                  full::DecayLengthXY,
+                  full::DecayLengthNormalised,
+                  full::DecayLengthXYNormalised,
+                  full::PtProng0,
+                  full::PtProng1,
+                  hf_cand::ImpactParameter0,
+                  hf_cand::ImpactParameter1,
+                  full::ImpactParameterNormalised0,
+                  full::ImpactParameterNormalised1,
+                  full::NSigTpcPi0,
+                  full::NSigTpcKa0,
+                  full::NSigTofPi0,
+                  full::NSigTofKa0,
+                  full::NSigTpcPi1,
+                  full::NSigTpcKa1,
+                  full::NSigTofPi1,
+                  full::NSigTofKa1,
+                  full::CandidateSelFlag,
+                  full::M,
+                  full::Pt,
+                  full::Cpa,
+                  full::CpaXY,
+                  full::MaxNormalisedDeltaIP,
+                  full::ImpactParameterProduct,
+                  full::Eta,
+                  full::Phi,
+                  full::Y,
+                  full::FlagMc,
+                  full::OriginMcRec)
 
 DECLARE_SOA_TABLE(HfCand2ProngFull, "AOD", "HFCAND2PFull",
                   full::CollisionId,
@@ -156,6 +191,23 @@ struct HfTreeCreatorD0ToKPi {
   Produces<o2::aod::HfCand2ProngFull> rowCandidateFull;
   Produces<o2::aod::HfCand2ProngFullEvents> rowCandidateFullEvents;
   Produces<o2::aod::HfCand2ProngFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCand2PLite> rowCandidateLite;
+
+  Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};
+  // parameters for production of training samples
+  Configurable<bool> fillOnlySignal{"fillOnlySignal", false, "Flag to fill derived tables with signal for ML trainings"};
+  Configurable<bool> fillOnlyBackground{"fillOnlyBackground", false, "Flag to fill derived tables with background for ML trainings"};
+  Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
+  Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
+
+  using SelectedCandidatesMc = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec, aod::HfSelD0>>;
+  using MatchedGenCandidatesMc = soa::Filtered<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>;
+
+  Filter filterSelectCandidates = aod::hf_sel_candidate_d0::isSelD0 >= 1 || aod::hf_sel_candidate_d0::isSelD0bar >= 1;
+  Filter filterMcGenMatching = nabs(o2::aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(BIT(DecayType::D0ToPiK));
+
+  Partition<SelectedCandidatesMc> reconstructedCandSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(DecayType::D0ToPiK));
+  Partition<SelectedCandidatesMc> reconstructedCandBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(DecayType::D0ToPiK));
 
   void init(InitContext const&)
   {
@@ -175,10 +227,43 @@ struct HfTreeCreatorD0ToKPi {
   }
 
   template <typename T, typename U>
-  auto fillTable(const T& candidate, const U& prong0, const U& prong1, int candFlag, int selection, double invMass, double cosThetaStar,
+  auto fillTable(const T& candidate, const U& prong0, const U& prong1, int candFlag, double invMass, double cosThetaStar,
                  double ct, double y, double e, int8_t flagMc, int8_t origin)
   {
-    if (selection >= 1) {
+    if (fillCandidateLiteTable) {
+      rowCandidateLite(
+        candidate.chi2PCA(),
+        candidate.decayLength(),
+        candidate.decayLengthXY(),
+        candidate.decayLengthNormalised(),
+        candidate.decayLengthXYNormalised(),
+        candidate.ptProng0(),
+        candidate.ptProng1(),
+        candidate.impactParameterNormalised0(),
+        candidate.impactParameterNormalised1(),
+        candidate.impactParameter0(),
+        candidate.impactParameter1(),
+        prong0.tpcNSigmaPi(),
+        prong0.tpcNSigmaKa(),
+        prong0.tofNSigmaPi(),
+        prong0.tofNSigmaKa(),
+        prong1.tpcNSigmaPi(),
+        prong1.tpcNSigmaKa(),
+        prong1.tofNSigmaPi(),
+        prong1.tofNSigmaKa(),
+        1 << candFlag,
+        invMass,
+        candidate.pt(),
+        candidate.cpa(),
+        candidate.cpaXY(),
+        candidate.maxNormalisedDeltaIP(),
+        candidate.impactParameterProduct(),
+        candidate.eta(),
+        candidate.phi(),
+        y,
+        flagMc,
+        origin);
+    } else {
       rowCandidateFull(
         candidate.collisionId(),
         candidate.posX(),
@@ -239,7 +324,7 @@ struct HfTreeCreatorD0ToKPi {
   }
 
   void processData(aod::Collisions const& collisions,
-                   soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates,
+                   soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>> const& candidates,
                    aod::BigTracksPID const&, aod::BCs const&)
   {
     // Filling event properties
@@ -249,15 +334,29 @@ struct HfTreeCreatorD0ToKPi {
     }
 
     // Filling candidate properties
-    rowCandidateFull.reserve(candidates.size());
+    if (fillCandidateLiteTable) {
+      rowCandidateLite.reserve(candidates.size());
+    } else {
+      rowCandidateFull.reserve(candidates.size());
+    }
     for (auto const& candidate : candidates) {
+      if (downSampleBkgFactor < 1.) {
+        float pseudoRndm = candidate.ptProng0() * 1000. - (int64_t)(candidate.ptProng0() * 1000);
+        if (candidate.pt() < ptMaxForDownSample && pseudoRndm >= downSampleBkgFactor) {
+          continue;
+        }
+      }
       auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
       auto prong1 = candidate.prong1_as<aod::BigTracksPID>();
       double yD = yD0(candidate);
       double eD = eD0(candidate);
       double ctD = ctD0(candidate);
-      fillTable(candidate, prong0, prong1, 0, candidate.isSelD0(), invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, 0, 0);
-      fillTable(candidate, prong0, prong1, 1, candidate.isSelD0bar(), invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, 0, 0);
+      if (candidate.isSelD0()) {
+        fillTable(candidate, prong0, prong1, 0, invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, 0, 0);
+      }
+      if (candidate.isSelD0bar()) {
+        fillTable(candidate, prong0, prong1, 1, invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, 0, 0);
+      }
     }
   }
 
@@ -265,8 +364,8 @@ struct HfTreeCreatorD0ToKPi {
 
   void processMc(aod::Collisions const& collisions,
                  aod::McCollisions const&,
-                 soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec, aod::HfSelD0> const& candidates,
-                 soa::Join<aod::McParticles, aod::HfCand2ProngMcGen> const& particles,
+                 SelectedCandidatesMc const& candidates,
+                 MatchedGenCandidatesMc const& particles,
                  aod::BigTracksPID const&, aod::BCs const&)
   {
     // Filling event properties
@@ -276,15 +375,69 @@ struct HfTreeCreatorD0ToKPi {
     }
 
     // Filling candidate properties
-    rowCandidateFull.reserve(candidates.size());
-    for (auto const& candidate : candidates) {
-      auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
-      auto prong1 = candidate.prong0_as<aod::BigTracksPID>();
-      double yD = yD0(candidate);
-      double eD = eD0(candidate);
-      double ctD = ctD0(candidate);
-      fillTable(candidate, prong0, prong1, 0, candidate.isSelD0(), invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
-      fillTable(candidate, prong0, prong1, 1, candidate.isSelD0bar(), invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+    if (fillOnlySignal) {
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(reconstructedCandSig.size());
+      } else {
+        rowCandidateFull.reserve(reconstructedCandSig.size());
+      }
+      for (const auto& candidate : reconstructedCandSig) {
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong0_as<aod::BigTracksPID>();
+        double yD = yD0(candidate);
+        double eD = eD0(candidate);
+        double ctD = ctD0(candidate);
+        if (candidate.isSelD0()) {
+          fillTable(candidate, prong0, prong1, 0, invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+        if (candidate.isSelD0bar()) {
+          fillTable(candidate, prong0, prong1, 1, invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+      }
+    } else if (fillOnlyBackground) {
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(reconstructedCandBkg.size());
+      } else {
+        rowCandidateFull.reserve(reconstructedCandBkg.size());
+      }
+      for (const auto& candidate : reconstructedCandBkg) {
+        if (downSampleBkgFactor < 1.) {
+          float pseudoRndm = candidate.ptProng0() * 1000. - (int64_t)(candidate.ptProng0() * 1000);
+          if (candidate.pt() < ptMaxForDownSample && pseudoRndm >= downSampleBkgFactor) {
+            continue;
+          }
+        }
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong0_as<aod::BigTracksPID>();
+        double yD = yD0(candidate);
+        double eD = eD0(candidate);
+        double ctD = ctD0(candidate);
+        if (candidate.isSelD0()) {
+          fillTable(candidate, prong0, prong1, 0, invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+        if (candidate.isSelD0bar()) {
+          fillTable(candidate, prong0, prong1, 1, invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+      }
+    } else {
+      if (fillCandidateLiteTable) {
+        rowCandidateLite.reserve(candidates.size());
+      } else {
+        rowCandidateFull.reserve(candidates.size());
+      }
+      for (const auto& candidate : candidates) {
+        auto prong0 = candidate.prong0_as<aod::BigTracksPID>();
+        auto prong1 = candidate.prong0_as<aod::BigTracksPID>();
+        double yD = yD0(candidate);
+        double eD = eD0(candidate);
+        double ctD = ctD0(candidate);
+        if (candidate.isSelD0()) {
+          fillTable(candidate, prong0, prong1, 0, invMassD0ToPiK(candidate), cosThetaStarD0(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+        if (candidate.isSelD0bar()) {
+          fillTable(candidate, prong0, prong1, 1, invMassD0barToKPi(candidate), cosThetaStarD0bar(candidate), ctD, yD, eD, candidate.flagMcMatchRec(), candidate.originMcRec());
+        }
+      }
     }
 
     // Filling particle properties

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -75,7 +75,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCand2PLite, "AOD", "HFCAND2PLITE",
+DECLARE_SOA_TABLE(HfCandD0Lite, "AOD", "HFCANDD0LITE",
                   hf_cand::Chi2PCA,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -108,7 +108,7 @@ DECLARE_SOA_TABLE(HfCand2PLite, "AOD", "HFCAND2PLITE",
                   full::FlagMc,
                   full::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCand2ProngFull, "AOD", "HFCAND2PFull",
+DECLARE_SOA_TABLE(HfCandD0Full, "AOD", "HFCANDD0FULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -165,7 +165,7 @@ DECLARE_SOA_TABLE(HfCand2ProngFull, "AOD", "HFCAND2PFull",
                   full::OriginMcRec,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCand2ProngFullEvents, "AOD", "HFCAND2PFullE",
+DECLARE_SOA_TABLE(HfCandD0FullEv, "AOD", "HFCANDD0FULLEV",
                   full::CollisionId,
                   collision::NumContrib,
                   collision::PosX,
@@ -174,7 +174,7 @@ DECLARE_SOA_TABLE(HfCand2ProngFullEvents, "AOD", "HFCAND2PFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCand2ProngFullParticles, "AOD", "HFCAND2PFullP",
+DECLARE_SOA_TABLE(HfCandD0FullP, "AOD", "HFCANDD0FULLP",
                   full::CollisionId,
                   full::Pt,
                   full::Eta,
@@ -188,10 +188,10 @@ DECLARE_SOA_TABLE(HfCand2ProngFullParticles, "AOD", "HFCAND2PFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorD0ToKPi {
-  Produces<o2::aod::HfCand2ProngFull> rowCandidateFull;
-  Produces<o2::aod::HfCand2ProngFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCand2ProngFullParticles> rowCandidateFullParticles;
-  Produces<o2::aod::HfCand2PLite> rowCandidateLite;
+  Produces<o2::aod::HfCandD0Full> rowCandidateFull;
+  Produces<o2::aod::HfCandD0FullEv> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandD0FullP> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandD0Lite> rowCandidateLite;
 
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};
   // parameters for production of training samples

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -75,7 +75,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandD0Lite, "AOD", "HFCANDD0LITE",
+DECLARE_SOA_TABLE(HfCandD0Lites, "AOD", "HFCANDD0LITE",
                   hf_cand::Chi2PCA,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -108,7 +108,7 @@ DECLARE_SOA_TABLE(HfCandD0Lite, "AOD", "HFCANDD0LITE",
                   full::FlagMc,
                   full::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCandD0Full, "AOD", "HFCANDD0FULL",
+DECLARE_SOA_TABLE(HfCandD0Fulls, "AOD", "HFCANDD0FULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -150,6 +150,7 @@ DECLARE_SOA_TABLE(HfCandD0Full, "AOD", "HFCANDD0FULL",
                   full::NSigTofKa1,
                   full::CandidateSelFlag,
                   full::M,
+                  full::MaxNormalisedDeltaIP,
                   full::ImpactParameterProduct,
                   full::CosThetaStar,
                   full::Pt,
@@ -165,7 +166,7 @@ DECLARE_SOA_TABLE(HfCandD0Full, "AOD", "HFCANDD0FULL",
                   full::OriginMcRec,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCandD0FullEv, "AOD", "HFCANDD0FULLEV",
+DECLARE_SOA_TABLE(HfCandD0FullEvs, "AOD", "HFCANDD0FULLEV",
                   full::CollisionId,
                   collision::NumContrib,
                   collision::PosX,
@@ -174,7 +175,7 @@ DECLARE_SOA_TABLE(HfCandD0FullEv, "AOD", "HFCANDD0FULLEV",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandD0FullP, "AOD", "HFCANDD0FULLP",
+DECLARE_SOA_TABLE(HfCandD0FullPs, "AOD", "HFCANDD0FULLP",
                   full::CollisionId,
                   full::Pt,
                   full::Eta,
@@ -188,10 +189,10 @@ DECLARE_SOA_TABLE(HfCandD0FullP, "AOD", "HFCANDD0FULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorD0ToKPi {
-  Produces<o2::aod::HfCandD0Full> rowCandidateFull;
-  Produces<o2::aod::HfCandD0FullEv> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandD0FullP> rowCandidateFullParticles;
-  Produces<o2::aod::HfCandD0Lite> rowCandidateLite;
+  Produces<o2::aod::HfCandD0Fulls> rowCandidateFull;
+  Produces<o2::aod::HfCandD0FullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandD0FullPs> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandD0Lites> rowCandidateLite;
 
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};
   // parameters for production of training samples
@@ -306,6 +307,7 @@ struct HfTreeCreatorD0ToKPi {
         prong1.tofNSigmaKa(),
         1 << candFlag,
         invMass,
+        candidate.maxNormalisedDeltaIP(),
         candidate.impactParameterProduct(),
         cosThetaStar,
         candidate.pt(),

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int); //! Event rejection flag
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);         //! Run number
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCand3ProngLite, "AOD", "HFCAND3PLite",
+DECLARE_SOA_TABLE(HfCandDpLite, "AOD", "HFCANDDPLITE",
                   hf_cand::Chi2PCA,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -110,7 +110,7 @@ DECLARE_SOA_TABLE(HfCand3ProngLite, "AOD", "HFCAND3PLite",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
+DECLARE_SOA_TABLE(HfCandDpFull, "AOD", "HFCANDDPFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -178,7 +178,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
+DECLARE_SOA_TABLE(HfCandDpFullE, "AOD", "HFCANDDPFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -187,7 +187,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
+DECLARE_SOA_TABLE(HfCandDpFullP, "AOD", "HFCANDDPFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -199,10 +199,10 @@ DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorDplusToPiKPi {
-  Produces<o2::aod::HfCand3ProngFull> rowCandidateFull;
-  Produces<o2::aod::HfCand3ProngFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCand3ProngFullParticles> rowCandidateFullParticles;
-  Produces<o2::aod::HfCand3ProngLite> rowCandidateLite;
+  Produces<o2::aod::HfCandDpFull> rowCandidateFull;
+  Produces<o2::aod::HfCandDpFullE> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandDpFullP> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandDpLite> rowCandidateLite;
 
   Configurable<int> selectionFlagDplus{"selectionFlagDplus", 1, "Selection Flag for Dplus"};
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int); //! Event rejection flag
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);         //! Run number
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandDpLite, "AOD", "HFCANDDPLITE",
+DECLARE_SOA_TABLE(HfCandDpLites, "AOD", "HFCANDDPLITE",
                   hf_cand::Chi2PCA,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -110,7 +110,7 @@ DECLARE_SOA_TABLE(HfCandDpLite, "AOD", "HFCANDDPLITE",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCandDpFull, "AOD", "HFCANDDPFULL",
+DECLARE_SOA_TABLE(HfCandDpFulls, "AOD", "HFCANDDPFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -178,7 +178,7 @@ DECLARE_SOA_TABLE(HfCandDpFull, "AOD", "HFCANDDPFULL",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandDpFullE, "AOD", "HFCANDDPFULLE",
+DECLARE_SOA_TABLE(HfCandDpFullEvs, "AOD", "HFCANDDPFULLEV",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -187,7 +187,7 @@ DECLARE_SOA_TABLE(HfCandDpFullE, "AOD", "HFCANDDPFULLE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandDpFullP, "AOD", "HFCANDDPFULLP",
+DECLARE_SOA_TABLE(HfCandDpFullPs, "AOD", "HFCANDDPFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -199,10 +199,10 @@ DECLARE_SOA_TABLE(HfCandDpFullP, "AOD", "HFCANDDPFULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorDplusToPiKPi {
-  Produces<o2::aod::HfCandDpFull> rowCandidateFull;
-  Produces<o2::aod::HfCandDpFullE> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandDpFullP> rowCandidateFullParticles;
-  Produces<o2::aod::HfCandDpLite> rowCandidateLite;
+  Produces<o2::aod::HfCandDpFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandDpFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandDpFullPs> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandDpLites> rowCandidateLite;
 
   Configurable<int> selectionFlagDplus{"selectionFlagDplus", 1, "Selection Flag for Dplus"};
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -75,7 +75,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int); //! Event rejection flag
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);         //! Run number
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandDsLite, "AOD", "HFCANDDsLite",
+DECLARE_SOA_TABLE(HfCandDsLite, "AOD", "HFCANDDSLITE",
                   full::PtProng0,
                   full::PtProng1,
                   full::PtProng2,
@@ -115,7 +115,7 @@ DECLARE_SOA_TABLE(HfCandDsLite, "AOD", "HFCANDDsLite",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCandDsFull, "AOD", "HFCANDDsFull",
+DECLARE_SOA_TABLE(HfCandDsFull, "AOD", "HFCANDDSFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -178,7 +178,7 @@ DECLARE_SOA_TABLE(HfCandDsFull, "AOD", "HFCANDDsFull",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandDsFullEvents, "AOD", "HFCANDDsFullE",
+DECLARE_SOA_TABLE(HfCandDsFullE, "AOD", "HFCANDDSFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -187,7 +187,7 @@ DECLARE_SOA_TABLE(HfCandDsFullEvents, "AOD", "HFCANDDsFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandDsFullParticles, "AOD", "HFCANDDsFullP",
+DECLARE_SOA_TABLE(HfCandDsFullP, "AOD", "HFCANDDSFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -200,8 +200,8 @@ DECLARE_SOA_TABLE(HfCandDsFullParticles, "AOD", "HFCANDDsFullP",
 /// Writes the full information in an output TTree
 struct HfTreeCreatorDsToKKPi {
   Produces<o2::aod::HfCandDsFull> rowCandidateFull;
-  Produces<o2::aod::HfCandDsFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandDsFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandDsFullE> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandDsFullP> rowCandidateFullParticles;
   Produces<o2::aod::HfCandDsLite> rowCandidateLite;
 
   Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -75,7 +75,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int); //! Event rejection flag
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);         //! Run number
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandDsLite, "AOD", "HFCANDDSLITE",
+DECLARE_SOA_TABLE(HfCandDsLites, "AOD", "HFCANDDSLITE",
                   full::PtProng0,
                   full::PtProng1,
                   full::PtProng2,
@@ -115,7 +115,7 @@ DECLARE_SOA_TABLE(HfCandDsLite, "AOD", "HFCANDDSLITE",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec)
 
-DECLARE_SOA_TABLE(HfCandDsFull, "AOD", "HFCANDDSFULL",
+DECLARE_SOA_TABLE(HfCandDsFulls, "AOD", "HFCANDDSFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -178,7 +178,7 @@ DECLARE_SOA_TABLE(HfCandDsFull, "AOD", "HFCANDDSFULL",
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandDsFullE, "AOD", "HFCANDDSFULLE",
+DECLARE_SOA_TABLE(HfCandDsFullEvs, "AOD", "HFCANDDSFULLEV",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -187,7 +187,7 @@ DECLARE_SOA_TABLE(HfCandDsFullE, "AOD", "HFCANDDSFULLE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandDsFullP, "AOD", "HFCANDDSFULLP",
+DECLARE_SOA_TABLE(HfCandDsFullPs, "AOD", "HFCANDDSFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -199,10 +199,10 @@ DECLARE_SOA_TABLE(HfCandDsFullP, "AOD", "HFCANDDSFULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorDsToKKPi {
-  Produces<o2::aod::HfCandDsFull> rowCandidateFull;
-  Produces<o2::aod::HfCandDsFullE> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandDsFullP> rowCandidateFullParticles;
-  Produces<o2::aod::HfCandDsLite> rowCandidateLite;
+  Produces<o2::aod::HfCandDsFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandDsFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandDsFullPs> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandDsLites> rowCandidateLite;
 
   Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds->PhiPi->KKpi, 2 for Ds->K0*K->KKPi"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 1, "Selection flag for Ds"};

--- a/PWGHF/TableProducer/treeCreatorLbToLcPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLbToLcPi.cxx
@@ -94,7 +94,7 @@ DECLARE_SOA_COLUMN(NSigTOFTrk3Pr, nSigTOFrk3Pr, float);
 } // namespace full
 
 // put the arguments into the table
-DECLARE_SOA_TABLE(HfCandLbFull, "AOD", "HFCANDLbFull",
+DECLARE_SOA_TABLE(HfCandLbFulls, "AOD", "HFCANDLBFULL",
                   full::RSecondaryVertex,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -187,7 +187,7 @@ struct HfTreeCreatorLbToLcPiAlice3PidIndexBuilder {
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorLbToLcPi {
-  Produces<o2::aod::HfCandLbFull> rowCandidateFull;
+  Produces<o2::aod::HfCandLbFulls> rowCandidateFull;
 
   using TracksExtendedPID = soa::Join<aod::BigTracksPID, aod::HfTrackIndexALICE3PID>;
 

--- a/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFULL",
+DECLARE_SOA_TABLE(HfCandCascFulls, "AOD", "HFCANDCASCFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -144,14 +144,14 @@ DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFULL",
                   full::FlagMc,
                   full::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandCascFullE, "AOD", "HFCANDCASCFULLE",
+DECLARE_SOA_TABLE(HfCandCascFullEs, "AOD", "HFCANDCASCFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
                   collision::PosY,
                   collision::PosZ);
 
-DECLARE_SOA_TABLE(HfCandCascFullP, "AOD", "HFCANDCASCFULLP",
+DECLARE_SOA_TABLE(HfCandCascFullPs, "AOD", "HFCANDCASCFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -164,9 +164,9 @@ DECLARE_SOA_TABLE(HfCandCascFullP, "AOD", "HFCANDCASCFULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorLcToK0sP {
-  Produces<o2::aod::HfCandCascFull> rowCandidateFull;
-  Produces<o2::aod::HfCandCascFullE> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandCascFullP> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandCascFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandCascFullEs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandCascFullPs> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFull",
+DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFULL",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -144,14 +144,14 @@ DECLARE_SOA_TABLE(HfCandCascFull, "AOD", "HFCANDCASCFull",
                   full::FlagMc,
                   full::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandCascFullEvents, "AOD", "HFCANDCASCFullE",
+DECLARE_SOA_TABLE(HfCandCascFullE, "AOD", "HFCANDCASCFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
                   collision::PosY,
                   collision::PosZ);
 
-DECLARE_SOA_TABLE(HfCandCascFullParticles, "AOD", "HFCANDCASCFullP",
+DECLARE_SOA_TABLE(HfCandCascFullP, "AOD", "HFCANDCASCFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -165,8 +165,8 @@ DECLARE_SOA_TABLE(HfCandCascFullParticles, "AOD", "HFCANDCASCFullP",
 /// Writes the full information in an output TTree
 struct HfTreeCreatorLcToK0sP {
   Produces<o2::aod::HfCandCascFull> rowCandidateFull;
-  Produces<o2::aod::HfCandCascFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandCascFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandCascFullE> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandCascFullP> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -84,7 +84,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
+DECLARE_SOA_TABLE(HfCandLcFull, "AOD", "HFCANDLCFULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -158,7 +158,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
                   full::IsCandidateSwapped,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
+DECLARE_SOA_TABLE(HfCandLcFullE, "AOD", "HFCANDLCFULLE",
                   full::CollisionId,
                   collision::NumContrib,
                   collision::PosX,
@@ -167,7 +167,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
+DECLARE_SOA_TABLE(HfCandLcFullP, "AOD", "HFCANDLCFULLP",
                   full::CollisionId,
                   full::Pt,
                   full::Eta,
@@ -181,9 +181,9 @@ DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorLcToPKPi {
-  Produces<o2::aod::HfCand3ProngFull> rowCandidateFull;
-  Produces<o2::aod::HfCand3ProngFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCand3ProngFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandLcFull> rowCandidateFull;
+  Produces<o2::aod::HfCandLcFullE> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandLcFullP> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -84,7 +84,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandLcFull, "AOD", "HFCANDLCFULL",
+DECLARE_SOA_TABLE(HfCandLcFulls, "AOD", "HFCANDLCFULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -158,7 +158,7 @@ DECLARE_SOA_TABLE(HfCandLcFull, "AOD", "HFCANDLCFULL",
                   full::IsCandidateSwapped,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCandLcFullE, "AOD", "HFCANDLCFULLE",
+DECLARE_SOA_TABLE(HfCandLcFullEvs, "AOD", "HFCANDLCFULLEV",
                   full::CollisionId,
                   collision::NumContrib,
                   collision::PosX,
@@ -167,7 +167,7 @@ DECLARE_SOA_TABLE(HfCandLcFullE, "AOD", "HFCANDLCFULLE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandLcFullP, "AOD", "HFCANDLCFULLP",
+DECLARE_SOA_TABLE(HfCandLcFullPs, "AOD", "HFCANDLCFULLP",
                   full::CollisionId,
                   full::Pt,
                   full::Eta,
@@ -181,9 +181,9 @@ DECLARE_SOA_TABLE(HfCandLcFullP, "AOD", "HFCANDLCFULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorLcToPKPi {
-  Produces<o2::aod::HfCandLcFull> rowCandidateFull;
-  Produces<o2::aod::HfCandLcFullE> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandLcFullP> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandLcFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandLcFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandLcFullPs> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorToXiPi.cxx
@@ -137,7 +137,7 @@ DECLARE_SOA_COLUMN(TofNSigmaPrFromLambda, tofNSigmaPrFromLambda, float);
 
 } // namespace full
 
-DECLARE_SOA_TABLE(HfToXiPiFull, "AOD", "HFTOXIPIFULL",
+DECLARE_SOA_TABLE(HfToXiPiFulls, "AOD", "HFTOXIPIFULL",
                   full::CollisionId, full::XPv, full::YPv, full::ZPv, collision::NumContrib,
                   full::XDecayVtxOmegac, full::YDecayVtxOmegac, full::ZDecayVtxOmegac,
                   full::XDecayVtxCascade, full::YDecayVtxCascade, full::ZDecayVtxCascade,
@@ -169,7 +169,7 @@ DECLARE_SOA_TABLE(HfToXiPiFull, "AOD", "HFTOXIPIFULL",
                   full::TofNSigmaPiFromOmega, full::TofNSigmaPiFromCasc, full::TofNSigmaPiFromLambda, full::TofNSigmaPrFromLambda,
                   full::FlagMcMatchRec, full::DebugMcRec);
 
-DECLARE_SOA_TABLE(HfToXiPiEvents, "AOD", "HFTOXIPIEVENTS",
+DECLARE_SOA_TABLE(HfToXiPiEvents, "AOD", "HFTOXIPIEVENT",
                   collision::NumContrib,
                   collision::PosX,
                   collision::PosY,
@@ -179,7 +179,7 @@ DECLARE_SOA_TABLE(HfToXiPiEvents, "AOD", "HFTOXIPIEVENTS",
 /// Writes the full information in an output TTree
 struct HfTreeCreatorToXiPi {
 
-  Produces<o2::aod::HfToXiPiFull> rowCandidateFull;
+  Produces<o2::aod::HfToXiPiFulls> rowCandidateFull;
   Produces<o2::aod::HfToXiPiEvents> rowCandidateEvents;
 
   void init(InitContext const&)

--- a/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
@@ -83,7 +83,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
+DECLARE_SOA_TABLE(HfCandXicFull, "AOD", "HFCANDXICFULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -157,7 +157,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFull, "AOD", "HFCAND3PFull",
                   full::IsCandidateSwapped,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
+DECLARE_SOA_TABLE(HfCandXicFullE, "AOD", "HFCANDXICFULLE",
                   full::CollisionId,
                   collision::BCId,
                   collision::NumContrib,
@@ -167,7 +167,7 @@ DECLARE_SOA_TABLE(HfCand3ProngFullEvents, "AOD", "HFCAND3PFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
+DECLARE_SOA_TABLE(HfCandXicFullP, "AOD", "HFCANDXICFULLP",
                   full::CollisionId,
                   collision::BCId,
                   full::Pt,
@@ -182,9 +182,9 @@ DECLARE_SOA_TABLE(HfCand3ProngFullParticles, "AOD", "HFCAND3PFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorXicToPKPi {
-  Produces<o2::aod::HfCand3ProngFull> rowCandidateFull;
-  Produces<o2::aod::HfCand3ProngFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCand3ProngFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandXicFull> rowCandidateFull;
+  Produces<o2::aod::HfCandXicFullE> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandXicFullP> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
@@ -83,7 +83,7 @@ DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
-DECLARE_SOA_TABLE(HfCandXicFull, "AOD", "HFCANDXICFULL",
+DECLARE_SOA_TABLE(HfCandXicFulls, "AOD", "HFCANDXICFULL",
                   full::CollisionId,
                   collision::PosX,
                   collision::PosY,
@@ -157,7 +157,7 @@ DECLARE_SOA_TABLE(HfCandXicFull, "AOD", "HFCANDXICFULL",
                   full::IsCandidateSwapped,
                   full::CandidateId);
 
-DECLARE_SOA_TABLE(HfCandXicFullE, "AOD", "HFCANDXICFULLE",
+DECLARE_SOA_TABLE(HfCandXicFullEvs, "AOD", "HFCANDXICFULLEV",
                   full::CollisionId,
                   collision::BCId,
                   collision::NumContrib,
@@ -167,7 +167,7 @@ DECLARE_SOA_TABLE(HfCandXicFullE, "AOD", "HFCANDXICFULLE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandXicFullP, "AOD", "HFCANDXICFULLP",
+DECLARE_SOA_TABLE(HfCandXicFullPs, "AOD", "HFCANDXICFULLP",
                   full::CollisionId,
                   collision::BCId,
                   full::Pt,
@@ -182,9 +182,9 @@ DECLARE_SOA_TABLE(HfCandXicFullP, "AOD", "HFCANDXICFULLP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorXicToPKPi {
-  Produces<o2::aod::HfCandXicFull> rowCandidateFull;
-  Produces<o2::aod::HfCandXicFullE> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandXicFullP> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandXicFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandXicFullEvs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandXicFullPs> rowCandidateFullParticles;
 
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
 

--- a/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
@@ -82,7 +82,7 @@ DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
 } // namespace full
 
 // put the arguments into the table
-DECLARE_SOA_TABLE(HfCandXiccFull, "AOD", "HFCANDXiccFull",
+DECLARE_SOA_TABLE(HfCandXiccFulls, "AOD", "HFCANDXICCFULL",
                   full::RSecondaryVertex,
                   full::DecayLength,
                   full::DecayLengthXY,
@@ -136,7 +136,7 @@ DECLARE_SOA_TABLE(HfCandXiccFull, "AOD", "HFCANDXiccFull",
                   full::MCflag,
                   full::OriginMcRec);
 
-DECLARE_SOA_TABLE(HfCandXiccFullEvents, "AOD", "HFCANDXiccFullE",
+DECLARE_SOA_TABLE(HfCandXiccFullEs, "AOD", "HFCANDXICCFULLE",
                   collision::BCId,
                   collision::NumContrib,
                   collision::PosX,
@@ -145,7 +145,7 @@ DECLARE_SOA_TABLE(HfCandXiccFullEvents, "AOD", "HFCANDXiccFullE",
                   full::IsEventReject,
                   full::RunNumber);
 
-DECLARE_SOA_TABLE(HfCandXiccFullParticles, "AOD", "HFCANDXiccFullP",
+DECLARE_SOA_TABLE(HfCandXiccFullPs, "AOD", "HFCANDXICCFULLP",
                   collision::BCId,
                   full::Pt,
                   full::Eta,
@@ -158,9 +158,9 @@ DECLARE_SOA_TABLE(HfCandXiccFullParticles, "AOD", "HFCANDXiccFullP",
 
 /// Writes the full information in an output TTree
 struct HfTreeCreatorXiccToPKPiPi {
-  Produces<o2::aod::HfCandXiccFull> rowCandidateFull;
-  Produces<o2::aod::HfCandXiccFullEvents> rowCandidateFullEvents;
-  Produces<o2::aod::HfCandXiccFullParticles> rowCandidateFullParticles;
+  Produces<o2::aod::HfCandXiccFulls> rowCandidateFull;
+  Produces<o2::aod::HfCandXiccFullEs> rowCandidateFullEvents;
+  Produces<o2::aod::HfCandXiccFullPs> rowCandidateFullParticles;
 
   void init(InitContext const&)
   {


### PR DESCRIPTION
This PR includes:
- improvements in the D0 tree creator including the possibility to store a "lite" tree for ML trainings (similar to the D+ one)
- fix of tree creator table names (the previous ones should not work with the AOD merger)