### PR TITLE
PWGHF: change filter -> testbit in toXiPi creator

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -88,10 +88,9 @@ struct HfCandidateCreatorToXiPi {
   using FilteredHfTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
   using MyCascTable = soa::Join<aod::CascDatas, aod::CascCovs>; // to use strangeness tracking, use aod::TraCascDatas instead of aod::CascDatas
   using MyV0Table = soa::Join<aod::V0Datas, aod::V0Covs>;
-  using MySkimIdx = soa::Filtered<HfCascLf2Prongs>;
+  using MySkimIdx = HfCascLf2Prongs;
 
   Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == 0); // filter to use only HF selected collisions
-  Filter filterSelectIndexes = (aod::hf_track_index::hfflag == 1);
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng > 0);
 
   Preslice<FilteredHfTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId; // aod::hf_track_association::collisionId
@@ -463,6 +462,10 @@ struct HfCandidateCreatorToXiPi {
       auto groupedCandidates = candidates.sliceBy(candidatesPerCollision, thisCollId);
 
       for (const auto& cand : groupedCandidates) {
+
+        if(!TESTBIT(cand.hfflag(), aod::hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi)){
+          continue;
+        }
 
         auto casc = cand.cascade_as<MyCascTable>();
         auto trackPion = cand.prong0_as<MyTracks>();           // pi <-- charm baryon

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -88,9 +88,10 @@ struct HfCandidateCreatorToXiPi {
   using FilteredHfTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
   using MyCascTable = soa::Join<aod::CascDatas, aod::CascCovs>; // to use strangeness tracking, use aod::TraCascDatas instead of aod::CascDatas
   using MyV0Table = soa::Join<aod::V0Datas, aod::V0Covs>;
-  using MySkimIdx = HfCascLf2Prongs;
+  using MySkimIdx = soa::Filtered<HfCascLf2Prongs>;
 
   Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == 0); // filter to use only HF selected collisions
+  Filter filterSelectIndexes = (aod::hf_track_index::hfflag == (uint8_t) 1);
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng > 0);
 
   Preslice<FilteredHfTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId; // aod::hf_track_association::collisionId
@@ -462,10 +463,6 @@ struct HfCandidateCreatorToXiPi {
       auto groupedCandidates = candidates.sliceBy(candidatesPerCollision, thisCollId);
 
       for (const auto& cand : groupedCandidates) {
-
-        if(!TESTBIT(cand.hfflag(), aod::hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi)){
-          continue;
-        }
 
         auto casc = cand.cascade_as<MyCascTable>();
         auto trackPion = cand.prong0_as<MyTracks>();           // pi <-- charm baryon

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -91,7 +91,7 @@ struct HfCandidateCreatorToXiPi {
   using MySkimIdx = soa::Filtered<HfCascLf2Prongs>;
 
   Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == 0); // filter to use only HF selected collisions
-  Filter filterSelectIndexes = (aod::hf_track_index::hfflag == (uint8_t)1);
+  Filter filterSelectIndexes = (aod::hf_track_index::hfflag == static_cast<uint8_t>(1));
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng > 0);
 
   Preslice<FilteredHfTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId; // aod::hf_track_association::collisionId


### PR DESCRIPTION
Since treating an uint8_t like an int in the Filter is not possible, replace table filtering with TESTBIT function in the candidates loop (toXiPi candidateCreator - process function dedicated to derived data)