### PR TITLE
[EMCAL-903] Explicit request on run number via metadata in CCDB acces…

### DIFF
--- a/EventFiltering/PWGJE/fullJetFilter.cxx
+++ b/EventFiltering/PWGJE/fullJetFilter.cxx
@@ -621,7 +621,10 @@ struct fullJetFilter {
       constexpr bool isFullJets = std::is_same<JetCollection, filteredFullJets>::value;
       constexpr bool isNeutralJets = std::is_same<JetCollection, filteredNeutralJets>::value;
       int64_t ts = bcs.iteratorAt(0).timestamp();
-      mHardwareTriggerConfig = getHWTriggerConfiguration(*(ccdb->getForTimeStamp<o2::ctp::CTPConfiguration>("CTP/Config/Config", ts)));
+      // Request run number in addition to timestamp in order to handle concurrent runs
+      std::map<std::string, std::string> metadata;
+      metadata["runNumber"] = std::to_string(run);
+      mHardwareTriggerConfig = getHWTriggerConfiguration(*(ccdb->getSpecific<o2::ctp::CTPConfiguration>("CTP/Config/Config", ts, metadata)));
       switch (mHardwareTriggerConfig) {
         case EMCALHWTriggerConfiguration::MB_ONLY: {
           LOG(info) << "Found hardware trigger configuration Min. bias only";


### PR DESCRIPTION
…s of trigger configuration

Multiple runs can be started the same time. In this case we have overlapping time intervals, and the
request by the timestamp is not enough. A request
on the run number via the metadata must be added.