### PR TITLE
PWGHF: Modified candidateSelectorDsToKKPi. Added HfMlResponseDsToKKPi

### DIFF
--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -20,9 +20,10 @@
 #include <string>
 #include <vector>
 
+#include "CommonConstants/PhysicsConstants.h"
+
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/HfMlResponse.h"
-#include "PWGHF/Core/PDG.h"
 
 // Fill the map of available input features
 // the key is the feature's name (std::string)

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -1,0 +1,197 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponseDsToKKPi.h
+/// \brief Class to compute the ML response for Ds∓ → K∓ K∓ π± analysis selections
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+
+#ifndef PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
+#define PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/Core/HfMlResponse.h"
+#include "PWGHF/Core/PDG.h"
+
+// Fill the map of available input features
+// the key is the feature's name (std::string)
+// the value is the corresponding value in EnumInputFeatures
+#define FILL_MAP_DS(FEATURE)                                         \
+  {                                                                  \
+#FEATURE, static_cast < uint8_t>(InputFeaturesDsToKKPi::FEATURE) \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the corresponding GETTER from OBJECT
+#define CHECK_AND_FILL_VEC_DS_FULL(OBJECT, FEATURE, GETTER)    \
+  case static_cast<uint8_t>(InputFeaturesDsToKKPi::FEATURE): { \
+    inputFeatures.emplace_back(OBJECT.GETTER());               \
+    break;                                                     \
+  }
+
+// Specific case of CHECK_AND_FILL_VEC_DS_FULL(OBJECT, FEATURE, GETTER)
+// where OBJECT is named candidate and FEATURE = GETTER
+#define CHECK_AND_FILL_VEC_DS(GETTER)                         \
+  case static_cast<uint8_t>(InputFeaturesDsToKKPi::GETTER): { \
+    inputFeatures.emplace_back(candidate.GETTER());           \
+    break;                                                    \
+  }
+
+// Variation of CHECK_AND_FILL_VEC_DS_FULL(OBJECT, FEATURE, GETTER)
+// where GETTER is a method of hfHelper
+#define CHECK_AND_FILL_VEC_DS_HFHELPER(OBJECT, FEATURE, GETTER) \
+  case static_cast<uint8_t>(InputFeaturesDsToKKPi::FEATURE): {  \
+    inputFeatures.emplace_back(hfHelper.GETTER(OBJECT));        \
+    break;                                                      \
+  }
+
+// Variation of CHECK_AND_FILL_VEC_DS_HFHELPER(OBJECT, FEATURE, GETTER)
+// where GETTER1 and GETTER2 are methods of hfHelper, and the variable
+// is filled depending on whether it is a DsToKKPi or a DsToPiKK
+#define CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(OBJECT, FEATURE, GETTER1, GETTER2) \
+  case static_cast<uint8_t>(InputFeaturesDsToKKPi::FEATURE): {                   \
+    if (caseDsToKKPi) {                                                          \
+      inputFeatures.emplace_back(hfHelper.GETTER1(OBJECT));                      \
+    } else {                                                                     \
+      inputFeatures.emplace_back(hfHelper.GETTER2(OBJECT));                      \
+    }                                                                            \
+    break;                                                                       \
+  }
+
+namespace o2::analysis
+{
+enum class InputFeaturesDsToKKPi : uint8_t { // controllare le varie input features
+  chi2PCA = 0,
+  decayLength,
+  decayLengthXY,
+  decayLengthNormalised,
+  decayLengthXYNormalised,
+  maxNormalisedDeltaIP,
+  impactParameterNormalised0,
+  cpa,
+  cpaXY,
+  ptProng0,
+  ptProng1,
+  ptProng2,
+  impactParameterXY0,
+  impactParameterXY1,
+  impactParameterXY2,
+  nSigTpcTofPi0,
+  nSigTpcTofPi1,
+  nSigTpcTofPi2,
+  nSigTpcTofKa0,
+  nSigTpcTofKa1,
+  nSigTpcTofKa2,
+  cos3PiK,
+  deltaMassPhi
+};
+
+template <typename TypeOutputScore = float>
+class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
+{
+ public:
+  /// Default constructor
+  HfMlResponseDsToKKPi() = default;
+  /// Default destructor
+  virtual ~HfMlResponseDsToKKPi() = default;
+
+  HfHelper hfHelper;
+
+  /// Method to get the input features vector needed for ML inference
+  /// \param candidate is the Ds candidate
+  /// \param prong0 is the candidate's prong0
+  /// \param prong1 is the candidate's prong1
+  /// \param prong2 is the candidate's prong2
+  /// \return inputFeatures vector
+  template <typename T1, typename T2>
+  std::vector<float> getInputFeatures(T1 const& candidate,
+                                      T2 const& prong0, T2 const& prong1, T2 const& prong2, bool const& caseDsToKKPi)
+  {
+    std::vector<float> inputFeatures;
+
+    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+      switch (idx) {
+        CHECK_AND_FILL_VEC_DS(chi2PCA);
+        CHECK_AND_FILL_VEC_DS(decayLength);
+        CHECK_AND_FILL_VEC_DS(decayLengthXY);
+        CHECK_AND_FILL_VEC_DS(decayLengthNormalised);
+        CHECK_AND_FILL_VEC_DS(decayLengthXYNormalised);
+        CHECK_AND_FILL_VEC_DS(maxNormalisedDeltaIP);
+        CHECK_AND_FILL_VEC_DS(cpa);
+        CHECK_AND_FILL_VEC_DS(cpaXY);
+        CHECK_AND_FILL_VEC_DS(ptProng0);
+        CHECK_AND_FILL_VEC_DS(ptProng1);
+        CHECK_AND_FILL_VEC_DS(ptProng2);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY0, impactParameter0);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY1, impactParameter1);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY2, impactParameter2);
+        // Combined PID variables
+        CHECK_AND_FILL_VEC_DS_FULL(prong0, nSigTpcTofPi0, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DS_FULL(prong1, nSigTpcTofPi1, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DS_FULL(prong2, nSigTpcTofPi2, tpcTofNSigmaPi);
+        CHECK_AND_FILL_VEC_DS_FULL(prong0, nSigTpcTofKa0, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_DS_FULL(prong1, nSigTpcTofKa1, tpcTofNSigmaKa);
+        CHECK_AND_FILL_VEC_DS_FULL(prong2, nSigTpcTofKa2, tpcTofNSigmaKa);
+
+        CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, cos3PiK, cos3PiKDsToKKPi, cos3PiKDsToPiKK);
+        CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, deltaMassPhi, deltaMassPhiDsToKKPi, deltaMassPhiDsToPiKK);
+      }
+    }
+
+    return inputFeatures;
+  }
+
+ protected:
+  /// Method to fill the map of available input features
+  void setAvailableInputFeatures()
+  {
+    MlResponse<TypeOutputScore>::mAvailableInputFeatures = {
+      FILL_MAP_DS(chi2PCA),
+      FILL_MAP_DS(decayLength),
+      FILL_MAP_DS(decayLengthXY),
+      FILL_MAP_DS(decayLengthNormalised),
+      FILL_MAP_DS(decayLengthXYNormalised),
+      FILL_MAP_DS(maxNormalisedDeltaIP),
+      FILL_MAP_DS(cpa),
+      FILL_MAP_DS(cpaXY),
+      FILL_MAP_DS(ptProng0),
+      FILL_MAP_DS(ptProng1),
+      FILL_MAP_DS(ptProng2),
+      FILL_MAP_DS(impactParameterXY0),
+      FILL_MAP_DS(impactParameterXY1),
+      FILL_MAP_DS(impactParameterXY2),
+      // Combined PID variables
+      FILL_MAP_DS(nSigTpcTofPi0),
+      FILL_MAP_DS(nSigTpcTofPi1),
+      FILL_MAP_DS(nSigTpcTofPi2),
+      FILL_MAP_DS(nSigTpcTofKa0),
+      FILL_MAP_DS(nSigTpcTofKa1),
+      FILL_MAP_DS(nSigTpcTofKa2),
+
+      FILL_MAP_DS(cos3PiK),
+      FILL_MAP_DS(deltaMassPhi)};
+  }
+};
+
+} // namespace o2::analysis
+
+#undef FILL_MAP_DS
+#undef CHECK_AND_FILL_VEC_DS_FULL
+#undef CHECK_AND_FILL_VEC_DS
+#undef CHECK_AND_FILL_VEC_DS_HFHELPER
+#undef CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED
+
+#endif // PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -16,8 +16,6 @@
 #ifndef PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
 #define PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
 
-#include <map>
-#include <string>
 #include <vector>
 
 #include "CommonConstants/PhysicsConstants.h"

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -18,8 +18,6 @@
 
 #include <vector>
 
-#include "CommonConstants/PhysicsConstants.h"
-
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/HfMlResponse.h"
 

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -72,14 +72,13 @@
 
 namespace o2::analysis
 {
-enum class InputFeaturesDsToKKPi : uint8_t { // controllare le varie input features
+enum class InputFeaturesDsToKKPi : uint8_t {
   chi2PCA = 0,
   decayLength,
   decayLengthXY,
   decayLengthNormalised,
   decayLengthXYNormalised,
   maxNormalisedDeltaIP,
-  impactParameterNormalised0,
   cpa,
   cpaXY,
   ptProng0,
@@ -114,6 +113,7 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
   /// \param prong0 is the candidate's prong0
   /// \param prong1 is the candidate's prong1
   /// \param prong2 is the candidate's prong2
+  /// \param caseDsToKKPi used to divide the case DsToKKPi from DsToPiKK
   /// \return inputFeatures vector
   template <typename T1, typename T2>
   std::vector<float> getInputFeatures(T1 const& candidate,
@@ -145,6 +145,7 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(prong1, nSigTpcTofKa1, tpcTofNSigmaKa);
         CHECK_AND_FILL_VEC_DS_FULL(prong2, nSigTpcTofKa2, tpcTofNSigmaKa);
 
+        // Ds specific variables
         CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, cos3PiK, cos3PiKDsToKKPi, cos3PiKDsToPiKK);
         CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, deltaMassPhi, deltaMassPhiDsToKKPi, deltaMassPhiDsToPiKK);
       }
@@ -180,6 +181,7 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_DS(nSigTpcTofKa1),
       FILL_MAP_DS(nSigTpcTofKa2),
 
+      // Ds specific variables
       FILL_MAP_DS(cos3PiK),
       FILL_MAP_DS(deltaMassPhi)};
   }

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -42,7 +42,7 @@ DECLARE_SOA_COLUMN(IsRecoHfFlag, isRecoHfFlag, int); //!
 DECLARE_SOA_COLUMN(IsRecoTopol, isRecoTopol, int);   //!
 DECLARE_SOA_COLUMN(IsRecoCand, isRecoCand, int);     //!
 DECLARE_SOA_COLUMN(IsRecoPid, isRecoPid, int);
-DECLARE_SOA_COLUMN(MlProbD0, mlProbD0, std::vector<float>); //!
+DECLARE_SOA_COLUMN(MlProbD0, mlProbD0, std::vector<float>);       //!
 DECLARE_SOA_COLUMN(MlProbD0bar, mlProbD0bar, std::vector<float>); //!
 } // namespace hf_sel_candidate_d0
 
@@ -110,7 +110,7 @@ DECLARE_SOA_TABLE(HfSelD0Alice3Forward, "AOD", "HFSELD0A3F", //!
 
 namespace hf_sel_candidate_dplus
 {
-DECLARE_SOA_COLUMN(IsSelDplusToPiKPi, isSelDplusToPiKPi, int); //!
+DECLARE_SOA_COLUMN(IsSelDplusToPiKPi, isSelDplusToPiKPi, int);                  //!
 DECLARE_SOA_COLUMN(MlProbDplusToPiKPi, mlProbDplusToPiKPi, std::vector<float>); //!
 } // namespace hf_sel_candidate_dplus
 
@@ -122,16 +122,17 @@ DECLARE_SOA_TABLE(HfMlDplusToPiKPi, "AOD", "HFMLDPLUS", //!
 
 namespace hf_sel_candidate_ds
 {
-DECLARE_SOA_COLUMN(IsSelDsToKKPi, isSelDsToKKPi, int); //!
-DECLARE_SOA_COLUMN(IsSelDsToPiKK, isSelDsToPiKK, int); //!
+DECLARE_SOA_COLUMN(IsSelDsToKKPi, isSelDsToKKPi, int);                  //!
+DECLARE_SOA_COLUMN(IsSelDsToPiKK, isSelDsToPiKK, int);                  //!
 DECLARE_SOA_COLUMN(MlProbDsToKKPi, mlProbDsToKKPi, std::vector<float>); //!
+DECLARE_SOA_COLUMN(MlProbDsToPiKK, mlProbDsToPiKK, std::vector<float>); //!
 } // namespace hf_sel_candidate_ds
 
 DECLARE_SOA_TABLE(HfSelDsToKKPi, "AOD", "HFSELDS", //!
                   hf_sel_candidate_ds::IsSelDsToKKPi, hf_sel_candidate_ds::IsSelDsToPiKK);
 
 DECLARE_SOA_TABLE(HfMlDsToKKPi, "AOD", "HFMLDS", //!
-                  hf_sel_candidate_ds::MlProbDsToKKPi);
+                  hf_sel_candidate_ds::MlProbDsToKKPi, hf_sel_candidate_ds::MlProbDsToPiKK);
 
 namespace hf_sel_candidate_lc
 {
@@ -223,7 +224,7 @@ DECLARE_SOA_TABLE(HfSelB0ToDPi, "AOD", "HFSELB0", //!
 
 namespace hf_sel_candidate_bs
 {
-DECLARE_SOA_COLUMN(IsSelBsToDsPi, isSelBsToDsPi, int); //!
+DECLARE_SOA_COLUMN(IsSelBsToDsPi, isSelBsToDsPi, int);                  //!
 DECLARE_SOA_COLUMN(MlProbBsToDsPi, mlProbBsToDsPi, std::vector<float>); //!
 } // namespace hf_sel_candidate_bs
 

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -313,18 +313,15 @@ struct HfCandidateSelectorDsToKKPi {
 
       if (applyMl) {
         // ML selections
-        bool caseDsToKKPi = false;
         bool isSelectedMlDsToKKPi = false;
         bool isSelectedMlDsToPiKK = false;
 
         if (topolDsToKKPi && pidDsToKKPi) {
-          caseDsToKKPi = true;
-          std::vector<float> inputFeaturesDsToKKPi = hfMlResponse.getInputFeatures(candidate, trackPos1, trackNeg, trackPos2, caseDsToKKPi);
+          std::vector<float> inputFeaturesDsToKKPi = hfMlResponse.getInputFeatures(candidate, trackPos1, trackNeg, trackPos2, true);
           isSelectedMlDsToKKPi = hfMlResponse.isSelectedMl(inputFeaturesDsToKKPi, candidate.pt(), outputMlDsToKKPi);
         }
         if (topolDsToPiKK && pidDsToPiKK) {
-          caseDsToKKPi = false;
-          std::vector<float> inputFeaturesDsToPiKK = hfMlResponse.getInputFeatures(candidate, trackPos1, trackNeg, trackPos2, caseDsToKKPi);
+          std::vector<float> inputFeaturesDsToPiKK = hfMlResponse.getInputFeatures(candidate, trackPos1, trackNeg, trackPos2, false);
           isSelectedMlDsToPiKK = hfMlResponse.isSelectedMl(inputFeaturesDsToPiKK, candidate.pt(), outputMlDsToPiKK);
         }
 

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -31,7 +31,7 @@ using namespace o2::analysis;
 using namespace o2::framework;
 
 /// Struct to extend TracksPid tables
-struct HfCandidateSelectorDplusToPiKPiExpressions {
+struct HfCandidateSelectorDsToKKPiExpressions {
   Spawns<aod::TracksPidPiExt> rowTracksPidFullPi;
   Spawns<aod::TracksPidKaExt> rowTracksPidFullKa;
 };
@@ -125,8 +125,8 @@ struct HfCandidateSelectorDsToKKPi {
         hfMlResponse.setModelPathsLocal(onnxFileNames);
       }
       hfMlResponse.init();
-      outputMlDsToKKPi.assign(static_cast<std::vector<int>>(cutDirMl).size(), -1.f); // dummy value for ML output
-      outputMlDsToPiKK.assign(static_cast<std::vector<int>>(cutDirMl).size(), -1.f); // dummy value for ML output
+      outputMlDsToKKPi.assign(cutDirMl.value.size(), -1.f); // dummy value for ML output
+      outputMlDsToPiKK.assign(cutDirMl.value.size(), -1.f); // dummy value for ML output
     }
   }
 
@@ -364,5 +364,7 @@ struct HfCandidateSelectorDsToKKPi {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<HfCandidateSelectorDsToKKPi>(cfgc)};
+  return WorkflowSpec{
+    adaptAnalysisTask<HfCandidateSelectorDsToKKPiExpressions>(cfgc),
+    adaptAnalysisTask<HfCandidateSelectorDsToKKPi>(cfgc)};
 }

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -125,8 +125,8 @@ struct HfCandidateSelectorDsToKKPi {
         hfMlResponse.setModelPathsLocal(onnxFileNames);
       }
       hfMlResponse.init();
-      outputMlDsToKKPi.assign(((std::vector<int>)cutDirMl).size(), -1.f); // dummy value for ML output
-      outputMlDsToPiKK.assign(((std::vector<int>)cutDirMl).size(), -1.f); // dummy value for ML output
+      outputMlDsToKKPi.assign(static_cast<std::vector<int>>(cutDirMl).size(), -1.f); // dummy value for ML output
+      outputMlDsToPiKK.assign(static_cast<std::vector<int>>(cutDirMl).size(), -1.f); // dummy value for ML output
     }
   }
 

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -79,10 +79,6 @@ struct HfCandidateSelectorDsToKKPi {
 
   using TracksSel = soa::Join<aod::TracksWDca, aod::TracksPidPiExt, aod::TracksPidKaExt>;
 
-  // Define histograms
-  AxisSpec axisMassDmeson{200, 1.7f, 2.1f};
-  AxisSpec axisBdtScore{100, 0.f, 1.f};
-  AxisSpec axisSelStatus{2, -0.5f, 1.5f};
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -62,6 +62,7 @@ struct HfCandidateSelectorDsToKKPi {
   Configurable<std::vector<int>> cutDirMl{"cutDirMl", std::vector<int>{hf_cuts_ml::vecCutDir}, "Whether to reject score values greater or smaller than the threshold"};
   Configurable<LabeledArray<double>> cutsMl{"cutsMl", {hf_cuts_ml::cuts[0], hf_cuts_ml::nBinsPt, hf_cuts_ml::nCutScores, hf_cuts_ml::labelsPt, hf_cuts_ml::labelsCutScore}, "ML selections per pT bin"};
   Configurable<int8_t> nClassesMl{"nClassesMl", (int8_t)hf_cuts_ml::nCutScores, "Number of classes in ML model"};
+  Configurable<std::vector<std::string>> namesInputFeatures{"namesInputFeatures", std::vector<std::string>{"feature1", "feature2"}, "Names of ML model input features"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"EventFiltering/PWGHF/BDTDs"}, "Paths of models on CCDB"};
@@ -112,6 +113,7 @@ struct HfCandidateSelectorDsToKKPi {
       } else {
         hfMlResponse.setModelPathsLocal(onnxFileNames);
       }
+      hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
       hfMlResponse.init();
     }
   }

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -21,7 +21,6 @@
 #include "Common/Core/TrackSelectorPID.h"
 
 #include "PWGHF/Core/HfHelper.h"
-#include "PWGHF/Core/HfMlResponse.h"
 #include "PWGHF/Core/HfMlResponseDsToKKPi.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"


### PR DESCRIPTION
Dear all,
In view of the selection of Ds-meson candidates with ML technique, I've added the separation between the different mass hypothesis in candidateSelectorDsToKKPi for the applyMl case. I've added a new HfMlResponseDsToKKPi following the same done for the D0 and D+ mesons.
Let me know for any comment/advise you have.

Best regards,
Samuele