### PR TITLE
PWGHF: protect access to cascData in toXiPi creator

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -147,6 +147,7 @@ struct HfCandidateCreatorToXiPi {
       auto trackPion = cand.prong0_as<TracksWCovDca>();
       auto cascAodElement = cand.cascade_as<aod::CascadesLinked>();
       int v0index = cascAodElement.v0Id();
+      if(!cascAodElement.has_cascData()) continue;
       auto casc = cascAodElement.cascData_as<MyCascTable>();
       auto trackXiDauCharged = casc.bachelor_as<TracksWCovDca>(); // pion <- xi track
       auto trackV0Dau0 = casc.posTrack_as<TracksWCovDca>();       // V0 positive daughter track


### PR DESCRIPTION
Protect access to cascData in candidateCreatorToXiPi (prevents the jobs from failing if the selections used for v0/cascades changed between derived data production and the start of the analysis on derived data)