### PR TITLE
PWGHF: Change in number of pT Bins and selection criteria for d0SoftPiNormalised

### DIFF
--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -356,7 +356,7 @@ static const std::vector<std::string> labelsCutVar = {"m", "DCA", "cos theta*", 
 
 namespace hf_cuts_dstar_to_d0_pi
 {
-static constexpr int nBinsPt = 10;
+static constexpr int nBinsPt = 23;
 static constexpr int nCutVars = 8;
 // default values for the pT bin edges (can be used to configure histogram axis)
 // offset by 1 from the bin numbers in cuts array
@@ -371,7 +371,20 @@ constexpr double binsPt[nBinsPt + 1] = {
   4.5,
   5.0,
   5.5,
-  6.0};
+  6.0,
+  6.5,
+  7.0,
+  7.5,
+  8.0,
+  9.0,
+  10.0,
+  12.0,
+  16.0,
+  20.0,
+  24.0,
+  36.0,
+  50.0,
+  100.0};
 auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
 
 // row labels
@@ -385,22 +398,48 @@ static const std::vector<std::string> labelsPt = {
   "pT bin 6",
   "pT bin 7",
   "pT bin 8",
-  "pT bin 9"};
+  "pT bin 9",
+  "pT bin 10",
+  "pT bin 11",
+  "pT bin 12",
+  "pT bin 13",
+  "pT bin 14",
+  "pT bin 15",
+  "pT bin 16",
+  "pT bin 17",
+  "pT bin 18",
+  "pT bin 19",
+  "pT bin 20",
+  "pT bin 21",
+  "pT bin 22"};
 
 // column label
 static const std::vector<std::string> labelsCutVar = {"ptSoftPiMin", "ptSoftPiMax", "d0SoftPi", "d0SoftPiNormalised", "deltaMInvDstar", "chi2PCA", "d0Prong0Normalised", "d0Prong1Normalised"};
 
 // default values for the cuts
-constexpr double cuts[nBinsPt][nCutVars] = {{0.05, 0.3, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.3, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.4, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.4, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.6, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.6, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 0.6, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 100, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 100, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5},
-                                            {0.05, 100, 0.1, 0.5, 0.2, 300.0, 0.5, 0.5}};
+constexpr double cuts[nBinsPt][nCutVars] = {{0.05, 0.3, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.3, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.4, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.4, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.6, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.6, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 0.6, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0},
+                                            {0.05, 100, 0.1, 0.0, 0.2, 300.0, 0.0, 0.0}};
 } // namespace hf_cuts_dstar_to_d0_pi
 
 namespace hf_cuts_lc_to_p_k_pi

--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -59,8 +59,8 @@ struct HfTaskDstarToD0Pi {
   {
     auto vecPtBins = (std::vector<double>)ptBins;
 
-    registry.add("Yield/hDeltaInvMassDstar2D", "#Delta #it{M}_{inv} D* Candidate; inv. mass (#pi #pi k) (GeV/#it{c}^{2});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{100, 0.13, 0.16}, {vecPtBins, "#it{p}_{T} (GeV/#it{c})"}}}, true);
-    registry.add("Yield/hDeltaInvMassDstar1D", "#Delta #it{M}_{inv} D* Candidate; inv. mass (#pi #pi k) (GeV/#it{c}^{2}); entries", {HistType::kTH1F, {{100, 0.13, 0.16}}}, true);
+    registry.add("Yield/hDeltaInvMassDstar2D", "#Delta #it{M}_{inv} D* Candidate; inv. mass ((#pi #pi k) - (#pi k)) (GeV/#it{c}^{2});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{100, 0.13, 0.16}, {vecPtBins, "#it{p}_{T} (GeV/#it{c})"}}}, true);
+    registry.add("Yield/hDeltaInvMassDstar1D", "#Delta #it{M}_{inv} D* Candidate; inv. mass ((#pi #pi k) - (#pi k)) (GeV/#it{c}^{2}); entries", {HistType::kTH1F, {{100, 0.13, 0.16}}}, true);
     registry.add("Yield/hInvMassDstar", "#Delta #it{M}_{inv} D* Candidate; inv. mass (#pi #pi k) (GeV/#it{c}^{2}); entries", {HistType::kTH1F, {{500, 0., 5.0}}}, true);
     registry.add("Yield/hInvMassD0", "#it{M}_{inv}D^{0} candidate;#it{M}_{inv} D^{0} (GeV/#it{c});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{500, 0., 5.0}, {vecPtBins, "#it{p}_{T} (GeV/#it{c})"}}}, true);
     // only QA

--- a/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
@@ -187,7 +187,7 @@ struct HfCandidateSelectorDstarToD0Pi {
     if (std::abs(candidate.impParamSoftPi()) > cutsDstar->get(binPt, "d0SoftPi")) {
       return false;
     }
-    if (std::abs(candidate.normalisedImpParamSoftPi()) > cutsDstar->get(binPt, "d0SoftPiNormalised")) {
+    if (std::abs(candidate.normalisedImpParamSoftPi()) < cutsDstar->get(binPt, "d0SoftPiNormalised")) {
       return false;
     }
     // selection on pT of soft Pi

--- a/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
@@ -187,7 +187,7 @@ struct HfCandidateSelectorDstarToD0Pi {
     if (std::abs(candidate.impParamSoftPi()) > cutsDstar->get(binPt, "d0SoftPi")) {
       return false;
     }
-    if (std::abs(candidate.normalisedImpParamSoftPi()) < cutsDstar->get(binPt, "d0SoftPiNormalised")) {
+    if (std::abs(candidate.normalisedImpParamSoftPi()) > cutsDstar->get(binPt, "d0SoftPiNormalised")) {
       return false;
     }
     // selection on pT of soft Pi


### PR DESCRIPTION
1. Increased number of pT bins for selected Dstar and D0 candidates
2. Inequality condition for ```d0SoftPiNormalised``` is corrected.