### PR TITLE
[PWGJE] fix track table production and isEventSelected()

### DIFF
--- a/PWGJE/TableProducer/jettrackderived.cxx
+++ b/PWGJE/TableProducer/jettrackderived.cxx
@@ -162,48 +162,48 @@ struct jetspectraDerivedMaker {
   void processData(CollisionCandidate const& collisions,
                    TrackCandidates const& tracks)
   {
-    for (const auto& collision : collisions){
-      if(!isEventSelected(collision)){
+    for (const auto& collision : collisions) {
+      if (!isEventSelected(collision)) {
         histos.fill(HIST("EventProp/rejectedCollId"), 1);
       }
     }
     tableTrack.reserve(tracks.size());
     for (const auto& trk : tracks) {
-      if (!customTrackCuts.IsSelected(trk)) {// we fill all tracks that have a collision(rejected or not) and pass this check !
+      if (!customTrackCuts.IsSelected(trk)) { // we fill all tracks that have a collision(rejected or not) and pass this check !
         continue;
-      }else{
-      tableTrack(trk.collisionId(),
-                 trk.trackTime(),
-                 trk.signed1Pt(), trk.eta(), trk.phi(), trk.pt(),
-                 trk.sigma1Pt(),
-                 trk.alpha(),
-                 trk.x(), trk.y(), trk.z(),
-                 trk.snp(),
-                 trk.tgl(),
-                 trk.isPVContributor(),
-                 trk.hasTRD(),
-                 trk.hasITS(),
-                 trk.hasTPC(),
-                 trk.isGlobalTrack(),
-                 trk.isGlobalTrackWoDCA(),
-                 trk.isGlobalTrackWoPtEta(),
-                 trk.flags(),
-                 trk.trackType(),
-                 trk.length(),
-                 trk.tpcChi2NCl(), trk.itsChi2NCl(), trk.tofChi2(),
-                 trk.tpcNClsShared(),
-                 trk.tpcNClsFindable(),
-                 trk.tpcNClsFindableMinusFound(),
-                 trk.tpcNClsFindableMinusCrossedRows(),
-                 trk.itsClusterMap(),
-                 trk.itsNCls(),
-                 trk.tpcFractionSharedCls(),
-                 trk.tpcNClsFound(),
-                 trk.tpcNClsCrossedRows(),
-                 trk.tpcCrossedRowsOverFindableCls(),
-                 trk.tpcFoundOverFindableCls(),
-                 trk.dcaXY(),
-                 trk.dcaZ());
+      } else {
+        tableTrack(trk.collisionId(),
+                   trk.trackTime(),
+                   trk.signed1Pt(), trk.eta(), trk.phi(), trk.pt(),
+                   trk.sigma1Pt(),
+                   trk.alpha(),
+                   trk.x(), trk.y(), trk.z(),
+                   trk.snp(),
+                   trk.tgl(),
+                   trk.isPVContributor(),
+                   trk.hasTRD(),
+                   trk.hasITS(),
+                   trk.hasTPC(),
+                   trk.isGlobalTrack(),
+                   trk.isGlobalTrackWoDCA(),
+                   trk.isGlobalTrackWoPtEta(),
+                   trk.flags(),
+                   trk.trackType(),
+                   trk.length(),
+                   trk.tpcChi2NCl(), trk.itsChi2NCl(), trk.tofChi2(),
+                   trk.tpcNClsShared(),
+                   trk.tpcNClsFindable(),
+                   trk.tpcNClsFindableMinusFound(),
+                   trk.tpcNClsFindableMinusCrossedRows(),
+                   trk.itsClusterMap(),
+                   trk.itsNCls(),
+                   trk.tpcFractionSharedCls(),
+                   trk.tpcNClsFound(),
+                   trk.tpcNClsCrossedRows(),
+                   trk.tpcCrossedRowsOverFindableCls(),
+                   trk.tpcFoundOverFindableCls(),
+                   trk.dcaXY(),
+                   trk.dcaZ());
       }
     }
   }

--- a/PWGJE/TableProducer/jettrackderived.cxx
+++ b/PWGJE/TableProducer/jettrackderived.cxx
@@ -109,6 +109,7 @@ struct jetspectraDerivedMaker {
     histos.add("EventProp/collisionVtxZSel8", "Collsion Vertex Z with event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/sampledvertexz", "Sampled collsion Vertex Z with event (sel8) selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/NumContrib", "Number of contributors to vertex of collision; number of contributors to vtx; number of entries", HistType::kTH1F, {{nBins, 0, 600}});
+    histos.add("EventProp/rejectedCollId", "CollisionId of collisions that did not pass the event selection; collisionId; number of entries", HistType::kTH1F, {{10, 0, 5}});
 
     const AxisSpec axisPercentileFT0A{binsPercentile, "Centrality FT0A"};
     const AxisSpec axisPercentileFT0C{binsPercentile, "Centrality FT0C"};
@@ -128,48 +129,49 @@ struct jetspectraDerivedMaker {
   {
     // here we already fill some event histos for cross checks
     if (!collision.sel8()) {
+      histos.fill(HIST("EventProp/rejectedCollId"), 2);
       return false;
     }
 
     if (abs(collision.posZ()) > ValVtx) {
+      histos.fill(HIST("EventProp/rejectedCollId"), 3);
       return false;
     }
     histos.fill(HIST("EventProp/collisionVtxZ"), collision.posZ());                                                              // test fill
                                                                                                                                  //  Last thing, check the sampling
     if (fractionOfEvents < 1.f && (static_cast<float>(rand_r(&randomSeed)) / static_cast<float>(RAND_MAX)) > fractionOfEvents) { // Skip events that are not sampled
+      histos.fill(HIST("EventProp/rejectedCollId"), 4);
       return false;
     }
     histos.fill(HIST("EventProp/sampledvertexz"), collision.posZ());
     histos.fill(HIST("EventProp/NumContrib"), collision.numContrib());
-    return true;
-
-    if (fillMultiplicity) {
-      histos.fill(HIST("Centrality/FT0M"), collision.centFT0M());
+    if (fillMultiplicity == true) {
       histos.fill(HIST("Centrality/FT0A"), collision.centFT0A());
-      histos.fill(HIST("Mult/FT0M"), collision.multFT0M());
+      histos.fill(HIST("Centrality/FT0C"), collision.centFT0C());
+      histos.fill(HIST("Mult/FT0C"), collision.multFT0C());
       histos.fill(HIST("Mult/FT0A"), collision.multFT0A());
       histos.fill(HIST("Mult/NTracksPV"), collision.multNTracksPV());
     }
+    return true;
   }
 
   Produces<o2::aod::JeTracks> tableTrack;
   using CollisionCandidate = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
   using TrackCandidates = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov>;
   unsigned int randomSeed = 0;
-  void processData(CollisionCandidate::iterator const& collision,
-                   TrackCandidates const& tracks,
-                   aod::BCs const&)
+  void processData(CollisionCandidate const& collisions,
+                   TrackCandidates const& tracks)
   {
-    if (!isEventSelected(collision)) {
-      return;
+    for (const auto& collision : collisions){
+      if(!isEventSelected(collision)){
+        histos.fill(HIST("EventProp/rejectedCollId"), 1);
+      }
     }
+    tableTrack.reserve(tracks.size());
     for (const auto& trk : tracks) {
-      if (!trk.has_collision() || !(collision.globalIndex() == trk.collisionId())) {
-        return;
-      }
-      if (!customTrackCuts.IsSelected(trk)) {
-        return;
-      }
+      if (!customTrackCuts.IsSelected(trk)) {// we fill all tracks that have a collision(rejected or not) and pass this check !
+        continue;
+      }else{
       tableTrack(trk.collisionId(),
                  trk.trackTime(),
                  trk.signed1Pt(), trk.eta(), trk.phi(), trk.pt(),
@@ -202,6 +204,7 @@ struct jetspectraDerivedMaker {
                  trk.tpcFoundOverFindableCls(),
                  trk.dcaXY(),
                  trk.dcaZ());
+      }
     }
   }
 

--- a/PWGJE/Tasks/trackJetqa.cxx
+++ b/PWGJE/Tasks/trackJetqa.cxx
@@ -145,7 +145,7 @@ struct TrackJetQa {
     histos.add("EventProp/collisionVtxZnoSel", "Collsion Vertex Z without event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/collisionVtxZSel8", "Collsion Vertex Z with event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/rejectedCollId", "CollisionId of collisions that did not pass the event selection; collisionId; number of entries", HistType::kTH1F, {{10, 0, 5}});
-    
+
     // Common axes
     const AxisSpec axisPercentileFT0M{binsPercentile, "Centrality FT0M"};
     const AxisSpec axisPercentileFT0A{binsPercentile, "Centrality FT0A"};
@@ -322,10 +322,10 @@ struct TrackJetQa {
   using TrackCandidates = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov>;
 
   void processFull(CollisionCandidate const& collisions,
-                  TrackCandidates const& tracks)
+                   TrackCandidates const& tracks)
   {
     for (const auto& collision : collisions) {
-      if(fillEventQa(collision)){
+      if (fillEventQa(collision)) {
 
         if (fillMultiplicity) {
           histos.fill(HIST("Centrality/FT0M"), collision.centFT0M());
@@ -335,8 +335,8 @@ struct TrackJetQa {
         auto tracksInCollision = tracks.sliceBy(trackPerColl, collision.globalIndex());
 
         for (const auto& track : tracksInCollision) {
-          if (track.has_collision() && (collision.globalIndex() == track.collisionId())) {//double check
-            if(fillTrackQa(track)){
+          if (track.has_collision() && (collision.globalIndex() == track.collisionId())) { // double check
+            if (fillTrackQa(track)) {
               if (fillMultiplicity) {
                 histos.fill(HIST("TrackEventPar/Sigma1PtFT0Mcent"), collision.centFT0M(), track.pt(), track.sigma1Pt());
                 histos.fill(HIST("TrackEventPar/MultCorrelations"), track.sigma1Pt(), track.pt(), collision.centFT0A(), collision.centFT0C(), collision.multFT0A(), collision.multFT0C(), collision.multNTracksPV());
@@ -344,8 +344,7 @@ struct TrackJetQa {
             }
           }
         }
-      }
-      else{
+      } else {
         histos.fill(HIST("EventProp/rejectedCollId"), 1);
       }
     }

--- a/PWGJE/Tasks/trackJetqa.cxx
+++ b/PWGJE/Tasks/trackJetqa.cxx
@@ -144,6 +144,8 @@ struct TrackJetQa {
     histos.add("EventProp/collisionVtxZ", "Collsion Vertex Z;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/collisionVtxZnoSel", "Collsion Vertex Z without event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
     histos.add("EventProp/collisionVtxZSel8", "Collsion Vertex Z with event selection;#it{Vtx}_{z} [cm];number of entries", HistType::kTH1F, {{nBins, -20, 20}});
+    histos.add("EventProp/rejectedCollId", "CollisionId of collisions that did not pass the event selection; collisionId; number of entries", HistType::kTH1F, {{10, 0, 5}});
+    
     // Common axes
     const AxisSpec axisPercentileFT0M{binsPercentile, "Centrality FT0M"};
     const AxisSpec axisPercentileFT0A{binsPercentile, "Centrality FT0A"};
@@ -187,16 +189,18 @@ struct TrackJetQa {
   }
 
   template <typename eventInfo>
-  void fillEventQa(eventInfo const& collision)
+  bool fillEventQa(eventInfo const& collision)
   {
     // fill event property variables
     histos.fill(HIST("EventProp/collisionVtxZnoSel"), collision.posZ());
     if (!collision.sel8()) {
-      return;
+      histos.fill(HIST("EventProp/rejectedCollId"), 2);
+      return false;
     }
     histos.fill(HIST("EventProp/collisionVtxZSel8"), collision.posZ());
     if (fabs(collision.posZ()) > ValVtx) {
-      return;
+      histos.fill(HIST("EventProp/rejectedCollId"), 3);
+      return false;
     }
     histos.fill(HIST("EventProp/collisionVtxZ"), collision.posZ());
     if (fillMultiplicity) {
@@ -206,23 +210,24 @@ struct TrackJetQa {
       histos.fill(HIST("Mult/FT0A"), collision.multFT0A());
       histos.fill(HIST("Mult/FT0C"), collision.multFT0C());
     }
+    return true;
   }
 
   template <typename Tracks>
-  void fillTrackQa(Tracks const& track)
+  bool fillTrackQa(Tracks const& track)
   {
     // check track selection
     if ((globalTrack == true) && (!track.isGlobalTrack())) {
-      return;
+      return false;
     }
     if ((globalTrackWoDCA == true) && (!track.isGlobalTrackWoDCA())) {
-      return;
+      return false;
     }
     if ((globalTrackWoPtEta == true) && (!track.isGlobalTrackWoPtEta())) {
-      return;
+      return false;
     }
     if ((customTrack == true) && (!customTrackCuts.IsSelected(track))) {
-      return;
+      return false;
     }
     // fill kinematic variables
     histos.fill(HIST("Kine/pt"), track.pt());
@@ -306,29 +311,42 @@ struct TrackJetQa {
     histos.fill(HIST("TPC/tpcCrossedRowsOverFindableCls"), track.pt(), track.tpcCrossedRowsOverFindableCls());
     histos.fill(HIST("TPC/tpcFractionSharedCls"), track.pt(), track.tpcFractionSharedCls());
     histos.fill(HIST("TPC/tpcChi2NCl"), track.pt(), track.tpcChi2NCl());
+
+    return true;
   }
 
   // Preslice<soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov>> trackPerColl = aod::track::collisionId;
   Preslice<aod::Track> trackPerColl = aod::track::collisionId;
   // SliceCache cacheTrk;
-  void processFull(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs> const& collisions,
-                   soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov> const& tracks)
+  using CollisionCandidate = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
+  using TrackCandidates = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov>;
+
+  void processFull(CollisionCandidate const& collisions,
+                  TrackCandidates const& tracks)
   {
     for (const auto& collision : collisions) {
-      fillEventQa(collision);
-      if (fillMultiplicity) {
-        histos.fill(HIST("Centrality/FT0M"), collision.centFT0M());
-        histos.fill(HIST("Mult/FT0M"), collision.multFT0M());
-        histos.fill(HIST("Mult/MultCorrelations"), collision.centFT0A(), collision.centFT0C(), collision.multFT0A(), collision.multFT0C(), collision.multNTracksPV());
-      }
-      auto tracksInCollision = tracks.sliceBy(trackPerColl, collision.globalIndex());
+      if(fillEventQa(collision)){
 
-      for (const auto& track : tracksInCollision) {
-        fillTrackQa(track);
         if (fillMultiplicity) {
-          histos.fill(HIST("TrackEventPar/Sigma1PtFT0Mcent"), collision.centFT0M(), track.pt(), track.sigma1Pt());
-          histos.fill(HIST("TrackEventPar/MultCorrelations"), track.sigma1Pt(), track.pt(), collision.centFT0A(), collision.centFT0C(), collision.multFT0A(), collision.multFT0C(), collision.multNTracksPV());
+          histos.fill(HIST("Centrality/FT0M"), collision.centFT0M());
+          histos.fill(HIST("Mult/FT0M"), collision.multFT0M());
+          histos.fill(HIST("Mult/MultCorrelations"), collision.centFT0A(), collision.centFT0C(), collision.multFT0A(), collision.multFT0C(), collision.multNTracksPV());
         }
+        auto tracksInCollision = tracks.sliceBy(trackPerColl, collision.globalIndex());
+
+        for (const auto& track : tracksInCollision) {
+          if (track.has_collision() && (collision.globalIndex() == track.collisionId())) {//double check
+            if(fillTrackQa(track)){
+              if (fillMultiplicity) {
+                histos.fill(HIST("TrackEventPar/Sigma1PtFT0Mcent"), collision.centFT0M(), track.pt(), track.sigma1Pt());
+                histos.fill(HIST("TrackEventPar/MultCorrelations"), track.sigma1Pt(), track.pt(), collision.centFT0A(), collision.centFT0C(), collision.multFT0A(), collision.multFT0C(), collision.multNTracksPV());
+              }
+            }
+          }
+        }
+      }
+      else{
+        histos.fill(HIST("EventProp/rejectedCollId"), 1);
       }
     }
   }


### PR DESCRIPTION
Hi @alicecaluisi , @nzardosh ,

this fixes the method isEventSelected() in the trackJetqa and the table in the corresponding table producer.
I also added a rejection histogram to monitor how many collisions are not present in the full process (to explain the subtle difference in the number of tracks between the full and derived process).

Cheerio,
Johanna