### PR TITLE
PWGCF: process switch MC without centrality

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
@@ -131,15 +131,15 @@ class FemtoDreamCollisionSelection
   /// \tparam T type of the collision
   /// \param col Collision
   template <typename T>
-  void fillQA(T const& col)
+  void fillQA(T const& col, float cent)
   {
     if (mHistogramRegistry) {
       mHistogramRegistry->fill(HIST("Event/Zvtx"), col.posZ());
       mHistogramRegistry->fill(HIST("Event/MultNTracksPV"), col.multNTracksPV());
       mHistogramRegistry->fill(HIST("Event/MultTPC"), col.multTPC());
       if (mCheckIsRun3) {
-        mHistogramRegistry->fill(HIST("Event/MultPercentile"), col.centFT0M());
-        mHistogramRegistry->fill(HIST("Event/MultPercentileVSMultNTracksPV"), col.centFT0M(), col.multNTracksPV());
+        mHistogramRegistry->fill(HIST("Event/MultPercentile"), cent);
+        mHistogramRegistry->fill(HIST("Event/MultPercentileVSMultNTracksPV"), cent, col.multNTracksPV());
       } else {
         mHistogramRegistry->fill(HIST("Event/MultNTracklets"), col.multTracklets());
       }

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -225,11 +225,11 @@ struct femtoDreamProducerReducedTask {
     int mult = 0;
     int multNtr = 0;
     if (ConfIsRun3) {
-      if constexpr (useCentrality){
+      if constexpr (useCentrality) {
         mult = col.centFT0M();
       } else {
         mult = 0.;
-      } 
+      }
       multNtr = col.multNTracksPV();
     } else {
       mult = 1; // multiplicity percentile is known in Run 2
@@ -314,7 +314,7 @@ struct femtoDreamProducerReducedTask {
     fillCollisionsAndTracks<false, true>(col, tracks);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processData, "Provide experimental data", true);
-  
+
   void processMC(aod::FemtoFullCollisionMC const& col,
                  aod::BCsWithTimestamps const&,
                  soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
@@ -328,9 +328,9 @@ struct femtoDreamProducerReducedTask {
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processMC, "Provide MC data", false);
 
   void processMC_noCentrality(aod::FemtoFullCollision_noCent_MC const& col,
-                 aod::BCsWithTimestamps const&,
-                 soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                 aod::McCollisions const& mcCollisions, aod::McParticles const& mcParticles)
+                              aod::BCsWithTimestamps const&,
+                              soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                              aod::McCollisions const& mcCollisions, aod::McParticles const& mcParticles)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -47,6 +47,7 @@ namespace o2::aod
 
 using FemtoFullCollision = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms>::iterator;
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::McCollisionLabels>::iterator;
+using FemtoFullCollision_noCent_MC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 
 using FemtoFullTracks = soa::Join<aod::FullTracks, aod::TracksDCA,
                                   aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
@@ -214,7 +215,7 @@ struct femtoDreamProducerReducedTask {
     }
   }
 
-  template <bool isMC, typename CollisionType, typename TrackType>
+  template <bool isMC, bool useCentrality, typename CollisionType, typename TrackType>
   void fillCollisionsAndTracks(CollisionType const& col, TrackType const& tracks) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
@@ -224,7 +225,11 @@ struct femtoDreamProducerReducedTask {
     int mult = 0;
     int multNtr = 0;
     if (ConfIsRun3) {
-      mult = col.centFT0M();
+      if constexpr (useCentrality){
+        mult = col.centFT0M();
+      } else {
+        mult = 0.;
+      } 
       multNtr = col.multNTracksPV();
     } else {
       mult = 1; // multiplicity percentile is known in Run 2
@@ -233,8 +238,7 @@ struct femtoDreamProducerReducedTask {
     if (ConfEvtUseTPCmult) {
       multNtr = col.multTPC();
     }
-
-    colCuts.fillQA(col);
+    colCuts.fillQA(col, mult);
 
     /// First thing to do is to check whether the basic event selection criteria are fulfilled
     /// That includes checking if there are any usable tracks in a collision
@@ -307,10 +311,10 @@ struct femtoDreamProducerReducedTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracks<false>(col, tracks);
+    fillCollisionsAndTracks<false, true>(col, tracks);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processData, "Provide experimental data", true);
-
+  
   void processMC(aod::FemtoFullCollisionMC const& col,
                  aod::BCsWithTimestamps const&,
                  soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
@@ -319,9 +323,21 @@ struct femtoDreamProducerReducedTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracks<true>(col, tracks);
+    fillCollisionsAndTracks<true, true>(col, tracks);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processMC, "Provide MC data", false);
+
+  void processMC_noCentrality(aod::FemtoFullCollision_noCent_MC const& col,
+                 aod::BCsWithTimestamps const&,
+                 soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                 aod::McCollisions const& mcCollisions, aod::McParticles const& mcParticles)
+  {
+    // get magnetic field for run
+    getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    // fill the tables
+    fillCollisionsAndTracks<true, false>(col, tracks);
+  }
+  PROCESS_SWITCH(femtoDreamProducerReducedTask, processMC_noCentrality, "Provide MC data", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -80,7 +80,7 @@ struct femtoDreamProducerTask {
 
   Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
-  //Configurable<bool> ConfIsUseMultiplicityPercentile{"ConfIsUseMultiplicityPercentile", true, "Use multiplicity percentile (ccdb object for MC may be missing)"};
+  // Configurable<bool> ConfIsUseMultiplicityPercentile{"ConfIsUseMultiplicityPercentile", true, "Use multiplicity percentile (ccdb object for MC may be missing)"};
   Configurable<bool> ConfIsForceGRP{"ConfIsForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
 
   /// Event cuts
@@ -157,7 +157,7 @@ struct femtoDreamProducerTask {
     if (doprocessData == false && doprocessMC == false && doprocessMC_noCentrality == false) {
       LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
-    if ( (doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) ) {
+    if ((doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true)) {
       LOGF(fatal,
            "Cannot enable more than one process switch at the same time. "
            "Please choose one.");
@@ -532,13 +532,13 @@ struct femtoDreamProducerTask {
     fillCollisionsAndTracksAndV0<true, true>(col, tracks, fullV0s);
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processMC, "Provide MC data", false);
-  
+
   void processMC_noCentrality(aod::FemtoFullCollision_noCent_MC const& col,
-                 aod::BCsWithTimestamps const&,
-                 soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                 aod::McCollisions const& mcCollisions,
-                 aod::McParticles const& mcParticles,
-                 soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
+                              aod::BCsWithTimestamps const&,
+                              soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                              aod::McCollisions const& mcCollisions,
+                              aod::McParticles const& mcParticles,
+                              soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -80,7 +80,6 @@ struct femtoDreamProducerTask {
 
   Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
-  // Configurable<bool> ConfIsUseMultiplicityPercentile{"ConfIsUseMultiplicityPercentile", true, "Use multiplicity percentile (ccdb object for MC may be missing)"};
   Configurable<bool> ConfIsForceGRP{"ConfIsForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
 
   /// Event cuts

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -48,6 +48,7 @@ namespace o2::aod
 using FemtoFullCollision =
   soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms>::iterator;
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::McCollisionLabels>::iterator;
+using FemtoFullCollision_noCent_MC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 
 using FemtoFullTracks =
   soa::Join<aod::FullTracks, aod::TracksDCA,
@@ -79,7 +80,7 @@ struct femtoDreamProducerTask {
 
   Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
-  Configurable<bool> ConfIsUseMultiplicityPercentile{"ConfIsUseMultiplicityPercentile", true, "Use multiplicity percentile (ccdb object for MC may be missing)"};
+  //Configurable<bool> ConfIsUseMultiplicityPercentile{"ConfIsUseMultiplicityPercentile", true, "Use multiplicity percentile (ccdb object for MC may be missing)"};
   Configurable<bool> ConfIsForceGRP{"ConfIsForceGRP", false, "Set true if the magnetic field configuration is not available in the usual CCDB directory (e.g. for Run 2 converted data or unanchorad Monte Carlo)"};
 
   /// Event cuts
@@ -153,12 +154,12 @@ struct femtoDreamProducerTask {
 
   void init(InitContext&)
   {
-    if (doprocessData == false && doprocessMC == false) {
+    if (doprocessData == false && doprocessMC == false && doprocessMC_noCentrality == false) {
       LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
-    if (doprocessData == true && doprocessMC == true) {
+    if ( (doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) ) {
       LOGF(fatal,
-           "Cannot enable processData and processMC at the same time. "
+           "Cannot enable more than one process switch at the same time. "
            "Please choose one.");
     }
 
@@ -343,7 +344,7 @@ struct femtoDreamProducerTask {
     }
   }
 
-  template <bool isMC, typename V0Type, typename TrackType, typename CollisionType>
+  template <bool isMC, bool useCentrality, typename V0Type, typename TrackType, typename CollisionType>
   void fillCollisionsAndTracksAndV0(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
   {
     const auto vtxZ = col.posZ();
@@ -351,7 +352,7 @@ struct femtoDreamProducerTask {
     float mult = 0;
     int multNtr = 0;
     if (ConfIsRun3) {
-      if (ConfIsUseMultiplicityPercentile) {
+      if constexpr (useCentrality) {
         mult = col.centFT0M();
       } else {
         mult = 0;
@@ -365,7 +366,7 @@ struct femtoDreamProducerTask {
       multNtr = col.multTPC();
     }
 
-    colCuts.fillQA(col);
+    colCuts.fillQA(col, mult);
 
     // check whether the basic event selection criteria are fulfilled
     // that included checking if there is at least on usable track or V0
@@ -513,7 +514,7 @@ struct femtoDreamProducerTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracksAndV0<false>(col, tracks, fullV0s);
+    fillCollisionsAndTracksAndV0<false, true>(col, tracks, fullV0s);
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processData,
                  "Provide experimental data", true);
@@ -528,9 +529,23 @@ struct femtoDreamProducerTask {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
     // fill the tables
-    fillCollisionsAndTracksAndV0<true>(col, tracks, fullV0s);
+    fillCollisionsAndTracksAndV0<true, true>(col, tracks, fullV0s);
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processMC, "Provide MC data", false);
+  
+  void processMC_noCentrality(aod::FemtoFullCollision_noCent_MC const& col,
+                 aod::BCsWithTimestamps const&,
+                 soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                 aod::McCollisions const& mcCollisions,
+                 aod::McParticles const& mcParticles,
+                 soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
+  {
+    // get magnetic field for run
+    getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    // fill the tables
+    fillCollisionsAndTracksAndV0<true, false>(col, tracks, fullV0s);
+  }
+  PROCESS_SWITCH(femtoDreamProducerTask, processMC_noCentrality, "Provide MC data without requiring a centrality calibration", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
- add a process switch in the producer task to run MC without centrality
  calibration