### PR TITLE
PWGMM: dndeta: rework

### DIFF
--- a/PWGMM/Mult/Core/CMakeLists.txt
+++ b/PWGMM/Mult/Core/CMakeLists.txt
@@ -8,11 +8,3 @@
 # In applying this license CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/DataModel" "${CMAKE_CURRENT_SOURCE_DIR}/Core/include")
-
-add_subdirectory(Core)
-add_subdirectory(DataModel)
-add_subdirectory(Tasks)
-add_subdirectory(TableProducer)
-

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -11,7 +11,6 @@
 
 #ifndef PWGMM_AXES_H
 #define PWGMM_AXES_H
-#include <cmath>
 #include "Framework/HistogramSpec.h"
 
 namespace pwgmm::mult {

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -16,25 +16,26 @@
 
 namespace pwgmm::mult {
 using namespace o2::framework;
+static constexpr std::string_view ptAxisName = "p_{T} (GeV/c)";
 //common axis definitions
-AxisSpec ZAxis = {301, -30.1, 30.1};          // Z vertex in cm
-AxisSpec DeltaZAxis = {61, -6.1, 6.1};        // Z vertex difference in cm
-AxisSpec DCAAxis = {601, -3.01, 3.01};        // DCA in cm
-AxisSpec EtaAxis = {22, -2.2, 2.2};           // Eta
+AxisSpec ZAxis = {301, -30.1, 30.1, "Z_{vtx} (cm)"};          // Z vertex in cm
+AxisSpec DeltaZAxis = {61, -6.1, 6.1, "#Delta Z (cm)"};       // Z vertex difference in cm
+AxisSpec DCAAxis = {601, -3.01, 3.01};                        // DCA in cm
+AxisSpec EtaAxis = {22, -2.2, 2.2, "#eta"};                   // Eta
 
-AxisSpec PhiAxis = {629, 0, o2::constants::math::TwoPI};        // Phi (azimuthal angle)
-AxisSpec PtAxis = {2401, -0.005, 24.005};     // Large fine-binned Pt
+AxisSpec PhiAxis = {629, 0, o2::constants::math::TwoPI, "#phi"};   // Phi (azimuthal angle)
+AxisSpec PtAxis = {2401, -0.005, 24.005, ptAxisName.data()};       // Large fine-binned Pt
 // Large wide-binned Pt (for efficiency)
 AxisSpec PtAxisEff = {{0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
-                       1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 18.0, 20.0}};
-AxisSpec PtAxis_wide = {1041, -0.05, 104.05}; // Smaller wider-binned Pt
-AxisSpec FT0CAxis = {1001, -0.5, 1000.5};     // FT0C amplitudes
-AxisSpec FT0AAxis = {3001, -0.5, 3000.5};     // FT0A amplitudes
-AxisSpec FDDAxis = {3001, -0.5, 3000.5};      // FDD amplitudes
-AxisSpec RapidityAxis = {102, -10.2, 10.2};   // Rapidity
-AxisSpec ScaleAxis = {121, -0.5, 120.5};      // Event scale
-AxisSpec MPIAxis = {51, -0.5, 50.5};          // N_{MPI}
-AxisSpec ProcAxis = {21, 89.5, 110.5};        // Process flag
+                       1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 18.0, 20.0}, ptAxisName.data()};
+AxisSpec PtAxis_wide = {1041, -0.05, 104.05, ptAxisName.data()}; // Smaller wider-binned Pt
+AxisSpec FT0CAxis = {1001, -0.5, 1000.5, "FT0C amplitude (arb. units)"};     // FT0C amplitudes
+AxisSpec FT0AAxis = {3001, -0.5, 3000.5, "FT0A amplitude (arb. units)"};     // FT0A amplitudes
+AxisSpec FDDAxis = {3001, -0.5, 3000.5, "FDD amplitude (arb. units)"};       // FDD amplitudes
+AxisSpec RapidityAxis = {102, -10.2, 10.2, "Y"};                             // Rapidity
+AxisSpec ScaleAxis = {121, -0.5, 120.5, "Event scale (GeV)"};                // Event scale
+AxisSpec MPIAxis = {51, -0.5, 50.5, "N_{MPI}"};                              // N_{MPI}
+AxisSpec ProcAxis = {21, 89.5, 110.5};                                       // Process flag
 
 // event selection/efficiency binning
 enum struct EvSelBins : int {

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -12,6 +12,7 @@
 #ifndef PWGMM_MULT_AXES_H
 #define PWGMM_MULT_AXES_H
 #include "Framework/HistogramSpec.h"
+#include "CommonConstants/MathConstants.h"
 
 namespace pwgmm::mult {
 using namespace o2::framework;
@@ -21,7 +22,7 @@ AxisSpec DeltaZAxis = {61, -6.1, 6.1};        // Z vertex difference in cm
 AxisSpec DCAAxis = {601, -3.01, 3.01};        // DCA in cm
 AxisSpec EtaAxis = {22, -2.2, 2.2};           // Eta
 
-AxisSpec PhiAxis = {629, 0, 2 * M_PI};        // Phi (azimuthal angle)
+AxisSpec PhiAxis = {629, 0, o2::constants::math::TwoPI};        // Phi (azimuthal angle)
 AxisSpec PtAxis = {2401, -0.005, 24.005};     // Large fine-binned Pt
 // Large wide-binned Pt (for efficiency)
 AxisSpec PtAxisEff = {{0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -9,14 +9,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_DNDETA_H
-#define PWGMM_DNDETA_H
+#ifndef PWGMM_AXES_H
+#define PWGMM_AXES_H
 #include <cmath>
 #include "Framework/HistogramSpec.h"
-#include "Framework/AnalysisDataModel.h"
 
-namespace pwgmm::dndeta {
-using namespace o2;
+namespace pwgmm::mult {
 using namespace o2::framework;
 //common axis definitions
 AxisSpec ZAxis = {301, -30.1, 30.1};          // Z vertex in cm
@@ -44,11 +42,11 @@ enum struct EvSelBins : int {
 };
 
 std::array<std::string_view, static_cast<size_t>(EvSelBins::kRejected)> EvSelBinLabels{
-  "All",
-  "Selected",
-  "Selected INEL>0",
-  "Selected INEL>0 (PV)",
-  "Rejected"};
+ "All",
+ "Selected",
+ "Selected INEL>0",
+ "Selected INEL>0 (PV)",
+ "Rejected"};
 
 enum struct EvEffBins : int {
   kGen = 1,
@@ -66,22 +64,5 @@ std::array<std::string_view, static_cast<size_t>(EvEffBins::kSelectedPVgt0)> EvE
   "Selected",
   "Selected INEL>0",
   "Selected INEL>0 (PV)"};
-
-// helper function to determine if collision/mccollison type contains centrality
-namespace
-{
-template <typename T>
-static constexpr bool hasCent()
-{
-  if constexpr (!soa::is_soa_join_v<T>) {
-    return false;
-  } else if constexpr (T::template contains<aod::HepMCHeavyIons>()) {
-    return true;
-  } else {
-    return false;
-  }
 }
-} // namespace
-}
-
-#endif // PWGMM_DNDETA_H
+#endif // PWGMM_AXES_H

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_AXES_H
-#define PWGMM_AXES_H
+#ifndef PWGMM_MULT_AXES_H
+#define PWGMM_MULT_AXES_H
 #include "Framework/HistogramSpec.h"
 
 namespace pwgmm::mult {
@@ -70,4 +70,4 @@ std::array<std::string_view, static_cast<size_t>(EvEffBins::kSelectedPVgt0)> EvE
   "Selected INEL>0",
   "Selected INEL>0 (PV)"};
 }
-#endif // PWGMM_AXES_H
+#endif // PWGMM_MULT_AXES_H

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_MULT_AXES_H
-#define PWGMM_MULT_AXES_H
+#ifndef PWGMM_MULT_CORE_INCLUDE_AXES_H_
+#define PWGMM_MULT_CORE_INCLUDE_AXES_H_
 #include "Framework/HistogramSpec.h"
 #include "CommonConstants/MathConstants.h"
 
@@ -74,4 +74,4 @@ std::array<std::string_view, static_cast<size_t>(EvEffBins::kSelectedPVgt0)> EvE
   "Selected INEL>0",
   "Selected INEL>0 (PV)"};
 } // namespace pwgmm::mult
-#endif // PWGMM_MULT_AXES_H
+#endif // PWGMM_MULT_CORE_INCLUDE_AXES_H_

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -40,6 +40,7 @@ enum struct EvSelBins : int {
   kRejected = 5
 };
 
+// labels for event selection axis
 std::array<std::string_view, static_cast<size_t>(EvSelBins::kRejected)> EvSelBinLabels{
  "All",
  "Selected",
@@ -56,6 +57,7 @@ enum struct EvEffBins : int {
   kSelectedPVgt0 = 6
 };
 
+// labels for event efficiency axis
 std::array<std::string_view, static_cast<size_t>(EvEffBins::kSelectedPVgt0)> EvEffBinLabels{
   "Generated",
   "Generated INEL>0",

--- a/PWGMM/Mult/Core/include/Axes.h
+++ b/PWGMM/Mult/Core/include/Axes.h
@@ -30,6 +30,10 @@ AxisSpec PtAxis_wide = {1041, -0.05, 104.05}; // Smaller wider-binned Pt
 AxisSpec FT0CAxis = {1001, -0.5, 1000.5};     // FT0C amplitudes
 AxisSpec FT0AAxis = {3001, -0.5, 3000.5};     // FT0A amplitudes
 AxisSpec FDDAxis = {3001, -0.5, 3000.5};      // FDD amplitudes
+AxisSpec RapidityAxis = {102, -10.2, 10.2};   // Rapidity
+AxisSpec ScaleAxis = {121, -0.5, 120.5};      // Event scale
+AxisSpec MPIAxis = {51, -0.5, 50.5};          // N_{MPI}
+AxisSpec ProcAxis = {21, 89.5, 110.5};        // Process flag
 
 // event selection/efficiency binning
 enum struct EvSelBins : int {

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_FUNCTIONS_H
-#define PWGMM_FUNCTIONS_H
+#ifndef PWGMM_MULT_FUNCTIONS_H
+#define PWGMM_MULT_FUNCTIONS_H
 #include "Common/DataModel/Centrality.h"
 
 namespace pwgmm::mult
@@ -39,4 +39,4 @@ static constexpr bool hasRecoCent()
 }
 } // namespace pwgmm::mult
 
-#endif // PWGMM_FUNCTIONS_H
+#endif // PWGMM_MULT_FUNCTIONS_H

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef PWGMM_FUNCTIONS_H
+#define PWGMM_FUNCTIONS_H
+#include <cmath>
+#include "Framework/AnalysisDataModel.h"
+
+namespace pwgmm::mult {
+using namespace o2;
+
+// helper function to determine if collision/mccollison type contains centrality
+template <typename T>
+static constexpr bool hasCent()
+{
+  if constexpr (!soa::is_soa_join_v<T>) {
+    return false;
+  } else if constexpr (T::template contains<aod::HepMCHeavyIons>()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+}
+
+#endif // PWGMM_FUNCTIONS_H

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_MULT_FUNCTIONS_H
-#define PWGMM_MULT_FUNCTIONS_H
+#ifndef PWGMM_MULT_CORE_INCLUDE_FUNCTIONS_H_
+#define PWGMM_MULT_CORE_INCLUDE_FUNCTIONS_H_
 #include "Common/DataModel/Centrality.h"
 
 namespace pwgmm::mult
@@ -39,4 +39,4 @@ static constexpr bool hasRecoCent()
 }
 } // namespace pwgmm::mult
 
-#endif // PWGMM_MULT_FUNCTIONS_H
+#endif // PWGMM_MULT_CORE_INCLUDE_FUNCTIONS_H_

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -11,23 +11,33 @@
 
 #ifndef PWGMM_FUNCTIONS_H
 #define PWGMM_FUNCTIONS_H
+#include "Common/DataModel/Centrality.h"
 #include "Framework/AnalysisDataModel.h"
 
-namespace pwgmm::mult {
+namespace pwgmm::mult
+{
 using namespace o2;
 
 // helper function to determine if collision/mccollison type contains centrality
 template <typename T>
-static constexpr bool hasCent()
+static constexpr bool hasSimCent()
 {
   if constexpr (!soa::is_soa_join_v<T>) {
     return false;
-  } else if constexpr (T::template contains<aod::HepMCHeavyIons>()) {
-    return true;
   } else {
-    return false;
+    return T::template contains<aod::HepMCHeavyIons>();
   }
 }
+
+template <typename T>
+static constexpr bool hasRecoCent()
+{
+  if constexpr (!soa::is_soa_join_v<T>) {
+    return false;
+  } else {
+    return T::template contains<aod::CentFT0Cs>() || T::template contains<aod::CentFT0Ms>();
+  }
 }
+} // namespace pwgmm::mult
 
 #endif // PWGMM_FUNCTIONS_H

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -12,7 +12,6 @@
 #ifndef PWGMM_FUNCTIONS_H
 #define PWGMM_FUNCTIONS_H
 #include "Common/DataModel/Centrality.h"
-#include "Framework/AnalysisDataModel.h"
 
 namespace pwgmm::mult
 {

--- a/PWGMM/Mult/Core/include/Functions.h
+++ b/PWGMM/Mult/Core/include/Functions.h
@@ -11,7 +11,6 @@
 
 #ifndef PWGMM_FUNCTIONS_H
 #define PWGMM_FUNCTIONS_H
-#include <cmath>
 #include "Framework/AnalysisDataModel.h"
 
 namespace pwgmm::mult {

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -18,45 +18,81 @@ namespace pwgmm::mult {
 // particle species to consider for tracking efficiency
 static constexpr std::string_view species[] = {"pi", "p", "e", "K"};
 static constexpr std::array<int, 4> speciesIds{kPiPlus, kProton, kElectron, kKPlus};
-static constexpr std::string_view EventsCategory = "Events";
-static constexpr std::string_view TracksCategory = "Tracks";
+static constexpr std::string_view prefix = "Tracks/Control/";
+static constexpr std::string_view PtGenSuff = "/PtGen";
+static constexpr std::string_view PtGenIdxSuff = "/PtGenI";
+static constexpr std::string_view PtEffSuff = "/PtEfficiency";
+static constexpr std::string_view PtEffIdxSuff = "/PtEfficiencyI";
+
+// histogram registry labels
 static constexpr std::string_view BinnedPrefix = "Centrality";
 static constexpr std::string_view InclusivePrefix = "Inclusive";
 
+
+
 namespace histograms {
 // events and collisions
-static constexpr std::string_view BCSelection = "BCSelection";                        // BC selection categories
-static constexpr std::string_view EventSelection = "Selection";                       // Collision selection categories
-static constexpr std::string_view NtrkZvtx = "NtrkZvtx";                              // N tracks vs vtx Z for selected collisions
-static constexpr std::string_view NtrkZvtxGen = "NtrkZvtxGen";                        // -- for selected simulated collisions
-static constexpr std::string_view NtrkZvtxGen_t = "NtrkZvtxGen_t";                    // N particles vs vtx Z for generated events
-static constexpr std::string_view Efficiency = "Efficiency";                          // simulated event selection efficiency
-static constexpr std::string_view EfficiencyMult = "EfficiencyMult";                  // simulated event selection efficiency vs generated multiplicity
-static constexpr std::string_view NotFoundZvtx = "NotFoundEventZvtx";                 // vtx Z distribution of events without reconstructed collisions
-static constexpr std::string_view Response = "Response";                              // simulated multiplicity response (N tracks vs N particles)
-static constexpr std::string_view MultiResponse = "MultiResponse";                    // -- multi-estimator
-static constexpr std::string_view SplitMult = "SplitMult";                            // split reconstructed events vs generated multiplicity
+static constexpr std::string_view BCSelection = "Events/BCSelection";                                           // BC selection categories
+static constexpr std::string_view EventSelection = "Events/Selection";                                          // Collision selection categories
+static constexpr std::string_view NtrkZvtx = "Events/NtrkZvtx";                                                 // N tracks vs vtx Z for selected collisions
+static constexpr std::string_view NtrkZvtxGen = "Events/NtrkZvtxGen";                                           // -- for selected simulated collisions
+static constexpr std::string_view NtrkZvtxGen_t = "Events/NtrkZvtxGen_t";                                       // N particles vs vtx Z for generated events
+static constexpr std::string_view Efficiency = "Events/Efficiency";                                             // simulated event selection efficiency
+static constexpr std::string_view EfficiencyMult = "Events/EfficiencyMult";                                     // simulated event selection efficiency vs generated multiplicity
+static constexpr std::string_view NotFoundZvtx = "Events/NotFoundEventZvtx";                                    // vtx Z distribution of events without reconstructed collisions
+static constexpr std::string_view Response = "Events/Response";                                                 // simulated multiplicity response (N tracks vs N particles)
+static constexpr std::string_view MultiResponse = "Events/MultiResponse";                                       // -- multi-estimator
+static constexpr std::string_view SplitMult = "Events/SplitMult";                                               // split reconstructed events vs generated multiplicity
+static constexpr std::string_view EventChi2 = "Events/Control/Chi2";                                            // collisions chi2 distribution
+static constexpr std::string_view EventTimeRes = "Events/Control/TimeResolution";                               // collisions time resolution distribution
 
 // particles and tracks
-static constexpr std::string_view EtaZvtx = "EtaZvtx";                                 // eta vs vtx Z distribution of tracks
-static constexpr std::string_view EtaZvtx_gt0 = "EtaZvtx_gt0";                         // -- for INEL>0 collisions
-static constexpr std::string_view EtaZvtx_PVgt0 = "EtaZvtx_PVgt0";                     // -- for INEL>0 (PV)
-static constexpr std::string_view EtaZvtxGen = "EtaZvtxGen";                           // eta vs vtx Z distribution of simulated tracks
-static constexpr std::string_view EtaZvtxGen_gt0 = "EtaZvtxGen_gt0";                   // -- for INEL>0 collisions
-static constexpr std::string_view EtaZvtxGen_PVgt0 = "EtaZvtxGen_PVgt0";               // -- for INEL>0 (PV)
-static constexpr std::string_view EtaZvtxGen_gt0t = "EtaZvtxGen_gt0t";                 // -- of particles for INEL>0 events
-static constexpr std::string_view ReassignedEtaZvtx = "Control/ReassignedEtaZvtx";     // -- of reassigned ambiguous tracks
-static constexpr std::string_view PhiEta = "PhiEta";                                   // eta vs phi distribution of tracks
-static constexpr std::string_view PhiEtaGen = "PhiEtaGen";                             // eta vs phi distribution of simulated tracks
-static constexpr std::string_view ReassignedPhiEta = "Control/ReassignedPhiEta";       // -- of reassigned ambiguous tracks
-static constexpr std::string_view PtEta = "Control/PtEta";                             // Pt vs eta distribution of tracks
-static constexpr std::string_view PtEtaGen = "Control/PtEtaGen";                       // Pt vs eta distribution of simulated tracks
-static constexpr std::string_view DCAXYPt = "Control/DCAXYPt";                         // transversal DCA vs Pt distribution of tracks
-static constexpr std::string_view ReassignedDCAXYPt = "Control/ReassignedDCAXYPt";     // -- of reassigned ambiguous tracks
-static constexpr std::string_view DCAZPt = "Control/DCAZPt";                           // longitudal DCA vs Pt distribution of tracks
-static constexpr std::string_view ReassignedDCAZPt = "Control/ReassignedDCAZPt";       // -- of reassigned ambiguous tracks
-static constexpr std::string_view ReassignedZvtxCorr = "Control/ReassignedZvtxCorr";   // original vs reassigned vtx Z correlation for reassigned ambiguous tracks
+static constexpr std::string_view EtaZvtx = "Tracks/EtaZvtx";                                                   // eta vs vtx Z distribution of tracks
+static constexpr std::string_view EtaZvtx_gt0 = "Tracks/EtaZvtx_gt0";                                           // -- for INEL>0 collisions
+static constexpr std::string_view EtaZvtx_PVgt0 = "Tracks/EtaZvtx_PVgt0";                                       // -- for INEL>0 (PV)
+static constexpr std::string_view EtaZvtxGen = "Tracks/EtaZvtxGen";                                             // eta vs vtx Z distribution of simulated tracks
+static constexpr std::string_view EtaZvtxGen_gt0 = "Tracks/EtaZvtxGen_gt0";                                     // -- for INEL>0 collisions
+static constexpr std::string_view EtaZvtxGen_PVgt0 = "Tracks/EtaZvtxGen_PVgt0";                                 // -- for INEL>0 (PV)
+static constexpr std::string_view EtaZvtxGen_t = "Tracks/EtaZvtxGen_t";                                         // -- of particles
+static constexpr std::string_view EtaZvtxGen_gt0t = "Tracks/EtaZvtxGen_gt0t";                                   // -- of particles for INEL>0 events
+static constexpr std::string_view ReassignedEtaZvtx = "Tracks/Control/ReassignedEtaZvtx";                       // -- of reassigned ambiguous tracks
+static constexpr std::string_view ExtraEtaZvtx = "Tracks/Control/ExtraEtaZvtx";                                 // -- of adopted orphan tracks
+static constexpr std::string_view PhiEta = "Tracks/PhiEta";                                                     // eta vs phi distribution of tracks
+static constexpr std::string_view PhiEtaDuplicates = "Tracks/Control/PhiEtaDuplicates";                         // -- of tracks belonging to the same particle
+static constexpr std::string_view PhiEtaGen = "Tracks/PhiEtaGen";                                               // -- of simulated tracks
+static constexpr std::string_view PhiEtaGenDuplicates = "Tracks/Control/PhiEtaGenDuplicates";                   // -- of multi-reconstructed particles
+static constexpr std::string_view ReassignedPhiEta = "Tracks/Control/ReassignedPhiEta";                         // -- of reassigned ambiguous tracks
+static constexpr std::string_view ExtraPhiEta = "Tracks/Control/ExtraPhiEta";                                   // -- of adopted orphaned tracks
+static constexpr std::string_view PtEta = "Tracks/Control/PtEta";                                               // Pt vs eta distribution of tracks
+static constexpr std::string_view PtEtaGen = "Tracks/Control/PtEtaGen";                                         // Pt vs eta distribution of simulated tracks
+static constexpr std::string_view DCAXYPt = "Tracks/Control/DCAXYPt";                                           // transversal DCA vs Pt distribution of tracks
+static constexpr std::string_view ReassignedDCAXYPt = "Tracks/Control/ReassignedDCAXYPt";                       // -- of reassigned ambiguous tracks
+static constexpr std::string_view ExtraDCAXYPt = "Tracks/Control/ExtraDCAXYPt";                                 // -- of adopted orphan tracks
+static constexpr std::string_view DCAZPt = "Tracks/Control/DCAZPt";                                             // longitudal DCA vs Pt distribution of tracks
+static constexpr std::string_view ReassignedDCAZPt = "Tracks/Control/ReassignedDCAZPt";                         // -- of reassigned ambiguous tracks
+static constexpr std::string_view ExtraDCAZPt = "Tracks/Control/ExtraDCAZPt";                                   // -- of adopted orphan tracks
+static constexpr std::string_view ReassignedZvtxCorr = "Tracks/Control/ReassignedZvtxCorr";                     // original vs reassigned vtx Z correlation for reassigned ambiguous tracks
 
+// efficiencies
+static constexpr std::string_view PtGen = "Tracks/Control/PtGen";                                               // pt distribution of particles
+static constexpr std::string_view PtGenF = "Tracks/Control/{}/PtGen";                                           // -- format placeholder
+static constexpr std::string_view PtGenIdx = "Tracks/Control/PtGenI";                                           // -- for the indexed efficiency
+static constexpr std::string_view PtGenIdxF = "Tracks/Control/{}/PtGenI";                                       // -- format placeholder
+static constexpr std::string_view PtGenNoEtaCut = "Tracks/Control/PtGenNoEtaCut";                               // -- with no eta restriction
+static constexpr std::string_view PtGenIdxNoEtaCut = "Tracks/Control/PtGenINoEtaCut";                           // -- for the indexed eff. with no eta restriction
+static constexpr std::string_view PtEfficiency = "Tracks/Control/PtEfficiency";                                 // generator-level pt distribution of selected tracks
+static constexpr std::string_view PtEfficiencyF = "Tracks/Control/{}/PtEfficiency";                             // -- format placeholder
+static constexpr std::string_view PtEfficiencyIdx = "Tracks/Control/PtEfficiencyI";                             // -- for the indexed efficiency
+static constexpr std::string_view PtEfficiencyIdxF = "Tracks/Control/{}/PtEfficiencyI";                         // -- format placeholder
+static constexpr std::string_view PtEfficiencyNoEtaCut = "Tracks/Control/PtEfficiencyNoEtaCut";                 // -- with no eta restriction
+static constexpr std::string_view PtEfficiencyIdxNoEtaCut = "Tracks/Control/PtEfficiencyINoEtaCut";             // -- for the indexed eff. with no eta restriction
+static constexpr std::string_view PtEfficiencyFakes = "Tracks/Control/PtFakes";                                 // pt distribution of fake tracks
+static constexpr std::string_view PtEfficiencySecondariesIdx = "Tracks/Control/PtSecondariesI";                 // generator-level pt distribution of secondary particles
+static constexpr std::string_view PtEfficiencySecondariesIdxNoEtaCut = "Tracks/Control/PtSecondariesINoEtaCut"; // -- for the indexed efficiency
+
+// misc.
+static constexpr std::string_view Mask = "Tracks/Control/Mask";                                                 // reco status bitmask
+static constexpr std::string_view ITSlayers = "Tracks/Control/ITSLayers";                                       // ITS layers hit distribution
 }
 }
 

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -11,18 +11,21 @@
 
 #ifndef PWGMM_MULT_HISTOGRAMS_H
 #define PWGMM_MULT_HISTOGRAMS_H
+#include "TPDGCode.h"
 #include <string_view>
 
 namespace pwgmm::mult {
-static constexpr std::array<std::array<std::string_view, 2>, 2> categories{
-  {
-   {"Tracks", "Events"},                       //
-   {"Tracks/Centrality", "Events/Centrality"}  //
-  }                                            //
-};
+// particle species to consider for tracking efficiency
+static constexpr std::string_view species[] = {"pi", "p", "e", "K"};
+static constexpr std::array<int, 4> speciesIds{kPiPlus, kProton, kElectron, kKPlus};
+static constexpr std::string_view EventsCategory = "Events";
+static constexpr std::string_view TracksCategory = "Tracks";
+static constexpr std::string_view CentralityPrefix = "Centrality";
 
 namespace histograms {
 // events and collisions
+static constexpr std::string_view BCSelection = "BCSelection";                        // BC selection categories
+static constexpr std::string_view EventSelection = "Selection";                       // Collision selection categories
 static constexpr std::string_view NtrkZvtx = "NtrkZvtx";                              // N tracks vs vtx Z for selected collisions
 static constexpr std::string_view NtrkZvtxGen = "NtrkZvtxGen";                        // -- for selected simulated collisions
 static constexpr std::string_view NtrkZvtxGen_t = "NtrkZvtxGen_t";                    // N particles vs vtx Z for generated events

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_MULT_HISTOGRAMS_H
-#define PWGMM_MULT_HISTOGRAMS_H
+#ifndef PWGMM_MULT_CORE_INCLUDE_HISTOGRAMS_H_
+#define PWGMM_MULT_CORE_INCLUDE_HISTOGRAMS_H_
 #include "TPDGCode.h"
 #include <string_view>
 
@@ -96,4 +96,4 @@ static constexpr std::string_view ITSlayers = "Tracks/Control/ITSLayers"; // ITS
 } // namespace histograms
 } // namespace pwgmm::mult
 
-#endif // PWGMM_MULT_HISTOGRAMS_H
+#endif // PWGMM_MULT_CORE_INCLUDE_HISTOGRAMS_H_

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -20,7 +20,8 @@ static constexpr std::string_view species[] = {"pi", "p", "e", "K"};
 static constexpr std::array<int, 4> speciesIds{kPiPlus, kProton, kElectron, kKPlus};
 static constexpr std::string_view EventsCategory = "Events";
 static constexpr std::string_view TracksCategory = "Tracks";
-static constexpr std::string_view CentralityPrefix = "Centrality";
+static constexpr std::string_view BinnedPrefix = "Centrality";
+static constexpr std::string_view InclusivePrefix = "Inclusive";
 
 namespace histograms {
 // events and collisions

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -9,18 +9,51 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_HISTOGRAMS_H
-#define PWGMM_HISTOGRAMS_H
-#include "Axes.h"
+#ifndef PWGMM_MULT_HISTOGRAMS_H
+#define PWGMM_MULT_HISTOGRAMS_H
+#include <string_view>
 
 namespace pwgmm::mult {
-using namespace o2::framework;
 static constexpr std::array<std::array<std::string_view, 2>, 2> categories{
   {
    {"Tracks", "Events"},                       //
    {"Tracks/Centrality", "Events/Centrality"}  //
   }                                            //
 };
+
+namespace histograms {
+// events and collisions
+static constexpr std::string_view NtrkZvtx = "NtrkZvtx";                              // N tracks vs vtx Z for selected collisions
+static constexpr std::string_view NtrkZvtxGen = "NtrkZvtxGen";                        // -- for selected simulated collisions
+static constexpr std::string_view NtrkZvtxGen_t = "NtrkZvtxGen_t";                    // N particles vs vtx Z for generated events
+static constexpr std::string_view Efficiency = "Efficiency";                          // simulated event selection efficiency
+static constexpr std::string_view EfficiencyMult = "EfficiencyMult";                  // simulated event selection efficiency vs generated multiplicity
+static constexpr std::string_view NotFoundZvtx = "NotFoundEventZvtx";                 // vtx Z distribution of events without reconstructed collisions
+static constexpr std::string_view Response = "Response";                              // simulated multiplicity response (N tracks vs N particles)
+static constexpr std::string_view MultiResponse = "MultiResponse";                    // -- multi-estimator
+static constexpr std::string_view SplitMult = "SplitMult";                            // split reconstructed events vs generated multiplicity
+
+// particles and tracks
+static constexpr std::string_view EtaZvtx = "EtaZvtx";                                 // eta vs vtx Z distribution of tracks
+static constexpr std::string_view EtaZvtx_gt0 = "EtaZvtx_gt0";                         // -- for INEL>0 collisions
+static constexpr std::string_view EtaZvtx_PVgt0 = "EtaZvtx_PVgt0";                     // -- for INEL>0 (PV)
+static constexpr std::string_view EtaZvtxGen = "EtaZvtxGen";                           // eta vs vtx Z distribution of simulated tracks
+static constexpr std::string_view EtaZvtxGen_gt0 = "EtaZvtxGen_gt0";                   // -- for INEL>0 collisions
+static constexpr std::string_view EtaZvtxGen_PVgt0 = "EtaZvtxGen_PVgt0";               // -- for INEL>0 (PV)
+static constexpr std::string_view EtaZvtxGen_gt0t = "EtaZvtxGen_gt0t";                 // -- of particles for INEL>0 events
+static constexpr std::string_view ReassignedEtaZvtx = "Control/ReassignedEtaZvtx";     // -- of reassigned ambiguous tracks
+static constexpr std::string_view PhiEta = "PhiEta";                                   // eta vs phi distribution of tracks
+static constexpr std::string_view PhiEtaGen = "PhiEtaGen";                             // eta vs phi distribution of simulated tracks
+static constexpr std::string_view ReassignedPhiEta = "Control/ReassignedPhiEta";       // -- of reassigned ambiguous tracks
+static constexpr std::string_view PtEta = "Control/PtEta";                             // Pt vs eta distribution of tracks
+static constexpr std::string_view PtEtaGen = "Control/PtEtaGen";                       // Pt vs eta distribution of simulated tracks
+static constexpr std::string_view DCAXYPt = "Control/DCAXYPt";                         // transversal DCA vs Pt distribution of tracks
+static constexpr std::string_view ReassignedDCAXYPt = "Control/ReassignedDCAXYPt";     // -- of reassigned ambiguous tracks
+static constexpr std::string_view DCAZPt = "Control/DCAZPt";                           // longitudal DCA vs Pt distribution of tracks
+static constexpr std::string_view ReassignedDCAZPt = "Control/ReassignedDCAZPt";       // -- of reassigned ambiguous tracks
+static constexpr std::string_view ReassignedZvtxCorr = "Control/ReassignedZvtxCorr";   // original vs reassigned vtx Z correlation for reassigned ambiguous tracks
+
+}
 }
 
-#endif // PWGMM_HISTOGRAMS_H
+#endif // PWGMM_MULT_HISTOGRAMS_H

--- a/PWGMM/Mult/Core/include/Histograms.h
+++ b/PWGMM/Mult/Core/include/Histograms.h
@@ -1,0 +1,26 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef PWGMM_HISTOGRAMS_H
+#define PWGMM_HISTOGRAMS_H
+#include "Axes.h"
+
+namespace pwgmm::mult {
+using namespace o2::framework;
+static constexpr std::array<std::array<std::string_view, 2>, 2> categories{
+  {
+   {"Tracks", "Events"},                       //
+   {"Tracks/Centrality", "Events/Centrality"}  //
+  }                                            //
+};
+}
+
+#endif // PWGMM_HISTOGRAMS_H

--- a/PWGMM/Mult/Core/include/Selections.h
+++ b/PWGMM/Mult/Core/include/Selections.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_SELECTIONS_H
-#define PWGMM_SELECTIONS_H
+#ifndef PWGMM_MULT_SELECTIONS_H
+#define PWGMM_MULT_SELECTIONS_H
 #include "Common/DataModel/TrackSelectionTables.h"
 
 namespace pwgmm::mult {
@@ -36,4 +36,4 @@ static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
   TrackSelectionFlags::kDCAxy;
 }
 
-#endif // PWGMM_SELECTIONS_H
+#endif // PWGMM_MULT_SELECTIONS_H

--- a/PWGMM/Mult/Core/include/Selections.h
+++ b/PWGMM/Mult/Core/include/Selections.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef PWGMM_SELECTIONS_H
+#define PWGMM_SELECTIONS_H
+#include "Common/DataModel/TrackSelectionTables.h"
+
+namespace pwgmm::mult {
+using namespace o2::aod::track;
+static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
+  TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
+  TrackSelectionFlags::kITSHits;
+
+static constexpr TrackSelectionFlags::flagtype trackSelectionTPC =
+  TrackSelectionFlags::kTPCNCls |
+  TrackSelectionFlags::kTPCCrossedRowsOverNCls |
+  TrackSelectionFlags::kTPCChi2NDF;
+
+static constexpr TrackSelectionFlags::flagtype trackSelectionDCA =
+  TrackSelectionFlags::kDCAz | TrackSelectionFlags::kDCAxy;
+
+static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
+  TrackSelectionFlags::kDCAxy;
+}
+
+#endif // PWGMM_SELECTIONS_H

--- a/PWGMM/Mult/Core/include/Selections.h
+++ b/PWGMM/Mult/Core/include/Selections.h
@@ -16,22 +16,22 @@
 namespace pwgmm::mult {
 using namespace o2::aod::track;
 
-// quality criteria for tracks with ITS contribution
+// default quality criteria for tracks with ITS contribution
 static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
   TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
   TrackSelectionFlags::kITSHits;
 
-// quality criteria for tracks with TPC contribution
+// default quality criteria for tracks with TPC contribution
 static constexpr TrackSelectionFlags::flagtype trackSelectionTPC =
   TrackSelectionFlags::kTPCNCls |
   TrackSelectionFlags::kTPCCrossedRowsOverNCls |
   TrackSelectionFlags::kTPCChi2NDF;
 
-// standard DCA cuts
+// default standard DCA cuts
 static constexpr TrackSelectionFlags::flagtype trackSelectionDCA =
   TrackSelectionFlags::kDCAz | TrackSelectionFlags::kDCAxy;
 
-// standard transversal-only DCA cuts
+// default standard transversal-only DCA cuts
 static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
   TrackSelectionFlags::kDCAxy;
 }

--- a/PWGMM/Mult/Core/include/Selections.h
+++ b/PWGMM/Mult/Core/include/Selections.h
@@ -15,18 +15,23 @@
 
 namespace pwgmm::mult {
 using namespace o2::aod::track;
+
+// quality criteria for tracks with ITS contribution
 static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
   TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
   TrackSelectionFlags::kITSHits;
 
+// quality criteria for tracks with TPC contribution
 static constexpr TrackSelectionFlags::flagtype trackSelectionTPC =
   TrackSelectionFlags::kTPCNCls |
   TrackSelectionFlags::kTPCCrossedRowsOverNCls |
   TrackSelectionFlags::kTPCChi2NDF;
 
+// standard DCA cuts
 static constexpr TrackSelectionFlags::flagtype trackSelectionDCA =
   TrackSelectionFlags::kDCAz | TrackSelectionFlags::kDCAxy;
 
+// standard transversal-only DCA cuts
 static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
   TrackSelectionFlags::kDCAxy;
 }

--- a/PWGMM/Mult/Core/include/Selections.h
+++ b/PWGMM/Mult/Core/include/Selections.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef PWGMM_MULT_SELECTIONS_H
-#define PWGMM_MULT_SELECTIONS_H
+#ifndef PWGMM_MULT_CORE_INCLUDE_SELECTIONS_H_
+#define PWGMM_MULT_CORE_INCLUDE_SELECTIONS_H_
 #include "Common/DataModel/TrackSelectionTables.h"
 
 namespace pwgmm::mult
@@ -37,4 +37,4 @@ static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
   TrackSelectionFlags::kDCAxy;
 } // namespace pwgmm::mult
 
-#endif // PWGMM_MULT_SELECTIONS_H
+#endif // PWGMM_MULT_CORE_INCLUDE_SELECTIONS_H_

--- a/PWGMM/Mult/Tasks/common.h
+++ b/PWGMM/Mult/Tasks/common.h
@@ -1,0 +1,87 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef PWGMM_DNDETA_H
+#define PWGMM_DNDETA_H
+#include <cmath>
+#include "Framework/HistogramSpec.h"
+#include "Framework/AnalysisDataModel.h"
+
+namespace pwgmm::dndeta {
+using namespace o2;
+using namespace o2::framework;
+//common axis definitions
+AxisSpec ZAxis = {301, -30.1, 30.1};          // Z vertex in cm
+AxisSpec DeltaZAxis = {61, -6.1, 6.1};        // Z vertex difference in cm
+AxisSpec DCAAxis = {601, -3.01, 3.01};        // DCA in cm
+AxisSpec EtaAxis = {22, -2.2, 2.2};           // Eta
+
+AxisSpec PhiAxis = {629, 0, 2 * M_PI};        // Phi (azimuthal angle)
+AxisSpec PtAxis = {2401, -0.005, 24.005};     // Large fine-binned Pt
+// Large wide-binned Pt (for efficiency)
+AxisSpec PtAxisEff = {{0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
+                       1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 18.0, 20.0}};
+AxisSpec PtAxis_wide = {1041, -0.05, 104.05}; // Smaller wider-binned Pt
+AxisSpec FT0CAxis = {1001, -0.5, 1000.5};     // FT0C amplitudes
+AxisSpec FT0AAxis = {3001, -0.5, 3000.5};     // FT0A amplitudes
+AxisSpec FDDAxis = {3001, -0.5, 3000.5};      // FDD amplitudes
+
+// event selection/efficiency binning
+enum struct EvSelBins : int {
+  kAll = 1,
+  kSelected = 2,
+  kSelectedgt0 = 3,
+  kSelectedPVgt0 = 4,
+  kRejected = 5
+};
+
+std::array<std::string_view, static_cast<size_t>(EvSelBins::kRejected)> EvSelBinLabels{
+  "All",
+  "Selected",
+  "Selected INEL>0",
+  "Selected INEL>0 (PV)",
+  "Rejected"};
+
+enum struct EvEffBins : int {
+  kGen = 1,
+  kGengt0 = 2,
+  kRec = 3,
+  kSelected = 4,
+  kSelectedgt0 = 5,
+  kSelectedPVgt0 = 6
+};
+
+std::array<std::string_view, static_cast<size_t>(EvEffBins::kSelectedPVgt0)> EvEffBinLabels{
+  "Generated",
+  "Generated INEL>0",
+  "Reconstructed",
+  "Selected",
+  "Selected INEL>0",
+  "Selected INEL>0 (PV)"};
+
+// helper function to determine if collision/mccollison type contains centrality
+namespace
+{
+template <typename T>
+static constexpr bool hasCent()
+{
+  if constexpr (!soa::is_soa_join_v<T>) {
+    return false;
+  } else if constexpr (T::template contains<aod::HepMCHeavyIons>()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+} // namespace
+}
+
+#endif // PWGMM_DNDETA_H

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -255,7 +255,6 @@ struct MultiplicityCounter {
   template <typename C>
   void processEventStatGeneral(FullBCs const& bcs, C const& collisions)
   {
-    constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>();
     std::vector<typename std::decay_t<decltype(collisions)>::iterator> cols;
     for (auto& bc : bcs) {
       if (!useEvSel || (bc.selection_bit(aod::evsel::kIsBBT0A) &&
@@ -279,7 +278,7 @@ struct MultiplicityCounter {
           }
         }
         for (auto& col : cols) {
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             float c = -1;
             if constexpr (C::template contains<aod::CentFT0Cs>()) {
               c = col.centFT0C();
@@ -359,8 +358,7 @@ struct MultiplicityCounter {
     FiTracks const& tracks)
   {
     float c = -1;
-    constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>();
-    if constexpr (hasCentrality) {
+    if constexpr (hasRecoCent<C>()) {
       if constexpr (C::template contains<aod::CentFT0Cs>()) {
         c = collision.centFT0C();
       } else if (C::template contains<aod::CentFT0Ms>()) {
@@ -372,7 +370,7 @@ struct MultiplicityCounter {
     }
 
     if (!useEvSel || collision.sel8()) {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         binnedRegistry.fill(HIST(EventSelection), 2., c);
       } else {
         inclusiveRegistry.fill(HIST(EventSelection), static_cast<float>(EvSelBins::kSelected));
@@ -387,7 +385,7 @@ struct MultiplicityCounter {
         if (std::abs(track.eta()) < estimatorEta) {
           ++Ntrks;
         }
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           binnedRegistry.fill(HIST(EtaZvtx), track.eta(), z, c);
           binnedRegistry.fill(HIST(PhiEta), track.phi(), track.eta(), c);
           binnedRegistry.fill(HIST(PtEta), track.pt(), track.eta(), c);
@@ -401,7 +399,7 @@ struct MultiplicityCounter {
           inclusiveRegistry.fill(HIST(DCAZPt), track.pt(), track.dcaZ());
         }
       }
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         binnedRegistry.fill(HIST(NtrkZvtx), Ntrks, z, c);
       } else {
         if (Ntrks > 0 || groupPVContrib.size() > 0) {
@@ -423,7 +421,7 @@ struct MultiplicityCounter {
         inclusiveRegistry.fill(HIST(NtrkZvtx), Ntrks, z);
       }
     } else {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         binnedRegistry.fill(HIST(EventSelection), 3., c);
       } else {
         inclusiveRegistry.fill(HIST(EventSelection), static_cast<float>(EvSelBins::kRejected));

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -9,8 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <cmath>
-
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -25,25 +23,13 @@
 #include <TPDGCode.h>
 
 #include "bestCollisionTable.h"
+#include "common.h"
 
 using namespace o2;
 using namespace o2::aod::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-
-AxisSpec ZAxis = {301, -30.1, 30.1};
-AxisSpec DeltaZAxis = {61, -6.1, 6.1};
-AxisSpec DCAAxis = {601, -3.01, 3.01};
-AxisSpec EtaAxis = {22, -2.2, 2.2};
-// AxisSpec MultAxis = {301, -0.5, 300.5};
-AxisSpec PhiAxis = {629, 0, 2 * M_PI};
-AxisSpec PtAxis = {2401, -0.005, 24.005};
-AxisSpec PtAxisEff = {{0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
-                       1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 18.0, 20.0}};
-AxisSpec PtAxis_wide = {1041, -0.05, 104.05};
-AxisSpec FT0CAxis = {1001, -0.5, 1000.5};
-AxisSpec FT0AAxis = {3001, -0.5, 3000.5};
-AxisSpec FDDAxis = {3001, -0.5, 3000.5};
+using namespace pwgmm::dndeta;
 
 static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
   TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
@@ -62,38 +48,6 @@ static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
 
 using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 using ReTracks = soa::Join<aod::ReassignedTracksCore, aod::ReassignedTracksExtra>;
-
-enum struct EvSelBins : int {
-  kAll = 1,
-  kSelected = 2,
-  kSelectedgt0 = 3,
-  kSelectedPVgt0 = 4,
-  kRejected = 5
-};
-
-enum struct EvEffBins : int {
-  kGen = 1,
-  kGengt0 = 2,
-  kRec = 3,
-  kSelected = 4,
-  kSelectedgt0 = 5,
-  kSelectedPVgt0 = 6
-};
-
-namespace
-{
-template <typename T>
-static constexpr bool hasCent()
-{
-  if constexpr (!soa::is_soa_join_v<T>) {
-    return false;
-  } else if (T::template contains<aod::HepMCHeavyIons>()) {
-    return true;
-  } else {
-    return false;
-  }
-}
-} // namespace
 
 static constexpr std::string_view species[] = {"pi", "p", "e", "K"};
 static constexpr std::array<int, 4> speciesIds{kPiPlus, kProton, kElectron, kKPlus};

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -56,11 +56,20 @@ struct MultiplicityCounter {
   ConfigurableAxis multBinning{"multBinning", {301, -0.5, 300.5}, ""};
   ConfigurableAxis centBinning{"centBinning", {VARIABLE_WIDTH, 0, 10, 20, 30, 40, 50, 60, 70, 80, 100}, ""};
 
-  HistogramRegistry registry{
-    "registry",
+  HistogramRegistry commonRegistry{
+    "Common",
     {
       {"Events/BCSelection", ";status;count", {HistType::kTH1F, {{3, 0.5, 3.5}}}} //
-    }                                                                             //
+    } //
+  };
+
+  HistogramRegistry inclusiveRegistry{
+    InclusivePrefix.data(),
+    {}
+  };
+  HistogramRegistry binnedRegistry{
+    BinnedPrefix.data(),
+    {}
   };
 
   std::vector<int> usedTracksIds;
@@ -73,24 +82,24 @@ struct MultiplicityCounter {
     AxisSpec MultAxis = {multBinning};
     AxisSpec CentAxis = {centBinning, "centrality"};
 
-    auto hstat = registry.get<TH1>(HIST("Events/BCSelection"));
+    auto hstat = inclusiveRegistry.get<TH1>(HIST("Events/BCSelection"));
     auto* x = hstat->GetXaxis();
     x->SetBinLabel(1, "Good BCs");
     x->SetBinLabel(2, "BCs with collisions");
     x->SetBinLabel(3, "BCs with pile-up/splitting");
 
     if (doprocessEventStat) {
-      registry.add({"Events/Control/Chi2", " ; #chi^2", {HistType::kTH1F, {{101, -0.1, 10.1}}}});
-      registry.add({"Events/Control/TimeResolution", " ; t (ms)", {HistType::kTH1F, {{1001, -0.1, 100.1}}}});
+      inclusiveRegistry.add({"Events/Control/Chi2", " ; #chi^2", {HistType::kTH1F, {{101, -0.1, 10.1}}}});
+      inclusiveRegistry.add({"Events/Control/TimeResolution", " ; t (ms)", {HistType::kTH1F, {{1001, -0.1, 100.1}}}});
     }
     if (doprocessEventStatCentralityFT0C || doprocessEventStatCentralityFT0M) {
-      registry.add({"Events/Centrality/Control/Chi2", " ; #chi^2; centrality", {HistType::kTH2F, {{101, -0.1, 10.1}, CentAxis}}});
-      registry.add({"Events/Centrality/Control/TimeResolution", " ; t (ms); centrality", {HistType::kTH2F, {{1001, -0.1, 100.1}, CentAxis}}});
+      binnedRegistry.add({"Events/Control/Chi2", " ; #chi^2; centrality", {HistType::kTH2F, {{101, -0.1, 10.1}, CentAxis}}});
+      binnedRegistry.add({"Events/Control/TimeResolution", " ; t (ms); centrality", {HistType::kTH2F, {{1001, -0.1, 100.1}, CentAxis}}});
     }
 
     if (doprocessCounting || doprocessCountingNoAmb) {
-      registry.add({"Events/Selection", ";status;events", {HistType::kTH1F, {{static_cast<int>(EvSelBins::kRejected), 0.5, static_cast<float>(EvSelBins::kRejected) + 0.5}}}});
-      hstat = registry.get<TH1>(HIST("Events/Selection"));
+      inclusiveRegistry.add({"Events/Selection", ";status;events", {HistType::kTH1F, {{static_cast<int>(EvSelBins::kRejected), 0.5, static_cast<float>(EvSelBins::kRejected) + 0.5}}}});
+      hstat = inclusiveRegistry.get<TH1>(HIST("Events/Selection"));
       x = hstat->GetXaxis();
       x->SetBinLabel(static_cast<int>(EvSelBins::kAll), "All");
       x->SetBinLabel(static_cast<int>(EvSelBins::kSelected), "Selected");
@@ -98,79 +107,79 @@ struct MultiplicityCounter {
       x->SetBinLabel(static_cast<int>(EvSelBins::kSelectedPVgt0), "Selected INEL>0 (PV)");
       x->SetBinLabel(static_cast<int>(EvSelBins::kRejected), "Rejected");
 
-      registry.add({"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtx_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtx_PVgt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/PhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
-      registry.add({"Tracks/Control/PtEta", " ; p_{T} (GeV/c); #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}});
-      registry.add({"Tracks/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
-      registry.add({"Tracks/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+      inclusiveRegistry.add({"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtx_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtx_PVgt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/PhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEta", " ; p_{T} (GeV/c); #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
       if (doprocessCounting) {
-        registry.add({"Tracks/Control/ReassignedDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
-        registry.add({"Tracks/Control/ReassignedDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
-        registry.add({"Tracks/Control/ExtraDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
-        registry.add({"Tracks/Control/ExtraDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
-        registry.add({"Tracks/Control/ExtraTracksEtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-        registry.add({"Tracks/Control/ExtraTracksPhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
-        registry.add({"Tracks/Control/ReassignedTracksEtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-        registry.add({"Tracks/Control/ReassignedTracksPhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
-        registry.add({"Tracks/Control/ReassignedVertexCorr", "; Z_{vtx}^{orig} (cm); Z_{vtx}^{re} (cm)", {HistType::kTH2F, {ZAxis, ZAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ReassignedDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ReassignedDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ExtraDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ExtraDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm)", {HistType::kTH2F, {PtAxis, DCAAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ExtraTracksEtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ExtraTracksPhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ReassignedTracksEtaZvtx", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ReassignedTracksPhiEta", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+        inclusiveRegistry.add({"Tracks/Control/ReassignedVertexCorr", "; Z_{vtx}^{orig} (cm); Z_{vtx}^{re} (cm)", {HistType::kTH2F, {ZAxis, ZAxis}}});
       }
     }
 
     if (doprocessCountingCentralityFT0C || doprocessCountingCentralityFT0M || doprocessCountingCentralityFT0CNoAmb || doprocessCountingCentralityFT0MNoAmb) {
-      registry.add({"Events/Centrality/Selection", ";status;centrality;events", {HistType::kTH2F, {{3, 0.5, 3.5}, CentAxis}}});
-      hstat = registry.get<TH2>(HIST("Events/Centrality/Selection"));
+      binnedRegistry.add({"Events/Selection", ";status;centrality;events", {HistType::kTH2F, {{3, 0.5, 3.5}, CentAxis}}});
+      hstat = binnedRegistry.get<TH2>(HIST("Events/Selection"));
       x = hstat->GetXaxis();
       x->SetBinLabel(1, "All");
       x->SetBinLabel(2, "Selected");
       x->SetBinLabel(3, "Rejected");
 
-      registry.add({"Events/Centrality/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/PhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/PtEta", " ; p_{T} (GeV/c); #eta; centrality", {HistType::kTHnSparseF, {PtAxis, EtaAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+      binnedRegistry.add({"Events/NtrkZvtx", "; N_{trk}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/PhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/PtEta", " ; p_{T} (GeV/c); #eta; centrality", {HistType::kTHnSparseF, {PtAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/DCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/DCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
       if (doprocessCountingCentralityFT0C || doprocessCountingCentralityFT0M) {
-        registry.add({"Tracks/Centrality/Control/ReassignedDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ReassignedDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ExtraDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ExtraDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ExtraTracksEtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ExtraTracksPhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ReassignedTracksEtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ReassignedTracksPhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-        registry.add({"Tracks/Centrality/Control/ReassignedVertexCorr", "; Z_{vtx}^{orig} (cm); Z_{vtx}^{re} (cm); centrality", {HistType::kTHnSparseF, {ZAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ReassignedDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ReassignedDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ExtraDCAXYPt", " ; p_{T} (GeV/c) ; DCA_{XY} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ExtraDCAZPt", " ; p_{T} (GeV/c) ; DCA_{Z} (cm); centrality", {HistType::kTHnSparseF, {PtAxis, DCAAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ExtraTracksEtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ExtraTracksPhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ReassignedTracksEtaZvtx", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ReassignedTracksPhiEta", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+        binnedRegistry.add({"Tracks/Control/ReassignedVertexCorr", "; Z_{vtx}^{orig} (cm); Z_{vtx}^{re} (cm); centrality", {HistType::kTHnSparseF, {ZAxis, ZAxis, CentAxis}}});
       }
     }
 
     if (doprocessGen || doprocessGenNoAmb) {
-      registry.add({"Events/NtrkZvtxGen", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
-      registry.add({"Events/NtrkZvtxGen_t", "; N_{part}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtxGen", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtxGen_t", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtxGen_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtxGen_PVgt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/EtaZvtxGen_gt0t", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
-      registry.add({"Tracks/Control/PtEtaGen", " ; p_{T} (GeV/c) ; #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Events/NtrkZvtxGen", "; N_{trk}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
+      inclusiveRegistry.add({"Events/NtrkZvtxGen_t", "; N_{part}; Z_{vtx} (cm); events", {HistType::kTH2F, {MultAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtxGen", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtxGen_t", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtxGen_gt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtxGen_PVgt0", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/EtaZvtxGen_gt0t", "; #eta; Z_{vtx} (cm); tracks", {HistType::kTH2F, {EtaAxis, ZAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEtaGen", " ; p_{T} (GeV/c) ; #eta", {HistType::kTH2F, {PtAxis, EtaAxis}}});
 
-      registry.add({"Tracks/PhiEtaGen", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Tracks/PhiEtaGen", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
 
-      registry.add({"Events/Efficiency", "; status; events", {HistType::kTH1F, {{static_cast<int>(EvEffBins::kSelectedPVgt0), 0.5, static_cast<float>(EvEffBins::kSelectedPVgt0) + 0.5}}}});
-      registry.add({"Events/NotFoundEventZvtx", " ; Z_{vtx} (cm)", {HistType::kTH1F, {ZAxis}}});
+      inclusiveRegistry.add({"Events/Efficiency", "; status; events", {HistType::kTH1F, {{static_cast<int>(EvEffBins::kSelectedPVgt0), 0.5, static_cast<float>(EvEffBins::kSelectedPVgt0) + 0.5}}}});
+      inclusiveRegistry.add({"Events/NotFoundEventZvtx", " ; Z_{vtx} (cm)", {HistType::kTH1F, {ZAxis}}});
 
       if (fillResponse) {
-        registry.add({"Events/Response", " ; N_{rec}; N_{gen}; Z_{vtx} (cm)", {HistType::kTHnSparseF, {MultAxis, MultAxis, ZAxis}}});
-        registry.add({"Events/EfficiencyMult", " ; N_{gen}; Z_{vtx} (cm)", {HistType::kTH2F, {MultAxis, ZAxis}}});
-        registry.add({"Events/SplitMult", " ; N_{gen} ; Z_{vtx} (cm)", {HistType::kTH2F, {MultAxis, ZAxis}}});
+        inclusiveRegistry.add({"Events/Response", " ; N_{rec}; N_{gen}; Z_{vtx} (cm)", {HistType::kTHnSparseF, {MultAxis, MultAxis, ZAxis}}});
+        inclusiveRegistry.add({"Events/EfficiencyMult", " ; N_{gen}; Z_{vtx} (cm)", {HistType::kTH2F, {MultAxis, ZAxis}}});
+        inclusiveRegistry.add({"Events/SplitMult", " ; N_{gen} ; Z_{vtx} (cm)", {HistType::kTH2F, {MultAxis, ZAxis}}});
         if (responseStudy) {
-          registry.add({"Events/Control/MultiResponse", " ; N_{gen}; N_{rec}; N_{PV cont}; N_{FT0A}; N_{FT0C}; N_{FDA}; N_{FDC}; Z_{vtx} (cm)", {HistType::kTHnSparseF, {MultAxis, MultAxis, MultAxis, FT0AAxis, FT0CAxis, FDDAxis, FDDAxis, ZAxis}}});
+          inclusiveRegistry.add({"Events/Control/MultiResponse", " ; N_{gen}; N_{rec}; N_{PV cont}; N_{FT0A}; N_{FT0C}; N_{FDA}; N_{FDC}; Z_{vtx} (cm)", {HistType::kTHnSparseF, {MultAxis, MultAxis, MultAxis, FT0AAxis, FT0CAxis, FDDAxis, FDDAxis, ZAxis}}});
         }
       }
 
-      auto heff = registry.get<TH1>(HIST("Events/Efficiency"));
+      auto heff = inclusiveRegistry.get<TH1>(HIST("Events/Efficiency"));
       x = heff->GetXaxis();
       x->SetBinLabel(static_cast<int>(EvEffBins::kGen), "Generated");
       x->SetBinLabel(static_cast<int>(EvEffBins::kGengt0), "Generated INEL>0");
@@ -182,31 +191,31 @@ struct MultiplicityCounter {
 
     if (doprocessGenFT0C || doprocessGenFT0M || doprocessGenFT0Chi || doprocessGenFT0Mhi ||
         doprocessGenFT0CNoAmb || doprocessGenFT0MNoAmb || doprocessGenFT0ChiNoAmb || doprocessGenFT0MhiNoAmb) {
-      registry.add({"Events/Centrality/NtrkZvtxGen", "; N_{trk}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
-      registry.add({"Events/Centrality/NtrkZvtxGen_t", "; N_{part}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtxGen", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtxGen_t", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtxGen_gt0", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtxGen_PVgt0", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/EtaZvtxGen_gt0t", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/PtEtaGen", " ; p_{T} (GeV/c) ; #eta; centrality", {HistType::kTHnSparseF, {PtAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Events/NtrkZvtxGen", "; N_{trk}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Events/NtrkZvtxGen_t", "; N_{part}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtxGen", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtxGen_t", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtxGen_gt0", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtxGen_PVgt0", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/EtaZvtxGen_gt0t", "; #eta; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {EtaAxis, ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/PtEtaGen", " ; p_{T} (GeV/c) ; #eta; centrality", {HistType::kTHnSparseF, {PtAxis, EtaAxis, CentAxis}}});
 
-      registry.add({"Tracks/Centrality/PhiEtaGen", "; #varphi; #eta; tracks", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/PhiEtaGenDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      registry.add({"Tracks/Centrality/Control/PhiEtaDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      registry.add({"Events/Centrality/Efficiency", "; status; centrality; events", {HistType::kTH2F, {{static_cast<int>(EvEffBins::kSelectedPVgt0), 0.5, static_cast<float>(EvEffBins::kSelectedPVgt0) + 0.5}, CentAxis}}});
-      registry.add({"Events/Centrality/NotFoundEventZvtx", " ; Z_{vtx} (cm); centrality; events", {HistType::kTH2F, {ZAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/PhiEtaGen", "; #varphi; #eta; tracks", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/PhiEtaGenDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Tracks/Control/PhiEtaDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      binnedRegistry.add({"Events/Efficiency", "; status; centrality; events", {HistType::kTH2F, {{static_cast<int>(EvEffBins::kSelectedPVgt0), 0.5, static_cast<float>(EvEffBins::kSelectedPVgt0) + 0.5}, CentAxis}}});
+      binnedRegistry.add({"Events/NotFoundEventZvtx", " ; Z_{vtx} (cm); centrality; events", {HistType::kTH2F, {ZAxis, CentAxis}}});
 
       if (fillResponse) {
-        registry.add({"Events/Centrality/Response", " ; N_{rec}; N_{gen}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, MultAxis, ZAxis, CentAxis}}});
-        registry.add({"Events/Centrality/EfficiencyMult", " ; N_{gen}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
-        registry.add({"Events/Centrality/SplitMult", " ; N_{gen} ; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Events/Response", " ; N_{rec}; N_{gen}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, MultAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Events/EfficiencyMult", " ; N_{gen}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
+        binnedRegistry.add({"Events/SplitMult", " ; N_{gen} ; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, ZAxis, CentAxis}}});
         if (responseStudy) {
-          registry.add({"Events/Centrality/Control/MultiResponse", " ; N_{gen}; N_{rec}, N_{PV cont}; N_{FT0A}; N_{FT0C}; N_{FDA}; N_{FDC}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, MultAxis, MultAxis, FT0AAxis, FT0CAxis, FDDAxis, FDDAxis, ZAxis, CentAxis}}});
+          binnedRegistry.add({"Events/Control/MultiResponse", " ; N_{gen}; N_{rec}, N_{PV cont}; N_{FT0A}; N_{FT0C}; N_{FDA}; N_{FDC}; Z_{vtx} (cm); centrality", {HistType::kTHnSparseF, {MultAxis, MultAxis, MultAxis, FT0AAxis, FT0CAxis, FDDAxis, FDDAxis, ZAxis, CentAxis}}});
         }
       }
 
-      auto heff = registry.get<TH2>(HIST("Events/Centrality/Efficiency"));
+      auto heff = binnedRegistry.get<TH2>(HIST("Events/Efficiency"));
       x = heff->GetXaxis();
       x->SetBinLabel(static_cast<int>(EvEffBins::kGen), "Generated");
       x->SetBinLabel(static_cast<int>(EvEffBins::kGengt0), "Generated INEL>0");
@@ -217,30 +226,30 @@ struct MultiplicityCounter {
     }
 
     if (doprocessTrackEfficiency || doprocessTrackEfficiencyNoAmb) {
-      registry.add({"Tracks/Control/PtGen", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtGenNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiency", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyFakes", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtGen", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtGenNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiency", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyFakes", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
       for (auto i = 0u; i < speciesIds.size(); ++i) {
-        registry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtGen").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-        registry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtEfficiency").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+        inclusiveRegistry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtGen").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+        inclusiveRegistry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtEfficiency").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
       }
     }
     if (doprocessTrackEfficiencyIndexed) {
-      registry.add({"Tracks/Control/PhiEtaGenDuplicates", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
-      registry.add({"Tracks/Control/PhiEtaDuplicates", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
-      registry.add({"Tracks/Control/PtGenI", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtGenINoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyI", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyINoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyISecondaries", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/PtEfficiencyISecondariesNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-      registry.add({"Tracks/Control/Mask", " ; bit", {HistType::kTH1F, {{17, -0.5, 16.5}}}});
-      registry.add({"Tracks/Control/ITSClusters", " ; layer", {HistType::kTH1F, {{8, 0.5, 8.5}}}});
+      inclusiveRegistry.add({"Tracks/Control/PhiEtaGenDuplicates", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/PhiEtaDuplicates", "; #varphi; #eta; tracks", {HistType::kTH2F, {PhiAxis, EtaAxis}}});
+      inclusiveRegistry.add({"Tracks/Control/PtGenI", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtGenINoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyI", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyINoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyISecondaries", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/PtEfficiencyISecondariesNoEtaCut", " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+      inclusiveRegistry.add({"Tracks/Control/Mask", " ; bit", {HistType::kTH1F, {{17, -0.5, 16.5}}}});
+      inclusiveRegistry.add({"Tracks/Control/ITSClusters", " ; layer", {HistType::kTH1F, {{8, 0.5, 8.5}}}});
       for (auto i = 0u; i < speciesIds.size(); ++i) {
-        registry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtGenI").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
-        registry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtEfficiencyI").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+        inclusiveRegistry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtGenI").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
+        inclusiveRegistry.add({(std::string("Tracks/Control/") + std::string(species[i]) + "/PtEfficiencyI").c_str(), " ; p_{T} (GeV/c)", {HistType::kTH1F, {PtAxisEff}}});
       }
     }
   }
@@ -254,7 +263,7 @@ struct MultiplicityCounter {
     for (auto& bc : bcs) {
       if (!useEvSel || (bc.selection_bit(aod::evsel::kIsBBT0A) &&
                         bc.selection_bit(aod::evsel::kIsBBT0C)) != 0) {
-        registry.fill(HIST("Events/BCSelection"), 1.);
+        commonRegistry.fill(HIST("Events/BCSelection"), 1.);
         cols.clear();
         for (auto& collision : collisions) {
           if (collision.has_foundBC()) {
@@ -267,9 +276,9 @@ struct MultiplicityCounter {
         }
         LOGP(debug, "BC {} has {} collisions", bc.globalBC(), cols.size());
         if (!cols.empty()) {
-          registry.fill(HIST("Events/BCSelection"), 2.);
+          commonRegistry.fill(HIST("Events/BCSelection"), 2.);
           if (cols.size() > 1) {
-            registry.fill(HIST("Events/BCSelection"), 3.);
+            commonRegistry.fill(HIST("Events/BCSelection"), 3.);
           }
         }
         for (auto& col : cols) {
@@ -280,11 +289,11 @@ struct MultiplicityCounter {
             } else if constexpr (C::template contains<aod::CentFT0Ms>()) {
               c = col.centFT0M();
             }
-            registry.fill(HIST("Events/Centrality/Control/Chi2"), col.chi2(), c);
-            registry.fill(HIST("Events/Centrality/Control/TimeResolution"), col.collisionTimeRes(), c);
+            binnedRegistry.fill(HIST("Events/Control/Chi2"), col.chi2(), c);
+            binnedRegistry.fill(HIST("Events/Control/TimeResolution"), col.collisionTimeRes(), c);
           } else {
-            registry.fill(HIST("Events/Control/Chi2"), col.chi2());
-            registry.fill(HIST("Events/Control/TimeResolution"), col.collisionTimeRes());
+            inclusiveRegistry.fill(HIST("Events/Control/Chi2"), col.chi2());
+            inclusiveRegistry.fill(HIST("Events/Control/TimeResolution"), col.collisionTimeRes());
           }
         }
       }
@@ -360,16 +369,16 @@ struct MultiplicityCounter {
       } else if (C::template contains<aod::CentFT0Ms>()) {
         c = collision.centFT0M();
       }
-      registry.fill(HIST("Events/Centrality/Selection"), 1., c);
+      binnedRegistry.fill(HIST("Events/Selection"), 1., c);
     } else {
-      registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kAll));
+      inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kAll));
     }
 
     if (!useEvSel || collision.sel8()) {
       if constexpr (hasCentrality) {
-        registry.fill(HIST("Events/Centrality/Selection"), 2., c);
+        binnedRegistry.fill(HIST("Events/Selection"), 2., c);
       } else {
-        registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelected));
+        inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelected));
       }
       auto z = collision.posZ();
       usedTracksIds.clear();
@@ -382,45 +391,45 @@ struct MultiplicityCounter {
           ++Ntrks;
         }
         if constexpr (hasCentrality) {
-          registry.fill(HIST("Tracks/Centrality/EtaZvtx"), track.eta(), z, c);
-          registry.fill(HIST("Tracks/Centrality/PhiEta"), track.phi(), track.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/PtEta"), track.pt(), track.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
+          binnedRegistry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z, c);
+          binnedRegistry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
         } else {
-          registry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
-          registry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
-          registry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
-          registry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
-          registry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
+          inclusiveRegistry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
+          inclusiveRegistry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
         }
       }
       if constexpr (hasCentrality) {
-        registry.fill(HIST("Events/Centrality/NtrkZvtx"), Ntrks, z, c);
+        binnedRegistry.fill(HIST("Events/NtrkZvtx"), Ntrks, z, c);
       } else {
         if (Ntrks > 0 || groupPVContrib.size() > 0) {
           if (groupPVContrib.size() > 0) {
-            registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedPVgt0));
+            inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedPVgt0));
           }
           if (Ntrks > 0) {
-            registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedgt0));
+            inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedgt0));
           }
           for (auto& track : tracks) {
             if (Ntrks > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
             }
             if (groupPVContrib.size() > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.eta(), z);
             }
           }
         }
-        registry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
+        inclusiveRegistry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
       }
     } else {
       if constexpr (hasCentrality) {
-        registry.fill(HIST("Events/Centrality/Selection"), 3., c);
+        binnedRegistry.fill(HIST("Events/Selection"), 3., c);
       } else {
-        registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kRejected));
+        inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kRejected));
       }
     }
   }
@@ -438,16 +447,16 @@ struct MultiplicityCounter {
       } else if (C::template contains<aod::CentFT0Ms>()) {
         c = collision.centFT0M();
       }
-      registry.fill(HIST("Events/Centrality/Selection"), 1., c);
+      binnedRegistry.fill(HIST("Events/Selection"), 1., c);
     } else {
-      registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kAll));
+      inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kAll));
     }
 
     if (!useEvSel || collision.sel8()) {
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Events/Centrality/Selection"), 2., c);
+        binnedRegistry.fill(HIST("Events/Selection"), 2., c);
       } else {
-        registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelected));
+        inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelected));
       }
       auto z = collision.posZ();
       usedTracksIds.clear();
@@ -475,44 +484,44 @@ struct MultiplicityCounter {
           ++Ntrks;
         }
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Tracks/Centrality/EtaZvtx"), otrack.eta(), z, c);
-          registry.fill(HIST("Tracks/Centrality/PhiEta"), otrack.phi(), otrack.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/PtEta"), otrack.pt(), otrack.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), otrack.pt(), track.bestDCAZ(), c);
+          binnedRegistry.fill(HIST("Tracks/EtaZvtx"), otrack.eta(), z, c);
+          binnedRegistry.fill(HIST("Tracks/PhiEta"), otrack.phi(), otrack.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/PtEta"), otrack.pt(), otrack.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAZPt"), otrack.pt(), track.bestDCAZ(), c);
         } else {
-          registry.fill(HIST("Tracks/EtaZvtx"), otrack.eta(), z);
-          registry.fill(HIST("Tracks/PhiEta"), otrack.phi(), otrack.eta());
-          registry.fill(HIST("Tracks/Control/PtEta"), otrack.pt(), otrack.eta());
-          registry.fill(HIST("Tracks/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY());
-          registry.fill(HIST("Tracks/Control/DCAZPt"), otrack.pt(), track.bestDCAZ());
+          inclusiveRegistry.fill(HIST("Tracks/EtaZvtx"), otrack.eta(), z);
+          inclusiveRegistry.fill(HIST("Tracks/PhiEta"), otrack.phi(), otrack.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEta"), otrack.pt(), otrack.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAXYPt"), otrack.pt(), track.bestDCAXY());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAZPt"), otrack.pt(), track.bestDCAZ());
         }
         if (!otrack.has_collision()) {
           if constexpr (hasRecoCent<C>()) {
-            registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksEtaZvtx"), otrack.eta(), z, c);
-            registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta(), c);
-            registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-            registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), otrack.eta(), z, c);
+            binnedRegistry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
           } else {
-            registry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), otrack.eta(), z);
-            registry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta());
-            registry.fill(HIST("Tracks/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY());
-            registry.fill(HIST("Tracks/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ExtraTracksEtaZvtx"), otrack.eta(), z);
+            inclusiveRegistry.fill(HIST("Tracks/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ExtraDCAZPt"), otrack.pt(), track.bestDCAZ());
           }
         } else if (otrack.collisionId() != track.bestCollisionId()) {
           usedTracksIdsDF.emplace_back(track.trackId());
           if constexpr (hasRecoCent<C>()) {
-            registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z, c);
-            registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta(), c);
-            registry.fill(HIST("Tracks/Centrality/Control/ReassignedVertexCorr"), otrack.collision_as<C>().posZ(), z, c);
-            registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
-            registry.fill(HIST("Tracks/Centrality/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z, c);
+            binnedRegistry.fill(HIST("Tracks/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ReassignedVertexCorr"), otrack.collision_as<C>().posZ(), z, c);
+            binnedRegistry.fill(HIST("Tracks/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
+            binnedRegistry.fill(HIST("Tracks/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ(), c);
           } else {
-            registry.fill(HIST("Tracks/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z);
-            registry.fill(HIST("Tracks/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta());
-            registry.fill(HIST("Tracks/Control/ReassignedVertexCorr"), otrack.collision_as<C>().posZ(), z);
-            registry.fill(HIST("Tracks/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY());
-            registry.fill(HIST("Tracks/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z);
+            inclusiveRegistry.fill(HIST("Tracks/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ReassignedVertexCorr"), otrack.collision_as<C>().posZ(), z);
+            inclusiveRegistry.fill(HIST("Tracks/Control/ReassignedDCAXYPt"), otrack.pt(), track.bestDCAXY());
+            inclusiveRegistry.fill(HIST("Tracks/Control/ReassignedDCAZPt"), otrack.pt(), track.bestDCAZ());
           }
         }
       }
@@ -528,35 +537,35 @@ struct MultiplicityCounter {
           ++Ntrks;
         }
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Tracks/Centrality/EtaZvtx"), track.eta(), z, c);
-          registry.fill(HIST("Tracks/Centrality/PhiEta"), track.phi(), track.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/PtEta"), track.pt(), track.eta(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
-          registry.fill(HIST("Tracks/Centrality/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
+          binnedRegistry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z, c);
+          binnedRegistry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY(), c);
+          binnedRegistry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ(), c);
         } else {
-          registry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
-          registry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
-          registry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
-          registry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
-          registry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
+          inclusiveRegistry.fill(HIST("Tracks/EtaZvtx"), track.eta(), z);
+          inclusiveRegistry.fill(HIST("Tracks/PhiEta"), track.phi(), track.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEta"), track.pt(), track.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAXYPt"), track.pt(), track.dcaXY());
+          inclusiveRegistry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
         }
       }
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Events/Centrality/NtrkZvtx"), Ntrks, z, c);
+        binnedRegistry.fill(HIST("Events/NtrkZvtx"), Ntrks, z, c);
       } else {
         if (Ntrks > 0 || groupPVContrib.size() > 0) {
           if (groupPVContrib.size() > 0) {
-            registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedPVgt0));
+            inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedPVgt0));
           }
           if (Ntrks > 0) {
-            registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedgt0));
+            inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelectedgt0));
           }
           for (auto& track : atracks) {
             if (Ntrks > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.track_as<FiTracks>().eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_gt0"), track.track_as<FiTracks>().eta(), z);
             }
             if (groupPVContrib.size() > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.track_as<FiTracks>().eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.track_as<FiTracks>().eta(), z);
             }
           }
           for (auto& track : tracks) {
@@ -567,20 +576,20 @@ struct MultiplicityCounter {
               continue;
             }
             if (Ntrks > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_gt0"), track.eta(), z);
             }
             if (groupPVContrib.size() > 0) {
-              registry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.eta(), z);
+              inclusiveRegistry.fill(HIST("Tracks/EtaZvtx_PVgt0"), track.eta(), z);
             }
           }
         }
-        registry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
+        inclusiveRegistry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
       }
     } else {
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Events/Centrality/Selection"), 3., c);
+        binnedRegistry.fill(HIST("Events/Selection"), 3., c);
       } else {
-        registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kRejected));
+        inclusiveRegistry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kRejected));
       }
     }
   }
@@ -674,18 +683,18 @@ struct MultiplicityCounter {
       if (std::abs(charge) < 3.) {
         continue;
       }
-      registry.fill(HIST("Tracks/Control/PtGenINoEtaCut"), particle.pt());
+      inclusiveRegistry.fill(HIST("Tracks/Control/PtGenINoEtaCut"), particle.pt());
 
       if (std::abs(particle.eta()) < estimatorEta) {
-        registry.fill(HIST("Tracks/Control/PtGenI"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtGenI"), particle.pt());
         if (particle.pdgCode() == speciesIds[0]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGenI"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGenI"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[1]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGenI"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGenI"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[2]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGenI"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGenI"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[3]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGenI"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGenI"), particle.pt());
         }
       }
       if (particle.has_tracks()) {
@@ -696,28 +705,28 @@ struct MultiplicityCounter {
         for (auto const& track : relatedTracks) {
           ++counter;
           if (!countedNoEtaCut) {
-            registry.fill(HIST("Tracks/Control/PtEfficiencyINoEtaCut"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyINoEtaCut"), particle.pt());
             countedNoEtaCut = true;
           }
           if (std::abs(track.eta()) < estimatorEta) {
             if (!counted) {
-              registry.fill(HIST("Tracks/Control/PtEfficiencyI"), particle.pt());
+              inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyI"), particle.pt());
               if (particle.pdgCode() == speciesIds[0]) {
-                registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiencyI"), particle.pt());
+                inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiencyI"), particle.pt());
               } else if (particle.pdgCode() == speciesIds[1]) {
-                registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiencyI"), particle.pt());
+                inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiencyI"), particle.pt());
               } else if (particle.pdgCode() == speciesIds[2]) {
-                registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiencyI"), particle.pt());
+                inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiencyI"), particle.pt());
               } else if (particle.pdgCode() == speciesIds[3]) {
-                registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiencyI"), particle.pt());
+                inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiencyI"), particle.pt());
               }
               counted = true;
             }
           }
           if (counter > 1) {
-            registry.fill(HIST("Tracks/Control/PtEfficiencyISecondariesNoEtaCut"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyISecondariesNoEtaCut"), particle.pt());
             if (std::abs(track.eta()) < estimatorEta) {
-              registry.fill(HIST("Tracks/Control/PtEfficiencyISecondaries"), particle.pt());
+              inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyISecondaries"), particle.pt());
             }
           }
         }
@@ -725,25 +734,25 @@ struct MultiplicityCounter {
           for (auto const& track : relatedTracks) {
             for (auto layer = 0; layer < 7; ++layer) {
               if (track.itsClusterMap() & (uint8_t(1) << layer)) {
-                registry.fill(HIST("Tracks/Control/ITSClusters"), layer + 1);
+                inclusiveRegistry.fill(HIST("Tracks/Control/ITSClusters"), layer + 1);
               }
             }
             auto hasbit = false;
             for (auto bit = 0; bit < 16; ++bit) {
               if (track.mcMask() & (uint8_t(1) << bit)) {
-                registry.fill(HIST("Tracks/Control/Mask"), bit);
+                inclusiveRegistry.fill(HIST("Tracks/Control/Mask"), bit);
                 hasbit = true;
               }
             }
             if (!hasbit) {
-              registry.fill(HIST("Tracks/Control/Mask"), 16);
+              inclusiveRegistry.fill(HIST("Tracks/Control/Mask"), 16);
             }
           }
         }
         if (relatedTracks.size() > 1) {
-          registry.fill(HIST("Tracks/Control/PhiEtaGenDuplicates"), particle.phi(), particle.eta());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PhiEtaGenDuplicates"), particle.phi(), particle.eta());
           for (auto const& track : relatedTracks) {
-            registry.fill(HIST("Tracks/Control/PhiEtaDuplicates"), track.phi(), track.eta());
+            inclusiveRegistry.fill(HIST("Tracks/Control/PhiEtaDuplicates"), track.phi(), track.eta());
           }
         }
       }
@@ -798,21 +807,21 @@ struct MultiplicityCounter {
       }
       if (otrack.has_mcParticle()) {
         auto particle = otrack.mcParticle_as<Particles>();
-        registry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
         if (std::abs(otrack.eta()) < estimatorEta) {
-          registry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
           if (particle.pdgCode() == speciesIds[0]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[1]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[2]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[3]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
           }
         }
       } else {
-        registry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), otrack.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), otrack.pt());
       }
     }
     for (auto const& track : tracks) {
@@ -824,21 +833,21 @@ struct MultiplicityCounter {
       }
       if (track.has_mcParticle()) {
         auto particle = track.template mcParticle_as<Particles>();
-        registry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
         if (std::abs(track.eta()) < estimatorEta) {
-          registry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
           if (particle.pdgCode() == speciesIds[0]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[1]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[2]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[3]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
           }
         }
       } else {
-        registry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), track.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), track.pt());
       }
     }
 
@@ -851,17 +860,17 @@ struct MultiplicityCounter {
       if (std::abs(charge) < 3.) {
         continue;
       }
-      registry.fill(HIST("Tracks/Control/PtGenNoEtaCut"), particle.pt());
+      inclusiveRegistry.fill(HIST("Tracks/Control/PtGenNoEtaCut"), particle.pt());
       if (std::abs(particle.eta()) < estimatorEta) {
-        registry.fill(HIST("Tracks/Control/PtGen"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtGen"), particle.pt());
         if (particle.pdgCode() == speciesIds[0]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[1]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[2]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[3]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGen"), particle.pt());
         }
       }
     }
@@ -899,21 +908,21 @@ struct MultiplicityCounter {
     for (auto const& track : tracks) {
       if (track.has_mcParticle()) {
         auto particle = track.template mcParticle_as<Particles>();
-        registry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyNoEtaCut"), particle.pt());
         if (std::abs(track.eta()) < estimatorEta) {
-          registry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiency"), particle.pt());
           if (particle.pdgCode() == speciesIds[0]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[1]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[2]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtEfficiency"), particle.pt());
           } else if (particle.pdgCode() == speciesIds[3]) {
-            registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
+            inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtEfficiency"), particle.pt());
           }
         }
       } else {
-        registry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), track.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEfficiencyFakes"), track.pt());
       }
     }
 
@@ -926,17 +935,17 @@ struct MultiplicityCounter {
       if (std::abs(charge) < 3.) {
         continue;
       }
-      registry.fill(HIST("Tracks/Control/PtGenNoEtaCut"), particle.pt());
+      inclusiveRegistry.fill(HIST("Tracks/Control/PtGenNoEtaCut"), particle.pt());
       if (std::abs(particle.eta()) < estimatorEta) {
-        registry.fill(HIST("Tracks/Control/PtGen"), particle.pt());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtGen"), particle.pt());
         if (particle.pdgCode() == speciesIds[0]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[0]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[1]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[1]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[2]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[2]) + HIST("/PtGen"), particle.pt());
         } else if (particle.pdgCode() == speciesIds[3]) {
-          registry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGen"), particle.pt());
+          inclusiveRegistry.fill(HIST("Tracks/Control/") + HIST(species[3]) + HIST("/PtGen"), particle.pt());
         }
       }
     }
@@ -991,18 +1000,18 @@ struct MultiplicityCounter {
       nCharged++;
     }
     if constexpr (hasRecoCent<C>()) {
-      registry.fill(HIST("Events/Centrality/NtrkZvtxGen_t"), nCharged, mcCollision.posZ(), c_gen);
-      registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kGen), c_gen);
+      binnedRegistry.fill(HIST("Events/NtrkZvtxGen_t"), nCharged, mcCollision.posZ(), c_gen);
+      binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGen), c_gen);
     } else {
-      registry.fill(HIST("Events/NtrkZvtxGen_t"), nCharged, mcCollision.posZ());
-      registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGen));
+      inclusiveRegistry.fill(HIST("Events/NtrkZvtxGen_t"), nCharged, mcCollision.posZ());
+      inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGen));
     }
 
     if (nCharged > 0) {
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kGengt0), c_gen);
+        binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGengt0), c_gen);
       } else {
-        registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGengt0));
+        inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGengt0));
       }
     }
     bool atLeastOne = false;
@@ -1030,9 +1039,9 @@ struct MultiplicityCounter {
           c_rec = collision.centFT0M();
         }
         c_recPerCol.emplace_back(c_rec);
-        registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kRec), c_gen);
+        binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kRec), c_gen);
       } else {
-        registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kRec));
+        inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kRec));
       }
       if (!useEvSel || collision.sel8()) {
         Nrec = 0;
@@ -1042,9 +1051,9 @@ struct MultiplicityCounter {
         auto groupPVcontrib = pvContribTracksIUEta1->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
         if (groupPVcontrib.size() > 0) {
           if constexpr (hasRecoCent<C>()) {
-            registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
+            binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
           } else {
-            registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
+            inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
           }
         }
 
@@ -1111,32 +1120,32 @@ struct MultiplicityCounter {
         }
 
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelected), c_gen);
+          binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelected), c_gen);
         } else {
-          registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelected));
+          inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelected));
         }
 
         if (Nrec > 0) {
           if constexpr (hasRecoCent<C>()) {
-            registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0), c_gen);
+            binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0), c_gen);
           } else {
-            registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0));
+            inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0));
           }
           atLeastOne_gt0 = true;
         }
         if (groupPVcontrib.size() > 0) {
           if constexpr (hasRecoCent<C>()) {
-            registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
+            binnedRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
           } else {
-            registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
+            inclusiveRegistry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
           }
           atLeastOne_PVgt0 = true;
         }
 
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Events/Centrality/NtrkZvtxGen"), Nrec, collision.posZ(), c_rec);
+          binnedRegistry.fill(HIST("Events/NtrkZvtxGen"), Nrec, collision.posZ(), c_rec);
         } else {
-          registry.fill(HIST("Events/NtrkZvtxGen"), Nrec, collision.posZ());
+          inclusiveRegistry.fill(HIST("Events/NtrkZvtxGen"), Nrec, collision.posZ());
         }
       }
     }
@@ -1144,33 +1153,33 @@ struct MultiplicityCounter {
     if (fillResponse) {
       for (auto i = 0U; i < NrecPerCol.size(); ++i) {
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Events/Centrality/Response"), NrecPerCol[i], nCharged, mcCollision.posZ(), c_recPerCol[i]);
-          registry.fill(HIST("Events/Centrality/EfficiencyMult"), nCharged, mcCollision.posZ(), c_recPerCol[i]);
+          binnedRegistry.fill(HIST("Events/Response"), NrecPerCol[i], nCharged, mcCollision.posZ(), c_recPerCol[i]);
+          binnedRegistry.fill(HIST("Events/EfficiencyMult"), nCharged, mcCollision.posZ(), c_recPerCol[i]);
           if (responseStudy) {
-            registry.fill(HIST("Events/Centrality/Control/MultiResponse"), nCharged, NrecPerCol[i], NPVPerCol[i], NFT0APerCol[i], NFT0CPerCol[i], NFDDAPerCol[i], NFDDCPerCol[i], mcCollision.posZ(), c_recPerCol[i]);
+            binnedRegistry.fill(HIST("Events/Control/MultiResponse"), nCharged, NrecPerCol[i], NPVPerCol[i], NFT0APerCol[i], NFT0CPerCol[i], NFDDAPerCol[i], NFDDCPerCol[i], mcCollision.posZ(), c_recPerCol[i]);
           }
         } else {
-          registry.fill(HIST("Events/Response"), NrecPerCol[i], nCharged, mcCollision.posZ());
-          registry.fill(HIST("Events/EfficiencyMult"), nCharged, mcCollision.posZ());
+          inclusiveRegistry.fill(HIST("Events/Response"), NrecPerCol[i], nCharged, mcCollision.posZ());
+          inclusiveRegistry.fill(HIST("Events/EfficiencyMult"), nCharged, mcCollision.posZ());
           if (responseStudy) {
-            registry.fill(HIST("Events/Control/MultiResponse"), nCharged, NrecPerCol[i], NPVPerCol[i], NFT0APerCol[i], NFT0CPerCol[i], NFDDAPerCol[i], NFDDCPerCol[i], mcCollision.posZ());
+            inclusiveRegistry.fill(HIST("Events/Control/MultiResponse"), nCharged, NrecPerCol[i], NPVPerCol[i], NFT0APerCol[i], NFT0CPerCol[i], NFDDAPerCol[i], NFDDCPerCol[i], mcCollision.posZ());
           }
         }
       }
       if (moreThanOne > 1) {
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Events/Centrality/SplitMult"), nCharged, mcCollision.posZ(), c_gen);
+          binnedRegistry.fill(HIST("Events/SplitMult"), nCharged, mcCollision.posZ(), c_gen);
         } else {
-          registry.fill(HIST("Events/SplitMult"), nCharged, mcCollision.posZ());
+          inclusiveRegistry.fill(HIST("Events/SplitMult"), nCharged, mcCollision.posZ());
         }
       }
     }
 
     if (collisions.size() == 0) {
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Events/Centrality/NotFoundEventZvtx"), mcCollision.posZ(), c_gen);
+        binnedRegistry.fill(HIST("Events/NotFoundEventZvtx"), mcCollision.posZ(), c_gen);
       } else {
-        registry.fill(HIST("Events/NotFoundEventZvtx"), mcCollision.posZ());
+        inclusiveRegistry.fill(HIST("Events/NotFoundEventZvtx"), mcCollision.posZ());
       }
     }
 
@@ -1184,38 +1193,38 @@ struct MultiplicityCounter {
         continue;
       }
       if constexpr (hasRecoCent<C>()) {
-        registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_t"), particle.eta(), mcCollision.posZ(), c_gen);
-        registry.fill(HIST("Tracks/Centrality/Control/PtEtaGen"), particle.pt(), particle.eta(), c_gen);
+        binnedRegistry.fill(HIST("Tracks/EtaZvtxGen_t"), particle.eta(), mcCollision.posZ(), c_gen);
+        binnedRegistry.fill(HIST("Tracks/Control/PtEtaGen"), particle.pt(), particle.eta(), c_gen);
       } else {
-        registry.fill(HIST("Tracks/EtaZvtxGen_t"), particle.eta(), mcCollision.posZ());
-        registry.fill(HIST("Tracks/Control/PtEtaGen"), particle.pt(), particle.eta());
+        inclusiveRegistry.fill(HIST("Tracks/EtaZvtxGen_t"), particle.eta(), mcCollision.posZ());
+        inclusiveRegistry.fill(HIST("Tracks/Control/PtEtaGen"), particle.pt(), particle.eta());
       }
       if (nCharged > 0) {
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ(), c_gen);
+          binnedRegistry.fill(HIST("Tracks/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ(), c_gen);
         } else {
-          registry.fill(HIST("Tracks/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ());
+          inclusiveRegistry.fill(HIST("Tracks/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ());
         }
       }
       if (atLeastOne) {
         if constexpr (hasRecoCent<C>()) {
-          registry.fill(HIST("Tracks/Centrality/EtaZvtxGen"), particle.eta(), mcCollision.posZ(), c_gen);
+          binnedRegistry.fill(HIST("Tracks/EtaZvtxGen"), particle.eta(), mcCollision.posZ(), c_gen);
           if (atLeastOne_gt0) {
-            registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_gt0"), particle.eta(), mcCollision.posZ(), c_gen);
+            binnedRegistry.fill(HIST("Tracks/EtaZvtxGen_gt0"), particle.eta(), mcCollision.posZ(), c_gen);
           }
           if (atLeastOne_PVgt0) {
-            registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_PVgt0"), particle.eta(), mcCollision.posZ(), c_gen);
+            binnedRegistry.fill(HIST("Tracks/EtaZvtxGen_PVgt0"), particle.eta(), mcCollision.posZ(), c_gen);
           }
-          registry.fill(HIST("Tracks/Centrality/PhiEtaGen"), particle.phi(), particle.eta(), c_gen);
+          binnedRegistry.fill(HIST("Tracks/PhiEtaGen"), particle.phi(), particle.eta(), c_gen);
         } else {
-          registry.fill(HIST("Tracks/EtaZvtxGen"), particle.eta(), mcCollision.posZ());
+          inclusiveRegistry.fill(HIST("Tracks/EtaZvtxGen"), particle.eta(), mcCollision.posZ());
           if (atLeastOne_gt0) {
-            registry.fill(HIST("Tracks/EtaZvtxGen_gt0"), particle.eta(), mcCollision.posZ());
+            inclusiveRegistry.fill(HIST("Tracks/EtaZvtxGen_gt0"), particle.eta(), mcCollision.posZ());
           }
           if (atLeastOne_PVgt0) {
-            registry.fill(HIST("Tracks/EtaZvtxGen_PVgt0"), particle.eta(), mcCollision.posZ());
+            inclusiveRegistry.fill(HIST("Tracks/EtaZvtxGen_PVgt0"), particle.eta(), mcCollision.posZ());
           }
-          registry.fill(HIST("Tracks/PhiEtaGen"), particle.phi(), particle.eta());
+          inclusiveRegistry.fill(HIST("Tracks/PhiEtaGen"), particle.phi(), particle.eta());
         }
       }
     }

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -23,13 +23,14 @@
 #include <TPDGCode.h>
 
 #include "bestCollisionTable.h"
-#include "common.h"
+#include "Axes.h"
+#include "Functions.h"
 
 using namespace o2;
 using namespace o2::aod::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-using namespace pwgmm::dndeta;
+using namespace pwgmm::mult;
 
 static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
   TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -325,25 +325,17 @@ struct MultiplicityCounter {
     usedTracksIdsDFMCEff.clear();
   }
 
-  // require ITS+TPC tracks
-  //  expressions::Filter trackSelectionProperGlobalOnly = ncheckbit(aod::track::detectorMap, (uint8_t)o2::aod::track::ITS) &&
-  //                                                       ncheckbit(aod::track::detectorMap, (uint8_t)o2::aod::track::TPC) &&
-  //                                                       ncheckbit(aod::track::trackCutFlag, trackSelectionITS) &&
-  //                                                       ncheckbit(aod::track::trackCutFlag, trackSelectionTPC) &&
-  //                                                       ifnode(dcaZ.node() > 0.f, nabs(aod::track::dcaZ) <= dcaZ  && ncheckbit(aod::track::trackCutFlag, trackSelectionDCAXYonly),
-  //                                                              ncheckbit(aod::track::trackCutFlag, trackSelectionDCA));
+  // require a mix of ITS+TPC and ITS-only tracks
+  expressions::Filter fTrackSelectionITS = ncheckbit(aod::track::v001::detectorMap, (uint8_t)o2::aod::track::ITS) &&
+                                           ncheckbit(aod::track::trackCutFlag, trackSelectionITS);
+  expressions::Filter fTrackSelectionTPC = ifnode(ncheckbit(aod::track::v001::detectorMap, (uint8_t)o2::aod::track::TPC),
+                                                  ncheckbit(aod::track::trackCutFlag, trackSelectionTPC), true);
+  expressions::Filter fTrackSelectionDCA = ifnode(dcaZ.node() > 0.f, nabs(aod::track::dcaZ) <= dcaZ && ncheckbit(aod::track::trackCutFlag, trackSelectionDCAXYonly),
+                                                  ncheckbit(aod::track::trackCutFlag, trackSelectionDCA));
 
-  //   require a mix of ITS+TPC and ITS-only tracks
-  expressions::Filter trackSelectionProperMixed = ncheckbit(aod::track::v001::detectorMap, (uint8_t)o2::aod::track::ITS) &&
-                                                  ncheckbit(aod::track::trackCutFlag, trackSelectionITS) &&
-                                                  ifnode(ncheckbit(aod::track::v001::detectorMap, (uint8_t)o2::aod::track::TPC),
-                                                         ncheckbit(aod::track::trackCutFlag, trackSelectionTPC), true) &&
-                                                  ifnode(dcaZ.node() > 0.f, nabs(aod::track::dcaZ) <= dcaZ && ncheckbit(aod::track::trackCutFlag, trackSelectionDCAXYonly),
-                                                         ncheckbit(aod::track::trackCutFlag, trackSelectionDCA));
-
-  expressions::Filter atrackFilter = (aod::track::bestCollisionId >= 0) &&
-                                     (ifnode(dcaZ.node() > 0.f, nabs(aod::track::bestDCAZ) <= dcaZ, nabs(aod::track::bestDCAZ) <= 2.0f)) &&
-                                     (nabs(aod::track::bestDCAXY) <= ((0.004f + 0.013f / npow(aod::track::pts, 1.1f))));
+  expressions::Filter fAtrackAssigned = (aod::track::bestCollisionId >= 0);
+  expressions::Filter fAtrackDCA = ifnode(dcaZ.node() > 0.f, nabs(aod::track::bestDCAZ) <= dcaZ, nabs(aod::track::bestDCAZ) <= 2.0f) &&
+                                   nabs(aod::track::bestDCAXY) <= ((0.004f + 0.013f / npow(aod::track::pts, 1.1f)));
 
   using ExTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA>;
   using FiTracks = soa::Filtered<ExTracks>;

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -25,27 +25,13 @@
 #include "bestCollisionTable.h"
 #include "Axes.h"
 #include "Functions.h"
+#include "Selections.h"
 
 using namespace o2;
 using namespace o2::aod::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace pwgmm::mult;
-
-static constexpr TrackSelectionFlags::flagtype trackSelectionITS =
-  TrackSelectionFlags::kITSNCls | TrackSelectionFlags::kITSChi2NDF |
-  TrackSelectionFlags::kITSHits;
-
-static constexpr TrackSelectionFlags::flagtype trackSelectionTPC =
-  TrackSelectionFlags::kTPCNCls |
-  TrackSelectionFlags::kTPCCrossedRowsOverNCls |
-  TrackSelectionFlags::kTPCChi2NDF;
-
-static constexpr TrackSelectionFlags::flagtype trackSelectionDCA =
-  TrackSelectionFlags::kDCAz | TrackSelectionFlags::kDCAxy;
-
-static constexpr TrackSelectionFlags::flagtype trackSelectionDCAXYonly =
-  TrackSelectionFlags::kDCAxy;
 
 using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 using ReTracks = soa::Join<aod::ReassignedTracksCore, aod::ReassignedTracksExtra>;

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -26,18 +26,19 @@
 #include "Axes.h"
 #include "Functions.h"
 #include "Selections.h"
+#include "Histograms.h"
+
+#include <ranges>
 
 using namespace o2;
 using namespace o2::aod::track;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace pwgmm::mult;
+using namespace pwgmm::mult::histograms;
 
 using LabeledTracks = soa::Join<aod::Tracks, aod::McTrackLabels>;
 using ReTracks = soa::Join<aod::ReassignedTracksCore, aod::ReassignedTracksExtra>;
-
-static constexpr std::string_view species[] = {"pi", "p", "e", "K"};
-static constexpr std::array<int, 4> speciesIds{kPiPlus, kProton, kElectron, kKPlus};
 
 struct MultiplicityCounter {
   SliceCache cache;

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -191,8 +191,8 @@ struct MultiplicityCounter {
       registry.add({"Tracks/Centrality/Control/PtEtaGen", " ; p_{T} (GeV/c) ; #eta; centrality", {HistType::kTHnSparseF, {PtAxis, EtaAxis, CentAxis}}});
 
       registry.add({"Tracks/Centrality/PhiEtaGen", "; #varphi; #eta; tracks", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      //      registry.add({"Tracks/Centrality/Control/PhiEtaGenDuplicates", "; #varphi; #eta; tracks", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
-      //      registry.add({"Tracks/Centrality/Control/PhiEtaDuplicates", "; #varphi; #eta; tracks", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      registry.add({"Tracks/Centrality/Control/PhiEtaGenDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
+      registry.add({"Tracks/Centrality/Control/PhiEtaDuplicates", "; #varphi; #eta; centrality", {HistType::kTHnSparseF, {PhiAxis, EtaAxis, CentAxis}}});
       registry.add({"Events/Centrality/Efficiency", "; status; centrality; events", {HistType::kTH2F, {{static_cast<int>(EvEffBins::kSelectedPVgt0), 0.5, static_cast<float>(EvEffBins::kSelectedPVgt0) + 0.5}, CentAxis}}});
       registry.add({"Events/Centrality/NotFoundEventZvtx", " ; Z_{vtx} (cm); centrality; events", {HistType::kTH2F, {ZAxis, CentAxis}}});
 

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -343,6 +343,7 @@ struct MultiplicityCounter {
 
   using ExCols = soa::Join<aod::Collisions, aod::EvSels>;
 
+  // PV contributors for INEL>0 (PV) collision sample definition
   Partition<FiTracks> pvContribTracksIUEta1 = (nabs(aod::track::eta) < 1.0f) && ((aod::track::flags & (uint32_t)o2::aod::track::PVContributor) == (uint32_t)o2::aod::track::PVContributor);
 
   template <typename C>

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -655,7 +655,7 @@ struct MultiplicityCounter {
   using LabeledTracksEx = soa::Join<LabeledTracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA>;
   using FiLTracks = soa::Filtered<LabeledTracksEx>;
   using ParticlesI = soa::Filtered<soa::Join<aod::McParticles, aod::ParticlesToTracks>>;
-  expressions::Filter primaries = (aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary;
+  expressions::Filter primaries = ncheckbit(aod::mcparticle::flags, (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
 
   template <typename C, typename MC>
   void processTrackEfficiencyIndexedGeneral(

--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -438,8 +438,7 @@ struct MultiplicityCounter {
     soa::SmallGroups<ReTracks> const& atracks)
   {
     float c = -1;
-    constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>();
-    if constexpr (hasCentrality) {
+    if constexpr (hasRecoCent<C>()) {
       if constexpr (C::template contains<aod::CentFT0Cs>()) {
         c = collision.centFT0C();
       } else if (C::template contains<aod::CentFT0Ms>()) {
@@ -451,7 +450,7 @@ struct MultiplicityCounter {
     }
 
     if (!useEvSel || collision.sel8()) {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Events/Centrality/Selection"), 2., c);
       } else {
         registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kSelected));
@@ -481,7 +480,7 @@ struct MultiplicityCounter {
         if (std::abs(otrack.eta()) < estimatorEta) {
           ++Ntrks;
         }
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Tracks/Centrality/EtaZvtx"), otrack.eta(), z, c);
           registry.fill(HIST("Tracks/Centrality/PhiEta"), otrack.phi(), otrack.eta(), c);
           registry.fill(HIST("Tracks/Centrality/Control/PtEta"), otrack.pt(), otrack.eta(), c);
@@ -495,7 +494,7 @@ struct MultiplicityCounter {
           registry.fill(HIST("Tracks/Control/DCAZPt"), otrack.pt(), track.bestDCAZ());
         }
         if (!otrack.has_collision()) {
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksEtaZvtx"), otrack.eta(), z, c);
             registry.fill(HIST("Tracks/Centrality/Control/ExtraTracksPhiEta"), otrack.phi(), otrack.eta(), c);
             registry.fill(HIST("Tracks/Centrality/Control/ExtraDCAXYPt"), otrack.pt(), track.bestDCAXY(), c);
@@ -508,7 +507,7 @@ struct MultiplicityCounter {
           }
         } else if (otrack.collisionId() != track.bestCollisionId()) {
           usedTracksIdsDF.emplace_back(track.trackId());
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksEtaZvtx"), otrack.eta(), z, c);
             registry.fill(HIST("Tracks/Centrality/Control/ReassignedTracksPhiEta"), otrack.phi(), otrack.eta(), c);
             registry.fill(HIST("Tracks/Centrality/Control/ReassignedVertexCorr"), otrack.collision_as<C>().posZ(), z, c);
@@ -534,7 +533,7 @@ struct MultiplicityCounter {
         if (std::abs(track.eta()) < estimatorEta) {
           ++Ntrks;
         }
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Tracks/Centrality/EtaZvtx"), track.eta(), z, c);
           registry.fill(HIST("Tracks/Centrality/PhiEta"), track.phi(), track.eta(), c);
           registry.fill(HIST("Tracks/Centrality/Control/PtEta"), track.pt(), track.eta(), c);
@@ -548,7 +547,7 @@ struct MultiplicityCounter {
           registry.fill(HIST("Tracks/Control/DCAZPt"), track.pt(), track.dcaZ());
         }
       }
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Events/Centrality/NtrkZvtx"), Ntrks, z, c);
       } else {
         if (Ntrks > 0 || groupPVContrib.size() > 0) {
@@ -584,7 +583,7 @@ struct MultiplicityCounter {
         registry.fill(HIST("Events/NtrkZvtx"), Ntrks, z);
       }
     } else {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Events/Centrality/Selection"), 3., c);
       } else {
         registry.fill(HIST("Events/Selection"), static_cast<float>(EvSelBins::kRejected));
@@ -774,8 +773,6 @@ struct MultiplicityCounter {
     FiLTracks const& tracks,
     soa::SmallGroups<ReTracks> const* atracks)
   {
-    constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>() || hasCent<MC>();
-
     if (useEvSel && !collision.sel8()) {
       return;
     }
@@ -784,7 +781,7 @@ struct MultiplicityCounter {
     }
     float c_rec = -1;
     float c_gen = -1;
-    if constexpr (hasCentrality) {
+    if constexpr (hasRecoCent<C>()) {
       if constexpr (C::template contains<aod::CentFT0Cs>()) {
         c_rec = collision.centFT0C();
       } else if (C::template contains<aod::CentFT0Ms>()) {
@@ -792,7 +789,7 @@ struct MultiplicityCounter {
       }
     }
     auto mcCollision = collision.mcCollision();
-    if constexpr (hasCent<MC>()) {
+    if constexpr (hasSimCent<MC>()) {
       c_gen = mcCollision.centrality();
     }
 
@@ -907,11 +904,9 @@ struct MultiplicityCounter {
     o2::soa::SmallGroups<soa::Join<C, aod::McCollisionLabels>> const& collisions,
     Particles const& particles, FiTracks const& tracks, FiReTracks const* atracks)
   {
-    constexpr bool hasCentrality = C::template contains<aod::CentFT0Cs>() || C::template contains<aod::CentFT0Ms>() || hasCent<MC>();
-
     float c_gen = -1;
     // add generated centrality estimation
-    if constexpr (hasCent<MC>()) {
+    if constexpr (hasSimCent<MC>()) {
       c_gen = mcCollision.centrality();
     }
 
@@ -930,7 +925,7 @@ struct MultiplicityCounter {
       }
       nCharged++;
     }
-    if constexpr (hasCentrality) {
+    if constexpr (hasRecoCent<C>()) {
       registry.fill(HIST("Events/Centrality/NtrkZvtxGen_t"), nCharged, mcCollision.posZ(), c_gen);
       registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kGen), c_gen);
     } else {
@@ -939,7 +934,7 @@ struct MultiplicityCounter {
     }
 
     if (nCharged > 0) {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kGengt0), c_gen);
       } else {
         registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kGengt0));
@@ -963,7 +958,7 @@ struct MultiplicityCounter {
     for (auto& collision : collisions) {
       usedTracksIds.clear();
       float c_rec = -1;
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         if constexpr (C::template contains<aod::CentFT0Cs>()) {
           c_rec = collision.centFT0C();
         } else if (C::template contains<aod::CentFT0Ms>()) {
@@ -981,7 +976,7 @@ struct MultiplicityCounter {
 
         auto groupPVcontrib = pvContribTracksIUEta1->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
         if (groupPVcontrib.size() > 0) {
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
           } else {
             registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
@@ -1050,14 +1045,14 @@ struct MultiplicityCounter {
           NFDDCPerCol.emplace_back(-1);
         }
 
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelected), c_gen);
         } else {
           registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelected));
         }
 
         if (Nrec > 0) {
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0), c_gen);
           } else {
             registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedgt0));
@@ -1065,7 +1060,7 @@ struct MultiplicityCounter {
           atLeastOne_gt0 = true;
         }
         if (groupPVcontrib.size() > 0) {
-          if constexpr (hasCentrality) {
+          if constexpr (hasRecoCent<C>()) {
             registry.fill(HIST("Events/Centrality/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0), c_gen);
           } else {
             registry.fill(HIST("Events/Efficiency"), static_cast<float>(EvEffBins::kSelectedPVgt0));
@@ -1073,7 +1068,7 @@ struct MultiplicityCounter {
           atLeastOne_PVgt0 = true;
         }
 
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Events/Centrality/NtrkZvtxGen"), Nrec, collision.posZ(), c_rec);
         } else {
           registry.fill(HIST("Events/NtrkZvtxGen"), Nrec, collision.posZ());
@@ -1083,7 +1078,7 @@ struct MultiplicityCounter {
 
     if (fillResponse) {
       for (auto i = 0U; i < NrecPerCol.size(); ++i) {
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Events/Centrality/Response"), NrecPerCol[i], nCharged, mcCollision.posZ(), c_recPerCol[i]);
           registry.fill(HIST("Events/Centrality/EfficiencyMult"), nCharged, mcCollision.posZ(), c_recPerCol[i]);
           if (responseStudy) {
@@ -1098,7 +1093,7 @@ struct MultiplicityCounter {
         }
       }
       if (moreThanOne > 1) {
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Events/Centrality/SplitMult"), nCharged, mcCollision.posZ(), c_gen);
         } else {
           registry.fill(HIST("Events/SplitMult"), nCharged, mcCollision.posZ());
@@ -1107,7 +1102,7 @@ struct MultiplicityCounter {
     }
 
     if (collisions.size() == 0) {
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Events/Centrality/NotFoundEventZvtx"), mcCollision.posZ(), c_gen);
       } else {
         registry.fill(HIST("Events/NotFoundEventZvtx"), mcCollision.posZ());
@@ -1123,7 +1118,7 @@ struct MultiplicityCounter {
       if (std::abs(charge) < 3.) {
         continue;
       }
-      if constexpr (hasCentrality) {
+      if constexpr (hasRecoCent<C>()) {
         registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_t"), particle.eta(), mcCollision.posZ(), c_gen);
         registry.fill(HIST("Tracks/Centrality/Control/PtEtaGen"), particle.pt(), particle.eta(), c_gen);
       } else {
@@ -1131,14 +1126,14 @@ struct MultiplicityCounter {
         registry.fill(HIST("Tracks/Control/PtEtaGen"), particle.pt(), particle.eta());
       }
       if (nCharged > 0) {
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ(), c_gen);
         } else {
           registry.fill(HIST("Tracks/EtaZvtxGen_gt0t"), particle.eta(), mcCollision.posZ());
         }
       }
       if (atLeastOne) {
-        if constexpr (hasCentrality) {
+        if constexpr (hasRecoCent<C>()) {
           registry.fill(HIST("Tracks/Centrality/EtaZvtxGen"), particle.eta(), mcCollision.posZ(), c_gen);
           if (atLeastOne_gt0) {
             registry.fill(HIST("Tracks/Centrality/EtaZvtxGen_gt0"), particle.eta(), mcCollision.posZ(), c_gen);

--- a/PWGMM/Mult/Tasks/puremc-dndeta.cxx
+++ b/PWGMM/Mult/Tasks/puremc-dndeta.cxx
@@ -18,23 +18,12 @@
 #include <TDatabasePDG.h>
 #include <TPDGCode.h>
 
+#include "Axes.h"
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-
-AxisSpec ZAxis = {301, -30.1, 30.1};
-AxisSpec DeltaZAxis = {61, -6.1, 6.1};
-AxisSpec DCAAxis = {601, -3.01, 3.01};
-AxisSpec EtaAxis = {62, -6.2, 6.2};
-AxisSpec RapidityAxis = {102, -10.2, 10.2};
-AxisSpec PhiAxis = {629, 0, 2 * M_PI};
-AxisSpec PtAxis = {2401, -0.005, 24.005};
-AxisSpec PtAxis_wide = {1041, -0.05, 104.05};
-AxisSpec PtAxisEff = {{0.1, 0.12, 0.14, 0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
-                       1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 18.0, 20.0}};
-AxisSpec ScaleAxis = {121, -0.5, 120.5};
-AxisSpec MPIAxis = {51, -0.5, 50.5};
-AxisSpec ProcAxis = {21, 89.5, 110.5};
+using namespace pwgmm::mult;
 
 auto static constexpr mincharge = 3.f;
 


### PR DESCRIPTION
Extensive rework of dndeta.cxx code:
* Separate common definitions for axes, histograms and selections into dedicated headers
* Separate track filters into logical parts
* Replace histogram identifiers with named strings for consistency and the ability to use them in external post-processing
* Unified binning and labeling for event selection and efficiency histograms
* Separate process functions that use ambiguous tracks and those that do not
* Simplify centrality detection
* Separate histogram registries for binned and inclusive cases