### PR TITLE
Allow running slightly more parallel analysis compile jobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set_property(GLOBAL PROPERTY REPORT_UNDEFINED_PROPERTIES)
 
 cmake_host_system_information(RESULT _totalmem QUERY TOTAL_PHYSICAL_MEMORY)
-math(EXPR _total_analysis_jobs "(${_totalmem}-4096)/4096")
+math(EXPR _total_analysis_jobs "(${_totalmem}-2048)/4096")
 if(_total_analysis_jobs LESS_EQUAL 0)
   set(_total_analysis_jobs 1)
 endif()


### PR DESCRIPTION
On build machines with little memory, such as the ARM VMs we have been allocated, compiling with the previous formula takes much too long (5 hours just for O2Physics).

On those machines, reserving 4 GiB for the system is overkill and cuts down the number of build slots unnecessarily. Reducing this to 2 GiB allows us to squeeze in one more build slot, bringing the total to 3 instead of 2.

The peak memory use per analysis build process looks accurate at around 4 GiB.

In theory, this change should reduce the time taken for analysis compilation on those machines by 1/3.