### PR TITLE
[PWGJE] adding TRD checks

### DIFF
--- a/PWGJE/Tasks/trackJetqa.cxx
+++ b/PWGJE/Tasks/trackJetqa.cxx
@@ -230,7 +230,7 @@ struct TrackJetQa {
       histos.fill(HIST("Kine/pt_TRD"), track.pt());
       histos.fill(HIST("TrackPar/Sigma1Pt_hasTRD"), track.pt(), track.sigma1Pt() * track.pt());
     }
-    if (!track.hasTRD()){
+    if (!track.hasTRD()) {
       histos.fill(HIST("TrackPar/Sigma1Pt_hasNoTRD"), track.pt(), track.sigma1Pt() * track.pt());
     }
     histos.fill(HIST("Kine/eta"), track.pt(), track.eta());


### PR DESCRIPTION
Hi @nzardosh ,

we observe a strong splitting in sigma(1/pT) vs pT and would like to do additional checks for tracks w/o TRD.

Cheerio,
Johanna