### PR TITLE
PWGHF: O2AT, adding tracks-extra and zdc converter workflows.

### DIFF
--- a/Tutorials/PWGHF/dpl-config_skim.json
+++ b/Tutorials/PWGHF/dpl-config_skim.json
@@ -18,6 +18,8 @@
         "ccdb-url": "http://alice-ccdb.cern.ch",
         "isRun2MC": "false"
     },
+    "tracks-extra-converter": "",
+    "zdc-converter": "",
     "track-propagation": {
         "ccdb-url": "http://alice-ccdb.cern.ch",
         "lutPath": "GLO/Param/MatLUT",

--- a/Tutorials/PWGHF/dpl-config_task.json
+++ b/Tutorials/PWGHF/dpl-config_task.json
@@ -21,6 +21,8 @@
         "ccdb-url": "http://alice-ccdb.cern.ch",
         "isRun2MC": "false"
     },
+    "tracks-extra-converter": "",
+    "zdc-converter": "",
     "track-propagation": {
         "ccdb-url": "http://alice-ccdb.cern.ch",
         "lutPath": "GLO/Param/MatLUT",

--- a/Tutorials/PWGHF/run_skim.sh
+++ b/Tutorials/PWGHF/run_skim.sh
@@ -36,7 +36,9 @@ o2-analysistutorial-hf-skim-creator-mini $OPTIONS | \
 o2-analysis-timestamp $OPTIONS | \
 o2-analysis-trackselection $OPTIONS | \
 o2-analysis-track-propagation $OPTIONS | \
-o2-analysis-bc-converter $OPTIONS \
+o2-analysis-bc-converter $OPTIONS | \
+o2-analysis-tracks-extra-converter $OPTIONS | \
+o2-analysis-zdc-converter $OPTIONS  \
 > "$LOGFILE" 2>&1
 
 # report status

--- a/Tutorials/PWGHF/run_task.sh
+++ b/Tutorials/PWGHF/run_task.sh
@@ -40,7 +40,9 @@ o2-analysis-pid-tpc-base $OPTIONS | \
 o2-analysis-pid-tpc-full $OPTIONS | \
 o2-analysis-pid-tof-base $OPTIONS | \
 o2-analysis-pid-tof-full $OPTIONS | \
-o2-analysis-bc-converter $OPTIONS \
+o2-analysis-bc-converter $OPTIONS | \
+o2-analysis-tracks-extra-converter $OPTIONS | \
+o2-analysis-zdc-converter $OPTIONS  \
 > "$LOGFILE" 2>&1
 
 # report status


### PR DESCRIPTION
- The tracks-extra-converter workflow is needed after the merge of this PR:
https://github.com/AliceO2Group/AliceO2/pull/12087

- The zdc-converter workflow is needed if we decide to run the exercise on the the MC charm enriched production LHC22b1b, that would allow to see a peak also running on very small files.


@vkucera @fcolamar let me know if you agree on doing the exercise on a MC production, otherwise, I can remove the zdc-converter, but I guess we will need anyway the tracks-extra converter 