### PR TITLE
Tools, PWGHF: Add flexibility to ML model input features definition

### DIFF
--- a/PWGHF/Core/HfMlResponse.h
+++ b/PWGHF/Core/HfMlResponse.h
@@ -22,8 +22,8 @@
 namespace o2::analysis
 {
 
-template <typename T = float, typename U = int8_t>
-class HfMlResponse : public MlResponse<T, U>
+template <typename TypeOutputScore = float, class EnumInputFeatures = uint8_t>
+class HfMlResponse : public MlResponse<TypeOutputScore, EnumInputFeatures>
 {
  public:
   /// Default constructor

--- a/PWGHF/Core/HfMlResponse.h
+++ b/PWGHF/Core/HfMlResponse.h
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file HFMLResponse.h
+/// \file HfMlResponse.h
 /// \brief Class to compute the ML response for HF-analysis selections
 /// \author Fabio Catalano <fabio.catalano@cern.ch>, CERN
 /// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
@@ -17,21 +17,13 @@
 #ifndef PWGHF_CORE_HFMLRESPONSE_H_
 #define PWGHF_CORE_HFMLRESPONSE_H_
 
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
-
-#include <map>
-#include <string>
-#include <vector>
-
-#include "CCDB/CcdbApi.h"
-#include "Framework/Array2D.h"
 #include "Tools/ML/MlResponse.h"
 
 namespace o2::analysis
 {
 
-template <typename T = float>
-class HfMlResponse : public o2::analysis::MlResponse<T>
+template <typename T = float, typename U = int8_t>
+class HfMlResponse : public MlResponse<T, U>
 {
  public:
   /// Default constructor

--- a/PWGHF/Core/HfMlResponse.h
+++ b/PWGHF/Core/HfMlResponse.h
@@ -22,8 +22,8 @@
 namespace o2::analysis
 {
 
-template <typename TypeOutputScore = float, class EnumInputFeatures = uint8_t>
-class HfMlResponse : public MlResponse<TypeOutputScore, EnumInputFeatures>
+template <typename TypeOutputScore = float>
+class HfMlResponse : public MlResponse<TypeOutputScore>
 {
  public:
   /// Default constructor

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -22,6 +22,32 @@
 
 #include "PWGHF/Core/HfMlResponse.h"
 
+// Fill the map of available input features
+// the key is the feature's name (std::string)
+// the value is the corresponding value in EnumInputFeatures
+#define FILL_MAP_DPLUS(FEATURE)                                          \
+  {                                                                      \
+#FEATURE, static_cast < uint8_t>(InputFeaturesDplusToPiKPi::FEATURE) \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the corresponding GETTER from OBJECT
+#define CHECK_AND_FILL_VEC_DPLUS_FULL(OBJECT, FEATURE, GETTER)     \
+  case static_cast<uint8_t>(InputFeaturesDplusToPiKPi::FEATURE): { \
+    inputFeatures.emplace_back(OBJECT.GETTER());                   \
+    break;                                                         \
+  }
+
+// Specific case of CHECK_AND_FILL_VEC_DPLUS_FULL(OBJECT, FEATURE, GETTER)
+// where OBJECT is named candidate and FEATURE = GETTER
+#define CHECK_AND_FILL_VEC_DPLUS(GETTER)                          \
+  case static_cast<uint8_t>(InputFeaturesDplusToPiKPi::GETTER): { \
+    inputFeatures.emplace_back(candidate.GETTER());               \
+    break;                                                        \
+  }
+
 namespace o2::analysis
 {
 
@@ -57,8 +83,8 @@ enum class InputFeaturesDplusToPiKPi : uint8_t {
   tpcTofNSigmaKa2
 };
 
-template <typename TypeOutputScore = float, class EnumInputFeatures = InputFeaturesDplusToPiKPi>
-class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore, EnumInputFeatures>
+template <typename TypeOutputScore = float>
+class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore>
 {
  public:
   /// Default constructor
@@ -78,40 +104,40 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore, EnumInputF
   {
     std::vector<float> inputFeatures;
 
-    for (const auto& idx : MlResponse<TypeOutputScore, EnumInputFeatures>::mCachedIndices) {
+    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
       switch (idx) {
-        CHECK_AND_FILL_VEC(ptProng0);
-        CHECK_AND_FILL_VEC(ptProng1);
-        CHECK_AND_FILL_VEC(ptProng2);
-        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY0, impactParameter0);
-        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY1, impactParameter1);
-        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY2, impactParameter2);
-        CHECK_AND_FILL_VEC(decayLength);
-        CHECK_AND_FILL_VEC(decayLengthXYNormalised);
-        CHECK_AND_FILL_VEC(cpa);
-        CHECK_AND_FILL_VEC(cpaXY);
-        CHECK_AND_FILL_VEC(maxNormalisedDeltaIP);
+        CHECK_AND_FILL_VEC_DPLUS(ptProng0);
+        CHECK_AND_FILL_VEC_DPLUS(ptProng1);
+        CHECK_AND_FILL_VEC_DPLUS(ptProng2);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY0, impactParameter0);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY1, impactParameter1);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_DPLUS(decayLength);
+        CHECK_AND_FILL_VEC_DPLUS(decayLengthXYNormalised);
+        CHECK_AND_FILL_VEC_DPLUS(cpa);
+        CHECK_AND_FILL_VEC_DPLUS(cpaXY);
+        CHECK_AND_FILL_VEC_DPLUS(maxNormalisedDeltaIP);
         // TPC PID variables
-        CHECK_AND_FILL_VEC_FULL(prong0, tpcNSigmaPi0, tpcNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong0, tpcNSigmaKa0, tpcNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong1, tpcNSigmaPi1, tpcNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong1, tpcNSigmaKa1, tpcNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong2, tpcNSigmaPi2, tpcNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong2, tpcNSigmaKa2, tpcNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tpcNSigmaPi0, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tpcNSigmaKa0, tpcNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tpcNSigmaPi1, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tpcNSigmaKa1, tpcNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tpcNSigmaPi2, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tpcNSigmaKa2, tpcNSigmaKa);
         // TOF PID variables
-        CHECK_AND_FILL_VEC_FULL(prong0, tofNSigmaPi0, tofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong0, tofNSigmaKa0, tofNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong1, tofNSigmaPi1, tofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong1, tofNSigmaKa1, tofNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong2, tofNSigmaPi2, tofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong2, tofNSigmaKa2, tofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tofNSigmaPi0, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tofNSigmaKa0, tofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tofNSigmaPi1, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tofNSigmaKa1, tofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tofNSigmaPi2, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tofNSigmaKa2, tofNSigmaKa);
         // Combined PID variables
-        CHECK_AND_FILL_VEC_FULL(prong0, tpcTofNSigmaPi0, tpcTofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong1, tpcTofNSigmaPi1, tpcTofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong2, tpcTofNSigmaPi2, tpcTofNSigmaPi);
-        CHECK_AND_FILL_VEC_FULL(prong0, tpcTofNSigmaKa0, tpcTofNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong1, tpcTofNSigmaKa1, tpcTofNSigmaKa);
-        CHECK_AND_FILL_VEC_FULL(prong2, tpcTofNSigmaKa2, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tpcTofNSigmaPi0, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tpcTofNSigmaPi1, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tpcTofNSigmaPi2, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong0, tpcTofNSigmaKa0, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong1, tpcTofNSigmaKa1, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(prong2, tpcTofNSigmaKa2, tpcTofNSigmaKa);
       }
     }
 
@@ -122,46 +148,46 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore, EnumInputF
   /// Method to fill the map of available input features
   void setAvailableInputFeatures()
   {
-    MlResponse<TypeOutputScore, EnumInputFeatures>::mAvailableInputFeatures = {
-      FILL_MAP(ptProng0),
-      FILL_MAP(ptProng1),
-      FILL_MAP(ptProng2),
-      FILL_MAP(impactParameterXY0),
-      FILL_MAP(impactParameterXY1),
-      FILL_MAP(impactParameterXY2),
-      FILL_MAP(decayLength),
-      FILL_MAP(decayLengthXYNormalised),
-      FILL_MAP(cpa),
-      FILL_MAP(cpaXY),
-      FILL_MAP(maxNormalisedDeltaIP),
+    MlResponse<TypeOutputScore>::mAvailableInputFeatures = {
+      FILL_MAP_DPLUS(ptProng0),
+      FILL_MAP_DPLUS(ptProng1),
+      FILL_MAP_DPLUS(ptProng2),
+      FILL_MAP_DPLUS(impactParameterXY0),
+      FILL_MAP_DPLUS(impactParameterXY1),
+      FILL_MAP_DPLUS(impactParameterXY2),
+      FILL_MAP_DPLUS(decayLength),
+      FILL_MAP_DPLUS(decayLengthXYNormalised),
+      FILL_MAP_DPLUS(cpa),
+      FILL_MAP_DPLUS(cpaXY),
+      FILL_MAP_DPLUS(maxNormalisedDeltaIP),
       // TPC PID variables
-      FILL_MAP(tpcNSigmaPi0),
-      FILL_MAP(tpcNSigmaKa0),
-      FILL_MAP(tpcNSigmaPi1),
-      FILL_MAP(tpcNSigmaKa1),
-      FILL_MAP(tpcNSigmaPi2),
-      FILL_MAP(tpcNSigmaKa2),
+      FILL_MAP_DPLUS(tpcNSigmaPi0),
+      FILL_MAP_DPLUS(tpcNSigmaKa0),
+      FILL_MAP_DPLUS(tpcNSigmaPi1),
+      FILL_MAP_DPLUS(tpcNSigmaKa1),
+      FILL_MAP_DPLUS(tpcNSigmaPi2),
+      FILL_MAP_DPLUS(tpcNSigmaKa2),
       // TOF PID variables
-      FILL_MAP(tofNSigmaPi0),
-      FILL_MAP(tofNSigmaKa0),
-      FILL_MAP(tofNSigmaPi1),
-      FILL_MAP(tofNSigmaKa1),
-      FILL_MAP(tofNSigmaPi2),
-      FILL_MAP(tofNSigmaKa2),
+      FILL_MAP_DPLUS(tofNSigmaPi0),
+      FILL_MAP_DPLUS(tofNSigmaKa0),
+      FILL_MAP_DPLUS(tofNSigmaPi1),
+      FILL_MAP_DPLUS(tofNSigmaKa1),
+      FILL_MAP_DPLUS(tofNSigmaPi2),
+      FILL_MAP_DPLUS(tofNSigmaKa2),
       // Combined PID variables
-      FILL_MAP(tpcTofNSigmaPi0),
-      FILL_MAP(tpcTofNSigmaPi1),
-      FILL_MAP(tpcTofNSigmaPi2),
-      FILL_MAP(tpcTofNSigmaKa0),
-      FILL_MAP(tpcTofNSigmaKa1),
-      FILL_MAP(tpcTofNSigmaKa2)};
+      FILL_MAP_DPLUS(tpcTofNSigmaPi0),
+      FILL_MAP_DPLUS(tpcTofNSigmaPi1),
+      FILL_MAP_DPLUS(tpcTofNSigmaPi2),
+      FILL_MAP_DPLUS(tpcTofNSigmaKa0),
+      FILL_MAP_DPLUS(tpcTofNSigmaKa1),
+      FILL_MAP_DPLUS(tpcTofNSigmaKa2)};
   }
 };
 
 } // namespace o2::analysis
 
-#undef FILL_MAP
-#undef CHECK_AND_FILL_VEC_FULL
-#undef CHECK_AND_FILL_VEC
+#undef FILL_MAP_DPLUS
+#undef CHECK_AND_FILL_VEC_DPLUS_FULL
+#undef CHECK_AND_FILL_VEC_DPLUS
 
 #endif // PWGHF_CORE_HFMLRESPONSEDPLUSTOPIKPI_H_

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -1,0 +1,120 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponseDplusToPiKPi.h
+/// \brief Class to compute the ML response for D± → π± K∓ π± analysis selections
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#ifndef PWGHF_CORE_HFMLRESPONSEDPLUSTOPIKPI_H_
+#define PWGHF_CORE_HFMLRESPONSEDPLUSTOPIKPI_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "PWGHF/Core/HfMlResponse.h"
+
+namespace o2::analysis
+{
+
+enum InputFeaturesDplusToPiKPi : int8_t {
+  ptProng0 = 0,
+  ptProng1,
+  ptProng2,
+  impactParameter0,
+  impactParameter1,
+  impactParameter2,
+  decayLength,
+  decayLengthXYNormalised,
+  cpa,
+  cpaXY,
+  maxNormalisedDeltaIP,
+  tpcTofNSigmaPi0,
+  tpcTofNSigmaPi1,
+  tpcTofNSigmaPi2,
+  tpcTofNSigmaKa0,
+  tpcTofNSigmaKa1,
+  tpcTofNSigmaKa2
+};
+
+template <typename T = float, typename U = InputFeaturesDplusToPiKPi>
+class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
+{
+ public:
+  /// Default constructor
+  HfMlResponseDplusToPiKPi() = default;
+  /// Default destructor
+  virtual ~HfMlResponseDplusToPiKPi() = default;
+
+  /// Method to get the input features vector needed for ML inference
+  /// \param candidate is the Dplus candidate
+  /// \param prong0 is the candidate's prong0
+  /// \param prong1 is the candidate's prong1
+  /// \param prong2 is the candidate's prong2
+  /// \return inputFeatures vector
+  template <typename T1, typename T2>
+  std::vector<T> getInputFeatures(T1 const& candidate, T2 const& prong0, T2 const& prong1, T2 const& prong2) const
+  {
+    std::vector<T> inputFeatures;
+
+    for (const auto& idx : MlResponse<T, U>::mCachedIndices) {
+      switch (idx) {
+        CHECK_AND_FILL_VEC(ptProng0);
+        CHECK_AND_FILL_VEC(ptProng1);
+        CHECK_AND_FILL_VEC(ptProng2);
+        CHECK_AND_FILL_VEC(impactParameter0);
+        CHECK_AND_FILL_VEC(impactParameter1);
+        CHECK_AND_FILL_VEC(impactParameter2);
+        CHECK_AND_FILL_VEC(decayLength);
+        CHECK_AND_FILL_VEC(decayLengthXYNormalised);
+        CHECK_AND_FILL_VEC(cpa);
+        CHECK_AND_FILL_VEC(cpaXY);
+        CHECK_AND_FILL_VEC(maxNormalisedDeltaIP);
+        CHECK_AND_FILL_VEC_FULL(prong0, tpcTofNSigmaPi0, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong1, tpcTofNSigmaPi1, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong2, tpcTofNSigmaPi2, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong0, tpcTofNSigmaKa0, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong1, tpcTofNSigmaKa1, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong2, tpcTofNSigmaKa2, tpcTofNSigmaKa);
+      }
+    }
+
+    return inputFeatures;
+  }
+
+ protected:
+  /// Method to fill the map of available input features
+  void setAvailableInputFeatures()
+  {
+    MlResponse<T, U>::mAvailableInputFeatures = {
+      FILL_MAP(ptProng0),
+      FILL_MAP(ptProng1),
+      FILL_MAP(ptProng2),
+      FILL_MAP(impactParameter0),
+      FILL_MAP(impactParameter1),
+      FILL_MAP(impactParameter2),
+      FILL_MAP(decayLength),
+      FILL_MAP(decayLengthXYNormalised),
+      FILL_MAP(cpa),
+      FILL_MAP(cpaXY),
+      FILL_MAP(maxNormalisedDeltaIP),
+      FILL_MAP(tpcTofNSigmaPi0),
+      FILL_MAP(tpcTofNSigmaPi1),
+      FILL_MAP(tpcTofNSigmaPi2),
+      FILL_MAP(tpcTofNSigmaKa0),
+      FILL_MAP(tpcTofNSigmaKa1),
+      FILL_MAP(tpcTofNSigmaKa2)};
+  }
+};
+
+} // namespace o2::analysis
+
+#endif // PWGHF_CORE_HFMLRESPONSEDPLUSTOPIKPI_H_

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -25,7 +25,7 @@
 namespace o2::analysis
 {
 
-enum InputFeaturesDplusToPiKPi : int8_t {
+enum class InputFeaturesDplusToPiKPi : uint8_t {
   ptProng0 = 0,
   ptProng1,
   ptProng2,
@@ -57,8 +57,8 @@ enum InputFeaturesDplusToPiKPi : int8_t {
   tpcTofNSigmaKa2
 };
 
-template <typename T = float, typename U = InputFeaturesDplusToPiKPi>
-class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
+template <typename TypeOutputScore = float, class EnumInputFeatures = InputFeaturesDplusToPiKPi>
+class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore, EnumInputFeatures>
 {
  public:
   /// Default constructor
@@ -73,11 +73,12 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
   /// \param prong2 is the candidate's prong2
   /// \return inputFeatures vector
   template <typename T1, typename T2>
-  std::vector<T> getInputFeatures(T1 const& candidate, T2 const& prong0, T2 const& prong1, T2 const& prong2) const
+  std::vector<float> getInputFeatures(T1 const& candidate,
+                                      T2 const& prong0, T2 const& prong1, T2 const& prong2)
   {
-    std::vector<T> inputFeatures;
+    std::vector<float> inputFeatures;
 
-    for (const auto& idx : MlResponse<T, U>::mCachedIndices) {
+    for (const auto& idx : MlResponse<TypeOutputScore, EnumInputFeatures>::mCachedIndices) {
       switch (idx) {
         CHECK_AND_FILL_VEC(ptProng0);
         CHECK_AND_FILL_VEC(ptProng1);
@@ -121,7 +122,7 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
   /// Method to fill the map of available input features
   void setAvailableInputFeatures()
   {
-    MlResponse<T, U>::mAvailableInputFeatures = {
+    MlResponse<TypeOutputScore, EnumInputFeatures>::mAvailableInputFeatures = {
       FILL_MAP(ptProng0),
       FILL_MAP(ptProng1),
       FILL_MAP(ptProng2),
@@ -158,5 +159,9 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
 };
 
 } // namespace o2::analysis
+
+#undef FILL_MAP
+#undef CHECK_AND_FILL_VEC_FULL
+#undef CHECK_AND_FILL_VEC
 
 #endif // PWGHF_CORE_HFMLRESPONSEDPLUSTOPIKPI_H_

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -29,14 +29,26 @@ enum InputFeaturesDplusToPiKPi : int8_t {
   ptProng0 = 0,
   ptProng1,
   ptProng2,
-  impactParameter0,
-  impactParameter1,
-  impactParameter2,
+  impactParameterXY0,
+  impactParameterXY1,
+  impactParameterXY2,
   decayLength,
   decayLengthXYNormalised,
   cpa,
   cpaXY,
   maxNormalisedDeltaIP,
+  tpcNSigmaPi0,
+  tpcNSigmaKa0,
+  tpcNSigmaPi1,
+  tpcNSigmaKa1,
+  tpcNSigmaPi2,
+  tpcNSigmaKa2,
+  tofNSigmaPi0,
+  tofNSigmaKa0,
+  tofNSigmaPi1,
+  tofNSigmaKa1,
+  tofNSigmaPi2,
+  tofNSigmaKa2,
   tpcTofNSigmaPi0,
   tpcTofNSigmaPi1,
   tpcTofNSigmaPi2,
@@ -70,14 +82,29 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
         CHECK_AND_FILL_VEC(ptProng0);
         CHECK_AND_FILL_VEC(ptProng1);
         CHECK_AND_FILL_VEC(ptProng2);
-        CHECK_AND_FILL_VEC(impactParameter0);
-        CHECK_AND_FILL_VEC(impactParameter1);
-        CHECK_AND_FILL_VEC(impactParameter2);
+        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY0, impactParameter0);
+        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY1, impactParameter1);
+        CHECK_AND_FILL_VEC_FULL(candidate, impactParameterXY2, impactParameter2);
         CHECK_AND_FILL_VEC(decayLength);
         CHECK_AND_FILL_VEC(decayLengthXYNormalised);
         CHECK_AND_FILL_VEC(cpa);
         CHECK_AND_FILL_VEC(cpaXY);
         CHECK_AND_FILL_VEC(maxNormalisedDeltaIP);
+        // TPC PID variables
+        CHECK_AND_FILL_VEC_FULL(prong0, tpcNSigmaPi0, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong0, tpcNSigmaKa0, tpcNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong1, tpcNSigmaPi1, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong1, tpcNSigmaKa1, tpcNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong2, tpcNSigmaPi2, tpcNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong2, tpcNSigmaKa2, tpcNSigmaKa);
+        // TOF PID variables
+        CHECK_AND_FILL_VEC_FULL(prong0, tofNSigmaPi0, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong0, tofNSigmaKa0, tofNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong1, tofNSigmaPi1, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong1, tofNSigmaKa1, tofNSigmaKa);
+        CHECK_AND_FILL_VEC_FULL(prong2, tofNSigmaPi2, tofNSigmaPi);
+        CHECK_AND_FILL_VEC_FULL(prong2, tofNSigmaKa2, tofNSigmaKa);
+        // Combined PID variables
         CHECK_AND_FILL_VEC_FULL(prong0, tpcTofNSigmaPi0, tpcTofNSigmaPi);
         CHECK_AND_FILL_VEC_FULL(prong1, tpcTofNSigmaPi1, tpcTofNSigmaPi);
         CHECK_AND_FILL_VEC_FULL(prong2, tpcTofNSigmaPi2, tpcTofNSigmaPi);
@@ -98,14 +125,29 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<T, U>
       FILL_MAP(ptProng0),
       FILL_MAP(ptProng1),
       FILL_MAP(ptProng2),
-      FILL_MAP(impactParameter0),
-      FILL_MAP(impactParameter1),
-      FILL_MAP(impactParameter2),
+      FILL_MAP(impactParameterXY0),
+      FILL_MAP(impactParameterXY1),
+      FILL_MAP(impactParameterXY2),
       FILL_MAP(decayLength),
       FILL_MAP(decayLengthXYNormalised),
       FILL_MAP(cpa),
       FILL_MAP(cpaXY),
       FILL_MAP(maxNormalisedDeltaIP),
+      // TPC PID variables
+      FILL_MAP(tpcNSigmaPi0),
+      FILL_MAP(tpcNSigmaKa0),
+      FILL_MAP(tpcNSigmaPi1),
+      FILL_MAP(tpcNSigmaKa1),
+      FILL_MAP(tpcNSigmaPi2),
+      FILL_MAP(tpcNSigmaKa2),
+      // TOF PID variables
+      FILL_MAP(tofNSigmaPi0),
+      FILL_MAP(tofNSigmaKa0),
+      FILL_MAP(tofNSigmaPi1),
+      FILL_MAP(tofNSigmaKa1),
+      FILL_MAP(tofNSigmaPi2),
+      FILL_MAP(tofNSigmaKa2),
+      // Combined PID variables
       FILL_MAP(tpcTofNSigmaPi0),
       FILL_MAP(tpcTofNSigmaPi1),
       FILL_MAP(tpcTofNSigmaPi2),

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -73,7 +73,7 @@ struct HfCandidateSelectorDplusToPiKPi {
   Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB"};
   Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
 
-  o2::analysis::HfMlResponseDplusToPiKPi<float, o2::analysis::InputFeaturesDplusToPiKPi> hfMlResponse;
+  o2::analysis::HfMlResponseDplusToPiKPi<float> hfMlResponse;
   std::vector<float> outputMlNotPreselected = {};
   std::vector<float> outputMl = {};
   o2::ccdb::CcdbApi ccdbApi;
@@ -121,7 +121,6 @@ struct HfCandidateSelectorDplusToPiKPi {
       }
       hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
       hfMlResponse.init();
-      // outputMl.assign(((std::vector<int>)cutDirMl).size(), -1.f); // dummy value for ML output
     }
   }
 
@@ -258,9 +257,6 @@ struct HfCandidateSelectorDplusToPiKPi {
         std::vector<float> inputFeatures = hfMlResponse.getInputFeatures(candidate, trackPos1, trackNeg, trackPos2);
         bool isSelectedMl = hfMlResponse.isSelectedMl(inputFeatures, ptCand, outputMl);
         hfMlDplusToPiKPiCandidate(outputMl);
-
-        LOG(info) << "pt prong0: " << candidate.ptProng0() << " " << inputFeatures[0];
-        LOG(info) << "cpa: " << candidate.cpa() << " " << inputFeatures[8];
 
         if (!isSelectedMl) {
           hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);

--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -28,32 +28,6 @@
 
 #include "Tools/ML/model.h"
 
-// Fill the map of available input features
-// the key is the feature's name (std::string)
-// the value is the corresponding value in EnumInputFeatures
-#define FILL_MAP(FEATURE)                                        \
-  {                                                              \
-#FEATURE, static_cast < uint8_t>(EnumInputFeatures::FEATURE) \
-  }
-
-// Check if the index of mCachedIndices (index associated to a FEATURE)
-// matches the entry in EnumInputFeatures associated to this FEATURE
-// if so, the inputFeatures vector is filled with the FEATURE's value
-// by calling the corresponding GETTER from OBJECT
-#define CHECK_AND_FILL_VEC_FULL(OBJECT, FEATURE, GETTER)   \
-  case static_cast<uint8_t>(EnumInputFeatures::FEATURE): { \
-    inputFeatures.emplace_back(OBJECT.GETTER());           \
-    break;                                                 \
-  }
-
-// Specific case of CHECK_AND_FILL_VEC_FULL(OBJECT, FEATURE, GETTER)
-// where OBJECT is named candidate and FEATURE = GETTER
-#define CHECK_AND_FILL_VEC(GETTER)                        \
-  case static_cast<uint8_t>(EnumInputFeatures::GETTER): { \
-    inputFeatures.emplace_back(candidate.GETTER());       \
-    break;                                                \
-  }
-
 namespace o2
 {
 namespace cuts_ml
@@ -69,8 +43,7 @@ namespace analysis
 {
 
 // TypeOutputScore is the type of the output score from o2::ml::OnnxModel (float by default)
-// EnumInputFeatures is the enumerator containing available input features of a given decay channel (type uint8_t by default)
-template <typename TypeOutputScore = float, class EnumInputFeatures = uint8_t>
+template <typename TypeOutputScore = float>
 class MlResponse
 {
  public:


### PR DESCRIPTION
Hi @fcatalan92 , @fgrosa !

I moved as much methods as I could to the mother class and put the `enum` as a template typename to give more generality. Also, this way the macros work for any type`U`, and we avoid `static_cast<int>` as we had before.

From what I found, calling `getInputFeatures` does not create a copy of the vector (feature of modern C++ compiler) so I left it this way.