### PR TITLE
PWGHF: Rename XiCZero -> XiC0

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -112,7 +112,7 @@ struct HfCandidateCreatorToXiPi {
     double massLambdaFromPDG = MassLambda0; // pdg code 3122
     double massXiFromPDG = MassXiMinus;     // pdg code 3312
     double massOmegacFromPDG = MassOmegaC0; // pdg code 4332
-    double massXicFromPDG = MassXiCZero;    // pdg code 4132
+    double massXicFromPDG = MassXiC0;       // pdg code 4132
 
     // 2-prong vertex fitter to build the omegac/xic vertex
     o2::vertexing::DCAFitterN<2> df;
@@ -364,7 +364,7 @@ struct HfCandidateCreatorToXiPiMc {
     int8_t debugGenLambda = 0;
 
     int pdgCodeOmegac0 = Pdg::kOmegaC0; // 4332
-    int pdgCodeXic0 = Pdg::kXiCZero;    // 4132
+    int pdgCodeXic0 = Pdg::kXiC0;       // 4132
     int pdgCodeXiMinus = kXiMinus;      // 3312
     int pdgCodeLambda = kLambda0;       // 3122
     int pdgCodePiPlus = kPiPlus;        // 211

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -3270,7 +3270,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
     massXi = o2::constants::physics::MassXiMinus;
     massOmega = o2::constants::physics::MassOmegaMinus;
     massLambda = o2::constants::physics::MassLambda0;
-    massXiczero = o2::constants::physics::MassXiCZero;
+    massXiczero = o2::constants::physics::MassXiC0;
     massXicplus = o2::constants::physics::MassXiCPlus;
 
     arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi] = std::array{massXi, massPi};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -3253,8 +3253,6 @@ struct HfTrackIndexSkimCreatorLfCascades {
   double massXi{0.};
   double massOmega{0.};
   double massLambda{0.};
-  double massXiczero{0.};
-  double massXicplus{0.};
 
   // histograms
   HistogramRegistry registry{"registry"};
@@ -3270,8 +3268,6 @@ struct HfTrackIndexSkimCreatorLfCascades {
     massXi = o2::constants::physics::MassXiMinus;
     massOmega = o2::constants::physics::MassOmegaMinus;
     massLambda = o2::constants::physics::MassLambda0;
-    massXiczero = o2::constants::physics::MassXiC0;
-    massXicplus = o2::constants::physics::MassXiCPlus;
 
     arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi] = std::array{massXi, massPi};
     arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi] = std::array{massOmega, massPi};

--- a/PWGHF/TableProducer/treeCreatorOmegacSt.cxx
+++ b/PWGHF/TableProducer/treeCreatorOmegacSt.cxx
@@ -438,7 +438,7 @@ struct HfTreeCreatorOmegacSt {
                 registry.fill(HIST("hMassOmegacVsPt"), massOmegaC, RecoDecay::pt(momenta[0], momenta[1]));
 
                 if ((std::abs(massOmegaC - o2::constants::physics::MassOmegaC0) < massWindowOmegaC) ||
-                    (std::abs(massXiC - o2::constants::physics::MassXiCZero) < massWindowXiC)) {
+                    (std::abs(massXiC - o2::constants::physics::MassXiC0) < massWindowXiC)) {
                   registry.fill(HIST("hDecayLength"), decayLength * 1e4);
                   registry.fill(HIST("hDecayLengthScaled"), decayLength * o2::constants::physics::MassOmegaC0 / RecoDecay::p(momenta[0], momenta[1]) * 1e4);
                   outputTable(massOmega,


### PR DESCRIPTION
Fixing the name to be consistent with the names of other particles.
Requires https://github.com/AliceO2Group/AliceO2/pull/12378
@qgp 