### PR TITLE
Remove the PID selection flag and add HasTOF

### DIFF
--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -52,21 +52,6 @@ using ResoCollision = ResoCollisions::iterator;
 // inspired from PWGCF/DataModel/FemtoDerived.h
 namespace resodaughter
 {
-enum PDGtype {
-  kPion = BIT(0),
-  kKaon = BIT(1),
-  kProton = BIT(2),
-  kHasTOF = BIT(6) // Save hasTOF info for TOF selection
-};
-
-#define requireTPCPIDCutInFilter(mask) ((aod::resodaughter::tpcPIDselectionFlag & (uint8_t)aod::resodaughter::mask) == (uint8_t)aod::resodaughter::mask)
-#define requireTOFPIDCutInFilter(mask) (((aod::resodaughter::tofPIDselectionFlag & (uint8_t)aod::resodaughter::kHasTOF) != (uint8_t)aod::resodaughter::kHasTOF) || (((aod::resodaughter::tofPIDselectionFlag & (uint8_t)aod::resodaughter::mask) == (uint8_t)aod::resodaughter::mask) && ((aod::resodaughter::tofPIDselectionFlag & (uint8_t)aod::resodaughter::kHasTOF) == (uint8_t)aod::resodaughter::kHasTOF)))
-#define requireTPCPIDPionCutInFilter() requireTPCPIDCutInFilter(PDGtype::kPion)
-#define requireTPCPIDKaonCutInFilter() requireTPCPIDCutInFilter(PDGtype::kKaon)
-#define requireTPCPIDProtonCutInFilter() requireTPCPIDCutInFilter(PDGtype::kProton)
-#define requireTOFPIDPionCutInFilter() requireTOFPIDCutInFilter(PDGtype::kPion)
-#define requireTOFPIDKaonCutInFilter() requireTOFPIDCutInFilter(PDGtype::kKaon)
-#define requireTOFPIDProtonCutInFilter() requireTOFPIDCutInFilter(PDGtype::kProton)
 
 DECLARE_SOA_INDEX_COLUMN(ResoCollision, resoCollision);
 DECLARE_SOA_COLUMN(Pt, pt, float);                                     //! p_T (GeV/c)
@@ -80,11 +65,10 @@ DECLARE_SOA_COLUMN(TempFitVar, tempFitVar, float);                     //! Obser
 DECLARE_SOA_COLUMN(Indices, indices, int[2]);                          //! Field for the track indices to remove auto-correlations
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);                                //! Sign of the track charge
 DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, uint8_t);   //! Number of TPC crossed rows
-DECLARE_SOA_COLUMN(TPCPIDselectionFlag, tpcPIDselectionFlag, uint8_t); //! TPC PID selection
-DECLARE_SOA_COLUMN(TOFPIDselectionFlag, tofPIDselectionFlag, uint8_t); //! TOF PID selection
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);      //! Is global track without DCA
 DECLARE_SOA_COLUMN(IsPrimaryTrack, isPrimaryTrack, bool);              //! Is primary track
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool);            //! Is primary vertex contributor
+DECLARE_SOA_COLUMN(HasTOF, hasTOF, bool);                              //! Has TOF
 DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls, float);
 DECLARE_SOA_COLUMN(DaughDCA, daughDCA, float);               //! DCA between daughters
 DECLARE_SOA_COLUMN(CascDaughDCA, cascdaughDCA, float);       //! DCA between daughters from cascade
@@ -127,8 +111,7 @@ DECLARE_SOA_TABLE(ResoTracks, "AOD", "RESOTRACKS",
                   o2::aod::track::DcaZ,
                   o2::aod::track::X,
                   o2::aod::track::Alpha,
-                  resodaughter::TPCPIDselectionFlag,
-                  resodaughter::TOFPIDselectionFlag,
+                  resodaughter::HasTOF,
                   o2::aod::pidtpc::TPCNSigmaPi,
                   o2::aod::pidtpc::TPCNSigmaKa,
                   o2::aod::pidtpc::TPCNSigmaPr,

--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -418,26 +418,6 @@ struct reso2initializer {
     for (auto& track : tracks) {
       if (!IsTrackSelected<isMC>(collision, track))
         continue;
-      // Add PID selection criteria here
-      uint8_t tpcPIDselections = 0;
-      uint8_t tofPIDselections = 0;
-      // TPC PID
-      if (std::abs(track.tpcNSigmaPi()) < pidnSigmaPreSelectionCut)
-        tpcPIDselections |= aod::resodaughter::PDGtype::kPion;
-      if (std::abs(track.tpcNSigmaKa()) < pidnSigmaPreSelectionCut)
-        tpcPIDselections |= aod::resodaughter::PDGtype::kKaon;
-      if (std::abs(track.tpcNSigmaPr()) < pidnSigmaPreSelectionCut)
-        tpcPIDselections |= aod::resodaughter::PDGtype::kProton;
-      // TOF PID
-      if (track.hasTOF()) {
-        tofPIDselections |= aod::resodaughter::PDGtype::kHasTOF;
-        if (std::abs(track.tofNSigmaPi()) < pidnSigmaPreSelectionCut)
-          tofPIDselections |= aod::resodaughter::PDGtype::kPion;
-        if (std::abs(track.tofNSigmaKa()) < pidnSigmaPreSelectionCut)
-          tofPIDselections |= aod::resodaughter::PDGtype::kKaon;
-        if (std::abs(track.tofNSigmaPr()) < pidnSigmaPreSelectionCut)
-          tofPIDselections |= aod::resodaughter::PDGtype::kProton;
-      }
       reso2trks(resoCollisions.lastIndex(),
                 track.pt(),
                 track.px(),
@@ -451,8 +431,7 @@ struct reso2initializer {
                 track.dcaZ(),
                 track.x(),
                 track.alpha(),
-                tpcPIDselections,
-                tofPIDselections,
+                track.hasTOF(),
                 track.tpcNSigmaPi(),
                 track.tpcNSigmaKa(),
                 track.tpcNSigmaPr(),

--- a/PWGLF/Tasks/f0980analysis.cxx
+++ b/PWGLF/Tasks/f0980analysis.cxx
@@ -156,9 +156,7 @@ struct f0980analysis {
   template <typename TrackType>
   bool SelPion(const TrackType track)
   {
-    if ((track.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) !=
-          aod::resodaughter::kHasTOF ||
-        !cfgUseTOF) {
+    if (track.hasTOF() || !cfgUseTOF) {
       if (std::fabs(track.tpcNSigmaPi()) > cfgMaxTPCStandalone) {
         return false;
       }

--- a/PWGLF/Tasks/k1analysis.cxx
+++ b/PWGLF/Tasks/k1analysis.cxx
@@ -191,11 +191,11 @@ struct k1analysis {
     return true;
   }
 
-  // PID selection tools from phianalysisrun3
+  // PID selection tools
   template <typename T>
   bool selectionPIDPion(const T& candidate, bool hasTOF)
   {
-    if (hasTOF && (candidate.tofNSigmaPi() * candidate.tofNSigmaPi() + candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi()) < (2.0 * nsigmaCutCombinedPion * nsigmaCutCombinedPion)) {
+    if (hasTOF && ((candidate.tofNSigmaPi() * candidate.tofNSigmaPi() + candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi()) < (nsigmaCutCombinedPion * nsigmaCutCombinedPion))) {
       return true;
     } else if (std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion) {
       return true;
@@ -205,7 +205,7 @@ struct k1analysis {
   template <typename T>
   bool selectionPIDKaon(const T& candidate, bool hasTOF)
   {
-    if (hasTOF && (candidate.tofNSigmaKa() * candidate.tofNSigmaKa() + candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa()) < (2.0 * nsigmaCutCombinedKaon * nsigmaCutCombinedKaon)) {
+    if (hasTOF && ((candidate.tofNSigmaKa() * candidate.tofNSigmaKa() + candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa()) < (nsigmaCutCombinedKaon * nsigmaCutCombinedKaon))) {
       return true;
     } else if (std::abs(candidate.tpcNSigmaKa()) < cMaxTPCnSigmaKaon) {
       return true;
@@ -262,8 +262,8 @@ struct k1analysis {
       if (!trackCut(trk1) || !trackCut(trk2))
         continue;
 
-      auto isTrk1hasTOF = ((trk1.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
-      auto isTrk2hasTOF = ((trk2.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
+      auto isTrk1hasTOF = trk1.hasTOF();
+      auto isTrk2hasTOF = trk2.hasTOF();
       auto trk1ptPi = trk1.pt();
       auto trk1NSigmaPiTPC = trk1.tpcNSigmaPi();
       auto trk1NSigmaPiTOF = (isTrk1hasTOF) ? trk1.tofNSigmaPi() : -999.;
@@ -340,7 +340,7 @@ struct k1analysis {
 
         auto bTrkPt = bTrack.pt();
         auto bTrkTPCnSigmaPi = bTrack.tpcNSigmaPi();
-        auto isbTrkhasTOF = ((bTrack.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
+        auto isbTrkhasTOF = bTrack.hasTOF();
         auto bTrack_TOFnSigma = (isbTrkhasTOF) ? bTrack.tofNSigmaPi() : -999.;
 
         // PID selection

--- a/PWGLF/Tasks/k892analysis.cxx
+++ b/PWGLF/Tasks/k892analysis.cxx
@@ -164,11 +164,11 @@ struct k892analysis {
 
     return true;
   }
-  // PID selection tools from phianalysisrun3
+  // PID selection tools
   template <typename T>
   bool selectionPIDPion(const T& candidate, bool hasTOF)
   {
-    if (hasTOF && (candidate.tofNSigmaPi() * candidate.tofNSigmaPi() + candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi()) < (2.0 * nsigmaCutCombinedPion * nsigmaCutCombinedPion)) {
+    if (hasTOF && ((candidate.tofNSigmaPi() * candidate.tofNSigmaPi() + candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi()) < (nsigmaCutCombinedPion * nsigmaCutCombinedPion))) {
       return true;
     } else if (std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion) {
       return true;
@@ -178,7 +178,7 @@ struct k892analysis {
   template <typename T>
   bool selectionPIDKaon(const T& candidate, bool hasTOF)
   {
-    if (hasTOF && (candidate.tofNSigmaKa() * candidate.tofNSigmaKa() + candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa()) < (2.0 * nsigmaCutCombinedKaon * nsigmaCutCombinedKaon)) {
+    if (hasTOF && ((candidate.tofNSigmaKa() * candidate.tofNSigmaKa() + candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa()) < (nsigmaCutCombinedKaon * nsigmaCutCombinedKaon))) {
       return true;
     } else if (std::abs(candidate.tpcNSigmaKa()) < cMaxTPCnSigmaKaon) {
       return true;
@@ -200,9 +200,8 @@ struct k892analysis {
       if (!trackCut(trk1) || !trackCut(trk2))
         continue;
 
-      auto isTrk1hasTOF = ((trk1.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
-      auto isTrk2hasTOF = ((trk2.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
-      auto trk1ptPi = trk1.pt();
+      auto isTrk1hasTOF = trk1.hasTOF();
+      auto isTrk2hasTOF = trk2.hasTOF();auto trk1ptPi = trk1.pt();
       auto trk1NSigmaPiTPC = trk1.tpcNSigmaPi();
       auto trk1NSigmaPiTOF = (isTrk1hasTOF) ? trk1.tofNSigmaPi() : -999.;
       auto trk2ptKa = trk2.pt();

--- a/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
+++ b/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
@@ -226,7 +226,7 @@ struct lambdaAnalysis {
         }
       } else {
         // TPC + TOF
-        if ((trkPr.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) {
+        if (trkPr.hasTOF()) {
           trk1HasTOF = true;
           for (int i = 0; i < static_cast<int>(prTofPIDpt.size()); ++i) {
             if (trkPr.pt() < prTofPIDpt[i]) {
@@ -253,7 +253,7 @@ struct lambdaAnalysis {
         }
       } else {
         // TPC + TOF
-        if ((trkKa.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) {
+        if (trkKa.hasTOF()) {
           trk2HasTOF = true;
           for (int i = 0; i < static_cast<int>(kaTofPIDpt.size()); ++i) {
             if (trkKa.pt() < kaTofPIDpt[i]) {

--- a/PWGLF/Tasks/lambda1520analysis.cxx
+++ b/PWGLF/Tasks/lambda1520analysis.cxx
@@ -298,8 +298,8 @@ struct lambda1520analysis {
       // Trk1: Proton, Trk2: Kaon
       bool isTrk1Selected{true}, isTrk2Selected{true}; //, isTrk1hasTOF{false}, isTrk2hasTOF{false};
 
-      auto isTrk1hasTOF = ((trk1.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
-      auto isTrk2hasTOF = ((trk2.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
+      auto isTrk1hasTOF = trk1.hasTOF();
+      auto isTrk2hasTOF = trk2.hasTOF();
 
       auto trk1ptPr = trk1.pt();
       auto trk1NSigmaPrTPC = trk1.tpcNSigmaPr();

--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -168,8 +168,8 @@ struct phianalysis {
       if (!trackCut(trk1) || !trackCut(trk2))
         continue;
 
-      auto isTrk1hasTOF = ((trk1.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
-      auto isTrk2hasTOF = ((trk2.tofPIDselectionFlag() & aod::resodaughter::kHasTOF) == aod::resodaughter::kHasTOF) ? true : false;
+      auto isTrk1hasTOF = trk1.hasTOF();
+      auto isTrk2hasTOF = trk2.hasTOF();
       auto trk1ptKa = trk1.pt();
       auto trk1NSigmaKaTPC = trk1.tpcNSigmaKa();
       auto trk1NSigmaKaTOF = (isTrk1hasTOF) ? trk1.tofNSigmaPi() : -999.;


### PR DESCRIPTION
The PID Selection flag has been introduced for the filter-level selection but never used.

To have a simplest shape, I removed the selection flag and add the hasTOF variable.