### PR TITLE
PWGCF: fix seeding in collision masker

### DIFF
--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -13,10 +13,12 @@
 /// \brief Tasks creates bitmasks for femtodream collisions
 /// \author Anton Riedel, TU München, anton.riedel@tum.de
 
+#include <cstdint>
 #include <vector>
 #include <bitset>
 #include <algorithm>
 #include <random>
+#include <chrono>
 
 #include "fairlogger/Logger.h"
 #include "Framework/Configurable.h"
@@ -54,7 +56,7 @@ struct femoDreamCollisionMasker {
 
   // configurable for downsampling
   Configurable<float> ConfDownsampling{"ConfDownsampling", -1., "Fraction of events to be used in mixed event sample. Factor should be between 0 and 1. Deactivate with negative value"};
-  Configurable<uint> ConfSeed{"ConfSeed", 29012024, "Seed for downsampling"};
+  Configurable<uint64_t> ConfSeed{"ConfSeed", 0, "Seed for downsampling. Set to 0 for using a seed unique in time."};
 
   std::mt19937* rng = nullptr;
 
@@ -94,8 +96,14 @@ struct femoDreamCollisionMasker {
   {
 
     // seed rng for downsampling
-    if (ConfSeed.value > 0) {
-      rng = new std::mt19937(ConfSeed.value);
+    if (ConfDownsampling.value > 0) {
+      uint64_t randomSeed = 0;
+      if (ConfSeed.value == 0) {
+        randomSeed = static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+      } else {
+        randomSeed = ConfSeed.value;
+      }
+      rng = new std::mt19937(randomSeed);
     }
 
     std::vector<std::string> MatchedWorkflows;
@@ -356,7 +364,7 @@ struct femoDreamCollisionMasker {
     bool UseInMixedEvent = true;
     std::uniform_real_distribution<> dist(0, 1);
 
-    if (ConfSeed.value > 0 && (1 - dist(*rng)) > ConfDownsampling.value) {
+    if (ConfDownsampling.value > 0 && (1 - dist(*rng)) > ConfDownsampling.value) {
       UseInMixedEvent = false;
     }
 


### PR DESCRIPTION
Add the option to use a unique seed in time for the downsampling. Also, apply a fix to disable the downsampling if the downsampling factor is set to a negative value, not the seed.