### PR TITLE
Implemented collision-track association to the table-maker and table-reader workflows

### DIFF
--- a/PWGDQ/Core/HistogramManager.cxx
+++ b/PWGDQ/Core/HistogramManager.cxx
@@ -110,8 +110,6 @@ void HistogramManager::AddHistClass(const char* histClass)
   fMainList->Add(hList);
   std::list<std::vector<int>> varList;
   fVariablesMap[histClass] = varList;
-  cout << "Adding histogram class " << histClass << endl;
-  cout << "Variable map size :: " << fVariablesMap.size() << endl;
 }
 
 //_________________________________________________________________
@@ -181,8 +179,6 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
   varVector.push_back(varT); // variable used for profiling in case of TProfile3D
   std::list varList = fVariablesMap[histClass];
   varList.push_back(varVector);
-  cout << "Adding histogram " << hname << endl;
-  cout << "size of array :: " << varList.size() << endl;
   fVariablesMap[histClass] = varList;
 
   // create and configure histograms according to required options
@@ -380,8 +376,6 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
   varVector.push_back(varT); // variable used for profiling in case of TProfile3D
   std::list varList = fVariablesMap[histClass];
   varList.push_back(varVector);
-  cout << "Adding histogram " << hname << endl;
-  cout << "size of array :: " << varList.size() << endl;
   fVariablesMap[histClass] = varList;
 
   TH1* h = nullptr;
@@ -548,8 +542,6 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
   }
   std::list varList = fVariablesMap[histClass];
   varList.push_back(varVector);
-  cout << "Adding histogram " << hname << endl;
-  cout << "size of array :: " << varList.size() << endl;
   fVariablesMap[histClass] = varList;
 
   uint32_t nbins = 1;
@@ -627,8 +619,6 @@ void HistogramManager::AddHistogram(const char* histClass, const char* hname, co
   }
   std::list varList = fVariablesMap[histClass];
   varList.push_back(varVector);
-  cout << "Adding histogram " << hname << endl;
-  cout << "size of array :: " << varList.size() << endl;
   fVariablesMap[histClass] = varList;
 
   // get the min and max for each axis

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -760,7 +760,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
   }
 
   if (groupStr.Contains("dilepton-track")) {
-    if (subGroupStr.Contains("mixedevent")) {        // for mixed event
+    if (subGroupStr.Contains("mixedevent")) { // for mixed event
       hm->AddHistogram(histClass, "Mass_Pt", "", false, 40, 0.0, 20.0, VarManager::kPairMass, 40, 0.0, 20.0, VarManager::kPairPt);
       hm->AddHistogram(histClass, "Mass", "", false, 750, 0.0, 30.0, VarManager::kPairMass);
       hm->AddHistogram(histClass, "Pt", "", false, 750, 0.0, 30.0, VarManager::kPairPt);

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -759,40 +759,48 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
     }
   }
 
-  if (groupStr.Contains("dilepton-hadron-mass")) {
-    hm->AddHistogram(histClass, "Mass_Dilepton", "", false, 125, 0.0, 5.0, VarManager::kPairMassDau);
-    hm->AddHistogram(histClass, "Mass_Hadron", "", false, 125, 0.0, 5.0, VarManager::kMassDau);
-    hm->AddHistogram(histClass, "Mass_Dilepton_Mass_Hadron", "", false, 125, 0.0, 5.0, VarManager::kPairMassDau, 125, 0.0, 5.0, VarManager::kMassDau);
-    hm->AddHistogram(histClass, "Pt_Dilepton", "", false, 120, 0.0, 30.0, VarManager::kPairPtDau);
-    hm->AddHistogram(histClass, "Pt_Track", "", false, 120, 0.0, 30.0, VarManager::kPt);
-    hm->AddHistogram(histClass, "Mass", "", false, 750, 0.0, 30.0, VarManager::kPairMass);
-    hm->AddHistogram(histClass, "Pt", "", false, 750, 0.0, 30.0, VarManager::kPairPt);
-    hm->AddHistogram(histClass, "Mass_Pt", "", false, 40, 0.0, 20.0, VarManager::kPairMass, 40, 0.0, 20.0, VarManager::kPairPt);
-    hm->AddHistogram(histClass, "Pt_Dilepton__Pt", "", false, 40, 0.0, 20.0, VarManager::kPairPtDau, 40, 0.0, 20.0, VarManager::kPairPt);
-    hm->AddHistogram(histClass, "Pt_Track__Pt", "", false, 40, 0.0, 20.0, VarManager::kPt, 40, 0.0, 20.0, VarManager::kPairPt);
-    hm->AddHistogram(histClass, "UsedKF", "", false, 2, -0.5, 1.5, VarManager::kUsedKF);
-    hm->AddHistogram(histClass, "KFMass", "", false, 750, 0.0, 30.0, VarManager::kKFMass);
-    hm->AddHistogram(histClass, "Lz", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLz);
-    hm->AddHistogram(histClass, "Lxy", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxy);
-    hm->AddHistogram(histClass, "Lxyz", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyz);
-    hm->AddHistogram(histClass, "Tauz", "", false, 4000, -0.01, 0.01, VarManager::kVertexingTauz);
-    hm->AddHistogram(histClass, "Tauxy", "", false, 4000, -0.01, 0.01, VarManager::kVertexingTauxy);
-    hm->AddHistogram(histClass, "LxyzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingLxyzErr);
-    hm->AddHistogram(histClass, "LzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingLzErr);
-    hm->AddHistogram(histClass, "TauzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingTauzErr);
-    hm->AddHistogram(histClass, "VtxingProcCode", "", false, 10, 0.0, 10.0, VarManager::kVertexingProcCode);
-    hm->AddHistogram(histClass, "VtxingChi2PCA", "", false, 100, 0.0, 10.0, VarManager::kVertexingChi2PCA);
-    hm->AddHistogram(histClass, "LzProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLzProjected);
-    hm->AddHistogram(histClass, "LxyProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyProjected);
-    hm->AddHistogram(histClass, "LxyzProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyzProjected);
-    hm->AddHistogram(histClass, "TauzProj", "", false, 4000, -0.5, 0.5, VarManager::kVertexingTauzProjected);
-    hm->AddHistogram(histClass, "TauxyProj", "", false, 4000, -0.5, 0.5, VarManager::kVertexingTauxyProjected);
-    hm->AddHistogram(histClass, "CosPointingAngle", "", false, 100, 0.0, 1.0, VarManager::kCosPointingAngle);
-  }
-
-  if (groupStr.Contains("dilepton-hadron-correlation")) {
-    hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
-    hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
+  if (groupStr.Contains("dilepton-track")) {
+    if (subGroupStr.Contains("mixedevent")) {        // for mixed event
+      hm->AddHistogram(histClass, "Mass_Pt", "", false, 40, 0.0, 20.0, VarManager::kPairMass, 40, 0.0, 20.0, VarManager::kPairPt);
+      hm->AddHistogram(histClass, "Mass", "", false, 750, 0.0, 30.0, VarManager::kPairMass);
+      hm->AddHistogram(histClass, "Pt", "", false, 750, 0.0, 30.0, VarManager::kPairPt);
+    }
+    if (subGroupStr.Contains("invmass")) {
+      hm->AddHistogram(histClass, "Mass_Dilepton", "", false, 125, 0.0, 5.0, VarManager::kPairMassDau);
+      hm->AddHistogram(histClass, "Mass_Hadron", "", false, 125, 0.0, 5.0, VarManager::kMassDau);
+      hm->AddHistogram(histClass, "Mass_Dilepton_Mass_Hadron", "", false, 125, 0.0, 5.0, VarManager::kPairMassDau, 125, 0.0, 5.0, VarManager::kMassDau);
+      hm->AddHistogram(histClass, "Pt_Dilepton", "", false, 120, 0.0, 30.0, VarManager::kPairPtDau);
+      hm->AddHistogram(histClass, "Pt_Track", "", false, 120, 0.0, 30.0, VarManager::kPt);
+      hm->AddHistogram(histClass, "Mass", "", false, 750, 0.0, 30.0, VarManager::kPairMass);
+      hm->AddHistogram(histClass, "Pt", "", false, 750, 0.0, 30.0, VarManager::kPairPt);
+      hm->AddHistogram(histClass, "Mass_Pt", "", false, 40, 0.0, 20.0, VarManager::kPairMass, 40, 0.0, 20.0, VarManager::kPairPt);
+      hm->AddHistogram(histClass, "Pt_Dilepton__Pt", "", false, 40, 0.0, 20.0, VarManager::kPairPtDau, 40, 0.0, 20.0, VarManager::kPairPt);
+      hm->AddHistogram(histClass, "Pt_Track__Pt", "", false, 40, 0.0, 20.0, VarManager::kPt, 40, 0.0, 20.0, VarManager::kPairPt);
+    }
+    if (subGroupStr.Contains("vertexing")) {
+      hm->AddHistogram(histClass, "UsedKF", "", false, 2, -0.5, 1.5, VarManager::kUsedKF);
+      hm->AddHistogram(histClass, "KFMass", "", false, 750, 0.0, 30.0, VarManager::kKFMass);
+      hm->AddHistogram(histClass, "Lz", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLz);
+      hm->AddHistogram(histClass, "Lxy", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxy);
+      hm->AddHistogram(histClass, "Lxyz", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyz);
+      hm->AddHistogram(histClass, "Tauz", "", false, 4000, -0.01, 0.01, VarManager::kVertexingTauz);
+      hm->AddHistogram(histClass, "Tauxy", "", false, 4000, -0.01, 0.01, VarManager::kVertexingTauxy);
+      hm->AddHistogram(histClass, "LxyzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingLxyzErr);
+      hm->AddHistogram(histClass, "LzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingLzErr);
+      hm->AddHistogram(histClass, "TauzErr", "", false, 100, 0.0, 10.0, VarManager::kVertexingTauzErr);
+      hm->AddHistogram(histClass, "VtxingProcCode", "", false, 10, 0.0, 10.0, VarManager::kVertexingProcCode);
+      hm->AddHistogram(histClass, "VtxingChi2PCA", "", false, 100, 0.0, 10.0, VarManager::kVertexingChi2PCA);
+      hm->AddHistogram(histClass, "LzProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLzProjected);
+      hm->AddHistogram(histClass, "LxyProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyProjected);
+      hm->AddHistogram(histClass, "LxyzProj", "", false, 1000, -2.0, 2.0, VarManager::kVertexingLxyzProjected);
+      hm->AddHistogram(histClass, "TauzProj", "", false, 4000, -0.5, 0.5, VarManager::kVertexingTauzProjected);
+      hm->AddHistogram(histClass, "TauxyProj", "", false, 4000, -0.5, 0.5, VarManager::kVertexingTauxyProjected);
+      hm->AddHistogram(histClass, "CosPointingAngle", "", false, 100, 0.0, 1.0, VarManager::kCosPointingAngle);
+    }
+    if (subGroupStr.Contains("correlation")) {
+      hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
+      hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
+    }
   }
 
   if (groupStr.Contains("dilepton-hadron-array-correlation")) {

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -37,7 +37,6 @@
 #include "Math/GenVector/Boost.h"
 
 #include "Framework/DataTypes.h"
-// #include "MCHTracking/TrackExtrap.h"
 #include "TGeoGlobalMagField.h"
 #include "Field/MagneticField.h"
 #include "ReconstructionDataFormats/Track.h"
@@ -46,6 +45,8 @@
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/CCDB/TriggerAliases.h"
 #include "ReconstructionDataFormats/DCA.h"
+#include "DetectorsBase/Propagator.h"
+#include "Common/Core/trackUtilities.h"
 
 #include "Math/SMatrix.h"
 #include "ReconstructionDataFormats/TrackFwd.h"
@@ -340,7 +341,6 @@ class VarManager : public TObject
     kMuonC1Pt2Phi,
     kMuonC1Pt2Tgl,
     kMuonC1Pt21Pt2,
-    kNMuonTrackVariables,
     kMuonTrackType,
     kMuonDCAx,
     kMuonDCAy,
@@ -349,6 +349,7 @@ class VarManager : public TObject
     kMftNClusters,
     kMftClusterSize,
     kMftMeanClusterSize,
+    kNMuonTrackVariables,
 
     // MC particle variables
     kMCPdgCode,
@@ -416,7 +417,6 @@ class VarManager : public TObject
     kPsi2C,
     kCos2DeltaPhi,
     kCos3DeltaPhi,
-    kNPairVariables,
     kDeltaPtotTracks,
     kVertexingLxyOverErr,
     kVertexingLzOverErr,
@@ -432,6 +432,7 @@ class VarManager : public TObject
     kKFChi2OverNDFGeo,
     kKFNContributorsPV,
     kKFCosPA,
+    kNPairVariables,
 
     // Candidate-track correlation variables
     kPairMass,
@@ -627,6 +628,8 @@ class VarManager : public TObject
   static void FillEvent(T const& event, float* values = nullptr);
   template <uint32_t fillMap, typename T>
   static void FillTrack(T const& track, float* values = nullptr);
+  template <uint32_t fillMap, typename T, typename C>
+  static void FillTrackCollision(T const& track, C const& collision, float* values = nullptr);
   template <typename U, typename T>
   static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename T1, typename T2>
@@ -815,7 +818,7 @@ void VarManager::FillPropagateMuon(const T& muon, const C& collision, float* val
   if (!values) {
     values = fgValues;
   }
-  if constexpr ((fillMap & MuonCov) > 0) {
+  if constexpr ((fillMap & MuonCov) > 0 || (fillMap & ReducedMuonCov) > 0) {
     double chi2 = muon.chi2();
     SMatrix5 tpars(muon.x(), muon.y(), muon.phi(), muon.tgl(), muon.signed1Pt());
     std::vector<double> v1{muon.cXX(), muon.cXY(), muon.cYY(), muon.cPhiX(), muon.cPhiY(),
@@ -968,14 +971,14 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kVtxZ] = event.posZ();
     values[kVtxNcontrib] = event.numContrib();
     if (fgUsedVars[kIsSel8]) {
-      values[kIsSel8] = (event.tag() & (uint64_t(1) << o2::aod::evsel::kIsTriggerTVX)) > 0;
+      values[kIsSel8] = (event.selection_bit(o2::aod::evsel::kIsTriggerTVX) > 0);
     }
     if (fgUsedVars[kIsDoubleGap]) {
-      values[kIsDoubleGap] = (event.tag() & (uint64_t(1) << (56 + kDoubleGap))) > 0;
+      values[kIsDoubleGap] = (event.tag_bit(56 + kDoubleGap) > 0);
     }
     if (fgUsedVars[kIsSingleGap] || fgUsedVars[kIsSingleGapA] || fgUsedVars[kIsSingleGapC]) {
-      values[kIsSingleGapA] = (event.tag() & (uint64_t(1) << (56 + kSingleGapA))) > 0;
-      values[kIsSingleGapC] = (event.tag() & (uint64_t(1) << (56 + kSingleGapC))) > 0;
+      values[kIsSingleGapA] = (event.tag_bit(56 + kSingleGapA) > 0);
+      values[kIsSingleGapC] = (event.tag_bit(56 + kSingleGapC) > 0);
       values[kIsSingleGap] = values[kIsSingleGapA] || values[kIsSingleGapC];
     }
   }
@@ -986,37 +989,37 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kCentVZERO] = event.centRun2V0M();
     values[kCentFT0C] = event.centFT0C();
     if (fgUsedVars[kIsINT7]) {
-      values[kIsINT7] = (event.triggerAlias() & (uint32_t(1) << kINT7)) > 0;
+      values[kIsINT7] = (event.alias_bit(kINT7) > 0);
     }
     if (fgUsedVars[kIsEMC7]) {
-      values[kIsEMC7] = (event.triggerAlias() & (uint32_t(1) << kEMC7)) > 0;
+      values[kIsEMC7] = (event.alias_bit(kEMC7) > 0);
     }
     if (fgUsedVars[kIsINT7inMUON]) {
-      values[kIsINT7inMUON] = (event.triggerAlias() & (uint32_t(1) << kINT7inMUON)) > 0;
+      values[kIsINT7inMUON] = (event.alias_bit(kINT7inMUON) > 0);
     }
     if (fgUsedVars[kIsMuonSingleLowPt7]) {
-      values[kIsMuonSingleLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonSingleLowPt7)) > 0;
+      values[kIsMuonSingleLowPt7] = (event.alias_bit(kMuonSingleLowPt7) > 0);
     }
     if (fgUsedVars[kIsMuonSingleHighPt7]) {
-      values[kIsMuonSingleHighPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonSingleHighPt7)) > 0;
+      values[kIsMuonSingleHighPt7] = (event.alias_bit(kMuonSingleHighPt7) > 0);
     }
     if (fgUsedVars[kIsMuonUnlikeLowPt7]) {
-      values[kIsMuonUnlikeLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonUnlikeLowPt7)) > 0;
+      values[kIsMuonUnlikeLowPt7] = (event.alias_bit(kMuonUnlikeLowPt7) > 0);
     }
     if (fgUsedVars[kIsMuonLikeLowPt7]) {
-      values[kIsMuonLikeLowPt7] = (event.triggerAlias() & (uint32_t(1) << kMuonLikeLowPt7)) > 0;
+      values[kIsMuonLikeLowPt7] = (event.alias_bit(kMuonLikeLowPt7) > 0);
     }
     if (fgUsedVars[kIsCUP8]) {
-      values[kIsCUP8] = (event.triggerAlias() & (uint32_t(1) << kCUP8)) > 0;
+      values[kIsCUP8] = (event.alias_bit(kCUP8) > 0);
     }
     if (fgUsedVars[kIsCUP9]) {
-      values[kIsCUP9] = (event.triggerAlias() & (uint32_t(1) << kCUP9)) > 0;
+      values[kIsCUP9] = (event.alias_bit(kCUP9) > 0);
     }
     if (fgUsedVars[kIsMUP10]) {
-      values[kIsMUP10] = (event.triggerAlias() & (uint32_t(1) << kMUP10)) > 0;
+      values[kIsMUP10] = (event.alias_bit(kMUP10) > 0);
     }
     if (fgUsedVars[kIsMUP11]) {
-      values[kIsMUP11] = (event.triggerAlias() & (uint32_t(1) << kMUP11)) > 0;
+      values[kIsMUP11] = (event.alias_bit(kMUP11) > 0);
     }
   }
 
@@ -1139,20 +1142,20 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kCharge] = track.sign();
 
     if constexpr ((fillMap & ReducedTrack) > 0 && !((fillMap & Pair) > 0)) {
-      values[kIsGlobalTrack] = track.filteringFlags() & (uint64_t(1) << 0);
-      values[kIsGlobalTrackSDD] = track.filteringFlags() & (uint64_t(1) << 1);
+      values[kIsGlobalTrack] = track.filteringFlags_bit(0);
+      values[kIsGlobalTrackSDD] = track.filteringFlags_bit(1);
       values[kIsAmbiguous] = track.isAmbiguous();
 
-      values[kIsLegFromGamma] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 2));
-      values[kIsLegFromK0S] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 3));
-      values[kIsLegFromLambda] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 4));
-      values[kIsLegFromAntiLambda] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 5));
-      values[kIsLegFromOmega] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << 6));
+      values[kIsLegFromGamma] = track.filteringFlags_bit(2);
+      values[kIsLegFromK0S] = track.filteringFlags_bit(3);
+      values[kIsLegFromLambda] = track.filteringFlags_bit(4);
+      values[kIsLegFromAntiLambda] = track.filteringFlags_bit(5);
+      values[kIsLegFromOmega] = track.filteringFlags_bit(6);
 
       values[kIsProtonFromLambdaAndAntiLambda] = static_cast<bool>((values[kIsLegFromLambda] * track.sign() > 0) || (values[kIsLegFromAntiLambda] * (-track.sign()) > 0));
 
       for (int i = 0; i < 8; i++) {
-        values[kIsDalitzLeg + i] = static_cast<bool>(track.filteringFlags() & (uint64_t(1) << (7 + i)));
+        values[kIsDalitzLeg + i] = track.filteringFlags_bit(7+i);
       }
     }
   }
@@ -1477,6 +1480,31 @@ void VarManager::FillTrack(T const& track, float* values)
 
   // Derived quantities which can be computed based on already filled variables
   FillTrackDerived(values);
+}
+
+template <uint32_t fillMap, typename T, typename C>
+void VarManager::FillTrackCollision(T const& track, C const& collision, float* values) {
+
+  if (!values) {
+    values = fgValues;
+  }
+  if constexpr ((fillMap & ReducedTrackBarrel) > 0 || (fillMap & TrackDCA) > 0) {
+    auto trackPar = getTrackPar(track);
+    std::array<float, 2> dca{1e10f, 1e10f};
+    trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, fgMagField, &dca);
+
+    values[kTrackDCAxy] = dca[0];
+    values[kTrackDCAz] = dca[1];
+    
+    if constexpr ((fillMap & ReducedTrackBarrelCov) > 0 || (fillMap & TrackCov) > 0) {
+      if (fgUsedVars[kTrackDCAsigXY]) {
+        values[kTrackDCAsigXY] = dca[0] / std::sqrt(track.cYY());
+      }
+      if (fgUsedVars[kTrackDCAsigZ]) {
+        values[kTrackDCAsigZ] = dca[1] / std::sqrt(track.cZZ());
+      }
+    }
+  }
 }
 
 template <typename U, typename T>

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1155,7 +1155,7 @@ void VarManager::FillTrack(T const& track, float* values)
       values[kIsProtonFromLambdaAndAntiLambda] = static_cast<bool>((values[kIsLegFromLambda] * track.sign() > 0) || (values[kIsLegFromAntiLambda] * (-track.sign()) > 0));
 
       for (int i = 0; i < 8; i++) {
-        values[kIsDalitzLeg + i] = track.filteringFlags_bit(7+i);
+        values[kIsDalitzLeg + i] = track.filteringFlags_bit(7 + i);
       }
     }
   }
@@ -1483,7 +1483,8 @@ void VarManager::FillTrack(T const& track, float* values)
 }
 
 template <uint32_t fillMap, typename T, typename C>
-void VarManager::FillTrackCollision(T const& track, C const& collision, float* values) {
+void VarManager::FillTrackCollision(T const& track, C const& collision, float* values)
+{
 
   if (!values) {
     values = fgValues;
@@ -1495,7 +1496,7 @@ void VarManager::FillTrackCollision(T const& track, C const& collision, float* v
 
     values[kTrackDCAxy] = dca[0];
     values[kTrackDCAz] = dca[1];
-    
+
     if constexpr ((fillMap & ReducedTrackBarrelCov) > 0 || (fillMap & TrackCov) > 0) {
       if (fgUsedVars[kTrackDCAsigXY]) {
         values[kTrackDCAsigXY] = dca[0] / std::sqrt(track.cYY());

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -39,8 +39,7 @@ namespace reducedevent
 {
 
 // basic event information
-DECLARE_SOA_COLUMN(Tag, tag, uint64_t);                   //!  Bit-field for storing event information (e.g. high level info, cut decisions)
-DECLARE_SOA_COLUMN(TriggerAlias, triggerAlias, uint32_t); //!  Trigger aliases bit field
+DECLARE_SOA_BITMAP_COLUMN(Tag, tag, 64);             //!  Bit-field for storing event information (e.g. high level info, cut decisions)
 DECLARE_SOA_COLUMN(Q2X0A, q2x0a, float);                  //!  Q-vector x component, with event eta gap A (harmonic 2 and power 0)
 DECLARE_SOA_COLUMN(Q2Y0A, q2y0a, float);                  //!  Q-vector y component, with event eta gap A (harmonic 2 and power 0)
 DECLARE_SOA_COLUMN(Q2X0B, q2x0b, float);                  //!  Q-vector x component, with event eta gap B (harmonic 2 and power 0)
@@ -68,7 +67,7 @@ DECLARE_SOA_TABLE(ReducedEvents, "AOD", "REDUCEDEVENT", //!   Main event informa
                   collision::CollisionTime, collision::CollisionTimeRes);
 
 DECLARE_SOA_TABLE(ReducedEventsExtended, "AOD", "REEXTENDED", //!  Extended event information
-                  bc::GlobalBC, bc::TriggerMask, timestamp::Timestamp, reducedevent::TriggerAlias, cent::CentRun2V0M,
+                  bc::GlobalBC, evsel::Alias, evsel::Selection, timestamp::Timestamp, cent::CentRun2V0M,
                   mult::MultTPC, mult::MultFV0A, mult::MultFV0C, mult::MultFT0A, mult::MultFT0C,
                   mult::MultFDDA, mult::MultFDDC, mult::MultZNA, mult::MultZNC, mult::MultTracklets, mult::MultNTracksPV,
                   cent::CentFT0C);
@@ -113,7 +112,7 @@ namespace reducedtrack
 // basic track information
 DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent); //!
 // ----  flags reserved for storing various information during filtering
-DECLARE_SOA_COLUMN(FilteringFlags, filteringFlags, uint64_t); //!
+DECLARE_SOA_BITMAP_COLUMN(FilteringFlags, filteringFlags, 64); //!
 // -----------------------------------------------------
 DECLARE_SOA_COLUMN(Pt, pt, float);                     //!
 DECLARE_SOA_COLUMN(Eta, eta, float);                   //!
@@ -153,6 +152,8 @@ DECLARE_SOA_TABLE(ReducedTracks, "AOD", "REDUCEDTRACK", //!
 
 // barrel track information
 DECLARE_SOA_TABLE(ReducedTracksBarrel, "AOD", "RTBARREL", //!
+                  track::X, track::Alpha, track::IsWithinBeamPipe<track::X>,
+                  track::Y, track::Z, track::Snp, track::Tgl, track::Signed1Pt,
                   track::TPCInnerParam, track::Flags,     // tracking status flags
                   track::ITSClusterMap, track::ITSChi2NCl,
                   track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
@@ -167,8 +168,6 @@ DECLARE_SOA_TABLE(ReducedTracksBarrel, "AOD", "RTBARREL", //!
 
 // barrel covariance matrix  TODO: add all the elements required for secondary vertexing
 DECLARE_SOA_TABLE(ReducedTracksBarrelCov, "AOD", "RTBARRELCOV", //!
-                  track::X, track::Alpha, track::IsWithinBeamPipe<track::X>,
-                  track::Y, track::Z, track::Snp, track::Tgl, track::Signed1Pt,
                   track::CYY, track::CZY, track::CZZ, track::CSnpY, track::CSnpZ,
                   track::CSnpSnp, track::CTglY, track::CTglZ, track::CTglSnp, track::CTglTgl,
                   track::C1PtY, track::C1PtZ, track::C1PtSnp, track::C1PtTgl, track::C1Pt21Pt2);
@@ -278,17 +277,17 @@ DECLARE_SOA_COLUMN(MftNClusters, mftNClusters, int);                            
 } // namespace reducedmft
 
 // MFT track kinematics
-DECLARE_SOA_TABLE(ReducedMFTTracks, "AOD", "RMFTTR", //!
+DECLARE_SOA_TABLE_FULL(ReducedMFTs, "ReducedMFTs", "AOD", "REDUCEDMFT", //!
                   o2::soa::Index<>, reducedmft::ReducedEventId, reducedmft::FilteringFlags,
                   reducedmft::Pt, reducedmft::Eta, reducedmft::Phi);
 
 // MFT tracks extra info (cluster size, sign)
-DECLARE_SOA_TABLE(ReducedMFTTracksExtra, "AOD", "RMFTTREXTRA", //!
+DECLARE_SOA_TABLE(ReducedMFTsExtra, "AOD", "RMFTEXTRA", //!
                   reducedmft::MftClusterSizesAndTrackFlags, reducedmft::Sign,
                   reducedmft::FwdDcaX, reducedmft::FwdDcaY, reducedmft::MftNClusters);
 
 // iterator
-using ReducedMFTTrack = ReducedMFTTracks::iterator;
+using ReducedMFT = ReducedMFTs::iterator;
 
 // muon quantities
 namespace reducedmuon
@@ -321,24 +320,26 @@ DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 16) & 0xFF); });
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });
-DECLARE_SOA_SELF_INDEX_COLUMN_FULL(MCHTrack, matchMCHTrack, int, "RTMuons_MatchMCHTrack");
-DECLARE_SOA_INDEX_COLUMN(ReducedMFTTrack, matchMFTTrack); //! matching index pointing to the ReducedMFTTrack table if filled
+DECLARE_SOA_SELF_INDEX_COLUMN_FULL(MatchMCHTrack, matchMCHTrack, int, "ReducedMuons_MatchMCHTrack");
+DECLARE_SOA_INDEX_COLUMN(ReducedMFT, matchMFTTrack); //!  matching index pointing to the ReducedMFTTrack table if filled
 } // namespace reducedmuon
 
 // Muon track kinematics
-DECLARE_SOA_TABLE(ReducedMuons, "AOD", "RTMUON", //!
-                  o2::soa::Index<>, reducedmuon::ReducedEventId, reducedmuon::FilteringFlags,
-                  reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign, reducedmuon::IsAmbiguous,
-                  reducedmuon::Px<reducedmuon::Pt, reducedmuon::Phi>,
-                  reducedmuon::Py<reducedmuon::Pt, reducedmuon::Phi>,
-                  reducedmuon::Pz<reducedmuon::Pt, reducedmuon::Eta>,
-                  reducedmuon::P<reducedmuon::Pt, reducedmuon::Eta>);
+DECLARE_SOA_TABLE_FULL(ReducedMuons, "ReducedMuons", "AOD", "REDUCEDMUON", //!
+                       o2::soa::Index<>, reducedmuon::ReducedEventId, 
+                       reducedmuon::MatchMCHTrackId, reducedmuon::ReducedMFTId,
+                       reducedmuon::FilteringFlags,
+                       reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign, reducedmuon::IsAmbiguous,
+                       reducedmuon::Px<reducedmuon::Pt, reducedmuon::Phi>,
+                       reducedmuon::Py<reducedmuon::Pt, reducedmuon::Phi>,
+                       reducedmuon::Pz<reducedmuon::Pt, reducedmuon::Eta>,
+                       reducedmuon::P<reducedmuon::Pt, reducedmuon::Eta>);
 
 // Muon track quality details
 DECLARE_SOA_TABLE(ReducedMuonsExtra, "AOD", "RTMUONEXTRA", //!
                   fwdtrack::NClusters, fwdtrack::PDca, fwdtrack::RAtAbsorberEnd,
                   fwdtrack::Chi2, fwdtrack::Chi2MatchMCHMID, fwdtrack::Chi2MatchMCHMFT,
-                  fwdtrack::MatchScoreMCHMFT, reducedmuon::MCHTrackId, reducedmuon::ReducedMFTTrackId,
+                  fwdtrack::MatchScoreMCHMFT,
                   fwdtrack::MCHBitMap, fwdtrack::MIDBitMap, fwdtrack::MIDBoards, fwdtrack::TrackType,
                   reducedmuon::FwdDcaX, reducedmuon::FwdDcaY,
                   fwdtrack::TrackTime, fwdtrack::TrackTimeRes);
@@ -372,6 +373,24 @@ DECLARE_SOA_TABLE(ReducedMuonsLabels, "AOD", "RTMUONSLABELS", //!
                   reducedmuonlabel::ReducedMCTrackId, reducedmuonlabel::McMask, reducedtrackMC::McReducedFlags);
 
 using ReducedMuonsLabel = ReducedMuonsLabels::iterator;
+
+namespace reducedtrack_association
+{
+DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent);      //! ReducedEvent index
+DECLARE_SOA_INDEX_COLUMN(ReducedTrack, reducedtrack);      //! ReducedTrack index
+DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon);        //! ReducedMuon index
+DECLARE_SOA_INDEX_COLUMN(ReducedMFT, reducedmft);     //! ReducedMFTTrack index
+} // namespace reducedtrack_association
+
+DECLARE_SOA_TABLE(ReducedTracksAssoc, "AOD", "RTASSOC", //! Table for reducedtrack-to-reducedcollision association
+                  reducedtrack_association::ReducedEventId,
+                  reducedtrack_association::ReducedTrackId);
+DECLARE_SOA_TABLE(ReducedMuonsAssoc, "AOD", "RMASSOC", //! Table for reducedmuon-to-reducedcollision association
+                  reducedtrack_association::ReducedEventId,
+                  reducedtrack_association::ReducedMuonId);                  
+DECLARE_SOA_TABLE(ReducedMFTAssoc, "AOD", "RMFTASSOC", //! Table for reducemft-to-reducedcollision association
+                  reducedtrack_association::ReducedEventId,
+                  reducedtrack_association::ReducedMFTId);                  
 
 namespace smearedtrack
 {
@@ -443,12 +462,14 @@ DECLARE_SOA_COLUMN(FwdDcaY2, fwdDcaY2, float); //! Y component of forward DCA
 namespace reducedpair
 {
 DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent);  //!
+DECLARE_SOA_INDEX_COLUMN_FULL(Index0, index0, int, ReducedTracks, "_0"); //! Index to first prong
+DECLARE_SOA_INDEX_COLUMN_FULL(Index1, index1, int, ReducedTracks, "_1"); //! Index to second prong
 DECLARE_SOA_COLUMN(Mass, mass, float);                 //!
 DECLARE_SOA_COLUMN(Pt, pt, float);                     //!
 DECLARE_SOA_COLUMN(Eta, eta, float);                   //!
 DECLARE_SOA_COLUMN(Phi, phi, float);                   //!
 DECLARE_SOA_COLUMN(Sign, sign, int);                   //!
-DECLARE_SOA_COLUMN(FilterMap, filterMap, uint32_t);    //!
+DECLARE_SOA_BITMAP_COLUMN(FilterMap, filterMap, 32);   //!
 DECLARE_SOA_COLUMN(McDecision, mcDecision, uint32_t);  //!
 DECLARE_SOA_COLUMN(Tauz, tauz, float);                 //! Longitudinal pseudo-proper time of lepton pair (in ns)
 DECLARE_SOA_COLUMN(TauzErr, tauzErr, float);           //! Error on longitudinal pseudo-proper time of lepton pair (in ns)
@@ -479,19 +500,33 @@ DECLARE_SOA_DYNAMIC_COLUMN(Rap, rap, //!
                            [](float pt, float eta, float m) -> float { return std::log((std::sqrt(m * m + pt * pt * std::cosh(eta) * std::cosh(eta)) + pt * std::sinh(eta)) / std::sqrt(m * m + pt * pt)); });
 } // namespace reducedpair
 
-DECLARE_SOA_TABLE(Dileptons, "AOD", "RTDILEPTON", //!
-                  reducedpair::ReducedEventId,
-                  reducedpair::Mass,
-                  reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                  reducedpair::FilterMap,
-                  reducedpair::McDecision,
+DECLARE_SOA_TABLE_FULL(Dielectrons, "Dielectrons", "AOD", "RTDIELECTRON", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::McDecision,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
+                  
+DECLARE_SOA_TABLE_FULL(Dimuons, "Dimuons", "AOD", "RTDIMUON", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::McDecision,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
                   reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
                   reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
                   reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
-                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);                  
 
-DECLARE_SOA_TABLE(DileptonsExtra, "AOD", "RTDILEPTONEXTRA", //!
+DECLARE_SOA_TABLE(DielectronsExtra, "AOD", "RTDIELEEXTRA", //!
+                  reducedpair::Index0Id, reducedpair::Index1Id,
+                  reducedpair::Tauz,
+                  reducedpair::Lz,
+                  reducedpair::Lxy);
+
+DECLARE_SOA_TABLE(DimuonsExtra, "AOD", "RTDIMUEXTRA", //!
                   dilepton_track_index::Index0Id, dilepton_track_index::Index1Id,
                   reducedpair::Tauz,
                   reducedpair::Lz,
@@ -536,8 +571,10 @@ DECLARE_SOA_TABLE(DimuonsAll, "AOD", "RTDIMUONALL", //!
                   reducedpair::Cos2DeltaPhi,
                   reducedpair::Cos3DeltaPhi);
 
-using Dilepton = Dileptons::iterator;
-using DileptonExtra = DileptonsExtra::iterator;
+using Dielectron = Dielectrons::iterator;
+using Dimuon = Dimuons::iterator;
+using DielectronExtra = DielectronsExtra::iterator;
+using DimuonExtra = DimuonsExtra::iterator;
 using DileptonFlow = DileptonsFlow::iterator;
 using DileptonInfo = DileptonsInfo::iterator;
 using DimuonAll = DimuonsAll::iterator;

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -39,7 +39,7 @@ namespace reducedevent
 {
 
 // basic event information
-DECLARE_SOA_BITMAP_COLUMN(Tag, tag, 64);             //!  Bit-field for storing event information (e.g. high level info, cut decisions)
+DECLARE_SOA_BITMAP_COLUMN(Tag, tag, 64);                  //!  Bit-field for storing event information (e.g. high level info, cut decisions)
 DECLARE_SOA_COLUMN(Q2X0A, q2x0a, float);                  //!  Q-vector x component, with event eta gap A (harmonic 2 and power 0)
 DECLARE_SOA_COLUMN(Q2Y0A, q2y0a, float);                  //!  Q-vector y component, with event eta gap A (harmonic 2 and power 0)
 DECLARE_SOA_COLUMN(Q2X0B, q2x0b, float);                  //!  Q-vector x component, with event eta gap B (harmonic 2 and power 0)
@@ -154,7 +154,7 @@ DECLARE_SOA_TABLE(ReducedTracks, "AOD", "REDUCEDTRACK", //!
 DECLARE_SOA_TABLE(ReducedTracksBarrel, "AOD", "RTBARREL", //!
                   track::X, track::Alpha, track::IsWithinBeamPipe<track::X>,
                   track::Y, track::Z, track::Snp, track::Tgl, track::Signed1Pt,
-                  track::TPCInnerParam, track::Flags,     // tracking status flags
+                  track::TPCInnerParam, track::Flags, // tracking status flags
                   track::ITSClusterMap, track::ITSChi2NCl,
                   track::TPCNClsFindable, track::TPCNClsFindableMinusFound, track::TPCNClsFindableMinusCrossedRows,
                   track::TPCNClsShared, track::TPCChi2NCl,
@@ -278,8 +278,8 @@ DECLARE_SOA_COLUMN(MftNClusters, mftNClusters, int);                            
 
 // MFT track kinematics
 DECLARE_SOA_TABLE_FULL(ReducedMFTs, "ReducedMFTs", "AOD", "REDUCEDMFT", //!
-                  o2::soa::Index<>, reducedmft::ReducedEventId, reducedmft::FilteringFlags,
-                  reducedmft::Pt, reducedmft::Eta, reducedmft::Phi);
+                       o2::soa::Index<>, reducedmft::ReducedEventId, reducedmft::FilteringFlags,
+                       reducedmft::Pt, reducedmft::Eta, reducedmft::Phi);
 
 // MFT tracks extra info (cluster size, sign)
 DECLARE_SOA_TABLE(ReducedMFTsExtra, "AOD", "RMFTEXTRA", //!
@@ -326,7 +326,7 @@ DECLARE_SOA_INDEX_COLUMN(ReducedMFT, matchMFTTrack); //!  matching index pointin
 
 // Muon track kinematics
 DECLARE_SOA_TABLE_FULL(ReducedMuons, "ReducedMuons", "AOD", "REDUCEDMUON", //!
-                       o2::soa::Index<>, reducedmuon::ReducedEventId, 
+                       o2::soa::Index<>, reducedmuon::ReducedEventId,
                        reducedmuon::MatchMCHTrackId, reducedmuon::ReducedMFTId,
                        reducedmuon::FilteringFlags,
                        reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign, reducedmuon::IsAmbiguous,
@@ -376,9 +376,9 @@ using ReducedMuonsLabel = ReducedMuonsLabels::iterator;
 
 namespace reducedtrack_association
 {
-DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent);      //! ReducedEvent index
-DECLARE_SOA_INDEX_COLUMN(ReducedTrack, reducedtrack);      //! ReducedTrack index
-DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon);        //! ReducedMuon index
+DECLARE_SOA_INDEX_COLUMN(ReducedEvent, reducedevent); //! ReducedEvent index
+DECLARE_SOA_INDEX_COLUMN(ReducedTrack, reducedtrack); //! ReducedTrack index
+DECLARE_SOA_INDEX_COLUMN(ReducedMuon, reducedmuon);   //! ReducedMuon index
 DECLARE_SOA_INDEX_COLUMN(ReducedMFT, reducedmft);     //! ReducedMFTTrack index
 } // namespace reducedtrack_association
 
@@ -387,10 +387,10 @@ DECLARE_SOA_TABLE(ReducedTracksAssoc, "AOD", "RTASSOC", //! Table for reducedtra
                   reducedtrack_association::ReducedTrackId);
 DECLARE_SOA_TABLE(ReducedMuonsAssoc, "AOD", "RMASSOC", //! Table for reducedmuon-to-reducedcollision association
                   reducedtrack_association::ReducedEventId,
-                  reducedtrack_association::ReducedMuonId);                  
+                  reducedtrack_association::ReducedMuonId);
 DECLARE_SOA_TABLE(ReducedMFTAssoc, "AOD", "RMFTASSOC", //! Table for reducemft-to-reducedcollision association
                   reducedtrack_association::ReducedEventId,
-                  reducedtrack_association::ReducedMFTId);                  
+                  reducedtrack_association::ReducedMFTId);
 
 namespace smearedtrack
 {
@@ -501,24 +501,24 @@ DECLARE_SOA_DYNAMIC_COLUMN(Rap, rap, //!
 } // namespace reducedpair
 
 DECLARE_SOA_TABLE_FULL(Dielectrons, "Dielectrons", "AOD", "RTDIELECTRON", //!
-                  o2::soa::Index<>, reducedpair::ReducedEventId,
-                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                  reducedpair::FilterMap, reducedpair::McDecision,
-                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
-                  
+                       o2::soa::Index<>, reducedpair::ReducedEventId,
+                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                       reducedpair::FilterMap, reducedpair::McDecision,
+                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
+
 DECLARE_SOA_TABLE_FULL(Dimuons, "Dimuons", "AOD", "RTDIMUON", //!
-                  o2::soa::Index<>, reducedpair::ReducedEventId,
-                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                  reducedpair::FilterMap, reducedpair::McDecision,
-                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
-                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);                  
+                       o2::soa::Index<>, reducedpair::ReducedEventId,
+                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                       reducedpair::FilterMap, reducedpair::McDecision,
+                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
+                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);
 
 DECLARE_SOA_TABLE(DielectronsExtra, "AOD", "RTDIELEEXTRA", //!
                   reducedpair::Index0Id, reducedpair::Index1Id,

--- a/PWGDQ/TableProducer/CMakeLists.txt
+++ b/PWGDQ/TableProducer/CMakeLists.txt
@@ -14,6 +14,11 @@ o2physics_add_dpl_workflow(table-maker
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(table-maker-with-assoc
+                    SOURCES tableMaker_withAssoc.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(table-maker-mc
                     SOURCES tableMakerMC.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -794,7 +794,7 @@ struct TableMaker {
     if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
       tag |= (collision.eventFilter() << 56);
     }
-    
+
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
     // TODO: These variables cannot be filled in the VarManager for the moment as long as BCsWithTimestamps are used.
     //       So temporarily, we filled them here, in order to be available for eventual QA of the skimming

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -139,8 +139,8 @@ struct TableMaker {
   Produces<ReducedMuonsExtra> muonExtra;
   Produces<ReducedMuonsCov> muonCov;
   Produces<ReducedMuonsInfo> muonInfo;
-  Produces<ReducedMFTTracks> trackMFT;
-  Produces<ReducedMFTTracksExtra> trackMFTExtra;
+  Produces<ReducedMFTs> trackMFT;
+  Produces<ReducedMFTsExtra> trackMFTExtra;
 
   OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
   OutputObj<TList> fStatsList{"Statistics"};  //! skimming statistics
@@ -372,17 +372,15 @@ struct TableMaker {
           VarManager::SetupMuonMagField();
         }
       }
-
       fCurrentRun = bc.runNumber();
     }
 
-    // get the trigger aliases
-    uint32_t triggerAliases = collision.alias_raw();
-
     // store the selection decisions
-    uint64_t tag = collision.selection_raw();
-    if (collision.sel7()) {
-      tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
+    uint64_t tag = 0;
+    // store some more information in the tag
+    // if the BC found by event selection does not coincide with the collision.bc()
+    if (collision.foundBC().globalIndex() != collision.bc().globalIndex()) {
+      tag |= (uint64_t(1) << 0);
     }
     // Put the 8 first bits of the event filter in the last 8 bits of the tag
     if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
@@ -401,6 +399,7 @@ struct TableMaker {
       fHistMan->FillHistClass("Event_BeforeCuts", VarManager::fgValues);
     }
 
+    uint32_t triggerAliases = collision.alias_raw();
     // fill stats information, before selections
     for (int i = 0; i < kNaliases; i++) {
       if (triggerAliases & (uint32_t(1) << i)) {
@@ -426,20 +425,20 @@ struct TableMaker {
     // create the event tables
     event(tag, bc.runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes());
     if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionMult) > 0 && (TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     collision.multTPC(), collision.multFV0A(), collision.multFV0C(), collision.multFT0A(), collision.multFT0C(),
                     collision.multFDDA(), collision.multFDDC(), collision.multZNA(), collision.multZNC(), collision.multTracklets(), collision.multNTracksPV(),
                     collision.centFT0C());
     } else if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionMult) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     collision.multTPC(), collision.multFV0A(), collision.multFV0C(), collision.multFT0A(), collision.multFT0C(),
                     collision.multFDDA(), collision.multFDDC(), collision.multZNA(), collision.multZNC(), collision.multTracklets(), collision.multNTracksPV(),
                     -1);
     } else if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, collision.centFT0C());
     } else {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO], -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO], -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
     }
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
@@ -539,7 +538,8 @@ struct TableMaker {
 
         // create the track tables
         trackBasic(event.lastIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), isAmbiguous);
-        trackBarrel(track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
+        trackBarrel(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
+                    track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
                     track.tpcNClsFindable(), track.tpcNClsFindableMinusFound(), track.tpcNClsFindableMinusCrossedRows(),
                     track.tpcNClsShared(), track.tpcChi2NCl(),
                     track.trdChi2(), track.trdPattern(), track.tofChi2(),
@@ -548,8 +548,7 @@ struct TableMaker {
                     track.detectorMap());
         trackBarrelInfo(track.collisionId(), collision.posX(), collision.posY(), collision.posZ());
         if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackCov)) {
-          trackBarrelCov(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
-                         track.cYY(), track.cZY(), track.cZZ(), track.cSnpY(), track.cSnpZ(),
+          trackBarrelCov(track.cYY(), track.cZY(), track.cZZ(), track.cSnpY(), track.cSnpZ(),
                          track.cSnpSnp(), track.cTglY(), track.cTglZ(), track.cTglSnp(), track.cTglTgl(),
                          track.c1PtY(), track.c1PtZ(), track.c1PtSnp(), track.c1PtTgl(), track.c1Pt21Pt2());
         }
@@ -557,7 +556,7 @@ struct TableMaker {
         if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackPID)) {
           float nSigmaEl = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaEl_Corr] : track.tpcNSigmaEl());
           float nSigmaPi = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaPi_Corr] : track.tpcNSigmaPi());
-          float nSigmaKa = ((fConfigComputeTPCpostCalib & fConfigComputeTPCpostCalibKaon) ? VarManager::fgValues[VarManager::kTPCnSigmaKa_Corr] : track.tpcNSigmaKa());
+          float nSigmaKa = ((fConfigComputeTPCpostCalib && fConfigComputeTPCpostCalibKaon) ? VarManager::fgValues[VarManager::kTPCnSigmaKa_Corr] : track.tpcNSigmaKa());
           float nSigmaPr = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaPr_Corr] : track.tpcNSigmaPr());
           trackBarrelPID(track.tpcSignal(),
                          nSigmaEl, track.tpcNSigmaMu(), nSigmaPi, nSigmaKa, nSigmaPr,
@@ -626,6 +625,9 @@ struct TableMaker {
       for (auto& muon : tracksMuon) {
         trackFilteringTag = uint64_t(0);
         VarManager::FillTrack<TMuonFillMap>(muon);
+        if (fPropMuon) {
+          VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+        }
 
         if (muon.index() > idxPrev + 1) { // checks if some muons are filtered even before the skimming function
           nDel += muon.index() - (idxPrev + 1);
@@ -726,10 +728,10 @@ struct TableMaker {
           }
         }
 
-        muonBasic(event.lastIndex(), trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
+        muonBasic(event.lastIndex(), newMatchIndex.find(muon.index())->second, newMFTMatchIndex.find(muon.index())->second, trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
         muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                   muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                  muon.matchScoreMCHMFT(), newMatchIndex.find(muon.index())->second, newMFTMatchIndex.find(muon.index())->second, muon.mchBitMap(), muon.midBitMap(),
+                  muon.matchScoreMCHMFT(), muon.mchBitMap(), muon.midBitMap(),
                   muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
                   muon.trackTime(), muon.trackTimeRes());
         muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
@@ -781,14 +783,18 @@ struct TableMaker {
 
     // get the trigger aliases
     uint32_t triggerAliases = collision.alias_raw();
-
     // store the selection decisions
-    uint64_t tag = collision.selection_raw();
-    if (collision.sel7()) {
-      tag |= (uint64_t(1) << evsel::kNsel); //! SEL7 stored at position kNsel in the tag bit map
+    uint64_t tag = 0;
+    // store some more information in the tag
+    // if the BC found by event selection does not coincide with the collision.bc()
+    if (collision.foundBC().globalIndex() != collision.bc().globalIndex()) {
+      tag |= (uint64_t(1) << 0);
     }
-    // TODO: Add the event level decisions from the filtering task into the tag
-
+    // Put the 8 first bits of the event filter in the last 8 bits of the tag
+    if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
+      tag |= (collision.eventFilter() << 56);
+    }
+    
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
     // TODO: These variables cannot be filled in the VarManager for the moment as long as BCsWithTimestamps are used.
     //       So temporarily, we filled them here, in order to be available for eventual QA of the skimming
@@ -826,20 +832,20 @@ struct TableMaker {
     // create the event tables
     event(tag, bc.runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes());
     if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionMult) > 0 && (TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     collision.multTPC(), collision.multFV0A(), collision.multFV0C(), collision.multFT0A(), collision.multFT0C(),
                     collision.multFDDA(), collision.multFDDC(), collision.multZNA(), collision.multZNC(), collision.multTracklets(), collision.multNTracksPV(),
                     collision.centFT0C());
     } else if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionMult) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     collision.multTPC(), collision.multFV0A(), collision.multFV0C(), collision.multFT0A(), collision.multFT0C(),
                     collision.multFDDA(), collision.multFDDC(), collision.multZNA(), collision.multZNC(), collision.multTracklets(), collision.multNTracksPV(),
                     -1);
     } else if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO],
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
                     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, collision.centFT0C());
     } else {
-      eventExtended(bc.globalBC(), bc.triggerMask(), bc.timestamp(), triggerAliases, VarManager::fgValues[VarManager::kCentVZERO], -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO], -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
     }
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
@@ -1056,10 +1062,10 @@ struct TableMaker {
           }
         }
 
-        muonBasic(event.lastIndex(), trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
+        muonBasic(event.lastIndex(), newMatchIndex.find(muon.index())->second, -1, trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
         muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                   muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                  muon.matchScoreMCHMFT(), newMatchIndex.find(muon.index())->second, -1, muon.mchBitMap(), muon.midBitMap(),
+                  muon.matchScoreMCHMFT(), muon.mchBitMap(), muon.midBitMap(),
                   muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
                   muon.trackTime(), muon.trackTimeRes());
         muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());

--- a/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
+++ b/PWGDQ/TableProducer/tableMakerJpsiHf.cxx
@@ -38,8 +38,8 @@ using namespace o2::aod::hf_cand_2prong;
 
 // Declarations of various short names
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
-using MyDileptonCandidatesSelected = soa::Join<aod::Dileptons, aod::DileptonsInfo>;
-using MyDileptonCandidatesSelectedWithDca = soa::Join<aod::Dileptons, aod::DileptonsExtra, aod::DileptonsInfo>;
+using MyDileptonCandidatesSelected = soa::Join<aod::Dimuons, aod::DileptonsInfo>;
+using MyDileptonCandidatesSelectedWithDca = soa::Join<aod::Dimuons, aod::DimuonsExtra, aod::DileptonsInfo>;
 using MyD0CandidatesSelected = soa::Join<aod::HfCand2Prong, aod::HfSelD0>;
 using MyD0CandidatesSelectedWithBdt = soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>;
 

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -607,7 +607,8 @@ struct TableMakerMC {
           }
 
           trackBasic(event.lastIndex(), trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), isAmbiguous);
-          trackBarrel(track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
+          trackBarrel(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
+                      track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
                       track.tpcNClsFindable(), track.tpcNClsFindableMinusFound(), track.tpcNClsFindableMinusCrossedRows(),
                       track.tpcNClsShared(), track.tpcChi2NCl(),
                       track.trdChi2(), track.trdPattern(), track.tofChi2(),
@@ -623,8 +624,7 @@ struct TableMakerMC {
                          track.trdSignal());
           trackBarrelLabels(fNewLabels.find(mctrack.index())->second, track.mcMask(), mcflags);
           if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackCov)) {
-            trackBarrelCov(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
-                           track.cYY(), track.cZY(), track.cZZ(), track.cSnpY(), track.cSnpZ(),
+            trackBarrelCov(track.cYY(), track.cZY(), track.cZZ(), track.cSnpY(), track.cSnpZ(),
                            track.cSnpSnp(), track.cTglY(), track.cTglZ(), track.cTglSnp(), track.cTglTgl(),
                            track.c1PtY(), track.c1PtZ(), track.c1PtSnp(), track.c1PtTgl(), track.c1Pt21Pt2());
           }
@@ -785,10 +785,10 @@ struct TableMakerMC {
             }
           }
 
-          muonBasic(event.lastIndex(), trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign(), isAmbiguous);
+          muonBasic(event.lastIndex(), newMatchIndex.find(muon.index())->second, -1, trackFilteringTag, muon.pt(), muon.eta(), muon.phi(), muon.sign(), isAmbiguous);
           muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                     muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                    muon.matchScoreMCHMFT(), newMatchIndex.find(muon.index())->second, -1, muon.mchBitMap(), muon.midBitMap(),
+                    muon.matchScoreMCHMFT(), muon.mchBitMap(), muon.midBitMap(),
                     muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
                     muon.trackTime(), muon.trackTimeRes());
           if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -147,7 +147,7 @@ struct TableMaker {
   Produces<ReducedMFTs> mftTrack;
   Produces<ReducedMFTsExtra> mftTrackExtra;
   Produces<ReducedMFTAssoc> mftAssoc;
-  
+
   OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
   OutputObj<TList> fStatsList{"Statistics"};  //! skimming statistics
   HistogramManager* fHistMan;
@@ -163,7 +163,7 @@ struct TableMaker {
   Configurable<std::string> fConfigAddEventHistogram{"cfgAddEventHistogram", "", "Comma separated list of histograms"};
   Configurable<std::string> fConfigAddTrackHistogram{"cfgAddTrackHistogram", "", "Comma separated list of histograms"};
   Configurable<std::string> fConfigAddMuonHistogram{"cfgAddMuonHistogram", "", "Comma separated list of histograms"};
-  
+
   // Selections to be applied as Filter on the Track and FwdTrack
   Configurable<bool> fIsRun2{"cfgIsRun2", false, "Whether we analyze Run-2 or Run-3 data"};
   Configurable<float> fConfigBarrelTrackMaxAbsEta{"cfgBarrelMaxAbsEta", 0.9f, "Eta absolute value cut for tracks in the barrel"};
@@ -174,7 +174,7 @@ struct TableMaker {
   Configurable<bool> fConfigBarrelRequireITS{"cfgBarrelRequireITS", true, "Require ITS for tracks in the barrel"};
   Configurable<float> fConfigBarrelMaxITSchi2{"cfgBarrelMaxITSchi2", 36.0f, "Maximum ITS chi2/ndf for tracks in the barrel"};
   Configurable<float> fConfigMuonPtLow{"cfgMuonLowPt", 1.0f, "Low pt cut for muons"};
-  
+
   // CCDB connection configurables
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/z/zhxiong/Postcalib/pass4/apass3BB", "base path to the ccdb object"};
@@ -190,7 +190,7 @@ struct TableMaker {
   Configurable<bool> fConfigIsOnlyforMaps{"cfgIsforMaps", false, "If true, run for postcalibration maps only"};
   Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
   Configurable<bool> fConfigDummyRunlist{"cfgDummyRunlist", false, "If true, use dummy runlist"};
-  Configurable<int> fConfigInitRunNumber{"cfgInitRunNumber", 543215, "Initial run number used in run by run checks"};  
+  Configurable<int> fConfigInitRunNumber{"cfgInitRunNumber", 543215, "Initial run number used in run by run checks"};
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
 
@@ -206,20 +206,20 @@ struct TableMaker {
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
 
   // maps used to store index info; NOTE: std::map are sorted in ascending order by default (needed for track to collision indices)
-  std::map<uint32_t, uint32_t> fCollIndexMap;       // key: old collision index, value: skimmed collision index 
-  std::map<uint32_t, uint32_t> fTrackIndexMap;     // key: old track global index, value: new track global index
-  std::map<uint32_t, uint32_t> fFwdTrackIndexMap;   // key: fwd-track global index, value: new fwd-track global index
+  std::map<uint32_t, uint32_t> fCollIndexMap;             // key: old collision index, value: skimmed collision index
+  std::map<uint32_t, uint32_t> fTrackIndexMap;            // key: old track global index, value: new track global index
+  std::map<uint32_t, uint32_t> fFwdTrackIndexMap;         // key: fwd-track global index, value: new fwd-track global index
   std::map<uint32_t, uint32_t> fFwdTrackIndexMapReversed; // key: new fwd-track global index, value: fwd-track global index
-  std::map<uint32_t, uint64_t> fFwdTrackFilterMap;  // key: fwd-track global index, value: fwd-track filter map
-  std::map<uint32_t, uint32_t> fMftIndexMap;        // key: MFT tracklet global index, value: new MFT tracklet global index
+  std::map<uint32_t, uint64_t> fFwdTrackFilterMap;        // key: fwd-track global index, value: fwd-track filter map
+  std::map<uint32_t, uint32_t> fMftIndexMap;              // key: MFT tracklet global index, value: new MFT tracklet global index
 
-  // FIXME: For now, the skimming is done using the Common track-collision association task, which does not allow to use 
+  // FIXME: For now, the skimming is done using the Common track-collision association task, which does not allow to use
   //       our own Filtered tracks. If the filter is very selective, then it may be worth to run the association in this workflow
   //       using the Common/CollisionAssociation class
-  /*Filter barrelSelectedTracks = ifnode(fIsRun2.node() == true, track::trackType == uint8_t(track::Run2Track), track::trackType == uint8_t(track::Track)) 
+  /*Filter barrelSelectedTracks = ifnode(fIsRun2.node() == true, track::trackType == uint8_t(track::Run2Track), track::trackType == uint8_t(track::Track))
                               && track::pt > fConfigBarrelTrackMinPt
-                              && nabs(track::eta) <= fConfigBarrelTrackMaxAbsEta 
-                              && ifnode(fConfigBarrelRequireITS.node() == true, track::itsChi2NCl < fConfigBarrelMaxITSchi2, true) 
+                              && nabs(track::eta) <= fConfigBarrelTrackMaxAbsEta
+                              && ifnode(fConfigBarrelRequireITS.node() == true, track::itsChi2NCl < fConfigBarrelMaxITSchi2, true)
                               && ifnode(fConfigBarrelRequireTPC.node() == true, track::tpcNClsFound > fConfigBarrelMinTPCncls && track::tpcChi2NCl < fConfigBarrelMaxTPCchi2, true);
 
   Filter muonFilter = o2::aod::fwdtrack::pt >= fConfigMuonPtLow;*/
@@ -259,29 +259,29 @@ struct TableMaker {
       histClasses += "Event_AfterCuts;";
     }
 
-/*
-    bool enableBarrelHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
-                               context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
-                               context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
-                               context.mOptions.get<bool>("processBarrelOnly") || context.mOptions.get<bool>("processBarrelOnlyWithCent") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCent") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithMults") || context.mOptions.get<bool>("processBarrelOnlyWithCentAndMults") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCentAndMults") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithCov") || context.mOptions.get<bool>("processBarrelOnlyWithEventFilter") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processBarrelOnlyWithCovAndEventFilter") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits") || context.mOptions.get<bool>("processBarrelOnlyWithV0Bits") ||
-                               context.mOptions.get<bool>("processBarrelOnlyWithV0BitsAndMaps") || context.mOptions.get<bool>("processAmbiguousBarrelOnly"));
-    bool enableMuonHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
-                             context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
-                             context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
-                             context.mOptions.get<bool>("processMuonOnly") || context.mOptions.get<bool>("processMuonOnlyWithCent") ||
-                             context.mOptions.get<bool>("processMuonOnlyWithMults") || context.mOptions.get<bool>("processMuonOnlyWithCentAndMults") ||
-                             context.mOptions.get<bool>("processMuonOnlyWithCovAndCent") ||
-                             context.mOptions.get<bool>("processMuonOnlyWithCov") || context.mOptions.get<bool>("processMuonOnlyWithCovAndEventFilter") || context.mOptions.get<bool>("processMuonOnlyWithEventFilter") ||
-                             context.mOptions.get<bool>("processMuonOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processAmbiguousMuonOnlyWithCov") || context.mOptions.get<bool>("processAmbiguousMuonOnly") ||
-                             context.mOptions.get<bool>("processMuonsAndMFT") || context.mOptions.get<bool>("processMuonsAndMFTWithFilter") || context.mOptions.get<bool>("processMuonMLOnly"));
-                             */
+    /*
+        bool enableBarrelHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
+                                   context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
+                                   context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
+                                   context.mOptions.get<bool>("processBarrelOnly") || context.mOptions.get<bool>("processBarrelOnlyWithCent") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCent") ||
+                                   context.mOptions.get<bool>("processBarrelOnlyWithMults") || context.mOptions.get<bool>("processBarrelOnlyWithCentAndMults") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCentAndMults") ||
+                                   context.mOptions.get<bool>("processBarrelOnlyWithCov") || context.mOptions.get<bool>("processBarrelOnlyWithEventFilter") ||
+                                   context.mOptions.get<bool>("processBarrelOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processBarrelOnlyWithCovAndEventFilter") ||
+                                   context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits") || context.mOptions.get<bool>("processBarrelOnlyWithV0Bits") ||
+                                   context.mOptions.get<bool>("processBarrelOnlyWithV0BitsAndMaps") || context.mOptions.get<bool>("processAmbiguousBarrelOnly"));
+        bool enableMuonHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
+                                 context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
+                                 context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
+                                 context.mOptions.get<bool>("processMuonOnly") || context.mOptions.get<bool>("processMuonOnlyWithCent") ||
+                                 context.mOptions.get<bool>("processMuonOnlyWithMults") || context.mOptions.get<bool>("processMuonOnlyWithCentAndMults") ||
+                                 context.mOptions.get<bool>("processMuonOnlyWithCovAndCent") ||
+                                 context.mOptions.get<bool>("processMuonOnlyWithCov") || context.mOptions.get<bool>("processMuonOnlyWithCovAndEventFilter") || context.mOptions.get<bool>("processMuonOnlyWithEventFilter") ||
+                                 context.mOptions.get<bool>("processMuonOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processAmbiguousMuonOnlyWithCov") || context.mOptions.get<bool>("processAmbiguousMuonOnly") ||
+                                 context.mOptions.get<bool>("processMuonsAndMFT") || context.mOptions.get<bool>("processMuonsAndMFTWithFilter") || context.mOptions.get<bool>("processMuonMLOnly"));
+                                 */
 
     bool enableBarrelHistos = (context.mOptions.get<bool>("processFullWithFilter"));
-    bool enableMuonHistos = (context.mOptions.get<bool>("processFullWithFilter"));                                
+    bool enableMuonHistos = (context.mOptions.get<bool>("processFullWithFilter"));
 
     if (enableBarrelHistos) {
       if (fDoDetailedQA) {
@@ -445,10 +445,11 @@ struct TableMaker {
   }
 
   template <uint32_t TEventFillMap, typename TEvents>
-  void skimCollisions(TEvents const &collisions, BCsWithTimestamps const &bcs) {
+  void skimCollisions(TEvents const& collisions, BCsWithTimestamps const& bcs)
+  {
     // Skim collisions
     // NOTE: So far, collisions are filtered based on the user specified analysis cuts and the filterPP event filter.
-    //      The collision-track associations which point to an event that is not selected for writing are discarded!  
+    //      The collision-track associations which point to an event that is not selected for writing are discarded!
 
     fCollIndexMap.clear();
     int multTPC = -1.0;
@@ -463,7 +464,7 @@ struct TableMaker {
     int multTracklets = -1.0;
     int multTracksPV = -1.0;
     float centFT0C = -1.0;
-    
+
     for (const auto& collision : collisions) {
 
       for (int i = 0; i < kNaliases; i++) {
@@ -542,7 +543,7 @@ struct TableMaker {
         multZNC = collision.multZNC();
         multTracklets = collision.multTracklets();
         multTracksPV = collision.multNTracksPV();
-      } 
+      }
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
         centFT0C = collision.centFT0C();
       }
@@ -555,16 +556,17 @@ struct TableMaker {
   }
 
   template <uint32_t TTrackFillMap, typename TEvent, typename TTracks>
-  void skimTracks(TEvent const &collision, BCsWithTimestamps const &bcs, TTracks const &tracks, TrackAssoc const &assocs) {
+  void skimTracks(TEvent const& collision, BCsWithTimestamps const& bcs, TTracks const& tracks, TrackAssoc const& assocs)
+  {
     // Skim the barrel tracks
     // Loop over the collision-track associations, retrieve the track, and apply track cuts for selection
     //     One can apply here cuts which depend on the association (e.g. DCA), which will discard (hopefully most) wrong associations.
     //     Tracks are written only once, even if they constribute to more than one association
-    
+
     uint64_t trackFilteringTag = uint64_t(0);
     uint64_t trackTempFilterMap = uint8_t(0);
-    
-    for (const auto &assoc : assocs) {
+
+    for (const auto& assoc : assocs) {
       auto track = assoc.template track_as<TTracks>();
 
       trackFilteringTag = uint64_t(0);
@@ -573,7 +575,7 @@ struct TableMaker {
       if (fDoDetailedQA) {
         fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
       }
-      
+
       // apply track cuts and fill stats histogram
       int i = 0;
       for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, i++) {
@@ -618,20 +620,20 @@ struct TableMaker {
             continue;
           }
         }
-      }   // end if V0Bits
+      } // end if V0Bits
       if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
         trackFilteringTag |= (uint64_t(track.dalitzBits()) << 5); // BIT5-12: Dalitz
       }
-      trackFilteringTag |= (uint64_t(trackTempFilterMap) << 13); // BIT13-...:  user track filters  
+      trackFilteringTag |= (uint64_t(trackTempFilterMap) << 13); // BIT13-...:  user track filters
       // write the track global index in the map for skimming (to make sure we have it just once)
       if (fTrackIndexMap.find(track.globalIndex()) == fTrackIndexMap.end()) {
         // NOTE: The collision ID that is written in the table is the one found in the first association for this track.
         //       However, in data analysis one should loop over associations, so this one should not be used.
         //      In the case of Run2-like analysis, there will be no associations, so this ID will be the one originally assigned in the AO2Ds (updated for the skims)
         uint32_t reducedEventIdx = fCollIndexMap[collision.globalIndex()];
-        // NOTE: trackBarrelInfo stores the index of the collision as in AO2D (for use in some cases where the analysis on skims is done 
+        // NOTE: trackBarrelInfo stores the index of the collision as in AO2D (for use in some cases where the analysis on skims is done
         //   in workflows where the original AO2Ds are also present)
-        trackBarrelInfo(collision.globalIndex(), collision.posX(), collision.posY(), collision.posZ());  
+        trackBarrelInfo(collision.globalIndex(), collision.posX(), collision.posY(), collision.posZ());
         trackBasic(reducedEventIdx, trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), 0);
         trackBarrel(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
                     track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
@@ -660,16 +662,16 @@ struct TableMaker {
       }
       // write the skimmed collision - track association
       trackBarrelAssoc(fCollIndexMap[collision.globalIndex()], fTrackIndexMap[track.globalIndex()]);
-    }  // end loop over associations
-  }  // end skimTracks
-  
+    } // end loop over associations
+  }   // end skimTracks
 
   template <uint32_t TMFTFillMap, typename TEvent>
-  void skimMFT(TEvent const &collision, BCsWithTimestamps const &bcs, MFTTracks const &mfts, MFTTrackAssoc const &mftAssocs) {
+  void skimMFT(TEvent const& collision, BCsWithTimestamps const& bcs, MFTTracks const& mfts, MFTTrackAssoc const& mftAssocs)
+  {
     // Skim MFT tracks
     // So far no cuts are applied here
 
-    for (const auto &assoc : mftAssocs) {
+    for (const auto& assoc : mftAssocs) {
       auto track = assoc.template mfttrack_as<MFTTracks>();
 
       if (fConfigQA) {
@@ -690,7 +692,8 @@ struct TableMaker {
   }
 
   template <uint32_t TMuonFillMap, typename TEvent, typename TMuons>
-  void skimMuons(TEvent const &collision, BCsWithTimestamps const &bcs, TMuons const &muons, FwdTrackAssoc const &muonAssocs) {
+  void skimMuons(TEvent const& collision, BCsWithTimestamps const& bcs, TMuons const& muons, FwdTrackAssoc const& muonAssocs)
+  {
     // Skim the fwd-tracks (muons)
     // Loop over the collision-track associations, recompute track properties depending on the collision assigned, and apply track cuts for selection
     //     Muons are written only once, even if they constribute to more than one association,
@@ -704,14 +707,14 @@ struct TableMaker {
     uint32_t counter = 0;
     for (const auto& assoc : muonAssocs) {
       // get the muon
-      auto muon = assoc.template fwdtrack_as<TMuons>();      
-      
+      auto muon = assoc.template fwdtrack_as<TMuons>();
+
       trackFilteringTag = uint64_t(0);
       VarManager::FillTrack<TMuonFillMap>(muon);
       // NOTE: If a muon is associated to multiple collisions, depending on the selections,
       //       it may be accepted for some associations and rejected for other
       VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
-      
+
       if (fDoDetailedQA) {
         fHistMan->FillHistClass("Muons_BeforeCuts", VarManager::fgValues);
       }
@@ -726,7 +729,7 @@ struct TableMaker {
           (reinterpret_cast<TH1I*>(fStatsList->At(2)))->Fill(static_cast<float>(i));
         }
       }
-      
+
       // don't skim the muon if no cut has passed
       if (!trackTempFilterMap) {
         continue;
@@ -737,24 +740,24 @@ struct TableMaker {
       if (fFwdTrackIndexMap.find(muon.globalIndex()) == fFwdTrackIndexMap.end()) {
         counter++;
         fFwdTrackIndexMap[muon.globalIndex()] = offset + counter;
-        fFwdTrackIndexMapReversed[offset+counter] = muon.globalIndex();
-        fFwdTrackFilterMap[muon.globalIndex()] = trackFilteringTag;  // store here the filtering tag so we don't repeat the cuts in the second iteration
-        if (muon.has_matchMCHTrack() && (fFwdTrackIndexMap.find(muon.matchMCHTrackId()) == fFwdTrackIndexMap.end())) {  // write also the matched MCH track
+        fFwdTrackIndexMapReversed[offset + counter] = muon.globalIndex();
+        fFwdTrackFilterMap[muon.globalIndex()] = trackFilteringTag;                                                    // store here the filtering tag so we don't repeat the cuts in the second iteration
+        if (muon.has_matchMCHTrack() && (fFwdTrackIndexMap.find(muon.matchMCHTrackId()) == fFwdTrackIndexMap.end())) { // write also the matched MCH track
           counter++;
           fFwdTrackIndexMap[muon.matchMCHTrackId()] = offset + counter;
-          fFwdTrackIndexMapReversed[offset+counter] = muon.matchMCHTrackId();
-          fFwdTrackFilterMap[muon.matchMCHTrackId()] = trackFilteringTag;  // store here the filtering tag so we don't repeat the cuts in the second iteration
+          fFwdTrackIndexMapReversed[offset + counter] = muon.matchMCHTrackId();
+          fFwdTrackFilterMap[muon.matchMCHTrackId()] = trackFilteringTag; // store here the filtering tag so we don't repeat the cuts in the second iteration
         }
       } else {
-        fFwdTrackFilterMap[muon.globalIndex()] |= trackFilteringTag;  // make a bitwise OR with previous existing cuts
+        fFwdTrackFilterMap[muon.globalIndex()] |= trackFilteringTag; // make a bitwise OR with previous existing cuts
       }
       // write the association table
       muonAssoc(fCollIndexMap[collision.globalIndex()], fFwdTrackIndexMap[muon.globalIndex()]);
-    }  // end loop over assocs
+    } // end loop over assocs
 
     // Now we have the full index map of selected muons so we can proceed with writing the muon tables
     // Special care needed for the MCH and MFT indices
-    for (const auto& [skimIdx , origIdx] : fFwdTrackIndexMapReversed) {
+    for (const auto& [skimIdx, origIdx] : fFwdTrackIndexMapReversed) {
       // get the muon
       auto muon = muons.rawIteratorAt(origIdx);
       uint32_t reducedEventIdx = fCollIndexMap[collision.globalIndex()];
@@ -764,7 +767,7 @@ struct TableMaker {
       //   So all the information which pertains to collision association or MFT associations should not be taken from the skimmed data, but recomputed at analysis time.
       uint32_t mchIdx = -1;
       uint32_t mftIdx = -1;
-      if (muon.trackType() == uint8_t(0) || muon.trackType() == uint8_t(2)) {    // MCH-MID (2) or global (0)
+      if (muon.trackType() == uint8_t(0) || muon.trackType() == uint8_t(2)) { // MCH-MID (2) or global (0)
         if (fFwdTrackIndexMap.find(muon.matchMCHTrackId()) != fFwdTrackIndexMap.end()) {
           mchIdx = fFwdTrackIndexMap[muon.matchMCHTrackId()];
         }
@@ -775,7 +778,7 @@ struct TableMaker {
       muonBasic(reducedEventIdx, mchIdx, mftIdx, fFwdTrackFilterMap[muon.globalIndex()], muon.pt(), muon.eta(), muon.phi(), muon.sign(), 0);
       muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
                 muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
-                muon.matchScoreMCHMFT(), 
+                muon.matchScoreMCHMFT(),
                 muon.mchBitMap(), muon.midBitMap(),
                 muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
                 muon.trackTime(), muon.trackTimeRes());
@@ -786,14 +789,15 @@ struct TableMaker {
                 VarManager::fgValues[VarManager::kMuonCTglX], VarManager::fgValues[VarManager::kMuonCTglY], VarManager::fgValues[VarManager::kMuonCTglPhi], VarManager::fgValues[VarManager::kMuonCTglTgl], VarManager::fgValues[VarManager::kMuonC1Pt2X], VarManager::fgValues[VarManager::kMuonC1Pt2Y],
                 VarManager::fgValues[VarManager::kMuonC1Pt2Phi], VarManager::fgValues[VarManager::kMuonC1Pt2Tgl], VarManager::fgValues[VarManager::kMuonC1Pt21Pt2]);
       }
-    }  // end loop over selected muons
-  }  // end skimMuons
+    } // end loop over selected muons
+  }   // end skimMuons
 
   // Produce standard barrel + muon tables with event filter (typically for pp and p-Pb) ------------------------------------------------------
   template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMFTFillMap, typename TEvents, typename TTracks, typename TMuons>
-  void fullSkimming(TEvents const &collisions, BCsWithTimestamps const &bcs,
-                    TTracks const &tracksBarrel, TMuons const &muons, MFTTracks const &mftTracks,
-                    TrackAssoc const &trackAssocs, FwdTrackAssoc const &fwdTrackAssocs, MFTTrackAssoc const &mftAssocs) {
+  void fullSkimming(TEvents const& collisions, BCsWithTimestamps const& bcs,
+                    TTracks const& tracksBarrel, TMuons const& muons, MFTTracks const& mftTracks,
+                    TrackAssoc const& trackAssocs, FwdTrackAssoc const& fwdTrackAssocs, MFTTrackAssoc const& mftAssocs)
+  {
 
     if (fCurrentRun != bcs.begin().runNumber()) {
       if (fConfigComputeTPCpostCalib) {
@@ -823,7 +827,7 @@ struct TableMaker {
       fCurrentRun = bcs.begin().runNumber();
     }
 
-    // skim collisions 
+    // skim collisions
     skimCollisions<TEventFillMap>(collisions, bcs);
     if (fCollIndexMap.size() == 0) {
       return;
@@ -872,15 +876,16 @@ struct TableMaker {
         auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
         skimMuons<TMuonFillMap>(collision, bcs, muons, groupedMuonIndices);
       }
-    }  // end loop over skimmed collisions
+    } // end loop over skimmed collisions
   }
 
-  // 
-  void processFullWithFilter(MyEventsWithMultsAndFilter const &collisions, BCsWithTimestamps const &bcs,
-                             MyBarrelTracksWithCov const &tracksBarrel,
-                             MyMuonsWithCov const &muons, MFTTracks const &mftTracks,
-                             TrackAssoc const &trackAssocs, FwdTrackAssoc const &fwdTrackAssocs, 
-                             MFTTrackAssoc const &mftAssocs) {
+  //
+  void processFullWithFilter(MyEventsWithMultsAndFilter const& collisions, BCsWithTimestamps const& bcs,
+                             MyBarrelTracksWithCov const& tracksBarrel,
+                             MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
+                             TrackAssoc const& trackAssocs, FwdTrackAssoc const& fwdTrackAssocs,
+                             MFTTrackAssoc const& mftAssocs)
+  {
     fullSkimming<gkEventFillMapWithMultsAndEventFilter, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
   }
 
@@ -894,7 +899,7 @@ struct TableMaker {
     }
     (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(0.0, static_cast<float>(kNaliases));
   }
-  
+
   PROCESS_SWITCH(TableMaker, processFullWithFilter, "Build full DQ skimmed data model, w/ event filtering", false);
   PROCESS_SWITCH(TableMaker, processOnlyBCs, "Analyze the BCs to store sampled lumi", false);
 };

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -1,0 +1,964 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
+//
+// TableMaker produces skimmed data using the DQ data model
+// Events to be written are filtered using a user provided event cut and optionally the filterPPwithAssociation task
+// Barrel and muon (collision-track) associations are filtered using multiple parallel selections (currently limited to 8 but easily extendable up to 64)
+// The skimming can optionally produce just the barrel, muon, or both barrel and muon tracks
+// The event filtering, centrality, and V0Bits (from v0-selector) can be switched on/off by selecting one
+//  of the process functions
+#include <iostream>
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/DataTypes.h"
+#include "Framework/runDataProcessing.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/CCDB/TriggerAliases.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/MftmchMatchingML.h"
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+#include "PWGDQ/Core/VarManager.h"
+#include "PWGDQ/Core/HistogramManager.h"
+#include "PWGDQ/Core/AnalysisCut.h"
+#include "PWGDQ/Core/AnalysisCompositeCut.h"
+#include "PWGDQ/Core/HistogramsLibrary.h"
+#include "PWGDQ/Core/CutsLibrary.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
+#include "DetectorsVertexing/VertexTrackMatcher.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
+#include "ReconstructionDataFormats/VtxTrackRef.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DetectorsVertexing/PVertexerParams.h"
+#include "MathUtils/Primitive2D.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "Field/MagneticField.h"
+#include "TGeoGlobalMagField.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+
+using std::cout;
+using std::endl;
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod;
+
+// TODO: Since DCA depends on which collision the track is associated to, we should remove writing and subscribing to DCA tables, to optimize on CPU / memory
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
+                                 aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                 aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                 aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
+using MyBarrelTracksWithCov = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA,
+                                        aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                        aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                        aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                        aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta>;
+using MyBarrelTracksWithV0Bits = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA,
+                                           aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                           aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                           aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                           aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta, aod::V0Bits>;
+using MyBarrelTracksWithV0BitsForMaps = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
+                                                  aod::pidTPCFullEl, aod::pidTPCFullPi,
+                                                  aod::pidTPCFullKa, aod::pidTPCFullPr, aod::V0Bits>;
+using MyBarrelTracksWithDalitzBits = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov, aod::TracksDCA,
+                                               aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi,
+                                               aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                               aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi,
+                                               aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFbeta, aod::DalitzBits>;
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyEventsWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults>;
+using MyEventsWithFilter = soa::Join<aod::Collisions, aod::EvSels, aod::DQEventFilter>;
+using MyEventsWithMultsAndFilter = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::DQEventFilter>;
+using MyEventsWithCent = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs>;
+using MyEventsWithCentAndMults = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs, aod::Mults>;
+using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
+using MyMuonsWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
+using MyMuonsColl = soa::Join<aod::FwdTracks, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
+using MyMuonsCollWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
+using ExtBCs = soa::Join<aod::BCs, aod::Timestamps, aod::MatchedBCCollisionsSparseMulti>;
+
+namespace o2::aod
+{
+DECLARE_SOA_TABLE(AmbiguousTracksMid, "AOD", "AMBIGUOUSTRACK", //! Table for tracks which are not uniquely associated with a collision
+                  o2::soa::Index<>, o2::aod::ambiguous::TrackId, o2::aod::ambiguous::BCIdSlice, o2::soa::Marker<2>);
+DECLARE_SOA_TABLE(AmbiguousTracksFwd, "AOD", "AMBIGUOUSFWDTR", //! Table for Fwd tracks which are not uniquely associated with a collision
+                  o2::soa::Index<>, o2::aod::ambiguous::FwdTrackId, o2::aod::ambiguous::BCIdSlice, o2::soa::Marker<2>);
+} // namespace o2::aod
+
+constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
+constexpr static uint32_t gkEventFillMapWithFilter = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::EventFilter;
+
+constexpr static uint32_t gkEventFillMapWithMult = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionMult;
+constexpr static uint32_t gkEventFillMapWithMultsAndEventFilter = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionMult | VarManager::ObjTypes::EventFilter;
+constexpr static uint32_t gkEventFillMapWithCent = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCent;
+constexpr static uint32_t gkEventFillMapWithCentAndMults = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCent | VarManager::CollisionMult;
+// constexpr static uint32_t gkEventFillMapWithCentRun2 = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCentRun2; // Unused variable
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackPID | VarManager::ObjTypes::TrackPIDExtra;
+constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID | VarManager::ObjTypes::TrackPIDExtra;
+constexpr static uint32_t gkTrackFillMapWithV0Bits = gkTrackFillMapWithCov | VarManager::ObjTypes::TrackV0Bits;
+constexpr static uint32_t gkTrackFillMapWithV0BitsForMaps = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackV0Bits | VarManager::ObjTypes::TrackTPCPID;
+constexpr static uint32_t gkTrackFillMapWithDalitzBits = gkTrackFillMap | VarManager::ObjTypes::DalitzBits;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
+constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
+constexpr static uint32_t gkMuonFillMapWithAmbi = VarManager::ObjTypes::Muon | VarManager::ObjTypes::AmbiMuon;
+constexpr static uint32_t gkMuonFillMapWithCovAmbi = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov | VarManager::ObjTypes::AmbiMuon;
+constexpr static uint32_t gkTrackFillMapWithAmbi = VarManager::ObjTypes::Track | VarManager::ObjTypes::AmbiTrack;
+constexpr static uint32_t gkMFTFillMap = VarManager::ObjTypes::TrackMFT;
+
+struct TableMaker {
+
+  Produces<ReducedEvents> event;
+  Produces<ReducedEventsExtended> eventExtended;
+  Produces<ReducedEventsVtxCov> eventVtxCov;
+  Produces<ReducedTracks> trackBasic;
+  Produces<ReducedTracksBarrel> trackBarrel;
+  Produces<ReducedTracksBarrelCov> trackBarrelCov;
+  Produces<ReducedTracksBarrelPID> trackBarrelPID;
+  Produces<ReducedTracksBarrelInfo> trackBarrelInfo;
+  Produces<ReducedTracksAssoc> trackBarrelAssoc;
+  Produces<ReducedMuons> muonBasic;
+  Produces<ReducedMuonsExtra> muonExtra;
+  Produces<ReducedMuonsCov> muonCov;
+  Produces<ReducedMuonsInfo> muonInfo;
+  Produces<ReducedMuonsAssoc> muonAssoc;
+  Produces<ReducedMFTs> mftTrack;
+  Produces<ReducedMFTsExtra> mftTrackExtra;
+  Produces<ReducedMFTAssoc> mftAssoc;
+  
+  OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
+  OutputObj<TList> fStatsList{"Statistics"};  //! skimming statistics
+  HistogramManager* fHistMan;
+
+  // Event and track AnalysisCut configurables
+  Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};
+  Configurable<std::string> fConfigTrackCuts{"cfgBarrelTrackCuts", "jpsiO2MCdebugCuts2", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigMuonCuts{"cfgMuonCuts", "muonQualityCuts", "Comma separated list of muon cuts"};
+
+  // Steer QA output
+  Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
+  Configurable<bool> fConfigDetailedQA{"cfgDetailedQA", false, "If true, include more QA histograms (BeforeCuts classes)"};
+  Configurable<std::string> fConfigAddEventHistogram{"cfgAddEventHistogram", "", "Comma separated list of histograms"};
+  Configurable<std::string> fConfigAddTrackHistogram{"cfgAddTrackHistogram", "", "Comma separated list of histograms"};
+  Configurable<std::string> fConfigAddMuonHistogram{"cfgAddMuonHistogram", "", "Comma separated list of histograms"};
+  
+  // Selections to be applied as Filter on the Track and FwdTrack
+  Configurable<bool> fIsRun2{"cfgIsRun2", false, "Whether we analyze Run-2 or Run-3 data"};
+  Configurable<float> fConfigBarrelTrackMaxAbsEta{"cfgBarrelMaxAbsEta", 0.9f, "Eta absolute value cut for tracks in the barrel"};
+  Configurable<float> fConfigBarrelTrackMinPt{"cfgBarrelMinPt", 0.5f, "Minimum pt for tracks in the barrel"};
+  Configurable<bool> fConfigBarrelRequireTPC{"cfgBarrelRequireTPC", true, "Require TPC for tracks in the barrel"};
+  Configurable<float> fConfigBarrelMinTPCncls{"cfgBarrelMinTPCncls", 50.0f, "Minimum TPC cls for tracks in the barrel"};
+  Configurable<float> fConfigBarrelMaxTPCchi2{"cfgBarrelMaxTPCchi2", 10.0f, "Maximum TPC chi2/ndf for tracks in the barrel"};
+  Configurable<bool> fConfigBarrelRequireITS{"cfgBarrelRequireITS", true, "Require ITS for tracks in the barrel"};
+  Configurable<float> fConfigBarrelMaxITSchi2{"cfgBarrelMaxITSchi2", 36.0f, "Maximum ITS chi2/ndf for tracks in the barrel"};
+  Configurable<float> fConfigMuonPtLow{"cfgMuonLowPt", 1.0f, "Low pt cut for muons"};
+  
+  // CCDB connection configurables
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/z/zhxiong/Postcalib/pass4/apass3BB", "base path to the ccdb object"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> grpmagPathRun2{"grpmagPathRun2", "GLO/GRP/GRP", "CCDB path of the GRPObject (Usage for Run 2)"};
+
+  // TPC postcalibration related options
+  Configurable<bool> fConfigComputeTPCpostCalib{"cfgTPCpostCalib", false, "If true, compute TPC post-calibrated n-sigmas(electrons, pions, protons)"};
+  Configurable<bool> fConfigComputeTPCpostCalibKaon{"cfgTPCpostCalibKaon", false, "If true, compute TPC post-calibrated n-sigmas for kaons"};
+  Configurable<std::string> fConfigRunPeriods{"cfgRunPeriods", "LHC22f", "run periods for used data"};
+  Configurable<bool> fConfigIsOnlyforMaps{"cfgIsforMaps", false, "If true, run for postcalibration maps only"};
+  Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
+  Configurable<bool> fConfigDummyRunlist{"cfgDummyRunlist", false, "If true, use dummy runlist"};
+  Configurable<int> fConfigInitRunNumber{"cfgInitRunNumber", 543215, "Initial run number used in run by run checks"};  
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  o2::parameters::GRPObject* grpmagrun2 = nullptr; // for run 2, we access the GRPObject from GLO/GRP/GRP
+  o2::parameters::GRPMagField* grpmag = nullptr;   // for run 3, we access GRPMagField from GLO/Config/GRPMagField
+
+  AnalysisCompositeCut* fEventCut;              //! Event selection cut
+  std::vector<AnalysisCompositeCut> fTrackCuts; //! Barrel track cuts
+  std::vector<AnalysisCompositeCut> fMuonCuts;  //! Muon track cuts
+
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
+  int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
+
+  // maps used to store index info; NOTE: std::map are sorted in ascending order by default (needed for track to collision indices)
+  std::map<uint32_t, uint32_t> fCollIndexMap;       // key: old collision index, value: skimmed collision index 
+  std::map<uint32_t, uint32_t> fTrackIndexMap;     // key: old track global index, value: new track global index
+  std::map<uint32_t, uint32_t> fFwdTrackIndexMap;   // key: fwd-track global index, value: new fwd-track global index
+  std::map<uint32_t, uint32_t> fFwdTrackIndexMapReversed; // key: new fwd-track global index, value: fwd-track global index
+  std::map<uint32_t, uint64_t> fFwdTrackFilterMap;  // key: fwd-track global index, value: fwd-track filter map
+  std::map<uint32_t, uint32_t> fMftIndexMap;        // key: MFT tracklet global index, value: new MFT tracklet global index
+
+  // FIXME: For now, the skimming is done using the Common track-collision association task, which does not allow to use 
+  //       our own Filtered tracks. If the filter is very selective, then it may be worth to run the association in this workflow
+  //       using the Common/CollisionAssociation class
+  /*Filter barrelSelectedTracks = ifnode(fIsRun2.node() == true, track::trackType == uint8_t(track::Run2Track), track::trackType == uint8_t(track::Track)) 
+                              && track::pt > fConfigBarrelTrackMinPt
+                              && nabs(track::eta) <= fConfigBarrelTrackMaxAbsEta 
+                              && ifnode(fConfigBarrelRequireITS.node() == true, track::itsChi2NCl < fConfigBarrelMaxITSchi2, true) 
+                              && ifnode(fConfigBarrelRequireTPC.node() == true, track::tpcNClsFound > fConfigBarrelMinTPCncls && track::tpcChi2NCl < fConfigBarrelMaxTPCchi2, true);
+
+  Filter muonFilter = o2::aod::fwdtrack::pt >= fConfigMuonPtLow;*/
+
+  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+  Preslice<aod::FwdTrackAssoc> fwdtrackIndicesPerCollision = aod::track_association::collisionId;
+  Preslice<aod::MFTTrackAssoc> mfttrackIndicesPerCollision = aod::track_association::collisionId;
+
+  void init(o2::framework::InitContext& context)
+  {
+    DefineCuts();
+    ccdb->setURL(fConfigCcdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    if (fPropMuon) {
+      if (!o2::base::GeometryManager::isGeometryLoaded()) {
+        ccdb->get<TGeoManager>(geoPath);
+      }
+    }
+
+    VarManager::SetDefaultVarNames();
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+    fHistMan->SetUseDefaultVariableNames(kTRUE);
+    fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    // Only use detailed QA when QA is set true
+    if (fConfigQA && fConfigDetailedQA) {
+      fDoDetailedQA = true;
+    }
+
+    // Create the histogram class names to be added to the histogram manager
+    TString histClasses = "";
+    if (fDoDetailedQA) {
+      histClasses += "Event_BeforeCuts;";
+    }
+    if (fConfigQA) {
+      histClasses += "Event_AfterCuts;";
+    }
+
+/*
+    bool enableBarrelHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
+                               context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
+                               context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
+                               context.mOptions.get<bool>("processBarrelOnly") || context.mOptions.get<bool>("processBarrelOnlyWithCent") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCent") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithMults") || context.mOptions.get<bool>("processBarrelOnlyWithCentAndMults") || context.mOptions.get<bool>("processBarrelOnlyWithCovWithCentAndMults") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithCov") || context.mOptions.get<bool>("processBarrelOnlyWithEventFilter") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processBarrelOnlyWithCovAndEventFilter") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithDalitzBits") || context.mOptions.get<bool>("processBarrelOnlyWithV0Bits") ||
+                               context.mOptions.get<bool>("processBarrelOnlyWithV0BitsAndMaps") || context.mOptions.get<bool>("processAmbiguousBarrelOnly"));
+    bool enableMuonHistos = (context.mOptions.get<bool>("processFull") || context.mOptions.get<bool>("processFullWithCov") ||
+                             context.mOptions.get<bool>("processFullWithCent") || context.mOptions.get<bool>("processFullWithCovAndEventFilter") ||
+                             context.mOptions.get<bool>("processFullWithCovMultsAndEventFilter") ||
+                             context.mOptions.get<bool>("processMuonOnly") || context.mOptions.get<bool>("processMuonOnlyWithCent") ||
+                             context.mOptions.get<bool>("processMuonOnlyWithMults") || context.mOptions.get<bool>("processMuonOnlyWithCentAndMults") ||
+                             context.mOptions.get<bool>("processMuonOnlyWithCovAndCent") ||
+                             context.mOptions.get<bool>("processMuonOnlyWithCov") || context.mOptions.get<bool>("processMuonOnlyWithCovAndEventFilter") || context.mOptions.get<bool>("processMuonOnlyWithEventFilter") ||
+                             context.mOptions.get<bool>("processMuonOnlyWithMultsAndEventFilter") || context.mOptions.get<bool>("processAmbiguousMuonOnlyWithCov") || context.mOptions.get<bool>("processAmbiguousMuonOnly") ||
+                             context.mOptions.get<bool>("processMuonsAndMFT") || context.mOptions.get<bool>("processMuonsAndMFTWithFilter") || context.mOptions.get<bool>("processMuonMLOnly"));
+                             */
+
+    bool enableBarrelHistos = (context.mOptions.get<bool>("processFullWithFilter"));
+    bool enableMuonHistos = (context.mOptions.get<bool>("processFullWithFilter"));                                
+
+    if (enableBarrelHistos) {
+      if (fDoDetailedQA) {
+        histClasses += "TrackBarrel_BeforeCuts;";
+      }
+      if (fConfigQA) {
+        for (auto& cut : fTrackCuts) {
+          histClasses += Form("TrackBarrel_%s;", cut.GetName());
+        }
+      }
+      if (fConfigIsOnlyforMaps) {
+        histClasses += "TrackBarrel_PostCalibElectron;";
+        histClasses += "TrackBarrel_PostCalibPion;";
+        histClasses += "TrackBarrel_PostCalibProton;";
+      }
+    }
+    if (enableMuonHistos) {
+      if (fDoDetailedQA) {
+        histClasses += "Muons_BeforeCuts;";
+        histClasses += "MftTracks;";
+      }
+      if (fConfigQA) {
+        for (auto& muonCut : fMuonCuts) {
+          histClasses += Form("Muons_%s;", muonCut.GetName());
+        }
+      }
+    }
+
+    VarManager::SetRunlist((TString)fConfigRunPeriods);
+    if (fConfigDummyRunlist) {
+      VarManager::SetDummyRunlist(fConfigInitRunNumber);
+    } else {
+      VarManager::SetRunlist((TString)fConfigRunPeriods);
+    }
+
+    DefineHistograms(histClasses);                   // define all histograms
+    VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+
+    // CCDB configuration
+    if (fConfigComputeTPCpostCalib) {
+      fCCDB->setURL(fConfigCcdbUrl.value);
+      fCCDB->setCaching(true);
+      fCCDB->setLocalObjectValidityChecking();
+      // Not later than now objects
+      fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+    }
+  }
+
+  void DefineCuts()
+  {
+    // Event cuts
+    fEventCut = new AnalysisCompositeCut(true);
+    TString eventCutStr = fConfigEventCuts.value;
+    fEventCut->AddCut(dqcuts::GetAnalysisCut(eventCutStr.Data()));
+
+    // Barrel track cuts
+    TString cutNamesStr = fConfigTrackCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    // Muon cuts
+    cutNamesStr = fConfigMuonCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fMuonCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+  }
+
+  void DefineHistograms(TString histClasses)
+  {
+    std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+    for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+      TString classStr = objArray->At(iclass)->GetName();
+      if (fConfigQA) {
+        fHistMan->AddHistClass(classStr.Data());
+      }
+
+      // fill the THn histograms
+      if (fConfigIsOnlyforMaps) {
+        if (classStr.Contains("PostCalibElectron")) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "postcalib_electron");
+        }
+        if (classStr.Contains("PostCalibPion")) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "postcalib_pion");
+        }
+        if (classStr.Contains("PostCalibProton")) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", "postcalib_proton");
+        }
+      }
+
+      TString histEventName = fConfigAddEventHistogram.value;
+      if (classStr.Contains("Event")) {
+        if (fConfigQA) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "event", histEventName);
+        }
+      }
+
+      TString histTrackName = fConfigAddTrackHistogram.value;
+      if (classStr.Contains("Track")) {
+        if (fConfigQA) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", histTrackName);
+        }
+      }
+
+      TString histMuonName = fConfigAddMuonHistogram.value;
+      if (classStr.Contains("Muons")) {
+        if (fConfigQA) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", histMuonName);
+        }
+      }
+
+      TString histMftName = fConfigAddMuonHistogram.value;
+      if (classStr.Contains("Mft")) {
+        if (fConfigDetailedQA) {
+          dqhistograms::DefineHistograms(fHistMan, objArray->At(iclass)->GetName(), "track", histMftName);
+        }
+      }
+    }
+
+    // create statistics histograms (event, tracks, muons)
+    fStatsList.setObject(new TList());
+    fStatsList->SetOwner(kTRUE);
+    std::vector<TString> eventLabels{"BCs", "Collisions before filtering", "Before cuts", "After cuts"};
+    TH2I* histEvents = new TH2I("EventStats", "Event statistics", eventLabels.size(), -0.5, eventLabels.size() - 0.5, kNaliases + 1, -0.5, kNaliases + 0.5);
+    int ib = 1;
+    for (auto label = eventLabels.begin(); label != eventLabels.end(); label++, ib++) {
+      histEvents->GetXaxis()->SetBinLabel(ib, (*label).Data());
+    }
+    for (int ib = 1; ib <= kNaliases; ib++) {
+      histEvents->GetYaxis()->SetBinLabel(ib, aliasLabels[ib - 1].data());
+    }
+    histEvents->GetYaxis()->SetBinLabel(kNaliases + 1, "Total");
+    fStatsList->Add(histEvents);
+
+    // Track statistics: one bin for each track selection and 5 bins for V0 tags (gamma, K0s, Lambda, anti-Lambda, Omega)
+    TH1I* histTracks = new TH1I("TrackStats", "Track statistics", fTrackCuts.size() + 5.0, -0.5, fTrackCuts.size() - 0.5 + 5.0);
+    ib = 1;
+    for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, ib++) {
+      histTracks->GetXaxis()->SetBinLabel(ib, (*cut).GetName());
+    }
+    const char* v0TagNames[5] = {"Photon conversion", "K^{0}_{s}", "#Lambda", "#bar{#Lambda}", "#Omega"};
+    for (ib = 0; ib < 5; ib++) {
+      histTracks->GetXaxis()->SetBinLabel(fTrackCuts.size() + 1 + ib, v0TagNames[ib]);
+    }
+    fStatsList->Add(histTracks);
+    TH1I* histMuons = new TH1I("MuonStats", "Muon statistics", fMuonCuts.size(), -0.5, fMuonCuts.size() - 0.5);
+    ib = 1;
+    for (auto cut = fMuonCuts.begin(); cut != fMuonCuts.end(); cut++, ib++) {
+      histMuons->GetXaxis()->SetBinLabel(ib, (*cut).GetName());
+    }
+    fStatsList->Add(histMuons);
+  }
+
+  template <uint32_t TEventFillMap, typename TEvents>
+  void skimCollisions(TEvents const &collisions, BCsWithTimestamps const &bcs) {
+    // Skim collisions
+    // NOTE: So far, collisions are filtered based on the user specified analysis cuts and the filterPP event filter.
+    //      The collision-track associations which point to an event that is not selected for writing are discarded!  
+
+    fCollIndexMap.clear();
+    int multTPC = -1.0;
+    float multFV0A = -1.0;
+    float multFV0C = -1.0;
+    float multFT0A = -1.0;
+    float multFT0C = -1.0;
+    float multFDDA = -1.0;
+    float multFDDC = -1.0;
+    float multZNA = -1.0;
+    float multZNC = -1.0;
+    int multTracklets = -1.0;
+    int multTracksPV = -1.0;
+    float centFT0C = -1.0;
+    
+    for (const auto& collision : collisions) {
+
+      for (int i = 0; i < kNaliases; i++) {
+        if (collision.alias_bit(i) > 0) {
+          (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(1.0, static_cast<float>(i));
+        }
+      }
+      (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(1.0, static_cast<float>(kNaliases));
+
+      // apply the event filter computed by filter-PP
+      if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
+        if (!collision.eventFilter()) {
+          continue;
+        }
+      }
+
+      auto bc = collision.template bc_as<BCsWithTimestamps>();
+      // store the selection decisions
+      uint64_t tag = 0;
+      // store some more information in the tag
+      // if the BC found by event selection does not coincide with the collision.bc()
+      if (collision.foundBC().globalIndex() != bc.globalIndex()) {
+        tag |= (uint64_t(1) << 0);
+      }
+      // Put the 8 first bits of the event filter in the last 8 bits of the tag
+      if constexpr ((TEventFillMap & VarManager::ObjTypes::EventFilter) > 0) {
+        tag |= (collision.eventFilter() << 56);
+      }
+
+      VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
+      // TODO: These variables cannot be filled in the VarManager for the moment as long as BCsWithTimestamps are used.
+      //       So temporarily, we filled them here, in order to be available for eventual QA of the skimming
+      VarManager::fgValues[VarManager::kRunNo] = bc.runNumber();
+      VarManager::fgValues[VarManager::kBC] = bc.globalBC();
+      VarManager::fgValues[VarManager::kTimestamp] = bc.timestamp();
+      VarManager::fgValues[VarManager::kRunIndex] = VarManager::GetRunIndex(bc.runNumber());
+      VarManager::FillEvent<TEventFillMap>(collision); // extract event information and place it in the fValues array
+      if (fDoDetailedQA) {
+        fHistMan->FillHistClass("Event_BeforeCuts", VarManager::fgValues);
+      }
+
+      uint32_t triggerAliases = collision.alias_raw();
+      // fill stats information, before selections
+      for (int i = 0; i < kNaliases; i++) {
+        if (triggerAliases & (uint32_t(1) << i)) {
+          (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(2.0, static_cast<float>(i));
+        }
+      }
+      (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(2.0, static_cast<float>(kNaliases));
+
+      if (!fEventCut->IsSelected(VarManager::fgValues)) {
+        continue;
+      }
+
+      // fill stats information, after selections
+      for (int i = 0; i < kNaliases; i++) {
+        if (triggerAliases & (uint32_t(1) << i)) {
+          (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(3.0, static_cast<float>(i));
+        }
+      }
+      (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(3.0, static_cast<float>(kNaliases));
+
+      fHistMan->FillHistClass("Event_AfterCuts", VarManager::fgValues);
+
+      // create the event tables
+      event(tag, bc.runNumber(), collision.posX(), collision.posY(), collision.posZ(), collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes());
+      if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionMult) > 0) {
+        multTPC = collision.multTPC();
+        multFV0A = collision.multFV0A();
+        multFV0C = collision.multFV0C();
+        multFT0A = collision.multFT0A();
+        multFT0C = collision.multFT0C();
+        multFDDA = collision.multFDDA();
+        multFDDC = collision.multFDDC();
+        multZNA = collision.multZNA();
+        multZNC = collision.multZNC();
+        multTracklets = collision.multTracklets();
+        multTracksPV = collision.multNTracksPV();
+      } 
+      if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionCent) > 0) {
+        centFT0C = collision.centFT0C();
+      }
+      eventExtended(bc.globalBC(), collision.alias_raw(), collision.selection_raw(), bc.timestamp(), VarManager::fgValues[VarManager::kCentVZERO],
+                    multTPC, multFV0A, multFV0C, multFT0A, multFT0C, multFDDA, multFDDC, multZNA, multZNC, multTracklets, multTracksPV, centFT0C);
+      eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
+
+      fCollIndexMap[collision.globalIndex()] = event.lastIndex();
+    }
+  }
+
+  template <uint32_t TTrackFillMap, typename TEvent, typename TTracks>
+  void skimTracks(TEvent const &collision, BCsWithTimestamps const &bcs, TTracks const &tracks, TrackAssoc const &assocs) {
+    // Skim the barrel tracks
+    // Loop over the collision-track associations, retrieve the track, and apply track cuts for selection
+    //     One can apply here cuts which depend on the association (e.g. DCA), which will discard (hopefully most) wrong associations.
+    //     Tracks are written only once, even if they constribute to more than one association
+    
+    uint64_t trackFilteringTag = uint64_t(0);
+    uint64_t trackTempFilterMap = uint8_t(0);
+    
+    for (const auto &assoc : assocs) {
+      auto track = assoc.template track_as<TTracks>();
+
+      trackFilteringTag = uint64_t(0);
+      trackTempFilterMap = uint8_t(0);
+      VarManager::FillTrack<TTrackFillMap>(track);
+      if (fDoDetailedQA) {
+        fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
+      }
+      
+      // apply track cuts and fill stats histogram
+      int i = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, i++) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          trackTempFilterMap |= (uint8_t(1) << i);
+          // NOTE: the QA is filled here for every (collision,track) association since the results of the track cuts can be different depending on which collision is associated (e.g. DCA cuts)
+          // TODO: create a statistics histograms with unique tracks
+          if (fConfigQA) {
+            fHistMan->FillHistClass(Form("TrackBarrel_%s", (*cut).GetName()), VarManager::fgValues);
+          }
+          (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(static_cast<float>(i));
+        }
+      }
+      if (!trackTempFilterMap) {
+        continue;
+      }
+
+      // store selection information in the track tag
+      if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackV0Bits)) { // BIT0-4: V0Bits
+        trackFilteringTag |= uint64_t(track.pidbit());
+        for (int iv0 = 0; iv0 < 5; iv0++) {
+          if (track.pidbit() & (uint8_t(1) << iv0)) {
+            (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(fTrackCuts.size() + static_cast<float>(iv0));
+          }
+        }
+        if (fConfigIsOnlyforMaps) {
+          if (trackFilteringTag & (uint64_t(1) << 0)) { // for electron
+            fHistMan->FillHistClass("TrackBarrel_PostCalibElectron", VarManager::fgValues);
+          }
+          if (trackFilteringTag & (uint64_t(1) << 1)) { // for pion
+            fHistMan->FillHistClass("TrackBarrel_PostCalibPion", VarManager::fgValues);
+          }
+          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 2)) * (track.sign()) > 0)) { // for proton from Lambda
+            fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
+          }
+          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 3)) * (track.sign()) < 0)) { // for proton from AntiLambda
+            fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
+          }
+        }
+        if (fConfigSaveElectronSample) { // only save electron sample
+          if (!(trackFilteringTag & (uint64_t(1) << 2))) {
+            continue;
+          }
+        }
+      }   // end if V0Bits
+      if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
+        trackFilteringTag |= (uint64_t(track.dalitzBits()) << 5); // BIT5-12: Dalitz
+      }
+      trackFilteringTag |= (uint64_t(trackTempFilterMap) << 13); // BIT13-...:  user track filters  
+      // write the track global index in the map for skimming (to make sure we have it just once)
+      if (fTrackIndexMap.find(track.globalIndex()) == fTrackIndexMap.end()) {
+        // NOTE: The collision ID that is written in the table is the one found in the first association for this track.
+        //       However, in data analysis one should loop over associations, so this one should not be used.
+        //      In the case of Run2-like analysis, there will be no associations, so this ID will be the one originally assigned in the AO2Ds (updated for the skims)
+        uint32_t reducedEventIdx = fCollIndexMap[collision.globalIndex()];
+        // NOTE: trackBarrelInfo stores the index of the collision as in AO2D (for use in some cases where the analysis on skims is done 
+        //   in workflows where the original AO2Ds are also present)
+        trackBarrelInfo(collision.globalIndex(), collision.posX(), collision.posY(), collision.posZ());  
+        trackBasic(reducedEventIdx, trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), 0);
+        trackBarrel(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
+                    track.tpcInnerParam(), track.flags(), track.itsClusterMap(), track.itsChi2NCl(),
+                    track.tpcNClsFindable(), track.tpcNClsFindableMinusFound(), track.tpcNClsFindableMinusCrossedRows(),
+                    track.tpcNClsShared(), track.tpcChi2NCl(),
+                    track.trdChi2(), track.trdPattern(), track.tofChi2(),
+                    track.length(), track.dcaXY(), track.dcaZ(),
+                    track.trackTime(), track.trackTimeRes(), track.tofExpMom(),
+                    track.detectorMap());
+        if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackCov)) {
+          trackBarrelCov(track.cYY(), track.cZY(), track.cZZ(), track.cSnpY(), track.cSnpZ(),
+                         track.cSnpSnp(), track.cTglY(), track.cTglZ(), track.cTglSnp(), track.cTglTgl(),
+                         track.c1PtY(), track.c1PtZ(), track.c1PtSnp(), track.c1PtTgl(), track.c1Pt21Pt2());
+        }
+        if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackPID)) {
+          float nSigmaEl = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaEl_Corr] : track.tpcNSigmaEl());
+          float nSigmaPi = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaPi_Corr] : track.tpcNSigmaPi());
+          float nSigmaKa = ((fConfigComputeTPCpostCalib && fConfigComputeTPCpostCalibKaon) ? VarManager::fgValues[VarManager::kTPCnSigmaKa_Corr] : track.tpcNSigmaKa());
+          float nSigmaPr = (fConfigComputeTPCpostCalib ? VarManager::fgValues[VarManager::kTPCnSigmaPr_Corr] : track.tpcNSigmaPr());
+          trackBarrelPID(track.tpcSignal(),
+                         nSigmaEl, track.tpcNSigmaMu(), nSigmaPi, nSigmaKa, nSigmaPr,
+                         track.beta(), track.tofNSigmaEl(), track.tofNSigmaMu(), track.tofNSigmaPi(), track.tofNSigmaKa(), track.tofNSigmaPr(),
+                         track.trdSignal());
+        }
+        fTrackIndexMap[track.globalIndex()] = trackBasic.lastIndex();
+      }
+      // write the skimmed collision - track association
+      trackBarrelAssoc(fCollIndexMap[collision.globalIndex()], fTrackIndexMap[track.globalIndex()]);
+    }  // end loop over associations
+  }  // end skimTracks
+  
+
+  template <uint32_t TMFTFillMap, typename TEvent>
+  void skimMFT(TEvent const &collision, BCsWithTimestamps const &bcs, MFTTracks const &mfts, MFTTrackAssoc const &mftAssocs) {
+    // Skim MFT tracks
+    // So far no cuts are applied here
+
+    for (const auto &assoc : mftAssocs) {
+      auto track = assoc.template mfttrack_as<MFTTracks>();
+
+      if (fConfigQA) {
+        VarManager::FillTrack<TMFTFillMap>(track);
+        fHistMan->FillHistClass("MftTracks", VarManager::fgValues);
+      }
+
+      // write the MFT track global index in the map for skimming (to make sure we have it just once)
+      if (fMftIndexMap.find(track.globalIndex()) == fMftIndexMap.end()) {
+        uint32_t reducedEventIdx = fCollIndexMap[collision.globalIndex()];
+        mftTrack(reducedEventIdx, uint64_t(0), track.pt(), track.eta(), track.phi());
+        mftTrackExtra(track.mftClusterSizesAndTrackFlags(), track.sign());
+
+        fMftIndexMap[track.globalIndex()] = mftTrack.lastIndex();
+      }
+      mftAssoc(fCollIndexMap[collision.globalIndex()], fMftIndexMap[track.globalIndex()]);
+    }
+  }
+
+  template <uint32_t TMuonFillMap, typename TEvent, typename TMuons>
+  void skimMuons(TEvent const &collision, BCsWithTimestamps const &bcs, TMuons const &muons, FwdTrackAssoc const &muonAssocs) {
+    // Skim the fwd-tracks (muons)
+    // Loop over the collision-track associations, recompute track properties depending on the collision assigned, and apply track cuts for selection
+    //     Muons are written only once, even if they constribute to more than one association,
+    //         which means that in the case of multiple associations, the track parameters are wrong and should be computed again at analysis time.
+
+    uint64_t trackFilteringTag = uint64_t(0);
+    uint8_t trackTempFilterMap = uint8_t(0);
+    fFwdTrackIndexMapReversed.clear();
+
+    uint32_t offset = muonBasic.lastIndex();
+    uint32_t counter = 0;
+    for (const auto& assoc : muonAssocs) {
+      // get the muon
+      auto muon = assoc.template fwdtrack_as<TMuons>();      
+      
+      trackFilteringTag = uint64_t(0);
+      VarManager::FillTrack<TMuonFillMap>(muon);
+      // NOTE: If a muon is associated to multiple collisions, depending on the selections,
+      //       it may be accepted for some associations and rejected for other
+      VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+      
+      if (fDoDetailedQA) {
+        fHistMan->FillHistClass("Muons_BeforeCuts", VarManager::fgValues);
+      }
+      // check the cuts and filters
+      int i = 0;
+      for (auto cut = fMuonCuts.begin(); cut != fMuonCuts.end(); cut++, i++) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          trackTempFilterMap |= (uint8_t(1) << i);
+          if (fConfigQA) {
+            fHistMan->FillHistClass(Form("Muons_%s", (*cut).GetName()), VarManager::fgValues);
+          }
+          (reinterpret_cast<TH1I*>(fStatsList->At(2)))->Fill(static_cast<float>(i));
+        }
+      }
+      
+      // don't skim the muon if no cut has passed
+      if (!trackTempFilterMap) {
+        continue;
+      }
+      trackFilteringTag |= uint64_t(trackTempFilterMap); // BIT0-7:  user selection cuts
+
+      // update the index map if this is a new muon (it can already exist in the map from a different collision association)
+      if (fFwdTrackIndexMap.find(muon.globalIndex()) == fFwdTrackIndexMap.end()) {
+        counter++;
+        fFwdTrackIndexMap[muon.globalIndex()] = offset + counter;
+        fFwdTrackIndexMapReversed[offset+counter] = muon.globalIndex();
+        fFwdTrackFilterMap[muon.globalIndex()] = trackFilteringTag;  // store here the filtering tag so we don't repeat the cuts in the second iteration
+        if (muon.has_matchMCHTrack() && (fFwdTrackIndexMap.find(muon.matchMCHTrackId()) == fFwdTrackIndexMap.end())) {  // write also the matched MCH track
+          counter++;
+          fFwdTrackIndexMap[muon.matchMCHTrackId()] = offset + counter;
+          fFwdTrackIndexMapReversed[offset+counter] = muon.matchMCHTrackId();
+          fFwdTrackFilterMap[muon.matchMCHTrackId()] = trackFilteringTag;  // store here the filtering tag so we don't repeat the cuts in the second iteration
+        }
+      } else {
+        fFwdTrackFilterMap[muon.globalIndex()] |= trackFilteringTag;  // make a bitwise OR with previous existing cuts
+      }
+      // write the association table
+      muonAssoc(fCollIndexMap[collision.globalIndex()], fFwdTrackIndexMap[muon.globalIndex()]);
+    }  // end loop over assocs
+
+    // Now we have the full index map of selected muons so we can proceed with writing the muon tables
+    // Special care needed for the MCH and MFT indices
+    for (const auto& [skimIdx , origIdx] : fFwdTrackIndexMapReversed) {
+      // get the muon
+      auto muon = muons.rawIteratorAt(origIdx);
+      uint32_t reducedEventIdx = fCollIndexMap[collision.globalIndex()];
+      // NOTE: Currently, one writes the original AO2D momentum-vector (pt, eta and phi) in the tables because we write only one instance of the muon track,
+      //       while multiple collision associations (and multiple mom vectors can exist)
+      //       The momentum can be recomputed at the analysis time based on the associations written in the skims
+      //   So all the information which pertains to collision association or MFT associations should not be taken from the skimmed data, but recomputed at analysis time.
+      uint32_t mchIdx = -1;
+      uint32_t mftIdx = -1;
+      if (muon.trackType() == uint8_t(0) || muon.trackType() == uint8_t(2)) {    // MCH-MID (2) or global (0)
+        if (fFwdTrackIndexMap.find(muon.matchMCHTrackId()) != fFwdTrackIndexMap.end()) {
+          mchIdx = fFwdTrackIndexMap[muon.matchMCHTrackId()];
+        }
+        if (fMftIndexMap.find(muon.matchMFTTrackId()) != fMftIndexMap.end()) {
+          mftIdx = fMftIndexMap[muon.matchMFTTrackId()];
+        }
+      }
+      muonBasic(reducedEventIdx, mchIdx, mftIdx, fFwdTrackFilterMap[muon.globalIndex()], muon.pt(), muon.eta(), muon.phi(), muon.sign(), 0);
+      muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
+                muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
+                muon.matchScoreMCHMFT(), 
+                muon.mchBitMap(), muon.midBitMap(),
+                muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
+                muon.trackTime(), muon.trackTimeRes());
+      muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
+      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
+        muonCov(VarManager::fgValues[VarManager::kX], VarManager::fgValues[VarManager::kY], VarManager::fgValues[VarManager::kZ], VarManager::fgValues[VarManager::kPhi], VarManager::fgValues[VarManager::kTgl], muon.sign() / VarManager::fgValues[VarManager::kPt],
+                VarManager::fgValues[VarManager::kMuonCXX], VarManager::fgValues[VarManager::kMuonCXY], VarManager::fgValues[VarManager::kMuonCYY], VarManager::fgValues[VarManager::kMuonCPhiX], VarManager::fgValues[VarManager::kMuonCPhiY], VarManager::fgValues[VarManager::kMuonCPhiPhi],
+                VarManager::fgValues[VarManager::kMuonCTglX], VarManager::fgValues[VarManager::kMuonCTglY], VarManager::fgValues[VarManager::kMuonCTglPhi], VarManager::fgValues[VarManager::kMuonCTglTgl], VarManager::fgValues[VarManager::kMuonC1Pt2X], VarManager::fgValues[VarManager::kMuonC1Pt2Y],
+                VarManager::fgValues[VarManager::kMuonC1Pt2Phi], VarManager::fgValues[VarManager::kMuonC1Pt2Tgl], VarManager::fgValues[VarManager::kMuonC1Pt21Pt2]);
+      }
+    }  // end loop over selected muons
+  }  // end skimMuons
+
+  // Produce standard barrel + muon tables with event filter (typically for pp and p-Pb) ------------------------------------------------------
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMFTFillMap, typename TEvents, typename TTracks, typename TMuons>
+  void fullSkimming(TEvents const &collisions, BCsWithTimestamps const &bcs,
+                    TTracks const &tracksBarrel, TMuons const &muons, MFTTracks const &mftTracks,
+                    TrackAssoc const &trackAssocs, FwdTrackAssoc const &fwdTrackAssocs, MFTTrackAssoc const &mftAssocs) {
+
+    if (fCurrentRun != bcs.begin().runNumber()) {
+      if (fConfigComputeTPCpostCalib) {
+        auto calibList = fCCDB->getForTimeStamp<TList>(fConfigCcdbPathTPC.value, bcs.begin().timestamp());
+        VarManager::SetCalibrationObject(VarManager::kTPCElectronMean, calibList->FindObject("mean_map_electron"));
+        VarManager::SetCalibrationObject(VarManager::kTPCElectronSigma, calibList->FindObject("sigma_map_electron"));
+        VarManager::SetCalibrationObject(VarManager::kTPCPionMean, calibList->FindObject("mean_map_pion"));
+        VarManager::SetCalibrationObject(VarManager::kTPCPionSigma, calibList->FindObject("sigma_map_pion"));
+        VarManager::SetCalibrationObject(VarManager::kTPCProtonMean, calibList->FindObject("mean_map_proton"));
+        VarManager::SetCalibrationObject(VarManager::kTPCProtonSigma, calibList->FindObject("sigma_map_proton"));
+        if (fConfigComputeTPCpostCalibKaon) {
+          VarManager::SetCalibrationObject(VarManager::kTPCKaonMean, calibList->FindObject("mean_map_kaon"));
+          VarManager::SetCalibrationObject(VarManager::kTPCKaonSigma, calibList->FindObject("sigma_map_kaon"));
+        }
+      }
+      if (fIsRun2 == true) {
+        grpmagrun2 = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpmagPathRun2, bcs.begin().timestamp());
+        if (grpmagrun2 != nullptr) {
+          o2::base::Propagator::initFieldFromGRP(grpmagrun2);
+        }
+      } else {
+        grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bcs.begin().timestamp());
+        if (grpmag != nullptr) {
+          o2::base::Propagator::initFieldFromGRP(grpmag);
+        }
+      }
+      fCurrentRun = bcs.begin().runNumber();
+    }
+
+    // skim collisions 
+    skimCollisions<TEventFillMap>(collisions, bcs);
+    if (fCollIndexMap.size() == 0) {
+      return;
+    }
+
+    if constexpr (static_cast<bool>(TTrackFillMap)) {
+      fTrackIndexMap.clear();
+      trackBasic.reserve(tracksBarrel.size());
+      trackBarrel.reserve(tracksBarrel.size());
+      trackBarrelInfo.reserve(tracksBarrel.size());
+      trackBarrelCov.reserve(tracksBarrel.size());
+      trackBarrelPID.reserve(tracksBarrel.size());
+      trackBarrelAssoc.reserve(tracksBarrel.size());
+    }
+
+    if constexpr (static_cast<bool>(TMFTFillMap)) {
+      fMftIndexMap.clear();
+      mftTrack.reserve(mftTracks.size());
+      mftTrackExtra.reserve(mftTracks.size());
+      mftAssoc.reserve(mftTracks.size());
+    }
+
+    if constexpr (static_cast<bool>(TMuonFillMap)) {
+      fFwdTrackIndexMap.clear();
+      fFwdTrackFilterMap.clear();
+      muonBasic.reserve(muons.size());
+      muonExtra.reserve(muons.size());
+      muonInfo.reserve(muons.size());
+      muonCov.reserve(muons.size());
+      muonAssoc.reserve(muons.size());
+    }
+
+    // loop over selected collisions and select the tracks and fwd tracks to be skimmed
+    for (auto const& [origIdx, skimIdx] : fCollIndexMap) {
+      auto collision = collisions.rawIteratorAt(origIdx);
+      // group the tracks and muons for this collision
+      if constexpr (static_cast<bool>(TTrackFillMap)) {
+        auto groupedTrackIndices = trackAssocs.sliceBy(trackIndicesPerCollision, origIdx);
+        skimTracks<TTrackFillMap>(collision, bcs, tracksBarrel, groupedTrackIndices);
+      }
+      if constexpr (static_cast<bool>(TMFTFillMap)) {
+        auto groupedMFTIndices = mftAssocs.sliceBy(mfttrackIndicesPerCollision, origIdx);
+        skimMFT<TMFTFillMap>(collision, bcs, mftTracks, groupedMFTIndices);
+      }
+      if constexpr (static_cast<bool>(TMuonFillMap)) {
+        auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
+        skimMuons<TMuonFillMap>(collision, bcs, muons, groupedMuonIndices);
+      }
+    }  // end loop over skimmed collisions
+  }
+
+  // 
+  void processFullWithFilter(MyEventsWithMultsAndFilter const &collisions, BCsWithTimestamps const &bcs,
+                             MyBarrelTracksWithCov const &tracksBarrel,
+                             MyMuonsWithCov const &muons, MFTTracks const &mftTracks,
+                             TrackAssoc const &trackAssocs, FwdTrackAssoc const &fwdTrackAssocs, 
+                             MFTTrackAssoc const &mftAssocs) {
+    fullSkimming<gkEventFillMapWithMultsAndEventFilter, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
+  }
+
+  // Process the BCs and store stats for luminosity retrieval -----------------------------------------------------------------------------------
+  void processOnlyBCs(soa::Join<aod::BCs, aod::BcSels>::iterator const& bc)
+  {
+    for (int i = 0; i < kNaliases; i++) {
+      if (bc.alias_bit(i) > 0) {
+        (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(0.0, static_cast<float>(i));
+      }
+    }
+    (reinterpret_cast<TH2I*>(fStatsList->At(0)))->Fill(0.0, static_cast<float>(kNaliases));
+  }
+  
+  PROCESS_SWITCH(TableMaker, processFullWithFilter, "Build full DQ skimmed data model, w/ event filtering", false);
+  PROCESS_SWITCH(TableMaker, processOnlyBCs, "Analyze the BCs to store sampled lumi", false);
+};
+
+void DefineHistograms(HistogramManager* histMan, TString histClasses, Configurable<std::string> configVar)
+{
+  //
+  // Define here the histograms for all the classes required in analysis.
+  //  The histogram classes are provided in the histClasses string, separated by semicolon ";"
+  //  The histogram classes and their components histograms are defined below depending on the name of the histogram class
+  //
+  std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+  for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+    TString classStr = objArray->At(iclass)->GetName();
+    histMan->AddHistClass(classStr.Data());
+
+    TString histName = configVar.value;
+    // NOTE: The level of detail for histogramming can be controlled via configurables
+    if (classStr.Contains("Event")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "event", histName);
+    }
+
+    if (classStr.Contains("Track") && !classStr.Contains("Pairs")) {
+      if (classStr.Contains("Barrel")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+        if (classStr.Contains("PIDCalibElectron")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_electron");
+        }
+        if (classStr.Contains("PIDCalibPion")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_pion");
+        }
+        if (classStr.Contains("PIDCalibProton")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_proton");
+        }
+      }
+      if (classStr.Contains("Muon")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+      }
+    }
+
+    if (classStr.Contains("Pairs")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", histName);
+    }
+
+    if (classStr.Contains("DileptonsSelected")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "barrel");
+    }
+
+    if (classStr.Contains("HadronsSelected")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+    }
+
+    if (classStr.Contains("DileptonHadronInvMass")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-mass");
+    }
+
+    if (classStr.Contains("DileptonHadronCorrelation")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-correlation");
+    }
+  } // end loop over histogram classes
+}
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<TableMaker>(cfgc)};
+}

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -14,6 +14,11 @@ o2physics_add_dpl_workflow(table-reader
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(table-reader-with-assoc
+                    SOURCES tableReader_withAssoc.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)                                       
+                    
 o2physics_add_dpl_workflow(efficiency
                     SOURCES dqEfficiency.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore
@@ -26,6 +31,11 @@ o2physics_add_dpl_workflow(filter-pp
 
 o2physics_add_dpl_workflow(filter-pp-with-association
                     SOURCES filterPPwithAssociation.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(filter-pp-with-association-with-common-associator
+                    SOURCES filterPPwithAssociation_withCommonAssociator.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -479,8 +479,10 @@ struct AnalysisMuonSelection {
 };
 
 struct AnalysisSameEventPairing {
-  Produces<aod::Dileptons> dileptonList;
-  Produces<aod::DileptonsExtra> dileptonExtraList;
+  Produces<aod::Dielectrons> dielectronList;
+  Produces<aod::Dimuons> dimuonList;
+  Produces<aod::DielectronsExtra> dielectronExtraList;
+  Produces<aod::DimuonsExtra> dimuonExtraList;
   Produces<aod::DimuonsAll> dimuonAllList;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   float mMagField = 0.0;
@@ -729,8 +731,10 @@ struct AnalysisSameEventPairing {
     uint8_t twoTrackFilter = 0;
     uint32_t dileptonFilterMap = 0;
     uint32_t dileptonMcDecision = 0;
-    dileptonList.reserve(1);
-    dileptonExtraList.reserve(1);
+    dielectronList.reserve(1);
+    dimuonList.reserve(1);
+    dielectronExtraList.reserve(1);
+    dimuonExtraList.reserve(1);
     if (fConfigFlatTables.value) {
       dimuonAllList.reserve(1);
     }
@@ -772,8 +776,15 @@ struct AnalysisSameEventPairing {
 
       dileptonFilterMap = twoTrackFilter;
       dileptonMcDecision = mcDecision;
-      dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
-      dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+      
+      if constexpr (TPairType == VarManager::kDecayToEE) {
+        dielectronList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
+        dielectronExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+      }
+      if constexpr (TPairType == VarManager::kDecayToMuMu) {
+        dimuonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
+        dimuonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+      }
 
       constexpr bool muonHasCov = ((TTrackFillMap & VarManager::ObjTypes::MuonCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedMuonCov) > 0);
       if constexpr ((TPairType == VarManager::kDecayToMuMu) && muonHasCov) {
@@ -1070,8 +1081,8 @@ struct AnalysisDileptonTrack {
   }
 
   // Template function to run pair - track combinations
-  template <int TCandidateType, uint32_t TEventFillMap, uint32_t TEventMCFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks, typename TEventsMC, typename TTracksMC>
-  void runDileptonTrack(TEvent const& event, TTracks const& tracks, soa::Join<aod::Dileptons, aod::DileptonsExtra> const& dileptons, TEventsMC const& eventsMC, TTracksMC const& tracksMC)
+  template <int TCandidateType, uint32_t TEventFillMap, uint32_t TEventMCFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks, typename TDileptons, typename TEventsMC, typename TTracksMC>
+  void runDileptonTrack(TEvent const& event, TTracks const& tracks, TDileptons const& dileptons, TEventsMC const& eventsMC, TTracksMC const& tracksMC)
   {
     VarManager::ResetValues(0, VarManager::kNVars, fValuesTrack);
     VarManager::ResetValues(0, VarManager::kNVars, fValuesDilepton);
@@ -1206,14 +1217,14 @@ struct AnalysisDileptonTrack {
   // Preslice<ReducedMCTracks> perReducedMcEvent = aod::reducedtrackMC::reducedMCeventId;
   PresliceUnsorted<ReducedMCTracks> perReducedMcEvent = aod::reducedtrackMC::reducedMCeventId;
 
-  void processDimuonMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyMuonTracksSelectedWithCov const& tracks, soa::Join<aod::Dileptons, aod::DileptonsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  void processDimuonMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyMuonTracksSelectedWithCov const& tracks, soa::Join<aod::Dimuons, aod::DimuonsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
   {
     runDileptonTrack<VarManager::kBcToThreeMuons, gkEventFillMapWithCov, gkMCEventFillMap, gkMuonFillMapWithCov>(event, tracks, dileptons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());
     groupedMCTracks.bindInternalIndicesTo(&tracksMC);
     runMCGen(groupedMCTracks);
   }
-  void processDielectronKaonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyBarrelTracksSelectedWithCov const& tracks, soa::Join<aod::Dileptons, aod::DileptonsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
+  void processDielectronKaonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyBarrelTracksSelectedWithCov const& tracks, soa::Join<aod::Dielectrons, aod::DielectronsExtra> const& dileptons, ReducedMCEvents const& eventsMC, ReducedMCTracks const& tracksMC)
   {
     runDileptonTrack<VarManager::kBtoJpsiEEK, gkEventFillMapWithCov, gkMCEventFillMap, gkTrackFillMapWithCov>(event, tracks, dileptons, eventsMC, tracksMC);
     auto groupedMCTracks = tracksMC.sliceBy(perReducedMcEvent, event.reducedMCevent().globalIndex());

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -776,7 +776,7 @@ struct AnalysisSameEventPairing {
 
       dileptonFilterMap = twoTrackFilter;
       dileptonMcDecision = mcDecision;
-      
+
       if constexpr (TPairType == VarManager::kDecayToEE) {
         dielectronList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
         dielectronExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);

--- a/PWGDQ/Tasks/filterPPwithAssociation_withCommonAssociator.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation_withCommonAssociator.cxx
@@ -1,0 +1,922 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
+//
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <cstring>
+#include <TH1F.h>
+#include <TH2I.h>
+#include <THashList.h>
+#include <TString.h>
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/DataTypes.h"
+#include "Framework/runDataProcessing.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/CCDB/TriggerAliases.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "EventFiltering/filterTables.h"
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+#include "PWGDQ/Core/VarManager.h"
+#include "PWGDQ/Core/HistogramManager.h"
+#include "PWGDQ/Core/AnalysisCut.h"
+#include "PWGDQ/Core/AnalysisCompositeCut.h"
+#include "PWGDQ/Core/HistogramsLibrary.h"
+#include "PWGDQ/Core/CutsLibrary.h"
+#include "CommonConstants/LHCConstants.h"
+#include "Common/Core/CollisionAssociation.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+
+using std::cout;
+using std::endl;
+using std::string;
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod;
+
+// Some definitions
+namespace
+{
+enum DQTriggers {
+  kSingleE = 0,
+  kDiElectron,
+  kSingleMuLow,
+  kSingleMuHigh,
+  kDiMuon,
+  kNTriggersDQ
+};
+} // namespace
+namespace o2::aod
+{
+namespace dqppfilter
+{
+DECLARE_SOA_COLUMN(IsDQEventSelected, isDQEventSelected, int);
+DECLARE_SOA_COLUMN(IsDQBarrelSelected, isDQBarrelSelected, uint32_t);
+DECLARE_SOA_COLUMN(IsDQMuonSelected, isDQMuonSelected, uint32_t);
+DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Collision index
+DECLARE_SOA_INDEX_COLUMN(Track, track);         //! Track index
+DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);   //! FwdTrack index
+} // namespace dqppfilter
+
+DECLARE_SOA_TABLE(DQEventCuts, "AOD", "DQEVENTCUTS", dqppfilter::IsDQEventSelected);
+DECLARE_SOA_TABLE(DQBarrelTrackCuts, "AOD", "DQBARRELCUTS", dqppfilter::IsDQBarrelSelected);
+DECLARE_SOA_TABLE(DQMuonsCuts, "AOD", "DQMUONCUTS", dqppfilter::IsDQMuonSelected);
+} // namespace o2::aod
+
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyEventsSelected = soa::Join<aod::Collisions, aod::EvSels, aod::DQEventCuts>;
+// TODO: subscribe to the bare needed minimum, in particular for the CEFP task
+// TODO: test working with TrackIU
+// TODO: remove the TOF pid if not needed (requires changes in VarManager to separate TrackPID into TPC and TOF)
+using MyBarrelTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
+                                 aod::pidTPCFullEl, aod::pidTPCFullPi,
+                                 aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                 aod::pidTOFFullEl, aod::pidTOFFullPi,
+                                 aod::pidTOFFullKa, aod::pidTOFFullPr>;
+using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA,
+                                         aod::pidTPCFullEl, aod::pidTPCFullPi,
+                                         aod::pidTPCFullKa, aod::pidTPCFullPr,
+                                         aod::pidTOFFullEl, aod::pidTOFFullPi,
+                                         aod::pidTOFFullKa, aod::pidTOFFullPr,
+                                         aod::DQBarrelTrackCuts>;
+
+using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
+using MyMuonsSelected = soa::Join<aod::FwdTracks, aod::FwdTracksDCA, aod::DQMuonsCuts>;
+
+constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackPID;
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
+
+void DefineHistograms(HistogramManager* histMan, TString histClasses);
+
+struct DQEventSelectionTask {
+  Produces<aod::DQEventCuts> eventSel;
+  OutputObj<THashList> fOutputList{"output"};
+  HistogramManager* fHistMan = nullptr;
+  AnalysisCompositeCut* fEventCut;
+
+  Configurable<std::string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Comma separated list of event cuts; multiple cuts are applied with a logical AND"};
+  Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
+  // TODO: configure the histogram classes to be filled by QA
+
+  void init(o2::framework::InitContext&)
+  {
+    // Construct the composite cut out of the user provided event selection cut(s)
+    TString eventCutStr = fConfigEventCuts.value;
+    fEventCut = new AnalysisCompositeCut(true);
+    if (!eventCutStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(eventCutStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fEventCut->AddCut(dqcuts::GetAnalysisCut(objArray->At(icut)->GetName()));
+      }
+    }
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+
+    if (fConfigQA) {
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+      DefineHistograms(fHistMan, "Event_BeforeCuts;Event_AfterCuts;"); // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                 // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+  }
+
+  template <uint32_t TEventFillMap, typename TEvent>
+  void runEventSelection(TEvent const& collision, aod::BCs const& bcs)
+  {
+    // Reset the Values array
+    VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
+
+    VarManager::FillEvent<gkEventFillMap>(collision);
+    if (fConfigQA) {
+      fHistMan->FillHistClass("Event_BeforeCuts", VarManager::fgValues);
+    }
+    if (fEventCut->IsSelected(VarManager::fgValues)) {
+      if (fConfigQA) {
+        fHistMan->FillHistClass("Event_AfterCuts", VarManager::fgValues);
+      }
+      eventSel(1);
+    } else {
+      eventSel(0);
+    }
+  }
+
+  void processEventSelection(MyEvents::iterator const& collision, aod::BCs const& bcs)
+  {
+    runEventSelection<gkEventFillMap>(collision, bcs);
+  }
+
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQEventSelectionTask, processEventSelection, "Run event selection", false);
+  PROCESS_SWITCH(DQEventSelectionTask, processDummy, "Dummy function", false);
+};
+
+struct DQBarrelTrackSelection {
+  Produces<aod::DQBarrelTrackCuts> trackSel;
+  OutputObj<THashList> fOutputList{"output"};
+  HistogramManager* fHistMan;
+
+  Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/i/iarsene/Calib/TPCpostCalib", "base path to the ccdb object"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<bool> fConfigComputeTPCpostCalib{"cfgTPCpostCalib", false, "If true, compute TPC post-calibrated n-sigmas"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  std::vector<AnalysisCompositeCut> fTrackCuts;
+  std::vector<TString> fCutHistNames;
+
+  int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
+
+  void init(o2::framework::InitContext&)
+  {
+    TString cutNamesStr = fConfigCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        AnalysisCompositeCut* cut = dqcuts::GetCompositeCut(objArray->At(icut)->GetName());
+        if (cut) {
+          fTrackCuts.push_back(*cut);
+        } else {
+          LOGF(fatal, "Invalid barrel track cut provided: %s", objArray->At(icut)->GetName());
+        }
+      }
+    }
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+
+    if (fConfigQA) {
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+      TString cutNames = "TrackBarrel_BeforeCuts;";
+      for (auto& cut : fTrackCuts) {
+        cutNames += Form("TrackBarrel_%s;", cut.GetName());
+        fCutHistNames.push_back(Form("TrackBarrel_%s", cut.GetName()));
+      }
+
+      DefineHistograms(fHistMan, cutNames.Data());     // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+
+      // CCDB configuration
+      if (fConfigComputeTPCpostCalib) {
+        fCCDB->setURL(fConfigCcdbUrl.value);
+        fCCDB->setCaching(true);
+        fCCDB->setLocalObjectValidityChecking();
+        // Not later than now objects
+        fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+      }
+    }
+  }
+
+  // Templated function instantianed for all of the process functions
+  template <uint32_t TTrackFillMap, typename TTracks>
+  void runTrackSelection(aod::BCsWithTimestamps const& bcs, TTracks const& tracksBarrel)
+  {
+    auto bc = bcs.begin(); // check just the first bc to get the run number
+    if (fCurrentRun != bc.runNumber()) {
+      fCurrentRun = bc.runNumber();
+      if (fConfigComputeTPCpostCalib) {
+        auto calibList = fCCDB->getForTimeStamp<TList>(fConfigCcdbPathTPC.value, bc.timestamp());
+        VarManager::SetCalibrationObject(VarManager::kTPCElectronMean, calibList->FindObject("mean_map_electron"));
+        VarManager::SetCalibrationObject(VarManager::kTPCElectronSigma, calibList->FindObject("sigma_map_electron"));
+        VarManager::SetCalibrationObject(VarManager::kTPCPionMean, calibList->FindObject("mean_map_pion"));
+        VarManager::SetCalibrationObject(VarManager::kTPCPionSigma, calibList->FindObject("sigma_map_pion"));
+        VarManager::SetCalibrationObject(VarManager::kTPCProtonMean, calibList->FindObject("mean_map_proton"));
+        VarManager::SetCalibrationObject(VarManager::kTPCProtonSigma, calibList->FindObject("sigma_map_proton"));
+      }
+    }
+
+    uint32_t filterMap = uint32_t(0);
+    trackSel.reserve(tracksBarrel.size());
+
+    VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
+    for (auto& track : tracksBarrel) {
+      filterMap = uint32_t(0);
+
+      VarManager::FillTrack<TTrackFillMap>(track);
+      if (fConfigQA) {
+        fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
+      }
+      int i = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMap |= (uint32_t(1) << i);
+          if (fConfigQA) {
+            fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+          }
+        }
+      }
+      trackSel(filterMap);
+    } // end loop over tracks
+  }
+
+  void processSelection(aod::BCsWithTimestamps const& bcs, MyBarrelTracks const& tracks)
+  {
+    runTrackSelection<gkTrackFillMap>(bcs, tracks);
+  }
+
+  void processDummy(MyBarrelTracks&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQBarrelTrackSelection, processSelection, "Run barrel track selection", false);
+  PROCESS_SWITCH(DQBarrelTrackSelection, processDummy, "Dummy function", false);
+};
+
+struct DQMuonsSelection {
+  Produces<aod::DQMuonsCuts> trackSel;
+  OutputObj<THashList> fOutputList{"output"};
+  HistogramManager* fHistMan;
+
+  Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonQualityCuts", "Comma separated list of ADDITIONAL muon track cuts"};
+  Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
+
+  // TODO: configure the histogram classes to be filled by QA
+
+  std::vector<AnalysisCompositeCut> fTrackCuts;
+  std::vector<TString> fCutHistNames;
+
+  void init(o2::framework::InitContext&)
+  {
+    TString cutNamesStr = fConfigCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars);
+
+    if (fConfigQA) {
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+      TString cutNames = "Muon_BeforeCuts;";
+      for (unsigned int i = 0; i < fTrackCuts.size(); i++) {
+        cutNames += Form("Muon_%s;", fTrackCuts[i].GetName());
+        fCutHistNames.push_back(Form("Muon_%s", fTrackCuts[i].GetName()));
+      }
+
+      DefineHistograms(fHistMan, cutNames.Data());     // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars()); // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+  }
+
+  template <uint32_t TMuonFillMap, typename TMuons>
+  void runMuonSelection(TMuons const& muons)
+  {
+    uint32_t filterMap = uint32_t(0);
+    trackSel.reserve(muons.size());
+
+    VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
+
+    for (auto& muon : muons) {
+      filterMap = uint32_t(0);
+      
+      VarManager::FillTrack<TMuonFillMap>(muon);
+      if (fConfigQA) {
+        fHistMan->FillHistClass("Muon_BeforeCuts", VarManager::fgValues);
+      }
+      int i = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); ++cut, ++i) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMap |= (uint32_t(1) << i);
+          if (fConfigQA) {
+            fHistMan->FillHistClass(fCutHistNames[i].Data(), VarManager::fgValues);
+          }
+        }
+      }
+      trackSel(filterMap);
+    } // end loop over muons
+  }
+
+  void processSelection(MyMuons const& muons)
+  {
+    runMuonSelection<gkMuonFillMap>(muons);
+  }
+  void processDummy(MyMuons&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQMuonsSelection, processSelection, "Run muon selection", false);
+  PROCESS_SWITCH(DQMuonsSelection, processDummy, "Dummy function", false);
+};
+
+/*
+struct DQTrackToCollisionAssociation {
+
+  Produces<TrackAssoc> association;
+  Produces<TrackCompColls> reverseIndices;
+  Produces<FwdTrackAssoc> fwdassociation;
+  Produces<FwdTrkCompColls> fwdreverseIndices;
+
+  // NOTE: the options for the collision associator are common for both the barrel and muon
+  //       We should add separate ones if needed
+  Configurable<float> nSigmaForTimeCompat{"nSigmaForTimeCompat", 4.f, "number of sigmas for time compatibility"};
+  Configurable<float> timeMargin{"timeMargin", 0.f, "time margin in ns added to uncertainty because of uncalibrated TPC"};
+  Configurable<bool> usePVAssociation{"usePVAssociation", true, "if the track is a PV contributor, use the collision time for it"};
+  Configurable<bool> includeUnassigned{"includeUnassigned", false, "consider also tracks which are not assigned to any collision"};
+  Configurable<bool> fillTableOfCollIdsPerTrack{"fillTableOfCollIdsPerTrack", false, "fill additional table with vector of collision ids per track"};
+  Configurable<int> bcWindowForOneSigma{"bcWindowForOneSigma", 60, "BC window to be multiplied by the number of sigmas to define maximum window to be considered"};
+
+  CollisionAssociation<true> collisionAssociatorBarrel;
+  CollisionAssociation<false> collisionAssociatorMuon;
+
+  Filter filterBarrelTrackSelected = aod::dqppfilter::isDQBarrelSelected > uint32_t(0);
+  Filter filterMuonTrackSelected = aod::dqppfilter::isDQMuonSelected > uint32_t(0);
+
+  void init(o2::framework::InitContext const&)
+  {
+    // set options in track-to-collision association
+    collisionAssociatorBarrel.setNumSigmaForTimeCompat(nSigmaForTimeCompat);
+    collisionAssociatorBarrel.setTimeMargin(timeMargin);
+    collisionAssociatorBarrel.setTrackSelectionOptionForStdAssoc(track_association::TrackSelection::None);
+    collisionAssociatorBarrel.setUsePvAssociation(usePVAssociation);
+    collisionAssociatorBarrel.setIncludeUnassigned(includeUnassigned);
+    collisionAssociatorBarrel.setFillTableOfCollIdsPerTrack(fillTableOfCollIdsPerTrack);
+    collisionAssociatorBarrel.setBcWindow(bcWindowForOneSigma);
+    // set options in muon-to-collision association
+    collisionAssociatorMuon.setNumSigmaForTimeCompat(nSigmaForTimeCompat);
+    collisionAssociatorMuon.setTimeMargin(timeMargin);
+    collisionAssociatorMuon.setTrackSelectionOptionForStdAssoc(track_association::TrackSelection::None);
+    collisionAssociatorMuon.setUsePvAssociation(false);
+    collisionAssociatorMuon.setIncludeUnassigned(includeUnassigned);
+    collisionAssociatorMuon.setFillTableOfCollIdsPerTrack(fillTableOfCollIdsPerTrack);
+    collisionAssociatorMuon.setBcWindow(bcWindowForOneSigma);
+  }
+
+  void processAssocWithTime(Collisions const& collisions, 
+                            MyBarrelTracksSelected const& tracksUnfiltered, soa::Filtered<MyBarrelTracksSelected> const& tracks,
+                            FwdTracks const& muons,
+                            AmbiguousTracks const& ambiguousTracks, AmbiguousFwdTracks const& ambiguousFwdTracks, BCs const& bcs)
+  {
+    collisionAssociatorBarrel.runAssocWithTime(collisions, tracksUnfiltered, tracks, ambiguousTracks, bcs, association, reverseIndices);
+    collisionAssociatorMuon.runAssocWithTime(collisions, muons, muons, ambiguousFwdTracks, bcs, fwdassociation, fwdreverseIndices);
+  };
+  void processDummy(Collisions&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQTrackToCollisionAssociation, processAssocWithTime, "Produce track-to-collision associations based on time", false);
+  PROCESS_SWITCH(DQTrackToCollisionAssociation, processDummy, "Dummy function", false);
+};
+*/
+
+struct DQFilterPPTask {
+  Produces<aod::DQEventFilter> eventFilter;
+  Produces<aod::DqFilters> dqtable;
+  OutputObj<THashList> fOutputList{"output"};
+  OutputObj<TH1I> fStats{"Statistics"};
+  HistogramManager* fHistMan;
+
+  Configurable<std::string> fConfigBarrelSelections{"cfgBarrelSels", "jpsiPID1:pairMassLow:1", "<track-cut>:[<pair-cut>]:<n>,[<track-cut>:[<pair-cut>]:<n>],..."};
+  Configurable<std::string> fConfigMuonSelections{"cfgMuonSels", "muonQualityCuts:pairNoCut:1", "<muon-cut>:[<pair-cut>]:<n>"};
+  Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
+  Configurable<bool> fConfigFilterLsBarrelTracksPairs{"cfgWithBarrelLS", false, "If true, also select like sign (--/++) barrel track pairs"};
+  Configurable<bool> fConfigFilterLsMuonsPairs{"cfgWithMuonLS", false, "If true, also select like sign (--/++) muon pairs"};
+
+  int fNBarrelCuts;                                    // number of barrel selections
+  int fNMuonCuts;                                      // number of muon selections
+  std::vector<bool> fBarrelRunPairing;                 // bit map on whether the selections require pairing (barrel)
+  std::vector<bool> fMuonRunPairing;                   // bit map on whether the selections require pairing (muon)
+  std::vector<int> fBarrelNreqObjs;                    // minimal number of tracks/pairs required (barrel)
+  std::vector<int> fMuonNreqObjs;                      // minimal number of tracks/pairs required (muon)
+  std::map<int, AnalysisCompositeCut> fBarrelPairCuts; // map of barrel pair cuts
+  std::map<int, AnalysisCompositeCut> fMuonPairCuts;   // map of muon pair cuts
+  std::map<int, TString> fBarrelPairHistNames;         // map with names of the barrel pairing histogram directories
+  std::map<int, TString> fMuonPairHistNames;           // map with names of the muon pairing histogram directories
+
+  std::map<uint64_t, uint64_t> fFiltersMap;           // map of filters for events that passed at least one filter
+  std::map<uint64_t, std::vector<bool>> fCEFPfilters; // map of CEFP filters for events that passed at least one filter
+
+  void DefineCuts()
+  {
+    TString barrelSelsStr = fConfigBarrelSelections.value;
+    std::unique_ptr<TObjArray> objArray(barrelSelsStr.Tokenize(","));
+    fNBarrelCuts = objArray->GetEntries();
+    if (fNBarrelCuts) {
+      for (int icut = 0; icut < fNBarrelCuts; ++icut) {
+        TString selStr = objArray->At(icut)->GetName();
+        std::unique_ptr<TObjArray> sel(selStr.Tokenize(":"));
+        if (sel->GetEntries() < 2 || sel->GetEntries() > 3) {
+          continue;
+        }
+        // if "sel" contains 3 entries, it means the user provided both the track and pair cuts
+        if (sel->GetEntries() == 3) {
+          fBarrelPairCuts[icut] = (*dqcuts::GetCompositeCut(sel->At(1)->GetName()));
+          fBarrelRunPairing.push_back(true);
+          fBarrelNreqObjs.push_back(std::atoi(sel->At(2)->GetName()));
+          fBarrelPairHistNames[icut] = Form("PairsBarrelSEPM_%s_%s", sel->At(0)->GetName(), sel->At(1)->GetName());
+        } else {
+          fBarrelNreqObjs.push_back(std::atoi(sel->At(1)->GetName()));
+          fBarrelRunPairing.push_back(false);
+        }
+      }
+    }
+    TString muonSelsStr = fConfigMuonSelections.value;
+    std::unique_ptr<TObjArray> objArray2(muonSelsStr.Tokenize(","));
+    fNMuonCuts = objArray2->GetEntries();
+    if (fNMuonCuts) {
+      for (int icut = 0; icut < fNMuonCuts; ++icut) {
+        TString selStr = objArray2->At(icut)->GetName();
+        std::unique_ptr<TObjArray> sel(selStr.Tokenize(":"));
+        if (sel->GetEntries() < 2 || sel->GetEntries() > 3) {
+          continue;
+        }
+        // if "sel" contains 3 entries, it means the user provided both the track and pair cuts
+        if (sel->GetEntries() == 3) {
+          fMuonPairCuts[icut] = (*dqcuts::GetCompositeCut(sel->At(1)->GetName()));
+          fMuonRunPairing.push_back(true);
+          fMuonNreqObjs.push_back(std::atoi(sel->At(2)->GetName()));
+          fMuonPairHistNames[icut] = Form("PairsForwardSEPM_%s_%s", sel->At(0)->GetName(), sel->At(1)->GetName());
+        } else {
+          fMuonNreqObjs.push_back(std::atoi(sel->At(1)->GetName()));
+          fMuonRunPairing.push_back(false);
+        }
+      }
+    }
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars);
+
+    // setup the Stats histogram
+    fStats.setObject(new TH1I("Statistics", "Stats for DQ triggers", fNBarrelCuts + fNMuonCuts + 2, -2.5, -0.5 + fNBarrelCuts + fNMuonCuts));
+    fStats->GetXaxis()->SetBinLabel(1, "Events inspected");
+    fStats->GetXaxis()->SetBinLabel(2, "Events selected");
+    if (fNBarrelCuts) {
+      for (int ib = 3; ib < 3 + fNBarrelCuts; ib++) {
+        fStats->GetXaxis()->SetBinLabel(ib, objArray->At(ib - 3)->GetName());
+      }
+    }
+    if (fNMuonCuts) {
+      for (int ib = 3 + fNBarrelCuts; ib < 3 + fNBarrelCuts + fNMuonCuts; ib++) {
+        fStats->GetXaxis()->SetBinLabel(ib, objArray2->At(ib - 3 - fNBarrelCuts)->GetName());
+      }
+    }
+  }
+
+  void init(o2::framework::InitContext&)
+  {
+    DefineCuts();
+
+    if (fConfigQA) {
+      // initialize the variable manager
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+      TString histNames = "";
+      for (const auto& [key, value] : fBarrelPairHistNames) {
+        histNames += value;
+        histNames += ";";
+      }
+      for (const auto& [key, value] : fMuonPairHistNames) {
+        histNames += value;
+        histNames += ";";
+      }
+      DefineHistograms(fHistMan, histNames.Data());
+      VarManager::SetUseVars(fHistMan->GetUsedVars());
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+  }
+
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons>
+  uint64_t runFilterPP(TEvent const& collision,
+                       aod::BCs const& bcs,
+                       TTracks const& tracksBarrel,
+                       TMuons const& muons,
+                       aod::TrackAssoc const& barrelAssocs, aod::FwdTrackAssoc const& muonAssocs)
+  {
+    // Reset the values array and compute event quantities
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<TEventFillMap>(collision); // event properties could be needed for cuts or histogramming
+
+    std::vector<int> objCountersBarrel(fNBarrelCuts, 0); // init all counters to zero
+    // count the number of barrel tracks fulfilling each cut
+    for (auto trackAssoc : barrelAssocs) {
+      auto track = trackAssoc.template track_as<TTracks>();
+      for (int i = 0; i < fNBarrelCuts; ++i) {
+        if (track.isDQBarrelSelected() & (uint32_t(1) << i)) {
+          objCountersBarrel[i] += 1;
+        }
+      }
+    }
+
+    // check which selections require pairing
+    uint32_t pairingMask = 0; // in order to know which of the selections actually require pairing
+    for (int i = 0; i < fNBarrelCuts; i++) {
+      if (fBarrelRunPairing[i]) {
+        if (objCountersBarrel[i] > 1) { // pairing has to be enabled and at least two tracks are needed
+          pairingMask |= (uint32_t(1) << i);
+        }
+        objCountersBarrel[i] = 0; // reset counters for selections where pairing is needed (count pairs instead)
+      }
+    }
+
+    // run pairing if there is at least one selection that requires it
+    uint32_t pairFilter = 0;
+    if (pairingMask > 0) {
+      // run pairing on the collision grouped associations
+      for (auto& [a1, a2] : combinations(barrelAssocs, barrelAssocs)) {
+
+        // get the tracks from the index stored in the association
+        auto t1 = a1.template track_as<TTracks>();
+        auto t2 = a2.template track_as<TTracks>();
+        
+        // check the pairing mask and that the tracks share a cut bit
+        pairFilter = pairingMask & t1.isDQBarrelSelected() & t2.isDQBarrelSelected();
+        if (pairFilter == 0) {
+          continue;
+        }
+        
+        // keep just opposite-sign pairs
+        if (!fConfigFilterLsBarrelTracksPairs) {
+          if (t1.sign() * t2.sign() > 0) {
+            continue;
+          }
+        }
+
+        // construct the pair and apply pair cuts
+        VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(t1, t2); // compute pair quantities
+        for (int icut = 0; icut < fNBarrelCuts; icut++) {
+          if (!(pairFilter & (uint32_t(1) << icut))) {
+            continue;
+          }
+          if (!fBarrelPairCuts[icut].IsSelected(VarManager::fgValues)) {
+            continue;
+          }
+          objCountersBarrel[icut] += 1; // count the pair
+          if (fConfigQA) {              // fill histograms if QA is enabled
+            fHistMan->FillHistClass(fBarrelPairHistNames[icut].Data(), VarManager::fgValues);
+          }
+        }
+      }
+    }
+
+    std::vector<int> objCountersMuon(fNMuonCuts, 0); // init all counters to zero
+    // count the number of muon tracks fulfilling each selection
+    for (auto muonAssoc : muonAssocs) {
+      auto muon = muonAssoc.template fwdtrack_as<TMuons>();
+      for (int i = 0; i < fNMuonCuts; ++i) {
+        if (muon.isDQMuonSelected() & (uint32_t(1) << i)) {
+          objCountersMuon[i] += 1;
+        }
+      }
+    }
+
+    // check which muon selections require pairing
+    pairingMask = 0; // reset the mask for the muons
+    for (int i = 0; i < fNMuonCuts; i++) {
+      if (fMuonRunPairing[i]) { // pairing has to be enabled and at least two tracks are needed
+        if (objCountersMuon[i] > 1) {
+          pairingMask |= (uint32_t(1) << i);
+        }
+        objCountersMuon[i] = 0; // reset counters for selections where pairing is needed (count pairs instead)
+      }
+    }
+
+    // run pairing if there is at least one selection that requires it
+    pairFilter = 0;
+    if (pairingMask > 0) {
+      // pairing is done using the collision grouped muon associations
+      for (auto& [a1, a2] : combinations(muonAssocs, muonAssocs)) {
+        
+        // get the real muon tracks
+        auto t1 = a1.template fwdtrack_as<TMuons>();
+        auto t2 = a2.template fwdtrack_as<TMuons>();
+
+        // check the pairing mask and that the tracks share a cut bit
+        pairFilter = pairingMask & t1.isDQMuonSelected() & t2.isDQMuonSelected();
+        if (pairFilter == 0) {
+          continue;
+        }
+
+        // keep just opposite-sign pairs
+        if (!fConfigFilterLsMuonsPairs) {
+          if (t1.sign() * t2.sign() > 0) {
+            continue;
+          }
+        }
+
+        // construct the pair and apply cuts
+        VarManager::FillPair<VarManager::kDecayToMuMu, TTrackFillMap>(t1, t2); // compute pair quantities
+        for (int icut = 0; icut < fNMuonCuts; icut++) {
+          if (!(pairFilter & (uint32_t(1) << icut))) {
+            continue;
+          }
+          if (!fMuonPairCuts[icut].IsSelected(VarManager::fgValues)) {
+            continue;
+          }
+          objCountersMuon[icut] += 1;
+          if (fConfigQA) {
+            fHistMan->FillHistClass(fMuonPairHistNames[icut].Data(), VarManager::fgValues);
+          }
+        }
+      }
+    }
+
+    // compute the decisions and publish
+    uint64_t filter = 0;
+    for (int i = 0; i < fNBarrelCuts; i++) {
+      if (objCountersBarrel[i] >= fBarrelNreqObjs[i]) {
+        filter |= (uint64_t(1) << i);
+      }
+    }
+    for (int i = 0; i < fNMuonCuts; i++) {
+      if (objCountersMuon[i] >= fMuonNreqObjs[i]) {
+        filter |= (uint64_t(1) << (i + fNBarrelCuts));
+      }
+    }
+    return filter;
+  }
+
+  Preslice<TrackAssoc> trackIndicesPerCollision = track_association::collisionId;
+  Preslice<FwdTrackAssoc> muonIndicesPerCollision = track_association::collisionId;
+
+  void processFilterPP(MyEventsSelected const& collisions,
+                       BCs const& bcs,
+                       MyBarrelTracksSelected const& tracks,
+                       MyMuonsSelected const& muons,
+                       TrackAssoc const& trackAssocs, FwdTrackAssoc const& muonAssocs)
+  {
+    fFiltersMap.clear();
+    fCEFPfilters.clear();
+
+    cout << "------------------- filterPP, n assocs barrel/muon :: " << trackAssocs.size() << " / " << muonAssocs.size() << endl;
+
+    uint64_t barrelMask = 0;
+    for (int i = 0; i < fNBarrelCuts; i++) {
+      barrelMask |= (uint64_t(1) << i);
+    }
+    uint64_t muonMask = 0;
+    for (int i = fNBarrelCuts; i < fNBarrelCuts + fNMuonCuts; i++) {
+      muonMask |= (uint64_t(1) << i);
+    }
+
+    // Loop over collisions
+    int event = 0;
+    int eventsFired = 0;
+    for (const auto& collision : collisions) {
+      // skip those that do not pass our selection
+      if (!collision.isDQEventSelected()) {
+        event++;
+        continue;
+      }
+      // group the tracks and muons for this collision
+      auto groupedTrackIndices = trackAssocs.sliceBy(trackIndicesPerCollision, collision.globalIndex());
+      auto groupedMuonIndices = muonAssocs.sliceBy(muonIndicesPerCollision, collision.globalIndex());
+
+      uint64_t filter = 0;
+      // if there is at least one track or muon, run the filtering function and compute triggers
+      if (groupedTrackIndices.size() > 0 || groupedMuonIndices.size() > 0) {
+        filter = runFilterPP<gkEventFillMap, gkTrackFillMap, gkMuonFillMap>(collision, bcs, tracks, muons, groupedTrackIndices, groupedMuonIndices);
+      }
+      if (filter == 0) {
+        event++;
+        continue;
+      }
+      eventsFired++;
+      // compute the CEPF decisions (this is done in a special setup with exactly kNTriggersDQ configured triggers)
+      std::vector<bool> decisions(kNTriggersDQ, false); // event decisions to be transmitted to CEFP
+      for (int i = 0; i < fNBarrelCuts; i++) {
+        if (filter & (uint64_t(1) << i)) {
+          if (i < kNTriggersDQ) {
+            decisions[i] = true;
+          }
+        }
+      }
+      for (int i = fNBarrelCuts; i < fNBarrelCuts + fNMuonCuts; i++) {
+        if (filter & (uint64_t(1) << i)) {
+          if (i < kNTriggersDQ) {
+            decisions[i] = true;
+          }
+        }
+      }
+      // if this collision fired at least one input, add it to the map, or if it is there already, update the decisions with a logical OR
+      // This may happen in the case when some collisions beyond the iterator are added because they contain ambiguous tracks fired on by another collision
+      if (fFiltersMap.find(collision.globalIndex()) == fFiltersMap.end()) {
+        fFiltersMap[collision.globalIndex()] = filter;
+        fCEFPfilters[collision.globalIndex()] = decisions;
+      } else { // this collision was already fired, possible via collision - track association; add as an OR the new decisions
+        fFiltersMap[collision.globalIndex()] |= filter;
+        for (int i = 0; i < kNTriggersDQ; i++) {
+          if (decisions[i]) {
+            fCEFPfilters[collision.globalIndex()][i] = true;
+          }
+        }
+      }
+      // Now check through the associated tracks / fwdtracks and assign the same filter to their parent collisions
+      // This is needed since if a collision was selected because of a track association from a neighbouring collision,
+      //   then one needs to select also that collision in order to be able to redo the pairing at analysis time.
+      if (filter & barrelMask) {
+        for (auto& a : groupedTrackIndices) {
+          auto t = a.template track_as<MyBarrelTracksSelected>();
+          if (!t.has_collision()) {
+            continue;
+          }
+          auto tColl = t.collisionId();
+          if (tColl == collision.globalIndex()) { // track from this collision, nothing to do
+            continue;
+          } else {
+            if (fFiltersMap.find(tColl) == fFiltersMap.end()) {
+              fFiltersMap[tColl] = filter;
+              fCEFPfilters[tColl] = decisions;
+            } else { // this collision was already fired, possible via collision - track association; add as an OR the new decisions
+              fFiltersMap[tColl] |= filter;
+              for (int i = 0; i < kNTriggersDQ; i++) {
+                if (decisions[i]) {
+                  fCEFPfilters[tColl][i] = true;
+                }
+              }
+            }
+          }
+        }
+      }
+      // Do the same for muons
+      if (filter & muonMask) {
+        for (auto& a : groupedMuonIndices) {
+          auto t = a.template fwdtrack_as<MyMuonsSelected>();
+          if (!t.has_collision()) {
+            continue;
+          }
+          auto tColl = t.collisionId();
+          if (tColl == collision.globalIndex()) { // track from this collision, nothing to do
+            continue;
+          } else {
+            if (fFiltersMap.find(tColl) == fFiltersMap.end()) {
+              fFiltersMap[tColl] = filter;
+              fCEFPfilters[tColl] = decisions;
+            } else { // this collision was already fired, possible via collision - track association; add as an OR the new decisions
+              fFiltersMap[tColl] |= filter;
+              for (int i = 0; i < kNTriggersDQ; i++) {
+                if (decisions[i]) {
+                  fCEFPfilters[tColl][i] = true;
+                }
+              }
+            }
+          }
+        }
+      }
+      event++;
+    }
+
+    // At this point, we have all the non-null decisions for all collisions.
+    // we loop again over collisions and create the decision tables
+    // NOTE: For the CEFP decisions, decisions are placed in a vector of bool in an ordered way:
+    //       start with all configured barrel selections and then continue with those from muons
+    //       The configured order has to be in sync with that implemented in the cefp task and can be done
+    //       by preparing a dedicated json configuration file
+    int totalEventsTriggered = 0;
+    for (const auto& collision : collisions) {
+      fStats->Fill(-2.0);
+      if (!collision.isDQEventSelected()) {
+        eventFilter(0);
+        dqtable(false, false, false, false, false);
+        continue;
+      }
+      fStats->Fill(-1.0);
+
+      if (fFiltersMap.find(collision.globalIndex()) == fFiltersMap.end()) {
+        eventFilter(0);
+        dqtable(false, false, false, false, false);
+      } else {
+        totalEventsTriggered++;
+        for (int i = 0; i < fNBarrelCuts + fNMuonCuts; i++) {
+          if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i))
+            fStats->Fill(static_cast<float>(i));
+        }
+        eventFilter(fFiltersMap[collision.globalIndex()]);
+        auto dqDecisions = fCEFPfilters[collision.globalIndex()];
+        dqtable(dqDecisions[0], dqDecisions[1], dqDecisions[2], dqDecisions[3], dqDecisions[4]);
+      }
+    }
+
+    cout << "-------------------- In this TF, eventsFired / totalTriggered :: " << eventsFired << "/" << totalEventsTriggered << endl;
+  }
+
+  // TODO: dummy function for the case when no process function is enabled
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(DQFilterPPTask, processFilterPP, "Run filter task", false);
+  PROCESS_SWITCH(DQFilterPPTask, processDummy, "Dummy function", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<DQEventSelectionTask>(cfgc),
+    adaptAnalysisTask<DQBarrelTrackSelection>(cfgc),
+    adaptAnalysisTask<DQMuonsSelection>(cfgc),
+    //adaptAnalysisTask<DQTrackToCollisionAssociation>(cfgc),
+    adaptAnalysisTask<DQFilterPPTask>(cfgc)};
+}
+
+void DefineHistograms(HistogramManager* histMan, TString histClasses)
+{
+  //
+  // Define here the histograms for all the classes required in analysis.
+  //
+  std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+  for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+    TString classStr = objArray->At(iclass)->GetName();
+    histMan->AddHistClass(classStr.Data());
+
+    if (classStr.Contains("Event")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "event", "trigger,vtxPbPb");
+    }
+
+    if (classStr.Contains("Track")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "its,tpcpid,dca");
+    }
+
+    if (classStr.Contains("Muon")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "muon");
+    }
+
+    if (classStr.Contains("Pairs")) {
+      if (classStr.Contains("Barrel")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "vertexing-barrel");
+      }
+      if (classStr.Contains("Forward")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "dimuon,vertexing-forward");
+      }
+    }
+  }
+}

--- a/PWGDQ/Tasks/filterPPwithAssociation_withCommonAssociator.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation_withCommonAssociator.cxx
@@ -346,7 +346,7 @@ struct DQMuonsSelection {
 
     for (auto& muon : muons) {
       filterMap = uint32_t(0);
-      
+
       VarManager::FillTrack<TMuonFillMap>(muon);
       if (fConfigQA) {
         fHistMan->FillHistClass("Muon_BeforeCuts", VarManager::fgValues);
@@ -420,7 +420,7 @@ struct DQTrackToCollisionAssociation {
     collisionAssociatorMuon.setBcWindow(bcWindowForOneSigma);
   }
 
-  void processAssocWithTime(Collisions const& collisions, 
+  void processAssocWithTime(Collisions const& collisions,
                             MyBarrelTracksSelected const& tracksUnfiltered, soa::Filtered<MyBarrelTracksSelected> const& tracks,
                             FwdTracks const& muons,
                             AmbiguousTracks const& ambiguousTracks, AmbiguousFwdTracks const& ambiguousFwdTracks, BCs const& bcs)
@@ -596,13 +596,13 @@ struct DQFilterPPTask {
         // get the tracks from the index stored in the association
         auto t1 = a1.template track_as<TTracks>();
         auto t2 = a2.template track_as<TTracks>();
-        
+
         // check the pairing mask and that the tracks share a cut bit
         pairFilter = pairingMask & t1.isDQBarrelSelected() & t2.isDQBarrelSelected();
         if (pairFilter == 0) {
           continue;
         }
-        
+
         // keep just opposite-sign pairs
         if (!fConfigFilterLsBarrelTracksPairs) {
           if (t1.sign() * t2.sign() > 0) {
@@ -654,7 +654,7 @@ struct DQFilterPPTask {
     if (pairingMask > 0) {
       // pairing is done using the collision grouped muon associations
       for (auto& [a1, a2] : combinations(muonAssocs, muonAssocs)) {
-        
+
         // get the real muon tracks
         auto t1 = a1.template fwdtrack_as<TMuons>();
         auto t2 = a2.template fwdtrack_as<TMuons>();
@@ -884,7 +884,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<DQEventSelectionTask>(cfgc),
     adaptAnalysisTask<DQBarrelTrackSelection>(cfgc),
     adaptAnalysisTask<DQMuonsSelection>(cfgc),
-    //adaptAnalysisTask<DQTrackToCollisionAssociation>(cfgc),
+    // adaptAnalysisTask<DQTrackToCollisionAssociation>(cfgc),
     adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -100,7 +100,7 @@ using MyBarrelTracksSelected = soa::Join<aod::ReducedTracks, aod::ReducedTracksB
 using MyBarrelTracksSelectedWithPrefilter = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelPID, aod::BarrelTrackCuts, aod::Prefilter>;
 using MyBarrelTracksSelectedWithCov = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelCov, aod::ReducedTracksBarrelPID, aod::BarrelTrackCuts>;
 using MyBarrelTracksSelectedWithColl = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelPID, aod::BarrelTrackCuts, aod::ReducedTracksBarrelInfo>;
-using MyPairCandidatesSelected = soa::Join<aod::Dileptons, aod::DileptonsExtra>;
+using MyDielectronCandidates = soa::Join<aod::Dielectrons, aod::DielectronsExtra>;
 using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
 using MyMuonTracksSelected = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::MuonTrackCuts>;
 using MyMuonTracksWithCov = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsCov>;
@@ -735,8 +735,10 @@ struct AnalysisEventMixing {
 
 struct AnalysisSameEventPairing {
 
-  Produces<aod::Dileptons> dileptonList;
-  Produces<aod::DileptonsExtra> dileptonExtraList;
+  Produces<aod::Dielectrons> dielectronList;
+  Produces<aod::Dimuons> dimuonList;
+  Produces<aod::DielectronsExtra> dielectronExtraList;
+  Produces<aod::DimuonsExtra> dimuonExtraList;
   Produces<aod::DimuonsAll> dimuonAllList;
   Produces<aod::DileptonFlow> dileptonFlowList;
   Produces<aod::DileptonsInfo> dileptonInfoList;
@@ -983,8 +985,10 @@ struct AnalysisSameEventPairing {
     uint32_t twoTrackFilter = 0;
     uint32_t dileptonFilterMap = 0;
     uint32_t dileptonMcDecision = 0; // placeholder, copy of the dqEfficiency.cxx one
-    dileptonList.reserve(1);
-    dileptonExtraList.reserve(1);
+    dielectronList.reserve(1);
+    dimuonList.reserve(1);
+    dielectronExtraList.reserve(1);
+    dimuonExtraList.reserve(1);
     dileptonInfoList.reserve(1);
     if (fConfigFlatTables.value) {
       dimuonAllList.reserve(1);
@@ -1018,18 +1022,23 @@ struct AnalysisSameEventPairing {
       // TODO: provide the type of pair to the dilepton table (e.g. ee, mumu, emu...)
       dileptonFilterMap = twoTrackFilter;
 
-      dileptonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
+      if constexpr (TPairType == pairTypeEE) {
+        dielectronList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
+      }
+      if constexpr (TPairType == pairTypeMuMu) {
+        dimuonList(event, VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), dileptonFilterMap, dileptonMcDecision);
+      }
       if constexpr ((TPairType == pairTypeMuMu && ((TTrackFillMap & VarManager::ObjTypes::ReducedMuonCollInfo) > 0)) || (TPairType == pairTypeEE && ((TTrackFillMap & VarManager::ObjTypes::ReducedTrackCollInfo) > 0))) {
         dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
       }
 
       constexpr bool trackHasCov = ((TTrackFillMap & VarManager::ObjTypes::TrackCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedTrackBarrelCov) > 0);
       if constexpr ((TPairType == pairTypeEE) && trackHasCov && (TTwoProngFitter == true)) {
-        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+        dielectronExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
       }
       if constexpr ((TPairType == pairTypeMuMu) && (TTwoProngFitter == true)) {
         // LOGP(info, "mu1 collId = {}, mu2 collId = {}", t1.collisionId(), t2.collisionId());
-        dileptonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+        dimuonExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
         if (fConfigFlatTables.value) {
           dimuonAllList(event.posX(), event.posY(), event.posZ(), event.numContrib(),
                         -999., -999., -999.,
@@ -1380,7 +1389,7 @@ struct AnalysisDileptonHadron {
 
   // Template function to run pair - hadron combinations
   template <int TCandidateType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks>
-  void runDileptonHadron(TEvent const& event, TTracks const& tracks, soa::Filtered<MyPairCandidatesSelected> const& dileptons)
+  void runDileptonHadron(TEvent const& event, TTracks const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
   {
 
     // set up KF or DCAfitter
@@ -1473,15 +1482,15 @@ struct AnalysisDileptonHadron {
     }
   }
 
-  void processSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyBarrelTracksSelectedWithCov const& tracks, soa::Filtered<MyPairCandidatesSelected> const& dileptons)
+  void processSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, MyBarrelTracksSelectedWithCov const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
   {
     runDileptonHadron<VarManager::kBtoJpsiEEK, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, dileptons);
   }
 
-  Preslice<soa::Filtered<MyPairCandidatesSelected>> perEventPairs = aod::reducedpair::reducedeventId;
+  Preslice<soa::Filtered<MyDielectronCandidates>> perEventPairs = aod::reducedpair::reducedeventId;
   Preslice<soa::Filtered<MyBarrelTracksSelected>> perEventTracks = aod::reducedtrack::reducedeventId;
 
-  void processMixedEvent(soa::Filtered<MyEventsHashSelected>& events, soa::Filtered<MyPairCandidatesSelected> const& dileptons, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+  void processMixedEvent(soa::Filtered<MyEventsHashSelected>& events, soa::Filtered<MyDielectronCandidates> const& dileptons, soa::Filtered<MyBarrelTracksSelected> const& tracks)
   {
     events.bindExternalIndices(&dileptons);
     events.bindExternalIndices(&tracks);

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1,0 +1,1753 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
+//   Configurable workflow for running several DQ or other PWG analyses
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <TH1F.h>
+#include <TH3F.h>
+#include <THashList.h>
+#include <TList.h>
+#include <TString.h>
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+#include "PWGDQ/Core/VarManager.h"
+#include "PWGDQ/Core/HistogramManager.h"
+#include "PWGDQ/Core/MixingHandler.h"
+#include "PWGDQ/Core/AnalysisCut.h"
+#include "PWGDQ/Core/AnalysisCompositeCut.h"
+#include "PWGDQ/Core/HistogramsLibrary.h"
+#include "PWGDQ/Core/CutsLibrary.h"
+#include "PWGDQ/Core/MixingLibrary.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "Field/MagneticField.h"
+#include "TGeoGlobalMagField.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "Common/Core/TableHelper.h"
+
+using std::cout;
+using std::endl;
+using std::string;
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod;
+
+// Some definitions
+namespace o2::aod
+{
+namespace dqanalysisflags
+{
+DECLARE_SOA_COLUMN(MixingHash, mixingHash, int);                         //! Hash used in event mixing
+DECLARE_SOA_COLUMN(IsEventSelected, isEventSelected, int);               //! Event decision
+DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelected, isBarrelSelected, 32);       //! Barrel track decisions
+DECLARE_SOA_BITMAP_COLUMN(IsMuonSelected, isMuonSelected, 32);           //! Muon track decisions (joinable to ReducedMuonsAssoc)
+DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelectedPrefilter, isBarrelSelectedPrefilter, 32);    //! Barrel prefilter decisions (joinable to ReducedTracksAssoc)
+// Bcandidate columns for ML analysis of B->Jpsi+K
+DECLARE_SOA_COLUMN(massBcandidate, MBcandidate, float);
+DECLARE_SOA_COLUMN(pTBcandidate, PtBcandidate, float);
+DECLARE_SOA_COLUMN(LxyBcandidate, lxyBcandidate, float);
+DECLARE_SOA_COLUMN(LxyzBcandidate, lxyzBcandidate, float);
+DECLARE_SOA_COLUMN(LzBcandidate, lzBcandidate, float);
+DECLARE_SOA_COLUMN(TauxyBcandidate, tauxyBcandidate, float);
+DECLARE_SOA_COLUMN(TauzBcandidate, tauzBcandidate, float);
+DECLARE_SOA_COLUMN(CosPBcandidate, cosPBcandidate, float);
+DECLARE_SOA_COLUMN(Chi2Bcandidate, chi2Bcandidate, float);
+} // namespace dqanalysisflags
+
+DECLARE_SOA_TABLE(EventCuts, "AOD", "DQANAEVCUTS", dqanalysisflags::IsEventSelected);          //!  joinable to ReducedEvents
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "DQANAMIXHASH", dqanalysisflags::MixingHash);           //!  joinable to ReducedEvents
+DECLARE_SOA_TABLE(BarrelTrackCuts, "AOD", "DQANATRKCUTS", dqanalysisflags::IsBarrelSelected);  //!  joinable to ReducedTracksAssoc
+DECLARE_SOA_TABLE(MuonTrackCuts, "AOD", "DQANAMUONCUTS", dqanalysisflags::IsMuonSelected);     //!  joinable to ReducedMuonsAssoc
+DECLARE_SOA_TABLE(Prefilter, "AOD", "DQPREFILTER", dqanalysisflags::IsBarrelSelectedPrefilter); //!  joinable to ReducedTracksAssoc
+DECLARE_SOA_TABLE(BmesonCandidates, "AOD", "DQBMESONS", dqanalysisflags::massBcandidate, dqanalysisflags::pTBcandidate, dqanalysisflags::LxyBcandidate, dqanalysisflags::LxyzBcandidate, dqanalysisflags::LzBcandidate, dqanalysisflags::TauxyBcandidate, dqanalysisflags::TauzBcandidate, dqanalysisflags::CosPBcandidate, dqanalysisflags::Chi2Bcandidate);
+} // namespace o2::aod
+
+// Declarations of various short names
+using MyEvents = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended>;
+using MyEventsSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::EventCuts>;
+using MyEventsHashSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::EventCuts, aod::MixingHashes>;
+using MyEventsVtxCov = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsVtxCov>;
+using MyEventsVtxCovSelected = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsVtxCov, aod::EventCuts>;
+using MyEventsVtxCovSelectedQvector = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsVtxCov, aod::EventCuts, aod::ReducedEventsQvector>;
+using MyEventsQvector = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::ReducedEventsQvector>;
+using MyEventsHashSelectedQvector = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended, aod::EventCuts, aod::MixingHashes, aod::ReducedEventsQvector>;
+
+using MyBarrelTracks = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelPID>;
+using MyBarrelTracksWithCov = soa::Join<aod::ReducedTracks, aod::ReducedTracksBarrel, aod::ReducedTracksBarrelCov, aod::ReducedTracksBarrelPID>;
+using MyDielectronCandidates = soa::Join<aod::Dielectrons, aod::DielectronsExtra>;
+using MyDimuonCandidates = soa::Join<aod::Dimuons, aod::DimuonsExtra>;
+using MyMuonTracks = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
+using MyMuonTracksWithCov = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsCov>;
+using MyMuonTracksSelectedWithColl = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsInfo, aod::MuonTrackCuts>;
+
+// bit maps used for the Fill functions of the VarManager
+constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended;
+constexpr static uint32_t gkEventFillMapWithCov = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended | VarManager::ObjTypes::ReducedEventVtxCov;
+constexpr static uint32_t gkEventFillMapWithQvector = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended | VarManager::ObjTypes::ReducedEventQvector;
+constexpr static uint32_t gkEventFillMapWithCovQvector = VarManager::ObjTypes::ReducedEvent | VarManager::ObjTypes::ReducedEventExtended | VarManager::ObjTypes::ReducedEventVtxCov | VarManager::ObjTypes::ReducedEventQvector;
+constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID;
+constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelCov | VarManager::ObjTypes::ReducedTrackBarrelPID;
+constexpr static uint32_t gkTrackFillMapWithColl = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::ReducedTrackBarrel | VarManager::ObjTypes::ReducedTrackBarrelPID | VarManager::ObjTypes::ReducedTrackCollInfo;
+
+constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra;
+constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
+constexpr static uint32_t gkMuonFillMapWithColl = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCollInfo;
+
+constexpr static int pairTypeEE = VarManager::kDecayToEE;
+constexpr static int pairTypeMuMu = VarManager::kDecayToMuMu;
+constexpr static int pairTypeEMu = VarManager::kElectronMuon;
+
+// Global function used to define needed histogram classes
+void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
+
+template <typename TMap>
+void PrintBitMap(TMap map, int nbits) {
+  for (int i=0; i<nbits; i++) {
+    cout << ((map & (TMap(1) << i))>0 ? "1" : "0");
+  }
+}
+
+// Analysis task that produces event decisions and the Hash table used in event mixing
+struct AnalysisEventSelection {
+  Produces<aod::EventCuts> eventSel;
+  Produces<aod::MixingHashes> hash;
+  OutputObj<THashList> fOutputList{"output"};
+  // TODO: Provide the mixing variables and binning directly via configurables (e.g. vectors of float)
+  Configurable<string> fConfigMixingVariables{"cfgMixingVars", "", "Mixing configs separated by a comma, default no mixing"};
+  Configurable<string> fConfigEventCuts{"cfgEventCuts", "eventStandard", "Event selection"};
+  Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
+  Configurable<std::string> fConfigAddEventHistogram{"cfgAddEventHistogram", "", "Comma separated list of histograms"};
+
+  HistogramManager* fHistMan = nullptr;
+  MixingHandler* fMixHandler = nullptr;
+  AnalysisCompositeCut* fEventCut;
+
+  void init(o2::framework::InitContext&)
+  {
+    fEventCut = new AnalysisCompositeCut(true);
+    TString eventCutStr = fConfigEventCuts.value;
+    fEventCut->AddCut(dqcuts::GetAnalysisCut(eventCutStr.Data()));
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+
+    VarManager::SetDefaultVarNames();
+    if (fConfigQA) {
+      fHistMan = new HistogramManager("analysisHistos", "", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+      DefineHistograms(fHistMan, "Event_BeforeCuts;Event_AfterCuts;", fConfigAddEventHistogram.value.data()); // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                                           // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+
+    TString mixVarsString = fConfigMixingVariables.value;
+    std::unique_ptr<TObjArray> objArray(mixVarsString.Tokenize(","));
+    if (objArray->GetEntries() > 0) {
+      fMixHandler = new MixingHandler("mixingHandler", "mixing handler");
+      fMixHandler->Init();
+      for (int iVar = 0; iVar < objArray->GetEntries(); ++iVar) {
+        dqmixing::SetUpMixing(fMixHandler, objArray->At(iVar)->GetName());
+      }
+    }
+  }
+
+  template <uint32_t TEventFillMap, typename TEvent>
+  void runEventSelection(TEvent const& event)
+  {
+    // Reset the fValues array and fill event observables
+    VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
+    VarManager::FillEvent<TEventFillMap>(event);
+    
+    // if QA is requested fill histograms before event selections
+    if (fConfigQA) {
+      fHistMan->FillHistClass("Event_BeforeCuts", VarManager::fgValues); // automatically fill all the histograms in the class Event
+    }
+    if (fEventCut->IsSelected(VarManager::fgValues)) {
+      if (fConfigQA) {
+        fHistMan->FillHistClass("Event_AfterCuts", VarManager::fgValues);
+      }
+      eventSel(1);
+    } else {
+      eventSel(0);
+    }
+
+    if (fMixHandler != nullptr) {
+      int hh = fMixHandler->FindEventCategory(VarManager::fgValues);
+      hash(hh);
+    }
+  }
+
+  void processSkimmed(MyEvents::iterator const& event)
+  {
+    runEventSelection<gkEventFillMap>(event);
+  }
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisEventSelection, processSkimmed, "Run event selection on DQ skimmed events", false);
+  PROCESS_SWITCH(AnalysisEventSelection, processDummy, "Dummy function", false);
+};
+
+// Produces a table with barrel track decisions (joinable to the ReducedTracksAssociations)
+// Here one should add all the track cuts needed through the workflow (e.g. cuts for same-even pairing, electron prefiltering, track for dilepton-track correlations)
+struct AnalysisTrackSelection {
+  Produces<aod::BarrelTrackCuts> trackSel;
+  OutputObj<THashList> fOutputList{"output"};
+  
+  Configurable<string> fConfigCuts{"cfgTrackCuts", "jpsiO2MCdebugCuts2", "Comma separated list of barrel track cuts"};
+  Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
+  Configurable<string> fConfigAddTrackHistogram{"cfgAddTrackHistogram", "", "Comma separated list of histograms"};
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/i/iarsene/Calib/TPCpostCalib", "base path to the ccdb object"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<bool> fConfigComputeTPCpostCalib{"cfgTPCpostCalib", false, "If true, compute TPC post-calibrated n-sigmas"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> fConfigRunPeriods{"cfgRunPeriods", "LHC22f", "run periods for used data"};
+  Configurable<bool> fConfigDummyRunlist{"cfgDummyRunlist", false, "If true, use dummy runlist"};
+  Configurable<int> fConfigInitRunNumber{"cfgInitRunNumber", 543215, "Initial run number used in run by run checks"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  HistogramManager* fHistMan;
+  std::vector<AnalysisCompositeCut> fTrackCuts;
+  
+  int fCurrentRun;        // current run (needed to detect run changes for loading CCDB parameters)
+
+  void init(o2::framework::InitContext&)
+  {
+    fCurrentRun = 0;
+
+    TString cutNamesStr = fConfigCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+
+    if (fConfigQA) {
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+      // set one histogram directory for each defined track cut
+      TString histDirNames = "TrackBarrel_BeforeCuts;";
+      for (auto& cut : fTrackCuts) {
+        histDirNames += Form("TrackBarrel_%s;", cut.GetName());
+      }
+
+      VarManager::SetRunlist((TString)fConfigRunPeriods);
+      DefineHistograms(fHistMan, histDirNames.Data(), fConfigAddTrackHistogram.value.data()); // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                           // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+    if (fConfigDummyRunlist) {
+      VarManager::SetDummyRunlist(fConfigInitRunNumber);
+    } else {
+      VarManager::SetRunlist((TString)fConfigRunPeriods);
+    }
+    if (fConfigComputeTPCpostCalib) {
+      fCCDB->setURL(fConfigCcdbUrl.value);
+      fCCDB->setCaching(true);
+      fCCDB->setLocalObjectValidityChecking();
+      fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+    }
+  }
+
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTracks>
+  void runTrackSelection(ReducedTracksAssoc const& assocs, TEvents const& events, TTracks const& tracks)
+  {
+    if (fConfigComputeTPCpostCalib && events.size()>0 && fCurrentRun != events.begin().runNumber()) {
+      auto calibList = fCCDB->getForTimeStamp<TList>(fConfigCcdbPathTPC.value, events.begin().timestamp());
+      VarManager::SetCalibrationObject(VarManager::kTPCElectronMean, calibList->FindObject("mean_map_electron"));
+      VarManager::SetCalibrationObject(VarManager::kTPCElectronSigma, calibList->FindObject("sigma_map_electron"));
+      VarManager::SetCalibrationObject(VarManager::kTPCPionMean, calibList->FindObject("mean_map_pion"));
+      VarManager::SetCalibrationObject(VarManager::kTPCPionSigma, calibList->FindObject("sigma_map_pion"));
+      VarManager::SetCalibrationObject(VarManager::kTPCProtonMean, calibList->FindObject("mean_map_proton"));
+      VarManager::SetCalibrationObject(VarManager::kTPCProtonSigma, calibList->FindObject("sigma_map_proton"));
+
+      o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, events.begin().timestamp());
+      if (grpmag != nullptr) {
+        VarManager::SetMagneticField(grpmag->getNominalL3Field());
+      } else {
+        LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", events.begin().timestamp());
+      }
+
+      fCurrentRun = events.begin().runNumber();
+    }
+
+    trackSel.reserve(assocs.size());
+    uint32_t filterMap = 0;
+    int iCut = 0;
+
+    for (auto& assoc : assocs) {
+      auto event = assoc.template reducedevent_as<TEvents>();
+      if (!event.isEventSelected()) {
+        trackSel(0);
+        continue;
+      }
+      VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
+      // fill event information which might be needed in histograms/cuts that combine track and event properties
+      VarManager::FillEvent<TEventFillMap>(event);
+
+      auto track = assoc.template reducedtrack_as<TTracks>();
+      filterMap = 0;
+      VarManager::FillTrack<TTrackFillMap>(track);
+      // compute quantities which depend on the associated collision, such as DCA
+      VarManager::FillTrackCollision<TTrackFillMap>(track, event);
+      if (fConfigQA) {
+        fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
+      }
+      iCut = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, iCut++) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMap |= (uint32_t(1) << iCut);
+          if (fConfigQA) {
+            fHistMan->FillHistClass(Form("TrackBarrel_%s", (*cut).GetName()), VarManager::fgValues);
+          }
+        }
+      }  // end loop over cuts
+      
+      trackSel(filterMap);
+    }  // end loop over associations
+  }  // end runTrackSelection()
+
+  void processSkimmed(ReducedTracksAssoc const& assocs, MyEventsSelected const& events, MyBarrelTracks const& tracks)
+  {
+    runTrackSelection<gkEventFillMap, gkTrackFillMap>(assocs, events, tracks);
+  }
+  void processSkimmedWithCov(ReducedTracksAssoc const& assocs, MyEventsVtxCovSelected const& events, MyBarrelTracksWithCov const& tracks)
+  {
+    runTrackSelection<gkEventFillMapWithCov, gkTrackFillMapWithCov>(assocs, events, tracks);
+  }
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisTrackSelection, processSkimmed, "Run barrel track selection on DQ skimmed track associations", false);
+  PROCESS_SWITCH(AnalysisTrackSelection, processSkimmedWithCov, "Run barrel track selection on DQ skimmed tracks w/ cov matrix associations", false);
+  PROCESS_SWITCH(AnalysisTrackSelection, processDummy, "Dummy function", false);
+};
+
+// Produces a table with muon decisions (joinable to the ReducedMuonsAssociations)
+// Here one should add all the track cuts needed through the workflow (e.g. cuts for same-event pairing, track for dilepton-track correlations)
+struct AnalysisMuonSelection {
+  Produces<aod::MuonTrackCuts> muonSel;
+  OutputObj<THashList> fOutputList{"output"};
+
+  Configurable<string> fConfigCuts{"cfgMuonCuts", "muonQualityCuts", "Comma separated list of muon cuts"};
+  Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
+  Configurable<std::string> fConfigAddMuonHistogram{"cfgAddMuonHistogram", "", "Comma separated list of histograms"};
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  HistogramManager* fHistMan;
+  std::vector<AnalysisCompositeCut> fMuonCuts;
+
+  int fCurrentRun;                // current run kept to detect run changes and trigger loading params from CCDB
+  
+  void init(o2::framework::InitContext&)
+  {
+    fCurrentRun = 0;
+    TString cutNamesStr = fConfigCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fMuonCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+
+    if (fConfigQA) {
+      VarManager::SetDefaultVarNames();
+      fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+      fHistMan->SetUseDefaultVariableNames(kTRUE);
+      fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+      // set one histogram directory for each defined track cut
+      TString histDirNames = "TrackMuon_BeforeCuts;";
+      for (auto& cut : fMuonCuts) {
+        histDirNames += Form("TrackMuon_%s;", cut.GetName());
+      }
+
+      DefineHistograms(fHistMan, histDirNames.Data(), fConfigAddMuonHistogram.value.data()); // define all histograms
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                          // provide the list of required variables so that VarManager knows what to fill
+      fOutputList.setObject(fHistMan->GetMainHistogramList());
+    }
+    
+    fCCDB->setURL(fConfigCcdbUrl.value);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
+    fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+  }
+
+  template <uint32_t TEventFillMap, uint32_t TMuonFillMap, typename TEvents, typename TMuons>
+  void runMuonSelection(ReducedMuonsAssoc const& assocs, TEvents const& events, TMuons const& muons)
+  {
+    if (events.size()>0 && fCurrentRun != events.begin().runNumber()) {
+      o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, events.begin().timestamp());
+      if (grpmag != nullptr) {
+        VarManager::SetMagneticField(grpmag->getNominalL3Field());
+      } else {
+        LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", events.begin().timestamp());
+      }
+      fCurrentRun = events.begin().runNumber();
+    }
+
+    muonSel.reserve(assocs.size());
+    uint32_t filterMap = 0;
+    int iCut = 0;
+
+    for (auto& assoc : assocs) {
+      auto event = assoc.template reducedevent_as<TEvents>();
+      if (!event.isEventSelected()) {
+        muonSel(0);
+        continue;
+      }
+      VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
+      // fill event information which might be needed in histograms/cuts that combine track and event properties
+      VarManager::FillEvent<TEventFillMap>(event);
+
+      auto track = assoc.template reducedmuon_as<TMuons>();
+      filterMap = 0;
+      VarManager::FillTrack<TMuonFillMap>(track);
+      // compute quantities which depend on the associated collision
+      VarManager::FillPropagateMuon<TMuonFillMap>(track, event);
+      if (fConfigQA) {
+        fHistMan->FillHistClass("TrackMuon_BeforeCuts", VarManager::fgValues);
+      }
+      iCut = 0;
+      for (auto cut = fMuonCuts.begin(); cut != fMuonCuts.end(); cut++, iCut++) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMap |= (uint32_t(1) << iCut);
+          if (fConfigQA) {
+            fHistMan->FillHistClass(Form("TrackMuon_%s", (*cut).GetName()), VarManager::fgValues);
+          }
+        }
+      }  // end loop over cuts
+      muonSel(filterMap);
+    }  // end loop over assocs
+  }
+
+  void processSkimmed(ReducedMuonsAssoc const& assocs, MyEventsSelected const& events, MyMuonTracksWithCov const& muons)
+  {
+    runMuonSelection<gkEventFillMap, gkMuonFillMapWithCov>(assocs, events, muons);
+  }
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisMuonSelection, processSkimmed, "Run muon selection on DQ skimmed muons", false);
+  PROCESS_SWITCH(AnalysisMuonSelection, processDummy, "Dummy function", false);
+};
+
+// Run the prefilter selection (e.g. electron prefiltering for photon conversions)
+// This takes uses a sample of tracks selected with loose cuts (fConfigPrefilterTrackCut) and combines them
+//  with the sample of tracks to be used in downstream analysis (fConfigTrackCuts). If a pair is found to pass
+//  the pair prefilter cut (cfgPrefilterPairCut), the analysis track is tagged to be removed from analysis.
+struct AnalysisPrefilterSelection {
+  Produces<aod::Prefilter> prefilter;   // joinable with ReducedTracksAssoc
+  
+  // Configurables
+  Configurable<std::string> fConfigPrefilterTrackCut{"cfgPrefilterTrackCut", "", "Prefilter track cut"};
+  Configurable<std::string> fConfigPrefilterPairCut{"cfgPrefilterPairCut", "", "Prefilter pair cut"};
+  Configurable<std::string> fConfigTrackCuts{"cfgTrackCuts", "", "Track cuts for which to run the prefilter"};
+
+  std::map<uint32_t, uint32_t> fPrefilterMap;
+  AnalysisCompositeCut* fPairCut;
+  uint32_t fPrefilterMask;
+  int fPrefilterCutBit;
+
+  Preslice<aod::ReducedTracksAssoc> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
+
+  void init(o2::framework::InitContext& initContext)
+  {
+    // get the list of track cuts to be prefiltered
+    TString trackCutsStr = fConfigTrackCuts.value;
+    TObjArray* objArrayTrackCuts = nullptr;
+    if (!trackCutsStr.IsNull()) {
+      objArrayTrackCuts = trackCutsStr.Tokenize(",");
+    }
+    if (objArrayTrackCuts->GetEntries() == 0) {
+      LOG(fatal) << " No track cuts to prefilter!";
+    }
+    
+    // get the list of cuts that were computed in the barrel track-selection task and create a bit mask
+    //  to mark just the ones we want to apply a prefilter on
+    fPrefilterMask = 0;
+    fPrefilterCutBit = -1;
+    string trackCuts;
+    getTaskOptionValue<string>(initContext, "analysis-track-selection", "cfgTrackCuts", trackCuts, false);
+    TString allTrackCutsStr = trackCuts;
+    TString prefilterTrackCutStr = fConfigPrefilterTrackCut.value;
+    if (!trackCutsStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(allTrackCutsStr.Tokenize(","));
+      if (objArray->FindObject(prefilterTrackCutStr.Data()) == nullptr) {
+        LOG(fatal) << " Prefilter track cut not among the cuts calculated by the track-selection task! ";
+      }
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        TString tempStr = objArray->At(icut)->GetName();
+        if (objArrayTrackCuts->FindObject(tempStr.Data()) != nullptr) {
+          fPrefilterMask |= (uint32_t(1) << icut);
+        }
+        if (tempStr.CompareTo(fConfigPrefilterTrackCut.value) == 0) {
+          fPrefilterCutBit = icut;
+        }
+      }
+    }
+    if (fPrefilterMask == 0) {
+      LOG(fatal) << "No specified track cuts for prefiltering";
+    }
+    if (fPrefilterCutBit < 0) {
+      LOG(fatal) << "No or incorrectly specified loose track prefilter cut";
+    }
+    
+    // setup the prefilter pair cut
+    fPairCut = new AnalysisCompositeCut(true);
+    TString pairCutStr = fConfigPrefilterPairCut.value;
+    if (!pairCutStr.IsNull()) {
+      fPairCut = dqcuts::GetCompositeCut(pairCutStr.Data());
+    }
+
+    VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
+    VarManager::SetDefaultVarNames();
+
+    VarManager::SetupTwoProngDCAFitter(5.0f, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, true); // TODO: get these parameters from Configurables
+    VarManager::SetupTwoProngFwdDCAFitter(5.0f, true, 200.0f, 1.0e-3f, 0.9f, true);
+  }
+
+  template <uint32_t TTrackFillMap, typename TTracks>
+  void runPrefilter(soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, TTracks const& tracks) {
+
+    for (auto& [assoc1, assoc2] : o2::soa::combinations(assocs, assocs)) {
+      auto track1 = assoc1.template reducedtrack_as<TTracks>();
+      auto track2 = assoc2.template reducedtrack_as<TTracks>();
+      
+      // NOTE: here we restrict to just pairs of opposite sign (conversions), but in principle this can be made
+      // a configurable and check also same-sign pairs (track splitting)
+      if (track1.sign() * track2.sign() > 0) {
+        continue;
+      }
+
+      // here we check the cuts fulfilled by both tracks, for both the tight and loose selections
+      uint32_t track1Candidate = (assoc1.isBarrelSelected_raw() & fPrefilterMask);
+      uint32_t track2Candidate = (assoc2.isBarrelSelected_raw() & fPrefilterMask);
+      bool track1Loose = assoc1.isBarrelSelected_bit(fPrefilterCutBit);
+      bool track2Loose = assoc2.isBarrelSelected_bit(fPrefilterCutBit);
+      
+      if (! ((track1Candidate>0 && track2Loose) || (track2Candidate>0 && track1Loose))) {
+        continue;
+      }
+
+      // compute pair quantities
+      VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(track1, track2);
+      // if the pair fullfils the criteria, add an entry into the prefilter map for the two tracks
+      if (fPairCut->IsSelected(VarManager::fgValues)) {
+        if (fPrefilterMap.find(track1.globalIndex()) == fPrefilterMap.end() && track1Candidate>0) {
+          fPrefilterMap[track1.globalIndex()] = track1Candidate;
+        }
+        if (fPrefilterMap.find(track2.globalIndex()) == fPrefilterMap.end() && track2Candidate>0) {
+          fPrefilterMap[track2.globalIndex()] = track2Candidate;
+        }
+      }
+    }  // end loop over combinations
+  }
+
+  void processBarrelSkimmed(MyEvents const& events, soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, MyBarrelTracks const& tracks) {
+    
+    fPrefilterMap.clear();
+
+    for (auto& event : events) {
+      auto groupedAssocs = assocs.sliceBy(trackAssocsPerCollision, event.globalIndex());
+      if (groupedAssocs.size() > 1) {
+        runPrefilter<gkTrackFillMap>(groupedAssocs, tracks);
+      }
+    }
+    uint32_t mymap = -1;
+    for (auto& assoc : assocs) {
+      auto track = assoc.template reducedtrack_as<MyBarrelTracks>();
+      mymap = -1;
+      if (fPrefilterMap.find(track.globalIndex()) != fPrefilterMap.end()) {
+        // NOTE: publish the bitwise negated bits (~), so there will be zeroes for cuts that failed the prefiltering and 1 everywhere else
+        mymap = ~fPrefilterMap[track.globalIndex()];
+      }
+      prefilter(mymap);
+    }
+  }
+
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisPrefilterSelection, processBarrelSkimmed, "Run Prefilter selection on reduced tracks", false);
+  PROCESS_SWITCH(AnalysisPrefilterSelection, processDummy, "Do nothing", false);
+};
+
+// Run the same-event pairing
+// This task assumes that both legs of the resonance fulfill the same cuts (symmetric decay channel)
+//  Runs combinatorics for barrel-barrel, muon-muon and barrel-muon combinations
+// TODO: implement properly the barrel-muon combinations
+// The task implements also process functions for running event mixing
+struct AnalysisSameEventPairing {
+
+  Produces<aod::Dielectrons> dielectronList;
+  Produces<aod::Dimuons> dimuonList;
+  Produces<aod::DielectronsExtra> dielectronsExtraList;
+  Produces<aod::DimuonsExtra> dimuonsExtraList;
+  Produces<aod::DimuonsAll> dimuonAllList;
+  Produces<aod::DileptonFlow> dileptonFlowList;
+  Produces<aod::DileptonsInfo> dileptonInfoList;
+    
+  o2::base::MatLayerCylSet* fLUT = nullptr;
+  int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
+
+  OutputObj<THashList> fOutputList{"output"};
+
+  Configurable<string> fConfigTrackCuts{"cfgTrackCuts", "jpsiO2MCdebugCuts2", "Comma separated list of barrel track cuts"};
+  Configurable<string> fConfigMuonCuts{"cfgMuonCuts", "", "Comma separated list of muon cuts"};
+  Configurable<string> fConfigPairCuts{"cfgPairCuts", "", "Comma separated list of pair cuts"};
+
+  Configurable<int> fConfigMixingDepth{"cfgMixingDepth", 100, "Number of Events stored for event mixing"};
+  Configurable<std::string> fConfigAddEventMixingHistogram{"cfgAddEventMixingHistogram", "", "Comma separated list of histograms"};
+  
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<string> fConfigCcdbPath{"ccdb-path", "Users/lm", "base path to the ccdb object"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<std::string> fConfigGRPMagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<bool> fConfigUseRemoteField{"cfgUseRemoteField", false, "Chose whether to fetch the magnetic field from ccdb or set it manually"};
+  Configurable<float> fConfigMagField{"cfgMagField", 5.0f, "Manually set magnetic field"};
+
+  Configurable<std::string> fConfigAddSEPHistogram{"cfgAddSEPHistogram", "", "Comma separated list of histograms"};
+  Configurable<bool> fConfigFlatTables{"cfgFlatTables", false, "Produce a single flat tables with all relevant information of the pairs and single tracks"};
+  Configurable<bool> fConfigUseKFVertexing{"cfgUseKFVertexing", false, "Use KF Particle for secondary vertex reconstruction (DCAFitter is used by default)"};
+  Configurable<bool> fConfigUseAbsDCA{"cfgUseAbsDCA", false, "Use absolute DCA minimization instead of chi^2 minimization in secondary vertexing"};
+  Configurable<bool> fConfigPropToPCA{"cfgPropToPCA", false, "Propagate tracks to secondary vertex"};
+  Configurable<bool> fConfigCorrFullGeo{"cfgCorrFullGeo", false, "Use full geometry to correct for MCS effects in track propagation"};
+  Configurable<bool> fConfigNoCorr{"cfgNoCorrFwdProp", false, "Do not correct for MCS effects in track propagation"};
+  Configurable<std::string> fConfigLutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
+  Configurable<std::string> fConfigGeoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+  Configurable<std::string> fConfigCollisionSystem{"syst", "pp", "Collision system, pp or PbPb"};
+  Configurable<float> fConfigCenterMassEnergy{"energy", 13600, "Center of mass energy in GeV"};
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+
+  Filter filterEventSelected = aod::dqanalysisflags::isEventSelected == 1;
+  
+  HistogramManager* fHistMan;
+
+  // keep histogram class names in maps, so we don't have to buld their names in the pair loops
+  std::map<int, std::vector<TString>> fTrackHistNames;
+  std::map<int, std::vector<TString>> fMuonHistNames;
+  std::map<int, std::vector<TString>> fTrackMuonHistNames;
+  std::vector<AnalysisCompositeCut> fPairCuts;
+
+  uint32_t fTrackFilterMask;        // mask for the track cuts required in this task to be applied on the barrel cuts produced upstream
+  uint32_t fMuonFilterMask;         // mask for the muon cuts required in this task to be applied on the muon cuts produced upstream
+  int fNCutsBarrel;
+  int fNCutsMuon;
+  int fNPairCuts;
+
+  NoBinningPolicy<aod::dqanalysisflags::MixingHash> hashBin;
+
+  Preslice<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts, aod::Prefilter>> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
+  Preslice<soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts>> muonAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
+
+  void init(o2::framework::InitContext& context)
+  {
+    /*bool enableBarrelHistos = context.mOptions.get<bool>("processDecayToEESkimmed") || context.mOptions.get<bool>("processDecayToEESkimmedNoTwoProngFitter") || 
+        context.mOptions.get<bool>("processDecayToEESkimmedWithCov") || context.mOptions.get<bool>("processDecayToEESkimmedWithCovNoTwoProngFitter") || 
+        context.mOptions.get<bool>("processDecayToEEVertexingSkimmed") || context.mOptions.get<bool>("processVnDecayToEESkimmed") || 
+        context.mOptions.get<bool>("processDecayToEEPrefilterSkimmed") || context.mOptions.get<bool>("processDecayToEEPrefilterSkimmedNoTwoProngFitter") || 
+        context.mOptions.get<bool>("processDecayToEESkimmedWithColl") || context.mOptions.get<bool>("processDecayToEESkimmedWithCollNoTwoProngFitter") || 
+        context.mOptions.get<bool>("processDecayToPiPiSkimmed") || context.mOptions.get<bool>("processAllSkimmed");  */
+    bool enableBarrelHistos = context.mOptions.get<bool>("processAllSkimmed");
+    bool enableBarrelMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed");
+    /*bool enableMuonHistos = context.mOptions.get<bool>("processDecayToMuMuSkimmed") || context.mOptions.get<bool>("processDecayToMuMuVertexingSkimmed") || 
+        context.mOptions.get<bool>("processDecayToMuMuSkimmedWithColl") || context.mOptions.get<bool>("processVnDecayToMuMuSkimmed") || 
+        context.mOptions.get<bool>("processAllSkimmed");*/
+    bool enableMuonHistos = context.mOptions.get<bool>("processAllSkimmed");
+    bool enableMuonMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed");
+
+    // Keep track of all the histogram class names to avoid composing strings in the pairing loop
+    TString histNames = "";
+    std::vector<TString> names;
+
+    TString cutNamesStr = fConfigPairCuts.value;
+    if (!cutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        fPairCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+
+    // get the list of cuts for tracks/muons, check that they were played by the barrel/muon selection tasks
+    //   and make a mask for active cuts (barrel and muon selection tasks may run more cuts, needed for other analyses)
+    TString trackCutsStr = fConfigTrackCuts.value;
+    TObjArray* objArrayTrackCuts = nullptr;
+    if (!trackCutsStr.IsNull()) {
+      objArrayTrackCuts = trackCutsStr.Tokenize(",");
+    }
+    TString muonCutsStr = fConfigMuonCuts.value;
+    TObjArray* objArrayMuonCuts = nullptr;
+    if (!muonCutsStr.IsNull()) {
+      objArrayMuonCuts = muonCutsStr.Tokenize(",");
+    }
+        
+    // get the barrel track selection cuts   
+    string tempCuts;
+    getTaskOptionValue<string>(context, "analysis-track-selection", "cfgTrackCuts", tempCuts, false);
+    TString tempCutsStr = tempCuts;
+    if (!trackCutsStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(tempCutsStr.Tokenize(","));
+      fNCutsBarrel = objArray->GetEntries();
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        TString tempStr = objArray->At(icut)->GetName();
+        if (objArrayTrackCuts->FindObject(tempStr.Data()) != nullptr) {
+          fTrackFilterMask |= (uint32_t(1) << icut);
+
+          if (enableBarrelHistos) {
+            names = {
+              Form("PairsBarrelSEPM_%s", objArray->At(icut)->GetName()),
+              Form("PairsBarrelSEPP_%s", objArray->At(icut)->GetName()),
+              Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName())};
+            histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+            if (enableBarrelMixingHistos) {
+              names.push_back(Form("PairsBarrelMEPM_%s", objArray->At(icut)->GetName()));
+              names.push_back(Form("PairsBarrelMEPP_%s", objArray->At(icut)->GetName()));
+              names.push_back(Form("PairsBarrelMEMM_%s", objArray->At(icut)->GetName()));
+              histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
+            }  
+            fTrackHistNames[icut] = names;
+
+            TString cutNamesStr = fConfigPairCuts.value;
+            if (!cutNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+              fNPairCuts = objArrayPair->GetEntries();
+              for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
+                names = {
+                  Form("PairsBarrelSEPM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsBarrelSEPP_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsBarrelSEMM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName())};
+                histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+                fTrackHistNames[fNCutsBarrel+icut*fNPairCuts+iPairCut] = names;
+              } // end loop (pair cuts)
+            }   // end if (pair cuts)
+          }  // end if enableBarrelHistos
+        }
+      }
+    }
+    // get the muon track selection cuts
+    getTaskOptionValue<string>(context, "analysis-muon-selection", "cfgMuonCuts", tempCuts, false);
+    tempCutsStr = tempCuts;
+    if (!muonCutsStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(tempCutsStr.Tokenize(","));
+      fNCutsMuon = objArray->GetEntries();
+      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+        TString tempStr = objArray->At(icut)->GetName();
+        if (objArrayMuonCuts->FindObject(tempStr.Data()) != nullptr) {
+          fMuonFilterMask |= (uint32_t(1) << icut);
+
+          if (enableMuonHistos) {
+            // no pair cuts
+            names = {
+              Form("PairsMuonSEPM_%s", objArray->At(icut)->GetName()),
+              Form("PairsMuonSEPP_%s", objArray->At(icut)->GetName()),
+              Form("PairsMuonSEMM_%s", objArray->At(icut)->GetName())};
+            histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+            if (enableMuonMixingHistos) {
+              names.push_back(Form("PairsMuonMEPM_%s", objArray->At(icut)->GetName()));  
+              names.push_back(Form("PairsMuonMEPP_%s", objArray->At(icut)->GetName()));  
+              names.push_back(Form("PairsMuonMEMM_%s", objArray->At(icut)->GetName()));  
+              histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
+            }
+            fMuonHistNames[icut] = names;
+
+            TString cutNamesStr = fConfigPairCuts.value;
+            if (!cutNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+              fNPairCuts = objArrayPair->GetEntries();
+              for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
+                names = {
+                  Form("PairsMuonSEPM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsMuonSEPP_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsMuonSEMM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName())};
+                histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+                fMuonHistNames[fNCutsMuon+icut*fNCutsMuon+iPairCut] = names;
+              } // end loop (pair cuts)
+            }   // end if (pair cuts)
+          }
+        }
+      }
+    }
+    
+    fCurrentRun = 0;
+
+    fCCDB->setURL(fConfigCcdbUrl.value);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
+
+    if (fConfigNoCorr) {
+      VarManager::SetupFwdDCAFitterNoCorr();
+    } else if (fConfigCorrFullGeo || (fConfigUseKFVertexing && fConfigPropToPCA)) {
+      if (!o2::base::GeometryManager::isGeometryLoaded()) {
+        fCCDB->get<TGeoManager>(fConfigGeoPath);
+      }
+    } else {
+      fLUT = o2::base::MatLayerCylSet::rectifyPtrFromFile(fCCDB->get<o2::base::MatLayerCylSet>(fConfigLutPath));
+      VarManager::SetupMatLUTFwdDCAFitter(fLUT);
+    }
+
+    VarManager::SetDefaultVarNames();
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+    fHistMan->SetUseDefaultVariableNames(kTRUE);
+    fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    /*if (context.mOptions.get<bool>("processElectronMuonSkimmed") || context.mOptions.get<bool>("processAllSkimmed")) {
+      TString cutNamesBarrel = fConfigTrackCuts.value;
+      TString cutNamesMuon = fConfigMuonCuts.value;
+      if (!cutNamesBarrel.IsNull() && !cutNamesMuon.IsNull()) {
+        std::unique_ptr<TObjArray> objArrayBarrel(cutNamesBarrel.Tokenize(","));
+        std::unique_ptr<TObjArray> objArrayMuon(cutNamesMuon.Tokenize(","));
+        if (objArrayBarrel->GetEntries() == objArrayMuon->GetEntries()) {   // one must specify equal number of barrel and muon cuts
+          for (int icut = 0; icut < objArrayBarrel->GetEntries(); ++icut) { // loop over track cuts
+            // no pair cuts
+            names = {
+              Form("PairsEleMuSEPM_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName()),
+              Form("PairsEleMuSEPP_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName()),
+              Form("PairsEleMuSEMM_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName())};
+            histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+            fTrackMuonHistNames.push_back(names);
+
+            TString cutNamesStr = fConfigPairCuts.value;
+            if (!cutNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+              for (int iPairCut = 0; iPairCut < objArrayPair->GetEntries(); ++iPairCut) { // loop over pair cuts
+                std::vector<TString> names = {
+                  Form("PairsEleMuSEPM_%s_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsEleMuSEPP_%s_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
+                  Form("PairsEleMuSEMM_%s_%s_%s", objArrayBarrel->At(icut)->GetName(), objArrayMuon->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName())};
+                histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+                fTrackMuonHistNames.push_back(names);
+              } // end loop (pair cuts)
+            }   // end if (pair cuts)
+          }     // end loop (track cuts)
+        }       // end if (equal number of cuts)
+      }         // end if (track cuts)
+    }*/
+
+    VarManager::SetCollisionSystem((TString)fConfigCollisionSystem, fConfigCenterMassEnergy); // set collision system and center of mass energy
+
+    DefineHistograms(fHistMan, histNames.Data(), fConfigAddSEPHistogram.value.data()); // define all histograms
+    VarManager::SetUseVars(fHistMan->GetUsedVars());                      // provide the list of required variables so that VarManager knows what to fill
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+  }
+
+  void initParamsFromCCDB(uint64_t timestamp, bool withTwoProngFitter = true) {
+
+    if (fConfigUseRemoteField.value) {
+      o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(fConfigGRPMagPath, timestamp);
+      float magField = 0.0;
+      if (grpmag != nullptr) {
+        magField = grpmag->getNominalL3Field();
+      } else {
+        LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", timestamp);
+      }
+      if (withTwoProngFitter) {
+        if (fConfigUseKFVertexing.value) {
+          VarManager::SetupTwoProngKFParticle(magField);
+        } else {
+          VarManager::SetupTwoProngDCAFitter(magField, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value); // TODO: get these parameters from Configurables
+          VarManager::SetupTwoProngFwdDCAFitter(magField, true, 200.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value);
+        }
+      } else {
+        VarManager::SetupTwoProngDCAFitter(magField, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value); // needed because take in varmanager Bz from fgFitterTwoProngBarrel for PhiV calculations
+      }
+    } else {
+      if (withTwoProngFitter) {
+        if (fConfigUseKFVertexing.value) {
+          VarManager::SetupTwoProngKFParticle(fConfigMagField.value);
+        } else {
+          VarManager::SetupTwoProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value); // TODO: get these parameters from Configurables
+          VarManager::SetupTwoProngFwdDCAFitter(fConfigMagField.value, true, 200.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value);
+        }
+      } else {
+        VarManager::SetupTwoProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value); // needed because take in varmanager Bz from fgFitterTwoProngBarrel for PhiV calculations
+      }
+    }    
+  }
+
+  // Template function to run same event pairing (barrel-barrel, muon-muon, barrel-muon)
+  template <bool TTwoProngFitter, int TPairType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTrackAssocs, typename TTracks>
+  void runSameEventPairing(TEvent const& event, TTrackAssocs const& assocs, TTracks const& tracks)
+  {
+    if (fCurrentRun != event.runNumber()) {
+      initParamsFromCCDB(event.timestamp(), TTwoProngFitter);
+      fCurrentRun = event.runNumber();
+    }
+
+    TString cutNames = fConfigTrackCuts.value;
+    std::map<int, std::vector<TString>> histNames = fTrackHistNames;
+    int ncuts = fNCutsBarrel;
+    if constexpr (TPairType == pairTypeMuMu) {
+      cutNames = fConfigMuonCuts.value;
+      histNames = fMuonHistNames;
+      ncuts = fNCutsMuon;
+    }
+    /*if constexpr (TPairType == pairTypeEMu) {
+      cutNames = fConfigMuonCuts.value;
+      histNames = fTrackMuonHistNames;
+    }*/
+  
+    uint32_t twoTrackFilter = 0;
+    int sign1 = 0;
+    int sign2 = 0;
+    dielectronList.reserve(1);
+    dimuonList.reserve(1);
+    dielectronsExtraList.reserve(1);
+    dimuonsExtraList.reserve(1);
+    dileptonInfoList.reserve(1);
+    if (fConfigFlatTables.value) {
+      dimuonAllList.reserve(1);
+    }
+    constexpr bool eventHasQvector = ((TEventFillMap & VarManager::ObjTypes::ReducedEventQvector) > 0);
+    constexpr bool trackHasCov = ((TTrackFillMap & VarManager::ObjTypes::TrackCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedTrackBarrelCov) > 0);
+
+    for (auto& [a1, a2] : o2::soa::combinations(assocs, assocs)) {
+
+      if constexpr (TPairType == VarManager::kDecayToEE || TPairType == VarManager::kDecayToPiPi) {
+        twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
+        
+        if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+          continue;
+        }
+                
+        auto t1 = a1.template reducedtrack_as<TTracks>();
+        auto t2 = a2.template reducedtrack_as<TTracks>();
+        sign1 = t1.sign();
+        sign2 = t2.sign();
+
+        VarManager::FillPair<TPairType, TTrackFillMap>(t1, t2);
+        if constexpr (TTwoProngFitter) {
+          VarManager::FillPairVertexing<TPairType, TEventFillMap, TTrackFillMap>(event, t1, t2, fConfigPropToPCA);
+        }
+        if constexpr (eventHasQvector) {
+          VarManager::FillPairVn<TPairType>(t1, t2);
+        }
+        
+        dielectronList(event, VarManager::fgValues[VarManager::kMass], 
+                  VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], 
+                  t1.sign() + t2.sign(), twoTrackFilter, 0);
+        
+        if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrackCollInfo) > 0) {
+          dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
+        }
+        if constexpr (trackHasCov && TTwoProngFitter) {
+          dielectronsExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+        }
+      }
+
+      if constexpr (TPairType == VarManager::kDecayToMuMu) {
+        
+        twoTrackFilter = a1.isMuonSelected_raw() & a2.isMuonSelected_raw() & fMuonFilterMask;
+        if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+          continue;
+        }
+        
+        auto t1 = a1.template reducedmuon_as<TTracks>();
+        auto t2 = a2.template reducedmuon_as<TTracks>();
+        sign1 = t1.sign();
+        sign2 = t2.sign();
+
+        VarManager::FillPair<TPairType, TTrackFillMap>(t1, t2);
+        if constexpr (TTwoProngFitter) {
+          VarManager::FillPairVertexing<TPairType, TEventFillMap, TTrackFillMap>(event, t1, t2, fConfigPropToPCA);
+        }
+        if constexpr (eventHasQvector) {
+          VarManager::FillPairVn<TPairType>(t1, t2);
+        }
+
+        dimuonList(event, VarManager::fgValues[VarManager::kMass], 
+                  VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], 
+                  t1.sign() + t2.sign(), twoTrackFilter, 0);
+        if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedMuonCollInfo) > 0) {
+          dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
+        }
+        
+        if constexpr (TTwoProngFitter) {
+          dimuonsExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
+          if (fConfigFlatTables.value) {
+            dimuonAllList(event.posX(), event.posY(), event.posZ(), event.numContrib(),
+                        -999., -999., -999.,
+                        VarManager::fgValues[VarManager::kMass],
+                        false,
+                        VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), VarManager::fgValues[VarManager::kVertexingChi2PCA],
+                        VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingTauzErr],
+                        VarManager::fgValues[VarManager::kVertexingTauxy], VarManager::fgValues[VarManager::kVertexingTauxyErr],
+                        VarManager::fgValues[VarManager::kCosPointingAngle],
+                        VarManager::fgValues[VarManager::kPt1], VarManager::fgValues[VarManager::kEta1], VarManager::fgValues[VarManager::kPhi1], t1.sign(),
+                        VarManager::fgValues[VarManager::kPt2], VarManager::fgValues[VarManager::kEta2], VarManager::fgValues[VarManager::kPhi2], t2.sign(),
+                        t1.fwdDcaX(), t1.fwdDcaY(), t2.fwdDcaX(), t2.fwdDcaY(),
+                        0., 0.,
+                        t1.chi2MatchMCHMID(), t2.chi2MatchMCHMID(),
+                        t1.chi2MatchMCHMFT(), t2.chi2MatchMCHMFT(),
+                        t1.chi2(), t2.chi2(),
+                        -999., -999., -999., -999.,
+                        -999., -999., -999., -999.,
+                        -999., -999., -999., -999.,
+                        -999., -999., -999., -999.,
+                        t1.isAmbiguous(), t2.isAmbiguous(),
+                        VarManager::fgValues[VarManager::kU2Q2], VarManager::fgValues[VarManager::kU3Q3],
+                        VarManager::fgValues[VarManager::kCos2DeltaPhi], VarManager::fgValues[VarManager::kCos3DeltaPhi]);
+          }
+        }
+      }
+      // TODO: the model for the electron-muon combination has to be thought through
+      /*if constexpr (TPairType == VarManager::kElectronMuon) {
+        twoTrackFilter = a1.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isMuonSelected_raw() & fTwoTrackFilterMask;
+      }*/
+      
+      if constexpr (eventHasQvector) {
+        dileptonFlowList(VarManager::fgValues[VarManager::kU2Q2], VarManager::fgValues[VarManager::kU3Q3], VarManager::fgValues[VarManager::kCos2DeltaPhi], VarManager::fgValues[VarManager::kCos3DeltaPhi]);
+      }
+      
+      // Fill histograms
+      for (int icut = 0; icut < ncuts; icut++) {
+        if (twoTrackFilter & (uint32_t(1) << icut)) {
+          if (sign1*sign2 < 0) {
+            fHistMan->FillHistClass(histNames[icut][0].Data(), VarManager::fgValues);
+          } else {
+            if (sign1 > 0) {
+              fHistMan->FillHistClass(histNames[icut][1].Data(), VarManager::fgValues);
+            } else {
+              fHistMan->FillHistClass(histNames[icut][2].Data(), VarManager::fgValues);
+            }
+          }
+          for (unsigned int iPairCut = 0; iPairCut < fPairCuts.size(); iPairCut++) {
+            AnalysisCompositeCut cut = fPairCuts.at(iPairCut);
+            if (!(cut.IsSelected(VarManager::fgValues))) // apply pair cuts
+              continue;
+            if (sign1*sign2 < 0) {
+              fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][0].Data(), VarManager::fgValues);
+            } else {
+              if (sign1 > 0) {
+                fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][1].Data(), VarManager::fgValues);
+              } else {
+                fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][2].Data(), VarManager::fgValues);
+              }
+            }
+          }      // end loop (pair cuts)
+        }
+      } // end loop (cuts)
+    }   // end loop over pairs of track associations
+  }
+
+  template <int TPairType, uint32_t TEventFillMap, typename TAssoc1, typename TAssoc2, typename TTracks1, typename TTracks2>
+  void runMixedPairing(TAssoc1 const& assocs1, TAssoc2 const& assocs2, TTracks1 const& tracks1, TTracks2 const& tracks2)
+  {
+    std::map<int, std::vector<TString>> histNames = fTrackHistNames;
+    int pairSign = 0;
+    int ncuts = 0;
+    uint32_t twoTrackFilter = 0;
+    for (auto& a1 : assocs1) {
+      for (auto& a2 : assocs2) {
+        if constexpr (TPairType == VarManager::kDecayToEE) {
+          twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
+          if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+            continue;
+          }
+          auto t1 = a1.template reducedtrack_as<TTracks1>();
+          auto t2 = a1.template reducedtrack_as<TTracks2>();
+          VarManager::FillPairME<TPairType>(t1, t2);
+          if constexpr ((TEventFillMap & VarManager::ObjTypes::ReducedEventQvector) > 0) {
+            VarManager::FillPairVn<TPairType>(t1, t2);
+          }
+          pairSign = t1.sign() + t2.sign();
+          ncuts = fNCutsBarrel;
+        }
+        if constexpr (TPairType == VarManager::kDecayToMuMu) {
+          twoTrackFilter = a1.isMuonSelected_raw() & a2.isMuonSelected_raw() & fMuonFilterMask;
+          if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+            continue;
+          }
+          auto t1 = a1.template reducedmuon_as<TTracks1>();
+          auto t2 = a1.template reducedmuon_as<TTracks2>();
+          VarManager::FillPairME<TPairType>(t1, t2);
+          if constexpr ((TEventFillMap & VarManager::ObjTypes::ReducedEventQvector) > 0) {
+            VarManager::FillPairVn<TPairType>(t1, t2);
+          }
+          ncuts = fNCutsMuon;
+          histNames = fMuonHistNames;
+        }
+        /*if constexpr (TPairType == VarManager::kElectronMuon) {
+          twoTrackFilter = a1.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isMuonSelected_raw() & fTrackFilterMask;
+        }*/
+
+        for (unsigned int icut = 0; icut < ncuts; icut++) {
+          if (!(twoTrackFilter & (uint32_t(1) << icut))) {
+            continue;        // cut not passed
+          }
+          if (pairSign == 0) {
+            fHistMan->FillHistClass(histNames[icut][3].Data(), VarManager::fgValues);
+          } else {
+            if (pairSign > 0) {
+              fHistMan->FillHistClass(histNames[icut][4].Data(), VarManager::fgValues);
+            } else {
+              fHistMan->FillHistClass(histNames[icut][5].Data(), VarManager::fgValues);
+            }
+          }
+        }   // end for (cuts)
+      }     // end for (track2)
+    }       // end for (track1)
+  }
+
+  // barrel-barrel and muon-muon event mixing
+  template <int TPairType, uint32_t TEventFillMap, typename TEvents, typename TAssocs, typename TTracks>
+  void runSameSideMixing(TEvents& events, TAssocs const& assocs, TTracks const& tracks, Preslice<TAssocs>& preSlice)
+  {
+    events.bindExternalIndices(&assocs);
+    int mixingDepth = fConfigMixingDepth.value;
+    for (auto& [event1, event2] : selfCombinations(hashBin, mixingDepth, -1, events, events)) {
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<TEventFillMap>(event1, VarManager::fgValues);
+
+      auto assocs1 = assocs.sliceBy(preSlice, event1.globalIndex());
+      assocs1.bindExternalIndices(&events);
+
+      auto assocs2 = assocs.sliceBy(preSlice, event2.globalIndex());
+      assocs2.bindExternalIndices(&events);
+
+      runMixedPairing<TPairType, TEventFillMap>(assocs1, assocs2, tracks, tracks);
+    } // end event loop
+  }
+
+  void processAllSkimmed(MyEventsVtxCovSelected const& events,
+                         soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts, aod::Prefilter> const& barrelAssocs, MyBarrelTracksWithCov const& barrelTracks,
+                         soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts> const& muonAssocs, MyMuonTracksWithCov const& muons)
+  {
+    for (auto& event : events) {
+      if (event.isEventSelected()==0) {
+        continue;
+      }
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+
+      auto groupedBarrelAssocs = barrelAssocs.sliceBy(trackAssocsPerCollision, event.globalIndex());
+      auto groupedMuonAssocs = muonAssocs.sliceBy(muonAssocsPerCollision, event.globalIndex());
+
+      if (groupedBarrelAssocs.size()>0) {
+        runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithCov>(event, groupedBarrelAssocs, barrelTracks);
+      }
+      if (groupedMuonAssocs.size()>0) {
+        runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMapWithCov>(event, groupedMuonAssocs, muons);
+      }
+      //runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+    }
+  }
+
+  void processMixingAllSkimmed(soa::Filtered<MyEventsHashSelected>& events, 
+                               soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts, aod::Prefilter> const& trackAssocs, MyBarrelTracksWithCov const& tracks,
+                               soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts> const& muonAssocs, MyMuonTracksWithCov const& muons)
+  {
+    runSameSideMixing<pairTypeEE, gkEventFillMap>(events, trackAssocs, tracks, trackAssocsPerCollision);
+    runSameSideMixing<pairTypeMuMu, gkEventFillMap>(events, muonAssocs, muons, muonAssocsPerCollision);
+  }
+
+/*
+  void processDecayToEESkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processDecayToEESkimmedNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processDecayToEESkimmedWithCov(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+  }
+  void processDecayToEESkimmedWithCovNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
+    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+  }
+  void processDecayToEEVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+  }
+  void processDecayToEEPrefilterSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processDecayToEEPrefilterSkimmedNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processDecayToEESkimmedWithColl(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
+  }
+  void processDecayToEESkimmedWithCollNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
+  }
+  void processDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
+  }
+  void processDecayToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithCov> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCov, gkMuonFillMapWithCov>(event, muons, muons);
+  }
+  void processDecayToMuMuSkimmedWithColl(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithColl> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMapWithColl>(event, muons, muons);
+  }
+  void processVnDecayToEESkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCovQvector, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processVnDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCovQvector, gkMuonFillMap>(event, muons, muons);
+  }
+  void processElectronMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+  }
+  void processDecayToPiPiSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToPiPi, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+  }
+  void processAllSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
+  {
+    // Reset the fValues array
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
+    runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+  }
+  */
+  // TODO: dummy function for the case when no process function is enabled
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisSameEventPairing, processAllSkimmed, "Run all types of pairing, with skimmed tracks/muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processMixingAllSkimmed, "Run all types of mixed pairing, with skimmed tracks/muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDummy, "Dummy function, enabled only if none of the others are enabled", false);
+/*
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks but no two prong fitter", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCov, "Run electron-electron pairing, with skimmed covariant tracks", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCovNoTwoProngFitter, "Run electron-electron pairing, with skimmed covariant tracks but no two prong fitter", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEVertexingSkimmed, "Run electron-electron pairing and vertexing, with skimmed electrons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmed, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection but no two prong fitter", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithColl, "Run electron-electron pairing, with skimmed tracks and with collision information", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCollNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and with collision information but no two prong fitter", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuVertexingSkimmed, "Run muon-muon pairing and vertexing, with skimmed muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmedWithColl, "Run muon-muon pairing keeping the info of AO2D collision, with skimmed muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks for vn", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed tracks for vn", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processElectronMuonSkimmed, "Run electron-muon pairing, with skimmed tracks/muons", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToPiPiSkimmed, "Run pion-pion pairing, with skimmed tracks", false);
+  PROCESS_SWITCH(AnalysisSameEventPairing, processAllSkimmed, "Run all types of pairing, with skimmed tracks/muons", false);
+  
+  */
+};
+
+// Combines dileptons with barrel or muon tracks for either resonance or correlation analyses
+// Dileptons produced with all the selection cuts specified in the same-event pairing task are combined with the 
+//   tracks passing the fConfigTrackCut cut. The dileptons cuts from the same-event pairing task are auto-detected
+struct AnalysisDileptonTrack {
+  Produces<aod::BmesonCandidates> BmesonsTable;
+  OutputObj<THashList> fOutputList{"output"};
+  
+  Configurable<string> fConfigTrackCut{"cfgTrackCut", "kaonPID", "Cut for the track to be correlated with the dileptons"};
+  Configurable<float> fConfigDileptonLowMass{"cfgDileptonLowMass", 2.8, "Low mass cut for the dileptons used in analysis"};
+  Configurable<float> fConfigDileptonHighMass{"cfgDileptonHighMass", 3.2, "High mass cut for the dileptons used in analysis"};
+  Configurable<float> fConfigDileptonpTCut{"cfgDileptonpTCut", 0.0, "pT cut for dileptons used in the triplet vertexing"};
+  Configurable<bool> fConfigUseKFVertexing{"cfgUseKFVertexing", false, "Use KF Particle for secondary vertex reconstruction (DCAFitter is used by default)"};
+
+  Configurable<std::string> fConfigHistogramSubgroups{"cfgDileptonTrackHistogramsSubgroups", "invmass,vertexing", "Comma separated list of dilepton-track histogram subgroups"};
+  Configurable<int> fConfigMixingDepth{"cfgMixingDepth", 5, "Event mixing pool depth"};
+
+  Configurable<bool> fConfigUseRemoteField{"cfgUseRemoteField", false, "Chose whether to fetch the magnetic field from ccdb or set it manually"};
+  Configurable<std::string> fConfigGRPmagPath{"cfgGrpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<float> fConfigMagField{"cfgMagField", 5.0f, "Manually set magnetic field"};
+
+  int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
+  int fNCuts;
+  int fTrackCutBit;
+  std::map<int, TString> fHistNamesDileptonTrack;
+  std::map<int, TString> fHistNamesDileptons;
+  std::map<int, TString> fHistNamesME;
+
+  Service<o2::ccdb::BasicCCDBManager> fCCDB;
+  
+  // TODO: The filter expressions seem to always use the default value of configurables, not the values from the actual configuration file
+  Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
+  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonpTCut.value && aod::reducedpair::mass > fConfigDileptonLowMass.value && aod::reducedpair::mass < fConfigDileptonHighMass.value && aod::reducedpair::sign == 0;
+  Filter filterBarrel = aod::dqanalysisflags::isBarrelSelected > uint32_t(0);
+  Filter filterMuon = aod::dqanalysisflags::isMuonSelected > uint32_t(0);
+
+  constexpr static uint32_t fgDileptonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::Pair; // fill map
+
+  // use two values array to avoid mixing up the quantities
+  float* fValuesDilepton;
+  float* fValuesHadron;
+  HistogramManager* fHistMan;
+
+  NoBinningPolicy<aod::dqanalysisflags::MixingHash> fHashBin;
+
+  void init(o2::framework::InitContext& context)
+  {
+    fCurrentRun = 0;
+    fValuesDilepton = new float[VarManager::kNVars];
+    fValuesHadron = new float[VarManager::kNVars];
+    fTrackCutBit = -1;
+    VarManager::SetDefaultVarNames();
+    fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
+    fHistMan->SetUseDefaultVariableNames(kTRUE);
+    fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    // For each track/muon selection used to produce dileptons, create a separate histogram directory using the
+    // name of the track/muon cut.
+    // Also, create a map which will hold the name of the histogram directories so they can be accessed directly in the pairing loop
+    bool isBarrel = context.mOptions.get<bool>("processBarrelSkimmed");
+    bool isBarrelME = context.mOptions.get<bool>("processBarrelMixedEvent");
+    bool isMuon = context.mOptions.get<bool>("processMuonSkimmed");
+    bool isMuonME = context.mOptions.get<bool>("processMuonMixedEvent");
+    if (isBarrel || isMuon) {
+      // get the list of single track and muon cuts computed in the dedicated tasks upstream
+      string tempCutsSingle;
+      if (isBarrel) {
+        getTaskOptionValue<string>(context, "analysis-track-selection", "cfgTrackCuts", tempCutsSingle, false);
+      } else {
+        getTaskOptionValue<string>(context, "analysis-muon-selection", "cfgMuonCuts", tempCutsSingle, false);
+      }
+      TString tempCutsSingleStr = tempCutsSingle;
+      TObjArray* objArraySingleCuts = nullptr;
+      if (!tempCutsSingleStr.IsNull()) {
+        objArraySingleCuts = tempCutsSingleStr.Tokenize(",");
+      }
+      if (objArraySingleCuts->FindObject(fConfigTrackCut.value.data()) == nullptr) {
+        LOG(fatal) << " Track cut chosen for the correlation task was not computed in the single-track task! Check it out!";
+      }
+      // get the cuts employed for same-event pairing
+      string tempCutsPair;
+      if (isBarrel) {
+        getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgTrackCuts", tempCutsPair, false);
+      } else {
+        getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgMuonCuts", tempCutsPair, false);
+      }
+      TString tempCutsPairStr = tempCutsPair;
+      if (!tempCutsSingleStr.IsNull() && !tempCutsPairStr.IsNull()) {
+        std::unique_ptr<TObjArray> objArray(tempCutsPairStr.Tokenize(","));
+        fNCuts = objArray->GetEntries();
+        for (int icut = 0; icut < objArraySingleCuts->GetEntries(); ++icut) {
+          TString tempStr = objArraySingleCuts->At(icut)->GetName();
+          if (objArray->FindObject(tempStr.Data()) != nullptr) {
+            fHistNamesDileptonTrack[icut] = Form("DileptonTrack_%s_%s", tempStr.Data(), fConfigTrackCut.value.data());
+            fHistNamesDileptons[icut] = Form("DileptonsSelected_%s", tempStr.Data());
+            DefineHistograms(fHistMan, fHistNamesDileptonTrack[icut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
+            DefineHistograms(fHistMan, fHistNamesDileptons[icut], "empty"); // define dilepton histograms
+            if (isBarrelME || isMuonME) {
+              fHistNamesME[icut] = Form("DileptonTrackME_%s", tempStr.Data());
+              DefineHistograms(fHistMan, fHistNamesME[icut], "mixedevent"); // define ME histograms
+            }
+          }
+          if (tempStr.CompareTo(fConfigTrackCut.value.data()) == 0) {
+            fTrackCutBit = icut;                                       // the bit correspoding to the track to be combined with dileptons
+          }
+        }
+      }
+    }
+    if (fHistNamesDileptons.size() == 0) {
+      LOG(fatal) << " No valid dilepton cuts "; 
+    }
+
+    if (context.mOptions.get<bool>("processBarrelMixedEvent")) {
+      DefineHistograms(fHistMan, "DileptonTrackME", "mixedevent"); // define all histograms
+    }
+
+    VarManager::SetUseVars(fHistMan->GetUsedVars());
+    fOutputList.setObject(fHistMan->GetMainHistogramList());
+  }
+
+  // init parameters from CCDB
+  void initParamsFromCCDB(uint64_t timestamp) {
+    if (fConfigUseRemoteField.value) {
+      o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(fConfigGRPmagPath.value, timestamp);
+      float magField = 0.0;
+      if (grpmag != nullptr) {
+        magField = grpmag->getNominalL3Field();
+      } else {
+        LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", timestamp);
+      }
+      if (fConfigUseKFVertexing.value) {
+        VarManager::SetupThreeProngKFParticle(magField);
+      } else {
+        VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+      }
+    } else {
+      if (fConfigUseKFVertexing.value) {
+        VarManager::SetupThreeProngKFParticle(fConfigMagField.value);
+      } else {
+        VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+      }
+    }
+  }
+
+  // Template function to run pair - hadron combinations
+  template <int TCandidateType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks, typename TTrackAssocs, typename TDileptons>
+  void runDileptonHadron(TEvent const& event, TTrackAssocs const& assocs, TTracks const& tracks, TDileptons const& dileptons)
+  {
+    VarManager::ResetValues(0, VarManager::kNVars, fValuesHadron);
+    VarManager::ResetValues(0, VarManager::kNVars, fValuesDilepton);
+    VarManager::FillEvent<TEventFillMap>(event, fValuesHadron);
+    VarManager::FillEvent<TEventFillMap>(event, fValuesDilepton);
+
+    for (auto dilepton : dileptons) {
+      // get full track info of tracks based on the index
+      auto lepton1 = tracks.rawIteratorAt(dilepton.index0Id());
+      auto lepton2 = tracks.rawIteratorAt(dilepton.index1Id());
+      // Check that the dilepton has zero charge
+      if (dilepton.sign() != 0) {
+        continue;
+      }
+
+      VarManager::FillTrack<fgDileptonFillMap>(dilepton, fValuesDilepton);
+      for (int icut = 0; icut<fNCuts; icut++) {
+        if (dilepton.filterMap_bit(icut)) {
+          fHistMan->FillHistClass(fHistNamesDileptons[icut].Data(), fValuesDilepton);
+        }
+      }
+
+      // loop over hadrons
+      for (auto& assoc : assocs) {
+        if constexpr (TCandidateType == VarManager::kBtoJpsiEEK) {
+          if (!assoc.isBarrelSelected_bit(fTrackCutBit)) {
+            continue;
+          }
+          auto track = assoc.template reducedtrack_as<TTracks>();
+          if (track.globalIndex() == dilepton.index0Id() || track.globalIndex() == dilepton.index1Id()) {
+            continue;
+          }
+          VarManager::FillDileptonHadron(dilepton, track, fValuesHadron);
+          VarManager::FillDileptonTrackVertexing<TCandidateType, TEventFillMap, TTrackFillMap>(event, lepton1, lepton2, track, fValuesHadron);
+        }
+        if constexpr (TCandidateType == VarManager::kBcToThreeMuons) {
+          if (!assoc.isMuonSelected_bit(fTrackCutBit)) {
+            continue;
+          }
+          auto track = assoc.template reducedmuon_as<TTracks>();
+          if (track.globalIndex() == dilepton.index0Id() || track.globalIndex() == dilepton.index1Id()) {
+            continue;
+          }
+          
+          VarManager::FillDileptonHadron(dilepton, track, fValuesHadron);
+          VarManager::FillDileptonTrackVertexing<TCandidateType, TEventFillMap, TTrackFillMap>(event, lepton1, lepton2, track, fValuesHadron);
+        }
+        
+        for (int icut = 0; icut<fNCuts; icut++) {
+          if (dilepton.filterMap_bit(icut)) {
+            fHistMan->FillHistClass(fHistNamesDileptonTrack[icut].Data(), fValuesHadron);
+          }
+        }
+        // table to be written out for ML analysis
+        BmesonsTable(fValuesHadron[VarManager::kPairMass], fValuesHadron[VarManager::kPairPt], fValuesHadron[VarManager::kVertexingLxy], fValuesHadron[VarManager::kVertexingLxyz], fValuesHadron[VarManager::kVertexingLz], fValuesHadron[VarManager::kVertexingTauxy], fValuesHadron[VarManager::kVertexingTauz], fValuesHadron[VarManager::kCosPointingAngle], fValuesHadron[VarManager::kVertexingChi2PCA]);
+      }
+    }
+  }
+
+  Preslice<aod::ReducedTracksAssoc> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
+  Preslice<MyDielectronCandidates> dielectronsPerCollision = aod::reducedpair::reducedeventId;
+  
+  void processBarrelSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events, 
+                            soa::Filtered<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> const& assocs,
+                            MyBarrelTracksWithCov const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
+  {
+    // set up KF or DCAfitter
+    if (events.size() == 0) {
+      return;
+    }
+    if (fCurrentRun != events.begin().runNumber()) { // start: runNumber
+      initParamsFromCCDB(events.begin().timestamp());
+      fCurrentRun = events.begin().runNumber();
+    } // end: runNumber
+    for (auto& event : events) {
+      auto groupedBarrelAssocs = assocs.sliceBy(trackAssocsPerCollision, event.globalIndex());
+      auto groupedDielectrons = dileptons.sliceBy(dielectronsPerCollision, event.globalIndex());
+      runDileptonHadron<VarManager::kBtoJpsiEEK, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, groupedBarrelAssocs, tracks, groupedDielectrons);
+    }
+  }
+
+  Preslice<aod::ReducedMuonsAssoc> muonAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
+  Preslice<MyDimuonCandidates> dimuonsPerCollision = aod::reducedpair::reducedeventId;
+
+  void processMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events, 
+                          soa::Filtered<soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts>> const& assocs,
+                          MyMuonTracksWithCov const& tracks, soa::Filtered<MyDimuonCandidates> const& dileptons)
+  {
+    // set up KF or DCAfitter
+    if (events.size() == 0) {
+      return;
+    }
+    if (fCurrentRun != events.begin().runNumber()) { // start: runNumber
+      initParamsFromCCDB(events.begin().timestamp());
+      fCurrentRun = events.begin().runNumber();
+    } // end: runNumber
+    for (auto& event : events) {
+      auto groupedMuonAssocs = assocs.sliceBy(muonAssocsPerCollision, event.globalIndex());
+      auto groupedDimuons = dileptons.sliceBy(dimuonsPerCollision, event.globalIndex());
+      runDileptonHadron<VarManager::kBcToThreeMuons, gkEventFillMapWithCov, gkMuonFillMapWithCov>(event, groupedMuonAssocs, tracks, groupedDimuons);
+    }
+  }
+
+  void processBarrelMixedEvent(soa::Filtered<MyEventsHashSelected>& events, 
+                               soa::Filtered<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> const& assocs,
+                               MyBarrelTracksWithCov const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
+  {
+    if (events.size() == 0) {
+      return;
+    }
+    events.bindExternalIndices(&dileptons);
+    events.bindExternalIndices(&assocs);
+
+    for (auto& [event1, event2] : selfCombinations(fHashBin, fConfigMixingDepth.value, -1, events, events)) {
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event1, VarManager::fgValues);
+
+      auto evDileptons = dileptons.sliceBy(dielectronsPerCollision, event1.globalIndex());
+      evDileptons.bindExternalIndices(&events);
+
+      auto evAssocs = assocs.sliceBy(trackAssocsPerCollision, event2.globalIndex());
+      evAssocs.bindExternalIndices(&events);
+
+      for (auto& assoc : evAssocs) {
+        if (!assoc.isBarrelSelected_bit(fTrackCutBit)) {
+          continue;
+        }
+        auto track = assoc.template reducedtrack_as<MyBarrelTracksWithCov>();
+
+        for (auto dilepton : evDileptons) {
+          VarManager::FillDileptonHadron(dilepton, track, VarManager::fgValues);
+          for (int icut=0; icut<fNCuts; icut++) {
+            if (dilepton.filterMap_bit(icut)) {
+              fHistMan->FillHistClass(fHistNamesME[icut].Data(), VarManager::fgValues);
+            }
+          }
+        } // end for (dileptons)
+      }   // end for (assocs)
+    } // end event loop
+  }
+
+  void processMuonMixedEvent(soa::Filtered<MyEventsHashSelected>& events, 
+                             soa::Filtered<soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts>> const& assocs,
+                             MyMuonTracksWithCov const& tracks, soa::Filtered<MyDimuonCandidates> const& dileptons)
+  {
+    if (events.size() == 0) {
+      return;
+    }
+    events.bindExternalIndices(&dileptons);
+    events.bindExternalIndices(&assocs);
+
+    for (auto& [event1, event2] : selfCombinations(fHashBin, fConfigMixingDepth.value, -1, events, events)) {
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event1, VarManager::fgValues);
+
+      auto evDileptons = dileptons.sliceBy(dimuonsPerCollision, event1.globalIndex());
+      evDileptons.bindExternalIndices(&events);
+
+      auto evAssocs = assocs.sliceBy(muonAssocsPerCollision, event2.globalIndex());
+      evAssocs.bindExternalIndices(&events);
+
+      for (auto& assoc : evAssocs) {
+        
+        if (!assoc.isMuonSelected_bit(fTrackCutBit)) {
+          continue;
+        }
+        auto track = assoc.template reducedmuon_as<MyMuonTracksWithCov>();
+        
+        for (auto dilepton : evDileptons) {
+          VarManager::FillDileptonHadron(dilepton, track, VarManager::fgValues);
+          for (int icut=0; icut<fNCuts; icut++) {
+            if (dilepton.filterMap_bit(icut)) {
+              fHistMan->FillHistClass(fHistNamesME[icut].Data(), VarManager::fgValues);
+            }
+          }
+        } // end for (dileptons)
+      }   // end for (assocs)
+    } // end event loop
+  }
+
+  void processDummy(MyEvents&)
+  {
+    // do nothing
+  }
+
+  PROCESS_SWITCH(AnalysisDileptonTrack, processBarrelSkimmed, "Run barrel dilepton-track pairing, using skimmed data", false);
+  PROCESS_SWITCH(AnalysisDileptonTrack, processMuonSkimmed, "Run muon dilepton-track pairing, using skimmed data", false);
+  PROCESS_SWITCH(AnalysisDileptonTrack, processBarrelMixedEvent, "Run barrel dilepton-hadron mixed event pairing", false);
+  PROCESS_SWITCH(AnalysisDileptonTrack, processMuonMixedEvent, "Run muon dilepton-hadron mixed event pairing", false);
+  PROCESS_SWITCH(AnalysisDileptonTrack, processDummy, "Dummy function", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<AnalysisEventSelection>(cfgc),
+    adaptAnalysisTask<AnalysisTrackSelection>(cfgc),
+    adaptAnalysisTask<AnalysisMuonSelection>(cfgc),
+    adaptAnalysisTask<AnalysisPrefilterSelection>(cfgc),
+    adaptAnalysisTask<AnalysisSameEventPairing>(cfgc),
+    adaptAnalysisTask<AnalysisDileptonTrack>(cfgc)
+  };
+}
+
+void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)
+{
+  //
+  // Define here the histograms for all the classes required in analysis.
+  //  The histogram classes are provided in the histClasses string, separated by semicolon ";"
+  //  The histogram classes and their components histograms are defined below depending on the name of the histogram class
+  //
+  std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
+  for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {
+    TString classStr = objArray->At(iclass)->GetName();
+    histMan->AddHistClass(classStr.Data());
+
+    TString histName = histGroups;
+    // NOTE: The level of detail for histogramming can be controlled via configurables
+    if (classStr.Contains("Event")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "event", histName);
+    }
+
+    if (classStr.Contains("Track") && !classStr.Contains("Pairs")) {
+      if (classStr.Contains("Barrel")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+        if (classStr.Contains("PIDCalibElectron")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_electron");
+        }
+        if (classStr.Contains("PIDCalibPion")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_pion");
+        }
+        if (classStr.Contains("PIDCalibProton")) {
+          dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "postcalib_proton");
+        }
+      }
+      if (classStr.Contains("Muon")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+      }
+    }
+
+    if (classStr.Contains("Pairs")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", histName);
+    }
+
+    if (classStr.Contains("DileptonsSelected")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "barrel");
+    }
+
+    if (classStr.Contains("DileptonTrack") && !classStr.Contains("ME")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-track", histName);
+    }
+
+    if (classStr.Contains("DileptonTrackME")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-track", "mixedevent");
+    }
+
+    if (classStr.Contains("HadronsSelected")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", histName);
+    }
+
+    if (classStr.Contains("DileptonHadronInvMass")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-mass");
+    }
+
+    if (classStr.Contains("DileptonHadronCorrelation")) {
+      dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "dilepton-hadron-correlation");
+    }
+  } // end loop over histogram classes
+}

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -56,11 +56,11 @@ namespace o2::aod
 {
 namespace dqanalysisflags
 {
-DECLARE_SOA_COLUMN(MixingHash, mixingHash, int);                         //! Hash used in event mixing
-DECLARE_SOA_COLUMN(IsEventSelected, isEventSelected, int);               //! Event decision
-DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelected, isBarrelSelected, 32);       //! Barrel track decisions
-DECLARE_SOA_BITMAP_COLUMN(IsMuonSelected, isMuonSelected, 32);           //! Muon track decisions (joinable to ReducedMuonsAssoc)
-DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelectedPrefilter, isBarrelSelectedPrefilter, 32);    //! Barrel prefilter decisions (joinable to ReducedTracksAssoc)
+DECLARE_SOA_COLUMN(MixingHash, mixingHash, int);                                     //! Hash used in event mixing
+DECLARE_SOA_COLUMN(IsEventSelected, isEventSelected, int);                           //! Event decision
+DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelected, isBarrelSelected, 32);                   //! Barrel track decisions
+DECLARE_SOA_BITMAP_COLUMN(IsMuonSelected, isMuonSelected, 32);                       //! Muon track decisions (joinable to ReducedMuonsAssoc)
+DECLARE_SOA_BITMAP_COLUMN(IsBarrelSelectedPrefilter, isBarrelSelectedPrefilter, 32); //! Barrel prefilter decisions (joinable to ReducedTracksAssoc)
 // Bcandidate columns for ML analysis of B->Jpsi+K
 DECLARE_SOA_COLUMN(massBcandidate, MBcandidate, float);
 DECLARE_SOA_COLUMN(pTBcandidate, PtBcandidate, float);
@@ -73,10 +73,10 @@ DECLARE_SOA_COLUMN(CosPBcandidate, cosPBcandidate, float);
 DECLARE_SOA_COLUMN(Chi2Bcandidate, chi2Bcandidate, float);
 } // namespace dqanalysisflags
 
-DECLARE_SOA_TABLE(EventCuts, "AOD", "DQANAEVCUTS", dqanalysisflags::IsEventSelected);          //!  joinable to ReducedEvents
-DECLARE_SOA_TABLE(MixingHashes, "AOD", "DQANAMIXHASH", dqanalysisflags::MixingHash);           //!  joinable to ReducedEvents
-DECLARE_SOA_TABLE(BarrelTrackCuts, "AOD", "DQANATRKCUTS", dqanalysisflags::IsBarrelSelected);  //!  joinable to ReducedTracksAssoc
-DECLARE_SOA_TABLE(MuonTrackCuts, "AOD", "DQANAMUONCUTS", dqanalysisflags::IsMuonSelected);     //!  joinable to ReducedMuonsAssoc
+DECLARE_SOA_TABLE(EventCuts, "AOD", "DQANAEVCUTS", dqanalysisflags::IsEventSelected);           //!  joinable to ReducedEvents
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "DQANAMIXHASH", dqanalysisflags::MixingHash);            //!  joinable to ReducedEvents
+DECLARE_SOA_TABLE(BarrelTrackCuts, "AOD", "DQANATRKCUTS", dqanalysisflags::IsBarrelSelected);   //!  joinable to ReducedTracksAssoc
+DECLARE_SOA_TABLE(MuonTrackCuts, "AOD", "DQANAMUONCUTS", dqanalysisflags::IsMuonSelected);      //!  joinable to ReducedMuonsAssoc
 DECLARE_SOA_TABLE(Prefilter, "AOD", "DQPREFILTER", dqanalysisflags::IsBarrelSelectedPrefilter); //!  joinable to ReducedTracksAssoc
 DECLARE_SOA_TABLE(BmesonCandidates, "AOD", "DQBMESONS", dqanalysisflags::massBcandidate, dqanalysisflags::pTBcandidate, dqanalysisflags::LxyBcandidate, dqanalysisflags::LxyzBcandidate, dqanalysisflags::LzBcandidate, dqanalysisflags::TauxyBcandidate, dqanalysisflags::TauzBcandidate, dqanalysisflags::CosPBcandidate, dqanalysisflags::Chi2Bcandidate);
 } // namespace o2::aod
@@ -120,9 +120,10 @@ constexpr static int pairTypeEMu = VarManager::kElectronMuon;
 void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
 
 template <typename TMap>
-void PrintBitMap(TMap map, int nbits) {
-  for (int i=0; i<nbits; i++) {
-    cout << ((map & (TMap(1) << i))>0 ? "1" : "0");
+void PrintBitMap(TMap map, int nbits)
+{
+  for (int i = 0; i < nbits; i++) {
+    cout << ((map & (TMap(1) << i)) > 0 ? "1" : "0");
   }
 }
 
@@ -154,7 +155,7 @@ struct AnalysisEventSelection {
       fHistMan->SetUseDefaultVariableNames(kTRUE);
       fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
       DefineHistograms(fHistMan, "Event_BeforeCuts;Event_AfterCuts;", fConfigAddEventHistogram.value.data()); // define all histograms
-      VarManager::SetUseVars(fHistMan->GetUsedVars());                                           // provide the list of required variables so that VarManager knows what to fill
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                                                        // provide the list of required variables so that VarManager knows what to fill
       fOutputList.setObject(fHistMan->GetMainHistogramList());
     }
 
@@ -175,7 +176,7 @@ struct AnalysisEventSelection {
     // Reset the fValues array and fill event observables
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
     VarManager::FillEvent<TEventFillMap>(event);
-    
+
     // if QA is requested fill histograms before event selections
     if (fConfigQA) {
       fHistMan->FillHistClass("Event_BeforeCuts", VarManager::fgValues); // automatically fill all the histograms in the class Event
@@ -213,7 +214,7 @@ struct AnalysisEventSelection {
 struct AnalysisTrackSelection {
   Produces<aod::BarrelTrackCuts> trackSel;
   OutputObj<THashList> fOutputList{"output"};
-  
+
   Configurable<string> fConfigCuts{"cfgTrackCuts", "jpsiO2MCdebugCuts2", "Comma separated list of barrel track cuts"};
   Configurable<bool> fConfigQA{"cfgQA", false, "If true, fill QA histograms"};
   Configurable<string> fConfigAddTrackHistogram{"cfgAddTrackHistogram", "", "Comma separated list of histograms"};
@@ -230,8 +231,8 @@ struct AnalysisTrackSelection {
 
   HistogramManager* fHistMan;
   std::vector<AnalysisCompositeCut> fTrackCuts;
-  
-  int fCurrentRun;        // current run (needed to detect run changes for loading CCDB parameters)
+
+  int fCurrentRun; // current run (needed to detect run changes for loading CCDB parameters)
 
   void init(o2::framework::InitContext&)
   {
@@ -261,7 +262,7 @@ struct AnalysisTrackSelection {
 
       VarManager::SetRunlist((TString)fConfigRunPeriods);
       DefineHistograms(fHistMan, histDirNames.Data(), fConfigAddTrackHistogram.value.data()); // define all histograms
-      VarManager::SetUseVars(fHistMan->GetUsedVars());                           // provide the list of required variables so that VarManager knows what to fill
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                                        // provide the list of required variables so that VarManager knows what to fill
       fOutputList.setObject(fHistMan->GetMainHistogramList());
     }
     if (fConfigDummyRunlist) {
@@ -280,7 +281,7 @@ struct AnalysisTrackSelection {
   template <uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTracks>
   void runTrackSelection(ReducedTracksAssoc const& assocs, TEvents const& events, TTracks const& tracks)
   {
-    if (fConfigComputeTPCpostCalib && events.size()>0 && fCurrentRun != events.begin().runNumber()) {
+    if (fConfigComputeTPCpostCalib && events.size() > 0 && fCurrentRun != events.begin().runNumber()) {
       auto calibList = fCCDB->getForTimeStamp<TList>(fConfigCcdbPathTPC.value, events.begin().timestamp());
       VarManager::SetCalibrationObject(VarManager::kTPCElectronMean, calibList->FindObject("mean_map_electron"));
       VarManager::SetCalibrationObject(VarManager::kTPCElectronSigma, calibList->FindObject("sigma_map_electron"));
@@ -329,11 +330,11 @@ struct AnalysisTrackSelection {
             fHistMan->FillHistClass(Form("TrackBarrel_%s", (*cut).GetName()), VarManager::fgValues);
           }
         }
-      }  // end loop over cuts
-      
+      } // end loop over cuts
+
       trackSel(filterMap);
-    }  // end loop over associations
-  }  // end runTrackSelection()
+    } // end loop over associations
+  }   // end runTrackSelection()
 
   void processSkimmed(ReducedTracksAssoc const& assocs, MyEventsSelected const& events, MyBarrelTracks const& tracks)
   {
@@ -371,8 +372,8 @@ struct AnalysisMuonSelection {
   HistogramManager* fHistMan;
   std::vector<AnalysisCompositeCut> fMuonCuts;
 
-  int fCurrentRun;                // current run kept to detect run changes and trigger loading params from CCDB
-  
+  int fCurrentRun; // current run kept to detect run changes and trigger loading params from CCDB
+
   void init(o2::framework::InitContext&)
   {
     fCurrentRun = 0;
@@ -398,10 +399,10 @@ struct AnalysisMuonSelection {
       }
 
       DefineHistograms(fHistMan, histDirNames.Data(), fConfigAddMuonHistogram.value.data()); // define all histograms
-      VarManager::SetUseVars(fHistMan->GetUsedVars());                          // provide the list of required variables so that VarManager knows what to fill
+      VarManager::SetUseVars(fHistMan->GetUsedVars());                                       // provide the list of required variables so that VarManager knows what to fill
       fOutputList.setObject(fHistMan->GetMainHistogramList());
     }
-    
+
     fCCDB->setURL(fConfigCcdbUrl.value);
     fCCDB->setCaching(true);
     fCCDB->setLocalObjectValidityChecking();
@@ -411,7 +412,7 @@ struct AnalysisMuonSelection {
   template <uint32_t TEventFillMap, uint32_t TMuonFillMap, typename TEvents, typename TMuons>
   void runMuonSelection(ReducedMuonsAssoc const& assocs, TEvents const& events, TMuons const& muons)
   {
-    if (events.size()>0 && fCurrentRun != events.begin().runNumber()) {
+    if (events.size() > 0 && fCurrentRun != events.begin().runNumber()) {
       o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, events.begin().timestamp());
       if (grpmag != nullptr) {
         VarManager::SetMagneticField(grpmag->getNominalL3Field());
@@ -451,9 +452,9 @@ struct AnalysisMuonSelection {
             fHistMan->FillHistClass(Form("TrackMuon_%s", (*cut).GetName()), VarManager::fgValues);
           }
         }
-      }  // end loop over cuts
+      } // end loop over cuts
       muonSel(filterMap);
-    }  // end loop over assocs
+    } // end loop over assocs
   }
 
   void processSkimmed(ReducedMuonsAssoc const& assocs, MyEventsSelected const& events, MyMuonTracksWithCov const& muons)
@@ -474,8 +475,8 @@ struct AnalysisMuonSelection {
 //  with the sample of tracks to be used in downstream analysis (fConfigTrackCuts). If a pair is found to pass
 //  the pair prefilter cut (cfgPrefilterPairCut), the analysis track is tagged to be removed from analysis.
 struct AnalysisPrefilterSelection {
-  Produces<aod::Prefilter> prefilter;   // joinable with ReducedTracksAssoc
-  
+  Produces<aod::Prefilter> prefilter; // joinable with ReducedTracksAssoc
+
   // Configurables
   Configurable<std::string> fConfigPrefilterTrackCut{"cfgPrefilterTrackCut", "", "Prefilter track cut"};
   Configurable<std::string> fConfigPrefilterPairCut{"cfgPrefilterPairCut", "", "Prefilter pair cut"};
@@ -499,7 +500,7 @@ struct AnalysisPrefilterSelection {
     if (objArrayTrackCuts->GetEntries() == 0) {
       LOG(fatal) << " No track cuts to prefilter!";
     }
-    
+
     // get the list of cuts that were computed in the barrel track-selection task and create a bit mask
     //  to mark just the ones we want to apply a prefilter on
     fPrefilterMask = 0;
@@ -529,7 +530,7 @@ struct AnalysisPrefilterSelection {
     if (fPrefilterCutBit < 0) {
       LOG(fatal) << "No or incorrectly specified loose track prefilter cut";
     }
-    
+
     // setup the prefilter pair cut
     fPairCut = new AnalysisCompositeCut(true);
     TString pairCutStr = fConfigPrefilterPairCut.value;
@@ -545,12 +546,13 @@ struct AnalysisPrefilterSelection {
   }
 
   template <uint32_t TTrackFillMap, typename TTracks>
-  void runPrefilter(soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, TTracks const& tracks) {
+  void runPrefilter(soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, TTracks const& tracks)
+  {
 
     for (auto& [assoc1, assoc2] : o2::soa::combinations(assocs, assocs)) {
       auto track1 = assoc1.template reducedtrack_as<TTracks>();
       auto track2 = assoc2.template reducedtrack_as<TTracks>();
-      
+
       // NOTE: here we restrict to just pairs of opposite sign (conversions), but in principle this can be made
       // a configurable and check also same-sign pairs (track splitting)
       if (track1.sign() * track2.sign() > 0) {
@@ -562,8 +564,8 @@ struct AnalysisPrefilterSelection {
       uint32_t track2Candidate = (assoc2.isBarrelSelected_raw() & fPrefilterMask);
       bool track1Loose = assoc1.isBarrelSelected_bit(fPrefilterCutBit);
       bool track2Loose = assoc2.isBarrelSelected_bit(fPrefilterCutBit);
-      
-      if (! ((track1Candidate>0 && track2Loose) || (track2Candidate>0 && track1Loose))) {
+
+      if (!((track1Candidate > 0 && track2Loose) || (track2Candidate > 0 && track1Loose))) {
         continue;
       }
 
@@ -571,18 +573,19 @@ struct AnalysisPrefilterSelection {
       VarManager::FillPair<VarManager::kDecayToEE, TTrackFillMap>(track1, track2);
       // if the pair fullfils the criteria, add an entry into the prefilter map for the two tracks
       if (fPairCut->IsSelected(VarManager::fgValues)) {
-        if (fPrefilterMap.find(track1.globalIndex()) == fPrefilterMap.end() && track1Candidate>0) {
+        if (fPrefilterMap.find(track1.globalIndex()) == fPrefilterMap.end() && track1Candidate > 0) {
           fPrefilterMap[track1.globalIndex()] = track1Candidate;
         }
-        if (fPrefilterMap.find(track2.globalIndex()) == fPrefilterMap.end() && track2Candidate>0) {
+        if (fPrefilterMap.find(track2.globalIndex()) == fPrefilterMap.end() && track2Candidate > 0) {
           fPrefilterMap[track2.globalIndex()] = track2Candidate;
         }
       }
-    }  // end loop over combinations
+    } // end loop over combinations
   }
 
-  void processBarrelSkimmed(MyEvents const& events, soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, MyBarrelTracks const& tracks) {
-    
+  void processBarrelSkimmed(MyEvents const& events, soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& assocs, MyBarrelTracks const& tracks)
+  {
+
     fPrefilterMap.clear();
 
     for (auto& event : events) {
@@ -626,7 +629,7 @@ struct AnalysisSameEventPairing {
   Produces<aod::DimuonsAll> dimuonAllList;
   Produces<aod::DileptonFlow> dileptonFlowList;
   Produces<aod::DileptonsInfo> dileptonInfoList;
-    
+
   o2::base::MatLayerCylSet* fLUT = nullptr;
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
 
@@ -638,7 +641,7 @@ struct AnalysisSameEventPairing {
 
   Configurable<int> fConfigMixingDepth{"cfgMixingDepth", 100, "Number of Events stored for event mixing"};
   Configurable<std::string> fConfigAddEventMixingHistogram{"cfgAddEventMixingHistogram", "", "Comma separated list of histograms"};
-  
+
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<string> fConfigCcdbPath{"ccdb-path", "Users/lm", "base path to the ccdb object"};
   Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
@@ -661,7 +664,7 @@ struct AnalysisSameEventPairing {
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
 
   Filter filterEventSelected = aod::dqanalysisflags::isEventSelected == 1;
-  
+
   HistogramManager* fHistMan;
 
   // keep histogram class names in maps, so we don't have to buld their names in the pair loops
@@ -670,8 +673,8 @@ struct AnalysisSameEventPairing {
   std::map<int, std::vector<TString>> fTrackMuonHistNames;
   std::vector<AnalysisCompositeCut> fPairCuts;
 
-  uint32_t fTrackFilterMask;        // mask for the track cuts required in this task to be applied on the barrel cuts produced upstream
-  uint32_t fMuonFilterMask;         // mask for the muon cuts required in this task to be applied on the muon cuts produced upstream
+  uint32_t fTrackFilterMask; // mask for the track cuts required in this task to be applied on the barrel cuts produced upstream
+  uint32_t fMuonFilterMask;  // mask for the muon cuts required in this task to be applied on the muon cuts produced upstream
   int fNCutsBarrel;
   int fNCutsMuon;
   int fNPairCuts;
@@ -683,16 +686,16 @@ struct AnalysisSameEventPairing {
 
   void init(o2::framework::InitContext& context)
   {
-    /*bool enableBarrelHistos = context.mOptions.get<bool>("processDecayToEESkimmed") || context.mOptions.get<bool>("processDecayToEESkimmedNoTwoProngFitter") || 
-        context.mOptions.get<bool>("processDecayToEESkimmedWithCov") || context.mOptions.get<bool>("processDecayToEESkimmedWithCovNoTwoProngFitter") || 
-        context.mOptions.get<bool>("processDecayToEEVertexingSkimmed") || context.mOptions.get<bool>("processVnDecayToEESkimmed") || 
-        context.mOptions.get<bool>("processDecayToEEPrefilterSkimmed") || context.mOptions.get<bool>("processDecayToEEPrefilterSkimmedNoTwoProngFitter") || 
-        context.mOptions.get<bool>("processDecayToEESkimmedWithColl") || context.mOptions.get<bool>("processDecayToEESkimmedWithCollNoTwoProngFitter") || 
+    /*bool enableBarrelHistos = context.mOptions.get<bool>("processDecayToEESkimmed") || context.mOptions.get<bool>("processDecayToEESkimmedNoTwoProngFitter") ||
+        context.mOptions.get<bool>("processDecayToEESkimmedWithCov") || context.mOptions.get<bool>("processDecayToEESkimmedWithCovNoTwoProngFitter") ||
+        context.mOptions.get<bool>("processDecayToEEVertexingSkimmed") || context.mOptions.get<bool>("processVnDecayToEESkimmed") ||
+        context.mOptions.get<bool>("processDecayToEEPrefilterSkimmed") || context.mOptions.get<bool>("processDecayToEEPrefilterSkimmedNoTwoProngFitter") ||
+        context.mOptions.get<bool>("processDecayToEESkimmedWithColl") || context.mOptions.get<bool>("processDecayToEESkimmedWithCollNoTwoProngFitter") ||
         context.mOptions.get<bool>("processDecayToPiPiSkimmed") || context.mOptions.get<bool>("processAllSkimmed");  */
     bool enableBarrelHistos = context.mOptions.get<bool>("processAllSkimmed");
     bool enableBarrelMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed");
-    /*bool enableMuonHistos = context.mOptions.get<bool>("processDecayToMuMuSkimmed") || context.mOptions.get<bool>("processDecayToMuMuVertexingSkimmed") || 
-        context.mOptions.get<bool>("processDecayToMuMuSkimmedWithColl") || context.mOptions.get<bool>("processVnDecayToMuMuSkimmed") || 
+    /*bool enableMuonHistos = context.mOptions.get<bool>("processDecayToMuMuSkimmed") || context.mOptions.get<bool>("processDecayToMuMuVertexingSkimmed") ||
+        context.mOptions.get<bool>("processDecayToMuMuSkimmedWithColl") || context.mOptions.get<bool>("processVnDecayToMuMuSkimmed") ||
         context.mOptions.get<bool>("processAllSkimmed");*/
     bool enableMuonHistos = context.mOptions.get<bool>("processAllSkimmed");
     bool enableMuonMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed");
@@ -721,8 +724,8 @@ struct AnalysisSameEventPairing {
     if (!muonCutsStr.IsNull()) {
       objArrayMuonCuts = muonCutsStr.Tokenize(",");
     }
-        
-    // get the barrel track selection cuts   
+
+    // get the barrel track selection cuts
     string tempCuts;
     getTaskOptionValue<string>(context, "analysis-track-selection", "cfgTrackCuts", tempCuts, false);
     TString tempCutsStr = tempCuts;
@@ -745,7 +748,7 @@ struct AnalysisSameEventPairing {
               names.push_back(Form("PairsBarrelMEPP_%s", objArray->At(icut)->GetName()));
               names.push_back(Form("PairsBarrelMEMM_%s", objArray->At(icut)->GetName()));
               histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
-            }  
+            }
             fTrackHistNames[icut] = names;
 
             TString cutNamesStr = fConfigPairCuts.value;
@@ -758,10 +761,10 @@ struct AnalysisSameEventPairing {
                   Form("PairsBarrelSEPP_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
                   Form("PairsBarrelSEMM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName())};
                 histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
-                fTrackHistNames[fNCutsBarrel+icut*fNPairCuts+iPairCut] = names;
+                fTrackHistNames[fNCutsBarrel + icut * fNPairCuts + iPairCut] = names;
               } // end loop (pair cuts)
             }   // end if (pair cuts)
-          }  // end if enableBarrelHistos
+          }     // end if enableBarrelHistos
         }
       }
     }
@@ -784,9 +787,9 @@ struct AnalysisSameEventPairing {
               Form("PairsMuonSEMM_%s", objArray->At(icut)->GetName())};
             histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
             if (enableMuonMixingHistos) {
-              names.push_back(Form("PairsMuonMEPM_%s", objArray->At(icut)->GetName()));  
-              names.push_back(Form("PairsMuonMEPP_%s", objArray->At(icut)->GetName()));  
-              names.push_back(Form("PairsMuonMEMM_%s", objArray->At(icut)->GetName()));  
+              names.push_back(Form("PairsMuonMEPM_%s", objArray->At(icut)->GetName()));
+              names.push_back(Form("PairsMuonMEPP_%s", objArray->At(icut)->GetName()));
+              names.push_back(Form("PairsMuonMEMM_%s", objArray->At(icut)->GetName()));
               histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
             }
             fMuonHistNames[icut] = names;
@@ -801,14 +804,14 @@ struct AnalysisSameEventPairing {
                   Form("PairsMuonSEPP_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName()),
                   Form("PairsMuonSEMM_%s_%s", objArray->At(icut)->GetName(), objArrayPair->At(iPairCut)->GetName())};
                 histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
-                fMuonHistNames[fNCutsMuon+icut*fNCutsMuon+iPairCut] = names;
+                fMuonHistNames[fNCutsMuon + icut * fNCutsMuon + iPairCut] = names;
               } // end loop (pair cuts)
             }   // end if (pair cuts)
           }
         }
       }
     }
-    
+
     fCurrentRun = 0;
 
     fCCDB->setURL(fConfigCcdbUrl.value);
@@ -867,11 +870,12 @@ struct AnalysisSameEventPairing {
     VarManager::SetCollisionSystem((TString)fConfigCollisionSystem, fConfigCenterMassEnergy); // set collision system and center of mass energy
 
     DefineHistograms(fHistMan, histNames.Data(), fConfigAddSEPHistogram.value.data()); // define all histograms
-    VarManager::SetUseVars(fHistMan->GetUsedVars());                      // provide the list of required variables so that VarManager knows what to fill
+    VarManager::SetUseVars(fHistMan->GetUsedVars());                                   // provide the list of required variables so that VarManager knows what to fill
     fOutputList.setObject(fHistMan->GetMainHistogramList());
   }
 
-  void initParamsFromCCDB(uint64_t timestamp, bool withTwoProngFitter = true) {
+  void initParamsFromCCDB(uint64_t timestamp, bool withTwoProngFitter = true)
+  {
 
     if (fConfigUseRemoteField.value) {
       o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(fConfigGRPMagPath, timestamp);
@@ -902,7 +906,7 @@ struct AnalysisSameEventPairing {
       } else {
         VarManager::SetupTwoProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value); // needed because take in varmanager Bz from fgFitterTwoProngBarrel for PhiV calculations
       }
-    }    
+    }
   }
 
   // Template function to run same event pairing (barrel-barrel, muon-muon, barrel-muon)
@@ -926,7 +930,7 @@ struct AnalysisSameEventPairing {
       cutNames = fConfigMuonCuts.value;
       histNames = fTrackMuonHistNames;
     }*/
-  
+
     uint32_t twoTrackFilter = 0;
     int sign1 = 0;
     int sign2 = 0;
@@ -945,11 +949,11 @@ struct AnalysisSameEventPairing {
 
       if constexpr (TPairType == VarManager::kDecayToEE || TPairType == VarManager::kDecayToPiPi) {
         twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
-        
+
         if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
           continue;
         }
-                
+
         auto t1 = a1.template reducedtrack_as<TTracks>();
         auto t2 = a2.template reducedtrack_as<TTracks>();
         sign1 = t1.sign();
@@ -962,11 +966,11 @@ struct AnalysisSameEventPairing {
         if constexpr (eventHasQvector) {
           VarManager::FillPairVn<TPairType>(t1, t2);
         }
-        
-        dielectronList(event, VarManager::fgValues[VarManager::kMass], 
-                  VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], 
-                  t1.sign() + t2.sign(), twoTrackFilter, 0);
-        
+
+        dielectronList(event, VarManager::fgValues[VarManager::kMass],
+                       VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
+                       t1.sign() + t2.sign(), twoTrackFilter, 0);
+
         if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrackCollInfo) > 0) {
           dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
         }
@@ -976,12 +980,12 @@ struct AnalysisSameEventPairing {
       }
 
       if constexpr (TPairType == VarManager::kDecayToMuMu) {
-        
+
         twoTrackFilter = a1.isMuonSelected_raw() & a2.isMuonSelected_raw() & fMuonFilterMask;
         if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
           continue;
         }
-        
+
         auto t1 = a1.template reducedmuon_as<TTracks>();
         auto t2 = a2.template reducedmuon_as<TTracks>();
         sign1 = t1.sign();
@@ -995,38 +999,38 @@ struct AnalysisSameEventPairing {
           VarManager::FillPairVn<TPairType>(t1, t2);
         }
 
-        dimuonList(event, VarManager::fgValues[VarManager::kMass], 
-                  VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], 
-                  t1.sign() + t2.sign(), twoTrackFilter, 0);
+        dimuonList(event, VarManager::fgValues[VarManager::kMass],
+                   VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
+                   t1.sign() + t2.sign(), twoTrackFilter, 0);
         if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedMuonCollInfo) > 0) {
           dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
         }
-        
+
         if constexpr (TTwoProngFitter) {
           dimuonsExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingLz], VarManager::fgValues[VarManager::kVertexingLxy]);
           if (fConfigFlatTables.value) {
             dimuonAllList(event.posX(), event.posY(), event.posZ(), event.numContrib(),
-                        -999., -999., -999.,
-                        VarManager::fgValues[VarManager::kMass],
-                        false,
-                        VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), VarManager::fgValues[VarManager::kVertexingChi2PCA],
-                        VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingTauzErr],
-                        VarManager::fgValues[VarManager::kVertexingTauxy], VarManager::fgValues[VarManager::kVertexingTauxyErr],
-                        VarManager::fgValues[VarManager::kCosPointingAngle],
-                        VarManager::fgValues[VarManager::kPt1], VarManager::fgValues[VarManager::kEta1], VarManager::fgValues[VarManager::kPhi1], t1.sign(),
-                        VarManager::fgValues[VarManager::kPt2], VarManager::fgValues[VarManager::kEta2], VarManager::fgValues[VarManager::kPhi2], t2.sign(),
-                        t1.fwdDcaX(), t1.fwdDcaY(), t2.fwdDcaX(), t2.fwdDcaY(),
-                        0., 0.,
-                        t1.chi2MatchMCHMID(), t2.chi2MatchMCHMID(),
-                        t1.chi2MatchMCHMFT(), t2.chi2MatchMCHMFT(),
-                        t1.chi2(), t2.chi2(),
-                        -999., -999., -999., -999.,
-                        -999., -999., -999., -999.,
-                        -999., -999., -999., -999.,
-                        -999., -999., -999., -999.,
-                        t1.isAmbiguous(), t2.isAmbiguous(),
-                        VarManager::fgValues[VarManager::kU2Q2], VarManager::fgValues[VarManager::kU3Q3],
-                        VarManager::fgValues[VarManager::kCos2DeltaPhi], VarManager::fgValues[VarManager::kCos3DeltaPhi]);
+                          -999., -999., -999.,
+                          VarManager::fgValues[VarManager::kMass],
+                          false,
+                          VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), VarManager::fgValues[VarManager::kVertexingChi2PCA],
+                          VarManager::fgValues[VarManager::kVertexingTauz], VarManager::fgValues[VarManager::kVertexingTauzErr],
+                          VarManager::fgValues[VarManager::kVertexingTauxy], VarManager::fgValues[VarManager::kVertexingTauxyErr],
+                          VarManager::fgValues[VarManager::kCosPointingAngle],
+                          VarManager::fgValues[VarManager::kPt1], VarManager::fgValues[VarManager::kEta1], VarManager::fgValues[VarManager::kPhi1], t1.sign(),
+                          VarManager::fgValues[VarManager::kPt2], VarManager::fgValues[VarManager::kEta2], VarManager::fgValues[VarManager::kPhi2], t2.sign(),
+                          t1.fwdDcaX(), t1.fwdDcaY(), t2.fwdDcaX(), t2.fwdDcaY(),
+                          0., 0.,
+                          t1.chi2MatchMCHMID(), t2.chi2MatchMCHMID(),
+                          t1.chi2MatchMCHMFT(), t2.chi2MatchMCHMFT(),
+                          t1.chi2(), t2.chi2(),
+                          -999., -999., -999., -999.,
+                          -999., -999., -999., -999.,
+                          -999., -999., -999., -999.,
+                          -999., -999., -999., -999.,
+                          t1.isAmbiguous(), t2.isAmbiguous(),
+                          VarManager::fgValues[VarManager::kU2Q2], VarManager::fgValues[VarManager::kU3Q3],
+                          VarManager::fgValues[VarManager::kCos2DeltaPhi], VarManager::fgValues[VarManager::kCos3DeltaPhi]);
           }
         }
       }
@@ -1034,15 +1038,15 @@ struct AnalysisSameEventPairing {
       /*if constexpr (TPairType == VarManager::kElectronMuon) {
         twoTrackFilter = a1.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isMuonSelected_raw() & fTwoTrackFilterMask;
       }*/
-      
+
       if constexpr (eventHasQvector) {
         dileptonFlowList(VarManager::fgValues[VarManager::kU2Q2], VarManager::fgValues[VarManager::kU3Q3], VarManager::fgValues[VarManager::kCos2DeltaPhi], VarManager::fgValues[VarManager::kCos3DeltaPhi]);
       }
-      
+
       // Fill histograms
       for (int icut = 0; icut < ncuts; icut++) {
         if (twoTrackFilter & (uint32_t(1) << icut)) {
-          if (sign1*sign2 < 0) {
+          if (sign1 * sign2 < 0) {
             fHistMan->FillHistClass(histNames[icut][0].Data(), VarManager::fgValues);
           } else {
             if (sign1 > 0) {
@@ -1055,16 +1059,16 @@ struct AnalysisSameEventPairing {
             AnalysisCompositeCut cut = fPairCuts.at(iPairCut);
             if (!(cut.IsSelected(VarManager::fgValues))) // apply pair cuts
               continue;
-            if (sign1*sign2 < 0) {
-              fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][0].Data(), VarManager::fgValues);
+            if (sign1 * sign2 < 0) {
+              fHistMan->FillHistClass(histNames[ncuts + icut * ncuts + iPairCut][0].Data(), VarManager::fgValues);
             } else {
               if (sign1 > 0) {
-                fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][1].Data(), VarManager::fgValues);
+                fHistMan->FillHistClass(histNames[ncuts + icut * ncuts + iPairCut][1].Data(), VarManager::fgValues);
               } else {
-                fHistMan->FillHistClass(histNames[ncuts+icut*ncuts+iPairCut][2].Data(), VarManager::fgValues);
+                fHistMan->FillHistClass(histNames[ncuts + icut * ncuts + iPairCut][2].Data(), VarManager::fgValues);
               }
             }
-          }      // end loop (pair cuts)
+          } // end loop (pair cuts)
         }
       } // end loop (cuts)
     }   // end loop over pairs of track associations
@@ -1113,7 +1117,7 @@ struct AnalysisSameEventPairing {
 
         for (unsigned int icut = 0; icut < ncuts; icut++) {
           if (!(twoTrackFilter & (uint32_t(1) << icut))) {
-            continue;        // cut not passed
+            continue; // cut not passed
           }
           if (pairSign == 0) {
             fHistMan->FillHistClass(histNames[icut][3].Data(), VarManager::fgValues);
@@ -1124,9 +1128,9 @@ struct AnalysisSameEventPairing {
               fHistMan->FillHistClass(histNames[icut][5].Data(), VarManager::fgValues);
             }
           }
-        }   // end for (cuts)
-      }     // end for (track2)
-    }       // end for (track1)
+        } // end for (cuts)
+      }   // end for (track2)
+    }     // end for (track1)
   }
 
   // barrel-barrel and muon-muon event mixing
@@ -1154,7 +1158,7 @@ struct AnalysisSameEventPairing {
                          soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts> const& muonAssocs, MyMuonTracksWithCov const& muons)
   {
     for (auto& event : events) {
-      if (event.isEventSelected()==0) {
+      if (event.isEventSelected() == 0) {
         continue;
       }
       // Reset the fValues array
@@ -1164,17 +1168,17 @@ struct AnalysisSameEventPairing {
       auto groupedBarrelAssocs = barrelAssocs.sliceBy(trackAssocsPerCollision, event.globalIndex());
       auto groupedMuonAssocs = muonAssocs.sliceBy(muonAssocsPerCollision, event.globalIndex());
 
-      if (groupedBarrelAssocs.size()>0) {
+      if (groupedBarrelAssocs.size() > 0) {
         runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithCov>(event, groupedBarrelAssocs, barrelTracks);
       }
-      if (groupedMuonAssocs.size()>0) {
+      if (groupedMuonAssocs.size() > 0) {
         runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMapWithCov>(event, groupedMuonAssocs, muons);
       }
-      //runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+      // runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
     }
   }
 
-  void processMixingAllSkimmed(soa::Filtered<MyEventsHashSelected>& events, 
+  void processMixingAllSkimmed(soa::Filtered<MyEventsHashSelected>& events,
                                soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts, aod::Prefilter> const& trackAssocs, MyBarrelTracksWithCov const& tracks,
                                soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts> const& muonAssocs, MyMuonTracksWithCov const& muons)
   {
@@ -1182,129 +1186,129 @@ struct AnalysisSameEventPairing {
     runSameSideMixing<pairTypeMuMu, gkEventFillMap>(events, muonAssocs, muons, muonAssocsPerCollision);
   }
 
-/*
-  void processDecayToEESkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processDecayToEESkimmedNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processDecayToEESkimmedWithCov(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
-  }
-  void processDecayToEESkimmedWithCovNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
-    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
-  }
-  void processDecayToEEVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
-  }
-  void processDecayToEEPrefilterSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processDecayToEEPrefilterSkimmedNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processDecayToEESkimmedWithColl(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
-  }
-  void processDecayToEESkimmedWithCollNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
-  }
-  void processDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
-  }
-  void processDecayToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithCov> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCov, gkMuonFillMapWithCov>(event, muons, muons);
-  }
-  void processDecayToMuMuSkimmedWithColl(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithColl> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMapWithColl>(event, muons, muons);
-  }
-  void processVnDecayToEESkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCovQvector, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processVnDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCovQvector, gkMuonFillMap>(event, muons, muons);
-  }
-  void processElectronMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
-  }
-  void processDecayToPiPiSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToPiPi, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-  }
-  void processAllSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
-  {
-    // Reset the fValues array
-    VarManager::ResetValues(0, VarManager::kNVars);
-    VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
-    runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
-    runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
-    runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
-  }
-  */
+  /*
+    void processDecayToEESkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processDecayToEESkimmedNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processDecayToEESkimmedWithCov(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+    }
+    void processDecayToEESkimmedWithCovNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMapWithCov>(event, VarManager::fgValues);
+      runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+    }
+    void processDecayToEEVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithCov> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCov, gkTrackFillMapWithCov>(event, tracks, tracks);
+    }
+    void processDecayToEEPrefilterSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processDecayToEEPrefilterSkimmedNoTwoProngFitter(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithPrefilter> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processDecayToEESkimmedWithColl(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
+    }
+    void processDecayToEESkimmedWithCollNoTwoProngFitter(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelectedWithColl> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<false, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMapWithColl>(event, tracks, tracks);
+    }
+    void processDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
+    }
+    void processDecayToMuMuVertexingSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithCov> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCov, gkMuonFillMapWithCov>(event, muons, muons);
+    }
+    void processDecayToMuMuSkimmedWithColl(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyMuonTracksSelectedWithColl> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMapWithColl>(event, muons, muons);
+    }
+    void processVnDecayToEESkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMapWithCovQvector, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processVnDecayToMuMuSkimmed(soa::Filtered<MyEventsVtxCovSelectedQvector>::iterator const& event, soa::Filtered<MyMuonTracksSelected> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMapWithCovQvector>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMapWithCovQvector, gkMuonFillMap>(event, muons, muons);
+    }
+    void processElectronMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+    }
+    void processDecayToPiPiSkimmed(soa::Filtered<MyEventsSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToPiPi, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+    }
+    void processAllSkimmed(soa::Filtered<MyEventsVtxCovSelected>::iterator const& event, soa::Filtered<MyBarrelTracksSelected> const& tracks, soa::Filtered<MyMuonTracksSelected> const& muons)
+    {
+      // Reset the fValues array
+      VarManager::ResetValues(0, VarManager::kNVars);
+      VarManager::FillEvent<gkEventFillMap>(event, VarManager::fgValues);
+      runSameEventPairing<true, VarManager::kDecayToEE, gkEventFillMap, gkTrackFillMap>(event, tracks, tracks);
+      runSameEventPairing<true, VarManager::kDecayToMuMu, gkEventFillMap, gkMuonFillMap>(event, muons, muons);
+      runSameEventPairing<true, VarManager::kElectronMuon, gkEventFillMap, gkTrackFillMap>(event, tracks, muons);
+    }
+    */
   // TODO: dummy function for the case when no process function is enabled
   void processDummy(MyEvents&)
   {
@@ -1314,35 +1318,35 @@ struct AnalysisSameEventPairing {
   PROCESS_SWITCH(AnalysisSameEventPairing, processAllSkimmed, "Run all types of pairing, with skimmed tracks/muons", false);
   PROCESS_SWITCH(AnalysisSameEventPairing, processMixingAllSkimmed, "Run all types of mixed pairing, with skimmed tracks/muons", false);
   PROCESS_SWITCH(AnalysisSameEventPairing, processDummy, "Dummy function, enabled only if none of the others are enabled", false);
-/*
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks but no two prong fitter", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCov, "Run electron-electron pairing, with skimmed covariant tracks", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCovNoTwoProngFitter, "Run electron-electron pairing, with skimmed covariant tracks but no two prong fitter", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEVertexingSkimmed, "Run electron-electron pairing and vertexing, with skimmed electrons", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmed, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection but no two prong fitter", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithColl, "Run electron-electron pairing, with skimmed tracks and with collision information", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCollNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and with collision information but no two prong fitter", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed muons", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuVertexingSkimmed, "Run muon-muon pairing and vertexing, with skimmed muons", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmedWithColl, "Run muon-muon pairing keeping the info of AO2D collision, with skimmed muons", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks for vn", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed tracks for vn", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processElectronMuonSkimmed, "Run electron-muon pairing, with skimmed tracks/muons", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToPiPiSkimmed, "Run pion-pion pairing, with skimmed tracks", false);
-  PROCESS_SWITCH(AnalysisSameEventPairing, processAllSkimmed, "Run all types of pairing, with skimmed tracks/muons", false);
-  
-  */
+  /*
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks but no two prong fitter", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCov, "Run electron-electron pairing, with skimmed covariant tracks", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCovNoTwoProngFitter, "Run electron-electron pairing, with skimmed covariant tracks but no two prong fitter", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEVertexingSkimmed, "Run electron-electron pairing and vertexing, with skimmed electrons", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmed, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEEPrefilterSkimmedNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and prefilter from AnalysisPrefilterSelection but no two prong fitter", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithColl, "Run electron-electron pairing, with skimmed tracks and with collision information", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToEESkimmedWithCollNoTwoProngFitter, "Run electron-electron pairing, with skimmed tracks and with collision information but no two prong fitter", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed muons", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuVertexingSkimmed, "Run muon-muon pairing and vertexing, with skimmed muons", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToMuMuSkimmedWithColl, "Run muon-muon pairing keeping the info of AO2D collision, with skimmed muons", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToEESkimmed, "Run electron-electron pairing, with skimmed tracks for vn", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processVnDecayToMuMuSkimmed, "Run muon-muon pairing, with skimmed tracks for vn", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processElectronMuonSkimmed, "Run electron-muon pairing, with skimmed tracks/muons", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processDecayToPiPiSkimmed, "Run pion-pion pairing, with skimmed tracks", false);
+    PROCESS_SWITCH(AnalysisSameEventPairing, processAllSkimmed, "Run all types of pairing, with skimmed tracks/muons", false);
+
+    */
 };
 
 // Combines dileptons with barrel or muon tracks for either resonance or correlation analyses
-// Dileptons produced with all the selection cuts specified in the same-event pairing task are combined with the 
+// Dileptons produced with all the selection cuts specified in the same-event pairing task are combined with the
 //   tracks passing the fConfigTrackCut cut. The dileptons cuts from the same-event pairing task are auto-detected
 struct AnalysisDileptonTrack {
   Produces<aod::BmesonCandidates> BmesonsTable;
   OutputObj<THashList> fOutputList{"output"};
-  
+
   Configurable<string> fConfigTrackCut{"cfgTrackCut", "kaonPID", "Cut for the track to be correlated with the dileptons"};
   Configurable<float> fConfigDileptonLowMass{"cfgDileptonLowMass", 2.8, "Low mass cut for the dileptons used in analysis"};
   Configurable<float> fConfigDileptonHighMass{"cfgDileptonHighMass", 3.2, "High mass cut for the dileptons used in analysis"};
@@ -1364,10 +1368,10 @@ struct AnalysisDileptonTrack {
   std::map<int, TString> fHistNamesME;
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
-  
+
   // TODO: The filter expressions seem to always use the default value of configurables, not the values from the actual configuration file
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
-  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonpTCut.value && aod::reducedpair::mass > fConfigDileptonLowMass.value && aod::reducedpair::mass < fConfigDileptonHighMass.value && aod::reducedpair::sign == 0;
+  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonpTCut.value&& aod::reducedpair::mass > fConfigDileptonLowMass.value&& aod::reducedpair::mass < fConfigDileptonHighMass.value&& aod::reducedpair::sign == 0;
   Filter filterBarrel = aod::dqanalysisflags::isBarrelSelected > uint32_t(0);
   Filter filterMuon = aod::dqanalysisflags::isMuonSelected > uint32_t(0);
 
@@ -1431,20 +1435,20 @@ struct AnalysisDileptonTrack {
             fHistNamesDileptonTrack[icut] = Form("DileptonTrack_%s_%s", tempStr.Data(), fConfigTrackCut.value.data());
             fHistNamesDileptons[icut] = Form("DileptonsSelected_%s", tempStr.Data());
             DefineHistograms(fHistMan, fHistNamesDileptonTrack[icut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
-            DefineHistograms(fHistMan, fHistNamesDileptons[icut], "empty"); // define dilepton histograms
+            DefineHistograms(fHistMan, fHistNamesDileptons[icut], "empty");                                    // define dilepton histograms
             if (isBarrelME || isMuonME) {
               fHistNamesME[icut] = Form("DileptonTrackME_%s", tempStr.Data());
               DefineHistograms(fHistMan, fHistNamesME[icut], "mixedevent"); // define ME histograms
             }
           }
           if (tempStr.CompareTo(fConfigTrackCut.value.data()) == 0) {
-            fTrackCutBit = icut;                                       // the bit correspoding to the track to be combined with dileptons
+            fTrackCutBit = icut; // the bit correspoding to the track to be combined with dileptons
           }
         }
       }
     }
     if (fHistNamesDileptons.size() == 0) {
-      LOG(fatal) << " No valid dilepton cuts "; 
+      LOG(fatal) << " No valid dilepton cuts ";
     }
 
     if (context.mOptions.get<bool>("processBarrelMixedEvent")) {
@@ -1456,7 +1460,8 @@ struct AnalysisDileptonTrack {
   }
 
   // init parameters from CCDB
-  void initParamsFromCCDB(uint64_t timestamp) {
+  void initParamsFromCCDB(uint64_t timestamp)
+  {
     if (fConfigUseRemoteField.value) {
       o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(fConfigGRPmagPath.value, timestamp);
       float magField = 0.0;
@@ -1498,7 +1503,7 @@ struct AnalysisDileptonTrack {
       }
 
       VarManager::FillTrack<fgDileptonFillMap>(dilepton, fValuesDilepton);
-      for (int icut = 0; icut<fNCuts; icut++) {
+      for (int icut = 0; icut < fNCuts; icut++) {
         if (dilepton.filterMap_bit(icut)) {
           fHistMan->FillHistClass(fHistNamesDileptons[icut].Data(), fValuesDilepton);
         }
@@ -1525,12 +1530,12 @@ struct AnalysisDileptonTrack {
           if (track.globalIndex() == dilepton.index0Id() || track.globalIndex() == dilepton.index1Id()) {
             continue;
           }
-          
+
           VarManager::FillDileptonHadron(dilepton, track, fValuesHadron);
           VarManager::FillDileptonTrackVertexing<TCandidateType, TEventFillMap, TTrackFillMap>(event, lepton1, lepton2, track, fValuesHadron);
         }
-        
-        for (int icut = 0; icut<fNCuts; icut++) {
+
+        for (int icut = 0; icut < fNCuts; icut++) {
           if (dilepton.filterMap_bit(icut)) {
             fHistMan->FillHistClass(fHistNamesDileptonTrack[icut].Data(), fValuesHadron);
           }
@@ -1543,8 +1548,8 @@ struct AnalysisDileptonTrack {
 
   Preslice<aod::ReducedTracksAssoc> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
   Preslice<MyDielectronCandidates> dielectronsPerCollision = aod::reducedpair::reducedeventId;
-  
-  void processBarrelSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events, 
+
+  void processBarrelSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events,
                             soa::Filtered<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> const& assocs,
                             MyBarrelTracksWithCov const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
   {
@@ -1566,7 +1571,7 @@ struct AnalysisDileptonTrack {
   Preslice<aod::ReducedMuonsAssoc> muonAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
   Preslice<MyDimuonCandidates> dimuonsPerCollision = aod::reducedpair::reducedeventId;
 
-  void processMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events, 
+  void processMuonSkimmed(soa::Filtered<MyEventsVtxCovSelected> const& events,
                           soa::Filtered<soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts>> const& assocs,
                           MyMuonTracksWithCov const& tracks, soa::Filtered<MyDimuonCandidates> const& dileptons)
   {
@@ -1585,7 +1590,7 @@ struct AnalysisDileptonTrack {
     }
   }
 
-  void processBarrelMixedEvent(soa::Filtered<MyEventsHashSelected>& events, 
+  void processBarrelMixedEvent(soa::Filtered<MyEventsHashSelected>& events,
                                soa::Filtered<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> const& assocs,
                                MyBarrelTracksWithCov const& tracks, soa::Filtered<MyDielectronCandidates> const& dileptons)
   {
@@ -1613,17 +1618,17 @@ struct AnalysisDileptonTrack {
 
         for (auto dilepton : evDileptons) {
           VarManager::FillDileptonHadron(dilepton, track, VarManager::fgValues);
-          for (int icut=0; icut<fNCuts; icut++) {
+          for (int icut = 0; icut < fNCuts; icut++) {
             if (dilepton.filterMap_bit(icut)) {
               fHistMan->FillHistClass(fHistNamesME[icut].Data(), VarManager::fgValues);
             }
           }
         } // end for (dileptons)
       }   // end for (assocs)
-    } // end event loop
+    }     // end event loop
   }
 
-  void processMuonMixedEvent(soa::Filtered<MyEventsHashSelected>& events, 
+  void processMuonMixedEvent(soa::Filtered<MyEventsHashSelected>& events,
                              soa::Filtered<soa::Join<aod::ReducedMuonsAssoc, aod::MuonTrackCuts>> const& assocs,
                              MyMuonTracksWithCov const& tracks, soa::Filtered<MyDimuonCandidates> const& dileptons)
   {
@@ -1644,22 +1649,22 @@ struct AnalysisDileptonTrack {
       evAssocs.bindExternalIndices(&events);
 
       for (auto& assoc : evAssocs) {
-        
+
         if (!assoc.isMuonSelected_bit(fTrackCutBit)) {
           continue;
         }
         auto track = assoc.template reducedmuon_as<MyMuonTracksWithCov>();
-        
+
         for (auto dilepton : evDileptons) {
           VarManager::FillDileptonHadron(dilepton, track, VarManager::fgValues);
-          for (int icut=0; icut<fNCuts; icut++) {
+          for (int icut = 0; icut < fNCuts; icut++) {
             if (dilepton.filterMap_bit(icut)) {
               fHistMan->FillHistClass(fHistNamesME[icut].Data(), VarManager::fgValues);
             }
           }
         } // end for (dileptons)
       }   // end for (assocs)
-    } // end event loop
+    }     // end event loop
   }
 
   void processDummy(MyEvents&)
@@ -1682,8 +1687,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<AnalysisMuonSelection>(cfgc),
     adaptAnalysisTask<AnalysisPrefilterSelection>(cfgc),
     adaptAnalysisTask<AnalysisSameEventPairing>(cfgc),
-    adaptAnalysisTask<AnalysisDileptonTrack>(cfgc)
-  };
+    adaptAnalysisTask<AnalysisDileptonTrack>(cfgc)};
 }
 
 void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)

--- a/PWGEM/Dilepton/Tasks/MCtemplates.cxx
+++ b/PWGEM/Dilepton/Tasks/MCtemplates.cxx
@@ -353,8 +353,8 @@ struct AnalysisTrackSelection {
 };
 
 struct AnalysisSameEventPairing {
-  Produces<aod::Dileptons> dileptonList;
-  Produces<aod::DileptonsExtra> dileptonExtraList;
+  Produces<aod::Dielectrons> dileptonList;
+  Produces<aod::DielectronsExtra> dileptonExtraList;
   OutputObj<THashList> fOutputList{"output"};
   Filter filterEventSelected = aod::emanalysisflags::isEventSelected == 1;
   Filter filterBarrelTrackSelected = aod::emanalysisflags::isBarrelSelected > 0;


### PR DESCRIPTION
For the moment, I just added new workflows, so the old workflows are still available. But we should delete the old ones as soon as the new ones are validated.