### PR TITLE
add KF particle cascade builder path

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -48,7 +48,7 @@ DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative pron
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
 
-// Saved from KF particle fit for specic table 
+// Saved from KF particle fit for specic table
 DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
 
 // Derived expressions
@@ -298,9 +298,9 @@ DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
 
 namespace kfcascdata
 {
-  // declare in different namespace to 'overload' operator
-  DECLARE_SOA_COLUMN(MLambda, mLambda, float); //!
-}
+// declare in different namespace to 'overload' operator
+DECLARE_SOA_COLUMN(MLambda, mLambda, float); //!
+} // namespace kfcascdata
 
 namespace cascdata
 {
@@ -345,18 +345,18 @@ DECLARE_SOA_COLUMN(DCAZCascToPV, dcaZCascToPV, float);         //!
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
-DECLARE_SOA_COLUMN(KFTrackMat, kfTrackCovMat, float[15]); //! covariance matrix elements for KF method
+DECLARE_SOA_COLUMN(KFTrackMat, kfTrackCovMat, float[15]);     //! covariance matrix elements for KF method
 
 // Selection to avoid spurious invariant mass correlation
 // bachelor-baryon cosine of pointing angle / DCA to PV
 DECLARE_SOA_COLUMN(BachBaryonCosPA, bachBaryonCosPA, float);         //! avoid bach-baryon correlated inv mass structure in analysis
 DECLARE_SOA_COLUMN(BachBaryonDCAxyToPV, bachBaryonDCAxyToPV, float); //! avoid bach-baryon correlated inv mass structure in analysis
 
-// Saved from KF particle fit for specic table 
+// Saved from KF particle fit for specic table
 // note: separate chi2 is a consequence of fit -> conversion -> propagation -> fit logic
 //       which, in turn, is necessary to do material corrections at the moment
 //       this could be improved in the future!
-DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
+DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float);           //!
 DECLARE_SOA_COLUMN(KFCascadeChi2, kfCascadeChi2, float); //!
 
 // Saved from strangeness tracking
@@ -460,7 +460,7 @@ DECLARE_SOA_TABLE(StoredKFCascDatas, "AOD", "KFCASCDATA", //!
                   cascdata::BachBaryonCosPA, cascdata::BachBaryonDCAxyToPV,
 
                   // KF particle fit specific
-                  kfcascdata::MLambda, cascdata::KFV0Chi2, cascdata::KFCascadeChi2, 
+                  kfcascdata::MLambda, cascdata::KFV0Chi2, cascdata::KFCascadeChi2,
 
                   // Dynamic columns
                   cascdata::Pt<cascdata::Px, cascdata::Py>,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -48,6 +48,9 @@ DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative pron
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
 
+// Saved from KF particle fit for specic table 
+DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
+
 // Derived expressions
 // Momenta
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! V0 pT
@@ -293,6 +296,12 @@ DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
                   v0tag::IsFromCascade,
                   v0tag::IsFromTrackedCascade);
 
+namespace kfcascdata
+{
+  // declare in different namespace to 'overload' operator
+  DECLARE_SOA_COLUMN(MLambda, mLambda, float); //!
+}
+
 namespace cascdata
 {
 // Necessary for full filtering functionality
@@ -336,11 +345,19 @@ DECLARE_SOA_COLUMN(DCAZCascToPV, dcaZCascToPV, float);         //!
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
+DECLARE_SOA_COLUMN(KFTrackMat, kfTrackCovMat, float[15]); //! covariance matrix elements for KF method
 
 // Selection to avoid spurious invariant mass correlation
 // bachelor-baryon cosine of pointing angle / DCA to PV
 DECLARE_SOA_COLUMN(BachBaryonCosPA, bachBaryonCosPA, float);         //! avoid bach-baryon correlated inv mass structure in analysis
 DECLARE_SOA_COLUMN(BachBaryonDCAxyToPV, bachBaryonDCAxyToPV, float); //! avoid bach-baryon correlated inv mass structure in analysis
+
+// Saved from KF particle fit for specic table 
+// note: separate chi2 is a consequence of fit -> conversion -> propagation -> fit logic
+//       which, in turn, is necessary to do material corrections at the moment
+//       this could be improved in the future!
+DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
+DECLARE_SOA_COLUMN(KFCascadeChi2, kfCascadeChi2, float); //!
 
 // Saved from strangeness tracking
 DECLARE_SOA_COLUMN(MatchingChi2, matchingChi2, float); //!
@@ -429,6 +446,39 @@ DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
                   cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
                   cascdata::Phi<cascdata::Px, cascdata::Py>);
 
+DECLARE_SOA_TABLE(StoredKFCascDatas, "AOD", "KFCASCDATA", //!
+                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId,
+                  cascdata::Sign, cascdata::MXi, cascdata::MOmega,
+                  cascdata::X, cascdata::Y, cascdata::Z,
+                  cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda,
+                  cascdata::PxPos, cascdata::PyPos, cascdata::PzPos,
+                  cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg,
+                  cascdata::PxBach, cascdata::PyBach, cascdata::PzBach,
+                  cascdata::Px, cascdata::Py, cascdata::Pz,
+                  cascdata::DCAV0Daughters, cascdata::DCACascDaughters,
+                  cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV, cascdata::DCAXYCascToPV, cascdata::DCAZCascToPV,
+                  cascdata::BachBaryonCosPA, cascdata::BachBaryonDCAxyToPV,
+
+                  // KF particle fit specific
+                  kfcascdata::MLambda, cascdata::KFV0Chi2, cascdata::KFCascadeChi2, 
+
+                  // Dynamic columns
+                  cascdata::Pt<cascdata::Px, cascdata::Py>,
+                  cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
+                  cascdata::CascRadius<cascdata::X, cascdata::Y>,
+                  cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
+                  cascdata::CascCosPA<cascdata::X, cascdata::Y, cascdata::Z, cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::DCAV0ToPV<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
+
+                  // Invariant masses
+                  cascdata::M<cascdata::MXi, cascdata::MOmega>,
+
+                  // Longitudinal
+                  cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
+                  cascdata::Phi<cascdata::Px, cascdata::Py>);
+
 DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
                   o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::StrangeTrackId, cascdata::CollisionId,
                   cascdata::Sign, cascdata::MXi, cascdata::MOmega,
@@ -441,6 +491,8 @@ DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
                   cascdata::DCAV0Daughters, cascdata::DCACascDaughters,
                   cascdata::DCAPosToPV, cascdata::DCANegToPV, cascdata::DCABachToPV, cascdata::DCAXYCascToPV, cascdata::DCAZCascToPV,
                   cascdata::BachBaryonCosPA, cascdata::BachBaryonDCAxyToPV,
+
+                  // Strangeness tracking specific
                   cascdata::MatchingChi2, cascdata::TopologyChi2, cascdata::ItsClsSize,
 
                   // Dynamic columns
@@ -463,14 +515,23 @@ DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
 DECLARE_SOA_TABLE_FULL(CascCovs, "CascCovs", "AOD", "CASCCOVS", //!
                        cascdata::PositionCovMat, cascdata::MomentumCovMat);
 
+DECLARE_SOA_TABLE_FULL(KFCascCovs, "KFCascCovs", "AOD", "KFCASCCOVS", //!
+                       cascdata::KFTrackMat);
+
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(CascDatas, StoredCascDatas, "CascDATAEXT", //!
                                 cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(KFCascDatas, StoredKFCascDatas, "KFCascDATAEXT", //!
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(TraCascDatas, StoredTraCascDatas, "TraCascDATAEXT", //!
                                 cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
 
 using CascData = CascDatas::iterator;
+using KFCascData = KFCascDatas::iterator;
 using TraCascData = TraCascDatas::iterator;
 
 // For compatibility with previous table declarations
@@ -480,13 +541,18 @@ using CascDataExt = CascDatas;
 namespace cascdata
 {
 DECLARE_SOA_INDEX_COLUMN(CascData, cascData); //! Index to CascData entry
+DECLARE_SOA_INDEX_COLUMN(KFCascData, kfCascData); //! Index to CascData entry
 }
 
 DECLARE_SOA_TABLE(CascDataLink, "AOD", "CASCDATALINK", //! Joinable table with Cascades which links to CascData which is not produced for all entries
                   cascdata::CascDataId);
+DECLARE_SOA_TABLE(KFCascDataLink, "AOD", "KFCASCDATALINK", //! Joinable table with Cascades which links to CascData which is not produced for all entries
+                  cascdata::KFCascDataId);
 
 using CascadesLinked = soa::Join<Cascades, CascDataLink>;
 using CascadeLinked = CascadesLinked::iterator;
+using KFCascadesLinked = soa::Join<Cascades, KFCascDataLink>;
+using KFCascadeLinked = KFCascadesLinked::iterator;
 
 namespace casctag
 {

--- a/PWGLF/TableProducer/CMakeLists.txt
+++ b/PWGLF/TableProducer/CMakeLists.txt
@@ -43,7 +43,7 @@ o2physics_add_dpl_workflow(lambdakzerotofpid
 
 o2physics_add_dpl_workflow(cascadebuilder
                     SOURCES cascadebuilder.cxx
-                    PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::DCAFitter O2Physics::AnalysisCore KFParticle::KFParticle
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(cascadelabelbuilder

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -161,7 +161,7 @@ struct cascadeBuilder {
   Configurable<float> dQAXiMassWindow{"dQAXiMassWindow", 0.005, "Xi mass window for ITS cluster map QA"};
   Configurable<float> dQAOmegaMassWindow{"dQAOmegaMassWindow", 0.005, "Omega mass window for ITS cluster map QA"};
 
-  // for KF particle operation 
+  // for KF particle operation
   Configurable<bool> kfTuneForOmega{"kfTuneForOmega", false, "if enabled, take main cascade properties from Omega fit instead of Xi fit (= default)"};
   Configurable<int> kfConstructMethod{"kfConstructMethod", 2, "KF Construct Method"};
   Configurable<bool> kfUseV0MassConstraint{"kfUseV0MassConstraint", true, "KF: use Lambda mass constraint"};
@@ -289,7 +289,7 @@ struct cascadeBuilder {
   void init(InitContext& context)
   {
     resetHistos();
-    registry.add("hKFParticleStatistics", "hKFParticleStatistics", kTH1F, {{10,-0.5f,9.5f}});
+    registry.add("hKFParticleStatistics", "hKFParticleStatistics", kTH1F, {{10, -0.5f, 9.5f}});
 
     // Optionally, add extra QA histograms to processing chain
     if (d_doQA) {
@@ -621,7 +621,7 @@ struct cascadeBuilder {
   // FIXME: could be an utility somewhere else
   // from Carolina Reetz (thank you!)
   template <typename T>
-  KFParticle createKFParticleFromTrackParCov(const o2::track::TrackParametrizationWithError<T>& trackparCov, int charge, float mass) 
+  KFParticle createKFParticleFromTrackParCov(const o2::track::TrackParametrizationWithError<T>& trackparCov, int charge, float mass)
   {
     std::array<T, 3> xyz, pxpypz;
     float xyzpxpypz[6];
@@ -643,7 +643,7 @@ struct cascadeBuilder {
     float Mini, SigmaMini, M, SigmaM;
     kfPart.GetMass(Mini, SigmaMini);
     LOG(debug) << "Daughter KFParticle mass before creation: " << Mini << " +- " << SigmaMini;
-    
+
     try {
       kfPart.Create(xyzpxpypz, cv.data(), charge, mass);
     } catch (std::runtime_error& e) {
@@ -670,9 +670,9 @@ struct cascadeBuilder {
     pxpypz[0] = kfParticle.GetPx();
     pxpypz[1] = kfParticle.GetPy();
     pxpypz[2] = kfParticle.GetPz();
-    
+
     // set covariance matrix elements (lower triangle)
-    for (int i =0; i < 21; i++) {
+    for (int i = 0; i < 21; i++) {
       cv[i] = kfParticle.GetCovariance(i);
     }
 
@@ -947,8 +947,8 @@ struct cascadeBuilder {
   {
     registry.fill(HIST("hKFParticleStatistics"), 0.0f);
     //*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*
-    // KF particle based rebuilding 
-    // dispenses prior V0 generation, uses constrained (re-)fit based on bachelor charge 
+    // KF particle based rebuilding
+    // dispenses prior V0 generation, uses constrained (re-)fit based on bachelor charge
     //*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*
 
     // Track casting
@@ -997,18 +997,18 @@ struct cascadeBuilder {
     o2::track::TrackParCov posTrackParCov = getTrackParCov(posTrack);
 
     float massPosTrack, massNegTrack;
-    if (cascadecandidate.charge < 0) { 
+    if (cascadecandidate.charge < 0) {
       massPosTrack = o2::constants::physics::MassProton;
       massNegTrack = o2::constants::physics::MassPionCharged;
-    }  else { 
+    } else {
       massPosTrack = o2::constants::physics::MassPionCharged;
       massNegTrack = o2::constants::physics::MassProton;
     }
 
     //__________________________________________
     //*>~<* step 1 : V0 with dca fitter, uses material corrections implicitly
-    // This is optional - move close to minima and therefore take material 
-    if(kfDoDCAFitterPreMinim){
+    // This is optional - move close to minima and therefore take material
+    if (kfDoDCAFitterPreMinim) {
       int nCand = 0;
       try {
         nCand = fitter.process(posTrackParCov, negTrackParCov);
@@ -1019,7 +1019,7 @@ struct cascadeBuilder {
       if (nCand == 0) {
         return false;
       }
-      // save classical DCA daughters 
+      // save classical DCA daughters
       cascadecandidate.v0dcadau = TMath::Sqrt(fitter.getChi2AtPCACandidate());
 
       // re-acquire from DCA fitter
@@ -1054,7 +1054,7 @@ struct cascadeBuilder {
 
     //__________________________________________
     //*>~<* step 3 : Cascade with dca fitter (with material corrections)
-    if(kfDoDCAFitterPreMinim){
+    if (kfDoDCAFitterPreMinim) {
       int nCandCascade = 0;
       try {
         nCandCascade = fitter.process(v0TrackParCov, lBachelorTrack);
@@ -1065,7 +1065,7 @@ struct cascadeBuilder {
       if (nCandCascade == 0)
         return false;
 
-      // save classical DCA daughters 
+      // save classical DCA daughters
       cascadecandidate.dcacascdau = TMath::Sqrt(fitter.getChi2AtPCACandidate());
 
       v0TrackParCov = fitter.getTrack(0);
@@ -1075,7 +1075,7 @@ struct cascadeBuilder {
     //__________________________________________
     //*>~<* step 4 : Cascade with KF particle (potentially mass-constrained if asked)
     float massBachelorPion = o2::constants::physics::MassPionCharged;
-    float massBachelorKaon = o2::constants::physics::MassKaonCharged;      
+    float massBachelorKaon = o2::constants::physics::MassKaonCharged;
 
     KFParticle kfpV0 = createKFParticleFromTrackParCov(v0TrackParCov, 0, o2::constants::physics::MassLambda);
     KFParticle kfpBachPion = createKFParticleFromTrackParCov(lBachelorTrack, cascadecandidate.charge, massBachelorPion);
@@ -1110,9 +1110,9 @@ struct cascadeBuilder {
 
     //__________________________________________
     //*>~<* step 5 : propagate cascade to primary vertex with material corrections if asked
-    if(!kfTuneForOmega){
+    if (!kfTuneForOmega) {
       lCascadeTrack = getTrackParCovFromKFP(KFXi, o2::track::PID::XiMinus, cascadecandidate.charge);
-    }else{
+    } else {
       lCascadeTrack = getTrackParCovFromKFP(KFOmega, o2::track::PID::OmegaMinus, cascadecandidate.charge);
     }
     dcaInfo[0] = 999;
@@ -1124,14 +1124,14 @@ struct cascadeBuilder {
     //__________________________________________
     //*>~<* step 6 : acquire all parameters for analysis
 
-    // basic indices 
+    // basic indices
     cascadecandidate.v0Id = v0.globalIndex();
     cascadecandidate.bachelorId = bachTrack.globalIndex();
 
-    // KF chi2 
+    // KF chi2
     cascadecandidate.kfV0Chi2 = KFV0.GetChi2();
     cascadecandidate.kfCascadeChi2 = KFXi.GetChi2();
-    if(kfTuneForOmega)
+    if (kfTuneForOmega)
       cascadecandidate.kfCascadeChi2 = KFOmega.GetChi2();
 
     // Daughter momentum not KF-updated FIXME
@@ -1144,15 +1144,15 @@ struct cascadeBuilder {
     cascadecandidate.v0pos[1] = KFV0.GetY();
     cascadecandidate.v0pos[2] = KFV0.GetZ();
 
-    // Mother position + momentum is KF updated 
-    if(!kfTuneForOmega){
+    // Mother position + momentum is KF updated
+    if (!kfTuneForOmega) {
       cascadecandidate.pos[0] = KFXi.GetX();
       cascadecandidate.pos[1] = KFXi.GetY();
       cascadecandidate.pos[2] = KFXi.GetZ();
       cascadecandidate.cascademom[0] = KFXi.GetPx();
       cascadecandidate.cascademom[1] = KFXi.GetPy();
       cascadecandidate.cascademom[2] = KFXi.GetPz();
-    }else{
+    } else {
       cascadecandidate.pos[0] = KFOmega.GetX();
       cascadecandidate.pos[1] = KFOmega.GetY();
       cascadecandidate.pos[2] = KFOmega.GetZ();
@@ -1176,7 +1176,7 @@ struct cascadeBuilder {
       return false;
 
     // Calculate masses a priori
-    cascadecandidate.kfMLambda = KFV0.GetMass(); 
+    cascadecandidate.kfMLambda = KFV0.GetMass();
     cascadecandidate.mXi = KFXi.GetMass();
     cascadecandidate.mOmega = KFOmega.GetMass();
     cascadecandidate.yXi = KFXi.GetRapidity();
@@ -1184,7 +1184,6 @@ struct cascadeBuilder {
     registry.fill(HIST("hKFParticleStatistics"), 1.0f);
     return true;
   }
-
 
   template <class TTrackTo, typename TCascTable>
   void buildStrangenessTables(TCascTable const& cascades)
@@ -1254,35 +1253,34 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
       registry.fill(HIST("hKFParticleStatistics"), 2.0f);
       kfcascdata(cascadecandidate.v0Id,
-               cascade.globalIndex(),
-               cascadecandidate.bachelorId,
-               cascade.collisionId(),
-               cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
-               cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
-               cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
-               cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
-               cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
-               cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
-               cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
-               cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
-               cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
-               cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
-               cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
-               cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz,
-               cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV, 
-               cascadecandidate.kfMLambda, cascadecandidate.kfV0Chi2, cascadecandidate.kfCascadeChi2);
+                 cascade.globalIndex(),
+                 cascadecandidate.bachelorId,
+                 cascade.collisionId(),
+                 cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
+                 cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
+                 cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
+                 cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
+                 cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
+                 cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+                 cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
+                 cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
+                 cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
+                 cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
+                 cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
+                 cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz,
+                 cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV,
+                 cascadecandidate.kfMLambda, cascadecandidate.kfV0Chi2, cascadecandidate.kfCascadeChi2);
 
       if (createCascCovMats) {
         gpu::gpustd::array<float, 15> covmatrix;
         float trackCovariance[15];
         covmatrix = lBachelorTrack.getCov();
-        for(int i=0;i<15;i++)
-          trackCovariance[i] = covmatrix[i]; 
+        for (int i = 0; i < 15; i++)
+          trackCovariance[i] = covmatrix[i];
         kfcasccovs(trackCovariance);
       }
     }
   }
-
 
   template <class TTrackTo, typename TCascTable, typename TStraTrack>
   void buildStrangenessTablesWithStrangenessTracking(TCascTable const& cascades, TStraTrack const& trackedCascades)

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -953,7 +953,7 @@ struct cascadeBuilder {
 
     // Track casting
     auto bachTrack = cascade.template bachelor_as<TTrackTo>();
-    auto v0 = cascade.template v0();
+    auto v0 = cascade.v0();
     auto posTrack = v0.template posTrack_as<TTrackTo>();
     auto negTrack = v0.template negTrack_as<TTrackTo>();
     auto const& collision = cascade.collision();

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -62,6 +62,17 @@
 #include "DataFormatsParameters/GRPMagField.h"
 #include "CCDB/BasicCCDBManager.h"
 
+#ifndef HomogeneousField
+#define HomogeneousField
+#endif
+
+/// includes KFParticle
+#include "KFParticle.h"
+#include "KFPTrack.h"
+#include "KFPVertex.h"
+#include "KFParticleBase.h"
+#include "KFVertex.h"
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
@@ -93,8 +104,10 @@ using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
 // Builder task: rebuilds multi-strange candidates
 struct cascadeBuilder {
   Produces<aod::StoredCascDatas> cascdata;
+  Produces<aod::StoredKFCascDatas> kfcascdata;
   Produces<aod::StoredTraCascDatas> trackedcascdata;
   Produces<aod::CascCovs> casccovs; // if requested by someone
+  Produces<aod::KFCascCovs> kfcasccovs; // if requested by someone
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
   Configurable<bool> d_UseAutodetectMode{"d_UseAutodetectMode", false, "Autodetect requested topo sels"};
@@ -148,6 +161,13 @@ struct cascadeBuilder {
   Configurable<float> dQAXiMassWindow{"dQAXiMassWindow", 0.005, "Xi mass window for ITS cluster map QA"};
   Configurable<float> dQAOmegaMassWindow{"dQAOmegaMassWindow", 0.005, "Omega mass window for ITS cluster map QA"};
 
+  // for KF particle operation 
+  Configurable<bool> kfTuneForOmega{"kfTuneForOmega", false, "if enabled, take main cascade properties from Omega fit instead of Xi fit (= default)"};
+  Configurable<int> kfConstructMethod{"kfConstructMethod", 2, "KF Construct Method"};
+  Configurable<bool> kfUseV0MassConstraint{"kfUseV0MassConstraint", true, "KF: use Lambda mass constraint"};
+  Configurable<bool> kfUseCascadeMassConstraint{"kfUseCascadeMassConstraint", false, "KF: use Cascade mass constraint - WARNING: not adequate for inv mass analysis of Xi"};
+  Configurable<bool> kfDoDCAFitterPreMinim{"kfDoDCAFitterPreMinim", true, "KF: do DCAFitter pre-optimization before KF fit to include material corrections"};
+
   ConfigurableAxis axisPtQA{"axisPtQA", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
 
   // for topo var QA
@@ -200,6 +220,7 @@ struct cascadeBuilder {
     std::array<float, 3> v0pos;
     std::array<float, 3> v0mompos;
     std::array<float, 3> v0momneg;
+    std::array<float, 3> cascademom;
     float v0dcadau;
     float v0dcapostopv;
     float v0dcanegtopv;
@@ -209,6 +230,9 @@ struct cascadeBuilder {
     float yOmega;
     float bachBaryonCosPA;
     float bachBaryonDCAxyToPV;
+    float kfMLambda;
+    float kfV0Chi2;
+    float kfCascadeChi2;
   } cascadecandidate;
 
   o2::track::TrackParCov lBachelorTrack;
@@ -265,6 +289,7 @@ struct cascadeBuilder {
   void init(InitContext& context)
   {
     resetHistos();
+    registry.add("hKFParticleStatistics", "hKFParticleStatistics", kTH1F, {{10,-0.5f,9.5f}});
 
     // Optionally, add extra QA histograms to processing chain
     if (d_doQA) {
@@ -582,12 +607,78 @@ struct cascadeBuilder {
     mRunNumber = bc.runNumber();
     // Set magnetic field value once known
     fitter.setBz(d_bz);
+    float magneticField = o2::base::Propagator::Instance()->getNominalBz();
+    /// Set magnetic field for KF vertexing
+    KFParticle::SetField(magneticField);
 
     if (useMatCorrType == 2) {
       // setMatLUT only after magfield has been initalized
       // (setMatLUT has implicit and problematic init field call if not)
       o2::base::Propagator::Instance()->setMatLUT(lut);
     }
+  }
+  // TrackParCov to KF converter
+  // FIXME: could be an utility somewhere else
+  // from Carolina Reetz (thank you!)
+  template <typename T>
+  KFParticle createKFParticleFromTrackParCov(const o2::track::TrackParametrizationWithError<T>& trackparCov, int charge, float mass) 
+  {
+    std::array<T, 3> xyz, pxpypz;
+    float xyzpxpypz[6];
+    trackparCov.getPxPyPzGlo(pxpypz);
+    trackparCov.getXYZGlo(xyz);
+    for (int i{0}; i < 3; ++i) {
+      xyzpxpypz[i] = xyz[i];
+      xyzpxpypz[i + 3] = pxpypz[i];
+    }
+
+    std::array<float, 21> cv;
+    try {
+      trackparCov.getCovXYZPxPyPzGlo(cv);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to get cov matrix from TrackParCov" << e.what();
+    }
+
+    KFParticle kfPart;
+    float Mini, SigmaMini, M, SigmaM;
+    kfPart.GetMass(Mini, SigmaMini);
+    LOG(debug) << "Daughter KFParticle mass before creation: " << Mini << " +- " << SigmaMini;
+    
+    try {
+      kfPart.Create(xyzpxpypz, cv.data(), charge, mass);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to create KFParticle from daughter TrackParCov" << e.what();
+    }
+
+    kfPart.GetMass(M, SigmaM);
+    LOG(debug) << "Daughter KFParticle mass after creation: " << M << " +- " << SigmaM;
+    return kfPart;
+  }
+
+  // KF to TrackParCov converter
+  // FIXME: could be an utility somewhere else
+  // from Carolina Reetz (thank you!)
+  o2::track::TrackParCov getTrackParCovFromKFP(const KFParticle& kfParticle, const o2::track::PID pid, const int sign)
+  {
+    o2::gpu::gpustd::array<float, 3> xyz, pxpypz;
+    o2::gpu::gpustd::array<float, 21> cv;
+
+    // get parameters from kfParticle
+    xyz[0] = kfParticle.GetX();
+    xyz[1] = kfParticle.GetY();
+    xyz[2] = kfParticle.GetZ();
+    pxpypz[0] = kfParticle.GetPx();
+    pxpypz[1] = kfParticle.GetPy();
+    pxpypz[2] = kfParticle.GetPz();
+    
+    // set covariance matrix elements (lower triangle)
+    for (int i =0; i < 21; i++) {
+      cv[i] = kfParticle.GetCovariance(i);
+    }
+
+    // create TrackParCov track
+    o2::track::TrackParCov track = o2::track::TrackParCov(xyz, pxpypz, cv, sign, true, pid);
+    return track;
   }
 
   template <typename TCollision, typename TTrack>
@@ -851,6 +942,250 @@ struct cascadeBuilder {
     return true;
   }
 
+  template <class TTrackTo, typename TCascObject>
+  bool buildCascadeCandidateWithKF(TCascObject const& cascade)
+  {
+    registry.fill(HIST("hKFParticleStatistics"), 0.0f);
+    //*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*
+    // KF particle based rebuilding 
+    // dispenses prior V0 generation, uses constrained (re-)fit based on bachelor charge 
+    //*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*
+
+    // Track casting
+    auto bachTrack = cascade.template bachelor_as<TTrackTo>();
+    auto v0 = cascade.template v0();
+    auto posTrack = v0.template posTrack_as<TTrackTo>();
+    auto negTrack = v0.template negTrack_as<TTrackTo>();
+    auto const& collision = cascade.collision();
+
+    if (calculateBachBaryonVars) {
+      // Calculates properties of the V0 comprised of bachelor and baryon in the cascade
+      // baryon: distinguished via bachelor charge
+      if (bachTrack.sign() < 0) {
+        processBachBaryonVariables(collision, bachTrack, posTrack);
+      } else {
+        processBachBaryonVariables(collision, bachTrack, negTrack);
+      }
+    }
+
+    // value 0.5: any considered cascade
+    statisticsRegistry.cascstats[kCascAll]++;
+
+    // Overall cascade charge
+    cascadecandidate.charge = bachTrack.signed1Pt() > 0 ? +1 : -1;
+
+    // bachelor DCA track to PV
+    // Calculate DCA with respect to the collision associated to the V0, not individual tracks
+    gpu::gpustd::array<float, 2> dcaInfo;
+
+    auto bachTrackPar = getTrackPar(bachTrack);
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, bachTrackPar, 2.f, fitter.getMatCorrType(), &dcaInfo);
+    cascadecandidate.bachDCAxy = dcaInfo[0];
+
+    o2::track::TrackParCov posTrackParCovForDCA = getTrackParCov(posTrack);
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, posTrackParCovForDCA, 2.f, fitter.getMatCorrType(), &dcaInfo);
+    cascadecandidate.v0dcapostopv = dcaInfo[0];
+    o2::track::TrackParCov negTrackParCovForDCA = getTrackParCov(negTrack);
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, negTrackParCovForDCA, 2.f, fitter.getMatCorrType(), &dcaInfo);
+    cascadecandidate.v0dcanegtopv = dcaInfo[0];
+
+    if (TMath::Abs(cascadecandidate.bachDCAxy) < dcabachtopv)
+      return false;
+
+    lBachelorTrack = getTrackParCov(bachTrack);
+    o2::track::TrackParCov negTrackParCov = getTrackParCov(negTrack);
+    o2::track::TrackParCov posTrackParCov = getTrackParCov(posTrack);
+
+    float massPosTrack, massNegTrack;
+    if (cascadecandidate.charge < 0) { 
+      massPosTrack = o2::constants::physics::MassProton;
+      massNegTrack = o2::constants::physics::MassPionCharged;
+    }  else { 
+      massPosTrack = o2::constants::physics::MassPionCharged;
+      massNegTrack = o2::constants::physics::MassProton;
+    }
+
+    //__________________________________________
+    //*>~<* step 1 : V0 with dca fitter, uses material corrections implicitly
+    // This is optional - move close to minima and therefore take material 
+    if(kfDoDCAFitterPreMinim){
+      int nCand = 0;
+      try {
+        nCand = fitter.process(posTrackParCov, negTrackParCov);
+      } catch (...) {
+        LOG(error) << "Exception caught in DCA fitter process call!";
+        return false;
+      }
+      if (nCand == 0) {
+        return false;
+      }
+      // save classical DCA daughters 
+      cascadecandidate.v0dcadau = TMath::Sqrt(fitter.getChi2AtPCACandidate());
+
+      // re-acquire from DCA fitter
+      posTrackParCov = fitter.getTrack(0);
+      negTrackParCov = fitter.getTrack(1);
+    }
+
+    //__________________________________________
+    //*>~<* step 2 : V0 with KF
+    // create KFParticle objects from trackParCovs
+    KFParticle kfpPos = createKFParticleFromTrackParCov(posTrackParCov, posTrackParCov.getCharge(), massPosTrack);
+    KFParticle kfpNeg = createKFParticleFromTrackParCov(negTrackParCov, negTrackParCov.getCharge(), massNegTrack);
+    const KFParticle* V0Daughters[2] = {&kfpPos, &kfpNeg};
+
+    // construct V0
+    KFParticle KFV0;
+    KFV0.SetConstructMethod(kfConstructMethod);
+    try {
+      KFV0.Construct(V0Daughters, 2);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to construct cascade V0 from daughter tracks: " << e.what();
+      return false;
+    }
+    if (kfUseV0MassConstraint) {
+      KFV0.SetNonlinearMassConstraint(o2::constants::physics::MassLambda);
+    }
+
+    // V0 constructed, now recovering TrackParCov for dca fitter minimization (with material correction)
+    KFV0.TransportToDecayVertex();
+    o2::track::TrackParCov v0TrackParCov = getTrackParCovFromKFP(KFV0, o2::track::PID::Lambda, 0);
+    v0TrackParCov.setAbsCharge(0); // to be sure
+
+    //__________________________________________
+    //*>~<* step 3 : Cascade with dca fitter (with material corrections)
+    if(kfDoDCAFitterPreMinim){
+      int nCandCascade = 0;
+      try {
+        nCandCascade = fitter.process(v0TrackParCov, lBachelorTrack);
+      } catch (...) {
+        LOG(error) << "Exception caught in DCA fitter process call!";
+        return false;
+      }
+      if (nCandCascade == 0)
+        return false;
+
+      // save classical DCA daughters 
+      cascadecandidate.dcacascdau = TMath::Sqrt(fitter.getChi2AtPCACandidate());
+
+      v0TrackParCov = fitter.getTrack(0);
+      lBachelorTrack = fitter.getTrack(1);
+    }
+
+    //__________________________________________
+    //*>~<* step 4 : Cascade with KF particle (potentially mass-constrained if asked)
+    float massBachelorPion = o2::constants::physics::MassPionCharged;
+    float massBachelorKaon = o2::constants::physics::MassKaonCharged;      
+
+    KFParticle kfpV0 = createKFParticleFromTrackParCov(v0TrackParCov, 0, o2::constants::physics::MassLambda);
+    KFParticle kfpBachPion = createKFParticleFromTrackParCov(lBachelorTrack, cascadecandidate.charge, massBachelorPion);
+    KFParticle kfpBachKaon = createKFParticleFromTrackParCov(lBachelorTrack, cascadecandidate.charge, massBachelorKaon);
+    const KFParticle* XiDaugthers[2] = {&kfpBachPion, &KFV0};
+    const KFParticle* OmegaDaugthers[2] = {&kfpBachKaon, &KFV0};
+
+    // construct mother
+    KFParticle KFXi, KFOmega;
+    KFXi.SetConstructMethod(kfConstructMethod);
+    KFOmega.SetConstructMethod(kfConstructMethod);
+    try {
+      KFXi.Construct(XiDaugthers, 2);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to construct xi from V0 and bachelor track: " << e.what();
+      return false;
+    }
+    try {
+      KFOmega.Construct(OmegaDaugthers, 2);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to construct omega from V0 and bachelor track: " << e.what();
+      return false;
+    }
+    if (kfUseCascadeMassConstraint) {
+      // set mass constraint if requested
+      // WARNING: this is only adequate for decay chains, i.e. XiC -> Xi or OmegaC -> Omega
+      KFXi.SetNonlinearMassConstraint(o2::constants::physics::MassXiMinus);
+      KFOmega.SetNonlinearMassConstraint(o2::constants::physics::MassOmegaMinus);
+    }
+    KFXi.TransportToDecayVertex();
+    KFOmega.TransportToDecayVertex();
+
+    //__________________________________________
+    //*>~<* step 5 : propagate cascade to primary vertex with material corrections if asked
+    if(!kfTuneForOmega){
+      lCascadeTrack = getTrackParCovFromKFP(KFXi, o2::track::PID::XiMinus, cascadecandidate.charge);
+    }else{
+      lCascadeTrack = getTrackParCovFromKFP(KFOmega, o2::track::PID::OmegaMinus, cascadecandidate.charge);
+    }
+    dcaInfo[0] = 999;
+    dcaInfo[1] = 999;
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorrCascade, &dcaInfo);
+    cascadecandidate.cascDCAxy = dcaInfo[0];
+    cascadecandidate.cascDCAz = dcaInfo[1];
+
+    //__________________________________________
+    //*>~<* step 6 : acquire all parameters for analysis
+
+    // basic indices 
+    cascadecandidate.v0Id = v0.globalIndex();
+    cascadecandidate.bachelorId = bachTrack.globalIndex();
+
+    // KF chi2 
+    cascadecandidate.kfV0Chi2 = KFV0.GetChi2();
+    cascadecandidate.kfCascadeChi2 = KFXi.GetChi2();
+    if(kfTuneForOmega)
+      cascadecandidate.kfCascadeChi2 = KFOmega.GetChi2();
+
+    // Daughter momentum not KF-updated FIXME
+    lBachelorTrack.getPxPyPzGlo(cascadecandidate.bachP);
+    posTrackParCov.getPxPyPzGlo(cascadecandidate.v0mompos);
+    negTrackParCov.getPxPyPzGlo(cascadecandidate.v0momneg);
+
+    // mother position information from KF
+    cascadecandidate.v0pos[0] = KFV0.GetX();
+    cascadecandidate.v0pos[1] = KFV0.GetY();
+    cascadecandidate.v0pos[2] = KFV0.GetZ();
+
+    // Mother position + momentum is KF updated 
+    if(!kfTuneForOmega){
+      cascadecandidate.pos[0] = KFXi.GetX();
+      cascadecandidate.pos[1] = KFXi.GetY();
+      cascadecandidate.pos[2] = KFXi.GetZ();
+      cascadecandidate.cascademom[0] = KFXi.GetPx();
+      cascadecandidate.cascademom[1] = KFXi.GetPy();
+      cascadecandidate.cascademom[2] = KFXi.GetPz();
+    }else{
+      cascadecandidate.pos[0] = KFOmega.GetX();
+      cascadecandidate.pos[1] = KFOmega.GetY();
+      cascadecandidate.pos[2] = KFOmega.GetZ();
+      cascadecandidate.cascademom[0] = KFOmega.GetPx();
+      cascadecandidate.cascademom[1] = KFOmega.GetPy();
+      cascadecandidate.cascademom[2] = KFOmega.GetPz();
+    }
+
+    // KF-aware cosPA
+    cascadecandidate.cosPA = RecoDecay::cpa(
+      array{collision.posX(), collision.posY(), collision.posZ()},
+      array{cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2]},
+      array{cascadecandidate.cascademom[0], cascadecandidate.cascademom[1], cascadecandidate.cascademom[2]});
+    if (cascadecandidate.cosPA < casccospa) {
+      return false;
+    }
+
+    // KF-aware Cascade radius
+    cascadecandidate.cascradius = RecoDecay::sqrtSumOfSquares(cascadecandidate.pos[0], cascadecandidate.pos[1]);
+    if (cascadecandidate.cascradius < cascradius)
+      return false;
+
+    // Calculate masses a priori
+    cascadecandidate.kfMLambda = KFV0.GetMass(); 
+    cascadecandidate.mXi = KFXi.GetMass();
+    cascadecandidate.mOmega = KFOmega.GetMass();
+    cascadecandidate.yXi = KFXi.GetRapidity();
+    cascadecandidate.yOmega = KFOmega.GetRapidity();
+    registry.fill(HIST("hKFParticleStatistics"), 1.0f);
+    return true;
+  }
+
+
   template <class TTrackTo, typename TCascTable>
   void buildStrangenessTables(TCascTable const& cascades)
   {
@@ -909,6 +1244,45 @@ struct cascadeBuilder {
     fillHistos();
     resetHistos();
   }
+
+  template <class TTrackTo, typename TCascTable>
+  void buildKFStrangenessTables(TCascTable const& cascades)
+  {
+    for (auto& cascade : cascades) {
+      bool validCascadeCandidateKF = buildCascadeCandidateWithKF<TTrackTo>(cascade);
+      if (!validCascadeCandidateKF)
+        continue; // doesn't pass cascade selections
+      registry.fill(HIST("hKFParticleStatistics"), 2.0f);
+      kfcascdata(cascadecandidate.v0Id,
+               cascade.globalIndex(),
+               cascadecandidate.bachelorId,
+               cascade.collisionId(),
+               cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
+               cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
+               cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
+               cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
+               cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
+               cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+               cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
+               cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
+               cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
+               cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
+               cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
+               cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz,
+               cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV, 
+               cascadecandidate.kfMLambda, cascadecandidate.kfV0Chi2, cascadecandidate.kfCascadeChi2);
+
+      if (createCascCovMats) {
+        gpu::gpustd::array<float, 15> covmatrix;
+        float trackCovariance[15];
+        covmatrix = lBachelorTrack.getCov();
+        for(int i=0;i<15;i++)
+          trackCovariance[i] = covmatrix[i]; 
+        kfcasccovs(trackCovariance);
+      }
+    }
+  }
+
 
   template <class TTrackTo, typename TCascTable, typename TStraTrack>
   void buildStrangenessTablesWithStrangenessTracking(TCascTable const& cascades, TStraTrack const& trackedCascades)
@@ -1132,6 +1506,20 @@ struct cascadeBuilder {
     }
   }
   PROCESS_SWITCH(cascadeBuilder, processRun3, "Produce Run 3 cascade tables", false);
+
+  void processRun3withKFParticle(aod::Collisions const& collisions, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::V0s const&)
+  {
+    for (const auto& collision : collisions) {
+      // Fire up CCDB
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      initCCDB(bc);
+      // Do analysis with collision-grouped V0s, retain full collision information
+      const uint64_t collIdx = collision.globalIndex();
+      auto CascadeTable_thisCollision = cascades.sliceBy(perCollision, collIdx);
+      buildKFStrangenessTables<FullTracksExtIU>(CascadeTable_thisCollision);
+    }
+  }
+  PROCESS_SWITCH(cascadeBuilder, processRun3withKFParticle, "Produce Run 3 KF cascade tables", false);
 
   void processRun3withStrangenessTracking(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::TrackedCascades const& trackedCascades)
   {
@@ -1420,6 +1808,7 @@ struct cascadePreselector {
 /// Extends the cascdata table with expression columns
 struct cascadeInitializer {
   Spawns<aod::CascData> cascdataext;
+  Spawns<aod::KFCascData> kfcascdataext;
   Spawns<aod::TraCascData> tracascdataext;
   void init(InitContext const&) {}
 };
@@ -1445,11 +1834,33 @@ struct cascadeLinkBuilder {
   }
 };
 
+struct kfcascadeLinkBuilder {
+  Produces<aod::KFCascDataLink> cascdataLink;
+
+  void init(InitContext const&) {}
+
+  // build Cascade -> CascData link table
+  void process(aod::Cascades const& casctable, aod::KFCascDatas const& cascdatatable)
+  {
+    std::vector<int> lIndices;
+    lIndices.reserve(casctable.size());
+    for (int ii = 0; ii < casctable.size(); ii++)
+      lIndices[ii] = -1;
+    for (auto& cascdata : cascdatatable) {
+      lIndices[cascdata.cascadeId()] = cascdata.globalIndex();
+    }
+    for (int ii = 0; ii < casctable.size(); ii++) {
+      cascdataLink(lIndices[ii]);
+    }
+  }
+};
+
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
     adaptAnalysisTask<cascadeBuilder>(cfgc),
     adaptAnalysisTask<cascadePreselector>(cfgc),
     adaptAnalysisTask<cascadeInitializer>(cfgc),
-    adaptAnalysisTask<cascadeLinkBuilder>(cfgc)};
+    adaptAnalysisTask<cascadeLinkBuilder>(cfgc),
+    adaptAnalysisTask<kfcascadeLinkBuilder>(cfgc)};
 }

--- a/PWGLF/Tasks/QC/CMakeLists.txt
+++ b/PWGLF/Tasks/QC/CMakeLists.txt
@@ -34,6 +34,11 @@ o2physics_add_dpl_workflow(strarecostudy
                     PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(kfperformancestudy
+                    SOURCES kfPerformanceStudy.cxx
+                    PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(tpc-dedx-postcalibration
                     SOURCES tpc_dEdx_postcalibration.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore

--- a/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
+++ b/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 //
-/// \brief this task allows for the direct one-to-one comparison of 
-//         cascades computed with standard DCAFitter methods and the KFparticle 
+/// \brief this task allows for the direct one-to-one comparison of
+//         cascades computed with standard DCAFitter methods and the KFparticle
 //         package. It is meant for the purposes of larger-scale QA of KF reco.
 
 #include "Framework/runDataProcessing.h"
@@ -44,15 +44,15 @@ struct kfPerformanceStudy {
   ConfigurableAxis axisXiMass{"axisXiMass", {200, 1.222f, 1.422f}, ""};
   ConfigurableAxis axisOmegaMass{"axisOmegaMass", {200, 1.572f, 1.772f}, ""};
   ConfigurableAxis axisDCAxy{"axisDCAxy", {200, -1.0f, 1.0f}, ""};
-  
+
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext const&)
   {
-    histos.add("hEventCounter", "hEventCounter", kTH1F, {{1,0.0f,1.0f}});
-    histos.add("hChargeCounter", "hChargeCounter", kTH1F, {{3,-1.5f,1.5f}});
+    histos.add("hEventCounter", "hEventCounter", kTH1F, {{1, 0.0f, 1.0f}});
+    histos.add("hChargeCounter", "hChargeCounter", kTH1F, {{3, -1.5f, 1.5f}});
 
-    //baseline simple histograms of mass
+    // baseline simple histograms of mass
     histos.add("hMassXiMinus", "hMassXiMinus", kTH2F, {axisPt, axisXiMass});
     histos.add("hMassXiPlus", "hMassXiPlus", kTH2F, {axisPt, axisXiMass});
     histos.add("hMassOmegaMinus", "hMassOmegaMinus", kTH2F, {axisPt, axisOmegaMass});
@@ -62,11 +62,11 @@ struct kfPerformanceStudy {
     histos.add("hKFMassOmegaMinus", "hKFMassOmegaMinus", kTH2F, {axisPt, axisOmegaMass});
     histos.add("hKFMassOmegaPlus", "hKFMassOmegaPlus", kTH2F, {axisPt, axisOmegaMass});
 
-    histos.add("h3dMassXiMinus", "h3dMassXiMinus", kTH3F, {axisPt, axisXiMass,axisXiMass});
-    histos.add("h3dMassXiPlus", "h3dMassXiPlus", kTH3F, {axisPt, axisXiMass,axisXiMass});
-    histos.add("h3dMassOmegaMinus", "h3dMassOmegaMinus", kTH3F, {axisPt, axisOmegaMass,axisOmegaMass});
-    histos.add("h3dMassOmegaPlus", "h3dMassOmegaPlus", kTH3F, {axisPt, axisOmegaMass,axisOmegaMass});
-    
+    histos.add("h3dMassXiMinus", "h3dMassXiMinus", kTH3F, {axisPt, axisXiMass, axisXiMass});
+    histos.add("h3dMassXiPlus", "h3dMassXiPlus", kTH3F, {axisPt, axisXiMass, axisXiMass});
+    histos.add("h3dMassOmegaMinus", "h3dMassOmegaMinus", kTH3F, {axisPt, axisOmegaMass, axisOmegaMass});
+    histos.add("h3dMassOmegaPlus", "h3dMassOmegaPlus", kTH3F, {axisPt, axisOmegaMass, axisOmegaMass});
+
     histos.add("h3dMassLambda", "h3dMassLambda", kTH3F, {axisPt, axisLambdaMass, axisLambdaMass}); /// for x check only
     histos.add("h3dDCAxy", "h3dDCAxy", kTH3F, {axisPt, axisDCAxy, axisDCAxy});
     histos.add("hPtCorrelation", "hPtCorrelation", kTH2F, {axisPt, axisPt});
@@ -75,58 +75,58 @@ struct kfPerformanceStudy {
   void process(aod::Collision const& Collision, CascadesCrossLinked const& Cascades, aod::CascDatas const&, aod::KFCascDatas const&, aod::TracksIU const&)
   {
     histos.fill(HIST("hEventCounter"), 0.5);
-    for (auto& cascade : Cascades) { // allows for cross-referencing everything 
-      float pt = 0.0f, ptKF = 0.0f; 
-      float massXi = 0.0f, massXiKF = 0.0f; 
-      float massOmega = 0.0f, massOmegaKF = 0.0f; 
-      float massLambda = 0.0f, massLambdaKF = 0.0f; 
-      float dcaXY = 0.0f, dcaXYKF = 0.0f; 
+    for (auto& cascade : Cascades) { // allows for cross-referencing everything
+      float pt = 0.0f, ptKF = 0.0f;
+      float massXi = 0.0f, massXiKF = 0.0f;
+      float massOmega = 0.0f, massOmegaKF = 0.0f;
+      float massLambda = 0.0f, massLambdaKF = 0.0f;
+      float dcaXY = 0.0f, dcaXYKF = 0.0f;
 
       // get charge from bachelor (unambiguous wrt to building)
       auto bachTrack = cascade.bachelor_as<aod::TracksIU>();
-      if(bachTrack.sign()<0)
+      if (bachTrack.sign() < 0)
         charge = -1;
 
       histos.fill(HIST("hChargeCounter"), charge);
 
-      if(cascade.has_cascData()){ 
+      if (cascade.has_cascData()) {
         // check aod::Cascades -> aod::CascData link
         // if present: this candidate was accepted by default DCAfitter building
-        auto cascdata = cascade.cascData(); 
+        auto cascdata = cascade.cascData();
         pt = cascdata.pt();
         massLambda = cascdata.mLambda();
         massXi = cascdata.mXi();
         massOmega = cascdata.mOmega();
         dcaXY = cascdata.dcaXYCascToPV();
       }
-      if(cascade.has_kfCascData()){ 
+      if (cascade.has_kfCascData()) {
         // check aod::Cascades -> aod::KFCascData link
         // if present: this candidate was accepted by KF building
-        auto cascdata = cascade.kfCascData(); 
+        auto cascdata = cascade.kfCascData();
         ptKF = cascdata.pt();
         massLambdaKF = cascdata.mLambda();
         massXiKF = cascdata.mXi();
         massOmegaKF = cascdata.mOmega();
         dcaXYKF = cascdata.dcaXYCascToPV();
       }
-      
+
       histos.fill(HIST("hPtCorrelation"), pt, ptKF);
       histos.fill(HIST("h3dMassLambda"), pt, massLambda, massLambdaKF); // <- implicit pT choice, beware
-      histos.fill(HIST("h3dDCAxy"), pt, dcaXY, dcaXYKF); // <- implicit pT choice, beware
-      if(charge<0){
+      histos.fill(HIST("h3dDCAxy"), pt, dcaXY, dcaXYKF);                // <- implicit pT choice, beware
+      if (charge < 0) {
         histos.fill(HIST("hMassXiMinus"), pt, massXi);
         histos.fill(HIST("hMassOmegaMinus"), pt, massOmega);
         histos.fill(HIST("hKFMassXiMinus"), ptKF, massXiKF);
         histos.fill(HIST("hKFMassOmegaMinus"), ptKF, massOmegaKF);
-        histos.fill(HIST("h3dMassXiMinus"), pt, massXi, massXiKF); // <- implicit pT choice, beware
+        histos.fill(HIST("h3dMassXiMinus"), pt, massXi, massXiKF);          // <- implicit pT choice, beware
         histos.fill(HIST("h3dMassOmegaMinus"), pt, massOmega, massOmegaKF); // <- implicit pT choice, beware
       }
-      if(charge>0){
+      if (charge > 0) {
         histos.fill(HIST("hMassXiPlus"), pt, massXi);
         histos.fill(HIST("hMassOmegaPlus"), pt, massOmega);
         histos.fill(HIST("hKFMassXiPlus"), ptKF, massXiKF);
         histos.fill(HIST("hKFMassOmegaPlus"), ptKF, massOmegaKF);
-        histos.fill(HIST("h3dMassXiPlus"), pt, massXi, massXiKF); // <- implicit pT choice, beware
+        histos.fill(HIST("h3dMassXiPlus"), pt, massXi, massXiKF);          // <- implicit pT choice, beware
         histos.fill(HIST("h3dMassOmegaPlus"), pt, massOmega, massOmegaKF); // <- implicit pT choice, beware
       }
     }

--- a/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
+++ b/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
@@ -81,6 +81,7 @@ struct kfPerformanceStudy {
       float massOmega = 0.0f, massOmegaKF = 0.0f;
       float massLambda = 0.0f, massLambdaKF = 0.0f;
       float dcaXY = 0.0f, dcaXYKF = 0.0f;
+      int charge = 0;
 
       // get charge from bachelor (unambiguous wrt to building)
       auto bachTrack = cascade.bachelor_as<aod::TracksIU>();

--- a/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
+++ b/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
@@ -76,17 +76,11 @@ struct kfPerformanceStudy {
   {
     histos.fill(HIST("hEventCounter"), 0.5);
     for (auto& cascade : Cascades) { // allows for cross-referencing everything 
-      float pt = 0.0f; 
-      float ptKF = 0.0f; 
-      float massXi = 0.0f; 
-      float massXiKF = 0.0f; 
-      float massOmega = 0.0f; 
-      float massOmegaKF = 0.0f; 
-      float massLambda = 0.0f; 
-      float massLambdaKF = 0.0f;
-      float dcaXY = 0.0f; 
-      float dcaXYKF = 0.0f;
-      int charge = 1;
+      float pt = 0.0f, ptKF = 0.0f; 
+      float massXi = 0.0f, massXiKF = 0.0f; 
+      float massOmega = 0.0f, massOmegaKF = 0.0f; 
+      float massLambda = 0.0f, massLambdaKF = 0.0f; 
+      float dcaXY = 0.0f, dcaXYKF = 0.0f; 
 
       // get charge from bachelor (unambiguous wrt to building)
       auto bachTrack = cascade.bachelor_as<aod::TracksIU>();

--- a/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
+++ b/PWGLF/Tasks/QC/kfPerformanceStudy.cxx
@@ -1,0 +1,145 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+/// \brief this task allows for the direct one-to-one comparison of 
+//         cascades computed with standard DCAFitter methods and the KFparticle 
+//         package. It is meant for the purpose of QA.
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/Multiplicity.h"
+#include <cmath>
+//#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using std::array;
+
+// allows for candidate-by-candidate comparison
+using CascadesCrossLinked = soa::Join<aod::Cascades, aod::CascDataLink, aod::KFCascDataLink>;
+
+struct kfPerformanceStudy {
+  // configurable binning of histograms
+  ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
+  ConfigurableAxis axisLambdaMass{"axisLambdaMass", {200, 1.101f, 1.131f}, ""};
+  ConfigurableAxis axisXiMass{"axisXiMass", {200, 1.222f, 1.422f}, ""};
+  ConfigurableAxis axisOmegaMass{"axisOmegaMass", {200, 1.572f, 1.772f}, ""};
+  ConfigurableAxis axisDCAxy{"axisDCAxy", {200, -1.0f, 1.0f}, ""};
+  
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext const&)
+  {
+    histos.add("hEventCounter", "hEventCounter", kTH1F, {{1,0.0f,1.0f}});
+    histos.add("hChargeCounter", "hChargeCounter", kTH1F, {{3,-1.5f,1.5f}});
+
+    //baseline simple histograms of mass
+    histos.add("hMassXiMinus", "hMassXiMinus", kTH2F, {axisPt, axisXiMass});
+    histos.add("hMassXiPlus", "hMassXiPlus", kTH2F, {axisPt, axisXiMass});
+    histos.add("hMassOmegaMinus", "hMassOmegaMinus", kTH2F, {axisPt, axisOmegaMass});
+    histos.add("hMassOmegaPlus", "hMassOmegaPlus", kTH2F, {axisPt, axisOmegaMass});
+    histos.add("hKFMassXiMinus", "hKFMassXiMinus", kTH2F, {axisPt, axisXiMass});
+    histos.add("hKFMassXiPlus", "hKFMassXiPlus", kTH2F, {axisPt, axisXiMass});
+    histos.add("hKFMassOmegaMinus", "hKFMassOmegaMinus", kTH2F, {axisPt, axisOmegaMass});
+    histos.add("hKFMassOmegaPlus", "hKFMassOmegaPlus", kTH2F, {axisPt, axisOmegaMass});
+
+    histos.add("h3dMassXiMinus", "h3dMassXiMinus", kTH3F, {axisPt, axisXiMass,axisXiMass});
+    histos.add("h3dMassXiPlus", "h3dMassXiPlus", kTH3F, {axisPt, axisXiMass,axisXiMass});
+    histos.add("h3dMassOmegaMinus", "h3dMassOmegaMinus", kTH3F, {axisPt, axisOmegaMass,axisOmegaMass});
+    histos.add("h3dMassOmegaPlus", "h3dMassOmegaPlus", kTH3F, {axisPt, axisOmegaMass,axisOmegaMass});
+    
+    histos.add("h3dMassLambda", "h3dMassLambda", kTH3F, {axisPt, axisLambdaMass, axisLambdaMass}); /// for x check only
+    histos.add("h3dDCAxy", "h3dDCAxy", kTH3F, {axisPt, axisDCAxy, axisDCAxy});
+    histos.add("hPtCorrelation", "hPtCorrelation", kTH2F, {axisPt, axisPt});
+  }
+
+  void process(aod::Collision const& Collision, CascadesCrossLinked const& Cascades, aod::CascDatas const&, aod::KFCascDatas const&, aod::TracksIU const&)
+  {
+    histos.fill(HIST("hEventCounter"), 0.5);
+    for (auto& cascade : Cascades) { // allows for cross-referencing everything 
+      float pt = 0.0f; 
+      float ptKF = 0.0f; 
+      float massXi = 0.0f; 
+      float massXiKF = 0.0f; 
+      float massOmega = 0.0f; 
+      float massOmegaKF = 0.0f; 
+      float massLambda = 0.0f; 
+      float massLambdaKF = 0.0f;
+      float dcaXY = 0.0f; 
+      float dcaXYKF = 0.0f;
+      int charge = 1;
+
+      auto bachTrack = cascade.bachelor_as<aod::TracksIU>();
+      if(bachTrack.sign()<0)
+        charge = -1;
+
+      histos.fill(HIST("hChargeCounter"), charge);
+
+      if(cascade.has_cascData()){
+        //was picked up by default DCAfitter recovery
+        auto cascdata = cascade.cascData(); 
+        pt = cascdata.pt();
+        massLambda = cascdata.mLambda();
+        massXi = cascdata.mXi();
+        massOmega = cascdata.mOmega();
+        dcaXY = cascdata.dcaXYCascToPV();
+      }
+      if(cascade.has_kfCascData()){
+        //was picked up by default DCAfitter recovery
+        auto cascdata = cascade.kfCascData(); 
+        ptKF = cascdata.pt();
+        massLambdaKF = cascdata.mLambda();
+        massXiKF = cascdata.mXi();
+        massOmegaKF = cascdata.mOmega();
+        dcaXYKF = cascdata.dcaXYCascToPV();
+      }
+      
+      histos.fill(HIST("hPtCorrelation"), pt, ptKF);
+      histos.fill(HIST("h3dMassLambda"), pt, massLambda, massLambdaKF);
+      histos.fill(HIST("h3dDCAxy"), pt, dcaXY, dcaXYKF);
+      if(charge<0){
+        histos.fill(HIST("hMassXiMinus"), pt, massXi);
+        histos.fill(HIST("hMassOmegaMinus"), pt, massOmega);
+        histos.fill(HIST("hKFMassXiMinus"), ptKF, massXiKF);
+        histos.fill(HIST("hKFMassOmegaMinus"), ptKF, massOmegaKF);
+        histos.fill(HIST("h3dMassXiMinus"), pt, massXi, massXiKF);
+        histos.fill(HIST("h3dMassOmegaMinus"), pt, massOmega, massOmegaKF);
+      }
+      if(charge>0){
+        histos.fill(HIST("hMassXiPlus"), pt, massXi);
+        histos.fill(HIST("hMassOmegaPlus"), pt, massOmega);
+        histos.fill(HIST("hKFMassXiPlus"), ptKF, massXiKF);
+        histos.fill(HIST("hKFMassOmegaPlus"), ptKF, massOmegaKF);
+        histos.fill(HIST("h3dMassXiPlus"), pt, massXi, massXiKF);
+        histos.fill(HIST("h3dMassOmegaPlus"), pt, massOmega, massOmegaKF);
+      }
+
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<kfPerformanceStudy>(cfgc)};
+}


### PR DESCRIPTION
* will allow for extensive testing with larger statistics 
* `CascData` kept unmodified; `KFCascData` provided in case KF particle path requested 
* KF particle path does *not* require the `lambdakzerobuilder` since lambdas are re-built using the exact case-by-case constraint from the bachelor. 
* Simultaneous generation of `CascData` and `KFCascData` is possible; `Linked` tables provide cross-referencing between base `Cascades` table and the `CascData` and `KFCascData` analysis tables for convenient access and comparisons (see example QC task `kfPerformanceStudy`). 
* to follow: adjustments and optimizations + similar path also for V0s in the `lambdakzerobuilder`