### PR TITLE
PWGCF - adding DO mesons to FemtoUniverse

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -84,6 +84,18 @@ class FemtoUniverseDetaDphiStar
         }
       }
     }
+    if constexpr (mPartOneType == o2::aod::femtouniverseparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+      for (int i = 0; i < 2; i++) {
+        std::string dirName = static_cast<std::string>(dirNames[3]);
+        histdetadpi[i][0] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[0][i])).c_str(), "; #Delta #eta; #Delta #phi", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        histdetadpi[i][1] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[1][i])).c_str(), "; #Delta #eta; #Delta #phi", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        if (plotForEveryRadii) {
+          for (int j = 0; j < 9; j++) {
+            histdetadpiRadii[i][j] = mHistogramRegistryQA->add<TH2>((dirName + static_cast<std::string>(histNamesRadii[i][j])).c_str(), "; #Delta #eta; #Delta #phi", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+          }
+        }
+      }
+    }
   }
   ///  Check if pair is close or not
   template <typename Part, typename Parts>
@@ -113,6 +125,28 @@ class FemtoUniverseDetaDphiStar
       // check if provided particles are in agreement with the class instantiation
       if (part1.partType() != o2::aod::femtouniverseparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtouniverseparticle::ParticleType::kV0) {
         LOG(fatal) << "FemtoUniverseDetaDphiStar: passed arguments don't agree with FemtoUniverseDetaDphiStar instantiation! Please provide kTrack,kV0 candidates.";
+        return false;
+      }
+
+      bool pass = false;
+      for (int i = 0; i < 2; i++) {
+        auto indexOfDaughter = part2.index() - 2 + i;
+        auto daughter = particles.begin() + indexOfDaughter;
+        auto deta = part1.eta() - daughter.eta();
+        auto dphiAvg = AveragePhiStar(part1, *daughter, i);
+        histdetadpi[i][0]->Fill(deta, dphiAvg);
+        if (pow(dphiAvg, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
+          pass = true;
+        } else {
+          histdetadpi[i][1]->Fill(deta, dphiAvg);
+        }
+      }
+      return pass;
+    } else if constexpr (mPartOneType == o2::aod::femtouniverseparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+      /// Track-D0 combination
+      // check if provided particles are in agreement with the class instantiation
+      if (part1.partType() != o2::aod::femtouniverseparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtouniverseparticle::ParticleType::kD0) {
+        LOG(fatal) << "FemtoUniverseDetaDphiStar: passed arguments don't agree with FemtoUniverseDetaDphiStar instantiation! Please provide kTrack, kD0 candidates.";
         return false;
       }
 
@@ -161,7 +195,7 @@ class FemtoUniverseDetaDphiStar
  private:
   HistogramRegistry* mHistogramRegistry = nullptr;   ///< For main output
   HistogramRegistry* mHistogramRegistryQA = nullptr; ///< For QA output
-  static constexpr std::string_view dirNames[3] = {"kTrack_kTrack/", "kTrack_kV0/", "kTrack_kPhi/"};
+  static constexpr std::string_view dirNames[4] = {"kTrack_kTrack/", "kTrack_kV0/", "kTrack_kPhi/", "kTrack_kD0/"};
 
   static constexpr std::string_view histNames[2][2] = {{"detadphidetadphi0Before_0", "detadphidetadphi0Before_1"},
                                                        {"detadphidetadphi0After_0", "detadphidetadphi0After_1"}};

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h
@@ -84,6 +84,19 @@ class FemtoUniversePairCleaner
         return false;
       }
       return part1.globalIndex() != part2.globalIndex();
+    } else if constexpr (mPartOneType == o2::aod::femtouniverseparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+      /// Track-D0 combination part1 is hadron and part2 is D0
+      if (part2.partType() != o2::aod::femtouniverseparticle::ParticleType::kD0) {
+        LOG(fatal) << "FemtoUniversePairCleaner: passed arguments don't agree with FemtoUniversePairCleaner instantiation! Please provide second argument kD0 candidate.";
+        return false;
+      }
+      // Getting D0 (part2) children
+      const auto& posChild = particles.iteratorAt(part2.index() - 2);
+      const auto& negChild = particles.iteratorAt(part2.index() - 1);
+      if (part1.globalIndex() == posChild.globalIndex() || part1.globalIndex() == negChild.globalIndex()) {
+        return false;
+      }
+      return part1.globalIndex() != part2.globalIndex();
     } else if constexpr (mPartOneType == o2::aod::femtouniverseparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
       /// Track-Phi combination part1 is Phi and part 2 is hadron
       if (part1.partType() != o2::aod::femtouniverseparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtouniverseparticle::ParticleType::kPhi) {

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
@@ -143,6 +143,8 @@ class FemtoUniverseParticleHisto
       /// to be implemented
     } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
       // Phi histograms
+    } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+      // D0/D0bar histograms
     } else {
       LOG(fatal) << "FemtoUniverseParticleHisto: Histogramming for requested object not defined - quitting!";
     }
@@ -179,6 +181,9 @@ class FemtoUniverseParticleHisto
       } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
         // Phi histograms
         tempFitVarAxisTitle = "#Phi invariant mass";
+      } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+        // D0/D0bar histograms
+        tempFitVarAxisTitle = "D^{0}/#bar{D^{0}} invariant mass";
       } else {
         LOG(fatal) << "FemtoUniverseParticleHisto: Histogramming for requested object not defined - quitting!";
       }
@@ -317,6 +322,8 @@ class FemtoUniverseParticleHisto
         /// Cascade histograms
       } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
         // Phi histograms
+      } else if constexpr (mParticleType == o2::aod::femtouniverseparticle::ParticleType::kD0) {
+        // D0/D0bar histograms
       } else {
         LOG(fatal) << "FemtoUniverseParticleHisto: Histogramming for requested object not defined - quitting!";
       }

--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -62,7 +62,7 @@ enum ParticleType {
 };
 
 static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "MCTruthTracks", "V0", "V0Child", "Cascade", "CascadeBachelor", "Phi", "PhiChild", "D0", "D0Child"}; //! Naming of the different particle types
-static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hPDGvspT", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy"};
+static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hPDGvspT", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy", "/hInvMass", "/hDCAxy"};
 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -229,7 +229,7 @@ struct femtoUniverseProducerTask {
     Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 321, "Particle 2 - PDG code"};
   } ConfPhiChildTwo;
 
-  //D0/D0bar mesons
+  // D0/D0bar mesons
   struct : o2::framework::ConfigurableGroup {
     Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
     Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
@@ -706,14 +706,14 @@ struct femtoUniverseProducerTask {
     std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
     double invMassD0 = 0.0;
     double invMassD0bar = 0.0;
-    //phiCuts.fillQA<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild>(col, p1, p1, p2, ConfPhiChildOne.ConfPDGCodePartOne, ConfPhiChildTwo.ConfPDGCodePartTwo); ///\todo fill QA also for daughters
+    // phiCuts.fillQA<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild>(col, p1, p1, p2, ConfPhiChildOne.ConfPDGCodePartOne, ConfPhiChildTwo.ConfPDGCodePartTwo); ///\todo fill QA also for daughters
 
     for (auto const& hfCand : hfCands) {
 
       if (!(hfCand.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
         continue;
       }
-    
+
       if (ConfD0Selection.yCandMax >= 0. && std::abs(hfHelper.yD0(hfCand)) > ConfD0Selection.yCandMax) {
         continue;
       }
@@ -729,31 +729,28 @@ struct femtoUniverseProducerTask {
       if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
         invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = -hfHelper.invMassD0ToPiK(hfCand);
-      }
-      else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
+      } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
         invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = hfHelper.invMassD0ToPiK(hfCand);
-      }
-      else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
+      } else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
         invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = hfHelper.invMassD0ToPiK(hfCand);
-      }
-      else {
+      } else {
         invMassD0 = 0.0;
         invMassD0bar = 0.0;
       }
 
-      outputParts(outputCollision.lastIndex(), 
-        hfCand.ptProng0(),
-        -999, //eta
-        -999, //phi
-        aod::femtouniverseparticle::ParticleType::kD0Child,
-        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
-        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
-        -999,
-        childIDs,
-        0,  // D0 mass
-        0); // D0bar mass
+      outputParts(outputCollision.lastIndex(),
+                  hfCand.ptProng0(),
+                  -999, // eta
+                  -999, // phi
+                  aod::femtouniverseparticle::ParticleType::kD0Child,
+                  -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
+                  -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
+                  -999,
+                  childIDs,
+                  0,  // D0 mass
+                  0); // D0bar mass
       const int rowOfPosTrack = outputParts.lastIndex();
       /*if constexpr (isMC) {
         fillMCParticle(tracks, o2::aod::femtouniverseparticle::ParticleType::kDmesonChild);
@@ -765,16 +762,16 @@ struct femtoUniverseProducerTask {
       childIDs[1] = rowInPrimaryTrackTableNeg;
 
       outputParts(outputCollision.lastIndex(),
-        hfCand.ptProng1(),
-        -999, //eta
-        -999, //phi
-        aod::femtouniverseparticle::ParticleType::kD0Child,
-        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
-        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
-        -999,
-        childIDs,
-        0,
-        0);
+                  hfCand.ptProng1(),
+                  -999, // eta
+                  -999, // phi
+                  aod::femtouniverseparticle::ParticleType::kD0Child,
+                  -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
+                  -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
+                  -999,
+                  childIDs,
+                  0,
+                  0);
       const int rowOfNegTrack = outputParts.lastIndex();
       /*if constexpr (isMC) {
       fillMCParticle(p2, o2::aod::femtouniverseparticle::ParticleType::kDmesonChild);
@@ -782,21 +779,21 @@ struct femtoUniverseProducerTask {
       std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
 
       outputParts(outputCollision.lastIndex(),
-        hfCand.pt(),
-        hfCand.eta(),
-        hfCand.phi(),
-        aod::femtouniverseparticle::ParticleType::kD0,
-        -999, // cut, cutContainerType
-        -999, // PID, cutContainerType
-        -999,
-        indexChildID,
-        invMassD0,      // D0 mass (mLambda)
-        invMassD0bar);  // D0bar mass (mAntiLambda)
-    
+                  hfCand.pt(),
+                  hfCand.eta(),
+                  hfCand.phi(),
+                  aod::femtouniverseparticle::ParticleType::kD0,
+                  -999, // cut, cutContainerType
+                  -999, // PID, cutContainerType
+                  -999,
+                  indexChildID,
+                  invMassD0,     // D0 mass (mLambda)
+                  invMassD0bar); // D0bar mass (mAntiLambda)
+
       if (ConfIsDebug) {
-        fillDebugParticle<false, false, true>(postrack);   // QA for positive daughter
-        fillDebugParticle<false, false, true>(negtrack);   // QA for negative daughter
-        fillDebugParticle<false, false, true>(hfCand);  // QA for D0/D0bar
+        fillDebugParticle<false, false, true>(postrack); // QA for positive daughter
+        fillDebugParticle<false, false, true>(negtrack); // QA for negative daughter
+        fillDebugParticle<false, false, true>(hfCand);   // QA for D0/D0bar
       }
       if constexpr (isMC) {
         fillMCParticle(hfCand, o2::aod::femtouniverseparticle::ParticleType::kD0);
@@ -1080,11 +1077,11 @@ struct femtoUniverseProducerTask {
   PROCESS_SWITCH(femtoUniverseProducerTask, processTrackPhiData,
                  "Provide experimental data for track phi", false);
 
-  void 
+  void
     processTrackD0mesonData(aod::FemtoFullCollision const& col,
-                           aod::BCsWithTimestamps const&,
-                           soa::Filtered<aod::FemtoFullTracks> const& tracks,
-                           soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
+                            aod::BCsWithTimestamps const&,
+                            soa::Filtered<aod::FemtoFullTracks> const& tracks,
+                            soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -430,7 +430,7 @@ struct femtoUniverseProducerTask {
     mRunNumber = bc.runNumber();
   }
 
-  template <bool isTrackOrV0, bool isPhi, bool isD0, typename ParticleType>
+  template <bool isTrackOrV0, bool isPhiOrD0, typename ParticleType>
   void fillDebugParticle(ParticleType const& particle)
   {
     if constexpr (isTrackOrV0) {
@@ -446,20 +446,13 @@ struct femtoUniverseProducerTask {
                        particle.tofNSigmaStorePi(), particle.tofNSigmaStoreKa(),
                        particle.tofNSigmaStorePr(), particle.tofNSigmaStoreDe(),
                        -999., -999., -999., -999., -999., -999.);
-    } else if constexpr (isPhi) {
+    } else if constexpr (isPhiOrD0) {
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999.,
                        -999., -999.,
                        -999., -999., -999.,
-                       -999.); // QA for phi
-    } else if constexpr (isD0) {
-      outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999.,
-                       -999., -999.,
-                       -999., -999., -999.,
-                       -999.); // QA for D0/D0bar
+                       -999.); // QA for phi or D0/D0bar
     } else {
       LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhi);
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
@@ -599,7 +592,7 @@ struct femtoUniverseProducerTask {
                   track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
       if (ConfIsDebug) {
-        fillDebugParticle<true, false, false>(track);
+        fillDebugParticle<true, false>(track);
       }
 
       if constexpr (isMC) {
@@ -689,9 +682,9 @@ struct femtoUniverseProducerTask {
                   v0.mLambda(),
                   v0.mAntiLambda());
       if (ConfIsDebug) {
-        fillDebugParticle<true, false, false>(postrack); // QA for positive daughter
-        fillDebugParticle<true, false, false>(negtrack); // QA for negative daughter
-        fillDebugParticle<false, false, false>(v0);      // QA for v0
+        fillDebugParticle<true, false>(postrack); // QA for positive daughter
+        fillDebugParticle<true, false>(negtrack); // QA for negative daughter
+        fillDebugParticle<false, false>(v0);      // QA for v0
       }
       if constexpr (isMC) {
         fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);
@@ -791,9 +784,9 @@ struct femtoUniverseProducerTask {
                   invMassD0bar); // D0bar mass (mAntiLambda)
 
       if (ConfIsDebug) {
-        fillDebugParticle<false, false, true>(postrack); // QA for positive daughter
-        fillDebugParticle<false, false, true>(negtrack); // QA for negative daughter
-        fillDebugParticle<false, false, true>(hfCand);   // QA for D0/D0bar
+        fillDebugParticle<false, true>(postrack); // QA for positive daughter
+        fillDebugParticle<false, true>(negtrack); // QA for negative daughter
+        fillDebugParticle<false, true>(hfCand);   // QA for D0/D0bar
       }
       if constexpr (isMC) {
         fillMCParticle(hfCand, o2::aod::femtouniverseparticle::ParticleType::kD0);
@@ -908,9 +901,9 @@ struct femtoUniverseProducerTask {
                   -999); // v0.mAntiLambda()
 
       if (ConfIsDebug) {
-        fillDebugParticle<true, false, false>(p1); // QA for positive daughter
-        fillDebugParticle<true, false, false>(p2); // QA for negative daughter
-        fillDebugParticle<false, true, false>(p1); // QA for phi
+        fillDebugParticle<true, false>(p1); // QA for positive daughter
+        fillDebugParticle<true, false>(p2); // QA for negative daughter
+        fillDebugParticle<false, true>(p1); // QA for phi
       }
       // if constexpr (isMC) {
       //   fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -454,7 +454,7 @@ struct femtoUniverseProducerTask {
                        -999., -999., -999.,
                        -999.); // QA for phi or D0/D0bar
     } else {
-      LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhi);
+      LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhiOrD0);
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999.,

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -30,6 +30,9 @@
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUtils.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/Core/HfHelper.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
@@ -226,6 +229,16 @@ struct femtoUniverseProducerTask {
     Configurable<int> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 321, "Particle 2 - PDG code"};
   } ConfPhiChildTwo;
 
+  //D0/D0bar mesons
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
+    Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
+    Configurable<float> yCandMax{"yCandMax", 4.0, "max. cand. rapidity"};
+    Configurable<float> ptCandMin{"ptCandMin", -1., "min. cand. pT"};
+  } ConfD0Selection;
+
+  HfHelper hfHelper;
+
   bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
   {
     //|nsigma_TPC| < 5 for p < 0.4 GeV/c
@@ -288,10 +301,10 @@ struct femtoUniverseProducerTask {
 
   void init(InitContext&)
   {
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0) == false && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth) == false) {
+    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackD0mesonData) == false && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth) == false) {
       LOGF(fatal, "Neither processFullData nor processFullMC enabled. Please choose one.");
     }
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0) == true && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth) == true) {
+    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackD0mesonData) == true && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth) == true) {
       LOGF(fatal,
            "Cannot enable process Data and process MC at the same time. "
            "Please choose one.");
@@ -417,7 +430,7 @@ struct femtoUniverseProducerTask {
     mRunNumber = bc.runNumber();
   }
 
-  template <bool isTrackOrV0, bool isPhi, typename ParticleType>
+  template <bool isTrackOrV0, bool isPhi, bool isD0, typename ParticleType>
   void fillDebugParticle(ParticleType const& particle)
   {
     if constexpr (isTrackOrV0) {
@@ -440,6 +453,13 @@ struct femtoUniverseProducerTask {
                        -999., -999.,
                        -999., -999., -999.,
                        -999.); // QA for phi
+    } else if constexpr (isD0) {
+      outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       -999., -999.,
+                       -999., -999., -999.,
+                       -999.); // QA for D0/D0bar
     } else {
       LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhi);
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
@@ -579,7 +599,7 @@ struct femtoUniverseProducerTask {
                   track.dcaXY(), childIDs, 0, 0);
       tmpIDtrack.push_back(track.globalIndex());
       if (ConfIsDebug) {
-        fillDebugParticle<true, false>(track);
+        fillDebugParticle<true, false, false>(track);
       }
 
       if constexpr (isMC) {
@@ -669,12 +689,117 @@ struct femtoUniverseProducerTask {
                   v0.mLambda(),
                   v0.mAntiLambda());
       if (ConfIsDebug) {
-        fillDebugParticle<true, false>(postrack); // QA for positive daughter
-        fillDebugParticle<true, false>(negtrack); // QA for negative daughter
-        fillDebugParticle<false, false>(v0);      // QA for v0
+        fillDebugParticle<true, false, false>(postrack); // QA for positive daughter
+        fillDebugParticle<true, false, false>(negtrack); // QA for negative daughter
+        fillDebugParticle<false, false, false>(v0);      // QA for v0
       }
       if constexpr (isMC) {
         fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);
+      }
+    }
+  }
+
+  template <bool isMC, typename HfCandidate, typename TrackType, typename CollisionType>
+  void fillD0mesons(CollisionType const& col, TrackType const& tracks, HfCandidate const& hfCands)
+  {
+    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    double invMassD0 = 0.0;
+    double invMassD0bar = 0.0;
+    //phiCuts.fillQA<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild>(col, p1, p1, p2, ConfPhiChildOne.ConfPDGCodePartOne, ConfPhiChildTwo.ConfPDGCodePartTwo); ///\todo fill QA also for daughters
+
+    for (auto const& hfCand : hfCands) {
+
+      if (!(hfCand.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        continue;
+      }
+    
+      if (ConfD0Selection.yCandMax >= 0. && std::abs(hfHelper.yD0(hfCand)) > ConfD0Selection.yCandMax) {
+        continue;
+      }
+
+      int postrackID = hfCand.globalIndex();
+      int rowInPrimaryTrackTablePos = -1;
+      rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+      childIDs[0] = rowInPrimaryTrackTablePos;
+      childIDs[1] = 0;
+      auto postrack = hfCand.template prong0_as<TrackType>();
+      auto negtrack = hfCand.template prong1_as<TrackType>();
+
+      if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
+        invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = -hfHelper.invMassD0ToPiK(hfCand);
+      }
+      else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
+        invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = hfHelper.invMassD0ToPiK(hfCand);
+      }
+      else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
+        invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = hfHelper.invMassD0ToPiK(hfCand);
+      }
+      else {
+        invMassD0 = 0.0;
+        invMassD0bar = 0.0;
+      }
+
+      outputParts(outputCollision.lastIndex(), 
+        hfCand.ptProng0(),
+        -999, //eta
+        -999, //phi
+        aod::femtouniverseparticle::ParticleType::kD0Child,
+        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
+        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
+        -999,
+        childIDs,
+        0,  // D0 mass
+        0); // D0bar mass
+      const int rowOfPosTrack = outputParts.lastIndex();
+      /*if constexpr (isMC) {
+        fillMCParticle(tracks, o2::aod::femtouniverseparticle::ParticleType::kDmesonChild);
+      }*/
+      int negtrackID = hfCand.prong1().globalIndex();
+      int rowInPrimaryTrackTableNeg = -1;
+      rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+      childIDs[0] = 0;
+      childIDs[1] = rowInPrimaryTrackTableNeg;
+
+      outputParts(outputCollision.lastIndex(),
+        hfCand.ptProng1(),
+        -999, //eta
+        -999, //phi
+        aod::femtouniverseparticle::ParticleType::kD0Child,
+        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
+        -999, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
+        -999,
+        childIDs,
+        0,
+        0);
+      const int rowOfNegTrack = outputParts.lastIndex();
+      /*if constexpr (isMC) {
+      fillMCParticle(p2, o2::aod::femtouniverseparticle::ParticleType::kDmesonChild);
+      }*/
+      std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
+
+      outputParts(outputCollision.lastIndex(),
+        hfCand.pt(),
+        hfCand.eta(),
+        hfCand.phi(),
+        aod::femtouniverseparticle::ParticleType::kD0,
+        -999, // cut, cutContainerType
+        -999, // PID, cutContainerType
+        -999,
+        indexChildID,
+        invMassD0,      // D0 mass (mLambda)
+        invMassD0bar);  // D0bar mass (mAntiLambda)
+    
+      if (ConfIsDebug) {
+        fillDebugParticle<false, false, true>(postrack);   // QA for positive daughter
+        fillDebugParticle<false, false, true>(negtrack);   // QA for negative daughter
+        fillDebugParticle<false, false, true>(hfCand);  // QA for D0/D0bar
+      }
+      if constexpr (isMC) {
+        fillMCParticle(hfCand, o2::aod::femtouniverseparticle::ParticleType::kD0);
       }
     }
   }
@@ -786,9 +911,9 @@ struct femtoUniverseProducerTask {
                   -999); // v0.mAntiLambda()
 
       if (ConfIsDebug) {
-        fillDebugParticle<true, false>(p1); // QA for positive daughter
-        fillDebugParticle<true, false>(p2); // QA for negative daughter
-        fillDebugParticle<false, true>(p1); // QA for phi
+        fillDebugParticle<true, false, false>(p1); // QA for positive daughter
+        fillDebugParticle<true, false, false>(p2); // QA for negative daughter
+        fillDebugParticle<false, true, false>(p1); // QA for phi
       }
       // if constexpr (isMC) {
       //   fillMCParticle(v0, o2::aod::femtouniverseparticle::ParticleType::kV0);
@@ -954,6 +1079,22 @@ struct femtoUniverseProducerTask {
   }
   PROCESS_SWITCH(femtoUniverseProducerTask, processTrackPhiData,
                  "Provide experimental data for track phi", false);
+
+  void 
+    processTrackD0mesonData(aod::FemtoFullCollision const& col,
+                           aod::BCsWithTimestamps const&,
+                           soa::Filtered<aod::FemtoFullTracks> const& tracks,
+                           soa::Join<aod::HfCand2Prong, aod::HfSelD0> const& candidates)
+  {
+    // get magnetic field for run
+    getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    // fill the tables
+    fillCollisions<false>(col, tracks);
+    fillTracks<false>(tracks);
+    fillD0mesons<false>(col, tracks, candidates);
+  }
+  PROCESS_SWITCH(femtoUniverseProducerTask, processTrackD0mesonData,
+                 "Provide experimental data for track D0 meson", false);
 
   void
     processTrackMCTruth(aod::FemtoFullCollisionMC const& col,

--- a/PWGCF/FemtoUniverse/Tasks/CMakeLists.txt
+++ b/PWGCF/FemtoUniverse/Tasks/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(femtouniverse-pair-track-v0
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femtouniverse-pair-track-d0
+          SOURCES femtoUniversePairTaskTrackD0.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtouniverse-pair-track-phi
           SOURCES femtoUniversePairTaskTrackPhi.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -1,0 +1,546 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoUniversePairTaskTrackD0.cxx
+/// \brief Tasks that reads the track tables and D0/D0bar mesons
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Georgios Mantzaridis, TU München, georgios.mantzaridis@tum.de
+/// \author Anton Riedel, TU München, anton.riedel@tum.de
+/// \author Zuzanna Chochulska, WUT Warsaw, zuzanna.chochulska.stud@pw.edu.pl
+/// \author Katarzyna Gwiździel, WUT Warsaw, katarzyna.gwizdziel@cern.ch
+
+#include <vector>
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/StepTHn.h"
+#include "Framework/O2DatabasePDGPlugin.h"
+#include "TDatabasePDG.h"
+#include "ReconstructionDataFormats/PID.h"
+#include "Common/DataModel/PIDResponse.h"
+
+#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseAngularContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUtils.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
+
+using namespace o2;
+using namespace o2::analysis::femtoUniverse;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::soa;
+
+namespace
+{
+static constexpr int nPart = 2;
+static constexpr int nCuts = 5;
+static const std::vector<std::string> partNames{"D0", "Track"};
+static const std::vector<std::string> cutNames{"MaxPt", "PIDthr", "nSigmaTPC", "nSigmaTPCTOF", "MaxP"};
+static const float cutsTable[nPart][nCuts]{
+  {4.05f, 1.f, 3.f, 3.f, 100.f},
+  {4.05f, 1.f, 3.f, 3.f, 100.f}};
+} // namespace
+
+struct femtoUniversePairTaskTrackD0 {
+
+  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
+  SliceCache cache;
+  Preslice<FemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
+
+  /// Table for both particles
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<float> ConfNsigmaCombinedProton{"ConfNsigmaCombinedProton", 3.0, "TPC and TOF Proton Sigma (combined) for momentum > 0.5"};
+    Configurable<float> ConfNsigmaTPCProton{"ConfNsigmaTPCProton", 3.0, "TPC Proton Sigma for momentum < 0.5"};
+    Configurable<float> ConfNsigmaCombinedPion{"ConfNsigmaCombinedPion", 3.0, "TPC and TOF Pion Sigma (combined) for momentum > 0.5"};
+    Configurable<float> ConfNsigmaTPCPion{"ConfNsigmaTPCPion", 3.0, "TPC Pion Sigma for momentum < 0.5"};
+
+    Configurable<LabeledArray<float>> ConfCutTable{"ConfCutTable", {cutsTable[0], nPart, nCuts, partNames, cutNames}, "Particle selections"};
+    Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
+    Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+    Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
+    Configurable<bool> ConfUse3D{"ConfUse3D", false, "Enable three dimensional histogramms (to be used only for analysis with high statistics): k* vs mT vs multiplicity"};
+    Configurable<int> ConfPhiBins{"ConfPhiBins", 29, "Number of phi bins in deta dphi"};
+    Configurable<int> ConfEtaBins{"ConfEtaBins", 29, "Number of eta bins in deta dphi"};
+  } ConfBothTracks;
+
+  /// Particle 1 --- IDENTIFIED TRACK
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
+    Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "Particle 2 - PDG code"};
+    // Configurable<uint32_t> ConfCutTrack{"ConfCutTrack", 5542474, "Particle 2 - Selection bit"};
+    Configurable<int> ConfPIDTrack{"ConfPIDTrack", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
+    Configurable<int8_t> ConfTrackSign{"ConfTrackSign", 1, "Track sign"};
+    Configurable<bool> ConfIsTrackIdentified{"ConfIsTrackIdentified", true, "Enable PID for the track"};
+  } ConfTrack;
+
+  /// Particle 2 --- D0/D0bar meson
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> ConfPDGCodeD0{"ConfPDGCodeD0", 421, "D0 meson - PDG code"};
+    Configurable<int> ConfPDGCodeD0bar{"ConfPDGCodeD0bar", -421, "D0bar meson - PDG code"};
+  } ConfDmesons;
+
+  /// Partitions for particle 1
+  Partition<FemtoFullParticles> partsTrack = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == int8_t(ConfTrack.ConfTrackSign));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsTrackMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack));
+
+  /// Partitions for particle 2
+  Partition<FemtoFullParticles> partsD0D0bar = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsD0D0barMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0));
+
+  /// Histogramming for particle 1
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartTrack;
+
+  /// Histogramming for particle 2
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kD0, 0> trackHistoPartD0D0bar;
+
+  /// Histogramming for Event
+  FemtoUniverseEventHisto eventHisto;
+
+  /// The configurables need to be passed to an std::vector
+  int vPIDTrack;
+  std::vector<float> kNsigma;
+
+  /// particle part
+  ConfigurableAxis ConfTempFitVarBins{"ConfDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarInvMassBins{"ConfDTempFitVarInvMassBins", {6000, 0.9, 4.0}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTempFitVarpTBins{"ConfTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+
+  /// Correlation part
+  ConfigurableAxis ConfMultBins{"ConfMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
+  // ConfigurableAxis ConfMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
+  ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
+  ConfigurableAxis ConfmTBins3D{"ConfmTBins3D", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfBothTracks.ConfUse3D>> to true in order to use)"};
+  ConfigurableAxis ConfmultBins3D{"ConfmultBins3D", {VARIABLE_WIDTH, 0.0f, 20.0f, 30.0f, 40.0f, 99999.0f}, "multiplicity Binning for the 3Dimensional plot: k* vs multiplicity vs mT (set <<ConfBothTracks.ConfUse3D>> to true in order to use)"};
+
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+
+  ConfigurableAxis ConfkstarBins{"ConfkstarBins", {1500, 0., 6.}, "binning kstar"};
+  ConfigurableAxis ConfkTBins{"ConfkTBins", {150, 0., 9.}, "binning kT"};
+  ConfigurableAxis ConfmTBins{"ConfmTBins", {225, 0., 7.5}, "binning mT"};
+  Configurable<bool> ConfIsCPR{"ConfIsCPR", true, "Close Pair Rejection"};
+  Configurable<bool> ConfCPRPlotPerRadii{"ConfCPRPlotPerRadii", false, "Plot CPR per radii"};
+  Configurable<float> ConfCPRdeltaPhiMax{"ConfCPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+  Configurable<float> ConfCPRdeltaEtaMax{"ConfCPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+
+  FemtoUniverseFemtoContainer<femtoUniverseFemtoContainer::EventType::same, femtoUniverseFemtoContainer::Observable::kstar> sameEventFemtoCont;
+  FemtoUniverseFemtoContainer<femtoUniverseFemtoContainer::EventType::mixed, femtoUniverseFemtoContainer::Observable::kstar> mixedEventFemtoCont;
+  FemtoUniverseAngularContainer<femtoUniverseAngularContainer::EventType::same, femtoUniverseAngularContainer::Observable::kstar> sameEventAngularCont;
+  FemtoUniverseAngularContainer<femtoUniverseAngularContainer::EventType::mixed, femtoUniverseAngularContainer::Observable::kstar> mixedEventAngularCont;
+  FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kD0> pairCleaner;
+  FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kD0> pairCloseRejection;
+  FemtoUniverseTrackSelection trackCuts;
+
+  /// Histogram output
+  HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  HistogramRegistry registry{"registry",
+                             {{"hInvMassD0", ";#it{M}(K^{-}#pi^{+}) (GeV/#it{c}^{2});counts", {HistType::kTH1F, {{300, 1.75, 2.05}}}},
+                              {"hInvMassD0bar", ";#it{M}(#pi^{-}K^{+}) (GeV/#it{c}^{2});counts", {HistType::kTH1F, {{300, 1.75, 2.05}}}},
+                              {"hPtD0", ";#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {{300, 0., 15.}}}},
+                              {"hPtD0bar", ";#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {{300, 0., 15.}}}},
+                              {"hPhiD0", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., 2. * o2::constants::math::PI}}}},
+                              {"hPhiD0bar", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., 2. * o2::constants::math::PI}}}},
+                              {"hEtaD0", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
+                              {"hEtaD0bar", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
+                              {"hDecayLengthD0", ";decay length (cm);counts", {HistType::kTH1F, {{100, 0., 0.5}}}},
+                              {"hDecayLengthD0bar", ";decay length (cm);counts", {HistType::kTH1F, {{100, 0., 0.5}}}},
+                              {"hDeltaPhi", "; #Delta #varphi (rad);counts", {HistType::kTH1F, {{80, -0.5 * o2::constants::math::PI, 2. * o2::constants::math::PI}}}},
+                              {"hPtDaughters", ";#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {{300, 0., 12.}}}},
+                              {"hMomentumDaughters", ";#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {{300, 0., 15.}}}},
+                              {"hSignDaughters", ";sign ;counts", {HistType::kTH1F, {{10, -2.5, 2.5}}}},
+                              {"hbetaDaughters", "; p (GeV/#it{c}); TOF #beta", {HistType::kTH2F, {{300, 0., 15.}, {200, 0., 2.}}}},
+                              {"hdEdxDaughters", "; p (GeV/#it{c}); TPC dE/dx (KeV/cm)", {HistType::kTH2F, {{300, 0., 15.}, {500, 0., 500.}}}},
+                              {"hDCAxyDaughters", "; #it{DCA}_{xy} (cm); counts", {HistType::kTH1F, {{140, 0., 0.14}}}},
+                              {"hDCAzDaughters", "; #it{DCA}_{z} (cm); counts", {HistType::kTH1F, {{140, 0., 0.14}}}}}};
+
+  // PID for protons
+  bool IsProtonNSigma(float mom, float nsigmaTPCPr, float nsigmaTOFPr) // previous version from: https://github.com/alisw/AliPhysics/blob/master/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.cxx
+  {
+    //|nsigma_TPC| < 3 for p < 0.5 GeV/c
+    //|nsigma_combined| < 3 for p > 0.5
+
+    // using configurables:
+    // ConfNsigmaTPCProton -> TPC Kaon Sigma for momentum < 0.5
+    // ConfNsigmaCombinedProton -> TPC and TOF Kaon Sigma (combined) for momentum > 0.5
+
+    if (mom < 0.5) {
+      if (TMath::Abs(nsigmaTPCPr) < ConfBothTracks.ConfNsigmaTPCProton) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom > 0.4) {
+      if (TMath::Hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfBothTracks.ConfNsigmaCombinedProton) {
+        // if (TMath::Abs(nsigmaTPCPr) < ConfBothTracks.ConfNsigmaCombinedProton) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    if (mom < 0.3) { // 0.0-0.3
+      if (TMath::Abs(nsigmaTPCK) < 3.0) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom < 0.45) { // 0.30 - 0.45
+      if (TMath::Abs(nsigmaTPCK) < 2.0) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom < 0.55) { // 0.45-0.55
+      if (TMath::Abs(nsigmaTPCK) < 1.0) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom < 1.5) { // 0.55-1.5 (now we use TPC and TOF)
+      if ((TMath::Abs(nsigmaTOFK) < 3.0) && (TMath::Abs(nsigmaTPCK) < 3.0)) {
+        {
+          return true;
+        }
+      } else {
+        return false;
+      }
+    } else if (mom > 1.5) { // 1.5 -
+      if ((TMath::Abs(nsigmaTOFK) < 2.0) && (TMath::Abs(nsigmaTPCK) < 3.0)) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  bool IsPionNSigma(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
+  {
+    //|nsigma_TPC| < 3 for p < 0.5 GeV/c
+    //|nsigma_combined| < 3 for p > 0.5
+
+    // using configurables:
+    // ConfNsigmaTPCPion -> TPC Kaon Sigma for momentum < 0.5
+    // ConfNsigmaCombinedPion -> TPC and TOF Pion Sigma (combined) for momentum > 0.5
+    if (true) {
+      if (mom < 0.5) {
+        if (TMath::Abs(nsigmaTPCPi) < ConfBothTracks.ConfNsigmaTPCPion) {
+          return true;
+        } else {
+          return false;
+        }
+      } else if (mom > 0.5) {
+        if (TMath::Hypot(nsigmaTOFPi, nsigmaTPCPi) < ConfBothTracks.ConfNsigmaCombinedPion) {
+          // if (TMath::Abs(nsigmaTPCPi) < ConfBothTracks.ConfNsigmaCombinedPion) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool IsParticleNSigma(float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    switch (ConfTrack.ConfPDGCodeTrack) {
+      case 2212:  // Proton
+      case -2212: // anty Proton
+        return IsProtonNSigma(mom, nsigmaTPCPr, nsigmaTOFPr);
+        break;
+      case 211:  // Pion
+      case -211: // Pion-
+        return IsPionNSigma(mom, nsigmaTPCPi, nsigmaTOFPi);
+        break;
+      case 321:  // Kaon+
+      case -321: // Kaon-
+        return IsKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+        break;
+      default:
+        return false;
+    }
+  }
+
+  void init(InitContext&)
+  {
+    eventHisto.init(&qaRegistry);
+    trackHistoPartD0D0bar.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarInvMassBins, ConfBothTracks.ConfIsMC, ConfDmesons.ConfPDGCodeD0);
+    if (!ConfTrack.ConfIsSame) {
+      trackHistoPartTrack.init(&qaRegistry, ConfTempFitVarpTBins, ConfTempFitVarBins, ConfBothTracks.ConfIsMC, ConfTrack.ConfPDGCodeTrack);
+    }
+
+    MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+
+    sameEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    mixedEventFemtoCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    sameEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfEtaBins, ConfBothTracks.ConfPhiBins, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+    mixedEventAngularCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfBothTracks.ConfEtaBins, ConfBothTracks.ConfPhiBins, ConfBothTracks.ConfIsMC, ConfBothTracks.ConfUse3D);
+
+    sameEventFemtoCont.setPDGCodes(ConfDmesons.ConfPDGCodeD0, ConfTrack.ConfPDGCodeTrack);
+    mixedEventFemtoCont.setPDGCodes(ConfDmesons.ConfPDGCodeD0, ConfTrack.ConfPDGCodeTrack);
+    sameEventAngularCont.setPDGCodes(ConfDmesons.ConfPDGCodeD0, ConfTrack.ConfPDGCodeTrack);
+    mixedEventAngularCont.setPDGCodes(ConfDmesons.ConfPDGCodeD0, ConfTrack.ConfPDGCodeTrack);
+
+    pairCleaner.init(&qaRegistry);
+    if (ConfIsCPR.value) {
+      pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
+    }
+
+    vPIDTrack = ConfTrack.ConfPIDTrack.value;
+    kNsigma = ConfBothTracks.ConfTrkPIDnSigmaMax.value;
+  }
+
+  template <typename CollisionType>
+  void fillCollision(CollisionType col)
+  {
+    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtr()}));
+    eventHisto.fillQA(col);
+  }
+
+    void processD0mesons(o2::aod::FDCollision& col, FemtoFullParticles& parts)
+  {
+    auto groupPartsD0D0bar = partsD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    //auto groupPartsD0D0barDaugh = partsD0D0barDaughters->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
+
+    for (auto& d0d0bar : groupPartsD0D0bar) {
+      if (d0d0bar.mLambda() > 0 && d0d0bar.mAntiLambda() < 0) {
+        registry.fill(HIST("hInvMassD0"), d0d0bar.mLambda());
+        registry.fill(HIST("hPtD0"), d0d0bar.pt());
+        registry.fill(HIST("hPhiD0"), d0d0bar.phi());
+        registry.fill(HIST("hEtaD0"), d0d0bar.eta());
+      }
+      if (d0d0bar.mLambda() < 0 && d0d0bar.mAntiLambda() > 0) {
+        registry.fill(HIST("hInvMassD0bar"), d0d0bar.mAntiLambda());
+        registry.fill(HIST("hPtD0bar"), d0d0bar.pt());
+        registry.fill(HIST("hPhiD0bar"), d0d0bar.phi());
+        registry.fill(HIST("hEtaD0bar"), d0d0bar.eta());
+      }
+    }
+
+    /*for (auto& daughD0D0bar : groupPartsD0D0barDaugh) {
+      if (daughD0D0bar.flagD0() == 1) {
+        registry.fill(HIST("hMomentumDaughters"), daughD0D0bar.p());
+        registry.fill(HIST("hPtDaughters"), daughD0D0bar.pt());
+        registry.fill(HIST("hSignDaughters"), daughD0D0bar.sign());
+        registry.fill(HIST("hbetaDaughters"), daughD0D0bar.beta(), daughD0D0bar.p());
+        registry.fill(HIST("hdEdxDaughters"), daughD0D0bar.tpcSignal(), daughD0D0bar.p());
+        registry.fill(HIST("hDCAxyDaughters"), daughD0D0bar.dcaXY());
+        registry.fill(HIST("hDCAzDaughters"), daughD0D0bar.dcaZ());
+      }
+      if (daughD0D0bar.flagD0bar() == 1) {
+        registry.fill(HIST("hMomentumDaughters"), daughD0D0bar.p());
+        registry.fill(HIST("hPtDaughters"), daughD0D0bar.pt());
+        registry.fill(HIST("hSignDaughters"), daughD0D0bar.sign());
+        registry.fill(HIST("hbetaDaughters"), daughD0D0bar.beta(), daughD0D0bar.p());
+        registry.fill(HIST("hdEdxDaughters"), daughD0D0bar.tpcSignal(), daughD0D0bar.p());
+        registry.fill(HIST("hDCAxyDaughters"), daughD0D0bar.dcaXY());
+        registry.fill(HIST("hDCAzDaughters"), daughD0D0bar.dcaZ());
+      }
+    }*/
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processD0mesons, "Enable processing D0 mesons", true);
+
+  /// This function processes the same event and takes care of all the histogramming
+  /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
+  /// @tparam PartitionType
+  /// @tparam PartType
+  /// @tparam isMC: enables Monte Carlo truth specific histograms
+  /// @param groupPartsTrack partition for the first particle passed by the process function
+  /// @param groupPartsD0 partition for the second particle passed by the process function
+  /// @param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
+  /// @param magFieldTesla magnetic field of the collision
+  /// @param multCol multiplicity of the collision
+  template <bool isMC, typename PartitionType, typename PartType>
+  void doSameEvent(PartitionType groupPartsTrack, PartitionType groupPartsD0, PartType parts, float magFieldTesla, int multCol)
+  {
+
+    /// Histogramming same event
+    for (auto& d0candidate : groupPartsD0) {
+      trackHistoPartD0D0bar.fillQA<isMC, false>(d0candidate);
+    }
+
+    if (!ConfTrack.ConfIsSame) {
+      for (auto& track : groupPartsTrack) {
+        if (ConfTrack.ConfIsTrackIdentified) {
+          if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
+            continue;
+          }
+        }
+        trackHistoPartTrack.fillQA<isMC, false>(track);
+      }
+    }
+    /// Now build the combinations
+    for (auto& [track, d0candidate] : combinations(CombinationsFullIndexPolicy(groupPartsTrack, groupPartsD0))) {
+      if (ConfTrack.ConfIsTrackIdentified) {
+        if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
+          continue;
+        }
+      }
+      // // Close Pair Rejection
+      if (ConfIsCPR.value) {
+        if (pairCloseRejection.isClosePair(track, d0candidate, parts, magFieldTesla)) {
+          continue;
+        }
+      }
+
+      // Track Cleaning
+      if (!pairCleaner.isCleanPair(track, d0candidate, parts)) {
+        continue;
+      }
+      sameEventFemtoCont.setPair<isMC>(track, d0candidate, multCol, ConfBothTracks.ConfUse3D);
+      sameEventAngularCont.setPair<isMC>(track, d0candidate, multCol, ConfBothTracks.ConfUse3D);
+    }
+  }
+
+  /// process function for to call doSameEvent with Data
+  /// \param col subscribe to the collision table (Data)
+  /// \param parts subscribe to the femtoUniverseParticleTable
+  void processSameEvent(o2::aod::FDCollision& col,
+                        FemtoFullParticles& parts)
+  {
+    fillCollision(col);
+
+    auto thegroupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsD0 = partsD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    doSameEvent<false>(thegroupPartsTrack, thegroupPartsD0, parts, col.magField(), col.multNtr());
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processSameEvent, "Enable processing same event", true);
+
+  /// process function for to call doSameEvent with Monte Carlo
+  /// \param col subscribe to the collision table (Monte Carlo Reconstructed reconstructed)
+  /// \param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
+  /// \param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
+  void processSameEventMC(o2::aod::FDCollision& col,
+                          soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                          o2::aod::FDMCParticles&)
+  {
+    fillCollision(col);
+
+    auto thegroupPartsD0 = partsD0D0barMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTrack = partsTrackMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    doSameEvent<true>(thegroupPartsTrack, thegroupPartsD0, parts, col.magField(), col.multNtr());
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processSameEventMC, "Enable processing same event for Monte Carlo", false);
+
+  /// This function processes the mixed event
+  /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
+  /// \tparam PartitionType
+  /// \tparam PartType
+  /// \tparam isMC: enables Monte Carlo truth specific histograms
+  /// \param groupPartsTrack partition for the identified passed by the process function
+  /// \param groupPartsD0 partition for D0 meson passed by the process function
+  /// \param parts femtoUniverseParticles table (in case of Monte Carlo joined with FemtoUniverseMCLabels)
+  /// \param magFieldTesla magnetic field of the collision
+  /// \param multCol multiplicity of the collision
+  template <bool isMC, typename PartitionType, typename PartType>
+  void doMixedEvent(PartitionType groupPartsTrack, PartitionType groupPartsD0, PartType parts, float magFieldTesla, int multCol)
+  {
+
+    for (auto& [track, d0candidate] : combinations(CombinationsFullIndexPolicy(groupPartsTrack, groupPartsD0))) {
+      if (ConfTrack.ConfIsTrackIdentified) {
+        if (!IsParticleNSigma(track.p(), trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton), trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion), trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon))) {
+          continue;
+        }
+      }
+      if (ConfIsCPR.value) {
+        if (pairCloseRejection.isClosePair(track, d0candidate, parts, magFieldTesla)) {
+          continue;
+        }
+      }
+
+      mixedEventFemtoCont.setPair<isMC>(track, d0candidate, multCol, ConfBothTracks.ConfUse3D);
+      mixedEventAngularCont.setPair<isMC>(track, d0candidate, multCol, ConfBothTracks.ConfUse3D);
+    }
+  }
+
+  /// process function for to call doMixedEvent with Data
+  /// @param cols subscribe to the collisions table (Data)
+  /// @param parts subscribe to the femtoUniverseParticleTable
+  void processMixedEvent(o2::aod::FDCollisions& cols,
+                         FemtoFullParticles& parts)
+  {
+    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
+
+      const int multiplicityCol = collision1.multNtr();
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
+
+      auto groupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsD0 = partsD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
+
+      const auto& magFieldTesla1 = collision1.magField();
+      const auto& magFieldTesla2 = collision2.magField();
+
+      if (magFieldTesla1 != magFieldTesla2) {
+        continue;
+      }
+      /// \todo before mixing we should check whether both collisions contain a pair of particles!
+      // if (partsD0.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTrack.size() == 0 ) continue;
+
+      doMixedEvent<false>(groupPartsTrack, groupPartsD0, parts, magFieldTesla1, multiplicityCol);
+    }
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processMixedEvent, "Enable processing mixed events", true);
+
+  /// brief process function for to call doMixedEvent with Monte Carlo
+  /// @param cols subscribe to the collisions table (Monte Carlo Reconstructed reconstructed)
+  /// @param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
+  /// @param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
+  void processMixedEventMC(o2::aod::FDCollisions& cols,
+                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+                           o2::aod::FDMCParticles&)
+  {
+    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
+
+      const int multiplicityCol = collision1.multNtr();
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
+
+      auto groupPartsTrack = partsTrackMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto groupPartsD0 = partsD0D0barMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
+
+      const auto& magFieldTesla1 = collision1.magField();
+      const auto& magFieldTesla2 = collision2.magField();
+
+      if (magFieldTesla1 != magFieldTesla2) {
+        continue;
+      }
+      /// \todo before mixing we should check whether both collisions contain a pair of particles!
+      // if (partsD0.size() == 0 || nPart2Evt1 == 0 || nPart1Evt2 == 0 || partsTrack.size() == 0 ) continue;
+
+      doMixedEvent<true>(groupPartsTrack, groupPartsD0, parts, magFieldTesla1, multiplicityCol);
+    }
+  }
+  PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processMixedEventMC, "Enable processing mixed events MC", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<femtoUniversePairTaskTrackD0>(cfgc),
+  };
+  return workflow;
+}

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -320,10 +320,10 @@ struct femtoUniversePairTaskTrackD0 {
     eventHisto.fillQA(col);
   }
 
-    void processD0mesons(o2::aod::FDCollision& col, FemtoFullParticles& parts)
+  void processD0mesons(o2::aod::FDCollision& col, FemtoFullParticles& parts)
   {
     auto groupPartsD0D0bar = partsD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    //auto groupPartsD0D0barDaugh = partsD0D0barDaughters->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
+    // auto groupPartsD0D0barDaugh = partsD0D0barDaughters->sliceByCached(aod::femtoworldparticle::femtoWorldCollisionId, col.globalIndex(), cache);
 
     for (auto& d0d0bar : groupPartsD0D0bar) {
       if (d0d0bar.mLambda() > 0 && d0d0bar.mAntiLambda() < 0) {


### PR DESCRIPTION
Adding the code for D0/D0bar mesons to the FemtoUniverse. I've modified .h files in the Core folder. I've added missed part for TempFitVarName in the FemtoDerived.h file. In the producer I've added the function for filling table with D mesons and process for them. I've modified CMakeLIsts.txt, because I've also added a first version of a task to run D0 analysis (check the simple distributions, like invMass, pT).