### PR TITLE
Bugfixes on TPC skimmer task (V0 logic + dereferencing)

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -177,10 +177,10 @@ struct TreeWriterTpcV0 {
 
     /// Loop over v0 candidates
     for (auto v0 : v0s) {
-      auto posTrack = v0.posTrack_as<Trks>();
-      auto negTrack = v0.negTrack_as<Trks>();
+      auto posTrack = v0.posTrack_as<soa::Filtered<Trks>>();
+      auto negTrack = v0.negTrack_as<soa::Filtered<Trks>>();
       // gamma
-      if (static_cast<bool>(posTrack.pidbit() & (1 << 0))) {
+      if (static_cast<bool>(posTrack.pidbit() & (1 << 0)) && static_cast<bool>(negTrack.pidbit() & (1 << 0))) {
         if (downsampleTsalisCharged(posTrack.pt(), downsamplingTsalisElectrons, sqrtSNN, o2::track::pid_constants::sMasses[o2::track::PID::Electron])) {
           fillSkimmedV0Table(v0, posTrack, collision, posTrack.tpcNSigmaEl(), posTrack.tofNSigmaEl(), posTrack.tpcExpSignalEl(posTrack.tpcSignal()), o2::track::PID::Electron, runnumber, dwnSmplFactor_El);
         }
@@ -189,7 +189,7 @@ struct TreeWriterTpcV0 {
         }
       }
       // Ks0
-      if (static_cast<bool>(posTrack.pidbit() & (1 << 1))) {
+      if (static_cast<bool>(posTrack.pidbit() & (1 << 1)) && static_cast<bool>(negTrack.pidbit() & (1 << 1))) {
         if (downsampleTsalisCharged(posTrack.pt(), downsamplingTsalisPions, sqrtSNN, o2::track::pid_constants::sMasses[o2::track::PID::Pion])) {
           fillSkimmedV0Table(v0, posTrack, collision, posTrack.tpcNSigmaPi(), posTrack.tofNSigmaPi(), posTrack.tpcExpSignalPi(posTrack.tpcSignal()), o2::track::PID::Pion, runnumber, dwnSmplFactor_Pi);
         }
@@ -198,7 +198,7 @@ struct TreeWriterTpcV0 {
         }
       }
       // Lambda
-      if (static_cast<bool>(posTrack.pidbit() & (1 << 2))) {
+      if (static_cast<bool>(posTrack.pidbit() & (1 << 2)) && static_cast<bool>(negTrack.pidbit() & (1 << 2))) {
         if (downsampleTsalisCharged(posTrack.pt(), downsamplingTsalisProtons, sqrtSNN, o2::track::pid_constants::sMasses[o2::track::PID::Proton])) {
           fillSkimmedV0Table(v0, posTrack, collision, posTrack.tpcNSigmaPr(), posTrack.tofNSigmaPr(), posTrack.tpcExpSignalPr(posTrack.tpcSignal()), o2::track::PID::Proton, runnumber, dwnSmplFactor_Pr);
         }
@@ -207,7 +207,7 @@ struct TreeWriterTpcV0 {
         }
       }
       // Antilambda
-      if (static_cast<bool>(posTrack.pidbit() & (1 << 3))) {
+      if (static_cast<bool>(posTrack.pidbit() & (1 << 3)) && static_cast<bool>(negTrack.pidbit() & (1 << 3))) {
         if (downsampleTsalisCharged(posTrack.pt(), downsamplingTsalisPions, sqrtSNN, o2::track::pid_constants::sMasses[o2::track::PID::Pion])) {
           fillSkimmedV0Table(v0, posTrack, collision, posTrack.tpcNSigmaPi(), posTrack.tofNSigmaPi(), posTrack.tpcExpSignalPi(posTrack.tpcSignal()), o2::track::PID::Pion, runnumber, dwnSmplFactor_Pi);
         }


### PR DESCRIPTION
TPC PID skimmed table creator:
- Fix selection logic used for V0bits from V0 decay daughters (previously only positive track's bit was explicitly checked leading to more combinatorics in saved candidates + impurity for negative tracks)
- Fix crash introduced by https://github.com/AliceO2Group/AliceO2/pull/12573 [since daily-20240125] due to mismatched type on "v0.[pos|neg]Track_as\<Trks\>" with filtered table declaration in process()