### PR TITLE
PWGHF: make the reduced data format for B hadrons self contained

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -45,7 +45,7 @@ DECLARE_SOA_COLUMN(Bz, bz, float); //! Magnetic field in z-direction
 DECLARE_SOA_COLUMN(OriginalCollisionCount, originalCollisionCount, int); //! Size of COLLISION table processed
 } // namespace hf_reduced_collision
 
-DECLARE_SOA_TABLE(HfReducedCollisions, "AOD", "HFREDCOLLISION", //! Table with collision for reduced workflow
+DECLARE_SOA_TABLE(HfRedCollisions, "AOD", "HFREDCOLLISION", //! Table with collision for reduced workflow
                   soa::Index<>,
                   collision::PosX,
                   collision::PosY,
@@ -58,9 +58,9 @@ DECLARE_SOA_TABLE(HfReducedCollisions, "AOD", "HFREDCOLLISION", //! Table with c
                   collision::CovZZ,
                   hf_reduced_collision::Bz);
 
-using HfReducedCollision = HfReducedCollisions::iterator;
+using HfRedCollision = HfRedCollisions::iterator;
 
-DECLARE_SOA_TABLE(HfOriginalCollisionsCounter, "AOD", "HFCOLCOUNTER", //! Table with original number of collisions
+DECLARE_SOA_TABLE(HfOrigColCounts, "AOD", "HFORIGCOLCOUNT", //! Table with original number of collisions
                   hf_reduced_collision::OriginalCollisionCount);
 
 namespace hf_track_par_cov
@@ -117,16 +117,19 @@ DECLARE_SOA_COLUMN(Pz, pz, float); //! Momentum in z-direction in GeV/c
 
 namespace hf_track_index_reduced
 {
-DECLARE_SOA_INDEX_COLUMN(HfReducedCollision, hfReducedCollision); //! ReducedCollision index
-DECLARE_SOA_INDEX_COLUMN(Track, track);                           //! Track index
-DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool);                         //! Flag to check if track has a TPC match
-DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool);                         //! Flag to check if track has a TOF match
+DECLARE_SOA_INDEX_COLUMN(HfRedCollision, hfRedCollision); //! ReducedCollision index
+DECLARE_SOA_COLUMN(TrackId, trackId, int);                //! Original track index
+DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(Prong1Id, prong1Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool);                 //! Flag to check if track has a TPC match
+DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool);                 //! Flag to check if track has a TOF match
 } // namespace hf_track_index_reduced
 
-DECLARE_SOA_TABLE(HfTracksReduced, "AOD", "HFTRACKRED", //! Table with track information for reduced workflow
+DECLARE_SOA_TABLE(HfRedTracks, "AOD", "HFREDTRACK", //! Table with track information for reduced workflow
                   soa::Index<>,
                   hf_track_index_reduced::TrackId,
-                  hf_track_index_reduced::HfReducedCollisionId,
+                  hf_track_index_reduced::HfRedCollisionId,
                   HFTRACKPARCOV_COLUMNS);
 
 namespace hf_track_pid_reduced
@@ -135,9 +138,9 @@ DECLARE_SOA_COLUMN(Pt, pt, float); //! Transverse momentum of the track in GeV/c
 } // namespace hf_track_pid_reduced
 
 // table with all attributes needed to call statusTpcAndTof() in the selector task
-DECLARE_SOA_TABLE(HfTracksPidReduced, "AOD", "HFTRACKPIDRED", //! Table with PID track information for reduced workflow
+DECLARE_SOA_TABLE(HfRedPidTracks, "AOD", "HFREDTRACKPID", //! Table with PID track information for reduced workflow
                   o2::soa::Index<>,
-                  hf_track_index_reduced::HfReducedCollisionId,
+                  hf_track_index_reduced::HfRedCollisionId,
                   hf_track_pid_reduced::Pt,
                   hf_track_index_reduced::HasTPC,
                   hf_track_index_reduced::HasTOF,
@@ -160,10 +163,10 @@ DECLARE_SOA_COLUMN(InvMass, invMass, float);         //! Invariant mass of 2pron
 
 } // namespace hf_cand_2prong_reduced
 
-DECLARE_SOA_TABLE(HfCand2ProngReduced, "AOD", "HFCAND2PRONGRED", //! Table with 2prong candidate information for reduced workflow
+DECLARE_SOA_TABLE(HfRedCand2Prongs, "AOD", "HFREDCAND2PRONG", //! Table with 2prong candidate information for reduced workflow
                   o2::soa::Index<>,
-                  hf_track_index::Prong0Id, hf_track_index::Prong1Id,
-                  hf_track_index_reduced::HfReducedCollisionId,
+                  hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id,
+                  hf_track_index_reduced::HfRedCollisionId,
                   HFTRACKPARCOV_COLUMNS,
                   hf_cand_2prong_reduced::CPA,
                   hf_cand_2prong_reduced::DecayLength,
@@ -185,10 +188,10 @@ auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)
 }
 } // namespace hf_cand_3prong_reduced
 
-DECLARE_SOA_TABLE(HfCand3ProngReduced, "AOD", "HFCAND3PRONGRED", //! Table with 3prong candidate information for reduced workflow
+DECLARE_SOA_TABLE(HfRedCand3Prongs, "AOD", "HFREDCAND3PRONG", //! Table with 3prong candidate information for reduced workflow
                   o2::soa::Index<>,
-                  hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_track_index::Prong2Id,
-                  hf_track_index_reduced::HfReducedCollisionId,
+                  hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id, hf_track_index_reduced::Prong2Id,
+                  hf_track_index_reduced::HfRedCollisionId,
                   HFTRACKPARCOV_COLUMNS,
                   hf_cand_3prong_reduced::CPA,
                   hf_cand_3prong_reduced::DecayLength,
@@ -211,24 +214,21 @@ DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track
 } // namespace hf_b0_mc
 
 // table with results of reconstruction level MC matching
-DECLARE_SOA_TABLE(HfDPiMcRecReduced, "AOD", "HFDPIMCRECRED", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
+DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
                   hf_cand_b0::Prong0Id,
                   hf_track_index::Prong1Id,
                   hf_cand_b0::FlagMcMatchRec,
-                  hf_cand_b0::OriginMcRec,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
 
 // Table with same size as HFCANDB0
-DECLARE_SOA_TABLE(HfB0McRecReduced, "AOD", "HFB0MCRECRED", //! Reconstruction-level MC information on B0 candidates for reduced workflow
+DECLARE_SOA_TABLE(HfMcRecRedB0s, "AOD", "HFMCRECREDB0", //! Reconstruction-level MC information on B0 candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchRec,
-                  hf_cand_b0::OriginMcRec,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
 
-DECLARE_SOA_TABLE(HfB0McGenReduced, "AOD", "HFB0MCGENRED", //! Generation-level MC information on B0 candidates for reduced workflow
+DECLARE_SOA_TABLE(HfMcGenRedB0s, "AOD", "HFMCGENREDB0", //! Generation-level MC information on B0 candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchGen,
-                  hf_cand_b0::OriginMcGen,
                   hf_b0_mc::PtTrack,
                   hf_b0_mc::YTrack,
                   hf_b0_mc::EtaTrack,
@@ -246,7 +246,7 @@ namespace hf_cand_b0_config
 DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int8_t); //! Flag to filter selected D+ mesons
 } // namespace hf_cand_b0_config
 
-DECLARE_SOA_TABLE(HfCandB0Config, "AOD", "HFCANDB0CONFIG", //! Table with configurables information for reduced workflow
+DECLARE_SOA_TABLE(HfCandB0Configs, "AOD", "HFCANDB0CONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_b0_config::MySelectionFlagD);
 
 namespace hf_bplus_mc
@@ -266,22 +266,19 @@ DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track
 } // namespace hf_bplus_mc
 
 // table with results of reconstruction level MC matching
-DECLARE_SOA_TABLE(HfD0PiMcRecReduced, "AOD", "HFD0PIMCRECRED", //! Table with reconstructed MC information on D0Pi(<-B+) pairs for reduced workflow
+DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with reconstructed MC information on D0Pi(<-B+) pairs for reduced workflow
                   hf_cand_bplus::Prong0Id,
                   hf_track_index::Prong1Id,
                   hf_cand_bplus::FlagMcMatchRec,
-                  hf_cand_bplus::OriginMcRec,
                   hf_bplus_mc::PtMother);
 
 // Table with same size as HFCANDBPLUS
-DECLARE_SOA_TABLE(HfBpMcRecReduced, "AOD", "HFBPMCRECRED", //! Reconstruction-level MC information on B+ candidates for reduced workflow
+DECLARE_SOA_TABLE(HfMcRecRedBps, "AOD", "HFMCRECREDBP", //! Reconstruction-level MC information on B+ candidates for reduced workflow
                   hf_cand_bplus::FlagMcMatchRec,
-                  hf_cand_bplus::OriginMcRec,
                   hf_bplus_mc::PtMother);
 
-DECLARE_SOA_TABLE(HfBpMcGenReduced, "AOD", "HFBPMCGENRED", //! Generation-level MC information on B+ candidates for reduced workflow
+DECLARE_SOA_TABLE(HfMcGenRedBps, "AOD", "HFMCGENREDBP", //! Generation-level MC information on B+ candidates for reduced workflow
                   hf_cand_bplus::FlagMcMatchGen,
-                  hf_cand_bplus::OriginMcGen,
                   hf_bplus_mc::PtTrack,
                   hf_bplus_mc::YTrack,
                   hf_bplus_mc::EtaTrack,
@@ -300,17 +297,17 @@ DECLARE_SOA_COLUMN(MySelectionFlagD0, mySelectionFlagD0, int8_t);       //! Flag
 DECLARE_SOA_COLUMN(MySelectionFlagD0bar, mySelectionFlagD0bar, int8_t); //! Flag to filter selected D0 mesons
 } // namespace hf_cand_bplus_config
 
-DECLARE_SOA_TABLE(HfCandBpConfig, "AOD", "HFCANDBPCONFIG", //! Table with configurables information for reduced workflow
+DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_bplus_config::MySelectionFlagD0,
                   hf_cand_bplus_config::MySelectionFlagD0bar);
 } // namespace aod
 
 namespace soa
 {
-DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand2ProngBase, aod::HfCand2ProngReduced);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfCand3ProngReduced);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfTracksReduced);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfTracksPidReduced);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand2ProngBase, aod::HfRedCand2Prongs);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfRedCand3Prongs);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedTracks);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedPidTracks);
 } // namespace soa
 } // namespace o2
 #endif // PWGHF_D2H_DATAMODEL_REDUCEDDATAMODEL_H_

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -209,6 +209,29 @@ DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3pro
                   HFTRACKPARCOV_COLUMNS,
                   o2::soa::Marker<2>);
 
+// Beauty candidates prongs
+namespace hf_cand_b0_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+} // namespace hf_cand_b0_reduced
+
+DECLARE_SOA_TABLE(HfRedB0Prongs, "AOD", "HFREDB0PRONG",
+                  hf_cand_b0_reduced::Prong0Id, hf_cand_b0_reduced::Prong1Id);
+
+using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
+
+namespace hf_cand_bplus_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed2Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+} // namespace hf_cand_bplus_reduced
+
+DECLARE_SOA_TABLE(HfRedBplusProngs, "AOD", "HFREDBPPRONG",
+                  hf_cand_bplus_reduced::Prong0Id, hf_cand_bplus_reduced::Prong1Id);
+
+using HfRedCandBplus = soa::Join<HfCandBplusExt, HfRedBplusProngs>;
+
 namespace hf_b0_mc
 {
 // MC Rec
@@ -225,16 +248,6 @@ DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's pro
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
-namespace hf_cand_b0_reduced
-{
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
-} // namespace hf_cand_b0_reduced
-
-DECLARE_SOA_TABLE(HfRedB0Prongs, "AOD", "HFREDB0PRONG",
-                  hf_cand_b0_reduced::Prong0Id, hf_cand_b0_reduced::Prong1Id);
-
-using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
@@ -292,8 +305,8 @@ DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with reconstructed MC information on D0Pi(<-B+) pairs for reduced workflow
-                  hf_cand_bplus::Prong0Id,
-                  hf_track_index::Prong1Id,
+                  hf_cand_bplus_reduced::Prong0Id,
+                  hf_cand_bplus_reduced::Prong1Id,
                   hf_cand_bplus::FlagMcMatchRec,
                   hf_bplus_mc::PtMother);
 
@@ -320,11 +333,13 @@ namespace hf_cand_bplus_config
 {
 DECLARE_SOA_COLUMN(MySelectionFlagD0, mySelectionFlagD0, int8_t);       //! Flag to filter selected D0 mesons
 DECLARE_SOA_COLUMN(MySelectionFlagD0bar, mySelectionFlagD0bar, int8_t); //! Flag to filter selected D0 mesons
+DECLARE_SOA_COLUMN(MyInvMassWindowD0Pi, myInvMassWindowD0Pi, float);    //! Half-width of the Bplus invariant-mass window in GeV/c2
 } // namespace hf_cand_bplus_config
 
 DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_bplus_config::MySelectionFlagD0,
-                  hf_cand_bplus_config::MySelectionFlagD0bar);
+                  hf_cand_bplus_config::MySelectionFlagD0bar,
+                  hf_cand_bplus_config::MyInvMassWindowD0Pi);
 } // namespace aod
 
 namespace soa

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -141,16 +141,8 @@ DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID tra
                   o2::soa::Index<>,
                   hf_track_index_reduced::HasTPC,
                   hf_track_index_reduced::HasTOF,
-                  pidtpc::TPCNSigmaEl,
-                  pidtpc::TPCNSigmaMu,
                   pidtpc::TPCNSigmaPi,
-                  pidtpc::TPCNSigmaKa,
-                  pidtpc::TPCNSigmaPr,
-                  pidtof::TOFNSigmaEl,
-                  pidtof::TOFNSigmaMu,
-                  pidtof::TOFNSigmaPi,
-                  pidtof::TOFNSigmaKa,
-                  pidtof::TOFNSigmaPr);
+                  pidtof::TOFNSigmaPi);
 
 DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTrackBases, "HFREDTRACKEXT", //! Track parameters at collision vertex
                                 aod::track::Pt);

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -121,7 +121,9 @@ DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool);                 //! Flag to check if t
 DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool);                 //! Flag to check if track has a TOF match
 } // namespace hf_track_index_reduced
 
-DECLARE_SOA_TABLE(HfRedTracksBase, "AOD", "HFREDTRACKBASE", //! Table with track information for reduced workflow
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
+DECLARE_SOA_TABLE(HfRedTrackBases, "AOD", "HFREDTRACKBASE", //! Table with track information for reduced workflow
                   soa::Index<>,
                   hf_track_index_reduced::TrackId,
                   hf_track_index_reduced::HfRedCollisionId,
@@ -150,7 +152,7 @@ DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID tra
                   pidtof::TOFNSigmaKa,
                   pidtof::TOFNSigmaPr);
 
-DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTracksBase, "HFREDTRACKEXT", //! Track parameters at collision vertex
+DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTrackBases, "HFREDTRACKEXT", //! Track parameters at collision vertex
                                 aod::track::Pt);
 
 using HfRedTracks = HfRedTracksExt;
@@ -171,7 +173,9 @@ auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)
 }
 } // namespace hf_charm_cand_reduced
 
-DECLARE_SOA_TABLE(HfRed2Prongs, "AOD", "HFRED2PRONGS", //! Table with 2prong candidate information for reduced workflow
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
+DECLARE_SOA_TABLE(HfRed2Prongs, "AOD", "HFRED2PRONG", //! Table with 2prong candidate information for reduced workflow
                   o2::soa::Index<>,
                   hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id,
                   hf_track_index_reduced::HfRedCollisionId,
@@ -187,6 +191,8 @@ DECLARE_SOA_TABLE(HfRed2ProngsCov, "AOD", "HFRED2PRONGSCOV", //! Table with 2pro
                   HFTRACKPARCOV_COLUMNS,
                   o2::soa::Marker<1>);
 
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
 DECLARE_SOA_TABLE(HfRed3Prongs, "AOD", "HFRED3PRONG", //! Table with 3prong candidate information for reduced workflow
                   o2::soa::Index<>,
                   hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id, hf_track_index_reduced::Prong2Id,
@@ -219,10 +225,21 @@ DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's pro
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
+namespace hf_cand_b0_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+} // namespace hf_cand_b0_reduced
+
+DECLARE_SOA_TABLE(HfRedB0Prongs, "AOD", "HFREDB0PRONG",
+                  hf_cand_b0_reduced::Prong0Id, hf_cand_b0_reduced::Prong1Id);
+
+using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
+
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
-                  hf_cand_b0::Prong0Id,
-                  hf_track_index::Prong1Id,
+                  hf_cand_b0_reduced::Prong0Id,
+                  hf_cand_b0_reduced::Prong1Id,
                   hf_cand_b0::FlagMcMatchRec,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
@@ -250,10 +267,12 @@ DECLARE_SOA_TABLE(HfMcGenRedB0s, "AOD", "HFMCGENREDB0", //! Generation-level MC 
 namespace hf_cand_b0_config
 {
 DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int8_t); //! Flag to filter selected D+ mesons
+DECLARE_SOA_COLUMN(MyInvMassWindowDPi, myInvMassWindowDPi, float); //! Half-width of the B0 invariant-mass window in GeV/c2
 } // namespace hf_cand_b0_config
 
 DECLARE_SOA_TABLE(HfCandB0Configs, "AOD", "HFCANDB0CONFIG", //! Table with configurables information for reduced workflow
-                  hf_cand_b0_config::MySelectionFlagD);
+                  hf_cand_b0_config::MySelectionFlagD,
+                  hf_cand_b0_config::MyInvMassWindowDPi);
 
 namespace hf_bplus_mc
 {
@@ -312,7 +331,7 @@ namespace soa
 {
 DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand2ProngBase, aod::HfRed2Prongs);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfRed3Prongs);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedTracks);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedTrackBases);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions, aod::HfRedCollisions);
 } // namespace soa
 } // namespace o2

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -81,22 +81,20 @@ DECLARE_SOA_COLUMN(C1PtZ, c1PtZ, float);         //! Covariance matrix
 DECLARE_SOA_COLUMN(C1PtSnp, c1PtSnp, float);     //! Covariance matrix
 DECLARE_SOA_COLUMN(C1PtTgl, c1PtTgl, float);     //! Covariance matrix
 DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //! Covariance matrix
-
-DECLARE_SOA_COLUMN(Px, px, float); //! Momentum in x-direction in GeV/c
-DECLARE_SOA_COLUMN(Py, py, float); //! Momentum in y-direction in GeV/c
-DECLARE_SOA_COLUMN(Pz, pz, float); //! Momentum in z-direction in GeV/c
 } // namespace hf_track_par_cov
 
 // general columns
-#define HFTRACKPARCOV_COLUMNS    \
+#define HFTRACKPAR_COLUMNS    \
   aod::track::X,                 \
     aod::track::Alpha,           \
     aod::track::Y,               \
     aod::track::Z,               \
     aod::track::Snp,             \
     aod::track::Tgl,             \
-    aod::track::Signed1Pt,       \
-    hf_track_par_cov::CYY,       \
+    aod::track::Signed1Pt
+
+#define HFTRACKPARCOV_COLUMNS    \
+  hf_track_par_cov::CYY,       \
     hf_track_par_cov::CZY,       \
     hf_track_par_cov::CZZ,       \
     hf_track_par_cov::CSnpY,     \
@@ -110,10 +108,7 @@ DECLARE_SOA_COLUMN(Pz, pz, float); //! Momentum in z-direction in GeV/c
     hf_track_par_cov::C1PtZ,     \
     hf_track_par_cov::C1PtSnp,   \
     hf_track_par_cov::C1PtTgl,   \
-    hf_track_par_cov::C1Pt21Pt2, \
-    hf_track_par_cov::Px,        \
-    hf_track_par_cov::Py,        \
-    hf_track_par_cov::Pz
+    hf_track_par_cov::C1Pt21Pt2
 
 namespace hf_track_index_reduced
 {
@@ -126,22 +121,22 @@ DECLARE_SOA_COLUMN(HasTPC, hasTPC, bool);                 //! Flag to check if t
 DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool);                 //! Flag to check if track has a TOF match
 } // namespace hf_track_index_reduced
 
-DECLARE_SOA_TABLE(HfRedTracks, "AOD", "HFREDTRACK", //! Table with track information for reduced workflow
+DECLARE_SOA_TABLE(HfRedTracksBase, "AOD", "HFREDTRACKBASE", //! Table with track information for reduced workflow
                   soa::Index<>,
                   hf_track_index_reduced::TrackId,
                   hf_track_index_reduced::HfRedCollisionId,
+                  HFTRACKPAR_COLUMNS,
+                  aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+
+DECLARE_SOA_TABLE(HfRedTracksCov, "AOD", "HFREDTRACKCOV", //! Table with track covariance information for reduced workflow
+                  soa::Index<>,
                   HFTRACKPARCOV_COLUMNS);
 
-namespace hf_track_pid_reduced
-{
-DECLARE_SOA_COLUMN(Pt, pt, float); //! Transverse momentum of the track in GeV/c
-} // namespace hf_track_pid_reduced
-
 // table with all attributes needed to call statusTpcAndTof() in the selector task
-DECLARE_SOA_TABLE(HfRedPidTracks, "AOD", "HFREDTRACKPID", //! Table with PID track information for reduced workflow
+DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID track information for reduced workflow
                   o2::soa::Index<>,
-                  hf_track_index_reduced::HfRedCollisionId,
-                  hf_track_pid_reduced::Pt,
                   hf_track_index_reduced::HasTPC,
                   hf_track_index_reduced::HasTOF,
                   pidtpc::TPCNSigmaEl,
@@ -155,28 +150,16 @@ DECLARE_SOA_TABLE(HfRedPidTracks, "AOD", "HFREDTRACKPID", //! Table with PID tra
                   pidtof::TOFNSigmaKa,
                   pidtof::TOFNSigmaPr);
 
-namespace hf_cand_2prong_reduced
+DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTracksBase, "HFREDTRACKEXT", //! Track parameters at collision vertex
+                                aod::track::Pt);
+
+using HfRedTracks = HfRedTracksExt;
+
+namespace hf_charm_cand_reduced
 {
-DECLARE_SOA_COLUMN(CPA, cpa, float);                 //! Cosinus pointing angle
-DECLARE_SOA_COLUMN(DecayLength, decayLength, float); //! Decay length in cm
-DECLARE_SOA_COLUMN(InvMass, invMass, float);         //! Invariant mass of 2prong candidate in GeV/c2
-
-} // namespace hf_cand_2prong_reduced
-
-DECLARE_SOA_TABLE(HfRedCand2Prongs, "AOD", "HFREDCAND2PRONG", //! Table with 2prong candidate information for reduced workflow
-                  o2::soa::Index<>,
-                  hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id,
-                  hf_track_index_reduced::HfRedCollisionId,
-                  HFTRACKPARCOV_COLUMNS,
-                  hf_cand_2prong_reduced::CPA,
-                  hf_cand_2prong_reduced::DecayLength,
-                  hf_cand_2prong_reduced::InvMass);
-
-namespace hf_cand_3prong_reduced
-{
-DECLARE_SOA_COLUMN(CPA, cpa, float);                 //! Cosinus pointing angle
-DECLARE_SOA_COLUMN(DecayLength, decayLength, float); //! Decay length in cm
-DECLARE_SOA_COLUMN(InvMass, invMass, float);         //! Invariant mass of 3prong candidate in GeV/c2
+DECLARE_SOA_COLUMN(InvMass, invMass, float);           //! Invariant mass of 2prong candidate in GeV/c2
+DECLARE_SOA_COLUMN(InvMassD0, invMassD0, float);       //! Invariant mass of 2prong candidate in GeV/c2
+DECLARE_SOA_COLUMN(InvMassD0Bar, invMassD0Bar, float); //! Invariant mass of 2prong candidate in GeV/c2
 
 template <typename T>
 auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)
@@ -186,16 +169,39 @@ auto invMassDplusToPiKPi(const T& pVec0, const T& pVec1, const T& pVec2)
                                  RecoDecay::getMassPDG(kKPlus),
                                  RecoDecay::getMassPDG(kPiPlus)});
 }
-} // namespace hf_cand_3prong_reduced
+} // namespace hf_charm_cand_reduced
 
-DECLARE_SOA_TABLE(HfRedCand3Prongs, "AOD", "HFREDCAND3PRONG", //! Table with 3prong candidate information for reduced workflow
+DECLARE_SOA_TABLE(HfRed2Prongs, "AOD", "HFRED2PRONGS", //! Table with 2prong candidate information for reduced workflow
+                  o2::soa::Index<>,
+                  hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id,
+                  hf_track_index_reduced::HfRedCollisionId,
+                  HFTRACKPAR_COLUMNS,
+                  hf_cand::XSecondaryVertex, hf_cand::YSecondaryVertex, hf_cand::ZSecondaryVertex,
+                  hf_charm_cand_reduced::InvMassD0, hf_charm_cand_reduced::InvMassD0Bar,
+                  aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+
+DECLARE_SOA_TABLE(HfRed2ProngsCov, "AOD", "HFRED2PRONGSCOV", //! Table with 2prong candidate covariance for reduced workflow
+                  o2::soa::Index<>,
+                  HFTRACKPARCOV_COLUMNS,
+                  o2::soa::Marker<1>);
+
+DECLARE_SOA_TABLE(HfRed3Prongs, "AOD", "HFRED3PRONG", //! Table with 3prong candidate information for reduced workflow
                   o2::soa::Index<>,
                   hf_track_index_reduced::Prong0Id, hf_track_index_reduced::Prong1Id, hf_track_index_reduced::Prong2Id,
                   hf_track_index_reduced::HfRedCollisionId,
+                  HFTRACKPAR_COLUMNS,
+                  hf_cand::XSecondaryVertex, hf_cand::YSecondaryVertex, hf_cand::ZSecondaryVertex,
+                  hf_charm_cand_reduced::InvMass,
+                  aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+
+DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3prong candidate covariance for reduced workflow
+                  o2::soa::Index<>,
                   HFTRACKPARCOV_COLUMNS,
-                  hf_cand_3prong_reduced::CPA,
-                  hf_cand_3prong_reduced::DecayLength,
-                  hf_cand_3prong_reduced::InvMass);
+                  o2::soa::Marker<2>);
 
 namespace hf_b0_mc
 {
@@ -304,10 +310,10 @@ DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with confi
 
 namespace soa
 {
-DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand2ProngBase, aod::HfRedCand2Prongs);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfRedCand3Prongs);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand2ProngBase, aod::HfRed2Prongs);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::HfCand3ProngBase, aod::HfRed3Prongs);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedTracks);
-DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::HfRedPidTracks);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions, aod::HfRedCollisions);
 } // namespace soa
 } // namespace o2
 #endif // PWGHF_D2H_DATAMODEL_REDUCEDDATAMODEL_H_

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -248,7 +248,6 @@ DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's pro
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
 } // namespace hf_b0_mc
 
-
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for reduced workflow
                   hf_cand_b0_reduced::Prong0Id,

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -84,30 +84,30 @@ DECLARE_SOA_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float); //! Covariance matrix
 } // namespace hf_track_par_cov
 
 // general columns
-#define HFTRACKPAR_COLUMNS    \
-  aod::track::X,                 \
-    aod::track::Alpha,           \
-    aod::track::Y,               \
-    aod::track::Z,               \
-    aod::track::Snp,             \
-    aod::track::Tgl,             \
+#define HFTRACKPAR_COLUMNS \
+  aod::track::X,           \
+    aod::track::Alpha,     \
+    aod::track::Y,         \
+    aod::track::Z,         \
+    aod::track::Snp,       \
+    aod::track::Tgl,       \
     aod::track::Signed1Pt
 
-#define HFTRACKPARCOV_COLUMNS    \
+#define HFTRACKPARCOV_COLUMNS  \
   hf_track_par_cov::CYY,       \
-    hf_track_par_cov::CZY,       \
-    hf_track_par_cov::CZZ,       \
-    hf_track_par_cov::CSnpY,     \
-    hf_track_par_cov::CSnpZ,     \
-    hf_track_par_cov::CSnpSnp,   \
-    hf_track_par_cov::CTglY,     \
-    hf_track_par_cov::CTglZ,     \
-    hf_track_par_cov::CTglSnp,   \
-    hf_track_par_cov::CTglTgl,   \
-    hf_track_par_cov::C1PtY,     \
-    hf_track_par_cov::C1PtZ,     \
-    hf_track_par_cov::C1PtSnp,   \
-    hf_track_par_cov::C1PtTgl,   \
+    hf_track_par_cov::CZY,     \
+    hf_track_par_cov::CZZ,     \
+    hf_track_par_cov::CSnpY,   \
+    hf_track_par_cov::CSnpZ,   \
+    hf_track_par_cov::CSnpSnp, \
+    hf_track_par_cov::CTglY,   \
+    hf_track_par_cov::CTglZ,   \
+    hf_track_par_cov::CTglSnp, \
+    hf_track_par_cov::CTglTgl, \
+    hf_track_par_cov::C1PtY,   \
+    hf_track_par_cov::C1PtZ,   \
+    hf_track_par_cov::C1PtSnp, \
+    hf_track_par_cov::C1PtTgl, \
     hf_track_par_cov::C1Pt21Pt2
 
 namespace hf_track_index_reduced

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -44,4 +44,3 @@ o2physics_add_dpl_workflow(data-creator-dplus-pi-reduced
                     SOURCES dataCreatorDplusPiReduced.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter
                     COMPONENT_NAME Analysis)
-

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -47,7 +47,7 @@ struct HfCandidateCreatorB0Reduced {
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
   // selection
   Configurable<double> invMassWindowDPiTolerance{"invMassWindowDPiTolerance", 0.01, "invariant-mass window tolerance for DPi pair preselections (GeV/c2)"};
-  // variable that will store the value of invMassWindowB0 (defined in dataCreatorDplusPiReduced.cxx)
+  // variable that will store the value of invMassWindowDPi (defined in dataCreatorDplusPiReduced.cxx)
   float myInvMassWindowDPi{1.};
 
   // O2DatabasePDG service
@@ -57,8 +57,6 @@ struct HfCandidateCreatorB0Reduced {
   double massD{0.};
   double massB0{0.};
   double invMass2DPi{0.};
-  double invMass2DPiMin{0.};
-  double invMass2DPiMax{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -98,14 +96,14 @@ struct HfCandidateCreatorB0Reduced {
                aod::HfOrigColCounts const& collisionsCounter,
                aod::HfCandB0Configs const& configs)
   {
-    // B0 invariant-mass window cut
+    // DPi invariant-mass window cut
     for (const auto& config : configs) {
       myInvMassWindowDPi = config.myInvMassWindowDPi();
     }
     // invMassWindowDPiTolerance is used to apply a slightly tighter cut than in DPi pair preselection
     // to avoid accepting DPi pairs that were not formed in DPi pair creator
-    invMass2DPiMin = (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance) * (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance);
-    invMass2DPiMax = (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance) * (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance);
+    double invMass2DPiMin = (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance) * (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance);
+    double invMass2DPiMax = (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance) * (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance);
 
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
@@ -142,7 +140,7 @@ struct HfCandidateCreatorB0Reduced {
           auto trackParCovPi = getTrackParCov(trackPion);
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
-          // compute invariant
+          // compute invariant mass square and apply selection
           invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -56,7 +56,6 @@ struct HfCandidateCreatorB0Reduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -70,7 +69,7 @@ struct HfCandidateCreatorB0Reduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -141,7 +140,7 @@ struct HfCandidateCreatorB0Reduced {
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
           // compute invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
@@ -165,7 +164,7 @@ struct HfCandidateCreatorB0Reduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD);    // momentum of D at the B0 vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
-          registry.fill(HIST("hMass2B0ToDPi"), invMass2DPi);
+          registry.fill(HIST("hMassB0ToDPi"), std::sqrt(invMass2DPi));
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -55,8 +55,8 @@ struct HfCandidateCreatorB0Reduced {
   // Fitter for B vertex (2-prong vertex filter)
   o2::vertexing::DCAFitterN<2> df2;
 
-  Preslice<aod::HfRedCand3Prongs> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
-  Preslice<aod::HfRedTracks> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov>> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRedTracks, aod::HfRedTracksCov>> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
 
   HistogramRegistry registry{"registry"};
 
@@ -79,8 +79,8 @@ struct HfCandidateCreatorB0Reduced {
   }
 
   void process(aod::HfRedCollisions const& collisions,
-               aod::HfRedCand3Prongs const& candsD,
-               aod::HfRedTracks const& tracksPion,
+               soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov>  const& candsD,
+               soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
                aod::HfOrigColCounts const& collisionsCounter)
   {
     for (const auto& collisionCounter : collisionsCounter) {

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -79,7 +79,7 @@ struct HfCandidateCreatorB0Reduced {
   }
 
   void process(aod::HfRedCollisions const& collisions,
-               soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov>  const& candsD,
+               soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov> const& candsD,
                soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
                aod::HfOrigColCounts const& collisionsCounter)
   {

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -16,6 +16,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 
@@ -34,6 +35,7 @@ using namespace o2::framework::expressions;
 /// Reconstruction of B0 candidates
 struct HfCandidateCreatorB0Reduced {
   Produces<aod::HfCandB0Base> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfRedB0Prongs> rowCandidateProngs; // table defined in ReducedDataModel.h
 
   // vertexing
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
@@ -44,26 +46,33 @@ struct HfCandidateCreatorB0Reduced {
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B0 is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
   // selection
-  Configurable<double> invMassWindowB0{"invMassWindowB0", 0.3, "invariant-mass window for B0 candidates"};
+  Configurable<double> invMassWindowDPiTolerance{"invMassWindowDPiTolerance", 0.01, "invariant-mass window tolerance for DPi pair preselections (GeV/c2)"};
+  // variable that will store the value of invMassWindowB0 (defined in dataCreatorDplusPiReduced.cxx)
+  float myInvMassWindowDPi{1.};
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD = RecoDecay::getMassPDG(pdg::Code::kDMinus);
-  double massB0 = RecoDecay::getMassPDG(pdg::Code::kB0);
-  double massDPi{0.};
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD{0.};
+  double massB0{0.};
+  double invMass2DPi{0.};
+  double invMass2DPiMin{0.};
+  double invMass2DPiMax{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
   o2::vertexing::DCAFitterN<2> df2;
 
   Preslice<soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov>> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
-  Preslice<soa::Join<aod::HfRedTracks, aod::HfRedTracksCov>> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRedTrackBases, aod::HfRedTracksCov>> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
 
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -76,13 +85,28 @@ struct HfCandidateCreatorB0Reduced {
     df2.setMinRelChi2Change(minRelChi2Change);
     df2.setUseAbsDCA(useAbsDCA);
     df2.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD = pdg->Mass(pdg::Code::kDMinus);
+    massB0 = pdg->Mass(pdg::Code::kB0);
   }
 
   void process(aod::HfRedCollisions const& collisions,
                soa::Join<aod::HfRed3Prongs, aod::HfRed3ProngsCov> const& candsD,
-               soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
-               aod::HfOrigColCounts const& collisionsCounter)
+               soa::Join<aod::HfRedTrackBases, aod::HfRedTracksCov> const& tracksPion,
+               aod::HfOrigColCounts const& collisionsCounter,
+               aod::HfCandB0Configs const& configs)
   {
+    // B0 invariant-mass window cut
+    for (const auto& config : configs) {
+      myInvMassWindowDPi = config.myInvMassWindowDPi();
+    }
+    // invMassWindowDPiTolerance is used to apply a slightly tighter cut than in DPi pair preselection
+    // to avoid accepting DPi pairs that were not formed in DPi pair creator
+    invMass2DPiMin = (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance) * (massB0 - myInvMassWindowDPi + invMassWindowDPiTolerance);
+    invMass2DPiMax = (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance) * (massB0 + myInvMassWindowDPi - invMassWindowDPiTolerance);
+
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
     }
@@ -111,13 +135,18 @@ struct HfCandidateCreatorB0Reduced {
         auto tracksPionThisCollision = tracksPion.sliceBy(tracksPionPerCollision, thisCollId);
         for (const auto& trackPion : tracksPionThisCollision) {
           // this track is among daughters
-          if (trackPion.trackId() == candD.prong0Id() || trackPion.trackId() == candD.prong0Id() || trackPion.trackId() == candD.prong0Id()) {
+          if (trackPion.trackId() == candD.prong0Id() || trackPion.trackId() == candD.prong1Id() || trackPion.trackId() == candD.prong2Id()) {
             continue;
           }
 
           auto trackParCovPi = getTrackParCov(trackPion);
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
+          // compute invariant
+          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
+            continue;
+          }
           // ---------------------------------
           // reconstruct the 2-prong B0 vertex
           if (df2.process(trackParCovD, trackParCovPi) == 0) {
@@ -138,13 +167,7 @@ struct HfCandidateCreatorB0Reduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD);    // momentum of D at the B0 vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
-          // compute invariant
-          massDPi = RecoDecay::m(std::array{pVecD, pVecPion}, std::array{massD, massPi});
-
-          if (std::abs(massDPi - massB0) > invMassWindowB0) {
-            continue;
-          }
-          registry.fill(HIST("hMassB0ToDPi"), massDPi);
+          registry.fill(HIST("hMass2B0ToDPi"), invMass2DPi);
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;
@@ -171,8 +194,9 @@ struct HfCandidateCreatorB0Reduced {
                            pVecPion[0], pVecPion[1], pVecPion[2],
                            dcaD.getY(), dcaPion.getY(),
                            std::sqrt(dcaD.getSigmaY2()), std::sqrt(dcaPion.getSigmaY2()),
-                           candD.globalIndex(), trackPion.globalIndex(),
                            hfFlag);
+
+          rowCandidateProngs(candD.globalIndex(), trackPion.globalIndex());
         } // pi loop
       }   // D loop
     }     // collision loop
@@ -182,11 +206,12 @@ struct HfCandidateCreatorB0Reduced {
 /// Extends the table base with expression columns and performs MC matching.
 struct HfCandidateCreatorB0ReducedExpressions {
   Spawns<aod::HfCandB0Ext> rowCandidateB0;
+  Spawns<aod::HfRedTracksExt> rowTracksExt;
   Produces<aod::HfMcRecRedB0s> rowB0McRec;
 
-  void processMc(HfMcRecRedDpPis const& rowsDPiMcRec)
+  void processMc(HfMcRecRedDpPis const& rowsDPiMcRec, HfRedB0Prongs const& candsB0)
   {
-    for (const auto& candB0 : *rowCandidateB0) {
+    for (const auto& candB0 : candsB0) {
       for (const auto& rowDPiMcRec : rowsDPiMcRec) {
         if ((rowDPiMcRec.prong0Id() != candB0.prong0Id()) || (rowDPiMcRec.prong1Id() != candB0.prong1Id())) {
           continue;

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -56,8 +56,8 @@ struct HfCandidateCreatorBplusReduced {
   // Fitter for B vertex (2-prong vertex filter)
   o2::vertexing::DCAFitterN<2> df2;
 
-  Preslice<aod::HfCand2ProngReduced> candsDPerCollision = hf_track_index_reduced::hfReducedCollisionId;
-  Preslice<aod::HfTracksReduced> tracksPionPerCollision = hf_track_index_reduced::hfReducedCollisionId;
+  Preslice<aod::HfRedCand2Prongs> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<aod::HfRedTracks> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
 
   HistogramRegistry registry{"registry"};
 
@@ -79,10 +79,10 @@ struct HfCandidateCreatorBplusReduced {
     df2.setWeightedFinalPCA(useWeightedFinalPCA);
   }
 
-  void process(aod::HfReducedCollisions const& collisions,
-               aod::HfCand2ProngReduced const& candsD,
-               aod::HfTracksReduced const& tracksPion,
-               aod::HfOriginalCollisionsCounter const& collisionsCounter)
+  void process(aod::HfRedCollisions const& collisions,
+               aod::HfRedCand2Prongs const& candsD,
+               aod::HfRedTracks const& tracksPion,
+               aod::HfOrigColCounts const& collisionsCounter)
   {
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
@@ -178,16 +178,16 @@ struct HfCandidateCreatorBplusReduced {
 /// Extends the table base with expression columns and performs MC matching.
 struct HfCandidateCreatorBplusReducedExpressions {
   Spawns<aod::HfCandBplusExt> rowCandidateBPlus;
-  Produces<aod::HfBpMcRecReduced> rowBplusMcRec;
+  Produces<aod::HfMcRecRedBps> rowBplusMcRec;
 
-  void processMc(HfD0PiMcRecReduced const& rowsD0PiMcRec)
+  void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec)
   {
     for (const auto& candBplus : *rowCandidateBPlus) {
       for (const auto& rowD0PiMcRec : rowsD0PiMcRec) {
         if ((rowD0PiMcRec.prong0Id() != candBplus.prong0Id()) || (rowD0PiMcRec.prong1Id() != candBplus.prong1Id())) {
           continue;
         }
-        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.originMcRec(), rowD0PiMcRec.ptMother());
+        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.ptMother());
       }
     }
   }

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -56,8 +56,8 @@ struct HfCandidateCreatorBplusReduced {
   // Fitter for B vertex (2-prong vertex filter)
   o2::vertexing::DCAFitterN<2> df2;
 
-  Preslice<aod::HfRedCand2Prongs> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
-  Preslice<aod::HfRedTracks> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRed2Prongs, aod::HfRed2ProngsCov>> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRedTracks, aod::HfRedTracksCov>> tracksPionPerCollision = hf_track_index_reduced::hfRedCollisionId;
 
   HistogramRegistry registry{"registry"};
 
@@ -80,8 +80,8 @@ struct HfCandidateCreatorBplusReduced {
   }
 
   void process(aod::HfRedCollisions const& collisions,
-               aod::HfRedCand2Prongs const& candsD,
-               aod::HfRedTracks const& tracksPion,
+               soa::Join<aod::HfRed2Prongs, aod::HfRed2ProngsCov> const& candsD,
+               soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
                aod::HfOrigColCounts const& collisionsCounter)
   {
     for (const auto& collisionCounter : collisionsCounter) {

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -16,6 +16,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -35,6 +36,7 @@ using namespace o2::framework::expressions;
 /// Reconstruction of B+ candidates
 struct HfCandidateCreatorBplusReduced {
   Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfRedBplusProngs> rowCandidateProngs; // table defined in ReducedDataModel.h
 
   // vertexing
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
@@ -45,12 +47,17 @@ struct HfCandidateCreatorBplusReduced {
   Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B+ is smaller than this"};
   Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
   // selection
-  Configurable<double> invMassWindowBplus{"invMassWindowBplus", 0.3, "invariant-mass window for B+ candidates"};
+  Configurable<double> invMassWindowD0PiTolerance{"invMassWindowD0PiTolerance", 0.01, "invariant-mass window tolerance for D0Pi pair preselections (GeV/c2)"};
+  // variable that will store the value of invMassWindowD0Pi (defined in dataCreatorD0PiReduced.cxx)
+  float myInvMassWindowD0Pi{1.};
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD0 = RecoDecay::getMassPDG(pdg::Code::kD0);
-  double massBplus = RecoDecay::getMassPDG(pdg::Code::kBPlus);
-  double massD0Pi{0.};
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD0{0.};
+  double massBplus{0.};
+  double invMass2D0Pi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -64,7 +71,7 @@ struct HfCandidateCreatorBplusReduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -77,13 +84,28 @@ struct HfCandidateCreatorBplusReduced {
     df2.setMinRelChi2Change(minRelChi2Change);
     df2.setUseAbsDCA(useAbsDCA);
     df2.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD0 = pdg->Mass(pdg::Code::kD0);
+    massBplus = pdg->Mass(pdg::Code::kBPlus);
   }
 
   void process(aod::HfRedCollisions const& collisions,
                soa::Join<aod::HfRed2Prongs, aod::HfRed2ProngsCov> const& candsD,
-               soa::Join<aod::HfRedTracks, aod::HfRedTracksCov> const& tracksPion,
-               aod::HfOrigColCounts const& collisionsCounter)
+               soa::Join<aod::HfRedTrackBases, aod::HfRedTracksCov> const& tracksPion,
+               aod::HfOrigColCounts const& collisionsCounter,
+               aod::HfCandBpConfigs const& configs)
   {
+    // D0Pi invariant-mass window cut
+    for (const auto& config : configs) {
+      myInvMassWindowD0Pi = config.myInvMassWindowD0Pi();
+    }
+    // invMassWindowD0PiTolerance is used to apply a slightly tighter cut than in D0Pi pair preselection
+    // to avoid accepting D0Pi pairs that were not formed in D0Pi pair creator
+    double invMass2D0PiMin = (massBplus - myInvMassWindowD0Pi + invMassWindowD0PiTolerance) * (massBplus - myInvMassWindowD0Pi + invMassWindowD0PiTolerance);
+    double invMass2D0PiMax = (massBplus + myInvMassWindowD0Pi - invMassWindowD0PiTolerance) * (massBplus + myInvMassWindowD0Pi - invMassWindowD0PiTolerance);
+
     for (const auto& collisionCounter : collisionsCounter) {
       registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
     }
@@ -114,6 +136,11 @@ struct HfCandidateCreatorBplusReduced {
           auto trackParCovPi = getTrackParCov(trackPion);
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
+          // compute invariant mass square and apply selection
+          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
+            continue;
+          }
           // ---------------------------------
           // reconstruct the 2-prong B+ vertex
           if (df2.process(trackParCovD, trackParCovPi) == 0) {
@@ -134,13 +161,7 @@ struct HfCandidateCreatorBplusReduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD0);   // momentum of D0 at the B+ vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B+ vertex
 
-          // compute invariant
-          massD0Pi = RecoDecay::m(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
-
-          if (std::abs(massD0Pi - massBplus) > invMassWindowBplus) {
-            continue;
-          }
-          registry.fill(HIST("hMassBplusToD0Pi"), massD0Pi);
+          registry.fill(HIST("hMass2BplusToD0Pi"), invMass2D0Pi);
 
           // compute impact parameters of D0 and Pi
           o2::dataformats::DCA dcaD0;
@@ -167,8 +188,9 @@ struct HfCandidateCreatorBplusReduced {
                            pVecPion[0], pVecPion[1], pVecPion[2],
                            dcaD0.getY(), dcaPion.getY(),
                            std::sqrt(dcaD0.getSigmaY2()), std::sqrt(dcaPion.getSigmaY2()),
-                           candD0.globalIndex(), trackPion.globalIndex(),
                            hfFlag);
+
+          rowCandidateProngs(candD0.globalIndex(), trackPion.globalIndex());
         } // pi loop
       }   // D0 loop
     }     // collision loop
@@ -178,11 +200,12 @@ struct HfCandidateCreatorBplusReduced {
 /// Extends the table base with expression columns and performs MC matching.
 struct HfCandidateCreatorBplusReducedExpressions {
   Spawns<aod::HfCandBplusExt> rowCandidateBPlus;
+  Spawns<aod::HfRedTracksExt> rowTracksExt;
   Produces<aod::HfMcRecRedBps> rowBplusMcRec;
 
-  void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec)
+  void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec, HfRedBplusProngs const& candsBplus)
   {
-    for (const auto& candBplus : *rowCandidateBPlus) {
+    for (const auto& candBplus : candsBplus) {
       for (const auto& rowD0PiMcRec : rowsD0PiMcRec) {
         if ((rowD0PiMcRec.prong0Id() != candBplus.prong0Id()) || (rowD0PiMcRec.prong1Id() != candBplus.prong1Id())) {
           continue;

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -57,7 +57,6 @@ struct HfCandidateCreatorBplusReduced {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double bz{0.};
 
   // Fitter for B vertex (2-prong vertex filter)
@@ -71,7 +70,7 @@ struct HfCandidateCreatorBplusReduced {
   void init(InitContext const&)
   {
     // histograms
-    registry.add("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -137,7 +136,7 @@ struct HfCandidateCreatorBplusReduced {
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
 
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
@@ -161,7 +160,7 @@ struct HfCandidateCreatorBplusReduced {
           df2.getTrack(0).getPxPyPzGlo(pVecD0);   // momentum of D0 at the B+ vertex
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B+ vertex
 
-          registry.fill(HIST("hMass2BplusToD0Pi"), invMass2D0Pi);
+          registry.fill(HIST("hMassBplusToD0Pi"), std::sqrt(invMass2D0Pi));
 
           // compute impact parameters of D0 and Pi
           o2::dataformats::DCA dcaD0;

--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -91,7 +91,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
     }
   }
 
-  void process(HfCandB0 const& hfCandsB0,
+  void process(HfRedCandB0 const& hfCandsB0,
                TracksPion const&,
                HfCandB0Configs const& configs)
   {

--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -90,8 +90,8 @@ struct HfCandidateSelectorB0ToDPiReduced {
   }
 
   void process(HfCandB0 const& hfCandsB0,
-               HfTracksPidReduced const&,
-               HfCandB0Config const& configs)
+               HfRedPidTracks const&,
+               HfCandB0Configs const& configs)
   {
     // get DplusPi creator configurable
     for (const auto& config : configs) {
@@ -143,7 +143,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
       }
       // track-level PID selection
       if (usePid) {
-        auto trackPi = hfCandB0.prong1_as<HfTracksPidReduced>();
+        auto trackPi = hfCandB0.prong1_as<HfRedPidTracks>();
         int pidTrackPi = selectorPion.statusTpcAndTof(trackPi);
         if (!hf_sel_candidate_b0::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B0 candidate selection failed at PID selection");

--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -63,6 +63,8 @@ struct HfCandidateSelectorB0ToDPiReduced {
 
   HistogramRegistry registry{"registry"};
 
+  using TracksPion = soa::Join<HfRedTracks, HfRedTracksPid>;
+
   void init(InitContext const& initContext)
   {
     if (usePid) {
@@ -90,7 +92,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
   }
 
   void process(HfCandB0 const& hfCandsB0,
-               HfRedPidTracks const&,
+               TracksPion const&,
                HfCandB0Configs const& configs)
   {
     // get DplusPi creator configurable
@@ -143,7 +145,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
       }
       // track-level PID selection
       if (usePid) {
-        auto trackPi = hfCandB0.prong1_as<HfRedPidTracks>();
+        auto trackPi = hfCandB0.prong1_as<TracksPion>();
         int pidTrackPi = selectorPion.statusTpcAndTof(trackPi);
         if (!hf_sel_candidate_b0::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B0 candidate selection failed at PID selection");

--- a/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
@@ -90,9 +90,9 @@ struct HfCandidateSelectorBplusToD0PiReduced {
   }
 
   void process(HfCandBplus const& hfCandBs,
-               HfCand2ProngReduced const&,
-               HfTracksPidReduced const&,
-               HfCandBpConfig const& configs)
+               HfRedCand2Prongs const&,
+               HfRedPidTracks const&,
+               HfCandBpConfigs const& configs)
   {
     // get DplusPi creator configurable
     for (const auto& config : configs) {
@@ -112,8 +112,8 @@ struct HfCandidateSelectorBplusToD0PiReduced {
     for (const auto& hfCandBp : hfCandBs) {
       int statusBplus = 0;
       auto ptCandBplus = hfCandBp.pt();
-      // auto candD0 = hfCandBp.prong0_as<HfCand2ProngReduced>();
-      // auto trackPi = hfCandBp.prong1_as<HfTracksPidReduced>();
+      // auto candD0 = hfCandBp.prong0_as<HfRedCand2Prongs>();
+      // auto trackPi = hfCandBp.prong1_as<HfRedPidTracks>();
 
       // check if flagged as B+ → D π
       if (!TESTBIT(hfCandBp.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
@@ -147,7 +147,7 @@ struct HfCandidateSelectorBplusToD0PiReduced {
       }
       // track-level PID selection
       if (usePid) {
-        auto trackPi = hfCandBp.prong1_as<HfTracksPidReduced>();
+        auto trackPi = hfCandBp.prong1_as<HfRedPidTracks>();
         int pidTrackPi = selectorPion.statusTpcAndTof(trackPi);
         if (!hf_sel_candidate_bplus::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B+ candidate selection failed at PID selection");

--- a/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
@@ -91,7 +91,7 @@ struct HfCandidateSelectorBplusToD0PiReduced {
     }
   }
 
-  void process(HfCandBplus const& hfCandBs,
+  void process(HfRedCandBplus const& hfCandBs,
                HfRed2Prongs const&,
                TracksPion const&,
                HfCandBpConfigs const& configs)

--- a/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorBplusToD0PiReduced.cxx
@@ -63,6 +63,8 @@ struct HfCandidateSelectorBplusToD0PiReduced {
 
   HistogramRegistry registry{"registry"};
 
+  using TracksPion = soa::Join<HfRedTracks, HfRedTracksPid>;
+
   void init(InitContext const& initContext)
   {
     if (usePid) {
@@ -90,8 +92,8 @@ struct HfCandidateSelectorBplusToD0PiReduced {
   }
 
   void process(HfCandBplus const& hfCandBs,
-               HfRedCand2Prongs const&,
-               HfRedPidTracks const&,
+               HfRed2Prongs const&,
+               TracksPion const&,
                HfCandBpConfigs const& configs)
   {
     // get DplusPi creator configurable
@@ -112,8 +114,8 @@ struct HfCandidateSelectorBplusToD0PiReduced {
     for (const auto& hfCandBp : hfCandBs) {
       int statusBplus = 0;
       auto ptCandBplus = hfCandBp.pt();
-      // auto candD0 = hfCandBp.prong0_as<HfRedCand2Prongs>();
-      // auto trackPi = hfCandBp.prong1_as<HfRedPidTracks>();
+      // auto candD0 = hfCandBp.prong0_as<HfRed2Prongs>();
+      // auto trackPi = hfCandBp.prong1_as<HfRedTracksPid>();
 
       // check if flagged as B+ → D π
       if (!TESTBIT(hfCandBp.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
@@ -147,7 +149,7 @@ struct HfCandidateSelectorBplusToD0PiReduced {
       }
       // track-level PID selection
       if (usePid) {
-        auto trackPi = hfCandBp.prong1_as<HfRedPidTracks>();
+        auto trackPi = hfCandBp.prong1_as<TracksPion>();
         int pidTrackPi = selectorPion.statusTpcAndTof(trackPi);
         if (!hf_sel_candidate_bplus::selectionPID(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B+ candidate selection failed at PID selection");

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -196,7 +196,7 @@ struct HfDataCreatorD0PiReduced {
     return true;
   }
 
-  template<bool doMC = false, typename P, typename T>
+  template <bool doMC = false, typename P, typename T>
   void runDataCreation(aod::Collisions const& collisions,
                        CandsDFiltered const& candsD0,
                        aod::TrackAssoc const& trackIndices,
@@ -428,10 +428,10 @@ struct HfDataCreatorD0PiReduced {
   }
 
   void process(aod::Collisions const& collisions,
-                CandsDFiltered const& candsD0,
-                aod::TrackAssoc const& trackIndices,
-                TracksPIDWithSel const& tracks,
-                aod::BCsWithTimestamps const& bcs)
+               CandsDFiltered const& candsD0,
+               aod::TrackAssoc const& trackIndices,
+               TracksPIDWithSel const& tracks,
+               aod::BCsWithTimestamps const& bcs)
   {
     runDataCreation<false>(collisions, candsD0, trackIndices, tracks, tracks, bcs);
   }

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -46,7 +46,7 @@ struct HfDataCreatorD0PiReduced {
   // Produces AOD tables to store track information
   Produces<aod::HfRedCollisions> hfReducedCollision;
   Produces<aod::HfOrigColCounts> hfCollisionCounter;
-  Produces<aod::HfRedTracksBase> hfTrackPion;
+  Produces<aod::HfRedTrackBases> hfTrackPion;
   Produces<aod::HfRedTracksCov> hfTrackCovPion;
   Produces<aod::HfRedTracksPid> hfTrackPidPion;
   Produces<aod::HfRed2Prongs> hfCand2Prong;

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -44,12 +44,14 @@ enum Event : uint8_t {
 /// Creation of D0-Pi pairs
 struct HfDataCreatorD0PiReduced {
   // Produces AOD tables to store track information
-  Produces<aod::HfReducedCollisions> hfReducedCollision;
-  Produces<aod::HfOriginalCollisionsCounter> hfCollisionCounter;
-  Produces<aod::HfTracksReduced> hfTrackPion;
-  Produces<aod::HfTracksPidReduced> hfTrackPidPion;
-  Produces<aod::HfCand2ProngReduced> hfCand2Prong;
-  Produces<aod::HfCandBpConfig> rowCandidateConfig;
+  Produces<aod::HfRedCollisions> hfReducedCollision;
+  Produces<aod::HfOrigColCounts> hfCollisionCounter;
+  Produces<aod::HfRedTracks> hfTrackPion;
+  Produces<aod::HfRedPidTracks> hfTrackPidPion;
+  Produces<aod::HfRedCand2Prongs> hfCand2Prong;
+  Produces<aod::HfCandBpConfigs> rowCandidateConfig;
+  Produces<aod::HfMcRecRedD0Pis> rowHfD0PiMcRecReduced;
+  Produces<aod::HfMcGenRedBps> rowHfBpMcGenReduced;
 
   // vertexing
   // Configurable<double> bz{"bz", 5., "magnetic field"};
@@ -96,6 +98,7 @@ struct HfDataCreatorD0PiReduced {
   using TracksPidAll = soa::Join<aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>;
   using TracksPIDWithSel = soa::Join<aod::TracksWCovDcaExtra, TracksPidAll, aod::TrackSelection>;
+  using TracksPIDWithSelAndMc = soa::Join<TracksPIDWithSel, aod::McTrackLabels>;
   using CandsDFiltered = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_d0::isSelD0 >= selectionFlagD0 || aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlagD0bar);
@@ -191,11 +194,13 @@ struct HfDataCreatorD0PiReduced {
     return true;
   }
 
-  void process(aod::Collisions const& collisions,
-               CandsDFiltered const& candsD0,
-               aod::TrackAssoc const& trackIndices,
-               TracksPIDWithSel const&,
-               aod::BCsWithTimestamps const&)
+  template<bool doMC = false, typename P, typename T>
+  void runDataCreation(aod::Collisions const& collisions,
+                       CandsDFiltered const& candsD0,
+                       aod::TrackAssoc const& trackIndices,
+                       T const& tracks,
+                       P const& particlesMc,
+                       aod::BCsWithTimestamps const& bcs)
   {
     // store configurables needed for B+ workflow
     if (!isHfCandBplusConfigFilled) {
@@ -209,9 +214,7 @@ struct HfDataCreatorD0PiReduced {
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize());
 
-    static int nCol = 0;
     for (const auto& collision : collisions) {
-      nCol++;
 
       // helpers for ReducedTables filling
       int hfReducedCollisionIndex = hfReducedCollision.lastIndex() + 1;
@@ -220,9 +223,6 @@ struct HfDataCreatorD0PiReduced {
       bool fillHfReducedCollision = false;
 
       auto primaryVertex = getPrimaryVertex(collision);
-      if (nCol % 10000 == 0) {
-        LOG(debug) << nCol << " collisions parsed";
-      }
 
       // Set the magnetic field from ccdb.
       // The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
@@ -243,18 +243,18 @@ struct HfDataCreatorD0PiReduced {
         float invMassD0;
 
         if (candD0.isSelD0() >= selectionFlagD0) {
-          invMassD0 = invMassD0ToPiK(candD0);
+          invMassD0 = o2::aod::hf_cand_2prong::invMassD0ToPiK(candD0);
           registry.fill(HIST("hMassD0ToKPi"), invMassD0);
         }
         if (candD0.isSelD0bar() >= selectionFlagD0bar) {
-          invMassD0 = invMassD0barToKPi(candD0);
+          invMassD0 = o2::aod::hf_cand_2prong::invMassD0barToKPi(candD0);
           registry.fill(HIST("hMassD0ToKPi"), invMassD0);
         }
         registry.fill(HIST("hPtD0"), candD0.pt());
         registry.fill(HIST("hCPAD0"), candD0.cpa());
 
-        auto track0 = candD0.prong0_as<TracksPIDWithSel>();
-        auto track1 = candD0.prong1_as<TracksPIDWithSel>();
+        auto track0 = candD0.template prong0_as<T>();
+        auto track1 = candD0.template prong1_as<T>();
         auto trackParCov0 = getTrackParCov(track0);
         auto trackParCov1 = getTrackParCov(track1);
 
@@ -294,7 +294,7 @@ struct HfDataCreatorD0PiReduced {
 
         auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (const auto& trackId : trackIdsThisCollision) {
-          auto trackPion = trackId.track_as<TracksPIDWithSel>();
+          auto trackPion = trackId.template track_as<T>();
 
           // apply selections on pion tracks
           if (!isPionSelected(trackPion, track0, track1, candD0) || !isSelectedTrackDCA(trackPion)) {
@@ -332,6 +332,31 @@ struct HfDataCreatorD0PiReduced {
             selectedTracksPion.emplace_back(trackPion.globalIndex());
           }
           fillHfCand2Prong = true;
+
+          if constexpr (doMC) {
+            // we check the MC matching to be stored
+            auto arrayDaughtersD0 = std::array{track0, track1};
+            auto arrayDaughtersBplus = std::array{track0, track1, trackPion};
+            int8_t sign{0};
+            int8_t flag{0};
+            // B+ → D0(bar) π+ → (K+ π-) π+
+            // Printf("Checking B+ → D0bar π+");
+            auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersBplus, pdg::Code::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+            if (indexRec > -1) {
+              // D0bar → K+ π-
+              // Printf("Checking D0bar → K+ π-");
+              indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD0, pdg::Code::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign, 1);
+              if (indexRec > -1) {
+                flag = sign * BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
+              } else {
+                LOGF(info, "WARNING: B+ decays in the expected final state but the condition on the intermediate state is not fulfilled");
+              }
+            }
+            auto indexMother = RecoDecay::getMother(particlesMc, trackPion.template mcParticle_as<P>(), pdg::Code::kBPlus, true);
+            auto particleMother = particlesMc.rawIteratorAt(indexMother);
+
+            rowHfD0PiMcRecReduced(candD0.globalIndex(), trackPion.globalIndex(), flag, particleMother.pt());
+          }
         }                       // pion loop
         if (fillHfCand2Prong) { // fill candD0 table only once per D0 candidate
           hfCand2Prong(track0.globalIndex(), track1.globalIndex(),
@@ -364,101 +389,72 @@ struct HfDataCreatorD0PiReduced {
                          collision.covXZ(), collision.covYZ(), collision.covZZ(),
                          bz);
     } // collision
-  }   // process
-};    // struct
 
-/// Performs MC matching.
-struct HfDataCreatorD0PiReducedMc {
-  Produces<aod::HfD0PiMcRecReduced> rowHfD0PiMcRecReduced;
-  Produces<aod::HfBpMcGenReduced> rowHfBPMcGenReduced;
-
-  void init(InitContext const&) {}
-
-  void processMc(aod::HfCand2ProngReduced const& candsD0,
-                 aod::HfTracksReduced const& tracksPion,
-                 aod::TracksWMc const&,
-                 aod::McParticles const& mcParticles)
-  {
-    int indexRec = -1;
-    int8_t sign = 0;
-    int8_t flag = 0;
-    int8_t origin = 0;
-
-    for (const auto& candD0 : candsD0) {
-      auto arrayDaughtersD0 = std::array{candD0.prong0_as<aod::TracksWMc>(),
-                                         candD0.prong1_as<aod::TracksWMc>()};
-
-      for (const auto& trackPion : tracksPion) {
-        if (trackPion.hfReducedCollisionId() != candD0.hfReducedCollisionId()) {
-          continue;
-        }
-        // const auto& trackId = trackPion.globalIndex();
-        auto arrayDaughtersBplus = std::array{candD0.prong0_as<aod::TracksWMc>(),
-                                              candD0.prong1_as<aod::TracksWMc>(),
-                                              trackPion.track_as<aod::TracksWMc>()};
-        // B+ → D0(bar) π+ → (K+ π-) π+
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersBplus, pdg::Code::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
-        if (indexRec > -1) {
-          // D0bar → K+ π-
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersD0, pdg::Code::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign, 1);
-          if (indexRec > -1) {
+    if constexpr (doMC) {
+      // Match generated particles.
+      for (const auto& particle : particlesMc) {
+        int8_t sign{0};
+        int8_t flag{0};
+        // B+ → D0bar π+
+        if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kBPlus, std::array{static_cast<int>(pdg::Code::kD0), +kPiPlus}, true)) {
+          // Match D0bar -> π- K+
+          auto candD0MC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
+          // Printf("Checking D0bar -> π- K+");
+          if (RecoDecay::isMatchedMCGen(particlesMc, candD0MC, static_cast<int>(pdg::Code::kD0), std::array{+kPiPlus, -kKPlus}, true, &sign)) {
             flag = sign * BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
-          } else {
-            LOGF(info, "WARNING: B+ decays in the expected final state but the condition on the intermediate state is not fulfilled");
           }
         }
-        auto indexMother = RecoDecay::getMother(mcParticles, trackPion.track_as<aod::TracksWMc>().mcParticle_as<aod::McParticles>(), pdg::Code::kBPlus, true);
-        auto particleMother = mcParticles.rawIteratorAt(indexMother);
 
-        rowHfD0PiMcRecReduced(candD0.globalIndex(), trackPion.globalIndex(), flag, origin, particleMother.pt());
-      }
-    } // rec
-
-    // Match generated particles.
-    for (const auto& particle : mcParticles) {
-      flag = 0;
-      origin = 0;
-      // B+ → D0bar π+
-      if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdg::Code::kBPlus, std::array{static_cast<int>(pdg::Code::kD0), +kPiPlus}, true)) {
-        // D0bar → π- K+
-        auto candD0MC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
-        if (RecoDecay::isMatchedMCGen(mcParticles, candD0MC, static_cast<int>(pdg::Code::kD0), std::array{+kPiPlus, -kKPlus}, true, &sign)) {
-          flag = sign * BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
+        // save information for B+ task
+        if (!TESTBIT(std::abs(flag), hf_cand_bplus::DecayType::BplusToD0Pi)) {
+          continue;
         }
-      }
 
-      // save information for B+ task
-      if (!TESTBIT(std::abs(flag), hf_cand_bplus::DecayType::BplusToD0Pi)) {
-        continue;
-      }
+        auto ptParticle = particle.pt();
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBPlus));
+        auto etaParticle = particle.eta();
 
-      auto ptParticle = particle.pt();
-      auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kBPlus));
-      auto etaParticle = particle.eta();
+        std::array<float, 2> ptProngs;
+        std::array<float, 2> yProngs;
+        std::array<float, 2> etaProngs;
+        int counter = 0;
+        for (const auto& daught : particle.template daughters_as<P>()) {
+          ptProngs[counter] = daught.pt();
+          etaProngs[counter] = daught.eta();
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          counter++;
+        }
+        rowHfBpMcGenReduced(flag, ptParticle, yParticle, etaParticle,
+                            ptProngs[0], yProngs[0], etaProngs[0],
+                            ptProngs[1], yProngs[1], etaProngs[1]);
+      } // gen
+    }
+  }
 
-      std::array<float, 2> ptProngs;
-      std::array<float, 2> yProngs;
-      std::array<float, 2> etaProngs;
-      int counter = 0;
-      for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
-        ptProngs[counter] = daught.pt();
-        etaProngs[counter] = daught.eta();
-        yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
-        counter++;
-      }
-      rowHfBPMcGenReduced(flag, origin,
-                          ptParticle, yParticle, etaParticle,
-                          ptProngs[0], yProngs[0], etaProngs[0],
-                          ptProngs[1], yProngs[1], etaProngs[1]);
-    } // gen
+  void process(aod::Collisions const& collisions,
+                CandsDFiltered const& candsD0,
+                aod::TrackAssoc const& trackIndices,
+                TracksPIDWithSel const& tracks,
+                aod::BCsWithTimestamps const& bcs)
+  {
+    runDataCreation<false>(collisions, candsD0, trackIndices, tracks, tracks, bcs);
+  }
+  PROCESS_SWITCH(HfDataCreatorD0PiReduced, process, "Process without MC info", true);
 
-  } // processMc
-  PROCESS_SWITCH(HfDataCreatorD0PiReducedMc, processMc, "Process MC", false);
+  void processMc(aod::Collisions const& collisions,
+                 CandsDFiltered const& candsD0,
+                 aod::TrackAssoc const& trackIndices,
+                 TracksPIDWithSelAndMc const& tracks,
+                 aod::McParticles const& particlesMc,
+                 aod::BCsWithTimestamps const& bcs)
+  {
+    runDataCreation<true>(collisions, candsD0, trackIndices, tracks, particlesMc, bcs);
+  }
+  PROCESS_SWITCH(HfDataCreatorD0PiReduced, processMc, "Process with MC info", false);
+
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<HfDataCreatorD0PiReduced>(cfgc),
-    adaptAnalysisTask<HfDataCreatorD0PiReducedMc>(cfgc)};
+  return WorkflowSpec{adaptAnalysisTask<HfDataCreatorD0PiReduced>(cfgc)};
 }

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -95,7 +95,6 @@ struct HfDataCreatorD0PiReduced {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double invMass2D0PiMin{0.};
   double invMass2D0PiMax{0.};
   double bz{0.};
@@ -317,7 +316,7 @@ struct HfDataCreatorD0PiReduced {
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
@@ -336,8 +335,7 @@ struct HfDataCreatorD0PiReduced {
                            trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
                            trackPion.c1PtTgl(), trackPion.c1Pt21Pt2());
             hfTrackPidPion(trackPion.hasTPC(), trackPion.hasTOF(),
-                           trackPion.tpcNSigmaEl(), trackPion.tpcNSigmaMu(), trackPion.tpcNSigmaPi(), trackPion.tpcNSigmaKa(), trackPion.tpcNSigmaPr(),
-                           trackPion.tofNSigmaEl(), trackPion.tofNSigmaMu(), trackPion.tofNSigmaPi(), trackPion.tofNSigmaKa(), trackPion.tofNSigmaPr());
+                           trackPion.tpcNSigmaPi(), trackPion.tofNSigmaPi());
             // add trackPion.globalIndex() to a list
             // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another D candidate
             // and keep track of their index in hfTrackPion for McRec purposes

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -441,10 +441,10 @@ struct HfDataCreatorD0PiReduced {
   }
 
   void processData(aod::Collisions const& collisions,
-               CandsDFiltered const& candsD0,
-               aod::TrackAssoc const& trackIndices,
-               TracksPIDWithSel const& tracks,
-               aod::BCsWithTimestamps const& bcs)
+                   CandsDFiltered const& candsD0,
+                   aod::TrackAssoc const& trackIndices,
+                   TracksPIDWithSel const& tracks,
+                   aod::BCsWithTimestamps const& bcs)
   {
     runDataCreation<false>(collisions, candsD0, trackIndices, tracks, tracks, bcs);
   }

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -94,7 +94,6 @@ struct HfDataCreatorDplusPiReduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMassD{0.};
   double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
@@ -320,7 +319,7 @@ struct HfDataCreatorDplusPiReduced {
           }
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
-          // compute invariant mass and apply selection
+          // compute invariant mass square and apply selection
           invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -193,7 +193,7 @@ struct HfDataCreatorDplusPiReduced {
     return true;
   }
 
-  template<bool doMC = false, typename P, typename T>
+  template <bool doMC = false, typename P, typename T>
   void runDataCreation(aod::Collisions const& collisions,
                        CandsDFiltered const& candsD,
                        aod::TrackAssoc const& trackIndices,
@@ -430,10 +430,10 @@ struct HfDataCreatorDplusPiReduced {
   }
 
   void process(aod::Collisions const& collisions,
-                CandsDFiltered const& candsD,
-                aod::TrackAssoc const& trackIndices,
-                TracksPIDWithSel const& tracks,
-                aod::BCsWithTimestamps const& bcs)
+               CandsDFiltered const& candsD,
+               aod::TrackAssoc const& trackIndices,
+               TracksPIDWithSel const& tracks,
+               aod::BCsWithTimestamps const& bcs)
   {
     runDataCreation<false>(collisions, candsD, trackIndices, tracks, tracks, bcs);
   }

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -94,7 +94,6 @@ struct HfDataCreatorDplusPiReduced {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
   double bz{0.};
@@ -320,7 +319,7 @@ struct HfDataCreatorDplusPiReduced {
           registry.fill(HIST("hPtPion"), trackPion.pt());
           std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
           // compute invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
@@ -339,8 +338,7 @@ struct HfDataCreatorDplusPiReduced {
                            trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
                            trackPion.c1PtTgl(), trackPion.c1Pt21Pt2());
             hfTrackPidPion(trackPion.hasTPC(), trackPion.hasTOF(),
-                           trackPion.tpcNSigmaEl(), trackPion.tpcNSigmaMu(), trackPion.tpcNSigmaPi(), trackPion.tpcNSigmaKa(), trackPion.tpcNSigmaPr(),
-                           trackPion.tofNSigmaEl(), trackPion.tofNSigmaMu(), trackPion.tofNSigmaPi(), trackPion.tofNSigmaKa(), trackPion.tofNSigmaPr());
+                           trackPion.tpcNSigmaPi(), trackPion.tofNSigmaPi());
             // add trackPion.globalIndex() to a list
             // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another D candidate
             // and keep track of their index in hfTrackPion for McRec purposes

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -44,12 +44,14 @@ enum Event : uint8_t {
 /// Creation of Dplus-Pi pairs
 struct HfDataCreatorDplusPiReduced {
   // Produces AOD tables to store track information
-  Produces<aod::HfReducedCollisions> hfReducedCollision;
-  Produces<aod::HfOriginalCollisionsCounter> hfCollisionCounter;
-  Produces<aod::HfTracksReduced> hfTrackPion;
-  Produces<aod::HfTracksPidReduced> hfTrackPidPion;
-  Produces<aod::HfCand3ProngReduced> hfCand3Prong;
-  Produces<aod::HfCandB0Config> rowCandidateConfig;
+  Produces<aod::HfRedCollisions> hfReducedCollision;
+  Produces<aod::HfOrigColCounts> hfCollisionCounter;
+  Produces<aod::HfRedTracks> hfTrackPion;
+  Produces<aod::HfRedPidTracks> hfTrackPidPion;
+  Produces<aod::HfRedCand3Prongs> hfCand3Prong;
+  Produces<aod::HfCandB0Configs> rowCandidateConfig;
+  Produces<aod::HfMcRecRedDpPis> rowHfDPiMcRecReduced;
+  Produces<aod::HfMcGenRedB0s> rowHfB0McGenReduced;
 
   // vertexing
   // Configurable<double> bz{"bz", 5., "magnetic field"};
@@ -95,6 +97,7 @@ struct HfDataCreatorDplusPiReduced {
   using TracksPidAll = soa::Join<aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr,
                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>;
   using TracksPIDWithSel = soa::Join<aod::TracksWCovDcaExtra, TracksPidAll, aod::TrackSelection>;
+  using TracksPIDWithSelAndMc = soa::Join<TracksPIDWithSel, aod::McTrackLabels>;
   using CandsDFiltered = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi>>;
 
   Filter filterSelectCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagD);
@@ -188,11 +191,13 @@ struct HfDataCreatorDplusPiReduced {
     return true;
   }
 
-  void process(aod::Collisions const& collisions,
-               CandsDFiltered const& candsD,
-               aod::TrackAssoc const& trackIndices,
-               TracksPIDWithSel const&,
-               aod::BCsWithTimestamps const&)
+  template<bool doMC = false, typename P, typename T>
+  void runDataCreation(aod::Collisions const& collisions,
+                       CandsDFiltered const& candsD,
+                       aod::TrackAssoc const& trackIndices,
+                       T const& tracks,
+                       P const& particlesMc,
+                       aod::BCsWithTimestamps const& bcs)
   {
     // store configurables needed for B0 workflow
     if (!isHfCandB0ConfigFilled) {
@@ -200,15 +205,10 @@ struct HfDataCreatorDplusPiReduced {
       isHfCandB0ConfigFilled = true;
     }
 
-    static int aodNumber = 0;
-    aodNumber++;
-
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize());
 
-    static int nCol = 0;
     for (const auto& collision : collisions) {
-      nCol++;
 
       // helpers for ReducedTables filling
       int hfReducedCollisionIndex = hfReducedCollision.lastIndex() + 1;
@@ -217,9 +217,6 @@ struct HfDataCreatorDplusPiReduced {
       bool fillHfReducedCollision = false;
 
       auto primaryVertex = getPrimaryVertex(collision);
-      if (nCol % 10000 == 0) {
-        LOG(debug) << nCol << " collisions parsed";
-      }
 
       // Set the magnetic field from ccdb.
       // The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
@@ -244,9 +241,9 @@ struct HfDataCreatorDplusPiReduced {
         registry.fill(HIST("hCPAD"), candD.cpa());
 
         // track0 <-> pi, track1 <-> K, track2 <-> pi
-        auto track0 = candD.prong0_as<TracksPIDWithSel>();
-        auto track1 = candD.prong1_as<TracksPIDWithSel>();
-        auto track2 = candD.prong2_as<TracksPIDWithSel>();
+        auto track0 = candD.template prong0_as<T>();
+        auto track1 = candD.template prong1_as<T>();
+        auto track2 = candD.template prong2_as<T>();
         auto trackParCov0 = getTrackParCov(track0);
         auto trackParCov1 = getTrackParCov(track1);
         auto trackParCov2 = getTrackParCov(track2);
@@ -297,7 +294,7 @@ struct HfDataCreatorDplusPiReduced {
 
         auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (const auto& trackId : trackIdsThisCollision) {
-          auto trackPion = trackId.track_as<TracksPIDWithSel>();
+          auto trackPion = trackId.template track_as<T>();
 
           // apply selections on pion tracks
           if (!isPionSelected(trackPion, track0, track1, track2) || !isSelectedTrackDCA(trackPion)) {
@@ -337,6 +334,32 @@ struct HfDataCreatorDplusPiReduced {
             selectedTracksPion.emplace_back(trackPion.globalIndex());
           }
           fillHfCand3Prong = true;
+
+          if constexpr (doMC) {
+            // we check the MC matching to be stored
+            auto arrayDaughtersD = std::array{track0, track1, track2};
+            auto arrayDaughtersB0 = std::array{track0, track1, track2, trackPion};
+            int8_t sign{0};
+            int8_t flag{0};
+            int8_t debug{0};
+            // B0 → D- π+ → (π- K+ π-) π+
+            auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, pdg::Code::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);
+            if (indexRec > -1) {
+              // D- → π- K+ π-
+              // Printf("Checking D- → π- K+ π-");
+              indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersD, pdg::Code::kDMinus, std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
+              if (indexRec > -1) {
+                flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
+              } else {
+                debug = 1;
+                LOGF(debug, "B0 decays in the expected final state but the condition on the intermediate state is not fulfilled");
+              }
+            }
+            auto indexMother = RecoDecay::getMother(particlesMc, trackPion.template mcParticle_as<P>(), pdg::Code::kB0, true);
+            auto particleMother = particlesMc.rawIteratorAt(indexMother);
+
+            rowHfDPiMcRecReduced(candD.globalIndex(), trackPion.globalIndex(), flag, debug, particleMother.pt());
+          }
         }                       // pion loop
         if (fillHfCand3Prong) { // fill candDplus table only once per D candidate
           hfCand3Prong(track0.globalIndex(), track1.globalIndex(), track2.globalIndex(),
@@ -357,6 +380,7 @@ struct HfDataCreatorDplusPiReduced {
           fillHfReducedCollision = true;
         }
       } // candsD loop
+
       registry.fill(HIST("hEvents"), 1 + Event::Processed);
       if (!fillHfReducedCollision) {
         registry.fill(HIST("hEvents"), 1 + Event::NoDPiSelected);
@@ -369,105 +393,71 @@ struct HfDataCreatorDplusPiReduced {
                          collision.covXZ(), collision.covYZ(), collision.covZZ(),
                          bz);
     } // collision
-  }   // process
-};    // struct
 
-/// Performs MC matching.
-struct HfDataCreatorDplusPiReducedMc {
-  Produces<aod::HfDPiMcRecReduced> rowHfDPiMcRecReduced;
-  Produces<aod::HfB0McGenReduced> rowHfB0McGenReduced;
-
-  void init(InitContext const&) {}
-
-  void processMc(aod::HfCand3ProngReduced const& candsD,
-                 aod::HfTracksReduced const& tracksPion,
-                 aod::TracksWMc const&,
-                 aod::McParticles const& mcParticles)
-  {
-    int indexRec = -1;
-    int8_t sign = 0;
-    int8_t flag = 0;
-    int8_t origin = 0;
-    int8_t debug = 0;
-
-    for (const auto& candD : candsD) {
-      auto arrayDaughtersD = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                        candD.prong1_as<aod::TracksWMc>(),
-                                        candD.prong2_as<aod::TracksWMc>()};
-
-      for (const auto& trackPion : tracksPion) {
-        if (trackPion.hfReducedCollisionId() != candD.hfReducedCollisionId()) {
-          continue;
-        }
-        // const auto& trackId = trackPion.globalIndex();
-        auto arrayDaughtersB0 = std::array{candD.prong0_as<aod::TracksWMc>(),
-                                           candD.prong1_as<aod::TracksWMc>(),
-                                           candD.prong2_as<aod::TracksWMc>(),
-                                           trackPion.track_as<aod::TracksWMc>()};
-        // B0 → D- π+ → (π- K+ π-) π+
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersB0, pdg::Code::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 2);
-        if (indexRec > -1) {
-          // D- → π- K+ π-
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersD, pdg::Code::kDMinus, std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
-          if (indexRec > -1) {
+    if constexpr (doMC) {
+      // Match generated particles.
+      for (const auto& particle : particlesMc) {
+        int8_t sign{0};
+        int8_t flag{0};
+        // B0 → D- π+
+        if (RecoDecay::isMatchedMCGen(particlesMc, particle, pdg::Code::kB0, std::array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
+          // Match D- -> π- K+ π-
+          auto candDMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
+          // Printf("Checking D- -> π- K+ π-");
+          if (RecoDecay::isMatchedMCGen(particlesMc, candDMC, -static_cast<int>(pdg::Code::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
             flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
-          } else {
-            debug = 1;
-            LOGF(info, "WARNING: B0 decays in the expected final state but the condition on the intermediate state is not fulfilled");
           }
         }
-        auto indexMother = RecoDecay::getMother(mcParticles, trackPion.track_as<aod::TracksWMc>().mcParticle_as<aod::McParticles>(), pdg::Code::kB0, true);
-        auto particleMother = mcParticles.rawIteratorAt(indexMother);
 
-        rowHfDPiMcRecReduced(candD.globalIndex(), trackPion.globalIndex(), flag, origin, debug, particleMother.pt());
-      }
-    } // rec
-
-    // Match generated particles.
-    for (const auto& particle : mcParticles) {
-      flag = 0;
-      origin = 0;
-      // B0 → D- π+
-      if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdg::Code::kB0, std::array{-static_cast<int>(pdg::Code::kDPlus), +kPiPlus}, true)) {
-        // D- → π- K+ π-
-        auto candDMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
-        if (RecoDecay::isMatchedMCGen(mcParticles, candDMC, -static_cast<int>(pdg::Code::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
-          flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
+        // save information for B0 task
+        if (!TESTBIT(std::abs(flag), hf_cand_b0::DecayType::B0ToDPi)) {
+          continue;
         }
-      }
 
-      // save information for B0 task
-      if (!TESTBIT(std::abs(flag), hf_cand_b0::DecayType::B0ToDPi)) {
-        continue;
-      }
+        auto ptParticle = particle.pt();
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+        auto etaParticle = particle.eta();
 
-      auto ptParticle = particle.pt();
-      auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
-      auto etaParticle = particle.eta();
+        std::array<float, 2> ptProngs;
+        std::array<float, 2> yProngs;
+        std::array<float, 2> etaProngs;
+        int counter = 0;
+        for (const auto& daught : particle.template daughters_as<P>()) {
+          ptProngs[counter] = daught.pt();
+          etaProngs[counter] = daught.eta();
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          counter++;
+        }
+        rowHfB0McGenReduced(flag, ptParticle, yParticle, etaParticle,
+                            ptProngs[0], yProngs[0], etaProngs[0],
+                            ptProngs[1], yProngs[1], etaProngs[1]);
+      } // gen
+    }
+  }
 
-      std::array<float, 2> ptProngs;
-      std::array<float, 2> yProngs;
-      std::array<float, 2> etaProngs;
-      int counter = 0;
-      for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
-        ptProngs[counter] = daught.pt();
-        etaProngs[counter] = daught.eta();
-        yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
-        counter++;
-      }
-      rowHfB0McGenReduced(flag, origin,
-                          ptParticle, yParticle, etaParticle,
-                          ptProngs[0], yProngs[0], etaProngs[0],
-                          ptProngs[1], yProngs[1], etaProngs[1]);
-    } // gen
+  void process(aod::Collisions const& collisions,
+                CandsDFiltered const& candsD,
+                aod::TrackAssoc const& trackIndices,
+                TracksPIDWithSel const& tracks,
+                aod::BCsWithTimestamps const& bcs)
+  {
+    runDataCreation<false>(collisions, candsD, trackIndices, tracks, tracks, bcs);
+  }
+  PROCESS_SWITCH(HfDataCreatorDplusPiReduced, process, "Process without MC info", true);
 
-  } // processMc
-  PROCESS_SWITCH(HfDataCreatorDplusPiReducedMc, processMc, "Process MC", false);
+  void processMc(aod::Collisions const& collisions,
+                 CandsDFiltered const& candsD,
+                 aod::TrackAssoc const& trackIndices,
+                 TracksPIDWithSelAndMc const& tracks,
+                 aod::McParticles const& particlesMc,
+                 aod::BCsWithTimestamps const& bcs)
+  {
+    runDataCreation<true>(collisions, candsD, trackIndices, tracks, particlesMc, bcs);
+  }
+  PROCESS_SWITCH(HfDataCreatorDplusPiReduced, processMc, "Process with MC info", false);
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<HfDataCreatorDplusPiReduced>(cfgc),
-    adaptAnalysisTask<HfDataCreatorDplusPiReducedMc>(cfgc)};
+  return WorkflowSpec{adaptAnalysisTask<HfDataCreatorDplusPiReduced>(cfgc)};
 }

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -16,6 +16,7 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 
 #include "PWGHF/Core/SelectorCuts.h"
@@ -42,6 +43,9 @@ struct HfTaskB0 {
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_b0_to_d_pi::vecBinsPt}, "pT bin limits"};
   // MC checks
   Configurable<bool> checkDecayTypeMc{"checkDecayTypeMc", false, "Flag to enable DecayType histogram"};
+
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   using TracksWithSel = soa::Join<aod::Tracks, aod::TrackSelection>;
 
@@ -268,7 +272,7 @@ struct HfTaskB0 {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(pdg::Code::kB0));
+        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, pdg->Mass(pdg::Code::kB0));
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }
@@ -280,7 +284,7 @@ struct HfTaskB0 {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, RecoDecay::getMassPDG(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -127,7 +127,7 @@ struct HfTaskB0Reduced {
     return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
   }
 
-  void process(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi>> const& candidates,
+  void process(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfSelB0ToDPi>> const& candidates,
                aod::HfRed3Prongs const&)
   {
     for (const auto& candidate : candidates) {
@@ -162,7 +162,7 @@ struct HfTaskB0Reduced {
   }   // process
 
   /// B0 MC analysis and fill histograms
-  void processMc(soa::Join<aod::HfCandB0, aod::HfMcRecRedB0s> const& candidates,
+  void processMc(soa::Join<aod::HfRedCandB0, aod::HfMcRecRedB0s> const& candidates,
                  aod::HfMcGenRedB0s const& particlesMc,
                  aod::HfRed3Prongs const&)
   {

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -127,7 +127,7 @@ struct HfTaskB0Reduced {
   }
 
   void process(soa::Filtered<soa::Join<aod::HfCandB0, aod::HfSelB0ToDPi>> const& candidates,
-               aod::HfCand3ProngReduced const&)
+               aod::HfRedCand3Prongs const&)
   {
     for (const auto& candidate : candidates) {
       if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
@@ -138,7 +138,7 @@ struct HfTaskB0Reduced {
       }
 
       auto ptCandB0 = candidate.pt();
-      auto candD = candidate.prong0_as<aod::HfCand3ProngReduced>();
+      auto candD = candidate.prong0_as<aod::HfRedCand3Prongs>();
 
       registry.fill(HIST("hMass"), invMassB0ToDPi(candidate), ptCandB0);
       registry.fill(HIST("hPtCand"), ptCandB0);
@@ -161,9 +161,9 @@ struct HfTaskB0Reduced {
   }   // process
 
   /// B0 MC analysis and fill histograms
-  void processMc(soa::Join<aod::HfCandB0, aod::HfB0McRecReduced> const& candidates,
-                 aod::HfB0McGenReduced const& mcParticles,
-                 aod::HfCand3ProngReduced const&)
+  void processMc(soa::Join<aod::HfCandB0, aod::HfMcRecRedB0s> const& candidates,
+                 aod::HfMcGenRedB0s const& particlesMc,
+                 aod::HfRedCand3Prongs const&)
   {
     // MC rec
     for (const auto& candidate : candidates) {
@@ -175,7 +175,7 @@ struct HfTaskB0Reduced {
       }
 
       auto ptCandB0 = candidate.pt();
-      auto candD = candidate.prong0_as<aod::HfCand3ProngReduced>();
+      auto candD = candidate.prong0_as<aod::HfRedCand3Prongs>();
 
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_b0::DecayType::B0ToDPi)) {
         registry.fill(HIST("hPtGenSig"), candidate.ptMother());

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -163,7 +163,7 @@ struct HfTaskB0Reduced {
 
   /// B0 MC analysis and fill histograms
   void processMc(soa::Join<aod::HfRedCandB0, aod::HfMcRecRedB0s> const& candidates,
-                 aod::HfMcGenRedB0s const& particlesMc,
+                 aod::HfMcGenRedB0s const& mcParticles,
                  aod::HfRed3Prongs const&)
   {
     // MC rec

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -158,7 +158,8 @@ struct HfTaskBplusReduced {
   }
 
   void process(soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
-               aod::HfRedCand2Prongs const&)
+               aod::HfRed2Prongs const&,
+               aod::HfRedTracks const&)
   {
     for (const auto& candidate : candidates) {
       if (!TESTBIT(candidate.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
@@ -168,9 +169,10 @@ struct HfTaskBplusReduced {
         continue;
       }
 
-      auto candD0 = candidate.prong0_as<HfRedCand2Prongs>();
-      // auto candPi = candidate.prong1_as<aod::HfRedPidTracks>();
+      auto candD0 = candidate.prong0_as<HfRed2Prongs>();
+      auto candPi = candidate.prong1_as<aod::HfRedTracks>();
       auto ptCandBplus = candidate.pt();
+      auto invMassD0 = (candPi.signed1Pt() < 0) ? candD0.invMassD0() : candD0.invMassD0Bar();
 
       registry.fill(HIST("hMass"), invMassBplusToD0Pi(candidate), ptCandBplus);
       registry.fill(HIST("hPtCand"), ptCandBplus);
@@ -189,7 +191,7 @@ struct HfTaskBplusReduced {
       registry.fill(HIST("hImpParErr"), candidate.errorImpactParameter1(), ptCandBplus);
       registry.fill(HIST("hDecLenErr"), candidate.errorDecayLength(), ptCandBplus);
       registry.fill(HIST("hDecLenXYErr"), candidate.errorDecayLengthXY(), ptCandBplus);
-      registry.fill(HIST("hInvMassD0"), candD0.invMass(), ptCandBplus);
+      registry.fill(HIST("hInvMassD0"), invMassD0, ptCandBplus);
       registry.fill(HIST("hCPAFinerBinning"), candidate.cpa(), ptCandBplus);
       registry.fill(HIST("hCPAxyFinerBinning"), candidate.cpaXY(), ptCandBplus);
     } // candidate loop
@@ -198,7 +200,7 @@ struct HfTaskBplusReduced {
   /// B+ MC analysis and fill histograms
   void processMc(soa::Join<aod::HfCandBplus, aod::HfMcRecRedBps> const& candidates,
                  aod::HfMcGenRedBps const& particlesMc,
-                 aod::HfRedCand2Prongs const&)
+                 aod::HfRed2Prongs const&)
   {
     // MC rec
     for (const auto& candidate : candidates) {
@@ -210,7 +212,12 @@ struct HfTaskBplusReduced {
       }
 
       auto ptCandBplus = candidate.pt();
-      auto candD0 = candidate.prong0_as<aod::HfRedCand2Prongs>();
+      auto candD0 = candidate.prong0_as<aod::HfRed2Prongs>();
+      std::array<float, 3> posPv{candidate.posX(), candidate.posY(), candidate.posZ()};
+      std::array<float, 3> posSvD{candD0.xSecondaryVertex(), candD0.ySecondaryVertex(), candD0.zSecondaryVertex()};
+      std::array<float, 3> momD{candD0.px(), candD0.py(), candD0.pz()};
+      auto cospD0 = RecoDecay::cpa(posPv, posSvD, momD);
+      auto decLenD0 = RecoDecay::distance(posPv, posSvD);
 
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
 
@@ -231,8 +238,8 @@ struct HfTaskBplusReduced {
         registry.fill(HIST("hPtProng1RecSig"), candidate.ptProng1(), ptCandBplus);
         registry.fill(HIST("hd0d0RecSig"), candidate.impactParameterProduct(), ptCandBplus);
         registry.fill(HIST("hDecLengthNormRecSig"), candidate.decayLengthXYNormalised(), ptCandBplus);
-        registry.fill(HIST("hCPAD0RecSig"), candD0.cpa(), candidate.ptProng0());
-        registry.fill(HIST("hDecLengthD0RecSig"), candD0.decayLength(), candidate.ptProng0());
+        registry.fill(HIST("hCPAD0RecSig"), cospD0, candidate.ptProng0());
+        registry.fill(HIST("hDecLengthD0RecSig"), decLenD0, candidate.ptProng0());
       } else {
         registry.fill(HIST("hPtRecBg"), ptCandBplus);
         registry.fill(HIST("hCPARecBg"), candidate.cpa(), ptCandBplus);
@@ -250,8 +257,8 @@ struct HfTaskBplusReduced {
         registry.fill(HIST("hPtProng1RecBg"), candidate.ptProng1(), ptCandBplus);
         registry.fill(HIST("hd0d0RecBg"), candidate.impactParameterProduct(), ptCandBplus);
         registry.fill(HIST("hDecLengthNormRecBg"), candidate.decayLengthXYNormalised(), ptCandBplus);
-        registry.fill(HIST("hCPAD0RecBg"), candD0.cpa(), candidate.ptProng0());
-        registry.fill(HIST("hDecLengthD0RecBg"), candD0.decayLength(), candidate.ptProng0());
+        registry.fill(HIST("hCPAD0RecBg"), cospD0, candidate.ptProng0());
+        registry.fill(HIST("hDecLengthD0RecBg"), decLenD0, candidate.ptProng0());
       }
     } // rec
 

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -199,7 +199,7 @@ struct HfTaskBplusReduced {
 
   /// B+ MC analysis and fill histograms
   void processMc(soa::Join<aod::HfRedCandBplus, aod::HfMcRecRedBps> const& candidates,
-                 aod::HfMcGenRedBps const& particlesMc,
+                 aod::HfMcGenRedBps const& mcParticles,
                  aod::HfRed2Prongs const&)
   {
     // MC rec

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -158,7 +158,7 @@ struct HfTaskBplusReduced {
   }
 
   void process(soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
-               aod::HfCand2ProngReduced const&)
+               aod::HfRedCand2Prongs const&)
   {
     for (const auto& candidate : candidates) {
       if (!TESTBIT(candidate.hfflag(), hf_cand_bplus::DecayType::BplusToD0Pi)) {
@@ -168,8 +168,8 @@ struct HfTaskBplusReduced {
         continue;
       }
 
-      auto candD0 = candidate.prong0_as<HfCand2ProngReduced>();
-      // auto candPi = candidate.prong1_as<aod::HfTracksPidReduced>();
+      auto candD0 = candidate.prong0_as<HfRedCand2Prongs>();
+      // auto candPi = candidate.prong1_as<aod::HfRedPidTracks>();
       auto ptCandBplus = candidate.pt();
 
       registry.fill(HIST("hMass"), invMassBplusToD0Pi(candidate), ptCandBplus);
@@ -196,9 +196,9 @@ struct HfTaskBplusReduced {
   }   // process
 
   /// B+ MC analysis and fill histograms
-  void processMc(soa::Join<aod::HfCandBplus, aod::HfBpMcRecReduced> const& candidates,
-                 aod::HfBpMcGenReduced const& mcParticles,
-                 aod::HfCand2ProngReduced const&)
+  void processMc(soa::Join<aod::HfCandBplus, aod::HfMcRecRedBps> const& candidates,
+                 aod::HfMcGenRedBps const& particlesMc,
+                 aod::HfRedCand2Prongs const&)
   {
     // MC rec
     for (const auto& candidate : candidates) {
@@ -210,7 +210,7 @@ struct HfTaskBplusReduced {
       }
 
       auto ptCandBplus = candidate.pt();
-      auto candD0 = candidate.prong0_as<aod::HfCand2ProngReduced>();
+      auto candD0 = candidate.prong0_as<aod::HfRedCand2Prongs>();
 
       if (TESTBIT(std::abs(candidate.flagMcMatchRec()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
 

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -157,7 +157,7 @@ struct HfTaskBplusReduced {
     return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
   }
 
-  void process(soa::Filtered<soa::Join<aod::HfCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
+  void process(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
                aod::HfRed2Prongs const&,
                aod::HfRedTracks const&)
   {
@@ -198,7 +198,7 @@ struct HfTaskBplusReduced {
   }   // process
 
   /// B+ MC analysis and fill histograms
-  void processMc(soa::Join<aod::HfCandBplus, aod::HfMcRecRedBps> const& candidates,
+  void processMc(soa::Join<aod::HfRedCandBplus, aod::HfMcRecRedBps> const& candidates,
                  aod::HfMcGenRedBps const& particlesMc,
                  aod::HfRed2Prongs const&)
   {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -718,7 +718,6 @@ DECLARE_SOA_TABLE(HfCandBplusBase, "AOD", "HFCANDBPLUSBASE",
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1,
-                  hf_cand_bplus::Prong0Id, hf_track_index::Prong1Id,
                   hf_track_index::HFflag,
                   /* dynamic columns */
                   hf_cand_2prong::M<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
@@ -747,7 +746,10 @@ DECLARE_SOA_TABLE(HfCandBplusBase, "AOD", "HFCANDBPLUSBASE",
 DECLARE_SOA_EXTENDED_TABLE_USER(HfCandBplusExt, HfCandBplusBase, "HFCANDBPLUSEXT",
                                 hf_cand_2prong::Px, hf_cand_2prong::Py, hf_cand_2prong::Pz);
 
-using HfCandBplus = HfCandBplusExt;
+DECLARE_SOA_TABLE(HfCandBplusProngs, "AOD", "HFCANDBPPRONGS",
+                  hf_cand_bplus::Prong0Id, hf_track_index::Prong1Id);
+
+using HfCandBplus = soa::Join<HfCandBplusExt, HfCandBplusProngs>;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandBplusMcRec, "AOD", "HFCANDBPMCREC",

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1883,7 +1883,6 @@ DECLARE_SOA_TABLE(HfCandB0Base, "AOD", "HFCANDB0BASE",
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1,
-                  hf_cand_b0::Prong0Id, hf_track_index::Prong1Id,
                   hf_track_index::HFflag,
                   /* dynamic columns */
                   hf_cand_2prong::M<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
@@ -1912,7 +1911,10 @@ DECLARE_SOA_TABLE(HfCandB0Base, "AOD", "HFCANDB0BASE",
 DECLARE_SOA_EXTENDED_TABLE_USER(HfCandB0Ext, HfCandB0Base, "HFCANDB0EXT",
                                 hf_cand_2prong::Px, hf_cand_2prong::Py, hf_cand_2prong::Pz);
 
-using HfCandB0 = HfCandB0Ext;
+DECLARE_SOA_TABLE(HfCandB0Prongs, "AOD", "HFCANDB0PRONGS",
+                  hf_cand_b0::Prong0Id, hf_track_index::Prong1Id);
+
+using HfCandB0 = soa::Join<HfCandB0Ext, HfCandB0Prongs>;
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandB0McRec, "AOD", "HFCANDB0MCREC",

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -420,7 +420,7 @@ bool selectionTopol(const T1& candBp, const T2& cuts, const T3& binsPt)
   }
 
   // B+ mass cut
-  if (std::abs(invMassBplusToD0Pi(candBp) - RecoDecay::getMassPDG(521)) > cuts->get(pTBin, "m")) {
+  if (std::abs(o2::aod::hf_cand_bplus::invMassBplusToD0Pi(candBp) - RecoDecay::getMassPDG(521)) > cuts->get(pTBin, "m")) {
     return false;
   }
 

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -361,7 +361,6 @@ struct HfCandidateCreatorB0Expressions {
 
     // Match reconstructed candidates.
     for (const auto& candidate : candsB0) {
-      // Printf("New rec. candidate");
       flag = 0;
       origin = 0;
       debug = 0;

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -40,6 +40,7 @@ using namespace o2::framework::expressions;
 /// Reconstruction of B0 candidates
 struct HfCandidateCreatorB0 {
   Produces<aod::HfCandB0Base> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfCandB0Prongs> rowCandidateProngs; // table defined in CandidateReconstructionTables.h
 
   // vertexing
   // Configurable<double> bz{"bz", 5., "magnetic field"};
@@ -313,8 +314,9 @@ struct HfCandidateCreatorB0 {
                            pVecPion[0], pVecPion[1], pVecPion[2],
                            dcaD.getY(), dcaPion.getY(),
                            std::sqrt(dcaD.getSigmaY2()), std::sqrt(dcaPion.getSigmaY2()),
-                           candD.globalIndex(), trackPion.globalIndex(),
                            hfFlag);
+
+          rowCandidateProngs(candD.globalIndex(), trackPion.globalIndex());
         } // pi loop
       }   // D loop
     }     // collision loop
@@ -331,10 +333,9 @@ struct HfCandidateCreatorB0Expressions {
 
   void processMc(aod::HfCand3Prong const& dplus,
                  aod::TracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& particlesMc,
+                 aod::HfCandB0Prongs const& candsB0)
   {
-    rowCandidateB0->bindExternalIndices(&tracks);
-    rowCandidateB0->bindExternalIndices(&dplus);
 
     int indexRec = -1;
     int8_t sign = 0;
@@ -343,8 +344,8 @@ struct HfCandidateCreatorB0Expressions {
     int8_t debug = 0;
 
     // Match reconstructed candidates.
-    // Spawned table can be used directly
-    for (const auto& candidate : *rowCandidateB0) {
+    for (const auto& candidate : candsB0) {
+      // Printf("New rec. candidate");
       flag = 0;
       origin = 0;
       debug = 0;

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -349,7 +349,7 @@ struct HfCandidateCreatorB0Expressions {
 
   void processMc(aod::HfCand3Prong const& dplus,
                  aod::TracksWMc const& tracks,
-                 aod::McParticles const& particlesMc,
+                 aod::McParticles const& mcParticles,
                  aod::HfCandB0Prongs const& candsB0)
   {
 

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -77,7 +77,6 @@ struct HfCandidateCreatorB0 {
   double massPi{0.};
   double massD{0.};
   double massB0{0.};
-  double invMass2DPi{0.};
   double invMass2DPiMin{0.};
   double invMass2DPiMax{0.};
   double bz{0.};
@@ -99,7 +98,7 @@ struct HfCandidateCreatorB0 {
   OutputObj<TH1F> hPtD{TH1F("hPtD", "D^{#minus} candidates;D^{#minus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hPtPion{TH1F("hPtPion", "#pi^{#plus} candidates;#pi^{#plus} candidate #it{p}_{T} (GeV/#it{c});entries", 100, 0., 10.)};
   OutputObj<TH1F> hCPAD{TH1F("hCPAD", "D^{#minus} candidates;D^{#minus} cosine of pointing angle;entries", 110, -1.1, 1.1)};
-  OutputObj<TH1F> hMass2B0ToDPi{TH1F("hMass2B0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMassB0ToDPi{TH1F("hMassB0ToDPi", "2-prong candidates;inv. mass (B^{0} #rightarrow D^{#minus}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#minus}#pi^{#plus}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
   OutputObj<TH1F> hCovPVXX{TH1F("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
 
@@ -300,11 +299,11 @@ struct HfCandidateCreatorB0 {
           df2.getTrack(1).getPxPyPzGlo(pVecPion); // momentum of Pi at the B0 vertex
 
           // calculate invariant mass square and apply selection
-          invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
+          auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});
           if ((invMass2DPi < invMass2DPiMin) || (invMass2DPi > invMass2DPiMax)) {
             continue;
           }
-          hMass2B0ToDPi->Fill(invMass2DPi);
+          hMassB0ToDPi->Fill(std::sqrt(invMass2DPi));
 
           // compute impact parameters of D and Pi
           o2::dataformats::DCA dcaD;

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -83,7 +83,6 @@ struct HfCandidateCreatorBplus {
   double massPi{0.};
   double massD0{0.};
   double massBplus{0.};
-  double invMass2D0Pi{0.};
   double invMass2D0PiMin{0.};
   double invMass2D0PiMax{0.};
   double bz{0.};
@@ -104,7 +103,7 @@ struct HfCandidateCreatorBplus {
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
   OutputObj<TH1F> hRapidityD0{TH1F("hRapidityD0", "D0 candidates;#it{y};entries", 100, -2, 2)};
   OutputObj<TH1F> hEtaPi{TH1F("hEtaPi", "Pion track;#it{#eta};entries", 400, -2., 2.)};
-  OutputObj<TH1F> hMass2BplusToD0Pi{TH1F("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMassBplusToD0Pi{TH1F("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
 
   void init(InitContext const&)
   {
@@ -315,11 +314,11 @@ struct HfCandidateCreatorBplus {
           int hfFlag = BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
 
           // compute invariant mass square and apply selection
-          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
+          auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
           if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
-          hMass2BplusToD0Pi->Fill(invMass2D0Pi);
+          hMassBplusToD0Pi->Fill(std::sqrt(invMass2D0Pi));
 
           // fill candidate table rows
           rowCandidateBase(collision.globalIndex(),

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -43,7 +43,7 @@ using namespace o2::aod::hf_cand_bplus;
 
 /// Reconstruction of B± → D0bar(D0) π± → (K± π∓) π±
 struct HfCandidateCreatorBplus {
-  Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfCandBplusBase> rowCandidateBase;     // table defined in CandidateReconstructionTables.h
   Produces<aod::HfCandBplusProngs> rowCandidateProngs; // table defined in CandidateReconstructionTables.h
 
   // vertexing parameters

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -349,7 +349,7 @@ struct HfCandidateCreatorBplusExpressions {
 
   void processMc(aod::HfCand2Prong const& dzero,
                  aod::TracksWMc const& tracks,
-                 aod::McParticles const& particlesMC,
+                 aod::McParticles const& mcParticles,
                  aod::HfCandBplusProngs const& candsBplus)
   {
 

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -362,7 +362,6 @@ struct HfCandidateCreatorBplusExpressions {
     // Match reconstructed candidates.
     // Spawned table can be used directly
     for (const auto& candidate : candsBplus) {
-      // Printf("New rec. candidate");
 
       flag = 0;
       origin = 0;

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -20,6 +20,7 @@
 
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
@@ -42,7 +43,8 @@ using namespace o2::aod::hf_cand_bplus;
 
 /// Reconstruction of B± → D0bar(D0) π± → (K± π∓) π±
 struct HfCandidateCreatorBplus {
-  Produces<aod::HfCandBplusBase> rowCandidateBase;
+  Produces<aod::HfCandBplusBase> rowCandidateBase; // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfCandBplusProngs> rowCandidateProngs; // table defined in CandidateReconstructionTables.h
 
   // vertexing parameters
   // Configurable<double> bz{"bz", 5., "magnetic field"};
@@ -75,11 +77,21 @@ struct HfCandidateCreatorBplus {
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
   int runNumber;
 
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massD0 = RecoDecay::getMassPDG(pdg::Code::kD0);
-  double massBplus = RecoDecay::getMassPDG(pdg::Code::kBPlus);
-  double massD0Pi = 0.;
-  double bz = 0.;
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double massPi{0.};
+  double massD0{0.};
+  double massBplus{0.};
+  double invMass2D0Pi{0.};
+  double invMass2D0PiMin{0.};
+  double invMass2D0PiMax{0.};
+  double bz{0.};
+
+  // Fitter for B vertex
+  o2::vertexing::DCAFitterN<2> dfB;
+  // Fitter to redo D-vertex to get extrapolated daughter tracks
+  o2::vertexing::DCAFitterN<2> df;
 
   using TracksWithSel = soa::Join<aod::TracksWCovDca, aod::TrackSelection>;
   using CandsDFiltered = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
@@ -92,15 +104,39 @@ struct HfCandidateCreatorBplus {
   OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
   OutputObj<TH1F> hRapidityD0{TH1F("hRapidityD0", "D0 candidates;#it{y};entries", 100, -2, 2)};
   OutputObj<TH1F> hEtaPi{TH1F("hEtaPi", "Pion track;#it{#eta};entries", 400, -2., 2.)};
-  OutputObj<TH1F> hMassBplusToD0Pi{TH1F("hMassBplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) (GeV/#it{c}^{2});entries", 500, 3., 8.)};
+  OutputObj<TH1F> hMass2BplusToD0Pi{TH1F("hMass2BplusToD0Pi", "2-prong candidates;inv. mass (B^{+} #rightarrow #bar{D^{0}}#pi^{+}) square (GeV^{2}/#it{c}^{4});entries", 500, 3., 8.)};
 
   void init(InitContext const&)
   {
+    // Initialise fitter for B vertex
+    dfB.setPropagateToPCA(propagateToPCA);
+    dfB.setMaxR(maxR);
+    dfB.setMinParamChange(minParamChange);
+    dfB.setMinRelChi2Change(minRelChi2Change);
+    dfB.setUseAbsDCA(true);
+    dfB.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Initial fitter to redo D-vertex to get extrapolated daughter tracks
+    df.setPropagateToPCA(propagateToPCA);
+    df.setMaxR(maxR);
+    df.setMinParamChange(minParamChange);
+    df.setMinRelChi2Change(minRelChi2Change);
+    df.setUseAbsDCA(useAbsDCA);
+    df.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    // Configure CCDB access
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
     runNumber = 0;
+
+    // invariant-mass window cut
+    massPi = pdg->Mass(kPiPlus);
+    massD0 = pdg->Mass(pdg::Code::kD0);
+    massBplus = pdg->Mass(pdg::Code::kBPlus);
+    invMass2D0PiMin = (massBplus - invMassWindowBplus) * (massBplus - invMassWindowBplus);
+    invMass2D0PiMax = (massBplus + invMassWindowBplus) * (massBplus + invMassWindowBplus);
   }
 
   /// Single-track cuts for pions on dcaXY
@@ -129,24 +165,6 @@ struct HfCandidateCreatorBplus {
                TracksWithSel const&,
                aod::BCsWithTimestamps const&)
   {
-
-    // Initialise fitter for B vertex
-    o2::vertexing::DCAFitterN<2> dfB;
-    dfB.setPropagateToPCA(propagateToPCA);
-    dfB.setMaxR(maxR);
-    dfB.setMinParamChange(minParamChange);
-    dfB.setMinRelChi2Change(minRelChi2Change);
-    dfB.setUseAbsDCA(true);
-    dfB.setWeightedFinalPCA(useWeightedFinalPCA);
-
-    // Initial fitter to redo D-vertex to get extrapolated daughter tracks
-    o2::vertexing::DCAFitterN<2> df;
-    df.setPropagateToPCA(propagateToPCA);
-    df.setMaxR(maxR);
-    df.setMinParamChange(minParamChange);
-    df.setMinRelChi2Change(minRelChi2Change);
-    df.setUseAbsDCA(useAbsDCA);
-    df.setWeightedFinalPCA(useWeightedFinalPCA);
 
     static int nCol = 0;
 
@@ -296,12 +314,12 @@ struct HfCandidateCreatorBplus {
 
           int hfFlag = BIT(hf_cand_bplus::DecayType::BplusToD0Pi);
 
-          // calculate invariant mass and fill the Invariant Mass control plot
-          massD0Pi = RecoDecay::m(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
-          if (std::abs(massD0Pi - massBplus) > invMassWindowBplus) {
+          // compute invariant mass square and apply selection
+          invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecBach}, std::array{massD0, massPi});
+          if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
             continue;
           }
-          hMassBplusToD0Pi->Fill(massD0Pi);
+          hMass2BplusToD0Pi->Fill(invMass2D0Pi);
 
           // fill candidate table rows
           rowCandidateBase(collision.globalIndex(),
@@ -313,8 +331,9 @@ struct HfCandidateCreatorBplus {
                            pVecBach[0], pVecBach[1], pVecBach[2],
                            impactParameter0.getY(), impactParameter1.getY(),
                            std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
-                           candD0.globalIndex(), trackPion.globalIndex(), // index D0 and bachelor
                            hfFlag);
+
+          rowCandidateProngs(candD0.globalIndex(), trackPion.globalIndex()); // index D0 and bachelor
         } // track loop
       }   // D0 cand loop
     }     // collision
@@ -331,10 +350,9 @@ struct HfCandidateCreatorBplusExpressions {
 
   void processMc(aod::HfCand2Prong const& dzero,
                  aod::TracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& particlesMC,
+                 aod::HfCandBplusProngs const& candsBplus)
   {
-    rowCandidateBPlus->bindExternalIndices(&tracks);
-    rowCandidateBPlus->bindExternalIndices(&dzero);
 
     int indexRec = -1, indexRecD0 = -1;
     int8_t signB = 0, signD0 = 0;
@@ -344,10 +362,12 @@ struct HfCandidateCreatorBplusExpressions {
 
     // Match reconstructed candidates.
     // Spawned table can be used directly
-    for (const auto& candidate : *rowCandidateBPlus) {
+    for (const auto& candidate : candsBplus) {
+      // Printf("New rec. candidate");
+
       flag = 0;
       origin = 0;
-      auto candDaughterD0 = candidate.prong0_as<aod::HfCand2Prong>();
+      auto candDaughterD0 = candidate.prong0();
       auto arrayDaughtersD0 = std::array{candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
       auto arrayDaughters = std::array{candidate.prong1_as<aod::TracksWMc>(), candDaughterD0.prong0_as<aod::TracksWMc>(), candDaughterD0.prong1_as<aod::TracksWMc>()};
 


### PR DESCRIPTION
@AlexBigO @apalasciano I made few changes in the reduced data model for B hadrons:
- I made it self contained so that the access to the parent `AO2D` files should not be needed anymore
- I changed a bit the data model, fragmenting more the tables (e.g. the covariances for pion and D tracks are separated now) and replacing the topological variables for the D mesons with the position of their decay vertex (so that we can recompute the topological variables if we want).

I still have to test the code, but you can already have a look if the changes are fine for you. Thanks!