### PR TITLE
PWGHF: Add possibility to select MC event based on generator information

### DIFF
--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -73,8 +73,7 @@ struct HfTaskMcValidationGen {
   Configurable<double> yVertexMax{"yVertexMax", 100., "max. y of generated primary vertex [cm]"};
   Configurable<double> zVertexMin{"zVertexMin", -100., "min. z of generated primary vertex [cm]"};
   Configurable<double> zVertexMax{"zVertexMax", 100., "max. z of generated primary vertex [cm]"};
-  Configurable<bool> checkEventGeneratorInfo{"checkEventGeneratorInfo", false, "Enable selection of events using the subGeneratorId information"};
-  Configurable<int> eventGeneratorType{"eventGeneratorType", 4, "Which kind of events to keep (0 = MB, 4 = charm injected, 5 = beauty injected)"};
+  Configurable<int> eventGeneratorType{"eventGeneratorType", -1, "If positive, enable event selection using subGeneratorId information. The value indicates which events to keep (0 = MB, 4 = charm triggered, 5 = beauty triggered)"};
 
   AxisSpec axisNhadrons{10, -0.5, 9.5};
   AxisSpec axisNquarks{20, -0.5, 19.5};
@@ -154,7 +153,7 @@ struct HfTaskMcValidationGen {
   void process(aod::McCollision const& mcCollision,
                aod::McParticles const& mcParticles)
   {
-    if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+    if (eventGeneratorType >= 0 && mcCollision.getSubGeneratorId() != eventGeneratorType) {
       collWithHFSignal(false);
       return;
     }
@@ -307,8 +306,7 @@ struct HfTaskMcValidationRec {
   Preslice<aod::Tracks> perCol = aod::track::collisionId;
 
   Configurable<bool> checkAmbiguousTracksWithHfEventsOnly{"checkAmbiguousTracksWithHfEventsOnly", false, "Activate checks for ambiguous tracks only for events with HF signals (including decay channels of interest)"};
-  Configurable<bool> checkEventGeneratorInfo{"checkEventGeneratorInfo", false, "Enable selection of events using the subGeneratorId information"};
-  Configurable<int> eventGeneratorType{"eventGeneratorType", 4, "Which kind of events to keep (0 = MB, 4 = charm injected, 5 = beauty injected)"};
+  Configurable<int> eventGeneratorType{"eventGeneratorType", -1, "If positive, enable event selection using subGeneratorId information. The value indicates which events to keep (0 = MB, 4 = charm triggered, 5 = beauty triggered)"};
 
   std::array<std::shared_ptr<TH1>, nCharmHadrons> histDeltaPt, histDeltaPx, histDeltaPy, histDeltaPz, histDeltaSecondaryVertexX, histDeltaSecondaryVertexY, histDeltaSecondaryVertexZ, histDeltaDecayLength;
   std::array<std::array<std::array<std::shared_ptr<TH1>, 3>, 2>, nCharmHadrons> histPtDau, histEtaDau, histImpactParameterDau;
@@ -428,7 +426,7 @@ struct HfTaskMcValidationRec {
         continue;
       }
       auto mcCollision = collision.mcCollision_as<McCollisionWithHFSignalInfo>();
-      if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+      if (eventGeneratorType >= 0 && mcCollision.getSubGeneratorId() != eventGeneratorType) {
         continue;
       }
       if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
@@ -504,7 +502,7 @@ struct HfTaskMcValidationRec {
       if (track.has_mcParticle()) {
         auto particle = track.mcParticle(); // get corresponding MC particle to check origin
         auto mcCollision = particle.mcCollision_as<McCollisionWithHFSignalInfo>();
-        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (eventGeneratorType >= 0 && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
         if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
@@ -564,7 +562,7 @@ struct HfTaskMcValidationRec {
 
       if (cand2Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
         auto mcCollision = cand2Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
-        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (eventGeneratorType >= 0 && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
       }
@@ -629,7 +627,7 @@ struct HfTaskMcValidationRec {
 
       if (cand3Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
         auto mcCollision = cand3Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
-        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (eventGeneratorType >= 0 && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
       }

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -73,6 +73,8 @@ struct HfTaskMcValidationGen {
   Configurable<double> yVertexMax{"yVertexMax", 100., "max. y of generated primary vertex [cm]"};
   Configurable<double> zVertexMin{"zVertexMin", -100., "min. z of generated primary vertex [cm]"};
   Configurable<double> zVertexMax{"zVertexMax", 100., "max. z of generated primary vertex [cm]"};
+  Configurable<bool> checkEventGeneratorInfo{"checkEventGeneratorInfo", false, "Enable selection of events using the subGeneratorId information"};
+  Configurable<int> eventGeneratorType{"eventGeneratorType", 4, "Which kind of events to keep (0 = MB, 4 = charm injected, 5 = beauty injected)"};
 
   AxisSpec axisNhadrons{10, -0.5, 9.5};
   AxisSpec axisNquarks{20, -0.5, 19.5};
@@ -152,7 +154,12 @@ struct HfTaskMcValidationGen {
   void process(aod::McCollision const& mcCollision,
                aod::McParticles const& mcParticles)
   {
+    if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+      collWithHFSignal(false);
+      return;
+    }
     if (!selectVertex(mcCollision)) {
+      collWithHFSignal(false);
       return;
     }
 
@@ -300,6 +307,8 @@ struct HfTaskMcValidationRec {
   Preslice<aod::Tracks> perCol = aod::track::collisionId;
 
   Configurable<bool> checkAmbiguousTracksWithHfEventsOnly{"checkAmbiguousTracksWithHfEventsOnly", false, "Activate checks for ambiguous tracks only for events with HF signals (including decay channels of interest)"};
+  Configurable<bool> checkEventGeneratorInfo{"checkEventGeneratorInfo", false, "Enable selection of events using the subGeneratorId information"};
+  Configurable<int> eventGeneratorType{"eventGeneratorType", 4, "Which kind of events to keep (0 = MB, 4 = charm injected, 5 = beauty injected)"};
 
   std::array<std::shared_ptr<TH1>, nCharmHadrons> histDeltaPt, histDeltaPx, histDeltaPy, histDeltaPz, histDeltaSecondaryVertexX, histDeltaSecondaryVertexY, histDeltaSecondaryVertexZ, histDeltaDecayLength;
   std::array<std::array<std::array<std::shared_ptr<TH1>, 3>, 2>, nCharmHadrons> histPtDau, histEtaDau, histImpactParameterDau;
@@ -310,7 +319,7 @@ struct HfTaskMcValidationRec {
 
   using HfCand2ProngWithMCRec = soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec>;
   using HfCand3ProngWithMCRec = soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec>;
-  using CollisionsWithMCLabels = soa::Join<aod::Collisions, aod::McCollisionLabels>;
+  using CollisionsWithMCLabels = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::HfSelCollision>;
   using TracksWithSel = soa::Join<aod::TracksWMc, aod::TracksExtra, aod::TrackSelection, aod::TrackCompColls>;
   using McCollisionWithHFSignalInfo = soa::Join<aod::McCollisions, aod::CollWithHFSignal>;
 
@@ -412,10 +421,16 @@ struct HfTaskMcValidationRec {
   {
     // loop over collisions
     for (auto collision = collisions.begin(); collision != collisions.end(); ++collision) {
+      if(collision.whyRejectColl() != 0) { // check that collision is selected by hf-track-index-skim-creator-tag-sel-collisions
+        continue;
+      }
       if (!collision.has_mcCollision()) {
         continue;
       }
       auto mcCollision = collision.mcCollision_as<McCollisionWithHFSignalInfo>();
+      if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        continue;
+      }
       if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
         continue;
       }
@@ -488,11 +503,12 @@ struct HfTaskMcValidationRec {
       uint index = uint(track.collisionId() >= 0);
       if (track.has_mcParticle()) {
         auto particle = track.mcParticle(); // get corresponding MC particle to check origin
-        if (checkAmbiguousTracksWithHfEventsOnly) {
-          auto mcCollision = particle.mcCollision_as<McCollisionWithHFSignalInfo>();
-          if (!mcCollision.hasHFsignal()) {
-            continue;
-          }
+        auto mcCollision = particle.mcCollision_as<McCollisionWithHFSignalInfo>();
+        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+          continue;
+        }
+        if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
+          continue;
         }
         auto origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true);
         histTracks->Fill(origin, track.pt());
@@ -545,6 +561,13 @@ struct HfTaskMcValidationRec {
 
     // loop over 2-prong candidates
     for (const auto& cand2Prong : cand2Prongs) {
+
+      if (cand2Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
+        auto mcCollision = cand2Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
+        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+          continue;
+        }
+      }
 
       // determine which kind of candidate it is
       bool isD0Sel = TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_2prong::DecayType::D0ToPiK);
@@ -603,6 +626,13 @@ struct HfTaskMcValidationRec {
 
     // loop over 3-prong candidates
     for (const auto& cand3Prong : cand3Prongs) {
+
+      if (cand3Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
+        auto mcCollision = cand3Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
+        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+          continue;
+        }
+      }
 
       // determine which kind of candidate it is
       bool isDPlusSel = TESTBIT(cand3Prong.hfflag(), o2::aod::hf_cand_3prong::DecayType::DplusToPiKPi);

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -154,7 +154,7 @@ struct HfTaskMcValidationGen {
   void process(aod::McCollision const& mcCollision,
                aod::McParticles const& mcParticles)
   {
-    if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+    if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
       collWithHFSignal(false);
       return;
     }
@@ -421,14 +421,14 @@ struct HfTaskMcValidationRec {
   {
     // loop over collisions
     for (auto collision = collisions.begin(); collision != collisions.end(); ++collision) {
-      if(collision.whyRejectColl() != 0) { // check that collision is selected by hf-track-index-skim-creator-tag-sel-collisions
+      if (collision.whyRejectColl() != 0) { // check that collision is selected by hf-track-index-skim-creator-tag-sel-collisions
         continue;
       }
       if (!collision.has_mcCollision()) {
         continue;
       }
       auto mcCollision = collision.mcCollision_as<McCollisionWithHFSignalInfo>();
-      if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+      if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
         continue;
       }
       if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
@@ -504,7 +504,7 @@ struct HfTaskMcValidationRec {
       if (track.has_mcParticle()) {
         auto particle = track.mcParticle(); // get corresponding MC particle to check origin
         auto mcCollision = particle.mcCollision_as<McCollisionWithHFSignalInfo>();
-        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
         if (checkAmbiguousTracksWithHfEventsOnly && !mcCollision.hasHFsignal()) {
@@ -564,7 +564,7 @@ struct HfTaskMcValidationRec {
 
       if (cand2Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
         auto mcCollision = cand2Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
-        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
       }
@@ -629,7 +629,7 @@ struct HfTaskMcValidationRec {
 
       if (cand3Prong.collision_as<CollisionsWithMCLabels>().has_mcCollision()) {
         auto mcCollision = cand3Prong.collision_as<CollisionsWithMCLabels>().mcCollision_as<McCollisionWithHFSignalInfo>();
-        if(checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
+        if (checkEventGeneratorInfo && mcCollision.getSubGeneratorId() != eventGeneratorType) {
           continue;
         }
       }


### PR DESCRIPTION
This PR add the possibility of using the subGeneratorId information recently added to the HF MC generator to select specific events from a gap-triggered production.