### PR TITLE
Core: modify maximum bc offset for tracks to be considered in time-based reassociation

### DIFF
--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -151,7 +151,7 @@ class CollisionAssociation
 
     // loop over collisions to find time-compatible tracks
     auto trackBegin = tracks.begin();
-    auto bOffsetMax = mBcWindowForOneSigma * mNumSigmaForTimeCompat + mTimeMargin / constants::lhc::LHCBunchSpacingNS;
+    auto bOffsetMax = mBcWindowForOneSigma * mNumSigmaForTimeCompat + mTimeMargin / o2::constants::lhc::LHCBunchSpacingNS;
     for (const auto& collision : collisions) {
       const float collTime = collision.collisionTime();
       const float collTimeRes2 = collision.collisionTimeRes() * collision.collisionTimeRes();
@@ -163,7 +163,7 @@ class CollisionAssociation
         }
 
         float trackTime = track.trackTime();
-        const int64_t bcOffsetWindow = (int64_t)globalBC[track.filteredIndex()] + trackTime / constants::lhc::LHCBunchSpacingNS - (int64_t)collBC;
+        const int64_t bcOffsetWindow = (int64_t)globalBC[track.filteredIndex()] + trackTime / o2::constants::lhc::LHCBunchSpacingNS - (int64_t)collBC;
         if (std::abs(bcOffsetWindow) > bOffsetMax) {
           continue;
         }
@@ -235,13 +235,13 @@ class CollisionAssociation
   }
 
  private:
-  float mNumSigmaForTimeCompat{4.};                                         // number of sigma for time compatibility
-  float mTimeMargin{500.};                                                  // additional time margin in ns
-  int mTrackSelection{track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
-  bool mUsePvAssociation{true};                                             // use the information of PV contributors
-  bool mIncludeUnassigned{true};                                            // include tracks that were originally not assigned to any collision
-  bool mFillTableOfCollIdsPerTrack{false};                                  // fill additional table with vectors of compatible collisions per track
-  int mBcWindowForOneSigma{115};                                            // BC window to be multiplied by the number of sigmas to define maximum window to be considered 
+  float mNumSigmaForTimeCompat{4.};                                                  // number of sigma for time compatibility
+  float mTimeMargin{500.};                                                           // additional time margin in ns
+  int mTrackSelection{o2::aod::track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
+  bool mUsePvAssociation{true};                                                      // use the information of PV contributors
+  bool mIncludeUnassigned{true};                                                     // include tracks that were originally not assigned to any collision
+  bool mFillTableOfCollIdsPerTrack{false};                                           // fill additional table with vectors of compatible collisions per track
+  int mBcWindowForOneSigma{115};                                                     // BC window to be multiplied by the number of sigmas to define maximum window to be considered 
 };
 
 #endif // COMMON_CORE_COLLISIONASSOCIATION_H_

--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -55,6 +55,7 @@ class CollisionAssociation
   void setUsePvAssociation(bool enable = true) { mUsePvAssociation = enable; }
   void setIncludeUnassigned(bool enable = true) { mIncludeUnassigned = enable; }
   void setFillTableOfCollIdsPerTrack(bool fill = true) { mFillTableOfCollIdsPerTrack = fill; }
+  void setBcWindow(int bcWindow = 115) { mBcWindowForOneSigma = bcWindow; }
 
   template <typename TTracks, typename Slice, typename Assoc, typename RevIndices>
   void runStandardAssoc(o2::aod::Collisions const& collisions,
@@ -150,7 +151,7 @@ class CollisionAssociation
 
     // loop over collisions to find time-compatible tracks
     auto trackBegin = tracks.begin();
-    constexpr auto bOffsetMax = 241; // 6 mus (ITS)
+    auto bOffsetMax = mBcWindowForOneSigma * mNumSigmaForTimeCompat + mTimeMargin / constants::lhc::LHCBunchSpacingNS;
     for (const auto& collision : collisions) {
       const float collTime = collision.collisionTime();
       const float collTimeRes2 = collision.collisionTimeRes() * collision.collisionTimeRes();
@@ -160,12 +161,13 @@ class CollisionAssociation
         if (!mIncludeUnassigned && !track.has_collision()) {
           continue;
         }
-        const int64_t bcOffset = (int64_t)globalBC[track.filteredIndex()] - (int64_t)collBC;
-        if (std::abs(bcOffset) > bOffsetMax) {
+
+        float trackTime = track.trackTime();
+        const int64_t bcOffsetWindow = (int64_t)globalBC[track.filteredIndex()] + trackTime / constants::lhc::LHCBunchSpacingNS - (int64_t)collBC;
+        if (std::abs(bcOffsetWindow) > bOffsetMax) {
           continue;
         }
 
-        float trackTime = track.trackTime();
         float trackTimeRes = track.trackTimeRes();
         if constexpr (isCentralBarrel) {
           if (mUsePvAssociation && track.isPVContributor()) {
@@ -174,6 +176,7 @@ class CollisionAssociation
           }
         }
 
+        const int64_t bcOffset = (int64_t)globalBC[track.filteredIndex()] - (int64_t)collBC;
         const float deltaTime = trackTime - collTime + bcOffset * o2::constants::lhc::LHCBunchSpacingNS;
         float sigmaTimeRes2 = collTimeRes2 + trackTimeRes * trackTimeRes;
         LOGP(debug, "collision time={}, collision time res={}, track time={}, track time res={}, bc collision={}, bc track={}, delta time={}", collTime, collision.collisionTimeRes(), track.trackTime(), track.trackTimeRes(), collBC, globalBC[track.filteredIndex()], deltaTime);
@@ -232,12 +235,22 @@ class CollisionAssociation
   }
 
  private:
+<<<<<<< HEAD
   float mNumSigmaForTimeCompat{4.};                                                  // number of sigma for time compatibility
   float mTimeMargin{500.};                                                           // additional time margin in ns
   int mTrackSelection{o2::aod::track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
   bool mUsePvAssociation{true};                                                      // use the information of PV contributors
   bool mIncludeUnassigned{true};                                                     // include tracks that were originally not assigned to any collision
   bool mFillTableOfCollIdsPerTrack{false};                                           // fill additional table with vectors of compatible collisions per track
+=======
+  float mNumSigmaForTimeCompat{4.};                                         // number of sigma for time compatibility
+  float mTimeMargin{500.};                                                  // additional time margin in ns
+  int mTrackSelection{track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
+  bool mUsePvAssociation{true};                                             // use the information of PV contributors
+  bool mIncludeUnassigned{true};                                            // include tracks that were originally not assigned to any collision
+  bool mFillTableOfCollIdsPerTrack{false};                                  // fill additional table with vectors of compatible collisions per track
+  int mBcWindowForOneSigma{115};                                            // BC window to be multiplied by the number of sigmas to define maximum window to be considered 
+>>>>>>> Modify maximum bc offset for tracks to be considered in time-based reassociation
 };
 
 #endif // COMMON_CORE_COLLISIONASSOCIATION_H_

--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -235,14 +235,6 @@ class CollisionAssociation
   }
 
  private:
-<<<<<<< HEAD
-  float mNumSigmaForTimeCompat{4.};                                                  // number of sigma for time compatibility
-  float mTimeMargin{500.};                                                           // additional time margin in ns
-  int mTrackSelection{o2::aod::track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
-  bool mUsePvAssociation{true};                                                      // use the information of PV contributors
-  bool mIncludeUnassigned{true};                                                     // include tracks that were originally not assigned to any collision
-  bool mFillTableOfCollIdsPerTrack{false};                                           // fill additional table with vectors of compatible collisions per track
-=======
   float mNumSigmaForTimeCompat{4.};                                         // number of sigma for time compatibility
   float mTimeMargin{500.};                                                  // additional time margin in ns
   int mTrackSelection{track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
@@ -250,7 +242,6 @@ class CollisionAssociation
   bool mIncludeUnassigned{true};                                            // include tracks that were originally not assigned to any collision
   bool mFillTableOfCollIdsPerTrack{false};                                  // fill additional table with vectors of compatible collisions per track
   int mBcWindowForOneSigma{115};                                            // BC window to be multiplied by the number of sigmas to define maximum window to be considered 
->>>>>>> Modify maximum bc offset for tracks to be considered in time-based reassociation
 };
 
 #endif // COMMON_CORE_COLLISIONASSOCIATION_H_

--- a/Common/TableProducer/fwdtrackToCollisionAssociator.cxx
+++ b/Common/TableProducer/fwdtrackToCollisionAssociator.cxx
@@ -37,6 +37,7 @@ struct FwdTrackToCollisionAssociation {
   Configurable<float> timeMargin{"timeMargin", 0.f, "time margin in ns added to uncertainty because of uncalibrated TPC"};
   Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
   Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
+  Configurable<int> bcWindowForOneSigma{"bcWindowForOneSigma", 115, "BC window to be multiplied by the number of sigmas to define maximum window to be considered"};
 
   CollisionAssociation<false> collisionAssociator;
 

--- a/Common/TableProducer/trackToCollisionAssociator.cxx
+++ b/Common/TableProducer/trackToCollisionAssociator.cxx
@@ -38,6 +38,7 @@ struct TrackToCollisionAssociation {
   Configurable<bool> usePVAssociation{"usePVAssociation", true, "if the track is a PV contributor, use the collision time for it"};
   Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
   Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
+  Configurable<int> bcWindowForOneSigma{"bcWindowForOneSigma", 60, "BC window to be multiplied by the number of sigmas to define maximum window to be considered"};
 
   CollisionAssociation<true> collisionAssociator;
 
@@ -61,6 +62,7 @@ struct TrackToCollisionAssociation {
     collisionAssociator.setUsePvAssociation(usePVAssociation);
     collisionAssociator.setIncludeUnassigned(includeUnassigned);
     collisionAssociator.setFillTableOfCollIdsPerTrack(fillTableOfCollIdsPerTrack);
+    collisionAssociator.setBcWindow(bcWindowForOneSigma);
   }
 
   void processAssocWithTime(Collisions const& collisions, TracksWithSel const& tracksUnfiltered, TracksWithSelFilter const& tracks, AmbiguousTracks const& ambiguousTracks, BCs const& bcs)


### PR DESCRIPTION
@sarahherrmann this PR should fix the issue that you spotted with the BC window for MFT tracks. I set the default to `115` for the forward track associator, while at `60` for the central barrel (considering that `60 * 4` gives what we had before).
Please check if it looks good to you. Thanks!