### PR TITLE
PWGEM/PhotonMeson: remove unnecessary PHOS/EMC dep. in MaterialBudgey

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/MaterialBudget.cxx
+++ b/PWGEM/PhotonMeson/Tasks/MaterialBudget.cxx
@@ -43,7 +43,7 @@ using namespace o2::framework::expressions;
 using namespace o2::soa;
 using namespace o2::aod::photonpair;
 
-using MyCollisions = soa::Join<aod::EMReducedEvents, aod::EMReducedEventsMult, aod::EMReducedEventsCent, aod::EMReducedEventsNgPCM, aod::EMReducedEventsNgPHOS, aod::EMReducedEventsNgEMC>;
+using MyCollisions = soa::Join<aod::EMReducedEvents, aod::EMReducedEventsMult, aod::EMReducedEventsCent, aod::EMReducedEventsNgPCM>;
 using MyCollision = MyCollisions::iterator;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;


### PR DESCRIPTION
PWGEM/PhotonMeson: remove unnecessary PHOS/EMC dep. in MaterialBudget