### PR TITLE
Implementing Muon to vertex propagation in the filterPP task

### DIFF
--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -40,6 +40,7 @@
 #include "PWGDQ/Core/HistogramsLibrary.h"
 #include "PWGDQ/Core/CutsLibrary.h"
 #include "CommonConstants/LHCConstants.h"
+#include "Common/Core/CollisionAssociation.h"
 #include "Common/DataModel/CollisionAssociationTables.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DataFormatsParameters/GRPObject.h"
@@ -83,16 +84,9 @@ DECLARE_SOA_INDEX_COLUMN(Track, track);         //! Track index
 DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);   //! FwdTrack index
 } // namespace dqppfilter
 
-DECLARE_SOA_TABLE(DQTrackAssoc, "AOD", "DQTRACKASSOC", //! Table for track-to-collision association (tracks can appear for several collisions)
-                  dqppfilter::CollisionId,
-                  dqppfilter::TrackId,
-                  dqppfilter::IsDQBarrelSelected);
-DECLARE_SOA_TABLE(DQMuonAssoc, "AOD", "DQMUONASSOC", //! Table for muon-to-collision association (tracks can appear for several collisions)
-                  dqppfilter::CollisionId,
-                  dqppfilter::FwdTrackId,
-                  dqppfilter::IsDQMuonSelected);
-
 DECLARE_SOA_TABLE(DQEventCuts, "AOD", "DQEVENTCUTS", dqppfilter::IsDQEventSelected);
+DECLARE_SOA_TABLE(DQBarrelTrackCuts, "AOD", "DQBARRELCUTS", dqppfilter::IsDQBarrelSelected);
+DECLARE_SOA_TABLE(DQMuonsCuts, "AOD", "DQMUONCUTS", dqppfilter::IsDQMuonSelected);
 } // namespace o2::aod
 
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
@@ -100,16 +94,24 @@ using MyEventsSelected = soa::Join<aod::Collisions, aod::EvSels, aod::DQEventCut
 // TODO: subscribe to the bare needed minimum, in particular for the CEFP task
 // TODO: test working with TrackIU
 // TODO: remove the TOF pid if not needed (requires changes in VarManager to separate TrackPID into TPC and TOF)
-using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection,
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
                                  aod::pidTPCFullEl, aod::pidTPCFullPi,
                                  aod::pidTPCFullKa, aod::pidTPCFullPr,
                                  aod::pidTOFFullEl, aod::pidTOFFullPi,
                                  aod::pidTOFFullKa, aod::pidTOFFullPr>;
-using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
+using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
+                                         aod::pidTPCFullEl, aod::pidTPCFullPi,
+                                         aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                         aod::pidTOFFullEl, aod::pidTOFFullPi,
+                                         aod::pidTOFFullKa, aod::pidTOFFullPr,
+                                         aod::DQBarrelTrackCuts>;
+
+using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
+using MyMuonsAssocSelected = soa::Join<FwdTrackAssoc, aod::DQMuonsCuts>; // As the kinelatic values must be re-computed for the muons tracks everytime it is associated to a collision, the selection is done not on the muon, but on the muon-collision association
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
-constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackPID;
-constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackPID;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses);
 
@@ -183,7 +185,7 @@ struct DQEventSelectionTask {
 };
 
 struct DQBarrelTrackSelection {
-  Produces<aod::DQTrackAssoc> trackAssoc;
+  Produces<aod::DQBarrelTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
@@ -191,42 +193,18 @@ struct DQBarrelTrackSelection {
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/i/iarsene/Calib/TPCpostCalib", "base path to the ccdb object"};
-  // Configurable<std::string> rct_path{"rct-path", "RCT/Info/RunInformation", "path to the ccdb RCT objects for the SOR timestamps"};
   Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
   Configurable<bool> fConfigComputeTPCpostCalib{"cfgTPCpostCalib", false, "If true, compute TPC post-calibrated n-sigmas"};
-  Configurable<bool> fIsRun2{"cfgIsRun2", false, "Whether we analyze Run-2 or Run-3 data"};
-  Configurable<float> fConfigBarrelTrackPtLow{"cfgBarrelLowPt", 0.5f, "Low pt cut for tracks in the barrel"};
-  Configurable<float> fConfigMinTpcSignal{"cfgMinTpcSignal", 65.0, "Minimum TPC signal"};
-  Configurable<float> fConfigMaxTpcSignal{"cfgMaxTpcSignal", 110.0, "Maximum TPC signal"};
-  Configurable<int> fConfigCollisionTrackAssoc{"cfgCollisionTrackAssoc", 0, "0 - standard association, 1 - time compatibility, 2 - ambiguous"};
-  Configurable<float> fConfigAssocTimeMargin{"cfgAssocTimeMargin", 0.0f, "Extra time margin to be considered when doing collision - track matching (in ns)"};
-  Configurable<float> fConfigSigmaForTimeCompat{"cfgSigmaForTimeCompat", 4.0, "nSigma window when doing collision - track matching "};
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
-  // o2::ccdb::CcdbApi fCCDB_api;                /// API to access CCDB headers
 
   std::vector<AnalysisCompositeCut> fTrackCuts;
   std::vector<TString> fCutHistNames;
 
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
-  std::map<int64_t, uint32_t> fSelectedTracks;
-
-  // int fTimeFrameAssociation;
-  // int fTimeFrameSelection;
-
-  Filter barrelSelectedTracks = ifnode(fIsRun2.node() == true, aod::track::trackType == uint8_t(aod::track::Run2Track), aod::track::trackType == uint8_t(aod::track::Track)) && o2::aod::track::pt >= fConfigBarrelTrackPtLow &&
-                                nabs(o2::aod::track::eta) <= 0.9f &&
-                                o2::aod::track::tpcSignal >= fConfigMinTpcSignal && o2::aod::track::tpcSignal <= fConfigMaxTpcSignal;
 
   void init(o2::framework::InitContext&)
   {
-    // fTimeFrameAssociation = 0;
-    // fTimeFrameSelection = 0;
-
-    if (fConfigCollisionTrackAssoc.value < 0 || fConfigCollisionTrackAssoc.value > 2) {
-      LOGF(fatal, "Invalid collision-track association option. Must be either 0, 1 or 2");
-    }
-
     TString cutNamesStr = fConfigCuts.value;
     if (!cutNamesStr.IsNull()) {
       std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
@@ -265,205 +243,6 @@ struct DQBarrelTrackSelection {
         // Not later than now objects
         fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
       }
-      /*fCCDB_api.init(fConfigCcdbUrl.value);
-      if (!fCCDB_api.isHostReachable()) {
-        LOGF(fatal, "CCDB host %s is not reacheable, cannot go forward", fConfigCcdbUrl.value.data());
-      }*/
-    }
-    fSelectedTracks.clear();
-  }
-
-  template <typename TTracks>
-  void associateTracksToCollisionsStandard(Collisions const& collisions,
-                                           TTracks const& tracksBarrel)
-  {
-    // This is the standard association: does nothing, just associate the already selected tracks to their own default collision
-    // loop over collisions to find time-compatible tracks
-    if (fSelectedTracks.size() == 0) {
-      return;
-    }
-
-    for (auto const& [trackIdx, filterMap] : fSelectedTracks) {
-      auto track = tracksBarrel.rawIteratorAt(trackIdx);
-      trackAssoc(track.collision().globalIndex(), trackIdx, filterMap);
-    }
-  }
-
-  template <typename TTracks>
-  void associateTracksToCollisionsTime(Collisions const& collisions,
-                                       TTracks const& tracksBarrel,
-                                       BCsWithTimestamps const& bcs)
-  {
-    // loop over collisions to find time-compatible tracks
-    if (fSelectedTracks.size() == 0) {
-      return;
-    }
-    float timeMargin = fConfigAssocTimeMargin.value;
-    float nSigmaForTimeCompat = fConfigSigmaForTimeCompat.value;
-
-    auto trackBegin = fSelectedTracks.begin();
-    const auto bOffsetMax = 241; // 6 mus (ITS)
-    for (const auto& collision : collisions) {
-      const float collTime = collision.collisionTime();
-      const float collTimeRes2 = collision.collisionTimeRes() * collision.collisionTimeRes();
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-      uint64_t collBC = bc.globalBC();
-      bool iteratorMoved = false;
-
-      for (auto trackFiltered = trackBegin; trackFiltered != fSelectedTracks.end(); trackFiltered++) {
-        auto track = tracksBarrel.rawIteratorAt(trackFiltered->first);
-        auto trackBC = track.collision().template bc_as<aod::BCsWithTimestamps>();
-        const int64_t bcOffset = (int64_t)trackBC.globalBC() - (int64_t)collBC;
-
-        float trackTime{0.};
-        float trackTimeRes{0.};
-        if (track.isPVContributor()) {
-          trackTime = track.collision().collisionTime(); // if PV contributor, we assume the time to be the one of the collision
-          trackTimeRes = 25.f;                           // 1 BC
-        } else {
-          trackTime = track.trackTime();
-          trackTimeRes = track.trackTimeRes();
-        }
-        const float deltaTime = trackTime - collTime + bcOffset * 25.f;
-        float sigmaTimeRes2 = collTimeRes2 + trackTimeRes * trackTimeRes;
-
-        // optimization to avoid looping over all collisions in the TF (loop just for +/- bOffsetMax around the track)
-        if (!iteratorMoved && bcOffset > -bOffsetMax) {
-          trackBegin = trackFiltered;
-          iteratorMoved = true;
-        } else if (bcOffset > bOffsetMax) {
-          break;
-        }
-
-        float thresholdTime = 0.;
-        if (track.isPVContributor()) {
-          thresholdTime = trackTimeRes;
-        } else if (TESTBIT(track.flags(), o2::aod::track::TrackTimeResIsRange)) {
-          thresholdTime = std::sqrt(sigmaTimeRes2) + timeMargin;
-        } else {
-          thresholdTime = nSigmaForTimeCompat * std::sqrt(sigmaTimeRes2) + timeMargin;
-        }
-
-        if (std::abs(deltaTime) < thresholdTime) {
-          const auto collIdx = collision.globalIndex();
-          trackAssoc(collIdx, trackFiltered->first, trackFiltered->second);
-        }
-      } // end loop for tracks
-    }   // end for collisions
-  }
-
-  template <typename TTracks>
-  void associateTracksToCollisionsAmbigous(Collisions const& collisions,
-                                           TTracks const& tracksBarrel,
-                                           BCsWithTimestamps const& bcs,
-                                           AmbiguousTracks const& ambTracks)
-  {
-    if (fSelectedTracks.size() == 0) {
-      return;
-    }
-
-    // map to keep all collision-track associations (ordered based on the key by construction); for each collision there is a vector of tracks
-    std::map<int64_t, std::vector<int64_t>> collTrackIds;
-    // map to hold collision - BC associations
-    std::map<uint64_t, uint64_t> collBCmap;
-
-    // create the standard collision - track associations (track and their default collision)
-    for (auto const& [trackIdx, filterMap] : fSelectedTracks) {
-      auto track = tracksBarrel.rawIteratorAt(trackIdx);
-      auto collId = track.collisionId();
-      if (collTrackIds.find(collId) == collTrackIds.end()) { // this colision is not in the map
-        std::vector<int64_t> idxs{trackIdx};
-        collTrackIds[collId] = idxs;
-      } else { // collision is in the map, add track to the vector
-        auto idxs = collTrackIds[collId];
-        // cout << "collision in the map already with " << idxs.size() << " tracks" << endl;
-        idxs.push_back(trackIdx);
-        collTrackIds[collId] = idxs;
-      }
-      auto collision = collisions.rawIteratorAt(collId);
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-      collBCmap[collId] = bc.globalBC();
-    }
-
-    // associate ambiguous tracks with compatible collisions
-    for (const auto& ambTrack : ambTracks) {
-      // use just the ambiguous tracks that are selected
-      if (fSelectedTracks.find(ambTrack.trackId()) == fSelectedTracks.end()) {
-        continue;
-      }
-      auto track = ambTrack.template track_as<TTracks>();
-
-      // Loop over all collisions
-      for (const auto& collision : collisions) {
-        const auto collId = collision.globalIndex();
-        // if this collision is the same as the default one of the track, skip since this association was added already
-        if (collId == track.collisionId()) {
-          continue;
-        }
-
-        // get the BC of this collision
-        auto bcColl = collision.template bc_as<aod::BCsWithTimestamps>();
-        const uint64_t mostProbableBc = bcColl.globalBC();
-        // loop over the track BC slice and check if this collision matches
-        for (const auto& bc : ambTrack.bc()) {
-          if (bc.globalBC() == mostProbableBc) { // found a match, add it to the association map
-            const int64_t trackId = track.globalIndex();
-            if (collTrackIds.find(collId) == collTrackIds.end()) {
-              std::vector<int64_t> idxs{trackId};
-              collTrackIds[collId] = idxs;
-            } else {
-              auto idxs = collTrackIds[collId];
-              idxs.push_back(trackId);
-              collTrackIds[collId] = idxs;
-            }
-            collBCmap[collId] = bc.globalBC();
-          }
-        } // end loop over BCs
-      }   // end loop over collisions
-    }     // end loop over ambiguous tracks
-
-    // associate tracks with in-bunch pileup collisions
-    // Loop over the already existing associations
-    // NOTE: to be checked if this does something, since the pileup collisions should had been already associated in the previous step
-    for (auto const& [collId, assocTracks] : collTrackIds) {
-      const uint64_t currentBC = collBCmap[collId];
-      std::vector<uint64_t> pileupCollIds{};
-      for (const auto& collision : collisions) { // NOTE: since collisions should be ordered in time, one could optimize here and not make the full loop
-        auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-        if (bc.globalBC() == currentBC) {
-          if (collision.globalIndex() != collId) { // found a pileup collision (different collisions pointing to the same BC)
-            pileupCollIds.push_back(collision.globalIndex());
-          }
-        }
-      }
-
-      // in-bunch pileup requires at least 2 collisions in the same bunch (collId + another one)
-      if (pileupCollIds.size() < 1) {
-        continue;
-      }
-
-      // here we have in bunch pileup and we will associate the tracks from collId to the other (pileup) collisions
-      for (const auto& pileupCollId : pileupCollIds) {
-        for (const auto& assocTrack : assocTracks) {
-          if (collTrackIds.find(pileupCollId) == collTrackIds.end()) { // this colision is not in the map
-            std::vector<int64_t> idxs{assocTrack};
-            collTrackIds[pileupCollId] = idxs;
-          } else {
-            auto idxs = collTrackIds[pileupCollId];
-            if (std::find(idxs.begin(), idxs.end(), assocTrack) == idxs.end()) { // check if the track is already in the list or not
-              idxs.push_back(assocTrack);
-            }
-            collTrackIds[pileupCollId] = idxs;
-          }
-        } // end loop over tracks associated to collId
-      }   // end loop over pileup collisions
-    }
-
-    // create the collision - track association table
-    for (auto const& [collId, assocTracks] : collTrackIds) {
-      for (const auto& assocTrack : assocTracks) {
-        trackAssoc(collId, assocTrack, fSelectedTracks[assocTrack]);
-      }
     }
   }
 
@@ -471,7 +250,6 @@ struct DQBarrelTrackSelection {
   template <uint32_t TTrackFillMap, typename TTracks>
   void runTrackSelection(aod::BCsWithTimestamps const& bcs, TTracks const& tracksBarrel)
   {
-    fSelectedTracks.clear();
     auto bc = bcs.begin(); // check just the first bc to get the run number
     if (fCurrentRun != bc.runNumber()) {
       fCurrentRun = bc.runNumber();
@@ -484,29 +262,13 @@ struct DQBarrelTrackSelection {
         VarManager::SetCalibrationObject(VarManager::kTPCProtonMean, calibList->FindObject("mean_map_proton"));
         VarManager::SetCalibrationObject(VarManager::kTPCProtonSigma, calibList->FindObject("sigma_map_proton"));
       }
-
-      /*std::map<std::string, std::string> metadata, headers;
-      const std::string run_path = Form("%s/%i", rct_path.value.data(), fCurrentRun);
-      headers = fCCDB_api.retrieveHeaders(run_path, metadata, -1);
-      if (headers.count("SOR") == 0) {
-        LOGF(fatal, "Cannot find start-of-run timestamp for run number in path '%s'.", run_path.data());
-      }
-      if (headers.count("EOR") == 0) {
-        LOGF(fatal, "Cannot find end-of-run timestamp for run number in path '%s'.", run_path.data());
-      }
-
-      int64_t sorTimestamp = atol(headers["SOR"].c_str()); // timestamp of the SOR in ms
-      int64_t eorTimestamp = atol(headers["EOR"].c_str()); // timestamp of the EOR in ms
-      */
     }
 
     uint32_t filterMap = uint32_t(0);
+    trackSel.reserve(tracksBarrel.size());
+
     VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
     for (auto& track : tracksBarrel) {
-      // NOTE: Here we explicitly remove orphan tracks
-      if (!track.has_collision()) {
-        continue;
-      }
       filterMap = uint32_t(0);
 
       VarManager::FillTrack<TTrackFillMap>(track);
@@ -522,24 +284,13 @@ struct DQBarrelTrackSelection {
           }
         }
       }
-      if (filterMap != 0) {
-        fSelectedTracks[track.globalIndex()] = filterMap;
-      }
+      trackSel(filterMap);
     } // end loop over tracks
   }
 
-  void processSelection(Collisions const& collisions, aod::BCsWithTimestamps const& bcs,
-                        MyBarrelTracks const& tracks, soa::Filtered<MyBarrelTracks> const& filteredTracks,
-                        AmbiguousTracks const& ambTracks)
+  void processSelection(aod::BCsWithTimestamps const& bcs, MyBarrelTracks const& tracks)
   {
-    runTrackSelection<gkTrackFillMap>(bcs, filteredTracks);
-    if (fConfigCollisionTrackAssoc.value == 0) {
-      associateTracksToCollisionsStandard(collisions, tracks);
-    } else if (fConfigCollisionTrackAssoc.value == 1) {
-      associateTracksToCollisionsTime(collisions, tracks, bcs);
-    } else {
-      associateTracksToCollisionsAmbigous(collisions, tracks, bcs, ambTracks);
-    }
+    runTrackSelection<gkTrackFillMap>(bcs, tracks);
   }
 
   void processDummy(MyBarrelTracks&)
@@ -552,46 +303,28 @@ struct DQBarrelTrackSelection {
 };
 
 struct DQMuonsSelection {
-  Produces<aod::DQMuonAssoc> muonAssoc;
+  Produces<aod::DQMuonsCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
-  HistogramRegistry registry{
-    "registry",
-    {{"Association/DeltaT", "; t_vtx - t_track; counts", {HistType::kTH1F, {{2000, -50., 50.}}}},
-     {"Association/AssociationTrackStatus", "; status; counts", {HistType::kTH1F, {{10, 0, 10}}}}}};
-
   Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonQualityCuts", "Comma separated list of ADDITIONAL muon track cuts"};
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
-  Configurable<float> fConfigMuonPtLow{"cfgMuonLowPt", 0.5f, "Low pt cut for muons"};
-  Configurable<int> fConfigCollisionMuonAssoc{"cfgCollisionMuonAssoc", 0, "0 - standard association, 1 - time compatibility, 2 - ambiguous"};
   Configurable<bool> fPropMuon{"cfgPropMuon", false, "Propgate muon tracks through absorber"};
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
-  Configurable<float> fConfigAssocTimeMargin{"cfgAssocTimeMargin", 0.0f, "Extra time margin to be considered when doing collision - muon matching (in ns)"};
-  Configurable<float> fConfigSigmaForTimeCompat{"cfgSigmaForTimeCompat", 4.0, "nSigma window when doing collision - track matching "};
-  Configurable<float> fSigmaTrack{"cfgSigmaTrack", 1.0, "Number of sigma for track time window"};
-  Configurable<float> fSigmaVtx{"cfgSigmaVtx", 4.0, "Number of sigma for vertex time window"};
-  Configurable<float> fTimeMarginTrack{"cfgTimeMarginTrack", 0.0, "Number of sigma for track time window"};
-  Configurable<float> fTimeMarginVtx{"cfgTimeMarginVtx", 0.0, "Number of sigma for vertex time window"};
-  Configurable<float> fTimeBias{"cfgTimeBias", 0.0, "Number of sigma for track time window"};
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
   o2::parameters::GRPMagField* grpmag = nullptr; // for run 3, we access GRPMagField from GLO/Config/GRPMagField
+
+  Preslice<aod::FwdTrackAssoc> fwdtrackIndicesPerCollision = aod::track_association::collisionId;
 
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
 
   // TODO: configure the histogram classes to be filled by QA
 
-  Filter muonFilter = o2::aod::fwdtrack::pt >= fConfigMuonPtLow;
-
   std::vector<AnalysisCompositeCut> fTrackCuts;
   std::vector<TString> fCutHistNames;
-
-  std::map<int64_t, uint32_t> fSelectedMuons;
-  std::map<int64_t, int> isMuonReassigned;
-  std::vector<std::pair<std::pair<double, double>, int>> vtxOrdBrack;
 
   void init(o2::framework::InitContext&)
   {
@@ -629,19 +362,10 @@ struct DQMuonsSelection {
       VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
       fOutputList.setObject(fHistMan->GetMainHistogramList());
     }
-
-    auto hstatus2 = registry.get<TH1>(HIST("Association/AssociationTrackStatus"));
-    auto* x3 = hstatus2->GetXaxis();
-    x3->SetBinLabel(1, "Ambiguous tracks");
-    x3->SetBinLabel(2, "Orphan tracks");
-    x3->SetBinLabel(3, "Associated tracks");
-    x3->SetBinLabel(4, "Ambiguous after assoc.");
-    x3->SetBinLabel(5, "Orphan after assoc.");
-    x3->SetBinLabel(6, "Reassociated ");
   }
 
-  template <uint32_t TMuonFillMap, typename TMuons>
-  void runMuonSelection(Collisions const& collisions, aod::BCsWithTimestamps const& bcs, TMuons const& muons)
+  template <uint32_t TMuonFillMap, typename TEvent, typename TMuons, typename AssocMuons>
+  void runMuonSelection(TEvent const& collision, aod::BCsWithTimestamps const& bcs, TMuons const& muons, AssocMuons const& muonAssocs)
   {
     auto bc = bcs.begin(); // check just the first bc to get the run number
     if (fCurrentRun != bc.runNumber()) {
@@ -655,18 +379,17 @@ struct DQMuonsSelection {
       }
     }
 
-    fSelectedMuons.clear();
-
     uint32_t filterMap = uint32_t(0);
-    VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
-    // TODO: fill event information which might be needed in histograms or cuts that combine track and event properties
+    trackSel.reserve(muons.size());
 
-    for (auto& muon : muons) {
+    VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
+
+    for (auto& muonAssoc : muonAssocs) {
       filterMap = uint32_t(0);
-      // NOTE: here we do not exclude orphan muon tracks
+      auto muon = muonAssoc.template fwdtrack_as<TMuons>();
       VarManager::FillTrack<TMuonFillMap>(muon);
       if (fPropMuon) {
-        VarManager::FillPropagateMuon<TMuonFillMap>(muon, collisions);
+        VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
       }
       if (fConfigQA) {
         fHistMan->FillHistClass("Muon_BeforeCuts", VarManager::fgValues);
@@ -680,336 +403,15 @@ struct DQMuonsSelection {
           }
         }
       }
-      if (filterMap != 0) {
-        fSelectedMuons[muon.globalIndex()] = filterMap;
-      }
+      trackSel(filterMap);
     } // end loop over muons
   }
 
-  void runCollisionMap(Collisions const& collisions, aod::BCsWithTimestamps const& bcstimestamp)
+  void processSelection(Collisions const& collisions, BCsWithTimestamps const& bcstimestamps, MyMuons const& muons, aod::FwdTrackAssoc const& muonAssocs)
   {
-    // association of time brackets to each collision
     for (auto& collision : collisions) {
-      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
-      double t0 = bc.globalBC() * o2::constants::lhc::LHCBunchSpacingNS - collision.collisionTime();
-      double err = collision.collisionTimeRes() * fSigmaVtx + fTimeMarginVtx;
-      std::pair<double, double> timeBracket = {t0 - err, t0 + err};
-      std::pair<std::pair<double, double>, int> timeNID = {timeBracket, collision.globalIndex()};
-      vtxOrdBrack.emplace_back(timeNID);
-    }
-    // sorting collision according to time
-    std::sort(vtxOrdBrack.begin(), vtxOrdBrack.end(), [](const std::pair<std::pair<double, double>, int>& a, const std::pair<std::pair<double, double>, int>& b) { return a.first.first < b.first.first; });
-  }
-
-  template <typename TMuons>
-  void associateMuonsToCollisionsStandard(Collisions const& collisions,
-                                          TMuons const& muons)
-  {
-    // This is the standard association: does nothing, just associate the already selected muons to their own default collision
-    if (fSelectedMuons.size() == 0) {
-      return;
-    }
-
-    for (auto const& [muonIdx, filterMap] : fSelectedMuons) {
-      auto muon = muons.rawIteratorAt(muonIdx);
-      // We do not associate orphan tracks here
-      if (muon.has_collision()) {
-        muonAssoc(muon.collision().globalIndex(), muonIdx, filterMap);
-      }
-    }
-  }
-
-  template <typename TMuons>
-  void associateMuonsToCollisionsTime(Collisions const& collisions,
-                                      TMuons const& muons,
-                                      BCs const& bcs)
-  {
-    // loop over collisions to find time-compatible muons
-    if (fSelectedMuons.size() == 0) {
-      return;
-    }
-    float timeMargin = fConfigAssocTimeMargin.value;
-    float nSigmaForTimeCompat = fConfigSigmaForTimeCompat.value;
-
-    auto trackBegin = fSelectedMuons.begin();
-    const auto bOffsetMax = 200; // check 200 BCs in past and future
-
-    for (const auto& collision : collisions) {
-      // get this collisions time and BC
-      const float collTime = collision.collisionTime();
-      const float collTimeRes2 = collision.collisionTimeRes() * collision.collisionTimeRes();
-      uint64_t collBC = collision.bc().globalBC();
-
-      bool iteratorMoved = false;
-      // loop over filtered muons
-      for (auto trackFiltered = trackBegin; trackFiltered != fSelectedMuons.end(); trackFiltered++) {
-        auto muon = muons.rawIteratorAt(trackFiltered->first);
-        if (!muon.has_collision()) {
-          continue;
-        }
-
-        const int64_t bcOffset = (int64_t)muon.collision().bc().globalBC() - (int64_t)collBC;
-        float trackTime = muon.trackTime();
-        float trackTimeRes = muon.trackTimeRes();
-        const float deltaTime = trackTime - collTime + bcOffset * 25.f;
-        // TODO: Time uncertainty is computed in quadrature, but maybe that should just be added linearly ?
-        float sigmaTimeRes2 = collTimeRes2 + trackTimeRes * trackTimeRes;
-
-        // optimization to only loop over tracks which are within a given BC window
-        if (!iteratorMoved && bcOffset > -bOffsetMax) {
-          trackBegin = trackFiltered;
-          iteratorMoved = true;
-        } else if (bcOffset > bOffsetMax) {
-          break;
-        }
-
-        // If the muon and collision are compatible, create the association
-        float thresholdTime = nSigmaForTimeCompat * std::sqrt(sigmaTimeRes2) + timeMargin;
-        if (std::abs(deltaTime) < thresholdTime) {
-          const auto collIdx = collision.globalIndex();
-          muonAssoc(collIdx, trackFiltered->first, trackFiltered->second);
-        }
-      } // end for tracks
-    }   // end for collisions
-  }
-
-  template <typename TMuons>
-  void associateMuonsToCollisionsAmbigous(Collisions const& collisions,
-                                          TMuons const& muons,
-                                          BCs const& bcs,
-                                          AmbiguousFwdTracks const& ambMuons)
-  {
-    if (fSelectedMuons.size() == 0) {
-      return;
-    }
-
-    std::map<int64_t, std::vector<int64_t>> collTrackIds; // map to keep all collision-track associations (ordered based on the key by construction)
-    std::map<uint64_t, uint64_t> collBCmap;               // map to hold collision - BC associations
-
-    // first lets associate all the non-orphan muons to their primary collision Id
-    for (auto const& [muonIdx, filterMap] : fSelectedMuons) {
-      auto muon = muons.rawIteratorAt(muonIdx);
-      if (!muon.has_collision()) {
-        continue;
-      }
-      auto collId = muon.collisionId();
-      if (collTrackIds.find(collId) == collTrackIds.end()) { // this colision is not in the map
-        std::vector<int64_t> idxs{muonIdx};
-        collTrackIds[collId] = idxs;
-      } else { // collision is in the map, add track to the associated vector
-        auto idxs = collTrackIds[collId];
-        idxs.push_back(muonIdx);
-        collTrackIds[collId] = idxs;
-      }
-      collBCmap[collId] = muon.collision().bc().globalBC();
-    }
-
-    // associate collisions with ambiguous tracks
-    for (const auto& ambMuon : ambMuons) {
-      // consider only the filtered muons
-      if (fSelectedMuons.find(ambMuon.fwdtrackId()) == fSelectedMuons.end()) {
-        continue;
-      }
-      auto muon = ambMuon.template fwdtrack_as<TMuons>();
-
-      // loop over collisions in the TF
-      for (const auto& collision : collisions) {
-        const auto collId = collision.globalIndex();
-        // If this is a non-orphan muons and is associated to this collisions, skip it (it is already taken into account)
-        if (muon.has_collision()) {
-          if (collId == muon.collisionId()) {
-            continue;
-          }
-        }
-
-        // TODO: maybe possibly dynamically expand the range of BCs on the ambMuon to take into account the time resolution of the
-        //       currently checked collision ?
-        const uint64_t mostProbableBc = collision.bc().globalBC(); // this collision's BC
-        // loop over the BCs compatible with the muon
-        for (const auto& bc : ambMuon.bc()) {
-          if (bc.globalBC() == mostProbableBc) { // found a match
-            const int64_t muonId = muon.globalIndex();
-            if (collTrackIds.find(collId) == collTrackIds.end()) { // this colision is not in the map, adding it
-              std::vector<int64_t> idxs{muonId};
-              collTrackIds[collId] = idxs;
-            } else {
-              auto idxs = collTrackIds[collId];
-              idxs.push_back(muonId);
-              collTrackIds[collId] = idxs;
-            }
-            collBCmap[collId] = bc.globalBC();
-          }
-        }
-      } // end loop over collisions
-    }   // end loop over ambiguous tracks
-
-    // associate tracks with in-bunch pileup collisions
-    // Check only collisions that are associated with filtered muons
-    for (auto const& [collId, assocTracks] : collTrackIds) {
-      const uint64_t currentBC = collBCmap[collId];
-      std::vector<int64_t> pileupCollIds{};
-      for (const auto& collision : collisions) { // NOTE: since collisions should be ordered in time, one could optimize here and not make the full loop (similar as with the tracks in the time based association)
-        if (collision.bc().globalBC() == currentBC) {
-          if (collision.globalIndex() != collId) { // add the collision only if its a different one
-            pileupCollIds.push_back(collision.globalIndex());
-          }
-        }
-      }
-
-      // in-bunch pileup requires at least 2 collisions in the same bunch (collId + another one)
-      if (pileupCollIds.size() < 1) {
-        continue;
-      }
-
-      // here we have in bunch pileup and we will associate the tracks from collId to the other (in-bunch pileup) collisions
-      for (const auto& pileupCollId : pileupCollIds) {
-        for (const auto& assocTrack : assocTracks) {
-          if (collTrackIds.find(pileupCollId) == collTrackIds.end()) { // this colision is not in the map
-            std::vector<int64_t> idxs{assocTrack};
-            collTrackIds[pileupCollId] = idxs;
-          } else {
-            auto idxs = collTrackIds[pileupCollId];
-            if (std::find(idxs.begin(), idxs.end(), assocTrack) == idxs.end()) { // add the muon only if it does not exist already
-              idxs.push_back(assocTrack);
-            }
-            collTrackIds[pileupCollId] = idxs;
-          }
-        } // end loop over associated muons
-      }   // end loop over pileup collisions
-    }
-
-    // create the collision - track association table
-    for (auto const& [collId, assocTracks] : collTrackIds) {
-      for (const auto& assocTrack : assocTracks) {
-        muonAssoc(collId, assocTrack, fSelectedMuons[assocTrack]); // writes in the table (collId, fwdtrackId, filterMap)
-      }
-    }
-  }
-
-  template <typename TMuons>
-  void associateMuonsToCollisionsAllTracks(Collisions const& collisions,
-                                           TMuons const& muons,
-                                           BCsWithTimestamps const& bcstimestamp,
-                                           AmbiguousFwdTracks const& ambiTracksFwd)
-  {
-    // first processing tracks registered in the ambigous tracks table
-    for (auto& ambiTrackFwd : ambiTracksFwd) {
-      if (fSelectedMuons.find(ambiTrackFwd.fwdtrackId()) == fSelectedMuons.end()) {
-        continue;
-      }
-      auto muon = ambiTrackFwd.template fwdtrack_as<TMuons>();
-      if (muon.collisionId() < 0) {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 1);
-      } else {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 0);
-      }
-      std::vector<int> vtxList;
-      const auto& bcSlice = ambiTrackFwd.bc();
-      int64_t trackBC = -1;
-      if (bcSlice.size() != 0) {
-        auto first = bcSlice.begin();
-        trackBC = first.globalBC();
-      }
-      double t0 = muon.trackTime() + trackBC * o2::constants::lhc::LHCBunchSpacingNS + fTimeBias; // computing track time relative to first BC of the compatible BC slice
-      double err = muon.trackTimeRes() * fSigmaTrack + fTimeMarginTrack;
-      double tmin = t0 - err;
-      double tmax = t0 + err;
-      double vtxminOK = 0;
-      double vtxmaxOK = 0;
-      for (auto& vtxBracket : vtxOrdBrack) {
-        double vtxmin = vtxBracket.first.first;
-        double vtxmax = vtxBracket.first.second;
-        if (tmax < vtxmin) {
-          break; // all following collisions will be later and not compatible
-        } else if (tmin > vtxmax) {
-          continue; // following vertex with longer span might still match this track
-        } else {
-          vtxList.push_back(vtxBracket.second);
-          vtxminOK = vtxmin;
-          vtxmaxOK = vtxmax;
-        }
-      }
-      isMuonReassigned[muon.globalIndex()] = -1;
-      if (vtxList.size() > 1) {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 3); // track is still ambiguous
-      } else if (vtxList.size() == 0) {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 4); // track is now orphan
-      } else {
-        isMuonReassigned[muon.globalIndex()] = vtxList.front();                             // track is non-ambiguously associated
-        muonAssoc(vtxList.front(), muon.globalIndex(), fSelectedMuons[muon.globalIndex()]); // writes in the table (collId, fwdtrackId, filterMap)
-        registry.fill(HIST("Association/AssociationTrackStatus"), 5);
-        registry.fill(HIST("Association/DeltaT"), (vtxminOK + vtxmaxOK) / 2 - t0);
-      }
-    }
-    auto trackBegin = fSelectedMuons.begin();
-    // now processing all other tracks (which were not registered in the ambiguous table)
-    for (auto trackFiltered = trackBegin; trackFiltered != fSelectedMuons.end(); trackFiltered++) {
-      auto muon = muons.rawIteratorAt(trackFiltered->first);
-      if (!(muon.has_collision())) {
-        continue;
-      }
-      if (isMuonReassigned.find(muon.globalIndex()) != isMuonReassigned.end()) {
-        continue;
-      }
-      registry.fill(HIST("Association/AssociationTrackStatus"), 2);
-      std::vector<int> vtxList;
-      auto collision = collisions.rawIteratorAt(muon.collisionId() - collisions.offset());
-      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-      double t0 = muon.trackTime() + bc.globalBC() * o2::constants::lhc::LHCBunchSpacingNS - collision.collisionTime() + fTimeBias; // computing track time relative to associated collisino time
-      double err = muon.trackTimeRes() * fSigmaTrack + fTimeMarginTrack;
-      double tmin = t0 - err;
-      double tmax = t0 + err;
-      double vtxminOK = 0;
-      double vtxmaxOK = 0;
-      for (auto& vtxBracket : vtxOrdBrack) {
-        double vtxmin = vtxBracket.first.first;
-        double vtxmax = vtxBracket.first.second;
-        if (tmax < vtxmin) {
-          break; // all following collisions will be later and not compatible
-        } else if (tmin > vtxmax) {
-          continue; // following vertex with longer span might still match this track
-        } else {
-          vtxList.push_back(vtxBracket.second);
-          vtxminOK = vtxmin;
-          vtxmaxOK = vtxmax;
-        }
-      }
-      isMuonReassigned[muon.globalIndex()] = -1;
-      if (vtxList.size() > 1) {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 3); // track is still ambiguous
-        for (auto& vtx : vtxList) {
-          muonAssoc(vtx, muon.globalIndex(), fSelectedMuons[muon.globalIndex()]); // writes in the table (collId, fwdtrackId, filterMap)
-        }
-      } else if (vtxList.size() == 0) {
-        registry.fill(HIST("Association/AssociationTrackStatus"), 4); // track is now orphan
-      } else {
-        isMuonReassigned[muon.globalIndex()] = vtxList.front();                             // track is non-ambiguously associated
-        muonAssoc(vtxList.front(), muon.globalIndex(), fSelectedMuons[muon.globalIndex()]); // writes in the table (collId, fwdtrackId, filterMap)
-        registry.fill(HIST("Association/AssociationTrackStatus"), 5);
-        registry.fill(HIST("Association/DeltaT"), (vtxminOK + vtxmaxOK) / 2 - t0);
-      }
-    }
-  }
-
-  void processSelection(Collisions const& collisions,
-                        BCsWithTimestamps const& bcstimestamp,
-                        BCs const& bcs,
-                        MyMuons const& muons,
-                        soa::Filtered<MyMuons> const& filteredMuons,
-                        AmbiguousFwdTracks const& ambFwdTracks)
-  {
-    runMuonSelection<gkMuonFillMap>(collisions, bcstimestamp, filteredMuons);
-    if (fConfigCollisionMuonAssoc.value == 0) {
-      associateMuonsToCollisionsStandard(collisions, muons);
-    } else if (fConfigCollisionMuonAssoc.value == 1) {
-      associateMuonsToCollisionsTime(collisions, muons, bcs);
-    } else if (fConfigCollisionMuonAssoc.value == 2) {
-      associateMuonsToCollisionsAmbigous(collisions, muons, bcs, ambFwdTracks);
-    } else {
-      runCollisionMap(collisions, bcstimestamp);
-      associateMuonsToCollisionsAllTracks(collisions, muons, bcstimestamp, ambFwdTracks);
-      isMuonReassigned.clear();
-      vtxOrdBrack.clear();
+      auto muonIdsThisCollision = muonAssocs.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
+      runMuonSelection<gkMuonFillMap>(collision, bcstimestamps, muons, muonIdsThisCollision);
     }
   }
   void processDummy(MyMuons&)
@@ -1020,6 +422,67 @@ struct DQMuonsSelection {
   PROCESS_SWITCH(DQMuonsSelection, processSelection, "Run muon selection", false);
   PROCESS_SWITCH(DQMuonsSelection, processDummy, "Dummy function", false);
 };
+
+/*
+struct DQTrackToCollisionAssociation {
+
+  Produces<TrackAssoc> association;
+  Produces<TrackCompColls> reverseIndices;
+  Produces<FwdTrackAssoc> fwdassociation;
+  Produces<FwdTrkCompColls> fwdreverseIndices;
+
+  // NOTE: the options for the collision associator are common for both the barrel and muon
+  //       We should add separate ones if needed
+  Configurable<float> nSigmaForTimeCompat{"nSigmaForTimeCompat", 4.f, "number of sigmas for time compatibility"};
+  Configurable<float> timeMargin{"timeMargin", 0.f, "time margin in ns added to uncertainty because of uncalibrated TPC"};
+  Configurable<bool> usePVAssociation{"usePVAssociation", true, "if the track is a PV contributor, use the collision time for it"};
+  Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
+  Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
+  Configurable<int> bcWindowForOneSigma{"bcWindowForOneSigma", 60, "BC window to be multiplied by the number of sigmas to define maximum window to be considered"};
+
+  CollisionAssociation<true> collisionAssociatorBarrel;
+  CollisionAssociation<false> collisionAssociatorMuon;
+
+  Filter filterBarrelTrackSelected = aod::dqppfilter::isDQBarrelSelected > uint32_t(0);
+  Filter filterMuonTrackSelected = aod::dqppfilter::isDQMuonSelected > uint32_t(0);
+
+  void init(o2::framework::InitContext const&)
+  {
+    // set options in track-to-collision association
+    collisionAssociatorBarrel.setNumSigmaForTimeCompat(nSigmaForTimeCompat);
+    collisionAssociatorBarrel.setTimeMargin(timeMargin);
+    collisionAssociatorBarrel.setTrackSelectionOptionForStdAssoc(track_association::TrackSelection::None);
+    collisionAssociatorBarrel.setUsePvAssociation(usePVAssociation);
+    collisionAssociatorBarrel.setIncludeUnassigned(includeUnassigned);
+    collisionAssociatorBarrel.setFillTableOfCollIdsPerTrack(fillTableOfCollIdsPerTrack);
+    collisionAssociatorBarrel.setBcWindow(bcWindowForOneSigma);
+    // set options in muon-to-collision association
+    collisionAssociatorMuon.setNumSigmaForTimeCompat(nSigmaForTimeCompat);
+    collisionAssociatorMuon.setTimeMargin(timeMargin);
+    collisionAssociatorMuon.setTrackSelectionOptionForStdAssoc(track_association::TrackSelection::None);
+    collisionAssociatorMuon.setUsePvAssociation(false);
+    collisionAssociatorMuon.setIncludeUnassigned(includeUnassigned);
+    collisionAssociatorMuon.setFillTableOfCollIdsPerTrack(fillTableOfCollIdsPerTrack);
+    collisionAssociatorMuon.setBcWindow(bcWindowForOneSigma);
+  }
+
+  void processAssocWithTime(Collisions const& collisions,
+                            MyBarrelTracksSelected const& tracksUnfiltered, soa::Filtered<MyBarrelTracksSelected> const& tracks,
+                            FwdTracks const& muons,
+                            AmbiguousTracks const& ambiguousTracks, AmbiguousFwdTracks const& ambiguousFwdTracks, BCs const& bcs)
+  {
+    collisionAssociatorBarrel.runAssocWithTime(collisions, tracksUnfiltered, tracks, ambiguousTracks, bcs, association, reverseIndices);
+    collisionAssociatorMuon.runAssocWithTime(collisions, muons, muons, ambiguousFwdTracks, bcs, fwdassociation, fwdreverseIndices);
+  };
+  void processDummy(Collisions&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQTrackToCollisionAssociation, processAssocWithTime, "Produce track-to-collision associations based on time", false);
+  PROCESS_SWITCH(DQTrackToCollisionAssociation, processDummy, "Dummy function", false);
+};
+*/
 
 struct DQFilterPPTask {
   Produces<aod::DQEventFilter> eventFilter;
@@ -1033,6 +496,16 @@ struct DQFilterPPTask {
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
   Configurable<std::string> fConfigFilterLsBarrelTracksPairs{"cfgWithBarrelLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) barrel track pairs"};
   Configurable<std::string> fConfigFilterLsMuonsPairs{"cfgWithMuonLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) muon pairs"};
+
+  Configurable<bool> fPropMuon{"cfgPropMuon", false, "Propgate muon tracks through absorber"};
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+  o2::parameters::GRPMagField* grpmag = nullptr; // for run 3, we access GRPMagField from GLO/Config/GRPMagField
+
+  int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
 
   int fNBarrelCuts;                                    // number of barrel selections
   int fNMuonCuts;                                      // number of muon selections
@@ -1114,6 +587,14 @@ struct DQFilterPPTask {
 
   void init(o2::framework::InitContext&)
   {
+    fCCDB->setURL(fConfigCcdbUrl);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
+    if (fPropMuon) {
+      if (!o2::base::GeometryManager::isGeometryLoaded()) {
+        fCCDB->get<TGeoManager>(geoPath);
+      }
+    }
     DefineCuts();
 
     if (fConfigQA) {
@@ -1137,13 +618,24 @@ struct DQFilterPPTask {
     }
   }
 
-  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons>
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons, typename AssocMuons>
   uint64_t runFilterPP(TEvent const& collision,
-                       aod::BCs const& bcs,
+                       aod::BCsWithTimestamps const& bcs,
                        TTracks const& tracksBarrel,
                        TMuons const& muons,
-                       DQTrackAssoc const& barrelAssocs, DQMuonAssoc const& muonAssocs)
+                       aod::TrackAssoc const& barrelAssocs, AssocMuons const& muonAssocs)
   {
+    auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+    if (fCurrentRun != bc.runNumber()) {
+      fCurrentRun = bc.runNumber();
+      if (fPropMuon) {
+        VarManager::SetupMuonMagField();
+      }
+      grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
+      if (grpmag != nullptr) {
+        o2::base::Propagator::initFieldFromGRP(grpmag);
+      }
+    }
     // Reset the values array and compute event quantities
     VarManager::ResetValues(0, VarManager::kNVars);
     VarManager::FillEvent<TEventFillMap>(collision); // event properties could be needed for cuts or histogramming
@@ -1151,8 +643,9 @@ struct DQFilterPPTask {
     std::vector<int> objCountersBarrel(fNBarrelCuts, 0); // init all counters to zero
     // count the number of barrel tracks fulfilling each cut
     for (auto trackAssoc : barrelAssocs) {
+      auto track = trackAssoc.template track_as<TTracks>();
       for (int i = 0; i < fNBarrelCuts; ++i) {
-        if (trackAssoc.isDQBarrelSelected() & (uint32_t(1) << i)) {
+        if (track.isDQBarrelSelected() & (uint32_t(1) << i)) {
           objCountersBarrel[i] += 1;
         }
       }
@@ -1185,16 +678,16 @@ struct DQFilterPPTask {
     if (pairingMask > 0) {
       // run pairing on the collision grouped associations
       for (auto& [a1, a2] : combinations(barrelAssocs, barrelAssocs)) {
-        // check the pairing mask and that the tracks share a cut bit
-        pairFilter = pairingMask & a1.isDQBarrelSelected() & a2.isDQBarrelSelected();
-        if (pairFilter == 0) {
-          continue;
-        }
 
         // get the tracks from the index stored in the association
         auto t1 = a1.template track_as<TTracks>();
         auto t2 = a2.template track_as<TTracks>();
 
+        // check the pairing mask and that the tracks share a cut bit
+        pairFilter = pairingMask & t1.isDQBarrelSelected() & t2.isDQBarrelSelected();
+        if (pairFilter == 0) {
+          continue;
+        }
         // construct the pair and apply pair cuts
         VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(t1, t2); // compute pair quantities
         for (int icut = 0; icut < fNBarrelCuts; icut++) {
@@ -1220,7 +713,7 @@ struct DQFilterPPTask {
     }
 
     std::vector<int> objCountersMuon(fNMuonCuts, 0); // init all counters to zero
-    // count the number of muon tracks fulfilling each selection
+    // count the number of muon-collision associations fulfilling each selection
     for (auto muon : muonAssocs) {
       for (int i = 0; i < fNMuonCuts; ++i) {
         if (muon.isDQMuonSelected() & (uint32_t(1) << i)) {
@@ -1268,6 +761,9 @@ struct DQFilterPPTask {
 
         // construct the pair and apply cuts
         VarManager::FillPair<VarManager::kDecayToMuMu, TTrackFillMap>(t1, t2); // compute pair quantities
+        if (fPropMuon) {
+          VarManager::FillPairPropagateMuon<TTrackFillMap>(t1, t2, collision);
+        }
         for (int icut = 0; icut < fNMuonCuts; icut++) {
           // select like-sign pairs if trigger has set boolean true within fConfigFilterLsMuonsPairs
           if (!(pairingLS & (uint32_t(1) << icut))) {
@@ -1304,17 +800,19 @@ struct DQFilterPPTask {
     return filter;
   }
 
-  Preslice<DQTrackAssoc> trackIndicesPerCollision = aod::dqppfilter::collisionId;
-  Preslice<DQMuonAssoc> muonIndicesPerCollision = aod::dqppfilter::collisionId;
+  Preslice<TrackAssoc> trackIndicesPerCollision = track_association::collisionId;
+  Preslice<FwdTrackAssoc> muonIndicesPerCollision = track_association::collisionId;
 
   void processFilterPP(MyEventsSelected const& collisions,
-                       aod::BCs const& bcs,
-                       MyBarrelTracks const& tracks,
+                       aod::BCsWithTimestamps const& bcs,
+                       MyBarrelTracksSelected const& tracks,
                        MyMuons const& muons,
-                       DQTrackAssoc const& trackAssocs, DQMuonAssoc const& muonAssocs)
+                       TrackAssoc const& trackAssocs, MyMuonsAssocSelected const& muonAssocs)
   {
     fFiltersMap.clear();
     fCEFPfilters.clear();
+
+    cout << "------------------- filterPP, n assocs barrel/muon :: " << trackAssocs.size() << " / " << muonAssocs.size() << endl;
 
     uint64_t barrelMask = 0;
     for (int i = 0; i < fNBarrelCuts; i++) {
@@ -1384,7 +882,10 @@ struct DQFilterPPTask {
       //   then one needs to select also that collision in order to be able to redo the pairing at analysis time.
       if (filter & barrelMask) {
         for (auto& a : groupedTrackIndices) {
-          auto t = a.template track_as<MyBarrelTracks>();
+          auto t = a.template track_as<MyBarrelTracksSelected>();
+          if (!t.has_collision()) {
+            continue;
+          }
           auto tColl = t.collisionId();
           if (tColl == collision.globalIndex()) { // track from this collision, nothing to do
             continue;
@@ -1407,6 +908,9 @@ struct DQFilterPPTask {
       if (filter & muonMask) {
         for (auto& a : groupedMuonIndices) {
           auto t = a.template fwdtrack_as<MyMuons>();
+          if (!t.has_collision()) {
+            continue;
+          }
           auto tColl = t.collisionId();
           if (tColl == collision.globalIndex()) { // track from this collision, nothing to do
             continue;
@@ -1440,6 +944,7 @@ struct DQFilterPPTask {
       if (!collision.isDQEventSelected()) {
         eventFilter(0);
         dqtable(false, false, false, false, false, false, false);
+        continue;
       }
       fStats->Fill(-1.0);
 
@@ -1477,6 +982,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<DQEventSelectionTask>(cfgc),
     adaptAnalysisTask<DQBarrelTrackSelection>(cfgc),
     adaptAnalysisTask<DQMuonsSelection>(cfgc),
+    // adaptAnalysisTask<DQTrackToCollisionAssociation>(cfgc),
     adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 


### PR DESCRIPTION
Changes in the VarManager.h :
 - Making the propagation of the mupn track to the vertex a utility function
 - Adding FillPairPropagateMuon to propagate muon pairs

Changes in the filterPPwithAssociation.cxx :
 - Use of the o2-analysis-track-to-collision-associator and o2-analysis-fwdtrack-to-collision-associator to do the track to collision association instead of doing it internally
 - Adding the fPropMuon boolean to have the muon to vertex propagation if needed