### PR TITLE
Implementing background subtraction in the JE framework

### DIFF
--- a/PWGJE/Core/CMakeLists.txt
+++ b/PWGJE/Core/CMakeLists.txt
@@ -11,7 +11,9 @@
 
 if(FastJet_FOUND)
 o2physics_add_library(PWGJECore
-               SOURCES  JetFinder.cxx
+               SOURCES  FastJetUtilities.cxx
+                        JetFinder.cxx
+                        JetBkgSubUtils.cxx
                PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore FastJet::FastJet FastJet::Contrib)
 
 o2physics_target_root_dictionary(PWGJECore
@@ -19,5 +21,6 @@ o2physics_target_root_dictionary(PWGJECore
                       JetUtilities.h
                       FastJetUtilities.h
                       JetTaggingUtilities.h
+                      JetBkgSubUtils.h
               LINKDEF PWGJECoreLinkDef.h)
 endif()

--- a/PWGJE/Core/FastJetUtilities.cxx
+++ b/PWGJE/Core/FastJetUtilities.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FastJetUtilities.h"
+
+void FastJetUtilities::setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index, int status)
+{
+  fastjet_user_info* user_info = new fastjet_user_info(status, index); // FIXME: can setting this as a pointer be avoided?
+  constituents.back().set_user_info(user_info);
+  if (index != -99999999) { // FIXME: needed for constituent subtraction as user_info is not propagated, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
+    int i = index;
+    if (status == static_cast<int>(JetConstituentStatus::track)) {
+      i = i + 1;
+    }
+    if (status == static_cast<int>(JetConstituentStatus::cluster)) {
+      i = -1 * (i + 1);
+    }
+    if (status == static_cast<int>(JetConstituentStatus::candidateHF)) {
+      i = 0;
+    }
+    constituents.back().set_user_index(i); // FIXME: needed for constituent subtraction, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
+  }
+}
+
+// Selector of HF candidates
+fastjet::Selector FastJetUtilities::SelectorIsHFCand()
+{
+  // This method is applied on particles or jet constituents only !!!
+  return fastjet::Selector(new SW_IsHFCand());
+}

--- a/PWGJE/Core/FastJetUtilities.h
+++ b/PWGJE/Core/FastJetUtilities.h
@@ -22,17 +22,21 @@
 #include <numeric>
 #include <tuple>
 #include <vector>
+#include <string>
 
-#include "PWGJE/Core/JetFinder.h"
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/Selector.hh"
 
 enum class JetConstituentStatus {
   track = 0,
   cluster = 1,
-  candidateHF = 2,
+  candidateHF = 2
 };
 
 namespace FastJetUtilities
 {
+
+static constexpr float mPion = 0.139; // TDatabasePDG::Instance()->GetParticle(211)->Mass(); //can be removed when pion mass becomes default for unidentified tracks
 
 // Class defined to store additional info which is passed to the FastJet object
 class fastjet_user_info : public fastjet::PseudoJet::UserInfoBase
@@ -66,24 +70,30 @@ class fastjet_user_info : public fastjet::PseudoJet::UserInfoBase
  * @param status status of constituent type
  */
 
-void setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track))
+void setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track));
+
+// Class defined to select the HF candidate particle
+// This method is applied on particles or jet constituents only !!!
+class SW_IsHFCand : public fastjet::SelectorWorker
 {
-  fastjet_user_info* user_info = new fastjet_user_info(status, index); // FIXME: can setting this as a pointer be avoided?
-  constituents.back().set_user_info(user_info);
-  if (index != -99999999) { // FIXME: needed for constituent subtraction as user_info is not propagated, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
-    int i = index;
-    if (status == static_cast<int>(JetConstituentStatus::track)) {
-      i = i + 1;
-    }
-    if (status == static_cast<int>(JetConstituentStatus::cluster)) {
-      i = -1 * (i + 1);
-    }
-    if (status == static_cast<int>(JetConstituentStatus::candidateHF)) {
-      i = 0;
-    }
-    constituents.back().set_user_index(i); // FIXME: needed for constituent subtraction, but need to be quite careful to make sure indices dont overlap between tracks, clusters and HF candidates. Current solution might not be optimal
+ public:
+  // default ctor
+  SW_IsHFCand() {}
+
+  // the selector's description
+  std::string description() const
+  {
+    return "HF candidate selector";
   }
-}
+
+  bool pass(const fastjet::PseudoJet& p) const
+  {
+    return (p.user_info<fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF));
+  }
+};
+
+// Selector of HF candidates
+fastjet::Selector SelectorIsHFCand();
 
 /**
  * Add track as a pseudojet object to the fastjet vector
@@ -96,7 +106,7 @@ void setFastJetUserInfo(std::vector<fastjet::PseudoJet>& constituents, int index
  */
 
 template <typename T>
-void fillTracks(const T& constituent, std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track), double mass = JetFinder::mPion)
+void fillTracks(const T& constituent, std::vector<fastjet::PseudoJet>& constituents, int index = -99999999, int status = static_cast<int>(JetConstituentStatus::track), double mass = mPion)
 {
   if (status == static_cast<int>(JetConstituentStatus::track) || status == static_cast<int>(JetConstituentStatus::candidateHF)) {
     auto p = std::sqrt((constituent.px() * constituent.px()) + (constituent.py() * constituent.py()) + (constituent.pz() * constituent.pz()));

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -138,11 +138,11 @@ std::tuple<double, double> JetBkgSubUtils::estimateRhoPerpCone(const std::vector
   return std::make_tuple(perpPtDensity, perpMdDensity);
 }
 
-std::vector<fastjet::PseudoJet> JetBkgSubUtils::doRhoAreaSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam)
+fastjet::PseudoJet JetBkgSubUtils::doRhoAreaSub(fastjet::PseudoJet& jet, double& rhoParam, double& rhoMParam)
 {
 
   fastjet::Subtractor sub = fastjet::Subtractor(rhoParam, rhoMParam);
-  return sub(jets);
+  return sub(jet);
 }
 
 std::vector<fastjet::PseudoJet> JetBkgSubUtils::doEventConstSub(std::vector<fastjet::PseudoJet>& inputParticles, double& rhoParam, double& rhoMParam)

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -142,6 +142,9 @@ fastjet::PseudoJet JetBkgSubUtils::doRhoAreaSub(fastjet::PseudoJet& jet, double&
 {
 
   fastjet::Subtractor sub = fastjet::Subtractor(rhoParam, rhoMParam);
+  if (doRhoMassSub) {
+    sub.set_safe_mass();
+  }
   return sub(jet);
 }
 
@@ -153,7 +156,7 @@ std::vector<fastjet::PseudoJet> JetBkgSubUtils::doEventConstSub(std::vector<fast
   constituentSub.set_max_distance(constSubRMax);
   constituentSub.set_alpha(constSubAlpha);
   constituentSub.set_ghost_area(ghostAreaSpec.ghost_area());
-  constituentSub.set_max_eta(bkgEtaMax);
+  constituentSub.set_max_eta(maxEtaEvent);
   if (removeHFCand) {
     constituentSub.set_particle_selector(&selRemoveHFCand);
   }
@@ -163,7 +166,7 @@ std::vector<fastjet::PseudoJet> JetBkgSubUtils::doEventConstSub(std::vector<fast
     constituentSub.set_do_mass_subtraction();
   }
 
-  return constituentSub.subtract_event(inputParticles);
+  return constituentSub.subtract_event(inputParticles, maxEtaEvent);
 }
 
 std::vector<fastjet::PseudoJet> JetBkgSubUtils::doJetConstSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam)

--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -1,0 +1,208 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// jet finder task
+//
+// Author: Hadi Hassan, Universiy of Jväskylä, hadi.hassan@cern.ch
+#include <memory>
+#include <tuple>
+#include "Framework/Logger.h"
+#include "Common/Core/RecoDecay.h"
+#include "PWGJE/Core/JetUtilities.h"
+#include "PWGJE/Core/JetBkgSubUtils.h"
+#include "PWGJE/Core/FastJetUtilities.h"
+
+JetBkgSubUtils::JetBkgSubUtils(float jetBkgR_out, float constSubAlpha_out, float constSubRMax_out, float bkgEtaMin_out, float bkgEtaMax_out, float bkgPhiMin_out, float bkgPhiMax_out, fastjet::GhostedAreaSpec ghostAreaSpec_out, int nHardReject) : jetBkgR(jetBkgR_out),
+                                                                                                                                                                                                                                                      constSubAlpha(constSubAlpha_out),
+                                                                                                                                                                                                                                                      constSubRMax(constSubRMax_out),
+                                                                                                                                                                                                                                                      bkgEtaMin(bkgEtaMin_out),
+                                                                                                                                                                                                                                                      bkgEtaMax(bkgEtaMax_out),
+                                                                                                                                                                                                                                                      bkgPhiMin(bkgPhiMin_out),
+                                                                                                                                                                                                                                                      bkgPhiMax(bkgPhiMax_out),
+                                                                                                                                                                                                                                                      ghostAreaSpec(ghostAreaSpec_out)
+
+{
+  // Note: if you are using the PerpCone method you should jetBkgR to be the same as the anit_kt jets R, otherwise use R=0.2
+  jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, fastjet::Best);
+  areaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, ghostAreaSpec);
+  selRho = fastjet::SelectorRapRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax) && !fastjet::SelectorNHardest(nHardReject); // here we have to put rap range, to be checked!
+}
+
+std::tuple<double, double> JetBkgSubUtils::estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles, bool doSparseSub)
+{
+
+  if (inputParticles.size() == 0) {
+    return std::make_tuple(0.0, 0.0);
+  }
+
+  // cluster the kT jets
+  fastjet::ClusterSequenceArea clusterSeq(removeHFCand ? selRemoveHFCand(inputParticles) : inputParticles, jetDefBkg, areaDefBkg);
+
+  // select jets in detector acceptance
+  std::vector<fastjet::PseudoJet> alljets = selRho(clusterSeq.inclusive_jets());
+
+  double totaljetAreaPhys(0), totalAreaCovered(0);
+  std::vector<double> rhovector;
+  std::vector<double> rhoMdvector;
+
+  // Fill a vector for pT/area to be used for the median
+  for (auto& ijet : alljets) {
+
+    // Physical area/ Physical jets (no ghost)
+    if (!clusterSeq.is_pure_ghost(ijet)) {
+      rhovector.push_back(ijet.perp() / ijet.area());
+      rhoMdvector.push_back(getMd(ijet) / ijet.area());
+
+      totaljetAreaPhys += ijet.area();
+    }
+    // Full area
+    totalAreaCovered += ijet.area();
+  }
+  // calculate Rho as the median of the jet pT / jet area
+  double rho = TMath::Median<double>(rhovector.size(), rhovector.data());
+  double rhoM = TMath::Median<double>(rhoMdvector.size(), rhoMdvector.data());
+
+  if (doSparseSub) {
+    // calculate The ocupancy factor, which the ratio of covered area / total area
+    double occupancyFactor = totalAreaCovered > 0 ? totaljetAreaPhys / totalAreaCovered : 1.;
+    rho *= occupancyFactor;
+    rhoM *= occupancyFactor;
+  }
+
+  return std::make_tuple(rho, rhoM);
+}
+
+std::tuple<double, double> JetBkgSubUtils::estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets)
+{
+
+  if (inputParticles.size() == 0 || jets.size() == 0) {
+    return std::make_tuple(0.0, 0.0);
+  }
+
+  // Select a list of particles without the HF candidate
+  std::vector<fastjet::PseudoJet> inputPartnoHF = removeHFCand ? selRemoveHFCand(inputParticles) : inputParticles;
+
+  double perpPtDensity1 = 0;
+  double perpPtDensity2 = 0;
+  double perpMdDensity1 = 0;
+  double perpMdDensity2 = 0;
+
+  fastjet::Selector selectJet = fastjet::SelectorEtaRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax);
+
+  std::vector<fastjet::PseudoJet> selectedJets = fastjet::sorted_by_pt(selectJet(jets));
+
+  if (selectedJets.size() == 0) {
+    return std::make_tuple(0.0, 0.0);
+  }
+
+  fastjet::PseudoJet leadingJet = selectedJets[0];
+
+  double dPhi1 = 999.;
+  double dPhi2 = 999.;
+  double dEta = 999.;
+  double PerpendicularConeAxisPhi1 = 999., PerpendicularConeAxisPhi2 = 999.;
+  // build 2 perp cones in phi around the leading jet (right and left of the jet)
+  PerpendicularConeAxisPhi1 = RecoDecay::constrainAngle<double, double>(leadingJet.phi() + (M_PI / 2.)); // This will contrain the angel between 0-2Pi
+  PerpendicularConeAxisPhi2 = RecoDecay::constrainAngle<double, double>(leadingJet.phi() - (M_PI / 2.)); // This will contrain the angel between 0-2Pi
+
+  for (auto& particle : inputPartnoHF) {
+    // sum the momentum of all paricles that fill the two cones
+    dPhi1 = particle.phi() - PerpendicularConeAxisPhi1;
+    dPhi1 = RecoDecay::constrainAngle<double, double>(dPhi1, -M_PI); // This will contrain the angel between -pi & Pi
+    dPhi2 = particle.phi() - PerpendicularConeAxisPhi2;
+    dPhi2 = RecoDecay::constrainAngle<double, double>(dPhi2, -M_PI); // This will contrain the angel between -pi & Pi
+    dEta = leadingJet.eta() - particle.eta();                        // The perp cone eta is the same as the leading jet since the cones are perpendicular only in phi
+    if (TMath::Sqrt(dPhi1 * dPhi1 + dEta * dEta) <= jetBkgR) {
+      perpPtDensity1 += particle.perp();
+      perpMdDensity1 += TMath::Sqrt(particle.m() * particle.m() + particle.pt() * particle.pt()) - particle.pt();
+    }
+
+    if (TMath::Sqrt(dPhi2 * dPhi2 + dEta * dEta) <= jetBkgR) {
+      perpPtDensity2 += particle.perp();
+      perpMdDensity2 += TMath::Sqrt(particle.m() * particle.m() + particle.pt() * particle.pt()) - particle.pt();
+    }
+  }
+
+  // Caculate rho as the ratio of average pT of the two cones / the cone area
+  double perpPtDensity = (perpPtDensity1 + perpPtDensity2) / (2 * M_PI * jetBkgR * jetBkgR);
+  double perpMdDensity = (perpMdDensity1 + perpMdDensity2) / (2 * M_PI * jetBkgR * jetBkgR);
+
+  return std::make_tuple(perpPtDensity, perpMdDensity);
+}
+
+std::vector<fastjet::PseudoJet> JetBkgSubUtils::doRhoAreaSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam)
+{
+
+  fastjet::Subtractor sub = fastjet::Subtractor(rhoParam, rhoMParam);
+  return sub(jets);
+}
+
+std::vector<fastjet::PseudoJet> JetBkgSubUtils::doEventConstSub(std::vector<fastjet::PseudoJet>& inputParticles, double& rhoParam, double& rhoMParam)
+{
+
+  fastjet::contrib::ConstituentSubtractor constituentSub(rhoParam, rhoMParam);
+  constituentSub.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); /// deltaR=sqrt((y_i-y_j)^2+(phi_i-phi_j)^2)), longitudinal Lorentz invariant
+  constituentSub.set_max_distance(constSubRMax);
+  constituentSub.set_alpha(constSubAlpha);
+  constituentSub.set_ghost_area(ghostAreaSpec.ghost_area());
+  constituentSub.set_max_eta(bkgEtaMax);
+  if (removeHFCand) {
+    constituentSub.set_particle_selector(&selRemoveHFCand);
+  }
+
+  // by default, the masses of all particles are set to zero. With this flag the jet mass will also be subtracted
+  if (doRhoMassSub) {
+    constituentSub.set_do_mass_subtraction();
+  }
+
+  return constituentSub.subtract_event(inputParticles);
+}
+
+std::vector<fastjet::PseudoJet> JetBkgSubUtils::doJetConstSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam)
+{
+
+  if (jets.size() == 0) {
+    return std::vector<fastjet::PseudoJet>();
+  }
+
+  // FIXME, this method works only if the input jets "jets" are reconstructed with area def "active_area_explicit_ghosts"
+  //  because it needs the ghosts to estimate the backgeound
+  fastjet::contrib::ConstituentSubtractor constituentSub(rhoParam, rhoMParam);
+  constituentSub.set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR); /// deltaR=sqrt((y_i-y_j)^2+(phi_i-phi_j)^2)), longitudinal Lorentz invariant
+  constituentSub.set_max_distance(constSubRMax);
+  constituentSub.set_alpha(constSubAlpha);
+  constituentSub.set_ghost_area(ghostAreaSpec.ghost_area());
+  constituentSub.set_max_eta(bkgEtaMax);
+  if (removeHFCand) {
+    constituentSub.set_particle_selector(&selRemoveHFCand);
+  }
+
+  // by default, the masses of all particles are set to zero. With this flag the jet mass will also be subtracted
+  if (doRhoMassSub) {
+    constituentSub.set_do_mass_subtraction();
+  }
+
+  // FIXME, This method doesn't propagate the area information, since after constituent subtraction
+  // the jet structure will change, so it no longer has the same area. fastjet developers said calculatig the area
+  // information will difficult
+  return constituentSub(jets);
+}
+
+double JetBkgSubUtils::getMd(fastjet::PseudoJet jet) const
+{
+  // Refere to https://arxiv.org/abs/1211.2811 for the rhoM caclulation
+  double sum(0);
+  for (auto constituent : jet.constituents()) {
+    sum += TMath::Sqrt(constituent.m() * constituent.m() + constituent.pt() * constituent.pt()) - constituent.pt();
+  }
+
+  return sum;
+}

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -117,6 +117,7 @@ class JetBkgSubUtils
     constSubAlpha = alpha_out;
     constSubRMax = rmax_out;
   }
+  void setMaxEtaEvent(float etaMaxEvent) { maxEtaEvent = etaMaxEvent; }
   void setDoRhoMassSub(bool doMSub_out = true) { doRhoMassSub = doMSub_out; }
   void setRemoveHFCandidate(bool removecandidate = true) { removeHFCand = removecandidate; }
   void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec_out) { ghostAreaSpec = ghostAreaSpec_out; }
@@ -130,6 +131,7 @@ class JetBkgSubUtils
   float getPhiMax() const { return bkgPhiMax; }
   float getEtaMin() const { return bkgEtaMin; }
   float getEtaMax() const { return bkgEtaMax; }
+  float getEtaMaxEvent() const { return maxEtaEvent; }
   float getConstSubAlpha() const { return constSubAlpha; }
   float getConstSubRMax() const { return constSubRMax; }
   float getDoRhoMassSub() const { return doRhoMassSub; }
@@ -148,6 +150,7 @@ class JetBkgSubUtils
   float constSubRMax = 0.6;
   float bkgEtaMin = -0.9;
   float bkgEtaMax = 0.9;
+  float maxEtaEvent = 0.9;
   float bkgPhiMin = -99.0;
   float bkgPhiMax = 99.0;
   bool doRhoMassSub = false; /// flag whether to do jet mass subtraction with the const sub

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -80,11 +80,11 @@ class JetBkgSubUtils
   std::tuple<double, double> estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
 
   /// @brief method that subtracts the background from jets using the area method
-  /// @param jets (all jets in the event)
+  /// @param jet input jet to be background subtracted
   /// @param rhoParam the underlying evvent density vs pT (to be set)
   /// @param rhoParam the underlying evvent density vs jet mass (to be set)
-  /// @return jets, a vector of background subtracted jets
-  std::vector<fastjet::PseudoJet> doRhoAreaSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam);
+  /// @return jet, background subtracted jet
+  fastjet::PseudoJet doRhoAreaSub(fastjet::PseudoJet& jet, double& rhoParam, double& rhoMParam);
 
   /// @brief method that subtracts the background from the input particles using the event-wise cosntituent subtractor
   /// @param inputParticles (all the tracks/clusters/particles in the event)

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -1,0 +1,166 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file JetBkgSubUtils.h
+/// \brief Jet background subtraction utilities
+///
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, JYU
+
+#ifndef PWGJE_CORE_JETBKGSUBUTILS_H_
+#define PWGJE_CORE_JETBKGSUBUTILS_H_
+
+#include <string>
+#include <memory>
+#include <tuple>
+#include <vector>
+#include <TMath.h>
+
+#include "PWGJE/Core/FastJetUtilities.h"
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
+#include "fastjet/tools/Subtractor.hh"
+#include "fastjet/contrib/ConstituentSubtractor.hh"
+
+#include "Framework/Logger.h"
+
+enum class BkgSubEstimator { none = 0,
+                             medianRho = 1,
+                             medianRhoSparse = 2,
+                             perpCone = 3
+};
+
+enum class BkgSubMode { none = 0,
+                        rhoAreaSub = 1,
+                        eventConstSub = 2,
+                        jetConstSub = 3
+};
+
+class JetBkgSubUtils
+{
+
+ public:
+  // Default contructor
+  JetBkgSubUtils() = default;
+
+  JetBkgSubUtils(float jetBkgR_out = 0.2, float constSubAlpha_out = 1., float constSubRMax_out = 0.6, float bkgEtaMin_out = -0.8, float bkgEtaMax_out = 0.8,
+                 float bkgPhiMin_out = 0., float bkgPhiMax_out = 2 * M_PI, fastjet::GhostedAreaSpec ghostAreaSpec_out = fastjet::GhostedAreaSpec(), int nHardReject = 2);
+
+  // Default destructor
+  ~JetBkgSubUtils() = default;
+
+  /// @brief Setting the jet algorithm and the recombination scheme
+  void setJetAlgorithmAndScheme(fastjet::JetAlgorithm algorithmBkg_out, fastjet::RecombinationScheme recombSchemeBkg_out)
+  {
+    algorithmBkg = algorithmBkg_out;
+    recombSchemeBkg = recombSchemeBkg_out;
+  }
+
+  /// @brief Method for estimating the jet background density using the median method or the sparse method
+  /// @param inputParticles (all particles in the event)
+  /// @param doSparseSub weather to do rho sparse subtraction
+  /// @return Rho, RhoM the underlying event density
+  std::tuple<double, double> estimateRhoAreaMedian(const std::vector<fastjet::PseudoJet>& inputParticles, bool doSparseSub);
+
+  /// @brief Background estimator using the perpendicular cone method
+  /// @param inputParticles
+  /// @param jets (all jets in the event)
+  /// @return Rho, RhoM the underlying event density
+  std::tuple<double, double> estimateRhoPerpCone(const std::vector<fastjet::PseudoJet>& inputParticles, const std::vector<fastjet::PseudoJet>& jets);
+
+  /// @brief method that subtracts the background from jets using the area method
+  /// @param jets (all jets in the event)
+  /// @param rhoParam the underlying evvent density vs pT (to be set)
+  /// @param rhoParam the underlying evvent density vs jet mass (to be set)
+  /// @return jets, a vector of background subtracted jets
+  std::vector<fastjet::PseudoJet> doRhoAreaSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam);
+
+  /// @brief method that subtracts the background from the input particles using the event-wise cosntituent subtractor
+  /// @param inputParticles (all the tracks/clusters/particles in the event)
+  /// @param rhoParam the underlying evvent density vs pT (to be set)
+  /// @param rhoParam the underlying evvent density vs jet mass (to be set)
+  /// @return inputParticles, a vector of background subtracted input particles
+  std::vector<fastjet::PseudoJet> doEventConstSub(std::vector<fastjet::PseudoJet>& inputParticles, double& rhoParam, double& rhoMParam);
+
+  /// @brief method that subtracts the background from jets using the jet-wise constituent subtractor
+  /// @param jets (all jets in the event)
+  /// @param rhoParam the underlying evvent density vs pT (to be set)
+  /// @param rhoParam the underlying evvent density vs jet mass (to be set)
+  /// @return jets, a vector of background subtracted jets
+  std::vector<fastjet::PseudoJet> doJetConstSub(std::vector<fastjet::PseudoJet>& jets, double& rhoParam, double& rhoMParam);
+
+  // Setters
+  void setJetBkgR(float jetbkgR_out) { jetBkgR = jetbkgR_out; }
+  void setPhiMinMax(float phimin_out, float phimax_out)
+  {
+    bkgPhiMin = phimin_out;
+    bkgPhiMax = phimax_out;
+  }
+  void setEtaMinMax(float etamin_out, float etamax_out)
+  {
+    bkgEtaMin = etamin_out;
+    bkgEtaMax = etamax_out;
+  }
+  void setConstSubAlphaRMax(float alpha_out, float rmax_out)
+  {
+    constSubAlpha = alpha_out;
+    constSubRMax = rmax_out;
+  }
+  void setDoRhoMassSub(bool doMSub_out = true) { doRhoMassSub = doMSub_out; }
+  void setRemoveHFCandidate(bool removecandidate = true) { removeHFCand = removecandidate; }
+  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec_out) { ghostAreaSpec = ghostAreaSpec_out; }
+  void setJetDefinition(fastjet::JetDefinition jetdefbkg_out) { jetDefBkg = jetdefbkg_out; }
+  void setAreaDefinition(fastjet::AreaDefinition areaDefBkg_out) { areaDefBkg = areaDefBkg_out; }
+  void setRhoSelector(fastjet::Selector selRho_out) { selRho = selRho_out; }
+
+  // Getters
+  float getJetBkgR() const { return jetBkgR; }
+  float getPhiMin() const { return bkgPhiMin; }
+  float getPhiMax() const { return bkgPhiMax; }
+  float getEtaMin() const { return bkgEtaMin; }
+  float getEtaMax() const { return bkgEtaMax; }
+  float getConstSubAlpha() const { return constSubAlpha; }
+  float getConstSubRMax() const { return constSubRMax; }
+  float getDoRhoMassSub() const { return doRhoMassSub; }
+  float getRemoveHFCandidate() const { return removeHFCand; }
+  fastjet::GhostedAreaSpec getGhostAreaSpec() const { return ghostAreaSpec; }
+  fastjet::JetDefinition getJetDefinition() const { return jetDefBkg; }
+  fastjet::AreaDefinition getAreaDefinition() const { return areaDefBkg; }
+  fastjet::Selector getRhoSelector() const { return selRho; }
+
+  // Calculate the jet mass
+  double getMd(fastjet::PseudoJet jet) const;
+
+ protected:
+  float jetBkgR = 0.2;
+  float constSubAlpha = 1.0;
+  float constSubRMax = 0.6;
+  float bkgEtaMin = -0.9;
+  float bkgEtaMax = 0.9;
+  float bkgPhiMin = -99.0;
+  float bkgPhiMax = 99.0;
+  bool doRhoMassSub = false; /// flag whether to do jet mass subtraction with the const sub
+  bool removeHFCand = false; /// flag whether to remove the HF candidate from the list of particles
+
+  fastjet::GhostedAreaSpec ghostAreaSpec = fastjet::GhostedAreaSpec();
+  fastjet::JetAlgorithm algorithmBkg = fastjet::kt_algorithm;
+  fastjet::RecombinationScheme recombSchemeBkg = fastjet::E_scheme;
+  fastjet::JetDefinition jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, fastjet::Best);
+  fastjet::AreaDefinition areaDefBkg = fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts, ghostAreaSpec);
+  fastjet::Selector selRho = fastjet::Selector();
+  fastjet::Selector selRemoveHFCand = !FastJetUtilities::SelectorIsHFCand();
+
+}; // class JetBkgSubUtils
+
+#endif // PWGJE_CORE_JETBKGSUBUTILS_H_

--- a/PWGJE/Core/JetFinder.cxx
+++ b/PWGJE/Core/JetFinder.cxx
@@ -32,48 +32,12 @@ void JetFinder::setParams()
     jetR = 5.0 * jetR;
   }
 
-  //selGhosts =fastjet::SelectorRapRange(ghostEtaMin,ghostEtaMax) && fastjet::SelectorPhiRange(phiMin,phiMax);
-  //ghostAreaSpec=fastjet::GhostedAreaSpec(selGhosts,ghostRepeatN,ghostArea,gridScatter,ktScatter,ghostktMean);
-  ghostAreaSpec = fastjet::GhostedAreaSpec(ghostEtaMax, ghostRepeatN, ghostArea, gridScatter, ktScatter, ghostktMean); //the first argument is rapidity not pseudorapidity, to be checked
+  // selGhosts =fastjet::SelectorRapRange(ghostEtaMin,ghostEtaMax) && fastjet::SelectorPhiRange(phiMin,phiMax);
+  // ghostAreaSpec=fastjet::GhostedAreaSpec(selGhosts,ghostRepeatN,ghostArea,gridScatter,ktScatter,ghostktMean);
+  ghostAreaSpec = fastjet::GhostedAreaSpec(ghostEtaMax, ghostRepeatN, ghostArea, gridScatter, ktScatter, ghostktMean); // the first argument is rapidity not pseudorapidity, to be checked
   jetDef = fastjet::JetDefinition(algorithm, jetR, recombScheme, strategy);
   areaDef = fastjet::AreaDefinition(areaType, ghostAreaSpec);
   selJets = fastjet::SelectorPtRange(jetPtMin, jetPtMax) && fastjet::SelectorEtaRange(jetEtaMin, jetEtaMax) && fastjet::SelectorPhiRange(jetPhiMin, jetPhiMax);
-  jetDefBkg = fastjet::JetDefinition(algorithmBkg, jetBkgR, recombSchemeBkg, strategyBkg);
-  areaDefBkg = fastjet::AreaDefinition(areaTypeBkg, ghostAreaSpec);
-  selRho = fastjet::SelectorRapRange(bkgEtaMin, bkgEtaMax) && fastjet::SelectorPhiRange(bkgPhiMin, bkgPhiMax); //&& !fastjet::SelectorNHardest(2)    //here we have to put rap range, to be checked!
-}
-
-/// Sets the background subtraction estimater pointer
-void JetFinder::setBkgE()
-{
-  if (bkgSubMode == BkgSubMode::rhoAreaSub || bkgSubMode == BkgSubMode::constSub) {
-    bkgE = decltype(bkgE)(new fastjet::JetMedianBackgroundEstimator(selRho, jetDefBkg, areaDefBkg));
-  } else {
-    if (bkgSubMode != BkgSubMode::none) {
-      LOGF(error, "requested subtraction mode not implemented!");
-    }
-  }
-}
-
-/// Sets the background subtraction pointer
-void JetFinder::setSub()
-{
-  //if rho < 1e-6 it is set to 1e-6 in AliPhysics
-  if (bkgSubMode == BkgSubMode::rhoAreaSub) {
-    sub = decltype(sub){new fastjet::Subtractor{bkgE.get()}};
-  } else if (bkgSubMode == BkgSubMode::constSub) { //event or jetwise
-    constituentSub = decltype(constituentSub){new fastjet::contrib::ConstituentSubtractor{bkgE.get()}};
-    constituentSub->set_distance_type(fastjet::contrib::ConstituentSubtractor::deltaR);
-    constituentSub->set_max_distance(constSubRMax);
-    constituentSub->set_alpha(constSubAlpha);
-    constituentSub->set_ghost_area(ghostArea);
-    constituentSub->set_max_eta(bkgEtaMax);
-    constituentSub->set_background_estimator(bkgE.get()); //what about rho_m
-  } else {
-    if (bkgSubMode != BkgSubMode::none) {
-      LOGF(error, "requested subtraction mode not implemented!");
-    }
-  }
 }
 
 /// Performs jet finding
@@ -81,23 +45,16 @@ void JetFinder::setSub()
 /// \param inputParticles vector of input particles/tracks
 /// \param jets veector of jets to be filled
 /// \return ClusterSequenceArea object needed to access constituents
-fastjet::ClusterSequenceArea JetFinder::findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets) //ideally find a way of passing the cluster sequence as a reeference
+fastjet::ClusterSequenceArea JetFinder::findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets) // ideally find a way of passing the cluster sequence as a reeference
 {
   setParams();
-  setBkgE();
   jets.clear();
 
-  if (bkgE) {
-    bkgE->set_particles(inputParticles);
-    setSub();
-  }
-  if (constituentSub) {
-    inputParticles = constituentSub->subtract_event(inputParticles);
-  }
   fastjet::ClusterSequenceArea clusterSeq(inputParticles, jetDef, areaDef);
-  jets = sub ? (*sub)(clusterSeq.inclusive_jets()) : clusterSeq.inclusive_jets();
+  jets = clusterSeq.inclusive_jets();
+
   jets = selJets(jets);
-  jets = sorted_by_pt(jets);
+  jets = fastjet::sorted_by_pt(jets);
   if (isReclustering) {
     jetR = jetR / 5.0;
   }

--- a/PWGJE/Core/JetFinder.h
+++ b/PWGJE/Core/JetFinder.h
@@ -27,9 +27,7 @@
 #include "fastjet/ClusterSequenceArea.hh"
 #include "fastjet/AreaDefinition.hh"
 #include "fastjet/JetDefinition.hh"
-#include "fastjet/tools/JetMedianBackgroundEstimator.hh"
 #include "fastjet/tools/Subtractor.hh"
-#include "fastjet/contrib/ConstituentSubtractor.hh"
 
 enum class JetType {
   full = 0,
@@ -41,13 +39,6 @@ class JetFinder
 {
 
  public:
-  enum class BkgSubMode { none,
-                          rhoAreaSub,
-                          constSub };
-  BkgSubMode bkgSubMode;
-
-  void setBkgSubMode(BkgSubMode bSM) { bkgSubMode = bSM; }
-
   /// Performs jet finding
   /// \note the input particle and jet lists are passed by reference
   /// \param inputParticles vector of input particles/tracks
@@ -79,15 +70,6 @@ class JetFinder
   float gridScatter;
   float ktScatter;
 
-  float jetBkgR;
-  float bkgPhiMin;
-  float bkgPhiMax;
-  float bkgEtaMin;
-  float bkgEtaMax;
-
-  float constSubAlpha;
-  float constSubRMax;
-
   bool isReclustering;
   bool isTriggering;
 
@@ -101,17 +83,8 @@ class JetFinder
   fastjet::Selector selJets;
   fastjet::Selector selGhosts;
 
-  fastjet::JetAlgorithm algorithmBkg;
-  fastjet::RecombinationScheme recombSchemeBkg;
-  fastjet::Strategy strategyBkg;
-  fastjet::AreaType areaTypeBkg;
-  fastjet::JetDefinition jetDefBkg;
-  fastjet::AreaDefinition areaDefBkg;
-  fastjet::Selector selRho;
-
   /// Default constructor
-  explicit JetFinder(float eta_Min = -0.9, float eta_Max = 0.9, float phi_Min = 0.0, float phi_Max = 2 * M_PI) : bkgSubMode(BkgSubMode::none),
-                                                                                                                 phiMin(phi_Min),
+  explicit JetFinder(float eta_Min = -0.9, float eta_Max = 0.9, float phi_Min = 0.0, float phi_Max = 2 * M_PI) : phiMin(phi_Min),
                                                                                                                  phiMax(phi_Max),
                                                                                                                  etaMin(eta_Min),
                                                                                                                  etaMax(eta_Max),
@@ -130,23 +103,12 @@ class JetFinder
                                                                                                                  ghostktMean(1e-100), // is float precise enough?
                                                                                                                  gridScatter(1.0),
                                                                                                                  ktScatter(0.1),
-                                                                                                                 jetBkgR(0.2),
-                                                                                                                 bkgPhiMin(phi_Min),
-                                                                                                                 bkgPhiMax(phi_Max),
-                                                                                                                 bkgEtaMin(eta_Min),
-                                                                                                                 bkgEtaMax(eta_Max),
-                                                                                                                 constSubAlpha(1.0),
-                                                                                                                 constSubRMax(0.6),
                                                                                                                  isReclustering(false),
                                                                                                                  isTriggering(false),
                                                                                                                  algorithm(fastjet::antikt_algorithm),
                                                                                                                  recombScheme(fastjet::E_scheme),
                                                                                                                  strategy(fastjet::Best),
-                                                                                                                 areaType(fastjet::active_area),
-                                                                                                                 algorithmBkg(fastjet::JetAlgorithm(fastjet::kt_algorithm)),
-                                                                                                                 recombSchemeBkg(fastjet::RecombinationScheme(fastjet::E_scheme)),
-                                                                                                                 strategyBkg(fastjet::Best),
-                                                                                                                 areaTypeBkg(fastjet::active_area)
+                                                                                                                 areaType(fastjet::active_area)
   {
 
     // default constructor
@@ -158,12 +120,6 @@ class JetFinder
   /// Sets the jet finding parameters
   void setParams();
 
-  /// Sets the background subtraction estimater pointer
-  void setBkgE();
-
-  /// Sets the background subtraction pointer
-  void setSub();
-
   /// Performs jet finding
   /// \note the input particle and jet lists are passed by reference
   /// \param inputParticles vector of input particles/tracks
@@ -172,12 +128,6 @@ class JetFinder
   fastjet::ClusterSequenceArea findJets(std::vector<fastjet::PseudoJet>& inputParticles, std::vector<fastjet::PseudoJet>& jets); // ideally find a way of passing the cluster sequence as a reeference
 
  private:
-  // void setParams();
-  // void setBkgSub();
-  std::unique_ptr<fastjet::BackgroundEstimatorBase> bkgE;
-  std::unique_ptr<fastjet::Subtractor> sub;
-  std::unique_ptr<fastjet::contrib::ConstituentSubtractor> constituentSub;
-
   ClassDefNV(JetFinder, 1);
 };
 

--- a/PWGJE/Core/PWGJECoreLinkDef.h
+++ b/PWGJE/Core/PWGJECoreLinkDef.h
@@ -17,6 +17,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class JetFinder + ;
+#pragma link C++ class JetBkgSubUtils + ;
 #pragma link C++ namespace JetUtilities + ;
 #pragma link C++ namespace FastJetUtilities + ;
 #pragma link C++ namespace JetTaggingUtilities + ;

--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -63,8 +63,6 @@ struct JetFinderTask {
   Configurable<float> jetGhostArea{"jetGhostArea", 0.005, "jet ghost area"};
   Configurable<int> ghostRepeat{"ghostRepeat", 1, "set to 0 to gain speed if you dont need area calculation"};
   Configurable<bool> DoTriggering{"DoTriggering", false, "used for the charged jet trigger to remove the eta constraint on the jet axis"};
-  Configurable<bool> DoRhoAreaSub{"DoRhoAreaSub", false, "do rho area subtraction"};
-  Configurable<bool> DoConstSub{"DoConstSub", false, "do constituent subtraction"};
 
   Service<o2::framework::O2DatabasePDG> pdgDatabase;
   std::string trackSelection;
@@ -74,18 +72,13 @@ struct JetFinderTask {
   JetFinder jetFinder;
   std::vector<fastjet::PseudoJet> inputParticles;
 
+  bool doConstSub = false;
+
   void init(InitContext const&)
   {
     trackSelection = static_cast<std::string>(trackSelections);
     eventSelection = static_cast<std::string>(eventSelections);
     particleSelection = static_cast<std::string>(particleSelections);
-
-    if (DoRhoAreaSub) {
-      jetFinder.setBkgSubMode(JetFinder::BkgSubMode::rhoAreaSub);
-    }
-    if (DoConstSub) {
-      jetFinder.setBkgSubMode(JetFinder::BkgSubMode::constSub);
-    }
 
     jetFinder.etaMin = trackEtaMin;
     jetFinder.etaMax = trackEtaMax;
@@ -125,7 +118,7 @@ struct JetFinderTask {
     }
     inputParticles.clear();
     analyseTracks<JetTracks, JetTracks::iterator>(inputParticles, tracks, trackSelection);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
 
   PROCESS_SWITCH(JetFinderTask, processChargedJets, "Data jet finding for charged jets", false);
@@ -138,7 +131,7 @@ struct JetFinderTask {
     }
     inputParticles.clear();
     analyseClusters(inputParticles, &clusters);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
   PROCESS_SWITCH(JetFinderTask, processNeutralJets, "Data jet finding for neutral jets", false);
 
@@ -152,7 +145,7 @@ struct JetFinderTask {
     inputParticles.clear();
     analyseTracks<JetTracks, JetTracks::iterator>(inputParticles, tracks, trackSelection);
     analyseClusters(inputParticles, &clusters);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
   PROCESS_SWITCH(JetFinderTask, processFullJets, "Data jet finding for full and neutral jets", false);
 
@@ -160,7 +153,7 @@ struct JetFinderTask {
   {
     // TODO: MC event selection?
     analyseParticles<soa::Filtered<aod::McParticles>, soa::Filtered<aod::McParticles>::iterator>(inputParticles, particleSelection, 1, particles, pdgDatabase);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
   PROCESS_SWITCH(JetFinderTask, processParticleLevelChargedJets, "Particle level charged jet finding", false);
 
@@ -168,7 +161,7 @@ struct JetFinderTask {
   {
     // TODO: MC event selection?
     analyseParticles<soa::Filtered<aod::McParticles>, soa::Filtered<aod::McParticles>::iterator>(inputParticles, particleSelection, 2, particles, pdgDatabase);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
   PROCESS_SWITCH(JetFinderTask, processParticleLevelNeutralJets, "Particle level neutral jet finding", false);
 
@@ -176,7 +169,7 @@ struct JetFinderTask {
   {
     // TODO: MC event selection?
     analyseParticles<soa::Filtered<aod::McParticles>, soa::Filtered<aod::McParticles>::iterator>(inputParticles, particleSelection, 0, particles, pdgDatabase);
-    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub);
+    findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub);
   }
 
   PROCESS_SWITCH(JetFinderTask, processParticleLevelFullJets, "Particle level full jet finding", false);

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -153,6 +153,7 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
     fastjet::ClusterSequenceArea clusterSeq(jetFinder.findJets(inputParticles, jets));
 
     // JetBkgSubUtils bkgSub(jetFinder.jetR, 1., 0.6, jetFinder.jetEtaMin, jetFinder.jetEtaMax, jetFinder.jetPhiMin, jetFinder.jetPhiMax, jetFinder.ghostAreaSpec);
+    // bkgSub.setMaxEtaEvent(jetFinder.etaMax);
     // auto[rho, rhoM] = bkgSub.estimateRhoAreaMedian(inputParticles, false);
     // jets = jetFinder.selJets(bkgSub.doRhoAreaSub(jets, rho, rhoM));
 

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -19,6 +19,7 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <optional>
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -36,6 +37,7 @@
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 #include "PWGHF/Core/PDG.h"
 
+// #include "PWGJE/Core/JetBkgSubUtils.h"
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/Core/JetFinder.h"
 #include "PWGJE/DataModel/Jet.h"
@@ -149,6 +151,11 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
     jetFinder.jetR = R;
     std::vector<fastjet::PseudoJet> jets;
     fastjet::ClusterSequenceArea clusterSeq(jetFinder.findJets(inputParticles, jets));
+
+    // JetBkgSubUtils bkgSub(jetFinder.jetR, 1., 0.6, jetFinder.jetEtaMin, jetFinder.jetEtaMax, jetFinder.jetPhiMin, jetFinder.jetPhiMax, jetFinder.ghostAreaSpec);
+    // auto[rho, rhoM] = bkgSub.estimateRhoAreaMedian(inputParticles, false);
+    // jets = jetFinder.selJets(bkgSub.doRhoAreaSub(jets, rho, rhoM));
+
     for (const auto& jet : jets) {
       bool isHFJet = false;
       if (doHFJetFinding) {
@@ -167,10 +174,10 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
       std::vector<int> candconst;
       std::vector<int> clusterconst;
       jetsTable(collision.globalIndex(), jet.pt(), jet.eta(), jet.phi(),
-                jet.E(), jet.m(), jet.area(), std::round(R * 100));
+                jet.E(), jet.m(), jet.has_area() ? jet.area() : -1., std::round(R * 100));
       for (const auto& constituent : sorted_by_pt(jet.constituents())) {
         // need to add seperate thing for constituent subtraction
-        if (DoConstSub) { // FIXME: needs to be addressed in Haadi's PR
+        if (DoConstSub) {
           constituentsSubTable(jetsTable.lastIndex(), constituent.pt(), constituent.eta(), constituent.phi(),
                                constituent.E(), constituent.m(), constituent.user_index());
         }

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -91,8 +91,6 @@ struct JetFinderHFTask {
   Configurable<int> jetRecombScheme{"jetRecombScheme", 0, "jet recombination scheme. 0 = E-scheme, 1 = pT-scheme, 2 = pT2-scheme"};
   Configurable<float> jetGhostArea{"jetGhostArea", 0.005, "jet ghost area"};
   Configurable<int> ghostRepeat{"ghostRepeat", 1, "set to 0 to gain speed if you dont need area calculation"};
-  Configurable<bool> DoRhoAreaSub{"DoRhoAreaSub", false, "do rho area subtraction"};
-  Configurable<bool> DoConstSub{"DoConstSub", false, "do constituent subtraction"};
 
   Service<o2::framework::O2DatabasePDG> pdgDatabase;
   std::string trackSelection;
@@ -102,6 +100,7 @@ struct JetFinderHFTask {
   JetFinder jetFinder;
   std::vector<fastjet::PseudoJet> inputParticles;
 
+  bool doConstSub = false;
   int candDecay;
   double candMass;
 
@@ -110,13 +109,6 @@ struct JetFinderHFTask {
     trackSelection = static_cast<std::string>(trackSelections);
     eventSelection = static_cast<std::string>(eventSelections);
     particleSelection = static_cast<std::string>(particleSelections);
-
-    if (DoRhoAreaSub) {
-      jetFinder.setBkgSubMode(JetFinder::BkgSubMode::rhoAreaSub);
-    }
-    if (DoConstSub) {
-      jetFinder.setBkgSubMode(JetFinder::BkgSubMode::constSub);
-    }
 
     jetFinder.etaMin = trackEtaMin;
     jetFinder.etaMax = trackEtaMax;
@@ -170,7 +162,7 @@ struct JetFinderHFTask {
         continue;
       }
       analyseTracks(inputParticles, tracks, trackSelection, std::optional{candidate});
-      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub, true);
+      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub, true);
     }
   }
 
@@ -188,7 +180,7 @@ struct JetFinderHFTask {
         continue;
       }
       analyseTracks(inputParticles, tracks, trackSelection, std::optional{candidate});
-      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub, true);
+      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub, true);
     }
   }
 
@@ -215,7 +207,7 @@ struct JetFinderHFTask {
     for (auto& candidate : candidates) {
       analyseParticles(inputParticles, particleSelection, jetTypeParticleLevel, particles, pdgDatabase, std::optional{candidate});
       FastJetUtilities::fillTracks(candidate, inputParticles, candidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), pdgDatabase->Mass(candidate.pdgCode()));
-      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub, true);
+      findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, doConstSub, true);
     }
   }
 


### PR DESCRIPTION
Implementing background subtraction methods in the O2Physics PWGJE framework. Three background estinators has been added:
- Median background estimator (as in AliPhysics).
- Rho sparse estimator, which is used for sparse events like in pp or p-Pb.
- The perpendicular cone method (used in few papers).

And three background subtraction methods has been added:
- The rho area subtraction.
- The fastjet builtin constituent subtraction method (eventwise).
- The fastjet builtin constituent subtraction jet-by-jet (jetwise).

This task also subtracted the background from the jet mass in the same methods.