### PR TITLE
Generate ClangBuildAnalyzer.ini file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,3 +84,5 @@ endif()
 
 set_root_pcm_dependencies()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangBuildAnalyzer.ini.in
+               ${CMAKE_CURRENT_BINARY_DIR}/ClangBuildAnalyzer.ini @ONLY)

--- a/cmake/ClangBuildAnalyzer.ini.in
+++ b/cmake/ClangBuildAnalyzer.ini.in
@@ -1,0 +1,36 @@
+# ClangBuildAnalyzer reads ClangBuildAnalyzer.ini file from the working directory
+# when invoked, and various aspects of reporting can be configured this way.
+# This file example is setup to be exactly like what the defaults are.
+
+# How many of most expensive things are reported?
+[counts]
+
+# files that took most time to parse
+fileParse = 10
+# files that took most time to generate code for
+fileCodegen = 10
+# functions that took most time to generate code for
+function = 30
+# header files that were most expensive to include
+header = 10
+# for each expensive header, this many include paths to it are shown
+headerChain = 5
+# templates that took longest to instantiate
+template = 30
+
+
+# Minimum times (in ms) for things to be recorded into trace
+[minTimes]
+
+# parse/codegen for a file
+file = 10
+
+
+[misc]
+
+# Maximum length of symbol names printed; longer names will get truncated
+maxNameLength = 120
+
+# Only print "root" headers in expensive header report, i.e.
+# only headers that are directly included by at least one source file
+onlyRootHeaders = true


### PR DESCRIPTION
Useful to customise the compile time profiling report.