### PR TITLE
PWGEM/PhotonMeson: update efficiency for primary muon

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/skimmerPrimaryMuon.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerPrimaryMuon.cxx
@@ -89,8 +89,8 @@ struct skimmerPrimaryMuon {
       {"Track/hTOFNsigmaPi_after", "TOF n sigma #pi vs. p_{in};p_{in} (GeV/c);n #sigma_{#pi}^{TOF}", {HistType::kTH2F, {{1000, 0.f, 1.f}, {100, -5.f, +5.f}}}},
       {"Pair/hMmumuPtmumu", "ULS m_{#mu#mu} vs. p_{T,#mu#mu};m_{#mu#mu} (GeV/c^{2});p_{T,#mu#mu} (GeV/c)", {HistType::kTH2F, {{100, 0.2f, 1.2f}, {120, 0.f, 1.2f}}}},
       // for MC primary muon
-      {"MC/Primary/hP_Pin", "p vs. p_{in};p (GeV/c);p_{in} (GeV/c)", {HistType::kTH2F, {{1000, 0.f, 1.f}, {1000, 0.f, 1.f}}}},
-      {"MC/Primary/hRelDiffP", "p vs. rel diff p;p (GeV/c);(p_{in} - p)/p", {HistType::kTH2F, {{1000, 0.f, 1.f}, {200, -1.f, 1.f}}}},
+      {"MC/Primary/hPt_Gen", "generated pT;p_{T,#mu}^{gen} (GeV/c)", {HistType::kTH1F, {{100, 0.f, 1.f}}}},
+      {"MC/Primary/hPt_Rec", "reconstructed pT;p_{T,#mu}^{rec} (GeV/c)", {HistType::kTH1F, {{100, 0.f, 1.f}}}},
       {"MC/Primary/hTPCdEdx_Pin", "TPC dE/dx vs. p_{in};p_{in} (GeV/c);TPC dE/dx", {HistType::kTH2F, {{1000, 0.f, 1.f}, {200, 0.f, 200.f}}}},
       {"MC/Primary/hTOFbeta_Pin", "TOF beta vs. p_{in};p_{in} (GeV/c);TOF #beta", {HistType::kTH2F, {{1000, 0.f, 1.f}, {250, 0.6f, 1.1f}}}},
       {"MC/Primary/hNclsITS", "Ncls ITS;N_{cls}^{ITS}", {HistType::kTH1F, {{8, -0.5f, +7.5f}}}},
@@ -99,8 +99,6 @@ struct skimmerPrimaryMuon {
       {"MC/Primary/hNcrTPC", "Ncr TPC;N_{cr}^{TPC}", {HistType::kTH1F, {{161, -0.5f, +160.5f}}}},
       {"MC/Primary/hNfTPC", "Nfindable TPC;N_{f}^{TPC}", {HistType::kTH1F, {{161, -0.5f, +160.5f}}}},
       {"MC/Primary/hChi2TPC", "chi2 TPC;#chi^{2}/N_{cls}^{TPC}", {HistType::kTH1F, {{100, 0.f, 10.f}}}},
-      {"MC/Primary/hChi2TPC_NclsTPC", "chi2 TPC;N_{cls}^{TPC};#chi^{2}/N_{cls}^{TPC}", {HistType::kTH2F, {{161, -0.5, 160.5}, {100, 0.f, 10.f}}}},
-      {"MC/Primary/hDCAxy_NclsTPC", "DCA xy vs. N_{cls}^{TPC};DCA_{xy} (cm);N_{cls}^{TPC}", {HistType::kTH2F, {{200, -1.f, +1.f}, {161, -0.5f, +160.5f}}}},
       {"MC/Primary/hDCAxyz", "DCA xy vs. z;DCA_{xy} (cm);DCA_{z} (cm)", {HistType::kTH2F, {{200, -1.f, +1.f}, {200, -1.f, +1.f}}}},
       {"MC/Primary/hDCA3D", "DCA;DCA_{3D} (cm)", {HistType::kTH1F, {{100, 0.f, +1.f}}}},
       {"MC/Primary/hDCAxy_resolution", "DCA xy resolution;DCA_{xy} resolution (cm)", {HistType::kTH1F, {{100, 0.f, +0.1f}}}},
@@ -109,8 +107,8 @@ struct skimmerPrimaryMuon {
       {"MC/Primary/hDCA3D_sigma", "DCA;DCA_{3D} (#sigma)", {HistType::kTH1F, {{100, 0.f, +10.f}}}},
       {"MC/Primary/hProdVtx", "#mu production vtx;X_{MC} (cm);Y_{MC} (cm)", {HistType::kTH2F, {{200, -100.f, +100.f}, {200, -100.f, +100.f}}}},
       // for MC seconday muon
-      {"MC/Secondary/hP_Pin", "p vs. p_{in};p (GeV/c);p_{in} (GeV/c)", {HistType::kTH2F, {{1000, 0.f, 1.f}, {1000, 0.f, 1.f}}}},
-      {"MC/Secondary/hRelDiffP", "p vs. rel diff p;p (GeV/c);(p_{in} - p)/p", {HistType::kTH2F, {{1000, 0.f, 1.f}, {200, -1.f, 1.f}}}},
+      {"MC/Secondary/hPt_Gen", "generated pT;p_{T,#mu}^{gen} (GeV/c)", {HistType::kTH1F, {{100, 0.f, 1.f}}}},
+      {"MC/Secondary/hPt_Rec", "reconstructed pT;p_{T,#mu}^{rec} (GeV/c)", {HistType::kTH1F, {{100, 0.f, 1.f}}}},
       {"MC/Secondary/hTPCdEdx_Pin", "TPC dE/dx vs. p_{in};p_{in} (GeV/c);TPC dE/dx", {HistType::kTH2F, {{1000, 0.f, 1.f}, {200, 0.f, 200.f}}}},
       {"MC/Secondary/hTOFbeta_Pin", "TOF beta vs. p_{in};p_{in} (GeV/c);TOF #beta", {HistType::kTH2F, {{1000, 0.f, 1.f}, {250, 0.6f, 1.1f}}}},
       {"MC/Secondary/hNclsITS", "Ncls ITS;N_{cls}^{ITS}", {HistType::kTH1F, {{8, -0.5f, +7.5f}}}},
@@ -119,8 +117,6 @@ struct skimmerPrimaryMuon {
       {"MC/Secondary/hNcrTPC", "Ncr TPC;N_{cr}^{TPC}", {HistType::kTH1F, {{161, -0.5f, +160.5f}}}},
       {"MC/Secondary/hNfTPC", "Nfindable TPC;N_{f}^{TPC}", {HistType::kTH1F, {{161, -0.5f, +160.5f}}}},
       {"MC/Secondary/hChi2TPC", "chi2 TPC;#chi^{2}/N_{cls}^{TPC}", {HistType::kTH1F, {{100, 0.f, 10.f}}}},
-      {"MC/Secondary/hChi2TPC_NclsTPC", "chi2 TPC;N_{cls}^{TPC};#chi^{2}/N_{cls}^{TPC}", {HistType::kTH2F, {{161, -0.5, 160.5}, {100, 0.f, 10.f}}}},
-      {"MC/Secondary/hDCAxy_NclsTPC", "DCA xy vs. N_{cls}^{TPC};DCA_{xy} (cm);N_{cls}^{TPC}", {HistType::kTH2F, {{200, -1.f, +1.f}, {161, -0.5f, +160.5f}}}},
       {"MC/Secondary/hDCAxyz", "DCA xy vs. z;DCA_{xy} (cm);DCA_{z} (cm)", {HistType::kTH2F, {{200, -1.f, +1.f}, {200, -1.f, +1.f}}}},
       {"MC/Secondary/hDCA3D", "DCA;DCA_{3D} (cm)", {HistType::kTH1F, {{100, 0.f, +1.f}}}},
       {"MC/Secondary/hDCAxy_resolution", "DCA xy resolution;DCA_{xy} resolution (cm)", {HistType::kTH1F, {{100, 0.f, +0.1f}}}},
@@ -213,11 +209,12 @@ struct skimmerPrimaryMuon {
 
       if constexpr (isMC) {
         auto mctrack = track.template mcParticle_as<aod::McParticles>();
-        if (abs(mctrack.pdgCode()) == 13 && mctrack.has_mothers()) {
-          auto mp = mctrack.template mothers_first_as<aod::McParticles>();
-          if (abs(mp.pdgCode()) == 221 || abs(mp.pdgCode()) == 223 || abs(mp.pdgCode()) == 333 || abs(mp.pdgCode()) == 113 || abs(mp.pdgCode()) == 331) {
-            fRegistry.fill(HIST("MC/Primary/hP_Pin"), track.p(), track.tpcInnerParam());
-            fRegistry.fill(HIST("MC/Primary/hRelDiffP"), track.p(), (track.tpcInnerParam() - track.p()) / track.p());
+        if (abs(mctrack.pdgCode()) == 13 /* && mctrack.has_mothers()*/) {
+          // auto mp = mctrack.template mothers_first_as<aod::McParticles>();
+          if (mctrack.isPhysicalPrimary()) {
+            if (isMuon(track)) {
+              fRegistry.fill(HIST("MC/Primary/hPt_Rec"), track.pt());
+            }
             fRegistry.fill(HIST("MC/Primary/hTPCdEdx_Pin"), track.tpcInnerParam(), track.tpcSignal());
             fRegistry.fill(HIST("MC/Primary/hTOFbeta_Pin"), track.tpcInnerParam(), track.beta());
             fRegistry.fill(HIST("MC/Primary/hNclsITS"), track.itsNCls());
@@ -226,8 +223,6 @@ struct skimmerPrimaryMuon {
             fRegistry.fill(HIST("MC/Primary/hNclsTPC"), track.tpcNClsFound());
             fRegistry.fill(HIST("MC/Primary/hNfTPC"), track.tpcNClsFindable());
             fRegistry.fill(HIST("MC/Primary/hChi2TPC"), track.tpcChi2NCl());
-            fRegistry.fill(HIST("MC/Primary/hChi2TPC_NclsTPC"), track.tpcNClsFound(), track.tpcChi2NCl());
-            fRegistry.fill(HIST("MC/Primary/hDCAxy_NclsTPC"), track.dcaXY(), track.tpcNClsFound());
             fRegistry.fill(HIST("MC/Primary/hDCAxyz"), track.dcaXY(), track.dcaZ());
             fRegistry.fill(HIST("MC/Primary/hDCA3D"), sqrt(pow(track.dcaXY(), 2) + pow(track.dcaZ(), 2)));
             fRegistry.fill(HIST("MC/Primary/hDCAxy_resolution"), sqrt(track.cYY()));
@@ -235,9 +230,10 @@ struct skimmerPrimaryMuon {
             fRegistry.fill(HIST("MC/Primary/hDCAxyz_sigma"), track.dcaXY() / sqrt(track.cYY()), track.dcaZ() / sqrt(track.cZZ()));
             fRegistry.fill(HIST("MC/Primary/hDCA3D_sigma"), sqrt(pow(track.dcaXY() / sqrt(track.cYY()), 2) + pow(track.dcaZ() / sqrt(track.cZZ()), 2)));
             fRegistry.fill(HIST("MC/Primary/hProdVtx"), mctrack.vx(), mctrack.vy());
-          } else if (abs(mp.pdgCode()) == 211 || abs(mp.pdgCode()) == 321) {
-            fRegistry.fill(HIST("MC/Secondary/hP_Pin"), track.p(), track.tpcInnerParam());
-            fRegistry.fill(HIST("MC/Secondary/hRelDiffP"), track.p(), (track.tpcInnerParam() - track.p()) / track.p());
+          } else {
+            if (isMuon(track)) {
+              fRegistry.fill(HIST("MC/Secondary/hPt_Rec"), track.pt());
+            }
             fRegistry.fill(HIST("MC/Secondary/hTPCdEdx_Pin"), track.tpcInnerParam(), track.tpcSignal());
             fRegistry.fill(HIST("MC/Secondary/hTOFbeta_Pin"), track.tpcInnerParam(), track.beta());
             fRegistry.fill(HIST("MC/Secondary/hNclsITS"), track.itsNCls());
@@ -246,8 +242,6 @@ struct skimmerPrimaryMuon {
             fRegistry.fill(HIST("MC/Secondary/hNclsTPC"), track.tpcNClsFound());
             fRegistry.fill(HIST("MC/Secondary/hNfTPC"), track.tpcNClsFindable());
             fRegistry.fill(HIST("MC/Secondary/hChi2TPC"), track.tpcChi2NCl());
-            fRegistry.fill(HIST("MC/Secondary/hChi2TPC_NclsTPC"), track.tpcNClsFound(), track.tpcChi2NCl());
-            fRegistry.fill(HIST("MC/Secondary/hDCAxy_NclsTPC"), track.dcaXY(), track.tpcNClsFound());
             fRegistry.fill(HIST("MC/Secondary/hDCAxyz"), track.dcaXY(), track.dcaZ());
             fRegistry.fill(HIST("MC/Secondary/hDCA3D"), sqrt(pow(track.dcaXY(), 2) + pow(track.dcaZ(), 2)));
             fRegistry.fill(HIST("MC/Secondary/hDCAxy_resolution"), sqrt(track.cYY()));
@@ -364,7 +358,7 @@ struct skimmerPrimaryMuon {
   using MyFilteredTracksMC = soa::Filtered<MyTracksMC>;
   Partition<MyFilteredTracksMC> posTracksMC = o2::aod::track::signed1Pt > 0.f;
   Partition<MyFilteredTracksMC> negTracksMC = o2::aod::track::signed1Pt < 0.f;
-  void processMC(soa::Join<aod::McCollisionLabels, aod::Collisions> const& collisions, aod::McCollisions const&, aod::BCsWithTimestamps const&, MyFilteredTracksMC const& tracks, aod::McParticles const&)
+  void processMC(soa::Join<aod::McCollisionLabels, aod::Collisions> const& collisions, aod::McCollisions const&, aod::BCsWithTimestamps const&, MyFilteredTracksMC const& tracks, aod::McParticles const& mcparticles)
   {
     stored_trackIds.reserve(tracks.size());
     for (auto& collision : collisions) {
@@ -386,7 +380,25 @@ struct skimmerPrimaryMuon {
 
     stored_trackIds.clear();
     stored_trackIds.shrink_to_fit();
+
+    // for generated info
+    for (auto& mcparticle : mcparticles) {
+      if (abs(mcparticle.pdgCode()) != 13) {
+        continue;
+      }
+
+      if (abs(mcparticle.eta()) > maxeta) {
+        continue;
+      }
+
+      if (mcparticle.isPhysicalPrimary()) {
+        fRegistry.fill(HIST("MC/Primary/hPt_Gen"), mcparticle.pt());
+      } else {
+        fRegistry.fill(HIST("MC/Secondary/hPt_Gen"), mcparticle.pt());
+      }
+    }
   }
+
   PROCESS_SWITCH(skimmerPrimaryMuon, processMC, "process reconstructed and MC info ", false);
 };
 

--- a/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
+++ b/PWGEM/PhotonMeson/Tasks/PhotonHBT.cxx
@@ -50,7 +50,7 @@ using namespace o2::framework::expressions;
 using namespace o2::soa;
 using namespace o2::aod::photonpair;
 
-using MyCollisions = soa::Join<aod::EMReducedEvents, aod::EMReducedEventsMult, aod::EMReducedEventsCent, aod::EMReducedEventsNgPCM, aod::EMReducedEventsNgPHOS, aod::EMReducedEventsNgEMC>;
+using MyCollisions = soa::Join<aod::EMReducedEvents, aod::EMReducedEventsMult, aod::EMReducedEventsCent, aod::EMReducedEventsNgPCM, aod::EMReducedEventsNgPHOS>;
 using MyCollision = MyCollisions::iterator;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0Recalculation, aod::V0KFEMReducedEventIds>;

--- a/PWGEM/PhotonMeson/Tasks/TagAndProbe.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TagAndProbe.cxx
@@ -60,9 +60,9 @@ struct TagAndProbe {
 
   Configurable<float> maxY{"maxY", 0.9, "maximum rapidity for reconstructed particles"};
   Configurable<std::string> fConfigTagPCMCut{"cfgTagPCMCuts", "tag_track", "Tag PCM photon cut. 1 per wagon"};
-  Configurable<std::string> fConfigTagPHOSCut{"cfgTagPHOSCuts", "tag", "Tag PHOS photon cuts. 1 per wagon"};
-  Configurable<std::string> fConfigTagEMCCut{"cfgTagEMCCuts", "tag", "Tag EMCal photon cuts. 1 per wagon"};
-  Configurable<std::string> fConfigProbePCMCuts{"cfgProbePCMCuts", "analysis,analysis_wo_mee,qc,qc_w_mee", "Comma separated list of V0 photon cuts"};
+  Configurable<std::string> fConfigTagPHOSCut{"cfgTagPHOSCuts", "test03", "Tag PHOS photon cuts. 1 per wagon"};
+  Configurable<std::string> fConfigTagEMCCut{"cfgTagEMCCuts", "standard", "Tag EMCal photon cuts. 1 per wagon"};
+  Configurable<std::string> fConfigProbePCMCuts{"cfgProbePCMCuts", "analysis,qc", "Comma separated list of V0 photon cuts"};
   Configurable<std::string> fConfigProbePHOSCuts{"cfgProbePHOSCuts", "test02,test03", "Comma separated list of PHOS photon cuts"};
   Configurable<std::string> fConfigProbeEMCCuts{"cfgProbeEMCCuts", "standard", "Comma separated list of EMCal photon cuts"};
   Configurable<float> minOpenAngle{"minOpenAngle", 0.0202, "apply min opening angle"};


### PR DESCRIPTION
This PR contains following commits:
PWGEM/PhotonMeson: update efficiency for primary muon
PWGEM/PhotonMeson: change default value in TAP
PWGEM/PhotonMeson: remove unnecessary dep.