### PR TITLE
PWGHF: Fix missing Spawn in D0 selector

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -30,6 +30,12 @@ using namespace o2;
 using namespace o2::analysis;
 using namespace o2::framework;
 
+/// Struct to extend TracksPid tables
+struct HfCandidateSelectorD0Expressions {
+  Spawns<aod::TracksPidPiExt> rowTracksPidFullPi;
+  Spawns<aod::TracksPidKaExt> rowTracksPidFullKa;
+};
+
 /// Struct for applying D0 selection cuts
 struct HfCandidateSelectorD0 {
   Produces<aod::HfSelD0> hfSelD0Candidate;
@@ -419,5 +425,6 @@ struct HfCandidateSelectorD0 {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
+    adaptAnalysisTask<HfCandidateSelectorD0Expressions>(cfgc),
     adaptAnalysisTask<HfCandidateSelectorD0>(cfgc)};
 }


### PR DESCRIPTION
Fix for bug introduced in https://github.com/AliceO2Group/O2Physics/pull/3789

The tables `TracksPidPiExt` and `TracksPidKaExt` are consumed but not produced.