### PR TITLE
[EMCAL-670] [EMCAL-1109] Addition of EMCalMCCluster tables

### DIFF
--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -17,6 +17,7 @@
 #define PWGJE_DATAMODEL_EMCALCLUSTERS_H_
 
 #include <string>
+#include <vector>
 #include "Framework/AnalysisDataModel.h"
 #include "EMCALClusterDefinition.h"
 
@@ -90,6 +91,17 @@ DECLARE_SOA_TABLE(EMCALAmbiguousClusters, "AOD", "EMCALAMBCLUS", //!
 
 using EMCALCluster = EMCALClusters::iterator;
 using EMCALAmbiguousCluster = EMCALAmbiguousClusters::iterator;
+
+namespace emcalclustermc
+{
+DECLARE_SOA_ARRAY_INDEX_COLUMN(McParticle, mcParticle);         //! Array of MC particles that deposited energy in this calo cell
+DECLARE_SOA_COLUMN(AmplitudeA, amplitudeA, std::vector<float>); //! Energy fraction deposited by a particle inside this calo cell.
+} // namespace emcalclustermc
+// table of cluster MC info that could be matched to a collision
+DECLARE_SOA_TABLE(EMCALMCClusters, "AOD", "EMCALMCCLUSTERS", //!
+                  emcalclustermc::McParticleIds, emcalclustermc::AmplitudeA);
+
+using EMCALMCCluster = EMCALMCClusters::iterator;
 
 namespace emcalclustercell
 {


### PR DESCRIPTION
- Add MC Cluster tables to `PWGJE/DataModel/EMCALClusters.h`
- Fill MC Cluster tables inside `PWGJE/TableProducer/emcalCorrectionTask.cxx`

IMPORTANT NOTE: This change is part part of two to include the MC Calo Labels into EMCal clusters. Part one is in O2 and required for this to compile. See PR https://github.com/AliceO2Group/AliceO2/pull/12660. 
Locally on a Mac everything runs fine, but on linux it crashes at the end of the ProcessMC function of the EMCalCorrectionTask. This crash is only for running the EMCalCorrectionTask with the ProcessMC. So to enable tests for more people and maybe even the GRID I thought we might want to push it. There should be no problem with all the currently used workflows and process functions!