### PR TITLE
PWGJE: Adding configurable for pTHat cut

### DIFF
--- a/PWGJE/Tasks/jetfinderQA.cxx
+++ b/PWGJE/Tasks/jetfinderQA.cxx
@@ -51,6 +51,8 @@ struct JetFinderQATask {
   Configurable<float> trackEtaMax{"trackEtaMax", 0.9, "maximum eta acceptance for tracks"};
   Configurable<float> trackPtMin{"trackPtMin", 0.15, "minimum pT acceptance for tracks"};
   Configurable<float> trackPtMax{"trackPtMax", 100.0, "maximum pT acceptance for tracks"};
+  Configurable<float> pTHatCutDetector{"pTHatCutDetector", 999.0, "maximum fraction of hard scattering for jet acceptance in detector MC"};
+  Configurable<float> pTHatCutParticle{"pTHatCutParticle", 999.0, "maximum fraction of hard scattering for jet acceptance in particle MC"};
   Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
   std::vector<bool> filledJetR;
   std::vector<double> jetRadiiValues;
@@ -176,6 +178,11 @@ struct JetFinderQATask {
   void fillHistograms(T const& jet, float weight = 1.0)
   {
 
+    double pTHat = 10. / (std::pow(weight, 1.0 / 6.0));
+    if (jet.pt() > pTHatCutDetector * pTHat) {
+      return;
+    }
+
     if (jet.r() == round(selectedJetsRadius * 100.0f)) {
       registry.fill(HIST("h_jet_pt"), jet.pt(), weight);
       registry.fill(HIST("h_jet_eta"), jet.eta(), weight);
@@ -201,6 +208,11 @@ struct JetFinderQATask {
   void fillMCPHistograms(T const& jet, float weight = 1.0)
   {
 
+    double pTHat = 10. / (std::pow(weight, 1.0 / 6.0));
+    if (jet.pt() > pTHatCutParticle * pTHat) {
+      return;
+    }
+
     if (jet.r() == round(selectedJetsRadius * 100.0f)) {
       registry.fill(HIST("h_jet_pt_part"), jet.pt(), weight);
       registry.fill(HIST("h_jet_eta_part"), jet.eta(), weight);
@@ -224,7 +236,17 @@ struct JetFinderQATask {
   template <typename T, typename U>
   void fillMCMatchedHistograms(T const& mcdjet, float weight = 1.0)
   {
+
+    double pTHat = 10. / (std::pow(weight, 1.0 / 6.0));
+    if (mcdjet.pt() > pTHatCutDetector * pTHat) {
+      return;
+    }
+
     for (auto& mcpjet : mcdjet.template matchedJetGeo_as<std::decay_t<U>>()) {
+
+      if (mcpjet.pt() > pTHatCutParticle * pTHat) {
+        continue;
+      }
 
       registry.fill(HIST("h3_jet_r_jet_pt_part_jet_pt"), mcdjet.r() / 100.0, mcpjet.pt(), mcdjet.pt(), weight);
       registry.fill(HIST("h3_jet_r_jet_eta_part_jet_eta"), mcdjet.r() / 100.0, mcpjet.eta(), mcdjet.eta(), weight);


### PR DESCRIPTION
Adding a configurable option for the pTHat cut in weighted MC, details of which have been discussed at previous O2 development meetings. Default value is 999.0 