### PR TITLE
[PWGDQ] Various fixes for muons 

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -558,7 +558,6 @@ class VarManager : public TObject
     o2::mch::TrackExtrap::setField();
   }
 
-
   // Setup the 2 prong DCAFitterN
   static void SetupTwoProngDCAFitter(float magField, bool propagateToPCA, float maxR, float maxDZIni, float minParamChange, float minRelChi2Change, bool useAbsDCA)
   {
@@ -2065,9 +2064,9 @@ void VarManager::FillPairVertexing(C const& collision, T const& t1, T const& t2,
           auto geoMan2 = o2::base::GeometryManager::meanMaterialBudget(t2.x(), t2.y(), t2.z(), KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY(), KFGeoTwoProng.GetZ());
           auto x2x01 = static_cast<float>(geoMan1.meanX2X0);
           auto x2x02 = static_cast<float>(geoMan2.meanX2X0);
-	  float B[3];
-	  float xyz[3] = {0, 0, 0};
-	  KFGeoTwoProng.GetFieldValue(xyz, B);
+          float B[3];
+          float xyz[3] = {0, 0, 0};
+          KFGeoTwoProng.GetFieldValue(xyz, B);
           pars1.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, B[2], x2x01);
           pars2.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, B[2], x2x02);
           v1 = {pars1.getPt(), pars1.getEta(), pars1.getPhi(), m1};

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -552,6 +552,12 @@ class VarManager : public TObject
     KFParticle::SetField(magField);
     fgUsedKF = true;
   }
+  // Setup magnetic field for muon propagation
+  static void SetupMuonMagField()
+  {
+    o2::mch::TrackExtrap::setField();
+  }
+
 
   // Setup the 2 prong DCAFitterN
   static void SetupTwoProngDCAFitter(float magField, bool propagateToPCA, float maxR, float maxDZIni, float minParamChange, float minRelChi2Change, bool useAbsDCA)
@@ -816,7 +822,6 @@ void VarManager::FillPropagateMuon(const T& muon, const C& collision, float* val
     o2::track::TrackParCovFwd fwdtrack{muon.z(), tpars, tcovs, chi2};
     o2::dataformats::GlobalFwdTrack propmuon;
     if (static_cast<int>(muon.trackType()) > 2) {
-      o2::mch::TrackExtrap::setField();
       o2::dataformats::GlobalFwdTrack track;
       track.setParameters(tpars);
       track.setZ(fwdtrack.getZ());
@@ -2060,8 +2065,11 @@ void VarManager::FillPairVertexing(C const& collision, T const& t1, T const& t2,
           auto geoMan2 = o2::base::GeometryManager::meanMaterialBudget(t2.x(), t2.y(), t2.z(), KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY(), KFGeoTwoProng.GetZ());
           auto x2x01 = static_cast<float>(geoMan1.meanX2X0);
           auto x2x02 = static_cast<float>(geoMan2.meanX2X0);
-          pars1.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, fgFitterTwoProngFwd.getBz(), x2x01);
-          pars2.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, fgFitterTwoProngFwd.getBz(), x2x02);
+	  float B[3];
+	  float xyz[3] = {0, 0, 0};
+	  KFGeoTwoProng.GetFieldValue(xyz, B);
+          pars1.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, B[2], x2x01);
+          pars2.propagateToVtxhelixWithMCS(KFGeoTwoProng.GetZ(), {KFGeoTwoProng.GetX(), KFGeoTwoProng.GetY()}, {KFGeoTwoProng.GetCovariance(0, 0), KFGeoTwoProng.GetCovariance(1, 1)}, B[2], x2x02);
           v1 = {pars1.getPt(), pars1.getEta(), pars1.getPhi(), m1};
           v2 = {pars2.getPt(), pars2.getEta(), pars2.getPhi(), m2};
           v12 = v1 + v2;

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -364,9 +364,9 @@ struct TableMaker {
           o2::base::Propagator::initFieldFromGRP(grpmagrun2);
         }
       } else {
-	if (fPropMuon){
-	  VarManager::SetupMuonMagField();
-	}
+        if (fPropMuon) {
+          VarManager::SetupMuonMagField();
+        }
         grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
         if (grpmag != nullptr) {
           o2::base::Propagator::initFieldFromGRP(grpmag);

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -190,7 +190,6 @@ struct TableMaker {
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::FwdTrackAssoc> fwdtrackIndicesPerCollision = aod::track_association::collisionId;
 
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
 
@@ -202,12 +201,12 @@ struct TableMaker {
   void init(o2::framework::InitContext& context)
   {
     DefineCuts();
-    ccdb->setURL(fConfigCcdbUrl);
-    ccdb->setCaching(true);
-    ccdb->setLocalObjectValidityChecking();
+    fCCDB->setURL(fConfigCcdbUrl);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
     if (fPropMuon) {
       if (!o2::base::GeometryManager::isGeometryLoaded()) {
-        ccdb->get<TGeoManager>(geoPath);
+        fCCDB->get<TGeoManager>(geoPath);
       }
     }
 
@@ -360,12 +359,15 @@ struct TableMaker {
         }
       }
       if (fIsRun2 == true) {
-        grpmagrun2 = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpmagPathRun2, bc.timestamp());
+        grpmagrun2 = fCCDB->getForTimeStamp<o2::parameters::GRPObject>(grpmagPathRun2, bc.timestamp());
         if (grpmagrun2 != nullptr) {
           o2::base::Propagator::initFieldFromGRP(grpmagrun2);
         }
       } else {
-        grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
+	if (fPropMuon){
+	  VarManager::SetupMuonMagField();
+	}
+        grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
         if (grpmag != nullptr) {
           o2::base::Propagator::initFieldFromGRP(grpmag);
         }

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -371,7 +371,7 @@ struct TableMakerMC {
             o2::base::Propagator::initFieldFromGRP(grpmagrun2);
           }
         } else {
-          if (fPropMuon){
+          if (fPropMuon) {
             VarManager::SetupMuonMagField();
           }
           grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
@@ -658,7 +658,7 @@ struct TableMakerMC {
           }
 
           VarManager::FillTrack<TMuonFillMap>(muon);
-	  if (fPropMuon) {
+          if (fPropMuon) {
             VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
           }
 

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -39,6 +39,13 @@
 #include "PWGDQ/Core/MCSignalLibrary.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/TrackSelectionTables.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "Field/MagneticField.h"
+#include "TGeoGlobalMagField.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "CCDB/BasicCCDBManager.h"
 
 using std::cout;
 using std::endl;
@@ -138,12 +145,23 @@ struct TableMakerMC {
   Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
   Configurable<bool> fConfigDetailedQA{"cfgDetailedQA", false, "If true, include more QA histograms (BeforeCuts classes)"};
   Configurable<bool> fIsAmbiguous{"cfgIsAmbiguous", false, "Whether we enable QA plots for ambiguous tracks"};
+  Configurable<std::string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<bool> fPropMuon{"cfgPropMuon", false, "Propgate muon tracks through absorber"};
+  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> grpmagPathRun2{"grpmagPathRun2", "GLO/GRP/GRP", "CCDB path of the GRPObject (Usage for Run 2)"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  o2::parameters::GRPObject* grpmagrun2 = nullptr; // for run 2, we access the GRPObject from GLO/GRP/GRP
+  o2::parameters::GRPMagField* grpmag = nullptr;   // for run 3, we access GRPMagField from GLO/Config/GRPMagField
 
   AnalysisCompositeCut* fEventCut;              //! Event selection cut
   std::vector<AnalysisCompositeCut> fTrackCuts; //! Barrel track cuts
   std::vector<AnalysisCompositeCut> fMuonCuts;  //! Muon track cuts
 
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
+  int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
 
   // TODO: filter on TPC dedx used temporarily until electron PID will be improved
   Filter barrelSelectedTracks = ifnode(fIsRun2.node() == true, aod::track::trackType == uint8_t(aod::track::Run2Track), aod::track::trackType == uint8_t(aod::track::Track)) && o2::aod::track::pt >= fConfigBarrelTrackPtLow && nabs(o2::aod::track::eta) <= 0.9f;
@@ -152,6 +170,15 @@ struct TableMakerMC {
 
   void init(o2::framework::InitContext& context)
   {
+    fCCDB->setURL(fConfigCcdbUrl);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
+    if (fPropMuon) {
+      if (!o2::base::GeometryManager::isGeometryLoaded()) {
+        fCCDB->get<TGeoManager>(geoPath);
+      }
+    }
+
     // Define cuts --------------------------------------------------------------------------------------------
     fEventCut = new AnalysisCompositeCut(true);
     TString eventCutStr = fConfigEventCuts.value;
@@ -336,6 +363,25 @@ struct TableMakerMC {
       if (!collision.has_mcCollision()) {
         continue;
       }
+      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+      if (fCurrentRun != bc.runNumber()) {
+        if (fIsRun2 == true) {
+          grpmagrun2 = fCCDB->getForTimeStamp<o2::parameters::GRPObject>(grpmagPathRun2, bc.timestamp());
+          if (grpmagrun2 != nullptr) {
+            o2::base::Propagator::initFieldFromGRP(grpmagrun2);
+          }
+        } else {
+          if (fPropMuon){
+            VarManager::SetupMuonMagField();
+          }
+          grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
+          if (grpmag != nullptr) {
+            o2::base::Propagator::initFieldFromGRP(grpmag);
+          }
+        }
+        fCurrentRun = bc.runNumber();
+      }
+
       // get the trigger aliases
       uint32_t triggerAliases = collision.alias_raw();
       // store the selection decisions
@@ -345,7 +391,6 @@ struct TableMakerMC {
       }
 
       auto mcCollision = collision.mcCollision();
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
       VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
       VarManager::fgValues[VarManager::kRunNo] = bc.runNumber();
       VarManager::fgValues[VarManager::kBC] = bc.globalBC();
@@ -613,6 +658,9 @@ struct TableMakerMC {
           }
 
           VarManager::FillTrack<TMuonFillMap>(muon);
+	  if (fPropMuon) {
+            VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+          }
 
           if (muon.index() > idxPrev + 1) { // checks if some muons are filtered even before the skimming function
             nDel += muon.index() - (idxPrev + 1);


### PR DESCRIPTION
- Moving initialization of magnetic field for muon propagation to avoid flooding logs
- Fixing magnetic field used in single muon propagation following KF vertexing
- Removing duplicate initialization of ccdb manager in tableMaker
- Adding muon propagation options in tableMakerMC