### PR TITLE
PWGCF: add downsampling to femtodream

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -46,7 +46,7 @@ DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);     //! Bit f
 DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);     //! Bit for track two
 DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, BitMaskType); //! Bit for track three
 
-DECLARE_SOA_COLUMN(Downsampling, downsampling, bool); //! Flag for downsampling
+DECLARE_SOA_COLUMN(Downsample, downsample, bool); //! Flag for downsampling
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
@@ -64,7 +64,7 @@ DECLARE_SOA_TABLE(FDColMasks, "AOD", "FDCOLMASK",
                   femtodreamcollision::BitMaskTrackThree);
 
 DECLARE_SOA_TABLE(FDDownSample, "AOD", "FDDOWNSAMPLE",
-                  femtodreamcollision::Downsampling);
+                  femtodreamcollision::Downsample);
 
 /// FemtoDreamTrack
 namespace femtodreamparticle

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -45,6 +45,8 @@ using BitMaskType = uint32_t; //! Definition of the data type for the collision 
 DECLARE_SOA_COLUMN(BitMaskTrackOne, bitmaskTrackOne, BitMaskType);     //! Bit for track one
 DECLARE_SOA_COLUMN(BitMaskTrackTwo, bitmaskTrackTwo, BitMaskType);     //! Bit for track two
 DECLARE_SOA_COLUMN(BitMaskTrackThree, bitmaskTrackThree, BitMaskType); //! Bit for track three
+
+DECLARE_SOA_COLUMN(Downsampling, downsampling, bool); //! Flag for downsampling
 } // namespace femtodreamcollision
 
 DECLARE_SOA_TABLE(FDCollisions, "AOD", "FDCOLLISION",
@@ -60,6 +62,9 @@ DECLARE_SOA_TABLE(FDColMasks, "AOD", "FDCOLMASK",
                   femtodreamcollision::BitMaskTrackOne,
                   femtodreamcollision::BitMaskTrackTwo,
                   femtodreamcollision::BitMaskTrackThree);
+
+DECLARE_SOA_TABLE(FDDownSample, "AOD", "FDDOWNSAMPLE",
+                  femtodreamcollision::Downsampling);
 
 /// FemtoDreamTrack
 namespace femtodreamparticle

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -356,7 +356,7 @@ struct femoDreamCollisionMasker {
     bool UseInMixedEvent = true;
     std::uniform_real_distribution<> dist(0, 1);
 
-    if (ConfSeed.value > 0 && (1-dist(*rng)) > ConfDownsampling.value) {
+    if (ConfSeed.value > 0 && (1 - dist(*rng)) > ConfDownsampling.value) {
       UseInMixedEvent = false;
     }
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -16,7 +16,6 @@
 #include <vector>
 #include <bitset>
 #include <algorithm>
-#include <stdlib.h>
 #include <random>
 
 #include "fairlogger/Logger.h"

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -16,6 +16,8 @@
 #include <vector>
 #include <bitset>
 #include <algorithm>
+#include <stdlib.h>
+#include <random>
 
 #include "fairlogger/Logger.h"
 #include "Framework/Configurable.h"
@@ -49,6 +51,13 @@ enum Tasks {
 
 struct femoDreamCollisionMasker {
   Produces<FDColMasks> Masks;
+  Produces<FDDownSample> DownSample;
+
+  // configurable for downsampling
+  Configurable<float> ConfDownsampling{"ConfDownsampling", -1., "Fraction of events to be used in mixed event sample. Factor should be between 0 and 1. Deactivate with negative value"};
+  Configurable<uint> ConfSeed{"ConfSeed", 29012024, "Seed for downsampling"};
+
+  std::mt19937* rng = nullptr;
 
   // particle selection bits
   std::array<std::vector<femtodreamparticle::cutContainerType>, CollisionMasks::kNParts> TrackCutBits;
@@ -84,6 +93,12 @@ struct femoDreamCollisionMasker {
 
   void init(InitContext& context)
   {
+
+    // seed rng for downsampling
+    if (ConfSeed.value > 0) {
+      rng = new std::mt19937(ConfSeed.value);
+    };
+
     std::vector<std::string> MatchedWorkflows;
     LOG(info) << "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*";
     LOG(info) << " Collision masker self-configuration ";
@@ -338,6 +353,15 @@ struct femoDreamCollisionMasker {
     Masks(static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartOne).to_ulong()),
           static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartTwo).to_ulong()),
           static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartThree).to_ulong()));
+
+    bool UseInMixedEvent = true;
+    std::uniform_real_distribution<> dist(0, 1);
+
+    if (ConfSeed.value > 0 && 1-dist(*rng) > ConfDownsampling.value) {
+      UseInMixedEvent = false;
+    }
+
+    DownSample(UseInMixedEvent);
   };
 };
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -357,7 +357,7 @@ struct femoDreamCollisionMasker {
     bool UseInMixedEvent = true;
     std::uniform_real_distribution<> dist(0, 1);
 
-    if (ConfSeed.value > 0 && 1-dist(*rng) > ConfDownsampling.value) {
+    if (ConfSeed.value > 0 && (1-dist(*rng)) > ConfDownsampling.value) {
       UseInMixedEvent = false;
     }
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -96,7 +96,7 @@ struct femoDreamCollisionMasker {
     // seed rng for downsampling
     if (ConfSeed.value > 0) {
       rng = new std::mt19937(ConfSeed.value);
-    };
+    }
 
     std::vector<std::string> MatchedWorkflows;
     LOG(info) << "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*";

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -70,7 +70,7 @@ struct femtoDreamPairTaskTrackTrack {
 
   using FilteredCollisions = soa::Filtered<FDCollisions>;
   using FilteredCollision = FilteredCollisions::iterator;
-  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks>>;
+  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
   femtodreamcollision::BitMaskType BitMask = -1;
 
@@ -388,8 +388,8 @@ struct femtoDreamPairTaskTrackTrack {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType& cols, PartType& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask;
-    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask;
+    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
+    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
     PartitionMaskedCol1.bindTable(cols);
     PartitionMaskedCol2.bindTable(cols);
     for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, ConfMixingDepth.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -388,8 +388,8 @@ struct femtoDreamPairTaskTrackTrack {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType& cols, PartType& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
-    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
+    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
+    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
     PartitionMaskedCol1.bindTable(cols);
     PartitionMaskedCol2.bindTable(cols);
     for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, ConfMixingDepth.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -65,7 +65,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   using FilteredCollisions = soa::Filtered<FDCollisions>;
   using FilteredCollision = FilteredCollisions::iterator;
-  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks>>;
+  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
   femtodreamcollision::BitMaskType BitMask = -1;
 
@@ -387,8 +387,8 @@ struct femtoDreamPairTaskTrackV0 {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType& cols, PartType& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask;
-    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask;
+    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
+    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
     PartitionMaskedCol1.bindTable(cols);
     PartitionMaskedCol2.bindTable(cols);
     for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, ConfMixingDepth.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -387,8 +387,8 @@ struct femtoDreamPairTaskTrackV0 {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType& cols, PartType& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
-    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsampling == true;
+    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
+    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
     PartitionMaskedCol1.bindTable(cols);
     PartitionMaskedCol2.bindTable(cols);
     for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, ConfMixingDepth.value, -1, PartitionMaskedCol1, PartitionMaskedCol2))) {


### PR DESCRIPTION
Depending on the dataframe size the computation cost for event mixing might too high for a given dataset. Add the option to uniformly exclude events (i.e. downsampling) from the mixing pool and reduce the computational cost.