### PR TITLE
PWGDQ: Include selection on the muon track type on track-efficiency-uncertainty code

### DIFF
--- a/PWGDQ/DataModel/MchTrkEffTables.h
+++ b/PWGDQ/DataModel/MchTrkEffTables.h
@@ -32,11 +32,12 @@ DECLARE_SOA_COLUMN(MchBitMap, mchBitMap, uint16_t); //! mch bit map
 DECLARE_SOA_COLUMN(EtaGen, etaGen, float);          //! simulated eta
 DECLARE_SOA_COLUMN(PtGen, ptGen, float);            //! simulated pt
 DECLARE_SOA_COLUMN(PhiGen, phiGen, float);          //! simulated phi
+DECLARE_SOA_COLUMN(TrackType, trackType, int);      //! track type
 } // namespace mch_trk_eff
 
 // Table
 DECLARE_SOA_TABLE(MchTrkEffBase, "AOD", "MCHTRKEFFBASE", //! table with muon track properties and mch bit map
-                  mch_trk_eff::Eta, mch_trk_eff::Pt, mch_trk_eff::Phi, mch_trk_eff::MchBitMap);
+                  mch_trk_eff::Eta, mch_trk_eff::Pt, mch_trk_eff::Phi, mch_trk_eff::MchBitMap, mch_trk_eff::TrackType);
 
 DECLARE_SOA_TABLE(MchTrkEffGen, "AOD", "MCHTRKEFFGEN", //! table with simulated muon track properties
                   mch_trk_eff::EtaGen, mch_trk_eff::PtGen, mch_trk_eff::PhiGen);

--- a/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
+++ b/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
@@ -107,9 +107,10 @@ struct tableMakerMuonMchTrkEfficiency {
   Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};                   /// Event selection list
   Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonQualityCuts", "Comma separated list of muon cuts"}; /// List of muon selections
   ///
-  Configurable<double> ptMuonMin{"ptMin", 0., "Lower bound of pT"};       /// Muon minimum pt to be studied
-  Configurable<double> etaMuonMin{"etaMin", 2.5, "Lower bound of |eta|"}; /// Muon minimum |eta| to be studied
-  Configurable<double> etaMuonMax{"etaMax", 4.0, "Upper bound of |eta|"}; /// Muon maximum |eta| to be studied
+  Configurable<int> muonSelType{"muonSelType", -1, "Selected muon track type"}; /// Muon track type to be selected if value >=0 (no selection by default)
+  Configurable<double> ptMuonMin{"ptMin", 0., "Lower bound of pT"};             /// Muon minimum pt to be studied
+  Configurable<double> etaMuonMin{"etaMin", 2.5, "Lower bound of |eta|"};       /// Muon minimum |eta| to be studied
+  Configurable<double> etaMuonMax{"etaMax", 4.0, "Upper bound of |eta|"};       /// Muon maximum |eta| to be studied
   ///
   Configurable<std::vector<double>> binsMuonPt{"binsPt", std::vector<double>{muon_trk_eff_bins::vecBinsPt}, "pT bin limits"}; /// Pt intervals for the histograms
   Configurable<int> nEtaBins{"nEtaBins", 12, "Number of Eta bins"};                                                           /// Number of eta bins for output histograms
@@ -420,6 +421,7 @@ struct tableMakerMuonMchTrkEfficiency {
       VarManager::FillTrack<TMuonFillMap>(muon);
 
       LOGF(debug, "  %i / %f / %f / %f", muon.trackType(), muon.eta(), muon.pt(), muon.p());
+      int mType = muon.trackType();
       double mPt = muon.pt();
       double mEta = TMath::Abs(muon.eta());
       double mPhi = muon.phi();
@@ -445,11 +447,14 @@ struct tableMakerMuonMchTrkEfficiency {
       bool isKineAcc = IsInKinematics(mEta, mPt);
       if (!isKineAcc)
         isMuonSelectedAny = false;
-
+      if (muonSelType >= 0) {
+        if (mType != muonSelType)
+          isMuonSelectedAny = false;
+      }
       FillHistos(mEta, mPhi, mPt, mchBitmap, isMuonSelectedAny);
 
       if (isMuonSelectedAny)
-        rowCandidateBase(mEta, mPt, mPhi, mchBitmap);
+        rowCandidateBase(mEta, mPt, mPhi, mchBitmap, mType);
 
     } // end loop on muons
     LOGF(debug, "end muon loop");
@@ -528,6 +533,7 @@ struct tableMakerMuonMchTrkEfficiency {
       VarManager::FillTrack<TMuonFillMap>(muon);
 
       LOGF(debug, "  %i / %f / %f / %f", muon.trackType(), muon.eta(), muon.pt(), muon.p());
+      int mType = muon.trackType();
       double mPt = muon.pt();
       double mEta = TMath::Abs(muon.eta());
       double mPhi = muon.phi();
@@ -551,13 +557,16 @@ struct tableMakerMuonMchTrkEfficiency {
       bool isKineAcc = IsInKinematics(mEta, mPt);
       if (!isKineAcc)
         isMuonSelectedAny = false;
-
+      if (muonSelType >= 0) {
+        if (mType != muonSelType)
+          isMuonSelectedAny = false;
+      }
       /// fill histograms
       FillHistos(mEta, mPhi, mPt, mchBitmap, isMuonSelectedAny);
       FillHistosMC(mEta, mPhi, mPt, mchBitmap, isMuonSelectedAny, mGenEta, mGenPt, mGenPhi);
 
       if (isMuonSelectedAny) {
-        rowCandidateBase(mEta, mPt, mPhi, mchBitmap);
+        rowCandidateBase(mEta, mPt, mPhi, mchBitmap, mType);
         rowCandidateGen(mGenEta, mGenPt, mGenPhi);
       }
 

--- a/PWGDQ/Tasks/taskMuonMchTrkEfficiency.cxx
+++ b/PWGDQ/Tasks/taskMuonMchTrkEfficiency.cxx
@@ -74,6 +74,8 @@ static const std::vector<std::string> labelsPtTrack{
 
 struct taskMuonMchTrkEfficiency {
 
+  Configurable<int> muonSelType{"muonSelType", 4, "Selected muon track type"}; /// Muon track type to be selected if value >=0 (no selection by default)
+
   Configurable<double> ptMuonMin{"ptMin", 0., "Lower bound of pT"};       /// Muon minimum pt to be studied
   Configurable<double> etaMuonMin{"etaMin", 2.5, "Lower bound of |eta|"}; /// Muon minimum |eta| to be studied
   Configurable<double> etaMuonMax{"etaMax", 4.0, "Upper bound of |eta|"}; /// Muon maximum |eta| to be studied
@@ -219,7 +221,14 @@ struct taskMuonMchTrkEfficiency {
   void processReco(aod::MchTrkEffBase const& mchtrkeffbases)
   {
     for (auto& mchtrkeffbase : mchtrkeffbases) {
-      if (IsInKinematics(mchtrkeffbase.eta(), mchtrkeffbase.pt()))
+      bool isSel = true;
+      if (!IsInKinematics(mchtrkeffbase.eta(), mchtrkeffbase.pt()))
+        isSel = false;
+      if (muonSelType >= 0) {
+        if (mchtrkeffbase.trackType() != muonSelType)
+          isSel = false;
+      }
+      if (isSel)
         FillHistos(mchtrkeffbase.eta(), mchtrkeffbase.pt(), mchtrkeffbase.phi(), mchtrkeffbase.mchBitMap());
     }
   }
@@ -233,7 +242,7 @@ struct taskMuonMchTrkEfficiency {
         FillHistosMC(mchtrkeffbase.eta(), mchtrkeffbase.pt(), mchtrkeffbase.phi(), mchtrkeffbase.mchBitMap(), mchtrkeffbase.etaGen(), mchtrkeffbase.ptGen(), mchtrkeffbase.phiGen());
     }
   }
-  PROCESS_SWITCH(taskMuonMchTrkEfficiency, processSim, "process reconstructed information", false);
+  PROCESS_SWITCH(taskMuonMchTrkEfficiency, processSim, "process simulated information", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
This patch includes the option to select the track type in the analysis of the track efficiency uncertainty.