### PR TITLE
PWGHF: Fix D* finding

### DIFF
--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1903,7 +1903,7 @@ struct HfTrackIndexSkimCreator {
                 }
               }
             } else {
-              isSelected2ProngCand = 0; // reset to 0 not to use the D9 to build a D* meson
+              isSelected2ProngCand = 0; // reset to 0 not to use the D0 to build a D* meson
             }
           } else {
             isSelected2ProngCand = 0; // reset to 0 not to use the D9 to build a D* meson

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1753,6 +1753,10 @@ struct HfTrackIndexSkimCreator {
             }
           }
 
+          // initialise PV refit coordinates and cov matrix for 2-prongs already here for D*
+          std::array<float, 3> pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+          std::array<float, 6> pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+
           // 2-prong vertex reconstruction
           if (sel2ProngStatusPos && sel2ProngStatusNeg) {
 
@@ -1771,8 +1775,6 @@ struct HfTrackIndexSkimCreator {
               df2.getTrack(1).getPxPyPzGlo(pvec1);
 
               /// PV refit excluding the candidate daughters, if contributors
-              std::array<float, 3> pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              std::array<float, 6> pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -1946,12 +1948,17 @@ struct HfTrackIndexSkimCreator {
                     if (fillHistograms) {
                       registry.fill(HIST("hMassDstarToD0Pi"), deltaMass);
                     }
+                    if constexpr (doPvRefit) {
+                      // fill table row with coordinates of PV refit (same as 2-prong because we do not remove the soft pion)
+                      rowDstarPVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
+                                      pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+                    }
                   }
                   if (debug) {
                     rowDstarCutStatus(cutStatus);
                   }
                 }
-              }
+              } // end of D*
 
               // preselection of 3-prong candidates
               if (doDstar && counterTrackPos2 < counterTrackPos1 + 1) { // we avoid duplication for 3-prongs
@@ -1981,8 +1988,8 @@ struct HfTrackIndexSkimCreator {
                 isSelected3ProngCand = 0;
               }
 
-              // if we did not preselected any D* or 3-prong candidate, continue
-              if (!debug && (isSelectedDstar == 0 && isSelected3ProngCand == 0)) {
+              // if we did not preselected any 3-prong candidate, continue
+              if (!debug && isSelected3ProngCand == 0) {
                 continue;
               }
 
@@ -2073,11 +2080,7 @@ struct HfTrackIndexSkimCreator {
                     LOG(info) << "####### [3 prong] nCandContr==" << nCandContr << " ---> some of the candidate daughters did not contribute to the original PV fit, PV refit not redone";
                   }
                 }
-                if (isSelectedDstar) {
-                  rowDstarPVrefit(pvRefitCoord3Prong2Pos1Neg[0], pvRefitCoord3Prong2Pos1Neg[1], pvRefitCoord3Prong2Pos1Neg[2],
-                                  pvRefitCovMatrix3Prong2Pos1Neg[0], pvRefitCovMatrix3Prong2Pos1Neg[1], pvRefitCovMatrix3Prong2Pos1Neg[2], pvRefitCovMatrix3Prong2Pos1Neg[3], pvRefitCovMatrix3Prong2Pos1Neg[4], pvRefitCovMatrix3Prong2Pos1Neg[5]);
-                }
-              } // end of D*
+              }
 
               if (!debug && isSelected3ProngCand == 0) { // below only for 3-prong candidates
                 continue;
@@ -2203,12 +2206,17 @@ struct HfTrackIndexSkimCreator {
                     if (fillHistograms) {
                       registry.fill(HIST("hMassDstarToD0Pi"), deltaMass);
                     }
+                    if constexpr (doPvRefit) {
+                      // fill table row with coordinates of PV refit (same as 2-prong because we do not remove the soft pion)
+                      rowDstarPVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
+                                      pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+                    }
                   }
                   if (debug) {
                     rowDstarCutStatus(cutStatus);
                   }
                 }
-              }
+              } // end of D*
 
               // preselection of 3-prong candidates
               if (doDstar && counterTrackNeg2 < counterTrackNeg1 + 1) { // we avoid duplication for 3-prongs
@@ -2239,7 +2247,7 @@ struct HfTrackIndexSkimCreator {
               }
 
               // if we did not preselected any D* or 3-prong candidate, continue
-              if (!debug && (isSelectedDstar == 0 && isSelected3ProngCand == 0)) {
+              if (!debug && isSelected3ProngCand == 0) {
                 continue;
               }
 
@@ -2330,14 +2338,6 @@ struct HfTrackIndexSkimCreator {
                     LOG(info) << "####### [3 prong] nCandContr==" << nCandContr << " ---> some of the candidate daughters did not contribute to the original PV fit, PV refit not redone";
                   }
                 }
-                if (isSelectedDstar) {
-                  rowDstarPVrefit(pvRefitCoord3Prong1Pos2Neg[0], pvRefitCoord3Prong1Pos2Neg[1], pvRefitCoord3Prong1Pos2Neg[2],
-                                  pvRefitCovMatrix3Prong1Pos2Neg[0], pvRefitCovMatrix3Prong1Pos2Neg[1], pvRefitCovMatrix3Prong1Pos2Neg[2], pvRefitCovMatrix3Prong1Pos2Neg[3], pvRefitCovMatrix3Prong1Pos2Neg[4], pvRefitCovMatrix3Prong1Pos2Neg[5]);
-                }
-              } // end of D*
-
-              if (!debug && isSelected3ProngCand == 0) { // below only for 3-prong candidates
-                continue;
               }
 
               // reconstruct the 3-prong secondary vertex

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2082,10 +2082,6 @@ struct HfTrackIndexSkimCreator {
                 }
               }
 
-              if (!debug && isSelected3ProngCand == 0) { // below only for 3-prong candidates
-                continue;
-              }
-
               // reconstruct the 3-prong secondary vertex
               if (df3.process(trackParVarPos1, trackParVarNeg1, trackParVarPos2) == 0) {
                 continue;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1906,7 +1906,7 @@ struct HfTrackIndexSkimCreator {
               isSelected2ProngCand = 0; // reset to 0 not to use the D0 to build a D* meson
             }
           } else {
-            isSelected2ProngCand = 0; // reset to 0 not to use the D9 to build a D* meson
+            isSelected2ProngCand = 0; // reset to 0 not to use the D0 to build a D* meson
           }
 
           // 3-prong vertex and D* reconstruction


### PR DESCRIPTION
Investigating a crash reported by @deependra170598 in the D* creator under development (see PR https://github.com/AliceO2Group/O2Physics/pull/3567), I fixed 3 bugs in the finding of D* mesons:
1) The selection flag of D0 mesons not selected because of track selections was not reset to 0, causing the creation of D* candidates associated to no D0 mesons or the previous last one (@deependra170598 this was the bug causing the crash in your code).
2) Only half of the D* candidates were found because in the 3-prong loops were triangular, however `(trackPos1 trackNeg1)_2prong trackPos2` is not equivalent to `(trackPos2 trackNeg1)_2prong trackPos1` for D* mesons because the pion from D0 and the soft pion are not exchangeable (while they are for 3-prong candidates). 
3) The D* table was filled with last 2-prong table index, however if J/psi mesons are enabled, it could not be the correct one.

I tested the new code on pp MC sample and I verified that
1) the modifications in this PR do not influence the 2-prong and 3-prong creation (while for D* mesons more signal and less background candidates are found)

<img width="1343" alt="image" src="https://github.com/AliceO2Group/O2Physics/assets/19532765/24eb83d5-1130-421c-aa3b-191f31fbee1a">

2) he impact on the CPU time is not dramatic

- before fix

<img width="1372" alt="image" src="https://github.com/AliceO2Group/O2Physics/assets/19532765/21819799-ad59-4072-8130-17b76654ab5f">

- after fix

<img width="1369" alt="image" src="https://github.com/AliceO2Group/O2Physics/assets/19532765/44ea89a4-c813-461f-b193-2853e159786a">

Finally, I also modified the PVrefit for D* meson candidates in order not to remove the soft pion (as done in Run2).