### PR TITLE
Added precision for cosines

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
@@ -310,7 +310,7 @@ struct createPCM {
               pvec0[0], pvec0[1], pvec0[2],
               pvec1[0], pvec1[1], pvec1[2],
               v0dca, pos.dcaXY(), ele.dcaXY(),
-              TMath::ACos(v0CosinePA), dcaV0toPV);
+              std::acos(v0CosinePA), dcaV0toPV);
     } else {
       // LOGF(info, "storing: collision.globalIndex() = %d , pos.globalIndex() = %d , ele.globalIndex() = %d, cospa = %f", collision.globalIndex(), pos.globalIndex(), ele.globalIndex(), v0CosinePA);
       pca_map[std::make_tuple(pos.globalIndex(), ele.globalIndex(), collision.globalIndex())] = v0dca;

--- a/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
@@ -283,7 +283,7 @@ struct createPCM {
     std::array<float, 3> pvxyz{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]};
 
     float v0dca = std::sqrt(fitter.getChi2AtPCACandidate()); // distance between 2 legs.
-    float v0CosinePA = RecoDecay::cpa(pVtx, svpos, pvxyz);
+    double v0CosinePA = RecoDecay::cpa(pVtx, svpos, pvxyz);
     float v0radius = RecoDecay::sqrtSumOfSquares(svpos[0], svpos[1]);
     float dcaV0toPV = calculateDCAStraightToPV(svpos[0], svpos[1], svpos[2], pvxyz[0], pvxyz[1], pvxyz[2], pVtx[0], pVtx[1], pVtx[2]);
 
@@ -310,7 +310,7 @@ struct createPCM {
               pvec0[0], pvec0[1], pvec0[2],
               pvec1[0], pvec1[1], pvec1[2],
               v0dca, pos.dcaXY(), ele.dcaXY(),
-              v0CosinePA, dcaV0toPV);
+              TMath::ACos(v0CosinePA), dcaV0toPV);
     } else {
       // LOGF(info, "storing: collision.globalIndex() = %d , pos.globalIndex() = %d , ele.globalIndex() = %d, cospa = %f", collision.globalIndex(), pos.globalIndex(), ele.globalIndex(), v0CosinePA);
       pca_map[std::make_tuple(pos.globalIndex(), ele.globalIndex(), collision.globalIndex())] = v0dca;

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -611,13 +611,14 @@ DECLARE_SOA_TABLE(HfCandCascBase, "AOD", "HFCANDCASCBASE", //!
                   v0data::DCAV0Daughters,
                   v0data::DCAPosToPV, // this is the impact param wrt prim vtx in xy!
                   v0data::DCANegToPV, // this is the impact param wrt prim vtx in xy!
-                  v0data::V0CosPA,
+                  v0data::V0PA,
                   /* dynamic columns */
                   hf_cand_2prong::M<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_cand_2prong::M2<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_cand_2prong::ImpactParameterProduct<hf_cand::ImpactParameter0, hf_cand::ImpactParameter1>,
                   hf_cand_2prong::CosThetaStar<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_cand_2prong::ImpactParameterProngSqSum<hf_cand::ImpactParameter0, hf_cand::ImpactParameter1>,
+                  v0data::V0CosPA<v0data::V0PA>,
                   /* dynamic columns that use candidate momentum components */
                   hf_cand::Pt<hf_cand_casc::Px, hf_cand_casc::Py>,
                   hf_cand::Pt2<hf_cand_casc::Px, hf_cand_casc::Py>,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -142,7 +142,7 @@ DECLARE_SOA_COLUMN(Z, z, float);         //! decay position Z
 DECLARE_SOA_COLUMN(DCAV0Daughters, dcaV0daughters, float); //! DCA between V0 daughters
 DECLARE_SOA_COLUMN(DCAPosToPV, dcapostopv, float);         //! DCA positive prong to PV
 DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative prong to PV
-DECLARE_SOA_COLUMN(V0PA, v0PA, float);               //! V0 pointing angle
+DECLARE_SOA_COLUMN(V0PA, v0PA, float);                     //! V0 pointing angle
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
 // Saved from finding: covariance matrix of parent track (on request)

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -142,7 +142,7 @@ DECLARE_SOA_COLUMN(Z, z, float);         //! decay position Z
 DECLARE_SOA_COLUMN(DCAV0Daughters, dcaV0daughters, float); //! DCA between V0 daughters
 DECLARE_SOA_COLUMN(DCAPosToPV, dcapostopv, float);         //! DCA positive prong to PV
 DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative prong to PV
-DECLARE_SOA_COLUMN(V0PA, v0PA, float);               //! V0 CosPA
+DECLARE_SOA_COLUMN(V0PA, v0PA, float);               //! V0 pointing angle
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
 // Saved from finding: covariance matrix of parent track (on request)

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -142,7 +142,7 @@ DECLARE_SOA_COLUMN(Z, z, float);         //! decay position Z
 DECLARE_SOA_COLUMN(DCAV0Daughters, dcaV0daughters, float); //! DCA between V0 daughters
 DECLARE_SOA_COLUMN(DCAPosToPV, dcapostopv, float);         //! DCA positive prong to PV
 DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative prong to PV
-DECLARE_SOA_COLUMN(V0CosPA, v0cosPA, float);               //! V0 CosPA
+DECLARE_SOA_COLUMN(V0PA, v0PA, float);               //! V0 CosPA
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
 // Saved from finding: covariance matrix of parent track (on request)
@@ -214,6 +214,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(PtAntiHypertriton, ptAntiHypertriton, //! V0 pT
 // Length quantities
 DECLARE_SOA_DYNAMIC_COLUMN(V0Radius, v0radius, //! V0 decay radius (2D, centered at zero)
                            [](float x, float y) -> float { return RecoDecay::sqrtSumOfSquares(x, y); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(V0CosPA, v0cosPA, //! Cosine of pointing angle (double precision please)
+                           [](float x) -> double { return std::cos(static_cast<double>(x)); });
 
 // Distance Over To Mom
 DECLARE_SOA_DYNAMIC_COLUMN(DistOverTotMom, distovertotmom, //! PV to V0decay distance over total momentum
@@ -344,12 +347,13 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::PxPos, v0data::PyPos, v0data::PzPos,
                        v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
                        v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
-                       v0data::V0CosPA, v0data::DCAV0ToPV,
+                       v0data::V0PA, v0data::DCAV0ToPV,
 
                        // Dynamic columns
                        v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
                        v0data::PtAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
                        v0data::V0Radius<v0data::X, v0data::Y>,
+                       v0data::V0CosPA<v0data::V0PA>,
                        v0data::DistOverTotMom<v0data::X, v0data::Y, v0data::Z, v0data::Px, v0data::Py, v0data::Pz>,
                        v0data::Alpha<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::QtArm<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
@@ -589,9 +593,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(CascRadius, cascradius, //!
 
 // CosPAs
 DECLARE_SOA_DYNAMIC_COLUMN(V0CosPA, v0cosPA, //!
-                           [](float Xlambda, float Ylambda, float Zlambda, float PxLambda, float PyLambda, float PzLambda, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{Xlambda, Ylambda, Zlambda}, std::array{PxLambda, PyLambda, PzLambda}); });
+                           [](float Xlambda, float Ylambda, float Zlambda, float PxLambda, float PyLambda, float PzLambda, float pvX, float pvY, float pvZ) -> double { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{Xlambda, Ylambda, Zlambda}, std::array{PxLambda, PyLambda, PzLambda}); });
 DECLARE_SOA_DYNAMIC_COLUMN(CascCosPA, casccosPA, //!
-                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{X, Y, Z}, std::array{Px, Py, Pz}); });
+                           [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> double { return RecoDecay::cpa(std::array{pvX, pvY, pvZ}, std::array{X, Y, Z}, std::array{Px, Py, Pz}); });
 DECLARE_SOA_DYNAMIC_COLUMN(DCAV0ToPV, dcav0topv, //!
                            [](float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ) -> float { return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz)); });
 

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -779,7 +779,7 @@ struct lambdakzeroBuilder {
               v0candidate.dcaV0dau,
               v0candidate.posDCAxy,
               v0candidate.negDCAxy,
-              TMath::ACos(v0candidate.cosPA),
+              std::acos(v0candidate.cosPA),
               v0candidate.dcav0topv);
 
       // populate V0 covariance matrices if required by any other task

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -195,7 +195,7 @@ struct lambdakzeroBuilder {
     float dcaV0dau;
     float posDCAxy;
     float negDCAxy;
-    float cosPA;
+    double cosPA;
     float dcav0topv;
     float V0radius;
     float lambdaMass;
@@ -779,7 +779,7 @@ struct lambdakzeroBuilder {
               v0candidate.dcaV0dau,
               v0candidate.posDCAxy,
               v0candidate.negDCAxy,
-              v0candidate.cosPA,
+              TMath::ACos(v0candidate.cosPA),
               v0candidate.dcav0topv);
 
       // populate V0 covariance matrices if required by any other task

--- a/PWGLF/TableProducer/lambdakzerofinder.cxx
+++ b/PWGLF/TableProducer/lambdakzerofinder.cxx
@@ -289,7 +289,7 @@ struct lambdakzerofinder {
             pvec0[0], pvec0[1], pvec0[2],
             pvec1[0], pvec1[1], pvec1[2],
             TMath::Sqrt(fitter.getChi2AtPCACandidate()),
-            t1.dcaXY(), t2.dcaXY(), TMath::ACos(cosPA), smallestDCA);
+            t1.dcaXY(), t2.dcaXY(), std::acos(cosPA), smallestDCA);
     v0datalink(v0cores.lastIndex());
     return 1;
   }

--- a/PWGLF/TableProducer/lambdakzerofinder.cxx
+++ b/PWGLF/TableProducer/lambdakzerofinder.cxx
@@ -289,7 +289,7 @@ struct lambdakzerofinder {
             pvec0[0], pvec0[1], pvec0[2],
             pvec1[0], pvec1[1], pvec1[2],
             TMath::Sqrt(fitter.getChi2AtPCACandidate()),
-            t1.dcaXY(), t2.dcaXY(), cosPA, smallestDCA);
+            t1.dcaXY(), t2.dcaXY(), TMath::ACos(cosPA), smallestDCA);
     v0datalink(v0cores.lastIndex());
     return 1;
   }


### PR DESCRIPTION
Following an offline discussing with @nepeivodaRS , we realised the V0 table implementation that stores *cosines* of pointing angles may be imprecise (also because of the known problem that the derivative of cos(x) goes to zero as x goes to zero). To improve, we now store the *pointing angle* itself in the table and calculate the cosine on-the-fly with `std::cos` for V0s. The CosPA dynamics for cascades have also been (mostly transparently) changed to return double-precision quantities. 