### PR TITLE
Common: fix type of globalBC

### DIFF
--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -178,7 +178,7 @@ class CollisionAssociation
         float trackTimeRes = track.trackTimeRes();
         if constexpr (isCentralBarrel) {
           if (mUsePvAssociation && track.isPVContributor()) {
-            trackTime = track.collision().collisionTime();    // if PV contributor, we assume the time to be the one of the collision
+            trackTime = track.collision().collisionTime();        // if PV contributor, we assume the time to be the one of the collision
             trackTimeRes = o2::constants::lhc::LHCBunchSpacingNS; // 1 BC
           }
         }

--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -125,10 +125,10 @@ class CollisionAssociation
                         RevIndices& reverseIndices)
   {
     // cache globalBC
-    std::vector<uint64_t> globalBC;
+    std::vector<int64_t> globalBC;
     for (const auto& track : tracks) {
       if (track.has_collision()) {
-        globalBC.push_back(track.collision().bc().globalBC());
+        globalBC.push_back((int64_t)track.collision().bc().globalBC());
       } else {
         for (const auto& ambTrack : ambiguousTracks) {
           if constexpr (isCentralBarrel) { // FIXME: to be removed as soon as it is possible to use getId<Table>() for joined tables
@@ -137,12 +137,12 @@ class CollisionAssociation
                 globalBC.push_back(-1);
                 break;
               }
-              globalBC.push_back(ambTrack.bc().begin().globalBC());
+              globalBC.push_back((int64_t)ambTrack.bc().begin().globalBC());
               break;
             }
           } else {
             if (ambTrack.template getId<TTracks>() == track.globalIndex()) {
-              globalBC.push_back(ambTrack.bc().begin().globalBC());
+              globalBC.push_back((int64_t)ambTrack.bc().begin().globalBC());
               break;
             }
           }
@@ -170,7 +170,7 @@ class CollisionAssociation
         if (globalBC[track.filteredIndex()] < 0) {
           continue;
         }
-        const int64_t bcOffsetWindow = (int64_t)globalBC[track.filteredIndex()] + trackTime / o2::constants::lhc::LHCBunchSpacingNS - (int64_t)collBC;
+        const int64_t bcOffsetWindow = globalBC[track.filteredIndex()] + trackTime / o2::constants::lhc::LHCBunchSpacingNS - (int64_t)collBC;
         if (std::abs(bcOffsetWindow) > bOffsetMax) {
           continue;
         }


### PR DESCRIPTION
This PR fixes the type of the globalBC vector, which has to be signed since it is filled with `-1` for unassigned tracks (thanks @jgrosseo for spotting it!)