### PR TITLE
PWGHF: Add protection in single muon task and modify the selection conditions in muon source task

### DIFF
--- a/PWGHF/HFL/Tasks/taskSingleMuon.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuon.cxx
@@ -133,7 +133,7 @@ struct HfTaskSingleMuon {
       const auto charge(muon.sign());
       const auto chi2(muon.chi2MatchMCHMFT());
 
-      if (muon.matchMFTTrackId() > 0) {
+      if (muon.has_matchMFTTrack()) {
         auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
         if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
           continue;
@@ -144,7 +144,7 @@ struct HfTaskSingleMuon {
       }
       // histograms before the acceptance cuts
       registry.fill(HIST("hMuBeforeCuts"), pt, eta, dcaXY, pDca, charge, chi2);
-      if (muon.matchMCHTrackId() > 0) {
+      if (muon.has_matchMCHTrack()) {
         auto muonType3 = muon.template matchMCHTrack_as<MyMuons>();
         registry.fill(HIST("h3DeltaPtBeforeCuts"), pt, eta, muonType3.pt() - pt);
       }
@@ -167,7 +167,7 @@ struct HfTaskSingleMuon {
       // histograms after acceptance cuts
       registry.fill(HIST("hMuAfterCuts"), pt, eta, dcaXY, pDca, charge, chi2);
       registry.fill(HIST("h2DCA"), muon.fwdDcaX(), muon.fwdDcaY());
-      if (muon.matchMCHTrackId() > 0) {
+      if (muon.has_matchMCHTrack()) {
         auto muonType3 = muon.template matchMCHTrack_as<MyMuons>();
         registry.fill(HIST("h3DeltaPtAfterCuts"), pt, eta, muonType3.pt() - pt);
       }
@@ -192,7 +192,7 @@ struct HfTaskSingleMuon {
       const auto charge(muon.sign());
       const auto chi2(muon.chi2MatchMCHMFT());
 
-      if (muon.matchMFTTrackId() > 0) {
+      if (muon.has_matchMFTTrack()) {
         auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
         if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
           continue;
@@ -203,7 +203,7 @@ struct HfTaskSingleMuon {
       }
       // histograms before the acceptance cuts
       registry.fill(HIST("hMuBeforeCuts"), pt, eta, dcaXY, pDca, charge, chi2);
-      if (muon.matchMCHTrackId() > 0) {
+      if (muon.has_matchMCHTrack()) {
         auto muonType3 = muon.template matchMCHTrack_as<MyMcMuons>();
         registry.fill(HIST("h3DeltaPtBeforeCuts"), pt, eta, muonType3.pt() - pt);
       }
@@ -225,7 +225,7 @@ struct HfTaskSingleMuon {
       // histograms after acceptance cuts
       registry.fill(HIST("hMuAfterCuts"), pt, eta, dcaXY, pDca, charge, chi2);
       registry.fill(HIST("h2DCA"), muon.fwdDcaX(), muon.fwdDcaY());
-      if (muon.matchMCHTrackId() > 0) {
+      if (muon.has_matchMCHTrack()) {
         auto muonType3 = muon.template matchMCHTrack_as<MyMcMuons>();
         registry.fill(HIST("h3DeltaPtAfterCuts"), pt, eta, muonType3.pt() - pt);
       }

--- a/PWGHF/HFL/Tasks/taskSingleMuon.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuon.cxx
@@ -133,12 +133,14 @@ struct HfTaskSingleMuon {
       const auto charge(muon.sign());
       const auto chi2(muon.chi2MatchMCHMFT());
 
-      auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
-      if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
-        continue;
-      }
-      if (reduceOrphMft && (!reduceAmbMft) && trkMFT.has_ambMftTrack()) {
-        continue;
+      if (muon.matchMFTTrackId() > 0) {
+        auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
+        if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
+          continue;
+        }
+        if (reduceOrphMft && (!reduceAmbMft) && trkMFT.has_ambMftTrack()) {
+          continue;
+        }
       }
       // histograms before the acceptance cuts
       registry.fill(HIST("hMuBeforeCuts"), pt, eta, dcaXY, pDca, charge, chi2);
@@ -190,12 +192,14 @@ struct HfTaskSingleMuon {
       const auto charge(muon.sign());
       const auto chi2(muon.chi2MatchMCHMFT());
 
-      auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
-      if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
-        continue;
-      }
-      if (reduceOrphMft && (!reduceAmbMft) && trkMFT.has_ambMftTrack()) {
-        continue;
+      if (muon.matchMFTTrackId() > 0) {
+        auto trkMFT = muon.template matchMFTTrack_as<MFTTracksExtra>();
+        if (reduceAmbMft && trkMFT.has_ambMftTrack()) {
+          continue;
+        }
+        if (reduceOrphMft && (!reduceAmbMft) && trkMFT.has_ambMftTrack()) {
+          continue;
+        }
       }
       // histograms before the acceptance cuts
       registry.fill(HIST("hMuBeforeCuts"), pt, eta, dcaXY, pDca, charge, chi2);

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -87,14 +87,22 @@ struct HfTaskSingleMuonSource {
       "Hadron",
       "Unidentified"};
 
+    AxisSpec axisColNumber{1, 0., 1., "Selected collisions"};
     AxisSpec axisDCA{5000, 0., 5., "DCA (cm)"};
     AxisSpec axisChi2{500, 0., 100., "#chi^{2} of MCH-MFT matching"};
     AxisSpec axisPt{200, 0., 100., "#it{p}_{T,reco} (GeV/#it{c})"};
+    AxisSpec axisEta{250, -5., 0., "#it{#eta}"};
 
-    HistogramConfigSpec h3PtDCAChi2{HistType::kTH3F, {axisPt, axisDCA, axisChi2}};
+    HistogramConfigSpec h1NCol{HistType::kTH1F, {axisColNumber}};
+    HistogramConfigSpec h2PtDCA{HistType::kTH2F, {axisPt, axisDCA}};
+    HistogramConfigSpec h2PtChi2{HistType::kTH2F, {axisPt, axisChi2}};
+    HistogramConfigSpec h2PtEta{HistType::kTH2F, {axisPt, axisEta}};
 
+    registry.add("h1NCollisions", "", h1NCol);
     for (const auto& src : muonSources) {
-      registry.add(Form("h3%sPtDCAChi2", src.Data()), "", h3PtDCAChi2);
+      registry.add(Form("h2%sPtDCA", src.Data()), "", h2PtDCA);
+      registry.add(Form("h2%sPtChi2", src.Data()), "", h2PtChi2);
+      registry.add(Form("h2%sPtEta", src.Data()), "", h2PtEta);
     }
   }
 
@@ -177,31 +185,31 @@ struct HfTaskSingleMuonSource {
   // this muon comes from beauty decay and does not have light flavor parent
   bool isBeautyMu(const uint8_t& mask)
   {
-    return (isMuon(mask) && TESTBIT(mask, HasBeautyParent) && (!TESTBIT(mask, HasLightParent)));
+    return (isMuon(mask) && TESTBIT(mask, HasBeautyParent) && (!TESTBIT(mask, HasLightParent)) && (!TESTBIT(mask, HasQuarkoniumParent)));
   }
 
   // this muon comes directly from beauty decay
   bool isBeautyDecayMu(const uint8_t& mask)
   {
-    return (isBeautyMu(mask) && (!TESTBIT(mask, HasCharmParent)));
+    return (isBeautyMu(mask) && (!TESTBIT(mask, HasCharmParent) && (!TESTBIT(mask, HasQuarkoniumParent))));
   }
 
   // this muon comes from non-prompt charm decay and does not have light flavor parent
   bool isNonpromptCharmMu(const uint8_t& mask)
   {
-    return (isBeautyMu(mask) && TESTBIT(mask, HasCharmParent));
+    return (isBeautyMu(mask) && TESTBIT(mask, HasCharmParent) && (!TESTBIT(mask, HasQuarkoniumParent)));
   }
 
   // this muon comes from prompt charm decay and does not have light flavor parent
   bool isPromptCharmMu(const uint8_t& mask)
   {
-    return (isMuon(mask) && TESTBIT(mask, HasCharmParent) && (!TESTBIT(mask, HasBeautyParent)) && (!TESTBIT(mask, HasLightParent)));
+    return (isMuon(mask) && TESTBIT(mask, HasCharmParent) && (!TESTBIT(mask, HasBeautyParent)) && (!TESTBIT(mask, HasLightParent)) && (!TESTBIT(mask, HasQuarkoniumParent)));
   }
 
   // this muon comes from light flavor quark decay
   bool isLightDecayMu(const uint8_t& mask)
   {
-    return (isMuon(mask) && TESTBIT(mask, HasLightParent) && (!TESTBIT(mask, IsSecondary)));
+    return (isMuon(mask) && TESTBIT(mask, HasLightParent) && (!TESTBIT(mask, IsSecondary)) && (!TESTBIT(mask, HasQuarkoniumParent)));
   }
 
   // this muon comes from transport
@@ -226,25 +234,39 @@ struct HfTaskSingleMuonSource {
   void fillHistograms(const McMuons::iterator& muon)
   {
     const auto mask(getMask(muon));
-    const auto pt(muon.pt()), chi2(muon.chi2MatchMCHMFT());
+    const auto pt(muon.pt()), chi2(muon.chi2MatchMCHMFT()), eta(muon.eta());
     const auto dca(RecoDecay::sqrtSumOfSquares(muon.fwdDcaX(), muon.fwdDcaY()));
 
     singleMuonSource(pt, dca, mask);
 
     if (isBeautyDecayMu(mask)) {
-      registry.fill(HIST("h3BeautyDecayMuPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2BeautyDecayMuPtDCA"), pt, dca);
+      registry.fill(HIST("h2BeautyDecayMuPtChi2"), pt, chi2);
+      registry.fill(HIST("h2BeautyDecayMuPtEta"), pt, eta);
     } else if (isNonpromptCharmMu(mask)) {
-      registry.fill(HIST("h3NonpromptCharmMuPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2NonpromptCharmMuPtDCA"), pt, dca);
+      registry.fill(HIST("h2NonpromptCharmMuPtChi2"), pt, chi2);
+      registry.fill(HIST("h2NonpromptCharmMuPtEta"), pt, eta);
     } else if (isPromptCharmMu(mask)) {
-      registry.fill(HIST("h3PromptCharmMuPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2PromptCharmMuPtDCA"), pt, dca);
+      registry.fill(HIST("h2PromptCharmMuPtChi2"), pt, chi2);
+      registry.fill(HIST("h2PromptCharmMuPtEta"), pt, eta);
     } else if (isLightDecayMu(mask)) {
-      registry.fill(HIST("h3LightDecayMuPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2LightDecayMuPtDCA"), pt, dca);
+      registry.fill(HIST("h2LightDecayMuPtChi2"), pt, chi2);
+      registry.fill(HIST("h2LightDecayMuPtEta"), pt, eta);
     } else if (isSecondaryMu(mask)) {
-      registry.fill(HIST("h3SecondaryMuPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2SecondaryMuPtDCA"), pt, dca);
+      registry.fill(HIST("h2SecondaryMuPtChi2"), pt, chi2);
+      registry.fill(HIST("h2SecondaryMuPtEta"), pt, eta);
     } else if (isHadron(mask)) {
-      registry.fill(HIST("h3HadronPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2HadronPtDCA"), pt, dca);
+      registry.fill(HIST("h2HadronPtChi2"), pt, chi2);
+      registry.fill(HIST("h2HadronPtEta"), pt, eta);
     } else if (isUnidentified(mask)) {
-      registry.fill(HIST("h3UnidentifiedPtDCAChi2"), pt, dca, chi2);
+      registry.fill(HIST("h2UnidentifiedPtDCA"), pt, dca);
+      registry.fill(HIST("h2UnidentifiedPtChi2"), pt, chi2);
+      registry.fill(HIST("h2UnidentifiedPtEta"), pt, eta);
     }
   }
 
@@ -259,6 +281,10 @@ struct HfTaskSingleMuonSource {
     if (std::abs(collision.posZ()) > edgeZ) {
       return;
     }
+
+    auto nCollision = collision.bc_as<aod::BCs>().runNumber();
+    singleMuonEvent(nCollision);
+    registry.fill(HIST("h1NCollisions"), 0.);
 
     for (const auto& muon : muons) {
       // muon selections

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -56,10 +56,12 @@ DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(DcaXY, dcaXY, float);
 DECLARE_SOA_COLUMN(Source, source, uint8_t);
 } // namespace muon_source
+DECLARE_SOA_TABLE(HfMuonEvent, "AOD", "MUONEVENT", muon_source::Nevent);
 DECLARE_SOA_TABLE(HfMuonSource, "AOD", "MUONSOURCE", muon_source::Pt, muon_source::DcaXY, muon_source::Source);
 } // namespace o2::aod
 
 struct HfTaskSingleMuonSource {
+  Produces<aod::HfMuonEvent> singleMuonEvent;
   Produces<aod::HfMuonSource> singleMuonSource;
 
   Configurable<bool> applyMcMask{"applyMcMask", true, "Flag of apply the mcMask selection"};

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -52,17 +52,14 @@ namespace o2::aod
 {
 namespace muon_source
 {
-DECLARE_SOA_COLUMN(Nevent, nevent, int);
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(DcaXY, dcaXY, float);
 DECLARE_SOA_COLUMN(Source, source, uint8_t);
 } // namespace muon_source
-DECLARE_SOA_TABLE(HfMuonEvent, "AOD", "MUONEVENT", muon_source::Nevent);
 DECLARE_SOA_TABLE(HfMuonSource, "AOD", "MUONSOURCE", muon_source::Pt, muon_source::DcaXY, muon_source::Source);
 } // namespace o2::aod
 
 struct HfTaskSingleMuonSource {
-  Produces<aod::HfMuonEvent> singleMuonEvent;
   Produces<aod::HfMuonSource> singleMuonSource;
 
   Configurable<bool> applyMcMask{"applyMcMask", true, "Flag of apply the mcMask selection"};
@@ -96,12 +93,10 @@ struct HfTaskSingleMuonSource {
     AxisSpec axisPt{200, 0., 100., "#it{p}_{T,reco} (GeV/#it{c})"};
     AxisSpec axisEta{250, -5., 0., "#it{#eta}"};
 
-    HistogramConfigSpec h1NCol{HistType::kTH1F, {axisColNumber}};
     HistogramConfigSpec h2PtDCA{HistType::kTH2F, {axisPt, axisDCA}};
     HistogramConfigSpec h2PtChi2{HistType::kTH2F, {axisPt, axisChi2}};
     HistogramConfigSpec h2PtEta{HistType::kTH2F, {axisPt, axisEta}};
 
-    registry.add("h1NCollisions", "", h1NCol);
     for (const auto& src : muonSources) {
       registry.add(Form("h2%sPtDCA", src.Data()), "", h2PtDCA);
       registry.add(Form("h2%sPtChi2", src.Data()), "", h2PtChi2);
@@ -284,10 +279,6 @@ struct HfTaskSingleMuonSource {
     if (std::abs(collision.posZ()) > edgeZ) {
       return;
     }
-
-    auto nCollision = collision.bc_as<aod::BCs>().runNumber();
-    singleMuonEvent(nCollision);
-    registry.fill(HIST("h1NCollisions"), 0.);
 
     for (const auto& muon : muons) {
       // muon selections

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -52,6 +52,7 @@ namespace o2::aod
 {
 namespace muon_source
 {
+DECLARE_SOA_COLUMN(Nevent, nevent, int);
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(DcaXY, dcaXY, float);
 DECLARE_SOA_COLUMN(Source, source, uint8_t);


### PR DESCRIPTION
A protection for the selection of MCH-MID matched tracks is added in taskSingleMuon.
New histograms of eta and number of collisions are added and the quarkonium decay muons are removed from heavy quark decay muons in taskSingleMuonSource.