### PR TITLE
PWGHF: Expression columns to compute combined PID variables

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -92,30 +92,30 @@ T1 combineNSigma(const T2& tpcNSigma, const T2& tofNSigma)
 namespace pid_tpc_tof
 {
 // Combined TPC and TOF NSigma
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaEl, tpctofNSigmaEl, //! Combined NSigma separation with the TPC & TOF detectors for electron
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, //! Combined NSigma separation with the TPC & TOF detectors for electron
                               float, pid_tpc_tof_utils::combineNSigma(o2::aod::pidtpc::tpcNSigmaEl, o2::aod::pidtof::tofNSigmaEl));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaMu, tpctofNSigmaMu, //! Combined NSigma separation with the TPC & TOF detectors for muon
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, //! Combined NSigma separation with the TPC & TOF detectors for muon
                               float, pid_tpc_tof_utils::combineNSigma(o2::aod::pidtpc::tpcNSigmaMu, o2::aod::pidtof::tofNSigmaMu));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPi, tpctofNSigmaPi, //! Combined NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, //! Combined NSigma separation with the TPC & TOF detectors for pion
                               float, pid_tpc_tof_utils::combineNSigma(o2::aod::pidtpc::tpcNSigmaPi, o2::aod::pidtof::tofNSigmaPi));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaKa, tpctofNSigmaKa, //! Combined NSigma separation with the TPC & TOF detectors for kaon
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, //! Combined NSigma separation with the TPC & TOF detectors for kaon
                               float, pid_tpc_tof_utils::combineNSigma(o2::aod::pidtpc::tpcNSigmaKa, o2::aod::pidtof::tofNSigmaKa));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPr, tpctofNSigmaPr, //! Combined NSigma separation with the TPC & TOF detectors for proton
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, //! Combined NSigma separation with the TPC & TOF detectors for proton
                               float, pid_tpc_tof_utils::combineNSigma(o2::aod::pidtpc::tpcNSigmaPr, o2::aod::pidtof::tofNSigmaPr));
 } // namespace pid_tpc_tof
 
 namespace pid_tpc_tof_tiny
 {
 // Combined binned TPC and TOF NSigma
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaEl, tpctofNSigmaEl, //! Combined binned NSigma separation with the TPC & TOF detectors for electron
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, //! Combined binned NSigma separation with the TPC & TOF detectors for electron
                               float, pid_tpc_tof_utils::combineNSigma<true>(o2::aod::pidtpc_tiny::tpcNSigmaStoreEl, o2::aod::pidtof_tiny::tofNSigmaStoreEl));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaMu, tpctofNSigmaMu, //! Combined binned NSigma separation with the TPC & TOF detectors for muon
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, //! Combined binned NSigma separation with the TPC & TOF detectors for muon
                               float, pid_tpc_tof_utils::combineNSigma<true>(o2::aod::pidtpc_tiny::tpcNSigmaStoreMu, o2::aod::pidtof_tiny::tofNSigmaStoreMu));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPi, tpctofNSigmaPi, //! Combined binned NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, //! Combined binned NSigma separation with the TPC & TOF detectors for pion
                               float, pid_tpc_tof_utils::combineNSigma<true>(o2::aod::pidtpc_tiny::tpcNSigmaStorePi, o2::aod::pidtof_tiny::tofNSigmaStorePi));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaKa, tpctofNSigmaKa, //! Combined binned NSigma separation with the TPC & TOF detectors for kaon
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, //! Combined binned NSigma separation with the TPC & TOF detectors for kaon
                               float, pid_tpc_tof_utils::combineNSigma<true>(o2::aod::pidtpc_tiny::tpcNSigmaStoreKa, o2::aod::pidtof_tiny::tofNSigmaStoreKa));
-DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPr, tpctofNSigmaPr, //! Combined binned NSigma separation with the TPC & TOF detectors for proton
+DECLARE_SOA_EXPRESSION_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, //! Combined binned NSigma separation with the TPC & TOF detectors for proton
                               float, pid_tpc_tof_utils::combineNSigma<true>(o2::aod::pidtpc_tiny::tpcNSigmaStorePr, o2::aod::pidtof_tiny::tofNSigmaStorePr));
 } // namespace pid_tpc_tof_tiny
 

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -66,8 +66,8 @@ namespace pid_tpc_tof_utils
 /// \param tpcNSigma is the (binned) NSigma separation in TPC (if tiny = true)
 /// \param tofNSigma is the (binned) NSigma separation in TOF (if tiny = true)
 /// \return Node containing the combined NSigma of TPC and TOF
-template <bool tiny = false, typename T1 = o2::framework::expressions::Node, typename T2>
-T1 combineNSigma(const T2& tpcNSigma, const T2& tofNSigma)
+template <bool tiny = false, typename T1>
+o2::framework::expressions::Node combineNSigma(const T1& tpcNSigma, const T1& tofNSigma)
 {
   float defaultNSigmaTolerance = .1f;
   float defaultNSigma = -999.f + defaultNSigmaTolerance; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -263,12 +263,12 @@ struct HfCandidateSelectorDplusToPiKPi {
                                          candidate.cpa(),
                                          candidate.cpaXY(),
                                          candidate.maxNormalisedDeltaIP(),
-                                         trackPos1.tpctofNSigmaPi(),
-                                         trackPos1.tpctofNSigmaKa(),
-                                         trackNeg.tpctofNSigmaPi(),
-                                         trackNeg.tpctofNSigmaKa(),
-                                         trackPos2.tpctofNSigmaPi(),
-                                         trackPos2.tpctofNSigmaKa()};
+                                         trackPos1.tpcTofNSigmaPi(),
+                                         trackPos1.tpcTofNSigmaKa(),
+                                         trackNeg.tpcTofNSigmaPi(),
+                                         trackNeg.tpcTofNSigmaKa(),
+                                         trackPos2.tpcTofNSigmaPi(),
+                                         trackPos2.tpcTofNSigmaKa()};
 
         bool isSelectedMl = hfMlResponse.isSelectedMl(inputFeatures, ptCand, outputMl);
         hfMlDplusToPiKPiCandidate(outputMl);

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -220,8 +220,6 @@ struct HfCandidateSelectorDplusToPiKPi {
       auto trackNeg = candidate.prong1_as<TracksSel>();  // negative daughter (positive for the antiparticles)
       auto trackPos2 = candidate.prong2_as<TracksSel>(); // positive daughter (negative for the antiparticles)
 
-      LOG(info) << "Combined PID = " << trackPos1.tpctofNSigmaPi();
-
       // topological selection
       if (!selection(candidate, trackPos1, trackNeg, trackPos2)) {
         hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);
@@ -253,14 +251,6 @@ struct HfCandidateSelectorDplusToPiKPi {
       }
 
       if (applyMl) {
-        // tracks without TPC nor TOF already rejected at PID selection level
-        auto combinedNSigmaPiPos1 = trackPos1.tpctofNSigmaPi();
-        auto combinedNSigmaKaPos1 = trackPos1.tpctofNSigmaKa();
-        auto combinedNSigmaPiNeg = trackNeg.tpctofNSigmaPi();
-        auto combinedNSigmaKaNeg = trackNeg.tpctofNSigmaKa();
-        auto combinedNSigmaPiPos2 = trackPos2.tpctofNSigmaPi();
-        auto combinedNSigmaKaPos2 = trackPos2.tpctofNSigmaKa();
-
         // ML selections
         std::vector<float> inputFeatures{candidate.ptProng0(),
                                          candidate.impactParameter0(),
@@ -273,12 +263,12 @@ struct HfCandidateSelectorDplusToPiKPi {
                                          candidate.cpa(),
                                          candidate.cpaXY(),
                                          candidate.maxNormalisedDeltaIP(),
-                                         combinedNSigmaPiPos1,
-                                         combinedNSigmaKaPos1,
-                                         combinedNSigmaPiNeg,
-                                         combinedNSigmaKaNeg,
-                                         combinedNSigmaPiPos2,
-                                         combinedNSigmaKaPos2};
+                                         trackPos1.tpctofNSigmaPi(),
+                                         trackPos1.tpctofNSigmaKa(),
+                                         trackNeg.tpctofNSigmaPi(),
+                                         trackNeg.tpctofNSigmaKa(),
+                                         trackPos2.tpctofNSigmaPi(),
+                                         trackPos2.tpctofNSigmaKa()};
 
         bool isSelectedMl = hfMlResponse.isSelectedMl(inputFeatures, ptCand, outputMl);
         hfMlDplusToPiKPiCandidate(outputMl);


### PR DESCRIPTION
Hi @vkucera !

In the end I defined a new `struct` before the main one in the selector, to `Spawns` the PID tables. I aim at using these tables in `prong0_as()` command, and I don't know if there is a way to both `Spawns` and consume a table in a `struct` (as I understand it, it is not possible), so spawning them *a priori* in a different `struct` is the only solution I found for the moment.

I added the columns and tables definitions in `CandidateReconstructionTables.h`, and put the possibility to compute combined PID variables also for the tiny/non-full versions of the PID tables.