### PR TITLE
PWGEM/PhotonMeson: add phiv template for pi0 and photon

### DIFF
--- a/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
+++ b/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
@@ -76,6 +76,7 @@ void o2::aod::emphotonhistograms::DefineHistograms(THashList* list, const char* 
     list->Add(new TH2F("hPCA_Rxy", "distance between 2 legs vs. R_{xy};R_{xy} (cm);PCA (cm)", 200, 0.f, 100.f, 200, 0.0f, 2.0f));
     list->Add(new TH2F("hDCAxyz", "DCA to PV;DCA_{xy} (cm);DCA_{z} (cm)", 200, -5.f, +5.f, 200, -5.f, +5.f));
     list->Add(new TH2F("hAPplot", "AP plot;#alpha;q_{T} (GeV/c)", 200, -1.0f, +1.0f, 250, 0.0f, 0.25f));
+    list->Add(new TH2F("hMassGammaPV", "hMassGamma;R_{xy} (cm);m_{ee} (GeV/c^{2})", 200, 0.0f, 100.0f, 100, 0.0f, 0.1f));
     list->Add(new TH2F("hMassGamma", "hMassGamma;R_{xy} (cm);m_{ee} (GeV/c^{2})", 200, 0.0f, 100.0f, 100, 0.0f, 0.1f));
     list->Add(new TH2F("hMassGamma_recalc", "recalc. hMassGamma;R_{xy} (cm);m_{ee} (GeV/c^{2})", 200, 0.0f, 100.0f, 100, 0.0f, 0.1f));
     list->Add(new TH2F("hGammaRxy", "conversion point in XY;V_{x} (cm);V_{y} (cm)", 400, -100.0f, 100.0f, 400, -100.0f, 100.0f));
@@ -176,8 +177,13 @@ void o2::aod::emphotonhistograms::DefineHistograms(THashList* list, const char* 
     if (TString(subGroup) == "mc") {
       list->Add(new TH1F("hPt_Photon_Primary", "pT;p_{T} (GeV/c)", 1000, 0.0f, 10));                                                  // for MC efficiency
       list->Add(new TH2F("hEtaPhi_Photon_Primary", "#eta vs. #varphi;#varphi (rad.);#eta", 180, 0, TMath::TwoPi(), 40, -2.0f, 2.0f)); // for MC efficiency
-    }                                                                                                                                 // end of mc
-  }                                                                                                                                   // end of DalitzEE
+
+      // create phiv template
+      list->Add(new TH2F("hMvsPhiV_Pi0", "m_{ee} vs. #varphi_{V};#varphi_{V} (rad.);m_{ee} (GeV/c^{2})", 32, 0, 3.2, 100, 0.0f, 0.1f));    // ee from pi0 dalitz decay
+      list->Add(new TH2F("hMvsPhiV_Photon", "m_{ee} vs. #varphi_{V};#varphi_{V} (rad.);m_{ee} (GeV/c^{2})", 32, 0, 3.2, 100, 0.0f, 0.1f)); // ee from photon conversion
+
+    } // end of mc
+  }   // end of DalitzEE
   if (TString(histClass) == "Track") {
     list->Add(new TH1F("hPt", "pT;p_{T} (GeV/c)", 1000, 0.0f, 10));
     list->Add(new TH1F("hQoverPt", "q/pT;q/p_{T} (GeV/c)^{-1}", 400, -20, 20));

--- a/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
+++ b/PWGEM/PhotonMeson/Core/HistogramsLibrary.cxx
@@ -117,13 +117,13 @@ void o2::aod::emphotonhistograms::DefineHistograms(THashList* list, const char* 
   }   // end of V0
 
   if (TString(histClass) == "DalitzEE") {
-    const int nm = 150;
+    const int nm = 147;
     double mee[nm] = {0.f};
-    for (int i = 0; i < 110; i++) {
-      mee[i] = 0.01 * i;
+    for (int i = 0; i < 40; i++) {
+      mee[i] = 0.001 * (i - 0) + 0.0;
     }
-    for (int i = 110; i < nm; i++) {
-      mee[i] = 0.1 * (i - 110) + 1.1;
+    for (int i = 40; i < nm; i++) {
+      mee[i] = 0.01 * (i - 40) + 0.04;
     }
 
     const int npt = 61;
@@ -147,7 +147,7 @@ void o2::aod::emphotonhistograms::DefineHistograms(THashList* list, const char* 
     const int ndim = 4; // m, pt, dca, phiv
     const int nbins[ndim] = {nm - 1, npt - 1, ndca - 1, 32};
     const double xmin[ndim] = {0.0, 0.0, 0.0, 0.0};
-    const double xmax[ndim] = {5.0, 10.0, 20.0, 3.2};
+    const double xmax[ndim] = {1.1, 10.0, 20.0, 3.2};
 
     THnSparseF* hs_dilepton_uls = new THnSparseF("hs_dilepton_uls", "hs_dilepton_uls;m_{ee} (GeV/c);p_{T,ee} (GeV/c);DCA_{xy,ee} (#sigma);#varphi_{V} (rad.);", ndim, nbins, xmin, xmax);
     hs_dilepton_uls->SetBinEdges(0, mee);

--- a/PWGEM/PhotonMeson/Core/HistogramsLibrary.h
+++ b/PWGEM/PhotonMeson/Core/HistogramsLibrary.h
@@ -75,6 +75,7 @@ void FillHistClass(THashList* list, const char* subGroup, T const& obj)
     reinterpret_cast<TH2F*>(list->FindObject("hPCA_Rxy"))->Fill(obj.v0radius(), obj.pca());
     reinterpret_cast<TH2F*>(list->FindObject("hDCAxyz"))->Fill(obj.dcaXYv0topv(), obj.dcaZv0topv());
     reinterpret_cast<TH2F*>(list->FindObject("hAPplot"))->Fill(obj.alpha(), obj.qtarm());
+    reinterpret_cast<TH2F*>(list->FindObject("hMassGammaPV"))->Fill(obj.v0radius(), obj.mGammaPV());
     reinterpret_cast<TH2F*>(list->FindObject("hMassGamma"))->Fill(obj.v0radius(), obj.mGamma());
     reinterpret_cast<TH2F*>(list->FindObject("hMassGamma_recalc"))->Fill(obj.recalculatedVtxR(), obj.mGamma());
     reinterpret_cast<TH2F*>(list->FindObject("hGammaRxy"))->Fill(obj.vx(), obj.vy());

--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -245,7 +245,8 @@ DECLARE_SOA_COLUMN(Vz, vz, float);                                      //! seco
 DECLARE_SOA_COLUMN(Px, px, float);                                      //! px for photon kf
 DECLARE_SOA_COLUMN(Py, py, float);                                      //! py for photon kf
 DECLARE_SOA_COLUMN(Pz, pz, float);                                      //! pz for photon kf
-DECLARE_SOA_COLUMN(MGamma, mGamma, float);                              //! invariant mass of dielectron
+DECLARE_SOA_COLUMN(MGamma, mGamma, float);                              //! invariant mass of dielectron at SV
+DECLARE_SOA_COLUMN(MGammaPV, mGammaPV, float);                          //! invariant mass of dielectron at PV
 DECLARE_SOA_COLUMN(DCAxyV0ToPV, dcaXYv0topv, float);                    //! DCAxy of V0 to PV
 DECLARE_SOA_COLUMN(DCAzV0ToPV, dcaZv0topv, float);                      //! DCAz of V0 to PV
 DECLARE_SOA_COLUMN(CosPA, cospa, float);                                //!
@@ -265,7 +266,7 @@ DECLARE_SOA_TABLE(V0PhotonsKF, "AOD", "V0PHOTONKF", //!
                   o2::soa::Index<>, v0photonkf::CollisionId, v0photonkf::PosTrackId, v0photonkf::NegTrackId,
                   v0photonkf::Vx, v0photonkf::Vy, v0photonkf::Vz,
                   v0photonkf::Px, v0photonkf::Py, v0photonkf::Pz,
-                  v0photonkf::MGamma,
+                  v0photonkf::MGamma, v0photonkf::MGammaPV,
                   v0photonkf::DCAxyV0ToPV, v0photonkf::DCAzV0ToPV,
                   v0photonkf::CosPA, v0photonkf::PCA,
                   v0photonkf::Alpha, v0photonkf::QtArm,

--- a/PWGEM/PhotonMeson/TableProducer/photonconversionbuilder.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/photonconversionbuilder.cxx
@@ -126,6 +126,7 @@ struct PhotonConversionBuilder {
       {"V0/hDCAxyz", "DCA to PV;DCA_{xy} (cm);DCA_{z} (cm)", {HistType::kTH2F, {{200, -5.f, +5.f}, {200, -5.f, +5.f}}}},
       {"V0/hMee_SVPV", "mee at PV and SV;m_{ee} at PV (GeV/c^{2});m_{ee} at SV (GeV/c^{2})", {HistType::kTH2F, {{100, 0.0f, 0.1f}, {100, 0, 0.1f}}}},
       {"V0/hMeeSV_Rxy", "mee at SV vs. R_{xy};R_{xy} (cm);m_{ee} at SV (GeV/c^{2})", {HistType::kTH2F, {{200, 0.0f, 100.f}, {100, 0, 0.1f}}}},
+      {"V0/hMeePV_Rxy", "mee at PV vs. R_{xy};R_{xy} (cm);m_{ee} at PV (GeV/c^{2})", {HistType::kTH2F, {{200, 0.0f, 100.f}, {100, 0, 0.1f}}}},
       {"V0/hPtDiff", "V0 KF pt leg sum vs. gamma pt;p_{T,#gamma} (GeV/c);p_{T,ee} (GeV/c)", {HistType::kTH2F, {{1000, 0.0f, 10.f}, {1000, 0, 10}}}},
       {"V0Leg/hPt", "pT of leg at SV;p_{T,e} (GeV/c)", {HistType::kTH1F, {{1000, 0.0f, 10.0f}}}},
       {"V0Leg/hEtaPhi", "#eta vs. #varphi of leg at SV;#varphi (rad.);#eta", {HistType::kTH2F, {{72, 0.0f, TMath::TwoPi()}, {400, -2, +2}}}},
@@ -461,11 +462,12 @@ struct PhotonConversionBuilder {
       ROOT::Math::PxPyPzMVector v0_sv = vpos_sv + vele_sv;
       registry.fill(HIST("V0/hMee_SVPV"), v0_pv.M(), v0_sv.M());
       registry.fill(HIST("V0/hMeeSV_Rxy"), rxy, v0_sv.M());
+      registry.fill(HIST("V0/hMeePV_Rxy"), rxy, v0_pv.M());
 
       v0photonskf(collision.globalIndex(), v0legs.lastIndex() + 1, v0legs.lastIndex() + 2,
                   gammaKF_DecayVtx.GetX(), gammaKF_DecayVtx.GetY(), gammaKF_DecayVtx.GetZ(),
                   gammaKF_DecayVtx.GetPx(), gammaKF_DecayVtx.GetPy(), gammaKF_DecayVtx.GetPz(),
-                  v0_sv.M(), dca_xy_v0_to_pv, dca_z_v0_to_pv,
+                  v0_sv.M(), v0_pv.M(), dca_xy_v0_to_pv, dca_z_v0_to_pv,
                   cospa_kf, pca_kf, alpha, qt, chi2kf);
 
       fFuncTableV0Recalculated(xyz[0], xyz[1], xyz[2]);

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversion.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaConversion.cxx
@@ -293,9 +293,9 @@ struct skimmerGammaConversion {
     // LOGF(info, "ele px = %f (original) , %f (KF at init) , %f (KF at PV) , %f (KF at SV)", ele.px(), kfp_ele.GetPx(), kfp_ele_PV.GetPx(), kfp_ele_DecayVtx.GetPx());
     // LOGF(info, "pos px = %f (original) , %f (KF at init) , %f (KF at PV) , %f (KF at SV)", pos.px(), kfp_pos.GetPx(), kfp_pos_PV.GetPx(), kfp_pos_DecayVtx.GetPx());
 
-    // ROOT::Math::PxPyPzMVector vpos_pv(kfp_pos_PV.GetPx(), kfp_pos_PV.GetPy(), kfp_pos_PV.GetPz(), o2::constants::physics::MassElectron);
-    // ROOT::Math::PxPyPzMVector vele_pv(kfp_ele_PV.GetPx(), kfp_ele_PV.GetPy(), kfp_ele_PV.GetPz(), o2::constants::physics::MassElectron);
-    // ROOT::Math::PxPyPzMVector v0_pv = vpos_pv + vele_pv;
+    ROOT::Math::PxPyPzMVector vpos_pv(kfp_pos_PV.GetPx(), kfp_pos_PV.GetPy(), kfp_pos_PV.GetPz(), o2::constants::physics::MassElectron);
+    ROOT::Math::PxPyPzMVector vele_pv(kfp_ele_PV.GetPx(), kfp_ele_PV.GetPy(), kfp_ele_PV.GetPz(), o2::constants::physics::MassElectron);
+    ROOT::Math::PxPyPzMVector v0_pv = vpos_pv + vele_pv;
 
     ROOT::Math::PxPyPzMVector vpos_sv(kfp_pos_DecayVtx.GetPx(), kfp_pos_DecayVtx.GetPy(), kfp_pos_DecayVtx.GetPz(), o2::constants::physics::MassElectron);
     ROOT::Math::PxPyPzMVector vele_sv(kfp_ele_DecayVtx.GetPx(), kfp_ele_DecayVtx.GetPy(), kfp_ele_DecayVtx.GetPz(), o2::constants::physics::MassElectron);
@@ -324,7 +324,7 @@ struct skimmerGammaConversion {
     v0photonskf(collision.globalIndex(), v0legs.lastIndex() + 1, v0legs.lastIndex() + 2,
                 gammaKF_DecayVtx.GetX(), gammaKF_DecayVtx.GetY(), gammaKF_DecayVtx.GetZ(),
                 gammaKF_DecayVtx.GetPx(), gammaKF_DecayVtx.GetPy(), gammaKF_DecayVtx.GetPz(),
-                v0_sv.M(), dca_xy_v0_to_pv, dca_z_v0_to_pv,
+                v0_sv.M(), v0_pv.M(), dca_xy_v0_to_pv, dca_z_v0_to_pv,
                 cospa_kf, pca_kf, alpha, qt, chi2kf);
 
     fillTrackTable(pos, kfp_pos_DecayVtx);

--- a/PWGEM/PhotonMeson/Tasks/dalitzEEQCMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/dalitzEEQCMC.cxx
@@ -89,7 +89,7 @@ struct DalitzEEQCMC {
     for (auto& cut : fDalitzEECuts) {
       std::string_view cutname = cut.GetName();
       THashList* list = reinterpret_cast<THashList*>(fMainList->FindObject("DalitzEE")->FindObject(cutname.data()));
-      o2::aod::emphotonhistograms::DefineHistograms(list, "DalitzEE");
+      o2::aod::emphotonhistograms::DefineHistograms(list, "DalitzEE", "mc");
     }
   }
 
@@ -176,26 +176,37 @@ struct DalitzEEQCMC {
           auto elemc = ele.template emmcparticle_as<aod::EMMCParticles>();
 
           int mother_id = FindLF(posmc, elemc, mcparticles);
-          if (mother_id < 0) {
+          int photonid = FindCommonMotherFrom2Prongs(posmc, elemc, -11, 11, 22, mcparticles);
+          if (mother_id < 0 && photonid < 0) {
             continue;
           }
-          auto mcmother = mcparticles.iteratorAt(mother_id);
+          if (mother_id > 0) {
+            auto mcmother = mcparticles.iteratorAt(mother_id);
+            if (IsPhysicalPrimary(mcmother.emreducedmcevent(), mcmother, mcparticles)) {
+              if (cut.IsSelected<MyMCTracks>(uls_pair)) {
+                values[0] = uls_pair.mee();
+                values[1] = uls_pair.pt();
+                values[2] = uls_pair.dcaeeXY();
+                values[3] = uls_pair.phiv();
+                reinterpret_cast<THnSparseF*>(list_dalitzee_cut->FindObject("hs_dilepton_uls"))->Fill(values);
 
-          if (!IsPhysicalPrimary(mcmother.emreducedmcevent(), mcmother, mcparticles)) {
-            continue;
-          }
-          if (cut.IsSelected<MyMCTracks>(uls_pair)) {
-            values[0] = uls_pair.mee();
-            values[1] = uls_pair.pt();
-            values[2] = uls_pair.dcaeeXY();
-            values[3] = uls_pair.phiv();
-            reinterpret_cast<THnSparseF*>(list_dalitzee_cut->FindObject("hs_dilepton_uls"))->Fill(values);
-            nuls++;
-            for (auto& track : {pos, ele}) {
-              if (std::find(used_trackIds.begin(), used_trackIds.end(), track.globalIndex()) == used_trackIds.end()) {
-                o2::aod::emphotonhistograms::FillHistClass<EMHistType::kTrack>(list_track_cut, "", track);
-                used_trackIds.emplace_back(track.globalIndex());
+                if (mcmother.pdgCode() == 111) {
+                  reinterpret_cast<TH2F*>(list_dalitzee_cut->FindObject("hMvsPhiV_Pi0"))->Fill(uls_pair.phiv(), uls_pair.mee());
+                }
+
+                nuls++;
+                for (auto& track : {pos, ele}) {
+                  if (std::find(used_trackIds.begin(), used_trackIds.end(), track.globalIndex()) == used_trackIds.end()) {
+                    o2::aod::emphotonhistograms::FillHistClass<EMHistType::kTrack>(list_track_cut, "", track);
+                    used_trackIds.emplace_back(track.globalIndex());
+                  }
+                }
               }
+            } // end of LF
+          } else if (photonid > 0) {
+            auto mcphoton = mcparticles.iteratorAt(photonid);
+            if (IsPhysicalPrimary(mcphoton.emreducedmcevent(), mcphoton, mcparticles) && IsEleFromPC(elemc, mcparticles) && IsEleFromPC(posmc, mcparticles)) {
+              reinterpret_cast<TH2F*>(list_dalitzee_cut->FindObject("hMvsPhiV_Photon"))->Fill(uls_pair.phiv(), uls_pair.mee());
             }
           }
         } // end of uls pair loop


### PR DESCRIPTION
This PR contains following commits.
[PWGEM/PhotonMeson: add a column in v0 photon table]
[PWGEM/PhotonMeson: add phiv template for pi0 and photon]