### PR TITLE
PWGHF: Fix typos in DplusPi creator

### DIFF
--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -538,7 +538,7 @@ struct HfDataCreatorDplusPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsDThisColl = candsD.sliceBy(candsDPerCollisionWithMl, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<true, true>(collision, candsD, trackIndices, tracks, particlesMc, bcs);
+      runDataCreation<true, true>(collision, candsDThisColl, trackIdsThisCollision, tracks, particlesMc, bcs);
     }
     runMcGen(particlesMc);
   }


### PR DESCRIPTION
Hello, just fixing typos in DplusPi creator in the process function with MC truth and ML info on D candidates.

Note: these typos are not present in D0Pi creator.