### PR TITLE
PWGLF: Extras in strangeness derived data

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -146,13 +146,12 @@ DECLARE_SOA_COLUMN(Y, y, float);         //! decay position Y
 DECLARE_SOA_COLUMN(Z, z, float);         //! decay position Z
 
 // decay daughter positions for refit studies (specific purpose)
-DECLARE_SOA_COLUMN(XPosAtDCA, xPosAtDCA, float);         //! decay position X
-DECLARE_SOA_COLUMN(YPosAtDCA, yPosAtDCA, float);         //! decay position Y
-DECLARE_SOA_COLUMN(ZPosAtDCA, zPosAtDCA, float);         //! decay position Z
-DECLARE_SOA_COLUMN(XNegAtDCA, xNegAtDCA, float);         //! decay position X
-DECLARE_SOA_COLUMN(YNegAtDCA, yNegAtDCA, float);         //! decay position Y
-DECLARE_SOA_COLUMN(ZNegAtDCA, zNegAtDCA, float);         //! decay position Z
-
+DECLARE_SOA_COLUMN(XPosAtDCA, xPosAtDCA, float); //! decay position X
+DECLARE_SOA_COLUMN(YPosAtDCA, yPosAtDCA, float); //! decay position Y
+DECLARE_SOA_COLUMN(ZPosAtDCA, zPosAtDCA, float); //! decay position Z
+DECLARE_SOA_COLUMN(XNegAtDCA, xNegAtDCA, float); //! decay position X
+DECLARE_SOA_COLUMN(YNegAtDCA, yNegAtDCA, float); //! decay position Y
+DECLARE_SOA_COLUMN(ZNegAtDCA, zNegAtDCA, float); //! decay position Z
 
 // Saved from finding: DCAs
 DECLARE_SOA_COLUMN(DCAV0Daughters, dcaV0daughters, float); //! DCA between V0 daughters
@@ -411,8 +410,8 @@ DECLARE_SOA_EXTENDED_TABLE_USER(V0Cores, StoredV0Cores, "V0COREEXT",            
                                 v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
 
 DECLARE_SOA_TABLE(V0TraPosAtDCAs, "AOD", "V0TRAPOSATDCAs", //! positions of tracks at their DCA for debug
-                       v0data::XPosAtDCA, v0data::YPosAtDCA, v0data::ZPosAtDCA,
-                       v0data::XNegAtDCA, v0data::YNegAtDCA, v0data::ZNegAtDCA);
+                  v0data::XPosAtDCA, v0data::YPosAtDCA, v0data::ZPosAtDCA,
+                  v0data::XNegAtDCA, v0data::YNegAtDCA, v0data::ZNegAtDCA);
 
 DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //! V0 covariance matrices
                        v0data::PositionCovMat, v0data::MomentumCovMat, o2::soa::Marker<1>);

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -495,10 +495,10 @@ using V0MCData = V0MCDatas::iterator;
 // definitions of indices for interlink tables
 namespace v0data
 {
-DECLARE_SOA_INDEX_COLUMN(V0Data, v0Data); //! Index to V0Data entry
+DECLARE_SOA_INDEX_COLUMN(V0Data, v0Data);                         //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN(V0fCData, v0fCData);                     //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN_FULL(V0MC, v0MC, int, V0MCCores, "_MC"); //!
-}
+} // namespace v0data
 
 DECLARE_SOA_TABLE(V0DataLink, "AOD", "V0DATALINK", //! Joinable table with V0s which links to V0Data which is not produced for all entries
                   o2::soa::Index<>, v0data::V0DataId, v0data::V0fCDataId);
@@ -996,10 +996,10 @@ using CascDataExt = CascDatas;
 
 namespace cascdata
 {
-DECLARE_SOA_INDEX_COLUMN(CascData, cascData); //! Index to CascData entry
-DECLARE_SOA_INDEX_COLUMN(KFCascData, kfCascData); //! Index to CascData entry
+DECLARE_SOA_INDEX_COLUMN(CascData, cascData);       //! Index to CascData entry
+DECLARE_SOA_INDEX_COLUMN(KFCascData, kfCascData);   //! Index to CascData entry
 DECLARE_SOA_INDEX_COLUMN(TraCascData, traCascData); //! Index to CascData entry
-}
+} // namespace cascdata
 
 DECLARE_SOA_TABLE(CascDataLink, "AOD", "CASCDATALINK", //! Joinable table with Cascades which links to CascData which is not produced for all entries
                   cascdata::CascDataId);
@@ -1043,7 +1043,7 @@ DECLARE_SOA_TABLE(CascTags, "AOD", "CASCTAGS",
 // Definition of labels for V0s
 namespace mcv0label
 {
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for V0
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                                               //! MC particle for V0
 DECLARE_SOA_INDEX_COLUMN_FULL(McMotherParticle, mcMotherParticle, int, McParticles, "_Mother"); //!
 } // namespace mcv0label
 
@@ -1064,9 +1064,9 @@ using McFullV0Label = McFullV0Labels::iterator;
 // Definition of labels for cascades
 namespace mccasclabel
 {
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle); //! MC particle for Cascade
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                                               //! MC particle for Cascade
 DECLARE_SOA_INDEX_COLUMN_FULL(McMotherParticle, mcMotherParticle, int, McParticles, "_Mother"); //!
-DECLARE_SOA_COLUMN(IsBachBaryonCandidate, isBachBaryonCandidate, bool); //! will this be built or not?
+DECLARE_SOA_COLUMN(IsBachBaryonCandidate, isBachBaryonCandidate, bool);                         //! will this be built or not?
 } // namespace mccasclabel
 
 DECLARE_SOA_TABLE(McCascLabels, "AOD", "MCCASCLABEL", //! Table joinable with CascData containing the MC labels

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -32,17 +32,19 @@ DECLARE_SOA_TABLE(StraCents, "AOD", "STRACENTS", //! centrality percentiles
                   cent::CentFT0C, cent::CentFV0A);
 DECLARE_SOA_TABLE(StraEvSels, "AOD", "STRAEVSELS", //! event selection: sel8
                   evsel::Sel8);
-DECLARE_SOA_TABLE(StraEPs, "AOD", "STRAEPS", //! centrality percentiles
-                  qvec::QvecFT0ARe, qvec::QvecFT0AIm, qvec::SumAmplFT0A,
-                  qvec::QvecFT0CRe, qvec::QvecFT0CIm, qvec::SumAmplFT0C,
-                  qvec::QvecFT0MRe, qvec::QvecFT0MIm, qvec::SumAmplFT0M,
+DECLARE_SOA_TABLE(StraFT0AQVs, "AOD", "STRAFT0AQVS", //! t0a Qvec
+                  qvec::QvecFT0ARe, qvec::QvecFT0AIm, qvec::SumAmplFT0A);
+DECLARE_SOA_TABLE(StraFT0CQVs, "AOD", "STRAFT0CQVS", //! t0c Qvec
+                  qvec::QvecFT0CRe, qvec::QvecFT0CIm, qvec::SumAmplFT0C);
+DECLARE_SOA_TABLE(StraFT0MQVs, "AOD", "STRAFT0MQVS", //! t0m Qvec
+                  qvec::QvecFT0MRe, qvec::QvecFT0MIm, qvec::SumAmplFT0M);
+DECLARE_SOA_TABLE(StraFV0AQVs, "AOD", "STRAFV0AQVS", //! v0a Qvec
                   qvec::QvecFV0ARe, qvec::QvecFV0AIm, qvec::SumAmplFV0A);
 DECLARE_SOA_TABLE(StraStamps, "AOD", "STRASTAMPS", //! information for ID-ing mag field if needed
                   bc::RunNumber, timestamp::Timestamp);
 
 using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
-using StraEP = StraEPs::iterator;
 
 namespace dautrack
 {
@@ -142,6 +144,15 @@ DECLARE_SOA_COLUMN(PzNeg, pzneg, float); //! negative track pz at min
 DECLARE_SOA_COLUMN(X, x, float);         //! decay position X
 DECLARE_SOA_COLUMN(Y, y, float);         //! decay position Y
 DECLARE_SOA_COLUMN(Z, z, float);         //! decay position Z
+
+// decay daughter positions for refit studies (specific purpose)
+DECLARE_SOA_COLUMN(XPosAtDCA, xPosAtDCA, float);         //! decay position X
+DECLARE_SOA_COLUMN(YPosAtDCA, yPosAtDCA, float);         //! decay position Y
+DECLARE_SOA_COLUMN(ZPosAtDCA, zPosAtDCA, float);         //! decay position Z
+DECLARE_SOA_COLUMN(XNegAtDCA, xNegAtDCA, float);         //! decay position X
+DECLARE_SOA_COLUMN(YNegAtDCA, yNegAtDCA, float);         //! decay position Y
+DECLARE_SOA_COLUMN(ZNegAtDCA, zNegAtDCA, float);         //! decay position Z
+
 
 // Saved from finding: DCAs
 DECLARE_SOA_COLUMN(DCAV0Daughters, dcaV0daughters, float); //! DCA between V0 daughters
@@ -398,6 +409,10 @@ DECLARE_SOA_TABLE_FULL(StoredV0Cores, "V0Cores", "AOD", "V0CORE", //! core infor
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(V0Cores, StoredV0Cores, "V0COREEXT",                                                  //!
                                 v0data::Px, v0data::Py, v0data::Pz, v0data::Pt, v0data::P, v0data::Phi, v0data::Eta); // the table name has here to be the one with EXT which is not nice and under study
+
+DECLARE_SOA_TABLE(V0TraPosAtDCAs, "AOD", "V0TRAPOSATDCAs", //! positions of tracks at their DCA for debug
+                       v0data::XPosAtDCA, v0data::YPosAtDCA, v0data::ZPosAtDCA,
+                       v0data::XNegAtDCA, v0data::YNegAtDCA, v0data::ZNegAtDCA);
 
 DECLARE_SOA_TABLE_FULL(V0Covs, "V0Covs", "AOD", "V0COVS", //! V0 covariance matrices
                        v0data::PositionCovMat, v0data::MomentumCovMat, o2::soa::Marker<1>);

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -853,9 +853,9 @@ struct lambdakzeroBuilder {
                 v0candidate.cosPA,
                 v0candidate.dcav0topv,
                 V0.v0Type());
-        if(createV0PosAtDCAs)
+        if (createV0PosAtDCAs)
           v0dauPositions(v0candidate.posPosition[0], v0candidate.posPosition[1], v0candidate.posPosition[2],
-                  v0candidate.negPosition[0], v0candidate.negPosition[1], v0candidate.negPosition[2]);
+                         v0candidate.negPosition[0], v0candidate.negPosition[1], v0candidate.negPosition[2]);
       } else {
         // place V0s built exclusively for the sake of cascades
         // in a fully independent table (though identical) to make

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -93,7 +93,7 @@ struct lambdakzeroBuilder {
   Produces<aod::V0Indices> v0indices;
   Produces<aod::StoredV0Cores> v0cores;
   Produces<aod::V0TrackXs> v0trackXs;
-  Produces<aod::V0Covs> v0covs; // covariances
+  Produces<aod::V0Covs> v0covs;                 // covariances
   Produces<aod::V0TraPosAtDCAs> v0dauPositions; // auxiliary debug information
 
   Produces<aod::V0fCIndices> v0fcindices;

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -94,6 +94,7 @@ struct lambdakzeroBuilder {
   Produces<aod::StoredV0Cores> v0cores;
   Produces<aod::V0TrackXs> v0trackXs;
   Produces<aod::V0Covs> v0covs; // covariances
+  Produces<aod::V0TraPosAtDCAs> v0dauPositions; // auxiliary debug information
 
   Produces<aod::V0fCIndices> v0fcindices;
   Produces<aod::StoredV0fCCores> v0fccores;
@@ -104,6 +105,7 @@ struct lambdakzeroBuilder {
 
   // Configurables related to table creation
   Configurable<int> createV0CovMats{"createV0CovMats", -1, {"Produces V0 cov matrices. -1: auto, 0: don't, 1: yes. Default: auto (-1)"}};
+  Configurable<int> createV0PosAtDCAs{"createV0PosAtDCAs", 0, {"Produces V0 track positions at minima. 0: don't, 1: yes. Default: no (0)"}};
 
   Configurable<bool> storePhotonCandidates{"storePhotonCandidates", false, "store photon candidates (yes/no)"};
 
@@ -214,6 +216,8 @@ struct lambdakzeroBuilder {
     std::array<float, 3> pos;
     std::array<float, 3> posP;
     std::array<float, 3> negP;
+    std::array<float, 3> posPosition;
+    std::array<float, 3> negPosition;
     float dcaV0dau;
     float posDCAxy;
     float negDCAxy;
@@ -635,6 +639,8 @@ struct lambdakzeroBuilder {
     lNegativeTrack = fitter.getTrack(1);
     lPositiveTrack.getPxPyPzGlo(v0candidate.posP);
     lNegativeTrack.getPxPyPzGlo(v0candidate.negP);
+    lPositiveTrack.getXYZGlo(v0candidate.posPosition);
+    lNegativeTrack.getXYZGlo(v0candidate.negPosition);
 
     // get decay vertex coordinates
     const auto& vtx = fitter.getPCACandidate();
@@ -847,6 +853,9 @@ struct lambdakzeroBuilder {
                 v0candidate.cosPA,
                 v0candidate.dcav0topv,
                 V0.v0Type());
+        if(createV0PosAtDCAs)
+          v0dauPositions(v0candidate.posPosition[0], v0candidate.posPosition[1], v0candidate.posPosition[2],
+                  v0candidate.negPosition[0], v0candidate.negPosition[1], v0candidate.negPosition[2]);
       } else {
         // place V0s built exclusively for the sake of cascades
         // in a fully independent table (though identical) to make

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -100,10 +100,10 @@ struct strangederivedbuilder {
 
   //__________________________________________________
   // Q-vectors
-  Produces<aod::StraFT0AQVs> StraFT0AQVs;     // FT0A Q-vector
-  Produces<aod::StraFT0CQVs> StraFT0CQVs;     // FT0C Q-vector
-  Produces<aod::StraFT0MQVs> StraFT0MQVs;     // FT0M Q-vector
-  Produces<aod::StraFV0AQVs> StraFV0AQVs;     // FV0A Q-vector
+  Produces<aod::StraFT0AQVs> StraFT0AQVs; // FT0A Q-vector
+  Produces<aod::StraFT0CQVs> StraFT0CQVs; // FT0C Q-vector
+  Produces<aod::StraFT0MQVs> StraFT0MQVs; // FT0M Q-vector
+  Produces<aod::StraFV0AQVs> StraFV0AQVs; // FV0A Q-vector
 
   // histogram registry for bookkeeping
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -44,6 +44,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "Common/TableProducer/PID/pidTOFBase.h"
 #include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/Qvectors.h"
 #include "Framework/StaticFor.h"
 
 using namespace o2;
@@ -96,6 +97,13 @@ struct strangederivedbuilder {
   // raw TOF PID for posterior use if requested
   Produces<aod::V0TOFs> v0tofs;     // V0 part
   Produces<aod::CascTOFs> casctofs; // cascade part
+
+  //__________________________________________________
+  // Q-vectors
+  Produces<aod::StraFT0AQVs> StraFT0AQVs;     // FT0A Q-vector
+  Produces<aod::StraFT0CQVs> StraFT0CQVs;     // FT0C Q-vector
+  Produces<aod::StraFT0MQVs> StraFT0MQVs;     // FT0M Q-vector
+  Produces<aod::StraFV0AQVs> StraFV0AQVs;     // FV0A Q-vector
 
   // histogram registry for bookkeeping
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -508,6 +516,23 @@ struct strangederivedbuilder {
     }
   }
 
+  void processFT0AQVectors(soa::Join<aod::Collisions, aod::QvectorFT0As>::iterator const& collision)
+  {
+    StraFT0AQVs(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.sumAmplFT0A());
+  }
+  void processFT0CQVectors(soa::Join<aod::Collisions, aod::QvectorFT0Cs>::iterator const& collision)
+  {
+    StraFT0CQVs(collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.sumAmplFT0C());
+  }
+  void processFT0MQVectors(soa::Join<aod::Collisions, aod::QvectorFT0Ms>::iterator const& collision)
+  {
+    StraFT0MQVs(collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.sumAmplFT0M());
+  }
+  void processFV0AQVectors(soa::Join<aod::Collisions, aod::QvectorFV0As>::iterator const& collision)
+  {
+    StraFV0AQVs(collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.sumAmplFV0A());
+  }
+
   PROCESS_SWITCH(strangederivedbuilder, processCollisionsV0sOnly, "Produce collisions (V0s only)", true);
   PROCESS_SWITCH(strangederivedbuilder, processCollisions, "Produce collisions (V0s + casc)", true);
   PROCESS_SWITCH(strangederivedbuilder, processTrackExtrasV0sOnly, "Produce track extra information (V0s only)", true);
@@ -519,6 +544,10 @@ struct strangederivedbuilder {
   PROCESS_SWITCH(strangederivedbuilder, processReconstructedSimulation, "Produce reco-ed simulated information", true);
   PROCESS_SWITCH(strangederivedbuilder, processProduceV0TOFs, "Produce V0TOFs table", true);
   PROCESS_SWITCH(strangederivedbuilder, processProduceCascTOFs, "Produce CascTOFs table", true);
+  PROCESS_SWITCH(strangederivedbuilder, processFT0AQVectors, "Produce FT0A Q-vectors table", false);
+  PROCESS_SWITCH(strangederivedbuilder, processFT0CQVectors, "Produce FT0C Q-vectors table", false);
+  PROCESS_SWITCH(strangederivedbuilder, processFT0MQVectors, "Produce FT0M Q-vectors table", false);
+  PROCESS_SWITCH(strangederivedbuilder, processFV0AQVectors, "Produce FV0A Q-vectors table", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
* adds optional q-vectors to strangeness derived builder and makes minor adjustments in the way q-vectors were declared in the strangeness derived data tables @mpuccio @ChiaraDeMartin95 
* adds optional positive and negative track positions at minima for refit studies @pzhristov 
* soon to follow: adjustments + addition of flattenicity and other variables