### PR TITLE
adding 3D k* calculation and new flags for mult./cent.

### DIFF
--- a/PWGCF/Femto3D/Core/femto3dPairTask.h
+++ b/PWGCF/Femto3D/Core/femto3dPairTask.h
@@ -81,6 +81,20 @@ float GetKstarFrom4vectors(TLorentzVector& first4momentum, TLorentzVector& secon
 
 //====================================================================================
 
+TVector3 Get3dKstarFrom4vectors(TLorentzVector& first4momentum, TLorentzVector& second4momentum)
+{
+  TLorentzVector fourmomentasum = first4momentum + second4momentum;
+  first4momentum.Boost(0.0, 0.0, (-1) * fourmomentasum.BoostVector().Z());  // boost to LCMS
+  second4momentum.Boost(0.0, 0.0, (-1) * fourmomentasum.BoostVector().Z()); // boost to LCMS
+
+  TVector3 qinv = first4momentum.Vect() - second4momentum.Vect();
+  qinv.RotateZ((-1) * fourmomentasum.Phi()); // rotate so the X axis is along pair's kT
+
+  return 0.5 * qinv;
+}
+
+//====================================================================================
+
 template <typename TrackType>
 class FemtoPair
 {
@@ -153,6 +167,7 @@ class FemtoPair
       return 1000;
   }
   float GetKstar() const;
+  TVector3 Get3dKstar() const;
   float GetKt() const;
 
  private:
@@ -211,6 +226,24 @@ float FemtoPair<TrackType>::GetKstar() const
   second4momentum.SetPtEtaPhiM(_second->pt(), _second->eta(), _second->phi(), particle_mass(_PDG2));
 
   return GetKstarFrom4vectors(first4momentum, second4momentum, _isidentical);
+}
+
+template <typename TrackType>
+TVector3 FemtoPair<TrackType>::Get3dKstar() const
+{
+  if (_first == NULL || _second == NULL)
+    return TVector3(-1000, -1000, -1000);
+  if (!(_magfield1 * _magfield2))
+    return TVector3(-1000, -1000, -1000);
+  if (!(_PDG1 * _PDG2))
+    return TVector3(-1000, -1000, -1000);
+
+  TLorentzVector first4momentum;
+  first4momentum.SetPtEtaPhiM(_first->pt(), _first->eta(), _first->phi(), particle_mass(_PDG1));
+  TLorentzVector second4momentum;
+  second4momentum.SetPtEtaPhiM(_second->pt(), _second->eta(), _second->phi(), particle_mass(_PDG2));
+
+  return Get3dKstarFrom4vectors(first4momentum, second4momentum);
 }
 
 template <typename TrackType>

--- a/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
+++ b/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
@@ -49,10 +49,13 @@ struct singleTrackSelector {
 
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply rapidity cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   // Configurable<int> trackSelection{"trackSelection", 1, "Track selection: 0 -> No Cut, 1 -> kGlobalTrack, 2 -> kGlobalTrackWoPtEta, 3 -> kGlobalTrackWoDCA, 4 -> kQualityTracks, 5 -> kInAcceptanceTracks"};
+  Configurable<int> centTableToUse{"centTableToUse", 1, "Flag to choose cent./mult.perc. estimator (Run3 only [FTOC for PbPb; FTOM for pp], for Run2 the V0M is used): 0 -> CentFV0As, 1 -> CentFT0Ms, 2 -> CentFT0As, 3 -> CentFT0Cs, 4 -> CentFDDMs, 5 -> CentNTPVs"};
+  Configurable<int> multTableToUse{"multTableToUse", 1, "Flag to choose mult. estimator (Run3 only): 0 -> TPCMults, 1 -> MultNTracksPV, 2 -> MultNTracksPVeta1"};
+  Configurable<bool> rejectNotPropagatedTrks{"rejectNotPropagatedTrks", true, "rejects tracks that are not propagated to the primary vertex"};
 
   Configurable<std::vector<int>> _particlesToKeep{"particlesToKeepPDGs", std::vector<int>{2212, 1000010020}, "PDG codes of perticles for which the 'singletrackselector' tables will be created (only proton and deurton are supported now)"};
   Configurable<std::vector<float>> keepWithinNsigmaTPC{"keepWithinNsigmaTPC", std::vector<float>{-4.0f, 4.0f}, "TPC range for preselection of particles specified with PDG"};
-  Configurable<std::vector<int>> _particlesToReject{"particlesToRejectPDGs", std::vector<int>{}, "PDG codes of perticles that will be rejected with TOF (only pion, kaon, proton and deurton are supported now)"};
+  Configurable<std::vector<int>> _particlesToReject{"particlesToRejectPDGs", std::vector<int>{211}, "PDG codes of particles that will be rejected with TOF (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> rejectWithinNsigmaTOF{"rejectWithinNsigmaTOF", std::vector<float>{-5.0f, 5.0f}, "TOF rejection Nsigma range for particles specified with PDG to be rejected"};
 
   Configurable<float> _min_P{"min_P", 0.f, "lower mometum limit"};
@@ -60,6 +63,7 @@ struct singleTrackSelector {
   Configurable<float> _eta{"eta", 100.f, "abs eta value limit"};
   Configurable<float> _dcaXY{"dcaXY", 1000.f, "Maximum dca of track in xy"};
   Configurable<float> _dcaZ{"dcaZ", 1000.f, "Maximum dca of track in xy"};
+  Configurable<float> _maxTofChi2{"maxTofChi2", 10.f, "Maximum TOF Chi2 value -> to remove mismatched tracks"};
 
   using Trks = soa::Join<aod::Tracks, aod::TracksExtra, aod::pidEvTimeFlags, aod::TracksDCA,
                          aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullKa,
@@ -68,7 +72,8 @@ struct singleTrackSelector {
                          aod::pidTOFFullPr, aod::pidTOFFullDe,
                          aod::TrackSelection, aod::pidTOFbeta>;
 
-  using Coll = soa::Join<aod::Collisions, aod::TPCMults, aod::EvSels, aod::CentFT0Ms>;
+  using CollRun2 = soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::CentRun2V0Ms>;
+  using CollRun3 = soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFDDMs, aod::CentNTPVs>;
 
   Produces<o2::aod::SingleTrackSels> tableRow;
   Produces<o2::aod::SingleCollSels> tableRowColl;
@@ -84,6 +89,7 @@ struct singleTrackSelector {
   Filter pFilter = o2::aod::track::p > _min_P&& o2::aod::track::p < _max_P;
   Filter etaFilter = nabs(o2::aod::track::eta) < _eta;
   Filter dcaFilter = (o2::aod::track::dcaXY <= _dcaXY) && (o2::aod::track::dcaZ <= _dcaZ);
+  Filter tofChi2Filter = o2::aod::track::tofChi2 < _maxTofChi2;
 
   int mRunNumber = 0;
   float d_bz = 0.f;
@@ -132,25 +138,20 @@ struct singleTrackSelector {
     d_bz = 0.1 * d_bz;
   }
 
-  template <bool isMC, typename Col, typename Trks>
-  inline void fillTheTables(Col collision, Trks const& tracks)
+  template <bool isMC, typename Trks>
+  inline void fillTrackTables(Trks const& tracks)
   {
     bool skip_track = false; // flag used for track rejection
-
-    tableRowColl(collision.multTPC(),
-                 collision.centFT0M(),
-                 collision.posZ(),
-                 d_bz);
 
     for (auto& track : tracks) {
       if constexpr (isMC) {
         if (!track.has_mcParticle())
           continue;
       }
-      skip_track = false;
-      if (Configurable<bool>{"rejectNotPropagatedTrks", true, "rejects tracks that are not propagated to the primary vertex"} && track.trackType() != aod::track::Track) {
+      if (rejectNotPropagatedTrks && track.trackType() != aod::track::Track) {
         continue;
       }
+      skip_track = false;
       for (auto i : particlesToReject) {
         // if satisfied, want to continue in the upper loop (over tracks) -- skip the current track
         // cannot use simple 'continue' since it will be applied to the current loop, so have to use a flag
@@ -216,25 +217,179 @@ struct singleTrackSelector {
     }
   }
 
-  void processData(soa::Filtered<Coll>::iterator const& collision, soa::Filtered<Trks> const& tracks, aod::BCsWithTimestamps const&)
+  void processDataRun2(soa::Filtered<CollRun2>::iterator const& collision, soa::Filtered<Trks> const& tracks, aod::BCsWithTimestamps const&)
   {
-
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     initCCDB(bc);
 
-    fillTheTables<false>(collision, tracks);
+    int multValue = -1;
+
+    switch (multTableToUse) {
+      case 0:
+        multValue = collision.multTPC();
+        break;
+      case 1:
+        multValue = collision.multNTracksPV();
+        break;
+      case 2:
+        multValue = collision.multNTracksPVeta1();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for mult. estimator has been choosen. Please check.");
+        break;
+    }
+
+    tableRowColl(multValue,
+                 collision.centRun2V0M(),
+                 collision.posZ(),
+                 d_bz);
+
+    fillTrackTables<false>(tracks);
   }
-  PROCESS_SWITCH(singleTrackSelector, processData, "process data", true);
+  PROCESS_SWITCH(singleTrackSelector, processDataRun2, "process data Run2", false);
 
-  void processMC(soa::Filtered<Coll>::iterator const& collision, soa::Filtered<soa::Join<Trks, aod::McTrackLabels>> const& tracks, aod::McParticles const&, aod::BCsWithTimestamps const&)
+  void processDataRun3(soa::Filtered<CollRun3>::iterator const& collision, soa::Filtered<Trks> const& tracks, aod::BCsWithTimestamps const&)
   {
-
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     initCCDB(bc);
 
-    fillTheTables<true>(collision, tracks);
+    float centValue = -100.0f;
+    int multValue = -1;
+
+    switch (centTableToUse) {
+      case 0:
+        centValue = collision.centFV0A();
+        break;
+      case 1:
+        centValue = collision.centFT0M();
+        break;
+      case 2:
+        centValue = collision.centFT0A();
+        break;
+      case 3:
+        centValue = collision.centFT0C();
+        break;
+      case 4:
+        centValue = collision.centFDDM();
+        break;
+      case 5:
+        centValue = collision.centNTPV();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for cent./mult.perc. estimator has been choosen. Please check.");
+        break;
+    }
+
+    switch (multTableToUse) {
+      case 0:
+        multValue = collision.multTPC();
+        break;
+      case 1:
+        multValue = collision.multNTracksPV();
+        break;
+      case 2:
+        multValue = collision.multNTracksPVeta1();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for mult. estimator has been choosen. Please check.");
+        break;
+    }
+
+    tableRowColl(multValue,
+                 centValue,
+                 collision.posZ(),
+                 d_bz);
+
+    fillTrackTables<false>(tracks);
   }
-  PROCESS_SWITCH(singleTrackSelector, processMC, "process MC", false);
+  PROCESS_SWITCH(singleTrackSelector, processDataRun3, "process data Run3", true);
+
+  void processMCRun2(soa::Filtered<CollRun2>::iterator const& collision, soa::Filtered<soa::Join<Trks, aod::McTrackLabels>> const& tracks, aod::McParticles const&, aod::BCsWithTimestamps const&)
+  {
+    auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+    initCCDB(bc);
+
+    int multValue = -1;
+
+    switch (multTableToUse) {
+      case 0:
+        multValue = collision.multTPC();
+        break;
+      case 1:
+        multValue = collision.multNTracksPV();
+        break;
+      case 2:
+        multValue = collision.multNTracksPVeta1();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for mult. estimator has been choosen. Please check.");
+        break;
+    }
+
+    tableRowColl(multValue,
+                 collision.centRun2V0M(),
+                 collision.posZ(),
+                 d_bz);
+
+    fillTrackTables<true>(tracks);
+  }
+  PROCESS_SWITCH(singleTrackSelector, processMCRun2, "process MC Run2", false);
+
+  void processMCRun3(soa::Filtered<CollRun3>::iterator const& collision, soa::Filtered<soa::Join<Trks, aod::McTrackLabels>> const& tracks, aod::McParticles const&, aod::BCsWithTimestamps const&)
+  {
+    auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+    initCCDB(bc);
+
+    float centValue = -100.0f;
+    int multValue = -1;
+
+    switch (centTableToUse) {
+      case 0:
+        centValue = collision.centFV0A();
+        break;
+      case 1:
+        centValue = collision.centFT0M();
+        break;
+      case 2:
+        centValue = collision.centFT0A();
+        break;
+      case 3:
+        centValue = collision.centFT0C();
+        break;
+      case 4:
+        centValue = collision.centFDDM();
+        break;
+      case 5:
+        centValue = collision.centNTPV();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for cent./mult.perc. estimator has been choosen. Please check.");
+        break;
+    }
+
+    switch (multTableToUse) {
+      case 0:
+        multValue = collision.multTPC();
+        break;
+      case 1:
+        multValue = collision.multNTracksPV();
+        break;
+      case 2:
+        multValue = collision.multNTracksPVeta1();
+        break;
+      default:
+        LOGF(fatal, "Invalid flag for mult. estimator has been choosen. Please check.");
+        break;
+    }
+
+    tableRowColl(multValue,
+                 centValue,
+                 collision.posZ(),
+                 d_bz);
+
+    fillTrackTables<true>(tracks);
+  }
+  PROCESS_SWITCH(singleTrackSelector, processMCRun3, "process MC Run3", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
@@ -57,13 +57,13 @@ struct FemtoCorrelations {
   Configurable<float> _vertexZ{"VertexZ", 10.0, "abs vertexZ value limit"};
 
   Configurable<int> _sign_1{"sign_1", 1, "sign of the first particle in a pair"};
-  Configurable<int> _particlePDG_1{"particlePDG_1", 2212, "PDG code of the first particle in a pair to perform PID for (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDG_1{"particlePDG_1", 2212, "PDG code of the first particle in a pair to perform PID for (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _tpcNSigma_1{"tpcNSigma_1", std::vector<float>{-3.0f, 3.0f}, "first particle PID: Nsigma range in TPC before the TOF is used"};
   Configurable<float> _PIDtrshld_1{"PIDtrshld_1", 10.0, "first particle PID: value of momentum from which the PID is done with TOF (before that only TPC is used)"};
   Configurable<std::vector<float>> _tofNSigma_1{"tofNSigma_1", std::vector<float>{-3.0f, 3.0f}, "first particle PID: Nsigma range in TOF"};
 
   Configurable<int> _sign_2{"sign_2", 1, "sign of the second particle in a pair"};
-  Configurable<int> _particlePDG_2{"particlePDG_2", 2212, "PDG code of the second particle in a pair to perform PID for (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDG_2{"particlePDG_2", 2212, "PDG code of the second particle in a pair to perform PID for (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _tpcNSigma_2{"tpcNSigma_2", std::vector<float>{-3.0f, 3.0f}, "second particle PID: Nsigma range in TPC before the TOF is used"};
   Configurable<float> _PIDtrshld_2{"PIDtrshld_2", 10.0, "second particle PID: value of momentum from which the PID is done with TOF (before that only TPC is used)"};
   Configurable<std::vector<float>> _tofNSigma_2{"tofNSigma_2", std::vector<float>{-3.0f, 3.0f}, "second particle PID: Nsigma range in TOF"};
@@ -80,6 +80,9 @@ struct FemtoCorrelations {
   Configurable<int> _multNsubBins{"multSubBins", 1, "number of sub-bins to perform the mixing within"};
   Configurable<std::vector<float>> _kTbins{"kTbins", std::vector<float>{0.0f, 100.0f}, "pair transverse momentum kT binning"};
   ConfigurableAxis CFkStarBinning{"CFkStarBinning", {500, 0.005, 5.005}, "k* binning of the CF (Nbins, lowlimit, uplimit)"};
+
+  Configurable<bool> _fill3dCF{"fill3dCF", false, "flag for filling 3D LCMS histos: true -- fill; false -- not"};
+  ConfigurableAxis CF3DkStarBinning{"CF3DkStarBinning", {100, -0.25, 0.25}, "k* binning of the CF 3D in LCMS (Nbins, lowlimit, uplimit)"};
 
   bool IsIdentical;
 
@@ -117,8 +120,12 @@ struct FemtoCorrelations {
 
   std::vector<std::shared_ptr<TH1>> MultHistos;
   std::vector<std::vector<std::shared_ptr<TH1>>> kThistos;
-  std::vector<std::vector<std::shared_ptr<TH1>>> SEhistos;
-  std::vector<std::vector<std::shared_ptr<TH1>>> MEhistos;
+  std::vector<std::vector<std::shared_ptr<TH1>>> SEhistos_1D;
+  std::vector<std::vector<std::shared_ptr<TH1>>> MEhistos_1D;
+
+  std::vector<std::vector<std::shared_ptr<TH3>>> SEhistos_3D;
+  std::vector<std::vector<std::shared_ptr<TH3>>> MEhistos_3D;
+  std::vector<std::vector<std::shared_ptr<TH3>>> kStarVSkStar3D;
 
   void init(o2::framework::InitContext&)
   {
@@ -141,28 +148,44 @@ struct FemtoCorrelations {
     TPCcuts_2 = std::make_pair(_particlePDG_2, _tpcNSigma_2);
     TOFcuts_2 = std::make_pair(_particlePDG_2, _tofNSigma_2);
 
-    const AxisSpec kStarAxis{CFkStarBinning, "k* (GeV/c)"};
-
     for (int i = 0; i < _centBins.value.size() - 1; i++) {
-      std::vector<std::shared_ptr<TH1>> SEperMult;
-      std::vector<std::shared_ptr<TH1>> MEperMult;
+      std::vector<std::shared_ptr<TH1>> SEperMult_1D;
+      std::vector<std::shared_ptr<TH1>> MEperMult_1D;
       std::vector<std::shared_ptr<TH1>> kTperMult;
 
-      auto hMult = registry.add<TH1>(Form("Cent%i/Mult_vs_cent%i", i, i), Form("Mult_vs_cent%i", i), kTH1F, {{5001, -0.5, 5000.5, "Nch"}});
+      auto hMult = registry.add<TH1>(Form("Cent%i/TPCMult_cent%i", i, i), Form("TPCMult_cent%i", i), kTH1F, {{5001, -0.5, 5000.5, "Mult."}});
       MultHistos.push_back(std::move(hMult));
 
       for (int j = 0; j < _kTbins.value.size() - 1; j++) {
-        auto hSE = registry.add<TH1>(Form("Cent%i/SE_cent%i_kT%i", i, i, j), Form("SE_cent%i_kT%i", i, j), kTH1F, {kStarAxis});
-        auto hME = registry.add<TH1>(Form("Cent%i/ME_cent%i_kT%i", i, i, j), Form("ME_cent%i_kT%i", i, j), kTH1F, {kStarAxis});
+        auto hSE_1D = registry.add<TH1>(Form("Cent%i/SE_1D_cent%i_kT%i", i, i, j), Form("SE_1D_cent%i_kT%i", i, j), kTH1F, {{CFkStarBinning, "k* (GeV/c)"}});
+        auto hME_1D = registry.add<TH1>(Form("Cent%i/ME_1D_cent%i_kT%i", i, i, j), Form("ME_1D_cent%i_kT%i", i, j), kTH1F, {{CFkStarBinning, "k* (GeV/c)"}});
         auto hkT = registry.add<TH1>(Form("Cent%i/kT_cent%i_kT%i", i, i, j), Form("kT_cent%i_kT%i", i, j), kTH1F, {{500, 0., 5., "kT"}});
-        SEperMult.push_back(std::move(hSE));
-        MEperMult.push_back(std::move(hME));
+        SEperMult_1D.push_back(std::move(hSE_1D));
+        MEperMult_1D.push_back(std::move(hME_1D));
         kTperMult.push_back(std::move(hkT));
       }
 
-      SEhistos.push_back(std::move(SEperMult));
-      MEhistos.push_back(std::move(MEperMult));
+      SEhistos_1D.push_back(std::move(SEperMult_1D));
+      MEhistos_1D.push_back(std::move(MEperMult_1D));
       kThistos.push_back(std::move(kTperMult));
+
+      if (_fill3dCF) {
+        std::vector<std::shared_ptr<TH3>> SEperMult_3D;
+        std::vector<std::shared_ptr<TH3>> MEperMult_3D;
+        std::vector<std::shared_ptr<TH3>> kStarVSkStar3DperMult;
+
+        for (int j = 0; j < _kTbins.value.size() - 1; j++) {
+          auto hSE_3D = registry.add<TH3>(Form("Cent%i/SE_3D_cent%i_kT%i", i, i, j), Form("SE_3D_cent%i_kT%i", i, j), kTH3F, {{CF3DkStarBinning, "k*_out (GeV/c)"}, {CF3DkStarBinning, "k*_side (GeV/c)"}, {CF3DkStarBinning, "k*_long (GeV/c)"}});
+          auto hME_3D = registry.add<TH3>(Form("Cent%i/ME_3D_cent%i_kT%i", i, i, j), Form("ME_3D_cent%i_kT%i", i, j), kTH3F, {{CF3DkStarBinning, "k*_out (GeV/c)"}, {CF3DkStarBinning, "k*_side (GeV/c)"}, {CF3DkStarBinning, "k*_long (GeV/c)"}});
+          auto hkStarVSkStar3D = registry.add<TH3>(Form("Cent%i/kStarVSkStar3D_cent%i_kT%i", i, i, j), Form("kStarVSkStar3D_3D_cent%i_kT%i", i, j), kTH3F, {{CF3DkStarBinning, "k*_out (GeV/c)"}, {CF3DkStarBinning, "k*_side (GeV/c)"}, {CF3DkStarBinning, "k*_long (GeV/c)"}});
+          SEperMult_3D.push_back(std::move(hSE_3D));
+          MEperMult_3D.push_back(std::move(hME_3D));
+          kStarVSkStar3DperMult.push_back(std::move(hkStarVSkStar3D));
+        }
+        SEhistos_3D.push_back(std::move(SEperMult_3D));
+        MEhistos_3D.push_back(std::move(MEperMult_3D));
+        kStarVSkStar3D.push_back(std::move(kStarVSkStar3DperMult));
+      }
     }
 
     registry.add("p_first", Form("p_%i", static_cast<int>(_particlePDG_1)), kTH1F, {{100, 0., 5., "p"}});
@@ -178,8 +201,14 @@ struct FemtoCorrelations {
   template <typename Type>
   void mixTracks(Type const& tracks, int multBin)
   { // template for identical particles from the same collision
-    if (multBin < 0 && multBin > SEhistos.size())
-      LOGF(fatal, "multBin value passed to the mixTracks function is less than 0 or exceeds the configured number of Cent. bins");
+    if (multBin >= 0) {
+      if (multBin > SEhistos_1D.size())
+        LOGF(fatal, "multBin value passed to the mixTracks function exceeds the configured number of Cent. bins (1D)");
+      if (_fill3dCF && multBin > SEhistos_3D.size())
+        LOGF(fatal, "multBin value passed to the mixTracks function exceeds the configured number of Cent. bins (3D)");
+    } else {
+      LOGF(fatal, "multBin value passed to the mixTracks function is less than 0");
+    }
 
     for (int ii = 0; ii < tracks.size(); ii++) { // nested loop for all the combinations
       for (int iii = ii + 1; iii < tracks.size(); iii++) {
@@ -187,12 +216,23 @@ struct FemtoCorrelations {
         Pair->SetPair(tracks[ii], tracks[iii]);
         float pair_kT = Pair->GetKt();
         int kTbin = o2::aod::singletrackselector::getBinIndex<int>(pair_kT, _kTbins);
-        if (kTbin < 0 && kTbin > SEhistos[multBin].size())
-          LOGF(fatal, "kTbin value obtained for a pair is less than 0 or exceeds the configured number of kT bins");
+        if (kTbin >= 0) {
+          if (kTbin > SEhistos_1D[multBin].size())
+            LOGF(fatal, "kTbin value obtained for a pair exceeds the configured number of kT bins (1D)");
+          if (_fill3dCF && kTbin > SEhistos_3D[multBin].size())
+            LOGF(fatal, "kTbin value obtained for a pair exceeds the configured number of kT bins (3D)");
+        } else {
+          LOGF(fatal, "kTbin value obtained for a pair is less than 0");
+        }
 
         if (!Pair->IsClosePair(_deta, _dphi, _radiusTPC)) {
           kThistos[multBin][kTbin]->Fill(pair_kT);
-          SEhistos[multBin][kTbin]->Fill(Pair->GetKstar()); // close pair rejection and fillig the SE histo
+          SEhistos_1D[multBin][kTbin]->Fill(Pair->GetKstar()); // close pair rejection and fillig the SE histo
+
+          if (_fill3dCF) {
+            TVector3 KstarLCMS = Pair->Get3dKstar();
+            SEhistos_3D[multBin][kTbin]->Fill(KstarLCMS.X(), KstarLCMS.Y(), KstarLCMS.Z());
+          }
         }
         Pair->ResetPair();
       }
@@ -202,8 +242,14 @@ struct FemtoCorrelations {
   template <int SE_or_ME, typename Type>
   void mixTracks(Type const& tracks1, Type const& tracks2, int multBin)
   { // last value: 0 -- SE; 1 -- ME
-    if (multBin < 0 && multBin > SEhistos.size())
-      LOGF(fatal, "multBin value passed to the mixTracks function is less than 0 or exceeds the configured number of Cent. bins");
+    if (multBin >= 0) {
+      if (multBin > SEhistos_1D.size())
+        LOGF(fatal, "multBin value passed to the mixTracks function exceeds the configured number of Cent. bins (1D)");
+      if (_fill3dCF && multBin > SEhistos_3D.size())
+        LOGF(fatal, "multBin value passed to the mixTracks function exceeds the configured number of Cent. bins (3D)");
+    } else {
+      LOGF(fatal, "multBin value passed to the mixTracks function is less than 0");
+    }
 
     for (auto ii : tracks1) {
       for (auto iii : tracks2) {
@@ -211,15 +257,32 @@ struct FemtoCorrelations {
         Pair->SetPair(ii, iii);
         float pair_kT = Pair->GetKt();
         int kTbin = o2::aod::singletrackselector::getBinIndex<int>(pair_kT, _kTbins);
-        if (kTbin < 0 && kTbin > SEhistos[multBin].size())
-          LOGF(fatal, "kTbin value obtained for a pair is less than 0 or exceeds the configured number of kT bins");
+        if (kTbin >= 0) {
+          if (kTbin > SEhistos_1D[multBin].size())
+            LOGF(fatal, "kTbin value obtained for a pair exceeds the configured number of kT bins (1D)");
+          if (_fill3dCF && kTbin > SEhistos_3D[multBin].size())
+            LOGF(fatal, "kTbin value obtained for a pair exceeds the configured number of kT bins (3D)");
+        } else {
+          LOGF(fatal, "kTbin value obtained for a pair is less than 0");
+        }
 
         if (!Pair->IsClosePair(_deta, _dphi, _radiusTPC)) {
           if (!SE_or_ME) {
-            SEhistos[multBin][kTbin]->Fill(Pair->GetKstar());
+            SEhistos_1D[multBin][kTbin]->Fill(Pair->GetKstar());
             kThistos[multBin][kTbin]->Fill(pair_kT);
+
+            if (_fill3dCF) {
+              TVector3 KstarLCMS = Pair->Get3dKstar();
+              SEhistos_3D[multBin][kTbin]->Fill(KstarLCMS.X(), KstarLCMS.Y(), KstarLCMS.Z());
+            }
           } else {
-            MEhistos[multBin][kTbin]->Fill(Pair->GetKstar());
+            MEhistos_1D[multBin][kTbin]->Fill(Pair->GetKstar());
+
+            if (_fill3dCF) {
+              TVector3 KstarLCMS = Pair->Get3dKstar();
+              MEhistos_3D[multBin][kTbin]->Fill(KstarLCMS.X(), KstarLCMS.Y(), KstarLCMS.Z());
+              kStarVSkStar3D[multBin][kTbin]->Fill(KstarLCMS.X(), KstarLCMS.Y(), KstarLCMS.Z(), Pair->GetKstar());
+            }
           }
         }
         Pair->ResetPair();

--- a/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
@@ -57,13 +57,13 @@ struct FemtoCorrelationsMC {
   Configurable<float> _vertexZ{"VertexZ", 10.0, "abs vertexZ value limit"};
 
   Configurable<int> _sign_1{"sign_1", 1, "sign of the first particle in a pair"};
-  Configurable<int> _particlePDG_1{"particlePDG_1", 2212, "PDG code of the first particle in a pair to perform PID for (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDG_1{"particlePDG_1", 2212, "PDG code of the first particle in a pair to perform PID for (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _tpcNSigma_1{"tpcNSigma_1", std::vector<float>{-3.0f, 3.0f}, "first particle PID: Nsigma range in TPC before the TOF is used"};
   Configurable<float> _PIDtrshld_1{"PIDtrshld_1", 10.0, "first particle PID: value of momentum from which the PID is done with TOF (before that only TPC is used)"};
   Configurable<std::vector<float>> _tofNSigma_1{"tofNSigma_1", std::vector<float>{-3.0f, 3.0f}, "first particle PID: Nsigma range in TOF"};
 
   Configurable<int> _sign_2{"sign_2", 1, "sign of the second particle in a pair"};
-  Configurable<int> _particlePDG_2{"particlePDG_2", 2212, "PDG code of the second particle in a pair to perform PID for (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDG_2{"particlePDG_2", 2212, "PDG code of the second particle in a pair to perform PID for (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _tpcNSigma_2{"tpcNSigma_2", std::vector<float>{-3.0f, 3.0f}, "second particle PID: Nsigma range in TPC before the TOF is used"};
   Configurable<float> _PIDtrshld_2{"PIDtrshld_2", 10.0, "second particle PID: value of momentum from which the PID is done with TOF (before that only TPC is used)"};
   Configurable<std::vector<float>> _tofNSigma_2{"tofNSigma_2", std::vector<float>{-3.0f, 3.0f}, "second particle PID: Nsigma range in TOF"};

--- a/PWGCF/Femto3D/Tasks/femto3dQA.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dQA.cxx
@@ -53,12 +53,12 @@ struct QAHistograms {
   Configurable<int> _tpcNClsShared{"maxTpcNClsShared", 0, "maximum allowed number of TPC shared clasters"};
   Configurable<int> _itsNCls{"minItsNCls", 0, "minimum allowed number of ITS clasters for a track"};
   Configurable<float> _itsChi2NCl{"itsChi2NCl", 100.0, "upper limit for chi2 value of a fit over ITS clasters for a track"};
-  Configurable<int> _particlePDG{"particlePDG", 2212, "PDG code of a particle to perform PID for (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDG{"particlePDG", 2212, "PDG code of a particle to perform PID for (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _tpcNSigma{"tpcNSigma", std::vector<float>{-4.0f, 4.0f}, "Nsigma range in TPC before the TOF is used"};
   Configurable<float> _PIDtrshld{"PIDtrshld", 10.0, "value of momentum from which the PID is done with TOF (before that only TPC is used)"};
   Configurable<std::vector<float>> _tofNSigma{"tofNSigma", std::vector<float>{-4.0f, 4.0f}, "Nsigma range in TOF"};
 
-  Configurable<int> _particlePDGtoReject{"particlePDGtoReject", 211, "PDG codes of perticles that will be rejected with TOF (only proton and deurton are supported now)"};
+  Configurable<int> _particlePDGtoReject{"particlePDGtoReject", 211, "PDG codes of perticles that will be rejected with TOF (only pion, kaon, proton and deurton are supported now)"};
   Configurable<std::vector<float>> _rejectWithinNsigmaTOF{"rejectWithinNsigmaTOF", std::vector<float>{-0.0f, 0.0f}, "TOF rejection Nsigma range for particles specified with PDG to be rejected"};
 
   std::pair<int, std::vector<float>> TPCcuts;


### PR DESCRIPTION
Dear @victor-gonzalez,

In this commit:

1. "femto3dPairTask": we're adding the calculation of the 3D k* in the LCMS and filling the corresponding histograms.
2. "singleTrackSelector": adding the options to choose cent. & must. estimators, cut on TOFchi2 and options to run on the Run2 data to perform the comparison of 3D femto characteristics calculation with results from a previous analysis.

Could you please approve the commit. Thank you.

Sincerely yours, Gleb.