### PR TITLE
PWGLF: Remove RecoDecay::getMassPDG

### DIFF
--- a/PWGLF/TableProducer/f1protonInitializer.cxx
+++ b/PWGLF/TableProducer/f1protonInitializer.cxx
@@ -33,7 +33,7 @@
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/Core/trackUtilities.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/DataModel/EventSelection.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -181,7 +181,7 @@ struct f1protoninitializer {
     if (fabs(candidate.dcav0topv(collision.posX(), collision.posY(), collision.posZ())) > cMaxV0DCA) {
       return false;
     }
-    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short);
+    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
     float lowmasscutks0 = 0.497 - 2.0 * cSigmaMassKs0;
     float highmasscutks0 = 0.497 + 2.0 * cSigmaMassKs0;
     if (fabs(CtauK0s) > cMaxV0LifeTime || candidate.mK0Short() < lowmasscutks0 || candidate.mK0Short() > highmasscutks0) {
@@ -191,9 +191,9 @@ struct f1protoninitializer {
   }
 
   /////////////////////////////////////////////////////////////
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massKa = RecoDecay::getMassPDG(kKPlus);
-  double massK0s = RecoDecay::getMassPDG(kK0Short);
+  double massPi = o2::analysis::pdg::MassPiPlus;
+  double massKa = o2::analysis::pdg::MassKPlus;
+  double massK0s = o2::analysis::pdg::MassK0Short;
   double massF1{0.};
   double masskKs0{0.};
   double pT{0.};

--- a/PWGLF/TableProducer/filterf1proton.cxx
+++ b/PWGLF/TableProducer/filterf1proton.cxx
@@ -39,6 +39,7 @@
 #include "DataFormatsTPC/BetheBlochAleph.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "CCDB/CcdbApi.h"
+#include "PWGHF/Core/PDG.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -315,7 +316,7 @@ struct filterf1proton {
     const float dcaDaughv0 = candidate.dcaV0daughters();
     const float cpav0 = candidate.v0cosPA(collision.posX(), collision.posY(), collision.posZ());
 
-    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short);
+    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
     float lowmasscutks0 = 0.497 - 2.0 * cSigmaMassKs0;
     float highmasscutks0 = 0.497 + 2.0 * cSigmaMassKs0;
 
@@ -389,10 +390,10 @@ struct filterf1proton {
 
   std::vector<double> BBProton, BBAntiproton, BBPion, BBAntipion, BBKaon, BBAntikaon;
   ROOT::Math::PtEtaPhiMVector F1Vector, KKs0Vector;
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massKa = RecoDecay::getMassPDG(kKPlus);
+  double massPi = o2::analysis::pdg::MassPiPlus;
+  double massKa = o2::analysis::pdg::MassKPlus;
   double massPr = o2::constants::physics::MassProton;
-  double massK0s = RecoDecay::getMassPDG(kK0Short);
+  double massK0s = o2::analysis::pdg::MassK0Short;
   double massF1{0.};
   double masskKs0{0.};
   double pT{0.};

--- a/PWGLF/TableProducer/v0qaanalysis.cxx
+++ b/PWGLF/TableProducer/v0qaanalysis.cxx
@@ -22,6 +22,7 @@
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/Centrality.h"
+#include "PWGHF/Core/PDG.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -91,9 +92,9 @@ struct v0qaanalysis {
 
     for (auto& v0 : V0s) { // loop over V0s
 
-      float ctauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(3122);
-      float ctauAntiLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(-3122);
-      float ctauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(310);
+      float ctauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0;
+      float ctauAntiLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0Bar;
+      float ctauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
 
       int posITSNhits = 0, negITSNhits = 0;
       for (unsigned int i = 0; i < 7; i++) {
@@ -195,9 +196,9 @@ struct v0qaanalysis {
           }
         }
 
-        float ctauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(3122);
-        float ctauAntiLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(-3122);
-        float ctauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(310);
+        float ctauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0;
+        float ctauAntiLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0Bar;
+        float ctauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
 
         if (v0.v0radius() > v0radius &&
             v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa &&

--- a/PWGLF/Tasks/QC/resonanceqa.cxx
+++ b/PWGLF/Tasks/QC/resonanceqa.cxx
@@ -44,7 +44,7 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/Core/trackUtilities.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/TrackSelection.h"
 #include "Framework/ASoAHelpers.h"
 
@@ -124,8 +124,8 @@ struct resonanceqa {
       histos.add("h1LambdastarRec", "Lambdastar meson Rec", kTH1F, {{100, 0.0f, 10.0f}});
     }
   }
-  double massPi = RecoDecay::getMassPDG(kPiPlus);
-  double massKa = RecoDecay::getMassPDG(kKPlus);
+  double massPi = o2::analysis::pdg::MassPiPlus;
+  double massKa = o2::analysis::pdg::MassKPlus;
   double massPr = 0.938272088f;
   double rapidity;
   double genMass, recMass, resolution;

--- a/PWGLF/Tasks/QC/v0cascadesqa.cxx
+++ b/PWGLF/Tasks/QC/v0cascadesqa.cxx
@@ -21,7 +21,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/trackUtilities.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "Common/Core/TrackSelection.h"
@@ -389,8 +389,8 @@ struct v0cascadesQA {
       float decayLength = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::sqrtSumOfSquares(v0.px(), v0.py(), v0.pz());
       histos_V0.fill(HIST("DecayLength"), decayLength);
 
-      float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0);
-      float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short);
+      float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0;
+      float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
 
       if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > V0_cosPA &&
           v0.v0radius() > V0_radius &&
@@ -427,7 +427,7 @@ struct v0cascadesQA {
           if (doextraanalysis)
             histos_V0.fill(HIST("InvMassLambdaVsPtVsPA"), v0.pt(), TMath::ACos(v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ())), v0.mLambda());
           histos_V0.fill(HIST("V0DCAV0ToPVLambda"), v0.dcav0topv(collision.posX(), collision.posY(), collision.posZ()));
-          if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > 0.999 && v0.dcaV0daughters() < 1 && TMath::Abs(v0.mK0Short() - RecoDecay::getMassPDG(310)) > 0.012 && TMath::Abs(v0.mAntiLambda() - RecoDecay::getMassPDG(3122)) > 0.08 && TMath::Abs(v0.mLambda() - RecoDecay::getMassPDG(3122)) < 0.002) {
+          if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > 0.999 && v0.dcaV0daughters() < 1 && TMath::Abs(v0.mK0Short() - o2::analysis::pdg::MassK0Short) > 0.012 && TMath::Abs(v0.mAntiLambda() - o2::analysis::pdg::MassLambda0) > 0.08 && TMath::Abs(v0.mLambda() - o2::analysis::pdg::MassLambda0) < 0.002) {
             histos_V0.fill(HIST("ResponsePionFromLambda"), v0.pt(), negdau.tpcNSigmaPi());
             histos_V0.fill(HIST("ResponseProtonFromLambda"), v0.pt(), posdau.tpcNSigmaPr());
           }
@@ -487,8 +487,8 @@ struct v0cascadesQA {
         lPDG = v0mcparticle.pdgCode();
       }
 
-      float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0);
-      float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short);
+      float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0;
+      float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short;
 
       if (v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > V0_cosPA &&
           v0.v0radius() > V0_radius &&
@@ -588,12 +588,12 @@ struct v0cascadesQA {
       histos_Casc.fill(HIST("CascDecayLengthOmega"), cascDecayLength, casc.sign());
 
       float cascTotalMomentum = RecoDecay::sqrtSumOfSquares(casc.px(), casc.py(), casc.pz());
-      float CtauXi = cascDecayLength / (cascTotalMomentum + 1E-10) * RecoDecay::getMassPDG(3322); // see O2Physics/Common/Core/MC.h for codes and names accepted
-      float CtauOmega = cascDecayLength / (cascTotalMomentum + 1E-10) * RecoDecay::getMassPDG(3334);
+      float CtauXi = cascDecayLength / (cascTotalMomentum + 1E-10) * o2::analysis::pdg::MassXi0; // see O2Physics/Common/Core/MC.h for codes and names accepted
+      float CtauOmega = cascDecayLength / (cascTotalMomentum + 1E-10) * o2::analysis::pdg::MassOmegaMinus;
 
       float v0TotalMomentum = RecoDecay::sqrtSumOfSquares(casc.pxpos() + casc.pxneg(), casc.pypos() + casc.pyneg(), casc.pzpos() + casc.pzneg());
       float v0DecayLength = std::sqrt(std::pow(casc.xlambda() - casc.x(), 2) + std::pow(casc.ylambda() - casc.y(), 2) + std::pow(casc.zlambda() - casc.z(), 2));
-      float CtauV0 = v0DecayLength / (v0TotalMomentum + 1E-10) * RecoDecay::getMassPDG(kLambda0);
+      float CtauV0 = v0DecayLength / (v0TotalMomentum + 1E-10) * o2::analysis::pdg::MassLambda0;
 
       histos_Casc.fill(HIST("CascCtauXi"), CtauXi, casc.sign());
       histos_Casc.fill(HIST("CascCtauOmega"), CtauOmega, casc.sign());

--- a/PWGLF/Tasks/hyperon-reco-test.cxx
+++ b/PWGLF/Tasks/hyperon-reco-test.cxx
@@ -21,7 +21,7 @@
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/Track.h"
 
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/Centrality.h"
@@ -101,7 +101,7 @@ struct myLambda {
         TMath::Abs(posdau.eta()) < rapidity && TMath::Abs(negdau.eta()) < rapidity && posdau.tpcNClsCrossedRows() > tpcNcl && negdau.tpcNClsCrossedRows() > tpcNcl && TMath::Abs(posdau.tpcNSigmaPr()) < tpcsigma && TMath::Abs(negdau.tpcNSigmaPi()) < tpcsigma &&
 
         // V0 cuts
-        v0.pt() > minpt && v0.v0radius() > v0radius && v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa && TMath::Abs(v0.mK0Short() - RecoDecay::getMassPDG(kK0Short)) > removeKs) {
+        v0.pt() > minpt && v0.v0radius() > v0radius && v0.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa && TMath::Abs(v0.mK0Short() - o2::analysis::pdg::MassK0Short) > removeKs) {
         registry.fill(HIST("hReduction"), 1.5);
         registry.fill(HIST("hmyLambda_after"), v0.mLambda(), v0.pt());
         registry.fill(HIST("hmyLambda_after_b"), v0.mLambda());
@@ -190,10 +190,10 @@ struct myXi {
         casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && v0.dcav0topv(collision.posX(), collision.posY(), collision.posZ()) > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
         registry.fill(HIST("hmyLambda"), v0.mLambda());
 
-        if (TMath::Abs(v0.mLambda() - RecoDecay::getMassPDG(kLambda0)) < v0masswindow &&
+        if (TMath::Abs(v0.mLambda() - o2::analysis::pdg::MassLambda0) < v0masswindow &&
 
             // Cascade cut
-            casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mOmega() - RecoDecay::getMassPDG(kOmegaMinus)) > removeOmega && casc.sign() < 0) {
+            casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mOmega() - o2::analysis::pdg::MassOmegaMinus) > removeOmega && casc.sign() < 0) {
           registry.fill(HIST("hReduction"), 1.5);
           registry.fill(HIST("hmyXi_after"), casc.mXi(), casc.pt());
           registry.fill(HIST("hmyXi_after_b"), casc.mXi());
@@ -288,10 +288,10 @@ struct myOmega {
         casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && v0.dcav0topv(collision.posX(), collision.posY(), collision.posZ()) > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
         registry.fill(HIST("hmyLambda"), v0.mLambda());
 
-        if (TMath::Abs(v0.mLambda() - RecoDecay::getMassPDG(kLambda0)) < v0masswindow &&
+        if (TMath::Abs(v0.mLambda() - o2::analysis::pdg::MassLambda0) < v0masswindow &&
 
             // Cascade cut
-            casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mXi() - RecoDecay::getMassPDG(kXiMinus)) > removeXi && casc.sign() < 0) {
+            casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mXi() - o2::analysis::pdg::MassXiMinus) > removeXi && casc.sign() < 0) {
           registry.fill(HIST("hReduction"), 1.5);
           registry.fill(HIST("hmyOmega_after"), casc.mOmega(), casc.pt());
           registry.fill(HIST("hmyOmega_after_b"), casc.mOmega());

--- a/PWGLF/Tasks/lambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/lambdakzeroanalysis.cxx
@@ -26,7 +26,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/trackUtilities.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "Common/Core/TrackSelection.h"
@@ -182,7 +182,7 @@ struct lambdakzeroAnalysis {
         registry.fill(HIST("V0loopFiltersCounts"), 1.5);
         if (TMath::Abs(v0.yLambda()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 3.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0) < lifetimecut->get("lifetimecutLambda")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0 < lifetimecut->get("lifetimecutLambda")) {
             registry.fill(HIST("V0loopFiltersCounts"), 4.5);
 
             // Lambda
@@ -210,7 +210,7 @@ struct lambdakzeroAnalysis {
         // K0Short
         if (TMath::Abs(v0.yK0Short()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 7.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short) < lifetimecut->get("lifetimecutK0S")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short < lifetimecut->get("lifetimecutK0S")) {
             registry.fill(HIST("V0loopFiltersCounts"), 8.5);
             if ((v0.qtarm() > paramArmenterosCut * TMath::Abs(v0.alpha())) || !boolArmenterosCut) {
               registry.fill(HIST("V0loopFiltersCounts"), 9.5);
@@ -249,7 +249,7 @@ struct lambdakzeroAnalysis {
         registry.fill(HIST("V0loopFiltersCounts"), 1.5);
         if (TMath::Abs(v0.yLambda()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 3.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0) < lifetimecut->get("lifetimecutLambda")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0 < lifetimecut->get("lifetimecutLambda")) {
             registry.fill(HIST("V0loopFiltersCounts"), 4.5);
 
             // Lambda
@@ -277,7 +277,7 @@ struct lambdakzeroAnalysis {
         // K0Short
         if (TMath::Abs(v0.yK0Short()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 7.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short) < lifetimecut->get("lifetimecutK0S")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short < lifetimecut->get("lifetimecutK0S")) {
             registry.fill(HIST("V0loopFiltersCounts"), 8.5);
             if ((v0.qtarm() > paramArmenterosCut * v0.alpha()) || !boolArmenterosCut) {
               registry.fill(HIST("V0loopFiltersCounts"), 9.5);

--- a/PWGLF/Tasks/lambdakzeroanalysisMC.cxx
+++ b/PWGLF/Tasks/lambdakzeroanalysisMC.cxx
@@ -27,7 +27,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
 #include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/trackUtilities.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "Common/Core/TrackSelection.h"
@@ -238,7 +238,7 @@ struct lambdakzeroAnalysisMc {
 
         if (TMath::Abs(v0.yLambda()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 3.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0) < lifetimecut->get("lifetimecutLambda")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0 < lifetimecut->get("lifetimecutLambda")) {
             registry.fill(HIST("V0loopFiltersCounts"), 4.5);
 
             // Lambda
@@ -312,7 +312,7 @@ struct lambdakzeroAnalysisMc {
         // K0Short
         if (TMath::Abs(v0.yK0Short()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 7.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short) < lifetimecut->get("lifetimecutK0S")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short < lifetimecut->get("lifetimecutK0S")) {
             registry.fill(HIST("V0loopFiltersCounts"), 8.5);
             if ((v0.qtarm() > paramArmenterosCut * TMath::Abs(v0.alpha())) || !boolArmenterosCut) {
               registry.fill(HIST("V0loopFiltersCounts"), 9.5);
@@ -370,7 +370,7 @@ struct lambdakzeroAnalysisMc {
 
         if (TMath::Abs(v0.yLambda()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 3.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kLambda0) < lifetimecut->get("lifetimecutLambda")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassLambda0 < lifetimecut->get("lifetimecutLambda")) {
             registry.fill(HIST("V0loopFiltersCounts"), 4.5);
             registry.fill(HIST("h3dMassLambda"), collision.centRun2V0M(), v0.pt(), v0.mLambda());
             registry.fill(HIST("h3dMassAntiLambda"), collision.centRun2V0M(), v0.pt(), v0.mAntiLambda());
@@ -403,7 +403,7 @@ struct lambdakzeroAnalysisMc {
         }
         if (TMath::Abs(v0.yK0Short()) < rapidity) {
           registry.fill(HIST("V0loopFiltersCounts"), 7.5);
-          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::getMassPDG(kK0Short) < lifetimecut->get("lifetimecutK0S")) {
+          if (v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::analysis::pdg::MassK0Short < lifetimecut->get("lifetimecutK0S")) {
             registry.fill(HIST("V0loopFiltersCounts"), 8.5);
             registry.fill(HIST("h3dMassK0Short"), collision.centRun2V0M(), v0.pt(), v0.mK0Short());
             registry.fill(HIST("hArmenterosPostAnalyserCuts"), v0.alpha(), v0.qtarm());

--- a/PWGLF/Tasks/phianalysisrun3.cxx
+++ b/PWGLF/Tasks/phianalysisrun3.cxx
@@ -44,7 +44,7 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/Core/trackUtilities.h"
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 #include "Common/Core/TrackSelection.h"
 #include "Framework/ASoAHelpers.h"
 
@@ -100,7 +100,7 @@ struct phianalysisrun3 {
     }
   }
 
-  double massKa = RecoDecay::getMassPDG(kKPlus);
+  double massKa = o2::analysis::pdg::MassKPlus;
   double rapidity;
   double genMass, recMass, resolution;
   double mass{0.};

--- a/PWGLF/Tasks/v0postprocessing.cxx
+++ b/PWGLF/Tasks/v0postprocessing.cxx
@@ -20,6 +20,7 @@
 #include "PWGLF/DataModel/v0qaanalysis.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/PIDResponse.h"
+#include "PWGHF/Core/PDG.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -141,8 +142,8 @@ struct v0postprocessing {
       if (candidate.v0cospa() > cospaK0s &&
           TMath::Abs(candidate.rapk0short()) < rap &&
           candidate.ctauk0short() < ctauK0s &&
-          TMath::Abs(candidate.massk0short() - RecoDecay::getMassPDG(310)) < 0.075 &&
-          TMath::Abs(candidate.masslambda() - RecoDecay::getMassPDG(3122)) > v0rejK0s) {
+          TMath::Abs(candidate.massk0short() - o2::analysis::pdg::MassK0Short) < 0.075 &&
+          TMath::Abs(candidate.masslambda() - o2::analysis::pdg::MassLambda0) > v0rejK0s) {
 
         registry.fill(HIST("hMassK0Short"), candidate.massk0short());
         registry.fill(HIST("hMassVsPtK0Short"), candidate.v0pt(), candidate.massk0short());
@@ -168,8 +169,8 @@ struct v0postprocessing {
       /* if (candidate.v0cospa() > cospaLambda &&
            TMath::Abs(candidate.raplambda()) < rap &&
            candidate.ctaulambda() < ctauK0s &&
-           TMath::Abs(candidate.masslambda() - RecoDecay::getMassPDG(3122)) < 0.075 &&
-           TMath::Abs(candidate.massk0short() - RecoDecay::getMassPDG(310)) > v0rejLambda) {
+           TMath::Abs(candidate.masslambda() - o2::analysis::pdg::MassLambda0) < 0.075 &&
+           TMath::Abs(candidate.massk0short() - o2::analysis::pdg::MassK0Short) > v0rejLambda) {
 
            registry.fill(HIST("hMassLambda"), candidate.masslambda());
            registry.fill(HIST("hMassVsPtLambda"), candidate.v0pt(), candidate.masslambda());
@@ -202,8 +203,8 @@ struct v0postprocessing {
         if (candidate.v0cospa() > cospaK0s &&
             TMath::Abs(candidate.rapk0short()) < rap &&
             candidate.ctauk0short() < ctauK0s &&
-            TMath::Abs(candidate.massk0short() - RecoDecay::getMassPDG(310)) < 0.075 &&
-            TMath::Abs(candidate.masslambda() - RecoDecay::getMassPDG(3122)) > v0rejK0s &&
+            TMath::Abs(candidate.massk0short() - o2::analysis::pdg::MassK0Short) < 0.075 &&
+            TMath::Abs(candidate.masslambda() - o2::analysis::pdg::MassLambda0) > v0rejK0s &&
             (candidate.pdgcode() == 310)) {
 
           registry.fill(HIST("hMassK0Short_MC"), candidate.massk0short());


### PR DESCRIPTION
Please note that this is an intermediate step of the ongoing effort to optimise memory consumption and to unify the location from where we pick the PDG masses. The ultimate goal is to get the masses from [`CommonConstants/PhysicsConstants.h`](https://github.com/AliceO2Group/AliceO2/blob/dev/Common/Constants/include/CommonConstants/PhysicsConstants.h) or from the `O2DatabasePDG` service.

Requires https://github.com/AliceO2Group/O2Physics/pull/3692