### PR TITLE
Fix obsolete V0 c-tor folling O2 PR11713

### DIFF
--- a/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
@@ -128,7 +128,7 @@ struct HfCandidateCreatorChic {
       prong1TrackParCov.propagateTo(jpsiCand.xSecondaryVertex(), bz);
       const std::array<float, 6> covJpsi = df2.calcPCACovMatrixFlat();
       // define the Jpsi track
-      auto trackJpsi = o2::dataformats::V0(vertexJpsi, pvecJpsi, covJpsi, prong0TrackParCov, prong1TrackParCov, {0, 0}, {0, 0}); // FIXME: also needs covxyz???
+      auto trackJpsi = o2::dataformats::V0(vertexJpsi, pvecJpsi, covJpsi, prong0TrackParCov, prong1TrackParCov); // FIXME: also needs covxyz???
 
       // -----------------------------------------------------------------
       // loop over gamma candidates

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
@@ -144,7 +144,7 @@ struct HfCandidateCreatorX {
       prong1TrackParCov.propagateTo(jpsiCand.xSecondaryVertex(), bz);
       const std::array<float, 6> covJpsi = df2.calcPCACovMatrixFlat();
       // define the Jpsi track
-      auto trackJpsi = o2::dataformats::V0(vertexJpsi, pvecJpsi, covJpsi, prong0TrackParCov, prong1TrackParCov, {0, 0}, {0, 0}); // FIXME: also needs covxyz???
+      auto trackJpsi = o2::dataformats::V0(vertexJpsi, pvecJpsi, covJpsi, prong0TrackParCov, prong1TrackParCov); // FIXME: also needs covxyz???
 
       // used to check that prongs used for Jpsi and X reco are not the same prongs
       int index0Jpsi = jpsiCand.prong0Id();

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -288,8 +288,7 @@ struct HfDataCreatorD0PiReduced {
 
         // D0(bar) → π∓ K±
         std::array<float, 3> pVecD0 = RecoDecay::pVec(pVec0, pVec1);
-        auto trackParCovD0 = o2::dataformats::V0(df2.getPCACandidatePos(), pVecD0, df2.calcPCACovMatrixFlat(),
-                                                 trackParCov0, trackParCov1, {0, 0}, {0, 0});
+        auto trackParCovD0 = o2::dataformats::V0(df2.getPCACandidatePos(), pVecD0, df2.calcPCACovMatrixFlat(), trackParCov0, trackParCov1);
 
         auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (const auto& trackId : trackIdsThisCollision) {

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -290,10 +290,8 @@ struct HfDataCreatorDplusPiReduced {
         // D∓ → π∓ K± π∓
         std::array<float, 3> pVecPiK = RecoDecay::pVec(pVec0, pVec1);
         std::array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1, pVec2);
-        auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(),
-                                                  trackParCov0, trackParCov1, {0, 0}, {0, 0});
-        auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(),
-                                                trackParCovPiK, trackParCov2, {0, 0}, {0, 0});
+        auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(), trackParCov0, trackParCov1);
+        auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(), trackParCovPiK, trackParCov2);
 
         auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (const auto& trackId : trackIdsThisCollision) {

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -229,10 +229,8 @@ struct HfCandidateCreatorB0 {
         // D∓ → π∓ K± π∓
         array<float, 3> pVecPiK = RecoDecay::pVec(pVec0, pVec1);
         array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1, pVec2);
-        auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(),
-                                                  trackParCov0, trackParCov1, {0, 0}, {0, 0});
-        auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(),
-                                                trackParCovPiK, trackParCov2, {0, 0}, {0, 0});
+        auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(), trackParCov0, trackParCov1);
+        auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(), trackParCovPiK, trackParCov2);
 
         int indexTrack0 = track0.globalIndex();
         int indexTrack1 = track1.globalIndex();

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -220,7 +220,7 @@ struct HfCandidateCreatorBplus {
         array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1);
 
         // build a D0 neutral track
-        auto trackD0 = o2::dataformats::V0(vertexD0, pVecD, df.calcPCACovMatrixFlat(), trackParCovProng0, trackParCovProng1, {0, 0}, {0, 0});
+        auto trackD0 = o2::dataformats::V0(vertexD0, pVecD, df.calcPCACovMatrixFlat(), trackParCovProng0, trackParCovProng1);
 
         int indexTrack0 = prong0.globalIndex();
         int indexTrack1 = prong1.globalIndex();

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -172,7 +172,7 @@ struct HfCandidateCreatorCascade {
       const std::array<float, 3> vertexV0 = {v0.x(), v0.y(), v0.z()};
       const std::array<float, 3> momentumV0 = {v0.px(), v0.py(), v0.pz()};
       // we build the neutral track to then build the cascade
-      auto trackV0 = o2::dataformats::V0(vertexV0, momentumV0, {0, 0, 0, 0, 0, 0}, trackParCovV0DaughPos, trackParCovV0DaughNeg, {0, 0}, {0, 0}); // build the V0 track (indices for v0 daughters set to 0 for now)
+      auto trackV0 = o2::dataformats::V0(vertexV0, momentumV0, {0, 0, 0, 0, 0, 0}, trackParCovV0DaughPos, trackParCovV0DaughNeg); // build the V0 track (indices for v0 daughters set to 0 for now)
 
       // reconstruct the cascade secondary vertex
       if (df.process(trackV0, trackParCovBach) == 0) {

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -135,10 +135,8 @@ struct HfCandidateCreatorLb {
 
       array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
       array<float, 3> pvecLc = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
-      auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(),
-                                         trackParVar0, trackParVar1, {0, 0}, {0, 0});
-      auto trackLc = o2::dataformats::V0(df3.getPCACandidatePos(), pvecLc, df3.calcPCACovMatrixFlat(),
-                                         trackpK, trackParVar2, {0, 0}, {0, 0});
+      auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
+      auto trackLc = o2::dataformats::V0(df3.getPCACandidatePos(), pvecLc, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 
       int index0Lc = track0.globalIndex();
       int index1Lc = track1.globalIndex();

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -124,10 +124,8 @@ struct HfCandidateCreatorXicc {
 
       array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
       array<float, 3> pvecxic = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
-      auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(),
-                                         trackParVar0, trackParVar1, {0, 0}, {0, 0});
-      auto trackxic = o2::dataformats::V0(df3.getPCACandidatePos(), pvecxic, df3.calcPCACovMatrixFlat(),
-                                          trackpK, trackParVar2, {0, 0}, {0, 0});
+      auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
+      auto trackxic = o2::dataformats::V0(df3.getPCACandidatePos(), pvecxic, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 
       int index0Xic = track0.globalIndex();
       int index1Xic = track1.globalIndex();

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2558,7 +2558,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
           const std::array<float, 3> vertexV0 = {v0.x(), v0.y(), v0.z()};
           // we build the neutral track to then build the cascade
-          auto trackV0 = o2::dataformats::V0(vertexV0, momentumV0, {0, 0, 0, 0, 0, 0}, trackParCovV0DaughPos, trackParCovV0DaughNeg, {0, 0}, {0, 0}); // build the V0 track
+          auto trackV0 = o2::dataformats::V0(vertexV0, momentumV0, {0, 0, 0, 0, 0, 0}, trackParCovV0DaughPos, trackParCovV0DaughNeg); // build the V0 track
 
           // now we find the DCA between the V0 and the bachelor, for the cascade
           int nCand2 = fitter.process(trackV0, trackBach);
@@ -2918,7 +2918,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
         std::array<float, 6> covVtxCasc = dfc.calcPCACovMatrixFlat();
         std::array<float, 3> pvecCascAsM = {pvecV0[0] + pvecXiDauPion[0], pvecV0[1] + pvecXiDauPion[1], pvecV0[2] + pvecXiDauPion[2]};
 
-        auto trackCasc = o2::dataformats::V0(coordVtxCasc, pvecCascAsM, covVtxCasc, trackV0, trackParVarXiDauCharged, {0, 0}, {0, 0});
+        auto trackCasc = o2::dataformats::V0(coordVtxCasc, pvecCascAsM, covVtxCasc, trackV0, trackParVarXiDauCharged);
 
         //-------------------combining cascade and pion tracks--------------------------
         // first loop over positive tracks


### PR DESCRIPTION
O2 [PR11713](https://github.com/AliceO2Group/AliceO2/pull/11713) splits V0 and Cascades classes to separate physics (kinematics) and indices (of prongs and PV) classes. Therefore, the dummy prondID indices passed to the V0 constructor in O2Physics should be suppressed