### PR TITLE
PWGCF: FemtoUniverse -- Removing unused configurables from MC producer + fixing names in track-Phi

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
@@ -68,7 +68,7 @@ class FemtoUniverseParticleHisto
   void init_debug(std::string folderName)
   {
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtouniverseMCparticle::MCTypeName[mc]).c_str();
-    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kMCTruthTrack) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hCharge").c_str(), "; Charge; Entries", kTH1F, {{5, -2.5, 2.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
@@ -123,7 +123,7 @@ class FemtoUniverseParticleHisto
 
     mHistogramRegistry->add((folderName + folderSuffix + "/hPt_ReconNoFake").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{240, 0, 6}});
 
-    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kMCTruthTrack) {
       /// Track histograms
       mHistogramRegistry->add((folderName + folderSuffix + "/hPDG").c_str(), "; PDG; Entries", kTH1I, {{6001, -3000, 3000}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{7, 0, 7}});
@@ -167,6 +167,9 @@ class FemtoUniverseParticleHisto
       if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child) {
         /// Track histograms
         tempFitVarAxisTitle = "DCA_{xy} (cm)";
+      } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kMCTruthTrack) {
+        /// MC Truth Track histograms
+        tempFitVarAxisTitle = "PDG code";
       } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0) {
         /// V0 histograms
         tempFitVarAxisTitle = "cos#alpha";
@@ -175,7 +178,7 @@ class FemtoUniverseParticleHisto
         tempFitVarAxisTitle = "cos#alpha";
       } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
         // Phi histograms
-        tempFitVarAxisTitle = "InvMass";
+        tempFitVarAxisTitle = "#Phi invariant mass";
       } else {
         LOG(fatal) << "FemtoUniverseParticleHisto: Histogramming for requested object not defined - quitting!";
       }
@@ -220,7 +223,7 @@ class FemtoUniverseParticleHisto
   void fillQA_debug(T const& part)
   {
     // Histograms holding further debug information
-    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kMCTruthTrack) {
       mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hCharge"), part.sign());
       mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
       mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtouniverseMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());
@@ -278,7 +281,7 @@ class FemtoUniverseParticleHisto
         mHistogramRegistry->fill(HIST(o2::aod::femtouniverseparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_ReconNoFake"), part.pt());
       }
 
-      if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child) {
+      if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kTrack || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtouniverseparticle::ParticleType::kMCTruthTrack) {
         /// Track histograms
         switch (mctruthorigin) {
           case (o2::aod::femtouniverseMCparticle::kPrimary):

--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -49,6 +49,7 @@ namespace femtouniverseparticle
 /// Distinuishes the different particle types
 enum ParticleType {
   kTrack,           //! Track
+  kMCTruthTrack,    //! MC Truth Track
   kV0,              //! V0
   kV0Child,         //! Child track of a V0
   kCascade,         //! Cascade
@@ -58,8 +59,8 @@ enum ParticleType {
   kNParticleTypes   //! Number of particle types
 };
 
-static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeBachelor", "kPhi", "kPhiChild"}; //! Naming of the different particle types
-static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy"};
+static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "MCTruthTracks", "V0", "V0Child", "Cascade", "CascadeBachelor", "Phi", "PhiChild"}; //! Naming of the different particle types
+static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hPDGvspT", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy"};
 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
@@ -12,6 +12,7 @@
 /// \file femtoUniverseProducerMCTruthTask.cxx
 /// \brief Tasks that produces the track tables used for the pairing
 /// \author Malgorzata Janik, WUT Warsaw, majanik@cern.ch
+/// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
 
 #include <CCDB/BasicCCDBManager.h>
 #include "Common/Core/trackUtilities.h"
@@ -48,9 +49,6 @@ namespace o2::aod
 
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 
-// using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
-// table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
-// to be used when we add v0Filter
 } // namespace o2::aod
 
 /// \todo fix how to pass array to setSelection, getRow() passing a different
@@ -74,58 +72,42 @@ int getRowDaughters(int daughID, T const& vecID)
 }
 
 struct femtoUniverseProducerMCTruthTask {
-
   int evCount = 0;
+  int mRunNumber;
+  float mMagField;
+  Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
+
+  // Tables being produced
   Produces<aod::FDCollisions> outputCollision;
   Produces<aod::FDParticles> outputParts;
-  /*
-  Produces<aod::FDMCParticles> outputPartsMC;
-  Produces<aod::FDExtParticles> outputDebugParts;
-  Produces<aod::FDMCLabels> outputPartsMCLabels;
-  Produces<aod::FDExtMCParticles> outputDebugPartsMC;
-*/
-  Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
-  // Choose if filtering or skimming version is run
-  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"};
-  // Choose if running on converted data or Run3  / Pilot
+
+  // Analysis configs
+  Configurable<bool> ConfIsTrigger{"ConfIsTrigger", false, "Store all collisions"}; // Choose if filtering or skimming version is run
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Running on MC; implemented only for Run3"};
   Configurable<bool> ConfIsForceGRP{"ConfIsForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
+  Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtouniverse tables"};
+  Configurable<bool> ConfIsActivatePhi{"ConfIsActivatePhi", true, "Activate filling of Phi into femtouniverse tables"};
+  Configurable<std::vector<int>> ConfPDGCodes{"ConfPDGCodes", std::vector<int>{211, -211, 2212, -2212, 333}, "PDG of particles to be stored"};
+  Configurable<bool> ConfAnalysisWithPID{"ConfAnalysisWithPID", true, "1: take only particles with specified PDG, 0: all particles"};
 
   /// Event cuts
-  FemtoUniverseCollisionSelection colCuts;
   Configurable<bool> ConfEvtUseTPCmult{"ConfEvtUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
   Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
-  Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtouniverse tables"};
-  Configurable<bool> ConfIsActivatePhi{"ConfIsActivatePhi", true, "Activate filling of Phi into femtouniverse tables"};
 
-  Configurable<std::vector<int>> ConfPDGCodes{"ConfPDGCodes", std::vector<int>{211, -211, 2212, -2212}, "PDG of particles to be stored"};
-  Configurable<bool> ConfAnalysisWithPID{"ConfAnalysisWithPID", true, "1: take only particles with specified PDG, 0: all particles"};
-
-  FemtoUniverseTrackSelection trackCuts;
-
+  // Track cuts
   struct : o2::framework::ConfigurableGroup {
     Configurable<float> ConfPtLowFilterCut{"ConfPtLowFilterCut", 0.14, "Lower limit for Pt for the filtering tracks"};   // pT low
     Configurable<float> ConfPtHighFilterCut{"ConfPtHighFilterCut", 5.0, "Higher limit for Pt for the filtering tracks"}; // pT high
     Configurable<float> ConfEtaFilterCut{"ConfEtaFilterCut", 0.8, "Eta cut for the filtering tracks"};
   } ConfFilteringTracks;
 
-  Configurable<std::vector<float>> ConfTrkCharge{FemtoUniverseTrackSelection::getSelectionName(femtoUniverseTrackSelection::kSign, "ConfTrk"), std::vector<float>{-1, 1}, FemtoUniverseTrackSelection::getSelectionHelper(femtoUniverseTrackSelection::kSign, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmin{FemtoUniverseTrackSelection::getSelectionName(femtoUniverseTrackSelection::kpTMin, "ConfTrk"), std::vector<float>{0.5f, 0.4f, 0.6f}, FemtoUniverseTrackSelection::getSelectionHelper(femtoUniverseTrackSelection::kpTMin, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkPtmax{
-    FemtoUniverseTrackSelection::getSelectionName(femtoUniverseTrackSelection::kpTMax, "ConfTrk"), std::vector<float>{5.4f, 5.6f, 5.5f}, FemtoUniverseTrackSelection::getSelectionHelper(femtoUniverseTrackSelection::kpTMax, "Track selection: ")};
-  Configurable<std::vector<float>> ConfTrkEta{FemtoUniverseTrackSelection::getSelectionName(femtoUniverseTrackSelection::kEtaMax, "ConfTrk"), std::vector<float>{0.8f, 0.7f, 0.9f}, FemtoUniverseTrackSelection::getSelectionHelper(femtoUniverseTrackSelection::kEtaMax, "Track selection: ")};
-  Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
-  // Numbers from ~/alice/O2/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h //static constexpr ID Pion = 2; static constexpr ID Kaon = 3; static constexpr ID Proton = 4; static constexpr ID Deuteron = 5;
-
+  FemtoUniverseCollisionSelection colCuts;
+  FemtoUniverseTrackSelection trackCuts;
   HistogramRegistry qaRegistry{"QAHistos", {}, OutputObjHandlingPolicy::QAObject};
-
-  int mRunNumber;
-  float mMagField;
-  Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
 
   void init(InitContext&)
   {
@@ -136,21 +118,15 @@ struct femtoUniverseProducerMCTruthTask {
     colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
 
     colCuts.init(&qaRegistry);
-
-    // trackCuts.setSelection(ConfTrkCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
-    // trackCuts.setSelection(ConfTrkPtmin, femtoDreamTrackSelection::kpTMin, femtoDreamSelection::kLowerLimit);
-    // trackCuts.setSelection(ConfTrkPtmax, femtoDreamTrackSelection::kpTMax, femtoDreamSelection::kUpperLimit);
-    // trackCuts.setSelection(ConfTrkEta, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
-
     trackCuts.init<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::TrackType::kNoChild, aod::femtouniverseparticle::cutContainerType>(&qaRegistry);
 
     mRunNumber = 0;
     mMagField = 0.0;
+
     /// Initializing CCDB
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
-
     int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
   }
@@ -158,7 +134,6 @@ struct femtoUniverseProducerMCTruthTask {
   template <typename CollisionType, typename TrackType>
   void fillCollisions(CollisionType const& col, TrackType const& tracks)
   {
-
     const auto vtxZ = col.posZ();
     const auto spher = 0; // colCuts.computeSphericity(col, tracks);
     int mult = 0;
@@ -174,6 +149,7 @@ struct femtoUniverseProducerMCTruthTask {
     if (ConfEvtUseTPCmult) {
       multNtr = col.multTPC();
     }
+
     // check whether the basic event selection criteria are fulfilled
     // if the basic selection is NOT fulfilled:
     // in case of skimming run - don't store such collisions
@@ -187,6 +163,7 @@ struct femtoUniverseProducerMCTruthTask {
     //    }
     //    return;
     //  }
+
     colCuts.fillQA(col);
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
   }
@@ -207,13 +184,15 @@ struct femtoUniverseProducerMCTruthTask {
         continue;
 
       uint32_t pdgCode = (uint32_t)particle.pdgCode();
+
       if (ConfAnalysisWithPID) {
         bool pass = false;
         std::vector<int> tmpPDGCodes = ConfPDGCodes; // necessary due to some features of the Configurable
         for (uint32_t pdg : tmpPDGCodes) {
-          // LOGF(info,"%d %d",pdg,pdgCode);
-          if (static_cast<int>(pdg) == static_cast<int>(pdgCode))
+          if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
             pass = true;
+            continue;
+          }
         }
         if (!pass)
           continue;
@@ -248,7 +227,6 @@ struct femtoUniverseProducerMCTruthTask {
       return;
     evCount++;
     // magnetic field for run not needed for mc truth
-
     // fill the tables
     fillCollisions(col, mcParticles);
     fillParticles(mcParticles);

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
@@ -191,12 +191,12 @@ struct femtoUniverseProducerMCTruthTask {
         for (uint32_t pdg : tmpPDGCodes) {
           if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
             pass = true;
-            continue;
           }
         }
         if (!pass)
           continue;
       }
+
       // we cannot use isSelectedMinimal since it takes Ncls
       // if (!trackCuts.isSelectedMinimal(track)) {
       //   continue;
@@ -209,11 +209,17 @@ struct femtoUniverseProducerMCTruthTask {
       // instead of the bitmask, the PDG of the particle is stored as uint32_t
 
       // now the table is filled
-      outputParts(outputCollision.lastIndex(), particle.pt(), particle.eta(),
-                  particle.phi(), aod::femtouniverseparticle::ParticleType::kTrack,
+      outputParts(outputCollision.lastIndex(),
+                  particle.pt(),
+                  particle.eta(),
+                  particle.phi(),
+                  aod::femtouniverseparticle::ParticleType::kMCTruthTrack,
                   0,
                   pdgCode,
-                  0, childIDs, 0, 0);
+                  pdgCode,
+                  childIDs,
+                  0,
+                  0);
     }
   }
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
@@ -48,7 +48,7 @@ namespace
 {
 static constexpr int nPart = 2;
 static constexpr int nCuts = 5;
-static const std::vector<std::string> partNames{"PartOne", "PartTwo"};
+static const std::vector<std::string> partNames{"PhiCandidate", "Hadron"};
 static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
 static const float cutsTable[nPart][nCuts]{
   {4.05f, 1.f, 3.f, 3.f, 100.f},
@@ -87,7 +87,7 @@ struct femtoUniversePairTaskTrackPhi {
   struct : o2::framework::ConfigurableGroup {
     Configurable<int> ConfTrackChoiceHadron{"ConfTrackChoiceHadron", 0, "Type of particle (track): {0:Proton, 1:Pion, 2:Kaon}"};
     Configurable<int> ConfPDGCodeHadron{"ConfPDGCodeHadron", 2212, "Particle 2 - PDG code"};
-    // Configurable<uint32_t> ConfCutPartTwo{"ConfCutPartTwo", 5542474, "Particle 2 - Selection bit"};
+    // Configurable<uint32_t> ConfCutHadron{"ConfCutHadron", 5542474, "Particle 2 - Selection bit"};
     Configurable<int> ConfPIDHadron{"ConfPIDHadron", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
   } trackHadronfilter;
 
@@ -118,7 +118,7 @@ struct femtoUniversePairTaskTrackPhi {
   FemtoUniverseEventHisto eventHisto;
 
   /// The configurables need to be passed to an std::vector
-  int vPIDPartOne, vPIDPartTwo;
+  int vPIDPhiCandidate, vPIDHadron;
   std::vector<float> kNsigma;
 
   /// particle part
@@ -293,8 +293,8 @@ struct femtoUniversePairTaskTrackPhi {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
 
-    vPIDPartOne = trackPhifilter.ConfPIDPhi.value;
-    vPIDPartTwo = trackHadronfilter.ConfPIDHadron.value;
+    vPIDPhiCandidate = trackPhifilter.ConfPIDPhi.value;
+    vPIDHadron = trackHadronfilter.ConfPIDHadron.value;
     kNsigma = twotracksconfigs.ConfTrkPIDnSigmaMax.value;
   }
 
@@ -326,17 +326,17 @@ struct femtoUniversePairTaskTrackPhi {
 
     if (!ConfIsSame) {
       for (auto& hadron : groupPartsHadron) {
-        // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+        // if (hadron.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
         //   continue;
         // }
         // if (!isFullPIDSelected(hadron.pidcut(),
         //                        hadron.p(),
-        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
-        //                        vPIDPartTwo,
+        //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
+        //                        vPIDHadron,
         //                        twotracksconfigs.ConfNspecies,
         //                        kNsigma,
-        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
-        //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+        //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
+        //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
         //   continue;
         // }
         if (!IsParticleNSigma(hadron.p(), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Kaon))) {
@@ -347,25 +347,25 @@ struct femtoUniversePairTaskTrackPhi {
     }
     /// Now build the combinations
     for (auto& [hadron, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsHadron, groupPartsPhi))) {
-      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
       //   continue;
       // }
       // if (!isFullPIDSelected(hadron.pidcut(),
       //                        hadron.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
-      //                        vPIDPartOne,
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "PIDthr"),
+      //                        vPIDPhiCandidate,
       //                        twotracksconfigs.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
       //     !isFullPIDSelected(phicandidate.pidcut(),
       //                        phicandidate.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
-      //                        vPIDPartTwo,
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
+      //                        vPIDHadron,
       //                        twotracksconfigs.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
       //   continue;
       // }
 
@@ -436,25 +436,25 @@ struct femtoUniversePairTaskTrackPhi {
   {
 
     for (auto& [hadron, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsHadron, groupPartsPhi))) {
-      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PartOne", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("PartTwo", "MaxPt")) {
+      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
       //   continue;
       // }
       // if (!isFullPIDSelected(hadron.pidcut(),
       //                        hadron.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "PIDthr"),
-      //                        vPIDPartOne,
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "PIDthr"),
+      //                        vPIDPhiCandidate,
       //                        twotracksconfigs.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PartOne", "nSigmaTPCTOF")) ||
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
       //     !isFullPIDSelected(phicandidate.pidcut(),
       //                        phicandidate.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "PIDthr"),
-      //                        vPIDPartTwo,
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
+      //                        vPIDHadron,
       //                        twotracksconfigs.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PartTwo", "nSigmaTPCTOF"))) {
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
+      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
       //   continue;
       // }
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
@@ -48,7 +48,7 @@ namespace
 {
 static constexpr int nPart = 2;
 static constexpr int nCuts = 5;
-static const std::vector<std::string> partNames{"PhiCandidate", "Hadron"};
+static const std::vector<std::string> partNames{"PhiCandidate", "Track"};
 static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
 static const float cutsTable[nPart][nCuts]{
   {4.05f, 1.f, 3.f, 3.f, 100.f},
@@ -60,8 +60,6 @@ struct femtoUniversePairTaskTrackPhi {
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   SliceCache cache;
   Preslice<FemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
-
-  /// Particle selection part
 
   /// Table for both particles
   struct : o2::framework::ConfigurableGroup {
@@ -79,37 +77,36 @@ struct femtoUniversePairTaskTrackPhi {
     Configurable<bool> ConfUse3D{"ConfUse3D", false, "Enable three dimensional histogramms (to be used only for analysis with high statistics): k* vs mT vs multiplicity"};
     Configurable<int> ConfPhiBins{"ConfPhiBins", 29, "Number of phi bins in deta dphi"};
     Configurable<int> ConfEtaBins{"ConfEtaBins", 29, "Number of eta bins in deta dphi"};
+  } ConfBothTracks;
 
-  } twotracksconfigs;
-
-  /// Particle 1 --- IDENTIFIED HADRON
-  Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
+  /// Particle 1 --- IDENTIFIED TRACK
   struct : o2::framework::ConfigurableGroup {
-    Configurable<int> ConfTrackChoiceHadron{"ConfTrackChoiceHadron", 0, "Type of particle (track): {0:Proton, 1:Pion, 2:Kaon}"};
-    Configurable<int> ConfPDGCodeHadron{"ConfPDGCodeHadron", 2212, "Particle 2 - PDG code"};
-    // Configurable<uint32_t> ConfCutHadron{"ConfCutHadron", 5542474, "Particle 2 - Selection bit"};
-    Configurable<int> ConfPIDHadron{"ConfPIDHadron", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
-  } trackHadronfilter;
-
-  /// Partition for particle 1
-  Partition<FemtoFullParticles> partsHadron = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
-  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsHadronMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
-
-  /// Histogramming for particle 1
-  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartHadron;
+    Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
+    Configurable<int> ConfTrackChoiceTrack{"ConfTrackChoiceTrack", 0, "Type of particle (track): {0:Proton, 1:Pion, 2:Kaon}"};
+    Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "Particle 2 - PDG code"};
+    // Configurable<uint32_t> ConfCutTrack{"ConfCutTrack", 5542474, "Particle 2 - Selection bit"};
+    Configurable<int> ConfPIDTrack{"ConfPIDTrack", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
+  } ConfTrack;
 
   /// Particle 2 --- PHI
   struct : o2::framework::ConfigurableGroup {
     Configurable<int> ConfPDGCodePhi{"ConfPDGCodePhi", 333, "Phi meson - PDG code"};
     Configurable<uint32_t> ConfCutPhi{"ConfCutPhi", 5542474, "Phi meson - Selection bit from cutCulator"};
-    Configurable<int> ConfPIDPhi{"ConfPIDPhi", 2, "Phi meson - Read from cutCulator"};           // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
-    Configurable<float> cfgPtLowPhi{"cfgPtLowPhi", 0.5, "Lower limit for Pt for the Phi meson"}; // change according to wrzesa cuts
-    Configurable<float> cfgPtHighPhi{"cfgPtHighPhi", 1.5, "Higher limit for Pt for the Phi meson"};
-  } trackPhifilter;
+    Configurable<int> ConfPIDPhi{"ConfPIDPhi", 2, "Phi meson - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>int>>
+    // Configurable<float> ConfPtLowPhi{"ConfPtLowPhi", 0.5, "Lower limit for Pt for the Phi meson"}; // change according to wrzesa cuts
+    // Configurable<float> ConfPtHighPhi{"ConfPtHighPhi", 1.5, "Higher limit for Pt for the Phi meson"};
+  } ConfPhi;
 
-  /// Partition for particle 2
+  /// Partitions for particle 1
+  Partition<FemtoFullParticles> partsTrack = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsTrackMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
+
+  /// Partitions for particle 2
   Partition<FemtoFullParticles> partsPhi = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kPhi));
   Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsPhiMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kPhi));
+
+  /// Histogramming for particle 1
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartTrack;
 
   /// Histogramming for particle 2
   FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kPhi, 0> trackHistoPartPhi;
@@ -118,7 +115,7 @@ struct femtoUniversePairTaskTrackPhi {
   FemtoUniverseEventHisto eventHisto;
 
   /// The configurables need to be passed to an std::vector
-  int vPIDPhiCandidate, vPIDHadron;
+  int vPIDPhiCandidate, vPIDTrack;
   std::vector<float> kNsigma;
 
   /// particle part
@@ -130,9 +127,8 @@ struct femtoUniversePairTaskTrackPhi {
   ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
   // ConfigurableAxis ConfMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
   ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
-
-  ConfigurableAxis ConfmTBins3D{"ConfmTBins3D", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<twotracksconfigs.ConfUse3D>> to true in order to use)"};
-  ConfigurableAxis ConfmultBins3D{"ConfmultBins3D", {VARIABLE_WIDTH, 0.0f, 20.0f, 30.0f, 40.0f, 99999.0f}, "multiplicity Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<twotracksconfigs.ConfUse3D>> to true in order to use)"};
+  ConfigurableAxis ConfmTBins3D{"ConfmTBins3D", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfBothTracks.ConfUse3D>> to true in order to use)"};
+  ConfigurableAxis ConfmultBins3D{"ConfmultBins3D", {VARIABLE_WIDTH, 0.0f, 20.0f, 30.0f, 40.0f, 99999.0f}, "multiplicity Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfBothTracks.ConfUse3D>> to true in order to use)"};
 
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
 
@@ -152,6 +148,7 @@ struct femtoUniversePairTaskTrackPhi {
   FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kPhi> pairCleaner;
   FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kPhi> pairCloseRejection;
   FemtoUniverseTrackSelection trackCuts;
+
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -168,14 +165,14 @@ struct femtoUniversePairTaskTrackPhi {
     // ConfNsigmaCombinedProton -> TPC and TOF Kaon Sigma (combined) for momentum > 0.5
 
     if (mom < 0.5) {
-      if (TMath::Abs(nsigmaTPCPr) < twotracksconfigs.ConfNsigmaTPCProton) {
+      if (TMath::Abs(nsigmaTPCPr) < ConfBothTracks.ConfNsigmaTPCProton) {
         return true;
       } else {
         return false;
       }
     } else if (mom > 0.4) {
-      // if (TMath::Hypot(nsigmaTOFPr, nsigmaTPCPr) < twotracksconfigs.ConfNsigmaCombinedProton) {
-      if (TMath::Abs(nsigmaTPCPr) < twotracksconfigs.ConfNsigmaCombinedProton) {
+      // if (TMath::Hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfBothTracks.ConfNsigmaCombinedProton) {
+      if (TMath::Abs(nsigmaTPCPr) < ConfBothTracks.ConfNsigmaCombinedProton) {
         return true;
       } else {
         return false;
@@ -233,14 +230,14 @@ struct femtoUniversePairTaskTrackPhi {
     // ConfNsigmaCombinedPion -> TPC and TOF Pion Sigma (combined) for momentum > 0.5
     if (true) {
       if (mom < 0.5) {
-        if (TMath::Abs(nsigmaTPCPi) < twotracksconfigs.ConfNsigmaTPCPion) {
+        if (TMath::Abs(nsigmaTPCPi) < ConfBothTracks.ConfNsigmaTPCPion) {
           return true;
         } else {
           return false;
         }
       } else if (mom > 0.5) {
-        // if (TMath::Hypot(nsigmaTOFPi, nsigmaTPCPi) < twotracksconfigs.ConfNsigmaCombinedPion) {
-        if (TMath::Abs(nsigmaTPCPi) < twotracksconfigs.ConfNsigmaCombinedPion) {
+        // if (TMath::Hypot(nsigmaTOFPi, nsigmaTPCPi) < ConfBothTracks.ConfNsigmaCombinedPion) {
+        if (TMath::Abs(nsigmaTPCPi) < ConfBothTracks.ConfNsigmaCombinedPion) {
           return true;
         } else {
           return false;
@@ -252,7 +249,7 @@ struct femtoUniversePairTaskTrackPhi {
 
   bool IsParticleNSigma(float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi, float nsigmaTPCK, float nsigmaTOFK)
   {
-    switch (trackHadronfilter.ConfTrackChoiceHadron) {
+    switch (ConfTrack.ConfTrackChoiceTrack) {
       case 0: // Proton
         return IsProtonNSigma(mom, nsigmaTPCPr, nsigmaTOFPr);
         break;
@@ -270,32 +267,32 @@ struct femtoUniversePairTaskTrackPhi {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartPhi.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarInvMassBins, twotracksconfigs.ConfIsMC, trackPhifilter.ConfPDGCodePhi);
-    if (!ConfIsSame) {
-      trackHistoPartHadron.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, twotracksconfigs.ConfIsMC, trackHadronfilter.ConfPDGCodeHadron);
+    trackHistoPartPhi.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarInvMassBins, ConfBothTracks.ConfIsMC, ConfPhi.ConfPDGCodePhi);
+    if (!ConfTrack.ConfIsSame) {
+      trackHistoPartTrack.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfBothTracks.ConfIsMC, ConfTrack.ConfPDGCodeTrack);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
-    sameEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
-    mixedEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
-    sameEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfEtaBins, twotracksconfigs.ConfPhiBins, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
-    mixedEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, twotracksconfigs.ConfEtaBins, twotracksconfigs.ConfPhiBins, twotracksconfigs.ConfIsMC, twotracksconfigs.ConfUse3D);
+    sameEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    mixedEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    sameEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfEtaBins, ConfBothTracks.ConfPhiBins, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    mixedEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfEtaBins, ConfBothTracks.ConfPhiBins, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
 
-    sameEventFemtoCont.setPDGCodes(trackPhifilter.ConfPDGCodePhi, trackHadronfilter.ConfPDGCodeHadron);
-    mixedEventFemtoCont.setPDGCodes(trackPhifilter.ConfPDGCodePhi, trackHadronfilter.ConfPDGCodeHadron);
-    sameEventAngularCont.setPDGCodes(trackPhifilter.ConfPDGCodePhi, trackHadronfilter.ConfPDGCodeHadron);
-    mixedEventAngularCont.setPDGCodes(trackPhifilter.ConfPDGCodePhi, trackHadronfilter.ConfPDGCodeHadron);
+    sameEventFemtoCont.setPDGCodes(ConfPhi.ConfPDGCodePhi, ConfTrack.ConfPDGCodeTrack);
+    mixedEventFemtoCont.setPDGCodes(ConfPhi.ConfPDGCodePhi, ConfTrack.ConfPDGCodeTrack);
+    sameEventAngularCont.setPDGCodes(ConfPhi.ConfPDGCodePhi, ConfTrack.ConfPDGCodeTrack);
+    mixedEventAngularCont.setPDGCodes(ConfPhi.ConfPDGCodePhi, ConfTrack.ConfPDGCodeTrack);
 
     pairCleaner.init(&qaRegistry);
     if (ConfIsCPR.value) {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
 
-    vPIDPhiCandidate = trackPhifilter.ConfPIDPhi.value;
-    vPIDHadron = trackHadronfilter.ConfPIDHadron.value;
-    kNsigma = twotracksconfigs.ConfTrkPIDnSigmaMax.value;
+    vPIDPhiCandidate = ConfPhi.ConfPIDPhi.value;
+    vPIDTrack = ConfTrack.ConfPIDTrack.value;
+    kNsigma = ConfBothTracks.ConfTrkPIDnSigmaMax.value;
   }
 
   template <typename CollisionType>
@@ -310,13 +307,13 @@ struct femtoUniversePairTaskTrackPhi {
   /// @tparam PartitionType
   /// @tparam PartType
   /// @tparam isMC: enables Monte Carlo truth specific histograms
-  /// @param groupPartsHadron partition for the first particle passed by the process function
+  /// @param groupPartsTrack partition for the first particle passed by the process function
   /// @param groupPartsPhi partition for the second particle passed by the process function
   /// @param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
   /// @param magFieldTesla magnetic field of the collision
   /// @param multCol multiplicity of the collision
   template <bool isMC, typename PartitionType, typename PartType>
-  void doSameEvent(PartitionType groupPartsHadron, PartitionType groupPartsPhi, PartType parts, float magFieldTesla, int multCol)
+  void doSameEvent(PartitionType groupPartsTrack, PartitionType groupPartsPhi, PartType parts, float magFieldTesla, int multCol)
   {
 
     /// Histogramming same event
@@ -324,68 +321,68 @@ struct femtoUniversePairTaskTrackPhi {
       trackHistoPartPhi.fillQA<isMC, false>(phicandidate);
     }
 
-    if (!ConfIsSame) {
-      for (auto& hadron : groupPartsHadron) {
-        // if (hadron.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
+    if (!ConfTrack.ConfIsSame) {
+      for (auto& track : groupPartsTrack) {
+        // if (track.p() > ConfBothTracks.ConfCutTable->get("Track", "MaxP") || track.pt() > ConfBothTracks.ConfCutTable->get("Track", "MaxPt")) {
         //   continue;
         // }
-        // if (!isFullPIDSelected(hadron.pidcut(),
-        //                        hadron.p(),
-        //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
-        //                        vPIDHadron,
-        //                        twotracksconfigs.ConfNspecies,
+        // if (!isFullPIDSelected(track.pidcut(),
+        //                        track.p(),
+        //                        ConfBothTracks.ConfCutTable->get("Track", "PIDthr"),
+        //                        vPIDTrack,
+        //                        ConfBothTracks.ConfNspecies,
         //                        kNsigma,
-        //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
-        //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
+        //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPC"),
+        //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPCTOF"))) {
         //   continue;
         // }
-        if (!IsParticleNSigma(hadron.p(), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Kaon))) {
+        if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
           continue;
         }
-        trackHistoPartHadron.fillQA<isMC, false>(hadron);
+        trackHistoPartTrack.fillQA<isMC, false>(track);
       }
     }
     /// Now build the combinations
-    for (auto& [hadron, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsHadron, groupPartsPhi))) {
-      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
+    for (auto& [track, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsTrack, groupPartsPhi))) {
+      // if (track.p() > ConfBothTracks.ConfCutTable->get("PhiCandidate", "MaxP") || track.pt() > ConfBothTracks.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > ConfBothTracks.ConfCutTable->get("Track", "MaxP") || phicandidate.pt() > ConfBothTracks.ConfCutTable->get("Track", "MaxPt")) {
       //   continue;
       // }
-      // if (!isFullPIDSelected(hadron.pidcut(),
-      //                        hadron.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "PIDthr"),
+      // if (!isFullPIDSelected(track.pidcut(),
+      //                        track.p(),
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "PIDthr"),
       //                        vPIDPhiCandidate,
-      //                        twotracksconfigs.ConfNspecies,
+      //                        ConfBothTracks.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
       //     !isFullPIDSelected(phicandidate.pidcut(),
       //                        phicandidate.p(),
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
-      //                        vPIDHadron,
-      //                        twotracksconfigs.ConfNspecies,
+      //                        ConfBothTracks.ConfCutTable->get("Track", "PIDthr"),
+      //                        vPIDTrack,
+      //                        ConfBothTracks.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
+      //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPC"),
+      //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPCTOF"))) {
       //   continue;
       // }
 
-      if (!IsParticleNSigma(hadron.p(), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Kaon))) {
+      if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
         continue;
       }
 
       // Close Pair Rejection
       // if (ConfIsCPR.value) {
-      if (pairCloseRejection.isClosePair(hadron, phicandidate, parts, magFieldTesla)) {
+      if (pairCloseRejection.isClosePair(track, phicandidate, parts, magFieldTesla)) {
         continue;
       }
       //}
 
       // Track Cleaning
-      if (!pairCleaner.isCleanPair(hadron, phicandidate, parts)) {
+      if (!pairCleaner.isCleanPair(track, phicandidate, parts)) {
         continue;
       }
-      sameEventFemtoCont.setPair<isMC>(hadron, phicandidate, multCol, twotracksconfigs.ConfUse3D);
-      sameEventAngularCont.setPair<isMC>(hadron, phicandidate, multCol, twotracksconfigs.ConfUse3D);
+      sameEventFemtoCont.setPair<isMC>(track, phicandidate, multCol, ConfBothTracks.ConfUse3D);
+      sameEventAngularCont.setPair<isMC>(track, phicandidate, multCol, ConfBothTracks.ConfUse3D);
     }
   }
 
@@ -397,10 +394,10 @@ struct femtoUniversePairTaskTrackPhi {
   {
     fillCollision(col);
 
-    auto thegroupPartsHadron = partsHadron->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto thegroupPartsPhi = partsPhi->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
-    doSameEvent<false>(thegroupPartsHadron, thegroupPartsPhi, parts, col.magField(), col.multNtr());
+    doSameEvent<false>(thegroupPartsTrack, thegroupPartsPhi, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processSameEvent, "Enable processing same event", true);
 
@@ -415,9 +412,9 @@ struct femtoUniversePairTaskTrackPhi {
     fillCollision(col);
 
     auto thegroupPartsPhi = partsPhiMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsHadron = partsHadronMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTrack = partsTrackMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
-    doSameEvent<true>(thegroupPartsHadron, thegroupPartsPhi, parts, col.magField(), col.multNtr());
+    doSameEvent<true>(thegroupPartsTrack, thegroupPartsPhi, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processSameEventMC, "Enable processing same event for Monte Carlo", false);
 
@@ -426,50 +423,50 @@ struct femtoUniversePairTaskTrackPhi {
   /// \tparam PartitionType
   /// \tparam PartType
   /// \tparam isMC: enables Monte Carlo truth specific histograms
-  /// \param groupPartsHadron partition for the identified passed by the process function
+  /// \param groupPartsTrack partition for the identified passed by the process function
   /// \param groupPartsPhi partition for Phi meson passed by the process function
   /// \param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
   /// \param magFieldTesla magnetic field of the collision
   /// \param multCol multiplicity of the collision
   template <bool isMC, typename PartitionType, typename PartType>
-  void doMixedEvent(PartitionType groupPartsHadron, PartitionType groupPartsPhi, PartType parts, float magFieldTesla, int multCol)
+  void doMixedEvent(PartitionType groupPartsTrack, PartitionType groupPartsPhi, PartType parts, float magFieldTesla, int multCol)
   {
 
-    for (auto& [hadron, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsHadron, groupPartsPhi))) {
-      // if (hadron.p() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxP") || hadron.pt() > twotracksconfigs.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxP") || phicandidate.pt() > twotracksconfigs.ConfCutTable->get("Hadron", "MaxPt")) {
+    for (auto& [track, phicandidate] : combinations(CombinationsFullIndexPolicy(groupPartsTrack, groupPartsPhi))) {
+      // if (track.p() > ConfBothTracks.ConfCutTable->get("PhiCandidate", "MaxP") || track.pt() > ConfBothTracks.ConfCutTable->get("PhiCandidate", "MaxPt") || phicandidate.p() > ConfBothTracks.ConfCutTable->get("Track", "MaxP") || phicandidate.pt() > ConfBothTracks.ConfCutTable->get("Track", "MaxPt")) {
       //   continue;
       // }
-      // if (!isFullPIDSelected(hadron.pidcut(),
-      //                        hadron.p(),
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "PIDthr"),
+      // if (!isFullPIDSelected(track.pidcut(),
+      //                        track.p(),
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "PIDthr"),
       //                        vPIDPhiCandidate,
-      //                        twotracksconfigs.ConfNspecies,
+      //                        ConfBothTracks.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "nSigmaTPC"),
+      //                        ConfBothTracks.ConfCutTable->get("PhiCandidate", "nSigmaTPCTOF")) ||
       //     !isFullPIDSelected(phicandidate.pidcut(),
       //                        phicandidate.p(),
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "PIDthr"),
-      //                        vPIDHadron,
-      //                        twotracksconfigs.ConfNspecies,
+      //                        ConfBothTracks.ConfCutTable->get("Track", "PIDthr"),
+      //                        vPIDTrack,
+      //                        ConfBothTracks.ConfNspecies,
       //                        kNsigma,
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPC"),
-      //                        twotracksconfigs.ConfCutTable->get("Hadron", "nSigmaTPCTOF"))) {
+      //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPC"),
+      //                        ConfBothTracks.ConfCutTable->get("Track", "nSigmaTPCTOF"))) {
       //   continue;
       // }
 
-      if (!IsParticleNSigma(hadron.p(), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Proton), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Pion), trackCuts.getNsigmaTPC(hadron, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(hadron, o2::track::PID::Kaon))) {
+      if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
         continue;
       }
 
       // // if (ConfIsCPR.value) {
-      if (pairCloseRejection.isClosePair(hadron, phicandidate, parts, magFieldTesla)) {
+      if (pairCloseRejection.isClosePair(track, phicandidate, parts, magFieldTesla)) {
         continue;
       }
       // }
 
-      mixedEventFemtoCont.setPair<isMC>(hadron, phicandidate, multCol, twotracksconfigs.ConfUse3D);
-      mixedEventAngularCont.setPair<isMC>(hadron, phicandidate, multCol, twotracksconfigs.ConfUse3D);
+      mixedEventFemtoCont.setPair<isMC>(track, phicandidate, multCol, ConfBothTracks.ConfUse3D);
+      mixedEventAngularCont.setPair<isMC>(track, phicandidate, multCol, ConfBothTracks.ConfUse3D);
     }
   }
 
@@ -484,7 +481,7 @@ struct femtoUniversePairTaskTrackPhi {
       const int multiplicityCol = collision1.multNtr();
       MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
 
-      auto groupPartsHadron = partsHadron->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
       auto groupPartsPhi = partsPhi->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
@@ -494,9 +491,9 @@ struct femtoUniversePairTaskTrackPhi {
         continue;
       }
       /// \todo before mixing we should check whether both collisions contain a pair of particles!
-      // if (partsPhi.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsHadron.size() == 0 ) continue;
+      // if (partsPhi.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTrack.size() == 0 ) continue;
 
-      doMixedEvent<false>(groupPartsHadron, groupPartsPhi, parts, magFieldTesla1, multiplicityCol);
+      doMixedEvent<false>(groupPartsTrack, groupPartsPhi, parts, magFieldTesla1, multiplicityCol);
     }
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processMixedEvent, "Enable processing mixed events", true);
@@ -514,7 +511,7 @@ struct femtoUniversePairTaskTrackPhi {
       const int multiplicityCol = collision1.multNtr();
       MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
 
-      auto groupPartsHadron = partsHadronMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsTrack = partsTrackMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
       auto groupPartsPhi = partsPhiMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
@@ -524,9 +521,9 @@ struct femtoUniversePairTaskTrackPhi {
         continue;
       }
       /// \todo before mixing we should check whether both collisions contain a pair of particles!
-      // if (partsPhi.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsHadron.size() == 0 ) continue;
+      // if (partsPhi.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTrack.size() == 0 ) continue;
 
-      doMixedEvent<true>(groupPartsHadron, groupPartsPhi, parts, magFieldTesla1, multiplicityCol);
+      doMixedEvent<true>(groupPartsTrack, groupPartsPhi, parts, magFieldTesla1, multiplicityCol);
     }
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackPhi, processMixedEventMC, "Enable processing mixed events MC", false);

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrack.cxx
@@ -131,7 +131,7 @@ struct femtoUniversePairTaskTrackTrack {
   FemtoUniverseAngularContainer<femtoUniverseAngularContainer::EventType::mixed, femtoUniverseAngularContainer::Observable::kstar> mixedEventAngularCont;
   FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCleaner;
   FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCloseRejection;
-  
+
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -158,7 +158,6 @@ struct femtoUniversePairTaskTrackTrack {
     mixedEventFemtoCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
     sameEventAngularCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
     mixedEventAngularCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
-
 
     pairCleaner.init(&qaRegistry);
     if (ConfIsCPR.value) {
@@ -262,7 +261,7 @@ struct femtoUniversePairTaskTrackTrack {
       if (!pairCleaner.isCleanPair(p1, p2, parts)) {
         continue;
       }
-      
+
       sameEventFemtoCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
       sameEventAngularCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
     }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrack.cxx
@@ -29,7 +29,8 @@
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseAngularContainer.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUtils.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
@@ -124,10 +125,13 @@ struct femtoUniversePairTaskTrackTrack {
   Configurable<int> ConfPhiBins{"ConfPhiBins", 29, "Number of phi bins in deta dphi"};
   Configurable<int> ConfEtaBins{"ConfEtaBins", 29, "Number of eta bins in deta dphi"};
 
-  FemtoUniverseContainer<femtoUniverseContainer::EventType::same, femtoUniverseContainer::Observable::kstar> sameEventCont;
-  FemtoUniverseContainer<femtoUniverseContainer::EventType::mixed, femtoUniverseContainer::Observable::kstar> mixedEventCont;
+  FemtoUniverseFemtoContainer<femtoUniverseFemtoContainer::EventType::same, femtoUniverseFemtoContainer::Observable::kstar> sameEventFemtoCont;
+  FemtoUniverseFemtoContainer<femtoUniverseFemtoContainer::EventType::mixed, femtoUniverseFemtoContainer::Observable::kstar> mixedEventFemtoCont;
+  FemtoUniverseAngularContainer<femtoUniverseAngularContainer::EventType::same, femtoUniverseAngularContainer::Observable::kstar> sameEventAngularCont;
+  FemtoUniverseAngularContainer<femtoUniverseAngularContainer::EventType::mixed, femtoUniverseAngularContainer::Observable::kstar> mixedEventAngularCont;
   FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCleaner;
   FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kTrack> pairCloseRejection;
+  
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -145,10 +149,17 @@ struct femtoUniversePairTaskTrackTrack {
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
-    sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfEtaBins, ConfPhiBins, ConfIsMC, ConfUse3D);
-    mixedEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfEtaBins, ConfPhiBins, ConfIsMC, ConfUse3D);
-    sameEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
-    mixedEventCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    sameEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D);
+    mixedEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D);
+    sameEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfEtaBins, ConfPhiBins, ConfIsMC, ConfUse3D);
+    mixedEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfEtaBins, ConfPhiBins, ConfIsMC, ConfUse3D);
+
+    sameEventFemtoCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    mixedEventFemtoCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    sameEventAngularCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+    mixedEventAngularCont.setPDGCodes(ConfPDGCodePartOne, ConfPDGCodePartTwo);
+
+
     pairCleaner.init(&qaRegistry);
     if (ConfIsCPR.value) {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
@@ -251,7 +262,9 @@ struct femtoUniversePairTaskTrackTrack {
       if (!pairCleaner.isCleanPair(p1, p2, parts)) {
         continue;
       }
-      sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+      
+      sameEventFemtoCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+      sameEventAngularCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
     }
   }
 
@@ -330,7 +343,8 @@ struct femtoUniversePairTaskTrackTrack {
         }
       }
 
-      mixedEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+      mixedEventFemtoCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+      mixedEventAngularCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
     }
   }
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
@@ -12,6 +12,7 @@
 /// \file femtoUniversePairTaskTrackTrackMcTruth.cxx
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
 /// \author Malgorzata Janik, WUT, majanik@cern.ch
+/// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
 
 #include <vector>
 #include "Framework/AnalysisTask.h"
@@ -55,11 +56,11 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
   Configurable<float> ConfPtHighPart1{"ConfPtHighPart1", 1.5, "Higher limit for Pt for the first particle"};
 
   /// Partition for particle 1
-  Partition<aod::FDParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (ConfNoPDGPartOne || aod::femtouniverseparticle::pidcut == ConfPDGCodePartOne) &&
+  Partition<aod::FDParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (ConfNoPDGPartOne || aod::femtouniverseparticle::pidcut == ConfPDGCodePartOne) &&
                                          aod::femtouniverseparticle::pt < ConfPtHighPart1 && aod::femtouniverseparticle::pt > ConfPtLowPart1&& nabs(aod::femtouniverseparticle::eta) < ConfEtaMax;
 
   /// Histogramming for particle 1
-  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> trackHistoPartOne;
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, 1> trackHistoPartOne;
 
   /// Particle 2
   Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
@@ -69,11 +70,11 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
   Configurable<float> ConfPtHighPart2{"ConfPtHighPart2", 1.5, "Higher limit for Pt for the second particle"};
 
   /// Partition for particle 2
-  Partition<aod::FDParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (ConfNoPDGPartTwo || aod::femtouniverseparticle::pidcut == ConfPDGCodePartTwo) &&
+  Partition<aod::FDParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (ConfNoPDGPartTwo || aod::femtouniverseparticle::pidcut == ConfPDGCodePartTwo) &&
                                          aod::femtouniverseparticle::pt < ConfPtHighPart2 && aod::femtouniverseparticle::pt > ConfPtLowPart2&& nabs(aod::femtouniverseparticle::eta) < ConfEtaMax;
 
   /// Histogramming for particle 2
-  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartTwo;
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, 2> trackHistoPartTwo;
 
   /// Histogramming for Event
   FemtoUniverseEventHisto eventHisto;
@@ -83,8 +84,8 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
   std::vector<float> kNsigma;
 
   /// particle part
-  ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarPDGBins{"ConfDTempFitVarInvMassBins", {6000, -2300, 2300}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
 
   /// Correlation part
   ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
@@ -120,9 +121,9 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
   {
 
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, 0, ConfPDGCodePartOne, false);
+    trackHistoPartOne.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarPDGBins, 0, ConfPDGCodePartOne, false);
     if (!ConfIsSame) {
-      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, 0, ConfPDGCodePartTwo, false);
+      trackHistoPartTwo.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarPDGBins, 0, ConfPDGCodePartTwo, false);
     }
 
     MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
@@ -193,7 +193,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
     auto thegroupPartsOne = partsOne->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
-    doSameEvent<false>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+    doSameEvent<true>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackTrackMcTruth, processSameEvent, "Enable processing same event", true);
 
@@ -240,7 +240,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
       /// \todo before mixing we should check whether both collisions contain a pair of particles!
       // if (partsOne.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTwo.size() == 0 ) continue;
 
-      doMixedEvent<false>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
+      doMixedEvent<true>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
     }
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackTrackMcTruth, processMixedEvent, "Enable processing mixed events", true);

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
@@ -193,7 +193,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
     auto thegroupPartsOne = partsOne->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
-    doSameEvent<true>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+    doSameEvent<false>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackTrackMcTruth, processSameEvent, "Enable processing same event", true);
 
@@ -240,7 +240,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
       /// \todo before mixing we should check whether both collisions contain a pair of particles!
       // if (partsOne.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTwo.size() == 0 ) continue;
 
-      doMixedEvent<true>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
+      doMixedEvent<false>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multiplicityCol);
     }
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackTrackMcTruth, processMixedEvent, "Enable processing mixed events", true);


### PR DESCRIPTION
* Removing unused configurables and other small fixes added to the MC producer.
* Fixing naming in the track-Phi task.
* Adding femto and angular containers for same and mixed events for the track-track.
* Adding PDG vs pT plot for MC Truth particles.