### PR TITLE
Safety changes for V0 type

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -945,7 +945,7 @@ struct HfFilter { // Main struct for HF triggers
           auto bachelorCasc = casc.bachelor_as<BigTracksPID>();
           auto v0DauPos = casc.posTrack_as<BigTracksPID>();
           auto v0DauNeg = casc.negTrack_as<BigTracksPID>();
-          
+
           if (!helper.isSelectedCascade(casc, std::array{bachelorCasc, v0DauPos, v0DauNeg}, collision)) {
             continue;
           }

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -294,7 +294,6 @@ struct HfFilter { // Main struct for HF triggers
   void process(CollsWithEvSel const& collisions,
                aod::BCsWithTimestamps const&,
                aod::V0Datas const& theV0s,
-               aod::V0sLinked const& v0Links,
                aod::CascDatas const& cascades,
                aod::Hf2Prongs const& cand2Prongs,
                aod::Hf3Prongs const& cand3Prongs,
@@ -943,15 +942,11 @@ struct HfFilter { // Main struct for HF triggers
       if (!keepEvent[kCharmBarToXiBach]) {
         auto cascThisColl = cascades.sliceBy(cascPerCollision, thisCollId);
         for (const auto& casc : cascThisColl) {
-          if (!casc.v0_as<aod::V0sLinked>().has_v0Data()) { // check that V0 data are stored
-            continue;
-          }
           auto bachelorCasc = casc.bachelor_as<BigTracksPID>();
-          auto v0 = casc.v0_as<aod::V0sLinked>();
-          auto v0Element = v0.v0Data_as<aod::V0Datas>();
-          auto v0DauPos = v0Element.posTrack_as<BigTracksPID>();
-          auto v0DauNeg = v0Element.negTrack_as<BigTracksPID>();
-          if (!helper.isSelectedCascade(casc, v0Element, std::array{bachelorCasc, v0DauPos, v0DauNeg}, collision)) {
+          auto v0DauPos = casc.posTrack_as<BigTracksPID>();
+          auto v0DauNeg = casc.negTrack_as<BigTracksPID>();
+          
+          if (!helper.isSelectedCascade(casc, std::array{bachelorCasc, v0DauPos, v0DauNeg}, collision)) {
             continue;
           }
           if (activateQA) {

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -321,8 +321,8 @@ class HfFilterHelper
   int8_t isSelectedXicInMassRange(const T& pTrackSameChargeFirst, const T& pTrackSameChargeSecond, const T& pTrackOppositeCharge, const float& ptXic, const int8_t isSelected, const int& activateQA, H2 hMassVsPt);
   template <typename V0, typename Coll, typename T, typename H2>
   int8_t isSelectedV0(const V0& v0, const std::array<T, 2>& dauTracks, const Coll& collision, const int& activateQA, H2 hV0Selected, std::array<H2, 4>& hArmPod);
-  template <typename Casc, typename V0, typename T, typename Coll>
-  bool isSelectedCascade(const Casc& casc, const V0& v0, const std::array<T, 3>& dauTracks, const Coll& collision);
+  template <typename Casc, typename T, typename Coll>
+  bool isSelectedCascade(const Casc& casc, const std::array<T, 3>& dauTracks, const Coll& collision);
   template <typename T, typename T2>
   int8_t isSelectedBachelorForCharmBaryon(const T& track, const T2& dca);
   template <typename T, typename U>
@@ -954,12 +954,11 @@ inline int8_t HfFilterHelper::isSelectedV0(const V0& v0, const std::array<T, 2>&
 
 /// Basic selection of cascade candidates
 /// \param casc is the cascade candidate
-/// \param v0 is the cascade daughter
 /// \param dauTracks is a 3-element array with bachelor, positive and negative V0 daughter tracks
 /// \param collision is the collision
 /// \return true if cascade passes all cuts
-template <typename Casc, typename V0, typename T, typename Coll>
-inline bool HfFilterHelper::isSelectedCascade(const Casc& casc, const V0& v0, const std::array<T, 3>& dauTracks, const Coll& collision)
+template <typename Casc, typename T, typename Coll>
+inline bool HfFilterHelper::isSelectedCascade(const Casc& casc, const std::array<T, 3>& dauTracks, const Coll& collision)
 {
   // eta of daughters
   if (std::fabs(dauTracks[0].eta()) > 1. || std::fabs(dauTracks[1].eta()) > 1. || std::fabs(dauTracks[2].eta()) > 1.) { // cut all V0 daughters with |eta| > 1.
@@ -967,7 +966,7 @@ inline bool HfFilterHelper::isSelectedCascade(const Casc& casc, const V0& v0, co
   }
 
   // V0 radius
-  if (v0.v0radius() < 1.2) {
+  if (casc.v0radius() < 1.2) {
     return false;
   }
 

--- a/EventFiltering/PWGLF/strangenessFilter.cxx
+++ b/EventFiltering/PWGLF/strangenessFilter.cxx
@@ -396,7 +396,7 @@ struct strangenessFilter {
     strgtable(keepEvent[0], keepEvent[1], keepEvent[2], keepEvent[3], keepEvent[4], keepEvent[5], keepEvent[6], keepEvent[7], keepEvent[8]);
   }
 
-  void processRun2(CollisionCandidates const& collision, TrackCandidates const& tracks, Cascades const& fullCasc, aod::V0sLinked const&, aod::V0Datas const& v0data, DaughterTracks& dtracks)
+  void processRun2(CollisionCandidates const& collision, TrackCandidates const& tracks, Cascades const& fullCasc, DaughterTracks& dtracks)
   {
     // Is event good? [0] = Omega, [1] = high-pT hadron + Xi, [2] = 2Xi, [3] = 3Xi, [4] = 4Xi, [5] single-Xi, [6] Omega with high radius
     // [7] tracked Xi, [8] tracked Omega, [9] tracked V0, [10] tracked 3Body
@@ -444,14 +444,9 @@ struct strangenessFilter {
 
     for (auto& casc : fullCasc) { // loop over cascades
       triggcounterForEstimates = 0;
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-      auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
       auto bachelor = casc.bachelor_as<DaughterTracks>();
-      auto posdau = v0.posTrack_as<DaughterTracks>();
-      auto negdau = v0.negTrack_as<DaughterTracks>();
+      auto posdau = casc.posTrack_as<DaughterTracks>();
+      auto negdau = casc.negTrack_as<DaughterTracks>();
 
       bool isXi = false;
       bool isXiYN = false;
@@ -657,8 +652,8 @@ struct strangenessFilter {
   ////////// Strangeness Filter - Run 3 MC /////////////
   //////////////////////////////////////////////////////
 
-  void processRun3(CollisionCandidatesRun3 const& collision, TrackCandidates const& tracks, Cascades const& fullCasc, aod::V0sLinked const&, aod::V0Datas const& v0data, DaughterTracks& dtracks,
-                   aod::AssignedTrackedCascades const& trackedCascades, aod::Cascades const& cascades, aod::AssignedTrackedV0s const& trackedV0s, aod::AssignedTracked3Bodys const& tracked3Bodys, aod::BCsWithTimestamps const&)
+  void processRun3(CollisionCandidatesRun3 const& collision, TrackCandidates const& tracks, Cascades const& fullCasc, DaughterTracks& dtracks,
+                   aod::AssignedTrackedCascades const& trackedCascades, aod::Cascades const& cascades, aod::AssignedTrackedV0s const& trackedV0s, aod::AssignedTracked3Bodys const& tracked3Bodys, aod::V0s const&, aod::BCsWithTimestamps const&)
   {
     // Is event good? [0] = Omega, [1] = high-pT hadron + Xi, [2] = 2Xi, [3] = 3Xi, [4] = 4Xi, [5] single-Xi, [6] Omega with high radius
     // [7] tracked Xi, [8] tracked Omega, [9] tracked V0, [10] tracked 3Body
@@ -703,16 +698,10 @@ struct strangenessFilter {
       triggcounterForEstimates = 0;
 
       hCandidate->Fill(0.5); // All candidates
-
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-      hCandidate->Fill(1.5);      // V0 exists
-      auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
+      hCandidate->Fill(1.5); // V0 exists - deprecated
       auto bachelor = casc.bachelor_as<DaughterTracks>();
-      auto posdau = v0.posTrack_as<DaughterTracks>();
-      auto negdau = v0.negTrack_as<DaughterTracks>();
+      auto posdau = casc.posTrack_as<DaughterTracks>();
+      auto negdau = casc.negTrack_as<DaughterTracks>();
 
       bool isXi = false;
       bool isXiYN = false;
@@ -1113,7 +1102,7 @@ struct strangenessFilter {
       // const auto itsTrack = trackedCascade.itsTrack();
       const auto cascade = trackedCascade.cascade();
       const auto bachelor = cascade.bachelor_as<DaughterTracks>();
-      const auto v0 = cascade.v0_as<o2::aod::V0sLinked>();
+      const auto v0 = cascade.v0_as<o2::aod::V0s>();
       const auto negTrack = v0.negTrack_as<DaughterTracks>();
       const auto posTrack = v0.posTrack_as<DaughterTracks>();
 

--- a/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createPCM.cxx
@@ -310,7 +310,7 @@ struct createPCM {
               pvec0[0], pvec0[1], pvec0[2],
               pvec1[0], pvec1[1], pvec1[2],
               v0dca, pos.dcaXY(), ele.dcaXY(),
-              v0CosinePA, dcaV0toPV);
+              v0CosinePA, dcaV0toPV, 3); // v0 type: photon-exclusive
     } else {
       // LOGF(info, "storing: collision.globalIndex() = %d , pos.globalIndex() = %d , ele.globalIndex() = %d, cospa = %f", collision.globalIndex(), pos.globalIndex(), ele.globalIndex(), v0CosinePA);
       pca_map[std::make_tuple(pos.globalIndex(), ele.globalIndex(), collision.globalIndex())] = v0dca;

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -118,11 +118,11 @@ struct HfCandidateCreatorCascade {
       float v0PosPx, v0PosPy, v0PosPz, v0NegPx, v0NegPy, v0NegPz;
       float dcaV0dau, dcaPosToPV, dcaNegToPV, v0cosPA;
       float posTrackX, negTrackX;
-      o2::track::TrackParCov trackParCovV0DaughPos; 
-      o2::track::TrackParCov trackParCovV0DaughNeg; 
+      o2::track::TrackParCov trackParCovV0DaughPos;
+      o2::track::TrackParCov trackParCovV0DaughNeg;
 
       auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if(v0index.has_v0Data()){
+      if (v0index.has_v0Data()) {
         // this V0 passed both standard V0 and cascade V0 selections
         auto v0row = v0index.v0Data();
         const auto& trackV0DaughPos = v0row.posTrack_as<aod::TracksWCov>();
@@ -149,7 +149,7 @@ struct HfCandidateCreatorCascade {
         v0cosPA = v0row.v0cosPA();
         posTrackX = v0row.posX();
         negTrackX = v0row.negX();
-      }else if(v0index.has_v0fCData()){
+      } else if (v0index.has_v0fCData()) {
         // this V0 passes only V0-for-cascade selections, use that instead
         auto v0row = v0index.v0fCData();
         const auto& trackV0DaughPos = v0row.posTrack_as<aod::TracksWCov>();
@@ -176,7 +176,7 @@ struct HfCandidateCreatorCascade {
         v0cosPA = v0row.v0cosPA();
         posTrackX = v0row.posX();
         negTrackX = v0row.negX();
-      }else{ 
+      } else {
         LOGF(warning, "V0Data/V0fCData not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
         continue; // this was inadequately linked, should not happen
       }
@@ -195,8 +195,8 @@ struct HfCandidateCreatorCascade {
       df.setBz(bz);
 
       auto trackParCovBach = getTrackParCov(bach);
-      trackParCovV0DaughPos.propagateTo(posTrackX, bz);             // propagate the track to the X closest to the V0 vertex
-      trackParCovV0DaughNeg.propagateTo(negTrackX, bz);             // propagate the track to the X closest to the V0 vertex
+      trackParCovV0DaughPos.propagateTo(posTrackX, bz); // propagate the track to the X closest to the V0 vertex
+      trackParCovV0DaughNeg.propagateTo(negTrackX, bz); // propagate the track to the X closest to the V0 vertex
       const std::array<float, 3> vertexV0 = {v0x, v0y, v0z};
       const std::array<float, 3> momentumV0 = {v0px, v0py, v0pz};
       // we build the neutral track to then build the cascade
@@ -253,8 +253,8 @@ struct HfCandidateCreatorCascade {
                        v0x, v0y, v0z,
                        // v0.posTrack(), v0.negTrack(), // why this was not fine?
                        posGlobalIndex, negGlobalIndex,
-                       v0PosPx, v0PosPy, v0PosPz, 
-                       v0NegPx, v0NegPy, v0NegPz, 
+                       v0PosPx, v0PosPy, v0PosPz,
+                       v0NegPx, v0NegPy, v0NegPz,
                        dcaV0dau,
                        dcaPosToPV,
                        dcaNegToPV,

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -87,9 +87,10 @@ struct HfCandidateCreatorCascade {
 
   void process(aod::Collisions const&,
                aod::HfCascades const& rowsTrackIndexCasc,
-               aod::TracksWCov const&,
                aod::V0sLinked const&,
                aod::V0Datas const&,
+               aod::V0fCDatas const&,
+               aod::TracksWCov const&,
                aod::BCsWithTimestamps const&)
   {
     // 2-prong vertex fitter
@@ -105,23 +106,80 @@ struct HfCandidateCreatorCascade {
 
     // loop over pairs of track indices
     for (const auto& casc : rowsTrackIndexCasc) {
-
       const auto& bach = casc.prong0_as<aod::TracksWCov>();
       LOGF(debug, "V0 %d in HF cascade %d.", casc.v0Id(), casc.globalIndex());
       if (!casc.has_v0()) {
         LOGF(error, "V0 not there for HF cascade %d. Skipping candidate.", casc.globalIndex());
         continue;
       }
-      if (!casc.v0_as<aod::V0sLinked>().has_v0Data()) {
-        if (!silenceV0DataWarning) {
-          LOGF(warning, "V0Data not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
-        }
-        continue;
+
+      int posGlobalIndex = -1, negGlobalIndex = -1;
+      float v0x, v0y, v0z, v0px, v0py, v0pz;
+      float v0PosPx, v0PosPy, v0PosPz, v0NegPx, v0NegPy, v0NegPz;
+      float dcaV0dau, dcaPosToPV, dcaNegToPV, v0cosPA;
+      float posTrackX, negTrackX;
+      o2::track::TrackParCov trackParCovV0DaughPos; 
+      o2::track::TrackParCov trackParCovV0DaughNeg; 
+
+      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
+      if(v0index.has_v0Data()){
+        // this V0 passed both standard V0 and cascade V0 selections
+        auto v0row = v0index.v0Data();
+        const auto& trackV0DaughPos = v0row.posTrack_as<aod::TracksWCov>();
+        const auto& trackV0DaughNeg = v0row.negTrack_as<aod::TracksWCov>();
+        trackParCovV0DaughPos = getTrackParCov(trackV0DaughPos); // check that aod::TracksWCov does not need TracksDCA!
+        trackParCovV0DaughNeg = getTrackParCov(trackV0DaughNeg); // check that aod::TracksWCov does not need TracksDCA!
+        posGlobalIndex = trackV0DaughPos.globalIndex();
+        negGlobalIndex = trackV0DaughNeg.globalIndex();
+        v0x = v0row.x();
+        v0y = v0row.y();
+        v0z = v0row.z();
+        v0px = v0row.px();
+        v0py = v0row.py();
+        v0pz = v0row.pz();
+        v0PosPx = v0row.pxpos();
+        v0PosPy = v0row.pypos();
+        v0PosPz = v0row.pzpos();
+        v0NegPx = v0row.pxneg();
+        v0NegPy = v0row.pyneg();
+        v0NegPz = v0row.pzneg();
+        dcaV0dau = v0row.dcaV0daughters();
+        dcaPosToPV = v0row.dcapostopv();
+        dcaNegToPV = v0row.dcanegtopv();
+        v0cosPA = v0row.v0cosPA();
+        posTrackX = v0row.posX();
+        negTrackX = v0row.negX();
+      }else if(v0index.has_v0fCData()){
+        // this V0 passes only V0-for-cascade selections, use that instead
+        auto v0row = v0index.v0fCData();
+        const auto& trackV0DaughPos = v0row.posTrack_as<aod::TracksWCov>();
+        const auto& trackV0DaughNeg = v0row.negTrack_as<aod::TracksWCov>();
+        trackParCovV0DaughPos = getTrackParCov(trackV0DaughPos); // check that aod::TracksWCov does not need TracksDCA!
+        trackParCovV0DaughNeg = getTrackParCov(trackV0DaughNeg); // check that aod::TracksWCov does not need TracksDCA!
+        posGlobalIndex = trackV0DaughPos.globalIndex();
+        negGlobalIndex = trackV0DaughNeg.globalIndex();
+        v0x = v0row.x();
+        v0y = v0row.y();
+        v0z = v0row.z();
+        v0px = v0row.px();
+        v0py = v0row.py();
+        v0pz = v0row.pz();
+        v0PosPx = v0row.pxpos();
+        v0PosPy = v0row.pypos();
+        v0PosPz = v0row.pzpos();
+        v0NegPx = v0row.pxneg();
+        v0NegPy = v0row.pyneg();
+        v0NegPz = v0row.pzneg();
+        dcaV0dau = v0row.dcaV0daughters();
+        dcaPosToPV = v0row.dcapostopv();
+        dcaNegToPV = v0row.dcanegtopv();
+        v0cosPA = v0row.v0cosPA();
+        posTrackX = v0row.posX();
+        negTrackX = v0row.negX();
+      }else{ 
+        LOGF(warning, "V0Data/V0fCData not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
+        continue; // this was inadequately linked, should not happen
       }
-      LOGF(debug, "V0Data ID: %d", casc.v0_as<aod::V0sLinked>().v0DataId());
-      const auto& v0 = casc.v0_as<aod::V0sLinked>().v0Data();
-      const auto& trackV0DaughPos = v0.posTrack_as<aod::TracksWCov>();
-      const auto& trackV0DaughNeg = v0.negTrack_as<aod::TracksWCov>();
 
       auto collision = casc.collision();
 
@@ -137,12 +195,10 @@ struct HfCandidateCreatorCascade {
       df.setBz(bz);
 
       auto trackParCovBach = getTrackParCov(bach);
-      auto trackParCovV0DaughPos = getTrackParCov(trackV0DaughPos); // check that aod::TracksWCov does not need TracksDCA!
-      auto trackParCovV0DaughNeg = getTrackParCov(trackV0DaughNeg); // check that aod::TracksWCov does not need TracksDCA!
-      trackParCovV0DaughPos.propagateTo(v0.posX(), bz);             // propagate the track to the X closest to the V0 vertex
-      trackParCovV0DaughNeg.propagateTo(v0.negX(), bz);             // propagate the track to the X closest to the V0 vertex
-      const std::array<float, 3> vertexV0 = {v0.x(), v0.y(), v0.z()};
-      const std::array<float, 3> momentumV0 = {v0.px(), v0.py(), v0.pz()};
+      trackParCovV0DaughPos.propagateTo(posTrackX, bz);             // propagate the track to the X closest to the V0 vertex
+      trackParCovV0DaughNeg.propagateTo(negTrackX, bz);             // propagate the track to the X closest to the V0 vertex
+      const std::array<float, 3> vertexV0 = {v0x, v0y, v0z};
+      const std::array<float, 3> momentumV0 = {v0px, v0py, v0pz};
       // we build the neutral track to then build the cascade
       auto trackV0 = o2::dataformats::V0(vertexV0, momentumV0, {0, 0, 0, 0, 0, 0}, trackParCovV0DaughPos, trackParCovV0DaughNeg); // build the V0 track (indices for v0 daughters set to 0 for now)
 
@@ -194,15 +250,15 @@ struct HfCandidateCreatorCascade {
                        impactParameterBach.getY(), impactParameterV0.getY(),
                        std::sqrt(impactParameterBach.getSigmaY2()), std::sqrt(impactParameterV0.getSigmaY2()),
                        casc.prong0Id(), casc.v0Id(),
-                       v0.x(), v0.y(), v0.z(),
+                       v0x, v0y, v0z,
                        // v0.posTrack(), v0.negTrack(), // why this was not fine?
-                       trackV0DaughPos.globalIndex(), trackV0DaughNeg.globalIndex(),
-                       v0.pxpos(), v0.pypos(), v0.pzpos(),
-                       v0.pxneg(), v0.pyneg(), v0.pzneg(),
-                       v0.dcaV0daughters(),
-                       v0.dcapostopv(),
-                       v0.dcanegtopv(),
-                       v0.v0cosPA());
+                       posGlobalIndex, negGlobalIndex,
+                       v0PosPx, v0PosPy, v0PosPz, 
+                       v0NegPx, v0NegPy, v0NegPz, 
+                       dcaV0dau,
+                       dcaPosToPV,
+                       dcaNegToPV,
+                       v0cosPA);
 
       // fill histograms
       if (fillHistograms) {

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -149,8 +149,8 @@ struct HfCandidateCreatorToXiPi {
       int v0index = cascAodElement.v0Id();
       auto casc = cascAodElement.cascData_as<MyCascTable>();
       auto trackXiDauCharged = casc.bachelor_as<TracksWCovDca>(); // pion <- xi track
-      auto trackV0Dau0 = casc.posTrack_as<TracksWCovDca>(); // V0 positive daughter track
-      auto trackV0Dau1 = casc.negTrack_as<TracksWCovDca>(); // V0 negative daughter track
+      auto trackV0Dau0 = casc.posTrack_as<TracksWCovDca>();       // V0 positive daughter track
+      auto trackV0Dau1 = casc.negTrack_as<TracksWCovDca>();       // V0 negative daughter track
 
       //-------------------------- V0 info---------------------------
       // pseudorapidity

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -82,7 +82,6 @@ struct HfCandidateCreatorToXiPi {
   using MyCascTable = soa::Join<aod::CascDatas, aod::CascCovs>; // to use strangeness tracking, use aod::TraCascDatas instead of aod::CascDatas
   using CascadesLinked = soa::Join<Cascades, CascDataLink>;
   using MyV0Table = soa::Join<aod::V0Datas, aod::V0Covs>;
-  using V0sLinked = soa::Join<V0s, V0DataLink>;
   using MySkimIdx = soa::Filtered<aod::HfCascLf2Prongs>;
 
   Filter filterSelectIndexes = (aod::hf_track_index::hfflag > static_cast<uint8_t>(0));
@@ -104,7 +103,6 @@ struct HfCandidateCreatorToXiPi {
                aod::BCsWithTimestamps const&,
                TracksWCovDca const&,
                MyCascTable const&, CascadesLinked const&,
-               MyV0Table const&, V0sLinked const&,
                MySkimIdx const& candidates)
   {
 
@@ -148,12 +146,11 @@ struct HfCandidateCreatorToXiPi {
 
       auto trackPion = cand.prong0_as<TracksWCovDca>();
       auto cascAodElement = cand.cascade_as<aod::CascadesLinked>();
+      int v0index = cascAodElement.v0Id();
       auto casc = cascAodElement.cascData_as<MyCascTable>();
       auto trackXiDauCharged = casc.bachelor_as<TracksWCovDca>(); // pion <- xi track
-      auto v0AodElement = casc.v0_as<aod::V0sLinked>();
-      auto v0 = v0AodElement.v0Data_as<MyV0Table>();      // V0 <-- xi
-      auto trackV0Dau0 = v0.posTrack_as<TracksWCovDca>(); // V0 positive daughter track
-      auto trackV0Dau1 = v0.negTrack_as<TracksWCovDca>(); // V0 negative daughter track
+      auto trackV0Dau0 = casc.posTrack_as<TracksWCovDca>(); // V0 positive daughter track
+      auto trackV0Dau1 = casc.negTrack_as<TracksWCovDca>(); // V0 negative daughter track
 
       //-------------------------- V0 info---------------------------
       // pseudorapidity
@@ -315,7 +312,7 @@ struct HfCandidateCreatorToXiPi {
                    impactParameterCasc.getY(), impactParPiFromCharmBaryonXY,
                    impactParameterCasc.getZ(), impactParPiFromCharmBaryonZ,
                    std::sqrt(impactParameterCasc.getSigmaY2()), std::sqrt(impactParameterPiFromCharmBaryon.getSigmaY2()),
-                   casc.v0Id(), v0.posTrackId(), v0.negTrackId(),
+                   v0index, casc.posTrackId(), casc.negTrackId(),
                    casc.cascadeId(), trackPion.globalIndex(), casc.bachelorId(),
                    mLambda, mCasc, mCharmBaryon,
                    cpaV0, cpaCharmBaryon, cpaCasc, cpaxyV0, cpaxyCharmBaryon, cpaxyCasc,

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -3381,7 +3381,6 @@ struct HfTrackIndexSkimCreatorLfCascades {
                          SelectedHfTrackAssoc const& trackIndices,
                          aod::TracksWCovDca const& tracks,
                          aod::BCsWithTimestamps const&,
-                         aod::V0sLinked const&,
                          V0Full const&)
   {
 
@@ -3432,16 +3431,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
         // cascade daughter - charged particle
         auto trackXiDauCharged = casc.bachelor_as<aod::TracksWCovDca>(); // pion <- xi track
         // cascade daughter - V0
-        if (!casc.v0_as<aod::V0sLinked>().has_v0Data()) { // check if V0 data are stored
-          continue;
-        }
-        registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists
-        auto v0 = casc.v0_as<aod::V0sLinked>();
-        auto v0Element = v0.v0Data_as<V0Full>(); // V0 element from LF table containing V0 info
-        // V0 positive daughter
-        auto trackV0PosDau = v0Element.posTrack_as<aod::TracksWCovDca>(); // p <- V0 track (positive track) 0
+        auto trackV0PosDau = casc.posTrack_as<aod::TracksWCovDca>(); // p <- V0 track (positive track) 0
         // V0 negative daughter
-        auto trackV0NegDau = v0Element.negTrack_as<aod::TracksWCovDca>(); // pion <- V0 track (negative track) 1
+        auto trackV0NegDau = casc.negTrack_as<aod::TracksWCovDca>(); // pion <- V0 track (negative track) 1
 
         // check that particles come from the same collision
         if (rejDiffCollTrack) {

--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -64,6 +64,7 @@ DECLARE_SOA_COLUMN(Phi, phi, float);                                 //! Phi
 DECLARE_SOA_COLUMN(PartType, partType, uint8_t);                     //! Type of the particle, according to resodaughter::ParticleType
 DECLARE_SOA_COLUMN(TempFitVar, tempFitVar, float);                   //! Observable for the template fitting (Track: DCA_xy, V0: CPA)
 DECLARE_SOA_COLUMN(Indices, indices, int[2]);                        //! Field for the track indices to remove auto-correlations
+DECLARE_SOA_COLUMN(CascadeIndices, cascIndices, int[3]);             //! Field for the track indices to remove auto-correlations (ordered: positive, negative, bachelor)
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);                              //! Sign of the track charge
 DECLARE_SOA_COLUMN(TPCNClsCrossedRows, tpcNClsCrossedRows, uint8_t); //! Number of TPC crossed rows
 DECLARE_SOA_COLUMN(IsGlobalTrackWoDCA, isGlobalTrackWoDCA, bool);    //! Is global track without DCA
@@ -164,7 +165,7 @@ DECLARE_SOA_TABLE(ResoCascades, "AOD", "RESOCASCADES",
                   resodaughter::Pz,
                   resodaughter::Eta,
                   resodaughter::Phi,
-                  resodaughter::Indices,
+                  resodaughter::CascadeIndices,
                   resodaughter::V0CosPA,
                   resodaughter::CascCosPA,
                   resodaughter::DaughDCA,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -121,7 +121,7 @@ DECLARE_SOA_INDEX_COLUMN(V0, v0);                                       //!
 DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra"); //!
 DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                        //!
-DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                  //!
+DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                          //!
 
 //______________________________________________________
 // REGULAR COLUMNS FOR V0CORES
@@ -555,7 +555,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras,
 DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrackExtra, strangeTrackExtra, int, DauTrackExtras, "_StrangeExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                                    //!
-DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                                          //!
+DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                                      //!
 
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCCORES

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -146,7 +146,7 @@ DECLARE_SOA_COLUMN(V0CosPA, v0cosPA, float);               //! V0 CosPA
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
 // Type of V0 from the svertexer (photon, regular, from cascade)
-DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t);           //! DCA V0 to PV
+DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t); //! DCA V0 to PV
 
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
@@ -352,7 +352,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::PxPos, v0data::PyPos, v0data::PzPos,
                        v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
                        v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
-                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type, 
+                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type,
 
                        // Dynamic columns
                        v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
@@ -363,7 +363,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::QtArm<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PsiPair<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PFracPos<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, //24
+                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, // 24
 
                        // Invariant masses
                        v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
@@ -386,9 +386,9 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::NegativePhi<v0data::PxNeg, v0data::PyNeg>,
                        v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
                        v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
-                       v0data::IsStandardV0<v0data::V0Type>, 
+                       v0data::IsStandardV0<v0data::V0Type>,
                        v0data::IsPhotonV0<v0data::V0Type>,
-                       o2::soa::Marker<1>); 
+                       o2::soa::Marker<1>);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(V0Cores, StoredV0Cores, "V0COREEXT",                                                  //!
@@ -396,7 +396,6 @@ DECLARE_SOA_EXTENDED_TABLE_USER(V0Cores, StoredV0Cores, "V0COREEXT",            
 
 DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //! V0 covariance matrices
                        v0data::PositionCovMat, v0data::MomentumCovMat, o2::soa::Marker<1>);
-
 
 DECLARE_SOA_TABLE(V0fCIndices, "AOD", "V0FCINDEX", //! index table when using AO2Ds
                   o2::soa::Index<>, v0data::PosTrackId, v0data::NegTrackId, v0data::CollisionId, v0data::V0Id, o2::soa::Marker<2>);
@@ -409,7 +408,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0fCCores, "V0fCCores", "AOD", "V0FCCORE", //! core
                        v0data::PxPos, v0data::PyPos, v0data::PzPos,
                        v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
                        v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
-                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type, 
+                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type,
 
                        // Dynamic columns
                        v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
@@ -420,7 +419,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0fCCores, "V0fCCores", "AOD", "V0FCCORE", //! core
                        v0data::QtArm<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PsiPair<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PFracPos<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, //24
+                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, // 24
 
                        // Invariant masses
                        v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
@@ -443,12 +442,12 @@ DECLARE_SOA_TABLE_FULL(StoredV0fCCores, "V0fCCores", "AOD", "V0FCCORE", //! core
                        v0data::NegativePhi<v0data::PxNeg, v0data::PyNeg>,
                        v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
                        v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
-                       v0data::IsStandardV0<v0data::V0Type>, 
-                       v0data::IsPhotonV0<v0data::V0Type>, 
-                       o2::soa::Marker<2>); 
+                       v0data::IsStandardV0<v0data::V0Type>,
+                       v0data::IsPhotonV0<v0data::V0Type>,
+                       o2::soa::Marker<2>);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
-DECLARE_SOA_EXTENDED_TABLE_USER(V0fCCores, StoredV0fCCores, "V0FCCOREEXT",                                                  //!
+DECLARE_SOA_EXTENDED_TABLE_USER(V0fCCores, StoredV0fCCores, "V0FCCOREEXT",                                            //!
                                 v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
 
 DECLARE_SOA_TABLE_FULL(V0fCCovs, "V0fCCovs", "AOD", "V0FCCOVS", //! V0 covariance matrices
@@ -478,7 +477,7 @@ using V0MCData = V0MCDatas::iterator;
 namespace v0data
 {
 DECLARE_SOA_INDEX_COLUMN(V0Data, v0Data); //! Index to V0Data entry
-DECLARE_SOA_INDEX_COLUMN(V0fCData, v0fCData); //! Index to V0Data entry
+DECLARE_SOA_INDEX_COLUMN(V0fCData, v0fCData);                     //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN_FULL(V0MC, v0MC, int, V0MCCores, "_MC"); //!
 }
 
@@ -551,7 +550,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, "_Bach");        
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrack, strangeTrack, int, Tracks, "_Strange"); //!
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                                     //!
 // FOR DERIVED
-DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra");             //! 
+DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra");             //!
 DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra");             //!
 DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrackExtra, strangeTrackExtra, int, DauTrackExtras, "_StrangeExtra"); //!
@@ -595,7 +594,7 @@ DECLARE_SOA_COLUMN(DCAZCascToPV, dcaZCascToPV, float);         //!
 // Saved from finding: track position at minima
 DECLARE_SOA_COLUMN(PosX, posX, float);   //! positive track X at min
 DECLARE_SOA_COLUMN(NegX, negX, float);   //! negative track X at min
-DECLARE_SOA_COLUMN(BachX, bachX, float);   //! bachelor track X at min
+DECLARE_SOA_COLUMN(BachX, bachX, float); //! bachelor track X at min
 
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCCOVS

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -387,7 +387,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
                        v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
                        v0data::IsStandardV0<v0data::V0Type>,
-                       v0data::IsPhotonV0<v0data::V0Type>,
+                       v0data::IsPhotonTPConly<v0data::V0Type>,
                        o2::soa::Marker<1>);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
@@ -443,7 +443,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0fCCores, "V0fCCores", "AOD", "V0FCCORE", //! core
                        v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
                        v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
                        v0data::IsStandardV0<v0data::V0Type>,
-                       v0data::IsPhotonV0<v0data::V0Type>,
+                       v0data::IsPhotonTPConly<v0data::V0Type>,
                        o2::soa::Marker<2>);
 
 // extended table with expression columns that can be used as arguments of dynamic columns

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -145,6 +145,9 @@ DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);         //! DCA negative pron
 DECLARE_SOA_COLUMN(V0CosPA, v0cosPA, float);               //! V0 CosPA
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
+// Type of V0 from the svertexer (photon, regular, from cascade)
+DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t);           //! DCA V0 to PV
+
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
 DECLARE_SOA_COLUMN(MomentumCovMat, momentumCovMat, float[6]); //! covariance matrix elements
@@ -325,10 +328,15 @@ DECLARE_SOA_DYNAMIC_COLUMN(PositiveEta, positiveeta, //! positive daughter eta
                            [](float PxPos, float PyPos, float PzPos) -> float { return RecoDecay::eta(std::array{PxPos, PyPos, PzPos}); });
 DECLARE_SOA_DYNAMIC_COLUMN(PositivePhi, positivephi, //! positive daughter phi
                            [](float PxPos, float PyPos) -> float { return RecoDecay::phi(PxPos, PyPos); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(IsStandardV0, isStandardV0, //! is standard V0
+                           [](uint8_t V0Type) -> bool { return V0Type & (1 << 0); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonV0, isPhotonV0, //! is photon V0
+                           [](uint8_t V0Type) -> bool { return V0Type & (1 << 1); });
 } // namespace v0data
 
 DECLARE_SOA_TABLE(V0Indices, "AOD", "V0INDEX", //! index table when using AO2Ds
-                  o2::soa::Index<>, v0data::PosTrackId, v0data::NegTrackId, v0data::CollisionId, v0data::V0Id);
+                  o2::soa::Index<>, v0data::PosTrackId, v0data::NegTrackId, v0data::CollisionId, v0data::V0Id, o2::soa::Marker<1>);
 
 DECLARE_SOA_TABLE(V0CollRefs, "AOD", "V0COLLREF", //! optional table to refer back to a collision
                   o2::soa::Index<>, v0data::StraCollisionId);
@@ -337,14 +345,14 @@ DECLARE_SOA_TABLE(V0Extras, "AOD", "V0EXTRA", //! optional table to refer to cus
                   o2::soa::Index<>, v0data::PosTrackExtraId, v0data::NegTrackExtraId);
 
 DECLARE_SOA_TABLE(V0TrackXs, "AOD", "V0TRACKX", //! track X positions at minima when using AO2Ds
-                  v0data::PosX, v0data::NegX);
+                  v0data::PosX, v0data::NegX, o2::soa::Marker<1>);
 
 DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core information about decay, viable with AO2Ds or derived
                        v0data::X, v0data::Y, v0data::Z,
                        v0data::PxPos, v0data::PyPos, v0data::PzPos,
                        v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
                        v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
-                       v0data::V0CosPA, v0data::DCAV0ToPV,
+                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type, 
 
                        // Dynamic columns
                        v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
@@ -355,7 +363,7 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::QtArm<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PsiPair<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::PFracPos<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
-                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, //24
 
                        // Invariant masses
                        v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
@@ -377,14 +385,74 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
                        v0data::NegativeEta<v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
                        v0data::NegativePhi<v0data::PxNeg, v0data::PyNeg>,
                        v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
-                       v0data::PositivePhi<v0data::PxPos, v0data::PyPos>);
+                       v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
+                       v0data::IsStandardV0<v0data::V0Type>, 
+                       v0data::IsPhotonV0<v0data::V0Type>,
+                       o2::soa::Marker<1>); 
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(V0Cores, StoredV0Cores, "V0COREEXT",                                                  //!
                                 v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
 
 DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //! V0 covariance matrices
-                       v0data::PositionCovMat, v0data::MomentumCovMat);
+                       v0data::PositionCovMat, v0data::MomentumCovMat, o2::soa::Marker<1>);
+
+
+DECLARE_SOA_TABLE(V0fCIndices, "AOD", "V0FCINDEX", //! index table when using AO2Ds
+                  o2::soa::Index<>, v0data::PosTrackId, v0data::NegTrackId, v0data::CollisionId, v0data::V0Id, o2::soa::Marker<2>);
+
+DECLARE_SOA_TABLE(V0fCTrackXs, "AOD", "V0FCTRACKX", //! track X positions at minima when using AO2Ds
+                  v0data::PosX, v0data::NegX, o2::soa::Marker<2>);
+
+DECLARE_SOA_TABLE_FULL(StoredV0fCCores, "V0fCCores", "AOD", "V0FCCORE", //! core information about decay, exclusive to V0s used in cascades but not passing in V0 selections - multiple viable getters skipped since use is protected to cascades only
+                       v0data::X, v0data::Y, v0data::Z,
+                       v0data::PxPos, v0data::PyPos, v0data::PzPos,
+                       v0data::PxNeg, v0data::PyNeg, v0data::PzNeg,
+                       v0data::DCAV0Daughters, v0data::DCAPosToPV, v0data::DCANegToPV,
+                       v0data::V0CosPA, v0data::DCAV0ToPV, v0data::V0Type, 
+
+                       // Dynamic columns
+                       v0data::PtHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
+                       v0data::PtAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PxNeg, v0data::PyNeg>,
+                       v0data::V0Radius<v0data::X, v0data::Y>,
+                       v0data::DistOverTotMom<v0data::X, v0data::Y, v0data::Z, v0data::Px, v0data::Py, v0data::Pz>,
+                       v0data::Alpha<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::QtArm<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::PsiPair<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::PFracPos<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::PFracNeg<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>, //24
+
+                       // Invariant masses
+                       v0data::MLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::MAntiLambda<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::MK0Short<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::MGamma<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::MHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::MAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::M<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+
+                       // Longitudinal
+                       v0data::YK0Short<v0data::Px, v0data::Py, v0data::Pz>,
+                       v0data::YLambda<v0data::Px, v0data::Py, v0data::Pz>,
+                       v0data::YHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::YAntiHypertriton<v0data::PxPos, v0data::PyPos, v0data::PzPos, v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::Rapidity<v0data::Px, v0data::Py, v0data::Pz>,
+                       v0data::NegativePt<v0data::PxNeg, v0data::PyNeg>,
+                       v0data::PositivePt<v0data::PxPos, v0data::PyPos>,
+                       v0data::NegativeEta<v0data::PxNeg, v0data::PyNeg, v0data::PzNeg>,
+                       v0data::NegativePhi<v0data::PxNeg, v0data::PyNeg>,
+                       v0data::PositiveEta<v0data::PxPos, v0data::PyPos, v0data::PzPos>,
+                       v0data::PositivePhi<v0data::PxPos, v0data::PyPos>,
+                       v0data::IsStandardV0<v0data::V0Type>, 
+                       v0data::IsPhotonV0<v0data::V0Type>, 
+                       o2::soa::Marker<2>); 
+
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(V0fCCores, StoredV0fCCores, "V0FCCOREEXT",                                                  //!
+                                v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
+
+DECLARE_SOA_TABLE_FULL(V0fCCovs, "V0fCCovs", "AOD", "V0FCCOVS", //! V0 covariance matrices
+                       v0data::PositionCovMat, v0data::MomentumCovMat, o2::soa::Marker<2>);
 
 DECLARE_SOA_TABLE(V0MCCores, "AOD", "V0MCCORE", //! MC properties of the V0 for posterior analysis
                   v0data::PDGCode, v0data::PDGCodeMother,
@@ -401,6 +469,8 @@ using V0Core = V0Cores::iterator;
 using V0TrackX = V0TrackXs::iterator;
 using V0Datas = soa::Join<V0Indices, V0TrackXs, V0Cores>;
 using V0Data = V0Datas::iterator;
+using V0fCDatas = soa::Join<V0fCIndices, V0fCTrackXs, V0fCCores>;
+using V0fCData = V0fCDatas::iterator;
 using V0MCDatas = soa::Join<V0MCCores, V0MCMothers>;
 using V0MCData = V0MCDatas::iterator;
 
@@ -408,11 +478,12 @@ using V0MCData = V0MCDatas::iterator;
 namespace v0data
 {
 DECLARE_SOA_INDEX_COLUMN(V0Data, v0Data); //! Index to V0Data entry
+DECLARE_SOA_INDEX_COLUMN(V0fCData, v0fCData); //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN_FULL(V0MC, v0MC, int, V0MCCores, "_MC"); //!
 }
 
 DECLARE_SOA_TABLE(V0DataLink, "AOD", "V0DATALINK", //! Joinable table with V0s which links to V0Data which is not produced for all entries
-                  v0data::V0DataId);
+                  o2::soa::Index<>, v0data::V0DataId, v0data::V0fCDataId);
 DECLARE_SOA_TABLE(V0MCRefs, "AOD", "V0MCREF", //! index table when using AO2Ds
                   o2::soa::Index<>, v0data::V0MCId);
 
@@ -472,18 +543,20 @@ namespace cascdata
 {
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCINDICES
-DECLARE_SOA_INDEX_COLUMN(V0, v0);                                           //!
-DECLARE_SOA_INDEX_COLUMN(Cascade, cascade);                                 //!
-DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, "");         //!
-DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrack, strangeTrack, int, Tracks, ""); //!
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                             //!
+DECLARE_SOA_INDEX_COLUMN(V0, v0);                                                   //!
+DECLARE_SOA_INDEX_COLUMN(Cascade, cascade);                                         //!
+DECLARE_SOA_INDEX_COLUMN_FULL(PosTrack, posTrack, int, Tracks, "_Pos");             //!
+DECLARE_SOA_INDEX_COLUMN_FULL(NegTrack, negTrack, int, Tracks, "_Neg");             //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, "_Bach");            //!
+DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrack, strangeTrack, int, Tracks, "_Strange"); //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);                                     //!
 // FOR DERIVED
-DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra");   //!
-DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra");   //!
-DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra"); //!
+DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra");             //! 
+DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra");             //!
+DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrackExtra, strangeTrackExtra, int, DauTrackExtras, "_StrangeExtra"); //!
-DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                          //!
-DECLARE_SOA_INDEX_COLUMN(MotherMCParticle, motherMCParticle);                                    //!
+DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                                    //!
+DECLARE_SOA_INDEX_COLUMN(MotherMCParticle, motherMCParticle);                                              //!
 
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCCORES
@@ -518,6 +591,11 @@ DECLARE_SOA_COLUMN(DCANegToPV, dcanegtopv, float);             //!
 DECLARE_SOA_COLUMN(DCABachToPV, dcabachtopv, float);           //!
 DECLARE_SOA_COLUMN(DCAXYCascToPV, dcaXYCascToPV, float);       //!
 DECLARE_SOA_COLUMN(DCAZCascToPV, dcaZCascToPV, float);         //!
+
+// Saved from finding: track position at minima
+DECLARE_SOA_COLUMN(PosX, posX, float);   //! positive track X at min
+DECLARE_SOA_COLUMN(NegX, negX, float);   //! negative track X at min
+DECLARE_SOA_COLUMN(BachX, bachX, float);   //! bachelor track X at min
 
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCCOVS
@@ -665,11 +743,11 @@ DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //! Pseudorapidity, conditionally
 // as possible for ease of use and comparison
 
 DECLARE_SOA_TABLE(CascIndices, "AOD", "CascINDEX", //! index table when using AO2Ds
-                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId, o2::soa::Marker<1>);
+                  o2::soa::Index<>, cascdata::CascadeId, v0data::PosTrackId, v0data::NegTrackId, cascdata::BachelorId, cascdata::CollisionId, o2::soa::Marker<1>);
 DECLARE_SOA_TABLE(KFCascIndices, "AOD", "KFCascINDEX", //! index table when using AO2Ds
-                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::CollisionId, o2::soa::Marker<2>);
+                  o2::soa::Index<>, cascdata::CascadeId, v0data::PosTrackId, v0data::NegTrackId, cascdata::BachelorId, cascdata::CollisionId, o2::soa::Marker<2>);
 DECLARE_SOA_TABLE(TraCascIndices, "AOD", "TraCascINDEX", //! index table when using AO2Ds
-                  o2::soa::Index<>, cascdata::V0Id, cascdata::CascadeId, cascdata::BachelorId, cascdata::StrangeTrackId, cascdata::CollisionId);
+                  o2::soa::Index<>, cascdata::CascadeId, v0data::PosTrackId, v0data::NegTrackId, cascdata::BachelorId, cascdata::StrangeTrackId, cascdata::CollisionId);
 
 DECLARE_SOA_TABLE(CascCollRefs, "AOD", "CASCCOLLREF", //! optional table to refer back to a collision
                   o2::soa::Index<>, cascdata::StraCollisionId, o2::soa::Marker<1>);
@@ -683,6 +761,10 @@ DECLARE_SOA_TABLE(CascExtras, "AOD", "CASCEXTRA", //! optional table to refer to
                   cascdata::BachTrackExtraId, o2::soa::Marker<1>);
 DECLARE_SOA_TABLE(StraTrackExtras, "AOD", "STRATRACKEXTRAS", //! optional table to refer to custom track extras
                   o2::soa::Index<>, cascdata::StrangeTrackExtraId);
+
+// Track positions at minima (valid for regular cascade table), replayable
+DECLARE_SOA_TABLE(CascTrackXs, "AOD", "CASCTRACKX", //! track X positions at minima when using AO2Ds
+                  cascdata::PosX, cascdata::NegX, cascdata::BachX);
 
 DECLARE_SOA_TABLE(StoredCascCores, "AOD", "CASCCORE", //! core information about decay, viable with AO2Ds or derived
                   cascdata::Sign, cascdata::MXi, cascdata::MOmega,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -103,11 +103,11 @@ DECLARE_SOA_COLUMN(PDGCode, pdgCode, int);                      //! pdg code
 DECLARE_SOA_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, bool); //! primary criterion
 } // namespace motherParticle
 
-DECLARE_SOA_TABLE(MotherMCParticles, "AOD", "MOTHERMCPART", //! mother MC information
+DECLARE_SOA_TABLE(MotherMCParts, "AOD", "MOTHERMCPARTS", //! mother MC information, abbreviated name due to size limit
                   motherParticle::Px, motherParticle::Py, motherParticle::Pz,
                   motherParticle::PDGCode, motherParticle::IsPhysicalPrimary);
 
-using MotherMCParticle = MotherMCParticles::iterator;
+using MotherMCPart = MotherMCParts::iterator;
 
 namespace v0data
 {
@@ -121,7 +121,7 @@ DECLARE_SOA_INDEX_COLUMN(V0, v0);                                       //!
 DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra"); //!
 DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                        //!
-DECLARE_SOA_INDEX_COLUMN(MotherMCParticle, motherMCParticle);                                  //!
+DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                  //!
 
 //______________________________________________________
 // REGULAR COLUMNS FOR V0CORES
@@ -461,7 +461,7 @@ DECLARE_SOA_TABLE(V0MCCores, "AOD", "V0MCCORE", //! MC properties of the V0 for 
                   v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC);
 
 DECLARE_SOA_TABLE(V0MCMothers, "AOD", "V0MCMOTHER", //! optional table for MC mothers
-                  o2::soa::Index<>, v0data::MotherMCParticleId);
+                  o2::soa::Index<>, v0data::MotherMCPartId);
 
 using V0Index = V0Indices::iterator;
 using V0Core = V0Cores::iterator;
@@ -555,7 +555,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras,
 DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrackExtra, strangeTrackExtra, int, DauTrackExtras, "_StrangeExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                                    //!
-DECLARE_SOA_INDEX_COLUMN(MotherMCParticle, motherMCParticle);                                              //!
+DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                                          //!
 
 //______________________________________________________
 // REGULAR COLUMNS FOR CASCCORES
@@ -859,7 +859,7 @@ DECLARE_SOA_TABLE(CascMCCores, "AOD", "CASCMCCORE", //! bachelor-baryon correlat
                   cascdata::PxMC, cascdata::PyMC, cascdata::PzMC);
 
 DECLARE_SOA_TABLE(CascMCMothers, "AOD", "CASCMCMOTHER", //! optional table for MC mothers
-                  o2::soa::Index<>, cascdata::MotherMCParticleId);
+                  o2::soa::Index<>, cascdata::MotherMCPartId);
 
 DECLARE_SOA_TABLE(CascBBs, "AOD", "CASCBB", //! bachelor-baryon correlation variables
                   cascdata::BachBaryonCosPA, cascdata::BachBaryonDCAxyToPV)

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -146,7 +146,7 @@ DECLARE_SOA_COLUMN(V0CosPA, v0cosPA, float);               //! V0 CosPA
 DECLARE_SOA_COLUMN(DCAV0ToPV, dcav0topv, float);           //! DCA V0 to PV
 
 // Type of V0 from the svertexer (photon, regular, from cascade)
-DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t); //! DCA V0 to PV
+DECLARE_SOA_COLUMN(V0Type, v0Type, uint8_t); //! type of V0. 0: built solely for cascades (does not pass standard V0 cuts), 1: standard 2, 3: photon-like with TPC-only use. Regular analysis should always use type 1.
 
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_COLUMN(PositionCovMat, positionCovMat, float[6]); //! covariance matrix elements
@@ -331,7 +331,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(PositivePhi, positivephi, //! positive daughter phi
 
 DECLARE_SOA_DYNAMIC_COLUMN(IsStandardV0, isStandardV0, //! is standard V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 0); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonV0, isPhotonV0, //! is photon V0
+DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonTPConly, isPhotonTPConly, //! is photon V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 1); });
 } // namespace v0data
 

--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -490,12 +490,13 @@ struct reso2initializer {
   template <bool isMC, typename CollisionType, typename CascType, typename TrackType>
   void fillCascades(CollisionType const& collision, CascType const& cascades, TrackType const& tracks)
   {
-    int childIDs[2] = {0, 0}; // these IDs are necessary to keep track of the children
+    int childIDs[3] = {0, 0, 0}; // these IDs are necessary to keep track of the children
     for (auto& casc : cascades) {
       if (!IsCascSelected<isMC>(collision, casc, tracks))
         continue;
-      childIDs[0] = casc.v0Id();
-      childIDs[1] = casc.bachelorId();
+      childIDs[0] = casc.posTrackId();
+      childIDs[1] = casc.negTrackId();
+      childIDs[2] = casc.bachelorId();
       reso2cascades(resoCollisions.lastIndex(),
                     casc.pt(),
                     casc.px(),

--- a/PWGLF/TableProducer/QC/strangenessQC.cxx
+++ b/PWGLF/TableProducer/QC/strangenessQC.cxx
@@ -177,10 +177,6 @@ struct strangenessQC {
 
     // cascades loop
     for (const auto& casc : Cascades) {
-      const auto& v0index = casc.v0_as<aod::V0sLinked>();
-      if (!(v0index.has_v0Data()))
-        continue; // skip those cascades for which V0 doesn't exist
-
       // Rapidity check
       if (TMath::Abs(casc.yXi()) > cascadesetting_rapidity &&
           TMath::Abs(casc.yOmega()) > cascadesetting_rapidity) {
@@ -204,10 +200,9 @@ struct strangenessQC {
       if (TMath::Abs(casc.mLambda() - pdgDB->Mass(3122)) > cascadesetting_v0masswindow)
         continue;
 
-      const auto& v0Casc = v0index.v0Data(); // de-reference index to correct v0data in case it exists
       const auto& bachDau = casc.bachelor_as<DaughterTracks>();
-      const auto& posDau = v0Casc.posTrack_as<DaughterTracks>();
-      const auto& negDau = v0Casc.negTrack_as<DaughterTracks>();
+      const auto& posDau = casc.posTrack_as<DaughterTracks>();
+      const auto& negDau = casc.negTrack_as<DaughterTracks>();
 
       float cascDecayLength = std::hypot(casc.x() - collision.posX(), casc.y() - collision.posY(), casc.z() - collision.posZ());
       float cascTotalMomentum = std::hypot(casc.px(), casc.py(), casc.pz());

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -111,7 +111,7 @@ struct cascadeBuilder {
   Produces<aod::StoredKFCascCores> kfcascdata;
   Produces<aod::StoredTraCascCores> trackedcascdata;
   Produces<aod::CascTrackXs> cascTrackXs; // if desired for replaying of position information
-  Produces<aod::CascBBs> cascbb; // if enabled
+  Produces<aod::CascBBs> cascbb;          // if enabled
   Produces<aod::CascCovs> casccovs; // if requested by someone
   Produces<aod::KFCascCovs> kfcasccovs; // if requested by someone
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -218,10 +218,10 @@ struct cascadeBuilder {
   // Helper struct to pass cascade information
   struct {
     int v0Id;
-    int positiveId; 
+    int positiveId;
     int negativeId;
     int bachelorId;
-    float positiveX; 
+    float positiveX;
     float negativeX;
     float bachelorX;
     int charge;
@@ -945,8 +945,8 @@ struct cascadeBuilder {
     cascadecandidate.positiveId = posTrack.globalIndex();
     cascadecandidate.negativeId = negTrack.globalIndex();
     cascadecandidate.bachelorId = bachTrack.globalIndex();
-    cascadecandidate.positiveX = v0.posX(); // from prior minimization
-    cascadecandidate.negativeX = v0.negX(); // from prior minimization
+    cascadecandidate.positiveX = v0.posX();             // from prior minimization
+    cascadecandidate.negativeX = v0.negX();             // from prior minimization
     cascadecandidate.bachelorX = lBachelorTrack.getX(); // from this minimization
     cascadecandidate.v0pos[0] = v0.x();
     cascadecandidate.v0pos[1] = v0.y();
@@ -1271,24 +1271,24 @@ struct cascadeBuilder {
     for (auto& cascade : cascades) {
       // de-reference from V0 pool, either specific for cascades or general
       // use templatizing to avoid code duplication
-      bool validCascadeCandidate = false; 
+      bool validCascadeCandidate = false;
       auto v0index = cascade.template v0_as<o2::aod::V0sLinked>();
-      if(v0index.has_v0Data()){
+      if (v0index.has_v0Data()) {
         // this V0 passed both standard V0 and cascade V0 selections
         auto v0row = v0index.template v0Data_as<V0full>();
         validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
-      }else if(v0index.has_v0fCData()){
+      } else if (v0index.has_v0fCData()) {
         // this V0 passes only V0-for-cascade selections, use that instead
         auto v0row = v0index.template v0fCData_as<V0fCfull>();
         validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
-      }else{ 
+      } else {
         continue; // this was inadequately linked, should not happen
       }
       if (!validCascadeCandidate)
         continue; // doesn't pass cascade selections
 
-      cascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
-              cascadecandidate.positiveId, cascadecandidate.negativeId, 
+      cascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),
+              cascadecandidate.positiveId, cascadecandidate.negativeId,
               cascadecandidate.bachelorId, cascade.collisionId());
       cascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1302,7 +1302,7 @@ struct cascadeBuilder {
                cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
                cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
                cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
-      if(createCascTrackXs){
+      if (createCascTrackXs) {
         cascTrackXs(cascadecandidate.positiveX, cascadecandidate.negativeX, cascadecandidate.bachelorX);
       }
       cascbb(cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV);
@@ -1347,8 +1347,8 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
       registry.fill(HIST("hKFParticleStatistics"), 2.0f);
 
-      kfcascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
-                cascadecandidate.positiveId, cascadecandidate.negativeId, 
+      kfcascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),
+                cascadecandidate.positiveId, cascadecandidate.negativeId,
                 cascadecandidate.bachelorId, cascade.collisionId());
       kfcascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                  cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1392,25 +1392,25 @@ struct cascadeBuilder {
 
       // de-reference from V0 pool, either specific for cascades or general
       // use templatizing to avoid code duplication
-      bool validCascadeCandidate = false; 
+      bool validCascadeCandidate = false;
       auto v0index = cascade.template v0_as<o2::aod::V0sLinked>();
-      if(v0index.has_v0Data()){
+      if (v0index.has_v0Data()) {
         // this V0 passed both standard V0 and cascade V0 selections
         auto v0row = v0index.template v0Data_as<V0full>();
         validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
-      }else if(v0index.has_v0fCData()){
+      } else if (v0index.has_v0fCData()) {
         // this V0 passes only V0-for-cascade selections, use that instead
         auto v0row = v0index.template v0fCData_as<V0fCfull>();
         validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
-      }else{ 
+      } else {
         continue; // this was inadequately linked, should not happen
       }
       if (!validCascadeCandidate)
         continue; // doesn't pass cascade selections
 
       // fill regular tables (no strangeness tracking)
-      cascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
-              cascadecandidate.positiveId, cascadecandidate.negativeId, 
+      cascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),
+              cascadecandidate.positiveId, cascadecandidate.negativeId,
               cascadecandidate.bachelorId, cascade.collisionId());
       cascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1424,7 +1424,7 @@ struct cascadeBuilder {
                cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
                cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
                cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
-      if(createCascTrackXs){
+      if (createCascTrackXs) {
         cascTrackXs(cascadecandidate.positiveX, cascadecandidate.negativeX, cascadecandidate.bachelorX);
       }
       cascbb(cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV);
@@ -1562,8 +1562,8 @@ struct cascadeBuilder {
         std::array<float, 3> cascadeMomentumVector;
         cascadeTrackPar.getPxPyPzGlo(cascadeMomentumVector);
 
-        trackedcascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(), 
-                       cascadecandidate.positiveId, cascadecandidate.negativeId, 
+        trackedcascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),
+                       cascadecandidate.positiveId, cascadecandidate.negativeId,
                        cascadecandidate.bachelorId, trackedCascade.trackId(), cascade.collisionId());
         trackedcascdata(cascadecandidate.charge, trackedCascade.xiMass(), trackedCascade.omegaMass(), // <--- stratrack masses
                         trackedCascade.decayX(), trackedCascade.decayY(), trackedCascade.decayZ(),    // <--- stratrack position

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -95,6 +95,7 @@ using TracksExtraWithPIDandLabels = soa::Join<aod::TracksExtra, aod::pidTPCFullP
 
 // Pre-selected V0s
 using V0full = soa::Join<aod::V0Datas, aod::V0Covs>;
+using V0fCfull = soa::Join<aod::V0fCDatas, aod::V0fCCovs>;
 using TaggedCascades = soa::Join<aod::Cascades, aod::CascTags>;
 
 // For MC association in pre-selection
@@ -109,7 +110,8 @@ struct cascadeBuilder {
   Produces<aod::StoredCascCores> cascdata;
   Produces<aod::StoredKFCascCores> kfcascdata;
   Produces<aod::StoredTraCascCores> trackedcascdata;
-  Produces<aod::CascBBs> cascbb;
+  Produces<aod::CascTrackXs> cascTrackXs; // if desired for replaying of position information
+  Produces<aod::CascBBs> cascbb; // if enabled
   Produces<aod::CascCovs> casccovs; // if requested by someone
   Produces<aod::KFCascCovs> kfcasccovs; // if requested by someone
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -118,6 +120,7 @@ struct cascadeBuilder {
 
   // Configurables related to table creation
   Configurable<int> createCascCovMats{"createCascCovMats", -1, {"Produces V0 cov matrices. -1: auto, 0: don't, 1: yes. Default: auto (-1)"}};
+  Configurable<int> createCascTrackXs{"createCascTrackXs", -1, {"Produces track X at minima table. -1: auto, 0: don't, 1: yes. Default: auto (-1)"}};
 
   // Topological selection criteria
   Configurable<int> tpcrefit{"tpcrefit", 0, "demand TPC refit"};
@@ -215,7 +218,12 @@ struct cascadeBuilder {
   // Helper struct to pass cascade information
   struct {
     int v0Id;
+    int positiveId; 
+    int negativeId;
     int bachelorId;
+    float positiveX; 
+    float negativeX;
+    float bachelorX;
     int charge;
     std::array<float, 3> pos;
     std::array<float, 3> bachP;
@@ -529,6 +537,11 @@ struct cascadeBuilder {
             LOGF(info, "Device named %s has subscribed to CascCovs table! Enabling.", device.name);
             createCascCovMats.value = 1;
           }
+          const std::string CascTracksXName = "CascTrackXs";
+          if (input.matcher.binding == CascTracksXName) {
+            LOGF(info, "Device named %s has subscribed to CascTrackXs table! Enabling.", device.name);
+            createCascTrackXs.value = 1;
+          }
         }
       }
 
@@ -760,19 +773,14 @@ struct cascadeBuilder {
     // to be added here as complementary information in the future
   }
 
-  template <class TTrackTo, typename TCascObject>
-  bool buildCascadeCandidate(TCascObject const& cascade)
+  template <class TTrackTo, typename TCascObject, typename TV0Object>
+  bool buildCascadeCandidate(TCascObject const& cascade, TV0Object const& v0)
   {
     // value 0.5: any considered cascade
     statisticsRegistry.cascstats[kCascAll]++;
 
     // Track casting
     auto bachTrack = cascade.template bachelor_as<TTrackTo>();
-    auto v0index = cascade.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0index.has_v0Data())) {
-      return false;
-    }
-    auto v0 = v0index.template v0Data_as<V0full>();
     auto posTrack = v0.template posTrack_as<TTrackTo>();
     auto negTrack = v0.template negTrack_as<TTrackTo>();
     auto const& collision = cascade.collision();
@@ -933,8 +941,13 @@ struct cascadeBuilder {
     cascadecandidate.yOmega = RecoDecay::y(array{cascadecandidate.bachP[0] + v0.pxpos() + v0.pxneg(), cascadecandidate.bachP[1] + v0.pypos() + v0.pyneg(), cascadecandidate.bachP[2] + v0.pzpos() + v0.pzneg()}, o2::constants::physics::MassOmegaMinus);
 
     // Populate information
-    cascadecandidate.v0Id = v0index.globalIndex();
+    // cascadecandidate.v0Id = v0index.globalIndex();
+    cascadecandidate.positiveId = posTrack.globalIndex();
+    cascadecandidate.negativeId = negTrack.globalIndex();
     cascadecandidate.bachelorId = bachTrack.globalIndex();
+    cascadecandidate.positiveX = v0.posX(); // from prior minimization
+    cascadecandidate.negativeX = v0.negX(); // from prior minimization
+    cascadecandidate.bachelorX = lBachelorTrack.getX(); // from this minimization
     cascadecandidate.v0pos[0] = v0.x();
     cascadecandidate.v0pos[1] = v0.y();
     cascadecandidate.v0pos[2] = v0.z();
@@ -1189,6 +1202,8 @@ struct cascadeBuilder {
 
     // basic indices
     cascadecandidate.v0Id = v0.globalIndex();
+    cascadecandidate.positiveId = posTrack.globalIndex();
+    cascadecandidate.negativeId = negTrack.globalIndex();
     cascadecandidate.bachelorId = bachTrack.globalIndex();
 
     // KF chi2
@@ -1254,11 +1269,26 @@ struct cascadeBuilder {
     statisticsRegistry.eventCounter++;
 
     for (auto& cascade : cascades) {
-      bool validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade);
+      // de-reference from V0 pool, either specific for cascades or general
+      // use templatizing to avoid code duplication
+      bool validCascadeCandidate = false; 
+      auto v0index = cascade.template v0_as<o2::aod::V0sLinked>();
+      if(v0index.has_v0Data()){
+        // this V0 passed both standard V0 and cascade V0 selections
+        auto v0row = v0index.template v0Data_as<V0full>();
+        validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
+      }else if(v0index.has_v0fCData()){
+        // this V0 passes only V0-for-cascade selections, use that instead
+        auto v0row = v0index.template v0fCData_as<V0fCfull>();
+        validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
+      }else{ 
+        continue; // this was inadequately linked, should not happen
+      }
       if (!validCascadeCandidate)
         continue; // doesn't pass cascade selections
 
-      cascidx(cascadecandidate.v0Id, cascade.globalIndex(),
+      cascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
+              cascadecandidate.positiveId, cascadecandidate.negativeId, 
               cascadecandidate.bachelorId, cascade.collisionId());
       cascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1272,6 +1302,9 @@ struct cascadeBuilder {
                cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
                cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
                cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
+      if(createCascTrackXs){
+        cascTrackXs(cascadecandidate.positiveX, cascadecandidate.negativeX, cascadecandidate.bachelorX);
+      }
       cascbb(cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV);
 
       // populate cascade covariance matrices if required by any other task
@@ -1314,7 +1347,8 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
       registry.fill(HIST("hKFParticleStatistics"), 2.0f);
 
-      kfcascidx(cascadecandidate.v0Id, cascade.globalIndex(),
+      kfcascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
+                cascadecandidate.positiveId, cascadecandidate.negativeId, 
                 cascadecandidate.bachelorId, cascade.collisionId());
       kfcascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                  cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1356,12 +1390,27 @@ struct cascadeBuilder {
         continue; // wasn't tracked
       }
 
-      bool validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade);
+      // de-reference from V0 pool, either specific for cascades or general
+      // use templatizing to avoid code duplication
+      bool validCascadeCandidate = false; 
+      auto v0index = cascade.template v0_as<o2::aod::V0sLinked>();
+      if(v0index.has_v0Data()){
+        // this V0 passed both standard V0 and cascade V0 selections
+        auto v0row = v0index.template v0Data_as<V0full>();
+        validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
+      }else if(v0index.has_v0fCData()){
+        // this V0 passes only V0-for-cascade selections, use that instead
+        auto v0row = v0index.template v0fCData_as<V0fCfull>();
+        validCascadeCandidate = buildCascadeCandidate<TTrackTo>(cascade, v0row);
+      }else{ 
+        continue; // this was inadequately linked, should not happen
+      }
       if (!validCascadeCandidate)
         continue; // doesn't pass cascade selections
 
       // fill regular tables (no strangeness tracking)
-      cascidx(cascadecandidate.v0Id, cascade.globalIndex(),
+      cascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(),
+              cascadecandidate.positiveId, cascadecandidate.negativeId, 
               cascadecandidate.bachelorId, cascade.collisionId());
       cascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
                cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
@@ -1375,6 +1424,9 @@ struct cascadeBuilder {
                cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
                cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
                cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
+      if(createCascTrackXs){
+        cascTrackXs(cascadecandidate.positiveX, cascadecandidate.negativeX, cascadecandidate.bachelorX);
+      }
       cascbb(cascadecandidate.bachBaryonCosPA, cascadecandidate.bachBaryonDCAxyToPV);
 
       // populate cascade covariance matrices if required by any other task
@@ -1510,8 +1562,9 @@ struct cascadeBuilder {
         std::array<float, 3> cascadeMomentumVector;
         cascadeTrackPar.getPxPyPzGlo(cascadeMomentumVector);
 
-        trackedcascidx(cascadecandidate.v0Id, cascade.globalIndex(), cascadecandidate.bachelorId,
-                       trackedCascade.trackId(), cascade.collisionId());
+        trackedcascidx(/*cascadecandidate.v0Id, */cascade.globalIndex(), 
+                       cascadecandidate.positiveId, cascadecandidate.negativeId, 
+                       cascadecandidate.bachelorId, trackedCascade.trackId(), cascade.collisionId());
         trackedcascdata(cascadecandidate.charge, trackedCascade.xiMass(), trackedCascade.omegaMass(), // <--- stratrack masses
                         trackedCascade.decayX(), trackedCascade.decayY(), trackedCascade.decayZ(),    // <--- stratrack position
                         cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
@@ -1530,7 +1583,7 @@ struct cascadeBuilder {
     resetHistos();
   }
 
-  void processRun2(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExt const&, aod::BCsWithTimestamps const&)
+  void processRun2(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, V0fCfull const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExt const&, aod::BCsWithTimestamps const&)
   {
     for (const auto& collision : collisions) {
       // Fire up CCDB
@@ -1544,7 +1597,7 @@ struct cascadeBuilder {
   }
   PROCESS_SWITCH(cascadeBuilder, processRun2, "Produce Run 2 cascade tables", false);
 
-  void processRun3(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&)
+  void processRun3(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, V0fCfull const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&)
   {
     for (const auto& collision : collisions) {
       // Fire up CCDB
@@ -1572,7 +1625,7 @@ struct cascadeBuilder {
   }
   PROCESS_SWITCH(cascadeBuilder, processRun3withKFParticle, "Produce Run 3 KF cascade tables", false);
 
-  void processRun3withStrangenessTracking(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::TrackedCascades const& trackedCascades)
+  void processRun3withStrangenessTracking(aod::Collisions const& collisions, aod::V0sLinked const&, V0full const&, V0fCfull const&, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::TrackedCascades const& trackedCascades)
   {
     for (const auto& collision : collisions) {
       // Fire up CCDB
@@ -1686,16 +1739,12 @@ struct cascadePreselector {
   template <class TTrackTo, typename TCascadeObject>
   void checkTrackQuality(TCascadeObject const& lCascadeCandidate, uint16_t& maskElement, bool passdEdx = false)
   {
-    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return;
-    }
-    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
+    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0s>();
 
     // Acquire all three daughter tracks, please
     auto lBachTrack = lCascadeCandidate.template bachelor_as<TTrackTo>();
-    auto lNegTrack = v0data.template negTrack_as<TTrackTo>();
-    auto lPosTrack = v0data.template posTrack_as<TTrackTo>();
+    auto lNegTrack = v0.template negTrack_as<TTrackTo>();
+    auto lPosTrack = v0.template posTrack_as<TTrackTo>();
 
     if (doQA) {
       histos.fill(HIST("hTrackStat"), packTrackProperties(lPosTrack), packTrackProperties(lNegTrack), packTrackProperties(lBachTrack));
@@ -1724,17 +1773,13 @@ struct cascadePreselector {
   template <class TTrackTo, typename TCascadeObject>
   void checkPDG(TCascadeObject const& lCascadeCandidate, uint16_t& maskElement)
   {
-    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return;
-    }
-    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
     int lPDG = -1;
 
     // Acquire all three daughter tracks, please
     auto lBachTrack = lCascadeCandidate.template bachelor_as<TTrackTo>();
-    auto lNegTrack = v0data.template negTrack_as<TTrackTo>();
-    auto lPosTrack = v0data.template posTrack_as<TTrackTo>();
+    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0s>();
+    auto lNegTrack = v0.template negTrack_as<TTrackTo>();
+    auto lPosTrack = v0.template posTrack_as<TTrackTo>();
 
     // Association check
     // There might be smarter ways of doing this in the future
@@ -1789,16 +1834,11 @@ struct cascadePreselector {
   template <class TTrackTo, typename TCascadeObject>
   void checkdEdx(TCascadeObject const& lCascadeCandidate, uint16_t& maskElement)
   {
-    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return;
-    }
-    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
-
     // Acquire all three daughter tracks, please
     auto lBachTrack = lCascadeCandidate.template bachelor_as<TTrackTo>();
-    auto lNegTrack = v0data.template negTrack_as<TTrackTo>();
-    auto lPosTrack = v0data.template posTrack_as<TTrackTo>();
+    auto v0 = lCascadeCandidate.template v0_as<o2::aod::V0s>();
+    auto lNegTrack = v0.template negTrack_as<TTrackTo>();
+    auto lPosTrack = v0.template posTrack_as<TTrackTo>();
 
     // dEdx check with LF PID
     if (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow &&

--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -1915,7 +1915,7 @@ struct cascadePreselector {
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all cascades are built. It will simply tag everything as true.
-  void processBuildAll(aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, aod::TracksExtra const&)
+  void processBuildAll(aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, aod::TracksExtra const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -1925,7 +1925,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const& v0table, LabeledTracksExtra const&, aod::McParticles const&)
+  void processBuildMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const& v0table, LabeledTracksExtra const&, aod::McParticles const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -1936,7 +1936,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildValiddEdx(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, TracksExtraWithPID const&)
+  void processBuildValiddEdx(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, TracksExtraWithPID const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -1947,7 +1947,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildValiddEdxMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0sLinked const&, aod::V0Datas const&, TracksExtraWithPIDandLabels const&, aod::McParticles const&)
+  void processBuildValiddEdxMCAssociated(aod::Collisions const& collisions, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, TracksExtraWithPIDandLabels const&, aod::McParticles const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {

--- a/PWGLF/TableProducer/cascadefinder.cxx
+++ b/PWGLF/TableProducer/cascadefinder.cxx
@@ -255,7 +255,7 @@ struct cascadefinder {
 
             lNCand++;
             // If we got here, it means this is a good candidate!
-            cascidx(/*v0.globalIndex(), */-1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
+            cascidx(/*v0.globalIndex(), */ -1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
             cascdata(-1, lXiMass, lOmegaMass,
                      posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],
@@ -346,7 +346,7 @@ struct cascadefinder {
             lNCand++;
             // If we got here, it means this is a good candidate!
 
-            cascidx(/*v0.globalIndex(), */-1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
+            cascidx(/*v0.globalIndex(), */ -1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
             cascdata(+1, lXiMass, lOmegaMass,
                      posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],

--- a/PWGLF/TableProducer/cascadefinder.cxx
+++ b/PWGLF/TableProducer/cascadefinder.cxx
@@ -255,7 +255,7 @@ struct cascadefinder {
 
             lNCand++;
             // If we got here, it means this is a good candidate!
-            cascidx(v0.globalIndex(), -1, v0.posTrack().globalIndex(), v0.negTrack().collisionId());
+            cascidx(/*v0.globalIndex(), */-1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
             cascdata(-1, lXiMass, lOmegaMass,
                      posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],
@@ -346,7 +346,7 @@ struct cascadefinder {
             lNCand++;
             // If we got here, it means this is a good candidate!
 
-            cascidx(v0.globalIndex(), -1, v0.posTrack().globalIndex(), v0.negTrack().collisionId());
+            cascidx(/*v0.globalIndex(), */-1, v0.posTrack().globalIndex(), v0.negTrack().globalIndex(), t0.globalIndex(), v0.negTrack().collisionId());
             cascdata(+1, lXiMass, lOmegaMass,
                      posXi[0], posXi[1], posXi[2], pos[0], pos[1], pos[2],
                      pvecpos[0], pvecpos[1], pvecpos[2],

--- a/PWGLF/TableProducer/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/cascademcbuilder.cxx
@@ -69,20 +69,12 @@ struct cascademcbuilder {
       float pxnegmc = -999.0f, pynegmc = -999.0f, pznegmc = -999.0f;
       float pxbachmc = -999.0f, pybachmc = -999.0f, pzbachmc = -999.0f;
       float px = -999.0f, py = -999.0f, pz = -999.0f;
-
-      // Loop over those that actually have the corresponding V0 associated to them
-      auto v0 = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0.has_v0Data())) {
-        casclabels(-1, -1);
-        continue; // skip those cascades for which V0 doesn't exist (but: should never happen)
-      }
-      auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
       int lLabel = -1, lMotherLabel = -1;
 
       // Acquire all three daughter tracks, please
       auto lBachTrack = casc.bachelor_as<aod::McTrackLabels>();
-      auto lNegTrack = v0data.negTrack_as<aod::McTrackLabels>();
-      auto lPosTrack = v0data.posTrack_as<aod::McTrackLabels>();
+      auto lNegTrack = casc.negTrack_as<aod::McTrackLabels>();
+      auto lPosTrack = casc.posTrack_as<aod::McTrackLabels>();
 
       // Association check
       // There might be smarter ways of doing this in the future
@@ -164,14 +156,12 @@ struct cascademcbuilder {
   void processKFCascades(aod::KFCascDatas const& casctable, aod::V0sLinked const&, aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const&)
   {
     for (auto& casc : casctable) {
-      // Loop over those that actually have the corresponding V0 associated to them
-      auto v0 = casc.v0_as<aod::V0s>();
       int lLabel = -1;
 
       // Acquire all three daughter tracks, please
       auto lBachTrack = casc.bachelor_as<aod::McTrackLabels>();
-      auto lNegTrack = v0.negTrack_as<aod::McTrackLabels>();
-      auto lPosTrack = v0.posTrack_as<aod::McTrackLabels>();
+      auto lNegTrack = casc.negTrack_as<aod::McTrackLabels>();
+      auto lPosTrack = casc.posTrack_as<aod::McTrackLabels>();
 
       // Association check
       // There might be smarter ways of doing this in the future
@@ -209,19 +199,12 @@ struct cascademcbuilder {
   void processTrackedCascades(aod::TraCascDatas const& casctable, aod::V0sLinked const&, aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const&)
   {
     for (auto& casc : casctable) {
-      // Loop over those that actually have the corresponding V0 associated to them
-      auto v0 = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0.has_v0Data())) {
-        tracasclabels(-1);
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-      auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
       int lLabel = -1;
 
       // Acquire all three daughter tracks, please
       auto lBachTrack = casc.bachelor_as<aod::McTrackLabels>();
-      auto lNegTrack = v0data.negTrack_as<aod::McTrackLabels>();
-      auto lPosTrack = v0data.posTrack_as<aod::McTrackLabels>();
+      auto lNegTrack = casc.negTrack_as<aod::McTrackLabels>();
+      auto lPosTrack = casc.posTrack_as<aod::McTrackLabels>();
 
       // Association check
       // There might be smarter ways of doing this in the future
@@ -261,18 +244,10 @@ struct cascademcbuilder {
     for (auto& casc : casctable) {
       bool bbTag = false; // bachelor-baryon correlation tag to pass
 
-      // Loop over those that actually have the corresponding V0 associated to them
-      auto v0 = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0.has_v0Data())) {
-        bbtags(bbTag);
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-      auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
-
       // Acquire all three daughter tracks, please
       auto lBachTrack = casc.bachelor_as<aod::McTrackLabels>();
-      auto lNegTrack = v0data.negTrack_as<aod::McTrackLabels>();
-      auto lPosTrack = v0data.posTrack_as<aod::McTrackLabels>();
+      auto lNegTrack = casc.negTrack_as<aod::McTrackLabels>();
+      auto lPosTrack = casc.posTrack_as<aod::McTrackLabels>();
 
       // Bachelor-baryon association checker
       // this will allow for analyses to pinpoint the effect of spurious, unwanted correlations!

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -242,9 +242,8 @@ struct cascadepid {
       for (auto const& cascade : CascTable_thisCollision) {
         // Track casting
         auto bachTrack = cascade.bachelor_as<FullTracksExtIU>();
-        auto v0 = cascade.v0();
-        auto posTrack = v0.posTrack_as<FullTracksExtIU>();
-        auto negTrack = v0.negTrack_as<FullTracksExtIU>();
+        auto posTrack = cascade.posTrack_as<FullTracksExtIU>();
+        auto negTrack = cascade.negTrack_as<FullTracksExtIU>();
 
         // FIXME: TOF calculation: under construction, to follow
 

--- a/PWGLF/TableProducer/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/cascqaanalysis.cxx
@@ -166,15 +166,13 @@ struct cascqaanalysis {
   bool AcceptCascCandidate(TCascade const& cascCand, float const& pvx, float const& pvy, float const& pvz)
   {
     // Access daughter tracks
-    auto v0index = cascCand.template v0_as<o2::aod::V0sLinked>();
-    auto v0 = v0index.v0Data();
-    auto posdau = v0.template posTrack_as<TCascTracksTo>();
-    auto negdau = v0.template negTrack_as<TCascTracksTo>();
+    auto posdau = cascCand.template posTrack_as<TCascTracksTo>();
+    auto negdau = cascCand.template negTrack_as<TCascTracksTo>();
     auto bachelor = cascCand.template bachelor_as<TCascTracksTo>();
 
     // Basic set of selections
     if (cascCand.cascradius() > cascradius &&
-        v0.v0radius() > v0radius &&
+        cascCand.v0radius() > v0radius &&
         cascCand.casccosPA(pvx, pvy, pvz) > casccospa &&
         cascCand.v0cosPA(pvx, pvy, pvz) > v0cospa &&
         TMath::Abs(posdau.eta()) < etadau &&
@@ -323,7 +321,6 @@ struct cascqaanalysis {
                              aod::PVMults, aod::FT0Mults, aod::FV0Mults,
                              aod::CentFT0Ms, aod::CentFV0As>::iterator const& collision,
                    soa::Filtered<aod::CascDataExt> const& Cascades,
-                   aod::V0sLinked const&,
                    aod::V0Datas const&,
                    DauTracks const&)
   {
@@ -352,21 +349,14 @@ struct cascqaanalysis {
 
     for (const auto& casc : Cascades) {              // loop over Cascades
       registry.fill(HIST("hCandidateCounter"), 0.5); // all candidates
-
-      // Access daughter tracks
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        return; // skip those cascades for which V0 doesn't exist
-      }
-      registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists
+      registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists, deprecated
 
       if (AcceptCascCandidate<DauTracks>(casc, collision.posX(), collision.posY(), collision.posZ())) {
         registry.fill(HIST("hCandidateCounter"), 2.5); // passed topo cuts
         // Fill table
         if (fRand->Rndm() < lEventScale) {
-          auto v0 = v0index.v0Data();
-          auto posdau = v0.posTrack_as<DauTracks>();
-          auto negdau = v0.negTrack_as<DauTracks>();
+          auto posdau = casc.posTrack_as<DauTracks>();
+          auto negdau = casc.negTrack_as<DauTracks>();
           auto bachelor = casc.bachelor_as<DauTracks>();
 
           // ITS N hits
@@ -423,8 +413,7 @@ struct cascqaanalysis {
                     soa::Filtered<LabeledCascades> const& Cascades,
                     DauTracks const&,
                     aod::McCollisions const&,
-                    aod::McParticles const& mcParticles,
-                    aod::V0sLinked const&)
+                    aod::McParticles const& mcParticles)
   {
     if (!AcceptEvent(collision, 1)) {
       return;
@@ -455,13 +444,7 @@ struct cascqaanalysis {
 
     for (const auto& casc : Cascades) {              // loop over Cascades
       registry.fill(HIST("hCandidateCounter"), 0.5); // all candidates
-      // Access daughter tracks
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        return; // skip those cascades for which V0 doesn't exist
-      }
-
-      registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists
+      registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists - deprecated
 
       if (AcceptCascCandidate<DauTracks>(casc, collision.posX(), collision.posY(), collision.posZ())) {
         registry.fill(HIST("hCandidateCounter"), 2.5); // passed topo cuts
@@ -479,9 +462,8 @@ struct cascqaanalysis {
         }
         if (fRand->Rndm() < lEventScale) {
           // Fill table
-          auto v0 = v0index.v0Data();
-          auto posdau = v0.posTrack_as<DauTracks>();
-          auto negdau = v0.negTrack_as<DauTracks>();
+          auto posdau = casc.posTrack_as<DauTracks>();
+          auto negdau = casc.negTrack_as<DauTracks>();
           auto bachelor = casc.bachelor_as<DauTracks>();
 
           // ITS N hits

--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -397,14 +397,9 @@ struct hstrangecorrelationfilter {
     /// _________________________________________________
     /// Step 3: Populate table with associated Cascades
     for (auto const& casc : Cascades) {
-      auto v0 = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0.has_v0Data())) {
-        return; // skip those cascades for which V0 doesn't exist
-      }
-      auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
       auto bachTrackCast = casc.bachelor_as<DauTracks>();
-      auto posTrackCast = v0data.posTrack_as<DauTracks>();
-      auto negTrackCast = v0data.negTrack_as<DauTracks>();
+      auto posTrackCast = casc.posTrack_as<DauTracks>();
+      auto negTrackCast = casc.negTrack_as<DauTracks>();
       auto origCascadeEntry = casc.cascade_as<CascadesLinkedTagged>();
 
       // minimum TPC crossed rows

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -777,11 +777,11 @@ struct lambdakzeroBuilder {
         continue; // doesn't pass selections
       }
 
-      // V0 logic reminder 
-      // 0: v0 saved for the only due to the cascade, 1: standalone v0, 3: standard v0 with photon-only test 
+      // V0 logic reminder
+      // 0: v0 saved for the only due to the cascade, 1: standalone v0, 3: standard v0 with photon-only test
 
-      if(V0.v0Type() > 0){
-        if(V0.v0Type() > 1 && !storePhotonCandidates) 
+      if (V0.v0Type() > 0) {
+        if (V0.v0Type() > 1 && !storePhotonCandidates)
           continue;
         // populates the various tables for analysis
         v0indices(V0.posTrackId(), V0.negTrackId(),
@@ -794,14 +794,14 @@ struct lambdakzeroBuilder {
                 v0candidate.posDCAxy,
                 v0candidate.negDCAxy,
                 v0candidate.cosPA,
-                v0candidate.dcav0topv, 
+                v0candidate.dcav0topv,
                 V0.v0Type());
-      }else{ 
-        // place V0s built exclusively for the sake of cascades 
-        // in a fully independent table (though identical) to make 
-        // sure there's no accidental usage of those candidates 
-        // N.B.: these are obtained with *other selections* in 
-        //       the svertexer! 
+      } else {
+        // place V0s built exclusively for the sake of cascades
+        // in a fully independent table (though identical) to make
+        // sure there's no accidental usage of those candidates
+        // N.B.: these are obtained with *other selections* in
+        //       the svertexer!
         v0fcindices(V0.posTrackId(), V0.negTrackId(),
                     V0.collisionId(), V0.globalIndex());
         v0fctrackXs(v0candidate.posTrackX, v0candidate.negTrackX);
@@ -812,7 +812,7 @@ struct lambdakzeroBuilder {
                   v0candidate.posDCAxy,
                   v0candidate.negDCAxy,
                   v0candidate.cosPA,
-                  v0candidate.dcav0topv, 
+                  v0candidate.dcav0topv,
                   V0.v0Type());
       }
 
@@ -1190,7 +1190,7 @@ struct lambdakzeroV0DataLinkBuilder {
     std::vector<int> lIndices, lfCIndices;
     lIndices.reserve(v0table.size());
     lfCIndices.reserve(v0table.size());
-    for (int ii = 0; ii < v0table.size(); ii++){
+    for (int ii = 0; ii < v0table.size(); ii++) {
       lIndices[ii] = -1;
       lfCIndices[ii] = -1;
     }

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -191,6 +191,8 @@ struct lambdakzeroBuilder {
                 kV0DCADau,
                 kV0CosPA,
                 kV0Radius,
+                kCountStandardV0,
+                kCountV0forCascade,
                 kNV0Steps };
 
   // Helper struct to pass V0 information
@@ -271,6 +273,8 @@ struct lambdakzeroBuilder {
     h->GetXaxis()->SetBinLabel(4, "DCA V0 Dau");
     h->GetXaxis()->SetBinLabel(5, "CosPA");
     h->GetXaxis()->SetBinLabel(6, "Radius");
+    h->GetXaxis()->SetBinLabel(7, "Count: Standard V0");
+    h->GetXaxis()->SetBinLabel(8, "Count: V0 exc. for casc");
 
     randomSeed = static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
 
@@ -784,6 +788,7 @@ struct lambdakzeroBuilder {
         if (V0.v0Type() > 1 && !storePhotonCandidates)
           continue;
         // populates the various tables for analysis
+        statisticsRegistry.v0stats[kCountStandardV0]++;
         v0indices(V0.posTrackId(), V0.negTrackId(),
                   V0.collisionId(), V0.globalIndex());
         v0trackXs(v0candidate.posTrackX, v0candidate.negTrackX);
@@ -802,6 +807,7 @@ struct lambdakzeroBuilder {
         // sure there's no accidental usage of those candidates
         // N.B.: these are obtained with *other selections* in
         //       the svertexer!
+        statisticsRegistry.v0stats[kCountV0forCascade]++;
         v0fcindices(V0.posTrackId(), V0.negTrackId(),
                     V0.collisionId(), V0.globalIndex());
         v0fctrackXs(v0candidate.posTrackX, v0candidate.negTrackX);

--- a/PWGLF/TableProducer/lambdakzerofinder.cxx
+++ b/PWGLF/TableProducer/lambdakzerofinder.cxx
@@ -289,8 +289,8 @@ struct lambdakzerofinder {
             pvec0[0], pvec0[1], pvec0[2],
             pvec1[0], pvec1[1], pvec1[2],
             TMath::Sqrt(fitter.getChi2AtPCACandidate()),
-            t1.dcaXY(), t2.dcaXY(), cosPA, smallestDCA);
-    v0datalink(v0cores.lastIndex());
+            t1.dcaXY(), t2.dcaXY(), cosPA, smallestDCA, 1);
+    v0datalink(v0cores.lastIndex(), -1);
     return 1;
   }
 

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -86,7 +86,7 @@ struct strangederivedbuilder {
   // mother information
   Produces<aod::V0MCMothers> v0mothers;               // V0 mother references
   Produces<aod::CascMCMothers> cascmothers;           // casc mother references
-  Produces<aod::MotherMCParts> motherMCParts; // mc particles for mothers
+  Produces<aod::MotherMCParts> motherMCParts;         // mc particles for mothers
 
   // histogram registry for bookkeeping
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -246,9 +246,8 @@ struct strangederivedbuilder {
     // index tracks that belong to CascDatas
     for (auto const& casc : Cascades) {
       auto bachTrack = casc.bachelor_as<TracksWithExtra>();
-      auto v0 = casc.v0();
-      auto posTrack = v0.posTrack_as<TracksWithExtra>();
-      auto negTrack = v0.negTrack_as<TracksWithExtra>();
+      auto posTrack = casc.posTrack_as<TracksWithExtra>();
+      auto negTrack = casc.negTrack_as<TracksWithExtra>();
       trackMap[posTrack.globalIndex()] = 0;
       trackMap[negTrack.globalIndex()] = 0;
       trackMap[bachTrack.globalIndex()] = 0;
@@ -257,9 +256,8 @@ struct strangederivedbuilder {
     // index tracks that belong to KFCascDatas
     for (auto const& casc : KFCascades) {
       auto bachTrack = casc.bachelor_as<TracksWithExtra>();
-      auto v0 = casc.v0();
-      auto posTrack = v0.posTrack_as<TracksWithExtra>();
-      auto negTrack = v0.negTrack_as<TracksWithExtra>();
+      auto posTrack = casc.posTrack_as<TracksWithExtra>();
+      auto negTrack = casc.negTrack_as<TracksWithExtra>();
       trackMap[posTrack.globalIndex()] = 0;
       trackMap[negTrack.globalIndex()] = 0;
       trackMap[bachTrack.globalIndex()] = 0;
@@ -268,9 +266,8 @@ struct strangederivedbuilder {
     // index tracks that belong to TraCascDatas
     for (auto const& casc : TraCascades) {
       auto bachTrack = casc.bachelor_as<TracksWithExtra>();
-      auto v0 = casc.v0();
-      auto posTrack = v0.posTrack_as<TracksWithExtra>();
-      auto negTrack = v0.negTrack_as<TracksWithExtra>();
+      auto posTrack = casc.posTrack_as<TracksWithExtra>();
+      auto negTrack = casc.negTrack_as<TracksWithExtra>();
       auto strangeTrack = casc.strangeTrack_as<TracksWithExtra>();
       trackMap[posTrack.globalIndex()] = 0;
       trackMap[negTrack.globalIndex()] = 0;
@@ -298,9 +295,8 @@ struct strangederivedbuilder {
     // populate track references
     for (auto const& casc : Cascades) {
       auto bachTrack = casc.bachelor_as<TracksWithExtra>();
-      auto v0 = casc.v0();
-      auto posTrack = v0.posTrack_as<TracksWithExtra>();
-      auto negTrack = v0.negTrack_as<TracksWithExtra>();
+      auto posTrack = casc.posTrack_as<TracksWithExtra>();
+      auto negTrack = casc.negTrack_as<TracksWithExtra>();
       cascExtras(trackMap[posTrack.globalIndex()],
                  trackMap[negTrack.globalIndex()],
                  trackMap[bachTrack.globalIndex()]); // joinable with CascDatas

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -86,7 +86,7 @@ struct strangederivedbuilder {
   // mother information
   Produces<aod::V0MCMothers> v0mothers;               // V0 mother references
   Produces<aod::CascMCMothers> cascmothers;           // casc mother references
-  Produces<aod::MotherMCParticles> motherMCParticles; // mc particles for mothers
+  Produces<aod::MotherMCParts> motherMCParts; // mc particles for mothers
 
   // histogram registry for bookkeeping
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -352,7 +352,7 @@ struct strangederivedbuilder {
     // populate motherMCParticles
     for (auto const& tr : mcParticles) {
       if (motherReference[tr.globalIndex()] >= 0) {
-        motherMCParticles(tr.px(), tr.py(), tr.pz(), tr.pdgCode(), tr.isPhysicalPrimary());
+        motherMCParts(tr.px(), tr.py(), tr.pz(), tr.pdgCode(), tr.isPhysicalPrimary());
       }
     }
   }

--- a/PWGLF/Tasks/QC/straRecoStudy.cxx
+++ b/PWGLF/Tasks/QC/straRecoStudy.cxx
@@ -617,14 +617,8 @@ struct straRecoStudy {
       return;
 
     auto bachPartTrack = casc.template bachelor_as<TracksCompleteIUMC>();
-
-    auto v0index = casc.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0index.has_v0Data())) {
-      return;
-    }
-    auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
-    auto posPartTrack = v0.template posTrack_as<TracksCompleteIUMC>();
-    auto negPartTrack = v0.template negTrack_as<TracksCompleteIUMC>();
+    auto posPartTrack = casc.template posTrack_as<TracksCompleteIUMC>();
+    auto negPartTrack = casc.template negTrack_as<TracksCompleteIUMC>();
 
     if (cascmc.pdgCode() == 3312) {
       histos.fill(HIST("h3dTrackPtsXiMinusP"), casc.pt(), posPartTrack.itsNCls(), posPartTrack.tpcNClsCrossedRows());
@@ -698,14 +692,14 @@ struct straRecoStudy {
     }
   }
 
-  void processCascade(CollisionsWithEvSels const& collisions, aod::V0Datas const&, soa::Filtered<CascMC> const& Cascades, TracksCompleteIUMC const& tracks, aod::McParticles const&, aod::V0sLinked const&)
+  void processCascade(CollisionsWithEvSels const& collisions, aod::V0Datas const&, soa::Filtered<CascMC> const& Cascades, TracksCompleteIUMC const& tracks, aod::McParticles const&)
   {
     for (auto& casc : Cascades) {
       processCascadeCandidate(casc);
     }
   }
   PROCESS_SWITCH(straRecoStudy, processCascade, "Regular cascade analysis", true);
-  void processTrackedCascade(CollisionsWithEvSels const& collisions, aod::V0Datas const&, TraCascMC const& Cascades, TracksCompleteIUMC const& tracks, aod::McParticles const&, aod::V0sLinked const&)
+  void processTrackedCascade(CollisionsWithEvSels const& collisions, aod::V0Datas const&, TraCascMC const& Cascades, TracksCompleteIUMC const& tracks, aod::McParticles const&)
   {
     for (auto& casc : Cascades) {
       processCascadeCandidate(casc);
@@ -723,13 +717,8 @@ struct straRecoStudy {
     }
     for (auto& casc : Cascades) {
       auto bachPartTrack = casc.bachelor_as<TracksCompleteIU>();
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        continue;
-      }
-      auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
-      auto posPartTrack = v0.posTrack_as<TracksCompleteIU>();
-      auto negPartTrack = v0.negTrack_as<TracksCompleteIU>();
+      auto posPartTrack = casc.posTrack_as<TracksCompleteIU>();
+      auto negPartTrack = casc.negTrack_as<TracksCompleteIU>();
 
       histos.fill(HIST("h2dITSCluMap_CascPositive"), (float)posPartTrack.itsClusterMap(), casc.v0radius());
       histos.fill(HIST("h2dITSCluMap_CascNegative"), (float)negPartTrack.itsClusterMap(), casc.v0radius());

--- a/PWGLF/Tasks/QC/v0cascadesqa.cxx
+++ b/PWGLF/Tasks/QC/v0cascadesqa.cxx
@@ -560,15 +560,9 @@ struct v0cascadesQA {
     }
 
     for (auto& casc : Cascades) {
-
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-      auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
       auto bachelor = casc.bachelor_as<DaughterTracks>();
-      auto posdau = v0.posTrack_as<DaughterTracks>();
-      auto negdau = v0.negTrack_as<DaughterTracks>();
+      auto posdau = casc.posTrack_as<DaughterTracks>();
+      auto negdau = casc.negTrack_as<DaughterTracks>();
 
       // histos_Casc.fill(HIST("XiProgSelections"), );
       // histos_Casc.fill(HIST("OmegaProgSelections"), );
@@ -666,14 +660,8 @@ struct v0cascadesQA {
 
         histos_Casc.fill(HIST("QA_XiMinusCandidates"), 1.5);
 
-        auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-        if (!(v0index.has_v0Data())) {
-          continue; // skip those cascades for which V0 doesn't exist
-        }
-        auto v0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
-
-        auto reconegtrack = v0.negTrack_as<MyTracksMC>();
-        auto recopostrack = v0.posTrack_as<MyTracksMC>();
+        auto reconegtrack = casc.negTrack_as<MyTracksMC>();
+        auto recopostrack = casc.posTrack_as<MyTracksMC>();
         auto recobachelor = casc.bachelor_as<MyTracksMC>();
         if (!reconegtrack.has_mcParticle() || !recopostrack.has_mcParticle() || !recobachelor.has_mcParticle()) {
           continue;

--- a/PWGLF/Tasks/cascadeanalysis.cxx
+++ b/PWGLF/Tasks/cascadeanalysis.cxx
@@ -188,14 +188,10 @@ struct cascadeAnalysis {
     bool lConsistentWithLambda = true;
     bool lConsistentWithXi = true;
     bool lConsistentWithOm = true;
-    auto v0 = lCascade.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return 0; // reject
-    }
-    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
+
     auto bachTrack = lCascade.template bachelor_as<TCascTracksTo>();
-    auto posTrack = v0data.template posTrack_as<TCascTracksTo>();
-    auto negTrack = v0data.template negTrack_as<TCascTracksTo>();
+    auto posTrack = lCascade.template posTrack_as<TCascTracksTo>();
+    auto negTrack = lCascade.template negTrack_as<TCascTracksTo>();
 
     // Bachelor: depends on type
     if (TMath::Abs(bachTrack.tpcNSigmaPi()) > tpcNsigmaBachelor && tpcNsigmaBachelor < 9.99)
@@ -224,15 +220,9 @@ struct cascadeAnalysis {
   // function to process cascades and generate corresponding invariant mass distributions
   {
     registry.fill(HIST("hCandidateCounter"), 0.5); // all candidates
-    auto v0 = casc.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return; // skip those cascades for which V0 doesn't exist
-    }
-    registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists
-    auto v0data = v0.v0Data();                     // de-reference index to correct v0data in case it exists
     auto bachTrackCast = casc.template bachelor_as<TCascTracksTo>();
-    auto posTrackCast = v0data.template posTrack_as<TCascTracksTo>();
-    auto negTrackCast = v0data.template negTrack_as<TCascTracksTo>();
+    auto posTrackCast = casc.template posTrack_as<TCascTracksTo>();
+    auto negTrackCast = casc.template negTrack_as<TCascTracksTo>();
 
     // track-level selections
     Bool_t lEnoughTPCNClsBac = kTRUE;
@@ -326,7 +316,7 @@ struct cascadeAnalysis {
     }
   }
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtIU const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -340,7 +330,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun3, "Process Run 3 data", true);
 
-  void processRun2(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExt const&)
+  void processRun2(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExt const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -357,7 +347,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun2, "Process Run 2 data", false);
 
-  void processRun3VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&)
+  void processRun3VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtIU const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -371,7 +361,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun3VsMultiplicity, "Process Run 3 data vs multiplicity", false);
 
-  void processRun2VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExt const&)
+  void processRun2VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExt const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -388,7 +378,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun2VsMultiplicity, "Process Run 2 data vs multiplicity", false);
 
-  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIUWithPID const&)
+  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtIUWithPID const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -403,7 +393,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun3WithPID, "Process Run 3 data  with PID", false);
 
-  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtWithPID const&)
+  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtWithPID const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -421,7 +411,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun2WithPID, "Process Run 2 data  with PID", false);
 
-  void processRun3VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIUWithPID const&)
+  void processRun3VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtIUWithPID const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -436,7 +426,7 @@ struct cascadeAnalysis {
   }
   PROCESS_SWITCH(cascadeAnalysis, processRun3VsMultiplicityWithPID, "Process Run 3 data vs multiplicity with PID", false);
 
-  void processRun2VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtWithPID const&)
+  void processRun2VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<aod::CascDataExt> const& Cascades, FullTracksExtWithPID const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria

--- a/PWGLF/Tasks/cascadeanalysisMC.cxx
+++ b/PWGLF/Tasks/cascadeanalysisMC.cxx
@@ -240,14 +240,10 @@ struct cascadeAnalysisMC {
     bool lConsistentWithLambda = true;
     bool lConsistentWithXi = true;
     bool lConsistentWithOm = true;
-    auto v0 = lCascade.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return 0; // reject
-    }
-    auto v0data = v0.v0Data(); // de-reference index to correct v0data in case it exists
+
     auto bachTrack = lCascade.template bachelor_as<TCascTracksTo>();
-    auto posTrack = v0data.template posTrack_as<TCascTracksTo>();
-    auto negTrack = v0data.template negTrack_as<TCascTracksTo>();
+    auto posTrack = lCascade.template posTrack_as<TCascTracksTo>();
+    auto negTrack = lCascade.template negTrack_as<TCascTracksTo>();
 
     // Bachelor: depends on type
     if (TMath::Abs(bachTrack.tpcNSigmaPi()) > tpcNsigmaBachelor && tpcNsigmaBachelor < 9.99)
@@ -286,15 +282,11 @@ struct cascadeAnalysisMC {
       if (TMath::Abs(cascmc.pdgCode()) == 3312 || TMath::Abs(cascmc.pdgCode()) == 3334)
         lPDG = cascmc.pdgCode();
     }
-    auto v0 = casc.template v0_as<o2::aod::V0sLinked>();
-    if (!(v0.has_v0Data())) {
-      return; // skip those cascades for which V0 doesn't exist
-    }
-    registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists
-    auto v0data = v0.v0Data();                     // de-reference index to correct v0data in case it exists
+
+    registry.fill(HIST("hCandidateCounter"), 1.5); // v0data exists - deprecated
     auto bachTrackCast = casc.template bachelor_as<TCascTracksTo>();
-    auto posTrackCast = v0data.template posTrack_as<TCascTracksTo>();
-    auto negTrackCast = v0data.template negTrack_as<TCascTracksTo>();
+    auto posTrackCast = casc.template posTrack_as<TCascTracksTo>();
+    auto negTrackCast = casc.template negTrack_as<TCascTracksTo>();
 
     // track-level selections
     Bool_t lEnoughTPCNClsBac = kTRUE;
@@ -388,7 +380,7 @@ struct cascadeAnalysisMC {
     }
   }
 
-  void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&, aod::McParticles const&)
+  void processRun3(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExtIU const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -402,7 +394,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun3, "Process Run 3 data", true);
 
-  void processRun2(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExt const&, aod::McParticles const&)
+  void processRun2(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExt const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -419,7 +411,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun2, "Process Run 2 data", false);
 
-  void processRun3VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&, aod::McParticles const&)
+  void processRun3VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExtIU const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -433,7 +425,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun3VsMultiplicity, "Process Run 3 data vs multiplicity", false);
 
-  void processRun2VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExt const&, aod::McParticles const&)
+  void processRun2VsMultiplicity(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExt const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -450,7 +442,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun2VsMultiplicity, "Process Run 2 data vs multiplicity", false);
 
-  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIUWithPID const&, aod::McParticles const&)
+  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -465,7 +457,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun3WithPID, "Process Run 3 data  with PID", false);
 
-  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtWithPID const&, aod::McParticles const&)
+  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria
@@ -483,7 +475,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun2WithPID, "Process Run 2 data  with PID", false);
 
-  void processRun3VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIUWithPID const&, aod::McParticles const&)
+  void processRun3VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExtIUWithPID const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -498,7 +490,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun3VsMultiplicityWithPID, "Process Run 3 data vs multiplicity with PID", false);
 
-  void processRun2VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtWithPID const&, aod::McParticles const&)
+  void processRun2VsMultiplicityWithPID(soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, FullTracksExtWithPID const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria

--- a/PWGLF/Tasks/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/hStrangeCorrelation.cxx
@@ -223,12 +223,8 @@ struct correlateStrangeness {
         auto assoc = assocCandidate.cascData();
 
         //---] removing autocorrelations [---
-        auto v0index = assoc.v0_as<o2::aod::V0sLinked>();
-        if (!(v0index.has_v0Data()))
-          continue;                      // this should not happen - included for safety
-        auto assocV0 = v0index.v0Data(); // de-reference index to correct v0data in case it exists
-        auto postrack = assocV0.posTrack_as<TracksComplete>();
-        auto negtrack = assocV0.negTrack_as<TracksComplete>();
+        auto postrack = assoc.posTrack_as<TracksComplete>();
+        auto negtrack = assoc.negTrack_as<TracksComplete>();
         auto bachtrack = assoc.bachelor_as<TracksComplete>();
         if (doAutocorrelationRejection) {
           if (trigg.globalIndex() == postrack.globalIndex()) {

--- a/PWGLF/Tasks/hyperon-reco-test.cxx
+++ b/PWGLF/Tasks/hyperon-reco-test.cxx
@@ -160,8 +160,6 @@ struct myXi {
 
   void process(aod::Collision const& collision,
                soa::Join<aod::CascDataExt, aod::McCascLabels> const& Cascades,
-               aod::V0sLinked const& V0linked,
-               aod::V0Datas const& V0s,
                DauTracks const& tracks,
                aod::McParticles const& mcParticles)
   {
@@ -177,20 +175,18 @@ struct myXi {
         }
       }
 
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      auto v0 = v0index.v0Data();
-      auto posdau = v0.posTrack_as<DauTracks>();
-      auto negdau = v0.negTrack_as<DauTracks>();
+      auto posdau = casc.posTrack_as<DauTracks>();
+      auto negdau = casc.negTrack_as<DauTracks>();
       auto bachelor = casc.bachelor_as<DauTracks>();
 
       if ( // Dau & bach track cuts
         TMath::Abs(posdau.eta()) < rapidity && TMath::Abs(negdau.eta()) < rapidity && TMath::Abs(bachelor.eta()) < rapidity && posdau.tpcNClsCrossedRows() > mincrossedrow && negdau.tpcNClsCrossedRows() > mincrossedrow && bachelor.tpcNClsCrossedRows() > mincrossedrow && posdau.pt() > minpt && negdau.pt() > minpt && bachelor.pt() > minpt && TMath::Abs(casc.dcapostopv()) > dcatopv && TMath::Abs(casc.dcanegtopv()) > dcatopv && TMath::Abs(casc.dcabachtopv()) > dcatopv && TMath::Abs(posdau.tpcNSigmaPr()) < tpcsigma && TMath::Abs(negdau.tpcNSigmaPi()) < tpcsigma && TMath::Abs(bachelor.tpcNSigmaPi()) < tpcsigma && bachelor.sign() < 0 &&
 
         // V0 cuts
-        casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && v0.dcav0topv() > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
-        registry.fill(HIST("hmyLambda"), v0.mLambda());
+        casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && casc.dcav0topv(collision.posX(), collision.posY(), collision.posZ()) > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
+        registry.fill(HIST("hmyLambda"), casc.mLambda());
 
-        if (TMath::Abs(v0.mLambda() - o2::constants::physics::MassLambda0) < v0masswindow &&
+        if (TMath::Abs(casc.mLambda() - o2::constants::physics::MassLambda0) < v0masswindow &&
 
             // Cascade cut
             casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mOmega() - o2::constants::physics::MassOmegaMinus) > removeOmega && casc.sign() < 0) {
@@ -258,8 +254,6 @@ struct myOmega {
 
   void process(aod::Collision const& collision,
                soa::Join<aod::CascDataExt, aod::McCascLabels> const& Cascades,
-               aod::V0sLinked const& V0linked,
-               aod::V0Datas const& V0s,
                DauTracks const& tracks,
                aod::McParticles const& mcParticles)
   {
@@ -275,20 +269,18 @@ struct myOmega {
         }
       }
 
-      auto v0index = casc.v0_as<o2::aod::V0sLinked>();
-      auto v0 = v0index.v0Data();
-      auto posdau = v0.posTrack_as<DauTracks>();
-      auto negdau = v0.negTrack_as<DauTracks>();
+      auto posdau = casc.posTrack_as<DauTracks>();
+      auto negdau = casc.negTrack_as<DauTracks>();
       auto bachelor = casc.bachelor_as<DauTracks>();
 
       if ( // Dau & bach track cuts
         TMath::Abs(posdau.eta()) < rapidity && TMath::Abs(negdau.eta()) < rapidity && TMath::Abs(bachelor.eta()) < rapidity && posdau.tpcNClsCrossedRows() > mincrossedrow && negdau.tpcNClsCrossedRows() > mincrossedrow && bachelor.tpcNClsCrossedRows() > mincrossedrow && posdau.pt() > minpt && negdau.pt() > minpt && bachelor.pt() > minpt && TMath::Abs(casc.dcapostopv()) > dcatopv && TMath::Abs(casc.dcanegtopv()) > dcatopv && TMath::Abs(casc.dcabachtopv()) > dcatopv && TMath::Abs(posdau.tpcNSigmaPr()) < tpcsigma && TMath::Abs(negdau.tpcNSigmaPi()) < tpcsigma && TMath::Abs(bachelor.tpcNSigmaKa()) < tpcsigma && bachelor.sign() < 0 &&
 
         // V0 cuts
-        casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && v0.dcav0topv() > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
-        registry.fill(HIST("hmyLambda"), v0.mLambda());
+        casc.v0radius() > v0radius && casc.dcaV0daughters() < dcav0dau && casc.dcav0topv(collision.posX(), collision.posY(), collision.posZ()) > dcav0topv && casc.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > v0cospa) {
+        registry.fill(HIST("hmyLambda"), casc.mLambda());
 
-        if (TMath::Abs(v0.mLambda() - o2::constants::physics::MassLambda0) < v0masswindow &&
+        if (TMath::Abs(casc.mLambda() - o2::constants::physics::MassLambda0) < v0masswindow &&
 
             // Cascade cut
             casc.cascradius() > cascradius && casc.dcacascdaughters() < dcacascdau && casc.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > casccospa && TMath::Abs(casc.mXi() - o2::constants::physics::MassXiMinus) > removeXi && casc.sign() < 0) {

--- a/Tutorials/PWGLF/Strangeness/strangeness_step4.cxx
+++ b/Tutorials/PWGLF/Strangeness/strangeness_step4.cxx
@@ -142,8 +142,6 @@ struct strangeness_tutorial {
   void processRecMC(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>::iterator const& collision,
                     soa::Filtered<soa::Join<aod::CascDatas, aod::McCascLabels>> const& Cascades,
                     soa::Filtered<soa::Join<aod::V0Datas, aod::McV0Labels>> const& V0s,
-                    aod::V0Datas const&, // it's needed to access the full table of V0s (not the filtered one) to make sure all the V0s related to cascades are present
-                    aod::V0sLinked const&,
                     DaughterTracks const&,
                     aod::McParticles const&)
   {
@@ -202,15 +200,9 @@ struct strangeness_tutorial {
 
     // Cascades
     for (const auto& casc : Cascades) {
-      const auto& v0index = casc.v0_as<aod::V0sLinked>();
-      if (!(v0index.has_v0Data())) {
-        continue; // skip those cascades for which V0 doesn't exist
-      }
-
-      const auto& v0Casc = v0index.v0Data(); // de-reference index to correct v0data in case it exists
       const auto& bachDaughterTrackCasc = casc.bachelor_as<DaughterTracks>();
-      const auto& posDaughterTrackCasc = v0Casc.posTrack_as<DaughterTracks>();
-      const auto& negDaughterTrackCasc = v0Casc.negTrack_as<DaughterTracks>();
+      const auto& posDaughterTrackCasc = casc.posTrack_as<DaughterTracks>();
+      const auto& negDaughterTrackCasc = casc.negTrack_as<DaughterTracks>();
 
       rXi.fill(HIST("hMassXi"), casc.mXi());
 


### PR DESCRIPTION
This PR takes into account the recent implementation of the `V0Type` column in the V0 data model to ensure safety of the analysis of V0s. It means to compartmentalize the standard V0s and the V0s built solely for the purpose of cascade finding, since these two populations have very different selection criteria at the secondary vertexer level and therefore cannot be mixed. 

The main change is that standard V0s (including photons, if those are meant to be built) are saved in `V0Datas`, while V0s built *solely* for the sake of cascade analysis are built in the `V0fCDatas` ('for Cascades') table. This means that no duplication of `DCAFitter` calls takes place at building/analysis time, while making absolutely sure that the V0s dedicated solely for cascade building are not analysed by mistake by an inadvertent analyser who missed the need to check the `V0Type` (which is also duplicated further in the analysis tables for completeness). 

The `V0DataLink` table now has two index columns: a column to `V0Datas` if the V0 passes standard V0 cuts and a column to `V0fCDatas` if the V0 does *not* pass V0 cuts but passes cascade cuts. Of course, this means that logically only one of these can ever be non-negative at a single time. 

An important side effect of this is that de-referencing a `V0Datas` table from a cascade analysis is strongly discouraged. For now, I have disabled that functionality altogether, but may add it as a separate table soon. However, it is only to be used with great care. On the positive side, this means that, while previously a cumbersome de-referencing step was necessary to de-reference track indices when dealing with cascades, this is now trivial as the positive and negative V0 track indices are referenced directly (instead of the original V0 index). 