### PR TITLE
Hotfix: Move spheoricty function from CollCuts

### DIFF
--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -357,6 +357,59 @@ struct reso2initializer {
     return returnValue;
   }
 
+  /// Compute the spherocity of an event
+  /// Important here is that the filter on tracks does not interfere here!
+  /// In Run 2 we used here global tracks within |eta| < 0.8
+  /// \tparam T type of the tracks
+  /// \param tracks All tracks
+  /// \return value of the spherocity of the event
+  template <typename T>
+  float ComputeSpherocity(T const& tracks, int nTracksMin, int spdef)
+  {
+    // if number of tracks is not enough for spherocity estimation.
+    int ntrks = tracks.size();
+    if (ntrks < nTracksMin)
+      return -99.;
+
+    // start computing spherocity
+
+    float ptSum = 0.;
+    for (auto const& track : tracks) {
+      if (ConfFillQA) {
+        qaRegistry.fill(HIST("Track/Phi"), track.phi());
+      }
+      if (spdef == 0) {
+        ptSum += 1.;
+      } else {
+        ptSum += track.pt();
+      }
+    }
+
+    float tempSph = 1.;
+    for (auto const& trk1 : tracks) {
+      float sum = 0., pt = 0.;
+      float phi1 = trk1.phi();
+      // float nx = TMath::Cos(phi1);
+      // float ny = TMath::Sin(phi1);
+      for (auto const& trk2 : tracks) {
+        pt = trk2.pt();
+        if (spdef == 0) {
+          pt = 1.;
+        }
+        float phi2 = trk2.phi();
+        // float px = pt * TMath::Cos(phi2);
+        // float py = pt * TMath::Sin(phi2);
+        sum += pt * abs(sin(phi1 - phi2));
+        // sum += TMath::Abs(px*ny - py*nx);
+      }
+      float sph = TMath::Power((sum / ptSum), 2);
+      if (sph < tempSph)
+        tempSph = sph;
+    }
+
+    return TMath::Power(TMath::Pi() / 2., 2) * tempSph;
+  }
+
   // Filter for all tracks
   template <bool isMC, typename TrackType, typename CollisionType>
   void fillTracks(CollisionType const& collision, TrackType const& tracks)
@@ -787,6 +840,7 @@ struct reso2initializer {
       qaRegistry.add("hGoodMCV0Indices", "hGoodMCV0Indices", kTH1F, {idxAxis});
       qaRegistry.add("hGoodCascIndices", "hGoodCascIndices", kTH1F, {idxAxis});
       qaRegistry.add("hGoodMCCascIndices", "hGoodMCCascIndices", kTH1F, {idxAxis});
+      qaRegistry.add("Phi", "#phi distribution", kTH1F, {{65, -0.1, 6.4}});
     }
     // MC histograms
     if (doprocessMCGenCount) {

--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -376,7 +376,7 @@ struct reso2initializer {
     float ptSum = 0.;
     for (auto const& track : tracks) {
       if (ConfFillQA) {
-        qaRegistry.fill(HIST("Track/Phi"), track.phi());
+        qaRegistry.fill(HIST("Phi"), track.phi());
       }
       if (spdef == 0) {
         ptSum += 1.;

--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -908,9 +908,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     fillTracks<false>(collision, tracks);

--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -908,9 +908,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     fillTracks<false>(collision, tracks);
@@ -985,9 +985,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     fillTracks<false>(collision, tracks);
@@ -1009,9 +1009,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     fillTracks<false>(collision, tracks);
@@ -1032,9 +1032,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     // Loop over tracks
@@ -1058,9 +1058,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     // Loop over tracks
@@ -1086,9 +1086,9 @@ struct reso2initializer {
     colCuts.fillQA(collision);
 
     if (ConfIsRun3) {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     } else {
-      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), colCuts.computeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
+      resoCollisions(collision.posX(), collision.posY(), collision.posZ(), collision.multFV0M(), MultEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), d_bz, bc.timestamp());
     }
 
     // Loop over tracks

--- a/PWGLF/Utils/collisionCuts.h
+++ b/PWGLF/Utils/collisionCuts.h
@@ -131,56 +131,6 @@ class CollisonCuts
     }
   }
 
-  /// Compute the spherocity of an event
-  /// Important here is that the filter on tracks does not interfere here!
-  /// In Run 2 we used here global tracks within |eta| < 0.8
-  /// \tparam T type of the tracks
-  /// \param tracks All tracks
-  /// \return value of the spherocity of the event
-  template <typename T>
-  float computeSpherocity(T const& tracks, int nTracksMin, int spdef)
-  {
-    // if number of tracks is not enough for spherocity estimation.
-    int ntrks = tracks.size();
-    if (ntrks < nTracksMin)
-      return -99.;
-
-    // start computing spherocity
-
-    float ptSum = 0.;
-    for (auto const& track : tracks) {
-      if (spdef == 0) {
-        ptSum += 1.;
-      } else {
-        ptSum += track.pt();
-      }
-    }
-
-    float tempSph = 1.;
-    for (auto const& trk1 : tracks) {
-      float sum = 0., pt = 0.;
-      float phi1 = trk1.phi();
-      // float nx = TMath::Cos(phi1);
-      // float ny = TMath::Sin(phi1);
-      for (auto const& trk2 : tracks) {
-        pt = trk2.pt();
-        if (spdef == 0) {
-          pt = 1.;
-        }
-        float phi2 = trk2.phi();
-        // float px = pt * TMath::Cos(phi2);
-        // float py = pt * TMath::Sin(phi2);
-        sum += pt * abs(sin(phi1 - phi2));
-        // sum += TMath::Abs(px*ny - py*nx);
-      }
-      float sph = TMath::Power((sum / ptSum), 2);
-      if (sph < tempSph)
-        tempSph = sph;
-    }
-
-    return TMath::Power(TMath::Pi() / 2., 2) * tempSph;
-  }
-
  private:
   HistogramRegistry* mHistogramRegistry = nullptr; ///< For QA output
   bool mCutsSet = false;                           ///< Protection against running without cuts

--- a/PWGLF/Utils/collisionCuts.h
+++ b/PWGLF/Utils/collisionCuts.h
@@ -64,7 +64,6 @@ class CollisonCuts
     mHistogramRegistry->add("Event/MultFT0M", "; FT0M signal; Entries", kTH1F, {{100000, 0, 100000}});
     mHistogramRegistry->add("Event/MultFT0C", "; FT0C signal; Entries", kTH1F, {{100000, 0, 100000}});
     mHistogramRegistry->add("Event/MultFT0A", "; FT0A signal; Entries", kTH1F, {{100000, 0, 100000}});
-    mHistogramRegistry->add("Track/Phi", "#phi distribution", kTH1F, {{65, -0.1, 6.4}});
   }
 
   /// Print some debug information
@@ -150,9 +149,6 @@ class CollisonCuts
 
     float ptSum = 0.;
     for (auto const& track : tracks) {
-      if (mHistogramRegistry) {
-        mHistogramRegistry->fill(HIST("Track/Phi"), track.phi());
-      }
       if (spdef == 0) {
         ptSum += 1.;
       } else {


### PR DESCRIPTION
It has to be placed in the main task.
Add a configurable variable to bypass this calculation.