### PR TITLE
Make sure PWCCFCore is available to TwoParticleCorrelations

### DIFF
--- a/PWGCF/TwoParticleCorrelations/Core/CMakeLists.txt
+++ b/PWGCF/TwoParticleCorrelations/Core/CMakeLists.txt
@@ -16,7 +16,7 @@ o2physics_add_library(TwoPartCorrCore
                                PIDSelectionFilterAndAnalysis.cxx
                                EventSelectionFilterAndAnalysis.cxx
                                FilterAndAnalysisFramework.cxx
-                      PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore)
+                      PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGCFCore)
 
 o2physics_target_root_dictionary(TwoPartCorrCore
                                  HEADERS SkimmingConfigurableCuts.h


### PR DESCRIPTION
Without this, it's not clear to me how one can avoid the error about the missing DptDptBinningCuts dictionary.