### PR TITLE
Fix ML folder path in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,6 @@
 * @AliceO2Group/core @alibuild @jgrosseo @iarsene @ktf @ddobrigk
 /Common/CCDB @alibuild @jgrosseo @iarsene @ekryshen @ddobrigk
 /Common/Tools/Multiplicity @alibuild @ddobrigk @victor-gonzalez
-/Common/Tools/ML @alibuild @fcatalan92 @fmazzasc
 /ALICE3 @alibuild @njacazio @vkucera @hscheid
 /DPG @alibuild @chiarazampolli @noferini
 /DPG/Tasks/AOTEvent @alibuild @ekryshen @strogolo
@@ -40,6 +39,7 @@
 /PWGUD @alibuild @pbuehler
 /PWGJE @alibuild @lhavener @maoyx @nzardosh @ddobrigk @mfasDa
 /Tools/PIDML @alibuild @saganatt
+/Tools/ML @alibuild @fcatalan92 @fmazzasc
 /Tutorials/PWGCF @alibuild @jgrosseo @saganatt @victor-gonzalez @zchochu
 /Tutorials/PWGDQ @alibuild @iarsene @dsekihat @feisenhu
 /Tutorials/PWGEM @alibuild @mikesas @rbailhac @dsekihat @ivorobye @feisenhu


### PR DESCRIPTION
@ddobrigk I found why I didn't have permission to merge a ML-related PR last time. The folder path was wrong.