### PR TITLE
PWGEM/DQ: EM filters, Boolean list for like-sign pair selection

### DIFF
--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -36,8 +36,8 @@ DECLARE_SOA_COLUMN(SingleMuHigh, hasSingleMuHigh, bool); //! single muon with hi
 DECLARE_SOA_COLUMN(DiElectron, hasDiElectron, bool);     //! dielectron trigger
 DECLARE_SOA_COLUMN(DiMuon, hasDiMuon, bool);             //! dimuon trigger with low pT on muons
 // EM dielectrons
-DECLARE_SOA_COLUMN(LMeeIMR, hasLMeeIMR, bool);           //! dielectron trigger for IMR
-DECLARE_SOA_COLUMN(LMeeHighMass, hasLMeeHighMass, bool); //! dielectron trigger for high mass
+DECLARE_SOA_COLUMN(LMeeIMR, hasLMeeIMR, bool); //! dielectron trigger for intermediate mass region
+DECLARE_SOA_COLUMN(LMeeHMR, hasLMeeHMR, bool); //! dielectron trigger for high mass region
 
 // heavy flavours
 DECLARE_SOA_COLUMN(HfHighPt2P, hasHfHighPt2P, bool);                 //! high-pT 2-prong charm hadron
@@ -155,7 +155,7 @@ using DiffractionBCFilter = DiffractionBCFilters::iterator;
 
 // Dileptons & Quarkonia
 DECLARE_SOA_TABLE(DqFilters, "AOD", "DqFilters", //!
-                  filtering::SingleE, filtering::DiElectron, filtering::SingleMuLow, filtering::SingleMuHigh, filtering::DiMuon, filtering::LMeeIMR, filtering::LMeeHighMass);
+                  filtering::SingleE, filtering::LMeeIMR, filtering::LMeeHMR, filtering::DiElectron, filtering::SingleMuLow, filtering::SingleMuHigh, filtering::DiMuon);
 using DqFilter = DqFilters::iterator;
 
 // heavy flavours

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -35,6 +35,9 @@ DECLARE_SOA_COLUMN(SingleMuLow, hasSingleMuLow, bool);   //! single muon with lo
 DECLARE_SOA_COLUMN(SingleMuHigh, hasSingleMuHigh, bool); //! single muon with high pT trigger
 DECLARE_SOA_COLUMN(DiElectron, hasDiElectron, bool);     //! dielectron trigger
 DECLARE_SOA_COLUMN(DiMuon, hasDiMuon, bool);             //! dimuon trigger with low pT on muons
+// EM dielectrons
+DECLARE_SOA_COLUMN(LMeeIMR, hasLMeeIMR, bool);           //! dielectron trigger for IMR
+DECLARE_SOA_COLUMN(LMeeHighMass, hasLMeeHighMass, bool); //! dielectron trigger for high mass
 
 // heavy flavours
 DECLARE_SOA_COLUMN(HfHighPt2P, hasHfHighPt2P, bool);                 //! high-pT 2-prong charm hadron
@@ -152,7 +155,7 @@ using DiffractionBCFilter = DiffractionBCFilters::iterator;
 
 // Dileptons & Quarkonia
 DECLARE_SOA_TABLE(DqFilters, "AOD", "DqFilters", //!
-                  filtering::SingleE, filtering::DiElectron, filtering::SingleMuLow, filtering::SingleMuHigh, filtering::DiMuon);
+                  filtering::SingleE, filtering::DiElectron, filtering::SingleMuLow, filtering::SingleMuHigh, filtering::DiMuon, filtering::LMeeIMR, filtering::LMeeHighMass);
 using DqFilter = DqFilters::iterator;
 
 // heavy flavours

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -54,6 +54,8 @@ namespace
 {
 enum DQTriggers {
   kSingleE = 0,
+  kLMeeIMR,
+  kLMeeHMR,
   kDiElectron,
   kSingleMuLow,
   kSingleMuHigh,
@@ -493,14 +495,14 @@ struct DQFilterPPTask {
     // if the event is not selected produce tables and return
     if (!collision.isDQEventSelected()) {
       eventFilter(0);
-      dqtable(false, false, false, false, false);
+      dqtable(false, false, false, false, false, false, false);
       return;
     }
     fStats->Fill(-1.0);
 
     if (tracksBarrel.size() == 0 && muons.size() == 0) {
       eventFilter(0);
-      dqtable(false, false, false, false, false);
+      dqtable(false, false, false, false, false, false, false);
       return;
     }
 
@@ -636,7 +638,7 @@ struct DQFilterPPTask {
       }
     }
     eventFilter(filter);
-    dqtable(decisions[0], decisions[1], decisions[2], decisions[3], decisions[4]);
+    dqtable(decisions[0], decisions[1], decisions[2], decisions[3], decisions[4], decisions[5], decisions[6]);
   }
 
   void processFilterPP(MyEventsSelected::iterator const& collision, aod::BCs const& bcs,

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -1031,8 +1031,8 @@ struct DQFilterPPTask {
   Configurable<std::string> fConfigBarrelSelections{"cfgBarrelSels", "jpsiPID1:pairMassLow:1", "<track-cut>:[<pair-cut>]:<n>,[<track-cut>:[<pair-cut>]:<n>],..."};
   Configurable<std::string> fConfigMuonSelections{"cfgMuonSels", "muonQualityCuts:pairNoCut:1", "<muon-cut>:[<pair-cut>]:<n>"};
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
-  Configurable<bool> fConfigFilterLsBarrelTracksPairs{"cfgWithBarrelLS", false, "If true, also select like sign (--/++) barrel track pairs"};
-  Configurable<bool> fConfigFilterLsMuonsPairs{"cfgWithMuonLS", false, "If true, also select like sign (--/++) muon pairs"};
+  Configurable<std::string> fConfigFilterLsBarrelTracksPairs{"cfgWithBarrelLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) barrel track pairs"};
+  Configurable<std::string> fConfigFilterLsMuonsPairs{"cfgWithMuonLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) muon pairs"};
 
   int fNBarrelCuts;                                    // number of barrel selections
   int fNMuonCuts;                                      // number of muon selections
@@ -1169,6 +1169,17 @@ struct DQFilterPPTask {
       }
     }
 
+    // check which selection should use like sign (LS) (--/++) barrel track pairs
+    uint32_t pairingLS = 0; // used to set in which cut setting LS pairs will be analysed
+    TString barrelLSstr = fConfigFilterLsBarrelTracksPairs.value;
+    std::unique_ptr<TObjArray> objArrayLS(barrelLSstr.Tokenize(","));
+    for (int icut = 0; icut < fNBarrelCuts; icut++) {
+      TString* objStr = (TString*)objArrayLS->At(icut);
+      if (!objStr->CompareTo("true")) {
+        pairingLS |= (uint32_t(1) << icut);
+      }
+    }
+
     // run pairing if there is at least one selection that requires it
     uint32_t pairFilter = 0;
     if (pairingMask > 0) {
@@ -1183,16 +1194,17 @@ struct DQFilterPPTask {
         // get the tracks from the index stored in the association
         auto t1 = a1.template track_as<TTracks>();
         auto t2 = a2.template track_as<TTracks>();
-        // keep just opposite-sign pairs
-        if (!fConfigFilterLsBarrelTracksPairs) {
-          if (t1.sign() * t2.sign() > 0) {
-            continue;
-          }
-        }
 
         // construct the pair and apply pair cuts
         VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(t1, t2); // compute pair quantities
         for (int icut = 0; icut < fNBarrelCuts; icut++) {
+          // select like-sign pairs if trigger has set boolean true within fConfigFilterLsBarrelTracksPairs
+          if (pairingLS & (uint32_t(1) << icut)) {
+            if (t1.sign() * t2.sign() > 0) {
+              continue;
+            }
+          }
+
           if (!(pairFilter & (uint32_t(1) << icut))) {
             continue;
           }
@@ -1228,6 +1240,16 @@ struct DQFilterPPTask {
       }
     }
 
+    pairingLS = 0; // reset the decisions for muons
+    TString musonLSstr = fConfigFilterLsMuonsPairs.value;
+    std::unique_ptr<TObjArray> objArrayMuonLS(musonLSstr.Tokenize(","));
+    for (int icut = 0; icut < fNMuonCuts; icut++) {
+      TString* objStr = (TString*)objArrayMuonLS->At(icut);
+      if (!objStr->CompareTo("true")) {
+        pairingLS |= (uint32_t(1) << icut);
+      }
+    }
+
     // run pairing if there is at least one selection that requires it
     pairFilter = 0;
     if (pairingMask > 0) {
@@ -1243,16 +1265,16 @@ struct DQFilterPPTask {
         // get the real muon tracks
         auto t1 = a1.template fwdtrack_as<TMuons>();
         auto t2 = a2.template fwdtrack_as<TMuons>();
-        // keep just opposite-sign pairs
-        if (!fConfigFilterLsMuonsPairs) {
-          if (t1.sign() * t2.sign() > 0) {
-            continue;
-          }
-        }
 
         // construct the pair and apply cuts
         VarManager::FillPair<VarManager::kDecayToMuMu, TTrackFillMap>(t1, t2); // compute pair quantities
         for (int icut = 0; icut < fNMuonCuts; icut++) {
+          // select like-sign pairs if trigger has set boolean true within fConfigFilterLsMuonsPairs
+          if (pairingLS & (uint32_t(1) << icut)) {
+            if (t1.sign() * t2.sign() > 0) {
+              continue;
+            }
+          }
           if (!(pairFilter & (uint32_t(1) << icut))) {
             continue;
           }
@@ -1417,13 +1439,13 @@ struct DQFilterPPTask {
       fStats->Fill(-2.0);
       if (!collision.isDQEventSelected()) {
         eventFilter(0);
-        dqtable(false, false, false, false, false);
+        dqtable(false, false, false, false, false, false, false);
       }
       fStats->Fill(-1.0);
 
       if (fFiltersMap.find(collision.globalIndex()) == fFiltersMap.end()) {
         eventFilter(0);
-        dqtable(false, false, false, false, false);
+        dqtable(false, false, false, false, false, false, false);
       } else {
         totalEventsTriggered++;
         for (int i = 0; i < fNBarrelCuts + fNMuonCuts; i++) {
@@ -1432,7 +1454,7 @@ struct DQFilterPPTask {
         }
         eventFilter(fFiltersMap[collision.globalIndex()]);
         auto dqDecisions = fCEFPfilters[collision.globalIndex()];
-        dqtable(dqDecisions[0], dqDecisions[1], dqDecisions[2], dqDecisions[3], dqDecisions[4]);
+        dqtable(dqDecisions[0], dqDecisions[1], dqDecisions[2], dqDecisions[3], dqDecisions[4], dqDecisions[5], dqDecisions[6]);
       }
     }
 

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -66,6 +66,8 @@ enum DQTriggers {
   kSingleMuLow,
   kSingleMuHigh,
   kDiMuon,
+  kLMeeIMR,
+  kLMeehighMass,
   kNTriggersDQ
 };
 } // namespace

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -1174,8 +1174,8 @@ struct DQFilterPPTask {
     TString barrelLSstr = fConfigFilterLsBarrelTracksPairs.value;
     std::unique_ptr<TObjArray> objArrayLS(barrelLSstr.Tokenize(","));
     for (int icut = 0; icut < fNBarrelCuts; icut++) {
-      TString* objStr = (TString*)objArrayLS->At(icut);
-      if (!objStr->CompareTo("true")) {
+      TString objStr = objArrayLS->At(icut)->GetName();
+      if (!objStr.CompareTo("true")) {
         pairingLS |= (uint32_t(1) << icut);
       }
     }
@@ -1199,7 +1199,7 @@ struct DQFilterPPTask {
         VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(t1, t2); // compute pair quantities
         for (int icut = 0; icut < fNBarrelCuts; icut++) {
           // select like-sign pairs if trigger has set boolean true within fConfigFilterLsBarrelTracksPairs
-          if (pairingLS & (uint32_t(1) << icut)) {
+          if (!(pairingLS & (uint32_t(1) << icut))) {
             if (t1.sign() * t2.sign() > 0) {
               continue;
             }
@@ -1244,8 +1244,8 @@ struct DQFilterPPTask {
     TString musonLSstr = fConfigFilterLsMuonsPairs.value;
     std::unique_ptr<TObjArray> objArrayMuonLS(musonLSstr.Tokenize(","));
     for (int icut = 0; icut < fNMuonCuts; icut++) {
-      TString* objStr = (TString*)objArrayMuonLS->At(icut);
-      if (!objStr->CompareTo("true")) {
+      TString objStr = objArrayMuonLS->At(icut)->GetName();
+      if (!objStr.CompareTo("true")) {
         pairingLS |= (uint32_t(1) << icut);
       }
     }
@@ -1270,7 +1270,7 @@ struct DQFilterPPTask {
         VarManager::FillPair<VarManager::kDecayToMuMu, TTrackFillMap>(t1, t2); // compute pair quantities
         for (int icut = 0; icut < fNMuonCuts; icut++) {
           // select like-sign pairs if trigger has set boolean true within fConfigFilterLsMuonsPairs
-          if (pairingLS & (uint32_t(1) << icut)) {
+          if (!(pairingLS & (uint32_t(1) << icut))) {
             if (t1.sign() * t2.sign() > 0) {
               continue;
             }

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -62,12 +62,12 @@ namespace
 {
 enum DQTriggers {
   kSingleE = 0,
+  kLMeeIMR,
+  kLMeeHMR,
   kDiElectron,
   kSingleMuLow,
   kSingleMuHigh,
   kDiMuon,
-  kLMeeIMR,
-  kLMeehighMass,
   kNTriggersDQ
 };
 } // namespace


### PR DESCRIPTION
This is a draft to include the dielectron triggers to the filtering schemes.


Using the filterPPwithAssociation.cxx task
Adding two filters: 
kLMeeIMR     (triggering for ee pairs with mass 1.3 to 3.5 GeV/c2)
kLMeeHMR   (triggering for ee pairs with mass above 3.5 GeV/c2)

Need to select LS pairs only for EM dielectron triggers.
So I implemented the selection of LS pairs by a comma separated list of booleans for each filter selected.

I would like to ask @vfeuilla to have a look at this PR. 
Local errors have prevented me to test it, yet. 