### PR TITLE
PWGHF: Lc-H correlator and task development

### DIFF
--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -87,6 +87,29 @@ DECLARE_SOA_TABLE(DHadronRecoInfo, "AOD", "DHADRONRECOINFO", //! D0-Hadrons pair
                   aod::hf_correlation_d0_hadron::MDbar,
                   aod::hf_correlation_d0_hadron::SignalStatus);
 
+// Note: definition of columns and tables for Lc-Hadron correlation pairs
+namespace hf_correlation_lc_hadron
+{
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);       //! DeltaPhi between Lc and Hadrons
+DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);       //! DeltaEta between Lc and Hadrons
+DECLARE_SOA_COLUMN(PtLc, ptLc, float);               //! Transverse momentum of Lc
+DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);       //! Transverse momentum of Hadron
+DECLARE_SOA_COLUMN(MLc, mLc, float);                 //! Invariant mass of Lc
+DECLARE_SOA_COLUMN(SignalStatus, signalStatus, int); //! Tag for LcToPKPi/LcToPiKP
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);           //! Pool Bin for the MixedEvent
+} // namespace hf_correlation_lc_hadron
+
+DECLARE_SOA_TABLE(LcHadronPair, "AOD", "LCHPAIR", //! Lc-Hadrons pairs Informations
+                  aod::hf_correlation_lc_hadron::DeltaPhi,
+                  aod::hf_correlation_lc_hadron::DeltaEta,
+                  aod::hf_correlation_lc_hadron::PtLc,
+                  aod::hf_correlation_lc_hadron::PtHadron,
+                  aod::hf_correlation_lc_hadron::PoolBin);
+
+DECLARE_SOA_TABLE(LcHadronRecoInfo, "AOD", "LCHRECOINFO", //! Lc-Hadrons pairs Reconstructed Informations
+                  aod::hf_correlation_lc_hadron::MLc,
+                  aod::hf_correlation_lc_hadron::SignalStatus);
+
 // definition of columns and tables for Ds-Hadron correlation pairs
 namespace hf_correlation_ds_hadron
 {
@@ -136,6 +159,15 @@ DECLARE_SOA_TABLE(DplusHadronPair, "AOD", "DPLUSHPAIR", //! D+-Hadrons pairs Inf
 DECLARE_SOA_TABLE(DplusHadronRecoInfo, "AOD", "DPLUSHRECOINFO", //! D+-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_dplus_hadron::MD,
                   aod::hf_correlation_dplus_hadron::SignalStatus);
+
+// Note: Table for selection of Lc in a collision
+namespace hf_selection_lc_collision
+{
+DECLARE_SOA_COLUMN(LcSel, lcSel, bool); //! Selection flag for Lc in a collision
+} // namespace hf_selection_lc_collision
+
+DECLARE_SOA_TABLE(LcSelection, "AOD", "LCINCOLL", // Selection of Lc in collisions
+                  aod::hf_selection_lc_collision::LcSel);
 
 // Table for selection of Dmeson in a collision
 namespace hf_selection_dmeson_collision

--- a/PWGHF/HFC/TableProducer/CMakeLists.txt
+++ b/PWGHF/HFC/TableProducer/CMakeLists.txt
@@ -43,3 +43,8 @@ o2physics_add_dpl_workflow(correlator-ds-hadrons
                     SOURCES correlatorDsHadrons.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(correlator-lc-hadrons
+                    SOURCES correlatorLcHadrons.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)

--- a/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
@@ -1,0 +1,700 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file correlatorLcHadrons.cxx
+/// \brief Lc-Hadrons correlator task - data-like, Mc-Reco and Mc-Gen analyses
+///
+/// \author Marianna Mazzilli <marianna.mazzilli@cern.ch>
+/// \author Zhen Zhang <zhenz@cern.ch>
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+
+#include "Common/Core/TrackSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/HFC/DataModel/CorrelationTables.h"
+
+using namespace o2;
+using namespace o2::analysis;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+///
+/// Returns deltaPhi values in range [-pi/2., 3.*pi/2.], typically used for correlation studies
+///
+double getDeltaPhi(double phiLc, double phiHadron)
+{
+  return RecoDecay::constrainAngle(phiHadron - phiLc, -o2::constants::math::PIHalf);
+}
+
+/// definition of variables for Lc hadron pairs (in data-like, Mc-reco and Mc-kine tasks)
+const int nBinsPtMassAndEfficiency = o2::analysis::hf_cuts_lc_to_p_k_pi::nBinsPt;
+const double efficiencyLcDefault[nBinsPtMassAndEfficiency] = {};
+auto vecEfficiencyLc = std::vector<double>{efficiencyLcDefault, efficiencyLcDefault + nBinsPtMassAndEfficiency};
+
+// histogram binning definition
+const int massAxisBins = 120;
+const double massAxisMin = 1.98;
+const double massAxisMax = 2.58;
+const int phiAxisBins = 32;
+const double phiAxisMin = -o2::constants::math::PIHalf;
+const double phiAxisMax = 3. * o2::constants::math::PIHalf;
+const int yAxisBins = 100;
+const double yAxisMin = -2.;
+const double yAxisMax = 2.;
+const int ptLcAxisBins = 180;
+const double ptLcAxisMin = 0.;
+const double ptLcAxisMax = 36.;
+
+// definition of ME variables
+std::vector<double> zBins{VARIABLE_WIDTH, -10.0, -2.5, 2.5, 10.0};
+std::vector<double> multBins{VARIABLE_WIDTH, 0., 200., 500., 5000.};
+std::vector<double> multBinsMcGen{VARIABLE_WIDTH, 0., 20., 50., 500.}; // In McGen multiplicity is defined by counting primaries
+using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFV0M<aod::mult::MultFV0A, aod::mult::MultFV0C>>;
+BinningType corrBinning{{zBins, multBins}, true};
+
+using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::LcSelection>>;
+using SelectedTracks = soa::Filtered<aod::TracksWDca>;
+using SelectedCandidatesData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
+using SelectedCandidatesMcRec = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>>;
+using SelectedCollisionsMcGen = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection>>;
+using SelectedTracksMcGen = soa::Filtered<aod::McParticles>;
+
+// Code to select collisions with at least one Lambda_c
+struct HfCorrelatorLcHadronsSelection {
+  Produces<aod::LcSelection> lcSel;
+
+  Configurable<int> selectionFlagLc{"selectionFlagLc", 1, "Selection Flag for Lc"};
+  Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
+
+  HfHelper hfHelper;
+  SliceCache cache;
+
+  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelLc>> selectedLcCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
+  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>> selectedLcCandidatesMc = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
+
+  void processLcSelectionData(aod::Collision const& collision,
+                              soa::Join<aod::HfCand3Prong, aod::HfSelLc> const& candidates)
+  {
+    bool isLcFound = 0;
+    if (selectedLcCandidates.size() > 0) {
+      auto selectedLcCandidatesGrouped = selectedLcCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+
+      for (const auto& candidate : selectedLcCandidatesGrouped) {
+        if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
+          continue;
+        }
+        if (yCandMax >= 0. && std::abs(hfHelper.yLc(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        isLcFound = 1;
+        break;
+      }
+    }
+    lcSel(isLcFound);
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadronsSelection, processLcSelectionData, "Process Lc Collision Selection Data", true);
+
+  void processLcSelectionMcRec(aod::Collision const& collision,
+                               soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec> const& candidates)
+  {
+    bool isLcFound = 0;
+    if (selectedLcCandidatesMc.size() > 0) {
+      auto selectedLcCandidatesGroupedMc = selectedLcCandidatesMc->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+      for (const auto& candidate : selectedLcCandidatesGroupedMc) {
+        // check decay channel flag for candidate
+        if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
+          continue;
+        }
+        if (yCandMax >= 0. && std::abs(hfHelper.yLc(candidate)) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+          continue;
+        }
+        isLcFound = 1;
+        break;
+      }
+    }
+    lcSel(isLcFound);
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadronsSelection, processLcSelectionMcRec, "Process Lc Selection McRec", false);
+
+  void processLcSelectionMcGen(aod::McCollision const& mcCollision,
+                               aod::McParticles const& mcParticles)
+  {
+    bool isLcFound = 0;
+    for (const auto& particle : mcParticles) {
+      if (std::abs(particle.pdgCode()) != pdg::Code::kLambdaCPlus) {
+        continue;
+      }
+      double yL = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::analysis::pdg::MassLambdaCPlus);
+      if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
+        continue;
+      }
+      if (ptCandMin >= 0. && particle.pt() < ptCandMin) {
+        continue;
+      }
+      isLcFound = 1;
+      break;
+    }
+    lcSel(isLcFound);
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadronsSelection, processLcSelectionMcGen, "Process Lc Selection McGen", false);
+};
+
+// Lc-Hadron correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via Mc truth)
+struct HfCorrelatorLcHadrons {
+  Produces<aod::LcHadronPair> entryLcHadronPair;
+  Produces<aod::LcHadronRecoInfo> entryLcHadronRecoInfo;
+
+  Configurable<int> selectionFlagLc{"selectionFlagLc", 1, "Selection Flag for Lc"};
+  Configurable<int> applyEfficiency{"applyEfficiency", 1, "Flag for applying Lc efficiency weights"};
+  Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. eta of tracks"};
+  Configurable<float> dcaXYTrackMax{"dcaXYTrackMax", 0.0025, "max. DCAxy of tracks"};
+  Configurable<float> dcaZTrackMax{"dcaZTrackMax", 0.0025, "max. DCAz of tracks"};
+  Configurable<float> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
+  Configurable<float> ptTrackMin{"ptTrackMin", 0.3, "min. track pT"};
+  Configurable<float> ptTrackMax{"ptTrackMax", 50., "max. track pT"};
+  Configurable<float> multMin{"multMin", 0., "minimum multiplicity accepted"};
+  Configurable<float> multMax{"multMax", 10000., "maximum multiplicity accepted"};
+  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{o2::analysis::hf_cuts_lc_to_p_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
+  Configurable<std::vector<double>> efficiencyLc{"efficiencyLc", std::vector<double>{vecEfficiencyLc}, "Efficiency values for Lc"};
+
+  HfHelper hfHelper;
+  SliceCache cache;
+
+  // Filters for ME
+  Filter collisionFilter = aod::hf_selection_lc_collision::lcSel == true;
+  Filter trackFilter = (nabs(aod::track::eta) < etaTrackMax) && (nabs(aod::track::pt) > ptTrackMin) && (nabs(aod::track::dcaXY) < dcaXYTrackMax) && (nabs(aod::track::dcaZ) < dcaZTrackMax);
+  Filter lcFilter = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= 1) || (aod::hf_sel_candidate_lc::isSelLcToPiKP >= 1);
+  Filter collisionFilterGen = aod::hf_selection_lc_collision::lcSel == true;
+  Filter particlesFilter = nabs(aod::mcparticle::pdgCode) == 4122 || ((aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
+
+  Preslice<aod::HfCand3Prong> perCol = aod::hf_cand::collisionId;
+
+  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelLc>> selectedLcCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
+  Partition<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>> selectedLcCandidatesMc = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
+
+  HistogramRegistry registry{
+    "registry",
+    {{"hPtCand", "Lc,Hadron candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng0", "Lc,Hadron candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng1", "Lc,Hadron candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng2", "Lc,Hadron candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hSelectionStatusLcToPKPi", "Lc,Hadron candidates;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hSelectionStatusLcToPiKP", "Lc,Hadron candidates;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hEta", "Lc,Hadron candidates;candidate #it{#eta};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hPhi", "Lc,Hadron candidates;candidate #it{#varphi};entries", {HistType::kTH1F, {{phiAxisBins, phiAxisMin, phiAxisMax}}}},
+     {"hY", "Lc,Hadron candidates;candidate #it{#y};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hPtCandMcRec", "Lc,Hadron candidates - Mc reco;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng0McRec", "Lc,Hadron candidates - Mc reco;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng1McRec", "Lc,Hadron candidates - Mc reco;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtProng2McRec", "Lc,Hadron candidates - Mc reco;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hSelectionStatusMcRec", "Lc,Hadron candidates - Mc reco;selection status;entries", {HistType::kTH1F, {{8, -0.5, 7.5}}}},
+     {"hEtaMcRec", "Lc,Hadron candidates - Mc reco;candidate #it{#eta};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hPhiMcRec", "Lc,Hadron candidates - Mc reco;candidate #it{#varphi};entries", {HistType::kTH1F, {{phiAxisBins, phiAxisMin, phiAxisMax}}}},
+     {"hYMcRec", "Lc,Hadron candidates - Mc reco;candidate #it{y};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hMcEvtCount", "Event counter - Mc gen;;entries", {HistType::kTH1F, {{1, -0.5, 0.5}}}},
+     {"hPtCandMcGen", "Lc,Hadron particles - Mc gen;particle #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtParticleAssocMcRec", "Associated Particles - Mc Rec;Hadron #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hPtParticleAssocMcGen", "Associated Particles - Mc Gen;Hadron #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{ptLcAxisBins, ptLcAxisMin, ptLcAxisMax}}}},
+     {"hEtaMcGen", "Lc,Hadron particles - Mc Gen;particle #it{#varphi};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hPhiMcGen", "Lc,Hadron particles - Mc Gen;particle #it{#varphi};entries", {HistType::kTH1F, {{phiAxisBins, phiAxisMin, phiAxisMax}}}},
+     {"hYMcGen", "Lc,Hadron candidates - Mc Gen;candidate #it{y};entries", {HistType::kTH1F, {{yAxisBins, yAxisMin, yAxisMax}}}},
+     {"hCountLcHadronPerEvent", "Lc,Hadron particles - Mc Gen;Number per event;entries", {HistType::kTH1F, {{21, -0.5, 20.5}}}},
+     {"hMultiplicityPreSelection", "multiplicity prior to selection;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"hMultV0M", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"hZvtx", "z vertex;z vertex;entries", {HistType::kTH1F, {{200, -20., 20.}}}},
+     {"hLcPoolBin", "Lc selected in pool Bin;pool Bin;entries", {HistType::kTH1F, {{9, 0., 9.}}}},
+     {"hTracksPoolBin", "Tracks selected in pool Bin;pool Bin;entries", {HistType::kTH1F, {{9, 0., 9.}}}}}};
+
+  void init(InitContext&)
+  {
+    auto vbins = (std::vector<double>)binsPt;
+    registry.add("hMassLcVsPt", "Lc candidates;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{massAxisBins, massAxisMin, massAxisMax}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassLcData", "Lc candidates;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{massAxisBins, massAxisMin, massAxisMax}}});
+    registry.add("hMassLcMcRec", "Lc candidates;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{massAxisBins, massAxisMin, massAxisMax}}});
+    registry.add("hMassLcVsPtMcRec", "Lc candidates;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{massAxisBins, massAxisMin, massAxisMax}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassLcMcRecSig", "Lc signal candidates - Mc reco;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{massAxisBins, massAxisMin, massAxisMax}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    // mass histogram for Lc background candidates only
+    registry.add("hMassLcMcRecBkg", "Lc background candidates - Mc reco;inv. mass (p k #pi) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{massAxisBins, massAxisMin, massAxisMax}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCountLctriggersMcGen", "Lc trigger particles - Mc gen;;N of trigger Lc", {HistType::kTH2F, {{1, -0.5, 0.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+  }
+
+  /// Lc-h correlation pair builder - for real data and data-like analysis (i.e. reco-level w/o matching request via Mc truth)
+  void processData(soa::Join<aod::Collisions, aod::Mults>::iterator const& collision,
+                   aod::TracksWDca const& tracks,
+                   soa::Join<aod::HfCand3Prong, aod::HfSelLc> const& candidates)
+  {
+    // protection against empty tables to be sliced
+    if (selectedLcCandidates.size() == 0) {
+      return;
+    }
+    int poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.multFV0M()));
+    int nTracks = 0;
+    if (collision.numContrib() > 1) {
+      for (const auto& track : tracks) {
+        if (std::abs(track.eta()) > etaTrackMax) {
+          continue;
+        }
+        if (std::abs(track.dcaXY()) > dcaXYTrackMax || std::abs(track.dcaZ()) > dcaZTrackMax) {
+          continue;
+        }
+        nTracks++;
+        registry.fill(HIST("hTracksPoolBin"), poolBin);
+      }
+    }
+    registry.fill(HIST("hMultiplicityPreSelection"), nTracks);
+    if (nTracks < multMin || nTracks > multMax) {
+      return;
+    }
+    registry.fill(HIST("hMultiplicity"), nTracks);
+
+    auto selectedLcCandidatesGrouped = selectedLcCandidates->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+
+    for (const auto& candidate : selectedLcCandidatesGrouped) {
+      if (yCandMax >= 0. && std::abs(hfHelper.yLc(candidate)) > yCandMax) {
+        continue;
+      }
+      if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+        continue;
+      }
+      if (candidate.pt() > ptTrackMax) {
+        continue;
+      }
+      // check decay channel flag for candidate
+      if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
+        continue;
+      }
+
+      double efficiencyWeight = 1.;
+      if (applyEfficiency) {
+        efficiencyWeight = 1. / efficiencyLc->at(o2::analysis::findBin(binsPt, candidate.pt()));
+      }
+      registry.fill(HIST("hPtCand"), candidate.pt());
+      registry.fill(HIST("hPtProng0"), candidate.ptProng0());
+      registry.fill(HIST("hPtProng1"), candidate.ptProng1());
+      registry.fill(HIST("hPtProng2"), candidate.ptProng2());
+      registry.fill(HIST("hEta"), candidate.eta());
+      registry.fill(HIST("hPhi"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+      registry.fill(HIST("hY"), hfHelper.yLc(candidate));
+      registry.fill(HIST("hLcPoolBin"), poolBin);
+      if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+        registry.fill(HIST("hMassLcVsPt"), hfHelper.invMassLcToPKPi(candidate), candidate.pt(), efficiencyWeight);
+        registry.fill(HIST("hMassLcData"), hfHelper.invMassLcToPKPi(candidate), efficiencyWeight);
+        registry.fill(HIST("hSelectionStatusLcToPKPi"), candidate.isSelLcToPKPi());
+      }
+      if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+        registry.fill(HIST("hMassLcVsPt"), hfHelper.invMassLcToPiKP(candidate), candidate.pt(), efficiencyWeight);
+        registry.fill(HIST("hMassLcData"), hfHelper.invMassLcToPiKP(candidate), efficiencyWeight);
+        registry.fill(HIST("hSelectionStatusLcToPiKP"), candidate.isSelLcToPiKP());
+      }
+      // Lc-Hadron correlation dedicated section
+      // if the candidate is a Lc, search for Hadrons and evaluate correlations
+
+      for (const auto& track : tracks) {
+        if (std::abs(track.eta()) > etaTrackMax) {
+          continue;
+        }
+        if (track.pt() < ptTrackMin) {
+          continue;
+        }
+        if (std::abs(track.dcaXY()) >= dcaXYTrackMax || std::abs(track.dcaZ()) >= dcaZTrackMax) {
+          continue; // Remove secondary tracks
+        }
+        // Remove Lc daughters by checking track indices
+        if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
+          continue;
+        }
+        if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPKPi(candidate), false);
+        }
+        if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPiKP(candidate), false);
+        }
+      } // Hadron Tracks loop
+    }   // end outer Lc loop
+    registry.fill(HIST("hZvtx"), collision.posZ());
+    registry.fill(HIST("hMultV0M"), collision.multFV0M());
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processData, "Process data", true);
+
+  /// Lc-Hadron correlation process starts for McRec
+  void processMcRec(soa::Join<aod::Collisions, aod::Mults>::iterator const& collision,
+                    aod::TracksWDca const& tracks,
+                    soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec> const& candidates)
+  {
+    if (selectedLcCandidatesMc.size() == 0) {
+      return;
+    }
+    int poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.multFV0M()));
+    int nTracks = 0;
+    if (collision.numContrib() > 1) {
+      for (const auto& track : tracks) {
+        if (std::abs(track.eta()) > etaTrackMax) {
+          continue;
+        }
+        if (std::abs(track.dcaXY()) > dcaXYTrackMax || std::abs(track.dcaZ()) > dcaZTrackMax) {
+          continue;
+        }
+        nTracks++;
+        registry.fill(HIST("hTracksPoolBin"), poolBin);
+      }
+    }
+    registry.fill(HIST("hMultiplicityPreSelection"), nTracks);
+    if (nTracks < multMin || nTracks > multMax) {
+      return;
+    }
+    registry.fill(HIST("hMultiplicity"), nTracks);
+
+    auto selectedLcCandidatesGroupedMc = selectedLcCandidatesMc->sliceByCached(aod::hf_cand::collisionId, collision.globalIndex(), cache);
+
+    // Mc reco level
+    bool isLcSignal = false;
+    for (const auto& candidate : selectedLcCandidatesGroupedMc) {
+      // check decay channel flag for candidate
+      if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
+        continue;
+      }
+      if (yCandMax >= 0. && std::abs(hfHelper.yLc(candidate)) > yCandMax) {
+        continue;
+      }
+      if (ptCandMin >= 0. && candidate.pt() < ptCandMin) {
+        continue;
+      }
+      if (candidate.pt() >= ptTrackMax) {
+        continue;
+      }
+      double efficiencyWeight = 1.;
+      if (applyEfficiency) {
+        efficiencyWeight = 1. / efficiencyLc->at(o2::analysis::findBin(binsPt, candidate.pt()));
+      }
+      isLcSignal = std::abs(candidate.flagMcMatchRec()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi;
+      if (isLcSignal) {
+        registry.fill(HIST("hPtCandMcRec"), candidate.pt());
+        registry.fill(HIST("hPtProng0McRec"), candidate.ptProng0());
+        registry.fill(HIST("hPtProng1McRec"), candidate.ptProng1());
+        registry.fill(HIST("hPtProng2McRec"), candidate.ptProng2());
+        registry.fill(HIST("hEtaMcRec"), candidate.eta());
+        registry.fill(HIST("hPhiMcRec"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+        registry.fill(HIST("hYMcRec"), hfHelper.yLc(candidate));
+        // LcToPKPi and LcToPiKP division
+        if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+          registry.fill(HIST("hMassLcMcRec"), hfHelper.invMassLcToPKPi(candidate), efficiencyWeight);
+          registry.fill(HIST("hMassLcMcRecSig"), hfHelper.invMassLcToPKPi(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hMassLcVsPtMcRec"), hfHelper.invMassLcToPKPi(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelLcToPKPi());
+        }
+        if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+          registry.fill(HIST("hMassLcMcRec"), hfHelper.invMassLcToPiKP(candidate), efficiencyWeight);
+          registry.fill(HIST("hMassLcMcRecSig"), hfHelper.invMassLcToPiKP(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hMassLcVsPtMcRec"), hfHelper.invMassLcToPiKP(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelLcToPiKP());
+        }
+      } else {
+        registry.fill(HIST("hPtCandMcRec"), candidate.pt());
+        registry.fill(HIST("hPtProng0McRec"), candidate.ptProng0());
+        registry.fill(HIST("hPtProng1McRec"), candidate.ptProng1());
+        registry.fill(HIST("hPtProng2McRec"), candidate.ptProng2());
+        registry.fill(HIST("hEtaMcRec"), candidate.eta());
+        registry.fill(HIST("hPhiMcRec"), RecoDecay::constrainAngle(candidate.phi(), -o2::constants::math::PIHalf));
+        registry.fill(HIST("hYMcRec"), hfHelper.yLc(candidate));
+        // LcToPKPi and LcToPiKP division
+        if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+          registry.fill(HIST("hMassLcMcRec"), hfHelper.invMassLcToPKPi(candidate), efficiencyWeight);
+          registry.fill(HIST("hMassLcMcRecBkg"), hfHelper.invMassLcToPKPi(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hMassLcVsPtMcRec"), hfHelper.invMassLcToPKPi(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelLcToPKPi());
+        }
+        if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+          registry.fill(HIST("hMassLcMcRec"), hfHelper.invMassLcToPiKP(candidate), efficiencyWeight);
+          registry.fill(HIST("hMassLcMcRecBkg"), hfHelper.invMassLcToPiKP(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hMassLcVsPtMcRec"), hfHelper.invMassLcToPiKP(candidate), candidate.pt(), efficiencyWeight);
+          registry.fill(HIST("hSelectionStatusMcRec"), candidate.isSelLcToPiKP());
+        }
+      }
+      registry.fill(HIST("hLcPoolBin"), poolBin);
+
+      // Lc-Hadron correlation dedicated section
+      // if the candidate is selected as Lc, search for Hadron ad evaluate correlations
+      for (const auto& track : tracks) {
+        if (std::abs(track.eta()) > etaTrackMax) {
+          continue;
+        }
+        if (track.pt() < ptTrackMin) {
+          continue;
+        }
+        if (std::abs(track.dcaXY()) >= dcaXYTrackMax || std::abs(track.dcaZ()) >= dcaZTrackMax) {
+          continue; // Remove secondary tracks
+        }
+        // Removing Lc daughters by checking track indices
+        if ((candidate.prong0Id() == track.globalIndex()) || (candidate.prong1Id() == track.globalIndex()) || (candidate.prong2Id() == track.globalIndex())) {
+          continue;
+        }
+        registry.fill(HIST("hPtParticleAssocMcRec"), track.pt());
+
+        if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPKPi(candidate), isLcSignal);
+        }
+        if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
+                            track.eta() - candidate.eta(),
+                            candidate.pt(),
+                            track.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPiKP(candidate), isLcSignal);
+        }
+      } // end inner loop (Tracks)
+    }   // end outer Lc loop
+    registry.fill(HIST("hZvtx"), collision.posZ());
+    registry.fill(HIST("hMultV0M"), collision.multFV0M());
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processMcRec, "Process Mc Reco mode", false);
+
+  /// Lc-Hadron correlation pair builder - for Mc gen-level analysis
+  void processMcGen(aod::McCollision const& mcCollision,
+                    soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& mcParticles)
+  {
+    int counterLcHadron = 0;
+    registry.fill(HIST("hMcEvtCount"), 0);
+
+    auto getTracksSize = [&mcParticles](aod::McCollision const& collision) {
+      int nTracks = 0;
+      for (const auto& track : mcParticles) {
+        if (track.isPhysicalPrimary() && std::abs(track.eta()) < 1.0) {
+          nTracks++;
+        }
+      }
+      return nTracks;
+    };
+    using BinningTypeMcGen = FlexibleBinningPolicy<std::tuple<decltype(getTracksSize)>, aod::mccollision::PosZ, decltype(getTracksSize)>;
+    BinningTypeMcGen corrBinningMcGen{{getTracksSize}, {zBins, multBinsMcGen}, true};
+
+    // Mc gen level
+    for (const auto& particle : mcParticles) {
+      if (std::abs(particle.pdgCode()) != pdg::Code::kLambdaCPlus) {
+        continue;
+      }
+      if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
+        double yL = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::analysis::pdg::MassLambdaCPlus);
+        if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && particle.pt() < ptCandMin) {
+          continue;
+        }
+        registry.fill(HIST("hPtCandMcGen"), particle.pt());
+        registry.fill(HIST("hEtaMcGen"), particle.eta());
+        registry.fill(HIST("hPhiMcGen"), RecoDecay::constrainAngle(particle.phi(), -o2::constants::math::PIHalf));
+        registry.fill(HIST("hYMcGen"), yL);
+        counterLcHadron++;
+
+        for (const auto& particleAssoc : mcParticles) {
+          bool flagMotherFound = false;
+          for (const auto& m : particleAssoc.mothers_as<aod::McParticles>()) {
+            if (m.globalIndex() == particle.globalIndex()) {
+              flagMotherFound = true;
+              break;
+            }
+          }
+          if (flagMotherFound) {
+            continue;
+          }
+          if (std::abs(particleAssoc.eta()) > etaTrackMax) {
+            continue;
+          }
+          if (particleAssoc.pt() < ptTrackMin) {
+            continue;
+          }
+
+          if ((std::abs(particleAssoc.pdgCode()) != kElectron) && (std::abs(particleAssoc.pdgCode()) != kMuonMinus) && (std::abs(particleAssoc.pdgCode()) != kPiPlus) && (std::abs(particle.pdgCode()) != kKPlus) && (std::abs(particleAssoc.pdgCode()) != kProton)) {
+            continue;
+          }
+          int poolBin = corrBinningMcGen.getBin(std::make_tuple(mcCollision.posZ(), getTracksSize(mcCollision)));
+          registry.fill(HIST("hPtParticleAssocMcGen"), particleAssoc.pt());
+          entryLcHadronPair(getDeltaPhi(particleAssoc.phi(), particle.phi()),
+                            particleAssoc.eta() - particle.eta(),
+                            particle.pt(),
+                            particleAssoc.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(o2::analysis::pdg::MassLambdaCPlus, true);
+        } // end inner loop
+      }
+    } // end outer loop
+    registry.fill(HIST("hCountLcHadronPerEvent"), counterLcHadron);
+    registry.fill(HIST("hZvtx"), mcCollision.posZ());
+    registry.fill(HIST("hMultiplicity"), getTracksSize(mcCollision));
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processMcGen, "Process Mc Gen mode", false);
+
+  void processDataMixedEvent(SelectedCollisions const& collisions,
+                             SelectedCandidatesData const& candidates,
+                             SelectedTracks const& tracks)
+  {
+    if (candidates.size() == 0) {
+      return;
+    }
+    auto tracksTuple = std::make_tuple(candidates, tracks);
+    Pair<SelectedCollisions, SelectedCandidatesData, SelectedTracks, BinningType> pairData{corrBinning, 5, -1, collisions, tracksTuple, &cache};
+
+    for (const auto& [c1, tracks1, c2, tracks2] : pairData) {
+      int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
+      for (const auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+        if (!TESTBIT(t1.hfflag(), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
+          continue;
+        }
+        if (yCandMax >= 0. && std::abs(hfHelper.yLc(t1)) > yCandMax) {
+          continue;
+        }
+        // LcToPKPi and LcToPiKP division
+        if (t1.isSelLcToPKPi() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(t1.phi(), t2.phi()),
+                            t1.eta() - t2.eta(),
+                            t1.pt(),
+                            t2.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPKPi(t1), false);
+        }
+        if (t1.isSelLcToPiKP() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(t1.phi(), t2.phi()),
+                            t1.eta() - t2.eta(),
+                            t1.pt(),
+                            t2.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPiKP(t1), false);
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processDataMixedEvent, "Process Mixed Event Data", false);
+
+  void processMcRecMixedEvent(SelectedCollisions const& collisions,
+                              SelectedCandidatesMcRec const& candidates,
+                              SelectedTracks const& tracks)
+  {
+    auto tracksTuple = std::make_tuple(candidates, tracks);
+    Pair<SelectedCollisions, SelectedCandidatesMcRec, SelectedTracks, BinningType> pairMcRec{corrBinning, 5, -1, collisions, tracksTuple, &cache};
+
+    for (const auto& [c1, tracks1, c2, tracks2] : pairMcRec) {
+      int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFV0M()));
+      for (const auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+        if (yCandMax >= 0. && std::abs(hfHelper.yLc(t1)) > yCandMax) {
+          continue;
+        }
+        if (t1.isSelLcToPKPi() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(t1.phi(), t2.phi()),
+                            t1.eta() - t2.eta(),
+                            t1.pt(),
+                            t2.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPKPi(t1), false);
+        }
+        if (t1.isSelLcToPiKP() >= selectionFlagLc) {
+          entryLcHadronPair(getDeltaPhi(t1.phi(), t2.phi()),
+                            t1.eta() - t2.eta(),
+                            t1.pt(),
+                            t2.pt(),
+                            poolBin);
+          entryLcHadronRecoInfo(hfHelper.invMassLcToPiKP(t1), false);
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processMcRecMixedEvent, "Process Mixed Event McRec", false);
+
+  void processMcGenMixedEvent(SelectedCollisionsMcGen const& collisions,
+                              SelectedTracksMcGen const& mcParticles)
+  {
+    auto getTracksSize = [&mcParticles, this](SelectedCollisionsMcGen::iterator const& collision) {
+      int nTracks = 0;
+      auto associatedTracks = mcParticles.sliceByCached(o2::aod::mcparticle::mcCollisionId, collision.globalIndex(), this->cache);
+      for (const auto& track : associatedTracks) {
+        if (track.isPhysicalPrimary() && std::abs(track.eta()) < 1.0) {
+          nTracks++;
+        }
+      }
+      return nTracks;
+    };
+
+    using BinningTypeMcGen = FlexibleBinningPolicy<std::tuple<decltype(getTracksSize)>, aod::mccollision::PosZ, decltype(getTracksSize)>;
+    BinningTypeMcGen corrBinningMcGen{{getTracksSize}, {zBins, multBins}, true};
+
+    auto tracksTuple = std::make_tuple(mcParticles, mcParticles);
+    Pair<SelectedCollisionsMcGen, SelectedTracksMcGen, SelectedTracksMcGen, BinningTypeMcGen> pairMcGen{corrBinningMcGen, 5, -1, collisions, tracksTuple, &cache};
+
+    for (const auto& [c1, tracks1, c2, tracks2] : pairMcGen) {
+      for (const auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+        // Check track t1 is Lc
+        if (std::abs(t1.pdgCode()) != pdg::Code::kLambdaCPlus) {
+          continue;
+        }
+
+        double yL = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, o2::analysis::pdg::MassLambdaCPlus);
+        if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
+          continue;
+        }
+        if (ptCandMin >= 0. && t1.pt() < ptCandMin) {
+          continue;
+        }
+
+        if (std::abs(t2.eta()) > etaTrackMax) {
+          continue;
+        }
+        if (t2.pt() < ptTrackMin) {
+          continue;
+        }
+        int poolBin = corrBinningMcGen.getBin(std::make_tuple(c2.posZ(), getTracksSize(c2)));
+        entryLcHadronPair(getDeltaPhi(t1.phi(), t2.phi()),
+                          t1.eta() - t2.eta(),
+                          t1.pt(),
+                          t2.pt(),
+                          poolBin);
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorLcHadrons, processMcGenMixedEvent, "Process Mixed Event McGen", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfCorrelatorLcHadronsSelection>(cfgc),
+                      adaptAnalysisTask<HfCorrelatorLcHadrons>(cfgc)};
+}

--- a/PWGHF/HFC/Tasks/CMakeLists.txt
+++ b/PWGHF/HFC/Tasks/CMakeLists.txt
@@ -34,6 +34,11 @@ o2physics_add_dpl_workflow(task-correlation-ds-hadrons
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(task-correlation-lc-hadrons
+                    SOURCES taskCorrelationLcHadrons.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(task-flow
                     SOURCES taskFlow.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::PWGCFCore

--- a/PWGHF/HFC/Tasks/taskCorrelationLcHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationLcHadrons.cxx
@@ -1,0 +1,271 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file taskCorrelationLcHadrons.cxx
+/// \brief Lc-Hadrons azimuthal correlations analysis task - data-like, Mc-Reco and Mc-Gen analyses
+/// \author Marianna Mazzilli <marianna.mazzilli@cern.ch>
+/// \author Zhen Zhang <zhenz@cern.ch>
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/Utils/utilsAnalysis.h"
+#include "PWGHF/HFC/DataModel/CorrelationTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+///
+/// Returns deltaPhi value in range [-pi/2., 3.*pi/2], typically used for correlation studies
+///
+double getDeltaPhi(double phiLc, double phiHadron)
+{
+  return RecoDecay::constrainAngle(phiHadron - phiLc, -o2::constants::math::PIHalf);
+}
+
+///
+/// Returns phi of candidate/particle evaluated from x and y components of segment connecting primary and secondary vertices
+///
+double evaluatePhiByVertex(double xVertex1, double xVertex2, double yVertex1, double yVertex2)
+{
+  return RecoDecay::phi(xVertex2 - xVertex1, yVertex2 - yVertex1);
+}
+
+// string definitions, used for histogram axis labels
+const TString stringPtLc = "#it{p}_{T}^{#Lambda_c} (GeV/#it{c});";
+const TString stringPtHadron = "#it{p}_{T}^{Hadron} (GeV/#it{c});";
+const TString stringPoolBin = "poolBin;";
+const TString stringDeltaEta = "#it{#eta}^{Hadron}-#it{#eta}^{#Lambda_c};";
+const TString stringDeltaPhi = "#it{#varphi}^{Hadron}-#it{#varphi}^{#Lambda_c} (rad);";
+const TString stringLcHadron = "#Lambda_c,Hadron candidates ";
+const TString stringSignal = "signal region;";
+const TString stringSideband = "sidebands;";
+const TString stringMcParticles = "Mc gen - #Lambda_c,Hadron particles;";
+const TString stringMcReco = "Mc reco - #Lambda_c,Hadron candidates ";
+
+const int nPtBinsCorrelations = 8;
+const double pTBinsCorrelations[nPtBinsCorrelations + 1] = {0., 2., 4., 6., 8., 12., 16., 24., 99.};
+auto vecBinsPtCorrelations = std::vector<double>{pTBinsCorrelations, pTBinsCorrelations + nPtBinsCorrelations + 1};
+const double signalRegionInnerDefault[nPtBinsCorrelations] = {2.269, 2.269, 2.269, 2.269, 2.269, 2.269, 2.269, 2.269};
+const double signalRegionOuterDefault[nPtBinsCorrelations] = {2.309, 2.309, 2.309, 2.309, 2.309, 2.309, 2.309, 2.309};
+const double sidebandLeftOuterDefault[nPtBinsCorrelations] = {2.209, 2.209, 2.209, 2.209, 2.209, 2.209, 2.209, 2.209};
+const double sidebandLeftInnerDefault[nPtBinsCorrelations] = {2.249, 2.249, 2.249, 2.249, 2.249, 2.249, 2.249, 2.249};
+const double sidebandRightInnerDefault[nPtBinsCorrelations] = {2.329, 2.329, 2.329, 2.329, 2.329, 2.329, 2.329, 2.329};
+const double sidebandRightOuterDefault[nPtBinsCorrelations] = {2.369, 2.369, 2.369, 2.369, 2.369, 2.369, 2.369, 2.369};
+auto vecSignalRegionInner = std::vector<double>{signalRegionInnerDefault, signalRegionInnerDefault + nPtBinsCorrelations};
+auto vecSignalRegionOuter = std::vector<double>{signalRegionOuterDefault, signalRegionOuterDefault + nPtBinsCorrelations};
+auto vecSidebandLeftInner = std::vector<double>{sidebandLeftInnerDefault, sidebandLeftInnerDefault + nPtBinsCorrelations};
+auto vecSidebandLeftOuter = std::vector<double>{sidebandLeftOuterDefault, sidebandLeftOuterDefault + nPtBinsCorrelations};
+auto vecSidebandRightInner = std::vector<double>{sidebandRightInnerDefault, sidebandRightInnerDefault + nPtBinsCorrelations};
+auto vecSidebandRightOuter = std::vector<double>{sidebandRightOuterDefault, sidebandRightOuterDefault + nPtBinsCorrelations};
+const int nPtBinsEfficiency = o2::analysis::hf_cuts_lc_to_p_k_pi::nBinsPt;
+const double efficiencyLcDefault[nPtBinsEfficiency] = {};
+auto vecEfficiencyLc = std::vector<double>{efficiencyLcDefault, efficiencyLcDefault + nPtBinsEfficiency};
+
+/// Lc-Hadron correlation pair filling task, from pair tables - for real data and data-like analysis (i.e. reco-level w/o matching request via Mc truth)
+struct HfTaskCorrelationLcHadrons {
+  // Pt ranges for correlation plots: the default values are those embedded in hf_cuts_lc_to_p_k_pi (i.e. the mass Pt bins), but can be redefined via json files
+  Configurable<int> applyEfficiency{"applyEfficiency", 1, "Flag for applying efficiency weights"};
+  Configurable<std::vector<double>> binsPtCorrelations{"binsPtCorrelations", std::vector<double>{vecBinsPtCorrelations}, "Pt bin limits for correlation plots"};
+  Configurable<std::vector<double>> binsPtEfficiency{"binsPtEfficiency", std::vector<double>{o2::analysis::hf_cuts_lc_to_p_k_pi::vecBinsPt}, "Pt bin limits for efficiency"};
+  // signal and sideband region edges, to be defined via json file (initialised to empty)
+  Configurable<std::vector<double>> signalRegionInner{"signalRegionInner", std::vector<double>{vecSignalRegionInner}, "Inner values of signal region vs Pt"};
+  Configurable<std::vector<double>> signalRegionOuter{"signalRegionOuter", std::vector<double>{vecSignalRegionOuter}, "Outer values of signal region vs Pt"};
+  Configurable<std::vector<double>> sidebandLeftInner{"sidebandLeftInner", std::vector<double>{vecSidebandLeftInner}, "Inner values of left sideband vs Pt"};
+  Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", std::vector<double>{vecSidebandLeftOuter}, "Outer values of left sideband vs Pt"};
+  Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", std::vector<double>{vecSidebandRightInner}, "Inner values of right sideband vs Pt"};
+  Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", std::vector<double>{vecSidebandRightOuter}, "Outer values of right sideband vs Pt"};
+  Configurable<std::vector<double>> efficiencyLc{"efficiencyLc", std::vector<double>{vecEfficiencyLc}, "Efficiency values for Lc "};
+
+  using LcHadronPairFull = soa::Join<aod::LcHadronPair, aod::LcHadronRecoInfo>;
+
+  HistogramRegistry registry{
+    "registry",
+    {
+      {"hDeltaEtaPtIntSignalRegion", stringLcHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {{200, -4., 4.}}}},
+      {"hDeltaPhiPtIntSignalRegion", stringLcHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}}}},
+      {"hCorrel2DPtIntSignalRegion", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}}}},
+      {"hCorrel2DVsPtSignalRegion", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}}, // note: axes 3 and 4 (the Pt) are updated in the init()
+      {"hDeltaEtaPtIntSidebands", stringLcHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {{200, -4., 4.}}}},
+      {"hDeltaPhiPtIntSidebands", stringLcHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}}}},
+      {"hCorrel2DPtIntSidebands", stringLcHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}}}},
+      {"hCorrel2DVsPtSidebands", stringLcHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}}, // note: axes 3 and 4 (the Pt) are updated in the init()
+      {"hDeltaEtaPtIntSignalRegionMcRec", stringLcHadron + stringSignal + stringDeltaEta + "entries", {HistType::kTH1F, {{200, -4., 4.}}}},
+      {"hDeltaPhiPtIntSignalRegionMcRec", stringLcHadron + stringSignal + stringDeltaPhi + "entries", {HistType::kTH1F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}}}},
+      {"hCorrel2DPtIntSignalRegionMcRec", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}}}},
+      {"hCorrel2DVsPtSignalRegionMcRec", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}},
+      {"hCorrel2DVsPtSignalMcRec", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}},
+      {"hCorrel2DVsPtBkgMcRec", stringLcHadron + stringSignal + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}},
+      {"hDeltaEtaPtIntSidebandsMcRec", stringLcHadron + stringSideband + stringDeltaEta + "entries", {HistType::kTH1F, {{200, -4., 4.}}}},
+      {"hDeltaPhiPtIntSidebandsMcRec", stringLcHadron + stringSideband + stringDeltaPhi + "entries", {HistType::kTH1F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}}}},
+      {"hCorrel2DPtIntSidebandsMcRec", stringLcHadron + stringSideband + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}}}},
+      {"hCorrel2DVsPtSidebandsMcRec", stringLcHadron + stringSideband + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPtHadron + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}},
+      {"hDeltaEtaPtIntMcGen", stringMcParticles + stringDeltaEta + "entries", {HistType::kTH1F, {{200, -4., 4.}}}},
+      {"hDeltaPhiPtIntMcGen", stringMcParticles + stringDeltaPhi + "entries", {HistType::kTH1F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}}}},
+      {"hCorrel2DPtIntMcGen", stringMcParticles + stringDeltaPhi + stringDeltaEta + "entries", {HistType::kTH2F, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}}}},
+      {"hCorrel2DVsPtMcGen", stringMcParticles + stringDeltaPhi + stringDeltaEta + stringPtLc + stringPoolBin + "entries", {HistType::kTHnSparseD, {{64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, {200, -4., 4.}, {10, 0., 10.}, {11, 0., 11.}, {9, 0., 9.}}}}, // note: axes 3 and 4 (the Pt) are updated in the init()
+    }};
+
+  void init(InitContext&)
+  {
+    // redefinition of Pt axes for THnSparse holding correlation entries
+    int nBinsPtAxis = binsPtCorrelations->size() - 1;
+    const double* valuesPtAxis = binsPtCorrelations->data();
+
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegion"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebands"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegion"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebands"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegionMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandsMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMcRec"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtBkgMcRec"))->Sumw2();
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->GetAxis(2)->Set(nBinsPtAxis, valuesPtAxis);
+    registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGen"))->Sumw2();
+  }
+
+  void processData(LcHadronPairFull const& pairEntries)
+  {
+    for (const auto& pairEntry : pairEntries) {
+      // define variables for widely used quantities
+      double deltaPhi = pairEntry.deltaPhi();
+      double deltaEta = pairEntry.deltaEta();
+      double ptLc = pairEntry.ptLc();
+      double ptHadron = pairEntry.ptHadron();
+      double massLc = pairEntry.mLc();
+      int effBinLc = o2::analysis::findBin(binsPtEfficiency, ptLc);
+      int ptBinLc = o2::analysis::findBin(binsPtCorrelations, ptLc);
+      int poolBin = pairEntry.poolBin();
+      // reject entries outside Pt ranges of interest
+      if (ptBinLc < 0 || effBinLc < 0) {
+        continue;
+      }
+      if (ptHadron > 10.0) {
+        ptHadron = 10.5;
+      }
+      double efficiencyWeight = 1.;
+      double efficiencyHadron = 1.; // Note: To be implemented later on
+      if (applyEfficiency) {
+        efficiencyWeight = 1. / (efficiencyLc->at(effBinLc) * efficiencyHadron);
+      }
+      // check if correlation entry belongs to signal region, sidebands or is outside both, and fill correlation plots
+      if (massLc > signalRegionInner->at(ptBinLc) && massLc < signalRegionOuter->at(ptBinLc)) {
+        // in signal region
+        registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSignalRegion"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSignalRegion"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSignalRegion"), deltaPhi, efficiencyWeight);
+      }
+
+      if ((massLc > sidebandLeftOuter->at(ptBinLc) && massLc < sidebandLeftInner->at(ptBinLc)) ||
+          (massLc > sidebandRightInner->at(ptBinLc) && massLc < sidebandRightOuter->at(ptBinLc))) {
+        // in sideband region
+        registry.fill(HIST("hCorrel2DVsPtSidebands"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSidebands"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSidebands"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSidebands"), deltaPhi, efficiencyWeight);
+      }
+    } // end loop
+  }
+  PROCESS_SWITCH(HfTaskCorrelationLcHadrons, processData, "Process data", true);
+
+  /// Lc-Hadron correlation pair filling task, from pair tables - for Mc reco-level analysis (candidates matched to true signal only, but also bkg sources are studied)
+  void processMcRec(LcHadronPairFull const& pairEntries)
+  {
+    for (const auto& pairEntry : pairEntries) {
+      // define variables for widely used quantities
+      double deltaPhi = pairEntry.deltaPhi();
+      double deltaEta = pairEntry.deltaEta();
+      double ptLc = pairEntry.ptLc();
+      double ptHadron = pairEntry.ptHadron();
+      double massLc = pairEntry.mLc();
+      double efficiencyWeight = 1.;
+      double efficiencyHadron = 1.;
+      int effBinLc = o2::analysis::findBin(binsPtEfficiency, ptLc);
+      int ptBinLc = o2::analysis::findBin(binsPtCorrelations, ptLc);
+      int poolBin = pairEntry.poolBin();
+      if (ptBinLc < 0 || effBinLc < 0) {
+        continue;
+      }
+      if (ptHadron > 10.0) {
+        ptHadron = 10.5;
+      }
+      if (applyEfficiency) {
+        efficiencyWeight = 1. / (efficiencyLc->at(effBinLc) * efficiencyHadron);
+      }
+      // fill correlation plots for signal/bagkground correlations
+      if (pairEntry.signalStatus()) {
+        registry.fill(HIST("hCorrel2DVsPtSignalMcRec"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+      } else {
+        registry.fill(HIST("hCorrel2DVsPtBkgMcRec"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+      }
+      // reject entries outside Pt ranges of interest
+
+      // check if correlation entry belongs to signal region, sidebands or is outside both, and fill correlation plots
+      if (massLc > signalRegionInner->at(ptBinLc) && massLc < signalRegionOuter->at(ptBinLc)) {
+        // in signal region
+        registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRec"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSignalRegionMcRec"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSignalRegionMcRec"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSignalRegionMcRec"), deltaPhi, efficiencyWeight);
+      }
+
+      if (((massLc > sidebandLeftOuter->at(ptBinLc)) && (massLc < sidebandLeftInner->at(ptBinLc))) ||
+          ((massLc > sidebandRightInner->at(ptBinLc) && massLc < sidebandRightOuter->at(ptBinLc)))) {
+        // in sideband region
+        registry.fill(HIST("hCorrel2DVsPtSidebandsMcRec"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hCorrel2DPtIntSidebandsMcRec"), deltaPhi, deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSidebandsMcRec"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSidebandsMcRec"), deltaPhi, efficiencyWeight);
+      }
+    } // end loop
+  }
+  PROCESS_SWITCH(HfTaskCorrelationLcHadrons, processMcRec, "Process Mc Reco mode", false);
+
+  /// Lc-Hadron correlation pair filling task, from pair tables - for Mc gen-level analysis (no filter/selection, only true signal)
+  void processMcGen(aod::LcHadronPair const& pairEntries)
+  {
+    for (const auto& pairEntry : pairEntries) {
+      // define variables for widely used quantities
+      double deltaPhi = pairEntry.deltaPhi();
+      double deltaEta = pairEntry.deltaEta();
+      double ptLc = pairEntry.ptLc();
+      double ptHadron = pairEntry.ptHadron();
+      int poolBin = pairEntry.poolBin();
+      // reject entries outside Pt ranges of interest
+      if (o2::analysis::findBin(binsPtCorrelations, ptLc) < 0) {
+        continue;
+      }
+      if (ptHadron > 10.0) {
+        ptHadron = 10.5;
+      }
+
+      registry.fill(HIST("hCorrel2DVsPtMcGen"), deltaPhi, deltaEta, ptLc, ptHadron, poolBin);
+      registry.fill(HIST("hCorrel2DPtIntMcGen"), deltaPhi, deltaEta);
+      registry.fill(HIST("hDeltaEtaPtIntMcGen"), deltaEta);
+      registry.fill(HIST("hDeltaPhiPtIntMcGen"), deltaPhi);
+    } // end loop
+  }
+  PROCESS_SWITCH(HfTaskCorrelationLcHadrons, processMcGen, "Process Mc Gen mode", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfTaskCorrelationLcHadrons>(cfgc)};
+}


### PR DESCRIPTION
Lambda_c -Hadron correlator and task development, which Lambda_c is for the decay channel Lambda_c->PKPi

Due to the update O2Physics for "CorrelationTables.h", I closed the previous PR, and moved the namespace for Lc-H to "CorrelationTables.h".