### PR TITLE
[PWGJE] fixing jetvalidation track input

### DIFF
--- a/Common/Core/TrackSelectionDefaults.cxx
+++ b/Common/Core/TrackSelectionDefaults.cxx
@@ -118,6 +118,7 @@ TrackSelection getGlobalTrackSelectionRun3HF()
 TrackSelection getJEGlobalTrackSelectionRun2()
 {
   TrackSelection selectedTracks = getGlobalTrackSelection();
+  selectedTracks.SetPtRange(0.15f, 1e15f);
   selectedTracks.SetRequireGoldenChi2(false);
   selectedTracks.SetMaxDcaXYPtDep([](float pt) { return 1e+10; });
   selectedTracks.SetEtaRange(-0.9f, 0.9f);

--- a/PWGJE/Tasks/jetvalidationqa.cxx
+++ b/PWGJE/Tasks/jetvalidationqa.cxx
@@ -181,8 +181,8 @@ struct jetTrackCollisionQa {
     mHistManager.fill(HIST("leadJetConstEta"), leadingConstTrackEta);
   } // end of fillLeadingJetConstQA template
 
-  Filter etafilter = (aod::jtrack::eta < etaup) && (aod::jtrack::eta > etalow);
-  Filter ptfilter = (aod::jtrack::pt < ptUp) && (aod::jtrack::pt > ptLow);
+  Filter etafilter = (aod::jtrack::eta <= etaup) && (aod::jtrack::eta >= etalow);
+  Filter ptfilter = (aod::jtrack::pt <= ptUp) && (aod::jtrack::pt >= ptLow);
   using Tracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection>;
   using TracksJE = soa::Filtered<soa::Join<aod::JTracks, aod::JTrackPIs>>;
 
@@ -329,7 +329,7 @@ struct jetTrackCollisionQa {
 struct mcJetTrackCollisionQa {
   // Track filter configs
   Configurable<float> ptLow{"ptLow", 0.15f, "lowest pt"};
-  Configurable<float> ptUp{"ptUp", 10e10f, "highest pt"};
+  Configurable<float> ptUp{"ptUp", 10e15f, "highest pt"};
   Configurable<float> etalow{"etaLow", -0.9f, "lowest eta"};
   Configurable<float> etaup{"etaUp", 0.9f, "highest eta"};
 


### PR DESCRIPTION
Hi,

we need to include the minimum pT cut in the **TrackSelectionDefaults.cxx** to assure that not the tracks fed to the jetfinder have the same minimum pT cut as the tracks filled in the jetvalidation task (here we used filters before; I added the >= which is redundant but a reminder that we include the first and last bins.).

Cheerio,
Johanna