### PR TITLE
PWGHF: implement D*+ in track-index-skim-creator

### DIFF
--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -225,7 +225,6 @@ namespace hf_cuts_presel_dstar
 static constexpr int nBinsPt = 2;
 static constexpr int nCutVars = 2;
 // default values for the pT bin edges (can be used to configure histogram axis)
-// common for any 2-prong candidate
 // offset by 1 from the bin numbers in cuts array
 constexpr double binsPt[nBinsPt + 1] = {
   1.,

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -91,13 +91,21 @@ constexpr double binsPtTrack[nBinsPtTrack + 1] = {
   1000.0};
 auto vecBinsPtTrack = std::vector<double>{binsPtTrack, binsPtTrack + nBinsPtTrack + 1};
 
-// default values for the cuts
+// default values for the cuts of displaced tracks
 constexpr double cutsTrack[nBinsPtTrack][nCutVarsTrack] = {{0.0025, 10.},  /* 0   < pt < 0.5 */
                                                            {0.0025, 10.},  /* 0.5 < pt < 1 */
                                                            {0.0025, 10.},  /* 1   < pt < 1.5 */
                                                            {0.0025, 10.},  /* 1.5 < pt < 2 */
                                                            {0.0000, 10.},  /* 2   < pt < 3 */
                                                            {0.0000, 10.}}; /* 3   < pt < 1000 */
+
+// default values for the cuts of primary tracks (e.g. D* soft pions)
+constexpr double cutsTrackPrimary[nBinsPtTrack][nCutVarsTrack] = {{0.0000, 2.},  /* 0   < pt < 0.5 */
+                                                                  {0.0000, 2.},  /* 0.5 < pt < 1 */
+                                                                  {0.0000, 2.},  /* 1   < pt < 1.5 */
+                                                                  {0.0000, 2.},  /* 1.5 < pt < 2 */
+                                                                  {0.0000, 2.},  /* 2   < pt < 3 */
+                                                                  {0.0000, 2.}}; /* 3   < pt < 1000 */
 
 // row labels
 static const std::vector<std::string> labelsPtTrack{};

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -212,6 +212,30 @@ static const std::vector<std::string> labelsPt{};
 static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL"};
 } // namespace hf_cuts_presel_3prong
 
+namespace hf_cuts_presel_dstar
+{
+static constexpr int nBinsPt = 2;
+static constexpr int nCutVars = 2;
+// default values for the pT bin edges (can be used to configure histogram axis)
+// common for any 2-prong candidate
+// offset by 1 from the bin numbers in cuts array
+constexpr double binsPt[nBinsPt + 1] = {
+  1.,
+  5.,
+  1000.0};
+auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
+
+// default values for the cuts
+constexpr double cuts[nBinsPt][nCutVars] = {{0.17, 0.05},  /* 1 < pt < 5 */
+                                            {0.17, 0.08}}; /* 5 < pt < 1000 */
+
+// row labels
+static const std::vector<std::string> labelsPt{};
+
+// column labels
+static const std::vector<std::string> labelsCutVar = {"deltaMassMax", "deltaMassD0"};
+} // namespace hf_cuts_presel_dstar
+
 namespace hf_cuts_d0_to_pi_k
 {
 static constexpr int nBinsPt = 25;

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -116,6 +116,8 @@ DECLARE_SOA_COLUMN(FlagDplusToPiKPi, flagDplusToPiKPi, uint8_t); //!
 DECLARE_SOA_COLUMN(FlagLcToPKPi, flagLcToPKPi, uint8_t);         //!
 DECLARE_SOA_COLUMN(FlagDsToKKPi, flagDsToKKPi, uint8_t);         //!
 DECLARE_SOA_COLUMN(FlagXicToPKPi, flagXicToPKPi, uint8_t);       //!
+
+DECLARE_SOA_COLUMN(FlagDstarToD0Pi, flagDstarToD0Pi, uint8_t); //!
 } // namespace hf_track_index
 
 DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates (Run 2 converted format)
@@ -184,10 +186,19 @@ namespace hf_track_index
 DECLARE_SOA_INDEX_COLUMN_FULL(ProngD0, prongD0, int, Hf2Prongs, ""); //! Index to a D0 prong
 } // namespace hf_track_index
 
-DECLARE_SOA_TABLE(HfDstars, "AOD", "HFDSTAR", //! D* -> D0pi candidates
+DECLARE_SOA_TABLE(HfDstars_000, "AOD", "HFDSTAR", //! D* -> D0pi candidates (Run 2 converted format)
                   o2::soa::Index<>,
                   hf_track_index::Prong0Id,
                   hf_track_index::ProngD0Id);
+
+DECLARE_SOA_TABLE(HfDstars_001, "AOD", "HFDSTAR", //! D* -> D0pi candidates (Run 3 format)
+                  o2::soa::Index<>,
+                  hf_track_index::CollisionId,
+                  hf_track_index::Prong0Id,
+                  hf_track_index::ProngD0Id,
+                  hf_track_index::HFflag);
+
+using HfDstars = HfDstars_001;
 using HfDstar = HfDstars::iterator;
 
 DECLARE_SOA_TABLE(HfCutStatus2Prong, "AOD", "HFCUTSTATUS2P", //!
@@ -200,6 +211,9 @@ DECLARE_SOA_TABLE(HfCutStatus3Prong, "AOD", "HFCUTSTATUS3P", //!
                   hf_track_index::FlagLcToPKPi,
                   hf_track_index::FlagDsToKKPi,
                   hf_track_index::FlagXicToPKPi);
+
+DECLARE_SOA_TABLE(HfCutStatusDstar, "AOD", "HFCUTSTATUSDST", //!
+                  hf_track_index::FlagDstarToD0Pi);
 
 namespace hf_pv_refit_cand_2prong
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -195,8 +195,7 @@ DECLARE_SOA_TABLE(HfDstars_001, "AOD", "HFDSTAR", //! D* -> D0pi candidates (Run
                   o2::soa::Index<>,
                   hf_track_index::CollisionId,
                   hf_track_index::Prong0Id,
-                  hf_track_index::ProngD0Id,
-                  hf_track_index::HFflag);
+                  hf_track_index::ProngD0Id);
 
 using HfDstars = HfDstars_001;
 using HfDstar = HfDstars::iterator;
@@ -215,7 +214,7 @@ DECLARE_SOA_TABLE(HfCutStatus3Prong, "AOD", "HFCUTSTATUS3P", //!
 DECLARE_SOA_TABLE(HfCutStatusDstar, "AOD", "HFCUTSTATUSDST", //!
                   hf_track_index::FlagDstarToD0Pi);
 
-namespace hf_pv_refit_cand_2prong
+namespace hf_pv_refit
 {
 DECLARE_SOA_COLUMN(PvRefitX, pvRefitX, float);             //!
 DECLARE_SOA_COLUMN(PvRefitY, pvRefitY, float);             //!
@@ -226,42 +225,42 @@ DECLARE_SOA_COLUMN(PvRefitSigmaY2, pvRefitSigmaY2, float); //!
 DECLARE_SOA_COLUMN(PvRefitSigmaXZ, pvRefitSigmaXZ, float); //!
 DECLARE_SOA_COLUMN(PvRefitSigmaYZ, pvRefitSigmaYZ, float); //!
 DECLARE_SOA_COLUMN(PvRefitSigmaZ2, pvRefitSigmaZ2, float); //!
-} // namespace hf_pv_refit_cand_2prong
+} // namespace hf_pv_refit
 
 DECLARE_SOA_TABLE(HfPvRefit2Prong, "AOD", "HFPVREFIT2PRONG", //!
-                  hf_pv_refit_cand_2prong::PvRefitX,
-                  hf_pv_refit_cand_2prong::PvRefitY,
-                  hf_pv_refit_cand_2prong::PvRefitZ,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaX2,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaXY,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaY2,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaXZ,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaYZ,
-                  hf_pv_refit_cand_2prong::PvRefitSigmaZ2);
-
-namespace hf_pv_refit_cand_3prong
-{
-DECLARE_SOA_COLUMN(PvRefitX, pvRefitX, float);             //!
-DECLARE_SOA_COLUMN(PvRefitY, pvRefitY, float);             //!
-DECLARE_SOA_COLUMN(PvRefitZ, pvRefitZ, float);             //!
-DECLARE_SOA_COLUMN(PvRefitSigmaX2, pvRefitSigmaX2, float); //!
-DECLARE_SOA_COLUMN(PvRefitSigmaXY, pvRefitSigmaXY, float); //!
-DECLARE_SOA_COLUMN(PvRefitSigmaY2, pvRefitSigmaY2, float); //!
-DECLARE_SOA_COLUMN(PvRefitSigmaXZ, pvRefitSigmaXZ, float); //!
-DECLARE_SOA_COLUMN(PvRefitSigmaYZ, pvRefitSigmaYZ, float); //!
-DECLARE_SOA_COLUMN(PvRefitSigmaZ2, pvRefitSigmaZ2, float); //!
-} // namespace hf_pv_refit_cand_3prong
+                  hf_pv_refit::PvRefitX,
+                  hf_pv_refit::PvRefitY,
+                  hf_pv_refit::PvRefitZ,
+                  hf_pv_refit::PvRefitSigmaX2,
+                  hf_pv_refit::PvRefitSigmaXY,
+                  hf_pv_refit::PvRefitSigmaY2,
+                  hf_pv_refit::PvRefitSigmaXZ,
+                  hf_pv_refit::PvRefitSigmaYZ,
+                  hf_pv_refit::PvRefitSigmaZ2);
 
 DECLARE_SOA_TABLE(HfPvRefit3Prong, "AOD", "HFPVREFIT3PRONG", //!
-                  hf_pv_refit_cand_3prong::PvRefitX,
-                  hf_pv_refit_cand_3prong::PvRefitY,
-                  hf_pv_refit_cand_3prong::PvRefitZ,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaX2,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaXY,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaY2,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaXZ,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaYZ,
-                  hf_pv_refit_cand_3prong::PvRefitSigmaZ2);
+                  hf_pv_refit::PvRefitX,
+                  hf_pv_refit::PvRefitY,
+                  hf_pv_refit::PvRefitZ,
+                  hf_pv_refit::PvRefitSigmaX2,
+                  hf_pv_refit::PvRefitSigmaXY,
+                  hf_pv_refit::PvRefitSigmaY2,
+                  hf_pv_refit::PvRefitSigmaXZ,
+                  hf_pv_refit::PvRefitSigmaYZ,
+                  hf_pv_refit::PvRefitSigmaZ2,
+                  o2::soa::Marker<1>);
+
+DECLARE_SOA_TABLE(HfPvRefitDstar, "AOD", "HFPVREFITDSTAR", //!
+                  hf_pv_refit::PvRefitX,
+                  hf_pv_refit::PvRefitY,
+                  hf_pv_refit::PvRefitZ,
+                  hf_pv_refit::PvRefitSigmaX2,
+                  hf_pv_refit::PvRefitSigmaXY,
+                  hf_pv_refit::PvRefitSigmaY2,
+                  hf_pv_refit::PvRefitSigmaXZ,
+                  hf_pv_refit::PvRefitSigmaYZ,
+                  hf_pv_refit::PvRefitSigmaZ2,
+                  o2::soa::Marker<2>);
 
 // general decay properties
 namespace hf_cand

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -264,7 +264,6 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
   Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the considered track"};
   Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
-  Configurable<bool> debug{"debug", true, "debug mode"};
   Configurable<bool> debugPvRefit{"debugPvRefit", false, "debug lines for primary vertex refit"};
   // Configurable<double> bz{"bz", 5., "bz field"};
   // quality cut
@@ -448,101 +447,83 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       registry.fill(HIST("hPtNoCuts"), trackPt);
     }
 
-    int iDebugCut = 2;
+    int iCut{2};
     // pT cut
     if (trackPt < ptMinTrack2Prong) {
       CLRBIT(statusProng, CandidateType::Cand2Prong); // set the nth bit to 0
-      if (debug) {
-        // cutStatus[CandidateType::Cand2Prong][0] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iCut);
       }
     }
     if (trackPt < ptMinTrack3Prong) {
       CLRBIT(statusProng, CandidateType::Cand3Prong);
-      if (debug) {
-        // cutStatus[CandidateType::Cand3Prong][0] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iCut);
       }
     }
     MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "proton " << indexBach << " pt = " << trackPt << " (cut " << ptMinTrackBach << ")");
 
     if (trackPt < ptMinTrackBach) {
       CLRBIT(statusProng, CandidateType::CandV0bachelor);
-      if (debug) {
-        // cutStatus[CandidateType::CandV0bachelor][0] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iCut);
       }
     }
     if (trackPt < ptMinSoftPionForDstar || trackPt > ptMaxSoftPionForDstar) {
       CLRBIT(statusProng, CandidateType::CandDstar);
-      if (debug && fillHistograms) {
-        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iCut);
       }
     }
 
-    iDebugCut = 3;
+    iCut = 3;
     // eta cut
-    if ((debug || TESTBIT(statusProng, CandidateType::Cand2Prong)) && (trackEta > etaMaxTrack2Prong || trackEta < etaMinTrack2Prong)) {
+    if (TESTBIT(statusProng, CandidateType::Cand2Prong) && (trackEta > etaMaxTrack2Prong || trackEta < etaMinTrack2Prong)) {
       CLRBIT(statusProng, CandidateType::Cand2Prong);
-      if (debug) {
-        // cutStatus[CandidateType::Cand2Prong][1] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iCut);
       }
     }
-    if ((debug || TESTBIT(statusProng, CandidateType::Cand3Prong)) && (trackEta > etaMaxTrack3Prong || trackEta < etaMinTrack3Prong)) {
+    if (TESTBIT(statusProng, CandidateType::Cand3Prong) && (trackEta > etaMaxTrack3Prong || trackEta < etaMinTrack3Prong)) {
       CLRBIT(statusProng, CandidateType::Cand3Prong);
-      if (debug) {
-        // cutStatus[CandidateType::Cand3Prong][1] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iCut);
       }
     }
     MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "proton " << indexBach << " eta = " << trackEta << " (cut " << etaMinTrackBach << " to " << etaMaxTrackBach << ")");
 
-    if ((debug || TESTBIT(statusProng, CandidateType::CandV0bachelor)) && (trackEta > etaMaxTrackBach || trackEta < etaMinTrackBach)) {
+    if (TESTBIT(statusProng, CandidateType::CandV0bachelor) && (trackEta > etaMaxTrackBach || trackEta < etaMinTrackBach)) {
       CLRBIT(statusProng, CandidateType::CandV0bachelor);
-      if (debug) {
-        // cutStatus[CandidateType::CandV0bachelor][1] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iDebugCut);
-        }
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iCut);
       }
     }
 
-    if ((debug || TESTBIT(statusProng, CandidateType::CandDstar)) && (trackEta > etaMaxSoftPionForDstar || trackEta < etaMinSoftPionForDstar)) {
+    if (TESTBIT(statusProng, CandidateType::CandDstar) && (trackEta > etaMaxSoftPionForDstar || trackEta < etaMinSoftPionForDstar)) {
       CLRBIT(statusProng, CandidateType::CandDstar);
-      if (debug && fillHistograms) {
-        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
+      if (fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iCut);
       }
     }
 
     // quality cut
     MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "proton " << indexBach << " tpcNClsFound = " << hfTrack.tpcNClsFound() << " (cut " << tpcNClsFoundMin.value << ")");
 
-    iDebugCut = 4;
+    iCut = 4;
     bool hasGoodQuality = true;
-    if (doCutQuality.value && (debug || statusProng > 0)) { // FIXME to make a more complete selection e.g track.flags() & o2::aod::track::TPCrefit && track.flags() & o2::aod::track::GoldenChi2 &&
+    if (doCutQuality.value && statusProng > 0) { // FIXME to make a more complete selection e.g track.flags() & o2::aod::track::TPCrefit && track.flags() & o2::aod::track::GoldenChi2 &&
       if (useIsGlobalTrack) {
-        if (hfTrack.isGlobalTrack() != (uint8_t) true) {
+        if (!hfTrack.isGlobalTrack()) {
           hasGoodQuality = false;
         }
       } else if (useIsGlobalTrackWoDCA) {
-        if (hfTrack.isGlobalTrackWoDCA() != (uint8_t) true) {
+        if (!hfTrack.isGlobalTrackWoDCA()) {
           hasGoodQuality = false;
         }
       } else {
         UChar_t clustermap = hfTrack.itsClusterMap();
         if (!(hfTrack.tpcNClsFound() >= tpcNClsFoundMin.value && // is this the number of TPC clusters? It should not be used
-              hfTrack.flags() & o2::aod::track::ITSrefit &&
+              TESTBIT(hfTrack.flags(), o2::aod::track::ITSrefit) &&
               (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
         }
@@ -554,8 +535,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
             continue;
           }
           CLRBIT(statusProng, iCandType);
-          if (debug && fillHistograms) {
-            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
+          if (fillHistograms) {
+            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iCut);
           }
         }
       }
@@ -563,7 +544,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     // quality cut for soft pion
     hasGoodQuality = true;
-    if (doCutQuality.value && (debug || TESTBIT(statusProng, CandidateType::CandDstar))) {
+    if (doCutQuality.value && TESTBIT(statusProng, CandidateType::CandDstar)) {
       if (useIsGlobalTrackForSoftPion) {
         if (!hfTrack.isGlobalTrack()) {
           hasGoodQuality = false;
@@ -584,20 +565,20 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       }
       if (!hasGoodQuality) {
         CLRBIT(statusProng, CandidateType::CandDstar);
-        if (debug && fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
+        if (fillHistograms) {
+          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iCut);
         }
       }
     }
 
     // DCA cut
-    iDebugCut = 5;
-    if ((debug || statusProng > 0)) {
+    iCut = 5;
+    if (statusProng > 0) {
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; ++iCandType) {
-        if ((debug || TESTBIT(statusProng, iCandType)) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
+        if (TESTBIT(statusProng, iCandType) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
           CLRBIT(statusProng, iCandType);
-          if (debug && fillHistograms) {
-            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
+          if (fillHistograms) {
+            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iCut);
           }
         }
       }
@@ -606,39 +587,31 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     // fill histograms
     if (fillHistograms) {
-      iDebugCut = 1;
+      iCut = 1;
       if (TESTBIT(statusProng, CandidateType::Cand2Prong)) {
         registry.fill(HIST("hPtCuts2Prong"), trackPt);
         registry.fill(HIST("hEtaCuts2Prong"), trackEta);
         registry.fill(HIST("hDCAToPrimXYVsPtCuts2Prong"), trackPt, dca[0]);
-        if (debug) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iDebugCut);
-        }
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand2Prong + iCut);
       }
       if (TESTBIT(statusProng, CandidateType::Cand3Prong)) {
         registry.fill(HIST("hPtCuts3Prong"), trackPt);
         registry.fill(HIST("hEtaCuts3Prong"), trackEta);
         registry.fill(HIST("hDCAToPrimXYVsPtCuts3Prong"), trackPt, dca[0]);
-        if (debug) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iDebugCut);
-        }
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::Cand3Prong + iCut);
       }
       if (TESTBIT(statusProng, CandidateType::CandV0bachelor)) {
         MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "Will be kept: Proton from Lc " << indexBach);
         registry.fill(HIST("hPtCutsV0bachelor"), trackPt);
         registry.fill(HIST("hEtaCutsV0bachelor"), trackEta);
         registry.fill(HIST("hDCAToPrimXYVsPtCutsV0bachelor"), trackPt, dca[0]);
-        if (debug) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iDebugCut);
-        }
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iCut);
       }
       if (TESTBIT(statusProng, CandidateType::CandDstar)) {
         registry.fill(HIST("hPtCutsSoftPionForDstar"), trackPt);
         registry.fill(HIST("hEtaCutsSoftPionForDstar"), trackEta);
         registry.fill(HIST("hDCAToPrimXYVsPtCutsSoftPionForDstar"), trackPt, dca[0]);
-        if (debug) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
-        }
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iCut);
       }
     }
   }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -289,6 +289,14 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   Configurable<LabeledArray<double>> cutsTrackBach{"cutsTrackBach", {hf_cuts_single_track::cutsTrack[0], nBinsPtTrack, nCutVarsTrack, labelsPtTrack, labelsCutVarTrack}, "Single-track selections per pT bin for the bachelor of V0-bachelor candidates"};
   Configurable<double> etaMinTrackBach{"etaMinTrackBach", -99999., "min. pseudorapidity for bachelor in cascade candidate"};
   Configurable<double> etaMaxTrackBach{"etaMaxTrackBach", 0.8, "max. pseudorapidity for bachelor in cascade candidate"};
+  // soft pion cuts for D*
+  Configurable<double> ptMinSoftPionForDstar{"ptMinSoftPionForDstar", 0.05, "min. track pT for soft pion in D* candidate"};
+  Configurable<double> ptMaxSoftPionForDstar{"ptMaxSoftPionForDstar", 2., "max. track pT for soft pion in D* candidate"};
+  Configurable<double> etaMinSoftPionForDstar{"etaMinSoftPionForDstar", -99999., "min. pseudorapidity for soft pion in D* candidate"};
+  Configurable<double> etaMaxSoftPionForDstar{"etaMaxSoftPionForDstar", 0.8, "max. pseudorapidity for soft pion in D* candidate"};
+  Configurable<bool> useIsGlobalTrackForSoftPion{"useIsGlobalTrackForSoftPion", false, "check isGlobalTrack status for soft pion tracks"};
+  Configurable<bool> useIsGlobalTrackWoDCAForSoftPion{"useIsGlobalTrackWoDCAForSoftPion", false, "check isGlobalTrackWoDCA status for soft pion tracks"};
+  Configurable<bool> useIsQualityTrackITSForSoftPion{"useIsQualityTrackITSForSoftPion", true, "check qualityTracksITS status for soft pion tracks"};
   // CCDB
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
@@ -332,6 +340,9 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     if (etaMinTrackBach == -99999.) {
       etaMinTrackBach.value = -etaMaxTrackBach;
     }
+    if (etaMinSoftPionForDstar == -99999.) {
+      etaMinSoftPionForDstar.value = -etaMaxSoftPionForDstar;
+    }
 
     if (fillHistograms) {
       // general tracks
@@ -347,12 +358,16 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       registry.add("hDCAToPrimXYVsPtCuts3Prong", "tracks selected for 3-prong vertexing;#it{p}_{T}^{track} (GeV/#it{c});DCAxy to prim. vtx. (cm);entries", {HistType::kTH2F, {{360, 0., 36.}, {400, -2., 2.}}});
       registry.add("hEtaCuts3Prong", "tracks selected for 3-prong vertexing;#it{#eta};entries", {HistType::kTH1F, {{static_cast<int>(0.6 * (etaMaxTrack3Prong - etaMinTrack3Prong) * 100), -1.2 * etaMinTrack3Prong, 1.2 * etaMaxTrack3Prong}}});
       // bachelor (for cascades) histograms
-      registry.add("hPtCutsV0bachelor", "tracks selected for 3-prong vertexing;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+      registry.add("hPtCutsV0bachelor", "tracks selected for V0-bachelor vertexing;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
       registry.add("hDCAToPrimXYVsPtCutsV0bachelor", "tracks selected for V0-bachelor vertexing;#it{p}_{T}^{track} (GeV/#it{c});DCAxy to prim. vtx. (cm);entries", {HistType::kTH2F, {{360, 0., 36.}, {400, -2., 2.}}});
-      registry.add("hEtaCutsV0bachelor", "tracks selected for 3-prong vertexing;#it{#eta};entries", {HistType::kTH1F, {{static_cast<int>(0.6 * (etaMaxTrackBach - etaMinTrackBach) * 100), -1.2 * etaMinTrackBach, 1.2 * etaMaxTrackBach}}});
+      registry.add("hEtaCutsV0bachelor", "tracks selected for V0-bachelor vertexing;#it{#eta};entries", {HistType::kTH1F, {{static_cast<int>(0.6 * (etaMaxTrackBach - etaMinTrackBach) * 100), -1.2 * etaMinTrackBach, 1.2 * etaMaxTrackBach}}});
+      // soft pion (for D*) histograms
+      registry.add("hPtCutsSoftPionForDstar", "tracks selected for D* soft pion;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+      registry.add("hDCAToPrimXYVsPtCutsSoftPionForDstar", "tracks selected for D* soft pion;#it{p}_{T}^{track} (GeV/#it{c});DCAxy to prim. vtx. (cm);entries", {HistType::kTH2F, {{360, 0., 36.}, {400, -2., 2.}}});
+      registry.add("hEtaCutsSoftPionForDstar", "tracks selected for D* soft pion;#it{#eta};entries", {HistType::kTH1F, {{static_cast<int>(0.6 * (etaMaxSoftPionForDstar - etaMinSoftPionForDstar) * 100), -1.2 * etaMinSoftPionForDstar, 1.2 * etaMaxSoftPionForDstar}}});
 
       std::string cutNames[nCuts + 1] = {"selected", "rej pT", "rej eta", "rej track quality", "rej dca"};
-      std::string candNames[CandidateType::NCandidateTypes] = {"2-prong", "3-prong", "bachelor"};
+      std::string candNames[CandidateType::NCandidateTypes] = {"2-prong", "3-prong", "bachelor", "dstar"};
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; iCandType++) {
         for (int iCut = 0; iCut < nCuts + 1; iCut++) {
           registry.get<TH1>(HIST("hRejTracks"))->GetXaxis()->SetBinLabel((nCuts + 1) * iCandType + iCut + 1, Form("%s %s", candNames[iCandType].data(), cutNames[iCut].data()));
@@ -463,6 +478,15 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         }
       }
     }
+    if (trackPt < ptMinSoftPionForDstar || trackPt > ptMaxSoftPionForDstar) {
+      CLRBIT(statusProng, CandidateType::CandDstar);
+      if (debug) {
+        // cutStatus[CandidateType::CandV0bachelor][0] = false;
+        if (fillHistograms) {
+          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
+        }
+      }
+    }
 
     iDebugCut = 3;
     // eta cut
@@ -500,8 +524,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "proton " << indexBach << " tpcNClsFound = " << hfTrack.tpcNClsFound() << " (cut " << tpcNClsFoundMin.value << ")");
 
     iDebugCut = 4;
+    bool hasGoodQuality = true;
     if (doCutQuality.value && (debug || statusProng > 0)) { // FIXME to make a more complete selection e.g track.flags() & o2::aod::track::TPCrefit && track.flags() & o2::aod::track::GoldenChi2 &&
-      bool hasGoodQuality = true;
       if (useIsGlobalTrack) {
         if (hfTrack.isGlobalTrack() != (uint8_t) true) {
           hasGoodQuality = false;
@@ -519,14 +543,47 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         }
       }
       if (!hasGoodQuality) {
-        statusProng = 0;
         MY_DEBUG_MSG(isProtonFromLc, LOG(info) << "proton " << indexBach << " did not pass clusters cut");
-        if (debug) {
-          for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; iCandType++) {
-            // cutStatus[iCandType][2] = false;
+        for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; iCandType++) {
+          if (iCandType == CandidateType::CandDstar) { // different quality criteria for D* soft pions
+            continue;
+          }
+          CLRBIT(statusProng, iCandType);
+          if (debug) {
             if (fillHistograms) {
               registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
             }
+          }
+        }
+      }
+    }
+
+    // quality cut for soft pion
+    hasGoodQuality = true;
+    if (doCutQuality.value && (debug || TESTBIT(statusProng, CandidateType::CandDstar))) {
+     if (useIsGlobalTrackForSoftPion) {
+        if (hfTrack.isGlobalTrack() != (uint8_t) true) {
+          hasGoodQuality = false;
+        }
+      } else if (useIsGlobalTrackWoDCAForSoftPion) {
+        if (hfTrack.isGlobalTrackWoDCA() != (uint8_t) true) {
+          hasGoodQuality = false;
+        }
+      } else if (useIsQualityTrackITSForSoftPion) {
+        if (hfTrack.isQualityTrackITS() != (uint8_t) true) {
+          hasGoodQuality = false;
+        }
+      } else {
+        UChar_t clustermap = hfTrack.itsClusterMap();
+        if ((hfTrack.flags() & o2::aod::track::ITSrefit && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
+          hasGoodQuality = false;
+        }
+      }
+      if (!hasGoodQuality) {
+        CLRBIT(statusProng, CandidateType::CandDstar);
+        if (debug) {
+          if (fillHistograms) {
+            registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
           }
         }
       }
@@ -591,6 +648,14 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         registry.fill(HIST("hDCAToPrimXYVsPtCutsV0bachelor"), trackPt, dca[0]);
         if (debug) {
           registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iDebugCut);
+        }
+      }
+      if (TESTBIT(statusProng, CandidateType::CandDstar)) {
+        registry.fill(HIST("hPtCutsSoftPionForDstar"), trackPt);
+        registry.fill(HIST("hEtaCutsSoftPionForDstar"), trackEta);
+        registry.fill(HIST("hDCAToPrimXYVsPtCutsSoftPionForDstar"), trackPt, dca[0]);
+        if (debug) {
+          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
         }
       }
     }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -586,11 +586,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       }
       if (!hasGoodQuality) {
         CLRBIT(statusProng, CandidateType::CandDstar);
-        if (debug) {
-          if (fillHistograms) {
-          if (debug && fillHistograms) {
-            registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
-          }
+        if (debug && fillHistograms) {
+          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
         }
       }
     }
@@ -602,8 +599,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         if ((debug || TESTBIT(statusProng, iCandType)) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
           CLRBIT(statusProng, iCandType);
           if (debug && fillHistograms) {
-              registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
-            }
+            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
           }
         }
       }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -580,7 +580,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         }
       } else {
         UChar_t clustermap = hfTrack.itsClusterMap();
-        if ((hfTrack.flags() & o2::aod::track::ITSrefit && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
+        if (!(hfTrack.flags() & o2::aod::track::ITSrefit && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
         }
       }
@@ -588,7 +588,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         CLRBIT(statusProng, CandidateType::CandDstar);
         if (debug) {
           if (fillHistograms) {
-          if (debug && fillHistograms) { 
+          if (debug && fillHistograms) {
             registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
             ....
           }
@@ -602,7 +602,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; ++iCandType) {
         if ((debug || TESTBIT(statusProng, iCandType)) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
           CLRBIT(statusProng, iCandType);
-          if (debug && fillHistograms) { 
+          if (debug && fillHistograms) {
               registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
             }
           }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -319,7 +319,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   // single-track cuts
   static const int nCuts = 4;
   // array of 2-prong and 3-prong cuts
-  std::array<LabeledArray<double>, 4> cutsSingleTrack;
+  std::array<LabeledArray<double>, CandidateType::NCandidateTypes> cutsSingleTrack;
 
   // QA of PV refit
   ConfigurableAxis axisPvRefitDeltaX{"axisPvRefitDeltaX", {1000, -0.5f, 0.5f}, "DeltaX binning PV refit"};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -602,8 +602,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; ++iCandType) {
         if ((debug || TESTBIT(statusProng, iCandType)) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
           CLRBIT(statusProng, iCandType);
-          if (debug) {
-            if (fillHistograms) {
+          if (debug && fillHistograms) { 
               registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
             }
           }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1414,7 +1414,7 @@ struct HfTrackIndexSkimCreator {
   /// \param deltaMass is the M(Kpipi) - M(Kpi) value to be filled in the control histogram
   /// \return a bitmap with selection outcome
   template <typename T1, typename T2>
-  uint8_t isDstarSelected(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, int8_t& cutStatus, T2& deltaMass)
+  uint8_t isDstarSelected(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, uint8_t& cutStatus, T2& deltaMass)
   {
     uint8_t isSelected{1};
     /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -347,7 +347,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     if (fillHistograms) {
       // general tracks
-      registry.add("hRejTracks", "Tracks;;entries", {HistType::kTH1F, {{15, 0.5, 15.5}}});
+      registry.add("hRejTracks", "Tracks;;entries", {HistType::kTH1F, {{20, 0.5, 20.5}}});
       registry.add("hPtNoCuts", "all tracks;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
 
       // 2-prong histograms
@@ -517,6 +517,16 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         // cutStatus[CandidateType::CandV0bachelor][1] = false;
         if (fillHistograms) {
           registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandV0bachelor + iDebugCut);
+        }
+      }
+    }
+
+    if ((debug || TESTBIT(statusProng, CandidateType::CandDstar)) && (trackEta > etaMaxSoftPionForDstar || trackEta < etaMinSoftPionForDstar)) {
+      CLRBIT(statusProng, CandidateType::CandDstar);
+      if (debug) {
+        // cutStatus[CandidateType::CandDstar][1] = false;
+        if (fillHistograms) {
+          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
         }
       }
     }
@@ -1111,7 +1121,7 @@ struct HfTrackIndexSkimCreator {
       registry.add("hMassLcToPKPi", "#Lambda_{c}^{#plus} candidates;inv. mass (p K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}});
       registry.add("hMassDsToKKPi", "D_{s}^{#plus} candidates;inv. mass (K K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}});
       registry.add("hMassXicToPKPi", "#Xi_{c}^{#plus} candidates;inv. mass (p K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 5.}}});
-      registry.add("hMassDstarToD0Pi", "D^{*#plus} candidates;inv. mass (K #pi #pi) - mass (K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0., 0.25}}});
+      registry.add("hMassDstarToD0Pi", "D^{*#plus} candidates;inv. mass (K #pi #pi) - mass (K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.135, 0.185}}});
 
       // needed for PV refitting
       if (doprocess2And3ProngsWithPvRefit) {
@@ -1444,7 +1454,7 @@ struct HfTrackIndexSkimCreator {
 
     // D0 mass
     double deltaMassD0 = cutsDstarToD0Pi->get(pTBin, deltaMassD0Index);
-    double invMassD0 = RecoDecay::m(arrMomD0, std::array{211, 321});
+    double invMassD0 = RecoDecay::m(arrMomD0, std::array{massPi, massK});
     if (std::abs(invMassD0 - massDzero) > deltaMassD0) {
       isSelected = 0;
       if (debug) {
@@ -1456,7 +1466,7 @@ struct HfTrackIndexSkimCreator {
 
     // D*+ mass
     double maxDeltaMass = cutsDstarToD0Pi->get(pTBin, deltaMassIndex);
-    double invMassDstar = RecoDecay::m(arrMom, std::array{211, 321, 211});
+    double invMassDstar = RecoDecay::m(arrMom, std::array{massPi, massK, massPi});
     deltaMass = invMassDstar - invMassD0;
     if (deltaMass > maxDeltaMass) {
       isSelected = 0;
@@ -1467,7 +1477,7 @@ struct HfTrackIndexSkimCreator {
       }
     }
 
-    return 0;
+    return isSelected;
   }
 
   /// Method for the PV refit excluding the candidate daughters

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -554,7 +554,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
             continue;
           }
           CLRBIT(statusProng, iCandType);
-          if (debug && fillHistograms) { ....
+          if (debug && fillHistograms) {
             if (fillHistograms) {
               registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
             }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -555,9 +555,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
           }
           CLRBIT(statusProng, iCandType);
           if (debug && fillHistograms) {
-            if (fillHistograms) {
-              registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
-            }
+            registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
           }
         }
       }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -588,7 +588,9 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         CLRBIT(statusProng, CandidateType::CandDstar);
         if (debug) {
           if (fillHistograms) {
+          if (debug && fillHistograms) { 
             registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
+            ....
           }
         }
       }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -481,11 +481,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     }
     if (trackPt < ptMinSoftPionForDstar || trackPt > ptMaxSoftPionForDstar) {
       CLRBIT(statusProng, CandidateType::CandDstar);
-      if (debug) {
-        // cutStatus[CandidateType::CandV0bachelor][0] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
-        }
+      if (debug && fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
       }
     }
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1426,8 +1426,8 @@ struct HfTrackIndexSkimCreator {
     };
     cacheIndices(cutsDstarToD0Pi.value, deltaMassIndex, deltaMassD0Index);
 
-    auto arrMom = array{pVecTrack0, pVecTrack1, pVecTrack2};
-    auto arrMomD0 = array{pVecTrack0, pVecTrack1};
+    auto arrMom = std::array{pVecTrack0, pVecTrack1, pVecTrack2};
+    auto arrMomD0 = std::array{pVecTrack0, pVecTrack1};
     auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + ptTolerance; // add tolerance because of no reco decay vertex
 
     // pT

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -554,7 +554,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
             continue;
           }
           CLRBIT(statusProng, iCandType);
-          if (debug) {
+          if (debug && fillHistograms) { ....
             if (fillHistograms) {
               registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iDebugCut);
             }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -578,7 +578,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         if (hfTrack.isQualityTrackITS() != (uint8_t) true) {
           hasGoodQuality = false;
         }
-      } else {
+      } else { // selections for Run2 converted data
         UChar_t clustermap = hfTrack.itsClusterMap();
         if (!(hfTrack.flags() & o2::aod::track::ITSrefit && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
@@ -1307,7 +1307,7 @@ struct HfTrackIndexSkimCreator {
   {
     if (debug || isSelected > 0) {
 
-      /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
+      /// FIXME: this would be better fixed by having a convention on the position of cuts in the 2D Array
       static std::vector<int> cospIndex;
       static auto cacheIndices = [](std::array<LabeledArray<double>, kN2ProngDecays>& cut2Prong, std::vector<int>& cosp) {
         cosp.resize(cut2Prong.size());
@@ -1355,7 +1355,7 @@ struct HfTrackIndexSkimCreator {
   {
     if (debug || isSelected > 0) {
 
-      /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
+      /// FIXME: this would be better fixed by having a convention on the position of cuts in the 2D Array
       static std::vector<int> cospIndex;
       static std::vector<int> decLenIndex;
       static auto cacheIndices = [](std::array<LabeledArray<double>, kN3ProngDecays>& cut3Prong, std::vector<int>& cosp, std::vector<int>& decL) {
@@ -1417,7 +1417,7 @@ struct HfTrackIndexSkimCreator {
   uint8_t isDstarSelected(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, uint8_t& cutStatus, T2& deltaMass)
   {
     uint8_t isSelected{1};
-    /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array
+    /// FIXME: this would be better fixed by having a convention on the position of cuts in the 2D Array
     int deltaMassIndex, deltaMassD0Index;
     static auto cacheIndices = [](LabeledArray<double>& cutDstar, int& deltaMassIdx, int& deltaMassD0Idx) {
       deltaMassIdx = cutDstar.colmap.find("deltaMassMax")->second;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -520,11 +520,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     if ((debug || TESTBIT(statusProng, CandidateType::CandDstar)) && (trackEta > etaMaxSoftPionForDstar || trackEta < etaMinSoftPionForDstar)) {
       CLRBIT(statusProng, CandidateType::CandDstar);
-      if (debug) {
-        // cutStatus[CandidateType::CandDstar][1] = false;
-        if (fillHistograms) {
-          registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
-        }
+      if (debug && fillHistograms) {
+        registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
       }
     }
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -562,7 +562,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     // quality cut for soft pion
     hasGoodQuality = true;
     if (doCutQuality.value && (debug || TESTBIT(statusProng, CandidateType::CandDstar))) {
-     if (useIsGlobalTrackForSoftPion) {
+      if (useIsGlobalTrackForSoftPion) {
         if (hfTrack.isGlobalTrack() != (uint8_t) true) {
           hasGoodQuality = false;
         }
@@ -1940,8 +1940,8 @@ struct HfTrackIndexSkimCreator {
               auto isSelProngPos2 = trackIndexPos2.isSelProng();
               uint8_t isSelectedDstar{0};
               if (doDstar && TESTBIT(isSelected2ProngCand, hf_cand_2prong::DecayType::D0ToPiK) && (whichHypo2Prong[0] == 1 || whichHypo2Prong[0] == 3)) { // the 2-prong decay is compatible with a D0
-                if (TESTBIT(isSelProngPos2, CandidateType::CandDstar)) { // compatible with a soft pion
-                  if (thisCollId != trackPos2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
+                if (TESTBIT(isSelProngPos2, CandidateType::CandDstar)) {                                                                                  // compatible with a soft pion
+                  if (thisCollId != trackPos2.collisionId()) {                                                                                            // this is not the "default" collision for this track, we have to re-propagate it
                     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos2, 2.f, noMatCorr, &dcaInfoPos2);
                     getPxPyPz(trackParVarPos2, pVecTrackPos2);
                     propagatedPos2 = true;
@@ -2191,8 +2191,8 @@ struct HfTrackIndexSkimCreator {
               auto isSelProngNeg2 = trackIndexNeg2.isSelProng();
               uint8_t isSelectedDstar{0};
               if (doDstar && TESTBIT(isSelected2ProngCand, hf_cand_2prong::DecayType::D0ToPiK) && (whichHypo2Prong[0] >= 2)) { // the 2-prong decay is compatible with a D0bar
-                if (TESTBIT(isSelProngNeg2, CandidateType::CandDstar)) { // compatible with a soft pion
-                  if (thisCollId != trackNeg2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
+                if (TESTBIT(isSelProngNeg2, CandidateType::CandDstar)) {                                                       // compatible with a soft pion
+                  if (thisCollId != trackNeg2.collisionId()) {                                                                 // this is not the "default" collision for this track, we have to re-propagate it
                     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg2, 2.f, noMatCorr, &dcaInfoNeg2);
                     getPxPyPz(trackParVarNeg2, pVecTrackNeg2);
                     propagatedNeg2 = true;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -565,20 +565,20 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     hasGoodQuality = true;
     if (doCutQuality.value && (debug || TESTBIT(statusProng, CandidateType::CandDstar))) {
       if (useIsGlobalTrackForSoftPion) {
-        if (hfTrack.isGlobalTrack() != (uint8_t) true) {
+        if (!hfTrack.isGlobalTrack()) {
           hasGoodQuality = false;
         }
       } else if (useIsGlobalTrackWoDCAForSoftPion) {
-        if (hfTrack.isGlobalTrackWoDCA() != (uint8_t) true) {
+        if (!hfTrack.isGlobalTrackWoDCA()) {
           hasGoodQuality = false;
         }
       } else if (useIsQualityTrackITSForSoftPion) {
-        if (hfTrack.isQualityTrackITS() != (uint8_t) true) {
+        if (!hfTrack.isQualityTrackITS()) {
           hasGoodQuality = false;
         }
       } else { // selections for Run2 converted data
         UChar_t clustermap = hfTrack.itsClusterMap();
-        if (!(hfTrack.flags() & o2::aod::track::ITSrefit && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
+        if (!(TESTBIT(hfTrack.flags(), o2::aod::track::ITSrefit) && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
         }
       }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1419,7 +1419,7 @@ struct HfTrackIndexSkimCreator {
   /// \param deltaMass is the M(Kpipi) - M(Kpi) value to be filled in the control histogram
   /// \return a bitmap with selection outcome
   template <typename T1, typename T2>
-  uint8_t isDstarSelected(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, int8_t cutStatus, T2& deltaMass)
+  uint8_t isDstarSelected(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, int8_t& cutStatus, T2& deltaMass)
   {
     uint8_t isSelected{1};
     /// FIXME: this would be better fixed by having a convention on the position of min and max in the 2D Array

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -590,7 +590,6 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
           if (fillHistograms) {
           if (debug && fillHistograms) {
             registry.fill(HIST("hRejTracks"), (nCuts + 1) * CandidateType::CandDstar + iDebugCut);
-            ....
           }
         }
       }


### PR DESCRIPTION
Hi @deependra170598, @skundu692, @fcatalan92, @vkucera, @lvermunt,

This PR implements the possibility to produce the table with daughter indices for D* candidates. In particular, the indices of the soft pion and the D0 daughter are stored.

The track selection for the soft pion is independent of the other tracks. In particular, it allows us to use also ITS-standalone tracks, set a lower pT threshold, and to set a different DCA cut (typically only upper values to remove secondaries from material and strangeness).

The D* selection is added in the for loops for the 3-prongs to exploit as much as possible the already existing code. 

It has still to be properly tested (I also want to evaluate the overhead compared to 2 prongs only and 2+3 prongs), but if you want you can start having a look at the code. Thanks!