### PR TITLE
PWGJE: Remove RecoDecay::getMassPDG

### DIFF
--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -120,13 +120,13 @@ void analyseClusters(std::vector<fastjet::PseudoJet>& inputParticles, T const& c
 template <typename T>
 bool analyseCandidate(std::vector<fastjet::PseudoJet>& inputParticles, int candPDG, float candPtMin, float candPtMax, float candYMin, float candYMax, T const& candidate)
 {
-  if (candidate.y(RecoDecay::getMassPDG(candPDG)) < candYMin || candidate.y(RecoDecay::getMassPDG(candPDG)) > candYMax) {
+  if (candidate.y(RecoDecay::getMassPDG(candPDG)) < candYMin || candidate.y(RecoDecay::getMassPDG(candPDG)) > candYMax) { // FIXME: Remove RecoDecay::getMassPDG
     return false;
   }
   if (candidate.pt() < candPtMin || candidate.pt() >= candPtMax) {
     return false;
   }
-  FastJetUtilities::fillTracks(candidate, inputParticles, candidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), RecoDecay::getMassPDG(candPDG));
+  FastJetUtilities::fillTracks(candidate, inputParticles, candidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), RecoDecay::getMassPDG(candPDG)); // FIXME: Remove RecoDecay::getMassPDG
   return true;
 }
 
@@ -234,7 +234,7 @@ void analyseParticles(std::vector<fastjet::PseudoJet>& inputParticles, std::stri
         continue;
       }
     }
-    FastJetUtilities::fillTracks(particle, inputParticles, particle.globalIndex(), static_cast<int>(JetConstituentStatus::track), RecoDecay::getMassPDG(particle.pdgCode()));
+    FastJetUtilities::fillTracks(particle, inputParticles, particle.globalIndex(), static_cast<int>(JetConstituentStatus::track), pdgParticle->Mass());
   }
 }
 

--- a/PWGJE/TableProducer/jetfinder.h
+++ b/PWGJE/TableProducer/jetfinder.h
@@ -30,7 +30,7 @@
 #include "Common/Core/TrackSelectionDefaults.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/Core/RecoDecay.h"
+#include "Common/Core/RecoDecay.h" // FIXME: Remove RecoDecay::getMassPDG
 #include "PWGJE/DataModel/EMCALClusters.h"
 
 #include "PWGHF/Core/SelectorCuts.h"

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -201,7 +201,7 @@ struct JetFinderHFTask {
 
     for (auto const& particle : particles) {
       if (std::abs(particle.flagMcMatchGen()) & (1 << candDecay)) {
-        auto particleY = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, RecoDecay::getMassPDG(particle.pdgCode()));
+        auto particleY = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, pdg->Mass(particle.pdgCode()));
         if (particleY < candYMin || particleY > candYMax) {
           continue;
         }
@@ -213,7 +213,7 @@ struct JetFinderHFTask {
     }
     for (auto& candidate : candidates) {
       analyseParticles(inputParticles, particleSelection, jetTypeParticleLevel, particles, pdg->Instance(), std::optional{candidate});
-      FastJetUtilities::fillTracks(candidate, inputParticles, candidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), RecoDecay::getMassPDG(candidate.pdgCode()));
+      FastJetUtilities::fillTracks(candidate, inputParticles, candidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), pdg->Mass(candidate.pdgCode()));
       findJets(jetFinder, inputParticles, jetRadius, collision, jetsTable, constituentsTable, constituentsSubTable, DoConstSub, true);
     }
   }

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -14,6 +14,7 @@
 // Authors: Nima Zardoshti, Jochen Klein
 
 #include "PWGJE/TableProducer/jetfinder.h"
+#include "Common/Core/RecoDecay.h"
 
 using namespace o2;
 using namespace o2::analysis;

--- a/PWGJE/Tasks/jetTutorial.cxx
+++ b/PWGJE/Tasks/jetTutorial.cxx
@@ -24,8 +24,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
-#include "Common/Core/RecoDecay.h"
-
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 

--- a/PWGJE/Tasks/jetTutorialSkeleton.cxx
+++ b/PWGJE/Tasks/jetTutorialSkeleton.cxx
@@ -24,8 +24,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
-#include "Common/Core/RecoDecay.h"
-
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 

--- a/PWGJE/Tasks/jetfinderQA.cxx
+++ b/PWGJE/Tasks/jetfinderQA.cxx
@@ -24,8 +24,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
-#include "Common/Core/RecoDecay.h"
-
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/Core/JetFinder.h"
 #include "PWGJE/DataModel/Jet.h"

--- a/PWGJE/Tasks/jetfinderhfQA.cxx
+++ b/PWGJE/Tasks/jetfinderhfQA.cxx
@@ -25,7 +25,7 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
-#include "Common/Core/RecoDecay.h"
+#include "PWGHF/Core/PDG.h"
 
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -237,7 +237,7 @@ struct JetFinderHFQATask {
       registry.fill(HIST("h3_jet_r_jet_pt_candidate_pt"), jet.r() / 100.0, jet.pt(), hfcandidate.pt(), weight);
       registry.fill(HIST("h3_jet_r_jet_pt_candidate_eta"), jet.r() / 100.0, jet.pt(), hfcandidate.eta(), weight);
       registry.fill(HIST("h3_jet_r_jet_pt_candidate_phi"), jet.r() / 100.0, jet.pt(), hfcandidate.phi(), weight);
-      registry.fill(HIST("h3_jet_r_jet_pt_candidate_y"), jet.r() / 100.0, jet.pt(), hfcandidate.y(RecoDecay::getMassPDG(421)), weight);
+      registry.fill(HIST("h3_jet_r_jet_pt_candidate_y"), jet.r() / 100.0, jet.pt(), hfcandidate.y(o2::analysis::pdg::MassD0), weight);
 
       if (jet.r() == round(selectedJetsRadius * 100.0f)) {
         if constexpr (std::is_same_v<std::decay_t<U>, soa::Join<aod::HfCand2Prong, aod::HfSelD0>> || std::is_same_v<std::decay_t<U>, soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfCand2ProngMcRec>>) {
@@ -322,7 +322,7 @@ struct JetFinderHFQATask {
         mcdCandPt = hfcandidate_mcd.pt();
         mcdCandPhi = hfcandidate_mcd.phi();
         mcdCandEta = hfcandidate_mcd.eta();
-        mcdCandY = hfcandidate_mcd.y(RecoDecay::getMassPDG(421));
+        mcdCandY = hfcandidate_mcd.y(o2::analysis::pdg::MassD0);
       }
 
       for (auto& hfcandidate_mcp : mcpjet.template hfcandidates_as<std::decay_t<O>>()) {
@@ -474,12 +474,12 @@ struct JetFinderHFQATask {
         registry.fill(HIST("h3_jet_r_jet_pt_candidate_pt_MB"), jet.r() / 100.0, jet.pt(), hfcandidate.pt());
         registry.fill(HIST("h3_jet_r_jet_pt_candidate_eta_MB"), jet.r() / 100.0, jet.pt(), hfcandidate.eta());
         registry.fill(HIST("h3_jet_r_jet_pt_candidate_phi_MB"), jet.r() / 100.0, jet.pt(), hfcandidate.phi());
-        registry.fill(HIST("h3_jet_r_jet_pt_candidate_y_MB"), jet.r() / 100.0, jet.pt(), hfcandidate.y(RecoDecay::getMassPDG(421)));
+        registry.fill(HIST("h3_jet_r_jet_pt_candidate_y_MB"), jet.r() / 100.0, jet.pt(), hfcandidate.y(o2::analysis::pdg::MassD0));
         if (collision.hasJetChHighPt() >= 1) {
           registry.fill(HIST("h3_jet_r_jet_pt_candidate_pt_Triggered"), jet.r() / 100.0, jet.pt(), hfcandidate.pt());
           registry.fill(HIST("h3_jet_r_jet_pt_candidate_eta_Triggered"), jet.r() / 100.0, jet.pt(), hfcandidate.eta());
           registry.fill(HIST("h3_jet_r_jet_pt_candidate_phi_Triggered"), jet.r() / 100.0, jet.pt(), hfcandidate.phi());
-          registry.fill(HIST("h3_jet_r_jet_pt_candidate_y_Triggered"), jet.r() / 100.0, jet.pt(), hfcandidate.y(RecoDecay::getMassPDG(421)));
+          registry.fill(HIST("h3_jet_r_jet_pt_candidate_y_Triggered"), jet.r() / 100.0, jet.pt(), hfcandidate.y(o2::analysis::pdg::MassD0));
         }
       }
     }

--- a/PWGJE/Tasks/jetsubstructure.cxx
+++ b/PWGJE/Tasks/jetsubstructure.cxx
@@ -20,7 +20,7 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoA.h"
-#include "TDatabasePDG.h"
+#include "Framework/O2DatabasePDGPlugin.h"
 
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/TrackSelectionDefaults.h"
@@ -50,6 +50,7 @@ struct JetSubstructureTask {
   Configurable<float> zCut{"zCut", 0.1, "soft drop z cut"};
   Configurable<float> beta{"beta", 0.0, "soft drop beta"};
 
+  Service<o2::framework::O2DatabasePDG> pdg;
   std::vector<fastjet::PseudoJet> jetConstituents;
   std::vector<fastjet::PseudoJet> jetReclustered;
   JetFinder jetReclusterer;
@@ -123,7 +124,7 @@ struct JetSubstructureTask {
   {
     jetConstituents.clear();
     for (auto& jetConstituent : jet.template tracks_as<aod::McParticles>()) {
-      FastJetUtilities::fillTracks(jetConstituent, jetConstituents, jetConstituent.globalIndex(), static_cast<int>(JetConstituentStatus::track), RecoDecay::getMassPDG(jetConstituent.pdgCode()));
+      FastJetUtilities::fillTracks(jetConstituent, jetConstituents, jetConstituent.globalIndex(), static_cast<int>(JetConstituentStatus::track), pdg->Mass(jetConstituent.pdgCode()));
     }
     jetReclustering(jet);
   }

--- a/PWGJE/Tasks/jetsubstructure.cxx
+++ b/PWGJE/Tasks/jetsubstructure.cxx
@@ -27,8 +27,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
-#include "Common/Core/RecoDecay.h"
-
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetSubstructure.h"
 #include "PWGJE/Core/JetFinder.h"

--- a/PWGJE/Tasks/jetsubstructurehf.cxx
+++ b/PWGJE/Tasks/jetsubstructurehf.cxx
@@ -21,7 +21,6 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoA.h"
 #include "Framework/O2DatabasePDGPlugin.h"
-#include "TDatabasePDG.h"
 
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/TrackSelectionDefaults.h"
@@ -144,7 +143,7 @@ struct JetSubstructureHFTask {
       FastJetUtilities::fillTracks(jetConstituent, jetConstituents, jetConstituent.globalIndex());
     }
     for (auto& jetHFCandidate : jet.template hfcandidates_as<CandidateTable>()) { // should only be one at the moment
-      FastJetUtilities::fillTracks(jetHFCandidate, jetConstituents, jetHFCandidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), RecoDecay::getMassPDG(candPDG));
+      FastJetUtilities::fillTracks(jetHFCandidate, jetConstituents, jetHFCandidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), pdg->Mass(candPDG));
     }
     jetReclustering(jet);
   }
@@ -155,10 +154,10 @@ struct JetSubstructureHFTask {
   {
     jetConstituents.clear();
     for (auto& jetConstituent : jet.template tracks_as<aod::McParticles>()) {
-      FastJetUtilities::fillTracks(jetConstituent, jetConstituents, jetConstituent.globalIndex(), static_cast<int>(JetConstituentStatus::track), RecoDecay::getMassPDG(jetConstituent.pdgCode()));
+      FastJetUtilities::fillTracks(jetConstituent, jetConstituents, jetConstituent.globalIndex(), static_cast<int>(JetConstituentStatus::track), pdg->Mass(jetConstituent.pdgCode()));
     }
     for (auto& jetHFCandidate : jet.template hfcandidates_as<aod::McParticles>()) { // should only be one at the moment
-      FastJetUtilities::fillTracks(jetHFCandidate, jetConstituents, jetHFCandidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), RecoDecay::getMassPDG(jetHFCandidate.pdgCode()));
+      FastJetUtilities::fillTracks(jetHFCandidate, jetConstituents, jetHFCandidate.globalIndex(), static_cast<int>(JetConstituentStatus::candidateHF), pdg->Mass(jetHFCandidate.pdgCode()));
     }
     jetReclustering(jet);
   }

--- a/PWGJE/Tasks/triggerCorrelations.cxx
+++ b/PWGJE/Tasks/triggerCorrelations.cxx
@@ -28,8 +28,6 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/CCDB/TriggerAliases.h"
 
-#include "Common/Core/RecoDecay.h"
-
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/DataModel/EMCALClusters.h"
 #include "PWGJE/Core/JetFinder.h"


### PR DESCRIPTION
Please note that this is an intermediate step of the ongoing effort to optimise memory consumption and to unify the location from where we pick the PDG masses. The ultimate goal is to get the masses from [`CommonConstants/PhysicsConstants.h`](https://github.com/AliceO2Group/AliceO2/blob/dev/Common/Constants/include/CommonConstants/PhysicsConstants.h) or from the `O2DatabasePDG` service.