### PR TITLE
PWGDQ: Improve filterPbPb and add muon process function

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -2341,6 +2341,26 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("eventDoubleGap")) {
+    cut->AddCut(VarManager::kIsDoubleGap, 0.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("eventSingleGap")) {
+    cut->AddCut(VarManager::kIsSingleGap, 0.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("eventSingleGapA")) {
+    cut->AddCut(VarManager::kIsSingleGapA, 0.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("eventSingleGapC")) {
+    cut->AddCut(VarManager::kIsSingleGapC, 0.5, 1.5);
+    return cut;
+  }
+
   // Event cuts based on centrality
   if (!nameStr.compare("eventStandardNoINT7Cent090")) {
     cut->AddCut(VarManager::kVtxZ, -10.0, 10.0);

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -17,6 +17,7 @@
 #ifndef PWGDQ_CORE_VARMANAGER_H_
 #define PWGDQ_CORE_VARMANAGER_H_
 
+#include <cstdint>
 #ifndef HomogeneousField
 #define HomogeneousField
 #endif
@@ -462,7 +463,7 @@ class VarManager : public TObject
   };
 
   enum EventFilters {
-    kDoubleGap = 1,
+    kDoubleGap = 0,
     kSingleGapA,
     kSingleGapC
   };
@@ -915,9 +916,16 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kVtxY] = event.posY();
     values[kVtxZ] = event.posZ();
     values[kVtxNcontrib] = event.numContrib();
-
     if (fgUsedVars[kIsSel8]) {
       values[kIsSel8] = (event.tag() & (uint64_t(1) << o2::aod::evsel::kIsTriggerTVX)) > 0;
+    }
+    if (fgUsedVars[kIsDoubleGap]) {
+      values[kIsDoubleGap] = (event.tag() & (uint64_t(1) << (56 + kDoubleGap))) > 0;
+    }
+    if (fgUsedVars[kIsSingleGap] || fgUsedVars[kIsSingleGapA] || fgUsedVars[kIsSingleGapC]) {
+      values[kIsSingleGapA] = (event.tag() & (uint64_t(1) << (56 + kSingleGapA))) > 0;
+      values[kIsSingleGapC] = (event.tag() & (uint64_t(1) << (56 + kSingleGapC))) > 0;
+      values[kIsSingleGap] = values[kIsSingleGapA] || values[kIsSingleGapC];
     }
   }
 

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -242,7 +242,7 @@ struct TableMaker {
                              context.mOptions.get<bool>("processMuonOnlyWithMults") || context.mOptions.get<bool>("processMuonOnlyWithCentAndMults") ||
                              context.mOptions.get<bool>("processMuonOnlyWithCovAndCent") ||
                              context.mOptions.get<bool>("processMuonOnlyWithCov") || context.mOptions.get<bool>("processMuonOnlyWithCovAndEventFilter") || context.mOptions.get<bool>("processMuonOnlyWithEventFilter") ||
-                             context.mOptions.get<bool>("processAmbiguousMuonOnlyWithCov") || context.mOptions.get<bool>("processAmbiguousMuonOnly") ||
+                             context.mOptions.get<bool>("processMuonOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processAmbiguousMuonOnlyWithCov") || context.mOptions.get<bool>("processAmbiguousMuonOnly") ||
                              context.mOptions.get<bool>("processMuonMLOnly") || context.mOptions.get<bool>("processMuonMLOnly"));
 
     if (enableBarrelHistos) {
@@ -369,9 +369,9 @@ struct TableMaker {
     if (collision.sel7()) {
       tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
     }
-    // Put the 32 first bits of the event filter in the last 32 bits of the tag
+    // Put the 8 first bits of the event filter in the last 8 bits of the tag
     if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
-      tag |= (collision.eventFilter() << 32);
+      tag |= (collision.eventFilter() << 56);
     }
 
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
@@ -1338,6 +1338,21 @@ struct TableMaker {
     }
   }
 
+  // Produce muon tables only, with multiplicity and event filtering ----------------------------------------------------------------------------------------
+  void processMuonOnlyWithMultsAndEventFilter(MyEventsWithMultsAndFilter::iterator const& collision, aod::BCsWithTimestamps const& bcs,
+                                              soa::Filtered<MyMuons> const& tracksMuon)
+  {
+    for (int i = 0; i < kNaliases; i++) {
+      if (collision.alias_bit(i) > 0) {
+        (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(1.0, static_cast<float>(i));
+      }
+    }
+    (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(1.0, static_cast<float>(kNaliases));
+    if (collision.eventFilter()) {
+      fullSkimming<gkEventFillMapWithMultsAndEventFilter, 0u, gkMuonFillMap>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr);
+    }
+  }
+
   // Produce MFT tracks tables and muons, with event filtering  ------------------------------------------------------------------------------------------------------------------
   void processMuonsAndMFTWithFilter(MyEventsWithFilter::iterator const& collision, aod::BCsWithTimestamps const& bcs,
                                     aod::MFTTracks const& tracksMft, soa::Filtered<MyMuonsWithCov> const& tracksMuon)
@@ -1464,6 +1479,7 @@ struct TableMaker {
   PROCESS_SWITCH(TableMaker, processBarrelOnly, "Build barrel-only DQ skimmed data model, w/o centrality", false);
   PROCESS_SWITCH(TableMaker, processMuonOnlyWithCent, "Build muon-only DQ skimmed data model, w/ centrality", false);
   PROCESS_SWITCH(TableMaker, processMuonOnlyWithMults, "Build muon-only DQ skimmed data model, w/ multiplicity", false);
+  PROCESS_SWITCH(TableMaker, processMuonOnlyWithMultsAndEventFilter, "Build muon-only DQ skimmed data model, w/ multiplicity, w/ event filter", false);
   PROCESS_SWITCH(TableMaker, processMuonOnlyWithCentAndMults, "Build muon-only DQ skimmed data model, w/ centrality and multiplicities", false);
   PROCESS_SWITCH(TableMaker, processMuonOnlyWithCovAndCent, "Build muon-only DQ skimmed data model, w/ centrality and muon cov matrix", false);
   PROCESS_SWITCH(TableMaker, processMuonOnlyWithCov, "Build muon-only DQ skimmed data model, w/ muon cov matrix", false);

--- a/PWGDQ/Tasks/filterPbPb.cxx
+++ b/PWGDQ/Tasks/filterPbPb.cxx
@@ -213,7 +213,7 @@ struct DQFilterPbPbTask {
       if (isSideAClean && isSideCClean) {
         FITDecision |= (uint64_t(1) << VarManager::kDoubleGap);
       }
-    } 
+    }
     if (eventTypes & (uint32_t(1) << 1)) {
       if (isSideAClean && !isSideCClean) {
         FITDecision |= (uint64_t(1) << VarManager::kSingleGapA);
@@ -300,7 +300,7 @@ struct DQFilterPbPbTask {
     TString eventTypesString = fConfigEventTypes.value;
     for (std::vector<std::string>::size_type i = 0; i < eventTypeOptions.size(); i++) {
       if (eventTypesString.Contains(eventTypeOptions[i])) {
-        eventTypeMap |= (uint32_t(1) << i); 
+        eventTypeMap |= (uint32_t(1) << i);
         LOGF(info, "filterPbPb will select '%s' events", eventTypeOptions[i]);
       }
     }

--- a/PWGDQ/Tasks/filterPbPb.cxx
+++ b/PWGDQ/Tasks/filterPbPb.cxx
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 //
+#include <fairlogger/Logger.h>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include "Framework/AnalysisTask.h"
@@ -33,12 +35,7 @@ using namespace o2::aod;
 
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
 using MyBCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels, aod::Run3MatchedToBCSparse>;
-using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection,
-                                 aod::pidTPCFullEl, aod::pidTPCFullPi,
-                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
-                                 aod::pidTOFFullEl, aod::pidTOFFullPi,
-                                 aod::pidTOFFullKa, aod::pidTOFFullPr>;
-
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection>;
 using MyMuons = aod::FwdTracks;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
@@ -48,9 +45,10 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses);
 struct DQFilterPbPbTask {
   Produces<aod::DQEventFilter> eventFilter;
   OutputObj<TH1I> fStats{"Statistics"};
-  OutputObj<TH1F> fIsEventDGOutcome{TH1F("Filter outcome", "Filter outcome", 7, -0.5, 6.5)};
+  OutputObj<TH1F> fIsEventDGOutcome{TH1F("Filter outcome", "Filter outcome", 8, -1.5, 6.5)};
 
   Configurable<std::string> fConfigBarrelSelections{"cfgBarrelSels", "jpsiPID1:2:5", "<track-cut>:<nmin>:<nmax>,[<track-cut>:<nmin>:<nmax>],..."};
+  Configurable<std::string> fConfigEventTypes{"cfgEventTypes", "doublegap,singlegap", "Which event types to select. doublegap, singlegap or both, comma separated"};
   Configurable<int> fConfigNDtColl{"cfgNDtColl", 4, "Number of standard deviations to consider in BC range"};
   Configurable<int> fConfigMinNBCs{"cfgMinNBCs", 7, "Minimum number of BCs to consider in BC range"};
   Configurable<int> fConfigMinNPVCs{"cfgMinNPVCs", 2, "Minimum number of PV contributors"};
@@ -73,17 +71,21 @@ struct DQFilterPbPbTask {
   std::vector<int> fBarrelNminTracks; // minimal number of tracks in barrel
   std::vector<int> fBarrelNmaxTracks; // maximal number of tracks in barrel
 
+  int eventTypeMap = 0;
+  std::vector<std::string> eventTypeOptions = {"doublegap", "singlegap"}; // Map for which types of event to select
+
   // Helper function for selecting DG events
   template <typename TEvent, typename TBCs, typename TTracks, typename TMuons>
   uint64_t isEventDG(TEvent const& collision, TBCs const& bcs, TTracks const& tracks, TMuons const& muons,
                      aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds,
-                     std::vector<float> FITAmpLimits, int nDtColl, int minNBCs, int minNPVCs, int maxNPVCs, float maxFITTime,
+                     int eventTypes, std::vector<float> FITAmpLimits, int nDtColl, int minNBCs, int minNPVCs, int maxNPVCs, float maxFITTime,
                      bool useFV0, bool useFT0, bool useFDD, bool doVetoFwd, bool doVetoBarrel)
   {
     fIsEventDGOutcome->Fill(0., 1.);
     // Find BC associated with collision
     if (!collision.has_foundBC()) {
-      return -1;
+      fIsEventDGOutcome->Fill(-1., 1);
+      return 0;
     }
     // foundBCId is stored in EvSels
     auto bc = collision.template foundBC_as<TBCs>();
@@ -207,12 +209,17 @@ struct DQFilterPbPbTask {
 
     // Compute FIT decision
     uint64_t FITDecision = 0;
-    if (isSideAClean && isSideCClean) {
-      FITDecision |= (uint64_t(1) << VarManager::kDoubleGap);
-    } else if (isSideAClean && !isSideCClean) {
-      FITDecision |= (uint64_t(1) << VarManager::kSingleGapA);
-    } else if (!isSideAClean && isSideCClean) {
-      FITDecision |= (uint64_t(1) << VarManager::kSingleGapC);
+    if (eventTypes & (uint32_t(1) << 0)) {
+      if (isSideAClean && isSideCClean) {
+        FITDecision |= (uint64_t(1) << VarManager::kDoubleGap);
+      }
+    } 
+    if (eventTypes & (uint32_t(1) << 1)) {
+      if (isSideAClean && !isSideCClean) {
+        FITDecision |= (uint64_t(1) << VarManager::kSingleGapA);
+      } else if (!isSideAClean && isSideCClean) {
+        FITDecision |= (uint64_t(1) << VarManager::kSingleGapC);
+      }
     }
     if (!FITDecision) {
       fIsEventDGOutcome->Fill(2, 1);
@@ -289,6 +296,17 @@ struct DQFilterPbPbTask {
   void init(o2::framework::InitContext&)
   {
     DefineCuts();
+
+    TString eventTypesString = fConfigEventTypes.value;
+    for (std::vector<std::string>::size_type i = 0; i < eventTypeOptions.size(); i++) {
+      if (eventTypesString.Contains(eventTypeOptions[i])) {
+        eventTypeMap |= (uint32_t(1) << i); 
+        LOGF(info, "filterPbPb will select '%s' events", eventTypeOptions[i]);
+      }
+    }
+    if (eventTypeMap == 0) {
+      LOGF(fatal, "No valid choice of event types to select. Use 'doublegap', 'singlegap' or both");
+    }
   }
 
   template <uint32_t TEventFillMap>
@@ -299,7 +317,7 @@ struct DQFilterPbPbTask {
 
     std::vector<float> FITAmpLimits = {fConfigFV0AmpLimit, fConfigFT0AAmpLimit, fConfigFT0CAmpLimit, fConfigFDDAAmpLimit, fConfigFDDCAmpLimit};
     uint64_t filter = isEventDG(collision, bcs, tracks, muons, ft0s, fv0as, fdds,
-                                FITAmpLimits, fConfigNDtColl, fConfigMinNBCs, fConfigMinNPVCs, fConfigMaxNPVCs, fConfigMaxFITTime,
+                                eventTypeMap, FITAmpLimits, fConfigNDtColl, fConfigMinNBCs, fConfigMinNPVCs, fConfigMaxNPVCs, fConfigMaxFITTime,
                                 fConfigUseFV0, fConfigUseFT0, fConfigUseFDD, fConfigVetoForward, fConfigVetoBarrel);
 
     bool isSelected = filter;


### PR DESCRIPTION
* Use 8 largest bits of reducedevent::Tag to store eventFilter instead of 32 largest bits
* VarManager: Write doublegap and singlegap booleans from reducedevent, making them available to tableReader
* CutsLibrary: Add cuts for selecting double/single gap events
* filterPbPb: Add config string for event type (any combination of 'singlegap', 'doublegap')
* tableMaker: Add process function appropriate for DG/SG filter with forward tracks