### PR TITLE
PWGHF: add sign of soft pion in D* table to avoid to access the track table

### DIFF
--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -120,9 +120,8 @@ struct TaskPolarisationCharmHadrons {
   }; // end init
 
   /// \param candidates are the selected candidates
-  /// \param tracks are the tracks
   template <uint8_t channel, bool withMl, typename Cand>
-  void runPolarisationAnalysis(Cand const& candidate, Tracks const& tracks)
+  void runPolarisationAnalysis(Cand const& candidate)
   {
 
     // loop over mass hypotheses
@@ -146,9 +145,8 @@ struct TaskPolarisationCharmHadrons {
         pyCharmHad = candidate.pyDstar();
         pzCharmHad = candidate.pzDstar();
         massDau = massPi; // (*)
-        auto prongSoftPi = candidate.template prongPi_as<aod::Tracks>();
-        invMassCharmHad = (prongSoftPi.sign() > 0) ? candidate.invMassDstar() : candidate.invMassAntiDstar();
-        invMassCharmHadForSparse = (prongSoftPi.sign() > 0) ? (invMassCharmHad - candidate.invMassD0()) : (invMassCharmHad - candidate.invMassD0Bar()); // different for D*
+        invMassCharmHad = (candidate.signSoftPi() > 0) ? candidate.invMassDstar() : candidate.invMassAntiDstar();
+        invMassCharmHadForSparse = (candidate.signSoftPi() > 0) ? (invMassCharmHad - candidate.invMassD0()) : (invMassCharmHad - candidate.invMassD0Bar()); // different for D*
         rapidity = candidate.y(massDstar);
         if constexpr (withMl) {
           outputMl[0] = -1.; // not yet implemented in the selector
@@ -233,14 +231,14 @@ struct TaskPolarisationCharmHadrons {
   /////////////////////////
 
   // Dstar with rectangular cuts
-  void processDstar(soa::Filtered<CandDstarWSelFlag>::iterator const& dstarCandidate, Tracks const& tracks)
+  void processDstar(soa::Filtered<CandDstarWSelFlag>::iterator const& dstarCandidate)
   {
-    runPolarisationAnalysis<charm_polarisation::DecayChannel::DstarToDzeroPi, false>(dstarCandidate, tracks);
+    runPolarisationAnalysis<charm_polarisation::DecayChannel::DstarToDzeroPi, false>(dstarCandidate);
   }
   PROCESS_SWITCH(TaskPolarisationCharmHadrons, processDstar, "Process Dstar candidates without ML", true);
 
   // Dstar with ML cuts
-  void processDstarWithMl(soa::Filtered<CandDstarWSelFlag>::iterator const&, Tracks const&)
+  void processDstarWithMl(soa::Filtered<CandDstarWSelFlag>::iterator const&)
   {
     // DUMMY
   }
@@ -251,16 +249,16 @@ struct TaskPolarisationCharmHadrons {
   ////////////////////////////
 
   // Lc->pKpi with rectangular cuts
-  void processLcToPKPi(soa::Filtered<CandLcToPKPiWSelFlag>::iterator const& lcCandidate, Tracks const& tracks)
+  void processLcToPKPi(soa::Filtered<CandLcToPKPiWSelFlag>::iterator const& lcCandidate)
   {
-    runPolarisationAnalysis<charm_polarisation::DecayChannel::LcToPKPi, false>(lcCandidate, tracks);
+    runPolarisationAnalysis<charm_polarisation::DecayChannel::LcToPKPi, false>(lcCandidate);
   }
   PROCESS_SWITCH(TaskPolarisationCharmHadrons, processLcToPKPi, "Process Lc candidates without ML", false);
 
   // Lc->pKpi with ML cuts
-  void processLcToPKPiWithMl(soa::Filtered<soa::Join<CandLcToPKPiWSelFlag, aod::HfMlLcToPKPi>>::iterator const& lcCandidate, Tracks const& tracks)
+  void processLcToPKPiWithMl(soa::Filtered<soa::Join<CandLcToPKPiWSelFlag, aod::HfMlLcToPKPi>>::iterator const& lcCandidate)
   {
-    runPolarisationAnalysis<charm_polarisation::DecayChannel::LcToPKPi, true>(lcCandidate, tracks);
+    runPolarisationAnalysis<charm_polarisation::DecayChannel::LcToPKPi, true>(lcCandidate);
   }
   PROCESS_SWITCH(TaskPolarisationCharmHadrons, processLcToPKPiWithMl, "Process Lc candidates with ML", false);
 };

--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -119,8 +119,7 @@ struct HfTaskDstarToD0Pi {
     registry.add("QA/hPtVsYNonPromptDstarGen", "MC Matched Non-Prompt D* Candidates at Generator Level; #it{p}_{T} of  D*; #it{y}", {HistType::kTH2F, {{vecPtBins, "#it{p}_{T} (GeV/#it{c})"}, {100, -5., 5.}}});
   }
 
-  void process(aod::Tracks const&,
-               CandDstarWSelFlag const&)
+  void process(CandDstarWSelFlag const&)
   {
     for (const auto& candDstar : rowsSelectedCandDstar) {
       auto yDstar = candDstar.y(constants::physics::MassDStar);
@@ -155,8 +154,8 @@ struct HfTaskDstarToD0Pi {
       auto invD0 = candDstar.invMassD0();
       auto invD0Bar = candDstar.invMassD0Bar();
 
-      auto prongSoftPi = candDstar.prongPi_as<aod::Tracks>();
-      if (prongSoftPi.sign() > 0) {
+      auto signDstar = candDstar.signSoftPi();
+      if (signDstar) {
         registry.fill(HIST("Yield/hDeltaInvMassDstar2D"), (invDstar - invD0), candDstar.pt());
         registry.fill(HIST("Yield/hInvMassD0"), invD0, candDstar.ptD0());
         registry.fill(HIST("Yield/hDeltaInvMassDstar1D"), (invDstar - invD0));
@@ -164,7 +163,7 @@ struct HfTaskDstarToD0Pi {
         // filling pt of two pronges of D0
         registry.fill(HIST("QA/hPtProng0D0"), candDstar.ptProng0());
         registry.fill(HIST("QA/hPtProng1D0"), candDstar.ptProng1());
-      } else if (prongSoftPi.sign() < 0) {
+      } else if (signDstar) {
         registry.fill(HIST("Yield/hDeltaInvMassDstar2D"), (invAntiDstar - invD0Bar), candDstar.pt());
         registry.fill(HIST("Yield/hInvMassD0"), invD0Bar, candDstar.ptD0());
         registry.fill(HIST("Yield/hDeltaInvMassDstar1D"), (invAntiDstar - invD0Bar));

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1556,6 +1556,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(NormalisedImpParamSoftPi, normalisedImpParamSoftPi,
 DECLARE_SOA_COLUMN(PxSoftPi, pxSoftPi, float);
 DECLARE_SOA_COLUMN(PySoftPi, pySoftPi, float);
 DECLARE_SOA_COLUMN(PzSoftPi, pzSoftPi, float);
+DECLARE_SOA_COLUMN(SignSoftPi, signSoftPi, int8_t);
 // Dstar momenta
 DECLARE_SOA_EXPRESSION_COLUMN(PxDstar, pxDstar, float, 1.f * aod::hf_cand::pxProng0 + 1.f * aod::hf_cand::pxProng1 + 1.f * aod::hf_cand_dstar::pxSoftPi);
 DECLARE_SOA_EXPRESSION_COLUMN(PyDstar, pyDstar, float, 1.f * aod::hf_cand::pyProng0 + 1.f * aod::hf_cand::pyProng1 + 1.f * aod::hf_cand_dstar::pySoftPi);
@@ -1658,6 +1659,7 @@ DECLARE_SOA_TABLE(HfCandDstarBase, "AOD", "HFCANDDSTRBASE",
                   hf_track_index::ProngD0Id, // Index column points to Hf2Prongs table filled by indexSkimcreator
                   // Softpi
                   hf_cand_dstar::PxSoftPi, hf_cand_dstar::PySoftPi, hf_cand_dstar::PzSoftPi,
+                  hf_cand_dstar::SignSoftPi,
                   hf_cand_dstar::ImpParamSoftPi, hf_cand_dstar::ErrorImpParamSoftPi,
                   // Two pronges of D0
                   hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0,

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -255,9 +255,10 @@ struct HfCandidateCreatorDstar {
       // D0 pt magnitude
       auto ptD0 = RecoDecay::pt(pVecD0);
 
-      // Soft pi momentum vector
+      // Soft pi momentum vector and sign
       std::array<float, 3> pVecSoftPi;
       trackPiParVar.getPxPyPzGlo(pVecSoftPi);
+      int8_t signSoftPi = static_cast<int8_t>(trackPi.sign());
 
       // D* pt magnitude
       auto ptDstar = RecoDecay::pt(pVecD0, pVecSoftPi);
@@ -267,6 +268,7 @@ struct HfCandidateCreatorDstar {
                        primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                        rowTrackIndexDstar.prong0Id(), rowTrackIndexDstar.prongD0Id(),
                        pVecSoftPi[0], pVecSoftPi[1], pVecSoftPi[2],
+                       signSoftPi,
                        impactParameterPi.getY(), std::sqrt(impactParameterPi.getSigmaY2()),
                        pVecD0Prong0[0], pVecD0Prong0[1], pVecD0Prong0[2],
                        pVecD0Prong1[0], pVecD0Prong1[1], pVecD0Prong1[2]);


### PR DESCRIPTION
@deependra170598 I made a small change in the D* table adding the soft pion sign, to avoid to access the track table later on to retrieve this information.