### PR TITLE
PWGHF: further optimise HF combinatorial

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -153,7 +153,7 @@ DECLARE_SOA_TABLE(HfSelCollision, "AOD", "HFSELCOLLISION", //!
 namespace hf_sel_track
 {
 DECLARE_SOA_COLUMN(IsSelProng, isSelProng, uint32_t); //!
-DECLARE_SOA_COLUMN(IsProton, isProton, int8_t);       //!
+DECLARE_SOA_COLUMN(IsProton, isProton, uint8_t);       //!
 DECLARE_SOA_COLUMN(IsPositive, isPositive, bool);     //!
 } // namespace hf_sel_track
 

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -153,7 +153,7 @@ DECLARE_SOA_TABLE(HfSelCollision, "AOD", "HFSELCOLLISION", //!
 namespace hf_sel_track
 {
 DECLARE_SOA_COLUMN(IsSelProng, isSelProng, uint32_t); //!
-DECLARE_SOA_COLUMN(IsProton, isProton, uint8_t);       //!
+DECLARE_SOA_COLUMN(IsProton, isProton, uint32_t);     //!
 DECLARE_SOA_COLUMN(IsPositive, isPositive, bool);     //!
 } // namespace hf_sel_track
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1277,7 +1277,7 @@ struct HfTrackIndexSkimCreator {
   Produces<aod::HfPvRefitDstar> rowDstarPVrefit;
 
   Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
-  Configurable<int> do3Prong{"do3Prong", 0, "do 3 prong"};
+  Configurable<bool> do3Prong{"do3Prong", 0, "do 3 prong"};
   Configurable<bool> doDstar{"doDstar", false, "do D* candidates"};
   Configurable<bool> debug{"debug", false, "debug mode"};
   Configurable<bool> debugPvRefit{"debugPvRefit", false, "debug lines for primary vertex refit"};
@@ -1288,8 +1288,8 @@ struct HfTrackIndexSkimCreator {
   // preselection
   Configurable<double> ptTolerance{"ptTolerance", 0.1, "pT tolerance in GeV/c for applying preselections before vertex reconstruction"};
   // preselection of 3-prongs using the decay length computed only with the first two tracks
-  Configurable<double> minTwoTrackDecayLengthFor3Prongs{"twoTrackDecayLengthFor3Prongs", 0., "Minimum decay length computed with 2 tracks for 3-prongs to speedup combinatorial"};
-  Configurable<double> maxTwoTrackChi2PcaFor3Prongs{"maxTwoTrackChi2PcaFor3Prongs", 10000., "Maximum chi2 pca computed with 2 tracks for 3-prongs to speedup combinatorial"};
+  Configurable<double> minTwoTrackDecayLengthFor3Prongs{"minTwoTrackDecayLengthFor3Prongs", 0., "Minimum decay length computed with 2 tracks for 3-prongs to speedup combinatorial"};
+  Configurable<double> maxTwoTrackChi2PcaFor3Prongs{"maxTwoTrackChi2PcaFor3Prongs", 1.e10, "Maximum chi2 pca computed with 2 tracks for 3-prongs to speedup combinatorial"};
   // vertexing
   // Configurable<double> bz{"bz", 5., "magnetic field kG"};
   Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
@@ -2381,7 +2381,7 @@ struct HfTrackIndexSkimCreator {
           }
 
           // if the cut on the decay length of 3-prongs computed with the first two tracks is enabled and the vertex was not computed for the D0, we compute it now
-          if (do3Prong == 1 && minTwoTrackDecayLengthFor3Prongs > 0.f && is2ProngCandidateGoodFor3Prong && nVtxFrom2ProngFitter == 0) {
+          if (do3Prong == 1 && is2ProngCandidateGoodFor3Prong && (minTwoTrackDecayLengthFor3Prongs > 0.f || maxTwoTrackChi2PcaFor3Prongs < 1.e9f) && nVtxFrom2ProngFitter == 0) {
             try {
               nVtxFrom2ProngFitter = df2.process(trackParVarPos1, trackParVarNeg1);
             } catch (...) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2307,7 +2307,7 @@ struct HfTrackIndexSkimCreator {
                   if constexpr (doPvRefit) {
                     // fill table row with coordinates of PV refit
                     rowProng2PVrefit(pvRefitCoord2Prong[0], pvRefitCoord2Prong[1], pvRefitCoord2Prong[2],
-                                    pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
+                                     pvRefitCovMatrix2Prong[0], pvRefitCovMatrix2Prong[1], pvRefitCovMatrix2Prong[2], pvRefitCovMatrix2Prong[3], pvRefitCovMatrix2Prong[4], pvRefitCovMatrix2Prong[5]);
                   }
 
                   if (debug) {
@@ -3017,10 +3017,9 @@ struct HfTrackIndexSkimCreatorCascades {
   double massK0s{0.};
   double massPi{0.};
   double massLc{0.};
-  double mass2K0sP{0.}; // WHY HERE?
 
   Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == 0);
-  Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandV0bachelor))) != 0u && (applyProtonPid == false || (aod::hf_sel_track::isProton & static_cast<uint8_t>(BIT(ChannelsProtonPid::LcToPK0S))) != 0u);
+  Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandV0bachelor))) != 0u && (applyProtonPid == false || (aod::hf_sel_track::isProton & static_cast<uint32_t>(BIT(ChannelsProtonPid::LcToPK0S))) != 0u);
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
@@ -3165,7 +3164,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
           // invariant-mass cut: we do it here, before updating the momenta of bach and V0 during the fitting to save CPU
           // TODO: but one should better check that the value here and after the fitter do not change significantly!!!
-          mass2K0sP = RecoDecay::m(std::array{std::array{bach.px(), bach.py(), bach.pz()}, momentumV0}, std::array{massP, massK0s});
+          double mass2K0sP = RecoDecay::m(std::array{std::array{bach.px(), bach.py(), bach.pz()}, momentumV0}, std::array{massP, massK0s});
           if ((cutInvMassCascLc >= 0.) && (std::abs(mass2K0sP - massLc) > cutInvMassCascLc)) {
             continue;
           }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2290,7 +2290,7 @@ struct HfTrackIndexSkimCreator {
                   pvCoord2Prong[2] = pvRefitCoord2Prong[2];
                 }
                 is2ProngSelected(pVecCandProng2, secondaryVertex2, pvCoord2Prong, cutStatus2Prong, isSelected2ProngCand);
-                if (is2ProngCandidateGoodFor3Prong) {
+                if (is2ProngCandidateGoodFor3Prong && do3Prong == 1) {
                   auto decLen = RecoDecay::distance(pvCoord2Prong, secondaryVertex2);
                   if (decLen < minTwoTrackDecayLengthFor3Prongs) {
                     is2ProngCandidateGoodFor3Prong = false;
@@ -2364,7 +2364,7 @@ struct HfTrackIndexSkimCreator {
           }
 
           // if the cut on the decay length of 3-prongs computed with the first two tracks is enabled and the vertex was not computed for the D0, we compute it now
-          if (minTwoTrackDecayLengthFor3Prongs > 0.f && is2ProngCandidateGoodFor3Prong && nVtxFrom2ProngFitter == 0) {
+          if (do3Prong == 1 && minTwoTrackDecayLengthFor3Prongs > 0.f && is2ProngCandidateGoodFor3Prong && nVtxFrom2ProngFitter == 0) {
             try {
               nVtxFrom2ProngFitter = df2.process(trackParVarPos1, trackParVarNeg1);
             } catch (...) {


### PR DESCRIPTION
This PR adds two optimisations for the HF combinatorial:
- For Lc->pK0S, the bachelor track is filtered considering the proton PID (no other hypotheses are used)
- For 3-prong channels, it adds the possibility to apply a cut on the decay length computed with the first two tracks to avoid the third loop