### PR TITLE
Update linters configuration

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -20,7 +20,7 @@ DISABLE_LINTERS:
   - REPOSITORY_SECRETLINT
   - REPOSITORY_TRIVY
 DISABLE_ERRORS_LINTERS: # If errors are found by these linters, they will be considered as non blocking.
-  - PYTHON_BANDIT # The bandit check is overly broad and complains about subprocess usage in Scripts/update_ccdb.py.
+  - PYTHON_BANDIT # The bandit check is overly broad and complains about subprocess usage.
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
 GITHUB_COMMENT_REPORTER: false
@@ -28,3 +28,6 @@ UPDATED_SOURCES_REPORTER: false
 PRINT_ALPACA: false # Don't print ASCII alpaca in the log
 PRINT_ALL_FILES: true # Print all processed files
 FLAVOR_SUGGESTIONS: false # Don't show suggestions about different MegaLinter flavors
+PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+PYTHON_PYRIGHT_CONFIG_FILE: pyproject.toml
+PYTHON_RUFF_CONFIG_FILE: pyproject.toml

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-build/c++11,-build/namespaces,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo
+filter=-build/c++11,-build/namespaces,-readability/fn_size,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+
+[tool.pyright]
+reportMissingImports = false
+reportUnboundVariable = false
+
+[tool.ruff]
+line-length = 120

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,0 @@
-{
-    "reportMissingImports": false,
-    "reportUnboundVariable": false
-}


### PR DESCRIPTION
- Create `pyproject.toml` for Python linters.
- Disable function length check in cpplint. 
  - @iarsene @dsekihat @feisenhu This stops MegaLinter from complaining about too long functions in the PWGDQ code. The remaining errors reported in the PWGDQ PRs should be fixed before merging.