### PR TITLE
PWGDQ/EM: PDG in history: check only for mother (comment out: check o…

### DIFF
--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -256,40 +256,44 @@ bool MCSignal::CheckProng(int i, bool checkSources, const T& track)
       if (!fProngs[i].fExcludePDGInHistory[k])
         nIncludedPDG++;
       int ith = 0;
-      if (!fProngs[i].fCheckGenerationsInTime) { // check generation back in time
-        while (currentMCParticle.has_mothers()) {
-          auto mother = currentMCParticle.template mothers_first_as<P>();
-          if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
-            pdgInHistory.emplace_back(mother.pdgCode());
-            break;
-          }
-          if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
-            return false;
-          }
-          ith++;
-          currentMCParticle = mother;
-          if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
-            break;
-          }
+
+      // Note: Currently no need to check generation InTime, so disable if case and always check BackInTime (direction of mothers)
+      //       The option to check for daughter in decay chain is still implemented but commented out.
+
+      // if (!fProngs[i].fCheckGenerationsInTime) { // check generation back in time
+      while (currentMCParticle.has_mothers()) {
+        auto mother = currentMCParticle.template mothers_first_as<P>();
+        if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+          pdgInHistory.emplace_back(mother.pdgCode());
+          break;
         }
-      } else { // check generation in time
-        if (!currentMCParticle.has_daughters())
+        if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(mother.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
           return false;
-        const auto& daughtersSlice = currentMCParticle.template daughters_as<P>();
-        for (auto& d : daughtersSlice) {
-          if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
-            pdgInHistory.emplace_back(d.pdgCode());
-            break;
-          }
-          if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
-            return false;
-          }
-          ith++;
-          if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
-            break;
-          }
+        }
+        ith++;
+        currentMCParticle = mother;
+        if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
+          break;
         }
       }
+      // } else { // check generation in time
+      //   if (!currentMCParticle.has_daughters())
+      //     return false;
+      //   const auto& daughtersSlice = currentMCParticle.template daughters_as<P>();
+      //   for (auto& d : daughtersSlice) {
+      //     if (!fProngs[i].fExcludePDGInHistory[k] && fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+      //       pdgInHistory.emplace_back(d.pdgCode());
+      //       break;
+      //     }
+      //     if (fProngs[i].fExcludePDGInHistory[k] && !fProngs[i].ComparePDG(d.pdgCode(), fProngs[i].fPDGInHistory[k], true, fProngs[i].fExcludePDGInHistory[k])) {
+      //       return false;
+      //     }
+      //     ith++;
+      //     if (ith > 10) { // need error message. Given pdg code was not found within 10 generations of the particles decay chain.
+      //       break;
+      //     }
+      //   }
+      // }
     }
     if (pdgInHistory.size() != nIncludedPDG) // vector has as many entries as mothers (daughters) defined for prong
       return false;

--- a/PWGDQ/Core/MCSignalLibrary.cxx
+++ b/PWGDQ/Core/MCSignalLibrary.cxx
@@ -100,12 +100,13 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
   if (!nameStr.compare("eFromNonpromptJpsi")) {
-    MCProng prong(3, {11, 443, 503}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
-    signal = new MCSignal(name, "Electrons from beauty jpsi decays", {prong}, {-1});
+    MCProng prong(2, {11, 443}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {503}, {false});
+    signal = new MCSignal(name, "Electrons from non-prompt jpsi decays with beauty in decay chain", {prong}, {-1});
     return signal;
   }
-  if (!nameStr.compare("eFromPromptJpsi")) {
-    MCProng prong(3, {11, 443, 503}, {true, true, true}, {false, false, true}, {0, 0, 0}, {0, 0, 0}, {false, false, false});
+  if (!nameStr.compare("ePrimaryFromPromptJpsi")) {
+    MCProng prong(2, {11, 443}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {503}, {true});
+    prong.SetSourceBit(0, MCProng::kPhysicalPrimary);
     signal = new MCSignal(name, "Electrons from prompt jpsi decays", {prong}, {-1});
     return signal;
   }
@@ -120,7 +121,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
   if (!nameStr.compare("promptJpsi")) {
-    MCProng prong(2, {443, 503}, {true, true}, {false, true}, {0, 0}, {0, 0}, {false, false});
+    MCProng prong(1, {443}, {true}, {false}, {0}, {0}, {false}, false, {503}, {true});
     signal = new MCSignal(name, "Prompt jpsi (not from beauty)", {prong}, {-1});
     return signal;
   }
@@ -149,9 +150,14 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "Prompt psi2s (not from beauty)", {prong}, {-1});
     return signal;
   }
-  if (!nameStr.compare("anyBeautyHadron")) {
+  if (!nameStr.compare("allBeautyHadrons")) {
     MCProng prong(1, {503}, {true}, {false}, {0}, {0}, {false});
     signal = new MCSignal(name, "All beauty hadrons", {prong}, {-1});
+    return signal;
+  }
+  if (!nameStr.compare("allOpenBeautyHadrons")) {
+    MCProng prong(1, {502}, {true}, {false}, {0}, {0}, {false});
+    signal = new MCSignal(name, "All open beauty hadrons", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("Bc")) {
@@ -190,6 +196,11 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "All charm hadrons", {prong}, {-1});
     return signal;
   }
+  if (!nameStr.compare("allOpenCharmHadrons")) {
+    MCProng prong(1, {402}, {true}, {false}, {0}, {0}, {false});
+    signal = new MCSignal(name, "All open charm hadrons", {prong}, {-1});
+    return signal;
+  }
   if (!nameStr.compare("allCharmFromBeauty")) {
     MCProng prong(2, {403, 503}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     signal = new MCSignal(name, "All charm hadrons from beauty", {prong}, {-1});
@@ -200,8 +211,14 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     signal = new MCSignal(name, "All prompt charm hadrons (not from beauty)", {prong}, {-1});
     return signal;
   }
-  if (!nameStr.compare("Pi0decayToe")) {
+  if (!nameStr.compare("Pi0DecayToe")) {
     MCProng prong(2, {111, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prong.SetSignalInTime(true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    signal = new MCSignal(name, "Pi0 decays into an electron", {prong}, {-1});
+    return signal;
+  }
+  if (!nameStr.compare("PromptPi0DecayToe")) {
+    MCProng prong(2, {111, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, true, {403, 503}, {true, true});
     prong.SetSignalInTime(true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
     signal = new MCSignal(name, "Pi0 decays into an electron", {prong}, {-1});
     return signal;
@@ -222,6 +239,12 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     MCProng prong(1, {901}, {true}, {false}, {0}, {0}, {false});
     // prong.SetSourceBit(0, MCProng::kPhysicalPrimary, false);  // set source to be ALICE primary particles
     signal = new MCSignal(name, "ligh flavor mesons", {prong}, {-1}); // pi0,eta,eta',rho,omega,phi
+    return signal;
+  }
+  if (!nameStr.compare("PromptJpsiDecayToe")) {
+    MCProng prong(2, {443, 11}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, true, {503}, {true});
+    prong.SetSignalInTime(true); // set direction to check for daughters (true, in time) or for mothers (false, back in time)
+    signal = new MCSignal(name, "Prompt jpsi (not from beauty) decay to electron", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("electronFromDs")) {
@@ -288,7 +311,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("ePrimaryFromPromptPi0")) {
     MCProng prong(2, {11, 111}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502, 402}, {true, true});
     prong.SetSourceBit(0, MCProng::kPhysicalPrimary);
-    signal = new MCSignal(name, "All prompt charm hadrons (not from beauty)", {prong}, {-1});
+    signal = new MCSignal(name, "Electrons from prompt pi0 decays", {prong}, {-1});
     return signal;
   }
   if (!nameStr.compare("eFromEta")) {
@@ -518,7 +541,7 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
   if (!nameStr.compare("eeFromAnything")) {
     MCProng prong(2, {11, MCProng::kPDGCodeNotAssigned}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     prong.SetSourceBit(0, MCProng::kPhysicalPrimary);
-    signal = new MCSignal(name, "ee pairs from pi0 decays", {prong, prong}, {1, 1}); // signal at pair level
+    signal = new MCSignal(name, "ee pairs from any decay", {prong, prong}, {1, 1}); // signal at pair level
     return signal;
   }
   if (!nameStr.compare("eeFromPi0")) {


### PR DESCRIPTION
…f daughter), adapt and add new MC Signals

When using checkIfPDGInHistory:
Always check if pdg value is in the direction of the mother. 
Comment out the daughter check.

MCSignalLibrary.cxx:
Add new signals
Adapt old versions of signals to be more precise.
Adapt naming of signals to be more consistent.