### PR TITLE
PWGLF / strange derived data: rounding some vars for better disk use

### DIFF
--- a/PWGLF/TableProducer/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/cascadebuilder.cxx
@@ -188,9 +188,9 @@ struct cascadeBuilder {
   ConfigurableAxis axisTopoVarDCAToPV{"axisTopoVarDCAToPV", {200, -1, 1.0}, "single track DCA to PV (cm)"};
   ConfigurableAxis axisTopoVarDCAV0ToPV{"axisTopoVarDCAV0ToPV", {200, 0, 5.0}, "V0 DCA to PV (cm)"};
 
-  // round some V0 core variables up to a certain level of precision if requested 
+  // round some V0 core variables up to a certain level of precision if requested
   // useful to keep derived data sizes under control
-  // variables that are rounded include the DCAs but not the CosPA (precision needed) 
+  // variables that are rounded include the DCAs but not the CosPA (precision needed)
   Configurable<bool> roundDCAVariables{"roundDCAVariables", false, "round topological variables"};
   Configurable<float> precisionDCAs{"precisionDCAs", 0.01f, "precision to keep the DCAs with"};
 
@@ -279,21 +279,23 @@ struct cascadeBuilder {
      {"hNegativeITSClusters", "hNegativeITSClusters", {HistType::kTH1D, {{10, -0.5f, 9.5f}}}},
      {"hBachelorITSClusters", "hBachelorITSClusters", {HistType::kTH1D, {{10, -0.5f, 9.5f}}}}}};
 
-  float roundToPrecision( float number, float step = 0.01){
+  float roundToPrecision(float number, float step = 0.01)
+  {
     // this function rounds a certain number in an axis that is quantized by
     // the variable 'step'; the rounded number is placed halfway between
     // n*step and (n+1)*step such that analysis can be done with absolutely
     // no issue with precision 'step'.
-    return step*static_cast<float>(static_cast<int>((number)/step))+TMath::Sign(1.0f,number)*(0.5f)*step;
+    return step * static_cast<float>(static_cast<int>((number) / step)) + TMath::Sign(1.0f, number) * (0.5f) * step;
   }
 
-  void roundCascadeCandidateVariables(){ 
-    // Do not round actual cascade (pseudo-)track DCAs -> consider they may be tracked, high precision 
-    cascadecandidate.dcacascdau = roundToPrecision ( cascadecandidate.dcacascdau , precisionDCAs); 
-    cascadecandidate.v0dcadau = roundToPrecision ( cascadecandidate.v0dcadau , precisionDCAs); 
-    cascadecandidate.v0dcanegtopv = roundToPrecision ( cascadecandidate.v0dcanegtopv , precisionDCAs); 
-    cascadecandidate.v0dcapostopv = roundToPrecision ( cascadecandidate.v0dcapostopv , precisionDCAs); 
-    cascadecandidate.bachDCAxy = roundToPrecision ( cascadecandidate.bachDCAxy , precisionDCAs); 
+  void roundCascadeCandidateVariables()
+  {
+    // Do not round actual cascade (pseudo-)track DCAs -> consider they may be tracked, high precision
+    cascadecandidate.dcacascdau = roundToPrecision(cascadecandidate.dcacascdau, precisionDCAs);
+    cascadecandidate.v0dcadau = roundToPrecision(cascadecandidate.v0dcadau, precisionDCAs);
+    cascadecandidate.v0dcanegtopv = roundToPrecision(cascadecandidate.v0dcanegtopv, precisionDCAs);
+    cascadecandidate.v0dcapostopv = roundToPrecision(cascadecandidate.v0dcapostopv, precisionDCAs);
+    cascadecandidate.bachDCAxy = roundToPrecision(cascadecandidate.bachDCAxy, precisionDCAs);
   }
 
   void resetHistos()
@@ -1311,8 +1313,8 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
 
       // round the DCA variables to a certain precision if asked
-      if ( roundDCAVariables ) 
-        roundCascadeCandidateVariables(); 
+      if (roundDCAVariables)
+        roundCascadeCandidateVariables();
 
       cascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),
               cascadecandidate.positiveId, cascadecandidate.negativeId,
@@ -1374,8 +1376,8 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
 
       // round the DCA variables to a certain precision if asked
-      if ( roundDCAVariables ) 
-        roundCascadeCandidateVariables(); 
+      if (roundDCAVariables)
+        roundCascadeCandidateVariables();
 
       registry.fill(HIST("hKFParticleStatistics"), 2.0f);
 
@@ -1441,8 +1443,8 @@ struct cascadeBuilder {
         continue; // doesn't pass cascade selections
 
       // round the DCA variables to a certain precision if asked
-      if ( roundDCAVariables ) 
-        roundCascadeCandidateVariables(); 
+      if (roundDCAVariables)
+        roundCascadeCandidateVariables();
 
       // fill regular tables (no strangeness tracking)
       cascidx(/*cascadecandidate.v0Id, */ cascade.globalIndex(),

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -147,9 +147,9 @@ struct lambdakzeroBuilder {
   Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
   Configurable<bool> skipGRPOquery{"skipGRPOquery", true, "skip grpo query"};
 
-  // round some V0 core variables up to a certain level of precision if requested 
+  // round some V0 core variables up to a certain level of precision if requested
   // useful to keep derived data sizes under control
-  // variables that are rounded include the DCAs but not the CosPA (precision needed) 
+  // variables that are rounded include the DCAs but not the CosPA (precision needed)
   Configurable<bool> roundDCAVariables{"roundDCAVariables", false, "round topological variables"};
   Configurable<float> precisionDCAs{"precisionDCAs", 0.01f, "precision to keep the DCAs with"};
 
@@ -244,19 +244,21 @@ struct lambdakzeroBuilder {
     return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz));
   }
 
-  float roundToPrecision( float number, float step = 0.01){
+  float roundToPrecision(float number, float step = 0.01)
+  {
     // this function rounds a certain number in an axis that is quantized by
     // the variable 'step'; the rounded number is placed halfway between
     // n*step and (n+1)*step such that analysis can be done with absolutely
     // no issue with precision 'step'.
-    return step*static_cast<float>(static_cast<int>((number)/step))+TMath::Sign(1.0f,number)*(0.5f)*step;
+    return step * static_cast<float>(static_cast<int>((number) / step)) + TMath::Sign(1.0f, number) * (0.5f) * step;
   }
 
-  void roundV0CandidateVariables(){ 
-    v0candidate.dcaV0dau = roundToPrecision ( v0candidate.dcaV0dau , precisionDCAs); 
-    v0candidate.posDCAxy = roundToPrecision ( v0candidate.posDCAxy , precisionDCAs); 
-    v0candidate.negDCAxy = roundToPrecision ( v0candidate.negDCAxy , precisionDCAs); 
-    v0candidate.dcav0topv = roundToPrecision ( v0candidate.dcav0topv , precisionDCAs); 
+  void roundV0CandidateVariables()
+  {
+    v0candidate.dcaV0dau = roundToPrecision(v0candidate.dcaV0dau, precisionDCAs);
+    v0candidate.posDCAxy = roundToPrecision(v0candidate.posDCAxy, precisionDCAs);
+    v0candidate.negDCAxy = roundToPrecision(v0candidate.negDCAxy, precisionDCAs);
+    v0candidate.dcav0topv = roundToPrecision(v0candidate.dcav0topv, precisionDCAs);
   }
 
   void resetHistos()
@@ -817,8 +819,8 @@ struct lambdakzeroBuilder {
       }
 
       // round the DCA variables to a certain precision if asked
-      if ( roundDCAVariables ) 
-        roundV0CandidateVariables(); 
+      if (roundDCAVariables)
+        roundV0CandidateVariables();
 
       // V0 logic reminder
       // 0: v0 saved for the only due to the cascade, 1: standalone v0, 3: standard v0 with photon-only test

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -147,7 +147,13 @@ struct lambdakzeroBuilder {
   Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
   Configurable<bool> skipGRPOquery{"skipGRPOquery", true, "skip grpo query"};
 
-  // generate and fill extra QA histograms is requested
+  // round some V0 core variables up to a certain level of precision if requested 
+  // useful to keep derived data sizes under control
+  // variables that are rounded include the DCAs but not the CosPA (precision needed) 
+  Configurable<bool> roundDCAVariables{"roundDCAVariables", false, "round topological variables"};
+  Configurable<float> precisionDCAs{"precisionDCAs", 0.01f, "precision to keep the DCAs with"};
+
+  // generate and fill extra QA histograms if requested
   Configurable<bool> d_doQA{"d_doQA", false, "Do basic QA"};
   Configurable<int> dQANBinsRadius{"dQANBinsRadius", 500, "Number of radius bins in QA histo"};
   Configurable<int> dQANBinsPtCoarse{"dQANBinsPtCoarse", 10, "Number of pT bins in QA histo"};
@@ -236,6 +242,21 @@ struct lambdakzeroBuilder {
   float CalculateDCAStraightToPV(float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ)
   {
     return std::sqrt((std::pow((pvY - Y) * Pz - (pvZ - Z) * Py, 2) + std::pow((pvX - X) * Pz - (pvZ - Z) * Px, 2) + std::pow((pvX - X) * Py - (pvY - Y) * Px, 2)) / (Px * Px + Py * Py + Pz * Pz));
+  }
+
+  float roundToPrecision( float number, float step = 0.01){
+    // this function rounds a certain number in an axis that is quantized by
+    // the variable 'step'; the rounded number is placed halfway between
+    // n*step and (n+1)*step such that analysis can be done with absolutely
+    // no issue with precision 'step'.
+    return step*static_cast<float>(static_cast<int>((number)/step))+TMath::Sign(1.0f,number)*(0.5f)*step;
+  }
+
+  void roundV0CandidateVariables(){ 
+    v0candidate.dcaV0dau = roundToPrecision ( v0candidate.dcaV0dau , precisionDCAs); 
+    v0candidate.posDCAxy = roundToPrecision ( v0candidate.posDCAxy , precisionDCAs); 
+    v0candidate.negDCAxy = roundToPrecision ( v0candidate.negDCAxy , precisionDCAs); 
+    v0candidate.dcav0topv = roundToPrecision ( v0candidate.dcav0topv , precisionDCAs); 
   }
 
   void resetHistos()
@@ -795,9 +816,12 @@ struct lambdakzeroBuilder {
         continue; // doesn't pass selections
       }
 
+      // round the DCA variables to a certain precision if asked
+      if ( roundDCAVariables ) 
+        roundV0CandidateVariables(); 
+
       // V0 logic reminder
       // 0: v0 saved for the only due to the cascade, 1: standalone v0, 3: standard v0 with photon-only test
-
       if (V0.v0Type() > 0) {
         if (V0.v0Type() > 1 && !storePhotonCandidates)
           continue;

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -124,9 +124,9 @@ struct strangederivedbuilder {
 
   Configurable<bool> fillEmptyCollisions{"fillEmptyCollisions", false, "fill collision entries without candidates"};
 
-  // round Nsigma variables up to a certain level of precision if requested 
+  // round Nsigma variables up to a certain level of precision if requested
   // useful to keep derived data sizes under control
-  // variables that are rounded include the DCAs but not the CosPA (precision needed) 
+  // variables that are rounded include the DCAs but not the CosPA (precision needed)
   Configurable<bool> roundNSigmaVariables{"roundNSigmaVariables", false, "round NSigma variables"};
   Configurable<float> precisionNSigmas{"precisionNSigmas", 0.1f, "precision to keep NSigmas"};
 
@@ -138,12 +138,13 @@ struct strangederivedbuilder {
 
   int64_t currentCollIdx;
 
-  float roundToPrecision( float number, float step = 0.01){
+  float roundToPrecision(float number, float step = 0.01)
+  {
     // this function rounds a certain number in an axis that is quantized by
     // the variable 'step'; the rounded number is placed halfway between
     // n*step and (n+1)*step such that analysis can be done with absolutely
     // no issue with precision 'step'.
-    return step*static_cast<float>(static_cast<int>((number)/step))+TMath::Sign(1.0f,number)*(0.5f)*step;
+    return step * static_cast<float>(static_cast<int>((number) / step)) + TMath::Sign(1.0f, number) * (0.5f) * step;
   }
 
   void init(InitContext& context)
@@ -345,14 +346,14 @@ struct strangederivedbuilder {
                        tr.tpcNClsFound(), tr.tpcNClsCrossedRows());
 
         // round if requested
-        if( roundNSigmaVariables ){
-          dauTrackTPCPIDs(tr.tpcSignal(), 
-                          roundToPrecision ( tr.tpcNSigmaEl(), precisionNSigmas ),
-                          roundToPrecision ( tr.tpcNSigmaPi(), precisionNSigmas ),
-                          roundToPrecision ( tr.tpcNSigmaKa(), precisionNSigmas ),
-                          roundToPrecision ( tr.tpcNSigmaPr(), precisionNSigmas ),
-                          roundToPrecision ( tr.tpcNSigmaHe(), precisionNSigmas ));
-        }else{
+        if (roundNSigmaVariables) {
+          dauTrackTPCPIDs(tr.tpcSignal(),
+                          roundToPrecision(tr.tpcNSigmaEl(), precisionNSigmas),
+                          roundToPrecision(tr.tpcNSigmaPi(), precisionNSigmas),
+                          roundToPrecision(tr.tpcNSigmaKa(), precisionNSigmas),
+                          roundToPrecision(tr.tpcNSigmaPr(), precisionNSigmas),
+                          roundToPrecision(tr.tpcNSigmaHe(), precisionNSigmas));
+        } else {
           dauTrackTPCPIDs(tr.tpcSignal(), tr.tpcNSigmaEl(),
                           tr.tpcNSigmaPi(), tr.tpcNSigmaKa(),
                           tr.tpcNSigmaPr(), tr.tpcNSigmaHe());

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -124,6 +124,12 @@ struct strangederivedbuilder {
 
   Configurable<bool> fillEmptyCollisions{"fillEmptyCollisions", false, "fill collision entries without candidates"};
 
+  // round Nsigma variables up to a certain level of precision if requested 
+  // useful to keep derived data sizes under control
+  // variables that are rounded include the DCAs but not the CosPA (precision needed) 
+  Configurable<bool> roundNSigmaVariables{"roundNSigmaVariables", false, "round NSigma variables"};
+  Configurable<float> precisionNSigmas{"precisionNSigmas", 0.1f, "precision to keep NSigmas"};
+
   // For manual sliceBy
   Preslice<aod::V0Datas> V0perCollision = o2::aod::v0data::collisionId;
   Preslice<aod::CascDatas> CascperCollision = o2::aod::cascdata::collisionId;
@@ -131,6 +137,14 @@ struct strangederivedbuilder {
   Preslice<aod::TraCascDatas> TraCascperCollision = o2::aod::cascdata::collisionId;
 
   int64_t currentCollIdx;
+
+  float roundToPrecision( float number, float step = 0.01){
+    // this function rounds a certain number in an axis that is quantized by
+    // the variable 'step'; the rounded number is placed halfway between
+    // n*step and (n+1)*step such that analysis can be done with absolutely
+    // no issue with precision 'step'.
+    return step*static_cast<float>(static_cast<int>((number)/step))+TMath::Sign(1.0f,number)*(0.5f)*step;
+  }
 
   void init(InitContext& context)
   {
@@ -329,9 +343,20 @@ struct strangederivedbuilder {
       if (trackMap[tr.globalIndex()] >= 0) {
         dauTrackExtras(tr.detectorMap(), tr.itsClusterSizes(),
                        tr.tpcNClsFound(), tr.tpcNClsCrossedRows());
-        dauTrackTPCPIDs(tr.tpcSignal(), tr.tpcNSigmaEl(),
-                        tr.tpcNSigmaPi(), tr.tpcNSigmaKa(),
-                        tr.tpcNSigmaPr(), tr.tpcNSigmaHe());
+
+        // round if requested
+        if( roundNSigmaVariables ){
+          dauTrackTPCPIDs(tr.tpcSignal(), 
+                          roundToPrecision ( tr.tpcNSigmaEl(), precisionNSigmas ),
+                          roundToPrecision ( tr.tpcNSigmaPi(), precisionNSigmas ),
+                          roundToPrecision ( tr.tpcNSigmaKa(), precisionNSigmas ),
+                          roundToPrecision ( tr.tpcNSigmaPr(), precisionNSigmas ),
+                          roundToPrecision ( tr.tpcNSigmaHe(), precisionNSigmas ));
+        }else{
+          dauTrackTPCPIDs(tr.tpcSignal(), tr.tpcNSigmaEl(),
+                          tr.tpcNSigmaPi(), tr.tpcNSigmaKa(),
+                          tr.tpcNSigmaPr(), tr.tpcNSigmaHe());
+        }
       }
     }
     // done!


### PR DESCRIPTION
This PR adds an option (default: `false`) to round some variables that are never used to their full precision in analysis. The idea behind this is to make the resulting data, if saved to disk, much more compressible and therefore save space. 

Side note: the `float roundToPrecision( float number, float step = 0.01)` function could be generally useful to round variables before saving derived data AO2D. The idea is that it rounds a certain number in an axis that is quantized by the variable 'step'; the rounded number is placed halfway between n*step and (n+1)*step such that analysis can be done with absolutely no issue with precision 'step'. Maybe it could be placed in a utils header in the `Common` directory in a next iteration if it really pays off - I will test and see how well this works once this PR is merged... 