### PR TITLE
RecoDecay: Remove getMassPDG

### DIFF
--- a/ALICE3/TableProducer/OTF/onTheFlyRICHPID.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyRICHPID.cxx
@@ -15,6 +15,9 @@
 
 #include <utility>
 #include <cmath>
+
+#include <TPDGCode.h>
+
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"

--- a/ALICE3/TableProducer/OTF/onTheFlyTOFPID.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyTOFPID.cxx
@@ -14,6 +14,9 @@
 //
 
 #include <utility>
+
+#include <TPDGCode.h>
+
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -17,17 +17,13 @@
 #ifndef COMMON_CORE_RECODECAY_H_
 #define COMMON_CORE_RECODECAY_H_
 
-// #include <tuple>
-#include <vector>  // std::vector
-#include <array>   // std::array
-#include <cmath>   // std::abs, std::sqrt
-#include <utility> // std::move
-
-// #include <TDatabasePDG.h>
-// #include <TPDGCode.h>
+#include <algorithm> // std::find
+#include <array>     // std::array
+#include <cmath>     // std::abs, std::sqrt
+#include <utility>   // std::move
+#include <vector>    // std::vector
 
 #include "CommonConstants/MathConstants.h"
-// #include "Framework/Logger.h"
 
 /// Base class for calculating properties of reconstructed decays
 ///

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -518,61 +518,6 @@ class RecoDecay
     return maxNormDeltaIP;
   }
 
-  /// Adds particle mass in the list.
-  /// \param pdg  PDG code
-  /// \param mass  particle mass
-  static void addMassPDG(int pdg, double mass)
-  {
-    mListMass.push_back(std::make_tuple(pdg, mass));
-  }
-
-  /// Returns particle mass based on PDG code.
-  /// \param pdg  PDG code
-  /// \return particle mass
-  static double getMassPDG(int pdg)
-  {
-    if (!mErrorShown) {
-      LOGF(error, "Function RecoDecay::getMassPDG is deprecated and will be removed soon.");
-      LOGF(error, "Please use the Mass function in the O2DatabasePDG service instead.");
-      LOGF(error, "See the example of usage in Tutorials/src/usingPDGService.cxx.");
-      mErrorShown = true;
-    }
-    // Try to get the particle mass from the list first.
-    for (const auto& particle : mListMass) {
-      if (std::get<0>(particle) == pdg) {
-        return std::get<1>(particle);
-      }
-    }
-    // Get the mass of the new particle and add it in the list.
-    double mass = 0.;
-    switch (pdg) {
-      // Particles that cannot be taken from ROOT ($ROOTSYS/etc/pdg_table.txt)
-      case 4422: {      // Ξcc (wrong mass in ROOT)
-        mass = 3.62155; // https://pdg.lbl.gov/ (2021)
-        break;
-      }
-      case 9920443: {   // χc1 aka X(3872)
-        mass = 3.87165; // https://pdg.lbl.gov/ (2021)
-        break;
-      }
-      case 4332: {     // Ω0c (wrong mass in ROOT)
-        mass = 2.6952; // https://pdg.lbl.gov/ (2022)
-        break;
-      }
-      // Take the rest from ROOT.
-      default: {
-        const TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(pdg);
-        if (!particle) { // Check that it's there.
-          LOGF(fatal, "Cannot find particle mass for PDG code %i", pdg);
-          return 999.;
-        }
-        mass = particle->Mass();
-      }
-    }
-    addMassPDG(pdg, mass);
-    return mass;
-  }
-
   /// Finds the mother of an MC particle by looking for the expected PDG code in the mother chain.
   /// \param particlesMC  table with MC particles
   /// \param particle  MC particle
@@ -999,13 +944,6 @@ class RecoDecay
     }
     return OriginType::None;
   }
-
- private:
-  static std::vector<std::tuple<int, double>> mListMass; ///< list of particle masses in form (PDG code, mass)
-  static bool mErrorShown;
 };
-
-std::vector<std::tuple<int, double>> RecoDecay::mListMass;
-bool RecoDecay::mErrorShown = false;
 
 #endif // COMMON_CORE_RECODECAY_H_

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -18,10 +18,10 @@
 #define COMMON_CORE_RECODECAY_H_
 
 // #include <tuple>
-#include <vector>
-#include <array>
-// #include <cmath>
-// #include <utility>
+#include <vector>  // std::vector
+#include <array>   // std::array
+#include <cmath>   // std::abs, std::sqrt
+#include <utility> // std::move
 
 // #include <TDatabasePDG.h>
 // #include <TPDGCode.h>

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -17,17 +17,17 @@
 #ifndef COMMON_CORE_RECODECAY_H_
 #define COMMON_CORE_RECODECAY_H_
 
-#include <tuple>
+// #include <tuple>
 #include <vector>
 #include <array>
-#include <cmath>
-#include <utility>
+// #include <cmath>
+// #include <utility>
 
-#include <TDatabasePDG.h>
-#include <TPDGCode.h>
+// #include <TDatabasePDG.h>
+// #include <TPDGCode.h>
 
 #include "CommonConstants/MathConstants.h"
-#include "Framework/Logger.h"
+// #include "Framework/Logger.h"
 
 /// Base class for calculating properties of reconstructed decays
 ///

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "FemtoDreamObjectSelection.h"
 #include "FemtoDreamSelection.h"

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include <TDatabasePDG.h>
+
 #include "FemtoDreamObjectSelection.h"
 #include "FemtoDreamSelection.h"
 #include "FemtoDreamTrackSelection.h"
@@ -555,7 +557,7 @@ std::array<cutContainerType, 5>
   cutContainerType output = 0;
   size_t counter = 0;
 
-  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass(); // FIXME: Get from the common header
   auto lambdaMassHypothesis = v0.mLambda();
   auto antiLambdaMassHypothesis = v0.mAntiLambda();
   auto diffLambda = abs(lambdaMassNominal - lambdaMassHypothesis);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseSelection.h"

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include <TDatabasePDG.h>
+
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
@@ -533,7 +535,7 @@ std::array<cutContainerType, 5>
   cutContainerType output = 0;
   size_t counter = 0;
 
-  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass(); // FIXME: Get from the common header
   auto lambdaMassHypothesis = phi.mLambda();
   auto antiLambdaMassHypothesis = phi.mAntiLambda();
   auto diffLambda = abs(lambdaMassNominal - lambdaMassHypothesis);
@@ -623,8 +625,8 @@ void FemtoUniversePhiSelection::fillQA(C const& col, V const& phi, T const& posT
   if (mHistogramRegistry) {
     TLorentzVector part1Vec;
     TLorentzVector part2Vec;
-    float mMassOne = TDatabasePDG::Instance()->GetParticle(321)->Mass();
-    float mMassTwo = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+    float mMassOne = TDatabasePDG::Instance()->GetParticle(321)->Mass(); // FIXME: Get from the common header
+    float mMassTwo = TDatabasePDG::Instance()->GetParticle(321)->Mass(); // FIXME: Get from the common header
 
     part1Vec.SetPtEtaPhiM(posTrack.pt(), posTrack.eta(), posTrack.phi(), mMassOne);
     part2Vec.SetPtEtaPhiM(negTrack.pt(), negTrack.eta(), negTrack.phi(), mMassTwo);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include <TDatabasePDG.h>
+
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
@@ -555,7 +557,7 @@ std::array<cutContainerType, 5>
   cutContainerType output = 0;
   size_t counter = 0;
 
-  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass();
+  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass(); // FIXME: Get from the common header
   auto lambdaMassHypothesis = v0.mLambda();
   auto antiLambdaMassHypothesis = v0.mAntiLambda();
   auto diffLambda = abs(lambdaMassNominal - lambdaMassHypothesis);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseObjectSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseSelection.h"

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -15,7 +15,7 @@
 /// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
 /// \author Malgorzata Janik, WUT Warsaw, majanik@cern.ch
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include <CCDB/BasicCCDBManager.h>
 #include "Common/Core/trackUtilities.h"

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -15,6 +15,8 @@
 /// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
 /// \author Malgorzata Janik, WUT Warsaw, majanik@cern.ch
 
+#include <TDatabasePDG.h>
+
 #include <CCDB/BasicCCDBManager.h>
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/EventSelection.h"
@@ -697,8 +699,8 @@ struct femtoUniverseProducerTask {
       TLorentzVector part1Vec;
       TLorentzVector part2Vec;
 
-      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPhiChildOne.ConfPDGCodePartOne)->Mass();
-      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPhiChildTwo.ConfPDGCodePartTwo)->Mass();
+      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPhiChildOne.ConfPDGCodePartOne)->Mass(); // FIXME: Get from the PDG service of the common header
+      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPhiChildTwo.ConfPDGCodePartTwo)->Mass(); // FIXME: Get from the PDG service of the common header
 
       part1Vec.SetPtEtaPhiM(p1.pt(), p1.eta(), p1.phi(), mMassOne);
       part2Vec.SetPtEtaPhiM(p2.pt(), p2.eta(), p2.phi(), mMassTwo);

--- a/PWGCF/FemtoWorld/Core/FemtoWorldPhiSelection.h
+++ b/PWGCF/FemtoWorld/Core/FemtoWorldPhiSelection.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "PWGCF/FemtoWorld/Core/FemtoWorldObjectSelection.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldTrackSelection.h"

--- a/PWGCF/FemtoWorld/Core/FemtoWorldPhiSelection.h
+++ b/PWGCF/FemtoWorld/Core/FemtoWorldPhiSelection.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include <TDatabasePDG.h>
+
 #include "PWGCF/FemtoWorld/Core/FemtoWorldObjectSelection.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldTrackSelection.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldSelection.h"
@@ -528,7 +530,7 @@ std::array<cutContainerType, 5> FemtoWorldPhiSelection::getCutContainer(C const&
   cutContainerType output = 0;
   size_t counter = 0;
 
-  // auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+  // auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(321)->Mass(); // FIXME: Get from the common header
   // auto lambdaMassHypothesis = v0.mPhi();
   // auto antiPhiMassHypothesis = v0.mAntiPhi();
   // auto diffPhi = abs(lambdaMassNominal - lambdaMassHypothesis);
@@ -557,8 +559,8 @@ std::array<cutContainerType, 5> FemtoWorldPhiSelection::getCutContainer(C const&
   TLorentzVector part2Vec;
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 321, "Particle 1 - PDG code"};
   Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 321, "Particle 2 - PDG code"};
-  float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass();
-  float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass();
+  float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass(); // FIXME: Get from the PDG service of the common header
+  float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass(); // FIXME: Get from the PDG service of the common header
   part1Vec.SetPtEtaPhiM(posTrack.pt(), posTrack.eta(), posTrack.phi(), mMassOne);
   part2Vec.SetPtEtaPhiM(negTrack.pt(), negTrack.eta(), negTrack.phi(), mMassTwo);
 
@@ -619,8 +621,8 @@ void FemtoWorldPhiSelection::fillQA(C const& col, V const& v0, T const& posTrack
     TLorentzVector part2Vec;
     Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 321, "Particle 1 - PDG code"};
     Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 321, "Particle 2 - PDG code"};
-    float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass();
-    float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass();
+    float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass(); // FIXME: Get from the PDG service of the common header
+    float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass(); // FIXME: Get from the PDG service of the common header
     part1Vec.SetPtEtaPhiM(posTrack.pt(), posTrack.eta(), posTrack.phi(), mMassOne);
     part2Vec.SetPtEtaPhiM(negTrack.pt(), negTrack.eta(), negTrack.phi(), mMassTwo);
 

--- a/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
+++ b/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
@@ -14,7 +14,7 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 /// \author Zuzanna Chochulska, WUT Warsaw, zchochul@cern.ch
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "CCDB/BasicCCDBManager.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldCollisionSelection.h"

--- a/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
+++ b/PWGCF/FemtoWorld/TableProducer/femtoWorldProducerTask.cxx
@@ -14,6 +14,8 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 /// \author Zuzanna Chochulska, WUT Warsaw, zchochul@cern.ch
 
+#include <TDatabasePDG.h>
+
 #include "CCDB/BasicCCDBManager.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldCollisionSelection.h"
 #include "PWGCF/FemtoWorld/Core/FemtoWorldTrackSelection.h"
@@ -843,8 +845,8 @@ struct femtoWorldProducerTask {
 
       TLorentzVector part1Vec;
       TLorentzVector part2Vec;
-      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass();
-      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass();
+      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass(); // FIXME: Get from the PDG service of the common header
+      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass(); // FIXME: Get from the PDG service of the common header
 
       part1Vec.SetPtEtaPhiM(p1.pt(), p1.eta(), p1.phi(), mMassOne);
       part2Vec.SetPtEtaPhiM(p2.pt(), p2.eta(), p2.phi(), mMassTwo);
@@ -1803,8 +1805,8 @@ struct femtoWorldProducerTask {
 
       TLorentzVector part1Vec;
       TLorentzVector part2Vec;
-      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass();
-      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass();
+      float mMassOne = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartOne)->Mass(); // FIXME: Get from the PDG service of the common header
+      float mMassTwo = TDatabasePDG::Instance()->GetParticle(ConfPDGCodePartTwo)->Mass(); // FIXME: Get from the PDG service of the common header
 
       part1Vec.SetPtEtaPhiM(p1.pt(), p1.eta(), p1.phi(), mMassOne);
       part2Vec.SetPtEtaPhiM(p2.pt(), p2.eta(), p2.phi(), mMassTwo);

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -26,6 +26,8 @@
 #include <KFPVertex.h>
 #include <KFVertex.h>
 
+#include <TPDGCode.h>
+
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -15,6 +15,8 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 
+#include <TPDGCode.h>
+
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -15,6 +15,8 @@
 /// \author Chiara Zampolli, <Chiara.Zampolli@cern.ch>, CERN
 ///         Paul Buehler, <paul.buehler@oeaw.ac.at>, Vienna
 
+#include <TPDGCode.h>
+
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"

--- a/PWGLF/TableProducer/f1protonreducedtable.cxx
+++ b/PWGLF/TableProducer/f1protonreducedtable.cxx
@@ -19,6 +19,9 @@
 #include <Math/Vector4D.h>
 #include <TMath.h>
 #include <fairlogger/Logger.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
+
 #include <iostream>
 #include <iterator>
 #include <string>
@@ -323,7 +326,7 @@ struct f1protonreducedtable {
     const float dcaDaughv0 = candidate.dcaV0daughters();
     const float cpav0 = candidate.v0cosPA(collision.posX(), collision.posY(), collision.posZ());
 
-    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass();
+    float CtauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass(); // FIXME: Get from the common header
     float lowmasscutks0 = 0.497 - 2.0 * cSigmaMassKs0;
     float highmasscutks0 = 0.497 + 2.0 * cSigmaMassKs0;
 
@@ -450,10 +453,10 @@ struct f1protonreducedtable {
 
   std::vector<double> BBProton, BBAntiproton, BBPion, BBAntipion, BBKaon, BBAntikaon;
   ROOT::Math::PtEtaPhiMVector F1Vector, F1VectorDummy, KKs0Vector, ProtonVectorDummy, ProtonVectorDummy2;
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();
-  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass();
-  double massK0s = TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass();
+  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass(); // FIXME: Get from the common header
+  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass(); // FIXME: Get from the common header
+  double massK0s = TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass(); // FIXME: Get from the common header
 
   double massF1{0.};
   double masskKs0{0.};

--- a/PWGLF/TableProducer/f1protonreducedtable.cxx
+++ b/PWGLF/TableProducer/f1protonreducedtable.cxx
@@ -20,7 +20,7 @@
 #include <TMath.h>
 #include <fairlogger/Logger.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 
 #include <iostream>
 #include <iterator>
@@ -453,9 +453,9 @@ struct f1protonreducedtable {
 
   std::vector<double> BBProton, BBAntiproton, BBPion, BBAntipion, BBKaon, BBAntikaon;
   ROOT::Math::PtEtaPhiMVector F1Vector, F1VectorDummy, KKs0Vector, ProtonVectorDummy, ProtonVectorDummy2;
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass(); // FIXME: Get from the common header
-  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass(); // FIXME: Get from the common header
+  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();   // FIXME: Get from the common header
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();    // FIXME: Get from the common header
+  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass();   // FIXME: Get from the common header
   double massK0s = TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass(); // FIXME: Get from the common header
 
   double massF1{0.};

--- a/PWGLF/Tasks/f0980analysis.cxx
+++ b/PWGLF/Tasks/f0980analysis.cxx
@@ -13,7 +13,7 @@
 
 #include <TLorentzVector.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 #include "TVector2.h"
 
 #include "Common/DataModel/Centrality.h"

--- a/PWGLF/Tasks/f0980analysis.cxx
+++ b/PWGLF/Tasks/f0980analysis.cxx
@@ -12,6 +12,8 @@
 /// \author Junlee Kim (jikim1290@gmail.com)
 
 #include <TLorentzVector.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
 #include "TVector2.h"
 
 #include "Common/DataModel/Centrality.h"
@@ -117,7 +119,7 @@ struct f0980analysis {
     histos.print();
   }
 
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();
+  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
 
   int RTIndex(double pairphi, double lhphi)
   {

--- a/PWGLF/Tasks/k1analysis.cxx
+++ b/PWGLF/Tasks/k1analysis.cxx
@@ -16,6 +16,8 @@
 /// \author Bong-Hwi Lim <bong-hwi.lim@cern.ch>
 
 #include <TLorentzVector.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -172,9 +174,9 @@ struct k1analysis {
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();
-  double massK892 = TDatabasePDG::Instance()->GetParticle(313)->Mass();
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();// FIXME: Get from the common header
+  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
+  double massK892 = TDatabasePDG::Instance()->GetParticle(313)->Mass(); // FIXME: Get from the common header
 
   template <typename TrackType>
   bool trackCut(const TrackType track)

--- a/PWGLF/Tasks/k1analysis.cxx
+++ b/PWGLF/Tasks/k1analysis.cxx
@@ -17,7 +17,7 @@
 
 #include <TLorentzVector.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -174,9 +174,9 @@ struct k1analysis {
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();// FIXME: Get from the common header
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();  // FIXME: Get from the common header
   double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
-  double massK892 = TDatabasePDG::Instance()->GetParticle(313)->Mass(); // FIXME: Get from the common header
+  double massK892 = TDatabasePDG::Instance()->GetParticle(313)->Mass();   // FIXME: Get from the common header
 
   template <typename TrackType>
   bool trackCut(const TrackType track)

--- a/PWGLF/Tasks/k892analysis.cxx
+++ b/PWGLF/Tasks/k892analysis.cxx
@@ -16,6 +16,8 @@
 /// \author Bong-Hwi Lim <bong-hwi.lim@cern.ch>, Sawan Sawan <sawan.sawan@cern.ch>
 
 #include <TLorentzVector.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -146,8 +148,8 @@ struct k892analysis {
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass();
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass(); // FIXME: Get from the common header
+  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
 
   template <typename TrackType>
   bool trackCut(const TrackType track)

--- a/PWGLF/Tasks/k892analysis.cxx
+++ b/PWGLF/Tasks/k892analysis.cxx
@@ -17,7 +17,7 @@
 
 #include <TLorentzVector.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -148,7 +148,7 @@ struct k892analysis {
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass(); // FIXME: Get from the common header
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();  // FIXME: Get from the common header
   double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
 
   template <typename TrackType>

--- a/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
+++ b/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
@@ -17,6 +17,7 @@
 
 #include <TLorentzVector.h>
 #include <TRandom.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -31,8 +32,8 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 // PDG p -> 2212, K -> 321
-const float massProton = TDatabasePDG::Instance()->GetParticle(2212)->Mass();
-const float massKaon = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+const float massProton = TDatabasePDG::Instance()->GetParticle(2212)->Mass(); // FIXME: Get from the common header
+const float massKaon = TDatabasePDG::Instance()->GetParticle(321)->Mass(); // FIXME: Get from the common header
 
 struct lambdaAnalysis {
 

--- a/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
+++ b/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
@@ -33,7 +33,7 @@ using namespace o2::framework::expressions;
 
 // PDG p -> 2212, K -> 321
 const float massProton = TDatabasePDG::Instance()->GetParticle(2212)->Mass(); // FIXME: Get from the common header
-const float massKaon = TDatabasePDG::Instance()->GetParticle(321)->Mass(); // FIXME: Get from the common header
+const float massKaon = TDatabasePDG::Instance()->GetParticle(321)->Mass();    // FIXME: Get from the common header
 
 struct lambdaAnalysis {
 

--- a/PWGLF/Tasks/lambda1520analysis.cxx
+++ b/PWGLF/Tasks/lambda1520analysis.cxx
@@ -14,6 +14,8 @@
 /// \author Hirak Kumar Koley <hirak.koley@cern.ch>
 
 #include <TLorentzVector.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "PWGLF/DataModel/LFResonanceTables.h"
@@ -202,8 +204,8 @@ struct lambda1520analysis {
     }
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKMinus)->Mass();
-  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass();
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKMinus)->Mass(); // FIXME: Get from the common header
+  double massPr = TDatabasePDG::Instance()->GetParticle(kProton)->Mass(); // FIXME: Get from the common header
 
   template <typename TrackType>
   bool trackCut(const TrackType track)

--- a/PWGLF/Tasks/lambda1520analysis.cxx
+++ b/PWGLF/Tasks/lambda1520analysis.cxx
@@ -15,7 +15,7 @@
 
 #include <TLorentzVector.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "PWGLF/DataModel/LFResonanceTables.h"

--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -16,6 +16,8 @@
 /// \author Bong-Hwi Lim <bong-hwi.lim@cern.ch>
 
 #include <TLorentzVector.h>
+#include <TDatabasePDG.h> // FIXME
+#include <TPDGCode.h> // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -121,7 +123,7 @@ struct phianalysis {
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();
+  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass(); // FIXME: Get from the common header
 
   template <typename TrackType>
   bool trackCut(const TrackType track)

--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -17,7 +17,7 @@
 
 #include <TLorentzVector.h>
 #include <TDatabasePDG.h> // FIXME
-#include <TPDGCode.h> // FIXME
+#include <TPDGCode.h>     // FIXME
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"

--- a/PWGLF/Tasks/rhoanalysis.cxx
+++ b/PWGLF/Tasks/rhoanalysis.cxx
@@ -19,6 +19,8 @@
 #include <iostream>
 #include <tuple>
 
+#include <TPDGCode.h>
+
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/DataProcessorSpec.h"

--- a/Tools/KFparticle/KFUtilities.h
+++ b/Tools/KFparticle/KFUtilities.h
@@ -21,6 +21,8 @@
 #define HomogeneousField
 #endif
 
+#include <TDatabasePDG.h>
+
 #include "KFParticle.h"
 #include "KFPTrack.h"
 #include "KFPVertex.h"
@@ -169,9 +171,9 @@ float cosThetaStarFromKF(int ip, int pdgvtx, int pdgprong0, int pdgprong1, KFPar
   py1 = kfpprong1.GetPy();
   pz1 = kfpprong1.GetPz();
   std::array<double, 2> m = {0., 0.};
-  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass();
-  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass();
-  double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass();
+  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass(); // FIXME: Use service of header
+  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass(); // FIXME: Use service of header
+  double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass(); // FIXME: Use service of header
   int iProng = ip;
 
   float cosThetastar = RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng);

--- a/Tools/KFparticle/KFUtilities.h
+++ b/Tools/KFparticle/KFUtilities.h
@@ -21,7 +21,7 @@
 #define HomogeneousField
 #endif
 
-#include <TDatabasePDG.h>
+#include <TDatabasePDG.h> // FIXME
 
 #include "KFParticle.h"
 #include "KFPTrack.h"
@@ -171,9 +171,9 @@ float cosThetaStarFromKF(int ip, int pdgvtx, int pdgprong0, int pdgprong1, KFPar
   py1 = kfpprong1.GetPy();
   pz1 = kfpprong1.GetPz();
   std::array<double, 2> m = {0., 0.};
-  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass(); // FIXME: Use service of header
-  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass(); // FIXME: Use service of header
-  double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass(); // FIXME: Use service of header
+  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass(); // FIXME: Get from the PDG service of the common header
+  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass(); // FIXME: Get from the PDG service of the common header
+  double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass(); // FIXME: Get from the PDG service of the common header
   int iProng = ip;
 
   float cosThetastar = RecoDecay::cosThetaStar(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}}, m, mTot, iProng);

--- a/Tools/KFparticle/KFUtilities.h
+++ b/Tools/KFparticle/KFUtilities.h
@@ -171,8 +171,8 @@ float cosThetaStarFromKF(int ip, int pdgvtx, int pdgprong0, int pdgprong1, KFPar
   py1 = kfpprong1.GetPy();
   pz1 = kfpprong1.GetPz();
   std::array<double, 2> m = {0., 0.};
-  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass(); // FIXME: Get from the PDG service of the common header
-  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass(); // FIXME: Get from the PDG service of the common header
+  m[0] = TDatabasePDG::Instance()->GetParticle(pdgprong0)->Mass();     // FIXME: Get from the PDG service of the common header
+  m[1] = TDatabasePDG::Instance()->GetParticle(pdgprong1)->Mass();     // FIXME: Get from the PDG service of the common header
   double mTot = TDatabasePDG::Instance()->GetParticle(pdgvtx)->Mass(); // FIXME: Get from the PDG service of the common header
   int iProng = ip;
 

--- a/Tutorials/PWGLF/Resonance/resonances_step1.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step1.cxx
@@ -14,6 +14,7 @@
 /// \since 23/04/2023
 
 #include <TLorentzVector.h>
+#include <TPDGCode.h>
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"


### PR DESCRIPTION
This is the last step of the `RecoDecay` part of the ongoing effort to optimise memory consumption and to unify the location from where we pick the PDG masses. The ultimate goal is to get the masses from [`CommonConstants/PhysicsConstants.h`](https://github.com/AliceO2Group/AliceO2/blob/dev/Common/Constants/include/CommonConstants/PhysicsConstants.h) (when the PDG code is known at compile time) or from the `O2DatabasePDG` service (otherwise).

See details in the dedicated issue: https://github.com/AliceO2Group/O2Physics/issues/2178

**Notes for code owners and developers:**

- Several files across O2Physics have been affected by the removal of the dependency of `RecoDecay` on `TDatabasePDG.h` and `TPDGCode.h` because they implicitly relied on it. This can be avoided if each file **explicitly** includes the headers for the things it **explicitly** needs (in this case `TDatabasePDG::Instance()` and the named PDG codes). It's a reminder for me that we should all try to pay attention to these details when writing and reviewing the code.
- I have added `FIXME` comments on the lines which should be modified in line with the aforementioned unification goal. Calling `TDatabasePDG::Instance()` each time a mass is requested causes a sizeable and unnecessary overhead in CPU and memory which can be avoided.
