### PR TITLE
[PWGJE] Fixing jetTrackDerived (table producer for track QA)

### DIFF
--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -97,11 +97,11 @@ DECLARE_SOA_COLUMN(Snp, snp, float);
 DECLARE_SOA_COLUMN(Tgl, tgl, float);
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
 DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool); //! Has or not the TRD match
-//DECLARE_SOA_DYNAMIC_COLUMN(TrackType, trackType, [](float v) -> uint8_t { return o2::aod::track::TrackTypeEnum::Track; });
+// DECLARE_SOA_DYNAMIC_COLUMN(TrackType, trackType, [](float v) -> uint8_t { return o2::aod::track::TrackTypeEnum::Track; });
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);                         // if a track passed the isGlobalTrackWoDCA requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // if a track passed the isGlobalTrackWoDCA requirement
-DECLARE_SOA_COLUMN(Flags, flags, uint32_t);          // Dummy
+DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                               // Dummy
 DECLARE_SOA_COLUMN(Length, length, float);
 DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);
 DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float);
@@ -119,7 +119,7 @@ DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls,
 DECLARE_SOA_COLUMN(TPCFoundOverFindableCls, tpcFoundOverFindableCls, float);
 DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
 DECLARE_SOA_COLUMN(DCAxy, dcaXY, float); //! Stored binned dcaxy
-DECLARE_SOA_COLUMN(DCAz, dcaZ, float); //! Stored binned dcaxy
+DECLARE_SOA_COLUMN(DCAz, dcaZ, float);   //! Stored binned dcaxy
 
 } // namespace jetspectra
 
@@ -151,7 +151,7 @@ DECLARE_SOA_TABLE(JeTracks, "AOD", "JETRACKS",
                   jetspectra::IsGlobalTrack,
                   jetspectra::IsGlobalTrackWoDCA,
                   jetspectra::IsGlobalTrackWoPtEta,
-                  jetspectra::Flags,//jetspectra:: ?
+                  jetspectra::Flags, // jetspectra:: ?
                   jetspectra::Length,
                   jetspectra::TPCChi2NCl, jetspectra::ITSChi2NCl, track::TOFChi2,
                   jetspectra::TPCNClsShared,

--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -65,7 +65,7 @@ DECLARE_SOA_COLUMN(Z, z, float);
 DECLARE_SOA_COLUMN(Snp, snp, float);
 DECLARE_SOA_COLUMN(Tgl, tgl, float);
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
-DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool); //! Has or not the TRD match
+DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool);                   //! Has or not the TRD match
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);                         // if a track passed the isGlobalTrackWoDCA requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // all tracks in the derived table have to pass this requirement !
@@ -87,7 +87,7 @@ DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls,
 DECLARE_SOA_COLUMN(TPCFoundOverFindableCls, tpcFoundOverFindableCls, float);
 DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
 DECLARE_SOA_COLUMN(DCAxy, dcaXY, float);
-DECLARE_SOA_COLUMN(DCAz, dcaZ, float); 
+DECLARE_SOA_COLUMN(DCAz, dcaZ, float);
 
 } // namespace jetspectra
 

--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -82,49 +82,26 @@ DECLARE_SOA_COLUMN(MultNTracksPV, multNTracksPV, int);
 DECLARE_SOA_COLUMN(MultTracklets, multTracklets, int);
 DECLARE_SOA_COLUMN(MultFT0M, multFT0M, float);
 DECLARE_SOA_COLUMN(CentFT0M, centFT0M, float);
-//  Track info
+// Track info
 DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Index to the collision
 DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float); //! Pt (signed) of the track
 DECLARE_SOA_COLUMN(Eta, eta, float);            //! Eta of the track
 DECLARE_SOA_COLUMN(Phi, phi, float);            //! Phi of the track
+DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(Sigma1Pt, sigma1Pt, float);
 DECLARE_SOA_COLUMN(Alpha, alpha, float);
 DECLARE_SOA_COLUMN(X, x, float);
 DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);
-DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(Snp, snp, float);
 DECLARE_SOA_COLUMN(Tgl, tgl, float);
-// DECLARE_SOA_COLUMN(EvTimeT0AC, evTimeT0AC, float);                               //! Event time of the track computed with the T0AC
-// DECLARE_SOA_COLUMN(EvTimeT0ACErr, evTimeT0ACErr, float);                         //! Resolution of the event time of the track computed with the T0AC
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
 DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool); //! Has or not the TRD match
-
-DECLARE_SOA_COLUMN(DCAxyStore, dcaxyStore, binningDCA::binned_t); //! Stored binned dcaxy
-DECLARE_SOA_COLUMN(DCAzStore, dcazStore, binningDCA::binned_t);   //! Stored binned dcaz
-DECLARE_SOA_DYNAMIC_COLUMN(DCAxy, dcaXY,                          //! Unpacked dcaxy
-                           [](binningDCA::binned_t binned) -> float { return unPack<binningDCA>(binned); });
-DECLARE_SOA_DYNAMIC_COLUMN(DCAz, dcaZ, //! Unpacked dcaz
-                           [](binningDCA::binned_t binned) -> float { return unPack<binningDCA>(binned); });
-// DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! Absolute value of signed pT
-//                            [](float signedPt) -> float { return std::abs(signedPt); });
-DECLARE_SOA_DYNAMIC_COLUMN(P, p, [](float signed1pt, float eta) -> float { return std::abs(signed1pt) * cosh(eta); });
-DECLARE_SOA_DYNAMIC_COLUMN(TrackType, trackType, [](float v) -> uint8_t { return o2::aod::track::TrackTypeEnum::Track; });
+//DECLARE_SOA_DYNAMIC_COLUMN(TrackType, trackType, [](float v) -> uint8_t { return o2::aod::track::TrackTypeEnum::Track; });
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);                         // if a track passed the isGlobalTrackWoDCA requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // if a track passed the isGlobalTrackWoDCA requirement
-DECLARE_SOA_DYNAMIC_COLUMN(Flags, flags, [](float v) -> uint32_t { return 0; });          // Dummy
-DECLARE_SOA_DYNAMIC_COLUMN(Rapidity, rapidity,                                            //! Track rapidity, computed under the mass assumption given as input
-                           [](float signed1Pt, float eta, float mass) -> float {
-                             const auto pt = std::abs(signed1Pt);
-                             const auto p = std::abs(signed1Pt) * cosh(eta);
-                             const auto pz = std::sqrt(p * p - pt * pt);
-                             const auto energy = sqrt(p * p + mass * mass);
-                             return 0.5f * log((energy + pz) / (energy - pz));
-                           });
-DECLARE_SOA_DYNAMIC_COLUMN(IsQualityTrackITS, isQualityTrackITS, [](float v) -> bool { return false; }); // Dummy
-DECLARE_SOA_DYNAMIC_COLUMN(IsQualityTrackTPC, isQualityTrackTPC, [](float v) -> bool { return false; }); // Dummy
-
+DECLARE_SOA_COLUMN(Flags, flags, uint32_t);          // Dummy
 DECLARE_SOA_COLUMN(Length, length, float);
 DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);
 DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float);
@@ -134,13 +111,15 @@ DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, int);
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int);
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int);
 DECLARE_SOA_COLUMN(ITSNCls, itsNCls, int);
-DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
 DECLARE_SOA_COLUMN(TPCFractionSharedCls, tpcFractionSharedCls, float);
 DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, int);
 DECLARE_SOA_COLUMN(TPCNClsFound, tpcNClsFound, int);
 DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, int);
 DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls, float);
 DECLARE_SOA_COLUMN(TPCFoundOverFindableCls, tpcFoundOverFindableCls, float);
+DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
+DECLARE_SOA_COLUMN(DCAxy, dcaXY, float); //! Stored binned dcaxy
+DECLARE_SOA_COLUMN(DCAz, dcaZ, float); //! Stored binned dcaxy
 
 } // namespace jetspectra
 
@@ -164,28 +143,15 @@ DECLARE_SOA_TABLE(JeTracks, "AOD", "JETRACKS",
                   jetspectra::Signed1Pt, jetspectra::Eta, jetspectra::Phi, jetspectra::Pt,
                   jetspectra::Sigma1Pt,
                   jetspectra::Alpha,
-                  jetspectra::X,
-                  jetspectra::Y,
-                  jetspectra::Z,
+                  jetspectra::X, jetspectra::Y, jetspectra::Z,
                   jetspectra::Snp,
                   jetspectra::Tgl,
                   jetspectra::IsPVContributor,
                   jetspectra::HasTRD,
-                  jetspectra::DCAxyStore,
-                  jetspectra::DCAzStore,
-                  jetspectra::DCAxy<jetspectra::DCAxyStore>,
-                  jetspectra::DCAz<jetspectra::DCAzStore>,
                   jetspectra::IsGlobalTrack,
                   jetspectra::IsGlobalTrackWoDCA,
                   jetspectra::IsGlobalTrackWoPtEta,
-                  // jetspectra::Pt<jetspectra::PtSigned>,
-                  // jetspectra::P<jetspectra::PtSigned, jetspectra::Eta>,
-                  // jetspectra::Rapidity<jetspectra::PtSigned, jetspectra::Eta>,
-                  jetspectra::Flags<track::TOFChi2>,
-                  jetspectra::TrackType<track::TOFChi2>,
-                  jetspectra::IsQualityTrackITS<track::TOFChi2>,
-                  jetspectra::IsQualityTrackTPC<track::TOFChi2>,
-                  // track::Sign<jetspectra::PtSigned>,
+                  jetspectra::Flags,//jetspectra:: ?
                   jetspectra::Length,
                   jetspectra::TPCChi2NCl, jetspectra::ITSChi2NCl, track::TOFChi2,
                   jetspectra::TPCNClsShared,
@@ -194,12 +160,13 @@ DECLARE_SOA_TABLE(JeTracks, "AOD", "JETRACKS",
                   jetspectra::TPCNClsFindableMinusCrossedRows,
                   jetspectra::ITSClusterMap,
                   jetspectra::ITSNCls,
-                  jetspectra::ITSNClsInnerBarrel,
                   jetspectra::TPCFractionSharedCls,
                   jetspectra::TPCNClsFound,
                   jetspectra::TPCNClsCrossedRows,
                   jetspectra::TPCCrossedRowsOverFindableCls,
-                  jetspectra::TPCFoundOverFindableCls);
+                  jetspectra::TPCFoundOverFindableCls,
+                  jetspectra::DCAxy,
+                  jetspectra::DCAz);
 } // namespace o2::aod
 
 #endif // PWGJE_DATAMODEL_TRACKJETQA_H_

--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -37,7 +37,7 @@ using namespace o2::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-// Derived data model for cut variation
+// Derived data model for track optimization (and cut variation)
 namespace o2::aod
 {
 namespace jetspectra
@@ -53,41 +53,18 @@ DECLARE_SOA_COLUMN(MultFT0M, multFT0M, float);
 DECLARE_SOA_COLUMN(CentFT0M, centFT0M, float);
 // Track info
 DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Index to the collision
-DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float); //! Pt (signed) of the track
-DECLARE_SOA_COLUMN(Eta, eta, float);            //! Eta of the track
-DECLARE_SOA_COLUMN(Phi, phi, float);            //! Phi of the track
-DECLARE_SOA_COLUMN(Pt, pt, float);
-DECLARE_SOA_COLUMN(Sigma1Pt, sigma1Pt, float);
-DECLARE_SOA_COLUMN(Alpha, alpha, float);
-DECLARE_SOA_COLUMN(X, x, float);
-DECLARE_SOA_COLUMN(Y, y, float);
-DECLARE_SOA_COLUMN(Z, z, float);
-DECLARE_SOA_COLUMN(Snp, snp, float);
-DECLARE_SOA_COLUMN(Tgl, tgl, float);
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
 DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool);                   //! Has or not the TRD match
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);                         // if a track passed the isGlobalTrackWoDCA requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // all tracks in the derived table have to pass this requirement !
-DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                               // Dummy
-DECLARE_SOA_COLUMN(Length, length, float);
-DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);
-DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float);
-DECLARE_SOA_COLUMN(TOFChi2, tofChi2, float);
-DECLARE_SOA_COLUMN(TPCNClsShared, tpcNClsShared, int);
-DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, int);
-DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int);
-DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int);
-DECLARE_SOA_COLUMN(ITSNCls, itsNCls, int);
+DECLARE_SOA_COLUMN(ITSNCls, itsNCls, uint8_t);
 DECLARE_SOA_COLUMN(TPCFractionSharedCls, tpcFractionSharedCls, float);
-DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, int);
-DECLARE_SOA_COLUMN(TPCNClsFound, tpcNClsFound, int);
-DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, int);
+DECLARE_SOA_COLUMN(ITSClusterMap, itsClusterMap, float);
+DECLARE_SOA_COLUMN(TPCNClsFound, tpcNClsFound, int16_t);
+DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, int16_t);
 DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls, float);
 DECLARE_SOA_COLUMN(TPCFoundOverFindableCls, tpcFoundOverFindableCls, float);
-DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
-DECLARE_SOA_COLUMN(DCAxy, dcaXY, float);
-DECLARE_SOA_COLUMN(DCAz, dcaZ, float);
 
 } // namespace jetspectra
 
@@ -108,33 +85,33 @@ using JeColl = JeColls::iterator;
 DECLARE_SOA_TABLE(JeTracks, "AOD", "JETRACKS",
                   o2::soa::Index<>,
                   jetspectra::CollisionId,
-                  jetspectra::Signed1Pt, jetspectra::Eta, jetspectra::Phi, jetspectra::Pt,
-                  jetspectra::Sigma1Pt,
-                  jetspectra::Alpha,
-                  jetspectra::X, jetspectra::Y, jetspectra::Z,
-                  jetspectra::Snp,
-                  jetspectra::Tgl,
+                  track::Signed1Pt, track::Eta, track::Phi, track::Pt,
+                  track::Sigma1Pt,
+                  track::Alpha,
+                  track::X, track::Y, track::Z,
+                  track::Snp,
+                  track::Tgl,
                   jetspectra::IsPVContributor,
                   jetspectra::HasTRD,
                   jetspectra::IsGlobalTrack,
                   jetspectra::IsGlobalTrackWoDCA,
                   jetspectra::IsGlobalTrackWoPtEta,
-                  jetspectra::Flags, // jetspectra:: ?
-                  jetspectra::Length,
-                  jetspectra::TPCChi2NCl, jetspectra::ITSChi2NCl, track::TOFChi2,
-                  jetspectra::TPCNClsShared,
-                  jetspectra::TPCNClsFindable,
-                  jetspectra::TPCNClsFindableMinusFound,
-                  jetspectra::TPCNClsFindableMinusCrossedRows,
-                  jetspectra::ITSClusterMap,
+                  track::Flags,
+                  track::Length,
+                  track::TPCChi2NCl, track::ITSChi2NCl, track::TOFChi2,
+                  track::TPCNClsShared,
+                  track::TPCNClsFindable,
+                  track::TPCNClsFindableMinusFound,
+                  track::TPCNClsFindableMinusCrossedRows,
+                  track::ITSClusterMap,  
                   jetspectra::ITSNCls,
                   jetspectra::TPCFractionSharedCls,
                   jetspectra::TPCNClsFound,
                   jetspectra::TPCNClsCrossedRows,
                   jetspectra::TPCCrossedRowsOverFindableCls,
                   jetspectra::TPCFoundOverFindableCls,
-                  jetspectra::DCAxy,
-                  jetspectra::DCAz);
+                  track::DcaXY,
+                  track::DcaZ);
 } // namespace o2::aod
 
 #endif // PWGJE_DATAMODEL_TRACKJETQA_H_

--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -43,37 +43,6 @@ namespace o2::aod
 namespace jetspectra
 {
 
-template <typename binningType>
-typename binningType::binned_t packInTable(const float& valueToBin)
-{
-  if (valueToBin <= binningType::binned_min) {
-    return (binningType::underflowBin);
-  } else if (valueToBin >= binningType::binned_max) {
-    return (binningType::overflowBin);
-  } else if (valueToBin >= 0) {
-    return (static_cast<typename binningType::binned_t>((valueToBin / binningType::bin_width) + 0.5f));
-  } else {
-    return (static_cast<typename binningType::binned_t>((valueToBin / binningType::bin_width) - 0.5f));
-  }
-}
-// Function to unpack a binned value into a float
-template <typename binningType>
-float unPack(const typename binningType::binned_t& valueToUnpack)
-{
-  return binningType::bin_width * static_cast<float>(valueToUnpack);
-}
-
-struct binningDCA {
- public:
-  typedef int16_t binned_t;
-  static constexpr int nbins = (1 << 8 * sizeof(binned_t)) - 2;
-  static constexpr binned_t overflowBin = nbins >> 1;
-  static constexpr binned_t underflowBin = -(nbins >> 1);
-  static constexpr float binned_max = 6.0;
-  static constexpr float binned_min = -6.0;
-  static constexpr float bin_width = (binned_max - binned_min) / nbins;
-};
-
 // Collision info
 DECLARE_SOA_INDEX_COLUMN(BC, bc); //! Most probably BC to where this collision has occurred
 DECLARE_SOA_COLUMN(RunNumber, runNumber, int);
@@ -97,10 +66,9 @@ DECLARE_SOA_COLUMN(Snp, snp, float);
 DECLARE_SOA_COLUMN(Tgl, tgl, float);
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
 DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool); //! Has or not the TRD match
-// DECLARE_SOA_DYNAMIC_COLUMN(TrackType, trackType, [](float v) -> uint8_t { return o2::aod::track::TrackTypeEnum::Track; });
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);                         // if a track passed the isGlobalTrackWoDCA requirement
-DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // if a track passed the isGlobalTrackWoDCA requirement
+DECLARE_SOA_COLUMN(IsGlobalTrackWoPtEta, isGlobalTrackWoPtEta, bool);                     // all tracks in the derived table have to pass this requirement !
 DECLARE_SOA_COLUMN(Flags, flags, uint32_t);                                               // Dummy
 DECLARE_SOA_COLUMN(Length, length, float);
 DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);
@@ -118,8 +86,8 @@ DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, int);
 DECLARE_SOA_COLUMN(TPCCrossedRowsOverFindableCls, tpcCrossedRowsOverFindableCls, float);
 DECLARE_SOA_COLUMN(TPCFoundOverFindableCls, tpcFoundOverFindableCls, float);
 DECLARE_SOA_COLUMN(ITSNClsInnerBarrel, itsNClsInnerBarrel, int);
-DECLARE_SOA_COLUMN(DCAxy, dcaXY, float); //! Stored binned dcaxy
-DECLARE_SOA_COLUMN(DCAz, dcaZ, float);   //! Stored binned dcaxy
+DECLARE_SOA_COLUMN(DCAxy, dcaXY, float);
+DECLARE_SOA_COLUMN(DCAz, dcaZ, float); 
 
 } // namespace jetspectra
 

--- a/PWGJE/DataModel/TrackJetQa.h
+++ b/PWGJE/DataModel/TrackJetQa.h
@@ -52,7 +52,7 @@ DECLARE_SOA_COLUMN(MultTracklets, multTracklets, int);
 DECLARE_SOA_COLUMN(MultFT0M, multFT0M, float);
 DECLARE_SOA_COLUMN(CentFT0M, centFT0M, float);
 // Track info
-DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Index to the collision
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);             //! Index to the collision
 DECLARE_SOA_COLUMN(IsPVContributor, isPVContributor, bool); //! IsPVContributor
 DECLARE_SOA_COLUMN(HasTRD, hasTRD, bool);                   //! Has or not the TRD match
 DECLARE_SOA_COLUMN(IsGlobalTrack, isGlobalTrack, bool);                                   // if a track passed the isGlobalTrack requirement
@@ -103,7 +103,7 @@ DECLARE_SOA_TABLE(JeTracks, "AOD", "JETRACKS",
                   track::TPCNClsFindable,
                   track::TPCNClsFindableMinusFound,
                   track::TPCNClsFindableMinusCrossedRows,
-                  track::ITSClusterMap,  
+                  track::ITSClusterMap,
                   jetspectra::ITSNCls,
                   jetspectra::TPCFractionSharedCls,
                   jetspectra::TPCNClsFound,

--- a/PWGJE/TableProducer/jettrackderived.cxx
+++ b/PWGJE/TableProducer/jettrackderived.cxx
@@ -105,10 +105,15 @@ struct jetspectraDerivedMaker {
     histos.add("EventProp/collisionVtxZSel8", "Collsion Vertex Z with event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/sampledvertexz", "Sampled collsion Vertex Z with event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
 
-    histos.add("Centrality/FT0M", "CentFT0M", HistType::kTH1D, {{binsPercentile, "Centrality FT0M"}});
-    histos.add("Mult/NTracksPV", "MultNTracksPV", HistType::kTH1D, {{binsMultiplicity, "MultNTracksPV"}});
-    histos.add("Mult/NTracklets", "MultTracklets", HistType::kTH1D, {{binsMultiplicity, "MultTracks"}});
-    histos.add("Mult/FT0M", "MultFT0M", HistType::kTH1D, {{binsMultiplicity, "Multiplicity FT0M"}});
+    const AxisSpec axisPercentile{binsPercentile, "Centrality FT0M"};
+    const AxisSpec axisMultiplicityPV{binsMultiplicity, "MultNTracksPV"};
+    const AxisSpec axisMultiplicityTracklets{binsMultiplicity, "MultTracklets"};
+    const AxisSpec axisMultiplicityFT0M{binsMultiplicity, "Multiplicity FT0M"};
+
+    histos.add("Centrality/FT0M", "CentFT0M", HistType::kTH1D, {axisPercentile});
+    histos.add("Mult/NTracksPV", "MultNTracksPV", HistType::kTH1D, {axisMultiplicityPV});
+    histos.add("Mult/NTracklets", "MultTracklets", HistType::kTH1D, {axisMultiplicityTracklets});
+    histos.add("Mult/FT0M", "MultFT0M", HistType::kTH1D, {axisMultiplicityFT0M});
   }
 
   template <typename CollisionType, typename TrackType>

--- a/PWGJE/TableProducer/jettrackderived.cxx
+++ b/PWGJE/TableProducer/jettrackderived.cxx
@@ -175,11 +175,11 @@ struct jetspectraDerivedMaker {
     tableTrack.reserve(tracks.size());
     for (const auto& trk : tracks) {
       if (!isTrackSelected(trk)) {
-        return;
+      return;
       }
 
       tableTrack(tableColl.lastIndex(),
-                 trk.pt() * trk.sign(), trk.eta(), trk.phi(), trk.pt(),
+                 trk.signed1Pt(), trk.eta(), trk.phi(), trk.pt(),
                  trk.sigma1Pt(),
                  trk.alpha(),
                  trk.x(), trk.y(), trk.z(),
@@ -187,8 +187,6 @@ struct jetspectraDerivedMaker {
                  trk.tgl(),
                  trk.isPVContributor(),
                  trk.hasTRD(),
-                 o2::aod::jetspectra::packInTable<o2::aod::jetspectra::binningDCA>(trk.dcaXY()),
-                 o2::aod::jetspectra::packInTable<o2::aod::jetspectra::binningDCA>(trk.dcaZ()),
                  trk.isGlobalTrack(),
                  trk.isGlobalTrackWoDCA(),
                  trk.isGlobalTrackWoPtEta(),
@@ -205,7 +203,9 @@ struct jetspectraDerivedMaker {
                  trk.tpcNClsFound(),
                  trk.tpcNClsCrossedRows(),
                  trk.tpcCrossedRowsOverFindableCls(),
-                 trk.tpcFoundOverFindableCls());
+                 trk.tpcFoundOverFindableCls(),
+                 trk.dcaXY(),
+                 trk.dcaZ());
     }
   }
   PROCESS_SWITCH(jetspectraDerivedMaker, processData, "Process data for derived dataset production", true);

--- a/PWGJE/TableProducer/jettrackderived.cxx
+++ b/PWGJE/TableProducer/jettrackderived.cxx
@@ -175,7 +175,7 @@ struct jetspectraDerivedMaker {
     tableTrack.reserve(tracks.size());
     for (const auto& trk : tracks) {
       if (!isTrackSelected(trk)) {
-      return;
+        return;
       }
 
       tableTrack(tableColl.lastIndex(),


### PR DESCRIPTION
Hi @nzardosh , @alicecaluisi ,

there was a mismatch in the table definition and filling which caused the histograms to be filled with different entries than expected.
This PR fixes the issue from  signed1Pt to DCAz and reduces the columns to the essential entries.

Cheerio,
Johanna