### PR TITLE
PWGHF: SigmaC candidate creation w/ or w/o time-reassociated tracks 

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -292,9 +292,9 @@ struct HfCandidateCreatorSigmac0plusplus {
     for (const auto& collision : collisions) {
 
       histos.fill(HIST("hCounter"), 1);
-      LOG(info) << "[processDataTimeAssoc] Collision with globalIndex " << collision.globalIndex();
-      LOG(info) << "[processDataTimeAssoc]     - number of tracks: " << tracks.size();
-      LOG(info) << "[processDataTimeAssoc]     - number of Lc candidates: " << candidates.size();
+      // LOG(info) << "[processDataTimeAssoc] Collision with globalIndex " << collision.globalIndex();
+      // LOG(info) << "[processDataTimeAssoc]     - number of tracks: " << tracks.size();
+      // LOG(info) << "[processDataTimeAssoc]     - number of Lc candidates: " << candidates.size();
 
       // slice by hand the assoc. track with time per collision
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, collision.globalIndex());
@@ -324,9 +324,9 @@ struct HfCandidateCreatorSigmac0plusplus {
   {
 
     histos.fill(HIST("hCounter"), 1);
-    LOG(info) << "[processDataNoTimeAssoc] Collision with globalIndex " << collision.globalIndex();
-    LOG(info) << "[processDataNoTimeAssoc]     - number of tracks: " << tracks.size();
-    LOG(info) << "[processDataNoTimeAssoc]     - number of Lc candidates: " << candidates.size();
+    // LOG(info) << "[processDataNoTimeAssoc] Collision with globalIndex " << collision.globalIndex();
+    // LOG(info) << "[processDataNoTimeAssoc]     - number of tracks: " << tracks.size();
+    // LOG(info) << "[processDataNoTimeAssoc]     - number of Lc candidates: " << candidates.size();
 
     /// loop over tracks for soft pion
     /// In this case, they are already grouped by collision, using the track::CollisionId

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -272,7 +272,7 @@ struct HfCandidateCreatorSigmac0plusplus {
       auto candidatesThisColl = candidates.sliceBy(hf3ProngPerCollision, thisCollId);
       makeSoftPiLcPair(trackSoftPi, candidatesThisColl, tracks);
     } else {
-      /// tracks already grouped by collision at the level of process function
+      /// tracks and candidates already grouped by collision at the level of process function
       makeSoftPiLcPair(trackSoftPi, candidates, tracks);
     }
 


### PR DESCRIPTION
Modification on the candidate creator done to enable the case w/o time-reassociated tracks, given that the `time-to-collision-associator` is quite CPU consuming and its importance for soft pions might be not crucial (to be tested in analysis).
Major changes:
- new `process` functions to handle this
- new `template` functions to handle the different data-type for the soft pion track