### PR TITLE
Rework UPC skimmer, part 2

### DIFF
--- a/PWGUD/Core/UPCCutparHolder.cxx
+++ b/PWGUD/Core/UPCCutparHolder.cxx
@@ -33,8 +33,8 @@ void UPCCutparHolder::setITSNClusLow(int ITSNClusLow) { fITSNClusLow = ITSNClusL
 void UPCCutparHolder::setITSNClusHigh(int ITSNClusHigh) { fITSNClusHigh = ITSNClusHigh; }
 void UPCCutparHolder::setITSChi2Low(float ITSChi2Low) { fITSChi2Low = ITSChi2Low; }
 void UPCCutparHolder::setITSChi2High(float ITSChi2High) { fITSChi2High = ITSChi2High; }
-void UPCCutparHolder::setTPCNClusCRLow(int TPCNClusCRLow) { fTPCNClusCRLow = TPCNClusCRLow; }
-void UPCCutparHolder::setTPCNClusCRHigh(int TPCNClusCRHigh) { fTPCNClusCRHigh = TPCNClusCRHigh; }
+void UPCCutparHolder::setTPCNClsLow(int TPCNClsLow) { fTPCNClsLow = TPCNClsLow; }
+void UPCCutparHolder::setTPCNClsHigh(int TPCNClsHigh) { fTPCNClsHigh = TPCNClsHigh; }
 void UPCCutparHolder::setTPCChi2Low(float TPCChi2Low) { fTPCChi2Low = TPCChi2Low; }
 void UPCCutparHolder::setTPCChi2High(float TPCChi2High) { fTPCChi2High = TPCChi2High; }
 void UPCCutparHolder::setCheckMaxDcaXY(bool checkMaxDcaXY) { fCheckMaxDcaXY = checkMaxDcaXY; }
@@ -68,8 +68,8 @@ int UPCCutparHolder::getITSNClusLow() const { return fITSNClusLow; }
 int UPCCutparHolder::getITSNClusHigh() const { return fITSNClusHigh; }
 float UPCCutparHolder::getITSChi2Low() const { return fITSChi2Low; }
 float UPCCutparHolder::getITSChi2High() const { return fITSChi2High; }
-int UPCCutparHolder::getTPCNClusCRLow() const { return fTPCNClusCRLow; }
-int UPCCutparHolder::getTPCNClusCRHigh() const { return fTPCNClusCRHigh; }
+int UPCCutparHolder::getTPCNClsLow() const { return fTPCNClsLow; }
+int UPCCutparHolder::getTPCNClsHigh() const { return fTPCNClsHigh; }
 float UPCCutparHolder::getTPCChi2Low() const { return fTPCChi2Low; }
 float UPCCutparHolder::getTPCChi2High() const { return fTPCChi2High; }
 bool UPCCutparHolder::getCheckMaxDcaXY() const { return fCheckMaxDcaXY; }

--- a/PWGUD/Core/UPCCutparHolder.h
+++ b/PWGUD/Core/UPCCutparHolder.h
@@ -72,8 +72,8 @@ class UPCCutparHolder
       fITSNClusHigh{ITSNClusHigh},
       fITSChi2Low{ITSChi2Low},
       fITSChi2High{ITSChi2High},
-      fTPCNClusCRLow{TPCNClusCRLow},
-      fTPCNClusCRHigh{TPCNClusCRHigh},
+      fTPCNClsLow{TPCNClusCRLow},
+      fTPCNClsHigh{TPCNClusCRHigh},
       fTPCChi2Low{TPCChi2Low},
       fTPCChi2High{TPCChi2High},
       fCheckMaxDcaXY{checkMaxDcaXY},
@@ -107,8 +107,8 @@ class UPCCutparHolder
   void setITSNClusHigh(int ITSNClusHigh);
   void setITSChi2Low(float ITSChi2Low);
   void setITSChi2High(float ITSChi2High);
-  void setTPCNClusCRLow(int TPCNClusCRLow);
-  void setTPCNClusCRHigh(int TPCNClusCRHigh);
+  void setTPCNClsLow(int TPCNClusCRLow);
+  void setTPCNClsHigh(int TPCNClusCRHigh);
   void setTPCChi2Low(float TPCChi2Low);
   void setTPCChi2High(float TPCChi2High);
   void setCheckMaxDcaXY(bool checkMaxDcaXY);
@@ -142,8 +142,8 @@ class UPCCutparHolder
   int getITSNClusHigh() const;
   float getITSChi2Low() const;
   float getITSChi2High() const;
-  int getTPCNClusCRLow() const;
-  int getTPCNClusCRHigh() const;
+  int getTPCNClsLow() const;
+  int getTPCNClsHigh() const;
   float getTPCChi2Low() const;
   float getTPCChi2High() const;
   bool getCheckMaxDcaXY() const;
@@ -195,10 +195,10 @@ class UPCCutparHolder
   float fITSChi2Low{0.};  // Minimal Chi2 in ITS per cluster
   float fITSChi2High{5.}; // Maximal Chi2 in ITS per cluster
   // quality: TPC
-  int fTPCNClusCRLow{70};   // Minimal number of TPC clusters (crossed rows)
-  int fTPCNClusCRHigh{161}; // Maximal number of TPC clusters (crossed rows)
-  float fTPCChi2Low{0.};    // Minimal Chi2 in TPC per cluster
-  float fTPCChi2High{4.};   // Maximal Chi2 in TPC per cluster
+  int fTPCNClsLow{60};    // Minimal number of TPC clusters
+  int fTPCNClsHigh{161};  // Maximal number of TPC clusters
+  float fTPCChi2Low{0.};  // Minimal Chi2 in TPC per cluster
+  float fTPCChi2High{4.}; // Maximal Chi2 in TPC per cluster
   // quality: DCA
   bool fCheckMaxDcaXY{true}; // Apply cut on maximal DCA_xy
   float fDcaZLow{-3.};       // Minimal DCA_z for barrel tracks
@@ -210,7 +210,7 @@ class UPCCutparHolder
 
   // tracks from collisions: consider only tracks from collisions with N tracks less or equal than fMaxNContrib
   int fMaxNContrib{999999}; // Central barrel: consider tracks from collisions with N contributors <= maxNContrib
-  int fAmbigSwitch{0}; // Central barrel: 0 -- loop over all tracks, 1 -- loop only over tracks with vertices
+  int fAmbigSwitch{0};      // Central barrel: 0 -- loop over all tracks, 1 -- loop only over tracks with vertices
 
   ClassDefNV(UPCCutparHolder, 1);
 };

--- a/PWGUD/Core/UPCCutparHolder.h
+++ b/PWGUD/Core/UPCCutparHolder.h
@@ -209,7 +209,7 @@ class UPCCutparHolder
   bool fProduceITSITS{false}; // Produce candidates using only ITS-TPC tracks as well
 
   // tracks from collisions: consider only tracks from collisions with N tracks less or equal than fMaxNContrib
-  int fMaxNContrib{2}; // Central barrel: consider tracks from collisions with N contributors <= maxNContrib
+  int fMaxNContrib{999999}; // Central barrel: consider tracks from collisions with N contributors <= maxNContrib
   int fAmbigSwitch{0}; // Central barrel: 0 -- loop over all tracks, 1 -- loop only over tracks with vertices
 
   ClassDefNV(UPCCutparHolder, 1);

--- a/PWGUD/Core/UPCHelpers.h
+++ b/PWGUD/Core/UPCHelpers.h
@@ -59,6 +59,7 @@ enum BarrelSels {
   kBarrelSelTPCChi2,
   kBarrelSelDCAXY,
   kBarrelSelDCAZ,
+  kAmbiguous,
   kNBarrelSels
 };
 
@@ -87,6 +88,10 @@ struct FITInfo {
   int32_t BGFDDApf = 0;
   int32_t BBFDDCpf = 0;
   int32_t BGFDDCpf = 0;
+  int32_t distClosestBcTOR = 999;
+  int32_t distClosestBcTSC = 999;
+  int32_t distClosestBcTVX = 999;
+  int32_t distClosestBcV0A = 999;
 };
 
 template <typename TSelectorsArray>
@@ -102,6 +107,9 @@ void applyFwdCuts(UPCCutparHolder& upcCuts, const ForwardTracks::iterator& track
 template <typename TSelectorsArray>
 void applyBarrelCuts(UPCCutparHolder& upcCuts, const BarrelTracks::iterator& track, TSelectorsArray& barrelSelectors)
 {
+  barrelSelectors[kAmbiguous] = true;
+  if (upcCuts.getAmbigSwitch())
+    barrelSelectors[kAmbiguous] = track.isPVContributor();
   barrelSelectors[kBarrelSelHasTOF] = true;
   if (upcCuts.getRequireTOF())
     barrelSelectors[kBarrelSelHasTOF] = track.hasTOF();                                                           // require TOF match if needed
@@ -113,7 +121,7 @@ void applyBarrelCuts(UPCCutparHolder& upcCuts, const BarrelTracks::iterator& tra
   barrelSelectors[kBarrelSelITSChi2] = track.itsChi2NCl() > upcCuts.getITSChi2Low() && track.itsChi2NCl() < upcCuts.getITSChi2High();
 
   // check TPC cuts
-  barrelSelectors[kBarrelSelTPCNCls] = track.tpcNClsCrossedRows() > static_cast<int16_t>(upcCuts.getTPCNClusCRLow()) && track.tpcNClsCrossedRows() < static_cast<int16_t>(upcCuts.getTPCNClusCRHigh());
+  barrelSelectors[kBarrelSelTPCNCls] = track.tpcNClsFound() > static_cast<int16_t>(upcCuts.getTPCNClsLow()) && track.tpcNClsFound() < static_cast<int16_t>(upcCuts.getTPCNClsHigh());
   barrelSelectors[kBarrelSelTPCChi2] = track.tpcChi2NCl() > upcCuts.getTPCChi2Low() && track.tpcChi2NCl() < upcCuts.getTPCChi2High();
 
   // check DCA

--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -132,6 +132,12 @@ DECLARE_SOA_DYNAMIC_COLUMN(BBFV0A, bbFV0A,
 DECLARE_SOA_DYNAMIC_COLUMN(BGFV0A, bgFV0A,
                            [](int32_t bgFV0Apf) -> bool { return TESTBIT(bgFV0Apf, 16); });
 
+DECLARE_SOA_COLUMN(DBcTOR, dBcTOR, int32_t); //! distance to closest TOR
+DECLARE_SOA_COLUMN(DBcTSC, dBcTSC, int32_t); //! distance to closest TVX & (TSC | TCE)
+DECLARE_SOA_COLUMN(DBcTVX, dBcTVX, int32_t); //! distance to closest TVX
+DECLARE_SOA_COLUMN(DBcV0A, dBcV0A, int32_t); //! distance to closest V0A
+DECLARE_SOA_COLUMN(DBcT0A, dBcT0A, int32_t); //! distance to closest T0A
+
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);
 
 DECLARE_SOA_INDEX_COLUMN(UDMcCollision, udMcCollision);
@@ -170,6 +176,13 @@ DECLARE_SOA_TABLE(UDCollisionsSels, "AOD", "UDCOLLISIONSEL",
                   udcollision::BBFV0A<udcollision::BBFV0APF>, udcollision::BGFV0A<udcollision::BGFV0APF>,
                   udcollision::BBFDDA<udcollision::BBFDDAPF>, udcollision::BBFDDC<udcollision::BBFDDCPF>, udcollision::BGFDDA<udcollision::BGFDDAPF>, udcollision::BGFDDC<udcollision::BGFDDCPF>);
 
+DECLARE_SOA_TABLE(UDCollisionsSelsExtra, "AOD", "UDCOLSELEXTRA",
+                  udcollision::DBcTOR,
+                  udcollision::DBcTSC,
+                  udcollision::DBcTVX,
+                  udcollision::DBcV0A,
+                  udcollision::DBcT0A);
+
 DECLARE_SOA_TABLE(UDCollsLabels, "AOD", "UDCOLLSLABEL",
                   udcollision::CollisionId);
 
@@ -178,6 +191,7 @@ DECLARE_SOA_TABLE(UDMcCollsLabels, "AOD", "UDMCCOLLSLABEL",
 
 using UDCollision = UDCollisions::iterator;
 using UDCollisionsSel = UDCollisionsSels::iterator;
+using UDCollisionsSelExtra = UDCollisionsSelsExtra::iterator;
 using UDCollsLabel = UDCollsLabels::iterator;
 using UDMcCollsLabel = UDMcCollsLabels::iterator;
 

--- a/PWGUD/Tasks/CMakeLists.txt
+++ b/PWGUD/Tasks/CMakeLists.txt
@@ -53,3 +53,8 @@ o2physics_add_dpl_workflow(upc-mft
                            SOURCES upcMft.cxx
                            PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::ReconstructionDataFormats O2::DetectorsBase O2::DetectorsCommonDataFormats
                            COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(upc-veto
+        SOURCES upcVetoAnalysis.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase
+        COMPONENT_NAME Analysis)

--- a/PWGUD/Tasks/upcVetoAnalysis.cxx
+++ b/PWGUD/Tasks/upcVetoAnalysis.cxx
@@ -1,0 +1,233 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonConstants/LHCConstants.h"
+#include "DataFormatsFIT/Triggers.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct UpcVetoAnalysis {
+  int32_t fRun{0};
+
+  float ampLo{0.f};
+  float ampHi{20000.f};
+  float damp{100.f};
+  int32_t nAmpThr;
+  int32_t nBCRanges{5};
+
+  std::bitset<o2::constants::lhc::LHCMaxBunches> bcPatternB;
+
+  HistogramRegistry hr{"hr", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void getBCPattern(const o2::aod::BCs::iterator& bc)
+  {
+    fRun = bc.runNumber();
+    o2::ccdb::CcdbApi ccdb_api;
+    ccdb_api.init("http://alice-ccdb.cern.ch");
+    std::map<string, string> metadata, headers;
+    headers = ccdb_api.retrieveHeaders(Form("RCT/Info/RunInformation/%i", fRun), metadata, -1);
+    int64_t ts = std::atol(headers["SOR"].c_str());
+    LOGP(info, "ts={}", ts);
+    auto grplhcif = ccdb_api.retrieveFromTFileAny<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF", metadata, ts);
+    bcPatternB = grplhcif->getBunchFilling().getBCPattern();
+  }
+
+  auto findClosestBCIter(int64_t globalBC, std::vector<int64_t>& bcs)
+  {
+    auto it = std::lower_bound(bcs.begin(), bcs.end(), globalBC);
+    auto bc1 = *it;
+    auto it1 = it;
+    if (it != bcs.begin())
+      --it;
+    auto it2 = it;
+    auto bc2 = *it;
+    auto dbc1 = bc1 >= globalBC ? bc1 - globalBC : globalBC - bc1;
+    auto dbc2 = bc2 >= globalBC ? bc2 - globalBC : globalBC - bc2;
+    return (dbc1 <= dbc2) ? it1 : it2;
+  }
+
+  template <typename T1, typename T2>
+  T2 findMaxInRange(int32_t range,
+                    int64_t cent,
+                    const typename std::vector<T1>::iterator startIt,
+                    std::vector<T1>& vPosi,
+                    std::vector<T2>& vVals)
+  {
+    auto pos = cent;
+    auto it = startIt;
+    T2 max = -999;
+    while (pos - cent < range && it != vPosi.end()) {
+      auto idx = it - vPosi.begin();
+      if (vVals[idx] > max)
+        max = vVals[idx];
+      ++it;
+      pos = *it;
+    }
+    it = startIt;
+    pos = cent;
+    while (cent - pos < range && it >= vPosi.begin()) {
+      --it;
+      pos = *it;
+      auto idx = it - vPosi.begin();
+      if (vVals[idx] > max)
+        max = vVals[idx];
+    }
+    return max;
+  }
+
+  void init(InitContext&)
+  {
+    const AxisSpec axisTrigCounter{1, 0., 1., ""};
+    hr.add("hCounterTCE", "", kTH1F, {axisTrigCounter});
+
+    nAmpThr = (ampHi - ampLo) / damp;
+    const AxisSpec axisCounters{100, 0.5, 100.5, ""};
+    const AxisSpec axisAmp{nAmpThr, ampLo, ampHi, ""};
+    const AxisSpec axisAmp2{1000, ampLo, ampHi * 10.f, ""};
+    const AxisSpec axisBCRanges{nBCRanges, 10., 60.};
+    hr.add("hSelBCsTOR", "", kTH1F, {axisCounters});
+    hr.add("hSelBCsTSC", "", kTH1F, {axisCounters});
+    hr.add("hSelBCsTVX", "", kTH1F, {axisCounters});
+    hr.add("hSelBCsV0A", "", kTH1F, {axisCounters});
+    hr.add("hSelBCAmpT0M", "", kTH2F, {axisAmp, axisBCRanges});
+    hr.add("hSelBCAmpV0A", "", kTH2F, {axisAmp, axisBCRanges});
+    hr.add("hAmpT0M", "", kTH1F, {axisAmp});
+    hr.add("hAmpV0A", "", kTH1F, {axisAmp});
+  }
+
+  void process(const o2::aod::BCs& bcs,
+               const o2::aod::FT0s& ft0s,
+               const o2::aod::FV0As& fv0as)
+  {
+    const o2::aod::BCs::iterator& fbc = bcs.begin();
+    if (fbc.runNumber() != fRun)
+      getBCPattern(fbc);
+
+    auto nBCs = bcs.size();
+
+    std::vector<int64_t> gbcs(nBCs, -1);
+    std::vector<int64_t> gbcsWithTOR;
+    std::vector<int64_t> gbcsWithT0;
+    std::vector<int64_t> gbcsWithTSC;
+    std::vector<int64_t> gbcsWithTVX;
+    std::vector<int64_t> gbcsWithV0A;
+    std::vector<float> ampsT0M;
+    std::vector<float> ampsV0A;
+
+    int64_t nBCsPat = 0;
+    for (const o2::aod::BCs::iterator& bc : bcs) {
+      if (bcPatternB[bc.globalBC() % 3564] == 0)
+        continue;
+      gbcs[bc.globalIndex()] = bc.globalBC();
+      nBCsPat++;
+      hr.get<TH1>(HIST("hSelBCsV0A"))->AddBinContent(1, 1);
+      hr.get<TH1>(HIST("hSelBCsTOR"))->AddBinContent(1, 1);
+      hr.get<TH1>(HIST("hSelBCsTSC"))->AddBinContent(1, 1);
+      hr.get<TH1>(HIST("hSelBCsTVX"))->AddBinContent(1, 1);
+    }
+
+    for (int32_t i = 1; i <= nBCRanges; ++i) {
+      auto bcRange = i * 10;
+      hr.get<TH2>(HIST("hSelBCAmpT0M"))->Fill(0.f, bcRange, nBCsPat);
+      hr.get<TH2>(HIST("hSelBCAmpV0A"))->Fill(0.f, bcRange, nBCsPat);
+    }
+
+    for (const o2::aod::FV0As::iterator& fv0a : fv0as) {
+      int64_t globalBC = gbcs[fv0a.bc().globalIndex()];
+      if (globalBC == -1)
+        continue;
+      if (std::abs(fv0a.time()) > 15.f)
+        continue;
+      gbcsWithV0A.push_back(globalBC);
+      const auto& amps = fv0a.amplitude();
+      auto amp = std::accumulate(amps.begin(), amps.end(), 0.f);
+      ampsV0A.push_back(amp);
+      hr.get<TH1>(HIST("hAmpV0A"))->Fill(amp);
+    }
+
+    for (const o2::aod::FT0s::iterator& ft0 : ft0s) {
+      if (TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitVertex) &&
+          TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitCen))
+        hr.get<TH1>(HIST("hCounterTCE"))->Fill(0);
+      int64_t globalBC = gbcs[ft0.bc().globalIndex()];
+      if (globalBC == -1)
+        continue;
+      gbcsWithT0.push_back(globalBC);
+      const auto& ampsA = ft0.amplitudeA();
+      const auto& ampsC = ft0.amplitudeC();
+      auto ampA = std::accumulate(ampsA.begin(), ampsA.end(), 0.f);
+      auto ampC = std::accumulate(ampsC.begin(), ampsC.end(), 0.f);
+      ampsT0M.push_back(ampA + ampC);
+      hr.get<TH1>(HIST("hAmpT0M"))->Fill(ampA + ampC);
+      if (!(std::abs(ft0.timeA()) > 2.f && std::abs(ft0.timeC()) > 2.f)) // TOR
+        gbcsWithTOR.push_back(globalBC);
+      if (TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitVertex)) // TVX
+        gbcsWithTVX.push_back(globalBC);
+      if (TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitVertex) &&
+          (TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitCen) ||
+           TESTBIT(ft0.triggerMask(), o2::fit::Triggers::bitSCen))) // TVX & (TSC | TCE)
+        gbcsWithTSC.push_back(globalBC);
+    }
+
+    for (auto gbc : gbcs) {
+      if (gbc == -1)
+        continue;
+      auto bcV0Ait = findClosestBCIter(gbc, gbcsWithV0A);
+      auto bcTORit = findClosestBCIter(gbc, gbcsWithTOR);
+      auto bcT0Mit = findClosestBCIter(gbc, gbcsWithT0);
+      auto bcTSCit = findClosestBCIter(gbc, gbcsWithTSC);
+      auto bcTVXit = findClosestBCIter(gbc, gbcsWithTVX);
+      auto bcV0A = bcV0Ait != gbcsWithV0A.end() ? *bcV0Ait : gbc + 999;
+      auto bcTOR = bcTORit != gbcsWithTOR.end() ? *bcTORit : gbc + 999;
+      auto bcTSC = bcTSCit != gbcsWithTSC.end() ? *bcTSCit : gbc + 999;
+      auto bcTVX = bcTVXit != gbcsWithTVX.end() ? *bcTVXit : gbc + 999;
+      auto bcDistV0A = std::abs(gbc - bcV0A);
+      auto bcDistTOR = std::abs(gbc - bcTOR);
+      auto bcDistTSC = std::abs(gbc - bcTSC);
+      auto bcDistTVX = std::abs(gbc - bcTVX);
+      for (int32_t vetoBC = 1; vetoBC <= 99; ++vetoBC) {
+        if (bcDistV0A < vetoBC)
+          hr.get<TH1>(HIST("hSelBCsV0A"))->AddBinContent(vetoBC + 1, 1);
+        if (bcDistTOR < vetoBC)
+          hr.get<TH1>(HIST("hSelBCsTOR"))->AddBinContent(vetoBC + 1, 1);
+        if (bcDistTSC < vetoBC)
+          hr.get<TH1>(HIST("hSelBCsTSC"))->AddBinContent(vetoBC + 1, 1);
+        if (bcDistTVX < vetoBC)
+          hr.get<TH1>(HIST("hSelBCsTVX"))->AddBinContent(vetoBC + 1, 1);
+      }
+      for (int32_t iBCRange = 1; iBCRange <= 5; ++iBCRange) {
+        auto bcRange = 5 + iBCRange * 10;
+        auto maxAmpV0A = findMaxInRange(bcRange, gbc, bcV0Ait, gbcsWithV0A, ampsV0A);
+        auto maxAmpT0M = findMaxInRange(bcRange, gbc, bcT0Mit, gbcsWithT0, ampsT0M);
+        for (int32_t iamp = 1; iamp <= nAmpThr; ++iamp) {
+          auto amp = damp * iamp;
+          if (maxAmpV0A < amp)
+            hr.get<TH2>(HIST("hSelBCAmpT0M"))->Fill(amp, bcRange + 1, 1);
+          if (maxAmpT0M < amp)
+            hr.get<TH2>(HIST("hSelBCAmpV0A"))->Fill(amp, bcRange + 1, 1);
+        }
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<UpcVetoAnalysis>(cfgc)};
+}


### PR DESCRIPTION
* Reworking central barrel selection
* Adding a task for veto efficiency analysis
* Adding a table containing distances to the closest FIT trigger signals wrt a UPC candidate