### PR TITLE
PWGLF: Update the common column name

### DIFF
--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -31,8 +31,8 @@ namespace o2::aod
 /// Resonance Collisions
 namespace resocollision
 {
-DECLARE_SOA_COLUMN(MultV0M, multV0M, float);         //! V0M multiplicity percentile (run2: V0M, run3: FT0A/C/M)
-DECLARE_SOA_COLUMN(MultFT0, multFT0, int);           //! FT0 multiplicity
+DECLARE_SOA_COLUMN(Cent, cent, float);               //! Centrality (Multiplicity) percentile (Default: FT0M)
+DECLARE_SOA_COLUMN(Mult, mult, int);                 //! FT0 multiplicity
 DECLARE_SOA_COLUMN(Spherocity, spherocity, float);   //! Spherocity of the event
 DECLARE_SOA_COLUMN(BMagField, bMagField, float);     //! Magnetic field
 } // namespace resocollision
@@ -41,8 +41,8 @@ DECLARE_SOA_TABLE(ResoCollisions, "AOD", "RESOCOL",
                   collision::PosX,
                   collision::PosY,
                   collision::PosZ,
-                  resocollision::MultV0M,
-                  resocollision::MultFT0,
+                  resocollision::Cent,
+                  resocollision::Mult,
                   resocollision::Spherocity,
                   resocollision::BMagField,
                   timestamp::Timestamp);

--- a/PWGLF/Tasks/f0980analysis.cxx
+++ b/PWGLF/Tasks/f0980analysis.cxx
@@ -183,7 +183,7 @@ struct f0980analysis {
         LHphi = trk.phi();
       }
     }
-    histos.fill(HIST("QA/LTpt"), LHpt, collision.multV0M(), LHphi);
+    histos.fill(HIST("QA/LTpt"), LHpt, collision.cent(), LHphi);
 
     TLorentzVector Pion1, Pion2, Reco;
     for (auto& [trk1, trk2] :
@@ -211,7 +211,7 @@ struct f0980analysis {
 
       if (trk1.sign() * trk2.sign() < 0) {
         histos.fill(HIST("hInvMass_f0980_US"), Reco.M(), Reco.Pt(),
-                    collision.multV0M(), RTIndex(Reco.Phi(), LHphi), LHpt);
+                    collision.cent(), RTIndex(Reco.Phi(), LHphi), LHpt);
         if constexpr (IsMC) {
           if (abs(trk1.pdgCode()) != 211 || abs(trk2.pdgCode()) != 211)
             continue;
@@ -220,14 +220,14 @@ struct f0980analysis {
           if (abs(trk1.motherPDG()) != 9010221)
             continue;
           histos.fill(HIST("MCL/hpT_f0980_REC"), Reco.M(), Reco.Pt(),
-                      collision.multV0M());
+                      collision.cent());
         }
       } else if (trk1.sign() > 0 && trk2.sign() > 0) {
         histos.fill(HIST("hInvMass_f0980_LSpp"), Reco.M(), Reco.Pt(),
-                    collision.multV0M(), RTIndex(Reco.Phi(), LHphi), LHpt);
+                    collision.cent(), RTIndex(Reco.Phi(), LHphi), LHpt);
       } else if (trk1.sign() < 0 && trk2.sign() < 0) {
         histos.fill(HIST("hInvMass_f0980_LSmm"), Reco.M(), Reco.Pt(),
-                    collision.multV0M(), RTIndex(Reco.Phi(), LHphi), LHpt);
+                    collision.cent(), RTIndex(Reco.Phi(), LHphi), LHpt);
       }
     }
   }

--- a/PWGLF/Tasks/k1analysis.cxx
+++ b/PWGLF/Tasks/k1analysis.cxx
@@ -341,14 +341,14 @@ struct k1analysis {
         histos.fill(HIST("k892invmass"), lResonanceK892.M()); // quick check
         if (trk1.sign() > 0) {                                // Positive pion
           if (trk2.sign() > 0)                                // Positive kaon
-            histos.fill(HIST("hK892invmass_PP"), collision.multV0M(), lResonanceK892.Pt(), lResonanceK892.M());
+            histos.fill(HIST("hK892invmass_PP"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M());
           else                                                                                                  // Negative kaon
-            histos.fill(HIST("hK892invmass_PN"), collision.multV0M(), lResonanceK892.Pt(), lResonanceK892.M()); // Anti-K(892)0
+            histos.fill(HIST("hK892invmass_PN"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M()); // Anti-K(892)0
         } else {                                                                                                // Negative pion
           if (trk2.sign() > 0)                                                                                  // Positive kaon
-            histos.fill(HIST("hK892invmass_NP"), collision.multV0M(), lResonanceK892.Pt(), lResonanceK892.M()); // K(892)0
+            histos.fill(HIST("hK892invmass_NP"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M()); // K(892)0
           else                                                                                                  // Negative kaon
-            histos.fill(HIST("hK892invmass_NN"), collision.multV0M(), lResonanceK892.Pt(), lResonanceK892.M());
+            histos.fill(HIST("hK892invmass_NN"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M());
         }
       }
       // Like-sign rejection for K(892)0 - disabled for further LS bkg study
@@ -427,32 +427,32 @@ struct k1analysis {
             if (bTrack.sign() > 0) {                              // bachelor pi+
               if (trk2.sign() > 0) {                              // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNP"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                                                 // bachelor pi-
               if (trk2.sign() > 0) {                                 // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPN"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           } else {                   // K892-LS (false)
             if (bTrack.sign() > 0) { // bachelor pi+
               if (trk2.sign() > 0) { // Kaon+
-                histos.fill(HIST("hK1invmass_PPP"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PPP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_PPN"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PPN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                 // bachelor pi-
               if (trk2.sign() > 0) { // Kaon_
-                histos.fill(HIST("hK1invmass_NNN"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NNN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_NNP"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NNP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           }
@@ -466,11 +466,11 @@ struct k1analysis {
               histos.fill(HIST("QAMC/K1PairAsymm"), lPairAsym);
 
               if ((bTrack.sign() > 0) && (trk2.sign() > 0)) { // Matter
-                histos.fill(HIST("hK1invmass_NPP_MC"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP_MC"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
                 histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
               }
               if ((bTrack.sign() < 0) && (trk2.sign() < 0)) { // Anti-matter
-                histos.fill(HIST("hK1invmass_PNN_MC"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN_MC"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
                 histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
               }
               histos.fill(HIST("hTrueK1pt"), lResonanceK1.Pt());
@@ -484,16 +484,16 @@ struct k1analysis {
             if (bTrack.sign() > 0) {                                  // bachelor pi+
               if (trk2.sign() > 0) {                                  // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP_Mix"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_PNP_Mix"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNP_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                 // bachelor pi-
               if (trk2.sign() > 0) { // kaon + means K(892)0 is matter.
-                histos.fill(HIST("hK1invmass_NPN_Mix"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPN_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN_Mix"), collision.multV0M(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           }
@@ -540,7 +540,7 @@ struct k1analysis {
   PROCESS_SWITCH(k1analysis, processMCTrue, "Process Event for MC", false);
 
   // Processing Event Mixing
-  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processME(o2::aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks)
   {
     auto tracksTuple = std::make_tuple(resotracks);

--- a/PWGLF/Tasks/k1analysis.cxx
+++ b/PWGLF/Tasks/k1analysis.cxx
@@ -282,6 +282,7 @@ struct k1analysis {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
+    auto multiplicity = collision.cent();
     TLorentzVector lDecayDaughter1, lDecayDaughter2, lResonanceK892, lDecayDaughter_bach, lResonanceK1;
     for (auto& [trk1, trk2] : combinations(CombinationsFullIndexPolicy(dTracks2, dTracks2))) {
       // Full index policy is needed to consider all possible combinations
@@ -341,14 +342,14 @@ struct k1analysis {
         histos.fill(HIST("k892invmass"), lResonanceK892.M()); // quick check
         if (trk1.sign() > 0) {                                // Positive pion
           if (trk2.sign() > 0)                                // Positive kaon
-            histos.fill(HIST("hK892invmass_PP"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M());
+            histos.fill(HIST("hK892invmass_PP"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M());
           else                                                                                                  // Negative kaon
-            histos.fill(HIST("hK892invmass_PN"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M()); // Anti-K(892)0
+            histos.fill(HIST("hK892invmass_PN"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M()); // Anti-K(892)0
         } else {                                                                                                // Negative pion
           if (trk2.sign() > 0)                                                                                  // Positive kaon
-            histos.fill(HIST("hK892invmass_NP"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M()); // K(892)0
+            histos.fill(HIST("hK892invmass_NP"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M()); // K(892)0
           else                                                                                                  // Negative kaon
-            histos.fill(HIST("hK892invmass_NN"), collision.cent(), lResonanceK892.Pt(), lResonanceK892.M());
+            histos.fill(HIST("hK892invmass_NN"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M());
         }
       }
       // Like-sign rejection for K(892)0 - disabled for further LS bkg study
@@ -427,32 +428,32 @@ struct k1analysis {
             if (bTrack.sign() > 0) {                              // bachelor pi+
               if (trk2.sign() > 0) {                              // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                                                 // bachelor pi-
               if (trk2.sign() > 0) {                                 // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           } else {                   // K892-LS (false)
             if (bTrack.sign() > 0) { // bachelor pi+
               if (trk2.sign() > 0) { // Kaon+
-                histos.fill(HIST("hK1invmass_PPP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PPP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_PPN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PPN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                 // bachelor pi-
               if (trk2.sign() > 0) { // Kaon_
-                histos.fill(HIST("hK1invmass_NNN"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NNN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_NNP"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NNP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           }
@@ -466,11 +467,11 @@ struct k1analysis {
               histos.fill(HIST("QAMC/K1PairAsymm"), lPairAsym);
 
               if ((bTrack.sign() > 0) && (trk2.sign() > 0)) { // Matter
-                histos.fill(HIST("hK1invmass_NPP_MC"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP_MC"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
                 histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
               }
               if ((bTrack.sign() < 0) && (trk2.sign() < 0)) { // Anti-matter
-                histos.fill(HIST("hK1invmass_PNN_MC"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN_MC"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
                 histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
               }
               histos.fill(HIST("hTrueK1pt"), lResonanceK1.Pt());
@@ -484,16 +485,16 @@ struct k1analysis {
             if (bTrack.sign() > 0) {                                  // bachelor pi+
               if (trk2.sign() > 0) {                                  // kaon + means K(892)0 is matter.
                 histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPP_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
-                histos.fill(HIST("hK1invmass_PNP_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNP_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             } else {                 // bachelor pi-
               if (trk2.sign() > 0) { // kaon + means K(892)0 is matter.
-                histos.fill(HIST("hK1invmass_NPN_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_NPN_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               } else {
                 histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN_Mix"), collision.cent(), lResonanceK1.Pt(), lResonanceK1.M());
+                histos.fill(HIST("hK1invmass_PNN_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               }
             }
           }

--- a/PWGLF/Tasks/k892analysis.cxx
+++ b/PWGLF/Tasks/k892analysis.cxx
@@ -303,14 +303,14 @@ struct k892analysis {
         if constexpr (!IsMix) {
           if (trk1.sign() > 0) {
             histos.fill(HIST("k892invmassDS"), lResonance.M());
-            histos.fill(HIST("h3k892invmassDS"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3k892invmassDS"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else {
             histos.fill(HIST("k892invmassDSAnti"), lResonance.M());
-            histos.fill(HIST("h3k892invmassDSAnti"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3k892invmassDSAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         } else {
           histos.fill(HIST("k892invmassME"), lResonance.M());
-          histos.fill(HIST("h3k892invmassME"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassME"), collision.cent(), lResonance.Pt(), lResonance.M());
         }
 
         // MC
@@ -332,11 +332,11 @@ struct k892analysis {
           if (trk1.motherPDG() > 0) {
             histos.fill(HIST("k892Rec"), lResonance.Pt());
             histos.fill(HIST("k892Recinvmass"), lResonance.M());
-            histos.fill(HIST("h3Reck892invmass"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3Reck892invmass"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else {
             histos.fill(HIST("k892RecAnti"), lResonance.Pt());
             histos.fill(HIST("k892Recinvmass"), lResonance.M());
-            histos.fill(HIST("h3Reck892invmassAnti"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3Reck892invmassAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         }
       } else {
@@ -344,10 +344,10 @@ struct k892analysis {
           continue;
         if (trk1.sign() > 0) {
           histos.fill(HIST("k892invmassLS"), lResonance.M());
-          histos.fill(HIST("h3k892invmassLS"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassLS"), collision.cent(), lResonance.Pt(), lResonance.M());
         } else {
           histos.fill(HIST("k892invmassLSAnti"), lResonance.M());
-          histos.fill(HIST("h3k892invmassLSAnti"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassLSAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
         }
       }
     }
@@ -395,7 +395,7 @@ struct k892analysis {
   PROCESS_SWITCH(k892analysis, processMCTrue, "Process Event for MC", false);
 
   // Processing Event Mixing
-  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processMELight(o2::aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks)
   {
     auto tracksTuple = std::make_tuple(resotracks);

--- a/PWGLF/Tasks/k892analysis.cxx
+++ b/PWGLF/Tasks/k892analysis.cxx
@@ -219,6 +219,7 @@ struct k892analysis {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
+    auto multiplicity = collision.cent();
     TLorentzVector lDecayDaughter1, lDecayDaughter2, lResonance;
     for (auto& [trk1, trk2] : combinations(CombinationsFullIndexPolicy(dTracks1, dTracks2))) {
       // Full index policy is needed to consider all possible combinations
@@ -303,14 +304,14 @@ struct k892analysis {
         if constexpr (!IsMix) {
           if (trk1.sign() > 0) {
             histos.fill(HIST("k892invmassDS"), lResonance.M());
-            histos.fill(HIST("h3k892invmassDS"), collision.cent(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3k892invmassDS"), multiplicity, lResonance.Pt(), lResonance.M());
           } else {
             histos.fill(HIST("k892invmassDSAnti"), lResonance.M());
-            histos.fill(HIST("h3k892invmassDSAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3k892invmassDSAnti"), multiplicity, lResonance.Pt(), lResonance.M());
           }
         } else {
           histos.fill(HIST("k892invmassME"), lResonance.M());
-          histos.fill(HIST("h3k892invmassME"), collision.cent(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassME"), multiplicity, lResonance.Pt(), lResonance.M());
         }
 
         // MC
@@ -332,11 +333,11 @@ struct k892analysis {
           if (trk1.motherPDG() > 0) {
             histos.fill(HIST("k892Rec"), lResonance.Pt());
             histos.fill(HIST("k892Recinvmass"), lResonance.M());
-            histos.fill(HIST("h3Reck892invmass"), collision.cent(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3Reck892invmass"), multiplicity, lResonance.Pt(), lResonance.M());
           } else {
             histos.fill(HIST("k892RecAnti"), lResonance.Pt());
             histos.fill(HIST("k892Recinvmass"), lResonance.M());
-            histos.fill(HIST("h3Reck892invmassAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3Reck892invmassAnti"), multiplicity, lResonance.Pt(), lResonance.M());
           }
         }
       } else {
@@ -344,10 +345,10 @@ struct k892analysis {
           continue;
         if (trk1.sign() > 0) {
           histos.fill(HIST("k892invmassLS"), lResonance.M());
-          histos.fill(HIST("h3k892invmassLS"), collision.cent(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassLS"), multiplicity, lResonance.Pt(), lResonance.M());
         } else {
           histos.fill(HIST("k892invmassLSAnti"), lResonance.M());
-          histos.fill(HIST("h3k892invmassLSAnti"), collision.cent(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3k892invmassLSAnti"), multiplicity, lResonance.Pt(), lResonance.M());
         }
       }
     }

--- a/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
+++ b/PWGLF/Tasks/lambda1520SpherocityAnalysis.cxx
@@ -372,11 +372,11 @@ struct lambdaAnalysis {
   void processData(resoCols::iterator const& collision, resoTracks const& tracks)
   {
 
-    histos.fill(HIST("Event/hCent"), collision.multV0M());
+    histos.fill(HIST("Event/hCent"), collision.cent());
     histos.fill(HIST("Event/hSph"), collision.spherocity());
-    histos.fill(HIST("Event/hSpCent"), collision.multV0M(), collision.spherocity());
+    histos.fill(HIST("Event/hSpCent"), collision.cent(), collision.spherocity());
 
-    fillDataHistos<false, false>(tracks, tracks, collision.spherocity(), collision.multV0M());
+    fillDataHistos<false, false>(tracks, tracks, collision.spherocity(), collision.cent());
   }
 
   PROCESS_SWITCH(lambdaAnalysis, processData, "Process for Same Event Data", true);
@@ -386,8 +386,8 @@ struct lambdaAnalysis {
   {
 
     histos.fill(HIST("Event/hSphRec"), collision.spherocity());
-    histos.fill(HIST("Event/hSpCentRec"), collision.multV0M(), collision.spherocity());
-    fillDataHistos<false, true>(tracks, tracks, collision.spherocity(), collision.multV0M());
+    histos.fill(HIST("Event/hSpCentRec"), collision.cent(), collision.spherocity());
+    fillDataHistos<false, true>(tracks, tracks, collision.spherocity(), collision.cent());
   }
   PROCESS_SWITCH(lambdaAnalysis, processMC, "Process Event for MC", false);
 
@@ -424,8 +424,8 @@ struct lambdaAnalysis {
   PROCESS_SWITCH(lambdaAnalysis, processMCTrue, "Process Event for MC", false);
 
   // Processing Event Mixing
-  using BinningType1 = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M, aod::resocollision::Spherocity>;
-  using BinningType2 = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningType1 = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent, aod::resocollision::Spherocity>;
+  using BinningType2 = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processMix(resoCols& collisions, resoTracks const& tracks)
   {
 
@@ -436,12 +436,12 @@ struct lambdaAnalysis {
     if (doSphMix) {
       SameKindPair<resoCols, resoTracks, BinningType1> pairs{binningPositions1, nMix, -1, collisions, tracksTuple, &cache}; // -1 is the number of the bin to skip
       for (auto& [c1, t1, c2, t2] : pairs) {
-        fillDataHistos<true, false>(t1, t2, c1.spherocity(), c1.multV0M());
+        fillDataHistos<true, false>(t1, t2, c1.spherocity(), c1.cent());
       }
     } else {
       SameKindPair<resoCols, resoTracks, BinningType2> pairs{binningPositions2, nMix, -1, collisions, tracksTuple, &cache}; // -1 is the number of the bin to skip
       for (auto& [c1, t1, c2, t2] : pairs) {
-        fillDataHistos<true, false>(t1, t2, c1.spherocity(), c1.multV0M());
+        fillDataHistos<true, false>(t1, t2, c1.spherocity(), c1.cent());
       }
     }
   }

--- a/PWGLF/Tasks/lambda1520analysis.cxx
+++ b/PWGLF/Tasks/lambda1520analysis.cxx
@@ -456,23 +456,23 @@ struct lambda1520analysis {
       if (trk1.sign() * trk2.sign() < 0) {
         if constexpr (!IsMix) {
           histos.fill(HIST("Result/Data/lambda1520invmass"), lResonance.M());
-          histos.fill(HIST("Result/Data/h3lambda1520invmass"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("Result/Data/h3lambda1520invmass"), collision.cent(), lResonance.Pt(), lResonance.M());
           if (isEtaAssym && trk1.eta() > 0.2 && trk1.eta() < 0.8 && trk2.eta() > 0.2 && trk2.eta() < 0.8) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassUnlikeSignAside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassUnlikeSignAside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassUnlikeSignAside"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else if (isEtaAssym && trk1.eta() > -0.6 && trk1.eta() < 0.0 && trk2.eta() > -0.6 && trk2.eta() < 0.0) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassUnlikeSignCside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassUnlikeSignCside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassUnlikeSignCside"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         } else {
           histos.fill(HIST("Result/Data/lambda1520invmassME"), lResonance.M());
-          histos.fill(HIST("Result/Data/h3lambda1520invmassME"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("Result/Data/h3lambda1520invmassME"), collision.cent(), lResonance.Pt(), lResonance.M());
           if (isEtaAssym && trk1.eta() > 0.2 && trk1.eta() < 0.8 && trk2.eta() > 0.2 && trk2.eta() < 0.8) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassMixedAside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassMixedAside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassMixedAside"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else if (isEtaAssym && trk1.eta() > -0.6 && trk1.eta() < 0.0 && trk2.eta() > -0.6 && trk2.eta() < 0.0) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassMixedCside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassMixedCside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassMixedCside"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         }
 
@@ -497,29 +497,29 @@ struct lambda1520analysis {
           if (trk1.motherPDG() > 0) {
             histos.fill(HIST("Result/MC/lambda1520Reco"), lResonance.Pt());
             histos.fill(HIST("Result/MC/hlambda1520Recoinvmass"), lResonance.M());
-            histos.fill(HIST("Result/MC/h3lambda1520Recoinvmass"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/MC/h3lambda1520Recoinvmass"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else {
             histos.fill(HIST("Result/MC/antilambda1520Reco"), lResonance.Pt());
             histos.fill(HIST("Result/MC/hantilambda1520Recoinvmass"), lResonance.M());
-            histos.fill(HIST("Result/MC/h3antilambda1520Recoinvmass"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/MC/h3antilambda1520Recoinvmass"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         }
       } else {
         if constexpr (!IsMix) {
           if (isEtaAssym && trk1.eta() > 0.2 && trk1.eta() < 0.8 && trk2.eta() > 0.2 && trk2.eta() < 0.8) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassLikeSignAside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassLikeSignAside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassLikeSignAside"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else if (isEtaAssym && trk1.eta() > -0.6 && trk1.eta() < 0.0 && trk2.eta() > -0.6 && trk2.eta() < 0.0) { // Eta-range will be updated
             histos.fill(HIST("Result/Data/hlambda1520invmassLikeSignCside"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassLikeSignCside"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassLikeSignCside"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
           // Like sign pair ++
           if (trk1.sign() > 0) {
             histos.fill(HIST("Result/Data/lambda1520invmassLSPP"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassLSPP"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassLSPP"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else { // Like sign pair --
             histos.fill(HIST("Result/Data/lambda1520invmassLSMM"), lResonance.M());
-            histos.fill(HIST("Result/Data/h3lambda1520invmassLSMM"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("Result/Data/h3lambda1520invmassLSMM"), collision.cent(), lResonance.Pt(), lResonance.M());
           }
         }
       }
@@ -568,7 +568,7 @@ struct lambda1520analysis {
   PROCESS_SWITCH(lambda1520analysis, processMCTrue, "Process Event for MC only", false);
 
   // Processing Event Mixing
-  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processME(o2::aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks)
   {
     auto tracksTuple = std::make_tuple(resotracks);

--- a/PWGLF/Tasks/phianalysis.cxx
+++ b/PWGLF/Tasks/phianalysis.cxx
@@ -235,12 +235,12 @@ struct phianalysis {
         if constexpr (!IsMix) {
           if (trk1.sign() > 0) {
             histos.fill(HIST("phiinvmassDS"), lResonance.M());
-            histos.fill(HIST("h3phiinvmassDS"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+            histos.fill(HIST("h3phiinvmassDS"), collision.cent(), lResonance.Pt(), lResonance.M());
           } else {
           }
         } else {
           histos.fill(HIST("phiinvmassME"), lResonance.M());
-          histos.fill(HIST("h3phiinvmassME"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3phiinvmassME"), collision.cent(), lResonance.Pt(), lResonance.M());
         }
 
         // MC
@@ -259,14 +259,14 @@ struct phianalysis {
           // MC histograms
           histos.fill(HIST("phiRec"), lResonance.Pt());
           histos.fill(HIST("phiRecinvmass"), lResonance.M());
-          histos.fill(HIST("h3Recphiinvmass"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3Recphiinvmass"), collision.cent(), lResonance.Pt(), lResonance.M());
         }
       } else {
         if constexpr (!IsMix)
           continue;
         if (trk1.sign() > 0) {
           histos.fill(HIST("phiinvmassLS"), lResonance.M());
-          histos.fill(HIST("h3phiinvmassLS"), collision.multV0M(), lResonance.Pt(), lResonance.M());
+          histos.fill(HIST("h3phiinvmassLS"), collision.cent(), lResonance.Pt(), lResonance.M());
         } else {
         }
       }
@@ -305,7 +305,7 @@ struct phianalysis {
   PROCESS_SWITCH(phianalysis, processMCTrue, "Process Event for MC", false);
 
   // Processing Event Mixing
-  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processMELight(o2::aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks)
   {
     auto tracksTuple = std::make_tuple(resotracks);

--- a/Tutorials/PWGLF/Resonance/resonances_step1.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step1.cxx
@@ -116,7 +116,7 @@ struct resonances_tutorial {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
-    auto multiplicity = collision.multV0M();
+    auto multiplicity = collision.cent();
     for (auto track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1) || !selectionPID(track1)) {
         continue; // track selection and PID selection
@@ -168,7 +168,7 @@ struct resonances_tutorial {
   {
     // Fill the event counter
     histos.fill(HIST("hVertexZ"), collision.posZ());
-    histos.fill(HIST("hMultiplicityPercent"), collision.multV0M());
+    histos.fill(HIST("hMultiplicityPercent"), collision.cent());
 
     fillHistograms<false, false>(collision, resotracks, resotracks); // Fill histograms, no MC, no mixing
   }

--- a/Tutorials/PWGLF/Resonance/resonances_step2.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step2.cxx
@@ -123,7 +123,7 @@ struct resonances_tutorial {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
-    auto multiplicity = collision.multV0M();
+    auto multiplicity = collision.cent();
     for (auto track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1) || !selectionPID(track1)) {
         continue; // track selection and PID selection
@@ -182,14 +182,14 @@ struct resonances_tutorial {
   {
     // Fill the event counter
     histos.fill(HIST("hVertexZ"), collision.posZ());
-    histos.fill(HIST("hMultiplicityPercent"), collision.multV0M());
+    histos.fill(HIST("hMultiplicityPercent"), collision.cent());
 
     fillHistograms<false, false>(collision, resotracks, resotracks); // Fill histograms, no MC, no mixing
   }
   PROCESS_SWITCH(resonances_tutorial, process, "Process event for data", true); // Basic processing
 
   // Processing Event Mixing
-  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::MultV0M>;
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
   void processME(o2::aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks)
   {
     auto tracksTuple = std::make_tuple(resotracks);


### PR DESCRIPTION
Updated from `MultV0M` to `Cent`

The variable `MultV0M` has contained the multiplicity/Centrality of the event which the type (V0M.FT0) can be set during the filter process.