### PR TITLE
PWGHF: Implement B0 ML and templatize task

### DIFF
--- a/PWGHF/Core/HfMlResponseB0ToDPi.h
+++ b/PWGHF/Core/HfMlResponseB0ToDPi.h
@@ -1,0 +1,221 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponsB0ToDPi.h
+/// \brief Class to compute the ML response for B0 → D∓ π± analysis selections
+/// \author Alexandre Bigot <alexandre.bigot@cern.ch>, IPHC Strasbourg
+
+#ifndef PWGHF_CORE_HFMLRESPONSEB0TODPI_H_
+#define PWGHF_CORE_HFMLRESPONSEB0TODPI_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "PWGHF/Core/HfMlResponse.h"
+
+// Fill the map of available input features
+// the key is the feature's name (std::string)
+// the value is the corresponding value in EnumInputFeatures
+#define FILL_MAP_B0(FEATURE)                                        \
+  {                                                                 \
+#FEATURE, static_cast < uint8_t>(InputFeaturesB0ToDPi::FEATURE) \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the corresponding GETTER from OBJECT
+#define CHECK_AND_FILL_VEC_B0_FULL(OBJECT, FEATURE, GETTER)   \
+  case static_cast<uint8_t>(InputFeaturesB0ToDPi::FEATURE): { \
+    inputFeatures.emplace_back(OBJECT.GETTER());              \
+    break;                                                    \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the GETTER function taking OBJECT in argument
+#define CHECK_AND_FILL_VEC_B0_FUNC(OBJECT, FEATURE, GETTER)   \
+  case static_cast<uint8_t>(InputFeaturesB0ToDPi::FEATURE): { \
+    inputFeatures.emplace_back(GETTER(OBJECT));               \
+    break;                                                    \
+  }
+
+// Specific case of CHECK_AND_FILL_VEC_B0_FULL(OBJECT, FEATURE, GETTER)
+// where OBJECT is named candidate and FEATURE = GETTER
+#define CHECK_AND_FILL_VEC_B0(GETTER)                        \
+  case static_cast<uint8_t>(InputFeaturesB0ToDPi::GETTER): { \
+    inputFeatures.emplace_back(candidate.GETTER());          \
+    break;                                                   \
+  }
+
+namespace o2::pid_tpc_tof_utils
+{
+template <typename T1>
+float getTpcTofNSigmaPi1(const T1& prong1)
+{
+  float defaultNSigma = -999.f; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h
+
+  bool hasTpc = prong1.hasTPC();
+  bool hasTof = prong1.hasTOF();
+
+  if (hasTpc && hasTof) {
+    float tpcNSigma = prong1.tpcNSigmaPi();
+    float tofNSigma = prong1.tofNSigmaPi();
+    return sqrt(.5f * tpcNSigma * tpcNSigma + .5f * tofNSigma * tofNSigma);
+  }
+  if (hasTpc) {
+    return abs(prong1.tpcNSigmaPi());
+  }
+  if (hasTof) {
+    return abs(prong1.tofNSigmaPi());
+  }
+  return defaultNSigma;
+}
+} // namespace o2::pid_tpc_tof_utils
+
+namespace o2::analysis
+{
+
+enum class InputFeaturesB0ToDPi : uint8_t {
+  ptProng0 = 0,
+  ptProng1,
+  impactParameter0,
+  impactParameter1,
+  impactParameterProduct,
+  chi2PCA,
+  decayLength,
+  decayLengthXY,
+  decayLengthNormalised,
+  decayLengthXYNormalised,
+  cpa,
+  cpaXY,
+  maxNormalisedDeltaIP,
+  prong0MlScoreBkg,
+  prong0MlScorePrompt,
+  prong0MlScoreNonprompt,
+  tpcNSigmaPi1,
+  tofNSigmaPi1,
+  tpcTofNSigmaPi1
+};
+
+template <typename TypeOutputScore = float>
+class HfMlResponseB0ToDPi : public HfMlResponse<TypeOutputScore>
+{
+ public:
+  /// Default constructor
+  HfMlResponseB0ToDPi() = default;
+  /// Default destructor
+  virtual ~HfMlResponseB0ToDPi() = default;
+
+  /// Method to get the input features vector needed for ML inference
+  /// \param candidate is the B0 candidate
+  /// \param prong1 is the candidate's prong1
+  /// \return inputFeatures vector
+  template <bool withDmesMl, typename T1, typename T2>
+  std::vector<float> getInputFeatures(T1 const& candidate,
+                                      T2 const& prong1)
+  {
+    std::vector<float> inputFeatures;
+
+    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+      if constexpr (withDmesMl) {
+        switch (idx) {
+          CHECK_AND_FILL_VEC_B0(ptProng0);
+          CHECK_AND_FILL_VEC_B0(ptProng1);
+          CHECK_AND_FILL_VEC_B0(impactParameter0);
+          CHECK_AND_FILL_VEC_B0(impactParameter1);
+          CHECK_AND_FILL_VEC_B0(impactParameterProduct);
+          CHECK_AND_FILL_VEC_B0(chi2PCA);
+          CHECK_AND_FILL_VEC_B0(decayLength);
+          CHECK_AND_FILL_VEC_B0(decayLengthXY);
+          CHECK_AND_FILL_VEC_B0(decayLengthNormalised);
+          CHECK_AND_FILL_VEC_B0(decayLengthXYNormalised);
+          CHECK_AND_FILL_VEC_B0(cpa);
+          CHECK_AND_FILL_VEC_B0(cpaXY);
+          CHECK_AND_FILL_VEC_B0(maxNormalisedDeltaIP);
+          CHECK_AND_FILL_VEC_B0(prong0MlScoreBkg);
+          CHECK_AND_FILL_VEC_B0(prong0MlScorePrompt);
+          CHECK_AND_FILL_VEC_B0(prong0MlScoreNonprompt);
+          // TPC PID variable
+          CHECK_AND_FILL_VEC_B0_FULL(prong1, tpcNSigmaPi1, tpcNSigmaPi);
+          // TOF PID variable
+          CHECK_AND_FILL_VEC_B0_FULL(prong1, tofNSigmaPi1, tofNSigmaPi);
+          // Combined PID variables
+          CHECK_AND_FILL_VEC_B0_FUNC(prong1, tpcTofNSigmaPi1, o2::pid_tpc_tof_utils::getTpcTofNSigmaPi1);
+        }
+      } else {
+        switch (idx) {
+          CHECK_AND_FILL_VEC_B0(ptProng0);
+          CHECK_AND_FILL_VEC_B0(ptProng1);
+          CHECK_AND_FILL_VEC_B0(impactParameter0);
+          CHECK_AND_FILL_VEC_B0(impactParameter1);
+          CHECK_AND_FILL_VEC_B0(impactParameterProduct);
+          CHECK_AND_FILL_VEC_B0(chi2PCA);
+          CHECK_AND_FILL_VEC_B0(decayLength);
+          CHECK_AND_FILL_VEC_B0(decayLengthXY);
+          CHECK_AND_FILL_VEC_B0(decayLengthNormalised);
+          CHECK_AND_FILL_VEC_B0(decayLengthXYNormalised);
+          CHECK_AND_FILL_VEC_B0(cpa);
+          CHECK_AND_FILL_VEC_B0(cpaXY);
+          CHECK_AND_FILL_VEC_B0(maxNormalisedDeltaIP);
+          // TPC PID variable
+          CHECK_AND_FILL_VEC_B0_FULL(prong1, tpcNSigmaPi1, tpcNSigmaPi);
+          // TOF PID variable
+          CHECK_AND_FILL_VEC_B0_FULL(prong1, tofNSigmaPi1, tofNSigmaPi);
+          // Combined PID variables
+          CHECK_AND_FILL_VEC_B0_FUNC(prong1, tpcTofNSigmaPi1, o2::pid_tpc_tof_utils::getTpcTofNSigmaPi1);
+        }
+      }
+    }
+
+    return inputFeatures;
+  }
+
+ protected:
+  /// Method to fill the map of available input features
+  void setAvailableInputFeatures()
+  {
+    MlResponse<TypeOutputScore>::mAvailableInputFeatures = {
+      FILL_MAP_B0(ptProng0),
+      FILL_MAP_B0(ptProng1),
+      FILL_MAP_B0(impactParameter0),
+      FILL_MAP_B0(impactParameter1),
+      FILL_MAP_B0(impactParameterProduct),
+      FILL_MAP_B0(chi2PCA),
+      FILL_MAP_B0(decayLength),
+      FILL_MAP_B0(decayLengthXY),
+      FILL_MAP_B0(decayLengthNormalised),
+      FILL_MAP_B0(decayLengthXYNormalised),
+      FILL_MAP_B0(cpa),
+      FILL_MAP_B0(cpaXY),
+      FILL_MAP_B0(maxNormalisedDeltaIP),
+      FILL_MAP_B0(prong0MlScoreBkg),
+      FILL_MAP_B0(prong0MlScorePrompt),
+      FILL_MAP_B0(prong0MlScoreNonprompt),
+      // TPC PID variable
+      FILL_MAP_B0(tpcNSigmaPi1),
+      // TOF PID variable
+      FILL_MAP_B0(tofNSigmaPi1),
+      // Combined PID variable
+      FILL_MAP_B0(tpcTofNSigmaPi1)};
+  }
+};
+
+} // namespace o2::analysis
+
+#undef FILL_MAP_B0
+#undef CHECK_AND_FILL_VEC_B0_FULL
+#undef CHECK_AND_FILL_VEC_B0_FUNC
+#undef CHECK_AND_FILL_VEC_B0
+
+#endif // PWGHF_CORE_HFMLRESPONSEB0TODPI_H_

--- a/PWGHF/Core/HfMlResponseB0ToDPi.h
+++ b/PWGHF/Core/HfMlResponseB0ToDPi.h
@@ -25,9 +25,9 @@
 // Fill the map of available input features
 // the key is the feature's name (std::string)
 // the value is the corresponding value in EnumInputFeatures
-#define FILL_MAP_B0(FEATURE)                                      \
-  {                                                               \
-    #FEATURE, static_cast<uint8_t>(InputFeaturesB0ToDPi::FEATURE) \
+#define FILL_MAP_B0(FEATURE)                                        \
+  {                                                                 \
+#FEATURE, static_cast < uint8_t>(InputFeaturesB0ToDPi::FEATURE) \
   }
 
 // Check if the index of mCachedIndices (index associated to a FEATURE)

--- a/PWGHF/Core/HfMlResponseB0ToDPi.h
+++ b/PWGHF/Core/HfMlResponseB0ToDPi.h
@@ -25,9 +25,9 @@
 // Fill the map of available input features
 // the key is the feature's name (std::string)
 // the value is the corresponding value in EnumInputFeatures
-#define FILL_MAP_B0(FEATURE)                                        \
-  {                                                                 \
-#FEATURE, static_cast < uint8_t>(InputFeaturesB0ToDPi::FEATURE) \
+#define FILL_MAP_B0(FEATURE)                                      \
+  {                                                               \
+    #FEATURE, static_cast<uint8_t>(InputFeaturesB0ToDPi::FEATURE) \
   }
 
 // Check if the index of mCachedIndices (index associated to a FEATURE)

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -25,7 +25,7 @@ o2physics_add_dpl_workflow(candidate-creator-bplus-reduced
 
 o2physics_add_dpl_workflow(candidate-selector-b0-to-d-pi-reduced
                     SOURCES candidateSelectorB0ToDPiReduced.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(candidate-selector-bplus-to-d0-pi-reduced

--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -68,15 +68,15 @@ struct HfCandidateSelectorB0ToDPiReduced {
   Configurable<std::vector<std::string>> namesInputFeatures{"namesInputFeatures", std::vector<std::string>{"feature1", "feature2"}, "Names of ML model input features"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"EventFiltering/PWGHF/BDTDPlus"}, "Paths of models on CCDB"};
-  Configurable<std::vector<std::string>> onnxFileNames{"onnxFileNames", std::vector<std::string>{"ModelHandler_onnx_DPlusToKPiPi.onnx"}, "ONNX file names for each pT bin (if not from CCDB full path)"};
+  Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"path_ccdb/BDT_B0/"}, "Paths of models on CCDB"};
+  Configurable<std::vector<std::string>> onnxFileNames{"onnxFileNames", std::vector<std::string>{"ModelHandler_onnx_B0ToDPi.onnx"}, "ONNX file names for each pT bin (if not from CCDB full path)"};
   Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB"};
   Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
   // variable that will store the value of selectionFlagD (defined in dataCreatorDplusPiReduced.cxx)
   int mySelectionFlagD = -1;
 
   o2::analysis::HfMlResponseB0ToDPi<float> hfMlResponse;
-  std::vector<float> outputMlNotPreselected = {};
+  float outputMlNotPreselected = -1.;
   std::vector<float> outputMl = {};
   o2::ccdb::CcdbApi ccdbApi;
 
@@ -223,7 +223,7 @@ struct HfCandidateSelectorB0ToDPiReduced {
         // B0 ML selections
         std::vector<float> inputFeatures = hfMlResponse.getInputFeatures<withDmesMl>(hfCandB0, trackPi);
         bool isSelectedMl = hfMlResponse.isSelectedMl(inputFeatures, ptCandB0, outputMl);
-        hfMlB0ToDPiCandidate(outputMl);
+        hfMlB0ToDPiCandidate(outputMl[1]); // storing ML score for signal class
 
         if (!isSelectedMl) {
           hfSelB0ToDPiCandidate(statusB0ToDPi);

--- a/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateSelectorB0ToDPiReduced.cxx
@@ -21,6 +21,7 @@
 #include "Common/Core/TrackSelectorPID.h"
 
 #include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/Core/HfMlResponseB0ToDPi.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -33,6 +34,7 @@ using namespace o2::analysis;
 
 struct HfCandidateSelectorB0ToDPiReduced {
   Produces<aod::HfSelB0ToDPi> hfSelB0ToDPiCandidate; // table defined in CandidateSelectionTables.h
+  Produces<aod::HfMlB0ToDPi> hfMlB0ToDPiCandidate;   // table defined in CandidateSelectionTables.h
 
   Configurable<float> ptCandMin{"ptCandMin", 0., "Lower bound of candidate pT"};
   Configurable<float> ptCandMax{"ptCandMax", 50., "Upper bound of candidate pT"};
@@ -57,16 +59,33 @@ struct HfCandidateSelectorB0ToDPiReduced {
   Configurable<LabeledArray<double>> cutsDmesMl{"cutsDmesMl", {hf_cuts_ml::cuts[0], hf_cuts_ml::nBinsPt, hf_cuts_ml::nCutScores, hf_cuts_ml::labelsPt, hf_cuts_ml::labelsDmesCutScore}, "D-meson ML cuts per pT bin"};
   // QA switch
   Configurable<bool> activateQA{"activateQA", false, "Flag to enable QA histogram"};
-
+  // B0 ML inference
+  Configurable<bool> applyB0Ml{"applyB0Ml", false, "Flag to apply ML selections"};
+  Configurable<std::vector<double>> binsPtB0Ml{"binsPtB0Ml", std::vector<double>{hf_cuts_ml::vecBinsPt}, "pT bin limits for ML application"};
+  Configurable<std::vector<int>> cutDirB0Ml{"cutDirB0Ml", std::vector<int>{hf_cuts_ml::vecCutDir}, "Whether to reject score values greater or smaller than the threshold"};
+  Configurable<LabeledArray<double>> cutsB0Ml{"cutsB0Ml", {hf_cuts_ml::cuts[0], hf_cuts_ml::nBinsPt, hf_cuts_ml::nCutScores, hf_cuts_ml::labelsPt, hf_cuts_ml::labelsCutScore}, "ML selections per pT bin"};
+  Configurable<int8_t> nClassesB0Ml{"nClassesB0Ml", (int8_t)hf_cuts_ml::nCutScores, "Number of classes in ML model"};
+  Configurable<std::vector<std::string>> namesInputFeatures{"namesInputFeatures", std::vector<std::string>{"feature1", "feature2"}, "Names of ML model input features"};
+  // CCDB configuration
+  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"EventFiltering/PWGHF/BDTDPlus"}, "Paths of models on CCDB"};
+  Configurable<std::vector<std::string>> onnxFileNames{"onnxFileNames", std::vector<std::string>{"ModelHandler_onnx_DPlusToKPiPi.onnx"}, "ONNX file names for each pT bin (if not from CCDB full path)"};
+  Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB"};
+  Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
   // variable that will store the value of selectionFlagD (defined in dataCreatorDplusPiReduced.cxx)
   int mySelectionFlagD = -1;
 
-  HfHelper hfHelper;
-  TrackSelectorPi selectorPion;
+  o2::analysis::HfMlResponseB0ToDPi<float> hfMlResponse;
+  std::vector<float> outputMlNotPreselected = {};
+  std::vector<float> outputMl = {};
+  o2::ccdb::CcdbApi ccdbApi;
 
-  HistogramRegistry registry{"registry"};
+  TrackSelectorPi selectorPion;
+  HfHelper hfHelper;
 
   using TracksPion = soa::Join<HfRedTracks, HfRedTracksPid>;
+
+  HistogramRegistry registry{"registry"};
 
   void init(InitContext const& initContext)
   {
@@ -101,6 +120,18 @@ struct HfCandidateSelectorB0ToDPiReduced {
         registry.get<TH2>(HIST("hSelections"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
       }
     }
+
+    if (applyB0Ml) {
+      hfMlResponse.configure(binsPtB0Ml, cutsB0Ml, cutDirB0Ml, nClassesB0Ml);
+      if (loadModelsFromCCDB) {
+        ccdbApi.init(ccdbUrl);
+        hfMlResponse.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
+      } else {
+        hfMlResponse.setModelPathsLocal(onnxFileNames);
+      }
+      hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
+      hfMlResponse.init();
+    }
   }
 
   /// Main function to perform B0 candidate creation
@@ -125,6 +156,9 @@ struct HfCandidateSelectorB0ToDPiReduced {
       // check if flagged as B0 → D π
       if (!TESTBIT(hfCandB0.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
         hfSelB0ToDPiCandidate(statusB0ToDPi);
+        if (applyB0Ml) {
+          hfMlB0ToDPiCandidate(outputMlNotPreselected);
+        }
         if (activateQA) {
           registry.fill(HIST("hSelections"), 1, ptCandB0);
         }
@@ -139,6 +173,9 @@ struct HfCandidateSelectorB0ToDPiReduced {
       // topological cuts
       if (!hfHelper.selectionB0ToDPiTopol(hfCandB0, cuts, binsPt)) {
         hfSelB0ToDPiCandidate(statusB0ToDPi);
+        if (applyB0Ml) {
+          hfMlB0ToDPiCandidate(outputMlNotPreselected);
+        }
         // LOGF(info, "B0 candidate selection failed at topology selection");
         continue;
       }
@@ -146,6 +183,9 @@ struct HfCandidateSelectorB0ToDPiReduced {
       if constexpr (withDmesMl) { // we include it in the topological selections
         if (!hfHelper.selectionDmesMlScoresForB(hfCandB0, cutsDmesMl, binsPtDmesMl)) {
           hfSelB0ToDPiCandidate(statusB0ToDPi);
+          if (applyB0Ml) {
+            hfMlB0ToDPiCandidate(outputMlNotPreselected);
+          }
           // LOGF(info, "B0 candidate selection failed at D-meson ML selection");
           continue;
         }
@@ -157,8 +197,8 @@ struct HfCandidateSelectorB0ToDPiReduced {
       }
 
       // track-level PID selection
+      auto trackPi = hfCandB0.template prong1_as<TracksPion>();
       if (usePionPid) {
-        auto trackPi = hfCandB0.template prong1_as<TracksPion>();
         int pidTrackPi{TrackSelectorPID::Status::NotApplicable};
         if (usePionPid == 1) {
           pidTrackPi = selectorPion.statusTpcOrTof(trackPi);
@@ -168,6 +208,9 @@ struct HfCandidateSelectorB0ToDPiReduced {
         if (!hfHelper.selectionB0ToDPiPid(pidTrackPi, acceptPIDNotApplicable.value)) {
           // LOGF(info, "B0 candidate selection failed at PID selection");
           hfSelB0ToDPiCandidate(statusB0ToDPi);
+          if (applyB0Ml) {
+            hfMlB0ToDPiCandidate(outputMlNotPreselected);
+          }
           continue;
         }
         SETBIT(statusB0ToDPi, SelectionStep::RecoPID); // RecoPID = 2 --> statusB0ToDPi = 7
@@ -175,6 +218,23 @@ struct HfCandidateSelectorB0ToDPiReduced {
           registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoPID, ptCandB0);
         }
       }
+
+      if (applyB0Ml) {
+        // B0 ML selections
+        std::vector<float> inputFeatures = hfMlResponse.getInputFeatures<withDmesMl>(hfCandB0, trackPi);
+        bool isSelectedMl = hfMlResponse.isSelectedMl(inputFeatures, ptCandB0, outputMl);
+        hfMlB0ToDPiCandidate(outputMl);
+
+        if (!isSelectedMl) {
+          hfSelB0ToDPiCandidate(statusB0ToDPi);
+          continue;
+        }
+        SETBIT(statusB0ToDPi, SelectionStep::RecoMl); // RecoML = 3 --> statusB0ToDPi = 15 if usePionPid, 11 otherwise
+        if (activateQA) {
+          registry.fill(HIST("hSelections"), 2 + SelectionStep::RecoMl, ptCandB0);
+        }
+      }
+
       hfSelB0ToDPiCandidate(statusB0ToDPi);
       // LOGF(info, "B0 candidate selection passed all selections");
     }

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -57,6 +57,8 @@ DECLARE_SOA_COLUMN(ImpactParameterProduct, impactParameterProduct, float);   //!
 DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of candidate
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
 DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);       //! Maximum normalized difference between measured and expected impact parameter of candidate prongs
+DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);                           //! ML score for background class
+DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);                     //! ML score for prompt class
 } // namespace hf_cand_b0_lite
 
 DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with some B0 properties
@@ -76,6 +78,8 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_b0_reduced::Prong0MlScoreBkg,
                   hf_cand_b0_reduced::Prong0MlScorePrompt,
                   hf_cand_b0_reduced::Prong0MlScoreNonprompt,
+                  hf_cand_b0_lite::MlScoreBkg,
+                  hf_cand_b0_lite::MlScorePrompt,
                   hf_sel_candidate_b0::IsSelB0ToDPi,
                   hf_cand_b0_lite::M,
                   hf_cand_b0_lite::Pt,
@@ -118,11 +122,11 @@ struct HfTaskB0Reduced {
 
   void init(InitContext&)
   {
-    std::array<bool, 2> processFuncData{doprocessData, doprocessDataWithDmesMl};
+    std::array<bool, 3> processFuncData{doprocessData, doprocessDataWithDmesMl, doprocessDataWithB0Ml};
     if ((std::accumulate(processFuncData.begin(), processFuncData.end(), 0)) > 1) {
       LOGP(fatal, "Only one process function for data can be enabled at a time.");
     }
-    std::array<bool, 2> processFuncMc{doprocessMc, doprocessMcWithDmesMl};
+    std::array<bool, 3> processFuncMc{doprocessMc, doprocessMcWithDmesMl, doprocessMcWithB0Ml};
     if ((std::accumulate(processFuncMc.begin(), processFuncMc.end(), 0)) > 1) {
       LOGP(fatal, "Only one process function for MC can be enabled at a time.");
     }
@@ -146,7 +150,7 @@ struct HfTaskB0Reduced {
     const AxisSpec axisPtDminus{100, 0.f, 50.f};
     const AxisSpec axisPtPi{100, 0.f, 10.f};
 
-    if (doprocessData || doprocessDataWithDmesMl) {
+    if (doprocessData || doprocessDataWithDmesMl || doprocessDataWithB0Ml) {
       if (fillHistograms) {
         registry.add("hMass", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});#it{M} (D#pi) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {axisPtB0, axisMassB0}});
         registry.add("hDecLength", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});B^{0} candidate decay length (cm);entries", {HistType::kTH2F, {axisPtB0, axisDecayLength}});
@@ -173,9 +177,15 @@ struct HfTaskB0Reduced {
           registry.add("hMlScorePromptD", "B^{0} candidates;#it{p}_{T}(D^{#minus}) (GeV/#it{c});prong0, D^{#minus} ML prompt score;entries", {HistType::kTH2F, {axisPtDminus, axisMlScore}});
           registry.add("hMlScoreNonPromptD", "B^{0} candidates;#it{p}_{T}(D^{#minus}) (GeV/#it{c});prong0, D^{#minus} ML nonprompt score;entries", {HistType::kTH2F, {axisPtDminus, axisMlScore}});
         }
+
+        // ML scores of B0 candidate
+        if (doprocessDataWithB0Ml) {
+          registry.add("hMlScoreBkgB0", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScorePromptB0", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+        }
       }
       if (fillSparses) {
-        if (!doprocessDataWithDmesMl) {
+        if (!(doprocessDataWithDmesMl || doprocessDataWithB0Ml)) {
           registry.add("hMassPtCutVars", "B^{0} candidates;#it{M} (D#pi) (GeV/#it{c}^{2});#it{p}_{T}(B^{0}) (GeV/#it{c});B^{0} candidate decay length (cm);B^{0} candidate norm. decay length XY (cm);B^{0} candidate impact parameter product (cm);B^{0} candidate cos(#vartheta_{P});#it{M} (K#pi) (GeV/#it{c}^{2});#it{p}_{T}(D^{#minus}) (GeV/#it{c});D^{#minus} candidate decay length (cm);D^{#minus} candidate cos(#vartheta_{P})", {HistType::kTHnSparseF, {axisMassB0, axisPtB0, axisDecayLength, axisNormDecayLength, axisImpParProd, axisCosp, axisMassDminus, axisPtDminus, axisDecayLength, axisCosp}});
         } else {
           registry.add("hMassPtCutVars", "B^{0} candidates;#it{M} (D#pi) (GeV/#it{c}^{2});#it{p}_{T}(B^{0}) (GeV/#it{c});B^{0} candidate decay length (cm);B^{0} candidate norm. decay length XY (cm);B^{0} candidate impact parameter product (cm);B^{0} candidate cos(#vartheta_{P});#it{M} (K#pi) (GeV/#it{c}^{2});#it{p}_{T}(D^{#minus}) (GeV/#it{c});D^{#minus} candidate ML score bkg;D^{#minus} candidate ML score nonprompt", {HistType::kTHnSparseF, {axisMassB0, axisPtB0, axisDecayLength, axisNormDecayLength, axisImpParProd, axisCosp, axisMassDminus, axisPtDminus, axisMlScore, axisMlScore}});
@@ -183,7 +193,7 @@ struct HfTaskB0Reduced {
       }
     }
 
-    if (doprocessMc || doprocessMcWithDmesMl) {
+    if (doprocessMc || doprocessMcWithDmesMl || doprocessMcWithB0Ml) {
       if (fillHistograms) {
         // gen histos
         registry.add("hEtaGen", "B^{0} particles (generated);#it{p}_{T}^{gen}(B^{0}) (GeV/#it{c});#it{#eta}^{gen}(B^{0});entries", {HistType::kTH2F, {axisPtB0, axisEta}});
@@ -262,6 +272,15 @@ struct HfTaskB0Reduced {
           registry.add("hMlScorePromptDRecBg", "B^{0} candidates (unmatched);#it{p}_{T}(D^{#minus}) (GeV/#it{c});prong0, D^{#minus} ML prompt score;entries", {HistType::kTH2F, {axisPtDminus, axisMlScore}});
           registry.add("hMlScoreNonPromptDRecBg", "B^{0} candidates (unmatched);#it{p}_{T}(D^{#minus}) (GeV/#it{c});prong0, D^{#minus} ML nonprompt score;entries", {HistType::kTH2F, {axisPtDminus, axisMlScore}});
         }
+        // ML scores of B0 candidate
+        if (doprocessMcWithB0Ml) {
+          // signal
+          registry.add("hMlScoreBkgB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScorePromptB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          // background
+          registry.add("hMlScoreBkgB0RecBg", "B^{0} candidates (unmatched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScorePromptB0RecBg", "B^{0} candidates (unmatched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+        }
       }
       if (fillSparses) {
         // gen sparses
@@ -269,7 +288,7 @@ struct HfTaskB0Reduced {
         registry.add("hPtYWithProngsInAccepanceGenSig", "B^{0} particles (generated-daughters in acceptance);#it{p}_{T}(B^{0}) (GeV/#it{c});#it{y}(B^{0})", {HistType::kTHnSparseF, {axisPtB0, axisEta}});
 
         // reco sparses
-        if (!doprocessDataWithDmesMl) {
+        if (!(doprocessDataWithDmesMl || doprocessDataWithB0Ml)) {
           registry.add("hMassPtCutVarsRecSig", "B^{0} candidates (matched);#it{M} (D#pi) (GeV/#it{c}^{2});#it{p}_{T}(B^{0}) (GeV/#it{c});B^{0} candidate decay length (cm);B^{0} candidate norm. decay length XY (cm);B^{0} candidate impact parameter product (cm);B^{0} candidate cos(#vartheta_{P});#it{M} (K#pi) (GeV/#it{c}^{2});#it{p}_{T}(D^{#minus}) (GeV/#it{c});D^{#minus} candidate decay length (cm);D^{#minus} candidate cos(#vartheta_{P})", {HistType::kTHnSparseF, {axisMassB0, axisPtB0, axisDecayLength, axisNormDecayLength, axisImpParProd, axisCosp, axisMassDminus, axisPtDminus, axisDecayLength, axisCosp}});
           if (fillBackground) {
             registry.add("hMassPtCutVarsRecBg", "B^{0} candidates (unmatched);#it{M} (D#pi) (GeV/#it{c}^{2});#it{p}_{T}(B^{0}) (GeV/#it{c});B^{0} candidate decay length (cm);B^{0} candidate norm. decay length XY (cm);B^{0} candidate impact parameter product (cm);B^{0} candidate cos(#vartheta_{P});#it{M} (K#pi) (GeV/#it{c}^{2});#it{p}_{T}(D^{#minus}) (GeV/#it{c});D^{#minus} candidate decay length (cm);D^{#minus} candidate cos(#vartheta_{P})", {HistType::kTHnSparseF, {axisMassB0, axisPtB0, axisDecayLength, axisNormDecayLength, axisImpParProd, axisCosp, axisMassDminus, axisPtDminus, axisDecayLength, axisCosp}});
@@ -294,11 +313,13 @@ struct HfTaskB0Reduced {
     return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
   }
 
-  /// Fill candidate histograms (reco no MC truth)
-  /// \param withDmesMl is the flag to enable the filling of hisgorams with ML scores for the D- daughter
+  /// Fill candidate information at reconstruction level
+  /// \param doMc is the flag to enable the filling with MC information
+  /// \param withDmesMl is the flag to enable the filling with ML scores for the D- daughter
+  /// \param withB0Ml is the flag to enable the filling with ML scores for the B0 candidate
   /// \param candidate is the B0 candidate
   /// \param candidatesD is the table with D- candidates
-  template <bool withDmesMl, typename Cand>
+  template <bool doMc, bool withDmesMl, bool withB0Ml, typename Cand>
   void fillCand(Cand const& candidate,
                 aod::HfRed3Prongs const& candidatesD)
   {
@@ -315,54 +336,157 @@ struct HfTaskB0Reduced {
     auto decLenD = RecoDecay::distance(posPv, posSvD);
     auto decLenXyD = RecoDecay::distanceXY(posPv, posSvD);
 
-    if (fillHistograms) {
-      registry.fill(HIST("hMass"), ptCandB0, invMassB0);
-      registry.fill(HIST("hPtProng0"), ptCandB0, ptD);
-      registry.fill(HIST("hPtProng1"), ptCandB0, candidate.ptProng1());
-      registry.fill(HIST("hImpParProd"), ptCandB0, candidate.impactParameterProduct());
-      registry.fill(HIST("hDecLength"), ptCandB0, candidate.decayLength());
-      registry.fill(HIST("hDecLengthXy"), ptCandB0, candidate.decayLengthXY());
-      registry.fill(HIST("hNormDecLengthXy"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
-      registry.fill(HIST("hDcaProng0"), ptCandB0, candidate.impactParameter0());
-      registry.fill(HIST("hDcaProng1"), ptCandB0, candidate.impactParameter1());
-      registry.fill(HIST("hCosp"), ptCandB0, candidate.cpa());
-      registry.fill(HIST("hCospXy"), ptCandB0, candidate.cpaXY());
-      registry.fill(HIST("hEta"), ptCandB0, candidate.eta());
-      registry.fill(HIST("hRapidity"), ptCandB0, hfHelper.yB0(candidate));
-      registry.fill(HIST("hInvMassD"), ptD, invMassD);
-      registry.fill(HIST("hDecLengthD"), ptD, decLenD);
-      registry.fill(HIST("hDecLengthXyD"), ptD, decLenXyD);
-      registry.fill(HIST("hCospD"), ptD, cospD);
-      registry.fill(HIST("hCospXyD"), ptD, cospXyD);
+    int8_t flagMcMatchRec = 0;
+    bool isSignal = false;
+    if constexpr (doMc) {
+      flagMcMatchRec = candidate.flagMcMatchRec();
+      isSignal = TESTBIT(std::abs(flagMcMatchRec), hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi);
+    }
 
-      if constexpr (withDmesMl) {
-        registry.fill(HIST("hMlScoreBkgD"), ptD, candidate.prong0MlScoreBkg());
-        registry.fill(HIST("hMlScorePromptD"), ptD, candidate.prong0MlScorePrompt());
-        registry.fill(HIST("hMlScoreNonPromptD"), ptD, candidate.prong0MlScoreNonprompt());
+    if (fillHistograms) {
+      if constexpr (doMc) {
+        if (isSignal) {
+          registry.fill(HIST("hMassRecSig"), ptCandB0, hfHelper.invMassB0ToDPi(candidate));
+          registry.fill(HIST("hPtProng0RecSig"), ptCandB0, candidate.ptProng0());
+          registry.fill(HIST("hPtProng1RecSig"), ptCandB0, candidate.ptProng1());
+          registry.fill(HIST("hImpParProdRecSig"), ptCandB0, candidate.impactParameterProduct());
+          registry.fill(HIST("hDecLengthRecSig"), ptCandB0, candidate.decayLength());
+          registry.fill(HIST("hDecLengthXyRecSig"), ptCandB0, candidate.decayLengthXY());
+          registry.fill(HIST("hNormDecLengthXyRecSig"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
+          registry.fill(HIST("hDcaProng0RecSig"), ptCandB0, candidate.impactParameter0());
+          registry.fill(HIST("hDcaProng1RecSig"), ptCandB0, candidate.impactParameter1());
+          registry.fill(HIST("hCospRecSig"), ptCandB0, candidate.cpa());
+          registry.fill(HIST("hCospXyRecSig"), ptCandB0, candidate.cpaXY());
+          registry.fill(HIST("hEtaRecSig"), ptCandB0, candidate.eta());
+          registry.fill(HIST("hRapidityRecSig"), ptCandB0, hfHelper.yB0(candidate));
+          registry.fill(HIST("hInvMassDRecSig"), ptD, invMassD);
+          registry.fill(HIST("hDecLengthDRecSig"), ptD, decLenD);
+          registry.fill(HIST("hDecLengthXyDRecSig"), ptD, decLenXyD);
+          registry.fill(HIST("hCospDRecSig"), ptD, cospD);
+          registry.fill(HIST("hCospXyDRecSig"), ptD, cospXyD);
+          if (checkDecayTypeMc) {
+            registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi, invMassB0, ptCandB0);
+          }
+          if constexpr (withDmesMl) {
+            registry.fill(HIST("hMlScoreBkgDRecSig"), ptD, candidate.prong0MlScoreBkg());
+            registry.fill(HIST("hMlScorePromptDRecSig"), ptD, candidate.prong0MlScorePrompt());
+            registry.fill(HIST("hMlScoreNonPromptDRecSig"), ptD, candidate.prong0MlScoreNonprompt());
+          }
+          if constexpr (withB0Ml) {
+            registry.fill(HIST("hMlScoreBkgB0RecSig"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
+            registry.fill(HIST("hMlScorePromptB0RecSig"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+          }
+        } else if (fillBackground) {
+          registry.fill(HIST("hMassRecBg"), ptCandB0, hfHelper.invMassB0ToDPi(candidate));
+          registry.fill(HIST("hPtProng0RecBg"), ptCandB0, candidate.ptProng0());
+          registry.fill(HIST("hPtProng1RecBg"), ptCandB0, candidate.ptProng1());
+          registry.fill(HIST("hImpParProdRecBg"), ptCandB0, candidate.impactParameterProduct());
+          registry.fill(HIST("hDecLengthRecBg"), ptCandB0, candidate.decayLength());
+          registry.fill(HIST("hDecLengthXyRecBg"), ptCandB0, candidate.decayLengthXY());
+          registry.fill(HIST("hNormDecLengthXyRecBg"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
+          registry.fill(HIST("hDcaProng0RecBg"), ptCandB0, candidate.impactParameter0());
+          registry.fill(HIST("hDcaProng1RecBg"), ptCandB0, candidate.impactParameter1());
+          registry.fill(HIST("hCospRecBg"), ptCandB0, candidate.cpa());
+          registry.fill(HIST("hCospXyRecBg"), ptCandB0, candidate.cpaXY());
+          registry.fill(HIST("hEtaRecBg"), ptCandB0, candidate.eta());
+          registry.fill(HIST("hRapidityRecBg"), ptCandB0, hfHelper.yB0(candidate));
+          registry.fill(HIST("hInvMassDRecBg"), ptD, invMassD);
+          registry.fill(HIST("hDecLengthDRecBg"), ptD, decLenD);
+          registry.fill(HIST("hDecLengthXyDRecBg"), ptD, decLenXyD);
+          registry.fill(HIST("hCospDRecBg"), ptD, cospD);
+          registry.fill(HIST("hCospXyDRecBg"), ptD, cospXyD);
+          if constexpr (withDmesMl) {
+            registry.fill(HIST("hMlScoreBkgDRecBg"), ptD, candidate.prong0MlScoreBkg());
+            registry.fill(HIST("hMlScorePromptDRecBg"), ptD, candidate.prong0MlScorePrompt());
+            registry.fill(HIST("hMlScoreNonPromptDRecBg"), ptD, candidate.prong0MlScoreNonprompt());
+          }
+          if constexpr (withB0Ml) {
+            registry.fill(HIST("hMlScoreBkgB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
+            registry.fill(HIST("hMlScorePromptB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+          }
+        } else if (checkDecayTypeMc) {
+          if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi)) { // B0 → Ds- π+ → (K- K+ π-) π+
+            registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi, invMassB0, ptCandB0);
+          } else if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::PartlyRecoDecay)) { // Partly reconstructed decay channel
+            registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::PartlyRecoDecay, invMassB0, ptCandB0);
+          } else {
+            registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::OtherDecay, invMassB0, ptCandB0);
+          }
+        }
+      } else {
+        registry.fill(HIST("hMass"), ptCandB0, invMassB0);
+        registry.fill(HIST("hPtProng0"), ptCandB0, candidate.ptProng0());
+        registry.fill(HIST("hPtProng1"), ptCandB0, candidate.ptProng1());
+        registry.fill(HIST("hImpParProd"), ptCandB0, candidate.impactParameterProduct());
+        registry.fill(HIST("hDecLength"), ptCandB0, candidate.decayLength());
+        registry.fill(HIST("hDecLengthXy"), ptCandB0, candidate.decayLengthXY());
+        registry.fill(HIST("hNormDecLengthXy"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
+        registry.fill(HIST("hDcaProng0"), ptCandB0, candidate.impactParameter0());
+        registry.fill(HIST("hDcaProng1"), ptCandB0, candidate.impactParameter1());
+        registry.fill(HIST("hCosp"), ptCandB0, candidate.cpa());
+        registry.fill(HIST("hCospXy"), ptCandB0, candidate.cpaXY());
+        registry.fill(HIST("hEta"), ptCandB0, candidate.eta());
+        registry.fill(HIST("hRapidity"), ptCandB0, hfHelper.yB0(candidate));
+        registry.fill(HIST("hInvMassD"), ptD, invMassD);
+        registry.fill(HIST("hDecLengthD"), ptD, decLenD);
+        registry.fill(HIST("hDecLengthXyD"), ptD, decLenXyD);
+        registry.fill(HIST("hCospD"), ptD, cospD);
+        registry.fill(HIST("hCospXyD"), ptD, cospXyD);
+
+        if constexpr (withDmesMl) {
+          registry.fill(HIST("hMlScoreBkgD"), ptD, candidate.prong0MlScoreBkg());
+          registry.fill(HIST("hMlScorePromptD"), ptD, candidate.prong0MlScorePrompt());
+          registry.fill(HIST("hMlScoreNonPromptD"), ptD, candidate.prong0MlScoreNonprompt());
+        }
       }
     }
     if (fillSparses) {
       if constexpr (withDmesMl) {
-        registry.fill(HIST("hMassPtCutVars"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
+        if (isSignal) {
+          if constexpr (withDmesMl) {
+            registry.fill(HIST("hMassPtCutVarsRecSig"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
+          } else {
+            registry.fill(HIST("hMassPtCutVarsRecSig"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
+          }
+        } else if (fillBackground) {
+          if constexpr (withDmesMl) {
+            registry.fill(HIST("hMassPtCutVarsRecBg"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
+          } else {
+            registry.fill(HIST("hMassPtCutVarsRecBg"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
+          }
+        }
       } else {
-        registry.fill(HIST("hMassPtCutVars"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
+        if constexpr (withDmesMl) {
+          registry.fill(HIST("hMassPtCutVars"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
+        } else {
+          registry.fill(HIST("hMassPtCutVars"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
+        }
       }
     }
     if (fillTree) {
       float pseudoRndm = ptD * 1000. - (int64_t)(ptD * 1000);
-      if (ptCandB0 >= ptMaxForDownSample || pseudoRndm < downSampleBkgFactor) {
-        int8_t flag{0};
-        int8_t origin{0};
+      if (flagMcMatchRec != 0 || (((doMc && fillBackground) || !doMc) && (ptCandB0 >= ptMaxForDownSample || pseudoRndm < downSampleBkgFactor))) {
         float prong0MlScoreBkg = -1.;
         float prong0MlScorePrompt = -1.;
         float prong0MlScoreNonprompt = -1.;
+        float candidateMlScoreBkg = -1;
+        float candidateMlScorePrompt = -1;
         if constexpr (withDmesMl) {
           prong0MlScoreBkg = candidate.prong0MlScoreBkg();
           prong0MlScorePrompt = candidate.prong0MlScorePrompt();
           prong0MlScoreNonprompt = candidate.prong0MlScoreNonprompt();
         }
+        if constexpr (withB0Ml) {
+          candidateMlScoreBkg = candidate.mlProbB0ToDPi()[0];
+          candidateMlScorePrompt = candidate.mlProbB0ToDPi()[1];
+        }
         auto prong1 = candidate.template prong1_as<TracksPion>();
 
+        float ptMother = -1.;
+        if constexpr (doMc) {
+          ptMother = candidate.ptMother();
+        }
+
         hfRedCandB0Lite(
           candidate.chi2PCA(),
           candidate.decayLength(),
@@ -380,151 +504,8 @@ struct HfTaskB0Reduced {
           prong0MlScoreBkg,
           prong0MlScorePrompt,
           prong0MlScoreNonprompt,
-          candidate.isSelB0ToDPi(),
-          invMassB0,
-          ptCandB0,
-          candidate.cpa(),
-          candidate.cpaXY(),
-          candidate.maxNormalisedDeltaIP(),
-          candidate.eta(),
-          candidate.phi(),
-          hfHelper.yB0(candidate),
-          flag,
-          origin,
-          -1.);
-      }
-    }
-  }
-
-  /// Fill candidate histograms (reco MC truth)
-  /// \param withDmesMl is the flag to enable the filling of hisgorams with ML scores for the D- daughter
-  /// \param candidate is the B0 candidate
-  /// \param candidatesD is the table with D- candidates
-  template <bool withDmesMl, typename Cand>
-  void fillCandMcReco(Cand const& candidate,
-                      aod::HfRed3Prongs const& candidatesD)
-  {
-    auto ptCandB0 = candidate.pt();
-    auto invMassB0 = hfHelper.invMassB0ToDPi(candidate);
-    auto candD = candidate.template prong0_as<aod::HfRed3Prongs>();
-    auto ptD = candidate.ptProng0();
-    auto invMassD = candD.invMass();
-    std::array<float, 3> posPv{candidate.posX(), candidate.posY(), candidate.posZ()};
-    std::array<float, 3> posSvD{candD.xSecondaryVertex(), candD.ySecondaryVertex(), candD.zSecondaryVertex()};
-    std::array<float, 3> momD{candD.px(), candD.py(), candD.pz()};
-    auto cospD = RecoDecay::cpa(posPv, posSvD, momD);
-    auto cospXyD = RecoDecay::cpaXY(posPv, posSvD, momD);
-    auto decLenD = RecoDecay::distance(posPv, posSvD);
-    auto decLenXyD = RecoDecay::distanceXY(posPv, posSvD);
-
-    int8_t flagMcMatchRec = candidate.flagMcMatchRec();
-    bool isSignal = TESTBIT(std::abs(flagMcMatchRec), hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi);
-    if (fillHistograms) {
-      if (isSignal) {
-        registry.fill(HIST("hMassRecSig"), ptCandB0, invMassB0);
-        registry.fill(HIST("hPtProng0RecSig"), ptCandB0, ptD);
-        registry.fill(HIST("hPtProng1RecSig"), ptCandB0, candidate.ptProng1());
-        registry.fill(HIST("hImpParProdRecSig"), ptCandB0, candidate.impactParameterProduct());
-        registry.fill(HIST("hDecLengthRecSig"), ptCandB0, candidate.decayLength());
-        registry.fill(HIST("hDecLengthXyRecSig"), ptCandB0, candidate.decayLengthXY());
-        registry.fill(HIST("hNormDecLengthXyRecSig"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
-        registry.fill(HIST("hDcaProng0RecSig"), ptCandB0, candidate.impactParameter0());
-        registry.fill(HIST("hDcaProng1RecSig"), ptCandB0, candidate.impactParameter1());
-        registry.fill(HIST("hCospRecSig"), ptCandB0, candidate.cpa());
-        registry.fill(HIST("hCospXyRecSig"), ptCandB0, candidate.cpaXY());
-        registry.fill(HIST("hEtaRecSig"), ptCandB0, candidate.eta());
-        registry.fill(HIST("hRapidityRecSig"), ptCandB0, hfHelper.yB0(candidate));
-        registry.fill(HIST("hInvMassDRecSig"), ptD, invMassD);
-        registry.fill(HIST("hDecLengthDRecSig"), ptD, decLenD);
-        registry.fill(HIST("hDecLengthXyDRecSig"), ptD, decLenXyD);
-        registry.fill(HIST("hCospDRecSig"), ptD, cospD);
-        registry.fill(HIST("hCospXyDRecSig"), ptD, cospXyD);
-        if (checkDecayTypeMc) {
-          registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi, invMassB0, ptCandB0);
-        }
-        if constexpr (withDmesMl) {
-          registry.fill(HIST("hMlScoreBkgDRecSig"), ptD, candidate.prong0MlScoreBkg());
-          registry.fill(HIST("hMlScorePromptDRecSig"), ptD, candidate.prong0MlScorePrompt());
-          registry.fill(HIST("hMlScoreNonPromptDRecSig"), ptD, candidate.prong0MlScoreNonprompt());
-        }
-      } else if (fillBackground) {
-        registry.fill(HIST("hMassRecBg"), ptCandB0, invMassB0);
-        registry.fill(HIST("hPtProng0RecBg"), ptCandB0, ptD);
-        registry.fill(HIST("hPtProng1RecBg"), ptCandB0, candidate.ptProng1());
-        registry.fill(HIST("hImpParProdRecBg"), ptCandB0, candidate.impactParameterProduct());
-        registry.fill(HIST("hDecLengthRecBg"), ptCandB0, candidate.decayLength());
-        registry.fill(HIST("hDecLengthXyRecBg"), ptCandB0, candidate.decayLengthXY());
-        registry.fill(HIST("hNormDecLengthXyRecBg"), ptCandB0, candidate.decayLengthXY() / candidate.errorDecayLengthXY());
-        registry.fill(HIST("hDcaProng0RecBg"), ptCandB0, candidate.impactParameter0());
-        registry.fill(HIST("hDcaProng1RecBg"), ptCandB0, candidate.impactParameter1());
-        registry.fill(HIST("hCospRecBg"), ptCandB0, candidate.cpa());
-        registry.fill(HIST("hCospXyRecBg"), ptCandB0, candidate.cpaXY());
-        registry.fill(HIST("hEtaRecBg"), ptCandB0, candidate.eta());
-        registry.fill(HIST("hRapidityRecBg"), ptCandB0, hfHelper.yB0(candidate));
-        registry.fill(HIST("hInvMassDRecBg"), ptD, invMassD);
-        registry.fill(HIST("hDecLengthDRecBg"), ptD, decLenD);
-        registry.fill(HIST("hDecLengthXyDRecBg"), ptD, decLenXyD);
-        registry.fill(HIST("hCospDRecBg"), ptD, cospD);
-        registry.fill(HIST("hCospXyDRecBg"), ptD, cospXyD);
-        if constexpr (withDmesMl) {
-          registry.fill(HIST("hMlScoreBkgDRecBg"), ptD, candidate.prong0MlScoreBkg());
-          registry.fill(HIST("hMlScorePromptDRecBg"), ptD, candidate.prong0MlScorePrompt());
-          registry.fill(HIST("hMlScoreNonPromptDRecBg"), ptD, candidate.prong0MlScoreNonprompt());
-        }
-      } else if (checkDecayTypeMc) {
-        if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi)) { // B0 → Ds- π+ → (K- K+ π-) π+
-          registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi, invMassB0, ptCandB0);
-        } else if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::PartlyRecoDecay)) { // Partly reconstructed decay channel
-          registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::PartlyRecoDecay, invMassB0, ptCandB0);
-        } else {
-          registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::OtherDecay, invMassB0, ptCandB0);
-        }
-      }
-    }
-    if (fillSparses) {
-      if (isSignal) {
-        if constexpr (withDmesMl) {
-          registry.fill(HIST("hMassPtCutVarsRecSig"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
-        } else {
-          registry.fill(HIST("hMassPtCutVarsRecSig"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
-        }
-      } else if (fillBackground) {
-        if constexpr (withDmesMl) {
-          registry.fill(HIST("hMassPtCutVarsRecBg"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, candidate.prong0MlScoreBkg(), candidate.prong0MlScoreNonprompt());
-        } else {
-          registry.fill(HIST("hMassPtCutVarsRecBg"), invMassB0, ptCandB0, candidate.decayLength(), candidate.decayLengthXY() / candidate.errorDecayLengthXY(), candidate.impactParameterProduct(), candidate.cpa(), invMassD, ptD, decLenD, cospD);
-        }
-      }
-    }
-    if (fillTree) {
-      float prong0MlScoreBkg = -1.;
-      float prong0MlScorePrompt = -1.;
-      float prong0MlScoreNonprompt = -1.;
-      if constexpr (withDmesMl) {
-        prong0MlScoreBkg = candidate.prong0MlScoreBkg();
-        prong0MlScorePrompt = candidate.prong0MlScorePrompt();
-        prong0MlScoreNonprompt = candidate.prong0MlScoreNonprompt();
-      }
-      auto prong1 = candidate.template prong1_as<TracksPion>();
-      float pseudoRndm = ptD * 1000. - (int64_t)(ptD * 1000);
-      if (isSignal || (fillBackground && (ptCandB0 >= ptMaxForDownSample || pseudoRndm < downSampleBkgFactor))) {
-        hfRedCandB0Lite(
-          candidate.chi2PCA(),
-          candidate.decayLength(),
-          candidate.decayLengthXY(),
-          candidate.decayLengthNormalised(),
-          candidate.decayLengthXYNormalised(),
-          invMassD,
-          ptD,
-          candidate.ptProng1(),
-          candidate.impactParameter0(),
-          candidate.impactParameter1(),
-          candidate.impactParameterProduct(),
-          prong1.tpcNSigmaPi(),
-          prong1.tofNSigmaPi(),
-          prong0MlScoreBkg,
-          prong0MlScorePrompt,
-          prong0MlScoreNonprompt,
+          candidateMlScoreBkg,
+          candidateMlScorePrompt,
           candidate.isSelB0ToDPi(),
           invMassB0,
           ptCandB0,
@@ -536,7 +517,7 @@ struct HfTaskB0Reduced {
           hfHelper.yB0(candidate),
           flagMcMatchRec,
           isSignal,
-          candidate.ptMother());
+          ptMother);
       }
     }
   }
@@ -591,11 +572,10 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false>(candidate, candidatesD);
+      fillCand<false, false, false>(candidate, candidatesD);
     } // candidate loop
   }   // processData
-
-  PROCESS_SWITCH(HfTaskB0Reduced, processData, "Process data without ML scores for D daughter", true);
+  PROCESS_SWITCH(HfTaskB0Reduced, processData, "Process data without ML scores for B0 and D daughter", true);
 
   void processDataWithDmesMl(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfRedB0DpMls, aod::HfSelB0ToDPi>> const& candidates,
                              aod::HfRed3Prongs const& candidatesD,
@@ -608,13 +588,28 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true>(candidate, candidatesD);
+      fillCand<false, true, false>(candidate, candidatesD);
     } // candidate loop
   }   // processDataWithDmesMl
+  PROCESS_SWITCH(HfTaskB0Reduced, processDataWithDmesMl, "Process data with(out) ML scores for D daughter (B0)", false);
 
-  PROCESS_SWITCH(HfTaskB0Reduced, processDataWithDmesMl, "Process data with ML scores for D daughter", false);
+  void processDataWithB0Ml(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfMlB0ToDPi, aod::HfSelB0ToDPi>> const& candidates,
+                           aod::HfRed3Prongs const& candidatesD,
+                           TracksPion const&)
+  {
+    for (const auto& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<false, false, true>(candidate, candidatesD);
+    } // candidate loop
+  }   // processDataWithB0Ml
+  PROCESS_SWITCH(HfTaskB0Reduced, processDataWithB0Ml, "Process data with(out) ML scores for B0 (D daughter)", false);
 
-  void processMc(soa::Join<aod::HfRedCandB0, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s> const& candidates,
+  void processMc(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s>> const& candidates,
                  aod::HfMcGenRedB0s const& mcParticles,
                  aod::HfRed3Prongs const& candidatesD,
                  TracksPion const&)
@@ -627,7 +622,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCandMcReco<false>(candidate, candidatesD);
+      fillCand<true, false, false>(candidate, candidatesD);
     } // rec
 
     // MC gen. level
@@ -635,9 +630,9 @@ struct HfTaskB0Reduced {
       fillCandMcGen(particle);
     } // gen
   }   // processMc
-  PROCESS_SWITCH(HfTaskB0Reduced, processMc, "Process MC without ML scores for D daughter", false);
+  PROCESS_SWITCH(HfTaskB0Reduced, processMc, "Process MC without ML scores for B0 and D daughter", false);
 
-  void processMcWithDmesMl(soa::Join<aod::HfRedCandB0, aod::HfRedB0DpMls, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s> const& candidates,
+  void processMcWithDmesMl(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfRedB0DpMls, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s>> const& candidates,
                            aod::HfMcGenRedB0s const& mcParticles,
                            aod::HfRed3Prongs const& candidatesD,
                            TracksPion const&)
@@ -650,7 +645,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCandMcReco<true>(candidate, candidatesD);
+      fillCand<true, true, false>(candidate, candidatesD);
     } // rec
 
     // MC gen. level
@@ -658,7 +653,30 @@ struct HfTaskB0Reduced {
       fillCandMcGen(particle);
     } // gen
   }   // processMcWithDmesMl
-  PROCESS_SWITCH(HfTaskB0Reduced, processMcWithDmesMl, "Process MC with ML scores for D daughter", false);
+  PROCESS_SWITCH(HfTaskB0Reduced, processMcWithDmesMl, "Process MC with(out) ML scores for D daughter (B0)", false);
+
+  void processMcWithB0Ml(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfMlB0ToDPi, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s>> const& candidates,
+                         aod::HfMcGenRedB0s const& mcParticles,
+                         aod::HfRed3Prongs const& candidatesD,
+                         TracksPion const&)
+  {
+    // MC rec
+    for (const auto& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<true, false, true>(candidate, candidatesD);
+    } // rec
+
+    // MC gen. level
+    for (const auto& particle : mcParticles) {
+      fillCandMcGen(particle);
+    } // gen
+  }   // processMcWithB0Ml
+  PROCESS_SWITCH(HfTaskB0Reduced, processMcWithB0Ml, "Process MC with(out) ML scores for B0 (D daughter)", false);
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -438,6 +438,10 @@ struct HfTaskB0Reduced {
           registry.fill(HIST("hMlScorePromptD"), ptD, candidate.prong0MlScorePrompt());
           registry.fill(HIST("hMlScoreNonPromptD"), ptD, candidate.prong0MlScoreNonprompt());
         }
+        if constexpr (withB0Ml) {
+          registry.fill(HIST("hMlScoreBkgB0"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
+          registry.fill(HIST("hMlScorePromptB0"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+        }
       }
     }
     if (fillSparses) {

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -57,8 +57,7 @@ DECLARE_SOA_COLUMN(ImpactParameterProduct, impactParameterProduct, float);   //!
 DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of candidate
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
 DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);       //! Maximum normalized difference between measured and expected impact parameter of candidate prongs
-DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);                           //! ML score for background class
-DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);                     //! ML score for prompt class
+DECLARE_SOA_COLUMN(MlScoreSig, mlScoreSig, float);                           //! ML score for signal class
 } // namespace hf_cand_b0_lite
 
 DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with some B0 properties
@@ -78,8 +77,7 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_b0_reduced::Prong0MlScoreBkg,
                   hf_cand_b0_reduced::Prong0MlScorePrompt,
                   hf_cand_b0_reduced::Prong0MlScoreNonprompt,
-                  hf_cand_b0_lite::MlScoreBkg,
-                  hf_cand_b0_lite::MlScorePrompt,
+                  hf_cand_b0_lite::MlScoreSig,
                   hf_sel_candidate_b0::IsSelB0ToDPi,
                   hf_cand_b0_lite::M,
                   hf_cand_b0_lite::Pt,
@@ -180,8 +178,7 @@ struct HfTaskB0Reduced {
 
         // ML scores of B0 candidate
         if (doprocessDataWithB0Ml) {
-          registry.add("hMlScoreBkgB0", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
-          registry.add("hMlScorePromptB0", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScoreSigB0", "B^{0} candidates;#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML signal score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
         }
       }
       if (fillSparses) {
@@ -275,11 +272,9 @@ struct HfTaskB0Reduced {
         // ML scores of B0 candidate
         if (doprocessMcWithB0Ml) {
           // signal
-          registry.add("hMlScoreBkgB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
-          registry.add("hMlScorePromptB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScoreSigB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML signal score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
           // background
-          registry.add("hMlScoreBkgB0RecBg", "B^{0} candidates (unmatched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML background score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
-          registry.add("hMlScorePromptB0RecBg", "B^{0} candidates (unmatched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML prompt score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
+          registry.add("hMlScoreSigB0RecBg", "B^{0} candidates (unmatched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML signal score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
         }
       }
       if (fillSparses) {
@@ -373,8 +368,7 @@ struct HfTaskB0Reduced {
             registry.fill(HIST("hMlScoreNonPromptDRecSig"), ptD, candidate.prong0MlScoreNonprompt());
           }
           if constexpr (withB0Ml) {
-            registry.fill(HIST("hMlScoreBkgB0RecSig"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
-            registry.fill(HIST("hMlScorePromptB0RecSig"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+            registry.fill(HIST("hMlScoreSigB0RecSig"), ptCandB0, candidate.mlProbB0ToDPi());
           }
         } else if (fillBackground) {
           registry.fill(HIST("hMassRecBg"), ptCandB0, hfHelper.invMassB0ToDPi(candidate));
@@ -401,8 +395,7 @@ struct HfTaskB0Reduced {
             registry.fill(HIST("hMlScoreNonPromptDRecBg"), ptD, candidate.prong0MlScoreNonprompt());
           }
           if constexpr (withB0Ml) {
-            registry.fill(HIST("hMlScoreBkgB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
-            registry.fill(HIST("hMlScorePromptB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+            registry.fill(HIST("hMlScoreSigB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi());
           }
         } else if (checkDecayTypeMc) {
           if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi)) { // B0 → Ds- π+ → (K- K+ π-) π+
@@ -439,8 +432,7 @@ struct HfTaskB0Reduced {
           registry.fill(HIST("hMlScoreNonPromptD"), ptD, candidate.prong0MlScoreNonprompt());
         }
         if constexpr (withB0Ml) {
-          registry.fill(HIST("hMlScoreBkgB0"), ptCandB0, candidate.mlProbB0ToDPi()[0]);
-          registry.fill(HIST("hMlScorePromptB0"), ptCandB0, candidate.mlProbB0ToDPi()[1]);
+          registry.fill(HIST("hMlScoreSigB0"), ptCandB0, candidate.mlProbB0ToDPi());
         }
       }
     }
@@ -473,16 +465,14 @@ struct HfTaskB0Reduced {
         float prong0MlScoreBkg = -1.;
         float prong0MlScorePrompt = -1.;
         float prong0MlScoreNonprompt = -1.;
-        float candidateMlScoreBkg = -1;
-        float candidateMlScorePrompt = -1;
+        float candidateMlScoreSig = -1;
         if constexpr (withDmesMl) {
           prong0MlScoreBkg = candidate.prong0MlScoreBkg();
           prong0MlScorePrompt = candidate.prong0MlScorePrompt();
           prong0MlScoreNonprompt = candidate.prong0MlScoreNonprompt();
         }
         if constexpr (withB0Ml) {
-          candidateMlScoreBkg = candidate.mlProbB0ToDPi()[0];
-          candidateMlScorePrompt = candidate.mlProbB0ToDPi()[1];
+          candidateMlScoreSig = candidate.mlProbB0ToDPi();
         }
         auto prong1 = candidate.template prong1_as<TracksPion>();
 
@@ -508,8 +498,7 @@ struct HfTaskB0Reduced {
           prong0MlScoreBkg,
           prong0MlScorePrompt,
           prong0MlScoreNonprompt,
-          candidateMlScoreBkg,
-          candidateMlScorePrompt,
+          candidateMlScoreSig,
           candidate.isSelB0ToDPi(),
           invMassB0,
           ptCandB0,

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -237,8 +237,8 @@ DECLARE_SOA_TABLE(HfSelLcToK0sP, "AOD", "HFSELLCK0SP", //!
 
 namespace hf_sel_candidate_b0
 {
-DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int);                  //!
-DECLARE_SOA_COLUMN(MlProbB0ToDPi, mlProbB0ToDPi, std::vector<float>); //!
+DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int);     //! selection flag on B0 candidate
+DECLARE_SOA_COLUMN(MlProbB0ToDPi, mlProbB0ToDPi, float); //! ML score of B0 candidate for signal class
 } // namespace hf_sel_candidate_b0
 
 DECLARE_SOA_TABLE(HfSelB0ToDPi, "AOD", "HFSELB0", //!

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -237,7 +237,7 @@ DECLARE_SOA_TABLE(HfSelLcToK0sP, "AOD", "HFSELLCK0SP", //!
 
 namespace hf_sel_candidate_b0
 {
-DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int); //!
+DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int);                  //!
 DECLARE_SOA_COLUMN(MlProbB0ToDPi, mlProbB0ToDPi, std::vector<float>); //!
 } // namespace hf_sel_candidate_b0
 

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -238,10 +238,14 @@ DECLARE_SOA_TABLE(HfSelLcToK0sP, "AOD", "HFSELLCK0SP", //!
 namespace hf_sel_candidate_b0
 {
 DECLARE_SOA_COLUMN(IsSelB0ToDPi, isSelB0ToDPi, int); //!
+DECLARE_SOA_COLUMN(MlProbB0ToDPi, mlProbB0ToDPi, std::vector<float>); //!
 } // namespace hf_sel_candidate_b0
 
 DECLARE_SOA_TABLE(HfSelB0ToDPi, "AOD", "HFSELB0", //!
                   hf_sel_candidate_b0::IsSelB0ToDPi);
+
+DECLARE_SOA_TABLE(HfMlB0ToDPi, "AOD", "HFMLB0", //!
+                  hf_sel_candidate_b0::MlProbB0ToDPi);
 
 namespace hf_sel_candidate_bs
 {


### PR DESCRIPTION
Hi @fgrosa , I implemented the ML inference for B0 in the reduced workflow.

Modifs:
- new ML-dedicated header for B0
- reduced B0 selector adapted so one can use ML selection
- reduced B0 task templatized to process data/MC and also to process either with ML information on D meson or on B0 (if we want D meson ML scores, it is to train BDT for B0; and if we want B0 ML scores, we already used the D meson ML scores for the training so we don't need to access them again --> no need to access D meson and B0 ML scores simultaneously).
- a bug was fixed: the B0 candidate tables consumed by the MC process functions did not use to be filtered, they are now

@apalasciano I tag you in case you're interested in using ML for B+ :)