### PR TITLE
DPL Analysis: remove uses of selected packs

### DIFF
--- a/Common/Tools/aodDataModelGraph.cxx
+++ b/Common/Tools/aodDataModelGraph.cxx
@@ -137,19 +137,20 @@ void displayOriginals(pack<Ts...>)
 template <typename C>
 void printColumn(char const* fg, char const* bg)
 {
-    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
+  fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
 }
 
 template <typename... C>
 int displayPersistentColumns(pack<C...>, const char* fg, const char* bg)
 {
   int n = 0;
-  ([&](){
+  ([&]() {
     if constexpr (o2::soa::is_persistent_v<C> && !o2::soa::is_index_column_v<C>) {
       printColumn<C>(fg, bg);
       ++n;
     }
-  }(), ...);
+  }(),
+   ...);
   if (n > 0) {
     fmt::printf("%s", "\n");
   }
@@ -160,12 +161,13 @@ template <typename... C>
 int displayDynamicColumns(pack<C...>, const char* fg, const char* bg)
 {
   int n = 0;
-  ([&](){
+  ([&]() {
     if constexpr (!o2::soa::is_persistent_v<C>) {
       printColumn<C>(fg, bg);
       ++n;
     }
-  }(), ...);
+  }(),
+   ...);
   if (n > 0) {
     fmt::printf("%s", "\n");
   }
@@ -175,11 +177,12 @@ int displayDynamicColumns(pack<C...>, const char* fg, const char* bg)
 template <typename... C>
 void displayIndexColumns(pack<C...>, char const* fg, char const* bg)
 {
-  ([&](){
+  ([&]() {
     if constexpr (o2::soa::is_index_column_v<C>) {
       printColumn<C>(fg, bg);
     }
-  }(), ...);
+  }(),
+   ...);
   fmt::printf("%s", "\n");
 }
 
@@ -201,11 +204,12 @@ void printIndex()
 template <typename T, typename... C>
 void dumpIndex(pack<C...>)
 {
-  ([&](){
+  ([&]() {
     if constexpr (o2::soa::is_index_column_v<C>) {
       printIndex<C, T>();
     }
-  }(), ...);
+  }(),
+   ...);
   fmt::printf("%s", "\n");
 }
 

--- a/Common/Tools/aodDataModelGraph.cxx
+++ b/Common/Tools/aodDataModelGraph.cxx
@@ -9,7 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include <fmt/printf.h>
-#include <map>
 #include "Framework/AnalysisDataModel.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "Common/DataModel/PIDResponse.h"
@@ -67,21 +66,21 @@ enum StyleType : int {
   BLUE = 3,
 };
 
-static std::vector<std::pair<std::string, StyleType>> tableStyles = {
-  {"HfTrackIndexProng", StyleType::BLUE},
-  {"HfCandProng", StyleType::BLUE},
-  {"pidResp", StyleType::GREEN},
-  {"Mults", StyleType::GREEN},
-  {"CentRun2V0Ms", StyleType::GREEN},
-  {"Timestamps", StyleType::GREEN},
-  {"Jet", StyleType::BLUE},
-  {"Mc", StyleType::RED},
-  {"V0Datas", StyleType::GREEN},
-  {"CascData", StyleType::GREEN},
-  {"TrackSelection", StyleType::GREEN},
-  {"TracksDCA", StyleType::GREEN},
-  {"Transient", StyleType::GREEN},
-  {"Extension", StyleType::GREEN},
+static std::array<std::pair<std::string, StyleType>, 14> tableStyles = {
+  std::make_pair("HfTrackIndexProng", StyleType::BLUE),
+  std::make_pair("HfCandProng", StyleType::BLUE),
+  std::make_pair("pidResp", StyleType::GREEN),
+  std::make_pair("Mults", StyleType::GREEN),
+  std::make_pair("CentRun2V0Ms", StyleType::GREEN),
+  std::make_pair("Timestamps", StyleType::GREEN),
+  std::make_pair("Jet", StyleType::BLUE),
+  std::make_pair("Mc", StyleType::RED),
+  std::make_pair("V0Datas", StyleType::GREEN),
+  std::make_pair("CascData", StyleType::GREEN),
+  std::make_pair("TrackSelection", StyleType::GREEN),
+  std::make_pair("TracksDCA", StyleType::GREEN),
+  std::make_pair("Transient", StyleType::GREEN),
+  std::make_pair("Extension", StyleType::GREEN),
 };
 
 template <typename T>
@@ -138,30 +137,49 @@ void displayOriginals(pack<Ts...>)
 template <typename C>
 void printColumn(char const* fg, char const* bg)
 {
-  if constexpr (!is_index_column_v<C>) {
     fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
-  }
-}
-
-template <typename C>
-void printIndexColumn(char const* fg, char const* bg)
-{
-  if constexpr (is_index_column_v<C>) {
-    fmt::printf("<TR><TD color='%s' bgcolor='%s'>%s</TD></TR>", fg, bg, C::columnLabel());
-  }
 }
 
 template <typename... C>
-void displayColumns(pack<C...>, const char* fg, const char* bg)
+int displayPersistentColumns(pack<C...>, const char* fg, const char* bg)
 {
-  (printColumn<C>(fg, bg), ...);
-  fmt::printf("%s", "\n");
+  int n = 0;
+  ([&](){
+    if constexpr (o2::soa::is_persistent_v<C> && !o2::soa::is_index_column_v<C>) {
+      printColumn<C>(fg, bg);
+      ++n;
+    }
+  }(), ...);
+  if (n > 0) {
+    fmt::printf("%s", "\n");
+  }
+  return n;
+}
+
+template <typename... C>
+int displayDynamicColumns(pack<C...>, const char* fg, const char* bg)
+{
+  int n = 0;
+  ([&](){
+    if constexpr (!o2::soa::is_persistent_v<C>) {
+      printColumn<C>(fg, bg);
+      ++n;
+    }
+  }(), ...);
+  if (n > 0) {
+    fmt::printf("%s", "\n");
+  }
+  return n;
 }
 
 template <typename... C>
 void displayIndexColumns(pack<C...>, char const* fg, char const* bg)
 {
-  (printIndexColumn<C>(fg, bg), ...);
+  ([&](){
+    if constexpr (o2::soa::is_index_column_v<C>) {
+      printColumn<C>(fg, bg);
+    }
+  }(), ...);
   fmt::printf("%s", "\n");
 }
 
@@ -183,7 +201,11 @@ void printIndex()
 template <typename T, typename... C>
 void dumpIndex(pack<C...>)
 {
-  (printIndex<C, T>(), ...);
+  ([&](){
+    if constexpr (o2::soa::is_index_column_v<C>) {
+      printIndex<C, T>();
+    }
+  }(), ...);
   fmt::printf("%s", "\n");
 }
 
@@ -195,19 +217,15 @@ void displayTable()
   fmt::printf(R"(%s[color="%s" cellpadding="0" fillcolor="%s" fontcolor="%s" label = <
 <TABLE cellpadding='2' cellspacing='0' cellborder='0' ><TH cellpadding='0' bgcolor="black"><TD bgcolor="%s"><font color="%s">%s</font></TD></TH>)",
               label, style.color, style.background, style.fontcolor, style.headerbgcolor, style.headerfontcolor, label);
-  if (pack_size(typename T::iterator::persistent_columns_t{}) -
-        pack_size(typename T::iterator::external_index_columns_t{}) >
-      0) {
-    displayColumns(typename T::iterator::persistent_columns_t{}, style.color, style.background);
+  if (displayPersistentColumns(typename T::table_t::columns{}, style.color, style.background) > 0) {
     fmt::printf("%s", "HR");
   }
-  if (pack_size(typename T::iterator::dynamic_columns_t{})) {
-    displayColumns(typename T::iterator::dynamic_columns_t{}, style.methodcolor, style.methodbgcolor);
+  if (displayDynamicColumns(typename T::table_t::columns{}, style.methodcolor, style.methodbgcolor) > 0) {
     fmt::printf("%s", "HR");
   }
-  displayIndexColumns(typename T::iterator::external_index_columns_t{}, style.indexcolor, style.indexbgcolor);
+  displayIndexColumns(typename T::table_t::columns{}, style.indexcolor, style.indexbgcolor);
   fmt::printf("%s", "</TABLE>\n>]\n");
-  dumpIndex<T>(typename T::iterator::external_index_columns_t{});
+  dumpIndex<T>(typename T::table_t::columns{});
 }
 
 template <typename T>

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -201,9 +201,9 @@ static const float defaultDownscaling[128][1]{
   {1.f},
   {1.f}}; /// Max number of columns for triggers is 128 (extendible)
 
-#define FILTER_CONFIGURABLE(_TYPE_)                                                                                                                                              \
-  Configurable<LabeledArray<float>> cfg##_TYPE_                                                                                                                                  \
-  {                                                                                                                                                                              \
+#define FILTER_CONFIGURABLE(_TYPE_)                                                                                                                                                         \
+  Configurable<LabeledArray<float>> cfg##_TYPE_                                                                                                                                             \
+  {                                                                                                                                                                                         \
 #_TYPE_, {defaultDownscaling[0], NumberOfColumns(typename _TYPE_::table_t::columns{}), 1, ColumnsNames(typename _TYPE_::table_t::columns{}), downscalingName }, #_TYPE_ " downscalings" \
   }
 

--- a/EventFiltering/cefpTask.cxx
+++ b/EventFiltering/cefpTask.cxx
@@ -204,7 +204,7 @@ static const float defaultDownscaling[128][1]{
 #define FILTER_CONFIGURABLE(_TYPE_)                                                                                                                                              \
   Configurable<LabeledArray<float>> cfg##_TYPE_                                                                                                                                  \
   {                                                                                                                                                                              \
-#_TYPE_, {defaultDownscaling[0], NumberOfColumns < _TYPE_>(), 1, ColumnsNames(typename _TYPE_::iterator::persistent_columns_t{}), downscalingName }, #_TYPE_ " downscalings" \
+#_TYPE_, {defaultDownscaling[0], NumberOfColumns(typename _TYPE_::table_t::columns{}), 1, ColumnsNames(typename _TYPE_::table_t::columns{}), downscalingName }, #_TYPE_ " downscalings" \
   }
 
 } // namespace

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -230,25 +230,41 @@ void addColumnToMap(std::unordered_map<std::string, std::unordered_map<std::stri
 template <typename T, typename... C>
 void addColumnsToMap(o2::framework::pack<C...>, std::unordered_map<std::string, std::unordered_map<std::string, float>>& map)
 {
-  (addColumnToMap<T, C>(map), ...);
+  ([&](){
+    if constexpr(soa::is_persistent_v<C>) {
+      addColumnToMap<T, C>(map);
+    }
+  }(), ...);
 }
 
 template <typename... T>
 void FillFiltersMap(o2::framework::pack<T...>, std::unordered_map<std::string, std::unordered_map<std::string, float>>& map)
 {
-  (addColumnsToMap<T>(typename T::iterator::persistent_columns_t{}, map), ...);
+  (addColumnsToMap<T>(typename T::table_t::columns{}, map), ...);
 }
 
 template <typename... C>
 static std::vector<std::string> ColumnsNames(o2::framework::pack<C...>)
 {
-  return {C::columnLabel()...};
+  std::vector<std::string> result;
+  ([&](){
+    if constexpr (soa::is_persistent_v<C>) {
+      result.push_back(C::columnLabel());
+    }
+  }(),...);
+  return result;
 }
 
-template <typename T>
-unsigned int NumberOfColumns()
+template <typename... C>
+unsigned int NumberOfColumns(o2::framework::pack<C...>)
 {
-  return o2::framework::pack_size(typename T::iterator::persistent_columns_t{});
+  unsigned int result = 0;
+  ([&](){
+    if constexpr (soa::is_persistent_v<C>) {
+      ++result;
+    }
+  }(), ...);
+  return result;
 }
 
 } // namespace o2::aod

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -230,11 +230,12 @@ void addColumnToMap(std::unordered_map<std::string, std::unordered_map<std::stri
 template <typename T, typename... C>
 void addColumnsToMap(o2::framework::pack<C...>, std::unordered_map<std::string, std::unordered_map<std::string, float>>& map)
 {
-  ([&](){
-    if constexpr(soa::is_persistent_v<C>) {
+  ([&]() {
+    if constexpr (soa::is_persistent_v<C>) {
       addColumnToMap<T, C>(map);
     }
-  }(), ...);
+  }(),
+   ...);
 }
 
 template <typename... T>
@@ -247,11 +248,12 @@ template <typename... C>
 static std::vector<std::string> ColumnsNames(o2::framework::pack<C...>)
 {
   std::vector<std::string> result;
-  ([&](){
+  ([&]() {
     if constexpr (soa::is_persistent_v<C>) {
       result.push_back(C::columnLabel());
     }
-  }(),...);
+  }(),
+   ...);
   return result;
 }
 
@@ -259,11 +261,12 @@ template <typename... C>
 unsigned int NumberOfColumns(o2::framework::pack<C...>)
 {
   unsigned int result = 0;
-  ([&](){
+  ([&]() {
     if constexpr (soa::is_persistent_v<C>) {
       ++result;
     }
-  }(), ...);
+  }(),
+   ...);
   return result;
 }
 


### PR DESCRIPTION
This removes uses of selected packs from O2Physics, so that we can proceed with removing their recursive template definitions from O2. This will eventually considerably improve compilation times. 