### PR TITLE
PWGHF: implement track selections for bachelor in lfCascade+bachelor decays

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -240,7 +240,7 @@ struct HfCandidateCreatorToXiPi {
         for (const auto& trackIndexPion : groupedTrackIndices) {
 
           // use bachelor selections from HfTrackIndexSkimCreatorTagSelTracks --> bit =2 is CandidateType::CandV0bachelor
-          if (!TESTBIT(trackIndexPion.isSelProng(), 2)) {
+          if (!TESTBIT(trackIndexPion.isSelProng(), 4)) {
             continue;
           }
 

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -239,7 +239,7 @@ struct HfCandidateCreatorToXiPi {
         auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (const auto& trackIndexPion : groupedTrackIndices) {
 
-          // use bachelor selections from HfTrackIndexSkimCreatorTagSelTracks --> bit =2 is CandidateType::CandV0bachelor
+          // use bachelor selections from HfTrackIndexSkimCreatorTagSelTracks --> bit = 4 is CandidateType::CandCascadeBachelor
           if (!TESTBIT(trackIndexPion.isSelProng(), 4)) {
             continue;
           }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -442,7 +442,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     if (fillHistograms) {
       // general tracks
-      registry.add("hRejTracks", "Tracks;;entries", {HistType::kTH1F, {{20, 0.5, 20.5}}});
+      registry.add("hRejTracks", "Tracks;;entries", {HistType::kTH1F, {{25, 0.5, 25.5}}});
       registry.add("hPtNoCuts", "all tracks;#it{p}_{T}^{track} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
 
       // 2-prong histograms


### PR DESCRIPTION
Modify the struct HfTrackIndexSkimCreatorTagSelTracks to implement a set of selection dedicated to the bachelor track in LF cascade+bachelor decays. Until now the selections dedicated to bachelor track of V0+bachelor decays were used also for the above-mentioned channel.