### PR TITLE
PWGHF: Removing decayLengthXYNormalized from Bdt

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -334,7 +334,6 @@ struct HfCandidateSelectorD0 {
                                          candidate.cpaXY(),
                                          candidate.decayLength(),
                                          candidate.decayLengthXY(),
-                                         candidate.decayLengthXYNormalised(),
                                          candidate.impactParameter0(),
                                          candidate.impactParameter1(),
                                          candidate.impactParameterProduct()};


### PR DESCRIPTION
@fgrosa 
Removing decayLengthXYNormalized from the input features of Bdt 
