### PR TITLE
[EMCAL-903] Add support for 2 more gamma triggers

### DIFF
--- a/EventFiltering/PWGJE/fullJetFilter.cxx
+++ b/EventFiltering/PWGJE/fullJetFilter.cxx
@@ -57,16 +57,22 @@ struct fullJetFilter {
     kJetFullLowPt,
     kJetNeutralHighPt,
     kJetNeutralLowPt,
+    kGammaVeryHighPtEMCAL,
+    kGammaVeryHighPtDCAL,
     kGammaHighPtEMCAL,
     kGammaHighPtDCAL,
     kGammaLowPtEMCAL,
     kGammaLowPtDCAL,
+    kGammaVeryLowPtEMCAL,
+    kGammaVeryLowPtDCAL,
     kCategories
   };
 
   enum class ThresholdType_t {
+    VERY_HIGH_THRESHOLD,
     HIGH_THRESHOLD,
-    LOW_THRESHOLD
+    LOW_THRESHOLD,
+    VERY_LOW_THRESHOLD
   };
 
   enum class EMCALHWTriggerConfiguration {
@@ -75,11 +81,23 @@ struct fullJetFilter {
     UNKNOWN
   };
 
+  enum class EMCALHWTriggerType {
+    TRG_EMC_MB,
+    TRG_EMC_L0,
+    TRG_EMC_GA,
+    TRG_EMC_JE,
+    TRG_UNKNOWN
+  };
+
   Produces<aod::FullJetFilters> tags;
 
   OutputObj<TH1D> hProcessedEvents{"hProcessedEvents"};
   OutputObj<TH2F> hEmcClusterPtEta{"hEmcClusterPtEta"};
   OutputObj<TH2F> hEmcClusterPtPhi{"hEmcClusterPtPhi"};
+  OutputObj<TH2F> hEmcClusterPtEtaMinBias{"hEmcClusterPtEtaMinBias"};
+  OutputObj<TH2F> hEmcClusterPtPhiMinBias{"hEmcClusterPtPhiMinBias"};
+  OutputObj<TH2F> hEmcClusterPtEtaLevel0{"hEmcClusterPtEtaLevel0"};
+  OutputObj<TH2F> hEmcClusterPtPhiLevel0{"hEmcClusterPtPhiLevel0"};
   OutputObj<TH2F> hSelectedClusterPtEta{"hSelectedClusterEta"};
   OutputObj<TH2F> hSelectedClusterPtPhi{"hSelectedClusterPhi"};
   OutputObj<TH2F> hSelectedClusterPtEtaLow{"hSelectedClusterEtaLow"};
@@ -90,6 +108,10 @@ struct fullJetFilter {
   OutputObj<TH2F> hSelectedJetPtPhi{"hSelectedJetPhi"};
   OutputObj<TH2F> hSelectedJetPtEtaLow{"hSelectedJetEtaLow"};
   OutputObj<TH2F> hSelectedJetPtPhiLow{"hSelectedJetPhiLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtEtaVeryHigh{"hSelectedGammaEMCALEtaVeryHigh"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtPhiVeryHigh{"hSelectedGammaEMCALPhiVeryHigh"};
+  OutputObj<TH2F> hSelectedGammaDCALPtEtaVeryHigh{"hSelectedGammaDCALEtaVeryHigh"};
+  OutputObj<TH2F> hSelectedGammaDCALPtPhiVeryHigh{"hSelectedGammaDCALPhiVeryHigh"};
   OutputObj<TH2F> hSelectedGammaEMCALPtEta{"hSelectedGammaEMCALEta"};
   OutputObj<TH2F> hSelectedGammaEMCALPtPhi{"hSelectedGammaEMCALPhi"};
   OutputObj<TH2F> hSelectedGammaDCALPtEta{"hSelectedGammaDCALEta"};
@@ -98,15 +120,23 @@ struct fullJetFilter {
   OutputObj<TH2F> hSelectedGammaEMCALPtPhiLow{"hSelectedGammaEMCALPhiLow"};
   OutputObj<TH2F> hSelectedGammaDCALPtEtaLow{"hSelectedGammaDCALEtaLow"};
   OutputObj<TH2F> hSelectedGammaDCALPtPhiLow{"hSelectedGammaDCALPhiLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtEtaVeryLow{"hSelectedGammaEMCALEtaVeryLow"};
+  OutputObj<TH2F> hSelectedGammaEMCALPtPhiVeryLow{"hSelectedGammaEMCALPhiVeryLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtEtaVeryLow{"hSelectedGammaDCALEtaVeryLow"};
+  OutputObj<TH2F> hSelectedGammaDCALPtPhiVeryLow{"hSelectedGammaDCALPhiVeryLow"};
   OutputObj<TH1D> hMaxJetPt{"hMaxJetPt"};
   OutputObj<TH1D> hSelectMaxJetPt{"hSelectMaxJetPt"};
   OutputObj<TH1D> hSelectMaxJetPtLow{"hSelectMaxJetPtLow"};
   OutputObj<TH1D> hMaxClusterEMCAL{"hMaxClusterEMCAL"};
   OutputObj<TH1D> hMaxClusterDCAL{"hMaxClusterDCAL"};
+  OutputObj<TH1D> hSelectGammaVeryHighMaxClusterEMCAL{"hSelectGammaVeryHighMaxClusterEMCAL"};
   OutputObj<TH1D> hSelectGammaMaxClusterEMCAL{"hSelectGammaMaxClusterEMCAL"};
-  OutputObj<TH1D> hSelectGammaLowMaxClusterEMCAL{"hSelectLowGammaMaxClusterEMCAL"};
+  OutputObj<TH1D> hSelectGammaLowMaxClusterEMCAL{"hSelectGammaLowMaxClusterEMCAL"};
+  OutputObj<TH1D> hSelectGammaVeryLowMaxClusterEMCAL{"hSelectGammaVeryLowMaxClusterEMCAL"};
+  OutputObj<TH1D> hSelectGammaVeryHighMaxClusterDCAL{"hSelectGammaVeryHighMaxClusterDCAL"};
   OutputObj<TH1D> hSelectGammaMaxClusterDCAL{"hSelectGammaMaxClusterDCAL"};
-  OutputObj<TH1D> hSelectGammaLowMaxClusterDCAL{"hSelectLowGammaMaxClusterDCAL"};
+  OutputObj<TH1D> hSelectGammaLowMaxClusterDCAL{"hSelectGammaLowMaxClusterDCAL"};
+  OutputObj<TH1D> hSelectGammaVeryLowMaxClusterDCAL{"hSelectGammaVertLowMaxClusterDCAL"};
 
   // Configurables
   Configurable<float> f_jetPtMin{"f_jetPtMin", 0.0, "minimum jet pT cut"};
@@ -118,10 +148,14 @@ struct fullJetFilter {
   Configurable<int> f_ObservalbeGammaTrigger{"fObservableGammaTrigger", 0, "Observable for the gamma trigger (0 - Energy, 1 - pt)"};
   Configurable<bool> b_PublishReadoutTrigger{"b_publishReadoutTrigger", false, "Publish EMCAL readout status as trigger flag"};
   Configurable<bool> b_PublishNeutralJetTrigger{"b_publishNeutralJetTrigger", false, "Publish trigger on neutral jets"};
+  Configurable<float> f_gammaPtMinEMCALVeryHigh{"f_gammaPtMinEMCALVeryHigh", 9.0, "minimum gamma pT cut in EMCAL very high threshold"};
   Configurable<float> f_gammaPtMinEMCALHigh{"f_gammaPtMinEMCALHigh", 4.0, "minimum gamma pT cut in EMCAL high threshold"};
   Configurable<float> f_gammaPtMinEMCALLow{"f_gammaPtMinEMCALLow", 1.5, "minimum gamma pT cut in EMCAL low threshold"};
+  Configurable<float> f_gammaPtMinEMCALVeryLow{"f_gammaPtMinEMCALVeryLow", 0.5, "minimum gamma pT cut in EMCAL very low threshold"};
+  Configurable<float> f_gammaPtMinDCALVeryHigh{"f_gammaPtMinDCALVeryHigh", 9.0, "minimum gamma pT cut in DCAL very high threshold"};
   Configurable<float> f_gammaPtMinDCALHigh{"f_gammaPtMinDCALHigh", 4.0, "minimum gamma pT cut in DCAL high threshold"};
   Configurable<float> f_gammaPtMinDCALLow{"f_gammaPtMinDCALLow", 1.5, "minimum gamma pT cut in DCAL low threshold"};
+  Configurable<float> f_gammaPtMinDCALVeryLow{"f_gammaPtMinDCALVeryLow", 0.5, "minimum gamma pT cut in DCAL very low threshold"};
   Configurable<float> f_gammaPtMinEMCALHighMB{"f_gammaPtMinEMCALHighMB", 4.0, "minimum gamma pT cut in EMCAL high threshold (MB-only runs)"};
   Configurable<float> f_gammaPtMinEMCALLowMB{"f_gammaPtMinEMCALLowMB", 1.5, "minimum gamma pT cut in EMCAL low threshold (MB-only runs)"};
   Configurable<float> f_gammaPtMinDCALHighMB{"f_gammaPtMinDCALHighMB", 4.0, "minimum gamma pT cut in DCAL high threshold (MB-only runs)"};
@@ -160,6 +194,10 @@ struct fullJetFilter {
 
     hEmcClusterPtEta.setObject(new TH2F("hEmcClusterPtEta", Form("Emc Clusters;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
     hEmcClusterPtPhi.setObject(new TH2F("hEmcClusterPtPhi", Form("Emc Clusters;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hEmcClusterPtEtaMinBias.setObject(new TH2F("hEmcClusterPtEtaMinBias", Form("Emc Clusters (MB);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hEmcClusterPtPhiMinBias.setObject(new TH2F("hEmcClusterPtPhiMinBias", Form("Emc Clusters (MB);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hEmcClusterPtEtaLevel0.setObject(new TH2F("hEmcClusterPtEtaLevel0", Form("Emc Clusters (L0);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hEmcClusterPtPhiLevel0.setObject(new TH2F("hEmcClusterPtPhiLevel0", Form("Emc Clusters (L0);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedClusterPtEta.setObject(new TH2F("hSelectedClusterPtEta", Form("Selected Clusters;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
     hSelectedClusterPtPhi.setObject(new TH2F("hSelectedClusterPtPhi", Form("Selected Clusters;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedClusterPtEtaLow.setObject(new TH2F("hSelectedClusterPtEtaLow", Form("Selected Clusters (low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
@@ -170,6 +208,10 @@ struct fullJetFilter {
     hSelectedJetPtPhi.setObject(new TH2F("hSelectedJetPtPhi", "Selected Jets;#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedJetPtEtaLow.setObject(new TH2F("hSelectedJetPtEtaLow", "Selected Jets (low threshold);#it{p}_{T};#eta", nPtBins, kMinPt, kMaxPt, nEtaBins, kMinEta, kMaxEta));
     hSelectedJetPtPhiLow.setObject(new TH2F("hSelectedJetPtPhiLow", "Selected Jets (low threshold);#it{p}_{T};#phi", nPtBins, kMinPt, kMaxPt, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaVeryHigh.setObject(new TH2F("hSelectedGammaEMCALEtaVeryHigh", Form("Selected Gammas EMCAL (very high threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhiVeryHigh.setObject(new TH2F("hSelectedGammaEMCALPhiVeryHigh", Form("Selected Gammas EMCAL (very high threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaVeryHigh.setObject(new TH2F("hSelectedGammaDCALEtaVeryHigh", Form("Selected Gammas DCAL (very high threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhiVeryHigh.setObject(new TH2F("hSelectedGammaDCALPhiVeryHigh", Form("Selected Gammas DCAL (very high threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedGammaEMCALPtEta.setObject(new TH2F("hSelectedGammaEMCALPtEta", Form("Selected Gammas EMCAL;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
     hSelectedGammaEMCALPtPhi.setObject(new TH2F("hSelectedGammaEMCALPtPhi", Form("Selected Gammas EMCAL;%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedGammaDCALPtEta.setObject(new TH2F("hSelectedGammaDCALPtEta", Form("Selected Gammas DCAL;%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
@@ -178,16 +220,24 @@ struct fullJetFilter {
     hSelectedGammaEMCALPtPhiLow.setObject(new TH2F("hSelectedGammaEMCALPtPhiLow", Form("Selected Gammas EMCAL (low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
     hSelectedGammaDCALPtEtaLow.setObject(new TH2F("hSelectedGammaDCALPtEtaLow", Form("Selected Gammas DCAL (low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
     hSelectedGammaDCALPtPhiLow.setObject(new TH2F("hSelectedGammaDCALPtPhiLow", Form("Selected Gammas DCAL (low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaEMCALPtEtaVeryLow.setObject(new TH2F("hSelectedGammaEMCALEtaVeryLow", Form("Selected Gammas EMCAL (very low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaEMCALPtPhiVeryLow.setObject(new TH2F("hSelectedGammaEMCALPhiVeryLow", Form("Selected Gammas EMCAL (very low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
+    hSelectedGammaDCALPtEtaVeryLow.setObject(new TH2F("hSelectedGammaDCALEtaVeryLow", Form("Selected Gammas DCAL (very low threshold);%s;#eta", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nEtaBins, kMinEta, kMaxEta));
+    hSelectedGammaDCALPtPhiVeryLow.setObject(new TH2F("hSelectedGammaDCALPhiVeryLow", Form("Selected Gammas DCAL (very low threshold);%s;#phi", (f_ObservalbeGammaTrigger == 0) ? "E (GeV)" : "#it{p}_{T}"), nPtBins, kMinPt, kMaxPt / 2, nPhiBins, kMinPhi, kMaxPhi));
 
     hMaxJetPt.setObject(new TH1D("hMaxJetPt", "Max. jet pt", nPtBins, kMinPt, kMaxPt));
     hSelectMaxJetPt.setObject(new TH1D("hSelectMaxJetPt", "Max. jet pt selected collisions", nPtBins, kMinPt, kMaxPt));
     hSelectMaxJetPtLow.setObject(new TH1D("hSelectMaxJetPtLow", "Max. jet pt selected collisions (low threshold)", nPtBins, kMinPt, kMaxPt));
     hMaxClusterEMCAL.setObject(new TH1D("hMaxClusterEMCAL", "Max.cluster pt EMCAL", nPtBins, kMinPt, kMaxPt));
     hMaxClusterDCAL.setObject(new TH1D("hMaxClusterDCAL", "Max. cluster pt DCAL", nPtBins, kMinPt, kMaxPt));
+    hSelectGammaVeryHighMaxClusterEMCAL.setObject(new TH1D("hSelectGammaVeryHighMaxClusterEMCAL", "Max. cluster pt selected Gamms EMCAL (very high threshold)", nPtBins, kMinPt, kMaxPt));
     hSelectGammaMaxClusterEMCAL.setObject(new TH1D("hSelectGammaMaxClusterEMCAL", "Max. cluster pt selected Gamms EMCAL", nPtBins, kMinPt, kMaxPt));
     hSelectGammaLowMaxClusterEMCAL.setObject(new TH1D("hSelectGammaLowMaxClusterEMCAL", "Max. cluster pt selected Gamms EMCAL (low threshold)", nPtBins, kMinPt, kMaxPt));
+    hSelectGammaVeryLowMaxClusterEMCAL.setObject(new TH1D("hSelectGammaVeryLowMaxClusterEMCAL", "Max. cluster pt selected Gamms EMCAL (very low threshold)", nPtBins, kMinPt, kMaxPt));
+    hSelectGammaVeryHighMaxClusterDCAL.setObject(new TH1D("hSelectGammaVeryHighMaxClusterDCAL", "Max. cluster pt selected Gamms DCAL (very high threshold)", nPtBins, kMinPt, kMaxPt));
     hSelectGammaMaxClusterDCAL.setObject(new TH1D("hSelectGammaMaxClusterDCAL", "Max. cluster pt selected Gamms DCAL", nPtBins, kMinPt, kMaxPt));
     hSelectGammaLowMaxClusterDCAL.setObject(new TH1D("hSelectGammaLowMaxClusterDCAL", "Max. cluster pt selected Gamms DCAL (low threshold)", nPtBins, kMinPt, kMaxPt));
+    hSelectGammaVeryLowMaxClusterDCAL.setObject(new TH1D("hSelectGammaVertLowMaxClusterDCAL", "Max. cluster pt selected Gamms DCAL (very low threshold)", nPtBins, kMinPt, kMaxPt));
 
     LOG(info) << "Jet trigger: " << (b_doJetTrigger ? "on" : "off");
     LOG(info) << "Gamma trigger: " << (b_doJetTrigger ? "on" : "off");
@@ -258,9 +308,14 @@ struct fullJetFilter {
   float getGammaThreshold(o2::emcal::AcceptanceType_t subdet, ThresholdType_t thresholdt, bool mblike)
   {
     float threshold = 0;
+    // Very-high and very-low threshold only needed and supported for trigger-like data
     switch (subdet) {
       case o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE: {
         switch (thresholdt) {
+          case ThresholdType_t::VERY_HIGH_THRESHOLD: {
+            threshold = mblike ? FLT_MAX : f_gammaPtMinEMCALVeryHigh;
+            break;
+          }
           case ThresholdType_t::HIGH_THRESHOLD: {
             threshold = mblike ? f_gammaPtMinEMCALHighMB : f_gammaPtMinEMCALHigh;
             break;
@@ -269,17 +324,29 @@ struct fullJetFilter {
             threshold = mblike ? f_gammaPtMinEMCALLowMB : f_gammaPtMinEMCALLow;
             break;
           }
+          case ThresholdType_t::VERY_LOW_THRESHOLD: {
+            threshold = mblike ? FLT_MAX : f_gammaPtMinEMCALVeryLow;
+            break;
+          }
         }
         break;
       }
       case o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE: {
         switch (thresholdt) {
+          case ThresholdType_t::VERY_HIGH_THRESHOLD: {
+            threshold = mblike ? FLT_MAX : f_gammaPtMinDCALVeryHigh;
+            break;
+          }
           case ThresholdType_t::HIGH_THRESHOLD: {
             threshold = mblike ? f_gammaPtMinDCALHighMB : f_gammaPtMinDCALHigh;
             break;
           }
           case ThresholdType_t::LOW_THRESHOLD: {
             threshold = mblike ? f_gammaPtMinDCALLowMB : f_gammaPtMinDCALLow;
+            break;
+          }
+          case ThresholdType_t::VERY_LOW_THRESHOLD: {
+            threshold = mblike ? FLT_MAX : f_gammaPtMinDCALVeryLow;
             break;
           }
         }
@@ -303,6 +370,9 @@ struct fullJetFilter {
       case ThresholdType_t::LOW_THRESHOLD:
         threshold = mblike ? f_jetPtMinLowMB : f_jetPtMinLow;
         break;
+      default:
+        // Very low and very high threshold not supported for jet trigger
+        threshold = FLT_MAX;
     }
     return threshold;
   }
@@ -381,14 +451,14 @@ struct fullJetFilter {
     return isEMCALMinBias(collision) || isEMCALLevel0(collision) || isEMCALLevel1(collision);
   }
 
-  void runGammaTrigger(const selectedClusters& clusters, std::array<bool, kCategories>& keepEvent)
+  void runGammaTrigger(const selectedClusters& clusters, EMCALHWTriggerType hardwaretrigger, std::array<bool, kCategories>& keepEvent)
   {
     double maxClusterObservableEMCAL = -1., maxClusterObservableDCAL = -1.;
-    static constexpr std::array<ThresholdType_t, 2> thresholds = {{ThresholdType_t::HIGH_THRESHOLD, ThresholdType_t::LOW_THRESHOLD}};
+    static constexpr std::array<ThresholdType_t, 4> thresholds = {{ThresholdType_t::VERY_HIGH_THRESHOLD, ThresholdType_t::HIGH_THRESHOLD, ThresholdType_t::LOW_THRESHOLD, ThresholdType_t::VERY_LOW_THRESHOLD}};
     static constexpr std::array<o2::emcal::AcceptanceType_t, 2> subdets = {{o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE, o2::emcal::AcceptanceType_t::DCAL_ACCEPTANCE}};
-    std::array<TH2*, 4> acceptanceHistsPtEta{{hSelectedGammaEMCALPtEta.object.get(), hSelectedGammaDCALPtEta.object.get(), hSelectedGammaEMCALPtEtaLow.object.get(), hSelectedGammaDCALPtEtaLow.object.get()}},
-      acceptanceHistsPtPhi{{hSelectedGammaEMCALPtPhi.object.get(), hSelectedGammaDCALPtPhi.object.get(), hSelectedGammaEMCALPtPhiLow.object.get(), hSelectedGammaDCALPtPhiLow.object.get()}};
-    std::array<TH1*, 4> maxClusterPtHists = {{hSelectGammaMaxClusterEMCAL.object.get(), hSelectGammaMaxClusterDCAL.object.get(), hSelectGammaLowMaxClusterEMCAL.object.get(), hSelectGammaLowMaxClusterDCAL.object.get()}};
+    std::array<TH2*, 8> acceptanceHistsPtEta{{hSelectedGammaEMCALPtEtaVeryHigh.object.get(), hSelectedGammaDCALPtEtaVeryHigh.object.get(), hSelectedGammaEMCALPtEta.object.get(), hSelectedGammaDCALPtEta.object.get(), hSelectedGammaEMCALPtEtaLow.object.get(), hSelectedGammaDCALPtEtaLow.object.get(), hSelectedGammaEMCALPtEtaVeryLow.object.get(), hSelectedGammaDCALPtEtaVeryLow.object.get()}},
+      acceptanceHistsPtPhi{{hSelectedGammaEMCALPtPhiVeryHigh.object.get(), hSelectedGammaDCALPtPhiVeryHigh.object.get(), hSelectedGammaEMCALPtPhi.object.get(), hSelectedGammaDCALPtPhi.object.get(), hSelectedGammaEMCALPtPhiLow.object.get(), hSelectedGammaDCALPtPhiLow.object.get(), hSelectedGammaEMCALPtPhiVeryLow.object.get(), hSelectedGammaDCALPtPhiVeryLow.object.get()}};
+    std::array<TH1*, 8> maxClusterPtHists = {{hSelectGammaVeryHighMaxClusterEMCAL.object.get(), hSelectGammaVeryHighMaxClusterDCAL.object.get(), hSelectGammaMaxClusterEMCAL.object.get(), hSelectGammaMaxClusterDCAL.object.get(), hSelectGammaLowMaxClusterEMCAL.object.get(), hSelectGammaLowMaxClusterDCAL.object.get(), hSelectGammaVeryLowMaxClusterEMCAL.object.get(), hSelectGammaVeryLowMaxClusterDCAL.object.get()}};
     struct ClusterData {
       float mTriggerObservable;
       float mEta;
@@ -410,15 +480,28 @@ struct fullJetFilter {
       }
       hEmcClusterPtEta->Fill(observableGamma, cluster.eta());
       hEmcClusterPtPhi->Fill(observableGamma, cluster.phi());
+      if (hardwaretrigger == EMCALHWTriggerType::TRG_EMC_L0) {
+        hEmcClusterPtEtaLevel0->Fill(observableGamma, cluster.eta());
+        hEmcClusterPtPhiLevel0->Fill(observableGamma, cluster.phi());
+      } else if (hardwaretrigger == EMCALHWTriggerType::TRG_EMC_MB) {
+        hEmcClusterPtEtaMinBias->Fill(observableGamma, cluster.eta());
+        hEmcClusterPtPhiMinBias->Fill(observableGamma, cluster.phi());
+      }
       analysedClusters.push_back({static_cast<float>(observableGamma), cluster.eta(), cluster.phi()});
     }
     hMaxClusterEMCAL->Fill(maxClusterObservableEMCAL);
     hMaxClusterDCAL->Fill(maxClusterObservableDCAL);
     for (decltype(thresholds.size()) ithreshold = 0; ithreshold < thresholds.size(); ithreshold++) {
+      if (thresholds[ithreshold] == ThresholdType_t::VERY_LOW_THRESHOLD) {
+        // Accept very-low threshold only in case of min. bias input to EMCAL/DCAL
+        if (hardwaretrigger != EMCALHWTriggerType::TRG_EMC_MB) {
+          continue;
+        }
+      }
       for (decltype(thresholds.size()) isubdet = 0; isubdet < subdets.size(); isubdet++) {
         if (isEvtSelectedGamma(subdets[isubdet] == o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE ? maxClusterObservableEMCAL : maxClusterObservableDCAL, subdets[isubdet], thresholds[ithreshold])) {
           maxClusterPtHists[ithreshold * subdets.size() + isubdet]->Fill(subdets[isubdet] == o2::emcal::AcceptanceType_t::EMCAL_ACCEPTANCE ? maxClusterObservableEMCAL : maxClusterObservableDCAL);
-          keepEvent[kGammaHighPtEMCAL + ithreshold * subdets.size() + isubdet] = true;
+          keepEvent[kGammaVeryHighPtEMCAL + ithreshold * subdets.size() + isubdet] = true;
           for (auto& cluster : analysedClusters) {
             acceptanceHistsPtEta[ithreshold * subdets.size() + isubdet]->Fill(cluster.mTriggerObservable, cluster.mEta);
             acceptanceHistsPtPhi[ithreshold * subdets.size() + isubdet]->Fill(cluster.mTriggerObservable, cluster.mPhi);
@@ -477,6 +560,9 @@ struct fullJetFilter {
             case ThresholdType_t::LOW_THRESHOLD:
               triggerIndex = kJetFullLowPt;
               break;
+            default:
+              // Very high / very low thresholds not supported for jet trigger
+              break;
           }
         } else {
           switch (thresholds[ithreshold]) {
@@ -485,6 +571,9 @@ struct fullJetFilter {
               break;
             case ThresholdType_t::LOW_THRESHOLD:
               triggerIndex = kJetNeutralLowPt;
+              break;
+            default:
+              // Very high / very low thresholds not supported for jet trigger
               break;
           }
         }
@@ -519,6 +608,7 @@ struct fullJetFilter {
         case EMCALHWTriggerConfiguration::MB_ONLY: {
           LOG(info) << "Found hardware trigger configuration Min. bias only";
           LOG(info) << "Gamma thresholds: High " << f_gammaPtMinEMCALHighMB << ", Low " << f_gammaPtMinEMCALLowMB << " (EMCAL), High " << f_gammaPtMinDCALHighMB << ", Low " << f_gammaPtMinDCALLowMB << " (DCAL)";
+          LOG(info) << "No extreme gamma thresholds used";
           LOG(info) << "Jet thresholds: High " << f_jetPtMinMB << ", Low " << f_jetPtMinLowMB;
           LOG(info) << "Jet type: full jets " << (isFullJets ? "yes" : "no") << ", neutral jets " << (isNeutralJets ? "yes" : "no");
           break;
@@ -526,6 +616,7 @@ struct fullJetFilter {
         case EMCALHWTriggerConfiguration::EMC_TRIGGERD: {
           LOG(info) << "Found hardware trigger configuration L0-triggered";
           LOG(info) << "Gamma thresholds: High " << f_gammaPtMinEMCALHigh << ", Low " << f_gammaPtMinEMCALLow << " (EMCAL), High " << f_gammaPtMinDCALHigh << ", Low " << f_gammaPtMinDCALLow << " (DCAL)";
+          LOG(info) << "Extreme gamma thresholds: Very high " << f_gammaPtMinEMCALVeryHigh << ", very low " << f_gammaPtMinEMCALVeryLow << " (EMCAL), very high " << f_gammaPtMinDCALVeryHigh << ", very low " << f_gammaPtMinDCALVeryLow << " (DCAL)";
           LOG(info) << "Jet thresholds: High " << f_jetPtMin << ", Low " << f_jetPtMinLow;
           LOG(info) << "Jet type: full jets " << (isFullJets ? "yes" : "no") << ", neutral jets " << (isNeutralJets ? "yes" : "no");
           break;
@@ -541,7 +632,7 @@ struct fullJetFilter {
     std::fill(keepEvent.begin(), keepEvent.end(), false);
 
     if (!b_IgnoreEmcalFlag && !hasEMCALData(collision)) {
-      tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8]);
+      tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8], keepEvent[9], keepEvent[10], keepEvent[11], keepEvent[12]);
       return; // Skip events where EMCAL is not live
     }
 
@@ -549,12 +640,19 @@ struct fullJetFilter {
       keepEvent[kEMCALReadout] = true;
     }
 
+    EMCALHWTriggerType hwtrigger = EMCALHWTriggerType::TRG_UNKNOWN;
+    if (isEMCALLevel0(collision)) {
+      hwtrigger = EMCALHWTriggerType::TRG_EMC_L0;
+    } else if (isEMCALMinBias(collision)) {
+      hwtrigger = EMCALHWTriggerType::TRG_EMC_MB;
+    }
+
     if (b_doJetTrigger) {
       runJetTrigger(jets, clusters, keepEvent);
     }
 
     if (b_doGammaTrigger) {
-      runGammaTrigger(clusters, keepEvent);
+      runGammaTrigger(clusters, hwtrigger, keepEvent);
     }
 
     for (int iDecision{0}; iDecision < kCategories; iDecision++) {
@@ -562,7 +660,7 @@ struct fullJetFilter {
         hProcessedEvents->Fill(iDecision);
       }
     }
-    tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8]);
+    tags(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8], keepEvent[9], keepEvent[10], keepEvent[11], keepEvent[12]);
   }
 
   void processFullJetTrigger(collisionInfo const& collision, filteredFullJets const& jets, selectedClusters const& clusters, BCsWithBcSelsRun3 const& bcs)

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -65,15 +65,19 @@ DECLARE_SOA_COLUMN(LLL, hasLLL, bool); //! has L-L-L tripletD
 DECLARE_SOA_COLUMN(JetChHighPt, hasJetChHighPt, bool); //! high-pT charged jet
 
 // full jets
-DECLARE_SOA_COLUMN(EMCALReadout, hasEMCALinReadout, bool);       //! EMCAL readout
-DECLARE_SOA_COLUMN(JetFullHighPt, hasJetFullHighPt, bool);       //! high-pT full jet
-DECLARE_SOA_COLUMN(JetFullLowPt, hasJetFullLowPt, bool);         //! low-pT full jet
-DECLARE_SOA_COLUMN(JetNeutralHighPt, hasJetNeutralHighPt, bool); //! high-pT neutral jet
-DECLARE_SOA_COLUMN(JetNeutralLowPt, hasJetNeutralLowPt, bool);   //! low-pT neutral jet
-DECLARE_SOA_COLUMN(GammaHighPtEMCAL, hasGammaHighPtEMCAL, bool); //! Photon trigger in EMCAL, high threshold
-DECLARE_SOA_COLUMN(GammaHighPtDCAL, hasGammaHighPtDCAL, bool);   //! Photon trigger in DCAL, high threshold
-DECLARE_SOA_COLUMN(GammaLowPtEMCAL, hasGammaLowPtEMCAL, bool);   //! Photon trigger in EMCAL, low threshold
-DECLARE_SOA_COLUMN(GammaLowPtDCAL, hasGammaLowPtDCAL, bool);     //! Photon trigger in DCAL, low threshold
+DECLARE_SOA_COLUMN(EMCALReadout, hasEMCALinReadout, bool);               //! EMCAL readout
+DECLARE_SOA_COLUMN(JetFullHighPt, hasJetFullHighPt, bool);               //! high-pT full jet
+DECLARE_SOA_COLUMN(JetFullLowPt, hasJetFullLowPt, bool);                 //! low-pT full jet
+DECLARE_SOA_COLUMN(JetNeutralHighPt, hasJetNeutralHighPt, bool);         //! high-pT neutral jet
+DECLARE_SOA_COLUMN(JetNeutralLowPt, hasJetNeutralLowPt, bool);           //! low-pT neutral jet
+DECLARE_SOA_COLUMN(GammaVeryHighPtEMCAL, hasGammaVeryHighPtEMCAL, bool); //! Photon trigger in EMCAL, very high threshold
+DECLARE_SOA_COLUMN(GammaVeryHighPtDCAL, hasGammaVeryHighPtDCAL, bool);   //! Photon trigger in DCAL, very high threshold
+DECLARE_SOA_COLUMN(GammaHighPtEMCAL, hasGammaHighPtEMCAL, bool);         //! Photon trigger in EMCAL, high threshold
+DECLARE_SOA_COLUMN(GammaHighPtDCAL, hasGammaHighPtDCAL, bool);           //! Photon trigger in DCAL, high threshold
+DECLARE_SOA_COLUMN(GammaLowPtEMCAL, hasGammaLowPtEMCAL, bool);           //! Photon trigger in EMCAL, low threshold
+DECLARE_SOA_COLUMN(GammaLowPtDCAL, hasGammaLowPtDCAL, bool);             //! Photon trigger in DCAL, low threshold
+DECLARE_SOA_COLUMN(GammaVeryLowPtEMCAL, hasGammaVeryLowPtEMCAL, bool);   //! Photon trigger in EMCAL, very low threshold
+DECLARE_SOA_COLUMN(GammaVeryLowPtDCAL, hasGammaVeryLowPtDCAL, bool);     //! Photon trigger in DCAL, very low threshold
 
 // strangeness (lf)
 DECLARE_SOA_COLUMN(Omega, hasOmega, bool);                       //! at leat 1 Omega
@@ -164,7 +168,7 @@ DECLARE_SOA_TABLE(JetFilters, "AOD", "JetFilters", //!
 using JetFilter = JetFilters::iterator;
 
 DECLARE_SOA_TABLE(FullJetFilters, "AOD", "FullJetFilters", //!
-                  filtering::EMCALReadout, filtering::JetFullHighPt, filtering::JetFullLowPt, filtering::JetNeutralHighPt, filtering::JetNeutralLowPt, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL, filtering::GammaLowPtEMCAL, filtering::GammaLowPtDCAL);
+                  filtering::EMCALReadout, filtering::JetFullHighPt, filtering::JetFullLowPt, filtering::JetNeutralHighPt, filtering::JetNeutralLowPt, filtering::GammaVeryHighPtEMCAL, filtering::GammaVeryHighPtDCAL, filtering::GammaHighPtEMCAL, filtering::GammaHighPtDCAL, filtering::GammaLowPtEMCAL, filtering::GammaLowPtDCAL, filtering::GammaVeryLowPtEMCAL, filtering::GammaVeryLowPtDCAL);
 
 using FullJetFilter = FullJetFilters::iterator;
 

--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -50,11 +50,22 @@ struct JetTriggerQA {
     kEmcalJetFullLow,
     kEmcalJetNeutral,
     kEmcalJetNeutralLow,
+    kEmcalGammaVeryHigh,
+    kDcalGammaVeryHigh,
     kEmcalGammaHigh,
     kDcalGammaHigh,
     kEmcalGammaLow,
     kDcalGammaLow,
+    kEmcalGammaVeryLow,
+    kDcalGammaVeryLow,
     kNTriggers
+  };
+
+  enum EMCALHardwareTrigger {
+    TRG_MB,
+    TRG_EMC7,
+    TRG_DMC7,
+    TRG_NTriggers
   };
 
   // Preslice<aod::JetTrackConstituents> perJetTrackConstituents = o2::aod::jetconstituents::jetId;
@@ -129,7 +140,7 @@ struct JetTriggerQA {
     registry.add("jetRPtEtaPhiNoFiducial", "JetRPtEtaPhiNoFiducial", hJetRPtEtaPhiNoFiducial);
     registry.add("jetRMaxPtEtaPhiNoFiducial", "JetRMaxPtEtaPhiNoFiducial", hJetRMaxPtEtaPhiNoFiducial);
 
-    registry.add("hProcessedEvents", "Processed events", HistType::kTH1D, {{17, -0.5, 16.5, "Trigger type"}});
+    registry.add("hProcessedEvents", "Processed events", HistType::kTH1D, {{15, -0.5, 14.5, "Trigger type"}});
     auto histProcessed = registry.get<TH1>(HIST("hProcessedEvents"));
     histProcessed->GetXaxis()->SetBinLabel(1, "MB");
     histProcessed->GetXaxis()->SetBinLabel(2, "Any EMC trigger");
@@ -138,18 +149,16 @@ struct JetTriggerQA {
     histProcessed->GetXaxis()->SetBinLabel(5, "Selected Full Jet low");
     histProcessed->GetXaxis()->SetBinLabel(6, "Selected Neutral Jet high");
     histProcessed->GetXaxis()->SetBinLabel(7, "Selected Neutral Jet low");
-    histProcessed->GetXaxis()->SetBinLabel(8, "Selected Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(9, "Selected Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(10, "Selected Gamma low EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(11, "Selected Gamma low DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(12, "Selected full jet high and Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(13, "Selected full jet high and Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(14, "Selected neutral jet high and Gamma high EMCAL");
-    histProcessed->GetXaxis()->SetBinLabel(15, "Selected neutral jet high and Gamma high DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(16, "Selected Gamma high EMCAL and high Gamma DCAL");
-    histProcessed->GetXaxis()->SetBinLabel(17, "Selected full jet high and neutral jet high");
+    histProcessed->GetXaxis()->SetBinLabel(8, "Selected Gamma very high EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(9, "Selected Gamma very high DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(10, "Selected Gamma high EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(11, "Selected Gamma high DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(12, "Selected Gamma low EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(13, "Selected Gamma low DCAL");
+    histProcessed->GetXaxis()->SetBinLabel(14, "Selected Gamma very low EMCAL");
+    histProcessed->GetXaxis()->SetBinLabel(15, "Selected Gamma very low DCAL");
 
-    std::array<std::string, TriggerType_t::kNTriggers> triggerlabels = {{"MB", "EMC Any", "EMC MB", "EMC jet full high", "EMC jet full low", "EMC jet neutral high", "EMC jet neutral low", "EMC gamma high", "DCL gamma high", "EMC gamma low", "DCL gamma low"}};
+    std::array<std::string, TriggerType_t::kNTriggers> triggerlabels = {{"MB", "EMC Any", "EMC MB", "EMC jet full high", "EMC jet full low", "EMC jet neutral high", "EMC jet neutral low", "EMC gamma very high", "DCL gamma very high", "EMC gamma high", "DCL gamma high", "EMC gamma low", "DCL gamma low", "EMC gamma very low", "DCL gamma very low"}};
     registry.add("hTriggerCorrelation", "Correlation between EMCAL triggers", HistType::kTH2D, {{TriggerType_t::kNTriggers, -0.5, TriggerType_t::kNTriggers - 0.5, "Main trigger"}, {TriggerType_t::kNTriggers, -0.5, TriggerType_t::kNTriggers - 0.5, "Associated trigger"}});
     auto triggerCorrelation = registry.get<TH2>(HIST("hTriggerCorrelation"));
     for (std::size_t triggertype = 0; triggertype < TriggerType_t::kNTriggers; triggertype++) {
@@ -162,13 +171,28 @@ struct JetTriggerQA {
     registry.add("hJetRPtPhi", "Jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
     registry.add("hJetRMaxPtEta", "Leading jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
     registry.add("hJetRMaxPtPhi", "Leading jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hClusterPtEta", Form("Cluster %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hClusterPtPhi", Form("Cluster %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
+    registry.add("hJetRMaxPtEtaMinBias", "Leading jets #it{p}_{T} and #eta (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+    registry.add("hJetRMaxPtPhiMinBias", "Leading jets #it{p}_{T} and #phi (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    registry.add("hJetRMaxPtEtaLevel0", "Leading jets #it{p}_{T} and #eta (level0)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+    registry.add("hJetRMaxPtPhiLevel0", "Leading jets #it{p}_{T} and #phi (level0)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
     registry.add("hClusterPtEtaPhi", Form("Cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hClusterPtEtaPhiMinBias", Form("Cluster %s (Min. bias trigger), #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hClusterPtEtaPhiLevel0", Form("Cluster %s (Level-0 trigger), #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hClusterEMCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (EMCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hClusterEMCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (EMCAL, min. bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hClusterEMCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (EMCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hClusterDCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (DCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterMaxPtEta", Form("Leading clusters %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hClusterMaxPtPhi", Form("Leading clusters %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
+    registry.add("hClusterDCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (DCAL, min, bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hClusterDCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (DCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hEventsNoMaxClusterEMCAL", "Events with no max. cluster in EMCAL", HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxClusterEMCALMinBias", "Events with no max. cluster in EMCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxClusterEMCALLevel0", "Events with no max. cluster in EMCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxClusterDCAL", ("Events with no max. cluster in DCAL"), HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxClusterDCALMinBias", "Events with no max. cluster in DCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxClusterDCALLevel0", "Events with no max. cluster in DCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+    registry.add("hEventsNoMaxJet", "Events with no max. jet", HistType::kTH1D, {{rAxis}});
+    registry.add("hEventsNoMaxJetMinBias", "Events with no max. jet (min. bias trigger)", HistType::kTH1D, {{rAxis}});
+    registry.add("hEventsNoMaxJetLevel0", "Events with no max. jet (level0 trigger)", HistType::kTH1D, {{rAxis}});
     registry.add("hJetRPtTrackPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
     registry.add("hJetRPtClusterPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
     registry.add("hJetRPtPtd", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
@@ -180,12 +204,8 @@ struct JetTriggerQA {
     registry.add("hJetRMaxPtClusterMaxPt", "Leading jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
 
     // Histograms for triggered events
-    registry.add("hSelectedClusterPtEta", Form("Selected Cluster %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedClusterPtPhi", Form("Selected Cluster %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedClusterPtEtaPhi", Form("Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedClusterMaxPtEtaPhi", Form("Leading Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedClusterMaxPtEta", Form("Leading selected clusters %s and #eta", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedClusterMaxPtPhi", Form("Leading selected clusters %s and #phi", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
 
     // Jet high trigger
     registry.add("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
@@ -213,39 +233,39 @@ struct JetTriggerQA {
     registry.add("hSelectedJetLowRPtZSqTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
     registry.add("hSelectedJetLowRPtZThetaSq", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
 
+    // EMCAL gamma very-high trigger
+    registry.add("hSelectedGammaEMCALPtEtaPhiVeryHigh", Form("Selected Gamma %s, #eta and #phi (EMCAL, very high threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
+    // DCAL gamma very-high trigger
+    registry.add("hSelectedGammaDCALPtEtaPhiVeryHigh", Form("Selected gamma %s, #eta and #phi (DCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (DCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
     // EG1 trigger
-    registry.add("hSelectedGammaEMCALPtEta", Form("Selected Gamma %s and #eta (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaEMCALPtPhi", Form("Selected Gamma %s and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaEMCALPtEtaPhi", Form("Selected Gamma %s, #eta and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (EMCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEta", Form("Leading selected gamma %s and #eta (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaEMCALMaxPtPhi", Form("Leading selected gamma %s and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
 
     // DG1 trigger
-    registry.add("hSelectedGammaDCALPtEta", Form("Selected Gamma %s and #eta (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALPtPhi", Form("Selected Gamma %s and #phi (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEta", Form("Leading selected gamma %s and #eta (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALMaxPtPhi", Form("Leading selected gamma %s and #phi (DCAL, high threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALPtEtaPhi", Form("Selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaDCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // EG2 trigger
-    registry.add("hSelectedGammaEMCALPtEtaLow", Form("Selected Gamma %s and #eta (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaEMCALPtPhiLow", Form("Selected Gamma %s and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaEMCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaEMCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEtaLow", Form("Leading selected gamma %s and #eta (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaEMCALMaxPtPhiLow", Form("Leading selected gamma %s and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
 
     // DG2 trigger
-    registry.add("hSelectedGammaDCALPtEtaLow", Form("Selected Gamma %s and #eta (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALPtPhiLow", Form("Selected Gamma %s and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEtaLow", Form("Leading selected gamma %s and #eta (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, etaAxis});
-    registry.add("hSelectedGammaDCALMaxPtPhiLow", Form("Leading selected gamma %s and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH2F, {observableAxisCluster, phiAxis});
     registry.add("hSelectedGammaDCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hSelectedGammaDCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedJetRMaxPtClusterMaxPt", "Leading selected jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
 
+    // EMCAL gamma very-low trigger
+    registry.add("hSelectedGammaEMCALPtEtaPhiVeryLow", Form("Selected gamma %s, #eta and #phi (EMCAL, very low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
+    //  DCAL gamma very-low trigger
+    registry.add("hSelectedGammaDCALPtEtaPhiVeryLow", Form("Selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
+    registry.add("hSelectedJetRMaxPtClusterMaxPt", "Leading selected jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
     registry.add("hJetRMaxPtJetPt", "Leading jet #it{p}_{T} vs jet #it{p}_{T}", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
     registry.add("hJetRMaxPtJetPtNoFiducial", "Leading jet #it{p}_{T} vs jet #it{p}_{T} (no fiducial cut)", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
     registry.add("hClusterEMCALMaxPtClusterEMCALPt", Form("Leading clusterEMCAL %s vs clusterEMCAL %s", observableName.data(), observableName.data()), HistType::kTH2F, {observableAxisMaxCluster, observableAxisCluster});
@@ -264,6 +284,10 @@ struct JetTriggerQA {
       registry.get<TH3>(HIST("hJetRPtZThetaSq"))->SetTitle("Jets (in emcal only)");
       registry.get<TH3>(HIST("hJetRMaxPtEta"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #eta");
       registry.get<TH3>(HIST("hJetRMaxPtPhi"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #phi");
+      registry.get<TH3>(HIST("hJetRMaxPtEtaMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #eta");
+      registry.get<TH3>(HIST("hJetRMaxPtPhiMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #phi");
+      registry.get<TH3>(HIST("hJetRMaxPtEtaLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #eta");
+      registry.get<TH3>(HIST("hJetRMaxPtPhiLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #phi");
       registry.get<TH3>(HIST("hJetRMaxPtClusterMaxPt"))->SetTitle("Leading jets (in emcal only) and clusters");
 
       registry.get<TH3>(HIST("hSelectedJetRPtEta"))->SetTitle("Selected jets (in emcal only) #it{p}_{T} and #eta");
@@ -368,7 +392,7 @@ struct JetTriggerQA {
     registry.fill(HIST("hTriggerCorrelation"), mainTrigger, assocTrigger);
   }
 
-  std::pair<double, double> fillGammaQA(const selectedClusters& clusters, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
+  std::pair<double, double> fillGammaQA(const selectedClusters& clusters, std::bitset<EMCALHardwareTrigger::TRG_NTriggers> hwtrg, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
   {
     auto isTrigger = [&triggerstatus](TriggerType_t triggertype) -> bool {
       return triggerstatus.test(triggertype);
@@ -404,86 +428,120 @@ struct JetTriggerQA {
         maxClusterObservableDCAL = clusterObservable;
         maxClusterDCAL = cluster;
       }
-      registry.fill(HIST("hClusterPtEta"), clusterObservable, cluster.eta());
-      registry.fill(HIST("hClusterPtPhi"), clusterObservable, cluster.phi());
       registry.fill(HIST("hClusterPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hClusterPtEtaPhiMinBias"), clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7) || hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
+        registry.fill(HIST("hClusterPtEtaPhiLevel0"), clusterObservable, cluster.eta(), cluster.phi());
+      }
       if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-        registry.fill(HIST("hSelectedClusterPtEta"), clusterObservable, cluster.eta());
-        registry.fill(HIST("hSelectedClusterPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedClusterPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
+      if (isTrigger(TriggerType_t::kEmcalGammaVeryHigh) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
+        registry.fill(HIST("hSelectedGammaEMCALPtEtaPhiVeryHigh"), clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (isTrigger(TriggerType_t::kDcalGammaVeryHigh) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
+        registry.fill(HIST("hSelectedGammaDCALPtEtaPhiVeryHigh"), clusterObservable, cluster.eta(), cluster.phi());
+      }
       if (isTrigger(TriggerType_t::kEmcalGammaHigh) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
-        registry.fill(HIST("hSelectedGammaEMCALPtEta"), clusterObservable, cluster.eta());
-        registry.fill(HIST("hSelectedGammaEMCALPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaEMCALPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
       if (isTrigger(TriggerType_t::kDcalGammaHigh) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
-        registry.fill(HIST("hSelectedGammaDCALPtEta"), clusterObservable, cluster.eta());
-        registry.fill(HIST("hSelectedGammaDCALPtPhi"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaDCALPtEtaPhi"), clusterObservable, cluster.eta(), cluster.phi());
       }
       if (isTrigger(TriggerType_t::kEmcalGammaLow) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
-        registry.fill(HIST("hSelectedGammaEMCALPtEtaLow"), clusterObservable, cluster.eta());
-        registry.fill(HIST("hSelectedGammaEMCALPtPhiLow"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaEMCALPtEtaPhiLow"), clusterObservable, cluster.eta(), cluster.phi());
       }
       if (isTrigger(TriggerType_t::kDcalGammaLow) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
-        registry.fill(HIST("hSelectedGammaDCALPtEtaLow"), clusterObservable, cluster.eta());
-        registry.fill(HIST("hSelectedGammaDCALPtPhiLow"), clusterObservable, cluster.phi());
         registry.fill(HIST("hSelectedGammaDCALPtEtaPhiLow"), clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (isTrigger(TriggerType_t::kEmcalGammaVeryLow) && isClusterInEmcal(cluster)) { // Only fill EMCAL clusters
+        registry.fill(HIST("hSelectedGammaEMCALPtEtaPhiVeryLow"), clusterObservable, cluster.eta(), cluster.phi());
+      }
+      if (isTrigger(TriggerType_t::kDcalGammaVeryLow) && !isClusterInEmcal(cluster)) { // Only fill DCAL clusters
+        registry.fill(HIST("hSelectedGammaDCALPtEtaPhiVeryLow"), clusterObservable, cluster.eta(), cluster.phi());
       }
     } // for clusters
 
     if (maxClusterObservableEMCAL > 0) {
-      registry.fill(HIST("hClusterMaxPtEta"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
-      registry.fill(HIST("hClusterMaxPtPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
       registry.fill(HIST("hClusterEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hClusterEMCALMaxPtEtaPhiMinBias"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
+        registry.fill(HIST("hClusterEMCALMaxPtEtaPhiLevel0"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
       for (const auto& cluster : analysedClusters) {
         if (cluster.mEMCALcluster) {
           registry.fill(HIST("hClusterEMCALMaxPtClusterEMCALPt"), maxClusterObservableEMCAL, cluster.mTriggerObservable);
         }
       }
       if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-        registry.fill(HIST("hSelectedClusterMaxPtEta"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
-        registry.fill(HIST("hSelectedClusterMaxPtPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedClusterMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
+      if (isTrigger(TriggerType_t::kEmcalGammaVeryHigh)) {
+        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
       if (isTrigger(TriggerType_t::kEmcalGammaHigh)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEta"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
       }
       if (isTrigger(TriggerType_t::kEmcalGammaLow)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta());
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.phi());
         registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
+      if (isTrigger(TriggerType_t::kEmcalGammaVeryLow)) {
+        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+      }
+    } else {
+      // count events where max. cluster has not been found
+      registry.fill(HIST("hEventsNoMaxClusterEMCAL"), 1.);
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hEventsNoMaxClusterEMCALMinBias"), 1.);
+      }
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
+        registry.fill(HIST("hEventsNoMaxClusterEMCALLevel0"), 1.);
       }
     }
     if (maxClusterObservableDCAL > 0) {
-      registry.fill(HIST("hClusterMaxPtEta"), maxClusterObservableDCAL, maxClusterDCAL.eta());
-      registry.fill(HIST("hClusterMaxPtPhi"), maxClusterObservableDCAL, maxClusterDCAL.phi());
       registry.fill(HIST("hClusterDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hClusterDCALMaxPtEtaPhiMinBias"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
+        registry.fill(HIST("hClusterDCALMaxPtEtaPhiLevel0"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
       for (const auto& cluster : analysedClusters) {
         if (!cluster.mEMCALcluster) {
           registry.fill(HIST("hClusterDCALMaxPtClusterDCALPt"), maxClusterObservableDCAL, cluster.mTriggerObservable);
         }
       }
+      if (isTrigger(TriggerType_t::kDcalGammaVeryHigh)) {
+        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryHigh"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
       if (isTrigger(TriggerType_t::kDcalGammaHigh)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEta"), maxClusterObservableDCAL, maxClusterDCAL.eta());
-        registry.fill(HIST("hSelectedGammaDCALMaxPtPhi"), maxClusterObservableDCAL, maxClusterDCAL.phi());
         registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
       }
       if (isTrigger(TriggerType_t::kDcalGammaLow)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaLow"), maxClusterObservableDCAL, maxClusterDCAL.eta());
-        registry.fill(HIST("hSelectedGammaDCALMaxPtPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.phi());
         registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
+      if (isTrigger(TriggerType_t::kDcalGammaVeryLow)) {
+        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+      }
+    } else {
+      registry.fill(HIST("hEventsNoMaxClusterDCAL"), 1.);
+      // count events where max. cluster has not been found
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hEventsNoMaxClusterDCALMinBias"), 1.);
+      }
+      if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
+        registry.fill(HIST("hEventsNoMaxClusterDCALLevel0"), 1.);
       }
     }
     return std::make_pair(maxClusterObservableEMCAL, maxClusterObservableDCAL);
   }
 
   template <typename JetCollection>
-  std::pair<std::vector<typename JetCollection::iterator>, std::vector<typename JetCollection::iterator>> fillJetQA(const JetCollection& jets, aod::Tracks const& tracks, selectedClusters const& clusters, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
+  std::pair<std::vector<typename JetCollection::iterator>, std::vector<typename JetCollection::iterator>> fillJetQA(const JetCollection& jets, aod::Tracks const& tracks, selectedClusters const& clusters, std::bitset<EMCALHardwareTrigger::TRG_NTriggers> hwtrg, const std::bitset<TriggerType_t::kNTriggers>& triggerstatus)
   {
     auto isTrigger = [&triggerstatus](TriggerType_t triggertype) -> bool {
       return triggerstatus.test(triggertype);
@@ -600,6 +658,17 @@ struct JetTriggerQA {
       triggerstatus.set(triggertype, true);
     };
 
+    std::bitset<EMCALHardwareTrigger::TRG_NTriggers> hardwaretriggers;
+    if (collision.alias_bit(triggerAliases::kTVXinEMC)) {
+      hardwaretriggers.set(EMCALHardwareTrigger::TRG_MB);
+    }
+    if (collision.alias_bit(triggerAliases::kEMC7)) {
+      hardwaretriggers.set(EMCALHardwareTrigger::TRG_EMC7);
+    }
+    if (collision.alias_bit(triggerAliases::kDMC7)) {
+      hardwaretriggers.set(EMCALHardwareTrigger::TRG_DMC7);
+    }
+
     fillEventSelectionCounter(0);
     setTrigger(TriggerType_t::kMinBias);
 
@@ -630,39 +699,37 @@ struct JetTriggerQA {
       fillEventSelectionCounter(6);
       setTrigger(TriggerType_t::kEmcalJetNeutralLow);
     }
-    if (collision.hasGammaHighPtEMCAL()) {
+    if (collision.hasGammaVeryHighPtEMCAL()) {
       fillEventSelectionCounter(7);
+      setTrigger(TriggerType_t::kEmcalGammaVeryHigh);
+    }
+    if (collision.hasGammaVeryHighPtDCAL()) {
+      fillEventSelectionCounter(8);
+      setTrigger(TriggerType_t::kDcalGammaVeryHigh);
+    }
+    if (collision.hasGammaHighPtEMCAL()) {
+      fillEventSelectionCounter(9);
       setTrigger(TriggerType_t::kEmcalGammaHigh);
     }
     if (collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(8);
+      fillEventSelectionCounter(10);
       setTrigger(TriggerType_t::kDcalGammaHigh);
     }
     if (collision.hasGammaLowPtEMCAL()) {
-      fillEventSelectionCounter(9);
+      fillEventSelectionCounter(11);
       setTrigger(TriggerType_t::kEmcalGammaLow);
     }
     if (collision.hasGammaLowPtDCAL()) {
-      fillEventSelectionCounter(10);
+      fillEventSelectionCounter(12);
       setTrigger(TriggerType_t::kDcalGammaLow);
     }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtEMCAL()) {
-      fillEventSelectionCounter(11);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(12);
-    }
-    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtEMCAL()) {
+    if (collision.hasGammaVeryLowPtEMCAL()) {
       fillEventSelectionCounter(13);
+      setTrigger(TriggerType_t::kEmcalGammaVeryLow);
     }
-    if (collision.hasJetNeutralHighPt() && collision.hasGammaHighPtDCAL()) {
+    if (collision.hasGammaVeryLowPtDCAL()) {
       fillEventSelectionCounter(14);
-    }
-    if (collision.hasJetFullHighPt() && collision.hasJetNeutralHighPt()) {
-      fillEventSelectionCounter(15);
-    }
-    if (collision.hasGammaHighPtEMCAL() && collision.hasGammaHighPtDCAL()) {
-      fillEventSelectionCounter(16);
+      setTrigger(TriggerType_t::kDcalGammaVeryLow);
     }
 
     // Create correlationMatrix
@@ -684,13 +751,24 @@ struct JetTriggerQA {
       }
     }
 
-    auto [maxClusterObservableEMCAL, maxClusterObservableDCAL] = fillGammaQA(clusters, triggerstatus);
-    auto [vecMaxJet, vecMaxJetNoFiducial] = fillJetQA(jets, tracks, clusters, triggerstatus);
+    auto [maxClusterObservableEMCAL, maxClusterObservableDCAL] = fillGammaQA(clusters, hardwaretriggers, triggerstatus);
+    auto [vecMaxJet, vecMaxJetNoFiducial] = fillJetQA(jets, tracks, clusters, hardwaretriggers, triggerstatus);
 
+    std::array<bool, 5> foundMaxJet;
+    std::fill(foundMaxJet.begin(), foundMaxJet.end(), false);
     for (auto maxJet : vecMaxJet) {
       double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
+      foundMaxJet[static_cast<int>(maxJet.r() * 1e-1) - 2] = true;
       registry.fill(HIST("hJetRMaxPtEta"), jetR, jetPt, jetEta);
       registry.fill(HIST("hJetRMaxPtPhi"), jetR, jetPt, jetPhi);
+      if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_MB)) {
+        registry.fill(HIST("hJetRMaxPtEtaMinBias"), jetR, jetPt, jetEta);
+        registry.fill(HIST("hJetRMaxPtPhiMinBias"), jetR, jetPt, jetPhi);
+      }
+      if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_EMC7)) {
+        registry.fill(HIST("hJetRMaxPtEtaLevel0"), jetR, jetPt, jetEta);
+        registry.fill(HIST("hJetRMaxPtPhiLevel0"), jetR, jetPt, jetPhi);
+      }
       // hJetRMaxPtEtaPhi->Fill(jetR, jetPt, jetEta, jetPhi);
       registry.get<THn>(HIST("jetRMaxPtEtaPhi"))->Fill(jetR, jetPt, jetEta, jetPhi);
       if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
@@ -711,6 +789,19 @@ struct JetTriggerQA {
         } // for jets
       }   // if maxJet.r() == std::round(f_jetR * 100)
     }     // for maxJet
+    // Fill counters for events without max jets
+    for (std::size_t ir = 0; ir < foundMaxJet.size(); ir++) {
+      if (!foundMaxJet[ir]) {
+        double rval = static_cast<double>(ir) / 10.;
+        registry.fill(HIST("hEventsNoMaxJet"), rval);
+        if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_MB)) {
+          registry.fill(HIST("hEventsNoMaxJetMinBias"), rval);
+        }
+        if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_EMC7)) {
+          registry.fill(HIST("hEventsNoMaxJetLevel0"), rval);
+        }
+      }
+    }
     for (auto maxJet : vecMaxJetNoFiducial) {
       double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
       // hJetRMaxPtEtaPhiNoFiducial->Fill(jetR, jetPt, jetEta, jetPhi);


### PR DESCRIPTION
- Add very low gamma threshold on-min. bias triggered
  events to bridge to Level-0 trigger
- Add very high gamma threshold to inspect the full
  integrated luminosity (mostly Level-0, negligible
  impact on min. bias)
- Enable both triggers only on trigger-like runs
- Add dedicated QA histograms for new triggers
- Add dedicated QA histograms for min. bias and
  Level-0 hardware triggers
- Remove redundant 2D histograms