### PR TITLE
MegaLinter: Make cpplint and clang-format check all C++ files. Disable clang-format

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -11,16 +11,16 @@ DISABLE:
   - COPYPASTE # abusive copy-pastes
   - SPELL # spelling mistakes
 DISABLE_LINTERS:
-  - CPP_CLANG_FORMAT
   - BASH_EXEC
   - BASH_SHFMT
+  - CPP_CLANG_FORMAT
   - JSON_PRETTIER
-  - YAML_V8R
-  - YAML_PRETTIER
   - REPOSITORY_DEVSKIM
   - REPOSITORY_KICS
   - REPOSITORY_SECRETLINT
   - REPOSITORY_TRIVY
+  - YAML_PRETTIER
+  - YAML_V8R
 DISABLE_ERRORS_LINTERS: # If errors are found by these linters, they will be considered as non blocking.
   - PYTHON_BANDIT # The bandit check is overly broad and complains about subprocess usage.
 SHOW_ELAPSED_TIME: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -32,3 +32,5 @@ FLAVOR_SUGGESTIONS: false # Don't show suggestions about different MegaLinter fl
 PYTHON_ISORT_CONFIG_FILE: pyproject.toml
 PYTHON_PYRIGHT_CONFIG_FILE: pyproject.toml
 PYTHON_RUFF_CONFIG_FILE: pyproject.toml
+CPP_CPPLINT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
+CPP_CLANG_FORMAT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -11,6 +11,7 @@ DISABLE:
   - COPYPASTE # abusive copy-pastes
   - SPELL # spelling mistakes
 DISABLE_LINTERS:
+  - CPP_CLANG_FORMAT
   - BASH_EXEC
   - BASH_SHFMT
   - JSON_PRETTIER


### PR DESCRIPTION
This configuration provides cpplint and clang-format with an exhaustive list of extensions of files to check.
The list is a union of the cpplint default list and the extensions of C++ files found in the O2 and O2Physics repositories, most importantly it adds `.C` ROOT macros.