### PR TITLE
PWGDQ: Change cuts relevant for DG rho0 analysis

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -302,8 +302,19 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   }
 
   if (!nameStr.compare("rho0Cuts")) {
-    cut->AddCut(GetAnalysisCut("rho0TrackCut"));
+    cut->AddCut(GetAnalysisCut("rho0Kine"));
+    cut->AddCut(GetAnalysisCut("pionQuality"));
     cut->AddCut(GetAnalysisCut("pionPIDnsigma"));
+    return cut;
+  }
+
+  if (!nameStr.compare("rho0Kine")) {
+    cut->AddCut(GetAnalysisCut("rho0Kine"));
+    return cut;
+  }
+
+  if (!nameStr.compare("openEtaSel")) {
+    cut->AddCut(GetAnalysisCut("openEtaSel"));
     return cut;
   }
 
@@ -1827,10 +1838,23 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
-  if (!nameStr.compare("rho0TrackCut")) {
+  if (!nameStr.compare("openEtaSel")) {
+    cut->AddCut(VarManager::kEta, -1.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("rho0Kine")) {
     cut->AddCut(VarManager::kPt, 0.1, 1000.0);
     cut->AddCut(VarManager::kEta, -1.1, 1.1);
+    return cut;
+  }
+
+  if (!nameStr.compare("pionQuality")) {
     cut->AddCut(VarManager::kTPCncls, 50.0, 1000.);
+    return cut;
+  }
+
+  if (!nameStr.compare("primaryVertexContributor")) {
     cut->AddCut(VarManager::kPVContributor, 0.5, 1.5);
     return cut;
   }

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -207,6 +207,7 @@ struct TableMaker {
                                context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
                                context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
                                context.mOptions.get<bool>("processBarrelOnly") || context.mOptions.get<bool>("processBarrelOnlyWithCent") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithMults") ||
                                context.mOptions.get<bool>("processBarrelOnlyWithCov") || context.mOptions.get<bool>("processBarrelOnlyWithEventFilter") ||
                                context.mOptions.get<bool>("processBarrelOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processBarrelOnlyWithCovAndEventFilter") ||
                                context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits") || context.mOptions.get<bool>("processBarrelOnlyWithV0Bits") ||


### PR DESCRIPTION
- CutsLibrary: Create open eta cut for event selection skims
- CutsLibrary: More separation in cuts for flexibility
- TableMaker: Enable barrel histograms for one process function in which they were missing