### PR TITLE
PWGHF: Fix issue with the debug histogram for BDT in the D0 selector

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -365,9 +365,9 @@ struct HfCandidateSelectorD0 {
         registry.fill(HIST("DebugBdt/hBdtScore2VsStatus"), outputMl[1], statusD0bar);
         registry.fill(HIST("DebugBdt/hBdtScore3VsStatus"), outputMl[2], statusD0);
         registry.fill(HIST("DebugBdt/hBdtScore3VsStatus"), outputMl[2], statusD0bar);
-      }
-      if (statusD0 != 0 || statusD0bar != 0) {
-        registry.fill(HIST("hMassDmesonSel"), invMassD0ToPiK(candidate));
+        if (statusD0 != 0 || statusD0bar != 0) {
+          registry.fill(HIST("DebugBdt/hMassDmesonSel"), invMassD0ToPiK(candidate));
+        }
       }
       hfSelD0Candidate(statusD0, statusD0bar, statusHFFlag, statusTopol, statusCand, statusPID);
     }


### PR DESCRIPTION
Moving the BDT debug histogram