### PR TITLE
PWGDQ: Adapt D0 BDT columns to new development in HF

### DIFF
--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -577,27 +577,33 @@ DECLARE_SOA_TABLE(RedJpDmColls, "AOD", "REDJPDMCOLL", //!
 
 namespace jpsidmescorr
 {
-DECLARE_SOA_INDEX_COLUMN(RedJpDmColl, redJpDmColl);    //!
-DECLARE_SOA_COLUMN(MassD0, massD0, float);             //!
-DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float);       //!
-DECLARE_SOA_COLUMN(Px, px, float);                     //!
-DECLARE_SOA_COLUMN(Py, py, float);                     //!
-DECLARE_SOA_COLUMN(Pz, pz, float);                     //!
-DECLARE_SOA_COLUMN(DecVtxX, decVtxX, float);           //!
-DECLARE_SOA_COLUMN(DecVtxY, decVtxY, float);           //!
-DECLARE_SOA_COLUMN(DecVtxZ, decVtxZ, float);           //!
-DECLARE_SOA_COLUMN(BdtBkg, bdtBkg, float);             //!
-DECLARE_SOA_COLUMN(BdtPrompt, bdtPrompt, float);       //!
-DECLARE_SOA_COLUMN(BdtNonprompt, bdtNonprompt, float); //!
-DECLARE_SOA_COLUMN(NumColls, numColls, uint64_t);      //!
-DECLARE_SOA_COLUMN(PtD0, ptD0, float);                 //!
-DECLARE_SOA_COLUMN(PtJpsi, ptJpsi, float);             //!
-DECLARE_SOA_COLUMN(RapD0, rapD0, float);               //!
-DECLARE_SOA_COLUMN(RapJpsi, rapJpsi, float);           //!
-DECLARE_SOA_COLUMN(PhiD0, phiD0, float);               //!
-DECLARE_SOA_COLUMN(PhiJpsi, phiJpsi, float);           //!
-DECLARE_SOA_COLUMN(DeltaY, deltaY, float);             //!
-DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);         //!
+DECLARE_SOA_INDEX_COLUMN(RedJpDmColl, redJpDmColl);                      //!
+DECLARE_SOA_COLUMN(MassD0, massD0, float);                               //!
+DECLARE_SOA_COLUMN(MassD0bar, massD0bar, float);                         //!
+DECLARE_SOA_COLUMN(Px, px, float);                                       //!
+DECLARE_SOA_COLUMN(Py, py, float);                                       //!
+DECLARE_SOA_COLUMN(Pz, pz, float);                                       //!
+DECLARE_SOA_COLUMN(DecVtxX, decVtxX, float);                             //!
+DECLARE_SOA_COLUMN(DecVtxY, decVtxY, float);                             //!
+DECLARE_SOA_COLUMN(DecVtxZ, decVtxZ, float);                             //!
+DECLARE_SOA_COLUMN(BdtBkgMassHypo0, bdtBkgMassHypo0, float);             //!
+DECLARE_SOA_COLUMN(BdtPromptMassHypo0, bdtPromptMassHypo0, float);       //!
+DECLARE_SOA_COLUMN(BdtNonpromptMassHypo0, bdtNonpromptMassHypo0, float); //!
+DECLARE_SOA_COLUMN(BdtBkg, bdtBkg, float);                               //!
+DECLARE_SOA_COLUMN(BdtPrompt, bdtPrompt, float);                         //!
+DECLARE_SOA_COLUMN(BdtNonprompt, bdtNonprompt, float);                   //!
+DECLARE_SOA_COLUMN(BdtBkgMassHypo1, bdtBkgMassHypo1, float);             //!
+DECLARE_SOA_COLUMN(BdtPromptMassHypo1, bdtPromptMassHypo1, float);       //!
+DECLARE_SOA_COLUMN(BdtNonpromptMassHypo1, bdtNonpromptMassHypo1, float); //!
+DECLARE_SOA_COLUMN(NumColls, numColls, uint64_t);                        //!
+DECLARE_SOA_COLUMN(PtD0, ptD0, float);                                   //!
+DECLARE_SOA_COLUMN(PtJpsi, ptJpsi, float);                               //!
+DECLARE_SOA_COLUMN(RapD0, rapD0, float);                                 //!
+DECLARE_SOA_COLUMN(RapJpsi, rapJpsi, float);                             //!
+DECLARE_SOA_COLUMN(PhiD0, phiD0, float);                                 //!
+DECLARE_SOA_COLUMN(PhiJpsi, phiJpsi, float);                             //!
+DECLARE_SOA_COLUMN(DeltaY, deltaY, float);                               //!
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);                           //!
 } // namespace jpsidmescorr
 
 DECLARE_SOA_TABLE(RedJpDmDileptons, "AOD", "REDJPDMDILEPTON", //!
@@ -633,9 +639,12 @@ DECLARE_SOA_TABLE(RedJpDmD0Masss, "AOD", "REDJPDMD0MASS", //!
                   jpsidmescorr::MassD0bar);
 
 DECLARE_SOA_TABLE(RedJpDmDmesBdts, "AOD", "REDJPDMDMESBDT", //!
-                  jpsidmescorr::BdtBkg,
-                  jpsidmescorr::BdtPrompt,
-                  jpsidmescorr::BdtNonprompt);
+                  jpsidmescorr::BdtBkgMassHypo0,
+                  jpsidmescorr::BdtPromptMassHypo0,
+                  jpsidmescorr::BdtNonpromptMassHypo0,
+                  jpsidmescorr::BdtBkgMassHypo1,
+                  jpsidmescorr::BdtPromptMassHypo1,
+                  jpsidmescorr::BdtNonpromptMassHypo1);
 
 DECLARE_SOA_TABLE(RedDleptDmesAll, "AOD", "RTDILPTDMESALL", //!
                   reducedpair::Mass,

--- a/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
+++ b/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
@@ -208,9 +208,19 @@ struct tableMakerJpsiHf {
             isJPsiFilled = true;
           }
           redDmesons(indexRed, dmeson.px(), dmeson.py(), dmeson.pz(), dmeson.xSecondaryVertex(), dmeson.ySecondaryVertex(), dmeson.zSecondaryVertex(), 0, 0);
+          std::array<float, 6> scores = {999., -999., -999., 999., -999., -999.}; // D0 + D0bar
           if constexpr (withBdt) {
-            auto scores = dmeson.mlProbD0();
-            redDmesBdts(scores[0], scores[1], scores[2]);
+            if (dmeson.mlProbD0().size() == 3) {
+              for (auto iScore{0u}; iScore<dmeson.mlProbD0().size(); ++iScore) {
+                scores[iScore] = dmeson.mlProbD0()[iScore];
+              }
+            }
+            if (dmeson.mlProbD0bar().size() == 3) {
+              for (auto iScore{0u}; iScore<dmeson.mlProbD0().size(); ++iScore) {
+                scores[iScore+3] = dmeson.mlProbD0bar()[iScore];
+              }
+            }
+            redDmesBdts(scores[0], scores[1], scores[2], scores[3], scores[4], scores[5]);
           }
 
           auto ptBinForBdt = findBin(pTBinsBDT, dmeson.pt());
@@ -224,7 +234,7 @@ struct tableMakerJpsiHf {
           }
           if (dmeson.isSelD0bar() >= 1) {
             massD0bar = hfHelper.invMassD0barToKPi(dmeson);
-            if (ptBinForBdt >= 0 && (scores[0] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[1] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[2] > bdtCutsForHistos->get(ptBinForBdt, 2u))) {
+            if (ptBinForBdt >= 0 && (scores[3] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[4] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[5] > bdtCutsForHistos->get(ptBinForBdt, 2u))) {
               VarManager::FillDileptonCharmHadron<VarManager::kD0barToKPi>(dilepton, dmeson, hfHelper, fValuesDileptonCharmHadron);
               fHistMan->FillHistClass("JPsiDmeson", fValuesDileptonCharmHadron);
               VarManager::ResetValues(0, VarManager::kNVars, fValuesDileptonCharmHadron);

--- a/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
+++ b/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
@@ -211,12 +211,12 @@ struct tableMakerJpsiHf {
           std::array<float, 6> scores = {999., -999., -999., 999., -999., -999.}; // D0 + D0bar
           if constexpr (withBdt) {
             if (dmeson.mlProbD0().size() == 3) {
-              for (auto iScore{0u}; iScore<dmeson.mlProbD0().size(); ++iScore) {
+              for (auto iScore{0u}; iScore < dmeson.mlProbD0().size(); ++iScore) {
                 scores[iScore] = dmeson.mlProbD0()[iScore];
               }
             }
             if (dmeson.mlProbD0bar().size() == 3) {
-              for (auto iScore{0u}; iScore<dmeson.mlProbD0().size(); ++iScore) {
+              for (auto iScore{0u}; iScore < dmeson.mlProbD0().size(); ++iScore) {
                 scores[iScore+3] = dmeson.mlProbD0bar()[iScore];
               }
             }
@@ -226,7 +226,7 @@ struct tableMakerJpsiHf {
           auto ptBinForBdt = findBin(pTBinsBDT, dmeson.pt());
           if (dmeson.isSelD0() >= 1) {
             massD0 = hfHelper.invMassD0ToPiK(dmeson);
-            if (ptBinForBdt >= 0 && (scores[0] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[1] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[2] > bdtCutsForHistos->get(ptBinForBdt, 2u))) {
+            if (ptBinForBdt >= 0 && ((scores[0] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[1] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[2] > bdtCutsForHistos->get(ptBinForBdt, 2u)) || !withBdt)) {
               VarManager::FillDileptonCharmHadron<VarManager::kD0ToPiK>(dilepton, dmeson, hfHelper, fValuesDileptonCharmHadron);
               fHistMan->FillHistClass("JPsiDmeson", fValuesDileptonCharmHadron);
               VarManager::ResetValues(0, VarManager::kNVars, fValuesDileptonCharmHadron);
@@ -234,7 +234,7 @@ struct tableMakerJpsiHf {
           }
           if (dmeson.isSelD0bar() >= 1) {
             massD0bar = hfHelper.invMassD0barToKPi(dmeson);
-            if (ptBinForBdt >= 0 && (scores[3] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[4] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[5] > bdtCutsForHistos->get(ptBinForBdt, 2u))) {
+            if (ptBinForBdt >= 0 && ((scores[3] < bdtCutsForHistos->get(ptBinForBdt, 0u) && scores[4] > bdtCutsForHistos->get(ptBinForBdt, 1u) && scores[5] > bdtCutsForHistos->get(ptBinForBdt, 2u)) || withBdt)) {
               VarManager::FillDileptonCharmHadron<VarManager::kD0barToKPi>(dilepton, dmeson, hfHelper, fValuesDileptonCharmHadron);
               fHistMan->FillHistClass("JPsiDmeson", fValuesDileptonCharmHadron);
               VarManager::ResetValues(0, VarManager::kNVars, fValuesDileptonCharmHadron);

--- a/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
+++ b/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
@@ -217,7 +217,7 @@ struct tableMakerJpsiHf {
             }
             if (dmeson.mlProbD0bar().size() == 3) {
               for (auto iScore{0u}; iScore < dmeson.mlProbD0().size(); ++iScore) {
-                scores[iScore+3] = dmeson.mlProbD0bar()[iScore];
+                scores[iScore + 3] = dmeson.mlProbD0bar()[iScore];
               }
             }
             redDmesBdts(scores[0], scores[1], scores[2], scores[3], scores[4], scores[5]);

--- a/PWGDQ/Tasks/taskJpsiHf.cxx
+++ b/PWGDQ/Tasks/taskJpsiHf.cxx
@@ -85,14 +85,14 @@ struct taskJPsiHf {
           rapDmeson = RecoDecay::y(std::array{dmeson.px(), dmeson.py(), dmeson.pz()}, dmeson.massD0());
           deltaRap = rapDilepton - rapDmeson;
           if ((dilepton.mass() > massDileptonCandMin && dilepton.mass() < massDileptonCandMax) && (dmeson.massD0() > massHfCandMin && dmeson.massD0() < massHfCandMax)) {
-            redDileptDimesAll(dilepton.mass(), dmeson.massD0(), ptDilepton, ptDmeson, rapDilepton, rapDmeson, phiDilepton, phiDmeson, deltaRap, deltaPhi, dmeson.bdtBkg(), dmeson.bdtPrompt(), dmeson.bdtNonprompt());
+            redDileptDimesAll(dilepton.mass(), dmeson.massD0(), ptDilepton, ptDmeson, rapDilepton, rapDmeson, phiDilepton, phiDmeson, deltaRap, deltaPhi, dmeson.bdtBkgMassHypo0(), dmeson.bdtPromptMassHypo0(), dmeson.bdtNonpromptMassHypo0());
           }
         }
         if (dmeson.massD0bar() > 0) {
           rapDmeson = RecoDecay::y(std::array{dmeson.px(), dmeson.py(), dmeson.pz()}, dmeson.massD0bar());
           deltaRap = rapDilepton - rapDmeson;
           if ((dilepton.mass() > massDileptonCandMin && dilepton.mass() < massDileptonCandMax) && (dmeson.massD0() > massHfCandMin && dmeson.massD0() < massHfCandMax)) {
-            redDileptDimesAll(dilepton.mass(), dmeson.massD0bar(), ptDilepton, ptDmeson, rapDilepton, rapDmeson, phiDilepton, phiDmeson, deltaRap, deltaPhi, dmeson.bdtBkg(), dmeson.bdtPrompt(), dmeson.bdtNonprompt());
+            redDileptDimesAll(dilepton.mass(), dmeson.massD0bar(), ptDilepton, ptDmeson, rapDilepton, rapDmeson, phiDilepton, phiDmeson, deltaRap, deltaPhi, dmeson.bdtBkgMassHypo1(), dmeson.bdtPromptMassHypo1(), dmeson.bdtNonpromptMassHypo1());
           }
         }
       }


### PR DESCRIPTION
Hi @lucamicheletti93 I have adapted the JPsi-D code for what concerns the D0 BDT tables to be compatible with the new developments in HF https://github.com/AliceO2Group/O2Physics/pull/3789