### PR TITLE
Remove using-directives from common headers

### DIFF
--- a/Common/CCDB/EventSelectionParams.cxx
+++ b/Common/CCDB/EventSelectionParams.cxx
@@ -11,7 +11,7 @@
 
 #include "EventSelectionParams.h"
 
-namespace evsel
+namespace o2::aod::evsel
 {
 const char* selectionLabels[kNsel] = {
   "kIsBBV0A",
@@ -49,6 +49,8 @@ const char* selectionLabels[kNsel] = {
   "kIsTriggerTVX",
   "kIsINT1"};
 }
+
+using namespace o2::aod::evsel;
 
 EventSelectionParams::EventSelectionParams(int system, int run)
 {

--- a/Common/CCDB/EventSelectionParams.cxx
+++ b/Common/CCDB/EventSelectionParams.cxx
@@ -48,7 +48,7 @@ const char* selectionLabels[kNsel] = {
   "kNoPileupTPC",
   "kIsTriggerTVX",
   "kIsINT1"};
-}
+} // namespace o2::aod::evsel
 
 using namespace o2::aod::evsel;
 

--- a/Common/CCDB/EventSelectionParams.h
+++ b/Common/CCDB/EventSelectionParams.h
@@ -15,7 +15,7 @@
 #include <Rtypes.h>
 #include <TMath.h>
 
-namespace evsel
+namespace o2::aod::evsel
 {
 // Event selection criteria
 enum EventSelectionFlags {
@@ -58,9 +58,7 @@ enum EventSelectionFlags {
 
 extern const char* selectionLabels[kNsel];
 
-} // namespace evsel
-
-using namespace evsel;
+} // namespace o2::aod::evsel
 
 class EventSelectionParams
 {
@@ -70,9 +68,9 @@ class EventSelectionParams
   void SetOnVsOfParams(float newV0MOnVsOfA, float newV0MOnVsOfB, float newSPDOnVsOfA, float newSPDOnVsOfB);
   bool* GetSelection(int iSelection);
 
-  bool selectionBarrel[kNsel];
-  bool selectionMuonWithPileupCuts[kNsel];
-  bool selectionMuonWithoutPileupCuts[kNsel];
+  bool selectionBarrel[o2::aod::evsel::kNsel];
+  bool selectionMuonWithPileupCuts[o2::aod::evsel::kNsel];
+  bool selectionMuonWithoutPileupCuts[o2::aod::evsel::kNsel];
 
   // time-of-flight offset
   float fV0ADist = 329.00 / TMath::Ccgs() * 1e9; // ns

--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -232,12 +232,12 @@ class CollisionAssociation
   }
 
  private:
-  float mNumSigmaForTimeCompat{4.};                                         // number of sigma for time compatibility
-  float mTimeMargin{500.};                                                  // additional time margin in ns
+  float mNumSigmaForTimeCompat{4.};                                                  // number of sigma for time compatibility
+  float mTimeMargin{500.};                                                           // additional time margin in ns
   int mTrackSelection{o2::aod::track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
-  bool mUsePvAssociation{true};                                             // use the information of PV contributors
-  bool mIncludeUnassigned{true};                                            // include tracks that were originally not assigned to any collision
-  bool mFillTableOfCollIdsPerTrack{false};                                  // fill additional table with vectors of compatible collisions per track
+  bool mUsePvAssociation{true};                                                      // use the information of PV contributors
+  bool mIncludeUnassigned{true};                                                     // include tracks that were originally not assigned to any collision
+  bool mFillTableOfCollIdsPerTrack{false};                                           // fill additional table with vectors of compatible collisions per track
 };
 
 #endif // COMMON_CORE_COLLISIONASSOCIATION_H_

--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include <memory>
+
 #include "CommonConstants/LHCConstants.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
@@ -41,9 +42,6 @@ enum TrackSelection {
 } // namespace track_association
 } // namespace o2::aod
 
-using namespace o2;
-using namespace o2::aod;
-
 template <bool isCentralBarrel>
 class CollisionAssociation
 {
@@ -59,7 +57,7 @@ class CollisionAssociation
   void setFillTableOfCollIdsPerTrack(bool fill = true) { mFillTableOfCollIdsPerTrack = fill; }
 
   template <typename TTracks, typename Slice, typename Assoc, typename RevIndices>
-  void runStandardAssoc(Collisions const& collisions,
+  void runStandardAssoc(o2::aod::Collisions const& collisions,
                         TTracks const& tracks,
                         Slice& perCollisions,
                         Assoc& association,
@@ -72,23 +70,23 @@ class CollisionAssociation
         if constexpr (isCentralBarrel) {
           bool hasGoodQuality = true;
           switch (mTrackSelection) {
-            case track_association::TrackSelection::CentralBarrelRun2: {
+            case o2::aod::track_association::TrackSelection::CentralBarrelRun2: {
               unsigned char itsClusterMap = track.itsClusterMap();
-              if (!(track.tpcNClsFound() >= 50 && track.flags() & track::ITSrefit && track.flags() & track::TPCrefit && (TESTBIT(itsClusterMap, 0) || TESTBIT(itsClusterMap, 1)))) {
+              if (!(track.tpcNClsFound() >= 50 && track.flags() & o2::aod::track::ITSrefit && track.flags() & o2::aod::track::TPCrefit && (TESTBIT(itsClusterMap, 0) || TESTBIT(itsClusterMap, 1)))) {
                 hasGoodQuality = false;
               }
               break;
             }
-            case track_association::TrackSelection::None: {
+            case o2::aod::track_association::TrackSelection::None: {
               break;
             }
-            case track_association::TrackSelection::GlobalTrackWoDCA: {
+            case o2::aod::track_association::TrackSelection::GlobalTrackWoDCA: {
               if (!track.isGlobalTrackWoDCA()) {
                 hasGoodQuality = false;
               }
               break;
             }
-            case track_association::TrackSelection::QualityTracksITS: {
+            case o2::aod::track_association::TrackSelection::QualityTracksITS: {
               if (!track.isQualityTrackITS()) {
                 hasGoodQuality = false;
               }
@@ -117,11 +115,11 @@ class CollisionAssociation
   }
 
   template <typename TTracksUnfiltered, typename TTracks, typename TAmbiTracks, typename Assoc, typename RevIndices>
-  void runAssocWithTime(Collisions const& collisions,
+  void runAssocWithTime(o2::aod::Collisions const& collisions,
                         TTracksUnfiltered const& tracksUnfiltered,
                         TTracks const& tracks,
                         TAmbiTracks const& ambiguousTracks,
-                        BCs const& bcs,
+                        o2::aod::BCs const& bcs,
                         Assoc& association,
                         RevIndices& reverseIndices)
   {
@@ -172,11 +170,11 @@ class CollisionAssociation
         if constexpr (isCentralBarrel) {
           if (mUsePvAssociation && track.isPVContributor()) {
             trackTime = track.collision().collisionTime();    // if PV contributor, we assume the time to be the one of the collision
-            trackTimeRes = constants::lhc::LHCBunchSpacingNS; // 1 BC
+            trackTimeRes = o2::constants::lhc::LHCBunchSpacingNS; // 1 BC
           }
         }
 
-        const float deltaTime = trackTime - collTime + bcOffset * constants::lhc::LHCBunchSpacingNS;
+        const float deltaTime = trackTime - collTime + bcOffset * o2::constants::lhc::LHCBunchSpacingNS;
         float sigmaTimeRes2 = collTimeRes2 + trackTimeRes * trackTimeRes;
         LOGP(debug, "collision time={}, collision time res={}, track time={}, track time res={}, bc collision={}, bc track={}, delta time={}", collTime, collision.collisionTimeRes(), track.trackTime(), track.trackTimeRes(), collBC, globalBC[track.filteredIndex()], deltaTime);
 
@@ -195,7 +193,7 @@ class CollisionAssociation
         if constexpr (isCentralBarrel) {
           if (mUsePvAssociation && track.isPVContributor()) {
             thresholdTime = trackTimeRes;
-          } else if (TESTBIT(track.flags(), track::TrackTimeResIsRange)) {
+          } else if (TESTBIT(track.flags(), o2::aod::track::TrackTimeResIsRange)) {
             thresholdTime = std::sqrt(sigmaTimeRes2) + mTimeMargin;
           } else {
             thresholdTime = mNumSigmaForTimeCompat * std::sqrt(sigmaTimeRes2) + mTimeMargin;
@@ -236,7 +234,7 @@ class CollisionAssociation
  private:
   float mNumSigmaForTimeCompat{4.};                                         // number of sigma for time compatibility
   float mTimeMargin{500.};                                                  // additional time margin in ns
-  int mTrackSelection{track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
+  int mTrackSelection{o2::aod::track_association::TrackSelection::GlobalTrackWoDCA}; // track selection for central barrel tracks (standard association only)
   bool mUsePvAssociation{true};                                             // use the information of PV contributors
   bool mIncludeUnassigned{true};                                            // include tracks that were originally not assigned to any collision
   bool mFillTableOfCollIdsPerTrack{false};                                  // fill additional table with vectors of compatible collisions per track

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -29,10 +29,6 @@
 #include "CommonConstants/MathConstants.h"
 #include "Framework/Logger.h"
 
-using std::array;
-using namespace o2;
-using namespace o2::constants::math;
-
 /// Base class for calculating properties of reconstructed decays
 ///
 /// Provides static helper functions for:
@@ -109,9 +105,9 @@ class RecoDecay
   /// \param args  pack of 3-vector arrays
   /// \return sum of vectors
   template <typename... T>
-  static auto sumOfVec(const array<T, 3>&... args)
+  static auto sumOfVec(const std::array<T, 3>&... args)
   {
-    return array{getElement(0, args...), getElement(1, args...), getElement(2, args...)};
+    return std::array{getElement(0, args...), getElement(1, args...), getElement(2, args...)};
   }
 
   /// Calculates scalar product of vectors.
@@ -120,7 +116,7 @@ class RecoDecay
   /// \param vec1,vec2  vectors
   /// \return scalar product
   template <std::size_t N, typename T, typename U>
-  static double dotProd(const array<T, N>& vec1, const array<U, N>& vec2)
+  static double dotProd(const std::array<T, N>& vec1, const std::array<U, N>& vec2)
   {
     double res{0};
     for (std::size_t iDim = 0; iDim < N; ++iDim) {
@@ -135,9 +131,9 @@ class RecoDecay
   /// \param vec1,vec2  vectors
   /// \return cross-product vector
   template <typename T, typename U>
-  static array<double, 3> crossProd(const array<T, 3>& vec1, const array<U, 3>& vec2)
+  static std::array<double, 3> crossProd(const std::array<T, 3>& vec1, const std::array<U, 3>& vec2)
   {
-    return array<double, 3>{(static_cast<double>(vec1[1]) * static_cast<double>(vec2[2])) - (static_cast<double>(vec1[2]) * static_cast<double>(vec2[1])),
+    return std::array<double, 3>{(static_cast<double>(vec1[1]) * static_cast<double>(vec2[2])) - (static_cast<double>(vec1[2]) * static_cast<double>(vec2[1])),
                             (static_cast<double>(vec1[2]) * static_cast<double>(vec2[0])) - (static_cast<double>(vec1[0]) * static_cast<double>(vec2[2])),
                             (static_cast<double>(vec1[0]) * static_cast<double>(vec2[1])) - (static_cast<double>(vec1[1]) * static_cast<double>(vec2[0]))};
   }
@@ -147,7 +143,7 @@ class RecoDecay
   /// \param vec  vector
   /// \return magnitude squared
   template <std::size_t N, typename T>
-  static double mag2(const array<T, N>& vec)
+  static double mag2(const std::array<T, N>& vec)
   {
     return dotProd(vec, vec);
   }
@@ -176,11 +172,11 @@ class RecoDecay
   /// \param mom  3-momentum array
   /// \return pseudorapidity
   template <typename T>
-  static double eta(const array<T, 3>& mom)
+  static double eta(const std::array<T, 3>& mom)
   {
     // eta = arctanh(pz/p)
-    if (std::abs(mom[0]) < Almost0 && std::abs(mom[1]) < Almost0) { // very small px and py
-      return static_cast<double>(mom[2] > 0 ? VeryBig : -VeryBig);
+    if (std::abs(mom[0]) < o2::constants::math::Almost0 && std::abs(mom[1]) < o2::constants::math::Almost0) { // very small px and py
+      return static_cast<double>(mom[2] > 0 ? o2::constants::math::VeryBig : -o2::constants::math::VeryBig);
     }
     return static_cast<double>(std::atanh(mom[2] / p(mom)));
   }
@@ -190,7 +186,7 @@ class RecoDecay
   /// \param mass  mass
   /// \return rapidity
   template <typename T, typename U>
-  static double y(const array<T, 3>& mom, U mass)
+  static double y(const std::array<T, 3>& mom, U mass)
   {
     // y = arctanh(pz/E)
     return std::atanh(mom[2] / e(mom, mass));
@@ -239,10 +235,10 @@ class RecoDecay
   /// \param mom  3-momentum array
   /// \return cosine of pointing angle
   template <typename T, typename U, typename V>
-  static double cpa(const T& posPV, const U& posSV, const array<V, 3>& mom)
+  static double cpa(const T& posPV, const U& posSV, const std::array<V, 3>& mom)
   {
     // CPA = (l . p)/(|l| |p|)
-    auto lineDecay = array{posSV[0] - posPV[0], posSV[1] - posPV[1], posSV[2] - posPV[2]};
+    auto lineDecay = std::array{posSV[0] - posPV[0], posSV[1] - posPV[1], posSV[2] - posPV[2]};
     auto cos = dotProd(lineDecay, mom) / std::sqrt(mag2(lineDecay) * mag2(mom));
     if (cos < -1.) {
       return -1.;
@@ -259,11 +255,11 @@ class RecoDecay
   /// \param mom  {x, y, z} or {x, y} momentum array
   /// \return cosine of pointing angle in {x, y}
   template <std::size_t N, typename T, typename U, typename V>
-  static double cpaXY(const T& posPV, const U& posSV, const array<V, N>& mom)
+  static double cpaXY(const T& posPV, const U& posSV, const std::array<V, N>& mom)
   {
     // CPAXY = (r . pT)/(|r| |pT|)
-    auto lineDecay = array{posSV[0] - posPV[0], posSV[1] - posPV[1]};
-    auto momXY = array{mom[0], mom[1]};
+    auto lineDecay = std::array{posSV[0] - posPV[0], posSV[1] - posPV[1]};
+    auto momXY = std::array{mom[0], mom[1]};
     auto cos = dotProd(lineDecay, momXY) / std::sqrt(mag2(lineDecay) * mag2(momXY));
     if (cos < -1.) {
       return -1.;
@@ -281,7 +277,7 @@ class RecoDecay
   /// \param length  decay length
   /// \return proper lifetime times c
   template <typename T, typename U, typename V>
-  static double ct(const array<T, 3>& mom, U length, V mass)
+  static double ct(const std::array<T, 3>& mom, U length, V mass)
   {
     // c t = l m c^2/(p c)
     return static_cast<double>(length) * static_cast<double>(mass) / p(mom);
@@ -295,7 +291,7 @@ class RecoDecay
   /// \param iProng  index of the prong
   /// \return cosine of θ* of the i-th prong under the assumption of the invariant mass
   template <typename T, typename U, typename V>
-  static double cosThetaStar(const array<array<T, 3>, 2>& arrMom, const array<U, 2>& arrMass, V mTot, int iProng)
+  static double cosThetaStar(const std::array<std::array<T, 3>, 2>& arrMom, const std::array<U, 2>& arrMass, V mTot, int iProng)
   {
     auto pVecTot = pVec(arrMom[0], arrMom[1]);                                                                             // momentum of the mother particle
     auto pTot = p(pVecTot);                                                                                                // magnitude of the momentum of the mother particle
@@ -315,7 +311,7 @@ class RecoDecay
   /// \param args  pack of 3-momentum arrays
   /// \return total 3-momentum array
   template <typename... T>
-  static auto pVec(const array<T, 3>&... args)
+  static auto pVec(const std::array<T, 3>&... args)
   {
     return sumOfVec(args...);
   }
@@ -332,7 +328,7 @@ class RecoDecay
   /// \param args  pack of 3-momentum arrays
   /// \return total momentum squared
   template <typename... T>
-  static double p2(const array<T, 3>&... args)
+  static double p2(const std::array<T, 3>&... args)
   {
     return sumOfSquares(getElement(0, args...), getElement(1, args...), getElement(2, args...));
   }
@@ -358,7 +354,7 @@ class RecoDecay
   /// \param args  pack of 3-(or 2-)momentum arrays
   /// \return total transverse momentum squared
   template <std::size_t N, typename... T>
-  static double pt2(const array<T, N>&... args)
+  static double pt2(const std::array<T, N>&... args)
   {
     return sumOfSquares(getElement(0, args...), getElement(1, args...));
   }
@@ -387,7 +383,7 @@ class RecoDecay
   /// \param mass  mass
   /// \return energy squared
   template <typename T, typename U>
-  static double e2(const array<T, 3>& mom, U mass)
+  static double e2(const std::array<T, 3>& mom, U mass)
   {
     return e2(mom[0], mom[1], mom[2], mass);
   }
@@ -417,7 +413,7 @@ class RecoDecay
   /// \param energy  energy
   /// \return invariant mass squared
   template <typename T>
-  static double m2(const array<T, 3>& mom, double energy)
+  static double m2(const std::array<T, 3>& mom, double energy)
   {
     return energy * energy - p2(mom);
   }
@@ -428,9 +424,9 @@ class RecoDecay
   /// \param arrMass  array of N masses (in the same order as arrMom)
   /// \return invariant mass squared
   template <std::size_t N, typename T, typename U>
-  static double m2(const array<array<T, 3>, N>& arrMom, const array<U, N>& arrMass)
+  static double m2(const std::array<std::array<T, 3>, N>& arrMom, const std::array<U, N>& arrMass)
   {
-    array<double, 3> momTotal{0., 0., 0.}; // candidate momentum vector
+    std::array<double, 3> momTotal{0., 0., 0.}; // candidate momentum vector
     double energyTot{0.};                  // candidate energy
     for (std::size_t iProng = 0; iProng < N; ++iProng) {
       for (std::size_t iMom = 0; iMom < 3; ++iMom) {
@@ -460,15 +456,15 @@ class RecoDecay
   /// \param mom  {x, y, z} particle momentum array
   /// \return impact parameter in {x, y}
   template <typename T, typename U, typename V>
-  static double impParXY(const T& point, const U& posSV, const array<V, 3>& mom)
+  static double impParXY(const T& point, const U& posSV, const std::array<V, 3>& mom)
   {
     // Ported from AliAODRecoDecay::ImpParXY
-    auto flightLineXY = array{posSV[0] - point[0], posSV[1] - point[1]};
-    auto k = dotProd(flightLineXY, array{mom[0], mom[1]}) / pt2(mom);
+    auto flightLineXY = std::array{posSV[0] - point[0], posSV[1] - point[1]};
+    auto k = dotProd(flightLineXY, std::array{mom[0], mom[1]}) / pt2(mom);
     auto dx = flightLineXY[0] - k * static_cast<double>(mom[0]);
     auto dy = flightLineXY[1] - k * static_cast<double>(mom[1]);
     auto absImpPar = sqrtSumOfSquares(dx, dy);
-    auto flightLine = array{posSV[0] - point[0], posSV[1] - point[1], posSV[2] - point[2]};
+    auto flightLine = std::array{posSV[0] - point[0], posSV[1] - point[1], posSV[2] - point[2]};
     auto cross = crossProd(mom, flightLine);
     return (cross[2] > 0. ? absImpPar : -1. * absImpPar);
   }
@@ -483,8 +479,8 @@ class RecoDecay
   /// \param momProng {x, y, z} or {x, y} prong momentum array
   /// \return normalized difference between expected and observed impact parameter
   template <std::size_t N, std::size_t M, typename T, typename U, typename V, typename W, typename X, typename Y>
-  static double normImpParMeasMinusExpProng(T decLenXY, U errDecLenXY, const array<V, N>& momMother, W impParProng,
-                                            X errImpParProng, const array<Y, M>& momProng)
+  static double normImpParMeasMinusExpProng(T decLenXY, U errDecLenXY, const std::array<V, N>& momMother, W impParProng,
+                                            X errImpParProng, const std::array<Y, M>& momProng)
   {
     // Ported from AliAODRecoDecayHF::Getd0MeasMinusExpProng adding normalization directly in the function
     auto sinThetaP = (static_cast<double>(momProng[0]) * static_cast<double>(momMother[1]) - static_cast<double>(momProng[1]) * static_cast<double>(momMother[0])) /
@@ -506,9 +502,9 @@ class RecoDecay
   /// \return maximum normalized difference between expected and observed impact parameters
   template <std::size_t N, std::size_t M, std::size_t K, typename T, typename U, typename V, typename W, typename X,
             typename Y, typename Z>
-  static double maxNormalisedDeltaIP(const T& posPV, const U& posSV, V errDecLenXY, const array<W, M>& momMother,
-                                     const array<X, N>& arrImpPar, const array<Y, N>& arrErrImpPar,
-                                     const array<array<Z, K>, N>& arrMom)
+  static double maxNormalisedDeltaIP(const T& posPV, const U& posSV, V errDecLenXY, const std::array<W, M>& momMother,
+                                     const std::array<X, N>& arrImpPar, const std::array<Y, N>& arrErrImpPar,
+                                     const std::array<std::array<Z, K>, N>& arrMom)
   {
     auto decLenXY = distanceXY(posPV, posSV);
     double maxNormDeltaIP{0.};
@@ -661,7 +657,7 @@ class RecoDecay
   template <std::size_t N, typename T>
   static void getDaughters(const T& particle,
                            std::vector<int>* list,
-                           const array<int, N>& arrPDGFinal,
+                           const std::array<int, N>& arrPDGFinal,
                            int8_t depthMax = -1,
                            int8_t stage = 0)
   {
@@ -726,9 +722,9 @@ class RecoDecay
   /// \return index of the mother particle if the mother and daughters are correct, -1 otherwise
   template <std::size_t N, typename T, typename U>
   static int getMatchedMCRec(const T& particlesMC,
-                             const array<U, N>& arrDaughters,
+                             const std::array<U, N>& arrDaughters,
                              int PDGMother,
-                             array<int, N> arrPDGDaughters,
+                             std::array<int, N> arrPDGDaughters,
                              bool acceptAntiParticles = false,
                              int8_t* sign = nullptr,
                              int depthMax = 1)
@@ -737,7 +733,7 @@ class RecoDecay
     int8_t sgn = 0;                        // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
     int indexMother = -1;                  // index of the mother particle
     std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters of the mother of the first provided daughter
-    array<int, N> arrDaughtersIndex;       // array of indices of provided daughters
+    std::array<int, N> arrDaughtersIndex;       // array of indices of provided daughters
     if (sign) {
       *sign = sgn;
     }
@@ -834,7 +830,7 @@ class RecoDecay
                             bool acceptAntiParticles = false,
                             int8_t* sign = nullptr)
   {
-    array<int, 0> arrPDGDaughters;
+    std::array<int, 0> arrPDGDaughters;
     return isMatchedMCGen(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles, sign);
   }
 
@@ -852,7 +848,7 @@ class RecoDecay
   static bool isMatchedMCGen(const T& particlesMC,
                              const U& candidate,
                              int PDGParticle,
-                             array<int, N> arrPDGDaughters,
+                             std::array<int, N> arrPDGDaughters,
                              bool acceptAntiParticles = false,
                              int8_t* sign = nullptr,
                              int depthMax = 1,

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -134,8 +134,8 @@ class RecoDecay
   static std::array<double, 3> crossProd(const std::array<T, 3>& vec1, const std::array<U, 3>& vec2)
   {
     return std::array<double, 3>{(static_cast<double>(vec1[1]) * static_cast<double>(vec2[2])) - (static_cast<double>(vec1[2]) * static_cast<double>(vec2[1])),
-                            (static_cast<double>(vec1[2]) * static_cast<double>(vec2[0])) - (static_cast<double>(vec1[0]) * static_cast<double>(vec2[2])),
-                            (static_cast<double>(vec1[0]) * static_cast<double>(vec2[1])) - (static_cast<double>(vec1[1]) * static_cast<double>(vec2[0]))};
+                                 (static_cast<double>(vec1[2]) * static_cast<double>(vec2[0])) - (static_cast<double>(vec1[0]) * static_cast<double>(vec2[2])),
+                                 (static_cast<double>(vec1[0]) * static_cast<double>(vec2[1])) - (static_cast<double>(vec1[1]) * static_cast<double>(vec2[0]))};
   }
 
   /// Calculates magnitude squared of a vector.
@@ -733,7 +733,7 @@ class RecoDecay
     int8_t sgn = 0;                        // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGMother)
     int indexMother = -1;                  // index of the mother particle
     std::vector<int> arrAllDaughtersIndex; // vector of indices of all daughters of the mother of the first provided daughter
-    std::array<int, N> arrDaughtersIndex;       // array of indices of provided daughters
+    std::array<int, N> arrDaughtersIndex;  // array of indices of provided daughters
     if (sign) {
       *sign = sgn;
     }

--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -72,7 +72,7 @@ struct TrackSelectionFlags {
   }
 };
 
-#define requireTrackCutInFilter(mask) ((aod::track::trackCutFlag & aod::track::mask) == aod::track::mask)
+#define requireTrackCutInFilter(mask) ((o2::aod::track::trackCutFlag & o2::aod::track::mask) == o2::aod::track::mask)
 #define requireQualityTracksInFilter() requireTrackCutInFilter(TrackSelectionFlags::kQualityTracks)
 #define requireQualityTracksITSInFilter() requireTrackCutInFilter(TrackSelectionFlags::kQualityTracksITS)
 #define requirePrimaryTracksInFilter() requireTrackCutInFilter(TrackSelectionFlags::kPrimaryTracks)
@@ -82,7 +82,7 @@ struct TrackSelectionFlags {
 #define requireGlobalTrackWoPtEtaInFilter() requireTrackCutInFilter(TrackSelectionFlags::kGlobalTrackWoPtEta)
 #define requireGlobalTrackWoDCAInFilter() requireTrackCutInFilter(TrackSelectionFlags::kGlobalTrackWoDCA)
 #define requireGlobalTrackWoDCATPCClusterInFilter() requireTrackCutInFilter(TrackSelectionFlags::kGlobalTrackWoDCATPCCluster)
-#define requireTrackWithinBeamPipe (nabs(aod::track::x) < o2::constants::geom::XBeamPipeOuterRef)
+#define requireTrackWithinBeamPipe (nabs(o2::aod::track::x) < o2::constants::geom::XBeamPipeOuterRef)
 
 // Columns to store track filter decisions
 DECLARE_SOA_COLUMN(IsGlobalTrackSDD, isGlobalTrackSDD, uint8_t);               //!

--- a/Common/TableProducer/PID/pidTOFBase.h
+++ b/Common/TableProducer/PID/pidTOFBase.h
@@ -26,11 +26,6 @@
 #include "PID/PIDTOF.h"
 #include "Common/DataModel/PIDResponse.h"
 
-using namespace o2;
-using namespace o2::track;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-
 static constexpr int nSpecies = 9;
 static constexpr int nParameters = 1;
 static const std::vector<std::string> particleNames{"El", "Mu", "Pi", "Ka", "Pr", "De", "Tr", "He", "Al"};

--- a/Common/TableProducer/PID/pidTPCBase.h
+++ b/Common/TableProducer/PID/pidTPCBase.h
@@ -21,11 +21,6 @@
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/PIDResponse.h"
 
-using namespace o2;
-using namespace o2::track;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-
 namespace o2::aod
 {
 

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -10,9 +10,6 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/ConfigParamSpec.h"
-using namespace o2;
-using namespace o2::framework;
-
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -27,7 +24,9 @@ using namespace o2::framework;
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "TH1D.h"
 
-using namespace evsel;
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::aod::evsel;
 
 using BCsWithRun2InfosTimestampsAndMatches = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps, aod::Run2MatchedToBCSparse>;
 using BCsWithRun3Matchings = soa::Join<aod::BCs, aod::Timestamps, aod::Run3MatchedToBCSparse>;

--- a/Common/Tools/Multiplicity/multCalibrator.cxx
+++ b/Common/Tools/Multiplicity/multCalibrator.cxx
@@ -27,6 +27,8 @@
 #include "TArrayF.h"
 #include "multCalibrator.h"
 
+using namespace std;
+
 const TString multCalibrator::fCentEstimName[kNCentEstim] = {
   "RawV0M", "RawT0M", "RawFDD", "RawNTracks",
   "ZeqV0M", "ZeqT0M", "ZeqFDD", "ZeqNTracks"};

--- a/Common/Tools/Multiplicity/multCalibrator.h
+++ b/Common/Tools/Multiplicity/multCalibrator.h
@@ -20,11 +20,10 @@
 #define MULTCALIBRATOR_H
 
 #include <iostream>
-#include "TNamed.h"
-#include "TH1D.h"
 #include <map>
 
-using namespace std;
+#include "TNamed.h"
+#include "TH1D.h"
 
 class multCalibrator : public TNamed
 {
@@ -47,7 +46,7 @@ class multCalibrator : public TNamed
   void SetBoundaries(Long_t lNB, Double_t* lB)
   {
     if (lNB < 2 || lNB > 1e+6) {
-      cout << "Please make sure you are using a reasonable number of boundaries!" << endl;
+      std::cout << "Please make sure you are using a reasonable number of boundaries!" << std::endl;
       lNB = -1;
     }
     lDesiredBoundaries = lB;

--- a/Common/Tools/Multiplicity/multGlauberNBDFitter.cxx
+++ b/Common/Tools/Multiplicity/multGlauberNBDFitter.cxx
@@ -34,6 +34,8 @@
 #include "TProfile.h"
 #include "TFitResult.h"
 
+using namespace std;
+
 ClassImp(multGlauberNBDFitter);
 
 multGlauberNBDFitter::multGlauberNBDFitter() : TNamed(),

--- a/Common/Tools/Multiplicity/multGlauberNBDFitter.h
+++ b/Common/Tools/Multiplicity/multGlauberNBDFitter.h
@@ -20,7 +20,6 @@
 #include "TH2.h"
 #include "TProfile.h"
 
-using namespace std;
 class multGlauberNBDFitter : public TNamed
 {
 

--- a/Common/Tools/Multiplicity/multMCCalibrator.cxx
+++ b/Common/Tools/Multiplicity/multMCCalibrator.cxx
@@ -29,6 +29,8 @@
 #include "multCalibrator.h"
 #include "multMCCalibrator.h"
 
+using namespace std;
+
 multMCCalibrator::multMCCalibrator() : TNamed(),
                                        fDataInputFileName("AnalysisResults.root"),
                                        fSimInputFileName("AnalysisResultsMC.root"),

--- a/Common/Tools/Multiplicity/multMCCalibrator.h
+++ b/Common/Tools/Multiplicity/multMCCalibrator.h
@@ -26,8 +26,6 @@
 #include "TProfile.h"
 #include <map>
 
-using namespace std;
-
 class multMCCalibrator : public TNamed
 {
 

--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -21,14 +21,16 @@
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "TH1F.h"
 #include "TH2F.h"
+
 using namespace o2::framework;
 using namespace o2;
-using namespace evsel;
+using namespace o2::aod::evsel;
 
 using BCsRun2 = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps, aod::BcSels, aod::Run2MatchedToBCSparse>;
 using BCsRun3 = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels, aod::Run3MatchedToBCSparse>;
 using ColEvSels = soa::Join<aod::Collisions, aod::EvSels>;
 using FullTracksIU = soa::Join<aod::TracksIU, aod::TracksExtra>;
+
 struct EventSelectionQaTask {
   Configurable<bool> isMC{"isMC", 0, "0 - data, 1 - MC"};
   Configurable<int> nGlobalBCs{"nGlobalBCs", 100000, "number of global bcs"};

--- a/DPG/Tasks/AOTTrack/PID/qaPIDTOFBeta.cxx
+++ b/DPG/Tasks/AOTTrack/PID/qaPIDTOFBeta.cxx
@@ -25,6 +25,10 @@
 #include "Common/DataModel/FT0Corrected.h"
 #include "Common/TableProducer/PID/pidTOFBase.h"
 
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
 /// Task to produce the TOF Beta QA plots
 struct tofPidBetaQa {
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/DPG/Tasks/AOTTrack/PID/qaPIDTOFEvTime.cxx
+++ b/DPG/Tasks/AOTTrack/PID/qaPIDTOFEvTime.cxx
@@ -28,6 +28,9 @@
 #include "Common/TableProducer/PID/pidTOFBase.h"
 #include "Framework/runDataProcessing.h"
 
+using namespace o2;
+using namespace o2::framework;
+
 struct tofPidCollisionTimeQa {
   ConfigurableAxis evTimeBins{"evTimeBins", {1000, -1000.f, 1000.f}, "Binning for the event time"};
   ConfigurableAxis evTimeDeltaBins{"evTimeDeltaBins", {1000, -1000.f, 1000.f}, "Binning for the delta between event times"};
@@ -312,7 +315,7 @@ struct tofPidCollisionTimeQa {
         const float& massT0C = collision.t0CCorrectedValid() ? o2::pid::tof::TOFMass<Trks::iterator>::GetTOFMass(trk, betaT0C) : 999.f;
         const float& massT0AC = collision.t0ACValid() ? o2::pid::tof::TOFMass<Trks::iterator>::GetTOFMass(trk, betaT0AC) : 999.f;
 
-        const float& deltaPi = trk.tofSignal() - trk.tofEvTime() - o2::pid::tof::ExpTimes<Trks::iterator, PID::Pion>::GetExpectedSignal(trk);
+        const float& deltaPi = trk.tofSignal() - trk.tofEvTime() - o2::pid::tof::ExpTimes<Trks::iterator, o2::track::PID::Pion>::GetExpectedSignal(trk);
 
         histos.fill(HIST("tofbeta/inclusive"), trk.p(), trk.beta());
         histos.fill(HIST("tofmass/inclusive"), trk.p(), trk.mass());

--- a/DPG/Tasks/TOF/tofSkimsTableCreator.h
+++ b/DPG/Tasks/TOF/tofSkimsTableCreator.h
@@ -19,11 +19,6 @@
 #ifndef DPG_TASKS_TOF_TOFSKIMSTABLECREATOR_H_
 #define DPG_TASKS_TOF_TOFSKIMSTABLECREATOR_H_
 
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-using namespace o2::track;
-
 #include "Common/TableProducer/PID/pidTOFBase.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/FT0Corrected.h"

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.h
@@ -16,15 +16,11 @@
 
 #ifndef DPG_TASKS_TPC_TPCSKIMSTABLECREATOR_H_
 #define DPG_TASKS_TPC_TPCSKIMSTABLECREATOR_H_
+
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/PIDResponse.h"
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-using namespace o2::track;
-using namespace o2::dataformats;
 
 namespace o2::aod
 {

--- a/DPG/Tasks/TPC/tpcTreeCreatorLight.h
+++ b/DPG/Tasks/TPC/tpcTreeCreatorLight.h
@@ -16,15 +16,11 @@
 
 #ifndef DPG_TASKS_TPC_TPCTREECREATORLIGHT_H_
 #define DPG_TASKS_TPC_TPCTREECREATORLIGHT_H_
+
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/PIDResponse.h"
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-using namespace o2::track;
-using namespace o2::dataformats;
 
 enum ParticleSpecies {
   kPionTrack = BIT(0),

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -48,11 +48,6 @@
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
-using namespace o2::constants::math;
-
 namespace o2::aod
 {
 
@@ -153,17 +148,17 @@ static const float massK0S = 0.497614;
 static const float massLambda = 1.11568;
 static const float massXi = 1.32171;
 
-static const AxisSpec ptAxis{50, 0.f, 50.f};
-static const AxisSpec pAxis{50, 0.f, 10.f};
-static const AxisSpec kstarAxis{100, 0.f, 1.f};
-static const AxisSpec etaAxis{30, -1.5f, 1.5f};
-static const AxisSpec nSigmaAxis{100, -10.f, 10.f};
-static const AxisSpec alphaAxis{100, -1.f, 1.f};
-static const AxisSpec qtAxis{100, 0.f, 0.25f};
-static const AxisSpec bdtAxis{100, 0.f, 1.f};
-static const AxisSpec phiAxis{36, 0., TwoPI};
-static const std::array<AxisSpec, kNCharmParticles + 8> massAxisC = {AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.65f, 2.05f}, AxisSpec{100, 1.75f, 2.15f}, AxisSpec{100, 2.05f, 2.45f}, AxisSpec{100, 2.25f, 2.65f}, AxisSpec{100, 0.139f, 0.159f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.f, 0.25f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 0.48f, 0.88f}, AxisSpec{100, 1.1f, 1.4f}, AxisSpec{100, 2.3f, 2.9f}, AxisSpec{100, 2.3f, 2.9f}};
-static const std::array<AxisSpec, kNBeautyParticles> massAxisB = {AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 4.8f, 6.0f}, AxisSpec{240, 5.0f, 6.2f}, AxisSpec{240, 5.0f, 6.2f}};
+static const o2::framework::AxisSpec ptAxis{50, 0.f, 50.f};
+static const o2::framework::AxisSpec pAxis{50, 0.f, 10.f};
+static const o2::framework::AxisSpec kstarAxis{100, 0.f, 1.f};
+static const o2::framework::AxisSpec etaAxis{30, -1.5f, 1.5f};
+static const o2::framework::AxisSpec nSigmaAxis{100, -10.f, 10.f};
+static const o2::framework::AxisSpec alphaAxis{100, -1.f, 1.f};
+static const o2::framework::AxisSpec qtAxis{100, 0.f, 0.25f};
+static const o2::framework::AxisSpec bdtAxis{100, 0.f, 1.f};
+static const o2::framework::AxisSpec phiAxis{36, 0., TwoPI};
+static const std::array<o2::framework::AxisSpec, kNCharmParticles + 8> massAxisC = {o2::framework::AxisSpec{100, 1.65f, 2.05f}, o2::framework::AxisSpec{100, 1.65f, 2.05f}, o2::framework::AxisSpec{100, 1.75f, 2.15f}, o2::framework::AxisSpec{100, 2.05f, 2.45f}, o2::framework::AxisSpec{100, 2.25f, 2.65f}, o2::framework::AxisSpec{100, 0.139f, 0.159f}, o2::framework::AxisSpec{100, 0.f, 0.25f}, o2::framework::AxisSpec{100, 0.f, 0.25f}, o2::framework::AxisSpec{100, 0.48f, 0.88f}, o2::framework::AxisSpec{100, 0.48f, 0.88f}, o2::framework::AxisSpec{100, 1.1f, 1.4f}, o2::framework::AxisSpec{100, 2.3f, 2.9f}, o2::framework::AxisSpec{100, 2.3f, 2.9f}};
+static const std::array<o2::framework::AxisSpec, kNBeautyParticles> massAxisB = {o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}};
 
 // default values for configurables
 // channels to trigger on for femto
@@ -209,7 +204,7 @@ static const std::vector<std::string> labelsColumnsCharmBaryons = {"MinPtXiPi", 
 // dummy array
 static const std::vector<std::string> labelsEmpty{};
 static constexpr double cutsTrackDummy[hf_cuts_single_track::nBinsPtTrack][hf_cuts_single_track::nCutVarsTrack] = {{0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}, {0., 10.}};
-LabeledArray<double> cutsSingleTrackDummy{cutsTrackDummy[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack};
+o2::framework::LabeledArray<double> cutsSingleTrackDummy{cutsTrackDummy[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack};
 
 /// load the TPC spline from the CCDB
 /// \param ccdbApi is Api for CCDB

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -753,7 +753,7 @@ int8_t isSelectedXicInMassRange(const T& pTrackSameChargeFirst, const T& pTrackS
 /// \param hArmPod is the pointer to an array of QA histo AP plot before selection
 /// \return an integer passes all cuts
 template <typename V0, typename Coll, typename T, typename H2, typename H3>
-int8_t isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const Coll& collision, const float& minGammaCosinePa, const float& minV0CosinePa, const float& minV0Radius, const float& maxNsigmaPrForLambda, const float& deltaMassK0s, const float& deltaMassLambda, const int& setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H2 hV0Selected, std::array<H2, 4>& hArmPod)
+int8_t isSelectedV0(const V0& v0, const std::array<T, 2>& dauTracks, const Coll& collision, const float& minGammaCosinePa, const float& minV0CosinePa, const float& minV0Radius, const float& maxNsigmaPrForLambda, const float& deltaMassK0s, const float& deltaMassLambda, const int& setTPCCalib, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplineProton, const int& activateQA, H2 hV0Selected, std::array<H2, 4>& hArmPod)
 {
   int8_t isSelected{BIT(kPhoton) | BIT(kK0S) | BIT(kLambda) | BIT(kAntiLambda)};
 
@@ -915,7 +915,7 @@ int8_t isSelectedV0(const V0& v0, const array<T, 2>& dauTracks, const Coll& coll
 /// \param hSplinePion spline of pion and anti-pion calibrations
 /// \return true if cascade passes all cuts
 template <typename Casc, typename V0, typename T, typename Coll, typename H3>
-bool isSelectedCascade(const Casc& casc, const V0& v0, const array<T, 3>& dauTracks, const Coll& collision, const float& minPtXiBachelor, const float& deltaMassXi, const float& deltaMassLambda, const float& cosPAXi, const float& cosPALambda, const float& DCAxyXi, const float& maxNsigma, const int& setTPCCalib, H3 hMapPion, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplinePion, const std::array<std::vector<double>, 2>& hSplineProton)
+bool isSelectedCascade(const Casc& casc, const V0& v0, const std::array<T, 3>& dauTracks, const Coll& collision, const float& minPtXiBachelor, const float& deltaMassXi, const float& deltaMassLambda, const float& cosPAXi, const float& cosPALambda, const float& DCAxyXi, const float& maxNsigma, const int& setTPCCalib, H3 hMapPion, H3 hMapProton, const std::array<std::vector<double>, 2>& hSplinePion, const std::array<std::vector<double>, 2>& hSplineProton)
 {
   // eta of daughters
   if (std::fabs(dauTracks[0].eta()) > 1. || std::fabs(dauTracks[1].eta()) > 1. || std::fabs(dauTracks[2].eta()) > 1.) { // cut all V0 daughters with |eta| > 1.
@@ -1273,7 +1273,7 @@ std::array<T, 3> PredictONNX(std::vector<T>& inputFeatures, std::shared_ptr<Ort:
 /// \param pidSpecies is the PID species
 /// \return the corrected Nsigma value for the PID species
 template <typename T, typename H3>
-float getTPCPostCalib(const array<H3, 2>& hCalibMap, const T& track, const int pidSpecies)
+float getTPCPostCalib(const std::array<H3, 2>& hCalibMap, const T& track, const int pidSpecies)
 {
   auto tpcNCls = track.tpcNClsFound();
   auto tpcPin = track.tpcInnerParam();

--- a/EventFiltering/PWGHF/HFFilterPrepareMLSamples.cxx
+++ b/EventFiltering/PWGHF/HFFilterPrepareMLSamples.cxx
@@ -116,7 +116,7 @@ struct HfFilterPrepareMlSamples { // Main struct
 
       // D0(bar) → π± K∓
       bool isInCorrectColl{false};
-      auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::array{trackPos, trackNeg}, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign);
+      auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, std::array{trackPos, trackNeg}, pdg::Code::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign);
       if (indexRec > -1) {
         auto particle = particlesMC.rawIteratorAt(indexRec);
         flag = RecoDecay::getCharmHadronOrigin(particlesMC, particle);
@@ -197,27 +197,27 @@ struct HfFilterPrepareMlSamples { // Main struct
       int8_t channel = -1;
 
       // D± → π± K∓ π±
-      auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDPlus, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
+      auto indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
       if (indexRec >= 0) {
         channel = kDplus;
       }
       if (indexRec < 0) {
         // Ds± → K± K∓ π±
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDS, array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDS, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec >= 0) {
           channel = kDs;
         }
       }
       if (indexRec < 0) {
         // Λc± → p± K∓ π±
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec >= 0) {
           channel = kLc;
         }
       }
       if (indexRec < 0) {
         // Ξc± → p± K∓ π±
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec >= 0) {
           channel = kXic;
         }

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -328,7 +328,7 @@ struct TableMaker {
     // store the selection decisions
     uint64_t tag = collision.selection_raw();
     if (collision.sel7()) {
-      tag |= (uint64_t(1) << kNsel); //! SEL7 stored at position kNsel in the tag bit map
+      tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
     }
     // TODO: Add the event level decisions from the filtering task into the tag
 
@@ -688,7 +688,7 @@ struct TableMaker {
     // store the selection decisions
     uint64_t tag = collision.selection_raw();
     if (collision.sel7()) {
-      tag |= (uint64_t(1) << kNsel); //! SEL7 stored at position kNsel in the tag bit map
+      tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
     }
     // TODO: Add the event level decisions from the filtering task into the tag
 

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -341,7 +341,7 @@ struct TableMakerMC {
       // store the selection decisions
       uint64_t tag = collision.selection_raw();
       if (collision.sel7()) {
-        tag |= (uint64_t(1) << kNsel); //! SEL7 stored at position kNsel in the tag bit map
+        tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
       }
 
       auto mcCollision = collision.mcCollision();

--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -191,7 +191,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Py, py, [](float pypos, float pyneg) -> float { retur
 DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, [](float pzpos, float pzneg) -> float { return pzpos + pzneg; });
 DECLARE_SOA_DYNAMIC_COLUMN(E, e, [](float pxpos, float pxneg, float pypos, float pyneg, float pzpos, float pzneg, float m = 0) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg, pzpos + pzneg, m); }); //! energy of v0 photn, mass to be given as argument when getter is called!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg); });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::eta(array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}); });
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::eta(std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::phi(pxpos + pxneg, pypos + pyneg); });
 DECLARE_SOA_DYNAMIC_COLUMN(P, p, [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg, pzpos + pzneg); });
 DECLARE_SOA_DYNAMIC_COLUMN(PPos, ppos, [](float px, float py, float pz) -> float { return RecoDecay::sqrtSumOfSquares(px, py, pz); });
@@ -253,7 +253,7 @@ DECLARE_SOA_COLUMN(ChiSquareNDF, chiSquareNDF, float); // Chi2 / NDF of the reco
 
 DECLARE_SOA_DYNAMIC_COLUMN(E, e, [](float px, float py, float pz, float m = 0) -> float { return RecoDecay::sqrtSumOfSquares(px, py, pz, m); }); //! energy of v0 photn, mass to be given as argument when getter is called!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float px, float py) -> float { return RecoDecay::sqrtSumOfSquares(px, py); });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float px, float py, float pz) -> float { return RecoDecay::eta(array{px, py, pz}); });
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float px, float py, float pz) -> float { return RecoDecay::eta(std::array{px, py, pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float px, float py) -> float { return RecoDecay::phi(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(P, p, [](float px, float py, float pz) -> float { return RecoDecay::sqrtSumOfSquares(px, py, pz); });
 DECLARE_SOA_DYNAMIC_COLUMN(V0Radius, v0radius, [](float vx, float vy) -> float { return RecoDecay::sqrtSumOfSquares(vx, vy); });
@@ -426,7 +426,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Px, px, [](float e, float x, float y, float z, float 
 DECLARE_SOA_DYNAMIC_COLUMN(Py, py, [](float e, float x, float y, float z, float m = 0) -> float { return y / RecoDecay::sqrtSumOfSquares(x, y, z) * sqrt(e * e - m * m); });
 DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, [](float e, float x, float y, float z, float m = 0) -> float { return z / RecoDecay::sqrtSumOfSquares(x, y, z) * sqrt(e * e - m * m); });
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float e, float x, float y, float z, float m = 0) -> float { return RecoDecay::sqrtSumOfSquares(x, y) / RecoDecay::sqrtSumOfSquares(x, y, z) * sqrt(e * e - m * m); });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float x, float y, float z) -> float { return RecoDecay::eta(array{x, y, z}); });
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float x, float y, float z) -> float { return RecoDecay::eta(std::array{x, y, z}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float x, float y) -> float { return RecoDecay::phi(x, y); });
 } // namespace phoscluster
 

--- a/PWGEM/PhotonMeson/Utils/PCMUtilities.h
+++ b/PWGEM/PhotonMeson/Utils/PCMUtilities.h
@@ -168,7 +168,7 @@ float getPsiPair(float pxpos, float pypos, float pzpos, float pxneg, float pyneg
 
   auto clipToPM1 = [](float x) { return x < -1.f ? -1.f : (x > 1.f ? 1.f : x); };
   float ptot2 = RecoDecay::p2(pxpos, pypos, pzpos) * RecoDecay::p2(pxneg, pyneg, pzneg);
-  float argcos = RecoDecay::dotProd(array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}) / std::sqrt(ptot2);
+  float argcos = RecoDecay::dotProd(std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}) / std::sqrt(ptot2);
   float thetaPos = std::atan2(RecoDecay::sqrtSumOfSquares(pxpos, pypos), pzpos);
   float thetaNeg = std::atan2(RecoDecay::sqrtSumOfSquares(pxneg, pyneg), pzneg);
   float argsin = (thetaNeg - thetaPos) / std::acos(clipToPM1(argcos));

--- a/PWGEM/Tasks/phosPi0.cxx
+++ b/PWGEM/Tasks/phosPi0.cxx
@@ -39,6 +39,7 @@
 ///
 
 using namespace o2;
+using namespace o2::aod::evsel;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 

--- a/PWGEM/Tasks/phosTrigQA.cxx
+++ b/PWGEM/Tasks/phosTrigQA.cxx
@@ -45,6 +45,7 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::aod::evsel;
 
 struct phosTrigQA {
 

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
@@ -113,7 +113,7 @@ struct HfCandidateCreatorChic {
       hCPAJpsi->Fill(jpsiCand.cpa());
       // create Jpsi track to pass to DCA fitter; use cand table + rebuild vertex
       const std::array<float, 3> vertexJpsi = {jpsiCand.xSecondaryVertex(), jpsiCand.ySecondaryVertex(), jpsiCand.zSecondaryVertex()};
-      array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
+      std::array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
       auto prong0 = jpsiCand.prong0_as<aod::TracksWCov>();
       auto prong1 = jpsiCand.prong1_as<aod::TracksWCov>();
       auto prong0TrackParCov = getTrackParCov(prong0);
@@ -138,12 +138,12 @@ struct HfCandidateCreatorChic {
         if (ecal.e() < energyGammaMin) {
           continue;
         }
-        auto etagamma = RecoDecay::eta(array{ecal.px(), ecal.py(), ecal.pz()});
+        auto etagamma = RecoDecay::eta(std::array{ecal.px(), ecal.py(), ecal.pz()});
         if (etagamma < etaGammaMin || etagamma > etaGammaMax) { // calcolare la pseudorapidità da posz
           continue;
         }
 
-        array<float, 3> pvecGamma{static_cast<float>(ecal.px()), static_cast<float>(ecal.py()), static_cast<float>(ecal.pz())};
+        std::array<float, 3> pvecGamma{static_cast<float>(ecal.px()), static_cast<float>(ecal.py()), static_cast<float>(ecal.pz())};
 
         // get track impact parameters
         // This modifies track momenta!
@@ -157,7 +157,7 @@ struct HfCandidateCreatorChic {
 
         // get uncertainty of the decay length
         // double phi, theta;
-        // getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, ChicsecondaryVertex, phi, theta);
+        // getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, ChicsecondaryVertex, phi, theta);
         // auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
         // auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -183,8 +183,8 @@ struct HfCandidateCreatorChic {
                          hfFlag, invMassJpsiToMuMu(jpsiCand));
 
         // calculate invariant mass
-        auto arrayMomenta = array{pvecJpsi, pvecGamma};
-        massJpsiGamma = RecoDecay::m(std::move(arrayMomenta), array{massJpsi, 0.});
+        auto arrayMomenta = std::array{pvecJpsi, pvecGamma};
+        massJpsiGamma = RecoDecay::m(std::move(arrayMomenta), std::array{massJpsi, 0.});
         if (jpsiCand.isSelJpsiToEE() > 0) {
           hMassChicToJpsiToEEGamma->Fill(massJpsiGamma);
         }
@@ -233,10 +233,10 @@ struct HfCandidateCreatorChicMc {
       auto jpsiTrack = candidate.prong0();
       auto daughterPosJpsi = jpsiTrack.prong0_as<aod::TracksWMc>();
       auto daughterNegJpsi = jpsiTrack.prong1_as<aod::TracksWMc>();
-      auto arrayJpsiDaughters = array{daughterPosJpsi, daughterNegJpsi};
+      auto arrayJpsiDaughters = std::array{daughterPosJpsi, daughterNegJpsi};
 
       // chi_c → J/ψ gamma
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, array{+kMuonPlus, -kMuonPlus}, true);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true);
       if (indexRec > -1) {
         hMassJpsiToMuMuMatched->Fill(invMassJpsiToMuMu(candidate.prong0()));
 
@@ -248,7 +248,7 @@ struct HfCandidateCreatorChicMc {
           hMassEMatched->Fill(sqrt(candidate.prong1().px() * candidate.prong1().px() + candidate.prong1().py() * candidate.prong1().py() + candidate.prong1().pz() * candidate.prong1().pz()));
           if (particleMother.has_daughters()) {
             std::vector<int> arrAllDaughtersIndex;
-            RecoDecay::getDaughters(particleMother, &arrAllDaughtersIndex, array{static_cast<int>(kGamma), static_cast<int>(pdg::Code::kJPsi)}, 1);
+            RecoDecay::getDaughters(particleMother, &arrAllDaughtersIndex, std::array{static_cast<int>(kGamma), static_cast<int>(pdg::Code::kJPsi)}, 1);
             if (arrAllDaughtersIndex.size() == 2) {
               flag = 1 << hf_cand_chic::DecayType::ChicToJpsiToMuMuGamma;
               hMassChicToJpsiToMuMuGammaMatched->Fill(invMassChicToJpsiGamma(candidate));
@@ -271,17 +271,17 @@ struct HfCandidateCreatorChicMc {
       channel = 0;
 
       // chi_c → J/ψ gamma
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kChiC1, array{static_cast<int>(pdg::Code::kJPsi), static_cast<int>(kGamma)}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kChiC1, std::array{static_cast<int>(pdg::Code::kJPsi), static_cast<int>(kGamma)}, true)) {
         // Match J/psi --> e+e-
         std::vector<int> arrDaughter;
-        RecoDecay::getDaughters(particle, &arrDaughter, array{static_cast<int>(pdg::Code::kJPsi)}, 1);
+        RecoDecay::getDaughters(particle, &arrDaughter, std::array{static_cast<int>(pdg::Code::kJPsi)}, 1);
         auto jpsiCandMC = particlesMC.rawIteratorAt(arrDaughter[0]);
-        if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdg::Code::kJPsi, array{+kElectron, -kElectron}, true)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdg::Code::kJPsi, std::array{+kElectron, -kElectron}, true)) {
           flag = 1 << hf_cand_chic::DecayType::ChicToJpsiToEEGamma;
         }
 
         if (flag == 0) {
-          if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdg::Code::kJPsi, array{+kMuonPlus, -kMuonPlus}, true)) {
+          if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdg::Code::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true)) {
             flag = 1 << hf_cand_chic::DecayType::ChicToJpsiToMuMuGamma;
           }
         }

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
@@ -286,9 +286,9 @@ struct HfCandidateCreatorXMc {
       auto daughterNegJpsi = jpsiTrack.prong1_as<aod::TracksWMc>();
       auto arrayJpsiDaughters = std::array{daughterPosJpsi, daughterNegJpsi};
       auto arrayDaughters = std::array{candidate.prong1_as<aod::TracksWMc>(),
-                                  candidate.prong2_as<aod::TracksWMc>(),
-                                  daughterPosJpsi,
-                                  daughterNegJpsi};
+                                       candidate.prong2_as<aod::TracksWMc>(),
+                                       daughterPosJpsi,
+                                       daughterNegJpsi};
 
       // X → J/ψ π+ π-
       // Printf("Checking X → J/ψ π+ π-");

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
@@ -129,7 +129,7 @@ struct HfCandidateCreatorX {
       hCPAJpsi->Fill(jpsiCand.cpa());
       // create Jpsi track to pass to DCA fitter; use cand table + rebuild vertex
       const std::array<float, 3> vertexJpsi = {jpsiCand.xSecondaryVertex(), jpsiCand.ySecondaryVertex(), jpsiCand.zSecondaryVertex()};
-      array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
+      std::array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
       auto prong0 = jpsiCand.prong0_as<aod::TracksWCov>();
       auto prong1 = jpsiCand.prong1_as<aod::TracksWCov>();
       auto prong0TrackParCov = getTrackParCov(prong0);
@@ -176,8 +176,8 @@ struct HfCandidateCreatorX {
 
           auto trackParVarPos = getTrackParCov(trackPos);
           auto trackParVarNeg = getTrackParCov(trackNeg);
-          array<float, 3> pvecPos;
-          array<float, 3> pvecNeg;
+          std::array<float, 3> pvecPos;
+          std::array<float, 3> pvecNeg;
 
           // reconstruct the 3-prong X vertex
           if (df3.process(trackJpsi, trackParVarPos, trackParVarNeg) == 0) {
@@ -209,7 +209,7 @@ struct HfCandidateCreatorX {
 
           // get uncertainty of the decay length
           double phi, theta;
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, XsecondaryVertex, phi, theta);
+          getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, XsecondaryVertex, phi, theta);
           auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
           auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -236,8 +236,8 @@ struct HfCandidateCreatorX {
                            hfFlag);
 
           // calculate invariant mass
-          auto arrayMomenta = array{pvecJpsi, pvecPos, pvecNeg};
-          massJpsiPiPi = RecoDecay::m(std::move(arrayMomenta), array{massJpsi, massPi, massPi});
+          auto arrayMomenta = std::array{pvecJpsi, pvecPos, pvecNeg};
+          massJpsiPiPi = RecoDecay::m(std::move(arrayMomenta), std::array{massJpsi, massPi, massPi});
           if (jpsiCand.isSelJpsiToEE() > 0) {
             hMassXToJpsiToEEPiPi->Fill(massJpsiPiPi);
           }
@@ -284,26 +284,26 @@ struct HfCandidateCreatorXMc {
       auto jpsiTrack = candidate.prong0();
       auto daughterPosJpsi = jpsiTrack.prong0_as<aod::TracksWMc>();
       auto daughterNegJpsi = jpsiTrack.prong1_as<aod::TracksWMc>();
-      auto arrayJpsiDaughters = array{daughterPosJpsi, daughterNegJpsi};
-      auto arrayDaughters = array{candidate.prong1_as<aod::TracksWMc>(),
+      auto arrayJpsiDaughters = std::array{daughterPosJpsi, daughterNegJpsi};
+      auto arrayDaughters = std::array{candidate.prong1_as<aod::TracksWMc>(),
                                   candidate.prong2_as<aod::TracksWMc>(),
                                   daughterPosJpsi,
                                   daughterNegJpsi};
 
       // X → J/ψ π+ π-
       // Printf("Checking X → J/ψ π+ π-");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, array{+kElectron, -kElectron}, true);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, std::array{+kElectron, -kElectron}, true);
       if (indexRec > -1) {
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdgCodeX, array{+kPiPlus, -kPiPlus, +kElectron, -kElectron}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdgCodeX, std::array{+kPiPlus, -kPiPlus, +kElectron, -kElectron}, true, &sign, 2);
         if (indexRec > -1) {
           flag = 1 << hf_cand_x::DecayType::XToJpsiToEEPiPi;
         }
       }
 
       if (flag == 0) {
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, array{+kMuonPlus, -kMuonPlus}, true);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayJpsiDaughters, pdg::Code::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true);
         if (indexRec > -1) {
-          indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdgCodeX, array{+kPiPlus, -kPiPlus, +kMuonPlus, -kMuonPlus}, true, &sign, 2);
+          indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdgCodeX, std::array{+kPiPlus, -kPiPlus, +kMuonPlus, -kMuonPlus}, true, &sign, 2);
           if (indexRec > -1) {
             flag = 1 << hf_cand_x::DecayType::XToJpsiToMuMuPiPi;
           }
@@ -328,17 +328,17 @@ struct HfCandidateCreatorXMc {
 
       // X → J/ψ π+ π-
       // Printf("Checking X → J/ψ π+ π-");
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdgCodeX, array{pdgCodeJpsi, +kPiPlus, -kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdgCodeX, std::array{pdgCodeJpsi, +kPiPlus, -kPiPlus}, true)) {
         // Match J/psi --> e+e-
         std::vector<int> arrDaughter;
-        RecoDecay::getDaughters(particle, &arrDaughter, array{pdgCodeJpsi}, 1);
+        RecoDecay::getDaughters(particle, &arrDaughter, std::array{pdgCodeJpsi}, 1);
         auto jpsiCandMC = particlesMC.rawIteratorAt(arrDaughter[0]);
-        if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdgCodeJpsi, array{+kElectron, -kElectron}, true)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdgCodeJpsi, std::array{+kElectron, -kElectron}, true)) {
           flag = 1 << hf_cand_x::DecayType::XToJpsiToEEPiPi;
         }
 
         if (flag == 0) {
-          if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdgCodeJpsi, array{+kMuonPlus, -kMuonPlus}, true)) {
+          if (RecoDecay::isMatchedMCGen(particlesMC, jpsiCandMC, pdgCodeJpsi, std::array{+kMuonPlus, -kMuonPlus}, true)) {
             flag = 1 << hf_cand_x::DecayType::XToJpsiToMuMuPiPi;
           }
         }

--- a/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
@@ -150,9 +150,9 @@ struct HfTreeCreatorChicToJpsiGamma {
     int indexCand = 0;
     rowCandidateFull.reserve(candidates.size());
     for (auto& candidate : candidates) {
-      array<float, 3> pvecChic = {candidate.px(), candidate.py(), candidate.pz()};
-      array<float, 3> pvecJpsi = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-      array<float, 3> pvecGamma = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+      std::array<float, 3> pvecChic = {candidate.px(), candidate.py(), candidate.pz()};
+      std::array<float, 3> pvecJpsi = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
+      std::array<float, 3> pvecGamma = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
       auto pchic = RecoDecay::p(pvecChic);
       auto pjpsi = RecoDecay::p(pvecJpsi);
       auto pl1 = std::abs(RecoDecay::dotProd(pvecChic, pvecJpsi)) / pchic;
@@ -214,7 +214,7 @@ struct HfTreeCreatorChicToJpsiGamma {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, massChic),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massChic),
           0., // put here the jpsi mass
           particle.flagMcMatchGen(),
           particle.originMcGen());

--- a/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
@@ -247,7 +247,7 @@ struct HfTreeCreatorXToJpsiPiPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, massX),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massX),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/ALICE3/Tasks/taskChic.cxx
+++ b/PWGHF/ALICE3/Tasks/taskChic.cxx
@@ -202,8 +202,8 @@ struct HfTaskChicMc {
     for (auto& particle : particlesMC) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
         auto mchic = RecoDecay::getMassPDG(pdg::Code::kChiC1); // chi_c1(1p)
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, mchic)) > yCandMax) {
-          // Printf("MC Gen.: Y rejection: %g", RecoDecay::Y(array{particle.px(), particle.py(), particle.pz()}, 3.87168));
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, mchic)) > yCandMax) {
+          // Printf("MC Gen.: Y rejection: %g", RecoDecay::Y(std::array{particle.px(), particle.py(), particle.pz()}, 3.87168));
           continue;
         }
 

--- a/PWGHF/ALICE3/Tasks/taskD0Alice3Barrel.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0Alice3Barrel.cxx
@@ -139,11 +139,11 @@ struct HfTaskD0Alice3Barrel {
 
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
+        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskD0Alice3Forward.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0Alice3Forward.cxx
@@ -68,11 +68,11 @@ struct HfTaskD0Alice3Forward {
 
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
+        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskD0ParametrizedPid.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0ParametrizedPid.cxx
@@ -115,11 +115,11 @@ struct HfTaskD0ParametrizedPid {
       float maxFiducialY = 0.8;
       float minFiducialY = -0.8;
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
+        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hGenPtVsY"), ptGen, std::abs(yGen));
         if (ptGen < 5.0) {
           maxFiducialY = -0.2 / 15 * ptGen * ptGen + 1.9 / 15 * ptGen + 0.5;

--- a/PWGHF/ALICE3/Tasks/taskJpsi.cxx
+++ b/PWGHF/ALICE3/Tasks/taskJpsi.cxx
@@ -251,7 +251,7 @@ struct HfTaskJpsiMc {
         registry.fill(HIST("hChi2PCASig"), candidate.chi2PCA(), candidate.pt());
         registry.fill(HIST("hCtSig"), ctJpsi(candidate), candidate.pt());
         registry.fill(HIST("hYSig"), yJpsi(candidate), candidate.pt());
-        registry.fill(HIST("hYGenSig"), RecoDecay::y(array{particleMother.px(), particleMother.py(), particleMother.pz()}, RecoDecay::getMassPDG(particleMother.pdgCode())), particleMother.pt());
+        registry.fill(HIST("hYGenSig"), RecoDecay::y(std::array{particleMother.px(), particleMother.py(), particleMother.pz()}, RecoDecay::getMassPDG(particleMother.pdgCode())), particleMother.pt());
 
       } else {
         registry.fill(HIST("hPtRecBg"), candidate.pt());
@@ -276,12 +276,12 @@ struct HfTaskJpsiMc {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto& particle : particlesMC) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
-        registry.fill(HIST("hYGen"), RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())), particle.pt());
+        registry.fill(HIST("hYGen"), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())), particle.pt());
         // registry.fill(HIST("hPtGenProng0"), particle.daughter0_as<McParticlesHf>().pt(), particle.pt());
         // registry.fill(HIST("hPtGenProng1"), particle.daughter1_as<McParticlesHf>().pt(), particle.pt());
       }

--- a/PWGHF/ALICE3/Tasks/taskLcAlice3.cxx
+++ b/PWGHF/ALICE3/Tasks/taskLcAlice3.cxx
@@ -136,11 +136,11 @@ struct HfTaskLcAlice3 {
 
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::LcToPKPi) {
-        if (std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
+        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskLcParametrizedPid.cxx
+++ b/PWGHF/ALICE3/Tasks/taskLcParametrizedPid.cxx
@@ -116,11 +116,11 @@ struct HfTaskLcParametrizedPid {
 
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::LcToPKPi) {
-        if (std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
+        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskX.cxx
+++ b/PWGHF/ALICE3/Tasks/taskX.cxx
@@ -209,8 +209,8 @@ struct HfTaskXMc {
     for (auto& particle : particlesMC) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
         // TODO: add X(3872) mass such that we can use the getMassPDG function instead of hardcoded mass
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, 3.87168)) > yCandMax) {
-          // Printf("MC Gen.: Y rejection: %g", RecoDecay::Y(array{particle.px(), particle.py(), particle.pz()}, 3.87168));
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, 3.87168)) > yCandMax) {
+          // Printf("MC Gen.: Y rejection: %g", RecoDecay::Y(std::array{particle.px(), particle.py(), particle.pz()}, 3.87168));
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -134,7 +134,7 @@ struct HfCandidateCreatorB0Reduced {
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
           // compute invariant
-          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+          massDPi = RecoDecay::m(std::array{pVecD, pVecPion}, std::array{massD, massPi});
 
           if (std::abs(massDPi - massB0) > invMassWindowB0) {
             continue;
@@ -150,7 +150,7 @@ struct HfCandidateCreatorB0Reduced {
           // get uncertainty of the decay length
           double phi, theta;
           // getPointDirection modifies phi and theta
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
+          getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
           auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
           auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -391,7 +391,7 @@ struct HfDataCreatorDplusPiReducedMc {
     int8_t debug = 0;
 
     for (const auto& candD : candsD) {
-      auto arrayDaughtersD = array{candD.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersD = std::array{candD.prong0_as<aod::TracksWMc>(),
                                    candD.prong1_as<aod::TracksWMc>(),
                                    candD.prong2_as<aod::TracksWMc>()};
 
@@ -400,17 +400,17 @@ struct HfDataCreatorDplusPiReducedMc {
           continue;
         }
         // const auto& trackId = trackPion.globalIndex();
-        auto arrayDaughtersB0 = array{candD.prong0_as<aod::TracksWMc>(),
+        auto arrayDaughtersB0 = std::array{candD.prong0_as<aod::TracksWMc>(),
                                       candD.prong1_as<aod::TracksWMc>(),
                                       candD.prong2_as<aod::TracksWMc>(),
                                       trackPion.track_as<aod::TracksWMc>()};
         // B0 → D- π+ → (π- K+ π-) π+
         // Printf("Checking B0 → D- π+");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           // D- → π- K+ π-
           // Printf("Checking D- → π- K+ π-");
-          indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+          indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
           if (indexRec > -1) {
             flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
           } else {
@@ -431,11 +431,11 @@ struct HfDataCreatorDplusPiReducedMc {
       flag = 0;
       origin = 0;
       // B0 → D- π+
-      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, std::array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
         // Match D- -> π- K+ π-
         auto candDMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking D- -> π- K+ π-");
-        if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
           flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
         }
       }
@@ -456,7 +456,7 @@ struct HfDataCreatorDplusPiReducedMc {
       for (auto const& daught : particle.daughters_as<aod::McParticles>()) {
         ptProngs[counter] = daught.pt();
         etaProngs[counter] = daught.eta();
-        yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+        yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
         counter++;
       }
       rowHfB0McGenReduced(flag, origin,

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -392,8 +392,8 @@ struct HfDataCreatorDplusPiReducedMc {
 
     for (const auto& candD : candsD) {
       auto arrayDaughtersD = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                   candD.prong1_as<aod::TracksWMc>(),
-                                   candD.prong2_as<aod::TracksWMc>()};
+                                        candD.prong1_as<aod::TracksWMc>(),
+                                        candD.prong2_as<aod::TracksWMc>()};
 
       for (const auto& trackPion : tracksPion) {
         if (trackPion.hfReducedCollisionId() != candD.hfReducedCollisionId()) {
@@ -401,9 +401,9 @@ struct HfDataCreatorDplusPiReducedMc {
         }
         // const auto& trackId = trackPion.globalIndex();
         auto arrayDaughtersB0 = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                      candD.prong1_as<aod::TracksWMc>(),
-                                      candD.prong2_as<aod::TracksWMc>(),
-                                      trackPion.track_as<aod::TracksWMc>()};
+                                           candD.prong1_as<aod::TracksWMc>(),
+                                           candD.prong2_as<aod::TracksWMc>(),
+                                           trackPion.track_as<aod::TracksWMc>()};
         // B0 → D- π+ → (π- K+ π-) π+
         // Printf("Checking B0 → D- π+");
         indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -267,7 +267,7 @@ struct HfTaskB0 {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -279,7 +279,7 @@ struct HfTaskB0 {
         for (auto const& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskBs.cxx
+++ b/PWGHF/D2H/Tasks/taskBs.cxx
@@ -263,7 +263,7 @@ struct HfTaskBs {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_bs::DecayTypeMc::BsToDsPiToKKPiPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBS));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBS));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -275,7 +275,7 @@ struct HfTaskBs {
         for (auto const& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -235,7 +235,7 @@ struct HfTaskD0 {
         auto indexMother = RecoDecay::getMother(particlesMC, candidate.prong0_as<aod::TracksWMc>().mcParticle_as<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>(), pdg::Code::kD0, true);
         auto particleMother = particlesMC.rawIteratorAt(indexMother);
         auto ptGen = particleMother.pt();                                                                                                                // gen. level pT
-        auto yGen = RecoDecay::y(array{particleMother.px(), particleMother.py(), particleMother.pz()}, RecoDecay::getMassPDG(particleMother.pdgCode())); // gen. level y
+        auto yGen = RecoDecay::y(std::array{particleMother.px(), particleMother.py(), particleMother.pz()}, RecoDecay::getMassPDG(particleMother.pdgCode())); // gen. level y
         registry.fill(HIST("hPtGenSig"), ptGen);                                                                                                         // gen. level pT
         auto ptRec = candidate.pt();
         auto yRec = yD0(candidate);
@@ -382,11 +382,11 @@ struct HfTaskD0 {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::D0ToPiK) {
-        if (yCandGenMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandGenMax) {
+        if (yCandGenMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandGenMax) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         registry.fill(HIST("hPtGen"), ptGen);
         registry.fill(HIST("hPtVsYGen"), ptGen, yGen);
         if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {

--- a/PWGHF/D2H/Tasks/taskDplus.cxx
+++ b/PWGHF/D2H/Tasks/taskDplus.cxx
@@ -194,7 +194,7 @@ struct HfTaskDplus {
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DplusToPiKPi) {
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -271,7 +271,7 @@ struct HfTaskDs {
           continue;
         }
         auto pt = particle.pt();
-        auto y = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto y = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandGenMax >= 0. && std::abs(y) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskLb.cxx
+++ b/PWGHF/D2H/Tasks/taskLb.cxx
@@ -240,7 +240,7 @@ struct HfTaskLbMc {
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << hf_cand_lb::DecayType::LbToLcPi) {
 
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kLambdaB0));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kLambdaB0));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -250,7 +250,7 @@ struct HfTaskLbMc {
         for (auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -452,7 +452,7 @@ struct HfTaskLc {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto const& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::LcToPKPi) {
-        auto yGen = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskSigmac.cxx
+++ b/PWGHF/D2H/Tasks/taskSigmac.cxx
@@ -378,7 +378,7 @@ struct HfTaskSigmac {
          OR
          consider the new parametrization of the fiducial acceptance (to be seen for reco signal in MC)
       */
-      if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
+      if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
         continue;
       }
 
@@ -498,9 +498,9 @@ struct HfTaskSigmac {
         auto indexMcScRec = RecoDecay::getMother(particlesMc, candSc.prong1_as<aod::TracksWMc>().mcParticle(), pdg::Code::kSigmaC0, true);
         auto particleSc = particlesMc.rawIteratorAt(indexMcScRec);
         // Get the corresponding MC particle for Lc
-        auto arrayDaughtersLc = array{candidateLc.prong0_as<aod::TracksWMc>(), candidateLc.prong1_as<aod::TracksWMc>(), candidateLc.prong2_as<aod::TracksWMc>()};
+        auto arrayDaughtersLc = std::array{candidateLc.prong0_as<aod::TracksWMc>(), candidateLc.prong1_as<aod::TracksWMc>(), candidateLc.prong2_as<aod::TracksWMc>()};
         int8_t sign = 0;
-        int indexMcLcRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersLc, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        int indexMcLcRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersLc, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         auto particleLc = particlesMc.rawIteratorAt(indexMcLcRec);
         // Get the corresponding MC particle for soft pion
         auto particleSoftPi = candSc.prong1_as<aod::TracksWMc>().mcParticle();
@@ -617,9 +617,9 @@ struct HfTaskSigmac {
         auto indexMcScRec = RecoDecay::getMother(particlesMc, candSc.prong1_as<aod::TracksWMc>().mcParticle(), pdg::Code::kSigmaCPlusPlus, true);
         auto particleSc = particlesMc.rawIteratorAt(indexMcScRec);
         // Get the corresponding MC particle for Lc
-        auto arrayDaughtersLc = array{candidateLc.prong0_as<aod::TracksWMc>(), candidateLc.prong1_as<aod::TracksWMc>(), candidateLc.prong2_as<aod::TracksWMc>()};
+        auto arrayDaughtersLc = std::array{candidateLc.prong0_as<aod::TracksWMc>(), candidateLc.prong1_as<aod::TracksWMc>(), candidateLc.prong2_as<aod::TracksWMc>()};
         int8_t sign = 0;
-        int indexMcLcRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersLc, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        int indexMcLcRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersLc, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         auto particleLc = particlesMc.rawIteratorAt(indexMcLcRec);
         // Get the corresponding MC particle for soft pion
         auto particleSoftPi = candSc.prong1_as<aod::TracksWMc>().mcParticle();

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -368,7 +368,7 @@ struct HfTaskXic {
     // MC gen.
     for (auto const& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::XicToPKPi) {
-        auto yParticle = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -380,7 +380,7 @@ struct HfTaskXic {
         for (auto const& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskXicc.cxx
+++ b/PWGHF/D2H/Tasks/taskXicc.cxx
@@ -262,13 +262,13 @@ struct HfTaskXiccMc {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::XiccToXicPi) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
-        registry.fill(HIST("hYGen"), RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())));
-        registry.fill(HIST("hPtvsEtavsYGen"), particle.pt(), particle.eta(), RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())));
+        registry.fill(HIST("hYGen"), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())));
+        registry.fill(HIST("hPtvsEtavsYGen"), particle.pt(), particle.eta(), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())));
       }
     } // end of loop of MC particles
   }   // end of process function

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -270,7 +270,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtProng0, ptProng0, //!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt2Prong0, pt2Prong0, //!
                            [](float px, float py) -> float { return RecoDecay::pt2(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(PVectorProng0, pVectorProng0, //!
-                           [](float px, float py, float pz) -> array<float, 3> { return array{px, py, pz}; });
+                           [](float px, float py, float pz) -> std::array<float, 3> { return std::array{px, py, pz}; });
 DECLARE_SOA_COLUMN(ImpactParameter0, impactParameter0, float);                     //!
 DECLARE_SOA_COLUMN(ErrorImpactParameter0, errorImpactParameter0, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised0, impactParameterNormalised0, //!
@@ -283,7 +283,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtProng1, ptProng1, //!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt2Prong1, pt2Prong1, //!
                            [](float px, float py) -> float { return RecoDecay::pt2(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(PVectorProng1, pVectorProng1, //!
-                           [](float px, float py, float pz) -> array<float, 3> { return array{px, py, pz}; });
+                           [](float px, float py, float pz) -> std::array<float, 3> { return std::array{px, py, pz}; });
 DECLARE_SOA_COLUMN(ImpactParameter1, impactParameter1, float);                     //!
 DECLARE_SOA_COLUMN(ErrorImpactParameter1, errorImpactParameter1, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised1, impactParameterNormalised1, //!
@@ -296,7 +296,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtProng2, ptProng2, //!
 DECLARE_SOA_DYNAMIC_COLUMN(Pt2Prong2, pt2Prong2, //!
                            [](float px, float py) -> float { return RecoDecay::pt2(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(PVectorProng2, pVectorProng2, //!
-                           [](float px, float py, float pz) -> array<float, 3> { return array{px, py, pz}; });
+                           [](float px, float py, float pz) -> std::array<float, 3> { return std::array{px, py, pz}; });
 DECLARE_SOA_COLUMN(ImpactParameter2, impactParameter2, float);                     //!
 DECLARE_SOA_COLUMN(ErrorImpactParameter2, errorImpactParameter2, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised2, impactParameterNormalised2, //!
@@ -311,35 +311,35 @@ DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
 DECLARE_SOA_DYNAMIC_COLUMN(P2, p2, //!
                            [](float px, float py, float pz) -> float { return RecoDecay::p2(px, py, pz); });
 DECLARE_SOA_DYNAMIC_COLUMN(PVector, pVector, //!
-                           [](float px, float py, float pz) -> array<float, 3> { return array{px, py, pz}; });
+                           [](float px, float py, float pz) -> std::array<float, 3> { return std::array{px, py, pz}; });
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //!
-                           [](float px, float py, float pz) -> float { return RecoDecay::eta(array{px, py, pz}); });
+                           [](float px, float py, float pz) -> float { return RecoDecay::eta(std::array{px, py, pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //!
                            [](float px, float py) -> float { return RecoDecay::phi(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(Y, y, //!
-                           [](float px, float py, float pz, double m) -> float { return RecoDecay::y(array{px, py, pz}, m); });
+                           [](float px, float py, float pz, double m) -> float { return RecoDecay::y(std::array{px, py, pz}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(E, e, //!
                            [](float px, float py, float pz, double m) -> float { return RecoDecay::e(px, py, pz, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(E2, e2, //!
                            [](float px, float py, float pz, double m) -> float { return RecoDecay::e2(px, py, pz, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(DecayLength, decayLength, //!
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS) -> float { return RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS) -> float { return RecoDecay::distance(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DecayLengthXY, decayLengthXY, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS) -> float { return RecoDecay::distanceXY(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS) -> float { return RecoDecay::distanceXY(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DecayLengthNormalised, decayLengthNormalised, //!
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float err) -> float { return RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}) / err; });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float err) -> float { return RecoDecay::distance(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}) / err; });
 DECLARE_SOA_DYNAMIC_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float err) -> float { return RecoDecay::distanceXY(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}) / err; });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float err) -> float { return RecoDecay::distanceXY(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}) / err; });
 DECLARE_SOA_COLUMN(ErrorDecayLength, errorDecayLength, float);     //!
 DECLARE_SOA_COLUMN(ErrorDecayLengthXY, errorDecayLengthXY, float); //!
 DECLARE_SOA_DYNAMIC_COLUMN(CPA, cpa,                               //!
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::cpa(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::cpa(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}, std::array{px, py, pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(CPAXY, cpaXY, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float px, float py) -> float { return RecoDecay::cpaXY(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, array{px, py}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float px, float py) -> float { return RecoDecay::cpaXY(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, std::array{px, py}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Ct, ct, //!
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) -> float { return RecoDecay::ct(array{px, py, pz}, RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}), m); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) -> float { return RecoDecay::ct(std::array{px, py, pz}, RecoDecay::distance(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}), m); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterXY, impactParameterXY, //!
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::impParXY(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::impParXY(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}, std::array{px, py, pz}); });
 } // namespace hf_cand
 
 // specific 2-prong decay properties
@@ -354,15 +354,15 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProduct, impactParameterProduct, //!
                            [](float dca1, float dca2) -> float { return dca1 * dca2; });
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m2(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m2(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, //!
                            [](float impParProng0, float impParProng1) -> float { return RecoDecay::sumOfSquares(impParProng0, impParProng1); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1}, array{errIp0, errIp1}, array{array{px0, py0}, array{px1, py1}}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, errDlxy, std::array{pxM, pyM}, std::array{ip0, ip1}, std::array{errIp0, errIp1}, std::array{std::array{px0, py0}, std::array{px1, py1}}); });
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); //! generator level
@@ -400,25 +400,25 @@ auto eD0(const T& candidate)
 template <typename T>
 auto invMassD0ToPiK(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)});
 }
 
 template <typename T>
 auto invMassD0barToKPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto cosThetaStarD0(const T& candidate)
 {
-  return candidate.cosThetaStar(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)}, RecoDecay::getMassPDG(pdg::Code::kD0), 1);
+  return candidate.cosThetaStar(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)}, RecoDecay::getMassPDG(pdg::Code::kD0), 1);
 }
 
 template <typename T>
 auto cosThetaStarD0bar(const T& candidate)
 {
-  return candidate.cosThetaStar(array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kD0), 0);
+  return candidate.cosThetaStar(std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kD0), 0);
 }
 
 // J/ψ
@@ -445,14 +445,14 @@ auto eJpsi(const T& candidate)
 template <typename T>
 auto invMassJpsiToEE(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kElectron), RecoDecay::getMassPDG(kElectron)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kElectron), RecoDecay::getMassPDG(kElectron)});
 }
 // J/ψ → μ+ μ−
 
 template <typename T>
 auto invMassJpsiToMuMu(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kMuonPlus), RecoDecay::getMassPDG(kMuonMinus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kMuonPlus), RecoDecay::getMassPDG(kMuonMinus)});
 }
 
 } // namespace hf_cand_2prong
@@ -539,13 +539,13 @@ DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //! py of candidate
                               float, 1.f * aod::hf_cand::pyProng0 + 1.f * aod::hf_cand::pyProng1);
 DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //! pz of candidate
                               float, 1.f * aod::hf_cand::pzProng0 + 1.f * aod::hf_cand::pzProng1);
-// DECLARE_SOA_DYNAMIC_COLUMN(M, m, [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) { return RecoDecay::M(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+// DECLARE_SOA_DYNAMIC_COLUMN(M, m, [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(PtV0Pos, ptV0Pos, //! pt of the positive V0 daughter
                            [](float px, float py) { return RecoDecay::pt(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(PtV0Neg, ptV0Neg, //! pt of the negative V0 daughter
                            [](float px, float py) { return RecoDecay::pt(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(CtV0, ctV0, //! c*t of the V0
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) -> float { return RecoDecay::ct(array{px, py, pz}, RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}), m); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz, double m) -> float { return RecoDecay::ct(std::array{px, py, pz}, RecoDecay::distance(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}), m); });
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); //! generator level
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);       //! particle origin, reconstruction level
@@ -557,13 +557,13 @@ DECLARE_SOA_COLUMN(V0Z, v0z, float);                        //! Z position of V0
 template <typename T>
 auto invMassLcToK0sP(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kProton), RecoDecay::getMassPDG(kK0Short)}); // first daughter is bachelor
+  return candidate.m(std::array{RecoDecay::getMassPDG(kProton), RecoDecay::getMassPDG(kK0Short)}); // first daughter is bachelor
 }
 
 template <typename T>
 auto invMassGammaToEE(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kElectron), RecoDecay::getMassPDG(kElectron)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kElectron), RecoDecay::getMassPDG(kElectron)});
 }
 
 template <typename T>
@@ -685,13 +685,13 @@ auto eBplus(const T& candidate)
 template <typename T>
 auto invMassBplusToD0Pi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kD0), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kD0), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto cosThetaStarBplus(const T& candidate)
 {
-  return candidate.cosThetaStar(array{RecoDecay::getMassPDG(pdg::Code::kD0), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kBPlus), 1);
+  return candidate.cosThetaStar(std::array{RecoDecay::getMassPDG(pdg::Code::kD0), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kBPlus), 1);
 }
 } // namespace hf_cand_bplus
 
@@ -756,13 +756,13 @@ DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //!
 DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //!
                               float, 1.f * aod::hf_cand::pzProng0 + 1.f * aod::hf_cand::pzProng1 + 1.f * aod::hf_cand::pzProng2);
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const array<double, 3>& m) -> float { return RecoDecay::m(array{array{px0, py0, pz0}, array{px1, py1, pz1}, array{px2, py2, pz2}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const std::array<double, 3>& m) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}, std::array{px2, py2, pz2}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const array<double, 3>& m) -> float { return RecoDecay::m2(array{array{px0, py0, pz0}, array{px1, py1, pz1}, array{px2, py2, pz2}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2, const std::array<double, 3>& m) -> float { return RecoDecay::m2(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}, std::array{px2, py2, pz2}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, //!
                            [](float impParProng0, float impParProng1, float impParProng2) -> float { return RecoDecay::sumOfSquares(impParProng0, impParProng1, impParProng2); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float ip2, float errIp2, float px0, float py0, float px1, float py1, float px2, float py2) -> float { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1, ip2}, array{errIp0, errIp1, errIp2}, array{array{px0, py0}, array{px1, py1}, array{px2, py2}}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float ip2, float errIp2, float px0, float py0, float px1, float py1, float px2, float py2) -> float { return RecoDecay::maxNormalisedDeltaIP(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, errDlxy, std::array{pxM, pyM}, std::array{ip0, ip1, ip2}, std::array{errIp0, errIp1, errIp2}, std::array{std::array{px0, py0}, std::array{px1, py1}, std::array{px2, py2}}); });
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);         //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! generator level
@@ -804,7 +804,7 @@ auto eDplus(const T& candidate)
 template <typename T>
 auto invMassDplusToPiKPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 // Ds± → K± K∓ π±
@@ -835,26 +835,26 @@ auto eDs(const T& candidate)
 template <typename T>
 auto invMassDsToKKPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto invMassDsToPiKK(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
 }
 
 template <typename T>
 auto deltaMassPhiDsToKKPi(const T& candidate)
 {
-  double invMassKKpair = RecoDecay::m(array{candidate.pVectorProng0(), candidate.pVectorProng1()}, array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
+  double invMassKKpair = RecoDecay::m(std::array{candidate.pVectorProng0(), candidate.pVectorProng1()}, std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
   return std::abs(invMassKKpair - RecoDecay::getMassPDG(pdg::Code::kPhi));
 }
 
 template <typename T>
 auto deltaMassPhiDsToPiKK(const T& candidate)
 {
-  double invMassKKpair = RecoDecay::m(array{candidate.pVectorProng1(), candidate.pVectorProng2()}, array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
+  double invMassKKpair = RecoDecay::m(std::array{candidate.pVectorProng1(), candidate.pVectorProng2()}, std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kKPlus)});
   return std::abs(invMassKKpair - RecoDecay::getMassPDG(pdg::Code::kPhi));
 }
 
@@ -866,9 +866,9 @@ template <typename T>
 auto cosPiKPhiRestFrame(const T& candidate, int option)
 {
   // Ported from AliAODRecoDecayHF3Prong::CosPiKPhiRFrame
-  array<float, 3> momPi;
-  array<float, 3> momK1;
-  array<float, 3> momK2;
+  std::array<float, 3> momPi;
+  std::array<float, 3> momK1;
+  std::array<float, 3> momK2;
 
   if (option == 0) { // KKPi
     momPi = candidate.pVectorProng2();
@@ -929,13 +929,13 @@ auto eLc(const T& candidate)
 template <typename T>
 auto invMassLcToPKPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kProton), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kProton), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto invMassLcToPiKP(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kProton)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kProton)});
 }
 
 // Ξc± → p± K∓ π±
@@ -1041,15 +1041,15 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProduct, impactParameterProduct, //!
                            [](float dca1, float dca2) -> float { return dca1 * dca2; });
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m2(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m2(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, //!
                            [](float impParProng0, float impParProng1) -> float { return RecoDecay::sumOfSquares(impParProng0, impParProng1); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1}, array{errIp0, errIp1}, array{array{px0, py0}, array{px1, py1}}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, errDlxy, std::array{pxM, pyM}, std::array{ip0, ip1}, std::array{errIp0, errIp1}, std::array{std::array{px0, py0}, std::array{px1, py1}}); });
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); //! generator level
@@ -1059,13 +1059,13 @@ DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);       //! particle origin,
 template <typename T>
 auto invMassXiczeroToXiPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kXiMinus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kXiMinus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto invMassOmegaczeroToOmegaPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kOmegaMinus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kOmegaMinus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 // mapping of decay types
@@ -1086,15 +1086,15 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProduct, impactParameterProduct, //!
                            [](float dca1, float dca2) -> float { return dca1 * dca2; });
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(M2, m2, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m2(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m2(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStar, cosThetaStar, //!
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m, double mTot, int iProng) -> float { return RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng); });
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterProngSqSum, impactParameterProngSqSum, //!
                            [](float impParProng0, float impParProng1) -> float { return RecoDecay::sumOfSquares(impParProng0, impParProng1); });
 DECLARE_SOA_DYNAMIC_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, //!
-                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, errDlxy, array{pxM, pyM}, array{ip0, ip1}, array{errIp0, errIp1}, array{array{px0, py0}, array{px1, py1}}); });
+                           [](float xVtxP, float yVtxP, float xVtxS, float yVtxS, float errDlxy, float pxM, float pyM, float ip0, float errIp0, float ip1, float errIp1, float px0, float py0, float px1, float py1) -> float { return RecoDecay::maxNormalisedDeltaIP(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, errDlxy, std::array{pxM, pyM}, std::array{ip0, ip1}, std::array{errIp0, errIp1}, std::array{std::array{px0, py0}, std::array{px1, py1}}); });
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); //! reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); //! generator level
@@ -1104,7 +1104,7 @@ DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);       //! particle origin,
 template <typename T>
 auto invMassXicplusToXiPiPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kXiMinus), RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kXiMinus), RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 // mapping of decay types
@@ -1152,19 +1152,19 @@ auto eX(const T& candidate)
 template <typename T>
 auto invMassXToJpsiPiPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(443), RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(443), RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 /// Difference between the X mass and the sum of the J/psi and di-pion masses
 template <typename T>
 auto qX(const T& candidate)
 {
-  auto piVec1 = array{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
-  auto piVec2 = array{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
+  auto piVec1 = std::array{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+  auto piVec2 = std::array{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
   double massPi = RecoDecay::getMassPDG(kPiPlus);
 
-  auto arrayMomenta = array{piVec1, piVec2};
-  double massPiPi = RecoDecay::m(arrayMomenta, array{massPi, massPi});
+  auto arrayMomenta = std::array{piVec1, piVec2};
+  double massPiPi = RecoDecay::m(arrayMomenta, std::array{massPi, massPi});
 
   // PDG mass, as reported in CMS paper https://arxiv.org/pdf/1302.3968.pdf
   double massJpsi = RecoDecay::getMassPDG(o2::analysis::pdg::kJPsi);
@@ -1177,16 +1177,16 @@ auto qX(const T& candidate)
 template <typename T>
 auto dRX(const T& candidate, int numPi)
 {
-  double etaJpsi = RecoDecay::eta(array{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()});
+  double etaJpsi = RecoDecay::eta(std::array{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()});
   double phiJpsi = RecoDecay::phi(candidate.pxProng0(), candidate.pyProng0());
 
   double etaPi, phiPi;
 
   if (numPi <= 1) {
-    etaPi = RecoDecay::eta(array{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()});
+    etaPi = RecoDecay::eta(std::array{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()});
     phiPi = RecoDecay::phi(candidate.pxProng1(), candidate.pyProng1());
   } else {
-    etaPi = RecoDecay::eta(array{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()});
+    etaPi = RecoDecay::eta(std::array{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()});
     phiPi = RecoDecay::phi(candidate.pxProng2(), candidate.pyProng2());
   }
 
@@ -1415,7 +1415,7 @@ auto eXicc(const T& candidate)
 template <typename T>
 auto invMassXiccToXicPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kXiCPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kXiCPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 } // namespace hf_cand_xicc
 
@@ -1664,7 +1664,7 @@ auto eChic(const T& candidate)
 template <typename T>
 auto invMassChicToJpsiGamma(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kJPsi), 0.});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kJPsi), 0.});
 }
 
 } // namespace hf_cand_chic
@@ -1757,7 +1757,7 @@ auto eLb(const T& candidate)
 template <typename T>
 auto invMassLbToLcPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kLambdaCPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 } // namespace hf_cand_lb
 
@@ -1851,13 +1851,13 @@ auto eB0(const T& candidate)
 template <typename T>
 auto invMassB0ToDPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kDMinus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kDMinus), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto cosThetaStarB0(const T& candidate)
 {
-  return candidate.cosThetaStar(array{RecoDecay::getMassPDG(pdg::Code::kDMinus), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kB0), 1);
+  return candidate.cosThetaStar(std::array{RecoDecay::getMassPDG(pdg::Code::kDMinus), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kB0), 1);
 }
 } // namespace hf_cand_b0
 
@@ -1950,13 +1950,13 @@ auto eBs(const T& candidate)
 template <typename T>
 auto invMassBsToDsPi(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(pdg::Code::kDSBar), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(pdg::Code::kDSBar), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>
 auto cosThetaStarBs(const T& candidate)
 {
-  return candidate.cosThetaStar(array{RecoDecay::getMassPDG(pdg::Code::kDSBar), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kBS), 1);
+  return candidate.cosThetaStar(std::array{RecoDecay::getMassPDG(pdg::Code::kDSBar), RecoDecay::getMassPDG(kPiPlus)}, RecoDecay::getMassPDG(pdg::Code::kBS), 1);
 }
 } // namespace hf_cand_bs
 
@@ -2031,14 +2031,14 @@ enum DecayType { Sc0ToPKPiPi = 0,
 template <typename T, typename U>
 auto invMassScRecoLcToPKPi(const T& candidateSc, const U& candidateLc)
 {
-  return candidateSc.m(array{static_cast<double>(hf_cand_3prong::invMassLcToPKPi(candidateLc)), RecoDecay::getMassPDG(kPiPlus)});
+  return candidateSc.m(std::array{static_cast<double>(hf_cand_3prong::invMassLcToPKPi(candidateLc)), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 /// @brief Sc inv. mass using reco mass for Lc in piKp and PDG mass for pion
 template <typename T, typename U>
 auto invMassScRecoLcToPiKP(const T& candidateSc, const U& candidateLc)
 {
-  return candidateSc.m(array{static_cast<double>(hf_cand_3prong::invMassLcToPiKP(candidateLc)), RecoDecay::getMassPDG(kPiPlus)});
+  return candidateSc.m(std::array{static_cast<double>(hf_cand_3prong::invMassLcToPiKP(candidateLc)), RecoDecay::getMassPDG(kPiPlus)});
 }
 
 template <typename T>

--- a/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
@@ -393,7 +393,7 @@ struct HfCorrelatorD0D0bar {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -416,7 +416,7 @@ struct HfCorrelatorD0D0bar {
         if (particle2.pdgCode() != pdg::Code::kD0Bar) { // check that inner particle is D0bar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -490,7 +490,7 @@ struct HfCorrelatorD0D0bar {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -514,7 +514,7 @@ struct HfCorrelatorD0D0bar {
         if (particle2.pdgCode() != PDG_t::kCharmBar) { // check that inner particle is a cbar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
@@ -394,7 +394,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -417,7 +417,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (particle2.pdgCode() != pdg::Code::kD0Bar) { // check that inner particle is D0bar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -491,7 +491,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -515,7 +515,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (particle2.pdgCode() != PDG_t::kCharmBar) { // check that inner particle is a cbar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -149,7 +149,7 @@ struct HfCorrelatorD0HadronsSelection {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -560,7 +560,7 @@ struct HfCorrelatorD0Hadrons {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -817,7 +817,7 @@ struct HfCorrelatorD0Hadrons {
           continue;
         }
 
-        double yD = RecoDecay::y(array{t1.px(), t1.py(), t1.pz()}, RecoDecay::getMassPDG(t1.pdgCode()));
+        double yD = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, RecoDecay::getMassPDG(t1.pdgCode()));
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorDMesonPairs.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDMesonPairs.cxx
@@ -333,7 +333,7 @@ struct HfCorrelatorDMesonPairs {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kD0 && std::abs(particle1.pdgCode()) != pdg::Code::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (!kinematicCutsGen(particle1)) {
         continue;
       }

--- a/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
@@ -378,7 +378,7 @@ struct HfCorrelatorDplusDminus {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -401,7 +401,7 @@ struct HfCorrelatorDplusDminus {
         if (particle2.pdgCode() != -pdg::Code::kDPlus) { // check that inner particle is a Dminus
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -475,7 +475,7 @@ struct HfCorrelatorDplusDminus {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -499,7 +499,7 @@ struct HfCorrelatorDplusDminus {
         if (particle2.pdgCode() != PDG_t::kCharmBar) {
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, RecoDecay::getMassPDG(particle2.pdgCode()))) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
@@ -129,7 +129,7 @@ struct HfDplusSelection {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -417,7 +417,7 @@ struct HfCorrelatorDplusHadrons {
       if (std::abs(particle1.pdgCode()) != pdg::Code::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, RecoDecay::getMassPDG(particle1.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -560,7 +560,7 @@ struct HfCorrelatorDplusHadrons {
           continue;
         }
 
-        double yD = RecoDecay::y(array{t1.px(), t1.py(), t1.pz()}, RecoDecay::getMassPDG(t1.pdgCode()));
+        double yD = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, RecoDecay::getMassPDG(t1.pdgCode()));
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -137,7 +137,7 @@ struct HfCorrelatorDsHadronsSelCollision {
       if (std::abs(particle.pdgCode()) != pdg::Code::kDS) {
         continue;
       }
-      double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+      double yD = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -588,7 +588,7 @@ struct HfCorrelatorDsHadrons {
         continue;
       }
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi) {
-        double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        double yD = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }
@@ -643,7 +643,7 @@ struct HfCorrelatorDsHadrons {
         continue;
       }
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::DsToKKPi) {
-        double yD = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        double yD = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -141,8 +141,8 @@ struct HfCandidateCreator2Prong {
       auto trackParVar1 = df.getTrack(1);
 
       // get track momenta
-      array<float, 3> pvec0;
-      array<float, 3> pvec1;
+      std::array<float, 3> pvec0;
+      std::array<float, 3> pvec1;
       trackParVar0.getPxPyPzGlo(pvec0);
       trackParVar1.getPxPyPzGlo(pvec1);
 
@@ -181,7 +181,7 @@ struct HfCandidateCreator2Prong {
 
       // get uncertainty of the decay length
       double phi, theta;
-      getPointDirection(array{primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()}, secondaryVertex, phi, theta);
+      getPointDirection(std::array{primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()}, secondaryVertex, phi, theta);
       auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
       auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -201,9 +201,9 @@ struct HfCandidateCreator2Prong {
       // fill histograms
       if (fillHistograms) {
         // calculate invariant masses
-        auto arrayMomenta = array{pvec0, pvec1};
-        massPiK = RecoDecay::m(arrayMomenta, array{massPi, massK});
-        massKPi = RecoDecay::m(arrayMomenta, array{massK, massPi});
+        auto arrayMomenta = std::array{pvec0, pvec1};
+        massPiK = RecoDecay::m(arrayMomenta, std::array{massPi, massK});
+        massKPi = RecoDecay::m(arrayMomenta, std::array{massK, massPi});
         hMass2->Fill(massPiK);
         hMass2->Fill(massKPi);
       }
@@ -256,11 +256,11 @@ struct HfCandidateCreator2ProngExpressions {
       // Printf("New rec. candidate");
       flag = 0;
       origin = 0;
-      auto arrayDaughters = array{candidate.prong0_as<aod::TracksWMc>(), candidate.prong1_as<aod::TracksWMc>()};
+      auto arrayDaughters = std::array{candidate.prong0_as<aod::TracksWMc>(), candidate.prong1_as<aod::TracksWMc>()};
 
       // D0(bar) → π± K∓
       // Printf("Checking D0(bar) → π± K∓");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign);
       if (indexRec > -1) {
         flag = sign * (1 << DecayType::D0ToPiK);
       }
@@ -268,7 +268,7 @@ struct HfCandidateCreator2ProngExpressions {
       // J/ψ → e+ e−
       if (flag == 0) {
         // Printf("Checking J/ψ → e+ e−");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kJPsi, array{+kElectron, -kElectron}, true);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kJPsi, std::array{+kElectron, -kElectron}, true);
         if (indexRec > -1) {
           flag = 1 << DecayType::JpsiToEE;
         }
@@ -277,7 +277,7 @@ struct HfCandidateCreator2ProngExpressions {
       // J/ψ → μ+ μ−
       if (flag == 0) {
         // Printf("Checking J/ψ → μ+ μ−");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kJPsi, array{+kMuonPlus, -kMuonPlus}, true);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true);
         if (indexRec > -1) {
           flag = 1 << DecayType::JpsiToMuMu;
         }
@@ -300,14 +300,14 @@ struct HfCandidateCreator2ProngExpressions {
 
       // D0(bar) → π± K∓
       // Printf("Checking D0(bar) → π± K∓");
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kD0, array{+kPiPlus, -kKPlus}, true, &sign)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign)) {
         flag = sign * (1 << DecayType::D0ToPiK);
       }
 
       // J/ψ → e+ e−
       if (flag == 0) {
         // Printf("Checking J/ψ → e+ e−");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kJPsi, array{+kElectron, -kElectron}, true)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kJPsi, std::array{+kElectron, -kElectron}, true)) {
           flag = 1 << DecayType::JpsiToEE;
         }
       }
@@ -315,7 +315,7 @@ struct HfCandidateCreator2ProngExpressions {
       // J/ψ → μ+ μ−
       if (flag == 0) {
         // Printf("Checking J/ψ → μ+ μ−");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kJPsi, array{+kMuonPlus, -kMuonPlus}, true)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true)) {
           flag = 1 << DecayType::JpsiToMuMu;
         }
       }

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -144,9 +144,9 @@ struct HfCandidateCreator3Prong {
       trackParVar2 = df.getTrack(2);
 
       // get track momenta
-      array<float, 3> pvec0;
-      array<float, 3> pvec1;
-      array<float, 3> pvec2;
+      std::array<float, 3> pvec0;
+      std::array<float, 3> pvec1;
+      std::array<float, 3> pvec2;
       trackParVar0.getPxPyPzGlo(pvec0);
       trackParVar1.getPxPyPzGlo(pvec1);
       trackParVar2.getPxPyPzGlo(pvec2);
@@ -190,7 +190,7 @@ struct HfCandidateCreator3Prong {
 
       // get uncertainty of the decay length
       double phi, theta;
-      getPointDirection(array{primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()}, secondaryVertex, phi, theta);
+      getPointDirection(std::array{primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()}, secondaryVertex, phi, theta);
       auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
       auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -211,8 +211,8 @@ struct HfCandidateCreator3Prong {
       // fill histograms
       if (fillHistograms) {
         // calculate invariant mass
-        auto arrayMomenta = array{pvec0, pvec1, pvec2};
-        massPiKPi = RecoDecay::m(std::move(arrayMomenta), array{massPi, massK, massPi});
+        auto arrayMomenta = std::array{pvec0, pvec1, pvec2};
+        massPiKPi = RecoDecay::m(std::move(arrayMomenta), std::array{massPi, massK, massPi});
         hMass3->Fill(massPiKPi);
       }
     }
@@ -276,11 +276,11 @@ struct HfCandidateCreator3ProngExpressions {
       swapping = 0;
       channel = 0;
       arrDaughIndex.clear();
-      auto arrayDaughters = array{candidate.prong0_as<aod::TracksWMc>(), candidate.prong1_as<aod::TracksWMc>(), candidate.prong2_as<aod::TracksWMc>()};
+      auto arrayDaughters = std::array{candidate.prong0_as<aod::TracksWMc>(), candidate.prong1_as<aod::TracksWMc>(), candidate.prong2_as<aod::TracksWMc>()};
 
       // D± → π± K∓ π±
       // Printf("Checking D± → π± K∓ π±");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDPlus, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
       if (indexRec > -1) {
         flag = sign * (1 << DecayType::DplusToPiKPi);
       }
@@ -288,13 +288,13 @@ struct HfCandidateCreator3ProngExpressions {
       // Ds± → K± K∓ π±
       if (flag == 0) {
         // Printf("Checking Ds± → K± K∓ π±");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDS, array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kDS, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           flag = sign * (1 << DecayType::DsToKKPi);
           if (arrayDaughters[0].has_mcParticle()) {
             swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
           }
-          RecoDecay::getDaughters(particlesMC.rawIteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMC.rawIteratorAt(indexRec), &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.rawIteratorAt(arrDaughIndex[iProng]);
@@ -312,7 +312,7 @@ struct HfCandidateCreator3ProngExpressions {
       // Λc± → p± K∓ π±
       if (flag == 0) {
         // Printf("Checking Λc± → p± K∓ π±");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           flag = sign * (1 << DecayType::LcToPKPi);
 
@@ -320,7 +320,7 @@ struct HfCandidateCreator3ProngExpressions {
           if (arrayDaughters[0].has_mcParticle()) {
             swapping = int8_t(std::abs(arrayDaughters[0].mcParticle().pdgCode()) == kPiPlus);
           }
-          RecoDecay::getDaughters(particlesMC.rawIteratorAt(indexRec), &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMC.rawIteratorAt(indexRec), &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
               auto daughI = particlesMC.rawIteratorAt(arrDaughIndex[iProng]);
@@ -340,7 +340,7 @@ struct HfCandidateCreator3ProngExpressions {
       // Ξc± → p± K∓ π±
       if (flag == 0) {
         // Printf("Checking Ξc± → p± K∓ π±");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           flag = sign * (1 << DecayType::XicToPKPi);
         }
@@ -365,16 +365,16 @@ struct HfCandidateCreator3ProngExpressions {
 
       // D± → π± K∓ π±
       // Printf("Checking D± → π± K∓ π±");
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kDPlus, array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
         flag = sign * (1 << DecayType::DplusToPiKPi);
       }
 
       // Ds± → K± K∓ π±
       if (flag == 0) {
         // Printf("Checking Ds± → K± K∓ π±");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kDS, array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kDS, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           flag = sign * (1 << DecayType::DsToKKPi);
-          RecoDecay::getDaughters(particle, &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particle, &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
               auto daughJ = particlesMC.rawIteratorAt(arrDaughIndex[jProng]);
@@ -392,11 +392,11 @@ struct HfCandidateCreator3ProngExpressions {
       // Λc± → p± K∓ π±
       if (flag == 0) {
         // Printf("Checking Λc± → p± K∓ π±");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           flag = sign * (1 << DecayType::LcToPKPi);
 
           // Printf("Flagging the different Λc± → p± K∓ π± decay channels");
-          RecoDecay::getDaughters(particle, &arrDaughIndex, array{0}, 1);
+          RecoDecay::getDaughters(particle, &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == 2) {
             for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
               auto daughJ = particlesMC.rawIteratorAt(arrDaughIndex[jProng]);
@@ -416,7 +416,7 @@ struct HfCandidateCreator3ProngExpressions {
       // Ξc± → p± K∓ π±
       if (flag == 0) {
         // Printf("Checking Ξc± → p± K∓ π±");
-        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           flag = sign * (1 << DecayType::XicToPKPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -352,12 +352,12 @@ struct HfCandidateCreatorB0Expressions {
       debug = 0;
       auto candD = candidate.prong0();
       auto arrayDaughtersB0 = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                    candD.prong1_as<aod::TracksWMc>(),
-                                    candD.prong2_as<aod::TracksWMc>(),
-                                    candidate.prong1_as<aod::TracksWMc>()};
+                                         candD.prong1_as<aod::TracksWMc>(),
+                                         candD.prong2_as<aod::TracksWMc>(),
+                                         candidate.prong1_as<aod::TracksWMc>()};
       auto arrayDaughtersD = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                   candD.prong1_as<aod::TracksWMc>(),
-                                   candD.prong2_as<aod::TracksWMc>()};
+                                        candD.prong1_as<aod::TracksWMc>(),
+                                        candD.prong2_as<aod::TracksWMc>()};
 
       // B0 → D- π+ → (π- K+ π-) π+
       // Printf("Checking B0 → D- π+");

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -227,8 +227,8 @@ struct HfCandidateCreatorB0 {
         df3.getTrack(2).getPxPyPzGlo(pVec2);
 
         // D∓ → π∓ K± π∓
-        array<float, 3> pVecPiK = RecoDecay::pVec(pVec0, pVec1);
-        array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1, pVec2);
+        std::array<float, 3> pVecPiK = RecoDecay::pVec(pVec0, pVec1);
+        std::array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1, pVec2);
         auto trackParCovPiK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecPiK, df3.calcPCACovMatrixFlat(), trackParCov0, trackParCov1);
         auto trackParCovD = o2::dataformats::V0(df3.getPCACandidatePos(), pVecD, df3.calcPCACovMatrixFlat(), trackParCovPiK, trackParCov2);
 
@@ -260,7 +260,7 @@ struct HfCandidateCreatorB0 {
           }
 
           hPtPion->Fill(trackPion.pt());
-          array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           auto trackParCovPi = getTrackParCov(trackPion);
 
           // ---------------------------------
@@ -283,7 +283,7 @@ struct HfCandidateCreatorB0 {
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
           // calculate invariant mass and apply selection
-          massDPi = RecoDecay::m(array{pVecD, pVecPion}, array{massD, massPi});
+          massDPi = RecoDecay::m(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if (std::abs(massDPi - massB0) > invMassWindowB0) {
             continue;
           }
@@ -298,7 +298,7 @@ struct HfCandidateCreatorB0 {
           // get uncertainty of the decay length
           double phi, theta;
           // getPointDirection modifies phi and theta
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
+          getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexB0, phi, theta);
           auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
           auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -351,21 +351,21 @@ struct HfCandidateCreatorB0Expressions {
       origin = 0;
       debug = 0;
       auto candD = candidate.prong0();
-      auto arrayDaughtersB0 = array{candD.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersB0 = std::array{candD.prong0_as<aod::TracksWMc>(),
                                     candD.prong1_as<aod::TracksWMc>(),
                                     candD.prong2_as<aod::TracksWMc>(),
                                     candidate.prong1_as<aod::TracksWMc>()};
-      auto arrayDaughtersD = array{candD.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersD = std::array{candD.prong0_as<aod::TracksWMc>(),
                                    candD.prong1_as<aod::TracksWMc>(),
                                    candD.prong2_as<aod::TracksWMc>()};
 
       // B0 → D- π+ → (π- K+ π-) π+
       // Printf("Checking B0 → D- π+");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
       if (indexRec > -1) {
         // D- → π- K+ π-
         // Printf("Checking D- → π- K+ π-");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
           flag = sign * BIT(hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi);
         } else {
@@ -376,10 +376,10 @@ struct HfCandidateCreatorB0Expressions {
 
       // B0 → Ds- π+ → (K- K+ π-) π+
       if (!flag) {
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
         if (indexRec > -1) {
           // Ds- → K- K+ π-
-          indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, -pdg::Code::kDS, array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+          indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, -pdg::Code::kDS, std::array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
           if (indexRec > -1) {
             flag = sign * BIT(hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi);
           }
@@ -421,11 +421,11 @@ struct HfCandidateCreatorB0Expressions {
       flag = 0;
       origin = 0;
       // B0 → D- π+
-      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, std::array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
         // Match D- -> π- K+ π-
         auto candDMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking D- -> π- K+ π-");
-        if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
           flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -218,7 +218,7 @@ struct HfCandidateCreatorBplus {
         df.getTrack(0).getPxPyPzGlo(pVec0);
         df.getTrack(1).getPxPyPzGlo(pVec1);
         // Get D0 momentum
-        array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1);
+        std::array<float, 3> pVecD = RecoDecay::pVec(pVec0, pVec1);
 
         // build a D0 neutral track
         auto trackD0 = o2::dataformats::V0(vertexD0, pVecD, df.calcPCACovMatrixFlat(), trackParCovProng0, trackParCovProng1);
@@ -290,14 +290,14 @@ struct HfCandidateCreatorBplus {
 
           // get uncertainty of the decay length
           double phi, theta;
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secVertexBplus, phi, theta);
+          getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secVertexBplus, phi, theta);
           auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
           auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
           int hfFlag = BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
 
           // calculate invariant mass and fill the Invariant Mass control plot
-          massD0Pi = RecoDecay::m(array{pVecD0, pVecBach}, array{massD0, massPi});
+          massD0Pi = RecoDecay::m(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
           if (std::abs(massD0Pi - massBplus) > invMassWindowBplus) {
             continue;
           }
@@ -350,13 +350,13 @@ struct HfCandidateCreatorBplusExpressions {
       flag = 0;
       origin = 0;
       auto candDaughterD0 = candidate.prong0_as<aod::HfCand2Prong>();
-      auto arrayDaughtersD0 = array{candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
-      auto arrayDaughters = array{candidate.prong1_as<aod::TracksWMc>(), candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
+      auto arrayDaughtersD0 = std::array{candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
+      auto arrayDaughters = std::array{candidate.prong1_as<aod::TracksWMc>(), candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
 
       // B± → D0bar(D0) π± → (K± π∓) π±
       // Printf("Checking B± → D0(bar) π±");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kBPlus, array{+kPiPlus, +kKPlus, -kPiPlus}, true, &signB, 2);
-      indexRecD0 = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersD0, -pdg::Code::kD0, array{+kKPlus, -kPiPlus}, true, &signD0, 1);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &signB, 2);
+      indexRecD0 = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersD0, -pdg::Code::kD0, std::array{+kKPlus, -kPiPlus}, true, &signD0, 1);
 
       if (indexRecD0 > -1 && indexRec > -1) {
         flag = signB * (1 << hf_cand_bplus::DecayType::BplusToD0Pi);
@@ -376,13 +376,13 @@ struct HfCandidateCreatorBplusExpressions {
       // B± → D0bar(D0) π± → (K± π∓) π±
       // Printf("Checking B± → D0(bar) π±");
       std::vector<int> arrayDaughterB;
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kBPlus, array{-kD0pdg, +kPiPlus}, true, &signB, 1, &arrayDaughterB)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kBPlus, std::array{-kD0pdg, +kPiPlus}, true, &signB, 1, &arrayDaughterB)) {
         // D0(bar) → π± K∓
         // Printf("Checking D0(bar) → π± K∓");
         for (auto iD : arrayDaughterB) {
           auto candDaughterMC = particlesMC.rawIteratorAt(iD);
           if (std::abs(candDaughterMC.pdgCode()) == kD0pdg) {
-            indexGenD0 = RecoDecay::isMatchedMCGen(particlesMC, candDaughterMC, pdg::Code::kD0, array{-kKPlus, +kPiPlus}, true, &signD0, 1);
+            indexGenD0 = RecoDecay::isMatchedMCGen(particlesMC, candDaughterMC, pdg::Code::kD0, std::array{-kKPlus, +kPiPlus}, true, &signD0, 1);
           }
         }
         if (indexGenD0 > -1) {

--- a/PWGHF/TableProducer/candidateCreatorBs.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBs.cxx
@@ -215,8 +215,8 @@ struct HfCandidateCreatorBs {
         df3.getTrack(2).getPxPyPzGlo(pVec2);
 
         // Ds∓ → K∓ K± π∓
-        array<float, 3> pVecKK = RecoDecay::pVec(pVec0, pVec1);
-        array<float, 3> pVecDs = RecoDecay::pVec(pVec0, pVec1, pVec2);
+        std::array<float, 3> pVecKK = RecoDecay::pVec(pVec0, pVec1);
+        std::array<float, 3> pVecDs = RecoDecay::pVec(pVec0, pVec1, pVec2);
         auto trackParCovKK = o2::dataformats::V0(df3.getPCACandidatePos(), pVecKK, df3.calcPCACovMatrixFlat(),
                                                  trackParCov0, trackParCov1);
         auto trackParCovDs = o2::dataformats::V0(df3.getPCACandidatePos(), pVecDs, df3.calcPCACovMatrixFlat(),
@@ -249,7 +249,7 @@ struct HfCandidateCreatorBs {
             continue;
           }
 
-          array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           auto trackParCovPi = getTrackParCov(trackPion);
 
           // ---------------------------------
@@ -270,7 +270,7 @@ struct HfCandidateCreatorBs {
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the Bs vertex
 
           // calculate invariant mass and apply selection
-          massDsPi = RecoDecay::m(array{pVecDs, pVecPion}, array{massDs, massPi});
+          massDsPi = RecoDecay::m(std::array{pVecDs, pVecPion}, std::array{massDs, massPi});
           if (std::abs(massDsPi - massBs) > invMassWindowBs) {
             continue;
           }
@@ -284,7 +284,7 @@ struct HfCandidateCreatorBs {
           // get uncertainty of the decay length
           double phi, theta;
           // getPointDirection modifies phi and theta
-          getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexBs, phi, theta);
+          getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexBs, phi, theta);
           auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
           auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -345,21 +345,21 @@ struct HfCandidateCreatorBsExpressions {
       flag = 0;
       arrDaughDsIndex.clear();
       auto candDs = candidate.prong0();
-      auto arrayDaughtersBs = array{candDs.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersBs = std::array{candDs.prong0_as<aod::TracksWMc>(),
                                     candDs.prong1_as<aod::TracksWMc>(),
                                     candDs.prong2_as<aod::TracksWMc>(),
                                     candidate.prong1_as<aod::TracksWMc>()};
-      auto arrayDaughtersDs = array{candDs.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersDs = std::array{candDs.prong0_as<aod::TracksWMc>(),
                                     candDs.prong1_as<aod::TracksWMc>(),
                                     candDs.prong2_as<aod::TracksWMc>()};
 
       // Checking Bs(bar) → Ds∓ π± → (K- K+ π∓) π±
-      indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersBs, pdg::Code::kBS, array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersBs, pdg::Code::kBS, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
       if (indexRec > -1) {
         // Checking Ds∓ → K- K+ π∓
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersDs, pdg::Code::kDSBar, array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersDs, pdg::Code::kDSBar, std::array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
         if (indexRec > -1) {
-          RecoDecay::getDaughters(particlesMc.rawIteratorAt(indexRec), &arrDaughDsIndex, array{0}, 1);
+          RecoDecay::getDaughters(particlesMc.rawIteratorAt(indexRec), &arrDaughDsIndex, std::array{0}, 1);
           if (arrDaughDsIndex.size() == 2) {
             for (auto iProng = 0u; iProng < arrDaughDsIndex.size(); ++iProng) {
               auto daughI = particlesMc.rawIteratorAt(arrDaughDsIndex[iProng]);
@@ -406,11 +406,11 @@ struct HfCandidateCreatorBsExpressions {
       flag = 0;
       arrDaughDsIndex.clear();
       // Bs(bar) → Ds∓ π±
-      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kBS, array{+pdg::Code::kDSBar, +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kBS, std::array{+pdg::Code::kDSBar, +kPiPlus}, true)) {
         // Match Ds∓ -> K- K+ π±
         auto candDsMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
-        if (RecoDecay::isMatchedMCGen(particlesMc, candDsMC, pdg::Code::kDSBar, array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2)) {
-          RecoDecay::getDaughters(candDsMC, &arrDaughDsIndex, array{0}, 1);
+        if (RecoDecay::isMatchedMCGen(particlesMc, candDsMC, pdg::Code::kDSBar, std::array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2)) {
+          RecoDecay::getDaughters(candDsMC, &arrDaughDsIndex, std::array{0}, 1);
           if (arrDaughDsIndex.size() == 2) {
             for (auto jProng = 0u; jProng < arrDaughDsIndex.size(); ++jProng) {
               auto daughJ = particlesMc.rawIteratorAt(arrDaughDsIndex[jProng]);

--- a/PWGHF/TableProducer/candidateCreatorBs.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBs.cxx
@@ -346,12 +346,12 @@ struct HfCandidateCreatorBsExpressions {
       arrDaughDsIndex.clear();
       auto candDs = candidate.prong0();
       auto arrayDaughtersBs = std::array{candDs.prong0_as<aod::TracksWMc>(),
-                                    candDs.prong1_as<aod::TracksWMc>(),
-                                    candDs.prong2_as<aod::TracksWMc>(),
-                                    candidate.prong1_as<aod::TracksWMc>()};
+                                         candDs.prong1_as<aod::TracksWMc>(),
+                                         candDs.prong2_as<aod::TracksWMc>(),
+                                         candidate.prong1_as<aod::TracksWMc>()};
       auto arrayDaughtersDs = std::array{candDs.prong0_as<aod::TracksWMc>(),
-                                    candDs.prong1_as<aod::TracksWMc>(),
-                                    candDs.prong2_as<aod::TracksWMc>()};
+                                         candDs.prong1_as<aod::TracksWMc>(),
+                                         candDs.prong2_as<aod::TracksWMc>()};
 
       // Checking Bs(bar) → Ds∓ π± → (K- K+ π∓) π±
       indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersBs, pdg::Code::kBS, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -194,8 +194,8 @@ struct HfCandidateCreatorCascade {
       auto trackParVarBach = df.getTrack(1);
 
       // get track momenta
-      array<float, 3> pVecV0;
-      array<float, 3> pVecBach;
+      std::array<float, 3> pVecV0;
+      std::array<float, 3> pVecBach;
       trackParVarV0.getPxPyPzGlo(pVecV0);
       trackParVarBach.getPxPyPzGlo(pVecBach);
 
@@ -211,7 +211,7 @@ struct HfCandidateCreatorCascade {
 
       // get uncertainty of the decay length
       double phi, theta;
-      getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertex, phi, theta);
+      getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertex, phi, theta);
       auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
       auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -239,7 +239,7 @@ struct HfCandidateCreatorCascade {
       // fill histograms
       if (fillHistograms) {
         // calculate invariant masses
-        mass2K0sP = RecoDecay::m(array{pVecBach, pVecV0}, array{massP, massK0s});
+        mass2K0sP = RecoDecay::m(std::array{pVecBach, pVecV0}, std::array{massP, massK0s});
         hMass2->Fill(mass2K0sP);
       }
     }
@@ -280,8 +280,8 @@ struct HfCandidateCreatorCascadeMc {
       const auto& trackV0DaughPos = candidate.posTrack_as<MyTracksWMc>();
       const auto& trackV0DaughNeg = candidate.negTrack_as<MyTracksWMc>();
 
-      auto arrayDaughtersV0 = array{trackV0DaughPos, trackV0DaughNeg};
-      auto arrayDaughtersLc = array{bach, trackV0DaughPos, trackV0DaughNeg};
+      auto arrayDaughtersV0 = std::array{trackV0DaughPos, trackV0DaughNeg};
+      auto arrayDaughtersLc = std::array{bach, trackV0DaughPos, trackV0DaughNeg};
 
       // First we check the K0s
       LOG(debug) << "\n";
@@ -297,13 +297,13 @@ struct HfCandidateCreatorCascadeMc {
       MY_DEBUG_MSG(isK0SfromLc, LOG(info) << "correct K0S in the Lc daughters: posTrack --> " << indexV0DaughPos << ", negTrack --> " << indexV0DaughNeg);
 
       // if (isLc) {
-      RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersV0, kK0Short, array{+kPiPlus, -kPiPlus}, false, &sign, 1);
+      RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersV0, kK0Short, std::array{+kPiPlus, -kPiPlus}, false, &sign, 1);
 
       if (sign != 0) { // we have already positively checked the K0s
         // then we check the Lc
         MY_DEBUG_MSG(sign, LOG(info) << "K0S was correct! now we check the Lc");
         MY_DEBUG_MSG(sign, LOG(info) << "index proton = " << indexBach);
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersLc, pdg::Code::kLambdaCPlus, array{+kProton, +kPiPlus, -kPiPlus}, true, &sign, 3); // 3-levels Lc --> p + K0 --> p + K0s --> p + pi+ pi-
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersLc, pdg::Code::kLambdaCPlus, std::array{+kProton, +kPiPlus, -kPiPlus}, true, &sign, 3); // 3-levels Lc --> p + K0 --> p + K0s --> p + pi+ pi-
         MY_DEBUG_MSG(sign, LOG(info) << "Lc found with sign " << sign; printf("\n"));
       }
 
@@ -321,9 +321,9 @@ struct HfCandidateCreatorCascadeMc {
     for (const auto& particle : particlesMC) {
       origin = 0;
       // checking if I have a Lc --> K0S + p
-      RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, array{+kProton, +kK0Short}, false, &sign, 2);
+      RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaCPlus, std::array{+kProton, +kK0Short}, false, &sign, 2);
       if (sign == 0) { // now check for anti-Lc
-        RecoDecay::isMatchedMCGen(particlesMC, particle, -pdg::Code::kLambdaCPlus, array{-kProton, +kK0Short}, false, &sign, 2);
+        RecoDecay::isMatchedMCGen(particlesMC, particle, -pdg::Code::kLambdaCPlus, std::array{-kProton, +kK0Short}, false, &sign, 2);
         sign = -sign;
       }
       if (sign != 0) {

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -247,12 +247,12 @@ struct HfCandidateCreatorLbMc {
       debug = 0;
       auto lcCand = candidate.prong0();
       auto arrayDaughters = std::array{lcCand.prong0_as<aod::TracksWMc>(),
-                                  lcCand.prong1_as<aod::TracksWMc>(),
-                                  lcCand.prong2_as<aod::TracksWMc>(),
-                                  candidate.prong1_as<aod::TracksWMc>()};
+                                       lcCand.prong1_as<aod::TracksWMc>(),
+                                       lcCand.prong2_as<aod::TracksWMc>(),
+                                       candidate.prong1_as<aod::TracksWMc>()};
       auto arrayDaughtersLc = std::array{lcCand.prong0_as<aod::TracksWMc>(),
-                                    lcCand.prong1_as<aod::TracksWMc>(),
-                                    lcCand.prong2_as<aod::TracksWMc>()};
+                                         lcCand.prong1_as<aod::TracksWMc>(),
+                                         lcCand.prong2_as<aod::TracksWMc>()};
       // Λb → Λc+ π-
       // Printf("Checking Λb → Λc+ π-");
       indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaB0, std::array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 2);

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -133,8 +133,8 @@ struct HfCandidateCreatorLb {
       trackParVar1.propagateTo(secondaryVertex[0], bz);
       trackParVar2.propagateTo(secondaryVertex[0], bz);
 
-      array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
-      array<float, 3> pvecLc = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
+      std::array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
+      std::array<float, 3> pvecLc = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
       auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
       auto trackLc = o2::dataformats::V0(df3.getPCACandidatePos(), pvecLc, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 
@@ -154,7 +154,7 @@ struct HfCandidateCreatorLb {
           continue;
         }
         hPtPion->Fill(trackPion.pt());
-        array<float, 3> pvecPion;
+        std::array<float, 3> pvecPion;
         auto trackParVarPi = getTrackParCov(trackPion);
 
         // reconstruct the 3-prong Lc vertex
@@ -183,7 +183,7 @@ struct HfCandidateCreatorLb {
 
         // get uncertainty of the decay length
         double phi, theta;
-        getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexLb, phi, theta);
+        getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexLb, phi, theta);
         auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
         auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -203,8 +203,8 @@ struct HfCandidateCreatorLb {
                          hfFlag);
 
         // calculate invariant mass
-        auto arrayMomenta = array{pvecLc, pvecPion};
-        massLcPi = RecoDecay::m(std::move(arrayMomenta), array{massLc, massPi});
+        auto arrayMomenta = std::array{pvecLc, pvecPion};
+        massLcPi = RecoDecay::m(std::move(arrayMomenta), std::array{massLc, massPi});
         if (lcCand.isSelLcToPKPi() > 0) {
           hMassLbToLcPi->Fill(massLcPi);
         }
@@ -246,20 +246,20 @@ struct HfCandidateCreatorLbMc {
       origin = 0;
       debug = 0;
       auto lcCand = candidate.prong0();
-      auto arrayDaughters = array{lcCand.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughters = std::array{lcCand.prong0_as<aod::TracksWMc>(),
                                   lcCand.prong1_as<aod::TracksWMc>(),
                                   lcCand.prong2_as<aod::TracksWMc>(),
                                   candidate.prong1_as<aod::TracksWMc>()};
-      auto arrayDaughtersLc = array{lcCand.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersLc = std::array{lcCand.prong0_as<aod::TracksWMc>(),
                                     lcCand.prong1_as<aod::TracksWMc>(),
                                     lcCand.prong2_as<aod::TracksWMc>()};
       // Λb → Λc+ π-
       // Printf("Checking Λb → Λc+ π-");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaB0, array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 2);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kLambdaB0, std::array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 2);
       if (indexRec > -1) {
         // Λb → Λc+ π-
         // Printf("Checking Λb → Λc+ π-");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersLc, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 1);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersLc, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 1);
         if (indexRec > -1) {
           flag = 1 << hf_cand_lb::DecayType::LbToLcPi;
         } else {
@@ -276,11 +276,11 @@ struct HfCandidateCreatorLbMc {
       flag = 0;
       origin = 0;
       // Λb → Λc+ π-
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaB0, array{static_cast<int>(pdg::Code::kLambdaCPlus), -kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kLambdaB0, std::array{static_cast<int>(pdg::Code::kLambdaCPlus), -kPiPlus}, true)) {
         // Match Λc+ -> pKπ
         auto LcCandMC = particlesMC.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking Λc+ → p K- π+");
-        if (RecoDecay::isMatchedMCGen(particlesMC, LcCandMC, static_cast<int>(pdg::Code::kLambdaCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, LcCandMC, static_cast<int>(pdg::Code::kLambdaCPlus), std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
           flag = sign * (1 << hf_cand_lb::DecayType::LbToLcPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -303,7 +303,7 @@ struct HfCandidateSigmac0plusplusMc {
       }
 
       /// matching to MC
-      auto arrayDaughters = array{candLc.prong0_as<TracksMC>(),
+      auto arrayDaughters = std::array{candLc.prong0_as<TracksMC>(),
                                   candLc.prong1_as<TracksMC>(),
                                   candLc.prong2_as<TracksMC>(),
                                   candSigmac.prong1_as<TracksMC>()};
@@ -314,7 +314,7 @@ struct HfCandidateSigmac0plusplusMc {
         ///   1. Σc0 → Λc+ π-,+
         ///   2. Λc+ → pK-π+ direct (i) or Λc+ → resonant channel Λc± → p± K*, Λc± → Δ(1232)±± K∓ or Λc± → Λ(1520) π±  (ii)
         ///   3. in case of (ii): resonant channel to pK-π+
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughters, pdg::Code::kSigmaC0, array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughters, pdg::Code::kSigmaC0, std::array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
         if (indexRec > -1) { /// due to (*) no need to check anything for LambdaC
           flag = sign * (1 << aod::hf_cand_sigmac::DecayType::Sc0ToPKPiPi);
         }
@@ -324,7 +324,7 @@ struct HfCandidateSigmac0plusplusMc {
         ///   1. Σc0 → Λc+ π-,+
         ///   2. Λc+ → pK-π+ direct (i) or Λc+ → resonant channel Λc± → p± K*, Λc± → Δ(1232)±± K∓ or Λc± → Λ(1520) π±  (ii)
         ///   3. in case of (ii): resonant channel to pK-π+
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughters, pdg::Code::kSigmaCPlusPlus, array{+kProton, -kKPlus, +kPiPlus, +kPiPlus}, true, &sign, 3);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughters, pdg::Code::kSigmaCPlusPlus, std::array{+kProton, -kKPlus, +kPiPlus, +kPiPlus}, true, &sign, 3);
         if (indexRec > -1) { /// due to (*) no need to check anything for LambdaC
           flag = sign * (1 << aod::hf_cand_sigmac::DecayType::ScplusplusToPKPiPi);
         }
@@ -350,7 +350,7 @@ struct HfCandidateSigmac0plusplusMc {
       ///   2. Λc+ → pK-π+ direct (i) or Λc+ → resonant channel Λc± → p± K*, Λc± → Δ(1232)±± K∓ or Λc± → Λ(1520) π±  (ii)
       ///   3. in case of (ii): resonant channel to pK-π+
       /// → here we check level 1. first, and then levels 2. and 3. are inherited by the Λc+ → pK-π+ MC matching in candidateCreator3Prong.cxx
-      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kSigmaC0, array{static_cast<int>(pdg::Code::kLambdaCPlus), static_cast<int>(kPiMinus)}, true, &sign, 1)) {
+      if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kSigmaC0, std::array{static_cast<int>(pdg::Code::kLambdaCPlus), static_cast<int>(kPiMinus)}, true, &sign, 1)) {
         // generated Σc0
         // for (auto& daughter : particle.daughters_as<LambdacMcGen>()) {
         for (auto const& daughter : particle.daughters_as<aod::McParticles>()) {
@@ -358,13 +358,13 @@ struct HfCandidateSigmac0plusplusMc {
           if (std::abs(daughter.pdgCode()) != pdg::Code::kLambdaCPlus)
             continue;
           // if (std::abs(daughter.flagMcMatchGen()) == (1 << DecayType::LcToPKPi)) {
-          if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+          if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
             /// Λc+ daughter decaying in pK-π+ found!
             flag = sign * (1 << aod::hf_cand_sigmac::DecayType::Sc0ToPKPiPi);
             break;
           }
         }
-      } else if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kSigmaCPlusPlus, array{static_cast<int>(pdg::Code::kLambdaCPlus), static_cast<int>(kPiPlus)}, true, &sign, 1)) {
+      } else if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kSigmaCPlusPlus, std::array{static_cast<int>(pdg::Code::kLambdaCPlus), static_cast<int>(kPiPlus)}, true, &sign, 1)) {
         // generated Σc++
         // for (auto& daughter : particle.daughters_as<LambdacMcGen>()) {
         for (auto const& daughter : particle.daughters_as<aod::McParticles>()) {
@@ -372,7 +372,7 @@ struct HfCandidateSigmac0plusplusMc {
           if (std::abs(daughter.pdgCode()) != pdg::Code::kLambdaCPlus)
             continue;
           // if (std::abs(daughter.flagMcMatchGen()) == (1 << DecayType::LcToPKPi)) {
-          if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kLambdaCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
+          if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
             /// Λc+ daughter decaying in pK-π+ found!
             flag = sign * (1 << aod::hf_cand_sigmac::DecayType::ScplusplusToPKPiPi);
             break;

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -304,9 +304,9 @@ struct HfCandidateSigmac0plusplusMc {
 
       /// matching to MC
       auto arrayDaughters = std::array{candLc.prong0_as<TracksMC>(),
-                                  candLc.prong1_as<TracksMC>(),
-                                  candLc.prong2_as<TracksMC>(),
-                                  candSigmac.prong1_as<TracksMC>()};
+                                       candLc.prong1_as<TracksMC>(),
+                                       candLc.prong2_as<TracksMC>(),
+                                       candSigmac.prong1_as<TracksMC>()};
       chargeSigmac = candSigmac.charge();
       if (chargeSigmac == 0) {
         /// candidate Σc0

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -122,8 +122,8 @@ struct HfCandidateCreatorXicc {
       trackParVar1.propagateTo(secondaryVertex[0], bz);
       trackParVar2.propagateTo(secondaryVertex[0], bz);
 
-      array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
-      array<float, 3> pvecxic = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
+      std::array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
+      std::array<float, 3> pvecxic = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
       auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
       auto trackxic = o2::dataformats::V0(df3.getPCACandidatePos(), pvecxic, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 
@@ -142,7 +142,7 @@ struct HfCandidateCreatorXicc {
         if (trackpion.globalIndex() == index0Xic || trackpion.globalIndex() == index1Xic || trackpion.globalIndex() == index2Xic) {
           continue;
         }
-        array<float, 3> pvecpion;
+        std::array<float, 3> pvecpion;
         auto trackParVarPi = getTrackParCov(trackpion);
 
         // reconstruct the 3-prong X vertex
@@ -168,7 +168,7 @@ struct HfCandidateCreatorXicc {
 
         // get uncertainty of the decay length
         double phi, theta;
-        getPointDirection(array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexXicc, phi, theta);
+        getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexXicc, phi, theta);
         auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
         auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
@@ -220,20 +220,20 @@ struct HfCandidateCreatorXiccMc {
       origin = 0;
       debug = 0;
       auto xicCand = candidate.prong0();
-      auto arrayDaughters = array{xicCand.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughters = std::array{xicCand.prong0_as<aod::TracksWMc>(),
                                   xicCand.prong1_as<aod::TracksWMc>(),
                                   xicCand.prong2_as<aod::TracksWMc>(),
                                   candidate.prong1_as<aod::TracksWMc>()};
-      auto arrayDaughtersXic = array{xicCand.prong0_as<aod::TracksWMc>(),
+      auto arrayDaughtersXic = std::array{xicCand.prong0_as<aod::TracksWMc>(),
                                      xicCand.prong1_as<aod::TracksWMc>(),
                                      xicCand.prong2_as<aod::TracksWMc>()};
       // Ξcc±± → p± K∓ π± π±
       // Printf("Checking Ξcc±± → p± K∓ π± π±");
-      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCCPlusPlus, array{+kProton, -kKPlus, +kPiPlus, +kPiPlus}, true, &sign, 2);
+      indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCCPlusPlus, std::array{+kProton, -kKPlus, +kPiPlus, +kPiPlus}, true, &sign, 2);
       if (indexRec > -1) {
         // Ξc± → p± K∓ π±
         // Printf("Checking Ξc± → p± K∓ π±");
-        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersXic, pdg::Code::kXiCPlus, array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 1);
+        indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughtersXic, pdg::Code::kXiCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 1);
         if (indexRec > -1) {
           flag = 1 << DecayType::XiccToXicPi;
         } else {
@@ -250,11 +250,11 @@ struct HfCandidateCreatorXiccMc {
       flag = 0;
       origin = 0;
       // Xicc → Xic + π+
-      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCCPlusPlus, array{static_cast<int>(pdg::Code::kXiCPlus), +kPiPlus}, true)) {
+      if (RecoDecay::isMatchedMCGen(particlesMC, particle, pdg::Code::kXiCCPlusPlus, std::array{static_cast<int>(pdg::Code::kXiCPlus), +kPiPlus}, true)) {
         // Match Xic -> pKπ
         auto XicCandMC = particlesMC.rawIteratorAt(particle.daughtersIds().front());
         // Printf("Checking Ξc± → p± K∓ π±");
-        if (RecoDecay::isMatchedMCGen(particlesMC, XicCandMC, static_cast<int>(pdg::Code::kXiCPlus), array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(particlesMC, XicCandMC, static_cast<int>(pdg::Code::kXiCPlus), std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign)) {
           flag = sign * (1 << DecayType::XiccToXicPi);
         }
       }

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -221,12 +221,12 @@ struct HfCandidateCreatorXiccMc {
       debug = 0;
       auto xicCand = candidate.prong0();
       auto arrayDaughters = std::array{xicCand.prong0_as<aod::TracksWMc>(),
-                                  xicCand.prong1_as<aod::TracksWMc>(),
-                                  xicCand.prong2_as<aod::TracksWMc>(),
-                                  candidate.prong1_as<aod::TracksWMc>()};
+                                       xicCand.prong1_as<aod::TracksWMc>(),
+                                       xicCand.prong2_as<aod::TracksWMc>(),
+                                       candidate.prong1_as<aod::TracksWMc>()};
       auto arrayDaughtersXic = std::array{xicCand.prong0_as<aod::TracksWMc>(),
-                                     xicCand.prong1_as<aod::TracksWMc>(),
-                                     xicCand.prong2_as<aod::TracksWMc>()};
+                                          xicCand.prong1_as<aod::TracksWMc>(),
+                                          xicCand.prong2_as<aod::TracksWMc>()};
       // Ξcc±± → p± K∓ π± π±
       // Printf("Checking Ξcc±± → p± K∓ π± π±");
       indexRec = RecoDecay::getMatchedMCRec(particlesMC, arrayDaughters, pdg::Code::kXiCCPlusPlus, std::array{+kProton, -kKPlus, +kPiPlus, +kPiPlus}, true, &sign, 2);

--- a/PWGHF/TableProducer/refitPvDummy.cxx
+++ b/PWGHF/TableProducer/refitPvDummy.cxx
@@ -23,6 +23,7 @@
 
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 
+using namespace o2;
 using namespace o2::framework;
 
 struct HfRefitPvDummy {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -401,7 +401,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   /// \param dca is a 2-element array with dca in transverse and longitudinal directions
   /// \param candType is the flag to decide which cuts to be applied (either for 2-prong, 3-prong, or cascade decays)
   /// \return true if track passes all cuts
-  bool isSelectedTrackDCA(const float& trackPt, const array<float, 2>& dca, const int candType)
+  bool isSelectedTrackDCA(const float& trackPt, const std::array<float, 2>& dca, const int candType)
   {
     auto pTBinTrack = findBin(binsPtTrack, trackPt);
     if (pTBinTrack == -1) {
@@ -1003,26 +1003,26 @@ struct HfTrackIndexSkimCreator {
       return;
     }
 
-    arrMass2Prong[hf_cand_2prong::DecayType::D0ToPiK] = array{array{massPi, massK},
-                                                              array{massK, massPi}};
+    arrMass2Prong[hf_cand_2prong::DecayType::D0ToPiK] = std::array{array{massPi, massK},
+                                                              std::array{massK, massPi}};
 
-    arrMass2Prong[hf_cand_2prong::DecayType::JpsiToEE] = array{array{massElectron, massElectron},
-                                                               array{massElectron, massElectron}};
+    arrMass2Prong[hf_cand_2prong::DecayType::JpsiToEE] = std::array{array{massElectron, massElectron},
+                                                               std::array{massElectron, massElectron}};
 
-    arrMass2Prong[hf_cand_2prong::DecayType::JpsiToMuMu] = array{array{massMuon, massMuon},
-                                                                 array{massMuon, massMuon}};
+    arrMass2Prong[hf_cand_2prong::DecayType::JpsiToMuMu] = std::array{array{massMuon, massMuon},
+                                                                 std::array{massMuon, massMuon}};
 
-    arrMass3Prong[hf_cand_3prong::DecayType::DplusToPiKPi] = array{array{massPi, massK, massPi},
-                                                                   array{massPi, massK, massPi}};
+    arrMass3Prong[hf_cand_3prong::DecayType::DplusToPiKPi] = std::array{array{massPi, massK, massPi},
+                                                                   std::array{massPi, massK, massPi}};
 
-    arrMass3Prong[hf_cand_3prong::DecayType::LcToPKPi] = array{array{massProton, massK, massPi},
-                                                               array{massPi, massK, massProton}};
+    arrMass3Prong[hf_cand_3prong::DecayType::LcToPKPi] = std::array{array{massProton, massK, massPi},
+                                                               std::array{massPi, massK, massProton}};
 
-    arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi] = array{array{massK, massK, massPi},
-                                                               array{massPi, massK, massK}};
+    arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi] = std::array{array{massK, massK, massPi},
+                                                               std::array{massPi, massK, massK}};
 
-    arrMass3Prong[hf_cand_3prong::DecayType::XicToPKPi] = array{array{massProton, massK, massPi},
-                                                                array{massPi, massK, massProton}};
+    arrMass3Prong[hf_cand_3prong::DecayType::XicToPKPi] = std::array{array{massProton, massK, massPi},
+                                                                std::array{massPi, massK, massProton}};
 
     // cuts for 2-prong decays retrieved by json. the order must be then one in hf_cand_2prong::DecayType
     cut2Prong = {cutsD0ToPiK, cutsJpsiToEE, cutsJpsiToMuMu};
@@ -1119,7 +1119,7 @@ struct HfTrackIndexSkimCreator {
     };
     cacheIndices(cut2Prong, massMinIndex, massMaxIndex, d0d0Index);
 
-    auto arrMom = array{pVecTrack0, pVecTrack1};
+    auto arrMom = std::array{pVecTrack0, pVecTrack1};
     auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1) + ptTolerance; // add tolerance because of no reco decay vertex
 
     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
@@ -1195,7 +1195,7 @@ struct HfTrackIndexSkimCreator {
     };
     cacheIndices(cut3Prong, massMinIndex, massMaxIndex);
 
-    auto arrMom = array{pVecTrack0, pVecTrack1, pVecTrack2};
+    auto arrMom = std::array{pVecTrack0, pVecTrack1, pVecTrack2};
     auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + ptTolerance; // add tolerance because of no reco decay vertex
 
     for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
@@ -1658,14 +1658,14 @@ struct HfTrackIndexSkimCreator {
               // get secondary vertex
               const auto& secondaryVertex2 = df2.getPCACandidate();
               // get track momenta
-              array<float, 3> pvec0;
-              array<float, 3> pvec1;
+              std::array<float, 3> pvec0;
+              std::array<float, 3> pvec1;
               df2.getTrack(0).getPxPyPzGlo(pvec0);
               df2.getTrack(1).getPxPyPzGlo(pvec1);
 
               /// PV refit excluding the candidate daughters, if contributors
-              array<float, 3> pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              array<float, 6> pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+              std::array<float, 3> pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+              std::array<float, 6> pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -1727,7 +1727,7 @@ struct HfTrackIndexSkimCreator {
 
               auto pVecCandProng2 = RecoDecay::pVec(pvec0, pvec1);
               // 2-prong selections after secondary vertex
-              array<float, 3> pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
+              std::array<float, 3> pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
               if constexpr (doPvRefit) {
                 pvCoord2Prong[0] = pvRefitCoord2Prong[0];
                 pvCoord2Prong[1] = pvRefitCoord2Prong[1];
@@ -1763,7 +1763,7 @@ struct HfTrackIndexSkimCreator {
                   registry.fill(HIST("hVtx2ProngX"), secondaryVertex2[0]);
                   registry.fill(HIST("hVtx2ProngY"), secondaryVertex2[1]);
                   registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
-                  array<array<float, 3>, 2> arrMom = {pvec0, pvec1};
+                  std::array<array<float, 3>, 2> arrMom = {pvec0, pvec1};
                   for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                     if (TESTBIT(isSelected2ProngCand, iDecay2P)) {
                       if (whichHypo2Prong[iDecay2P] == 1 || whichHypo2Prong[iDecay2P] == 3) {
@@ -1847,16 +1847,16 @@ struct HfTrackIndexSkimCreator {
               // get secondary vertex
               const auto& secondaryVertex3 = df3.getPCACandidate();
               // get track momenta
-              array<float, 3> pvec0;
-              array<float, 3> pvec1;
-              array<float, 3> pvec2;
+              std::array<float, 3> pvec0;
+              std::array<float, 3> pvec1;
+              std::array<float, 3> pvec2;
               df3.getTrack(0).getPxPyPzGlo(pvec0);
               df3.getTrack(1).getPxPyPzGlo(pvec1);
               df3.getTrack(2).getPxPyPzGlo(pvec2);
 
               /// PV refit excluding the candidate daughters, if contributors
-              array<float, 3> pvRefitCoord3Prong2Pos1Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              array<float, 6> pvRefitCovMatrix3Prong2Pos1Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+              std::array<float, 3> pvRefitCoord3Prong2Pos1Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+              std::array<float, 6> pvRefitCovMatrix3Prong2Pos1Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -1945,7 +1945,7 @@ struct HfTrackIndexSkimCreator {
 
               auto pVecCandProng3Pos = RecoDecay::pVec(pvec0, pvec1, pvec2);
               // 3-prong selections after secondary vertex
-              array<float, 3> pvCoord3Prong2Pos1Neg = {collision.posX(), collision.posY(), collision.posZ()};
+              std::array<float, 3> pvCoord3Prong2Pos1Neg = {collision.posX(), collision.posY(), collision.posZ()};
               if constexpr (doPvRefit) {
                 pvCoord3Prong2Pos1Neg[0] = pvRefitCoord3Prong2Pos1Neg[0];
                 pvCoord3Prong2Pos1Neg[1] = pvRefitCoord3Prong2Pos1Neg[1];
@@ -1982,7 +1982,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
+                std::array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (whichHypo3Prong[iDecay3P] == 1 || whichHypo3Prong[iDecay3P] == 3) {
@@ -2067,16 +2067,16 @@ struct HfTrackIndexSkimCreator {
               // get secondary vertex
               const auto& secondaryVertex3 = df3.getPCACandidate();
               // get track momenta
-              array<float, 3> pvec0;
-              array<float, 3> pvec1;
-              array<float, 3> pvec2;
+              std::array<float, 3> pvec0;
+              std::array<float, 3> pvec1;
+              std::array<float, 3> pvec2;
               df3.getTrack(0).getPxPyPzGlo(pvec0);
               df3.getTrack(1).getPxPyPzGlo(pvec1);
               df3.getTrack(2).getPxPyPzGlo(pvec2);
 
               /// PV refit excluding the candidate daughters, if contributors
-              array<float, 3> pvRefitCoord3Prong1Pos2Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              array<float, 6> pvRefitCovMatrix3Prong1Pos2Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+              std::array<float, 3> pvRefitCoord3Prong1Pos2Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+              std::array<float, 6> pvRefitCovMatrix3Prong1Pos2Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -2165,7 +2165,7 @@ struct HfTrackIndexSkimCreator {
 
               auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
               // 3-prong selections after secondary vertex
-              array<float, 3> pvCoord3Prong1Pos2Neg = {collision.posX(), collision.posY(), collision.posZ()};
+              std::array<float, 3> pvCoord3Prong1Pos2Neg = {collision.posX(), collision.posY(), collision.posZ()};
               if constexpr (doPvRefit) {
                 pvCoord3Prong1Pos2Neg[0] = pvRefitCoord3Prong1Pos2Neg[0];
                 pvCoord3Prong1Pos2Neg[1] = pvRefitCoord3Prong1Pos2Neg[1];
@@ -2200,7 +2200,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
+                std::array<array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (whichHypo3Prong[iDecay3P] == 1 || whichHypo3Prong[iDecay3P] == 3) {
@@ -2539,7 +2539,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
           // invariant-mass cut: we do it here, before updating the momenta of bach and V0 during the fitting to save CPU
           // TODO: but one should better check that the value here and after the fitter do not change significantly!!!
-          mass2K0sP = RecoDecay::m(array{array{bach.px(), bach.py(), bach.pz()}, momentumV0}, array{massP, massK0s});
+          mass2K0sP = RecoDecay::m(std::array{array{bach.px(), bach.py(), bach.pz()}, momentumV0}, std::array{massP, massK0s});
           if ((cutInvMassCascLc >= 0.) && (std::abs(mass2K0sP - massLc) > cutInvMassCascLc)) {
             MY_DEBUG_MSG(isK0SfromLc && isProtonFromLc, LOG(info) << "True Lc from proton " << indexBach << " and K0S pos " << indexV0DaughPos << " and neg " << indexV0DaughNeg << " rejected due to invMass cut: " << mass2K0sP << ", mass Lc " << massLc << " (cut " << cutInvMassCascLc << ")");
             continue;
@@ -2578,7 +2578,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
           // invariant mass
           // re-calculate invariant masses with updated momenta, to fill the histogram
-          mass2K0sP = RecoDecay::m(array{pVecBach, pVecV0}, array{massP, massK0s});
+          mass2K0sP = RecoDecay::m(std::array{pVecBach, pVecV0}, std::array{massP, massK0s});
 
           std::array<float, 3> posCasc = {0., 0., 0.};
           const auto& cascVtx = fitter.getPCACandidate();
@@ -2676,14 +2676,14 @@ struct HfTrackIndexSkimCreatorLfCascades {
       return;
     }
 
-    arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::XiczeroToXiPi] = array{array{massXi, massPi},
-                                                                            array{massPi, massXi}};
+    arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::XiczeroToXiPi] = std::array{array{massXi, massPi},
+                                                                            std::array{massPi, massXi}};
 
-    arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::OmegaczeroToOmegaPi] = array{array{massOmega, massPi},
-                                                                                  array{massPi, massOmega}};
+    arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::OmegaczeroToOmegaPi] = std::array{array{massOmega, massPi},
+                                                                                  std::array{massPi, massOmega}};
 
-    arrMass3Prong[hf_cand_casc_lf_3prong::DecayType::XicplusToXiPiPi] = array{array{massXi, massPi, massPi},
-                                                                              array{massPi, massPi, massXi}};
+    arrMass3Prong[hf_cand_casc_lf_3prong::DecayType::XicplusToXiPiPi] = std::array{array{massXi, massPi, massPi},
+                                                                              std::array{massPi, massPi, massXi}};
 
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
@@ -2905,8 +2905,8 @@ struct HfTrackIndexSkimCreatorLfCascades {
           continue;
         }
 
-        array<float, 3> pvecV0;        // V0
-        array<float, 3> pvecXiDauPion; // bach pion
+        std::array<float, 3> pvecV0;        // V0
+        std::array<float, 3> pvecXiDauPion; // bach pion
 
         dfc.getTrack(0).getPxPyPzGlo(pvecV0);
         dfc.getTrack(1).getPxPyPzGlo(pvecXiDauPion);
@@ -2990,7 +2990,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
 
-                array<array<float, 3>, 3> arr3Mom = {pVec1, pVec2, pVec3};
+                std::array<array<float, 3>, 3> arr3Mom = {pVec1, pVec2, pVec3};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   auto mass3Prong = RecoDecay::m(arr3Mom, arrMass3Prong[iDecay3P][0]);
                   switch (iDecay3P) {
@@ -3025,7 +3025,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
             registry.fill(HIST("hVtx2ProngY"), secondaryVertex2[1]);
             registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
 
-            array<array<float, 3>, 2> arrMom = {pVec1, pVec2};
+            std::array<array<float, 3>, 2> arrMom = {pVec1, pVec2};
             for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
               auto mass2Prong = RecoDecay::m(arrMom, arrMass2Prong[iDecay2P][0]);
               switch (iDecay2P) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1004,25 +1004,25 @@ struct HfTrackIndexSkimCreator {
     }
 
     arrMass2Prong[hf_cand_2prong::DecayType::D0ToPiK] = std::array{array{massPi, massK},
-                                                              std::array{massK, massPi}};
+                                                                   std::array{massK, massPi}};
 
     arrMass2Prong[hf_cand_2prong::DecayType::JpsiToEE] = std::array{array{massElectron, massElectron},
-                                                               std::array{massElectron, massElectron}};
+                                                                    std::array{massElectron, massElectron}};
 
     arrMass2Prong[hf_cand_2prong::DecayType::JpsiToMuMu] = std::array{array{massMuon, massMuon},
-                                                                 std::array{massMuon, massMuon}};
+                                                                      std::array{massMuon, massMuon}};
 
     arrMass3Prong[hf_cand_3prong::DecayType::DplusToPiKPi] = std::array{array{massPi, massK, massPi},
-                                                                   std::array{massPi, massK, massPi}};
+                                                                        std::array{massPi, massK, massPi}};
 
     arrMass3Prong[hf_cand_3prong::DecayType::LcToPKPi] = std::array{array{massProton, massK, massPi},
-                                                               std::array{massPi, massK, massProton}};
+                                                                    std::array{massPi, massK, massProton}};
 
     arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi] = std::array{array{massK, massK, massPi},
-                                                               std::array{massPi, massK, massK}};
+                                                                    std::array{massPi, massK, massK}};
 
     arrMass3Prong[hf_cand_3prong::DecayType::XicToPKPi] = std::array{array{massProton, massK, massPi},
-                                                                std::array{massPi, massK, massProton}};
+                                                                     std::array{massPi, massK, massProton}};
 
     // cuts for 2-prong decays retrieved by json. the order must be then one in hf_cand_2prong::DecayType
     cut2Prong = {cutsD0ToPiK, cutsJpsiToEE, cutsJpsiToMuMu};
@@ -2677,13 +2677,13 @@ struct HfTrackIndexSkimCreatorLfCascades {
     }
 
     arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::XiczeroToXiPi] = std::array{array{massXi, massPi},
-                                                                            std::array{massPi, massXi}};
+                                                                                 std::array{massPi, massXi}};
 
     arrMass2Prong[hf_cand_casc_lf_2prong::DecayType::OmegaczeroToOmegaPi] = std::array{array{massOmega, massPi},
-                                                                                  std::array{massPi, massOmega}};
+                                                                                       std::array{massPi, massOmega}};
 
     arrMass3Prong[hf_cand_casc_lf_3prong::DecayType::XicplusToXiPiPi] = std::array{array{massXi, massPi, massPi},
-                                                                              std::array{massPi, massPi, massXi}};
+                                                                                   std::array{massPi, massPi, massXi}};
 
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);

--- a/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
@@ -366,7 +366,7 @@ struct HfTreeCreatorB0ToDPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
+++ b/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
@@ -319,7 +319,7 @@ struct HfTreeCreatorBplusToD0Pi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.globalIndex());
       }

--- a/PWGHF/TableProducer/treeCreatorBsToDsPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorBsToDsPi.cxx
@@ -355,7 +355,7 @@ struct HfTreeCreatorBsToDsPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen());
       }
     }

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -452,7 +452,7 @@ struct HfTreeCreatorD0ToKPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           particle.globalIndex());

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -446,7 +446,7 @@ struct HfTreeCreatorDplusToPiKPi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -507,7 +507,7 @@ struct HfTreeCreatorDsToKKPi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
@@ -293,7 +293,7 @@ struct HfTreeCreatorLcToK0sP {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()},
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()},
                        RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen());

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -316,7 +316,7 @@ struct HfTreeCreatorLcToPKPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           particle.globalIndex());

--- a/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
@@ -318,7 +318,7 @@ struct HfTreeCreatorXicToPKPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           particle.globalIndex());

--- a/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
@@ -268,7 +268,7 @@ struct HfTreeCreatorXiccToPKPiPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
+          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode())),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/Tasks/taskLcCentrality.cxx
+++ b/PWGHF/Tasks/taskLcCentrality.cxx
@@ -178,7 +178,7 @@ struct HfTaskLcCentralityMc {
     // Printf("MC Particles: %d", particlesMC.size());
     for (auto& particle : particlesMC) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << DecayType::LcToPKPi) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()))) > yCandMax) {
           continue;
         }
         auto ptGen = particle.pt();

--- a/PWGHF/Tasks/taskMcEfficiency.cxx
+++ b/PWGHF/Tasks/taskMcEfficiency.cxx
@@ -398,7 +398,7 @@ struct HfTaskMcEfficiency {
         }
         /// check if we end-up with the correct final state using MC info
         int8_t sign = 0;
-        if (std::abs(mcParticle.pdgCode()) == pdg::kD0 && !RecoDecay::isMatchedMCGen(mcParticles, mcParticle, pdg::kD0, array{+kPiPlus, -kKPlus}, true, &sign)) {
+        if (std::abs(mcParticle.pdgCode()) == pdg::kD0 && !RecoDecay::isMatchedMCGen(mcParticles, mcParticle, pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign)) {
           /// check if we have D0(bar) → π± K∓
           continue;
         }

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -41,21 +41,21 @@
 #include "PWGJE/Core/JetFinder.h"
 #include "PWGJE/DataModel/Jet.h"
 
-using JetTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection>>;
+using JetTracks = o2::soa::Filtered<o2::soa::Join<o2::aod::Tracks, o2::aod::TrackSelection>>;
 using JetClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
 
-using ParticlesD0 = soa::Filtered<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>;
-using ParticlesLc = soa::Filtered<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>;
-using ParticlesBplus = soa::Filtered<soa::Join<aod::McParticles, aod::HfCandBplusMcGen>>;
+using ParticlesD0 = o2::soa::Filtered<o2::soa::Join<o2::aod::McParticles, o2::aod::HfCand2ProngMcGen>>;
+using ParticlesLc = o2::soa::Filtered<o2::soa::Join<o2::aod::McParticles, o2::aod::HfCand3ProngMcGen>>;
+using ParticlesBplus = o2::soa::Filtered<o2::soa::Join<o2::aod::McParticles, o2::aod::HfCandBplusMcGen>>;
 
-using CandidatesD0Data = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
-using CandidatesD0MCD = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfCand2ProngMcRec>>;
+using CandidatesD0Data = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCand2Prong, o2::aod::HfSelD0>>;
+using CandidatesD0MCD = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCand2Prong, o2::aod::HfSelD0, o2::aod::HfCand2ProngMcRec>>;
 
-using CandidatesBplusData = soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>>;
-using CandidatesBplusMCD = soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi, aod::HfCandBplusMcRec>>;
+using CandidatesBplusData = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCandBplus, o2::aod::HfSelBplusToD0Pi>>;
+using CandidatesBplusMCD = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCandBplus, o2::aod::HfSelBplusToD0Pi, o2::aod::HfCandBplusMcRec>>;
 
-using CandidatesLcData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
-using CandidatesLcMCD = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>>;
+using CandidatesLcData = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCand3Prong, o2::aod::HfSelLc>>;
+using CandidatesLcMCD = o2::soa::Filtered<o2::soa::Join<o2::aod::HfCand3Prong, o2::aod::HfSelLc, o2::aod::HfCand3ProngMcRec>>;
 
 // functions for track, cluster and candidate selection
 
@@ -97,7 +97,7 @@ void analyseTracks(std::vector<fastjet::PseudoJet>& inputParticles, T const& tra
       }
 
       if constexpr (std::is_same_v<std::decay_t<U>, CandidatesBplusData::iterator> || std::is_same_v<std::decay_t<U>, CandidatesBplusData::filtered_iterator> || std::is_same_v<std::decay_t<U>, CandidatesBplusMCD::iterator> || std::is_same_v<std::decay_t<U>, CandidatesBplusMCD::filtered_iterator>) {
-        if (cand.template prong0_as<aod::HfCand2Prong>().template prong0_as<JetTracks>().globalIndex() == track.globalIndex() || cand.template prong0_as<aod::HfCand2Prong>().template prong1_as<JetTracks>().globalIndex() == track.globalIndex() || cand.template prong1_as<JetTracks>().globalIndex() == track.globalIndex()) {
+        if (cand.template prong0_as<o2::aod::HfCand2Prong>().template prong0_as<JetTracks>().globalIndex() == track.globalIndex() || cand.template prong0_as<o2::aod::HfCand2Prong>().template prong1_as<JetTracks>().globalIndex() == track.globalIndex() || cand.template prong1_as<JetTracks>().globalIndex() == track.globalIndex()) {
           continue;
         }
       }
@@ -195,7 +195,7 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
 template <typename T>
 bool checkDaughters(T const& particle, int globalIndex)
 {
-  for (auto daughter : particle.template daughters_as<aod::McParticles>()) {
+  for (auto daughter : particle.template daughters_as<o2::aod::McParticles>()) {
     if (daughter.globalIndex() == globalIndex) {
       return true;
     }

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -197,7 +197,7 @@ struct JetFinderHFTask {
 
     for (auto const& particle : particles) {
       if (std::abs(particle.flagMcMatchGen()) & (1 << candDecay)) {
-        auto particleY = RecoDecay::y(array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto particleY = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
         if (particleY < candYMin || particleY > candYMax) {
           continue;
         }

--- a/PWGJE/Tasks/emceventselectionqa.cxx
+++ b/PWGJE/Tasks/emceventselectionqa.cxx
@@ -162,7 +162,7 @@ struct EmcEventSelectionQA {
         }
       }
 
-      if (bc.selection_bit(kIsTriggerTVX)) {
+      if (bc.selection_bit(aod::evsel::kIsTriggerTVX)) {
         mHistManager.fill(HIST("hBCTVX"), bcID);
       }
 

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -76,7 +76,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(DistOverTotMom, distovertotmom, //! PV to V0decay dis
 
 // CosPA
 DECLARE_SOA_DYNAMIC_COLUMN(V0CosPA, v0cosPA, //! V0 CosPA
-                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(array{pvX, pvY, pvZ}, array{X, Y, Z}, array{Px, Py, Pz}); });
+                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{X, Y, Z}, std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DCAV0ToPV, dcav0topv, //! DCA of V0 to PV
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
 
@@ -84,15 +84,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(DCAV0ToPV, dcav0topv, //! DCA of V0 to PV
 DECLARE_SOA_DYNAMIC_COLUMN(Alpha, alpha, //! Armenteros Alpha
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) {
                              float momTot = RecoDecay::p(pxpos + pxneg, pypos + pyneg, pzpos + pzneg);
-                             float lQlNeg = RecoDecay::dotProd(array{pxneg, pyneg, pzneg}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
-                             float lQlPos = RecoDecay::dotProd(array{pxpos, pypos, pzpos}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
+                             float lQlNeg = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
+                             float lQlPos = RecoDecay::dotProd(std::array{pxpos, pypos, pzpos}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
                              return (lQlPos - lQlNeg) / (lQlPos + lQlNeg); // alphav0
                            });
 
 DECLARE_SOA_DYNAMIC_COLUMN(QtArm, qtarm, //! Armenteros Qt
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) {
                              float momTot = RecoDecay::p2(pxpos + pxneg, pypos + pyneg, pzpos + pzneg);
-                             float dp = RecoDecay::dotProd(array{pxneg, pyneg, pzneg}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg});
+                             float dp = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg});
                              return std::sqrt(RecoDecay::p2(pxneg, pyneg, pzneg) - dp * dp / momTot); // qtarm
                            });
 
@@ -101,7 +101,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PsiPair, psipair, //! psi pair angle
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) {
                              auto clipToPM1 = [](float x) { return x < -1.f ? -1.f : (x > 1.f ? 1.f : x); };
                              float ptot2 = RecoDecay::p2(pxpos, pypos, pzpos) * RecoDecay::p2(pxneg, pyneg, pzneg);
-                             float argcos = RecoDecay::dotProd(array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}) / std::sqrt(ptot2);
+                             float argcos = RecoDecay::dotProd(std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}) / std::sqrt(ptot2);
                              float thetaPos = std::atan2(RecoDecay::sqrtSumOfSquares(pxpos, pypos), pzpos);
                              float thetaNeg = std::atan2(RecoDecay::sqrtSumOfSquares(pxneg, pyneg), pzneg);
                              float argsin = (thetaNeg - thetaPos) / std::acos(clipToPM1(argcos));
@@ -125,45 +125,45 @@ DECLARE_SOA_DYNAMIC_COLUMN(PFracNeg, pfracneg,
 
 // Calculated on the fly with mass assumption + dynamic tables
 DECLARE_SOA_DYNAMIC_COLUMN(MLambda, mLambda, //! mass under lambda hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged}); });
 DECLARE_SOA_DYNAMIC_COLUMN(MAntiLambda, mAntiLambda, //! mass under antilambda hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
 DECLARE_SOA_DYNAMIC_COLUMN(MK0Short, mK0Short, //! mass under K0short hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged}); });
 DECLARE_SOA_DYNAMIC_COLUMN(MGamma, mGamma, //! mass under gamma hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron}); });
 // Account for rigidity in case of hypertriton
 DECLARE_SOA_DYNAMIC_COLUMN(MHypertriton, mHypertriton, //! mass under hypertriton  hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{2.0f * pxpos, 2.0f * pypos, 2.0f * pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{2.0f * pxpos, 2.0f * pypos, 2.0f * pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged}); });
 DECLARE_SOA_DYNAMIC_COLUMN(MAntiHypertriton, mAntiHypertriton, //! mass under antihypertriton hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{2.0f * pxneg, 2.0f * pyneg, 2.0f * pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3}); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{2.0f * pxneg, 2.0f * pyneg, 2.0f * pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3}); });
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //! mass under a certain hypothesis (0:K0, 1:L, 2:Lbar, 3:gamma, 4:hyp, 5:ahyp)
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg, int value) -> float {
                              if (value == 0)
-                               return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
+                               return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
                              if (value == 1)
-                               return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
+                               return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
                              if (value == 2)
-                               return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
+                               return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
                              if (value == 3)
-                               return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
+                               return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
                              if (value == 4)
-                               return RecoDecay::m(array{array{2.0f * pxpos, 2.0f * pypos, 2.0f * pzpos}, array{pxneg, pyneg, pzneg}}, array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged});
+                               return RecoDecay::m(std::array{std::array{2.0f * pxpos, 2.0f * pypos, 2.0f * pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassHelium3, o2::constants::physics::MassPionCharged});
                              if (value == 5)
-                               return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{2.0f * pxneg, 2.0f * pyneg, 2.0f * pzneg}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3});
+                               return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{2.0f * pxneg, 2.0f * pyneg, 2.0f * pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassHelium3});
                              return 0.0f;
                            });
 
 DECLARE_SOA_DYNAMIC_COLUMN(YK0Short, yK0Short, //! V0 y with K0short hypothesis
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassKaonNeutral); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassKaonNeutral); });
 DECLARE_SOA_DYNAMIC_COLUMN(YLambda, yLambda, //! V0 y with lambda or antilambda hypothesis
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassLambda); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassLambda); });
 DECLARE_SOA_DYNAMIC_COLUMN(YHypertriton, yHypertriton, //! V0 y with hypertriton hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::y(array{2.0f * pxpos + pxneg, 2.0f * pypos + pyneg, 2.0f * pzpos + pzneg}, o2::constants::physics::MassHyperTriton); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::y(std::array{2.0f * pxpos + pxneg, 2.0f * pypos + pyneg, 2.0f * pzpos + pzneg}, o2::constants::physics::MassHyperTriton); });
 DECLARE_SOA_DYNAMIC_COLUMN(YAntiHypertriton, yAntiHypertriton, //! V0 y with antihypertriton hypothesis
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::y(array{pxpos + 2.0f * pxneg, pypos + 2.0f * pyneg, pzpos + 2.0f * pzneg}, o2::constants::physics::MassHyperTriton); });
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::y(std::array{pxpos + 2.0f * pxneg, pypos + 2.0f * pyneg, pzpos + 2.0f * pzneg}, o2::constants::physics::MassHyperTriton); });
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //! V0 eta
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(array{Px, Py, Pz}); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! V0 phi
                            [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });
 
@@ -172,11 +172,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(NegativePt, negativept, //! negative daughter pT
 DECLARE_SOA_DYNAMIC_COLUMN(PositivePt, positivept, //! positive daughter pT
                            [](float pxpos, float pypos) -> float { return RecoDecay::sqrtSumOfSquares(pxpos, pypos); });
 DECLARE_SOA_DYNAMIC_COLUMN(NegativeEta, negativeeta, //! negative daughter eta
-                           [](float PxNeg, float PyNeg, float PzNeg) -> float { return RecoDecay::eta(array{PxNeg, PyNeg, PzNeg}); });
+                           [](float PxNeg, float PyNeg, float PzNeg) -> float { return RecoDecay::eta(std::array{PxNeg, PyNeg, PzNeg}); });
 DECLARE_SOA_DYNAMIC_COLUMN(NegativePhi, negativephi, //! negative daughter phi
                            [](float PxNeg, float PyNeg) -> float { return RecoDecay::phi(PxNeg, PyNeg); });
 DECLARE_SOA_DYNAMIC_COLUMN(PositiveEta, positiveeta, //! positive daughter eta
-                           [](float PxPos, float PyPos, float PzPos) -> float { return RecoDecay::eta(array{PxPos, PyPos, PzPos}); });
+                           [](float PxPos, float PyPos, float PzPos) -> float { return RecoDecay::eta(std::array{PxPos, PyPos, PzPos}); });
 DECLARE_SOA_DYNAMIC_COLUMN(PositivePhi, positivephi, //! positive daughter phi
                            [](float PxPos, float PyPos) -> float { return RecoDecay::phi(PxPos, PyPos); });
 
@@ -377,15 +377,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(CascRadius, cascradius, //!
 
 // CosPAs
 DECLARE_SOA_DYNAMIC_COLUMN(V0CosPA, v0cosPA, //!
-                           [](float Xlambda, float Ylambda, float Zlambda, float PxLambda, float PyLambda, float PzLambda, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(array{pvX, pvY, pvZ}, array{Xlambda, Ylambda, Zlambda}, array{PxLambda, PyLambda, PzLambda}); });
+                           [](float Xlambda, float Ylambda, float Zlambda, float PxLambda, float PyLambda, float PzLambda, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{Xlambda, Ylambda, Zlambda}, std::array{PxLambda, PyLambda, PzLambda}); });
 DECLARE_SOA_DYNAMIC_COLUMN(CascCosPA, casccosPA, //!
-                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(array{pvX, pvY, pvZ}, array{X, Y, Z}, array{Px, Py, Pz}); });
+                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{X, Y, Z}, std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DCAV0ToPV, dcav0topv, //!
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
 
 // Calculated on the fly with mass assumption + dynamic tables
 DECLARE_SOA_DYNAMIC_COLUMN(MLambda, mLambda, //!
-                           [](int charge, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(array{array{pxpos, pypos, pzpos}, array{pxneg, pyneg, pzneg}}, charge < 0 ? array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged} : array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
+                           [](int charge, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, charge < 0 ? std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged} : std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //! mass under a certain hypothesis (0:K0, 1:L, 2:Lbar, 3:gamma, 4:hyp, 5:ahyp)
                            [](float mXi, float mOmega, int value) -> float {
                              if (value == 0 || value == 1)
@@ -396,11 +396,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(M, m, //! mass under a certain hypothesis (0:K0, 1:L,
                            });
 
 DECLARE_SOA_DYNAMIC_COLUMN(YXi, yXi, //!
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassXiMinus); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassXiMinus); });
 DECLARE_SOA_DYNAMIC_COLUMN(YOmega, yOmega, //!
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassOmegaMinus); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassOmegaMinus); });
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //!
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(array{Px, Py, Pz}); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! cascade phi
                            [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });
 } // namespace cascdata

--- a/PWGLF/DataModel/Vtx3BodyTables.h
+++ b/PWGLF/DataModel/Vtx3BodyTables.h
@@ -75,9 +75,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(MHypertriton, mHypertriton, //! mass under Hypertrito
 DECLARE_SOA_DYNAMIC_COLUMN(MAntiHypertriton, mAntiHypertriton, //! mass under antiHypertriton hypothesis
                            [](float pxtrack0, float pytrack0, float pztrack0, float pxtrack1, float pytrack1, float pztrack1, float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::m(std::array{std::array{pxtrack0, pytrack0, pztrack0}, std::array{pxtrack1, pytrack1, pztrack1}, std::array{pxtrack2, pytrack2, pztrack2}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton, o2::constants::physics::MassDeuteron}); });
 
-DECLARE_SOA_DYNAMIC_COLUMN(YHypertriton, yHypertriton,                                                                                                      //! 3 body vtx y with hypertriton or antihypertriton hypothesis
+DECLARE_SOA_DYNAMIC_COLUMN(YHypertriton, yHypertriton,                                                                                                           //! 3 body vtx y with hypertriton or antihypertriton hypothesis
                            [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassHyperTriton); }); // here MassHyperTriton = 2.992
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta,                                                                                                                        //! 3 body vtx eta
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta,                                                                                                                             //! 3 body vtx eta
                            [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! 3 body vtx phi
                            [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });

--- a/PWGLF/DataModel/Vtx3BodyTables.h
+++ b/PWGLF/DataModel/Vtx3BodyTables.h
@@ -65,20 +65,20 @@ DECLARE_SOA_DYNAMIC_COLUMN(DistOverTotMom, distovertotmom, //! PV to 3 body deca
 
 // CosPA
 DECLARE_SOA_DYNAMIC_COLUMN(VtxCosPA, vtxcosPA, //! 3 body vtx CosPA
-                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(array{pvX, pvY, pvZ}, array{X, Y, Z}, array{Px, Py, Pz}); });
+                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{X, Y, Z}, std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DCAVtxToPV, dcavtxtopv, //! DCA of 3 body vtx to PV
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
 
 // Calculated on the fly with mass assumption + dynamic tables
 DECLARE_SOA_DYNAMIC_COLUMN(MHypertriton, mHypertriton, //! mass under Hypertriton hypothesis
-                           [](float pxtrack0, float pytrack0, float pztrack0, float pxtrack1, float pytrack1, float pztrack1, float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::m(array{array{pxtrack0, pytrack0, pztrack0}, array{pxtrack1, pytrack1, pztrack1}, array{pxtrack2, pytrack2, pztrack2}}, array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged, o2::constants::physics::MassDeuteron}); });
+                           [](float pxtrack0, float pytrack0, float pztrack0, float pxtrack1, float pytrack1, float pztrack1, float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::m(std::array{std::array{pxtrack0, pytrack0, pztrack0}, std::array{pxtrack1, pytrack1, pztrack1}, std::array{pxtrack2, pytrack2, pztrack2}}, std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged, o2::constants::physics::MassDeuteron}); });
 DECLARE_SOA_DYNAMIC_COLUMN(MAntiHypertriton, mAntiHypertriton, //! mass under antiHypertriton hypothesis
-                           [](float pxtrack0, float pytrack0, float pztrack0, float pxtrack1, float pytrack1, float pztrack1, float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::m(array{array{pxtrack0, pytrack0, pztrack0}, array{pxtrack1, pytrack1, pztrack1}, array{pxtrack2, pytrack2, pztrack2}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton, o2::constants::physics::MassDeuteron}); });
+                           [](float pxtrack0, float pytrack0, float pztrack0, float pxtrack1, float pytrack1, float pztrack1, float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::m(std::array{std::array{pxtrack0, pytrack0, pztrack0}, std::array{pxtrack1, pytrack1, pztrack1}, std::array{pxtrack2, pytrack2, pztrack2}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton, o2::constants::physics::MassDeuteron}); });
 
 DECLARE_SOA_DYNAMIC_COLUMN(YHypertriton, yHypertriton,                                                                                                      //! 3 body vtx y with hypertriton or antihypertriton hypothesis
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(array{Px, Py, Pz}, o2::constants::physics::MassHyperTriton); }); // here MassHyperTriton = 2.992
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassHyperTriton); }); // here MassHyperTriton = 2.992
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta,                                                                                                                        //! 3 body vtx eta
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(array{Px, Py, Pz}); });
+                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! 3 body vtx phi
                            [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });
 
@@ -89,15 +89,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(Track1Pt, track1pt, //! daughter1 pT
 DECLARE_SOA_DYNAMIC_COLUMN(Track2Pt, track2pt, //! daughter2 pT
                            [](float pxtrack2, float pytrack2) -> float { return RecoDecay::sqrtSumOfSquares(pxtrack2, pytrack2); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track0Eta, track0eta, //! daughter0 eta
-                           [](float pxtrack0, float pytrack0, float pztrack0) -> float { return RecoDecay::eta(array{pxtrack0, pytrack0, pztrack0}); });
+                           [](float pxtrack0, float pytrack0, float pztrack0) -> float { return RecoDecay::eta(std::array{pxtrack0, pytrack0, pztrack0}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track0Phi, track0phi, //! daughter0 phi
                            [](float pxtrack0, float pytrack0) -> float { return RecoDecay::phi(pxtrack0, pytrack0); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track1Eta, track1eta, //! daughter1 eta
-                           [](float pxtrack1, float pytrack1, float pztrack1) -> float { return RecoDecay::eta(array{pxtrack1, pytrack1, pztrack1}); });
+                           [](float pxtrack1, float pytrack1, float pztrack1) -> float { return RecoDecay::eta(std::array{pxtrack1, pytrack1, pztrack1}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track1Phi, track1phi, //! daughter1 phi
                            [](float pxtrack1, float pytrack1) -> float { return RecoDecay::phi(pxtrack1, pytrack1); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track2Eta, track2eta, //! daughter2 eta
-                           [](float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::eta(array{pxtrack2, pytrack2, pztrack2}); });
+                           [](float pxtrack2, float pytrack2, float pztrack2) -> float { return RecoDecay::eta(std::array{pxtrack2, pytrack2, pztrack2}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Track2Phi, track2phi, //! daughter2 phi
                            [](float pxtrack2, float pytrack2) -> float { return RecoDecay::phi(pxtrack2, pytrack2); });
 

--- a/PWGLF/TableProducer/f1protonInitializer.cxx
+++ b/PWGLF/TableProducer/f1protonInitializer.cxx
@@ -294,16 +294,16 @@ struct f1protoninitializer {
           if (numberPiKpair == 1) {
             qaRegistry.fill(HIST("hInvMassk0"), track3.mK0Short(), track3.pt());
           }
-          pT = RecoDecay::pt(array{track1.px() + track2.px() + track3.px(), track1.py() + track2.py() + track3.py()});
-          auto arrMomF1 = array{
-            array{track1.px(), track1.py(), track1.pz()},
-            array{track2.px(), track2.py(), track2.pz()},
-            array{track3.px(), track3.py(), track3.pz()}};
-          auto arrMom23 = array{
-            array{track2.px(), track2.py(), track2.pz()},
-            array{track3.px(), track3.py(), track3.pz()}};
-          masskKs0 = RecoDecay::m(arrMom23, array{massKa, massK0s});
-          massF1 = RecoDecay::m(arrMomF1, array{massPi, massKa, massK0s});
+          pT = RecoDecay::pt(std::array{track1.px() + track2.px() + track3.px(), track1.py() + track2.py() + track3.py()});
+          auto arrMomF1 = std::array{
+            std::array{track1.px(), track1.py(), track1.pz()},
+            std::array{track2.px(), track2.py(), track2.pz()},
+            std::array{track3.px(), track3.py(), track3.pz()}};
+          auto arrMom23 = std::array{
+            std::array{track2.px(), track2.py(), track2.pz()},
+            std::array{track3.px(), track3.py(), track3.pz()}};
+          masskKs0 = RecoDecay::m(arrMom23, std::array{massKa, massK0s});
+          massF1 = RecoDecay::m(arrMomF1, std::array{massPi, massKa, massK0s});
           qaRegistry.fill(HIST("hInvMassKKs0"), masskKs0);
           if ((masskKs0 > cMaxMassKKs0) || (massF1 > cMaxMassF1) || (pT < cMinF1Pt)) {
             continue;

--- a/PWGMM/Lumi/Tasks/LumiFDDFT0.cxx
+++ b/PWGMM/Lumi/Tasks/LumiFDDFT0.cxx
@@ -46,6 +46,7 @@
 #include "CCDB/CcdbApi.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 
+using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using BCsWithTimestamps = soa::Join<aod::BCs, aod::Timestamps>;

--- a/PWGMM/Lumi/Tasks/lumi.cxx
+++ b/PWGMM/Lumi/Tasks/lumi.cxx
@@ -77,6 +77,7 @@ DECLARE_SOA_TABLE(EventInfo, "AOD", "EventInfo", full::TimeStamp, full::VertexX,
                   full::VertexChi2, full::NContrib);
 } // namespace o2::aod
 
+using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 

--- a/PWGMM/Mult/Tasks/dndeta-hi.cxx
+++ b/PWGMM/Mult/Tasks/dndeta-hi.cxx
@@ -56,6 +56,7 @@ using namespace o2::framework::expressions;
 using namespace o2::aod::track;
 
 using namespace o2::aod;
+using namespace o2::aod::evsel;
 using namespace o2::analysis;
 using namespace o2::aod::hf_cand_2prong;
 using namespace o2::aod::hf_cand_bplus;

--- a/PWGMM/Mult/Tasks/dndeta-mft.cxx
+++ b/PWGMM/Mult/Tasks/dndeta-mft.cxx
@@ -196,7 +196,7 @@ struct PseudorapidityDensityMFT {
 
     std::vector<typename std::decay_t<decltype(collisions)>::iterator> cols;
     for (auto& bc : bcs) {
-      if (!useEvSel || (useEvSel && ((bc.selection_bit(evsel::kIsBBT0A) & bc.selection_bit(evsel::kIsBBT0C)) != 0))) {
+      if (!useEvSel || (useEvSel && ((bc.selection_bit(aod::evsel::kIsBBT0A) & bc.selection_bit(aod::evsel::kIsBBT0C)) != 0))) {
         registry.fill(HIST("EventSelection"), 5.);
         cols.clear();
         for (auto& collision : collisions) {

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -27,9 +27,9 @@
 #include "bestCollisionTable.h"
 
 using namespace o2;
+using namespace o2::aod::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::aod::track;
 
 AxisSpec ZAxis = {301, -30.1, 30.1};
 AxisSpec DeltaZAxis = {61, -6.1, 6.1};
@@ -267,8 +267,8 @@ struct MultiplicityCounter {
     constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>();
     std::vector<typename std::decay_t<decltype(collisions)>::iterator> cols;
     for (auto& bc : bcs) {
-      if (!useEvSel || (bc.selection_bit(evsel::kIsBBT0A) &&
-                        bc.selection_bit(evsel::kIsBBT0C)) != 0) {
+      if (!useEvSel || (bc.selection_bit(aod::evsel::kIsBBT0A) &&
+                        bc.selection_bit(aod::evsel::kIsBBT0C)) != 0) {
         registry.fill(HIST("Events/BCSelection"), 1.);
         cols.clear();
         for (auto& collision : collisions) {

--- a/PWGUD/Core/UDHelpers.h
+++ b/PWGUD/Core/UDHelpers.h
@@ -472,25 +472,25 @@ void fillBGBBFlags(upchelpers::FITInfo& info, uint64_t const& minbc, BCR const& 
 
     // 0 <= bit <= 31
     auto bit = bc2u.globalBC() - minbc;
-    if (!bc2u.selection_bit(evsel::kNoBGT0A))
+    if (!bc2u.selection_bit(o2::aod::evsel::kNoBGT0A))
       SETBIT(info.BGFT0Apf, bit);
-    if (!bc2u.selection_bit(evsel::kNoBGT0C))
+    if (!bc2u.selection_bit(o2::aod::evsel::kNoBGT0C))
       SETBIT(info.BGFT0Cpf, bit);
-    if (bc2u.selection_bit(evsel::kIsBBT0A))
+    if (bc2u.selection_bit(o2::aod::evsel::kIsBBT0A))
       SETBIT(info.BBFT0Apf, bit);
-    if (bc2u.selection_bit(evsel::kIsBBT0C))
+    if (bc2u.selection_bit(o2::aod::evsel::kIsBBT0C))
       SETBIT(info.BBFT0Cpf, bit);
-    if (!bc2u.selection_bit(evsel::kNoBGV0A))
+    if (!bc2u.selection_bit(o2::aod::evsel::kNoBGV0A))
       SETBIT(info.BGFV0Apf, bit);
-    if (bc2u.selection_bit(evsel::kIsBBV0A))
+    if (bc2u.selection_bit(o2::aod::evsel::kIsBBV0A))
       SETBIT(info.BBFV0Apf, bit);
-    if (!bc2u.selection_bit(evsel::kNoBGFDA))
+    if (!bc2u.selection_bit(o2::aod::evsel::kNoBGFDA))
       SETBIT(info.BGFDDApf, bit);
-    if (!bc2u.selection_bit(evsel::kNoBGFDC))
+    if (!bc2u.selection_bit(o2::aod::evsel::kNoBGFDC))
       SETBIT(info.BGFDDCpf, bit);
-    if (bc2u.selection_bit(evsel::kIsBBFDA))
+    if (bc2u.selection_bit(o2::aod::evsel::kIsBBFDA))
       SETBIT(info.BBFDDApf, bit);
-    if (bc2u.selection_bit(evsel::kIsBBFDC))
+    if (bc2u.selection_bit(o2::aod::evsel::kIsBBFDC))
       SETBIT(info.BBFDDCpf, bit);
   }
 }

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -381,13 +381,13 @@ struct UpcCandProducer {
         for (auto amp : ampsC)
           fitInfo.ampFT0C += amp;
         fitInfo.triggerMaskFT0 = ft0.triggerMask();
-        if (!bc.selection_bit(evsel::kNoBGT0A))
+        if (!bc.selection_bit(o2::aod::evsel::kNoBGT0A))
           SETBIT(fitInfo.BGFT0Apf, bit);
-        if (!bc.selection_bit(evsel::kNoBGT0C))
+        if (!bc.selection_bit(o2::aod::evsel::kNoBGT0C))
           SETBIT(fitInfo.BGFT0Cpf, bit);
-        if (bc.selection_bit(evsel::kIsBBT0A))
+        if (bc.selection_bit(o2::aod::evsel::kIsBBT0A))
           SETBIT(fitInfo.BBFT0Apf, bit);
-        if (bc.selection_bit(evsel::kIsBBT0C))
+        if (bc.selection_bit(o2::aod::evsel::kIsBBT0C))
           SETBIT(fitInfo.BBFT0Cpf, bit);
       }
       if (bc.has_foundFV0()) {
@@ -398,9 +398,9 @@ struct UpcCandProducer {
         for (auto amp : amps)
           fitInfo.ampFV0A += amp;
         fitInfo.triggerMaskFV0A = fv0a.triggerMask();
-        if (!bc.selection_bit(evsel::kNoBGV0A))
+        if (!bc.selection_bit(o2::aod::evsel::kNoBGV0A))
           SETBIT(fitInfo.BGFV0Apf, bit);
-        if (bc.selection_bit(evsel::kIsBBV0A))
+        if (bc.selection_bit(o2::aod::evsel::kIsBBV0A))
           SETBIT(fitInfo.BBFV0Apf, bit);
       }
       if (bc.has_foundFDD()) {
@@ -418,13 +418,13 @@ struct UpcCandProducer {
           fitInfo.ampFDDC += amp;
         }
         fitInfo.triggerMaskFDD = fdd.triggerMask();
-        if (!bc.selection_bit(evsel::kNoBGFDA))
+        if (!bc.selection_bit(o2::aod::evsel::kNoBGFDA))
           SETBIT(fitInfo.BGFDDApf, bit);
-        if (!bc.selection_bit(evsel::kNoBGFDC))
+        if (!bc.selection_bit(o2::aod::evsel::kNoBGFDC))
           SETBIT(fitInfo.BGFDDCpf, bit);
-        if (bc.selection_bit(evsel::kIsBBFDA))
+        if (bc.selection_bit(o2::aod::evsel::kIsBBFDA))
           SETBIT(fitInfo.BBFDDApf, bit);
-        if (bc.selection_bit(evsel::kIsBBFDC))
+        if (bc.selection_bit(o2::aod::evsel::kIsBBFDC))
           SETBIT(fitInfo.BBFDDCpf, bit);
       }
       ++curit;

--- a/PWGUD/Tasks/diffMCDataScanner.cxx
+++ b/PWGUD/Tasks/diffMCDataScanner.cxx
@@ -199,7 +199,7 @@ struct BCInfo {
     {{"numberCollisions", "#numberCollisions", {HistType::kTH1F, {{11, -0.5, 10.5}}}},
      {"numberCollisionsGT", "#numberCollisionsGT", {HistType::kTH1F, {{11, -0.5, 10.5}}}},
      {"Aliases", "#Aliases", {HistType::kTH1F, {{kNaliases, 0., kNaliases}}}},
-     {"Selection", "#Selection", {HistType::kTH1F, {{evsel::kNsel, 0., evsel::kNsel}}}},
+     {"Selection", "#Selection", {HistType::kTH1F, {{aod::evsel::kNsel, 0., aod::evsel::kNsel}}}},
      {"DetectorSignals", "#DetectorSignals", {HistType::kTH1F, {{6, 0., 6}}}}}};
 
   void init(o2::framework::InitContext&)
@@ -231,7 +231,7 @@ struct BCInfo {
     }
 
     // update Selection
-    for (auto ii = 0; ii < evsel::kNsel; ii++) {
+    for (auto ii = 0; ii < aod::evsel::kNsel; ii++) {
       registry.get<TH1>(HIST("Selection"))->Fill(ii, bc.selection_bit(ii));
     }
 

--- a/PWGUD/Tasks/upcAnalysis.cxx
+++ b/PWGUD/Tasks/upcAnalysis.cxx
@@ -21,6 +21,7 @@
 #include "TLorentzVector.h"
 
 using namespace o2;
+using namespace o2::aod::evsel;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 

--- a/PWGUD/Tasks/upcForward.cxx
+++ b/PWGUD/Tasks/upcForward.cxx
@@ -24,11 +24,15 @@ alien:///alice/data/2015/LHC15o/000246392/pass5_lowIR/PWGZZ/Run3_Conversion/148_
 #include <TString.h>
 #include "TLorentzVector.h"
 #include "Common/CCDB/TriggerAliases.h"
+
 using namespace std;
 using namespace o2;
+using namespace o2::aod::evsel;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+
 #define mmuon 0.1057 // mass of muon
+
 struct UPCForward {
   // defining histograms using histogram registry
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/Tools/KFparticle/KFUtilities.h
+++ b/Tools/KFparticle/KFUtilities.h
@@ -56,9 +56,9 @@ KFPTrack createKFPTrack(const o2::track::TrackParametrizationWithError<float>& t
                         int16_t tpcNClsFound,
                         float tpcChi2NCl)
 {
-  array<float, 3> trkpos_par;
-  array<float, 3> trkmom_par;
-  array<float, 21> trk_cov;
+  std::array<float, 3> trkpos_par;
+  std::array<float, 3> trkmom_par;
+  std::array<float, 21> trk_cov;
   trackparCov.getXYZGlo(trkpos_par);
   trackparCov.getPxPyPzGlo(trkmom_par);
   trackparCov.getCovXYZPxPyPzGlo(trk_cov);
@@ -123,7 +123,7 @@ float cpaFromKF(KFParticle kfp, KFParticle PV)
   py = kfp.GetPy();
   pz = kfp.GetPz();
 
-  float cpa = RecoDecay::cpa(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz});
+  float cpa = RecoDecay::cpa(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}, std::array{px, py, pz});
   return cpa;
 }
 
@@ -144,7 +144,7 @@ float cpaXYFromKF(KFParticle kfp, KFParticle PV)
   px = kfp.GetPx();
   py = kfp.GetPy();
 
-  float cpaXY = RecoDecay::cpaXY(array{xVtxP, yVtxP}, array{xVtxS, yVtxS}, array{px, py});
+  float cpaXY = RecoDecay::cpaXY(std::array{xVtxP, yVtxP}, std::array{xVtxS, yVtxS}, std::array{px, py});
   return cpaXY;
 }
 
@@ -168,13 +168,13 @@ float cosThetaStarFromKF(int ip, int pdgvtx, int pdgprong0, int pdgprong1, KFPar
   px1 = kfpprong1.GetPx();
   py1 = kfpprong1.GetPy();
   pz1 = kfpprong1.GetPz();
-  array<double, 2> m = {0., 0.};
+  std::array<double, 2> m = {0., 0.};
   m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass();
   m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass();
   double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass();
   int iProng = ip;
 
-  float cosThetastar = RecoDecay::cosThetaStar(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m, mTot, iProng);
+  float cosThetastar = RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng);
   return cosThetastar;
 }
 
@@ -200,7 +200,7 @@ float impParXYFromKF(KFParticle kfpParticle, KFParticle Vertex)
   py = kfpParticle.GetPy();
   pz = kfpParticle.GetPz();
 
-  float impParXY = RecoDecay::impParXY(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz});
+  float impParXY = RecoDecay::impParXY(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}, std::array{px, py, pz});
   return impParXY;
 }
 

--- a/Tools/KFparticle/qaKFEventTrack.h
+++ b/Tools/KFparticle/qaKFEventTrack.h
@@ -14,12 +14,10 @@
 
 #ifndef TOOLS_KFPARTICLE_QAKFEVENTTRACK_H_
 #define TOOLS_KFPARTICLE_QAKFEVENTTRACK_H_
+
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Common/Core/trackUtilities.h"
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::track;
 
 enum FlagsTracks {
   kITS = BIT(0),

--- a/Tools/KFparticle/qaKFParticle.h
+++ b/Tools/KFparticle/qaKFParticle.h
@@ -14,12 +14,10 @@
 
 #ifndef TOOLS_KFPARTICLE_QAKFPARTICLE_H_
 #define TOOLS_KFPARTICLE_QAKFPARTICLE_H_
+
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Common/Core/trackUtilities.h"
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::track;
 
 enum Source {
   kPrompt = BIT(0),

--- a/Tools/KFparticle/qaKFParticleLc.h
+++ b/Tools/KFparticle/qaKFParticleLc.h
@@ -14,12 +14,10 @@
 
 #ifndef TOOLS_KFPARTICLE_QAKFPARTICLELC_H_
 #define TOOLS_KFPARTICLE_QAKFPARTICLELC_H_
+
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Common/Core/trackUtilities.h"
-using namespace o2;
-using namespace o2::framework;
-using namespace o2::track;
 
 enum Source {
   kPrompt = BIT(0),

--- a/Tools/PIDML/pidML.h
+++ b/Tools/PIDML/pidML.h
@@ -20,8 +20,6 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Common/DataModel/PIDResponse.h"
 
-using namespace o2;
-
 namespace o2::aod
 {
 namespace pidtracks

--- a/Tools/PIDML/pidOnnxInterface.h
+++ b/Tools/PIDML/pidOnnxInterface.h
@@ -45,11 +45,8 @@ static const std::vector<std::string> cutVarLabels = {
   "TPC", "TPC + TOF", "TPC + TOF + TRD"};
 } // namespace pidml_pt_cuts
 
-using namespace pidml_pt_cuts;
-using namespace o2::framework;
-
 struct PidONNXInterface {
-  PidONNXInterface(std::string& localPath, std::string& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi& ccdbApi, uint64_t timestamp, std::vector<int> const& pids, LabeledArray<double> const& pTLimits, std::vector<double> const& minCertainties, bool autoMode) : mNPids{pids.size()}, mPTLimits{pTLimits}
+  PidONNXInterface(std::string& localPath, std::string& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi& ccdbApi, uint64_t timestamp, std::vector<int> const& pids, o2::framework::LabeledArray<double> const& pTLimits, std::vector<double> const& minCertainties, bool autoMode) : mNPids{pids.size()}, mPTLimits{pTLimits}
   {
     if (pids.size() == 0) {
       LOG(fatal) << "PID ML Interface needs at least 1 output pid to predict";
@@ -119,12 +116,12 @@ struct PidONNXInterface {
   void fillDefaultConfiguration(std::vector<double>& minCertainties)
   {
     // FIXME: A more sophisticated strategy should be based on pid values as well
-    mPTLimits = LabeledArray{cuts[0], nPids, nCutVars, pidLabels, cutVarLabels};
+    mPTLimits = o2::framework::LabeledArray{pidml_pt_cuts::cuts[0], pidml_pt_cuts::nPids, pidml_pt_cuts::nCutVars, pidml_pt_cuts::pidLabels, pidml_pt_cuts::cutVarLabels};
     minCertainties = std::vector<double>(mNPids, 0.5);
   }
 
   std::vector<PidONNXModel> mModels;
   std::size_t mNPids;
-  LabeledArray<double> mPTLimits;
+  o2::framework::LabeledArray<double> mPTLimits;
 };
 #endif // TOOLS_PIDML_PIDONNXINTERFACE_H_

--- a/Tutorials/PWGHF/taskMini.cxx
+++ b/Tutorials/PWGHF/taskMini.cxx
@@ -201,8 +201,8 @@ struct HfTrackIndexSkimCreator {
         //  get secondary vertex
         const auto& secondaryVertex = df2.getPCACandidate();
         // get track momenta
-        array<float, 3> pVec0;
-        array<float, 3> pVec1;
+        std::array<float, 3> pVec0;
+        std::array<float, 3> pVec1;
         df2.getTrack(0).getPxPyPzGlo(pVec0);
         df2.getTrack(1).getPxPyPzGlo(pVec1);
 
@@ -251,7 +251,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtProng1, ptProng1, //! pt of prong 1
                            [](float px, float py) -> float { return RecoDecay::pt(px, py); });
 // candidate properties
 DECLARE_SOA_DYNAMIC_COLUMN(DecayLength, decayLength, //! decay length of candidate
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS) -> float { return RecoDecay::distance(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS) -> float { return RecoDecay::distance(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}); });
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! pt of candidate
                            [](float px, float py) -> float { return RecoDecay::pt(px, py); });
 DECLARE_SOA_EXPRESSION_COLUMN(Px, px, //! px of candidate
@@ -261,9 +261,9 @@ DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //! py of candidate
 DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //! pz of candidate
                               float, 1.f * pzProng0 + 1.f * pzProng1);
 DECLARE_SOA_DYNAMIC_COLUMN(M, m, //! invariant mass of candidate
-                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const array<double, 2>& m) -> float { return RecoDecay::m(array{array{px0, py0, pz0}, array{px1, py1, pz1}}, m); });
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, const std::array<double, 2>& m) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m); });
 DECLARE_SOA_DYNAMIC_COLUMN(CPA, cpa, //! cosine of pointing angle of candidate
-                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::cpa(array{xVtxP, yVtxP, zVtxP}, array{xVtxS, yVtxS, zVtxS}, array{px, py, pz}); });
+                           [](float xVtxP, float yVtxP, float zVtxP, float xVtxS, float yVtxS, float zVtxS, float px, float py, float pz) -> float { return RecoDecay::cpa(std::array{xVtxP, yVtxP, zVtxP}, std::array{xVtxS, yVtxS, zVtxS}, std::array{px, py, pz}); });
 
 /// @brief Invariant mass of a D0 -> π K candidate
 /// @tparam T
@@ -272,7 +272,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(CPA, cpa, //! cosine of pointing angle of candidate
 template <typename T>
 auto invMassD0(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kPiPlus), RecoDecay::getMassPDG(kKPlus)});
 }
 
 /// @brief Invariant mass of a D0bar -> K π candidate
@@ -282,7 +282,7 @@ auto invMassD0(const T& candidate)
 template <typename T>
 auto invMassD0bar(const T& candidate)
 {
-  return candidate.m(array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
+  return candidate.m(std::array{RecoDecay::getMassPDG(kKPlus), RecoDecay::getMassPDG(kPiPlus)});
 }
 } // namespace hf_cand_prong2
 
@@ -363,8 +363,8 @@ struct HfCandidateCreator2Prong {
       auto trackParVar1 = df.getTrack(1);
 
       // get track momenta
-      array<float, 3> pVec0;
-      array<float, 3> pVec1;
+      std::array<float, 3> pVec0;
+      std::array<float, 3> pVec1;
       trackParVar0.getPxPyPzGlo(pVec0);
       trackParVar1.getPxPyPzGlo(pVec1);
 

--- a/Tutorials/Skimming/spectraUPCProvider.cxx
+++ b/Tutorials/Skimming/spectraUPCProvider.cxx
@@ -24,6 +24,7 @@
 #include "DataModel/UDDerived.h"
 
 using namespace o2;
+using namespace o2::aod::evsel;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 

--- a/Tutorials/Skimming/spectraUPCReference.cxx
+++ b/Tutorials/Skimming/spectraUPCReference.cxx
@@ -22,6 +22,7 @@
 #include "TLorentzVector.h"
 
 using namespace o2;
+using namespace o2::aod::evsel;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 


### PR DESCRIPTION
Using-directives should never appear in headers because they irreversibly pollute the global namespace wherever they are included and can lead to unexpected behaviour, such as name conflicts. See [O2 CodingGuidelines](https://rawgit.com/AliceO2Group/CodingGuidelines/master/coding_guidelines.html?showone=Using_declarations_and_directives#Using_declarations_and_directives).

In fact, the `evsel` namespace was indeed defined ambiguously, once as `o2::aod::evsel` in `EventSelection.h` and another time as just `evsel` in `EventSelectionParams.h`. Maybe @ekryshen can comment whether this was intentional or not.

@ddobrigk I think we should have a CI check that forbids `using namespace` in header files. That would require fixing remaining occurrences in the PWG directories (which I did not do in this PR).