### PR TITLE
PWGHF: adding the info about the number of prongs that contributes to the PV estimation in the candidate creator.

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -405,6 +405,7 @@ DECLARE_SOA_COLUMN(ImpactParameter2, impactParameter2, float);                  
 DECLARE_SOA_COLUMN(ErrorImpactParameter2, errorImpactParameter2, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised2, impactParameterNormalised2, //!
                            [](float dca, float err) -> float { return dca / err; });
+DECLARE_SOA_COLUMN(NProngsContributorsPV, nProngsContributorsPV, uint8_t); //!
 // candidate properties
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //!
                            [](float px, float py) -> float { return RecoDecay::pt(px, py); });
@@ -780,7 +781,7 @@ DECLARE_SOA_TABLE(HfCand3ProngBase, "AOD", "HFCAND3PBASE", //!
                   hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1, hf_cand::ImpactParameter2,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1, hf_cand::ErrorImpactParameter2,
-                  hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_track_index::Prong2Id,
+                  hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_track_index::Prong2Id, hf_cand::NProngsContributorsPV,
                   hf_track_index::HFflag,
                   /* dynamic columns */
                   hf_cand_3prong::M<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>,

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -199,13 +199,13 @@ struct HfCandidateCreator3Prong {
 
       auto indexCollision = collision.globalIndex();
       uint8_t nProngsContributorsPV = 0;
-      if (indexCollision == track0.collisionId() && track0.isPVContributor()){
+      if (indexCollision == track0.collisionId() && track0.isPVContributor()) {
         nProngsContributorsPV += 1;
       }
-      if (indexCollision == track1.collisionId() && track1.isPVContributor()){
+      if (indexCollision == track1.collisionId() && track1.isPVContributor()) {
         nProngsContributorsPV += 1;
       }
-      if (indexCollision == track2.collisionId() && track2.isPVContributor()){
+      if (indexCollision == track2.collisionId() && track2.isPVContributor()) {
         nProngsContributorsPV += 1;
       }
 

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -93,7 +93,7 @@ struct HfCandidateCreator3Prong {
   template <bool doPvRefit = false, typename Cand>
   void runCreator3Prong(aod::Collisions const& collisions,
                         Cand const& rowsTrackIndexProng3,
-                        aod::TracksWCov const& tracks,
+                        aod::TracksWCovExtra const& tracks,
                         aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     // 3-prong vertex fitter
@@ -109,9 +109,9 @@ struct HfCandidateCreator3Prong {
 
     // loop over triplets of track indices
     for (const auto& rowTrackIndexProng3 : rowsTrackIndexProng3) {
-      auto track0 = rowTrackIndexProng3.template prong0_as<aod::TracksWCov>();
-      auto track1 = rowTrackIndexProng3.template prong1_as<aod::TracksWCov>();
-      auto track2 = rowTrackIndexProng3.template prong2_as<aod::TracksWCov>();
+      auto track0 = rowTrackIndexProng3.template prong0_as<aod::TracksWCovExtra>();
+      auto track1 = rowTrackIndexProng3.template prong1_as<aod::TracksWCovExtra>();
+      auto track2 = rowTrackIndexProng3.template prong2_as<aod::TracksWCovExtra>();
       auto trackParVar0 = getTrackParCov(track0);
       auto trackParVar1 = getTrackParCov(track1);
       auto trackParVar2 = getTrackParCov(track2);
@@ -197,8 +197,20 @@ struct HfCandidateCreator3Prong {
       auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
       auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
 
+      auto indexCollision = collision.globalIndex();
+      uint8_t nProngsContributorsPV = 0;
+      if (indexCollision == track0.collisionId() && track0.isPVContributor()){
+	nProngsContributorsPV += 1;
+      }
+      if (indexCollision == track1.collisionId() && track1.isPVContributor()){
+	nProngsContributorsPV += 1;
+      }
+      if (indexCollision == track2.collisionId() && track2.isPVContributor()){
+	nProngsContributorsPV += 1;
+      }
+
       // fill candidate table rows
-      rowCandidateBase(collision.globalIndex(),
+      rowCandidateBase(indexCollision,
                        primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                        secondaryVertex[0], secondaryVertex[1], secondaryVertex[2],
                        errorDecayLength, errorDecayLengthXY,
@@ -208,7 +220,7 @@ struct HfCandidateCreator3Prong {
                        pvec2[0], pvec2[1], pvec2[2],
                        impactParameter0.getY(), impactParameter1.getY(), impactParameter2.getY(),
                        std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()), std::sqrt(impactParameter2.getSigmaY2()),
-                       rowTrackIndexProng3.prong0Id(), rowTrackIndexProng3.prong1Id(), rowTrackIndexProng3.prong2Id(),
+                       rowTrackIndexProng3.prong0Id(), rowTrackIndexProng3.prong1Id(), rowTrackIndexProng3.prong2Id(), nProngsContributorsPV,
                        rowTrackIndexProng3.hfflag());
 
       // fill histograms
@@ -223,7 +235,7 @@ struct HfCandidateCreator3Prong {
 
   void processPvRefit(aod::Collisions const& collisions,
                       soa::Join<aod::Hf3Prongs, aod::HfPvRefit3Prong> const& rowsTrackIndexProng3,
-                      aod::TracksWCov const& tracks,
+                      aod::TracksWCovExtra const& tracks,
                       aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     runCreator3Prong<true>(collisions, rowsTrackIndexProng3, tracks, bcWithTimeStamps);
@@ -233,7 +245,7 @@ struct HfCandidateCreator3Prong {
 
   void processNoPvRefit(aod::Collisions const& collisions,
                         aod::Hf3Prongs const& rowsTrackIndexProng3,
-                        aod::TracksWCov const& tracks,
+                        aod::TracksWCovExtra const& tracks,
                         aod::BCsWithTimestamps const& bcWithTimeStamps)
   {
     runCreator3Prong(collisions, rowsTrackIndexProng3, tracks, bcWithTimeStamps);

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -200,13 +200,13 @@ struct HfCandidateCreator3Prong {
       auto indexCollision = collision.globalIndex();
       uint8_t nProngsContributorsPV = 0;
       if (indexCollision == track0.collisionId() && track0.isPVContributor()){
-	nProngsContributorsPV += 1;
+        nProngsContributorsPV += 1;
       }
       if (indexCollision == track1.collisionId() && track1.isPVContributor()){
-	nProngsContributorsPV += 1;
+        nProngsContributorsPV += 1;
       }
       if (indexCollision == track2.collisionId() && track2.isPVContributor()){
-	nProngsContributorsPV += 1;
+        nProngsContributorsPV += 1;
       }
 
       // fill candidate table rows

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -32,6 +32,7 @@ namespace o2::aod
 namespace full
 {
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_COLUMN(NProngsContributorsPV, nProngsContributorsPV, int8_t);
 DECLARE_SOA_COLUMN(RSecondaryVertex, rSecondaryVertex, float);
 DECLARE_SOA_COLUMN(PtProng0, ptProng0, float);
 DECLARE_SOA_COLUMN(PProng0, pProng0, float);
@@ -97,6 +98,7 @@ DECLARE_SOA_TABLE(HfCandLcFulls, "AOD", "HFCANDLCFULL",
                   collision::PosX,
                   collision::PosY,
                   collision::PosZ,
+                  hf_cand::NProngsContributorsPV,
                   hf_cand::XSecondaryVertex,
                   hf_cand::YSecondaryVertex,
                   hf_cand::ZSecondaryVertex,
@@ -254,6 +256,7 @@ struct HfTreeCreatorLcToPKPi {
             candidate.posX(),
             candidate.posY(),
             candidate.posZ(),
+            candidate.nProngsContributorsPV(),
             candidate.xSecondaryVertex(),
             candidate.ySecondaryVertex(),
             candidate.zSecondaryVertex(),
@@ -390,6 +393,7 @@ struct HfTreeCreatorLcToPKPi {
             candidate.posX(),
             candidate.posY(),
             candidate.posZ(),
+            candidate.nProngsContributorsPV(),
             candidate.xSecondaryVertex(),
             candidate.ySecondaryVertex(),
             candidate.zSecondaryVertex(),


### PR DESCRIPTION
The info about the prong contributors to the PV is needed to properly estimate the barrel multiplicity.
PR to be extended to the 2-prong candidate creator.

@fgrosa @vkucera 