### PR TITLE
PWGJE+EM: Add EMCal ambiguous collision table and include in QC task

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/emcalPi0QC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalPi0QC.cxx
@@ -203,18 +203,9 @@ struct Pi0QCTask {
     }
 
     // meson related histograms
-    mHistManager.add("invMassVsPt", "invariant mass and pT of meson candidates", o2HistType::kTH2F, {invmassBinning, pTBinning});
-    mHistManager.add("invMassVsPtBackground", "invariant mass and pT of background meson candidates", o2HistType::kTH2F, {invmassBinning, pTBinning});
-    mHistManager.add("invMassVsPtMixedBackground", "invariant mass and pT of mixed background meson candidates", o2HistType::kTH2F, {invmassBinning, pTBinning});
-
-    if (mSplitEMCalDCal) {
-      mHistManager.add("invMassVsPt_EMCal", "invariant mass and pT of meson candidates with both clusters on EMCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-      mHistManager.add("invMassVsPtBackground_EMCal", "invariant mass and pT of background meson candidates with both clusters on EMCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-      mHistManager.add("invMassVsPtMixedBackground_EMCal", "invariant mass and pT of mixed background meson candidates with both clusters on EMCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-      mHistManager.add("invMassVsPt_DCal", "invariant mass and pT of meson candidates with both clusters on DCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-      mHistManager.add("invMassVsPtBackground_DCal", "invariant mass and pT of background meson candidates with both clusters on DCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-      mHistManager.add("invMassVsPtMixedBackground_DCal", "invariant mass and pT of mixed background meson candidates with both clusters on DCal", o2HistType::kTH2F, {invmassBinning, pTBinning});
-    }
+    mHistManager.add("invMassVsPt", "invariant mass and pT of meson candidates", o2HistType::kTH2F, {{400, 0, 0.8}, {energyAxis}});
+    mHistManager.add("invMassVsPtBackground", "invariant mass and pT of background meson candidates", o2HistType::kTH2F, {{400, 0, 0.8}, {energyAxis}});
+    mHistManager.add("invMassVsPtMixedBackground", "invariant mass and pT of mixed background meson candidates", o2HistType::kTH2F, {{400, 0, 0.8}, {energyAxis}});
 
     if (mVetoBCID->length()) {
       std::stringstream parser(mVetoBCID.value);
@@ -415,14 +406,6 @@ struct Pi0QCTask {
         Meson meson(mPhotons[ig1], mPhotons[ig2]);
         if (meson.getOpeningAngle() > mMinOpenAngleCut) {
           mHistManager.fill(HIST("invMassVsPt"), meson.getMass(), meson.getPt());
-
-          if (mSplitEMCalDCal) {
-            if (!mPhotons[ig1].onDCal && !mPhotons[ig2].onDCal) {
-              mHistManager.fill(HIST("invMassVsPt_EMCal"), meson.getMass(), meson.getPt());
-            } else if (mPhotons[ig1].onDCal && mPhotons[ig2].onDCal) {
-              mHistManager.fill(HIST("invMassVsPt_DCal"), meson.getMass(), meson.getPt());
-            }
-          }
         }
 
         // calculate background candidates (rotation background)
@@ -473,23 +456,9 @@ struct Pi0QCTask {
       // Fill histograms
       if (mesonRotated1.getOpeningAngle() > mMinOpenAngleCut) {
         mHistManager.fill(HIST("invMassVsPtBackground"), mesonRotated1.getMass(), mesonRotated1.getPt());
-        if (mSplitEMCalDCal) {
-          if (!mPhotons[ig1].onDCal && !mPhotons[ig2].onDCal && !mPhotons[ig3].onDCal) {
-            mHistManager.fill(HIST("invMassVsPtBackground_EMCal"), mesonRotated1.getMass(), mesonRotated1.getPt());
-          } else if (mPhotons[ig1].onDCal && mPhotons[ig2].onDCal && mPhotons[ig3].onDCal) {
-            mHistManager.fill(HIST("invMassVsPtBackground_DCal"), mesonRotated1.getMass(), mesonRotated1.getPt());
-          }
-        }
       }
       if (mesonRotated2.getOpeningAngle() > mMinOpenAngleCut) {
         mHistManager.fill(HIST("invMassVsPtBackground"), mesonRotated2.getMass(), mesonRotated2.getPt());
-        if (mSplitEMCalDCal) {
-          if (!mPhotons[ig1].onDCal && !mPhotons[ig2].onDCal && !mPhotons[ig3].onDCal) {
-            mHistManager.fill(HIST("invMassVsPtBackground_EMCal"), mesonRotated2.getMass(), mesonRotated2.getPt());
-          } else if (mPhotons[ig1].onDCal && mPhotons[ig2].onDCal && mPhotons[ig3].onDCal) {
-            mHistManager.fill(HIST("invMassVsPtBackground_DCal"), mesonRotated2.getMass(), mesonRotated2.getPt());
-          }
-        }
       }
     }
   }
@@ -501,13 +470,6 @@ struct Pi0QCTask {
         Meson meson(gamma, evtMix.vecEvtMix[i][ig1]);
         if (meson.getOpeningAngle() > mMinOpenAngleCut) {
           mHistManager.fill(HIST("invMassVsPtMixedBackground"), meson.getMass(), meson.getPt());
-          if (mSplitEMCalDCal) {
-            if (!gamma.onDCal && !evtMix.vecEvtMix[i][ig1].onDCal) {
-              mHistManager.fill(HIST("invMassVsPtMixedBackground_EMCal"), meson.getMass(), meson.getPt());
-            } else if (gamma.onDCal && evtMix.vecEvtMix[i][ig1].onDCal) {
-              mHistManager.fill(HIST("invMassVsPtMixedBackground_DCal"), meson.getMass(), meson.getPt());
-            }
-          }
         }
       }
     }

--- a/PWGJE/DataModel/EMCALMatchedCollisions.h
+++ b/PWGJE/DataModel/EMCALMatchedCollisions.h
@@ -1,0 +1,40 @@
+// Copyright 2019-2023 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \brief  Table definitions for defining whether a collision is matched to a buch crossing including either one or multiple collisions
+/// \file   EMCALMatchedCollisions.h
+/// \author Nicolas Strangmann <nicolas.strangmann@cern.ch>
+/// \since  2023-12-16
+
+#ifndef PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_
+#define PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_
+
+#include <string>
+#include "Framework/AnalysisDataModel.h"
+#include "EMCALClusterDefinition.h"
+
+namespace o2::aod
+{
+namespace emcalcollisionmatch
+{
+DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! collisionID used as index for matched collisions
+DECLARE_SOA_COLUMN(Ambiguous, ambiguous, bool); //! boolean stating whether the collision is ambiguous (in a BC with multiple collisions)
+} // namespace emcalcollisionmatch
+
+DECLARE_SOA_TABLE(EMCALMatchedCollisions, "AOD", "EMCALMCS",                                           //!
+                  o2::soa::Index<>, emcalcollisionmatch::CollisionId, emcalcollisionmatch::Ambiguous); //
+
+using EMCALMatchedCollision = EMCALMatchedCollisions::iterator;
+
+} // namespace o2::aod
+
+#endif // PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_

--- a/PWGJE/DataModel/EMCALMatchedCollisions.h
+++ b/PWGJE/DataModel/EMCALMatchedCollisions.h
@@ -15,8 +15,8 @@
 /// \author Nicolas Strangmann <nicolas.strangmann@cern.ch>
 /// \since  2023-12-16
 
-#ifndef PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_
-#define PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_
+#ifndef PWGJE_DATAMODEL_EMCALMATCHEDCOLLISIONS_H_
+#define PWGJE_DATAMODEL_EMCALMATCHEDCOLLISIONS_H_
 
 #include <string>
 #include "Framework/AnalysisDataModel.h"
@@ -37,4 +37,4 @@ using EMCALMatchedCollision = EMCALMatchedCollisions::iterator;
 
 } // namespace o2::aod
 
-#endif // PWGJE_DATAMODEL_EMCALMATCHEDCOLLISION_H_
+#endif // PWGJE_DATAMODEL_EMCALMATCHEDCOLLISIONS_H_

--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -220,7 +220,7 @@ struct EmcalCorrectionTask {
 
     int nBCsProcessed = 0;
     int nCellsProcessed = 0;
-    std::unordered_map<uint64_t, int> numberCollsInBC;  // Number of collisions mapped to the global BC index of all BCs
+    std::unordered_map<uint64_t, int> numberCollsInBC; // Number of collisions mapped to the global BC index of all BCs
     for (auto bc : bcs) {
       LOG(debug) << "Next BC";
       // Convert aod::Calo to o2::emcal::Cell which can be used with the clusterizer.

--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -29,6 +29,7 @@
 #include "DetectorsBase/GeometryManager.h"
 
 #include "PWGJE/DataModel/EMCALClusters.h"
+#include "PWGJE/DataModel/EMCALMatchedCollisions.h"
 
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -58,6 +59,7 @@ struct EmcalCorrectionTask {
   Produces<o2::aod::EMCALClusterCells> clustercells; // cells belonging to given cluster
   Produces<o2::aod::EMCALAmbiguousClusterCells> clustercellsambiguous;
   Produces<o2::aod::EMCALMatchedTracks> matchedTracks;
+  Produces<o2::aod::EMCALMatchedCollisions> emcalcollisionmatch;
 
   // Preslices
   Preslice<myGlobTracks> perCollision = o2::aod::track::collisionId;
@@ -218,6 +220,7 @@ struct EmcalCorrectionTask {
 
     int nBCsProcessed = 0;
     int nCellsProcessed = 0;
+    std::unordered_map<uint64_t, int> numberCollsInBC;  // Number of collisions mapped to the global BC index of all BCs
     for (auto bc : bcs) {
       LOG(debug) << "Next BC";
       // Convert aod::Calo to o2::emcal::Cell which can be used with the clusterizer.
@@ -226,6 +229,8 @@ struct EmcalCorrectionTask {
       // Get the collisions matched to the BC using foundBCId of the collision
       auto collisionsInFoundBC = collisions.sliceBy(collisionsPerFoundBC, bc.globalIndex());
       auto cellsInBC = cells.sliceBy(cellsPerFoundBC, bc.globalIndex());
+
+      numberCollsInBC.insert(std::pair<uint64_t, int>(bc.globalIndex(), collisionsInFoundBC.size()));
 
       if (!cellsInBC.size()) {
         LOG(debug) << "No cells found for BC";
@@ -302,6 +307,18 @@ struct EmcalCorrectionTask {
       LOG(debug) << "Done with process BC.";
       nBCsProcessed++;
     } // end of bc loop
+
+    // Loop through all collisions and fill emcalcollisionmatch with a boolean stating, whether the collision was ambiguous (not the only collision in its BC)
+    for (const auto& collision : collisions) {
+      auto globalbcid = collision.foundBC_as<bcEvSels>().globalIndex();
+      auto found = numberCollsInBC.find(globalbcid);
+      if (found != numberCollsInBC.end()) {
+        emcalcollisionmatch(collision.globalIndex(), found->second != 1);
+      } else {
+        LOG(warning) << "BC not found in map of number of collisions.";
+      }
+    } // end of collision loop
+
     LOG(detail) << "Processed " << nBCsProcessed << " BCs with " << nCellsProcessed << " cells";
   }
   PROCESS_SWITCH(EmcalCorrectionTask, processFull, "run full analysis", true);
@@ -561,8 +578,7 @@ struct EmcalCorrectionTask {
       mHistManager.fill(HIST("hClusterE"), cluster.E());
       mHistManager.fill(HIST("hClusterEtaPhi"), pos.Eta(), TVector2::Phi_0_2pi(pos.Phi()));
       if (IndexMapPair && trackGlobalIndex) {
-        for (unsigned int iTrack = 0;
-             iTrack < std::get<0>(*IndexMapPair)[iCluster].size(); iTrack++) {
+        for (unsigned int iTrack = 0; iTrack < std::get<0>(*IndexMapPair)[iCluster].size(); iTrack++) {
           if (std::get<0>(*IndexMapPair)[iCluster][iTrack] >= 0) {
             LOG(debug) << "Found track " << (*trackGlobalIndex)[std::get<0>(*IndexMapPair)[iCluster][iTrack]] << " in cluster " << cluster.getID();
             matchedTracks(clusters.lastIndex(), (*trackGlobalIndex)[std::get<0>(*IndexMapPair)[iCluster][iTrack]]);


### PR DESCRIPTION
- Add table EMCALMatchedCollisions, which for every collision contains a boolean stating whether multiple collisions were found in the BC
- That table is filled in the emcalCorrectionTask for every collision to make it joinable with the collision table
- emcalPi0QC task reads this table to enable correct event normalization
- Bug fix in emcalPi0QC task NCell cut
- Combined event histograms in emcalPi0QC task
