### PR TITLE
PWGCF: Fix FemtoDream

### DIFF
--- a/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/FemtoDreamTrackSelection.h
@@ -137,13 +137,17 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
   bool isSelectedMinimal(T const& track);
 
   /// Obtain the bit-wise container for the selections
+  /// Pt, eta and dca are not necessarily taken from the track table. For example, for V0 daughters they are recaluated and stored in the V0 table
   /// \todo For the moment, PID is separated from the other selections, hence instead of a single value an std::array of size two is returned
   /// \tparam cutContainerType Data type of the bit-wise container for the selections
   /// \tparam T Data type of the track
   /// \param track Track
+  /// \param Pt pt of the track
+  /// \param Eta eta of the track
+  /// \param Dca dca of the track with respect to primary vertex
   /// \return The bit-wise container for the selections, separately with all selection criteria, and the PID
-  template <typename cutContainerType, typename T>
-  std::array<cutContainerType, 2> getCutContainer(T const& track);
+  template <typename cutContainerType, typename T, typename R>
+  std::array<cutContainerType, 2> getCutContainer(T const& track, R Pt, R Eta, R Dcaxy);
 
   /// Some basic QA histograms
   /// \tparam part Type of the particle for proper naming of the folders for QA
@@ -478,15 +482,15 @@ bool FemtoDreamTrackSelection::isSelectedMinimal(T const& track)
   return true;
 }
 
-template <typename cutContainerType, typename T>
-std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T const& track)
+template <typename cutContainerType, typename T, typename R>
+std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T const& track, R Pt, R Eta, R Dca)
 {
   cutContainerType output = 0;
   size_t counter = 0;
   cutContainerType outputPID = 0;
   const auto sign = track.sign();
-  const auto pT = track.pt();
-  const auto eta = track.eta();
+  const auto pt = Pt;
+  const auto eta = Eta;
   const auto tpcNClsF = track.tpcNClsFound();
   const auto tpcRClsC = track.tpcCrossedRowsOverFindableCls();
   const auto tpcNClsC = track.tpcNClsCrossedRows();
@@ -495,7 +499,7 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
   const auto itsNClsIB = track.itsNClsInnerBarrel();
   const auto dcaXY = track.dcaXY();
   const auto dcaZ = track.dcaZ();
-  const auto dca = std::sqrt(pow(dcaXY, 2.) + pow(dcaZ, 2.));
+  const auto dca = Dca;
 
   std::vector<float> pidTPC, pidTOF;
   for (auto it : mPIDspecies) {
@@ -523,7 +527,7 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
           break;
         case (femtoDreamTrackSelection::kpTMin):
         case (femtoDreamTrackSelection::kpTMax):
-          observable = pT;
+          observable = pt;
           break;
         case (femtoDreamTrackSelection::kEtaMax):
           observable = eta;

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -552,8 +552,8 @@ template <typename cutContainerType, typename C, typename V, typename T>
 std::array<cutContainerType, 5>
   FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0, T const& posTrack, T const& negTrack)
 {
-  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack,v0.positivept(),v0.positiveeta(),v0.dcapostopv());
-  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack,v0.negativept(),v0.negativeeta(),v0.dcanegtopv());
+  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack, v0.positivept(), v0.positiveeta(), v0.dcapostopv());
+  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack, v0.negativept(), v0.negativeeta(), v0.dcanegtopv());
   cutContainerType output = 0;
   size_t counter = 0;
 

--- a/PWGCF/FemtoDream/FemtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/FemtoDreamV0Selection.h
@@ -552,8 +552,8 @@ template <typename cutContainerType, typename C, typename V, typename T>
 std::array<cutContainerType, 5>
   FemtoDreamV0Selection::getCutContainer(C const& col, V const& v0, T const& posTrack, T const& negTrack)
 {
-  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack);
-  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack);
+  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack,v0.positivept(),v0.positiveeta(),v0.dcapostopv());
+  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack,v0.negativept(),v0.negativeeta(),v0.dcanegtopv());
   cutContainerType output = 0;
   size_t counter = 0;
 

--- a/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/femtoDreamDebugV0.cxx
@@ -41,7 +41,7 @@ struct femtoDreamDebugV0 {
 
   Configurable<int> ConfV01_PDGCode{"ConfV01_PDGCode", 3122, "V0 - PDG code"};
   Configurable<int> ConfV01_ChildPos_PDGCode{"ConfV01_PosChild_PDGCode", 2212, "Positive Child - PDG code"};
-  Configurable<int> ConfV01_NegChild_PDGCode{"ConfV01_NegChild_PDGCode", 211, "Negative Child- PDG code"};
+  Configurable<int> ConfV01_ChildNeg_PDGCode{"ConfV01_NegChild_PDGCode", 211, "Negative Child- PDG code"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_CutBit{"ConfV01_CutBit", 338, "V0 - Selection bit from cutCulator"};
   ConfigurableAxis ConfV0TempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "V0: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfV0TempFitVarMomentumBins{"ConfV0TempFitVarMomentumBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
@@ -57,6 +57,7 @@ struct femtoDreamDebugV0 {
 
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_CutBit{"ConfV01_ChildPos_CutBit", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_TPCBit{"ConfV01_ChildPos_TPCBit", 4, "Positive Child of V0 - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildNeg_CutBit{"ConfV01_ChildNeg_CutBit", 149, "Negative Child of V0 - PID bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildNeg_TPCBit{"ConfV01_ChildNeg_TPCBit", 8, "Negative Child of V0 - PID bit from cutCulator"};
   ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "V0 child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "V0 child: pT binning of the pT vs. TempFitVar plot"};
@@ -79,7 +80,7 @@ struct femtoDreamDebugV0 {
   {
     eventHisto.init(&EventRegistry);
     posChildHistos.init(&V0Registry, ConfV0ChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
-    negChildHistos.init(&V0Registry, ConfV0ChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_NegChild_PDGCode, true);
+    negChildHistos.init(&V0Registry, ConfV0ChildTempFitVarMomentumBins, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
     V0Histos.init(&V0Registry, ConfV0TempFitVarMomentumBins, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
   }
 
@@ -107,7 +108,7 @@ struct femtoDreamDebugV0 {
           (posChild.cut() & ConfV01_ChildPos_CutBit) == ConfV01_ChildPos_CutBit &&
           (posChild.pidcut() & ConfV01_ChildPos_TPCBit) == ConfV01_ChildPos_TPCBit &&
           negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-          (negChild.cut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit &&
+          (negChild.cut() & ConfV01_ChildNeg_CutBit) == ConfV01_ChildNeg_CutBit &&
           (negChild.pidcut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit) {
         V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value));
         posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value));

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -259,7 +259,7 @@ struct femtoDreamProducerReducedTask {
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // an array of two bit-wise containers of the systematic variations is obtained
       // one container for the track quality cuts and one for the PID cuts
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track,track.pt(),track.eta(),sqrtf(powf(track.dcaXY(),2.f)+powf(track.dcaZ(),2.f)));
+      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(),

--- a/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerReducedTask.cxx
@@ -259,7 +259,7 @@ struct femtoDreamProducerReducedTask {
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // an array of two bit-wise containers of the systematic variations is obtained
       // one container for the track quality cuts and one for the PID cuts
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track);
+      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track,track.pt(),track.eta(),sqrtf(powf(track.dcaXY(),2.f)+powf(track.dcaZ(),2.f)));
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(),

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -380,7 +380,7 @@ struct femtoDreamProducerTask {
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the pri,v0.dcamary track table row <-> aod::track table global index
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
 
     for (auto& track : tracks) {
       /// if the most open selection criteria are not fulfilled there is no

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -380,7 +380,7 @@ struct femtoDreamProducerTask {
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
 
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the pri,v0.dcamary track table row <-> aod::track table global index
 
     for (auto& track : tracks) {
       /// if the most open selection criteria are not fulfilled there is no
@@ -390,7 +390,7 @@ struct femtoDreamProducerTask {
       }
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // the bit-wise container of the systematic variations is obtained
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track);
+      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track,track.pt(),track.eta(),sqrtf(powf(track.dcaXY(),2.f)+powf(track.dcaZ(),2.f)));
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(),
@@ -442,12 +442,12 @@ struct femtoDreamProducerTask {
         rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
         childIDs[0] = rowInPrimaryTrackTablePos;
         childIDs[1] = 0;
-        outputParts(outputCollision.lastIndex(), v0.positivept(),
-                    v0.positiveeta(), v0.positivephi(),
+        outputParts(outputCollision.lastIndex(),
+		    v0.positivept(), v0.positiveeta(), v0.positivephi(),
                     aod::femtodreamparticle::ParticleType::kV0Child,
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID),
-                    0.,
+                    postrack.dcaXY(),
                     childIDs,
                     0,
                     0);
@@ -467,7 +467,7 @@ struct femtoDreamProducerTask {
                     aod::femtodreamparticle::ParticleType::kV0Child,
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegCuts),
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kNegPID),
-                    0.,
+                    negtrack.dcaXY(),
                     childIDs,
                     0,
                     0);

--- a/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/femtoDreamProducerTask.cxx
@@ -390,7 +390,7 @@ struct femtoDreamProducerTask {
       }
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // the bit-wise container of the systematic variations is obtained
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track,track.pt(),track.eta(),sqrtf(powf(track.dcaXY(),2.f)+powf(track.dcaZ(),2.f)));
+      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(),
@@ -443,7 +443,7 @@ struct femtoDreamProducerTask {
         childIDs[0] = rowInPrimaryTrackTablePos;
         childIDs[1] = 0;
         outputParts(outputCollision.lastIndex(),
-		    v0.positivept(), v0.positiveeta(), v0.positivephi(),
+                    v0.positivept(), v0.positiveeta(), v0.positivephi(),
                     aod::femtodreamparticle::ParticleType::kV0Child,
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosCuts),
                     cutContainerV0.at(femtoDreamV0Selection::V0ContainerPosition::kPosPID),


### PR DESCRIPTION
Two fixes:
- For v0 daughters, certain track variables get recomputed by the lambdakzero-builder. Since these values are used to fill the femto tables, these values should also explicitly be used for the daughter selections.
- Fix bug in debug-v0 task