### PR TITLE
[EMCAL-1111] Add option for global cell scale in correction task

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -77,6 +77,8 @@ struct EmcalCorrectionTask {
   Configurable<std::string> nonlinearityFunction{"nonlinearityFunction", "DATA_TestbeamFinal", "Nonlinearity correction at cluster level"};
   Configurable<bool> disableNonLin{"disableNonLin", false, "Disable NonLin correction if set to true"};
   Configurable<bool> hasShaperCorrection{"hasShaperCorrection", true, "Apply correction for shaper saturation"};
+  Configurable<int> applyCellAbsScale{"applyCellAbsScale", 0, "Enable absolute cell energy scale to correct for energy loss in material in front of EMCal"};
+  Configurable<std::vector<float>> vCellAbsScaleFactor{"cellAbsScaleFactor", {1.f}, "values for absolute cell energy calibration. Different values correspond to different regions or SM types of EMCal"};
   Configurable<float> logWeight{"logWeight", 4.5, "logarithmic weight for the cluster center of gravity calculation"};
   Configurable<float> exoticCellFraction{"exoticCellFraction", 0.97, "Good cell if fraction < 1-ecross/ecell"};
   Configurable<float> exoticCellDiffTime{"exoticCellDiffTime", 1.e6, "If time of candidate to exotic and close cell is larger than exoticCellDiffTime (in ns), it must be noisy, set amp to 0"};
@@ -245,6 +247,9 @@ struct EmcalCorrectionTask {
         auto amplitude = cell.amplitude();
         if (static_cast<bool>(hasShaperCorrection)) {
           amplitude = o2::emcal::NonlinearityHandler::evaluateShaperCorrectionCellEnergy(amplitude);
+        }
+        if (applyCellAbsScale) {
+          amplitude *= GetAbsCellScale(cell.cellNumber());
         }
         cellsBC.emplace_back(cell.cellNumber(),
                              amplitude,
@@ -729,6 +734,23 @@ struct EmcalCorrectionTask {
       res = mClusterizers.at(0)->getGeometry()->GlobalRowColFromIndex(cell.getTower());
       // NOTE: Reversed column and row because it's more natural for presentation.
       mHistManager.fill(HIST("hCellRowCol"), std::get<1>(res), std::get<0>(res));
+    }
+  }
+
+  float GetAbsCellScale(const int cellID)
+  {
+    // Apply cell scale based on SM types (Full, Half (not used), EMC 1/3, DCal, DCal 1/3)
+    // Same as in Run2 data
+    if (applyCellAbsScale == 1) {
+      int iSM = mClusterizers.at(0)->getGeometry()->GetSuperModuleNumber(cellID);
+      return vCellAbsScaleFactor.value[mClusterizers.at(0)->getGeometry()->GetSMType(iSM)];
+
+      // Apply cell scale based on columns to accoutn for material of TRD structures
+    } else if (applyCellAbsScale == 2) {
+      auto res = mClusterizers.at(0)->getGeometry()->GlobalRowColFromIndex(cellID);
+      return vCellAbsScaleFactor.value[std::get<1>(res)];
+    } else {
+      return 1.f;
     }
   }
 };


### PR DESCRIPTION
- The global cell scale corrects for energy loss in the material in front of the emcal. The factor needs to be applied on cell level.
- Here, two scenarios are implemented: Calibration depending on the supermodule type (Full, 2/3, 1/3) or depending on the column of the Detector. The column by column calibration is supposed to distinguish regions behind the TRD support structure and the rest of the detector.
- The calibration is Off by default (will be enabled as soon as it is validated)
- The calibration coefficients are configurable and are stored in a vector