### PR TITLE
PWGEM/PhotonMeson: MCV0 studies and cleanup

### DIFF
--- a/PWGEM/PhotonMeson/DataModel/mcV0Tables.h
+++ b/PWGEM/PhotonMeson/DataModel/mcV0Tables.h
@@ -32,38 +32,69 @@ enum TrackTypes : uint8_t {
 };
 
 // Track Pos
-DECLARE_SOA_COLUMN(RecoPosPt, recoPosPt, float);   //! Reconstructed pt of positive sign track
-DECLARE_SOA_COLUMN(RecoPosEta, recoPosEta, float); //! Reconstructed eta of positive sign track
-DECLARE_SOA_COLUMN(RecoPosTgl, recoPosTgl, float); //! Reconstructed tgl of positive sign track
-DECLARE_SOA_COLUMN(RecoPosX, recoPosX, float);     //! Reconstructed X of positive sign track
-DECLARE_SOA_COLUMN(RecoPosY, recoPosY, float);     //! Reconstructed X of positive sign track
-DECLARE_SOA_COLUMN(RecoPosZ, recoPosZ, float);     //! Reconstructed X of positive sign track
+DECLARE_SOA_COLUMN(RecoPosPt, recoPosPt, float);        //! Reconstructed pt of pos track
+DECLARE_SOA_COLUMN(RecoPosEta, recoPosEta, float);      //! Reconstructed eta of pos track
+DECLARE_SOA_COLUMN(RecoPosTgl, recoPosTgl, float);      //! Reconstructed tgl of pos track
+DECLARE_SOA_COLUMN(RecoPosX, recoPosX, float);          //! Reconstructed X of pos track
+DECLARE_SOA_COLUMN(RecoPosY, recoPosY, float);          //! Reconstructed X of pos track
+DECLARE_SOA_COLUMN(RecoPosZ, recoPosZ, float);          //! Reconstructed X of pos track
+DECLARE_SOA_COLUMN(RecoPosT, recoPosT, float);          //! Estimated time of the pos track in ns wrt collision()
+DECLARE_SOA_COLUMN(RecoPosSign, recoPosSign, int16_t);  //! Sign of pos track
+DECLARE_SOA_COLUMN(RecoPosHasITS, recoPosHasITS, bool); //! if pos track has ITS
+DECLARE_SOA_COLUMN(RecoPosHasTPC, recoPosHasTPC, bool); //! if pos track has TPC
+DECLARE_SOA_COLUMN(RecoPosHasTRD, recoPosHasTRD, bool); //! if pos track has TRD
+DECLARE_SOA_COLUMN(RecoPosHasTOF, recoPosHasTOF, bool); //! if pos track has TOF
 // Track Ele
-DECLARE_SOA_COLUMN(RecoElePt, recoElePt, float);   //! Reconstructed pt of negative sign track
-DECLARE_SOA_COLUMN(RecoEleTgl, recoEleTgl, float); //! Reconstructed tgl of negative sign track
-DECLARE_SOA_COLUMN(RecoEleEta, recoEleEta, float); //! Reconstructed eta of negative sign track
-DECLARE_SOA_COLUMN(RecoEleX, recoEleX, float);     //! Reconstructed X of negative sign track
-DECLARE_SOA_COLUMN(RecoEleY, recoEleY, float);     //! Reconstructed X of negative sign track
-DECLARE_SOA_COLUMN(RecoEleZ, recoEleZ, float);     //! Reconstructed X of negative sign track
+DECLARE_SOA_COLUMN(RecoElePt, recoElePt, float);        //! Reconstructed pt of ele track
+DECLARE_SOA_COLUMN(RecoEleTgl, recoEleTgl, float);      //! Reconstructed tgl of ele track
+DECLARE_SOA_COLUMN(RecoEleEta, recoEleEta, float);      //! Reconstructed eta of ele track
+DECLARE_SOA_COLUMN(RecoEleX, recoEleX, float);          //! Reconstructed X of ele track
+DECLARE_SOA_COLUMN(RecoEleY, recoEleY, float);          //! Reconstructed X of ele track
+DECLARE_SOA_COLUMN(RecoEleZ, recoEleZ, float);          //! Reconstructed X of ele track
+DECLARE_SOA_COLUMN(RecoEleT, recoEleT, float);          //! Estimated time of the ele track in ns wrt collision()
+DECLARE_SOA_COLUMN(RecoEleSign, recoEleSign, int16_t);  //! Sign of ele track
+DECLARE_SOA_COLUMN(RecoEleHasITS, recoEleHasITS, bool); //! If ele track has ITS
+DECLARE_SOA_COLUMN(RecoEleHasTPC, recoEleHasTPC, bool); //! If ele track has TPC
+DECLARE_SOA_COLUMN(RecoEleHasTRD, recoEleHasTRD, bool); //! If ele track has TRD
+DECLARE_SOA_COLUMN(RecoEleHasTOF, recoEleHasTOF, bool); //! If ele track has TOF
 // MC particle pos
-DECLARE_SOA_COLUMN(MCPosPt, mcPosPt, float);   //! Generated pt of positive sign particle
-DECLARE_SOA_COLUMN(MCPosEta, mcPosEta, float); //! Generated eta of positive sign particle
-DECLARE_SOA_COLUMN(MCPosX, mcPosX, float);     //! Generated x of positive sign particle
-DECLARE_SOA_COLUMN(MCPosY, mcPosY, float);     //! Generated y of positive sign particle
-DECLARE_SOA_COLUMN(MCPosZ, mcPosZ, float);     //! Generated z of positive sign particle
+DECLARE_SOA_COLUMN(MCPosPt, mcPosPt, float);   //! Generated pt of pos particle
+DECLARE_SOA_COLUMN(MCPosEta, mcPosEta, float); //! Generated eta of pos particle
+DECLARE_SOA_COLUMN(MCPosX, mcPosX, float);     //! Generated x of pos particle
+DECLARE_SOA_COLUMN(MCPosY, mcPosY, float);     //! Generated y of pos particle
+DECLARE_SOA_COLUMN(MCPosZ, mcPosZ, float);     //! Generated z of pos particle
 // MC particle ele
-DECLARE_SOA_COLUMN(MCElePt, mcElePt, float);   //! Generated pt of negative sign particle
-DECLARE_SOA_COLUMN(MCEleEta, mcEleEta, float); //! Generated eta of negative sign particle
-DECLARE_SOA_COLUMN(MCEleX, mcEleX, float);     //! Generated x of negative sign particle
-DECLARE_SOA_COLUMN(MCEleY, mcEleY, float);     //! Generated y of negative sign particle
-DECLARE_SOA_COLUMN(MCEleZ, mcEleZ, float);     //! Generated z of negative sign particle
-// Propagated MC position
-DECLARE_SOA_COLUMN(MCPosPropX, mcPosPropX, float); //! Propagated generated x of positive sign particle
-DECLARE_SOA_COLUMN(MCPosPropY, mcPosPropY, float); //! Propagated generated y of positive sign particle
-DECLARE_SOA_COLUMN(MCPosPropZ, mcPosPropZ, float); //! Propagated generated z of positive sign particle
-DECLARE_SOA_COLUMN(MCElePropX, mcElePropX, float); //! Propagated generated x of negative sign particle
-DECLARE_SOA_COLUMN(MCElePropY, mcElePropY, float); //! Propagated generated y of negative sign particle
-DECLARE_SOA_COLUMN(MCElePropZ, mcElePropZ, float); //! Propagated generated z of negative sign particle
+DECLARE_SOA_COLUMN(MCElePt, mcElePt, float);   //! Generated pt of ele particle
+DECLARE_SOA_COLUMN(MCEleEta, mcEleEta, float); //! Generated eta of ele particle
+DECLARE_SOA_COLUMN(MCEleX, mcEleX, float);     //! Generated x of ele particle
+DECLARE_SOA_COLUMN(MCEleY, mcEleY, float);     //! Generated y of ele particle
+DECLARE_SOA_COLUMN(MCEleZ, mcEleZ, float);     //! Generated z of ele particle
+// Propagated MC pos
+DECLARE_SOA_COLUMN(MCPosPropX, mcPosPropX, float);     //! Propagated generated x of pos particle
+DECLARE_SOA_COLUMN(MCPosPropY, mcPosPropY, float);     //! Propagated generated y of pos particle
+DECLARE_SOA_COLUMN(MCPosPropZ, mcPosPropZ, float);     //! Propagated generated z of pos particle
+DECLARE_SOA_COLUMN(MCPosPropEta, mcPosPropEta, float); //! Propagated generated eta of pos particle
+DECLARE_SOA_COLUMN(MCPosPropTgl, mcPosPropTgl, float); //! Propagated generated tgl of pos particle
+DECLARE_SOA_COLUMN(MCPosPropPt, mcPosPropPt, float);   //! Propagated generated Pt of pos particle
+// Propagated MC ele
+DECLARE_SOA_COLUMN(MCElePropX, mcElePropX, float);     //! Propagated generated x of ele particle
+DECLARE_SOA_COLUMN(MCElePropY, mcElePropY, float);     //! Propagated generated y of ele particle
+DECLARE_SOA_COLUMN(MCElePropZ, mcElePropZ, float);     //! Propagated generated z of ele particle
+DECLARE_SOA_COLUMN(MCElePropEta, mcElePropEta, float); //! Propagated generated eta of ele particle
+DECLARE_SOA_COLUMN(MCElePropTgl, mcElePropTgl, float); //! Propagated generated tgl of ele particle
+DECLARE_SOA_COLUMN(MCElePropPt, mcElePropPt, float);   //! Propagated generated Pt of ele particle
+// MC mother particle
+DECLARE_SOA_COLUMN(MCMotherIsPrimary, mcMotherIsPrimary, bool);     //! If MC mother is primary
+DECLARE_SOA_COLUMN(MCMotherIsGenerator, mcMotherIsGenerator, bool); //! If MC mother is generated
+DECLARE_SOA_COLUMN(MCMotherPt, mcMotherPt, float);                  //! Mother particle Pt
+DECLARE_SOA_COLUMN(MCMotherEta, mcMotherEta, float);                //! Mother particle eta
+DECLARE_SOA_COLUMN(MCMotherX, mcMotherX, float);                    //! Mother particle vertex x
+DECLARE_SOA_COLUMN(MCMotherY, mcMotherY, float);                    //! Mother particle vertex y
+DECLARE_SOA_COLUMN(MCMotherZ, mcMotherZ, float);                    //! Mother particle vertex z
+// MC Primary Vertex
+DECLARE_SOA_COLUMN(MCPVtxX, mcPVtxX, float); //! MC Primary vertex X
+DECLARE_SOA_COLUMN(MCPVtxY, mcPVtxY, float); //! MC Primary vertex Y
+DECLARE_SOA_COLUMN(MCPVtxZ, mcPVtxZ, float); //! MC Primary vertex Z
 // TrackType
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //! Track type, see enum TrackTypes
 } // namespace mcV0
@@ -72,18 +103,30 @@ DECLARE_SOA_TABLE(MCV0, "AOD", "MCV0", o2::soa::Index<>,
                   // Track Pos
                   mcV0::RecoPosPt, mcV0::RecoPosEta, mcV0::RecoPosTgl,
                   mcV0::RecoPosX, mcV0::RecoPosY, mcV0::RecoPosZ,
+                  mcV0::RecoPosT, mcV0::RecoPosSign,
+                  mcV0::RecoPosHasITS, mcV0::RecoPosHasTPC, mcV0::RecoPosHasTRD, mcV0::RecoPosHasTOF,
                   // Track Ele
                   mcV0::RecoElePt, mcV0::RecoEleEta, mcV0::RecoEleTgl,
                   mcV0::RecoEleX, mcV0::RecoEleY, mcV0::RecoEleZ,
+                  mcV0::RecoEleT, mcV0::RecoEleSign,
+                  mcV0::RecoEleHasITS, mcV0::RecoEleHasTPC, mcV0::RecoEleHasTRD, mcV0::RecoEleHasTOF,
                   // MC particle pos
                   mcV0::MCPosPt, mcV0::MCPosEta,
                   mcV0::MCPosX, mcV0::MCPosY, mcV0::MCPosZ,
                   // MC particle ele
                   mcV0::MCElePt, mcV0::MCEleEta,
                   mcV0::MCEleX, mcV0::MCEleY, mcV0::MCEleZ,
-                  // Propagated MC position
+                  // Propagated MC pos
                   mcV0::MCPosPropX, mcV0::MCPosPropY, mcV0::MCPosPropZ,
+                  mcV0::MCPosPropEta, mcV0::MCPosPropTgl, mcV0::MCPosPropPt,
+                  // Propagated MC pos
                   mcV0::MCElePropX, mcV0::MCElePropY, mcV0::MCElePropZ,
+                  mcV0::MCElePropEta, mcV0::MCElePropTgl, mcV0::MCElePropPt,
+                  // MC mother particle
+                  mcV0::MCMotherIsPrimary, mcV0::MCMotherIsGenerator, mcV0::MCMotherPt, mcV0::MCMotherEta,
+                  mcV0::MCMotherX, mcV0::MCMotherY, mcV0::MCMotherZ,
+                  // Primary Vertex
+                  mcV0::MCPVtxX, mcV0::MCPVtxY, mcV0::MCPVtxZ,
                   // Track type
                   mcV0::TrackType);
 } // namespace o2::aod

--- a/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
@@ -21,7 +21,6 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
-#include "ReconstructionDataFormats/Track.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/CollisionAssociationTables.h"
@@ -34,12 +33,13 @@
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "PWGEM/PhotonMeson/Utils/PCMUtilities.h"
+#include "PWGEM/PhotonMeson/Utils/TrackSelection.h"
 
 using namespace o2;
+using namespace o2::soa;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace o2::soa;
-using std::array;
+using namespace o2::pwgem::photonmeson;
 
 using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TracksDCA>;
 // using FullTracksExt = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksExtra, aod::TracksDCA>;
@@ -134,10 +134,12 @@ struct createPCM {
 
     // Material correction in the DCA fitter
     o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
-    if (useMatCorrType == 1)
+    if (useMatCorrType == 1) {
       matCorr = o2::base::Propagator::MatCorrType::USEMatCorrTGeo;
-    if (useMatCorrType == 2)
+    }
+    if (useMatCorrType == 2) {
       matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+    }
     fitter.setMatCorrType(matCorr);
   }
 
@@ -161,16 +163,16 @@ struct createPCM {
     }
 
     auto run3grp_timestamp = bc.timestamp();
-    o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
-    o2::parameters::GRPMagField* grpmag = 0x0;
-    if (grpo) {
+    auto* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
+    o2::parameters::GRPMagField* grpmag = nullptr;
+    if (grpo != nullptr) {
       o2::base::Propagator::initFieldFromGRP(grpo);
       // Fetch magnetic field from ccdb for current collision
       d_bz = grpo->getNominalL3Field();
       LOG(info) << "Retrieved GRP for timestamp " << run3grp_timestamp << " with magnetic field of " << d_bz << " kZG";
     } else {
       grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, run3grp_timestamp);
-      if (!grpmag) {
+      if (grpmag == nullptr) {
         LOG(fatal) << "Got nullptr from CCDB for path " << grpmagPath << " of object GRPMagField and " << grpPath << " of object GRPObject for timestamp " << run3grp_timestamp;
       }
       o2::base::Propagator::initFieldFromGRP(grpmag);
@@ -189,29 +191,29 @@ struct createPCM {
     }
   }
 
-  float v0_alpha(float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg)
+  static float v0_alpha(float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg)
   {
     float momTot = RecoDecay::p(pxpos + pxneg, pypos + pyneg, pzpos + pzneg);
-    float lQlNeg = RecoDecay::dotProd(array{pxneg, pyneg, pzneg}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
-    float lQlPos = RecoDecay::dotProd(array{pxpos, pypos, pzpos}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
+    float lQlNeg = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
+    float lQlPos = RecoDecay::dotProd(std::array{pxpos, pypos, pzpos}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}) / momTot;
     return (lQlPos - lQlNeg) / (lQlPos + lQlNeg);
   }
-  float v0_qt(float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg)
+  static float v0_qt(float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg)
   {
     float momTot = RecoDecay::p2(pxpos + pxneg, pypos + pyneg, pzpos + pzneg);
-    float dp = RecoDecay::dotProd(array{pxneg, pyneg, pzneg}, array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg});
+    float dp = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg});
     return std::sqrt(RecoDecay::p2(pxneg, pyneg, pzneg) - dp * dp / momTot);
   }
 
   template <typename TTrack>
   bool reconstructV0(TTrack const& ele, TTrack const& pos)
   {
-    bool isITSonly_pos = pos.hasITS() & !pos.hasTPC();
-    bool isITSonly_ele = ele.hasITS() & !ele.hasTPC();
-    bool isTPConly_pos = !pos.hasITS() & pos.hasTPC();
-    bool isTPConly_ele = !ele.hasITS() & ele.hasTPC();
-    bool isITSTPC_pos = pos.hasITS() & pos.hasTPC();
-    bool isITSTPC_ele = ele.hasITS() & ele.hasTPC();
+    bool isITSonly_pos = pos.hasITS() && !pos.hasTPC();
+    bool isITSonly_ele = ele.hasITS() && !ele.hasTPC();
+    bool isTPConly_pos = !pos.hasITS() && pos.hasTPC();
+    bool isTPConly_ele = !ele.hasITS() && ele.hasTPC();
+    bool isITSTPC_pos = pos.hasITS() && pos.hasTPC();
+    bool isITSTPC_ele = ele.hasITS() && ele.hasTPC();
 
     if ((isITSonly_pos && isTPConly_ele) || (isITSonly_ele && isTPConly_pos)) {
       return false;
@@ -238,9 +240,9 @@ struct createPCM {
     // fitter is memeber variable.
     auto pTrack = getTrackParCov(pos); // positive
     auto nTrack = getTrackParCov(ele); // negative
-    array<float, 3> svpos = {0.};      // secondary vertex position
-    array<float, 3> pvec0 = {0.};
-    array<float, 3> pvec1 = {0.};
+    std::array<float, 3> svpos = {0.}; // secondary vertex position
+    std::array<float, 3> pvec0 = {0.};
+    std::array<float, 3> pvec1 = {0.};
 
     int nCand = fitter.process(pTrack, nTrack);
     if (nCand != 0) {
@@ -269,7 +271,7 @@ struct createPCM {
 
     float xyz[3] = {0.f, 0.f, 0.f};
     Vtx_recalculation(o2::base::Propagator::Instance(), pos, ele, xyz);
-    float recalculatedVtxR = sqrt(pow(xyz[0], 2) + pow(xyz[1], 2));
+    float recalculatedVtxR = std::sqrt(pow(xyz[0], 2) + pow(xyz[1], 2));
     // LOGF(info, "recalculated vtx : x = %f , y = %f , z = %f", xyz[0], xyz[1], xyz[2]);
     if (recalculatedVtxR > std::min(pos.x(), ele.x()) + margin_r && (pos.x() > 1.f && ele.x() > 1.f)) {
       return false;
@@ -288,10 +290,10 @@ struct createPCM {
   template <typename TCollision, typename TTrack>
   void fillV0Table(TCollision const& collision, TTrack const& ele, TTrack const& pos, const bool filltable)
   {
-    array<float, 3> pVtx = {collision.posX(), collision.posY(), collision.posZ()};
-    array<float, 3> svpos = {0.}; // secondary vertex position
-    array<float, 3> pvec0 = {0.};
-    array<float, 3> pvec1 = {0.};
+    std::array<float, 3> pVtx = {collision.posX(), collision.posY(), collision.posZ()};
+    std::array<float, 3> svpos = {0.}; // secondary vertex position
+    std::array<float, 3> pvec0 = {0.};
+    std::array<float, 3> pvec1 = {0.};
 
     auto pTrack = getTrackParCov(pos); // positive
     auto nTrack = getTrackParCov(ele); // negative
@@ -309,12 +311,10 @@ struct createPCM {
       return;
     }
 
-    float px = pvec0[0] + pvec1[0];
-    float py = pvec0[1] + pvec1[1];
-    float pz = pvec0[2] + pvec1[2];
+    std::array<float, 3> pvxyz{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]};
 
     float v0dca = fitter.getChi2AtPCACandidate(); // distance between 2 legs.
-    float v0CosinePA = RecoDecay::cpa(pVtx, array{svpos[0], svpos[1], svpos[2]}, array{px, py, pz});
+    float v0CosinePA = RecoDecay::cpa(pVtx, svpos, pvxyz);
     float v0radius = RecoDecay::sqrtSumOfSquares(svpos[0], svpos[1]);
 
     if (v0dca > maxdcav0dau) {
@@ -359,7 +359,7 @@ struct createPCM {
       return false;
     }
 
-    if (track.hasITS() & !track.hasTPC() & (track.hasTRD() | track.hasTOF())) { // remove unrealistic track. this should not happen.
+    if (track.hasITS() && !track.hasTPC() && (track.hasTRD() || track.hasTOF())) { // remove unrealistic track. this should not happen.
       return false;
     }
 
@@ -376,7 +376,7 @@ struct createPCM {
       if (track.itsChi2NCl() > maxchi2its) {
         return false;
       }
-      bool isITSonly = track.hasITS() & !track.hasTPC() & !track.hasTRD() & !track.hasTOF();
+      bool isITSonly = isITSonlyTrack(track);
       if (isITSonly) {
         if (track.pt() > maxpt_itsonly) {
           return false;

--- a/PWGEM/PhotonMeson/Tasks/MaterialBudget.cxx
+++ b/PWGEM/PhotonMeson/Tasks/MaterialBudget.cxx
@@ -41,6 +41,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/MaterialBudgetMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/MaterialBudgetMC.cxx
@@ -42,6 +42,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
+++ b/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
@@ -48,6 +48,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGamma.cxx
@@ -49,6 +49,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMC.cxx
@@ -43,6 +43,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/TagAndProbe.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TagAndProbe.cxx
@@ -42,6 +42,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
@@ -49,6 +49,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
@@ -50,6 +50,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::aod::photonpair;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation>;
 using MyV0Photon = MyV0Photons::iterator;

--- a/PWGEM/PhotonMeson/Utils/PairUtilities.h
+++ b/PWGEM/PhotonMeson/Utils/PairUtilities.h
@@ -16,9 +16,10 @@
 #define PWGEM_PHOTONMESON_UTILS_PAIRUTILITIES_H_
 
 #include <TVector2.h>
-#include "Framework/AnalysisTask.h"
+#include <cmath>
 
-//_______________________________________________________________________
+namespace o2::aod::photonpair
+{
 enum PairType {
   kPCMPCM = 0,
   kPHOSPHOS = 1,
@@ -28,11 +29,7 @@ enum PairType {
   kPHOSEMC = 5,
   kPCMPCMibw = 6,
 };
-//_______________________________________________________________________
-namespace o2::aod
-{
-namespace photonpair
-{
+
 template <typename U1, typename U2, typename TG1, typename TG2, typename TCut1, typename TCut2>
 bool IsSelectedPair(TG1 const& g1, TG2 const& g2, TCut1 const& cut1, TCut2 const& cut2)
 {
@@ -40,9 +37,9 @@ bool IsSelectedPair(TG1 const& g1, TG2 const& g2, TCut1 const& cut1, TCut2 const
   bool is_g2_selected = false;
   is_g1_selected = cut1.template IsSelected<U1>(g1);
   is_g2_selected = cut2.template IsSelected<U2>(g2);
-  return (is_g1_selected & is_g2_selected);
+  return (is_g1_selected && is_g2_selected);
 }
-//_______________________________________________________________________
+
 template <typename TV0Leg, typename TCluster>
 bool DoesV0LegMatchWithCluster(TV0Leg const& v0leg, TCluster const& cluster, const float max_deta, const float max_dphi, const float max_Ep_width)
 {
@@ -50,12 +47,8 @@ bool DoesV0LegMatchWithCluster(TV0Leg const& v0leg, TCluster const& cluster, con
   float dphi = TVector2::Phi_mpi_pi(TVector2::Phi_0_2pi(v0leg.phi()) - TVector2::Phi_0_2pi(cluster.phi()));
   // float dR = sqrt(deta * deta + dphi * dphi);
   float Ep = cluster.e() / v0leg.p();
-  return (pow(deta / max_deta, 2) + pow(dphi / max_dphi, 2) < 1) & (abs(Ep - 1) < max_Ep_width);
+  return (pow(deta / max_deta, 2) + pow(dphi / max_dphi, 2) < 1) && (abs(Ep - 1) < max_Ep_width);
 }
-//_______________________________________________________________________
-} // namespace photonpair
-} // namespace o2::aod
-//_______________________________________________________________________
-//_______________________________________________________________________
-//_______________________________________________________________________
+} // namespace o2::aod::photonpair
+
 #endif // PWGEM_PHOTONMESON_UTILS_PAIRUTILITIES_H_

--- a/PWGEM/PhotonMeson/Utils/TrackSelection.h
+++ b/PWGEM/PhotonMeson/Utils/TrackSelection.h
@@ -15,6 +15,9 @@
 #ifndef PWGEM_PHOTONMESON_UTILS_TRACKSELECTION_H_
 #define PWGEM_PHOTONMESON_UTILS_TRACKSELECTION_H_
 
+#include "TPDGCode.h"
+#include "Framework/AnalysisDataModel.h"
+
 namespace o2::pwgem::photonmeson
 {
 
@@ -201,6 +204,31 @@ template <typename TTrack>
 inline bool isTPConly_ITSonly(TTrack const& track0, TTrack const& track1)
 {
   return (isTPConlyTrack(track0) && isITSonlyTrack(track1)) || (isTPConlyTrack(track1) && isITSonlyTrack(track0));
+}
+
+/**
+ * @brief Check if MC particles have the expected&same mother particle
+ *
+ * @param mc1 MCParticle 0
+ * @param mc2 MCParticle 1
+ * @return true if the mother particle is the expected type and the same for both
+ */
+template <PDG_t motherType>
+inline bool checkMCParticles(aod::McParticle const& mc1, aod::McParticle const& mc2)
+{
+  if (abs(mc1.pdgCode()) != kElectron || abs(mc2.pdgCode()) != kElectron) {
+    return false;
+  }
+  if (!mc1.has_mothers() || !mc2.has_mothers()) {
+    return false;
+  }
+  if (mc1.mothersIds()[0] != mc2.mothersIds()[0]) {
+    return false;
+  }
+  if (mc1.template mothers_first_as<aod::McParticles>().pdgCode() != motherType) {
+    return false;
+  }
+  return true;
 }
 } // namespace o2::pwgem::photonmeson
 


### PR DESCRIPTION
First commit is a cleanup commit (functionality stays the same):
 - change bool comparisons from & to && -> gets rid of a lot of anoying compiler warnings since these appeared in header files
 - moved one enum in the photon meson namespace to not pollute the global namespace
 - some minor changes to improve readability (mostly subjective and just where I spotted it)

I can drop this commit upon request, just these compiler warnings are _really_ annoying when I wanted to search for the ones I was responsible for :)

Second commit added the following for the MCV0 study:
 - add information of kinematics of propagated mcParticles
 - add information of the photon particle
 - add primary vertex information