### PR TITLE
PWGCF: Masked Mixing in FemtoDream

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -34,9 +34,9 @@ DECLARE_SOA_COLUMN(MagField, magField, float);     //! Magnetic field of the eve
 
 using BitMaskType = uint32_t; //! Definition of the data type for the collision masks
 
-DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);    //! Bit for track one
-DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);    //! Bit for track two
-DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, BitMaskType);    //! Bit for track three
+DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);     //! Bit for track one
+DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);     //! Bit for track two
+DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, BitMaskType); //! Bit for track three
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -32,7 +32,7 @@ DECLARE_SOA_COLUMN(MultNtr, multNtr, int);         //! multiplicity of charged t
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
 DECLARE_SOA_COLUMN(MagField, magField, float);     //! Magnetic field of the event
 
-using BitMaskType = uint64_t; //! Definition of the data type for the collision masks
+using BitMaskType = uint32_t; //! Definition of the data type for the collision masks
 
 DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);    //! Bit for track one
 DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);    //! Bit for track two

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -31,7 +31,9 @@ DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
 DECLARE_SOA_COLUMN(MultNtr, multNtr, int);         //! multiplicity of charged tracks as defined in the producer
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
 DECLARE_SOA_COLUMN(MagField, magField, float);     //! Magnetic field of the event
-
+DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, uint32_t);    //! Bit for track one
+DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, uint32_t);    //! Bit for track two
+DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, uint32_t);    //! Bit for track three
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
@@ -42,6 +44,12 @@ DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
                   femtodreamcollision::Sphericity,
                   femtodreamcollision::MagField);
 using FDCollision = FDCollisions::iterator;
+
+DECLARE_SOA_TABLE(FDColMasks, "AOD", "FDCOLMASK",
+                  femtodreamcollision::BitMaskTrackOne,
+                  femtodreamcollision::BitMaskTrackTwo,
+                  femtodreamcollision::BitMaskTrackThree);
+using FDColMask = FDColMasks::iterator;
 
 /// FemtoDreamTrack
 namespace femtodreamparticle

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -31,9 +31,12 @@ DECLARE_SOA_COLUMN(MultV0M, multV0M, float);       //! V0M multiplicity
 DECLARE_SOA_COLUMN(MultNtr, multNtr, int);         //! multiplicity of charged tracks as defined in the producer
 DECLARE_SOA_COLUMN(Sphericity, sphericity, float); //! Sphericity of the event
 DECLARE_SOA_COLUMN(MagField, magField, float);     //! Magnetic field of the event
-DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, uint32_t);    //! Bit for track one
-DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, uint32_t);    //! Bit for track two
-DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, uint32_t);    //! Bit for track three
+
+using BitMaskType = uint64_t; //! Definition of the data type for the collision masks
+
+DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);    //! Bit for track one
+DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);    //! Bit for track two
+DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, BitMaskType);    //! Bit for track three
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
@@ -49,7 +52,6 @@ DECLARE_SOA_TABLE(FDColMasks, "AOD", "FDCOLMASK",
                   femtodreamcollision::BitMaskTrackOne,
                   femtodreamcollision::BitMaskTrackTwo,
                   femtodreamcollision::BitMaskTrackThree);
-using FDColMask = FDColMasks::iterator;
 
 /// FemtoDreamTrack
 namespace femtodreamparticle

--- a/PWGCF/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FemtoDream/CMakeLists.txt
@@ -14,6 +14,11 @@ o2physics_add_dpl_workflow(femtodream-producer
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femtodream-collision-masker
+	  SOURCES femtoDreamCollisionMasker.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtodream-producer-reduced
           SOURCES femtoDreamProducerReducedTask.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FemtoDream/CMakeLists.txt
@@ -19,11 +19,11 @@ o2physics_add_dpl_workflow(femtodream-collision-masker
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(femtodream-producer-reduced
-          SOURCES femtoDreamProducerReducedTask.cxx
-          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-          COMPONENT_NAME Analysis)
-
+# o2physics_add_dpl_workflow(femtodream-producer-reduced
+#           SOURCES femtoDreamProducerReducedTask.cxx
+#           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+#           COMPONENT_NAME Analysis)
+#
 o2physics_add_dpl_workflow(femtodream-pair-track-track
           SOURCES femtoDreamPairTaskTrackTrack.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
@@ -59,7 +59,7 @@ o2physics_add_executable(femtodream-cutculator
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(femtodream-producer-v0
-          SOURCES femtoDreamProducerTaskV0Only.cxx
-          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-          COMPONENT_NAME Analysis)
+# o2physics_add_dpl_workflow(femtodream-producer-v0
+#           SOURCES femtoDreamProducerTaskV0Only.cxx
+#           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+#           COMPONENT_NAME Analysis)

--- a/PWGCF/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FemtoDream/CMakeLists.txt
@@ -19,11 +19,11 @@ o2physics_add_dpl_workflow(femtodream-collision-masker
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
-# o2physics_add_dpl_workflow(femtodream-producer-reduced
-#           SOURCES femtoDreamProducerReducedTask.cxx
-#           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-#           COMPONENT_NAME Analysis)
-#
+o2physics_add_dpl_workflow(femtodream-producer-reduced
+          SOURCES femtoDreamProducerReducedTask.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtodream-pair-track-track
           SOURCES femtoDreamPairTaskTrackTrack.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
@@ -59,7 +59,7 @@ o2physics_add_executable(femtodream-cutculator
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
-# o2physics_add_dpl_workflow(femtodream-producer-v0
-#           SOURCES femtoDreamProducerTaskV0Only.cxx
-#           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-#           COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(femtodream-producer-v0
+          SOURCES femtoDreamProducerTaskV0Only.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)

--- a/PWGCF/FemtoDream/CMakeLists.txt
+++ b/PWGCF/FemtoDream/CMakeLists.txt
@@ -15,7 +15,7 @@ o2physics_add_dpl_workflow(femtodream-producer
           COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(femtodream-collision-masker
-	  SOURCES femtoDreamCollisionMasker.cxx
+    SOURCES femtoDreamCollisionMasker.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -22,6 +22,7 @@
 #include "FemtoDreamTrackSelection.h"
 #include "FemtoDreamV0Selection.h"
 #include <bitset>
+#include <functional>
 #include <iostream>
 #include <random>
 #include <string>
@@ -322,20 +323,31 @@ class FemtoDreamCutculator
                 << " not recognized - available options are (T/V)" << std::endl;
       return;
     }
-    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)>
-      bitOutput = output;
+    std::bitset<8 * sizeof(aod::femtodreamparticle::cutContainerType)> bitOutput = output;
     std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
     std::cout << "CutCulator has spoken - your selection bit is" << std::endl;
     std::cout << bitOutput << " (bitwise)" << std::endl;
     std::cout << output << " (number representation)" << std::endl;
-    std::cout << "PID for these species is stored:" << std::endl;
-    int index = 0;
+    std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+    std::cout << "PID bits for these species are available:" << std::endl;
     int randomIndex = 0;
     std::random_device rd;
     std::mt19937 rng(rd());
     std::uniform_int_distribution<int> uni(0, mPIDValues.size() - 1);
-    for (auto id : mPIDspecies) {
-      std::cout << o2::track::PID::getName(id) << " : " << index++ << std::endl;
+    std::sort(mPIDValues.begin(), mPIDValues.end(), std::greater<>());
+    int Bit = 0;
+
+    std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+    for (std::size_t i = 0; i < mPIDspecies.size(); i++) {
+      for (std::size_t j = 0; j < mPIDValues.size(); j++) {
+        std::cout << "Species " << o2::track::PID::getName(mPIDspecies.at(i)) << " with |NSigma|<" << mPIDValues.at(j) << std::endl;
+        Bit = (2 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 2;
+        // TPCBit = mPIDValues.size()*(mPIDspecies.size()-(i+1)) + 2*(mPIDValues.size()-j);
+        // TPCTOFBit =TPCBit-1;
+        std::cout << "Bit for Nsigma TPC: " << (1 << (Bit + 1)) << std::endl;
+        std::cout << "Bit for Nsigma TPCTOF: " << (1 << Bit) << std::endl;
+        std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+      }
       if (SysChecks) {
         // Seed the random number generator
         // Select a random element
@@ -345,20 +357,14 @@ class FemtoDreamCutculator
         std::cout << "Nsigma TPCTOF: " << mPIDValues[randomIndex] << std::endl;
       }
     }
-    std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
   }
 
  private:
-  boost::property_tree::ptree
-    mConfigTree; ///< the dpl-config.json buffered into a ptree
-  FemtoDreamTrackSelection
-    mTrackSel; ///< for setting up the bit-wise selection container for tracks
-  FemtoDreamV0Selection
-    mV0Sel; ///< for setting up the bit-wise selection container for V0s
-  std::vector<o2::track::PID::ID>
-    mPIDspecies; ///< list of particle species for which PID is stored
-  std::vector<float>
-    mPIDValues; ///< list of nsigma values for which PID is stored
+  boost::property_tree::ptree mConfigTree;     ///< the dpl-config.json buffered into a ptree
+  FemtoDreamTrackSelection mTrackSel;          ///< for setting up the bit-wise selection container for tracks
+  FemtoDreamV0Selection mV0Sel;                ///< for setting up the bit-wise selection container for V0s
+  std::vector<o2::track::PID::ID> mPIDspecies; ///< list of particle species for which PID is stored
+  std::vector<float> mPIDValues;               ///< list of nsigma values for which PID is stored
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/FemtoDreamCutculator.h
+++ b/PWGCF/FemtoDream/FemtoDreamCutculator.h
@@ -342,8 +342,6 @@ class FemtoDreamCutculator
       for (std::size_t j = 0; j < mPIDValues.size(); j++) {
         std::cout << "Species " << o2::track::PID::getName(mPIDspecies.at(i)) << " with |NSigma|<" << mPIDValues.at(j) << std::endl;
         Bit = (2 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 2;
-        // TPCBit = mPIDValues.size()*(mPIDspecies.size()-(i+1)) + 2*(mPIDValues.size()-j);
-        // TPCTOFBit =TPCBit-1;
         std::cout << "Bit for Nsigma TPC: " << (1 << (Bit + 1)) << std::endl;
         std::cout << "Bit for Nsigma TPCTOF: " << (1 << Bit) << std::endl;
         std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -133,5 +133,18 @@ int checkDaughterType(o2::aod::femtodreamparticle::ParticleType partType, int mo
   return partOrigin;
 };
 
+  template <typename T, typename R>
+  bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
+  {
+    for (const auto& obj : myVector) {
+      if (obj.name == name) {
+        if (std::abs(static_cast<float>((obj.defaultValue.template get<R>() - value))) < 1e-2) {
+          return true; // Found a match
+        }
+      }
+    }
+    return false; // No match found
+  }
+
 } // namespace o2::analysis::femtoDream
 #endif // PWGCF_FEMTODREAM_FEMTOUTILS_H_

--- a/PWGCF/FemtoDream/FemtoUtils.h
+++ b/PWGCF/FemtoDream/FemtoUtils.h
@@ -17,6 +17,7 @@
 #define PWGCF_FEMTODREAM_FEMTOUTILS_H_
 
 #include <vector>
+#include <string>
 #include <functional>
 #include <algorithm>
 #include "Framework/ASoAHelpers.h"
@@ -24,6 +25,8 @@
 
 namespace o2::analysis::femtoDream
 {
+
+// TODO: remove all these functions pertaining to PID selection for the next tutorial session they have been removed from femtodream tasks but are still present in tutorial files
 
 enum kDetector { kTPC,
                  kTPCTOF,
@@ -133,18 +136,18 @@ int checkDaughterType(o2::aod::femtodreamparticle::ParticleType partType, int mo
   return partOrigin;
 };
 
-  template <typename T, typename R>
-  bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
-  {
-    for (const auto& obj : myVector) {
-      if (obj.name == name) {
-        if (std::abs(static_cast<float>((obj.defaultValue.template get<R>() - value))) < 1e-2) {
-          return true; // Found a match
-        }
+template <typename T, typename R>
+bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
+{
+  for (const auto& obj : myVector) {
+    if (obj.name == name) {
+      if (std::abs(static_cast<float>((obj.defaultValue.template get<R>() - value))) < 1e-2) {
+        return true; // Found a match
       }
     }
-    return false; // No match found
   }
+  return false; // No match found
+}
 
 } // namespace o2::analysis::femtoDream
 #endif // PWGCF_FEMTODREAM_FEMTOUTILS_H_

--- a/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
@@ -175,15 +175,17 @@ struct femoDreamCollisionMasker {
           }
         }
       }
+    }
 
-      LOG(info) << "Configured values";
-      for (int i = 0; i < CollisionMasks::kNParts; i++) {
-        LOG(info) << "Part " << i+1;
-        for (size_t j = 0; j < TrackCutBits.at(i).size(); j++) {
-          LOG(info) << "Index " << j << " ->    CutBit: " << TrackCutBits.at(i).at(j);
-          LOG(info) << "Index " << j << " ->    TPCBit: " << TrackPIDTPCBits.at(i).at(j);
-          LOG(info) << "Index " << j << " -> TPCTOFBit: " << TrackPIDTPCTOFBits.at(i).at(j);
-        }
+    LOG(info) << "Configured values";
+    for (int part = 0; part < CollisionMasks::kNParts; part++) {
+      LOG(info) << "for Part " << part + 1;
+      for (size_t index = 0; index < TrackCutBits.at(part).size(); index++) {
+        LOG(info) << "with Index " << index;
+        LOG(info) << "->    CutBit: " << TrackCutBits.at(part).at(index);
+        LOG(info) << "->    TPCBit: " << TrackPIDTPCBits.at(part).at(index);
+        LOG(info) << "-> TPCTOFBit: " << TrackPIDTPCTOFBits.at(part).at(index);
+        LOG(info) << "->  PIDThres: " << TrackPIDThreshold.at(part).at(index);
       }
     }
 
@@ -214,12 +216,12 @@ struct femoDreamCollisionMasker {
       // check track cuts
       if ((track.cut() & TrackCutBits.at(P).at(index)) == TrackCutBits.at(P).at(index)) {
         // check pid cuts
-        if (track.p() < TrackPIDThreshold.at(P).at(index)) {
-          if ((track.cut() & TrackPIDTPCBits.at(P).at(index)) == TrackPIDTPCBits.at(P).at(index)) {
+        if (track.p() <= TrackPIDThreshold.at(P).at(index)) {
+          if ((track.pidcut() & TrackPIDTPCBits.at(P).at(index)) == TrackPIDTPCBits.at(P).at(index)) {
             BitSet.at(P).set(index);
           }
         } else {
-          if ((track.cut() & TrackPIDTPCTOFBits.at(P).at(index)) == TrackPIDTPCTOFBits.at(P).at(index)) {
+          if ((track.pidcut() & TrackPIDTPCTOFBits.at(P).at(index)) == TrackPIDTPCTOFBits.at(P).at(index)) {
             BitSet.at(P).set(index);
           }
         }

--- a/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks creates bitmasks for collisions
 /// \author Anton Riedel, TU München, anton.riedel@tum.de
 
+#include <Framework/Configurable.h>
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/runDataProcessing.h"
@@ -50,48 +51,80 @@ struct femtoDreamCollisionMasker {
   /// track momemtum threshold for PID
   std::array<std::vector<float>, CollisionMasks::kNParts> TrackPIDThreshold = {};
 
+  // Configurable<bool> ConfSelfConfiguration{"ConfSelfConfiguration", true, "Flag to active self-configuration"};
+
+  // particle 1
+  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart1{"ConfTrackCutsBitsPart1", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart2{"ConfTrackCutsBitsPart2", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart3{"ConfTrackCutsBitsPart3", {1}, "Cut bits for collision masking"};
+  //
+  // // particle 2
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart1{"ConfTrackPIDTPCBitsPart1", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart2{"ConfTrackPIDTPCBitsPart2", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart3{"ConfTrackPIDTPCBitsPart3", {1}, "Cut bits for collision masking"};
+  //
+  // // particle 3
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart1{"ConfTrackPIDTPCTOFBitsPart1", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart2{"ConfTrackPIDTPCTOFBitsPart2", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart3{"ConfTrackPIDTPCTOFBitsPart3", {1}, "Cut bits for collision masking"};
+  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart1{"ConTrackPIDThresholdPart1", {0.75}, "Cut bits for collision masking"};
+  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart2{"ConTrackPIDThresholdPart2", {0.75}, "Cut bits for collision masking"};
+  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart3{"ConTrackPIDThresholdPart3", {0.75}, "Cut bits for collision masking"};
+
   void init(InitContext& context)
   {
-    LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-    LOGF(info, " Collision masker self-configuration ");
-    LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-    auto& workflows = context.services().get<RunningWorkflowInfo const>();
-    for (DeviceSpec const& device : workflows.devices) {
-      if (device.name.compare("femto-dream-pair-task-track-track") == 0) {
-        for (auto const& option : device.options) {
-          LOG(info) << option.name;
-          if (option.name.compare(std::string("ConfCutPartOne")) == 0) {
-            TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDTPCPartOne")) == 0) {
-            TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDTPCTOFPartOne")) == 0) {
-            TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDThresPartOne")) == 0) {
-            TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
-          } else if (option.name.compare(std::string("ConfCutPartTwo")) == 0) {
-            TrackCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDTPCPartTwo")) == 0) {
-            TrackPIDTPCBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDTPCTOFPartTwo")) == 0) {
-            TrackPIDTPCTOFBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-          } else if (option.name.compare(std::string("ConfPIDThresPartTwo")) == 0) {
-            TrackPIDThreshold.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+		// asdf
+    // if (ConfSelfConfiguration.value) {
+      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
+      LOGF(info, " Collision masker self-configuration ");
+      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
+      auto& workflows = context.services().get<RunningWorkflowInfo const>();
+      for (DeviceSpec const& device : workflows.devices) {
+        if (device.name.compare("femto-dream-pair-task-track-track") == 0) {
+          for (auto const& option : device.options) {
+            LOG(info) << option.name;
+            if (option.name.compare(std::string("ConfCutPartOne")) == 0) {
+              TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDTPCPartOne")) == 0) {
+              TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDTPCTOFPartOne")) == 0) {
+              TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDThresPartOne")) == 0) {
+              TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+            } else if (option.name.compare(std::string("ConfCutPartTwo")) == 0) {
+              TrackCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDTPCPartTwo")) == 0) {
+              TrackPIDTPCBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDTPCTOFPartTwo")) == 0) {
+              TrackPIDTPCTOFBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+            } else if (option.name.compare(std::string("ConfPIDThresPartTwo")) == 0) {
+              TrackPIDThreshold.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+            }
           }
         }
       }
-    }
-    // for(auto i : TrackCutBits.at(0)){
-    // 	LOG(info) << i;
+    // } else {
+    //   TrackCutBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackCutBitsPart1.value, ConfTrackCutBitsPart2.value, ConfTrackCutBitsPart3.value};
+    //   TrackPIDTPCBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackPIDTPCBitsPart1.value, ConfTrackPIDTPCBitsPart2.value, ConfTrackPIDTPCBitsPart3.value};
+    //   TrackPIDTPCTOFBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackPIDTPCTOFBitsPart1.value, ConfTrackPIDTPCTOFBitsPart2.value, ConfTrackPIDTPCTOFBitsPart3.value};
+    //   TrackPIDThreshold = std::array<std::vector<float>, CollisionMasks::kNParts>{ConfTrackPIDThresholdsPart1.value, ConfTrackPIDThresholdsPart2.value, ConfTrackPIDThresholdsPart3.value};
     // }
   };
 
-  void process(FDCollision const& col, FDParticles const& parts)
+  void processTrack(FDCollision const& col, FDParticles const& parts)
   {
+    // create a bit mask for particle one, particle two and particle three
     std::array<std::bitset<64>, CollisionMasks::kNParts> Mask = {{0}};
+    // iterate over all tracks in this collision
     for (auto& part : parts) {
+      // iterate over particleOne/Two/Three
       for (size_t nPart = 0; nPart < CollisionMasks::kNParts; nPart++) {
+        // iterate over all selections for particleOne/Two/Three
         for (size_t index = 0; index < TrackCutBits.at(nPart).size(); index++) {
+        // set the bit at the index of the selection equal to one if the track passes
+          // check track cuts
           if ((part.cut() & TrackCutBits.at(nPart).at(index)) == TrackCutBits.at(nPart).at(index)) {
+            // check pid cuts
             if (part.p() < TrackPIDThreshold.at(nPart).at(index)) {
               if ((part.cut() & TrackPIDTPCBits.at(nPart).at(index)) == TrackPIDTPCBits.at(nPart).at(index)) {
                 Mask.at(nPart).set(index);
@@ -105,11 +138,10 @@ struct femtoDreamCollisionMasker {
         }
       }
     }
-
     // LOG(info) << "Part1:" << Mask.at(CollisionMasks::kPartOne).to_string();
     // LOG(info) << "Part2:" << Mask.at(CollisionMasks::kPartTwo).to_string();
     // LOG(info) << "Part3:" << Mask.at(CollisionMasks::kPartThree).to_string();
-
+    // fill bitmask for each collision
     Masks(static_cast<uint32_t>(Mask.at(CollisionMasks::kPartOne).to_ulong()),
           static_cast<uint32_t>(Mask.at(CollisionMasks::kPartTwo).to_ulong()),
           static_cast<uint32_t>(Mask.at(CollisionMasks::kPartThree).to_ulong()));

--- a/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
@@ -10,23 +10,24 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoDreamCollisionMasker.cxx
-/// \brief Tasks creates bitmasks for collisions
+/// \brief Tasks creates bitmasks for femtodream collisions
 /// \author Anton Riedel, TU München, anton.riedel@tum.de
 
-#include <Framework/Configurable.h>
+#include <vector>
+#include <bitset>
+#include <algorithm>
+
+#include "fairlogger/Logger.h"
+#include "Framework/Configurable.h"
 #include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/RunningWorkflowInfo.h"
 
-#include <cstdint>
-#include <vector>
-#include <algorithm>
-#include <bitset>
 #include "PWGCF/DataModel/FemtoDerived.h"
 
+using namespace o2;
 using namespace o2::aod;
 using namespace o2::framework;
 
@@ -36,120 +37,263 @@ enum Parts {
   kPartOne,
   kPartTwo,
   kPartThree,
-  kNParts
+  kNParts,
 };
-}
+enum Tasks {
+  kTrackTrack,
+  kTrackV0,
+  kNTasks,
+};
+} // namespace CollisionMasks
 
-struct femtoDreamCollisionMasker {
+struct femoDreamCollisionMasker {
   Produces<FDColMasks> Masks;
-  /// track selection bits
-  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackCutBits = {};
-  /// track tpc pid bits
-  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackPIDTPCBits = {};
-  /// track tpctof pid bits
-  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackPIDTPCTOFBits = {};
-  /// track momemtum threshold for PID
-  std::array<std::vector<float>, CollisionMasks::kNParts> TrackPIDThreshold = {};
 
-  // Configurable<bool> ConfSelfConfiguration{"ConfSelfConfiguration", true, "Flag to active self-configuration"};
+  // particle selection bits
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> TrackCutBits;
+  // particle tpc pid bits
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> TrackPIDTPCBits;
+  // particle tpctof pid bits
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> TrackPIDTPCTOFBits;
+  // particle momemtum threshold for PID
+  std::array<std::vector<float>, CollisionMasks::kNParts> TrackPIDThreshold;
 
-  // particle 1
-  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart1{"ConfTrackCutsBitsPart1", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart2{"ConfTrackCutsBitsPart2", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackCutBitsPart3{"ConfTrackCutsBitsPart3", {1}, "Cut bits for collision masking"};
-  //
-  // // particle 2
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart1{"ConfTrackPIDTPCBitsPart1", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart2{"ConfTrackPIDTPCBitsPart2", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCBitsPart3{"ConfTrackPIDTPCBitsPart3", {1}, "Cut bits for collision masking"};
-  //
-  // // particle 3
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart1{"ConfTrackPIDTPCTOFBitsPart1", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart2{"ConfTrackPIDTPCTOFBitsPart2", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<uint32_t>> ConfTrackPIDTPCTOFBitsPart3{"ConfTrackPIDTPCTOFBitsPart3", {1}, "Cut bits for collision masking"};
-  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart1{"ConTrackPIDThresholdPart1", {0.75}, "Cut bits for collision masking"};
-  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart2{"ConTrackPIDThresholdPart2", {0.75}, "Cut bits for collision masking"};
-  // Configurable<std::vector<float>> ConfTrackPIDThresholdsPart3{"ConTrackPIDThresholdPart3", {0.75}, "Cut bits for collision masking"};
+  // particle selection for v0
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> V0CutBits;
+
+  // particle selection bits for v0 children
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> PosChildCutBits;
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> NegChildCutBits;
+
+  // particle tpc pid bits for v0 children
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> PosChildPIDTPCBits;
+  std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> NegChildPIDTPCBits;
+
+  // cuts from filters on the pair task
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterPtMin;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterPtMax;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterEtaMin;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterEtaMax;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterInvMassMin;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterInvMassMax;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterInvMassAntiMin;
+  std::array<std::vector<float>, CollisionMasks::kNParts> FilterInvMassAntiMax;
+
+  int TaskFinder = -1;
 
   void init(InitContext& context)
   {
-		// asdf
-    // if (ConfSelfConfiguration.value) {
-      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-      LOGF(info, " Collision masker self-configuration ");
-      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-      auto& workflows = context.services().get<RunningWorkflowInfo const>();
-      for (DeviceSpec const& device : workflows.devices) {
-        if (device.name.compare("femto-dream-pair-task-track-track") == 0) {
-          for (auto const& option : device.options) {
-            LOG(info) << option.name;
-            if (option.name.compare(std::string("ConfCutPartOne")) == 0) {
-              TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDTPCPartOne")) == 0) {
-              TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDTPCTOFPartOne")) == 0) {
-              TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDThresPartOne")) == 0) {
-              TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
-            } else if (option.name.compare(std::string("ConfCutPartTwo")) == 0) {
-              TrackCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDTPCPartTwo")) == 0) {
-              TrackPIDTPCBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDTPCTOFPartTwo")) == 0) {
-              TrackPIDTPCTOFBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
-            } else if (option.name.compare(std::string("ConfPIDThresPartTwo")) == 0) {
-              TrackPIDThreshold.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
-            }
+    LOG(info) << "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*";
+    LOG(info) << " Collision masker self-configuration ";
+    LOG(info) << "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*";
+    auto& workflows = context.services().get<RunningWorkflowInfo const>();
+    for (DeviceSpec const& device : workflows.devices) {
+      if (device.name.find("femto-dream-pair-task-track-track") != std::string::npos) {
+        LOG(info) << "Matched workflow: " << device.name;
+        TaskFinder = CollisionMasks::kTrackTrack;
+        for (auto const& option : device.options) {
+          if (option.name.compare(std::string("ConfTrk1_CutBit")) == 0) {
+            TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_TPCBit")) == 0) {
+            TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_TPCTOFBit")) == 0) {
+            TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_PIDThres")) == 0) {
+            TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_minPt")) == 0) {
+            FilterPtMin.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_maxPt")) == 0) {
+            FilterPtMax.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_minEta")) == 0) {
+            FilterEtaMin.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_maxEta")) == 0) {
+            FilterEtaMax.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk2_CutBit")) == 0) {
+            TrackCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk2_TPCBit")) == 0) {
+            TrackPIDTPCBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk2_TPCTOFBit")) == 0) {
+            TrackPIDTPCTOFBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk2_PIDThres")) == 0) {
+            TrackPIDThreshold.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk2_minPt")) == 0) {
+            FilterPtMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk2_maxPt")) == 0) {
+            FilterPtMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk2_minEta")) == 0) {
+            FilterEtaMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk2_maxEta")) == 0) {
+            FilterEtaMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          }
+        }
+      } else if (device.name.find(std::string("femto-dream-pair-task-track-v0")) != std::string::npos) {
+        LOG(info) << "Matched workflow: " << device.name;
+        TaskFinder = CollisionMasks::kTrackV0;
+        for (auto const& option : device.options) {
+          if (option.name.compare(std::string("ConfTrk1_CutBit")) == 0) {
+            TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_TPCBit")) == 0) {
+            TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_TPCTOFBit")) == 0) {
+            TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfTrk1_PIDThres")) == 0) {
+            TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_minPt")) == 0) {
+            FilterPtMin.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_maxPt")) == 0) {
+            FilterPtMax.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_minEta")) == 0) {
+            FilterEtaMin.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfTrk1_maxEta")) == 0) {
+            FilterEtaMax.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_CutBit")) == 0) {
+            V0CutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfV02_minPt")) == 0) {
+            FilterPtMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_maxPt")) == 0) {
+            FilterPtMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_minEta")) == 0) {
+            FilterEtaMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_maxEta")) == 0) {
+            FilterEtaMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_minInvMass")) == 0) {
+            FilterInvMassMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_maxInvMass")) == 0) {
+            FilterInvMassMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_minInvMassAnti")) == 0) {
+            FilterInvMassAntiMin.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfV02_maxInvMassAnti")) == 0) {
+            FilterInvMassAntiMax.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfChildPos_CutBit")) == 0) {
+            PosChildCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfChildPos_TPCBit")) == 0) {
+            PosChildCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfChildNeg_CutBit")) == 0) {
+            NegChildCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
+          } else if (option.name.compare(std::string("ConfChildNeg_TPCBit")) == 0) {
+            NegChildCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
           }
         }
       }
-    // } else {
-    //   TrackCutBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackCutBitsPart1.value, ConfTrackCutBitsPart2.value, ConfTrackCutBitsPart3.value};
-    //   TrackPIDTPCBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackPIDTPCBitsPart1.value, ConfTrackPIDTPCBitsPart2.value, ConfTrackPIDTPCBitsPart3.value};
-    //   TrackPIDTPCTOFBits = std::array<std::vector<uint32_t>, CollisionMasks::kNParts>{ConfTrackPIDTPCTOFBitsPart1.value, ConfTrackPIDTPCTOFBitsPart2.value, ConfTrackPIDTPCTOFBitsPart3.value};
-    //   TrackPIDThreshold = std::array<std::vector<float>, CollisionMasks::kNParts>{ConfTrackPIDThresholdsPart1.value, ConfTrackPIDThresholdsPart2.value, ConfTrackPIDThresholdsPart3.value};
-    // }
-  };
 
-  void processTrack(FDCollision const& col, FDParticles const& parts)
+      LOG(info) << "Configured values";
+      for (int i = 0; i < CollisionMasks::kNParts; i++) {
+        LOG(info) << "Part " << i+1;
+        for (size_t j = 0; j < TrackCutBits.at(i).size(); j++) {
+          LOG(info) << "Index " << j << " ->    CutBit: " << TrackCutBits.at(i).at(j);
+          LOG(info) << "Index " << j << " ->    TPCBit: " << TrackPIDTPCBits.at(i).at(j);
+          LOG(info) << "Index " << j << " -> TPCTOFBit: " << TrackPIDTPCTOFBits.at(i).at(j);
+        }
+      }
+    }
+
+    if (8 * sizeof(femtodreamcollision::BitMaskType) < TrackCutBits.at(CollisionMasks::kPartOne).size() ||
+        8 * sizeof(femtodreamcollision::BitMaskType) < TrackCutBits.at(CollisionMasks::kPartTwo).size() ||
+        8 * sizeof(femtodreamcollision::BitMaskType) < TrackCutBits.at(CollisionMasks::kPartThree).size()) {
+      LOG(fatal) << "Too many variations!";
+      LOG(fatal) << "Collision masker only supports up to " << 8 * sizeof(femtodreamcollision::BitMaskType) << " variations!";
+    }
+  }
+
+  // make bitmask for a track
+  template <typename T, typename R>
+  void MaskForTrack(T& BitSet, CollisionMasks::Parts P, R& track)
   {
-    // create a bit mask for particle one, particle two and particle three
-    std::array<std::bitset<64>, CollisionMasks::kNParts> Mask = {{0}};
-    // iterate over all tracks in this collision
-    for (auto& part : parts) {
-      // iterate over particleOne/Two/Three
-      for (size_t nPart = 0; nPart < CollisionMasks::kNParts; nPart++) {
-        // iterate over all selections for particleOne/Two/Three
-        for (size_t index = 0; index < TrackCutBits.at(nPart).size(); index++) {
-        // set the bit at the index of the selection equal to one if the track passes
-          // check track cuts
-          if ((part.cut() & TrackCutBits.at(nPart).at(index)) == TrackCutBits.at(nPart).at(index)) {
-            // check pid cuts
-            if (part.p() < TrackPIDThreshold.at(nPart).at(index)) {
-              if ((part.cut() & TrackPIDTPCBits.at(nPart).at(index)) == TrackPIDTPCBits.at(nPart).at(index)) {
-                Mask.at(nPart).set(index);
-              }
-            } else {
-              if ((part.cut() & TrackPIDTPCTOFBits.at(nPart).at(index)) == TrackPIDTPCTOFBits.at(nPart).at(index)) {
-                Mask.at(nPart).set(index);
-              }
-            }
+    if (track.partType() != static_cast<uint8_t>(femtodreamparticle::kTrack)) {
+      return;
+    }
+    // LOG(info) << "cutbits size: " << TrackCutBits.at(P).size();
+    for (size_t index = 0; index < TrackCutBits.at(P).size(); index++) {
+      // check filter cuts
+      if (track.pt() < FilterPtMin.at(P).at(index) || track.pt() > FilterPtMax.at(P).at(index) ||
+          track.eta() < FilterEtaMin.at(P).at(index) || track.eta() > FilterEtaMax.at(P).at(index)) {
+        // if they are not passed, skip the particle
+        continue;
+      }
+      // set the bit at the index of the selection equal to one if the track passes all selections
+      // check track cuts
+      if ((track.cut() & TrackCutBits.at(P).at(index)) == TrackCutBits.at(P).at(index)) {
+        // check pid cuts
+        if (track.p() < TrackPIDThreshold.at(P).at(index)) {
+          if ((track.cut() & TrackPIDTPCBits.at(P).at(index)) == TrackPIDTPCBits.at(P).at(index)) {
+            BitSet.at(P).set(index);
+          }
+        } else {
+          if ((track.cut() & TrackPIDTPCTOFBits.at(P).at(index)) == TrackPIDTPCTOFBits.at(P).at(index)) {
+            BitSet.at(P).set(index);
           }
         }
       }
     }
-    // LOG(info) << "Part1:" << Mask.at(CollisionMasks::kPartOne).to_string();
-    // LOG(info) << "Part2:" << Mask.at(CollisionMasks::kPartTwo).to_string();
-    // LOG(info) << "Part3:" << Mask.at(CollisionMasks::kPartThree).to_string();
+  }
+
+  // make bit mask for v0
+  template <typename T, typename R, typename S>
+  void MaskForV0(T& BitSet, CollisionMasks::Parts P, R& v0, S& tracks)
+  {
+    if (v0.partType() != static_cast<uint8_t>(femtodreamparticle::kV0)) {
+      return;
+    }
+    for (size_t index = 0; index < V0CutBits.at(P).size(); index++) {
+      // check filter cuts
+      if (v0.pt() < FilterPtMin.at(P).at(index) || v0.pt() > FilterPtMax.at(P).at(index) ||
+          v0.eta() < FilterEtaMin.at(P).at(index) || v0.eta() > FilterEtaMax.at(P).at(index) ||
+          v0.mLambda() < FilterInvMassMin.at(P).at(index) || v0.mLambda() > FilterInvMassMax.at(P).at(index) ||
+          v0.mAntiLambda() < FilterInvMassAntiMin.at(P).at(index) || v0.mAntiLambda() > FilterInvMassAntiMax.at(P).at(index)) {
+        // if they are not passed, skip the particle
+        continue;
+      }
+      // check cut bit of v0
+      if ((v0.cut() & TrackCutBits.at(P).at(index)) == TrackCutBits.at(P).at(index)) {
+        const auto& posChild = tracks.iteratorAt(v0.index() - 2);
+        const auto& negChild = tracks.iteratorAt(v0.index() - 1);
+        // check cut on v0 children
+        if ((posChild.cut() & PosChildCutBits.at(P).at(index)) == PosChildCutBits.at(P).at(index) &&
+            (posChild.pidcut() & PosChildPIDTPCBits.at(P).at(index)) == PosChildPIDTPCBits.at(P).at(index) &&
+            (negChild.cut() & NegChildCutBits.at(P).at(index)) == NegChildCutBits.at(P).at(index) &&
+            (negChild.pidcut() & NegChildPIDTPCBits.at(P).at(index)) == NegChildPIDTPCBits.at(P).at(index)) {
+          BitSet.at(P).set(index);
+        }
+      }
+    }
+  }
+
+  void process(FDCollision const& col, FDParticles const& parts)
+  {
+    // create a bit mask for particle one, particle two and particle three
+    std::array<std::bitset<8 * sizeof(femtodreamcollision::BitMaskType)>, CollisionMasks::kNParts> Mask = {{0}};
+
+    switch (TaskFinder) {
+      case CollisionMasks::kTrackTrack:
+        // pair-track-track task
+        // create mask for track 1 and track 2
+        for (auto const& part : parts) {
+          MaskForTrack(Mask, CollisionMasks::kPartOne, part);
+          MaskForTrack(Mask, CollisionMasks::kPartTwo, part);
+        }
+        break;
+      case CollisionMasks::kTrackV0:
+        // pair-track-v0 task
+        // create mask for track 1 and v0 2
+        for (auto const& part : parts) {
+          MaskForTrack(Mask, CollisionMasks::kPartOne, part);
+          MaskForV0(Mask, CollisionMasks::kPartTwo, part, parts);
+        }
+        break;
+      default:
+        LOG(fatal) << "No femtodream pair task found!";
+    }
     // fill bitmask for each collision
-    Masks(static_cast<uint32_t>(Mask.at(CollisionMasks::kPartOne).to_ulong()),
-          static_cast<uint32_t>(Mask.at(CollisionMasks::kPartTwo).to_ulong()),
-          static_cast<uint32_t>(Mask.at(CollisionMasks::kPartThree).to_ulong()));
+    // LOG(info) << Mask.at(CollisionMasks::kPartOne).to_string();
+    // LOG(info) << Mask.at(CollisionMasks::kPartTwo).to_string();
+    Masks(static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartOne).to_ulong()),
+          static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartTwo).to_ulong()),
+          static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartThree).to_ulong()));
   };
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<femtoDreamCollisionMasker>(cfgc)};
+  WorkflowSpec workflow{adaptAnalysisTask<femoDreamCollisionMasker>(cfgc)};
   return workflow;
 };

--- a/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
@@ -1,0 +1,123 @@
+// Copyright 2019-2023 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoDreamCollisionMasker.cxx
+/// \brief Tasks creates bitmasks for collisions
+/// \author Anton Riedel, TU München, anton.riedel@tum.de
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/RunningWorkflowInfo.h"
+
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <bitset>
+#include "PWGCF/DataModel/FemtoDerived.h"
+
+using namespace o2::aod;
+using namespace o2::framework;
+
+namespace CollisionMasks
+{
+enum Parts {
+  kPartOne,
+  kPartTwo,
+  kPartThree,
+  kNParts
+};
+}
+
+struct femtoDreamCollisionMasker {
+  Produces<FDColMasks> Masks;
+  /// track selection bits
+  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackCutBits = {};
+  /// track tpc pid bits
+  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackPIDTPCBits = {};
+  /// track tpctof pid bits
+  std::array<std::vector<uint32_t>, CollisionMasks::kNParts> TrackPIDTPCTOFBits = {};
+  /// track momemtum threshold for PID
+  std::array<std::vector<float>, CollisionMasks::kNParts> TrackPIDThreshold = {};
+
+  void init(InitContext& context)
+  {
+    LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
+    LOGF(info, " Collision masker self-configuration ");
+    LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
+    auto& workflows = context.services().get<RunningWorkflowInfo const>();
+    for (DeviceSpec const& device : workflows.devices) {
+      if (device.name.compare("femto-dream-pair-task-track-track") == 0) {
+        for (auto const& option : device.options) {
+          LOG(info) << option.name;
+          if (option.name.compare(std::string("ConfCutPartOne")) == 0) {
+            TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDTPCPartOne")) == 0) {
+            TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDTPCTOFPartOne")) == 0) {
+            TrackPIDTPCTOFBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDThresPartOne")) == 0) {
+            TrackPIDThreshold.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<float>());
+          } else if (option.name.compare(std::string("ConfCutPartTwo")) == 0) {
+            TrackCutBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDTPCPartTwo")) == 0) {
+            TrackPIDTPCBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDTPCTOFPartTwo")) == 0) {
+            TrackPIDTPCTOFBits.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<uint32_t>());
+          } else if (option.name.compare(std::string("ConfPIDThresPartTwo")) == 0) {
+            TrackPIDThreshold.at(CollisionMasks::kPartTwo).push_back(option.defaultValue.get<float>());
+          }
+        }
+      }
+    }
+    // for(auto i : TrackCutBits.at(0)){
+    // 	LOG(info) << i;
+    // }
+  };
+
+  void process(FDCollision const& col, FDParticles const& parts)
+  {
+    std::array<std::bitset<64>, CollisionMasks::kNParts> Mask = {{0}};
+    for (auto& part : parts) {
+      for (size_t nPart = 0; nPart < CollisionMasks::kNParts; nPart++) {
+        for (size_t index = 0; index < TrackCutBits.at(nPart).size(); index++) {
+          if ((part.cut() & TrackCutBits.at(nPart).at(index)) == TrackCutBits.at(nPart).at(index)) {
+            if (part.p() < TrackPIDThreshold.at(nPart).at(index)) {
+              if ((part.cut() & TrackPIDTPCBits.at(nPart).at(index)) == TrackPIDTPCBits.at(nPart).at(index)) {
+                Mask.at(nPart).set(index);
+              }
+            } else {
+              if ((part.cut() & TrackPIDTPCTOFBits.at(nPart).at(index)) == TrackPIDTPCTOFBits.at(nPart).at(index)) {
+                Mask.at(nPart).set(index);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // LOG(info) << "Part1:" << Mask.at(CollisionMasks::kPartOne).to_string();
+    // LOG(info) << "Part2:" << Mask.at(CollisionMasks::kPartTwo).to_string();
+    // LOG(info) << "Part3:" << Mask.at(CollisionMasks::kPartThree).to_string();
+
+    Masks(static_cast<uint32_t>(Mask.at(CollisionMasks::kPartOne).to_ulong()),
+          static_cast<uint32_t>(Mask.at(CollisionMasks::kPartTwo).to_ulong()),
+          static_cast<uint32_t>(Mask.at(CollisionMasks::kPartThree).to_ulong()));
+  };
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{adaptAnalysisTask<femtoDreamCollisionMasker>(cfgc)};
+  return workflow;
+};

--- a/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/femtoDreamCollisionMasker.cxx
@@ -219,7 +219,7 @@ struct femoDreamCollisionMasker {
 
   // make bit mask for v0
   template <typename T, typename R, typename S>
-  void MaskForV0(T& BitSet, CollisionMasks::Parts P, R& v0, S& tracks)
+  void MaskForV0(T& BitSet, CollisionMasks::Parts P, R& v0, S& parts)
   {
     if (v0.partType() != static_cast<uint8_t>(femtodreamparticle::kV0)) {
       return;
@@ -235,10 +235,12 @@ struct femoDreamCollisionMasker {
       }
       // check cut bit of v0
       if ((v0.cut() & V0CutBits.at(P).at(index)) == V0CutBits.at(P).at(index)) {
-        // const auto& posChild = tracks.iteratorAt(v0.index() - 2);
-        auto posChild = v0.template children_as<FDParticles>().front();
-        // const auto& negChild = tracks.iteratorAt(v0.index() - 1);
-        auto negChild = v0.template children_as<FDParticles>().back();
+        const auto& posChild = parts.iteratorAt(v0.index() - 2);
+        const auto& negChild = parts.iteratorAt(v0.index() - 1);
+        // This is how it is supposed to work but there seems to be an issue
+        // for now, keep in sync with femtodreampairtasktrackv0
+        // auto posChild = v0.template children_as<FDParticles>().front();
+        // auto negChild = v0.template children_as<FDParticles>().back();
         // check cut on v0 children
         if ((posChild.cut() & PosChildCutBits.at(P).at(index)) == PosChildCutBits.at(P).at(index) &&
             (posChild.pidcut() & PosChildPIDTPCBits.at(P).at(index)) == PosChildPIDTPCBits.at(P).at(index) &&
@@ -271,6 +273,7 @@ struct femoDreamCollisionMasker {
           MaskForTrack(Mask, CollisionMasks::kPartOne, part);
           MaskForV0(Mask, CollisionMasks::kPartTwo, part, parts);
         }
+        // TODO: add all supported pair/triplet tasks
         break;
       default:
         LOG(fatal) << "No femtodream pair task found!";

--- a/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugTrack.cxx
@@ -13,6 +13,7 @@
 /// \brief Tasks that reads the particle tables and fills QA histograms for tracks
 /// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
+#include <Framework/Expressions.h>
 #include "DataFormatsParameters/GRPObject.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisTask.h"
@@ -44,12 +45,12 @@ struct femtoDreamDebugTrack {
   SliceCache cache;
 
   Configurable<LabeledArray<float>> ConfCutTable{"ConfCutTable", {cutsTable[0], nCuts, cutNames}, "Particle selections"};
-  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
   Configurable<int> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint32_t> ConfCutPartOne{"ConfCutPartOne", 5542474, "Particle 1 - Selection bit from cutCulator"};
-  Configurable<int> ConfPIDPartOne{"ConfPIDPartOne", 1, "Particle 1 - Read from cutCulator"};
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{3.5f, 3.f, 2.5f}, "This configurable needs to be the same as the one used in the producer task"};
+  Configurable<float> ConfPIDThresPartOne{"ConfPIDThresPartOne", 0.75, "Particle 1 - Read from cutCulator"};
+  Configurable<uint32_t> ConfPIDTPCPartOne{"ConfPIDTPCPartOne", 1, "Particle 1 - Read from cutCulator"};
+  Configurable<uint32_t> ConfPIDTPCTOFPartOne{"ConfPIDTPCTOFPartOne", 1, "Particle 1 - Read from cutCulator"};
   ConfigurableAxis ConfTempFitVarBins{"ConfTempFitVarBins", {300, -0.15, 0.15}, "Binning of the TempFitVar"};
   ConfigurableAxis ConfNsigmaTPCBins{"ConfNsigmaTPCBins", {1600, -8, 8}, "Binning of Nsigma TPC plot"};
   ConfigurableAxis ConfNsigmaTOFBins{"ConfNsigmaTOFBins", {3000, -15, 15}, "Binning of the Nsigma TOF plot"};
@@ -59,21 +60,20 @@ struct femtoDreamDebugTrack {
   ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis for inv mass"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
-  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ncheckbit(aod::femtodreamparticle::cut, ConfCutPartOne) &&
+                                           ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= ConfPIDThresPartOne, ncheckbit(aod::femtodreamparticle::pidcut, ConfPIDTPCPartOne), ncheckbit(aod::femtodreamparticle::pidcut, ConfPIDTPCTOFPartOne));
+
   Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::fdCollisionId;
 
   using FemtoFullParticlesMC = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>;
-  Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfCutPartOne) == ConfCutPartOne);
+  Partition<FemtoFullParticlesMC> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ncheckbit(aod::femtodreamparticle::cut, ConfCutPartOne);
   Preslice<FemtoFullParticlesMC> perColGen = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
 
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack> trackHisto;
-
-  /// The configurables need to be passed to an std::vector
-  int vPIDPartOne;
-  std::vector<float> kNsigma;
 
   /// Histogram output
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -82,8 +82,6 @@ struct femtoDreamDebugTrack {
   {
     eventHisto.init(&qaRegistry);
     trackHisto.init(&qaRegistry, ConfTempFitVarMomentumBins, ConfTempFitVarBins, ConfNsigmaTPCBins, ConfNsigmaTOFBins, ConfNsigmaTPCTOFBins, ConfDummy, ConfIsMC, ConfPDGCodePartOne.value, true);
-    vPIDPartOne = ConfPIDPartOne.value;
-    kNsigma = ConfTrkPIDnSigmaMax.value;
   }
 
   /// Porduce QA plots for sigle track selection in FemtoDream framework
@@ -92,12 +90,7 @@ struct femtoDreamDebugTrack {
   {
     eventHisto.fillQA(col);
     for (auto& part : groupPartsOne) {
-      if (part.p() > ConfCutTable->get("MaxP") || part.pt() > ConfCutTable->get("MaxPt")) {
-        continue;
-      }
-      if (!isFullPIDSelected(part.pidcut(), part.p(), ConfCutTable->get("PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfCutTable->get("nSigmaTPC"), ConfCutTable->get("nSigmaTPCTOF"))) {
-        continue;
-      }
+      // if( (part.p() < ConfPIDThresPartOne.value && (part.pidcut() & (1u << (ConfPIDTPCPartOne.value))) != 0u) || (part.p() > ConfPIDThresPartOne.value && (part.pidcut() & (1u << (ConfPIDTPCTOFPartOne.value))) != 0u)){
       trackHisto.fillQA<isMC, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
     }
   }

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -56,18 +56,13 @@ struct femtoDreamDebugV0 {
   ConfigurableAxis ConfChildNsigmaTPCTOFBins{"ConfChildNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
 
   Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
-  Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
-  Configurable<float> ConfChildPosPidnSigmaMax{"ConfChildPosPidnSigmaMax", 3.f, "Positive Child of V0 - Selection bit from cutCulator"};
-  Configurable<float> ConfChildNegPidnSigmaMax{"ConfChildNegPidnSigmaMax", 3.f, "Negative Child of V0 - Selection bit from cutCulator"};
-  Configurable<int> ConfChildPosIndex{"ConfChildPosIndex", 1, "Positive Child of V0 - Index from cutCulator"};
-  Configurable<int> ConfChildNegIndex{"ConfChildNegIndex", 0, "Negative Child of V0 - Index from cutCulator"};
-  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f}, "V0 child sel: Max. PID nSigma TPC"};
-  Configurable<int> ConfChildnSpecies{"ConfChildnSpecies", 2, "Number of particle spieces (for V0 children) with PID info"};
+  Configurable<uint32_t> ConfPIDTPCChildPos{"ConfPIDTPCChildPos", 4, "Positive Child of V0 - PID bit from cutCulator"};
+  Configurable<uint32_t> ConfPIDTPCChildNeg{"ConfPIDTPCChildNeg", 8, "Negative Child of V0 - PID bit from cutCulator"};
   ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
-  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfCutV0) == ConfCutV0);
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && (ncheckbit(aod::femtodreamparticle::cut,ConfCutV0));
   Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming
@@ -104,9 +99,12 @@ struct femtoDreamDebugV0 {
         continue;
       }
       // check cuts on V0 children
-      if ((posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (posChild.cut() & ConfCutChildPos) == ConfCutChildPos) &&
-          (negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) && (negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) &&
-          isFullPIDSelected(posChild.pidcut(), posChild.p(), 999.f, ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildPosPidnSigmaMax.value, 1.f) && isFullPIDSelected(negChild.pidcut(), negChild.p(), 999.f, ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfChildNegPidnSigmaMax.value, 1.f)) {
+      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
+				(posChild.cut() & ConfCutChildPos) == ConfCutChildPos &&
+				(posChild.pidcut() & ConfPIDTPCChildPos) == ConfPIDTPCChildPos &&
+          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
+				(negChild.cut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg &&
+				(negChild.pidcut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg){
         V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
         posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
         negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -13,7 +13,6 @@
 /// \brief Tasks that reads the particle tables and fills QA histograms for V0s
 /// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
 
-#include <fairlogger/Logger.h>
 #include <cstdint>
 #include <iostream>
 #include <vector>
@@ -24,6 +23,7 @@
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/StepTHn.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "fairlogger/Logger.h"
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "FemtoDreamParticleHisto.h"
@@ -39,30 +39,30 @@ using namespace o2::soa;
 struct femtoDreamDebugV0 {
   SliceCache cache;
 
-  Configurable<int> ConfPDGCodeV0{"ConfPDGCodePartOne", 3122, "V0 - PDG code"};
-  Configurable<int> ConfPDGCodeChildPos{"ConfPDGCodeChildPos", 2212, "Positive Child - PDG code"};
-  Configurable<int> ConfPDGCodeChildNeg{"ConfPDGCodeChildNeg", 211, "Negative Child- PDG code"};
-  Configurable<uint32_t> ConfCutV0{"ConfCutV0", 338, "V0 - Selection bit from cutCulator"};
+  Configurable<int> ConfV01_PDGCode{"ConfV01_PDGCode", 3122, "V0 - PDG code"};
+  Configurable<int> ConfV01_ChildPos_PDGCode{"ConfV01_PosChild_PDGCode", 2212, "Positive Child - PDG code"};
+  Configurable<int> ConfV01_NegChild_PDGCode{"ConfV01_NegChild_PDGCode", 211, "Negative Child- PDG code"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_CutBit{"ConfV01_CutBit", 338, "V0 - Selection bit from cutCulator"};
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarMomentumBins{"ConfV0TempFitVarMomentumBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
 
-  Configurable<int> ConfTempFitVarMomentum{"ConfTempFitVarMomentum", 0, "Momentum used for binning: 0 -> pt; 1 -> preco; 2 -> ptpc"};
+  Configurable<int> ConfV0TempFitVarMomentum{"ConfV0TempFitVarMomentum", 0, "Momentum used for binning: 0 -> pt; 1 -> preco; 2 -> ptpc"};
 
   ConfigurableAxis ConfV0InvMassBins{"ConfV0InvMassBins", {200, 1, 1.2}, "V0: InvMass binning"};
 
-  ConfigurableAxis ConfChildTempFitVarMomentumBins{"ConfChildTempFitVarMomentumBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
-  ConfigurableAxis ConfChildNsigmaTPCBins{"ConfChildNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
-  ConfigurableAxis ConfChildNsigmaTOFBins{"ConfChildNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
-  ConfigurableAxis ConfChildNsigmaTPCTOFBins{"ConfChildNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
+  ConfigurableAxis ConfV0ChildTempFitVarMomentumBins{"ConfV0ChildTempFitVarMomentumBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
+  ConfigurableAxis ConfV0ChildNsigmaTPCBins{"ConfV0ChildNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
+  ConfigurableAxis ConfV0ChildNsigmaTOFBins{"ConfV0ChildNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+  ConfigurableAxis ConfV0ChildNsigmaTPCTOFBins{"ConfV0ChildNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
 
-  Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
-  Configurable<uint32_t> ConfPIDTPCChildPos{"ConfPIDTPCChildPos", 4, "Positive Child of V0 - PID bit from cutCulator"};
-  Configurable<uint32_t> ConfPIDTPCChildNeg{"ConfPIDTPCChildNeg", 8, "Negative Child of V0 - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_CutBit{"ConfV01_ChildPos_CutBit", 150, "Positive Child of V0 - Selection bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_TPCBit{"ConfV01_ChildPos_TPCBit", 4, "Positive Child of V0 - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildNeg_TPCBit{"ConfV01_ChildNeg_TPCBit", 8, "Negative Child of V0 - PID bit from cutCulator"};
   ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
-  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && (ncheckbit(aod::femtodreamparticle::cut, ConfCutV0));
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && (ncheckbit(aod::femtodreamparticle::cut, ConfV01_CutBit));
   Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming
@@ -78,9 +78,9 @@ struct femtoDreamDebugV0 {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry);
-    posChildHistos.init(&V0Registry, ConfChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfChildNsigmaTPCBins, ConfChildNsigmaTOFBins, ConfChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfPDGCodeChildPos.value, true);
-    negChildHistos.init(&V0Registry, ConfChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfChildNsigmaTPCBins, ConfChildNsigmaTOFBins, ConfChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfPDGCodeChildNeg, true);
-    V0Histos.init(&V0Registry, ConfV0TempFitVarMomentumBins, ConfV0TempFitVarBins, ConfChildNsigmaTPCBins, ConfChildNsigmaTOFBins, ConfChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfPDGCodeV0.value, true);
+    posChildHistos.init(&V0Registry, ConfV0ChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
+    negChildHistos.init(&V0Registry, ConfV0ChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_NegChild_PDGCode, true);
+    V0Histos.init(&V0Registry, ConfV0TempFitVarMomentumBins, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
@@ -92,27 +92,26 @@ struct femtoDreamDebugV0 {
       if (!part.has_children()) {
         continue;
       }
-        // const auto& posChild = tracks.iteratorAt(v0.index() - 2);
-        auto posChild = part.template children_as<FemtoFullParticles>().front();
-        // const auto& negChild = tracks.iteratorAt(v0.index() - 1);
-        auto negChild = part.template children_as<FemtoFullParticles>().back();
-        // check cut on v0 children
-      // const auto& posChild = parts.iteratorAt(part.index() - 2);
-      // const auto& negChild = parts.iteratorAt(part.index() - 1);
+      // check cut on v0 children
+      // TODO: check if this should be possible
+      // auto posChild = part.template children_as<FemtoFullParticles>().front();
+      // auto negChild = part.template children_as<FemtoFullParticles>().back();
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
       if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
         LOG(warn) << "Indices of V0 children do not match";
         continue;
       }
       // check cuts on V0 children
       if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-          (posChild.cut() & ConfCutChildPos) == ConfCutChildPos &&
-          (posChild.pidcut() & ConfPIDTPCChildPos) == ConfPIDTPCChildPos &&
+          (posChild.cut() & ConfV01_ChildPos_CutBit) == ConfV01_ChildPos_CutBit &&
+          (posChild.pidcut() & ConfV01_ChildPos_TPCBit) == ConfV01_ChildPos_TPCBit &&
           negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-          (negChild.cut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg &&
-          (negChild.pidcut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg) {
-        V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
-        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
-        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
+          (negChild.cut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit &&
+          (negChild.pidcut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit) {
+        V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value));
+        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value));
+        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value));
       }
     }
   }

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -92,8 +92,13 @@ struct femtoDreamDebugV0 {
       if (!part.has_children()) {
         continue;
       }
-      const auto& posChild = parts.iteratorAt(part.index() - 2);
-      const auto& negChild = parts.iteratorAt(part.index() - 1);
+        // const auto& posChild = tracks.iteratorAt(v0.index() - 2);
+        auto posChild = part.template children_as<FemtoFullParticles>().front();
+        // const auto& negChild = tracks.iteratorAt(v0.index() - 1);
+        auto negChild = part.template children_as<FemtoFullParticles>().back();
+        // check cut on v0 children
+      // const auto& posChild = parts.iteratorAt(part.index() - 2);
+      // const auto& negChild = parts.iteratorAt(part.index() - 1);
       if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
         LOG(warn) << "Indices of V0 children do not match";
         continue;

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -62,7 +62,7 @@ struct femtoDreamDebugV0 {
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
-  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && (ncheckbit(aod::femtodreamparticle::cut,ConfCutV0));
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && (ncheckbit(aod::femtodreamparticle::cut, ConfCutV0));
   Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Histogramming
@@ -100,11 +100,11 @@ struct femtoDreamDebugV0 {
       }
       // check cuts on V0 children
       if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-				(posChild.cut() & ConfCutChildPos) == ConfCutChildPos &&
-				(posChild.pidcut() & ConfPIDTPCChildPos) == ConfPIDTPCChildPos &&
+          (posChild.cut() & ConfCutChildPos) == ConfCutChildPos &&
+          (posChild.pidcut() & ConfPIDTPCChildPos) == ConfPIDTPCChildPos &&
           negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-				(negChild.cut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg &&
-				(negChild.pidcut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg){
+          (negChild.cut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg &&
+          (negChild.pidcut() & ConfPIDTPCChildNeg) == ConfPIDTPCChildNeg) {
         V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
         posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));
         negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value));

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -214,18 +214,6 @@ struct femtoDreamPairTaskTrackTrack {
     }
   };
 
-  template <typename T, typename R>
-  bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
-  {
-    for (const auto& obj : myVector) {
-      if (obj.name == name) {
-        if (std::abs(static_cast<float>((obj.defaultValue.template get<R>() - value))) < 1e-2) {
-          return true; // Found a match
-        }
-      }
-    }
-    return false; // No match found
-  }
 
   template <typename CollisionType>
   void fillCollision(CollisionType col)
@@ -385,7 +373,7 @@ struct femtoDreamPairTaskTrackTrack {
     PartitionMaskedCol1.bindTable(cols);
     PartitionMaskedCol2.bindTable(cols);
 
-    for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockStrictlyUpperSameIndexPolicy(colBinning, ConfNEventsMix.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {
+    for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(colBinning, ConfNEventsMix.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {
       const auto multiplicityCol = collision1.multNtr();
       const auto magFieldTesla1 = collision1.magField();
       MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackTrack.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 CERN and copyright holders of ALICE O2.pairtasktracktrack
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -35,83 +35,66 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::analysis::femtoDream;
 
-namespace
-{
-static constexpr int nTrack = 1;
-static constexpr int nV0Children = 2;
-static constexpr int nCuts = 3;
-static const std::vector<std::string> TrackName{"Track"};
-static const std::vector<std::string> V0ChildrenName{"PosChild", "NegChild"};
-static const std::vector<std::string> cutNames{"PIDthr", "nSigmaTPC", "nSigmaTPCTOF"};
-static const float cutsTableTrack[nTrack][nCuts]{{0.75f, 3.f, 3.f}};
-static const float cutsTableV0Children[nV0Children][nCuts]{
-  {99.f, 5.f, 5.f},
-  {99.f, 5.f, 5.f}};
-} // namespace
-
 struct femtoDreamPairTaskTrackV0 {
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
   /// Particle 1 (track)
-  Configurable<LabeledArray<float>> ConfTrkCutTable{"ConfTrkCutTable", {cutsTableTrack[0], nTrack, nCuts, TrackName, cutNames}, "Particle selections"};
-  Configurable<int> ConfTrkPDGCodePartOne{"ConfTrkPDGCodePartOne", 2212, "Particle 1 (Track) - PDG code"};
-  Configurable<uint32_t> ConfTrkCutPartOne{"ConfTrkCutPartOne", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
-  Configurable<int> ConfTrkPIDPartOne{"ConfTrkPIDPartOne", 2, "Particle 1 - Read from cutCulator"};
-  Configurable<int> ConfNspecies{"ConfNspecies", 2, "Number of particle spieces with PID info"};
-  Configurable<std::vector<float>> ConfTrkPIDnSigmaMax{"ConfTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
+  Configurable<int> ConfTrk1_PDGCode{"ConfTrk1_PDGCode", 2212, "PDG code of Particle 1 (Track)"};
+  Configurable<uint32_t> ConfTrk1_CutBit{"ConfTrkCutPartOne", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
+  Configurable<uint32_t> ConfTrk1_TPCBit{"ConfTrk1_TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
+  Configurable<uint32_t> ConfTrk1_TPCTOFBit{"ConfTrk1_TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
+  Configurable<float> ConfTrk1_PIDThres{"ConfPIDThresPartOne", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
+  Configurable<float> ConfTrk1_minPt{"ConfTrk1_minPt", 0., "Minimum pT of partricle 1 (Track)"};
+  Configurable<float> ConfTrk1_maxPt{"ConfTrk1_maxPt", 999., "Maximum pT of partricle 1 (Track)"};
+  Configurable<float> ConfTrk1_minEta{"ConfTrk1_minEta", -10., "Minimum eta of partricle 1 (Track)"};
+  Configurable<float> ConfTrk1_maxEta{"ConfTrk1_maxEta", 10., "Maximum eta of partricle 1 (Track)"};
+
   ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTrkTempFitVarpTBins{"ConfTrkTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
-  Configurable<float> ConfTrkminPt{"ConfTrkminPt", 0., "Minimum pT of Partricle 1 (Track)"};
-  Configurable<float> ConfTrkmaxPt{"ConfTrkmaxPt", 999., "Maximum pT of Partricle 1 (Track)"};
-  Configurable<float> ConfTrkminEta{"ConfTrkminEta", -10., "Minimum eta of Partricle 1 (Track)"};
-  Configurable<float> ConfTrkmaxEta{"ConfTrkmaxEta", 10., "Maximum eta of Partricle 1 (Track)"};
-
-  Filter trackPtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt > ConfTrkminPt, true);
-  Filter trackPtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt < ConfTrkmaxPt, true);
-  Filter trackEtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta > ConfTrkminEta, true);
-  Filter trackEtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta < ConfTrkmaxEta, true);
+  Filter trackPtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt > ConfTrk1_minPt, true);
+  Filter trackPtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt < ConfTrk1_maxPt, true);
+  Filter trackEtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta > ConfTrk1_minEta, true);
+  Filter trackEtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta < ConfTrk1_maxEta, true);
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
 
   /// Particle 2 (V0)
-  Configurable<LabeledArray<float>> ConfV0ChildrenCutTable{"ConfV0ChildrenCutTable", {cutsTableV0Children[0], nV0Children, nCuts, V0ChildrenName, cutNames}, "V0 Children selections"};
-  Configurable<int> ConfV0PDGCodePartTwo{"ConfV0PDGCodePartTwo", 3122, "Particle 2 (V0) - PDG code"};
-  Configurable<uint32_t> ConfV0CutPartTwo{"ConfV0CutPartTwo", 338, "Particle 2 (V0) - Selection bit"};
+  Configurable<int> ConfV02_PDGCode{"ConfV02_PDGCode", 3122, "PDG code of particle 2 (V0)"};
+  Configurable<uint32_t> ConfV02_CutBit{"ConfV02_CutBit", 338, "Selection bit for particle 2 (V0)"};
+  Configurable<uint32_t> ConfChildPos_CutBit{"ConfChildPos_CutBit", 149, "Selection bit for positive child of V0"};
+  Configurable<uint32_t> ConfChildPos_TPCBit{"ConfChildPos_TPCBit", 2, "PID TPC bit for positive child of V0"};
+  Configurable<uint32_t> ConfChildNeg_CutBit{"ConfChildNeg_CutBit", 149, "Selection bit for negative child of V0"};
+  Configurable<uint32_t> ConfChildNeg_TPCBit{"ConfChildNeg_TPCBit", 2, "PID TPC bit for negative child of V0"};
+
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarInvMassBins{"ConfV0TempFitVarInvMassBins", {200, 1, 1.2}, "V0: InvMass binning"};
 
-  Configurable<uint32_t> ConfCutChildPos{"ConfCutChildPos", 150, "Positive Child of V0 - Selection bit from cutCulator"};
-  Configurable<uint32_t> ConfCutChildNeg{"ConfCutChildNeg", 149, "Negative Child of V0 - Selection bit from cutCulator"};
-  Configurable<int> ConfChildPosIndex{"ConfChildPosIndex", 1, "Positive Child of V0 - Index from cutCulator"};
-  Configurable<int> ConfChildNegIndex{"ConfChildNegIndex", 0, "Negative Child of V0 - Index from cutCulator"};
-  Configurable<std::vector<float>> ConfChildPIDnSigmaMax{"ConfChildPIDnSigmaMax", std::vector<float>{4.f, 3.f}, "V0 child sel: Max. PID nSigma TPC"};
-  Configurable<int> ConfChildnSpecies{"ConfChildnSpecies", 2, "Number of particle spieces (for V0 children) with PID info"};
   ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
-  Configurable<float> ConfV0minMass{"ConfV0minMass", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
-  Configurable<float> ConfV0maxMass{"ConfV0maxMass", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
-  Configurable<float> ConfV0minMassAnti{"ConfV0minMassAnti", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
-  Configurable<float> ConfV0maxMassAnti{"ConfV0maxMassAnti", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
+  Configurable<float> ConfV02_minInvMass{"ConfV02_minInvMass", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
+  Configurable<float> ConfV02_maxInvMass{"ConfV02_maxInvMass", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
+  Configurable<float> ConfV02_minInvMassAnti{"ConfV02_minInvMassAnti", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
+  Configurable<float> ConfV02_maxInvMassAnti{"ConfV02_maxInvMassAnti", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
 
-  Configurable<float> ConfV0minPt{"ConfV0minPt", 0., "Minimum pT of Partricle 2 (V0)"};
-  Configurable<float> ConfV0maxPt{"ConfV0maxPt", 999., "Maximum pT of Partricle 2 (V0)"};
-  Configurable<float> ConfV0minEta{"ConfV0minEta", -10., "Minimum eta of Partricle 2 (V0)"};
-  Configurable<float> ConfV0maxEta{"ConfV0maxEta", 10., "Maximum eta of Partricle 2 (V0)"};
+  Configurable<float> ConfV02_minPt{"ConfV02_minPt", 0., "Minimum pT of Partricle 2 (V0)"};
+  Configurable<float> ConfV02_maxPt{"ConfV02_maxPt", 999., "Maximum pT of Partricle 2 (V0)"};
+  Configurable<float> ConfV02_minEta{"ConfV02_minEta", -10., "Minimum eta of Partricle 2 (V0)"};
+  Configurable<float> ConfV02_maxEta{"ConfV02_maxEta", 10., "Maximum eta of Partricle 2 (V0)"};
 
-  Filter v0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda > ConfV0minMass, true);
-  Filter v0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda < ConfV0maxMass, true);
-  Filter antiv0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda > ConfV0minMassAnti, true);
-  Filter antiv0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda < ConfV0maxMassAnti, true);
+  Filter v0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda > ConfV02_minInvMass, true);
+  Filter v0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda < ConfV02_maxInvMass, true);
+  Filter antiv0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda > ConfV02_minInvMassAnti, true);
+  Filter antiv0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda < ConfV02_maxInvMassAnti, true);
 
-  Filter v0PtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt > ConfV0minPt, true);
-  Filter v0PtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt < ConfV0maxPt, true);
-  Filter v0EtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta > ConfV0minEta, true);
-  Filter v0EtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta < ConfV0maxEta, true);
+  Filter v0PtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt > ConfV02_minPt, true);
+  Filter v0PtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt < ConfV02_maxPt, true);
+  Filter v0EtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta > ConfV02_minEta, true);
+  Filter v0EtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta < ConfV02_maxEta, true);
 
   /// Histogramming for particle 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
@@ -125,18 +108,19 @@ struct femtoDreamPairTaskTrackV0 {
   using FilteredFDMCPart = FilteredFDMCParts::iterator;
 
   /// Partition for particle 1
-  Partition<FilteredFDParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfTrkCutPartOne) == ConfTrkCutPartOne);
-  Partition<FilteredFDMCParts> partsOneMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && ((aod::femtodreamparticle::cut & ConfTrkCutPartOne) == ConfTrkCutPartOne);
+  Partition<FilteredFDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                                 (ncheckbit(aod::femtodreamparticle::cut, ConfTrk1_CutBit)) &&
+                                                 ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= ConfTrk1_PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCBit), ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCTOFBit));
+  Partition<FilteredFDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                                 (ncheckbit(aod::femtodreamparticle::cut, ConfTrk1_CutBit)) &&
+                                                 ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= ConfTrk1_PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCBit), ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCTOFBit));
 
   /// Partition for particle 2
-  Partition<FilteredFDParticles> partsTwo = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV0CutPartTwo) == ConfV0CutPartTwo);
-  Partition<FilteredFDMCParts> partsTwoMC = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV0CutPartTwo) == ConfV0CutPartTwo);
+  Partition<FilteredFDParticles> PartitionV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV02_CutBit) == ConfV02_CutBit);
+  Partition<FilteredFDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & ConfV02_CutBit) == ConfV02_CutBit);
 
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
-
-  int vPIDPartOne;
-  std::vector<float> kNsigma;
 
   /// Correlation part
   Configurable<bool> ConfIsMC{"ConfIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
@@ -172,85 +156,73 @@ struct femtoDreamPairTaskTrackV0 {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry);
-    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrkPDGCodePartOne);
-    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfV0TempFitVarInvMassBins, ConfIsMC, ConfV0PDGCodePartTwo);
+    trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrk1_PDGCode);
+    trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfV0TempFitVarInvMassBins, ConfIsMC, ConfV02_PDGCode);
     posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
     negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
 
     sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D, ConfExtendedPlots, ConfHighkstarCut);
-    sameEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);
+    sameEventCont.setPDGCodes(ConfTrk1_PDGCode, ConfV02_PDGCode);
     mixedEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D, ConfExtendedPlots, ConfHighkstarCut);
-    mixedEventCont.setPDGCodes(ConfTrkPDGCodePartOne, ConfV0PDGCodePartTwo);
+    mixedEventCont.setPDGCodes(ConfTrk1_PDGCode, ConfV02_PDGCode);
     pairCleaner.init(&qaRegistry);
     if (ConfIsCPR.value) {
       pairCloseRejection.init(&resultRegistry, &qaRegistry, ConfCPRdeltaPhiMax.value, ConfCPRdeltaEtaMax.value, ConfCPRPlotPerRadii.value);
     }
-    vPIDPartOne = ConfTrkPIDPartOne.value;
-    kNsigma = ConfTrkPIDnSigmaMax.value;
   }
 
   /// This function processes the same event and takes care of all the histogramming
   /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
   template <bool isMC, typename PartitionType, typename PartType>
-  void doSameEvent(PartitionType groupPartsOne, PartitionType groupPartsTwo, PartType parts, float magFieldTesla, int multCol)
+  void doSameEvent(PartitionType SliceTrk1, PartitionType SliceV02, PartType parts, float magFieldTesla, int multCol)
   {
-
     /// Histogramming same event
-    for (auto& part : groupPartsOne) {
-      if (!isFullPIDSelected(part.pidcut(), part.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
-        continue;
-      }
+    for (auto& part : SliceTrk1) {
       trackHistoPartOne.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt);
     }
-    for (auto& part : groupPartsTwo) {
+    for (auto& part : SliceV02) {
       const auto& posChild = parts.iteratorAt(part.index() - 2);
       const auto& negChild = parts.iteratorAt(part.index() - 1);
       // check cuts on V0 children
-      if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
-        continue;
+      if (((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit)) {
+        trackHistoPartTwo.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt);
+        posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt);
+        negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt);
       }
-      trackHistoPartTwo.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt);
-      posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt);
-      negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt);
     }
 
     /// Now build the combinations
-    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      if (!isFullPIDSelected(p1.pidcut(), p1.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
-        continue;
-      }
+    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
       const auto& posChild = parts.iteratorAt(p2.index() - 2);
       const auto& negChild = parts.iteratorAt(p2.index() - 1);
       // check cuts on V0 children
-      if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
-        continue;
-      }
-      if (ConfIsCPR.value) {
-        if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+      if (((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit)) {
+        if (ConfIsCPR.value) {
+          if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+            continue;
+          }
+        }
+        // track cleaning
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
           continue;
         }
+        sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D, ConfExtendedPlots);
       }
-      // track cleaning
-      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-        continue;
-      }
-      sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D, ConfExtendedPlots);
     }
   }
 
-  void processSameEvent(o2::aod::FDCollision& col,
-                        FilteredFDParticles& parts)
+  void processSameEvent(o2::aod::FDCollision& col, FilteredFDParticles& parts)
   {
     eventHisto.fillQA(col);
-
-    auto thegroupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-
-    doSameEvent<false>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+    auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<false>(SliceTrk1, SliceV02, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEvent, "Enable processing same event", true);
 
@@ -258,28 +230,26 @@ struct femtoDreamPairTaskTrackV0 {
   // void processSameEventMC(o2::aod::FDCollision& col, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts, o2::aod::FDMCParticles&)
   {
     eventHisto.fillQA(col);
-    auto thegroupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    doSameEvent<true>(thegroupPartsOne, thegroupPartsTwo, parts, col.magField(), col.multNtr());
+    auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMC, "Enable processing same event MC", false);
 
   /// This function processes the mixed event
   /// \todo the trivial loops over the collisions and tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
   template <bool isMC, typename PartitionType, typename PartType>
-  void doMixedEvent(PartitionType groupPartsOne, PartitionType groupPartsTwo, PartType parts, float magFieldTesla, int multCol)
+  void doMixedEvent(PartitionType SliceTrk1, PartitionType SliceV02, PartType parts, float magFieldTesla, int multCol)
   {
 
-    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      if (!isFullPIDSelected(p1.pidcut(), p1.p(), ConfTrkCutTable->get("Track", "PIDthr"), vPIDPartOne, ConfNspecies, kNsigma, ConfTrkCutTable->get("Track", "nSigmaTPC"), ConfTrkCutTable->get("Track", "nSigmaTPCTOF"))) {
-        continue;
-      }
+    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
       const auto& posChild = parts.iteratorAt(p2.index() - 2);
       const auto& negChild = parts.iteratorAt(p2.index() - 1);
       // check cuts on V0 children
-      if (!((posChild.cut() & ConfCutChildPos) == ConfCutChildPos) || !((negChild.cut() & ConfCutChildNeg) == ConfCutChildNeg) ||
-          !isFullPIDSelected(posChild.pidcut(), posChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildPosIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("PosChild", "nSigmaTPCTOF")) ||
-          !isFullPIDSelected(negChild.pidcut(), negChild.p(), ConfV0ChildrenCutTable->get("PosChild", "PIDthr"), ConfChildNegIndex.value, ConfChildnSpecies.value, ConfChildPIDnSigmaMax.value, ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPC"), ConfV0ChildrenCutTable->get("NegChild", "nSigmaTPCTOF"))) {
+      if (((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((posChild.cut() & ConfChildPos_CutBit) == ConfChildPos_CutBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit) &&
+          ((negChild.pidcut() & ConfChildNeg_TPCBit) == ConfChildNeg_TPCBit)) {
         continue;
       }
       if (ConfIsCPR.value) {
@@ -295,14 +265,13 @@ struct femtoDreamPairTaskTrackV0 {
     }
   }
 
-  void processMixedEvent(o2::aod::FDCollisions& cols,
-                         FilteredFDParticles& parts)
+  void processMixedEvent(o2::aod::FDCollisions& cols, FilteredFDParticles& parts)
   {
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, ConfNEventsMix, -1, cols, cols)) {
       const int multCol = collision1.multNtr();
 
-      auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwo->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
       const auto& magFieldTesla2 = collision2.magField();
@@ -310,8 +279,7 @@ struct femtoDreamPairTaskTrackV0 {
       if (magFieldTesla1 != magFieldTesla2) {
         continue;
       }
-
-      doMixedEvent<false>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multCol);
+      doMixedEvent<false>(SliceTrk1, SliceV02, parts, magFieldTesla1, multCol);
     }
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEvent, "Enable processing mixed events", true);
@@ -322,8 +290,8 @@ struct femtoDreamPairTaskTrackV0 {
     for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, ConfNEventsMix, -1, cols, cols)) {
       const int multCol = collision1.multNtr();
 
-      auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-      auto groupPartsTwo = partsTwoMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+      auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
 
       const auto& magFieldTesla1 = collision1.magField();
       const auto& magFieldTesla2 = collision2.magField();
@@ -332,7 +300,7 @@ struct femtoDreamPairTaskTrackV0 {
         continue;
       }
 
-      doMixedEvent<true>(groupPartsOne, groupPartsTwo, parts, magFieldTesla1, multCol);
+      doMixedEvent<true>(SliceMCTrk1, SliceMCV02, parts, magFieldTesla1, multCol);
     }
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMC, "Enable processing mixed events MC", false);

--- a/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamPairTaskTrackV0.cxx
@@ -14,6 +14,8 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include <Framework/Expressions.h>
+#include <sys/stat.h>
+#include <cstdint>
 #include <vector>
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
@@ -56,7 +58,7 @@ struct femtoDreamPairTaskTrackV0 {
   Configurable<float> ConfTrk1_minEta{"ConfTrk1_minEta", -10., "Minimum eta of partricle 1 (Track)"};
   Configurable<float> ConfTrk1_maxEta{"ConfTrk1_maxEta", 10., "Maximum eta of partricle 1 (Track)"};
 
-  ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkDTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfTrkTempFitVarBins{"ConfTrkTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfTrkTempFitVarpTBins{"ConfTrkTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
 
   Filter trackPtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt > ConfTrk1_minPt, true);
@@ -79,8 +81,8 @@ struct femtoDreamPairTaskTrackV0 {
   ConfigurableAxis ConfV0TempFitVarpTBins{"ConfV0TempFitVarpTBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarInvMassBins{"ConfV0TempFitVarInvMassBins", {200, 1, 1.2}, "V0: InvMass binning"};
 
-  ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0ChildTempFitVarBins{"ConfV0ChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfV0ChildTempFitVarpTBins{"ConfV0ChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
 
   Configurable<float> ConfV02_minInvMass{"ConfV02_minInvMass", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
   Configurable<float> ConfV02_maxInvMass{"ConfV02_maxInvMass", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
@@ -164,8 +166,8 @@ struct femtoDreamPairTaskTrackV0 {
     eventHisto.init(&qaRegistry);
     trackHistoPartOne.init(&qaRegistry, ConfTrkTempFitVarpTBins, ConfTrkTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfTrk1_PDGCode);
     trackHistoPartTwo.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfV0TempFitVarInvMassBins, ConfIsMC, ConfV02_PDGCode);
-    posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
-    negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
+    posChildHistos.init(&qaRegistry, ConfV0ChildTempFitVarpTBins, ConfV0ChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
+    negChildHistos.init(&qaRegistry, ConfV0ChildTempFitVarpTBins, ConfV0ChildTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, false, false);
 
     sameEventCont.init(&resultRegistry, ConfkstarBins, ConfMultBins, ConfkTBins, ConfmTBins, ConfmultBins3D, ConfmTBins3D, ConfIsMC, ConfUse3D, ConfExtendedPlots, ConfHighkstarCut);
     sameEventCont.setPDGCodes(ConfTrk1_PDGCode, ConfV02_PDGCode);
@@ -183,7 +185,7 @@ struct femtoDreamPairTaskTrackV0 {
     for (DeviceSpec const& device : workflows.devices) {
       if (device.name.find("femto-dream-pair-task-track-v0") != std::string::npos) {
         if (containsNameValuePair(device.options, "ConfTrk1_CutBit", ConfTrk1_CutBit.value) &&
-            containsNameValuePair(device.options, "ConfTrk1_TPCBit", ConfTrk1_TPCBit.value) &&
+            containsNameValuePair(device.options, "CnfTrk1_TPCBit", ConfTrk1_TPCBit.value) &&
             containsNameValuePair(device.options, "ConfTrk1_TPCTOFBit", ConfTrk1_TPCTOFBit.value) &&
             containsNameValuePair(device.options, "ConfTrk1_PIDThres", ConfTrk1_PIDThres.value) &&
             containsNameValuePair(device.options, "ConfTrk1_minPt", ConfTrk1_minPt.value) &&
@@ -220,51 +222,55 @@ struct femtoDreamPairTaskTrackV0 {
   }
 
   /// This function processes the same event and takes care of all the histogramming
-  /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
-  template <bool isMC, typename PartitionType>
-  void doSameEvent(PartitionType SliceTrk1, PartitionType SliceV02, float magFieldTesla, int multCol)
+  template <bool isMC, typename T, typename R, typename S>
+  void doSameEvent(T& SliceTrk1, R& SliceV02, S& parts, float magFieldTesla, int multCol)
   {
     /// Histogramming same event
     for (auto& part : SliceTrk1) {
       trackHistoPartOne.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt);
     }
+
     for (auto& v0 : SliceV02) {
-        // const auto& posChild = tracks.iteratorAt(v0.index() - 2);
-        auto posChild = v0.template children_as<FilteredFDParticles>().front();
-        // const auto& negChild = tracks.iteratorAt(v0.index() - 1);
-        auto negChild = v0.template children_as<FilteredFDParticles>().back();
+      const auto& posChild = parts.iteratorAt(v0.index() - 2);
+      const auto& negChild = parts.iteratorAt(v0.index() - 1);
+      // This is how it is supposed to work but there seems to be an issue
+      // with partitions and accessing elements in tables that have been
+      // with an SELF_INDEX column. Under investigation. Maybe need to change
+      // femtdream dataformat to take special care of v0 candidates
+      // auto posChild = v0.template children_as<S>().front();
+      // auto negChild = v0.template children_as<S>().back();
       // check cuts on V0 children
       if (((posChild.cut() & ConfV02_ChildPos_CutBit) == ConfV02_ChildPos_CutBit) &&
           ((posChild.pidcut() & ConfV02_ChildPos_TPCBit) == ConfV02_ChildPos_TPCBit) &&
           ((negChild.cut() & ConfV02_ChildNeg_CutBit) == ConfV02_ChildNeg_CutBit) &&
           ((negChild.pidcut() & ConfV02_ChildNeg_TPCBit) == ConfV02_ChildNeg_TPCBit)) {
         trackHistoPartTwo.fillQA<isMC, false>(v0, aod::femtodreamparticle::kPt);
-        // posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt);
-        // negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt);
+        posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt);
+        negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt);
       }
     }
 
     /// Now build the combinations
-    // for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
-    //   const auto& posChild = parts.iteratorAt(p2.index() - 2);
-    //   const auto& negChild = parts.iteratorAt(p2.index() - 1);
-    //   // check cuts on V0 children
-    //   if (((posChild.cut() & ConfV02_ChildPos_CutBit) == ConfV02_ChildPos_CutBit) &&
-    //       ((posChild.pidcut() & ConfV02_ChildPos_TPCBit) == ConfV02_ChildPos_TPCBit) &&
-    //       ((negChild.cut() & ConfV02_ChildNeg_CutBit) == ConfV02_ChildNeg_CutBit) &&
-    //       ((negChild.pidcut() & ConfV02_ChildNeg_TPCBit) == ConfV02_ChildNeg_TPCBit)) {
-    //     if (ConfIsCPR.value) {
-    //       if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
-    //         continue;
-    //       }
-    //     }
-    //     // track cleaning
-    //     if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-    //       continue;
-    //     }
-    //     sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D, ConfExtendedPlots);
-    //   }
-    // }
+    for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+      const auto& posChild = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild = parts.iteratorAt(p2.index() - 1);
+      // check cuts on V0 children
+      if (((posChild.cut() & ConfV02_ChildPos_CutBit) == ConfV02_ChildPos_CutBit) &&
+          ((posChild.pidcut() & ConfV02_ChildPos_TPCBit) == ConfV02_ChildPos_TPCBit) &&
+          ((negChild.cut() & ConfV02_ChildNeg_CutBit) == ConfV02_ChildNeg_CutBit) &&
+          ((negChild.pidcut() & ConfV02_ChildNeg_TPCBit) == ConfV02_ChildNeg_TPCBit)) {
+        if (ConfIsCPR.value) {
+          if (pairCloseRejection.isClosePair(p1, p2, parts, magFieldTesla)) {
+            continue;
+          }
+        }
+        // track cleaning
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          continue;
+        }
+        sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D, ConfExtendedPlots);
+      }
+    }
   }
 
   void processSameEvent(o2::aod::FDCollision const& col, FilteredFDParticles const& parts)
@@ -272,22 +278,19 @@ struct femtoDreamPairTaskTrackV0 {
     eventHisto.fillQA(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    doSameEvent<false>(SliceTrk1, SliceV02, col.magField(), col.multNtr());
+    doSameEvent<false>(SliceTrk1, SliceV02, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEvent, "Enable processing same event", true);
 
-  void processSameEventMasked(MaskedCollisions const& cols, FilteredFDParticles const& parts)
+  void processSameEventMasked(MaskedCollision const& col, FilteredFDParticles const& parts)
   {
-
-    Partition<MaskedCollisions> PartitionMaskedCols = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne,MaskBit) || ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo,MaskBit);
-    PartitionMaskedCols.bindTable(cols);
-
-    for (auto const& col : PartitionMaskedCols) {
-      eventHisto.fillQA(col);
-      auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-      auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-      doSameEvent<false>(SliceTrk1, SliceV02, col.magField(), col.multNtr());
+    if ((col.bitmaskTrackOne() & MaskBit) != MaskBit && (col.bitmaskTrackTwo() & MaskBit) != MaskBit) {
+      return;
     }
+    eventHisto.fillQA(col);
+    auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<false>(SliceTrk1, SliceV02, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", false);
 
@@ -297,7 +300,7 @@ struct femtoDreamPairTaskTrackV0 {
     eventHisto.fillQA(col);
     auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    doSameEvent<true>(SliceMCTrk1, SliceMCV02, col.magField(), col.multNtr());
+    doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col.magField(), col.multNtr());
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMC, "Enable processing same event MC", false);
 


### PR DESCRIPTION
Introduce two new features in FemtoDream

1. PID selection with bit masks
Bit masks for the PID selection in FemtoDream have been implemented from the very beginning, but the selection of them has been very clunky and the user had to provide a lot of unnecessary information to compute the bit mask at run time. Now the mechanism has been overhauled. The user gets the bit masks for different PID selections from the cutculator directly and then just passes them as a configurable.

2. Event selection and mixing with bit masks
Event mixing has been very primitive so far, i.e. using the framework-provided functions to generate binned groups of events and then pairing particles from these events to generate a mixed event sample. However, so far there has been no check if a track that passed the specified selections is contained in every event used for the mixing (which can lead to weird behavior, especially if the selections are tight or the track type is rare, like a v0). Therefore, we added new columns to the FemtoDreamCollision table containing a bit mask that indicates if a track of interest is contained in the collision. This makes it very easy to partition out all the collisions that contain tracks of interest before feeding them to the framework-provided functions for the mixing.
The FemtoDreamCollisionMasker, which generates these new bit masks for the collisions, is supposed to run alongside the various pair tasks on derived data to dynamically generate the bit mask for each variation of the pair task (i.e. the CollisionMasker is a dependency of the main task and there can be many variations as subwagons). This is made possible by iterating over the configurables of all the tasks on the wagon and flagging the collisions according to that. That also means that the pair task itself needs to iterate over the configurables of all the tasks to find out which bit in the bitmask it needs to check for. Maybe this can be optimized in the future with functionality provided by the framework.