### PR TITLE
PWGCF: Update trigger

### DIFF
--- a/EventFiltering/PWGCF/CFFilterAll.cxx
+++ b/EventFiltering/PWGCF/CFFilterAll.cxx
@@ -95,6 +95,7 @@ static const std::vector<std::string> SpeciesAvgTPCTOFName{"Proton", "AntiProton
 static const std::vector<std::string> TPCTOFAvgName{"TPC Avg", "TOF Avg"};
 static const std::vector<std::string> PidCutsName{"TPC min", "TPC max", "TOF min", "TOF max", "TPCTOF max"};
 static const std::vector<std::string> PtCutsName{"Pt min (particle)", "Pt max (particle)", "Pt min (antiparticle)", "Pt max (antiparticle)", "P thres"};
+static const std::vector<std::string> MomCorCutsName{"Momemtum Correlation min", "Momemtum Correlation max"};
 static const std::vector<std::string> ThreeBodyFilterNames{"PPP", "PPL", "PLL", "LLL"};
 static const std::vector<std::string> TwoBodyFilterNames{"PD", "LD"};
 static const std::vector<std::string> ParticleNames{"PPP", "aPaPaP", "PPL", "aPaPaL", "PLL", "aPaLaL", "LLL", "aLaLaL", "PD", "aPaD", "LD", "aLaD"};
@@ -106,6 +107,7 @@ static const int nPidCutsDaughers = 2;
 static const int nPtCuts = 5;
 static const int nAllTriggers = 6;
 static const int nTriggerAllNames = 12;
+static const int nMomCorCuts = 2;
 
 static const float pidcutsTable[nTracks][kNPIDLimits]{
   {-6.f, 6.f, -6.f, 6.f, 6.f},
@@ -130,6 +132,9 @@ static const float ptcutsTable[kNParticleRejection][nPtCuts]{
   {0.f, 6.f, 0.f, 6.f, 99.f}};
 static const float NClustersMin[1][nTracks]{
   {60.0f, 60.0f}};
+static const float MomCorLimits[2][nMomCorCuts] =
+  {{-0.1, 0.1},
+   {-0.1, 0.1}};
 
 static const float triggerSwitches[1][nAllTriggers]{
   {1, 1, 1, 1, 1, 1}};
@@ -334,8 +339,8 @@ struct CFFilter {
     "ConfTrkITSRefit",
     false,
     "True: require ITS refit"};
-  // PID selections
 
+  // PID selections
   Configurable<LabeledArray<float>> ConfPIDCuts{
     "ConfPIDCuts",
     {CFTrigger::pidcutsTable[0], CFTrigger::nTracks, CFTrigger::kNPIDLimits, CFTrigger::SpeciesName, CFTrigger::PidCutsName},
@@ -344,10 +349,6 @@ struct CFFilter {
     "ConfPIDCutsAnti",
     {CFTrigger::pidcutsTableAnti[0], CFTrigger::nTracks, CFTrigger::kNPIDLimits, CFTrigger::SpeciesNameAnti, CFTrigger::PidCutsName},
     "Particle PID selections for antiparticles; perfect case scenario identical to particles"};
-  Configurable<LabeledArray<float>> ConfPtCuts{
-    "ConfPtCuts",
-    {CFTrigger::ptcutsTable[0], CFTrigger::kNParticleSpecies, CFTrigger::nPtCuts, CFTrigger::SpeciesNameAll, CFTrigger::PtCutsName},
-    "Particle Momentum selections"};
   Configurable<bool> ConfRejectNOTDeuteron{
     "ConfRejectNOTDeuteron",
     false,
@@ -360,6 +361,20 @@ struct CFFilter {
     "ConfPIDTPCTOFAvg",
     {CFTrigger::pidTPCTOFAvgTable[0], CFTrigger::nPidAvg, CFTrigger::nTracks, CFTrigger::SpeciesAvgTPCTOFName, CFTrigger::TPCTOFAvgName},
     "Average expected nSigma of TPC and TOF, which is substracted in calculation of combined TPC and TOF nSigma"};
+
+  // Momentum selections
+  Configurable<LabeledArray<float>> ConfMomCorCut{
+    "ConfMomCorCuts",
+    {CFTrigger::MomCorLimits[0], CFTrigger::nTracks, CFTrigger::nMomCorCuts, CFTrigger::SpeciesName, CFTrigger::MomCorCutsName},
+    "Momentum correlation selections (particle)"};
+  Configurable<LabeledArray<float>> ConfMomCorCutAnti{
+    "ConfMomCorCutsAnti",
+    {CFTrigger::MomCorLimits[0], CFTrigger::nTracks, CFTrigger::nMomCorCuts, CFTrigger::SpeciesNameAnti, CFTrigger::MomCorCutsName},
+    "Momentum correlation selections (antipartilce)"};
+  Configurable<LabeledArray<float>> ConfPtCuts{
+    "ConfPtCuts",
+    {CFTrigger::ptcutsTable[0], CFTrigger::kNParticleSpecies, CFTrigger::nPtCuts, CFTrigger::SpeciesNameAll, CFTrigger::PtCutsName},
+    "Particle Momentum selections"};
 
   // Configs for V0
   Configurable<float> ConfV0PtMin{
@@ -551,8 +566,8 @@ struct CFFilter {
     // TEST P TPC
     registry.add("TrackCuts/Proton/fPProton", "Momentum of protons at PV;p (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
     registry.add("TrackCuts/Proton/fPTPCProton", "Momentum of protons at TPC inner wall;p_{TPC} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
-
     registry.add("TrackCuts/Proton/fPtProton", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
+    registry.add("TrackCuts/Proton/fMomCorProton", "Momentum correlation;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/Proton/fEtaProton", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/Proton/fPhiProton", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/Proton/fNsigmaTPCvsPProton", "NSigmaTPC Proton;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -572,6 +587,7 @@ struct CFFilter {
 
     // antiproton
     registry.add("TrackCuts/AntiProton/fPtAntiProton", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
+    registry.add("TrackCuts/AntiProton/fMomCorAntiProton", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/AntiProton/fEtaAntiProton", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/AntiProton/fPhiAntiProton", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/AntiProton/fNsigmaTPCvsPAntiProton", "NSigmaTPC AntiProton;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -591,6 +607,7 @@ struct CFFilter {
 
     // deuteron
     registry.add("TrackCuts/Deuteron/fPtDeuteron", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
+    registry.add("TrackCuts/Deuteron/fMomCorDeuteron", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/Deuteron/fEtaDeuteron", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/Deuteron/fPhiDeuteron", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/Deuteron/fNsigmaTPCvsPDeuteron", "NSigmaTPC Deuteron;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -610,6 +627,7 @@ struct CFFilter {
 
     // antideuteron
     registry.add("TrackCuts/AntiDeuteron/fPtAntiDeuteron", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
+    registry.add("TrackCuts/AntiDeuteron/fMomCorAntiDeuteron", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/AntiDeuteron/fEtaAntiDeuteron", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/AntiDeuteron/fPhiAntiDeuteron", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/AntiDeuteron/fNsigmaTPCvsPAntiDeuteron", "NSigmaTPC AntiDeuteron;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -700,6 +718,8 @@ struct CFFilter {
     registry.add("ppp/fSE_particle_downsample", "Same Event distribution (downsampled)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ppp/fSE_antiparticle", "Same Event distribution", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ppp/fSE_antiparticle_downsample", "Same Event distribution (downsampled)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("ppp/fProtonPtVsQ3", "pT (proton) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ppp/fAntiProtonPtVsQ3", "pT (antiproton) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
 
     // for ppl
     registry.add("ppl/fMultiplicity", "Multiplicity of all processed events;Mult;Entries", HistType::kTH1F, {{1000, 0, 1000}});
@@ -708,6 +728,10 @@ struct CFFilter {
     registry.add("ppl/fSE_particle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ppl/fSE_antiparticle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ppl/fSE_antiparticle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("ppl/fProtonPtVsQ3", "pT (proton) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ppl/fAntiProtonPtVsQ3", "pT (proton) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ppl/fLambdaPtVsQ3", "pT (lambda) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ppl/fAntiLambdaPtVsQ3", "pT (antilambda) vs Q_{3};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
 
     // for pll
     registry.add("pll/fMultiplicity", "Multiplicity of all processed events;Mult;Entries", HistType::kTH1F, {{1000, 0, 1000}});
@@ -716,14 +740,23 @@ struct CFFilter {
     registry.add("pll/fSE_particle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("pll/fSE_antiparticle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("pll/fSE_antiparticle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("pll/fProtonPtVsQ3", "Q3 vs pT (proton)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pll/fAntiProtonPtVsQ3", "Q3 vs pT (antiproton)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pll/fLambdaPtVsQ3", "Q3 vs pT (lambda)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pll/fAntiLambdaPtVsQ3", "Q3 vs pT (antilambda)", {HistType::kTH2F, {
+                                                                                       {150, 0, 1.5},
+                                                                                       {500, 0, 10},
+                                                                                     }});
 
-    // for pll
+    // for lll
     registry.add("lll/fMultiplicity", "Multiplicity of all processed events;Mult;Entries", HistType::kTH1F, {{1000, 0, 1000}});
     registry.add("lll/fZvtx", "Zvtx of all processed events;Z_{vtx};Entries", HistType::kTH1F, {{1000, -15, 15}});
     registry.add("lll/fSE_particle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("lll/fSE_particle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("lll/fSE_antiparticle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("lll/fSE_antiparticle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("lll/fLambdaPtVsQ3", "Q3 vs pT (lambda)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("lll/fAntiLambdaPtVsQ3", "Q3 vs pT (antilambda)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
 
     // for pd
     registry.add("pd/fMultiplicity", "Multiplicity of all processed events;Mult;Entries", HistType::kTH1F, {{1000, 0, 1000}});
@@ -732,6 +765,10 @@ struct CFFilter {
     registry.add("pd/fSE_particle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("pd/fSE_antiparticle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("pd/fSE_antiparticle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("pd/fProtonPtVskstar", "pT (proton) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pd/fAntiProtonPtVskstar", "pT (antiproton) vs k^{*};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pd/fDeuteronPtVskstar", "pT (deuteron) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("pd/fAntiDeuteronPtVskstar", "pT (antideuteron) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
 
     // for ld
     registry.add("ld/fMultiplicity", "Multiplicity of all processed events", HistType::kTH1F, {{1000, 0, 1000}});
@@ -740,6 +777,10 @@ struct CFFilter {
     registry.add("ld/fSE_particle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ld/fSE_antiparticle", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
     registry.add("ld/fSE_antiparticle_downsample", "Same Event distribution;SE;Q_{3} (GeV/c)", HistType::kTH1F, {{8000, 0, 8}});
+    registry.add("ld/fDeuteronPtVskstar", "pT (deuteron) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ld/fAntiDeuteronPtVskstar", "pT (antideuteron) vs k^{*};Q_{3} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ld/fLambdaPtVskstar", "pT (lambda) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
+    registry.add("ld/fAntiLambdaPtVskstar", "pT (antilambda) vs k^{*};k^{*} (GeV/c);p_{T} (GeV/c)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
   }
 
   float mMassElectron = o2::constants::physics::MassElectron;
@@ -767,6 +808,7 @@ struct CFFilter {
   {
     const auto charge = track.sign();
     const auto pT = track.pt();
+    float momCor = track.tpcInnerParam() - track.p();
     const auto eta = track.eta();
     const auto tpcNClsF = track.tpcNClsFound();
     const auto tpcRClsC = track.tpcCrossedRowsOverFindableCls();
@@ -784,12 +826,24 @@ struct CFFilter {
       if (pT > ConfPtCuts->get(partSpecies, "Pt max (particle)")) {
         return false;
       }
+      if (momCor < ConfMomCorCut->get(partSpecies, "Momemtum Correlation min")) {
+        return false;
+      }
+      if (momCor > ConfMomCorCut->get(partSpecies, "Momemtum Correlation max")) {
+        return false;
+      }
     }
     if (charge < 0) {
       if (pT < ConfPtCuts->get(partSpecies, "Pt min (antiparticle)")) {
         return false;
       }
       if (pT > ConfPtCuts->get(partSpecies, "Pt max (antiparticle)")) {
+        return false;
+      }
+      if (momCor < ConfMomCorCutAnti->get(partSpecies, "Momemtum Correlation min")) {
+        return false;
+      }
+      if (momCor > ConfMomCorCutAnti->get(partSpecies, "Momemtum Correlation max")) {
         return false;
       }
     }
@@ -1289,6 +1343,7 @@ struct CFFilter {
             registry.fill(HIST("TrackCuts/Proton/fPProton"), track.p());
             registry.fill(HIST("TrackCuts/Proton/fPTPCProton"), track.tpcInnerParam());
             registry.fill(HIST("TrackCuts/Proton/fPtProton"), track.pt());
+            registry.fill(HIST("TrackCuts/Proton/fMomCorProton"), track.p(), track.tpcInnerParam() - track.p());
             registry.fill(HIST("TrackCuts/Proton/fEtaProton"), track.eta());
             registry.fill(HIST("TrackCuts/Proton/fPhiProton"), track.phi());
             registry.fill(HIST("TrackCuts/Proton/fNsigmaTPCvsPProton"), track.tpcInnerParam(), nTPCSigmaP[0]);
@@ -1314,6 +1369,7 @@ struct CFFilter {
 
             registry.fill(HIST("TrackCuts/TPCSignal/fTPCSignalAntiProton"), track.tpcInnerParam(), track.tpcSignal());
             registry.fill(HIST("TrackCuts/AntiProton/fPtAntiProton"), track.pt());
+            registry.fill(HIST("TrackCuts/AntiProton/fMomCorAntiProton"), track.p(), track.tpcInnerParam() - track.p());
             registry.fill(HIST("TrackCuts/AntiProton/fEtaAntiProton"), track.eta());
             registry.fill(HIST("TrackCuts/AntiProton/fPhiAntiProton"), track.phi());
             registry.fill(HIST("TrackCuts/AntiProton/fNsigmaTPCvsPAntiProton"), track.tpcInnerParam(), nTPCSigmaN[0]);
@@ -1342,6 +1398,7 @@ struct CFFilter {
 
             registry.fill(HIST("TrackCuts/TPCSignal/fTPCSignalDeuteron"), track.tpcInnerParam(), track.tpcSignal());
             registry.fill(HIST("TrackCuts/Deuteron/fPtDeuteron"), track.pt());
+            registry.fill(HIST("TrackCuts/Deuteron/fMomCorDeuteron"), track.p(), track.tpcInnerParam() - track.p());
             registry.fill(HIST("TrackCuts/Deuteron/fEtaDeuteron"), track.eta());
             registry.fill(HIST("TrackCuts/Deuteron/fPhiDeuteron"), track.phi());
             registry.fill(HIST("TrackCuts/Deuteron/fNsigmaTPCvsPDeuteron"), track.tpcInnerParam(), nTPCSigmaP[1]);
@@ -1366,6 +1423,7 @@ struct CFFilter {
 
             registry.fill(HIST("TrackCuts/TPCSignal/fTPCSignalAntiDeuteron"), track.tpcInnerParam(), track.tpcSignal());
             registry.fill(HIST("TrackCuts/AntiDeuteron/fPtAntiDeuteron"), track.pt());
+            registry.fill(HIST("TrackCuts/AntiDeuteron/fMomCorAntiDeuteron"), track.p(), track.tpcInnerParam() - track.p());
             registry.fill(HIST("TrackCuts/AntiDeuteron/fEtaAntiDeuteron"), track.eta());
             registry.fill(HIST("TrackCuts/AntiDeuteron/fPhiAntiDeuteron"), track.phi());
             registry.fill(HIST("TrackCuts/AntiDeuteron/fNsigmaTPCvsPAntiDeuteron"), track.tpcInnerParam(), nTPCSigmaN[1]);
@@ -1505,6 +1563,9 @@ struct CFFilter {
             for (; iProton3 != protons.end(); ++iProton3) {
               Q3 = getQ3(*iProton1, *iProton2, *iProton3);
               registry.fill(HIST("ppp/fSE_particle"), Q3);
+              registry.fill(HIST("ppp/fProtonPtVsQ3"), Q3, (*iProton1).Pt());
+              registry.fill(HIST("ppp/fProtonPtVsQ3"), Q3, (*iProton2).Pt());
+              registry.fill(HIST("ppp/fProtonPtVsQ3"), Q3, (*iProton3).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPPP)) {
                 if (ConfDownsample->get("Switch", "PPP") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "PPP")) {
@@ -1525,6 +1586,9 @@ struct CFFilter {
             for (; iAntiProton3 != antiprotons.end(); ++iAntiProton3) {
               Q3 = getQ3(*iAntiProton1, *iAntiProton2, *iAntiProton3);
               registry.fill(HIST("ppp/fSE_antiparticle"), Q3);
+              registry.fill(HIST("ppp/fAntiProtonPtVsQ3"), Q3, (*iAntiProton1).Pt());
+              registry.fill(HIST("ppp/fAntiProtonPtVsQ3"), Q3, (*iAntiProton2).Pt());
+              registry.fill(HIST("ppp/fAntiProtonPtVsQ3"), Q3, (*iAntiProton3).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPPP)) {
                 if (ConfDownsample->get("Switch", "aPaPaP") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aPaPaP")) {
@@ -1555,6 +1619,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iProton1, *iProton2, *iLambda1);
               registry.fill(HIST("ppl/fSE_particle"), Q3);
+              registry.fill(HIST("ppl/fProtonPtVsQ3"), Q3, (*iProton1).Pt());
+              registry.fill(HIST("ppl/fProtonPtVsQ3"), Q3, (*iProton2).Pt());
+              registry.fill(HIST("ppl/fLambdaPtVsQ3"), Q3, (*iLambda1).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPPL)) {
                 if (ConfDownsample->get("Switch", "PPL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "PPL")) {
@@ -1582,6 +1649,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iAntiProton1, *iAntiProton2, *iAntiLambda1);
               registry.fill(HIST("ppl/fSE_antiparticle"), Q3);
+              registry.fill(HIST("ppl/fAntiProtonPtVsQ3"), Q3, (*iAntiProton1).Pt());
+              registry.fill(HIST("ppl/fAntiProtonPtVsQ3"), Q3, (*iAntiProton2).Pt());
+              registry.fill(HIST("ppl/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda1).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPPL)) {
                 if (ConfDownsample->get("Switch", "aPaPaL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aPaPaL")) {
@@ -1617,6 +1687,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iLambda1, *iLambda2, *iProton1);
               registry.fill(HIST("pll/fSE_particle"), Q3);
+              registry.fill(HIST("pll/fProtonPtVsQ3"), Q3, (*iProton1).Pt());
+              registry.fill(HIST("pll/fLambdaPtVsQ3"), Q3, (*iLambda1).Pt());
+              registry.fill(HIST("pll/fLambdaPtVsQ3"), Q3, (*iLambda2).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPLL)) {
                 if (ConfDownsample->get("Switch", "PLL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "PLL")) {
@@ -1649,6 +1722,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iAntiLambda1, *iAntiLambda2, *iAntiProton1);
               registry.fill(HIST("pll/fSE_antiparticle"), Q3);
+              registry.fill(HIST("pll/fAntiProtonPtVsQ3"), Q3, (*iAntiProton1).Pt());
+              registry.fill(HIST("pll/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda1).Pt());
+              registry.fill(HIST("pll/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda2).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kPLL)) {
                 if (ConfDownsample->get("Switch", "aPaLaL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aPaLaL")) {
@@ -1687,6 +1763,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iLambda1, *iLambda2, *iLambda3);
               registry.fill(HIST("lll/fSE_particle"), Q3);
+              registry.fill(HIST("lll/fLambdaPtVsQ3"), Q3, (*iLambda1).Pt());
+              registry.fill(HIST("lll/fLambdaPtVsQ3"), Q3, (*iLambda2).Pt());
+              registry.fill(HIST("lll/fLambdaPtVsQ3"), Q3, (*iLambda3).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kLLL)) {
                 if (ConfDownsample->get("Switch", "LLL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "LLL")) {
@@ -1722,6 +1801,9 @@ struct CFFilter {
               }
               Q3 = getQ3(*iAntiLambda1, *iAntiLambda2, *iAntiLambda3);
               registry.fill(HIST("lll/fSE_antiparticle"), Q3);
+              registry.fill(HIST("lll/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda1).Pt());
+              registry.fill(HIST("lll/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda2).Pt());
+              registry.fill(HIST("lll/fAntiLambdaPtVsQ3"), Q3, (*iAntiLambda3).Pt());
               if (Q3 < ConfQ3Limits->get(static_cast<uint>(0), CFTrigger::kLLL)) {
                 if (ConfDownsample->get("Switch", "aLaLaL") > 0) {
                   if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aLaLaL")) {
@@ -1742,6 +1824,8 @@ struct CFFilter {
           for (auto iDeuteron = deuterons.begin(); iDeuteron != deuterons.end(); ++iDeuteron) {
             kstar = getkstar(*iProton, *iDeuteron);
             registry.fill(HIST("pd/fSE_particle"), kstar);
+            registry.fill(HIST("pd/fProtonPtVskstar"), kstar, (*iProton).Pt());
+            registry.fill(HIST("pd/fDeuteronPtVskstar"), kstar, (*iDeuteron).Pt());
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kPD)) {
               if (ConfDownsample->get("Switch", "PD") > 0) {
                 if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "PD")) {
@@ -1759,6 +1843,8 @@ struct CFFilter {
           for (auto iAntiDeuteron = antideuterons.begin(); iAntiDeuteron != antideuterons.end(); ++iAntiDeuteron) {
             kstar = getkstar(*iAntiProton, *iAntiDeuteron);
             registry.fill(HIST("pd/fSE_antiparticle"), kstar);
+            registry.fill(HIST("pd/fAntiProtonPtVskstar"), kstar, (*iAntiProton).Pt());
+            registry.fill(HIST("pd/fAntiDeuteronPtVskstar"), kstar, (*iAntiDeuteron).Pt());
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kPD)) {
               if (ConfDownsample->get("Switch", "aPaD") > 0) {
                 if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aPaD")) {
@@ -1778,6 +1864,8 @@ struct CFFilter {
           for (auto iLambda = lambdas.begin(); iLambda != lambdas.end(); ++iLambda) {
             kstar = getkstar(*iDeuteron, *iLambda);
             registry.fill(HIST("ld/fSE_particle"), kstar);
+            registry.fill(HIST("ld/fDeuteronPtVskstar"), kstar, (*iDeuteron).Pt());
+            registry.fill(HIST("ld/fLambdaPtVskstar"), kstar, (*iLambda).Pt());
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kLD)) {
               if (ConfDownsample->get("Switch", "LD") > 0) {
                 if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "LD")) {
@@ -1794,6 +1882,8 @@ struct CFFilter {
           for (auto iAntiLambda = antilambdas.begin(); iAntiLambda != antilambdas.end(); ++iAntiLambda) {
             kstar = getkstar(*iAntiDeuteron, *iAntiLambda);
             registry.fill(HIST("ld/fSE_antiparticle"), kstar);
+            registry.fill(HIST("ld/fAntiDeuteronPtVskstar"), kstar, (*iAntiDeuteron).Pt());
+            registry.fill(HIST("ld/fAntiLambdaPtVskstar"), kstar, (*iAntiLambda).Pt());
             if (kstar < ConfKstarLimits->get(static_cast<uint>(0), CFTrigger::kLD)) {
               if (ConfDownsample->get("Switch", "aLaD") > 0) {
                 if (rng->Uniform(0., 1.) < ConfDownsample->get("Factor", "aLaD")) {

--- a/EventFiltering/PWGCF/CFFilterAll.cxx
+++ b/EventFiltering/PWGCF/CFFilterAll.cxx
@@ -587,7 +587,7 @@ struct CFFilter {
 
     // antiproton
     registry.add("TrackCuts/AntiProton/fPtAntiProton", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
-    registry.add("TrackCuts/AntiProton/fMomCorAntiProton", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
+    registry.add("TrackCuts/AntiProton/fMomCorAntiProton", "Momentum correlation;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/AntiProton/fEtaAntiProton", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/AntiProton/fPhiAntiProton", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/AntiProton/fNsigmaTPCvsPAntiProton", "NSigmaTPC AntiProton;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -607,7 +607,7 @@ struct CFFilter {
 
     // deuteron
     registry.add("TrackCuts/Deuteron/fPtDeuteron", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
-    registry.add("TrackCuts/Deuteron/fMomCorDeuteron", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
+    registry.add("TrackCuts/Deuteron/fMomCorDeuteron", "Momentum correlation;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/Deuteron/fEtaDeuteron", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/Deuteron/fPhiDeuteron", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/Deuteron/fNsigmaTPCvsPDeuteron", "NSigmaTPC Deuteron;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -627,7 +627,7 @@ struct CFFilter {
 
     // antideuteron
     registry.add("TrackCuts/AntiDeuteron/fPtAntiDeuteron", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
-    registry.add("TrackCuts/AntiDeuteron/fMomCorAntiDeuteron", "Momentum correlations;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
+    registry.add("TrackCuts/AntiDeuteron/fMomCorAntiDeuteron", "Momentum correlation;p_{reco} (GeV/c); (p_{TPC} - p_{reco}) (GeV/c)", {HistType::kTH2F, {{1000, 0, 10}, {600, -3, 3}}});
     registry.add("TrackCuts/AntiDeuteron/fEtaAntiDeuteron", "Pseudorapidity of all processed tracks;#eta;Entries", HistType::kTH1F, {{1000, -2, 2}});
     registry.add("TrackCuts/AntiDeuteron/fPhiAntiDeuteron", "Azimuthal angle of all processed tracks;#phi;Entries", HistType::kTH1F, {{720, 0, TMath::TwoPi()}});
     registry.add("TrackCuts/AntiDeuteron/fNsigmaTPCvsPAntiDeuteron", "NSigmaTPC AntiDeuteron;p_{TPC} (GeV/c);n#sigma_{TPC}", {HistType::kTH2F, {{100, 0.0f, 10.0f}, {100, -10.f, 10.f}}});
@@ -743,10 +743,7 @@ struct CFFilter {
     registry.add("pll/fProtonPtVsQ3", "Q3 vs pT (proton)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
     registry.add("pll/fAntiProtonPtVsQ3", "Q3 vs pT (antiproton)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
     registry.add("pll/fLambdaPtVsQ3", "Q3 vs pT (lambda)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
-    registry.add("pll/fAntiLambdaPtVsQ3", "Q3 vs pT (antilambda)", {HistType::kTH2F, {
-                                                                                       {150, 0, 1.5},
-                                                                                       {500, 0, 10},
-                                                                                     }});
+    registry.add("pll/fAntiLambdaPtVsQ3", "Q3 vs pT (antilambda)", {HistType::kTH2F, {{150, 0, 1.5}, {500, 0, 10}}});
 
     // for lll
     registry.add("lll/fMultiplicity", "Multiplicity of all processed events;Mult;Entries", HistType::kTH1F, {{1000, 0, 1000}});


### PR DESCRIPTION
- Add cut and histograms to study the correlation between the momentum of a track at the TPC inner wall and the reconstructed momentum.
- Add histograms to plot the particle pT vs Q3/kstar of the pair