### PR TITLE
Improved TOF intercept calculation

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -162,9 +162,8 @@ struct femtoUniverseProducerTask {
   Configurable<float> ConfTrkPIDnSigmaOffsetTOF{"ConfTrkPIDnSigmaOffsetTOF", 0., "Offset for TOF nSigma because of bad calibration"};
   Configurable<std::vector<int>> ConfTrkPIDspecies{"ConfTrkPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton, o2::track::PID::Deuteron}, "Trk sel: Particles species for PID"};
   // Numbers from ~/alice/O2/DataFormats/Reconstruction/include/ReconstructionDataFormats/PID.h //static constexpr ID Pion = 2; static constexpr ID Kaon = 3; static constexpr ID Proton = 4; static constexpr ID Deuteron = 5;
-  Configurable<float> ConfTPCTOFnSigmaCutPion{"ConfTPCTOFnSigmaCutPion", 10., "TPC TOF combined NSigma cut for pions"};
-  Configurable<float> ConfTPCTOFnSigmaCutProton{"ConfTPCTOFnSigmaCutProton", 10., "TPC TOF combined NSigma cut for protons"};
-  Configurable<float> ConfTPCTOFnSigmaCutKaon{"ConfTPCTOFnSigmaCutKaon", 10., "TPC TOF combined NSigma cut for kaons"};
+  Configurable<float> ConfTOFnSigmaCut{"ConfTOFnSigmaCut", 5., "TOF NSigma cut"};
+  Configurable<float> ConfTOFpTmin{"ConfTOFpTmin", 0.5, "TOF pT min"};
 
   // TrackSelection *o2PhysicsTrackSelection;
   /// \todo Labeled array (see Track-Track task)
@@ -624,9 +623,15 @@ struct femtoUniverseProducerTask {
       }
 
       if (!(ConfIsActivateV0 || ConfIsActivatePhi)) {
-        if (track.pt() > 0.5) {
-          if (!(TMath::Hypot(trackCuts.getNsigmaTPC(track, o2::track::PID::Pion), trackCuts.getNsigmaTOF(track, o2::track::PID::Pion)) < ConfTPCTOFnSigmaCutPion || TMath::Hypot(trackCuts.getNsigmaTPC(track, o2::track::PID::Proton), trackCuts.getNsigmaTOF(track, o2::track::PID::Proton)) < ConfTPCTOFnSigmaCutProton || TMath::Hypot(trackCuts.getNsigmaTPC(track, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(track, o2::track::PID::Kaon)) < ConfTPCTOFnSigmaCutKaon)) {
+        if (track.pt() > ConfTOFpTmin) {
+          if (!track.hasTOF()) {
             continue;
+          }
+          std::vector<int> tmpPids = ConfChildPIDspecies;
+          for (o2::track::PID pid : tmpPids) {
+            if (!trackCuts.getNsigmaTOF(track, pid) < ConfTOFnSigmaCut) {
+              continue;
+            }
           }
         }
       }

--- a/PWGLF/DataModel/LFStrangenessPIDTables.h
+++ b/PWGLF/DataModel/LFStrangenessPIDTables.h
@@ -45,10 +45,10 @@ namespace v0data
 // lengths as stored in the AO2D for TOF calculations
 DECLARE_SOA_COLUMN(PosTOFLengthToPV, posTOFLengthToPV, float); //! positive track length to PV
 DECLARE_SOA_COLUMN(NegTOFLengthToPV, negTOFLengthToPV, float); //! negative track length to PV
-DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float); //! positive track signal
-DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float); //! negative track signal
-DECLARE_SOA_COLUMN(PosTOFEventTime, posTOFEventTime, float); //! positive track event time
-DECLARE_SOA_COLUMN(NegTOFEventTime, negTOFEventTime, float); //! negative track event time
+DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float);         //! positive track signal
+DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float);         //! negative track signal
+DECLARE_SOA_COLUMN(PosTOFEventTime, posTOFEventTime, float);   //! positive track event time
+DECLARE_SOA_COLUMN(NegTOFEventTime, negTOFEventTime, float);   //! negative track event time
 
 // recalculated lengths
 DECLARE_SOA_COLUMN(PosTOFLength, posTOFLength, float); //! positive track length, recalculated
@@ -91,12 +91,12 @@ namespace cascdata
 DECLARE_SOA_COLUMN(PosTOFLengthToPV, posTOFLengthToPV, float);   //! positive track length
 DECLARE_SOA_COLUMN(NegTOFLengthToPV, negTOFLengthToPV, float);   //! negative track length
 DECLARE_SOA_COLUMN(BachTOFLengthToPV, bachTOFLengthToPV, float); //! bachelor track length
-DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float);   //! positive track signal
-DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float);   //! negative track signal
-DECLARE_SOA_COLUMN(BachTOFSignal, bachTOFSignal, float); //! bachelor track signal
-DECLARE_SOA_COLUMN(PosTOFEventTime, posTOFEventTime, float);   //! positive track event time
-DECLARE_SOA_COLUMN(NegTOFEventTime, negTOFEventTime, float);   //! negative track event time
-DECLARE_SOA_COLUMN(BachTOFEventTime, bachTOFEventTime, float); //! bachelor track event time
+DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float);           //! positive track signal
+DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float);           //! negative track signal
+DECLARE_SOA_COLUMN(BachTOFSignal, bachTOFSignal, float);         //! bachelor track signal
+DECLARE_SOA_COLUMN(PosTOFEventTime, posTOFEventTime, float);     //! positive track event time
+DECLARE_SOA_COLUMN(NegTOFEventTime, negTOFEventTime, float);     //! negative track event time
+DECLARE_SOA_COLUMN(BachTOFEventTime, bachTOFEventTime, float);   //! bachelor track event time
 
 // delta-times
 DECLARE_SOA_COLUMN(PosTOFDeltaTXiPi, posTOFDeltaTXiPi, float);   //! positive track TOFDeltaT from pion <- lambda <- xi expectation
@@ -111,16 +111,16 @@ DECLARE_SOA_COLUMN(NegTOFDeltaTOmPr, negTOFDeltaTOmPr, float);   //! negative tr
 DECLARE_SOA_COLUMN(BachTOFDeltaTOmPi, bachTOFDeltaTOmPi, float); //! bachelor track TOFDeltaT from pion <- omega expectation
 
 // n-sigmas
-DECLARE_SOA_COLUMN(PosNSigmaXiPi, posNSigmaXiPi, float);         //! positive track NSigma from pion <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(PosNSigmaXiPr, posNSigmaXiPr, float);         //! positive track NSigma from proton <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(NegNSigmaXiPi, negNSigmaXiPi, float);         //! negative track NSigma from pion <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(NegNSigmaXiPr, negNSigmaXiPr, float);         //! negative track NSigma from proton <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(BachNSigmaXiPi, bachNSigmaXiPi, float);       //! bachelor track NSigma from pion <- xi expectation
-DECLARE_SOA_COLUMN(PosNSigmaOmPi, posNSigmaOmPi, float);         //! positive track NSigma from pion <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(PosNSigmaOmPr, posNSigmaOmPr, float);         //! positive track NSigma from proton <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(NegNSigmaOmPi, negNSigmaOmPi, float);         //! negative track NSigma from pion <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(NegNSigmaOmPr, negNSigmaOmPr, float);         //! negative track NSigma from proton <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(BachNSigmaOmKa, bachNSigmaOmKa, float);       //! bachelor track NSigma from kaon <- omega expectation
+DECLARE_SOA_COLUMN(PosNSigmaXiPi, posNSigmaXiPi, float);   //! positive track NSigma from pion <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(PosNSigmaXiPr, posNSigmaXiPr, float);   //! positive track NSigma from proton <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(NegNSigmaXiPi, negNSigmaXiPi, float);   //! negative track NSigma from pion <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(NegNSigmaXiPr, negNSigmaXiPr, float);   //! negative track NSigma from proton <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(BachNSigmaXiPi, bachNSigmaXiPi, float); //! bachelor track NSigma from pion <- xi expectation
+DECLARE_SOA_COLUMN(PosNSigmaOmPi, posNSigmaOmPi, float);   //! positive track NSigma from pion <- lambda <- omega expectation
+DECLARE_SOA_COLUMN(PosNSigmaOmPr, posNSigmaOmPr, float);   //! positive track NSigma from proton <- lambda <- omega expectation
+DECLARE_SOA_COLUMN(NegNSigmaOmPi, negNSigmaOmPi, float);   //! negative track NSigma from pion <- lambda <- omega expectation
+DECLARE_SOA_COLUMN(NegNSigmaOmPr, negNSigmaOmPr, float);   //! negative track NSigma from proton <- lambda <- omega expectation
+DECLARE_SOA_COLUMN(BachNSigmaOmKa, bachNSigmaOmKa, float); //! bachelor track NSigma from kaon <- omega expectation
 } // namespace cascdata
 
 DECLARE_SOA_TABLE(CascTOFs, "AOD", "CascTOF", // raw information table (for debug, etc)

--- a/PWGLF/DataModel/LFStrangenessPIDTables.h
+++ b/PWGLF/DataModel/LFStrangenessPIDTables.h
@@ -43,12 +43,16 @@ namespace v0data
 {
 // ==== TOF INFORMATION ===
 // lengths as stored in the AO2D for TOF calculations
-DECLARE_SOA_COLUMN(PosTOFLength, posTOFLength, float); //! positive track length
-DECLARE_SOA_COLUMN(NegTOFLength, negTOFLength, float); //! negative track length
+DECLARE_SOA_COLUMN(PosTOFLengthToPV, posTOFLengthToPV, float); //! positive track length to PV
+DECLARE_SOA_COLUMN(NegTOFLengthToPV, negTOFLengthToPV, float); //! negative track length to PV
 DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float); //! positive track signal
 DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float); //! negative track signal
 DECLARE_SOA_COLUMN(PosTOFEventTime, posTOFEventTime, float); //! positive track event time
 DECLARE_SOA_COLUMN(NegTOFEventTime, negTOFEventTime, float); //! negative track event time
+
+// recalculated lengths
+DECLARE_SOA_COLUMN(PosTOFLength, posTOFLength, float); //! positive track length, recalculated
+DECLARE_SOA_COLUMN(NegTOFLength, negTOFLength, float); //! negative track length, recalculated
 
 // delta-times
 DECLARE_SOA_COLUMN(PosTOFDeltaTLaPi, posTOFDeltaTLaPi, float); //! positive track TOFDeltaT from pion <- lambda expectation
@@ -68,13 +72,14 @@ DECLARE_SOA_COLUMN(NegNSigmaK0Pi, negNSigmaK0Pi, float); //! positive track NSig
 } // namespace v0data
 
 DECLARE_SOA_TABLE(V0TOFs, "AOD", "V0TOF", // raw information table (for debug, etc)
-                  v0data::PosTOFLength, v0data::NegTOFLength,
+                  v0data::PosTOFLengthToPV, v0data::NegTOFLengthToPV,
                   v0data::PosTOFSignal, v0data::NegTOFSignal,
-                  v0data::PosTOFEventTime, v0data::NegTOFEventTime,
+                  v0data::PosTOFEventTime, v0data::NegTOFEventTime);
+DECLARE_SOA_TABLE(V0TOFPIDs, "AOD", "V0TOFPID", // processed info table (for analysis)
+                  v0data::PosTOFLength, v0data::NegTOFLength,
                   v0data::PosTOFDeltaTLaPi, v0data::PosTOFDeltaTLaPr,
                   v0data::NegTOFDeltaTLaPi, v0data::NegTOFDeltaTLaPr,
-                  v0data::PosTOFDeltaTK0Pi, v0data::NegTOFDeltaTK0Pi);
-DECLARE_SOA_TABLE(V0TOFPIDs, "AOD", "V0TOFPID", // nsigma table (for analysis)
+                  v0data::PosTOFDeltaTK0Pi, v0data::NegTOFDeltaTK0Pi,
                   v0data::PosNSigmaLaPi, v0data::PosNSigmaLaPr,
                   v0data::NegNSigmaLaPi, v0data::NegNSigmaLaPr,
                   v0data::PosNSigmaK0Pi, v0data::NegNSigmaK0Pi);
@@ -83,9 +88,9 @@ namespace cascdata
 {
 // ==== TOF INFORMATION ===
 // lengths as stored in the AO2D for TOF calculations
-DECLARE_SOA_COLUMN(PosTOFLength, posTOFLength, float);   //! positive track length
-DECLARE_SOA_COLUMN(NegTOFLength, negTOFLength, float);   //! negative track length
-DECLARE_SOA_COLUMN(BachTOFLength, bachTOFLength, float); //! bachelor track length
+DECLARE_SOA_COLUMN(PosTOFLengthToPV, posTOFLengthToPV, float);   //! positive track length
+DECLARE_SOA_COLUMN(NegTOFLengthToPV, negTOFLengthToPV, float);   //! negative track length
+DECLARE_SOA_COLUMN(BachTOFLengthToPV, bachTOFLengthToPV, float); //! bachelor track length
 DECLARE_SOA_COLUMN(PosTOFSignal, posTOFSignal, float);   //! positive track signal
 DECLARE_SOA_COLUMN(NegTOFSignal, negTOFSignal, float);   //! negative track signal
 DECLARE_SOA_COLUMN(BachTOFSignal, bachTOFSignal, float); //! bachelor track signal
@@ -119,16 +124,16 @@ DECLARE_SOA_COLUMN(BachNSigmaOmKa, bachNSigmaOmKa, float);       //! bachelor tr
 } // namespace cascdata
 
 DECLARE_SOA_TABLE(CascTOFs, "AOD", "CascTOF", // raw information table (for debug, etc)
-                  cascdata::PosTOFLength, cascdata::NegTOFLength, cascdata::BachTOFLength,
+                  cascdata::PosTOFLengthToPV, cascdata::NegTOFLengthToPV, cascdata::BachTOFLengthToPV,
                   cascdata::PosTOFSignal, cascdata::NegTOFSignal, cascdata::BachTOFSignal,
-                  cascdata::PosTOFEventTime, cascdata::NegTOFEventTime, cascdata::BachTOFEventTime,
+                  cascdata::PosTOFEventTime, cascdata::NegTOFEventTime, cascdata::BachTOFEventTime);
+DECLARE_SOA_TABLE(CascTOFPIDs, "AOD", "CASCTOFPID", // processed information for analysis
                   cascdata::PosTOFDeltaTXiPi, cascdata::PosTOFDeltaTXiPr,
                   cascdata::NegTOFDeltaTXiPi, cascdata::NegTOFDeltaTXiPr,
                   cascdata::BachTOFDeltaTXiPi,
                   cascdata::PosTOFDeltaTOmPi, cascdata::PosTOFDeltaTOmPr,
                   cascdata::NegTOFDeltaTOmPi, cascdata::NegTOFDeltaTOmPr,
-                  cascdata::BachTOFDeltaTOmPi);
-DECLARE_SOA_TABLE(CascTOFPIDs, "AOD", "CASCTOFPID", // nsigma table (for analysis)
+                  cascdata::BachTOFDeltaTOmPi,
                   cascdata::PosNSigmaXiPi, cascdata::PosNSigmaXiPr,
                   cascdata::NegNSigmaXiPi, cascdata::NegNSigmaXiPr,
                   cascdata::BachNSigmaXiPi,

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -77,7 +77,6 @@ using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
 
 struct cascadepid {
   // TOF pid for strangeness (recalculated with topology)
-  Produces<aod::CascTOFs> casctof;       // raw table for checks
   Produces<aod::CascTOFPIDs> casctofpid; // table with Nsigmas
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -246,14 +245,6 @@ struct cascadepid {
         auto negTrack = cascade.negTrack_as<FullTracksExtIU>();
 
         // FIXME: TOF calculation: under construction, to follow
-
-        if (fillRawPID) {
-          casctof(posTrack.length(), negTrack.length(), bachTrack.length(),
-                  posTrack.tofSignal(), negTrack.tofSignal(), bachTrack.tofSignal(),
-                  posTrack.tofEvTime(), negTrack.tofEvTime(), bachTrack.tofEvTime(),
-                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
-        }
       }
     }
   }

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -110,9 +110,9 @@ struct lambdakzeropid {
   float maxSnp;  // max sine phi for propagation
   float maxStep; // max step size (cm) for propagation
 
-  /// function to calculate track length of this track up to a certain segment of a detector 
+  /// function to calculate track length of this track up to a certain segment of a detector
   /// to be used internally in another funcrtion that calculates length until it finds the proper one
-  /// warning: this could be optimised further for speed 
+  /// warning: this could be optimised further for speed
   /// \param track the input track
   /// \param x1 x of the first point of the detector segment
   /// \param y1 y of the first point of the detector segment
@@ -123,15 +123,15 @@ struct lambdakzeropid {
   {
     // don't make use of the track parametrization
     float length = -104;
-    
+
     // causality protection
     std::array<float, 3> mom;
     track.getPxPyPzGlo(mom);
     // get start point
     std::array<float, 3> startPoint;
     track.getXYZGlo(startPoint);
-    
-    if( ((x1+x2)*mom[0] + (y1+y2)*mom[1]) < 0.0f )
+
+    if (((x1 + x2) * mom[0] + (y1 + y2) * mom[1]) < 0.0f)
       return -101;
 
     // get circle X, Y please
@@ -140,33 +140,33 @@ struct lambdakzeropid {
     track.getCircleParams(magneticField, trcCircle, sna, csa);
 
     // Calculate necessary inner product
-    float segmentModulus = std::hypot(x2-x1, y2-y1);
-    float alongSegment = ((trcCircle.xC - x1) * (x2 - x1) + (trcCircle.yC - y1) * (y2 - y1))/segmentModulus;
-    
-    // find point of closest approach between segment and circle center
-    float pcaX = (x2-x1)*alongSegment/segmentModulus + x1;
-    float pcaY = (y2-y1)*alongSegment/segmentModulus + y1;
+    float segmentModulus = std::hypot(x2 - x1, y2 - y1);
+    float alongSegment = ((trcCircle.xC - x1) * (x2 - x1) + (trcCircle.yC - y1) * (y2 - y1)) / segmentModulus;
 
-    float centerDistToPC = std::hypot(pcaX-trcCircle.xC, pcaY-trcCircle.yC);
+    // find point of closest approach between segment and circle center
+    float pcaX = (x2 - x1) * alongSegment / segmentModulus + x1;
+    float pcaY = (y2 - y1) * alongSegment / segmentModulus + y1;
+
+    float centerDistToPC = std::hypot(pcaX - trcCircle.xC, pcaY - trcCircle.yC);
 
     // distance pca-to-intercept in multiples of segment modulus (for convenience)
-    if(centerDistToPC > trcCircle.rC)
+    if (centerDistToPC > trcCircle.rC)
       return -103;
-    
-    float pcaToIntercept = TMath::Sqrt(TMath::Abs(trcCircle.rC * trcCircle.rC - centerDistToPC*centerDistToPC));
 
-    float interceptX1 = pcaX + (x2-x1)/segmentModulus*pcaToIntercept;
-    float interceptY1 = pcaY + (y2-y1)/segmentModulus*pcaToIntercept;
-    float interceptX2 = pcaX - (x2-x1)/segmentModulus*pcaToIntercept;
-    float interceptY2 = pcaY - (y2-y1)/segmentModulus*pcaToIntercept;
-    
-    float scalarCheck1 = ((x2-x1)*(interceptX1-x1) + (y2-y1)*(interceptY1-y1))/segmentModulus;
-    float scalarCheck2 = ((x2-x1)*(interceptX2-x1) + (y2-y1)*(interceptY2-y1))/segmentModulus;
-    
+    float pcaToIntercept = TMath::Sqrt(TMath::Abs(trcCircle.rC * trcCircle.rC - centerDistToPC * centerDistToPC));
+
+    float interceptX1 = pcaX + (x2 - x1) / segmentModulus * pcaToIntercept;
+    float interceptY1 = pcaY + (y2 - y1) / segmentModulus * pcaToIntercept;
+    float interceptX2 = pcaX - (x2 - x1) / segmentModulus * pcaToIntercept;
+    float interceptY2 = pcaY - (y2 - y1) / segmentModulus * pcaToIntercept;
+
+    float scalarCheck1 = ((x2 - x1) * (interceptX1 - x1) + (y2 - y1) * (interceptY1 - y1)) / segmentModulus;
+    float scalarCheck2 = ((x2 - x1) * (interceptX2 - x1) + (y2 - y1) * (interceptY2 - y1)) / segmentModulus;
+
     float cosAngle1 = -1000, sinAngle1 = -1000, modulus1 = -1000;
     float cosAngle2 = -1000, sinAngle2 = -1000, modulus2 = -1000;
     float length1 = -1000, length2 = -1000;
-    
+
     modulus1 = std::hypot(interceptX1 - trcCircle.xC, interceptY1 - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
     cosAngle1 = (interceptX1 - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (interceptY1 - trcCircle.yC) * (startPoint[1] - trcCircle.yC);
     sinAngle1 = (interceptX1 - trcCircle.xC) * (startPoint[1] - trcCircle.yC) - (interceptY1 - trcCircle.yC) * (startPoint[0] - trcCircle.xC);
@@ -182,33 +182,35 @@ struct lambdakzeropid {
     sinAngle2 /= modulus2;
     length2 = trcCircle.rC * TMath::ACos(cosAngle2);
     length2 *= sqrt(1.0f + track.getTgl() * track.getTgl());
-    
+
     // rotate transverse momentum vector such that it is at intercepts
     float angle1 = TMath::ACos(cosAngle1);
-    if(sinAngle1<0) angle1 *= -1.0f;
-    float px1 = + TMath::Cos(angle1)*mom[0] + TMath::Sin(angle1)*mom[1];
-    float py1 = - TMath::Sin(angle1)*mom[0] + TMath::Cos(angle1)*mom[1];
-    
+    if (sinAngle1 < 0)
+      angle1 *= -1.0f;
+    float px1 = +TMath::Cos(angle1) * mom[0] + TMath::Sin(angle1) * mom[1];
+    float py1 = -TMath::Sin(angle1) * mom[0] + TMath::Cos(angle1) * mom[1];
+
     float angle2 = TMath::ACos(cosAngle2);
-    if(sinAngle2<0) angle2 *= -1.0f;
-    float px2 = + TMath::Cos(angle2)*mom[0] + TMath::Sin(angle2)*mom[1];
-    float py2 = - TMath::Sin(angle2)*mom[0] + TMath::Cos(angle2)*mom[1];
-    
-    float midSegX = 0.5f*(x2+x1);
-    float midSegY = 0.5f*(y2+y1);
-    
-    float scalarMomentumCheck1 = px1*midSegX+py1*midSegY;
-    float scalarMomentumCheck2 = px2*midSegX+py2*midSegY;
-    
+    if (sinAngle2 < 0)
+      angle2 *= -1.0f;
+    float px2 = +TMath::Cos(angle2) * mom[0] + TMath::Sin(angle2) * mom[1];
+    float py2 = -TMath::Sin(angle2) * mom[0] + TMath::Cos(angle2) * mom[1];
+
+    float midSegX = 0.5f * (x2 + x1);
+    float midSegY = 0.5f * (y2 + y1);
+
+    float scalarMomentumCheck1 = px1 * midSegX + py1 * midSegY;
+    float scalarMomentumCheck2 = px2 * midSegX + py2 * midSegY;
+
     float halfPerimeter = TMath::Pi() * trcCircle.rC; // perimeter check. Length should not pass this ever
-    
+
     if (scalarCheck1 > 0.0f && scalarCheck1 < segmentModulus && length1 < halfPerimeter && scalarMomentumCheck1 > 0.0f) {
       length = length1;
-      //X = interceptX1; Y = interceptY1;
+      // X = interceptX1; Y = interceptY1;
     }
     if (scalarCheck2 > 0.0f && scalarCheck2 < segmentModulus && length2 < halfPerimeter && scalarMomentumCheck2 > 0.0f) {
       length = length2;
-      //X = interceptX2; Y = interceptY2;
+      // X = interceptX2; Y = interceptY2;
     }
     return length;
   }
@@ -216,20 +218,22 @@ struct lambdakzeropid {
   /// function to calculate track length of this track up to a certain segmented detector
   /// \param track the input track
   /// \param magneticField the magnetic field to use when propagating
-  float findInterceptLength(o2::track::TrackParCov track, float magneticField){
-   for(int iSeg=0; iSeg<18; iSeg++){
+  float findInterceptLength(o2::track::TrackParCov track, float magneticField)
+  {
+    for (int iSeg = 0; iSeg < 18; iSeg++) {
       // Detector segmentation loop
-      float segmentAngle = 20.0f/180.0f * TMath::Pi();
-      float theta = static_cast<float>(iSeg)*20.0f/180.0f * TMath::Pi();
-      float halfWidth = tofPosition*TMath::Tan(0.5f*segmentAngle);
-      float x1 = TMath::Cos(theta)*(-halfWidth) + TMath::Sin(theta)*tofPosition;
-      float y1 = -TMath::Sin(theta)*(-halfWidth) + TMath::Cos(theta)*tofPosition;
-      float x2 = TMath::Cos(theta)*(+halfWidth) + TMath::Sin(theta)*tofPosition;
-      float y2 = -TMath::Sin(theta)*(+halfWidth) + TMath::Cos(theta)*tofPosition;
+      float segmentAngle = 20.0f / 180.0f * TMath::Pi();
+      float theta = static_cast<float>(iSeg) * 20.0f / 180.0f * TMath::Pi();
+      float halfWidth = tofPosition * TMath::Tan(0.5f * segmentAngle);
+      float x1 = TMath::Cos(theta) * (-halfWidth) + TMath::Sin(theta) * tofPosition;
+      float y1 = -TMath::Sin(theta) * (-halfWidth) + TMath::Cos(theta) * tofPosition;
+      float x2 = TMath::Cos(theta) * (+halfWidth) + TMath::Sin(theta) * tofPosition;
+      float y2 = -TMath::Sin(theta) * (+halfWidth) + TMath::Cos(theta) * tofPosition;
       float length = trackLengthToSegment(track, x1, y1, x2, y2, magneticField);
-      if( length > 0 ) return length;
+      if (length > 0)
+        return length;
     }
-    return -100; // not reached / not found 
+    return -100; // not reached / not found
   }
 
   void init(InitContext& context)

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -356,10 +356,10 @@ struct lambdakzeropid {
         deltaTimeNegativeK0ShortPi = (negTrackRow.tofSignal() - negTrackRow.tofEvTime()) - (timeK0Short + timeNegativePi);
 
         v0tofpid(lengthPositive, lengthNegative,
-                  deltaTimePositiveLambdaPi, deltaTimePositiveLambdaPr,
-                  deltaTimeNegativeLambdaPi, deltaTimeNegativeLambdaPr,
-                  deltaTimePositiveK0ShortPi, deltaTimeNegativeK0ShortPi,
-                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f); //FIXME
+                 deltaTimePositiveLambdaPi, deltaTimePositiveLambdaPr,
+                 deltaTimeNegativeLambdaPi, deltaTimeNegativeLambdaPr,
+                 deltaTimePositiveK0ShortPi, deltaTimeNegativeK0ShortPi,
+                 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f); // FIXME
 
         auto originalV0 = v0.v0_as<TaggedV0s>(); // this could look confusing, so:
         // the first v0 is the v0data row; the getter de-references the v0 (stored indices) row

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -77,7 +77,6 @@ using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
 
 struct lambdakzeropid {
   // TOF pid for strangeness (recalculated with topology)
-  Produces<aod::V0TOFs> v0tof;       // raw table for checks
   Produces<aod::V0TOFPIDs> v0tofpid; // table with Nsigmas
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -91,7 +90,6 @@ struct lambdakzeropid {
   Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
   Configurable<float> tofPosition{"tofPosition", 377.934f, "TOF effective (inscribed) radius"};
   Configurable<bool> checkTPCCompatibility{"checkTPCCompatibility", true, "check compatibility with dE/dx in QA plots"};
-  Configurable<bool> fillRawPID{"fillRawPID", true, "fill raw PID tables for debug/x-check"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -357,14 +355,11 @@ struct lambdakzeropid {
         deltaTimePositiveK0ShortPi = (posTrackRow.tofSignal() - posTrackRow.tofEvTime()) - (timeK0Short + timeNegativePi);
         deltaTimeNegativeK0ShortPi = (negTrackRow.tofSignal() - negTrackRow.tofEvTime()) - (timeK0Short + timeNegativePi);
 
-        if (fillRawPID) {
-          v0tof(posTrackRow.length(), negTrackRow.length(),
-                posTrackRow.tofSignal(), negTrackRow.tofSignal(),
-                posTrackRow.tofEvTime(), negTrackRow.tofEvTime(),
-                deltaTimePositiveLambdaPi, deltaTimePositiveLambdaPr,
-                deltaTimeNegativeLambdaPi, deltaTimeNegativeLambdaPr,
-                deltaTimePositiveK0ShortPi, deltaTimeNegativeK0ShortPi);
-        }
+        v0tofpid(lengthPositive, lengthNegative,
+                  deltaTimePositiveLambdaPi, deltaTimePositiveLambdaPr,
+                  deltaTimeNegativeLambdaPi, deltaTimeNegativeLambdaPr,
+                  deltaTimePositiveK0ShortPi, deltaTimeNegativeK0ShortPi,
+                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f); //FIXME
 
         auto originalV0 = v0.v0_as<TaggedV0s>(); // this could look confusing, so:
         // the first v0 is the v0data row; the getter de-references the v0 (stored indices) row

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -181,7 +181,7 @@ struct strangederivedbuilder {
       if (strange || fillEmptyCollisions) {
         strangeColl(collision.posX(), collision.posY(), collision.posZ());
         strangeCents(collision.centFT0M(), collision.centFT0A(),
-                       collision.centFT0C(), collision.centFV0A());
+                     collision.centFT0C(), collision.centFV0A());
         currentCollIdx++;
       }
       for (int i = 0; i < V0Table_thisColl.size(); i++)

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -85,9 +85,9 @@ struct strangederivedbuilder {
 
   //__________________________________________________
   // mother information
-  Produces<aod::V0MCMothers> v0mothers;               // V0 mother references
-  Produces<aod::CascMCMothers> cascmothers;           // casc mother references
-  Produces<aod::MotherMCParts> motherMCParts;         // mc particles for mothers
+  Produces<aod::V0MCMothers> v0mothers;       // V0 mother references
+  Produces<aod::CascMCMothers> cascmothers;   // casc mother references
+  Produces<aod::MotherMCParts> motherMCParts; // mc particles for mothers
 
   //__________________________________________________
   // raw TOF PID for posterior use if requested


### PR DESCRIPTION
@njacazio This PR exchanges the old radial-intercept-with-TOF calculation in the strangeness framework with a much improved calculation in which the 18-sector segmentation of the TOF is considered properly. The intercept is still calculated with an effective TOF radius, but this calculation should now be significantly more accurate than the previous one and uses an effective TOF radius of 377.64cm that has been extracted from the full geometrical model of the TOF. Further developments will still come with more extensive testing. 