### PR TITLE
Rearranging HF code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,11 +30,7 @@
 /PWGEM @alibuild @mikesas @rbailhac @feisenhu
 /PWGEM/Dilepton @alibuild @mikesas @rbailhac @dsekihat @ivorobye @feisenhu
 /PWGEM/PhotonMeson @alibuild @mikesas @rbailhac @m-c-danisch @novitzky @mhemmer-cern
-/PWGHF @alibuild @vkucera @fcolamar @adubla
-/PWGHF/D2H @alibuild @vkucera @fcolamar @adubla @fcatalan92 @lvermunt @mfaggin
-/PWGHF/HFC @alibuild @vkucera @fcolamar @adubla @mmazzilli @deepathoms
-/PWGHF/HFJ @alibuild @vkucera @fcolamar @adubla @nzardosh @rvertesi
-/PWGHF/HFL @alibuild @vkucera @fcolamar @adubla @NicoleBastid @gtaillepied
+/PWGHF @alibuild @vkucera @fcolamar @adubla @fgrosa @fcatalan92 @mfaggin @mmazzilli @deepathoms @nzardosh @NicoleBastid @gtaillepied
 /PWGLF @alibuild @lramona @alcaliva @lbariogl @chiarapinto @BongHwi @lbarnby @mbombara @iravasen @njacazio @ChiaraDeMartin95 @skundu692
 /PWGMM @alibuild @aalkin
 /PWGMM/Lumi @alibuild @aalkin


### PR DESCRIPTION
After a discussion among HF conveners and Vit and Francesco, we have all agreed to modify the ownership of HF codes, granting it to PAG coordinators and PWG conveners for the overall HF folder, in order to optimize the code and PR handling.
This PR updates the code ownership in this sense.