### PR TITLE
PWGHF:Add missing repropagation of reassociated tracks

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -309,11 +309,13 @@ DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with recon
                   hf_cand_bplus_reduced::Prong0Id,
                   hf_cand_bplus_reduced::Prong1Id,
                   hf_cand_bplus::FlagMcMatchRec,
+                  hf_cand_bplus::DebugMcRec,
                   hf_bplus_mc::PtMother);
 
 // Table with same size as HFCANDBPLUS
 DECLARE_SOA_TABLE(HfMcRecRedBps, "AOD", "HFMCRECREDBP", //! Reconstruction-level MC information on B+ candidates for reduced workflow
                   hf_cand_bplus::FlagMcMatchRec,
+                  hf_cand_bplus::DebugMcRec,
                   hf_bplus_mc::PtMother);
 
 DECLARE_SOA_TABLE(HfMcGenRedBps, "AOD", "HFMCGENREDBP", //! Generation-level MC information on B+ candidates for reduced workflow

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -267,11 +267,17 @@ struct HfCandidateCreatorB0ReducedExpressions {
   void processMc(HfMcRecRedDpPis const& rowsDPiMcRec, HfRedB0Prongs const& candsB0)
   {
     for (const auto& candB0 : candsB0) {
+      bool filledMcInfo{false};
       for (const auto& rowDPiMcRec : rowsDPiMcRec) {
         if ((rowDPiMcRec.prong0Id() != candB0.prong0Id()) || (rowDPiMcRec.prong1Id() != candB0.prong1Id())) {
           continue;
         }
         rowB0McRec(rowDPiMcRec.flagMcMatchRec(), rowDPiMcRec.debugMcRec(), rowDPiMcRec.ptMother());
+        filledMcInfo = true;
+        break;
+      }
+      if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D-Pi creator
+        rowB0McRec(0, -1, -1.f);
       }
     }
   }

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -202,11 +202,17 @@ struct HfCandidateCreatorBplusReducedExpressions {
   void processMc(HfMcRecRedD0Pis const& rowsD0PiMcRec, HfRedBplusProngs const& candsBplus)
   {
     for (const auto& candBplus : candsBplus) {
+      bool filledMcInfo{false};
       for (const auto& rowD0PiMcRec : rowsD0PiMcRec) {
         if ((rowD0PiMcRec.prong0Id() != candBplus.prong0Id()) || (rowD0PiMcRec.prong1Id() != candBplus.prong1Id())) {
           continue;
         }
-        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.ptMother());
+        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.debugMcRec(), rowD0PiMcRec.ptMother());
+        filledMcInfo = true;
+        break;
+      }
+      if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D-Pi creator
+        rowBplusMcRec(0, -1, -1.f);
       }
     }
   }

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -82,19 +82,14 @@ struct HfDataCreatorD0PiReduced {
   Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
   Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
   // magnetic field setting from CCDB
-  Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::string> ccdbPathLut{"ccdbPathLut", "GLO/Param/MatLUT", "Path for LUT parametrization"};
-  Configurable<std::string> ccdbPathGeo{"ccdbPathGeo", "GLO/Config/GeometryAligned", "Path of the geometry file"};
-  Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
   Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
 
   HfHelper hfHelper;
 
   // CCDB service
   Service<o2::ccdb::BasicCCDBManager> ccdb;
-  o2::base::MatLayerCylSet* lut;
-  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
   int runNumber;
 
   // O2DatabasePDG service
@@ -159,7 +154,6 @@ struct HfDataCreatorD0PiReduced {
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
-    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(ccdbPathLut));
     runNumber = 0;
 
     // invariant-mass window cut
@@ -172,19 +166,21 @@ struct HfDataCreatorD0PiReduced {
 
   /// Pion selection (D0 Pi <-- B+)
   /// \param trackPion is a track with the pion hypothesis
+  /// \param trackParCovPion is the track parametrisation of the pion
+  /// \param dcaPion is the 2-D array with track DCAs of the pion
   /// \param track0 is prong0 of selected D0 candidate
   /// \param track1 is prong1 of selected D0 candidate
   /// \param candD0 is the D0 candidate
   /// \return true if trackPion passes all cuts
-  template <typename T1, typename T2, typename T3>
-  bool isPionSelected(const T1& trackPion, const T2& track0, const T2& track1, const T3& candD0)
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isPionSelected(const T1& trackPion, const T2& trackParCovPion, const T3& dcaPion, const T1& track0, const T1& track1, const T4& candD0)
   {
     // check isGlobalTrackWoDCA status for pions if wanted
     if (usePionIsGlobalTrackWoDCA && !trackPion.isGlobalTrackWoDCA()) {
       return false;
     }
     // minimum pT selection
-    if (trackPion.pt() < ptPionMin || !isSelectedTrackDCA(trackPion)) {
+    if (trackParCovPion.getPt() < ptPionMin || !isSelectedTrackDCA(trackParCovPion, dcaPion)) {
       return false;
     }
     // reject pion not compatible with D0/D0bar hypothesis
@@ -201,20 +197,21 @@ struct HfDataCreatorD0PiReduced {
   }
 
   /// Single-track cuts for pions on dcaXY
-  /// \param track is a track
+  /// \param trackPar is the track parametrisation
+  /// \param dca is the 2-D array with track DCAs
   /// \return true if track passes all cuts
-  template <typename T>
-  bool isSelectedTrackDCA(const T& track)
+  template <typename T1, typename T2>
+  bool isSelectedTrackDCA(const T1& trackPar, const T2& dca)
   {
-    auto pTBinTrack = findBin(binsPtPion, track.pt());
+    auto pTBinTrack = findBin(binsPtPion, trackPar.getPt());
     if (pTBinTrack == -1) {
       return false;
     }
 
-    if (std::abs(track.dcaXY()) < cutsTrackPionDCA->get(pTBinTrack, "min_dcaxytoprimary")) {
+    if (std::abs(dca[0]) < cutsTrackPionDCA->get(pTBinTrack, "min_dcaxytoprimary")) {
       return false; // minimum DCAxy
     }
-    if (std::abs(track.dcaXY()) > cutsTrackPionDCA->get(pTBinTrack, "max_dcaxytoprimary")) {
+    if (std::abs(dca[0]) > cutsTrackPionDCA->get(pTBinTrack, "max_dcaxytoprimary")) {
       return false; // maximum DCAxy
     }
     return true;
@@ -243,7 +240,11 @@ struct HfDataCreatorD0PiReduced {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     if (runNumber != bc.runNumber()) {
       LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
-      initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+      o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrpMag, bc.timestamp());
+      if (grpo == nullptr) {
+        LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+      }
+      o2::base::Propagator::initFieldFromGRP(grpo);
       bz = o2::base::Propagator::Instance()->getNominalBz();
       LOG(info) << ">>>>>>>>>>>> Magnetic field: " << bz;
     }
@@ -309,11 +310,19 @@ struct HfDataCreatorD0PiReduced {
         auto trackPion = trackId.template track_as<T>();
 
         // apply selections on pion tracks
-        if (!isPionSelected(trackPion, track0, track1, candD0) || !isSelectedTrackDCA(trackPion)) {
+        auto trackParCovPion = getTrackParCov(trackPion);
+        o2::gpu::gpustd::array<float, 2> dcaPion{trackPion.dcaXY(), trackPion.dcaZ()};
+        std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+        if (trackPion.collisionId() != thisCollId) {
+          o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCovPion, 2.f, noMatCorr, &dcaPion);
+          getPxPyPz(trackParCovPion, pVecPion);
+        }
+
+        // apply selections on pion tracks
+        if (!isPionSelected(trackPion, trackParCovPion, dcaPion, track0, track1, candD0)) {
           continue;
         }
-        registry.fill(HIST("hPtPion"), trackPion.pt());
-        std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+        registry.fill(HIST("hPtPion"), trackParCovPion.getPt());
         // compute invariant mass square and apply selection
         auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});
         if ((invMass2D0Pi < invMass2D0PiMin) || (invMass2D0Pi > invMass2D0PiMax)) {
@@ -324,15 +333,15 @@ struct HfDataCreatorD0PiReduced {
         // if information on track already stored, go to next track
         if (!selectedTracksPion.count(trackPion.globalIndex())) {
           hfTrackPion(trackPion.globalIndex(), indexHfReducedCollision,
-                      trackPion.x(), trackPion.alpha(),
-                      trackPion.y(), trackPion.z(), trackPion.snp(),
-                      trackPion.tgl(), trackPion.signed1Pt());
-          hfTrackCovPion(trackPion.cYY(), trackPion.cZY(), trackPion.cZZ(),
-                         trackPion.cSnpY(), trackPion.cSnpZ(),
-                         trackPion.cSnpSnp(), trackPion.cTglY(), trackPion.cTglZ(),
-                         trackPion.cTglSnp(), trackPion.cTglTgl(),
-                         trackPion.c1PtY(), trackPion.c1PtZ(), trackPion.c1PtSnp(),
-                         trackPion.c1PtTgl(), trackPion.c1Pt21Pt2());
+                      trackParCovPion.getX(), trackParCovPion.getAlpha(),
+                      trackParCovPion.getY(), trackParCovPion.getZ(), trackParCovPion.getSnp(),
+                      trackParCovPion.getTgl(), trackParCovPion.getQ2Pt());
+          hfTrackCovPion(trackParCovPion.getSigmaY2(), trackParCovPion.getSigmaZY(), trackParCovPion.getSigmaZ2(),
+                         trackParCovPion.getSigmaSnpY(), trackParCovPion.getSigmaSnpZ(),
+                         trackParCovPion.getSigmaSnp2(), trackParCovPion.getSigmaTglY(), trackParCovPion.getSigmaTglZ(),
+                         trackParCovPion.getSigmaTglSnp(), trackParCovPion.getSigmaTgl2(),
+                         trackParCovPion.getSigma1PtY(), trackParCovPion.getSigma1PtZ(), trackParCovPion.getSigma1PtSnp(),
+                         trackParCovPion.getSigma1PtTgl(), trackParCovPion.getSigma1Pt2());
           hfTrackPidPion(trackPion.hasTPC(), trackPion.hasTOF(),
                          trackPion.tpcNSigmaPi(), trackPion.tofNSigmaPi());
           // add trackPion.globalIndex() to a list

--- a/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorD0PiReduced.cxx
@@ -149,6 +149,7 @@ struct HfDataCreatorD0PiReduced {
     df2.setMinRelChi2Change(minRelChi2Change);
     df2.setUseAbsDCA(useAbsDCA);
     df2.setWeightedFinalPCA(useWeightedFinalPCA);
+    df2.setMatCorrType(noMatCorr);
 
     // Configure CCDB access
     ccdb->setURL(ccdbUrl);

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -149,6 +149,7 @@ struct HfDataCreatorDplusPiReduced {
     df3.setMinRelChi2Change(minRelChi2Change);
     df3.setUseAbsDCA(useAbsDCA);
     df3.setWeightedFinalPCA(useWeightedFinalPCA);
+    df3.setMatCorrType(noMatCorr);
 
     // Configure CCDB access
     ccdb->setURL(ccdbUrl);

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -41,6 +41,7 @@ DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);                               //!
 DECLARE_SOA_COLUMN(MProng0, mProng0, float);                                 //! Invariant mass of prong0 (GeV/c)
 DECLARE_SOA_COLUMN(M, m, float);                                             //! Invariant mass of candidate (GeV/c2)
 DECLARE_SOA_COLUMN(Pt, pt, float);                                           //! Transverse momentum of candidate (GeV/c)
+DECLARE_SOA_COLUMN(PtGen, ptGen, float);                                     //! Transverse momentum of candidate (GeV/c)
 DECLARE_SOA_COLUMN(P, p, float);                                             //! Momentum of candidate (GeV/c)
 DECLARE_SOA_COLUMN(Y, y, float);                                             //! Rapidity of candidate
 DECLARE_SOA_COLUMN(Eta, eta, float);                                         //! Pseudorapidity of candidate
@@ -85,7 +86,8 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_b0_lite::Phi,
                   hf_cand_b0_lite::Y,
                   hf_cand_3prong::FlagMcMatchRec,
-                  hf_cand_3prong::OriginMcRec);
+                  hf_cand_3prong::OriginMcRec,
+                  hf_cand_b0_lite::PtGen);
 } // namespace o2::aod
 
 /// B0 analysis task
@@ -373,7 +375,8 @@ struct HfTaskB0Reduced {
           candidate.phi(),
           hfHelper.yB0(candidate),
           flag,
-          origin);
+          origin,
+          -1.);
       }
     }
   }
@@ -506,7 +509,8 @@ struct HfTaskB0Reduced {
           candidate.phi(),
           hfHelper.yB0(candidate),
           flagMcMatchRec,
-          isSignal);
+          isSignal,
+          candidate.ptMother());
       }
     }
   }

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -673,6 +673,7 @@ DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction le
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);       // particle origin, reconstruction level
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);       // particle origin, generator level
+DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
 
 enum DecayType { BplusToD0Pi = 0 };
 } // namespace hf_cand_bplus


### PR DESCRIPTION
In this PR I added the re-propagation of re-associated pion tracks (not done before). 
In addition, it removes the usage of the LUT for the DCAFitter since HF decays should always be within the beampipe, there is no need of material correction (this should be fixed everywhere in HF code, since it allows us to spare memory)