### PR TITLE
Move to expression columns for most used columns

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -187,11 +187,11 @@ DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //! V0 pz
                               float, 1.f * aod::v0data::pzpos + 1.f * aod::v0data::pzneg);
 
 DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! Transverse momentum in GeV/c
-                              nsqrt(aod::v0data::px * aod::v0data::px +
+                              nsqrt(aod::v0data::px* aod::v0data::px +
                                     aod::v0data::py * aod::v0data::py));
 DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //! Total momentum in GeV/c
-                              nsqrt(aod::v0data::px * aod::v0data::px +
-                                    aod::v0data::py * aod::v0data::py + 
+                              nsqrt(aod::v0data::px* aod::v0data::px +
+                                    aod::v0data::py * aod::v0data::py +
                                     aod::v0data::pz * aod::v0data::pz));
 DECLARE_SOA_EXPRESSION_COLUMN(Phi, phi, float, //! Phi in the range [0, 2pi)
                               o2::constants::math::PI + natan2(-1.0f * aod::v0data::py, -1.0f * aod::v0data::px));
@@ -259,10 +259,10 @@ DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //!
                        v0data::PositionCovMat, v0data::MomentumCovMat);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
-DECLARE_SOA_EXTENDED_TABLE_USER(V0Datas, StoredV0Datas, "V0DATAEXT", //!
+DECLARE_SOA_EXTENDED_TABLE_USER(V0Datas, StoredV0Datas, "V0DATAEXT",                                                  //!
                                 v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
 
-//using V0Datas = soa::Join<V0Indices,V0Topos>
+// using V0Datas = soa::Join<V0Indices,V0Topos>
 using V0Data = V0Datas::iterator;
 namespace v0data
 {
@@ -436,11 +436,11 @@ DECLARE_SOA_EXPRESSION_COLUMN(PyLambda, pylambda, //!
 DECLARE_SOA_EXPRESSION_COLUMN(PzLambda, pzlambda, //!
                               float, 1.f * aod::cascdata::pzpos + 1.f * aod::cascdata::pzneg);
 DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! Transverse momentum in GeV/c
-                              nsqrt(aod::cascdata::px * aod::cascdata::px +
+                              nsqrt(aod::cascdata::px* aod::cascdata::px +
                                     aod::cascdata::py * aod::cascdata::py));
 DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //! Total momentum in GeV/c
-                              nsqrt(aod::cascdata::px * aod::cascdata::px +
-                                    aod::cascdata::py * aod::cascdata::py + 
+                              nsqrt(aod::cascdata::px* aod::cascdata::px +
+                                    aod::cascdata::py * aod::cascdata::py +
                                     aod::cascdata::pz * aod::cascdata::pz));
 DECLARE_SOA_EXPRESSION_COLUMN(Phi, phi, float, //! Phi in the range [0, 2pi)
                               o2::constants::math::PI + natan2(-1.0f * aod::cascdata::py, -1.0f * aod::cascdata::px));

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -52,11 +52,6 @@ DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance mat
 DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
 
 // Derived expressions
-// Momenta
-// DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! V0 pT
-//                            [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg); });
-// DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! V0 pT
-//                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return std::hypot(pxpos + pxneg, pypos + pyneg, pzpos + pzneg); });
 // Account for rigidity in case of hypertriton
 DECLARE_SOA_DYNAMIC_COLUMN(PtHypertriton, ptHypertriton, //! V0 pT
                            [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(2.0f * pxpos + pxneg, 2.0f * pypos + pyneg); });

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -53,10 +53,10 @@ DECLARE_SOA_COLUMN(KFV0Chi2, kfV0Chi2, float); //!
 
 // Derived expressions
 // Momenta
-DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! V0 pT
-                           [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg); });
-DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! V0 pT
-                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return std::hypot(pxpos + pxneg, pypos + pyneg, pzpos + pzneg); });
+// DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! V0 pT
+//                            [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(pxpos + pxneg, pypos + pyneg); });
+// DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! V0 pT
+//                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return std::hypot(pxpos + pxneg, pypos + pyneg, pzpos + pzneg); });
 // Account for rigidity in case of hypertriton
 DECLARE_SOA_DYNAMIC_COLUMN(PtHypertriton, ptHypertriton, //! V0 pT
                            [](float pxpos, float pypos, float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(2.0f * pxpos + pxneg, 2.0f * pypos + pyneg); });
@@ -170,10 +170,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(Rapidity, rapidity, //! rapidity (0:K0, 1:L, 2:Lbar)
                                return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassLambda);
                              return 0.0f;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //! V0 eta
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
-DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! V0 phi
-                           [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });
 
 DECLARE_SOA_DYNAMIC_COLUMN(NegativePt, negativept, //! negative daughter pT
                            [](float pxneg, float pyneg) -> float { return RecoDecay::sqrtSumOfSquares(pxneg, pyneg); });
@@ -194,6 +190,31 @@ DECLARE_SOA_EXPRESSION_COLUMN(Py, py, //! V0 py
                               float, 1.f * aod::v0data::pypos + 1.f * aod::v0data::pyneg);
 DECLARE_SOA_EXPRESSION_COLUMN(Pz, pz, //! V0 pz
                               float, 1.f * aod::v0data::pzpos + 1.f * aod::v0data::pzneg);
+
+DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! Transverse momentum in GeV/c
+                              nsqrt(aod::v0data::px * aod::v0data::px +
+                                    aod::v0data::py * aod::v0data::py));
+DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //! Total momentum in GeV/c
+                              nsqrt(aod::v0data::px * aod::v0data::px +
+                                    aod::v0data::py * aod::v0data::py + 
+                                    aod::v0data::pz * aod::v0data::pz));
+DECLARE_SOA_EXPRESSION_COLUMN(Phi, phi, float, //! Phi in the range [0, 2pi)
+                              o2::constants::math::PI + natan2(-1.0f * aod::v0data::py, -1.0f * aod::v0data::px));
+DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //! Pseudorapidity, conditionally defined to avoid FPEs
+                              ifnode((nsqrt(aod::v0data::px * aod::v0data::px +
+                                            aod::v0data::py * aod::v0data::py +
+                                            aod::v0data::pz * aod::v0data::pz) -
+                                      aod::v0data::pz) < static_cast<float>(1e-7),
+                                     ifnode(aod::v0data::pz < 0.f, -100.f, 100.f),
+                                     0.5f * nlog((nsqrt(aod::v0data::px * aod::v0data::px +
+                                                        aod::v0data::py * aod::v0data::py +
+                                                        aod::v0data::pz * aod::v0data::pz) +
+                                                  aod::v0data::pz) /
+                                                 (nsqrt(aod::v0data::px * aod::v0data::px +
+                                                        aod::v0data::py * aod::v0data::py +
+                                                        aod::v0data::pz * aod::v0data::pz) -
+                                                  aod::v0data::pz))));
+
 } // namespace v0data
 
 DECLARE_SOA_TABLE_FULL(StoredV0Datas, "V0Datas", "AOD", "V0DATA", //!
@@ -205,8 +226,6 @@ DECLARE_SOA_TABLE_FULL(StoredV0Datas, "V0Datas", "AOD", "V0DATA", //!
                        v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
 
                        // Dynamic columns
-                       v0data::Pt<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
-                       v0data::P<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
                        v0data::PtAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
                        v0data::V0Radius<v0data::X, v0data::Y>,
@@ -234,8 +253,6 @@ DECLARE_SOA_TABLE_FULL(StoredV0Datas, "V0Datas", "AOD", "V0DATA", //!
                        v0data::YHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::YAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::Rapidity<v0data::Px, v0data::Py, v0data::Pz>,
-                       v0data::Eta<v0data::Px, v0data::Py, v0data::Pz>,
-                       v0data::Phi<v0data::Px, v0data::Py>,
                        v0data::NegativePt<v0data::PxNeg, v0data::PyNeg>,
                        v0data::PositivePt<v0data::PxPos, v0data::PyPos>,
                        v0data::NegativeEta<v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
@@ -248,8 +265,9 @@ DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //!
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(V0Datas, StoredV0Datas, "V0DATAEXT", //!
-                                v0data::Px, v0data::Py, v0data::Pz); // the table name has here to be the one with EXT which is not nice and under study
+                                v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
 
+//using V0Datas = soa::Join<V0Indices,V0Topos>
 using V0Data = V0Datas::iterator;
 namespace v0data
 {
@@ -374,10 +392,6 @@ DECLARE_SOA_COLUMN(TopologyChi2, topologyChi2, float); //!
 DECLARE_SOA_COLUMN(ItsClsSize, itsCluSize, float);     //!
 
 // Derived expressions
-// Momenta
-DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //!
-                           [](float Px, float Py) -> float { return RecoDecay::sqrtSumOfSquares(Px, Py); });
-
 // Length quantities
 DECLARE_SOA_DYNAMIC_COLUMN(V0Radius, v0radius, //!
                            [](float xlambda, float ylambda) -> float { return RecoDecay::sqrtSumOfSquares(xlambda, ylambda); });
@@ -416,10 +430,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(Rapidity, rapidity, //! rapidity (0, 1: Xi; 2, 3: Ome
                                return RecoDecay::y(std::array{Px, Py, Pz}, o2::constants::physics::MassOmegaMinus);
                              return 0.0f;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //!
-                           [](float Px, float Py, float Pz) -> float { return RecoDecay::eta(std::array{Px, Py, Pz}); });
-DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! cascade phi
-                           [](float Px, float Py) -> float { return RecoDecay::phi(Px, Py); });
 } // namespace cascdata
 
 namespace cascdataext
@@ -430,6 +440,29 @@ DECLARE_SOA_EXPRESSION_COLUMN(PyLambda, pylambda, //!
                               float, 1.f * aod::cascdata::pypos + 1.f * aod::cascdata::pyneg);
 DECLARE_SOA_EXPRESSION_COLUMN(PzLambda, pzlambda, //!
                               float, 1.f * aod::cascdata::pzpos + 1.f * aod::cascdata::pzneg);
+DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //! Transverse momentum in GeV/c
+                              nsqrt(aod::cascdata::px * aod::cascdata::px +
+                                    aod::cascdata::py * aod::cascdata::py));
+DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //! Total momentum in GeV/c
+                              nsqrt(aod::cascdata::px * aod::cascdata::px +
+                                    aod::cascdata::py * aod::cascdata::py + 
+                                    aod::cascdata::pz * aod::cascdata::pz));
+DECLARE_SOA_EXPRESSION_COLUMN(Phi, phi, float, //! Phi in the range [0, 2pi)
+                              o2::constants::math::PI + natan2(-1.0f * aod::cascdata::py, -1.0f * aod::cascdata::px));
+DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //! Pseudorapidity, conditionally defined to avoid FPEs
+                              ifnode((nsqrt(aod::cascdata::px * aod::cascdata::px +
+                                            aod::cascdata::py * aod::cascdata::py +
+                                            aod::cascdata::pz * aod::cascdata::pz) -
+                                      aod::cascdata::pz) < static_cast<float>(1e-7),
+                                     ifnode(aod::cascdata::pz < 0.f, -100.f, 100.f),
+                                     0.5f * nlog((nsqrt(aod::cascdata::px * aod::cascdata::px +
+                                                        aod::cascdata::py * aod::cascdata::py +
+                                                        aod::cascdata::pz * aod::cascdata::pz) +
+                                                  aod::cascdata::pz) /
+                                                 (nsqrt(aod::cascdata::px * aod::cascdata::px +
+                                                        aod::cascdata::py * aod::cascdata::py +
+                                                        aod::cascdata::pz * aod::cascdata::pz) -
+                                                  aod::cascdata::pz))));
 } // namespace cascdataext
 
 DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
@@ -446,7 +479,6 @@ DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
                   cascdata::BachBaryonCosPA, cascdata::BachBaryonDCAxyToPV,
 
                   // Dynamic columns
-                  cascdata::Pt<cascdata::Px, cascdata::Py>,
                   cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
                   cascdata::CascRadius<cascdata::X, cascdata::Y>,
                   cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
@@ -460,9 +492,7 @@ DECLARE_SOA_TABLE(StoredCascDatas, "AOD", "CASCDATA", //!
                   // Longitudinal
                   cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
                   cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Rapidity<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Phi<cascdata::Px, cascdata::Py>);
+                  cascdata::Rapidity<cascdata::Px, cascdata::Py, cascdata::Pz>);
 
 DECLARE_SOA_TABLE(StoredKFCascDatas, "AOD", "KFCASCDATA", //!
                   o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId,
@@ -481,7 +511,6 @@ DECLARE_SOA_TABLE(StoredKFCascDatas, "AOD", "KFCASCDATA", //!
                   kfcascdata::MLambda, cascdata::KFV0Chi2, cascdata::KFCascadeChi2,
 
                   // Dynamic columns
-                  cascdata::Pt<cascdata::Px, cascdata::Py>,
                   cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
                   cascdata::CascRadius<cascdata::X, cascdata::Y>,
                   cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
@@ -493,9 +522,7 @@ DECLARE_SOA_TABLE(StoredKFCascDatas, "AOD", "KFCASCDATA", //!
 
                   // Longitudinal
                   cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Phi<cascdata::Px, cascdata::Py>);
+                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>);
 
 DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
                   o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::StrangeTrackId, cascdata::CollisionId,
@@ -514,7 +541,6 @@ DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
                   cascdata::MatchingChi2, cascdata::TopologyChi2, cascdata::ItsClsSize,
 
                   // Dynamic columns
-                  cascdata::Pt<cascdata::Px, cascdata::Py>,
                   cascdata::V0Radius<cascdata::Xlambda, cascdata::Ylambda>,
                   cascdata::CascRadius<cascdata::X, cascdata::Y>,
                   cascdata::V0CosPA<cascdata::Xlambda, cascdata::Ylambda, cascdata::Zlambda, cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda>,
@@ -526,9 +552,7 @@ DECLARE_SOA_TABLE(StoredTraCascDatas, "AOD", "TRACASCDATA", //!
 
                   // Longitudinal
                   cascdata::YXi<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Eta<cascdata::Px, cascdata::Py, cascdata::Pz>,
-                  cascdata::Phi<cascdata::Px, cascdata::Py>);
+                  cascdata::YOmega<cascdata::Px, cascdata::Py, cascdata::Pz>);
 
 DECLARE_SOA_TABLE_FULL(CascCovs, "CascCovs", "AOD", "CASCCOVS", //!
                        cascdata::PositionCovMat, cascdata::MomentumCovMat);
@@ -538,15 +562,17 @@ DECLARE_SOA_TABLE_FULL(KFCascCovs, "KFCascCovs", "AOD", "KFCASCCOVS", //!
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(CascDatas, StoredCascDatas, "CascDATAEXT", //!
-                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda, cascdataext::Pt, cascdataext::P, cascdataext::Eta, cascdataext::Phi);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(KFCascDatas, StoredKFCascDatas, "KFCascDATAEXT", //!
-                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda,
+                                cascdataext::Pt, cascdataext::P, cascdataext::Eta, cascdataext::Phi);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(TraCascDatas, StoredTraCascDatas, "TraCascDATAEXT", //!
-                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda);
+                                cascdataext::PxLambda, cascdataext::PyLambda, cascdataext::PzLambda,
+                                cascdataext::Pt, cascdataext::P, cascdataext::Eta, cascdataext::Phi);
 
 using CascData = CascDatas::iterator;
 using KFCascData = KFCascDatas::iterator;

--- a/PWGLF/Tasks/cascadeanalysis.cxx
+++ b/PWGLF/Tasks/cascadeanalysis.cxx
@@ -295,31 +295,31 @@ struct cascadeAnalysis {
       if (casc.sign() < 0) {                         // FIXME: could be done better...
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.mXi());
+            registry.fill(HIST("h2dMassXiMinus"), casc.pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.mXi());
+            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h2dMassOmegaMinus"), casc.pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.pt(), casc.mOmega());
           }
         }
       } else {
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.mXi());
+            registry.fill(HIST("h2dMassXiPlus"), casc.pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.mXi());
+            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h2dMassOmegaPlus"), casc.pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.pt(), casc.mOmega());
           }
         }
       }

--- a/PWGLF/Tasks/cascadeanalysisMC.cxx
+++ b/PWGLF/Tasks/cascadeanalysisMC.cxx
@@ -357,31 +357,31 @@ struct cascadeAnalysisMC {
       if (casc.sign() < 0) {                         // FIXME: could be done better...
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi && ((!assocMC) || (lPDG == 3312))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiMinus"), casc.template pt(), casc.mXi());
+            registry.fill(HIST("h2dMassXiMinus"), casc.pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.template pt(), casc.mXi());
+            registry.fill(HIST("h3dMassXiMinus"), lPercentile, casc.pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om && ((!assocMC) || (lPDG == 3334))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaMinus"), casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h2dMassOmegaMinus"), casc.pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h3dMassOmegaMinus"), lPercentile, casc.pt(), casc.mOmega());
           }
         }
       } else {
         if (TMath::Abs(casc.yXi()) < 0.5 && lCompatiblePID_Xi && ((!assocMC) || (lPDG == -3312))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassXiPlus"), casc.template pt(), casc.mXi());
+            registry.fill(HIST("h2dMassXiPlus"), casc.pt(), casc.mXi());
           } else {
-            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.template pt(), casc.mXi());
+            registry.fill(HIST("h3dMassXiPlus"), lPercentile, casc.pt(), casc.mXi());
           }
         }
         if (TMath::Abs(casc.yOmega()) < 0.5 && lCompatiblePID_Om && ((!assocMC) || (lPDG == -3334))) {
           if (!doCentralityStudy) {
-            registry.fill(HIST("h2dMassOmegaPlus"), casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h2dMassOmegaPlus"), casc.pt(), casc.mOmega());
           } else {
-            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.template pt(), casc.mOmega());
+            registry.fill(HIST("h3dMassOmegaPlus"), lPercentile, casc.pt(), casc.mOmega());
           }
         }
       }


### PR DESCRIPTION
This PR moves the most commonly used variables to expression columns in the strangeness model. As next few steps, the CosPAs will be changed into regular columns, so they can be filtered on, and indices and other variables will be further separated into sub-tables that are joinable.

Combined with the already modular strangeness PID tables and some further adjustments, one of the goals here is that, should the need arise, the intermediate format from the builders could already serve as derived data. 