### PR TITLE
Switch table producers that produce V0s to produce V0s_001 temporarily

### DIFF
--- a/PWGLF/TableProducer/lambdakzerofinder.cxx
+++ b/PWGLF/TableProducer/lambdakzerofinder.cxx
@@ -125,7 +125,7 @@ struct lambdakzerofinder {
   Produces<aod::V0Indices> v0indices;
   Produces<aod::StoredV0Cores> v0cores;
   Produces<aod::V0TrackXs> v0trackXs;
-  Produces<aod::V0s> v0;
+  Produces<aod::V0s_001> v0;
   Produces<aod::V0DataLink> v0datalink;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 

--- a/PWGLF/TableProducer/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/lambdakzeromcfinder.cxx
@@ -66,7 +66,7 @@ using namespace ROOT::Math;
 using LabeledTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels>;
 
 struct lambdakzeromcfinder {
-  Produces<aod::V0s> v0;
+  Produces<aod::V0s_001> v0;
   Produces<aod::McFullV0Labels> fullv0labels;
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};


### PR DESCRIPTION
@shahor02 this is required so that the change in O2 can go or, indeed, the analysis CI might complain as the new version of O2 will not compile against the older version of O2Physics. Once O2Physics switches to being built against the new O2, I can switch these tasks to produce the generic `V0s`. 

Technically, once this PR is merged, we could ignore the fullCI because then for sure the compilation will work...