### PR TITLE
PWGJE: Fix dummy subscription in HFJ substructure output task

### DIFF
--- a/PWGJE/Tasks/jetsubstructurehf.cxx
+++ b/PWGJE/Tasks/jetsubstructurehf.cxx
@@ -130,7 +130,7 @@ struct JetSubstructureHFTask {
     jetSubstructurehfTable(zg, rg, nsd);
   }
 
-  void processDummy(aod::Tracks const& track)
+  void processDummy(aod::Tracks const& tracks)
   {
   }
   PROCESS_SWITCH(JetSubstructureHFTask, processDummy, "Dummy process function turned on by default", true);

--- a/PWGJE/Tasks/jetsubstructurehfoutput.cxx
+++ b/PWGJE/Tasks/jetsubstructurehfoutput.cxx
@@ -64,7 +64,7 @@ struct JetSubstructureHFOutputTask {
     jetSubstructureOutputTable(jet.globalIndex(), jet.zg(), jet.rg(), jet.nsd());
   }
 
-  void processDummy(typename CollisionTable::iterator const& collision)
+  void processDummy(aod::Collision const& collision)
   {
   }
   PROCESS_SWITCH(JetSubstructureHFOutputTask, processDummy, "Dummy process function turned on by default", true);


### PR DESCRIPTION
This fixes the subscription of `processDummy` in `JetSubstructureHFOutputTask` which cannot subscribe to `McCollisions` when running the `JetSubstructureOutputMCParticleLevelD0` template instance on real data and therefore crashes.