### PR TITLE
[EMCal-689] emctmmonitor: change pT binning and added cuts

### DIFF
--- a/PWGJE/Tasks/emctmmonitor.cxx
+++ b/PWGJE/Tasks/emctmmonitor.cxx
@@ -79,6 +79,12 @@ struct TrackMatchingMonitor {
   Configurable<float> minTime{"minTime", -25., "Minimum cluster time for time cut"};
   Configurable<float> maxTime{"maxTime", +20., "Maximum cluster time for time cut"};
   Configurable<float> minM02{"minM02", 0.1, "Minimum M02 for M02 cut"};
+  Configurable<float> maxM02{"maxM02", 0.9, "Maximum M02 for M02 cut"};
+  Configurable<float> maxM02HighPt{"maxM02HighPt", 0.6, "Maximum M02 for M02 cut for high pT"};
+  Configurable<float> M02highPt{"M02highPt", 15., "pT threshold for maxM02HighPt cut. Set to negative value to disable it!"};
+  Configurable<float> minDEta{"minDEta", 0.01, "Minimum dEta between track and cluster"};
+  Configurable<float> minDPhi{"minDPhi", 0.01, "Minimum dPhi between track and cluster"};
+  Configurable<std::vector<float>> eOverPRange{"eOverPRange", {0.9, 1.2}, "E/p range where one would search for electrons (first <= E/p <= second)"};
 
   std::vector<int> mVetoBCIDs;
   std::vector<int> mSelectBCIDs;
@@ -102,10 +108,10 @@ struct TrackMatchingMonitor {
     const o2Axis dPhiAxis{100, -0.4, 0.4, "d#it{#varphi} (rad)"};
     const o2Axis dRAxis{100, 0.0, 0.4, "d#it{R}"};
     const o2Axis eoverpAxis{500, 0, 10, "#it{E}_{cluster}/#it{p}_{track}"};
-    const o2Axis nSigmaAxis{100, -5., 5., "N#sigma"};
-    const o2Axis trackptAxis{200, 0, 100, "#it{p}_{T,track}"};
+    const o2Axis nSigmaAxis{100, -10., +3., "N#sigma"};
+    const o2Axis trackptAxis{makePtBinning(), "#it{p}_{T,track}"};
     const o2Axis trackpAxis{200, 0, 100, "#it{p}_{track}"};
-    const o2Axis clusterptAxis{200, 0, 100, "#it{p}_{T}"};
+    const o2Axis clusterptAxis{makePtBinning(), "#it{p}_{T}"};
     o2Axis timeAxis{mClusterTimeBinning, "t_{cl} (ns)"};
 
     int MaxMatched = 20; // maximum number of matched tracks, hardcoded in emcalCorrectionTask.cxx!
@@ -150,7 +156,9 @@ struct TrackMatchingMonitor {
     mHistManager.add("clusterTM_EoverP_p", "cluster E/electron p", o2HistType::kTH3F, {eoverpAxis, trackptAxis, nmatchedtrack});                                                          // E over p vs track pT for the Nth closest positron track
     mHistManager.add("clusterTM_EoverP_electron_ASide", "cluster E/electron p in A-Side", o2HistType::kTH3F, {eoverpAxis, trackptAxis, nmatchedtrack});                                   // E over p vs track pT for the Nth closest electron/positron track in A-Side
     mHistManager.add("clusterTM_EoverP_electron_CSide", "cluster E/electron p in C-Side", o2HistType::kTH3F, {eoverpAxis, trackptAxis, nmatchedtrack});                                   // E over p vs track pT for the Nth closest electron/positron track in C-Side
-    mHistManager.add("clusterTM_NSigma_e", "NSigma electron", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                                               // NSigma track pT for the Nth closest electron track
+    mHistManager.add("clusterTM_NSigma", "electron NSigma for matched track", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                               // NSigma_electron vs track pT for the Nth closest track
+    mHistManager.add("clusterTM_NSigma_cut", "electron NSigma for matched track with cuts", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                 // NSigma_electron vs track pT for the Nth closest track with cuts on E/p and cluster cuts
+    mHistManager.add("clusterTM_NSigma_e", "NSigma electron", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                                               // NSigma vs track pT for the Nth closest electron track
     mHistManager.add("clusterTM_NSigma_p", "NSigma positron", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                                               // NSigma vs track pT for the Nth closest positron track
     mHistManager.add("clusterTM_NSigma_electron_ASide", "NSigma electron in A-Side", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                        // NSigma vs track pT for the Nth closest electron/positron track in A-Side
     mHistManager.add("clusterTM_NSigma_electron_CSide", "NSigma positron in C-Side", o2HistType::kTH3F, {nSigmaAxis, trackptAxis, nmatchedtrack});                                        // NSigma vs track pT for the Nth closest electron/positron track in C-Side
@@ -185,7 +193,7 @@ struct TrackMatchingMonitor {
   // define cluster filter. It selects only those clusters which are of the type
   // sadly passing of the string at runtime is not possible for technical region so cluster definition is
   // an integer instead
-  Filter clusterDefinitionSelection = (o2::aod::emcalcluster::definition == mClusterDefinition) && (o2::aod::emcalcluster::time >= minTime) && (o2::aod::emcalcluster::time <= maxTime) && (o2::aod::emcalcluster::m02 > minM02);
+  Filter clusterDefinitionSelection = (o2::aod::emcalcluster::definition == mClusterDefinition) && (o2::aod::emcalcluster::time >= minTime) && (o2::aod::emcalcluster::time <= maxTime) && (o2::aod::emcalcluster::m02 > minM02) && (o2::aod::emcalcluster::m02 < maxM02);
 
   /// \brief Process EMCAL clusters that are matched to a collisions
   void processCollisions(collisionEvSelIt const& theCollision, selectedClusters const& clusters, o2::aod::EMCALClusterCells const& emccluscells, o2::aod::Calos const& allcalos, o2::aod::EMCALMatchedTracks const& matchedtracks, tracksPID const& alltrack)
@@ -263,6 +271,9 @@ struct TrackMatchingMonitor {
       // In this example the counter t is just used to only look at the closest match
       double dEta, dPhi, pT, abs_p;
       pT = cluster.energy() / cosh(cluster.eta());
+      if (M02highPt > 0. && cluster.m02() >= maxM02HighPt && pT >= M02highPt) { // high pT M02 cut
+        continue;
+      }
       auto tracksofcluster = matchedtracks.sliceBy(perClusterMatchedTracks, cluster.globalIndex());
       int t = 0;
       int tAli = 0;
@@ -278,15 +289,24 @@ struct TrackMatchingMonitor {
           dEta = match.track_as<tracksPID>().eta() - cluster.eta();
           dPhi = match.track_as<tracksPID>().phi() - cluster.phi();
         }
+        if (dEta >= minDEta || dPhi >= minDPhi) { // dEta and dPhi cut
+          continue;
+        }
+        double eOverP = cluster.energy() / abs_p;
+        double NSigmaEl = match.track_as<tracksPID>().tpcNSigmaEl();
         mHistManager.fill(HIST("clusterTM_dEtaTN"), dEta, t);
         mHistManager.fill(HIST("clusterTM_dPhiTN"), dPhi, t);
         mHistManager.fill(HIST("clusterTM_dRTN"), std::sqrt(dPhi * dPhi + dEta * dEta), t);
-        mHistManager.fill(HIST("clusterTM_EoverP_E"), cluster.energy() / abs_p, cluster.energy(), t);
+        mHistManager.fill(HIST("clusterTM_EoverP_E"), eOverP, cluster.energy(), t);
         mHistManager.fill(HIST("clusterTM_dEtadPhi"), dEta, dPhi, t);
         mHistManager.fill(HIST("clusterEMatched"), cluster.energy(), t);
         mHistManager.fill(HIST("clusterTM_dEtaPt"), dEta, pT, t);
         mHistManager.fill(HIST("clusterTM_EvsP"), cluster.energy(), abs_p, t);
-        mHistManager.fill(HIST("clusterTM_EoverP_Pt"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+        mHistManager.fill(HIST("clusterTM_EoverP_Pt"), eOverP, match.track_as<tracksPID>().pt(), t);
+        mHistManager.fill(HIST("clusterTM_NSigma"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
+        if (eOverPRange->at(0) <= eOverP && eOverP <= eOverPRange->at(1)) {
+          mHistManager.fill(HIST("clusterTM_NSigma_cut"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
+        }
         // A- and C-side
         if (match.track_as<tracksPID>().eta() > 0.0) {
           mHistManager.fill(HIST("clusterTM_dEtadPhi_ASide"), dEta, dPhi, t);
@@ -315,51 +335,51 @@ struct TrackMatchingMonitor {
             mHistManager.fill(HIST("clusterTM_NegdEtadPhi_0_75leqPl1_25"), dEta, dPhi, t);
           }
         }
-        if (tpcNsigmaElectron->at(0) <= match.track_as<tracksPID>().tpcNSigmaEl() && match.track_as<tracksPID>().tpcNSigmaEl() <= tpcNsigmaElectron->at(1)) {                 // E/p for e+/e-
+        if (tpcNsigmaElectron->at(0) <= NSigmaEl && NSigmaEl <= tpcNsigmaElectron->at(1)) {                                                                                   // E/p for e+/e-
           if (usePionRejection && (tpcNsigmaPion->at(0) <= match.track_as<tracksPID>().tpcNSigmaPi() || match.track_as<tracksPID>().tpcNSigmaPi() <= tpcNsigmaPion->at(1))) { // with pion rejection
-            mHistManager.fill(HIST("clusterTM_EoverP_ep"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_ep"), eOverP, match.track_as<tracksPID>().pt(), t);
             if (match.track_as<tracksPID>().eta() >= 0.) {
-              mHistManager.fill(HIST("clusterTM_EoverP_electron_ASide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_electron_ASide"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_ASide"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_electron_ASide"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             } else {
-              mHistManager.fill(HIST("clusterTM_EoverP_electron_CSide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_electron_CSide"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_CSide"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_electron_CSide"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             }
             if (match.track_as<tracksPID>().sign() == -1) {
-              mHistManager.fill(HIST("clusterTM_EoverP_e"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_e"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_e"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_e"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             } else if (match.track_as<tracksPID>().sign() == +1) {
-              mHistManager.fill(HIST("clusterTM_EoverP_p"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_p"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_p"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_p"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             }
           } else { // without pion rejection
-            mHistManager.fill(HIST("clusterTM_EoverP_ep"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_ep"), eOverP, match.track_as<tracksPID>().pt(), t);
             if (match.track_as<tracksPID>().eta() >= 0.) {
-              mHistManager.fill(HIST("clusterTM_EoverP_electron_ASide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_electron_ASide"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_ASide"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_electron_ASide"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             } else {
-              mHistManager.fill(HIST("clusterTM_EoverP_electron_CSide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_electron_CSide"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_electron_CSide"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_electron_CSide"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             }
             if (match.track_as<tracksPID>().sign() == -1) {
-              mHistManager.fill(HIST("clusterTM_EoverP_e"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_e"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_e"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_e"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             } else if (match.track_as<tracksPID>().sign() == +1) {
-              mHistManager.fill(HIST("clusterTM_EoverP_p"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
-              mHistManager.fill(HIST("clusterTM_NSigma_p"), match.track_as<tracksPID>().tpcNSigmaEl(), match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_EoverP_p"), eOverP, match.track_as<tracksPID>().pt(), t);
+              mHistManager.fill(HIST("clusterTM_NSigma_p"), NSigmaEl, match.track_as<tracksPID>().pt(), t);
             }
           }
-        } else if (tpcNsigmaBack->at(0) <= match.track_as<tracksPID>().tpcNSigmaEl() && match.track_as<tracksPID>().tpcNSigmaEl() <= tpcNsigmaBack->at(1)) { // E/p for hadrons / background
-          mHistManager.fill(HIST("clusterTM_EoverP_hadron"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+        } else if (tpcNsigmaBack->at(0) <= NSigmaEl && NSigmaEl <= tpcNsigmaBack->at(1)) { // E/p for hadrons / background
+          mHistManager.fill(HIST("clusterTM_EoverP_hadron"), eOverP, match.track_as<tracksPID>().pt(), t);
           if (match.track_as<tracksPID>().eta() >= 0.) {
-            mHistManager.fill(HIST("clusterTM_EoverP_hadron_ASide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_hadron_ASide"), eOverP, match.track_as<tracksPID>().pt(), t);
           } else {
-            mHistManager.fill(HIST("clusterTM_EoverP_hadron_CSide"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_hadron_CSide"), eOverP, match.track_as<tracksPID>().pt(), t);
           }
           if (match.track_as<tracksPID>().sign() == -1) {
-            mHistManager.fill(HIST("clusterTM_EoverP_hn"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_hn"), eOverP, match.track_as<tracksPID>().pt(), t);
           } else if (match.track_as<tracksPID>().sign() == +1) {
-            mHistManager.fill(HIST("clusterTM_EoverP_hp"), cluster.energy() / abs_p, match.track_as<tracksPID>().pt(), t);
+            mHistManager.fill(HIST("clusterTM_EoverP_hp"), eOverP, match.track_as<tracksPID>().pt(), t);
           }
         }
         if ((fabs(dEta) <= 0.01 + pow(match.track_as<tracksPID>().pt() + 4.07, -2.5)) &&
@@ -428,6 +448,33 @@ struct TrackMatchingMonitor {
         result.emplace_back(100. + 5.0 * (i - 215));
       else if (i < 245)
         result.emplace_back(200. + 10.0 * (i - 235));
+    }
+    return result;
+  }
+
+  /// \brief Create binning for pT axis (variable bin size)
+  /// direct port from binning often used in AliPhysics for debugging
+  /// \return vector with bin limits
+  std::vector<double> makePtBinning() const
+  {
+    std::vector<double> result;
+    result.reserve(1000);
+    double epsilon = 1e-6;
+    double valGammaPt = 0;
+    for (int i = 0; i < 1000; ++i) {
+      result.push_back(valGammaPt);
+      if (valGammaPt < 1.0 - epsilon)
+        valGammaPt += 0.1;
+      else if (valGammaPt < 5 - epsilon)
+        valGammaPt += 0.2;
+      else if (valGammaPt < 10 - epsilon)
+        valGammaPt += 0.5;
+      else if (valGammaPt < 50 - epsilon)
+        valGammaPt += 1;
+      else if (valGammaPt < 100 - epsilon)
+        valGammaPt += 5;
+      else
+        break;
     }
     return result;
   }


### PR DESCRIPTION
- Change of pT binning, to follow in line with a pT binning which was used in AliPhysics
- Added cuts for track-cluster dPhi and dEta as configurable
- Added cluster cut for M02 max as well as a high pT region for a stronger M02 max cut as configurable
- All the cut standard values are identical to what was used in the EMCal perfomance paper for Run 2