### PR TITLE
PWGHF: Add extra checks for partly reco decays in B0 reduced workflow

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -248,6 +248,13 @@ DECLARE_SOA_COLUMN(EtaProng0, etaProng0, float); //! Pseudorapidity of the track
 DECLARE_SOA_COLUMN(PtProng1, ptProng1, float);   //! Transverse momentum of the track's prong1 in GeV/c
 DECLARE_SOA_COLUMN(YProng1, yProng1, float);     //! Rapidity of the track's prong1
 DECLARE_SOA_COLUMN(EtaProng1, etaProng1, float); //! Pseudorapidity of the track's prong1
+
+DECLARE_SOA_COLUMN(PdgCodeBeautyMother, pdgCodeBeautyMother, int); //! Pdg code of beauty mother
+DECLARE_SOA_COLUMN(PdgCodeCharmMother, pdgCodeCharmMother, int);   //! Pdg code of charm mother
+DECLARE_SOA_COLUMN(PdgCodeProng0, pdgCodeProng0, int);             //! Pdg code of prong0
+DECLARE_SOA_COLUMN(PdgCodeProng1, pdgCodeProng1, int);             //! Pdg code of prong1
+DECLARE_SOA_COLUMN(PdgCodeProng2, pdgCodeProng2, int);             //! Pdg code of prong2
+DECLARE_SOA_COLUMN(PdgCodeProng3, pdgCodeProng3, int);             //! Pdg code of prong3
 } // namespace hf_b0_mc
 
 // table with results of reconstruction level MC matching
@@ -258,11 +265,31 @@ DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with recon
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
 
+// try with extended table ?
+// DECLARE_SOA_EXTENDED_TABLE_USER(ExTable, Tracks, "EXTABLE",
+DECLARE_SOA_TABLE(HfMcCheckDpPis, "AOD", "HFMCCHECKDPPI", //! Table with reconstructed MC information on DPi(<-B0) pairs for MC checks in reduced workflow
+                  hf_b0_mc::PdgCodeBeautyMother,
+                  hf_b0_mc::PdgCodeCharmMother,
+                  hf_b0_mc::PdgCodeProng0,
+                  hf_b0_mc::PdgCodeProng1,
+                  hf_b0_mc::PdgCodeProng2,
+                  hf_b0_mc::PdgCodeProng3,
+                  o2::soa::Marker<1>);
+
 // Table with same size as HFCANDB0
 DECLARE_SOA_TABLE(HfMcRecRedB0s, "AOD", "HFMCRECREDB0", //! Reconstruction-level MC information on B0 candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchRec,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
+
+DECLARE_SOA_TABLE(HfMcCheckB0s, "AOD", "HFMCCHECKB0", //! Table with reconstructed MC information on B0 candidates for MC checks in reduced workflow
+                  hf_b0_mc::PdgCodeBeautyMother,
+                  hf_b0_mc::PdgCodeCharmMother,
+                  hf_b0_mc::PdgCodeProng0,
+                  hf_b0_mc::PdgCodeProng1,
+                  hf_b0_mc::PdgCodeProng2,
+                  hf_b0_mc::PdgCodeProng3,
+                  o2::soa::Marker<2>);
 
 DECLARE_SOA_TABLE(HfMcGenRedB0s, "AOD", "HFMCGENREDB0", //! Generation-level MC information on B0 candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchGen,

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -413,7 +413,7 @@ struct HfDataCreatorDplusPiReduced {
             // b-hadron hypothesis
             std::array<int, 3> bHadronMotherHypos = {Pdg::kB0, Pdg::kBS, Pdg::kLambdaB0};
             // c-hadron hypothesis
-            std::array<int, 3> cHadronMotherHypos = {Pdg::kDPlus, Pdg::kDS, 413}; // 413: D*
+            std::array<int, 3> cHadronMotherHypos = {Pdg::kDPlus, Pdg::kDS, Pdg::kDStar};
 
             for (const auto& bHadronMotherHypo : bHadronMotherHypos) {
               int index0Mother = RecoDecay::getMother(particlesMc, particleProng0, bHadronMotherHypo, true);
@@ -433,9 +433,13 @@ struct HfDataCreatorDplusPiReduced {
                   pdgCodeProng3 = particleProng1.pdgCode();
                   // look for common c-hadron mother among prongs 0, 1 and 2
                   for (const auto& cHadronMotherHypo : cHadronMotherHypos) {
-                    int index0CharmMother = RecoDecay::getMother(particlesMc, particleProng0, cHadronMotherHypo, true, &sign, 1);
-                    int index1CharmMother = RecoDecay::getMother(particlesMc, particleProng1, cHadronMotherHypo, true, &sign, 1);
-                    int index2CharmMother = RecoDecay::getMother(particlesMc, particleProng2, cHadronMotherHypo, true, &sign, 1);
+                    int8_t depthMax = 1;
+                    if (cHadronMotherHypo == Pdg::kDStar) {
+                      depthMax = 2;
+                    }
+                    int index0CharmMother = RecoDecay::getMother(particlesMc, particleProng0, cHadronMotherHypo, true, &sign, depthMax);
+                    int index1CharmMother = RecoDecay::getMother(particlesMc, particleProng1, cHadronMotherHypo, true, &sign, depthMax);
+                    int index2CharmMother = RecoDecay::getMother(particlesMc, particleProng2, cHadronMotherHypo, true, &sign, depthMax);
                     if (index0CharmMother > -1 && index1CharmMother > -1 && index2CharmMother > -1) {
                       if (index0CharmMother == index1CharmMother && index1CharmMother == index2CharmMother) {
                         pdgCodeCharmMother = particlesMc.rawIteratorAt(index0CharmMother).pdgCode();

--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -61,6 +61,7 @@ struct HfDataCreatorDplusPiReduced {
   Produces<aod::HfRed3ProngsMl> hfCand3ProngMl;
   Produces<aod::HfCandB0Configs> rowCandidateConfig;
   Produces<aod::HfMcRecRedDpPis> rowHfDPiMcRecReduced;
+  Produces<aod::HfMcCheckDpPis> rowHfDPiMcCheckReduced;
   Produces<aod::HfMcGenRedB0s> rowHfB0McGenReduced;
 
   // vertexing
@@ -83,6 +84,9 @@ struct HfDataCreatorDplusPiReduced {
   // magnetic field setting from CCDB
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+
+  // MC extra
+  Configurable<bool> checkDecayTypeMc{"checkDecayTypeMc", false, "flag to enable MC checks on decay type"};
 
   HfHelper hfHelper;
 
@@ -362,6 +366,12 @@ struct HfDataCreatorDplusPiReduced {
           int8_t sign{0};
           int8_t flag{0};
           int8_t debug{0};
+          int pdgCodeBeautyMother{0};
+          int pdgCodeCharmMother{0};
+          int pdgCodeProng0{0};
+          int pdgCodeProng1{0};
+          int pdgCodeProng2{0};
+          int pdgCodeProng3{0};
           // B0 → D- π+ → (π- K+ π-) π+
           auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, Pdg::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
           auto motherPt = -1.f;
@@ -383,7 +393,7 @@ struct HfDataCreatorDplusPiReduced {
             }
           }
           // B0 → Ds- π+ → (K- K+ π-) π+
-          if (!flag) {
+          if (!flag && checkDecayTypeMc) {
             indexRec = RecoDecay::getMatchedMCRec(particlesMc, arrayDaughtersB0, Pdg::kB0, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
             if (indexRec > -1) {
               // Ds- → K- K+ π-
@@ -395,13 +405,15 @@ struct HfDataCreatorDplusPiReduced {
           }
           // Partly reconstructed decays, i.e. the 4 prongs have a common b-hadron ancestor
           // convention: final state particles are prong0,1,2,3
-          if (!flag) {
+          if (!flag && checkDecayTypeMc) {
             auto particleProng0 = arrayDaughtersB0[0].mcParticle();
             auto particleProng1 = arrayDaughtersB0[1].mcParticle();
             auto particleProng2 = arrayDaughtersB0[2].mcParticle();
             auto particleProng3 = arrayDaughtersB0[3].mcParticle();
             // b-hadron hypothesis
             std::array<int, 3> bHadronMotherHypos = {Pdg::kB0, Pdg::kBS, Pdg::kLambdaB0};
+            // c-hadron hypothesis
+            std::array<int, 3> cHadronMotherHypos = {Pdg::kDPlus, Pdg::kDS, 413}; // 413: D*
 
             for (const auto& bHadronMotherHypo : bHadronMotherHypos) {
               int index0Mother = RecoDecay::getMother(particlesMc, particleProng0, bHadronMotherHypo, true);
@@ -413,6 +425,24 @@ struct HfDataCreatorDplusPiReduced {
               if (index0Mother > -1 && index1Mother > -1 && index2Mother > -1 && index3Mother > -1) {
                 if (index0Mother == index1Mother && index1Mother == index2Mother && index2Mother == index3Mother) {
                   flag = BIT(hf_cand_b0::DecayTypeMc::PartlyRecoDecay);
+                  pdgCodeBeautyMother = particlesMc.rawIteratorAt(index0Mother).pdgCode();
+                  pdgCodeCharmMother = 1;
+                  pdgCodeProng0 = particleProng0.pdgCode();
+                  pdgCodeProng1 = particleProng1.pdgCode();
+                  pdgCodeProng2 = particleProng1.pdgCode();
+                  pdgCodeProng3 = particleProng1.pdgCode();
+                  // look for common c-hadron mother among prongs 0, 1 and 2
+                  for (const auto& cHadronMotherHypo : cHadronMotherHypos) {
+                    int index0CharmMother = RecoDecay::getMother(particlesMc, particleProng0, cHadronMotherHypo, true, &sign, 1);
+                    int index1CharmMother = RecoDecay::getMother(particlesMc, particleProng1, cHadronMotherHypo, true, &sign, 1);
+                    int index2CharmMother = RecoDecay::getMother(particlesMc, particleProng2, cHadronMotherHypo, true, &sign, 1);
+                    if (index0CharmMother > -1 && index1CharmMother > -1 && index2CharmMother > -1) {
+                      if (index0CharmMother == index1CharmMother && index1CharmMother == index2CharmMother) {
+                        pdgCodeCharmMother = particlesMc.rawIteratorAt(index0CharmMother).pdgCode();
+                        break;
+                      }
+                    }
+                  }
                   break;
                 }
               }
@@ -420,6 +450,9 @@ struct HfDataCreatorDplusPiReduced {
           }
 
           rowHfDPiMcRecReduced(indexHfCand3Prong, selectedTracksPion[trackPion.globalIndex()], flag, debug, motherPt);
+          if (checkDecayTypeMc) {
+            rowHfDPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
+          }
         }
         fillHfCand3Prong = true;
       }                       // pion loop

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -90,11 +90,25 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec,
                   hf_cand_b0_lite::PtGen);
+
+DECLARE_SOA_TABLE(HfRedB0McCheck, "AOD", "HFREDB0MCCHECK", //! Table with MC decay type check
+                  hf_cand_b0_lite::MProng0,
+                  hf_cand_b0_lite::PtProng0,
+                  hf_cand_b0_lite::M,
+                  hf_cand_b0_lite::Pt,
+                  hf_cand_b0_lite::MlScoreSig,
+                  hf_b0_mc::PdgCodeBeautyMother,
+                  hf_b0_mc::PdgCodeCharmMother,
+                  hf_b0_mc::PdgCodeProng0,
+                  hf_b0_mc::PdgCodeProng1,
+                  hf_b0_mc::PdgCodeProng2,
+                  hf_b0_mc::PdgCodeProng3);
 } // namespace o2::aod
 
 /// B0 analysis task
 struct HfTaskB0Reduced {
   Produces<aod::HfRedCandB0Lites> hfRedCandB0Lite;
+  Produces<aod::HfRedB0McCheck> hfRedB0McCheck;
 
   Configurable<int> selectionFlagB0{"selectionFlagB0", 1, "Selection Flag for B0"};
   Configurable<float> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
@@ -107,8 +121,6 @@ struct HfTaskB0Reduced {
   Configurable<bool> fillBackground{"fillBackground", false, "Flag to enable filling of background histograms/sparses/tree (only MC)"};
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
-  // MC checks
-  Configurable<bool> checkDecayTypeMc{"checkDecayTypeMc", false, "Flag to enable DecayType histogram"};
 
   HfHelper hfHelper;
 
@@ -124,7 +136,7 @@ struct HfTaskB0Reduced {
     if ((std::accumulate(processFuncData.begin(), processFuncData.end(), 0)) > 1) {
       LOGP(fatal, "Only one process function for data can be enabled at a time.");
     }
-    std::array<bool, 3> processFuncMc{doprocessMc, doprocessMcWithDmesMl, doprocessMcWithB0Ml};
+    std::array<bool, 5> processFuncMc{doprocessMc, doprocessMcWithDecayTypeCheck, doprocessMcWithDmesMl, doprocessMcWithB0Ml, doprocessMcWithB0MlAndDecayTypeCheck};
     if ((std::accumulate(processFuncMc.begin(), processFuncMc.end(), 0)) > 1) {
       LOGP(fatal, "Only one process function for MC can be enabled at a time.");
     }
@@ -190,7 +202,7 @@ struct HfTaskB0Reduced {
       }
     }
 
-    if (doprocessMc || doprocessMcWithDmesMl || doprocessMcWithB0Ml) {
+    if (doprocessMc || doprocessMcWithDecayTypeCheck || doprocessMcWithDmesMl || doprocessMcWithB0Ml || doprocessMcWithB0MlAndDecayTypeCheck) {
       if (fillHistograms) {
         // gen histos
         registry.add("hEtaGen", "B^{0} particles (generated);#it{p}_{T}^{gen}(B^{0}) (GeV/#it{c});#it{#eta}^{gen}(B^{0});entries", {HistType::kTH2F, {axisPtB0, axisEta}});
@@ -245,7 +257,7 @@ struct HfTaskB0Reduced {
           registry.add("hCospXyDRecBg", "B^{0} candidates (unmatched);#it{p}_{T}(D^{#minus}) (GeV/#it{c});D^{#minus} candidate cos(#vartheta_{P}^{XY});entries", {HistType::kTH2F, {axisPtDminus, axisCosp}});
         }
         // MC checks
-        if (checkDecayTypeMc) {
+        if (doprocessMcWithDecayTypeCheck || doprocessMcWithB0MlAndDecayTypeCheck) {
           constexpr uint8_t kNBinsDecayTypeMc = hf_cand_b0::DecayTypeMc::NDecayTypeMc;
           TString labels[kNBinsDecayTypeMc];
           labels[hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi] = "B^{0} #rightarrow (D^{#minus} #rightarrow #pi^{#minus} K^{#plus} #pi^{#minus}) #pi^{#plus}";
@@ -270,7 +282,7 @@ struct HfTaskB0Reduced {
           registry.add("hMlScoreNonPromptDRecBg", "B^{0} candidates (unmatched);#it{p}_{T}(D^{#minus}) (GeV/#it{c});prong0, D^{#minus} ML nonprompt score;entries", {HistType::kTH2F, {axisPtDminus, axisMlScore}});
         }
         // ML scores of B0 candidate
-        if (doprocessMcWithB0Ml) {
+        if (doprocessMcWithB0Ml || doprocessMcWithB0MlAndDecayTypeCheck) {
           // signal
           registry.add("hMlScoreSigB0RecSig", "B^{0} candidates (matched);#it{p}_{T}(B^{0}) (GeV/#it{c});prong0, B^{0} ML signal score;entries", {HistType::kTH2F, {axisPtB0, axisMlScore}});
           // background
@@ -310,11 +322,12 @@ struct HfTaskB0Reduced {
 
   /// Fill candidate information at reconstruction level
   /// \param doMc is the flag to enable the filling with MC information
+  /// \param withDecayTypeCheck is the flag to enable MC with decay type check
   /// \param withDmesMl is the flag to enable the filling with ML scores for the D- daughter
   /// \param withB0Ml is the flag to enable the filling with ML scores for the B0 candidate
   /// \param candidate is the B0 candidate
   /// \param candidatesD is the table with D- candidates
-  template <bool doMc, bool withDmesMl, bool withB0Ml, typename Cand>
+  template <bool doMc, bool withDecayTypeCheck, bool withDmesMl, bool withB0Ml, typename Cand>
   void fillCand(Cand const& candidate,
                 aod::HfRed3Prongs const& candidatesD)
   {
@@ -359,7 +372,7 @@ struct HfTaskB0Reduced {
           registry.fill(HIST("hDecLengthXyDRecSig"), ptD, decLenXyD);
           registry.fill(HIST("hCospDRecSig"), ptD, cospD);
           registry.fill(HIST("hCospXyDRecSig"), ptD, cospXyD);
-          if (checkDecayTypeMc) {
+          if constexpr (withDecayTypeCheck) {
             registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi, invMassB0, ptCandB0);
           }
           if constexpr (withDmesMl) {
@@ -397,7 +410,7 @@ struct HfTaskB0Reduced {
           if constexpr (withB0Ml) {
             registry.fill(HIST("hMlScoreSigB0RecBg"), ptCandB0, candidate.mlProbB0ToDPi());
           }
-        } else if (checkDecayTypeMc) {
+        } else if constexpr (withDecayTypeCheck) {
           if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi)) { // B0 → Ds- π+ → (K- K+ π-) π+
             registry.fill(HIST("hDecayTypeMc"), 1 + hf_cand_b0::DecayTypeMc::B0ToDsPiToKKPiPi, invMassB0, ptCandB0);
           } else if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::PartlyRecoDecay)) { // Partly reconstructed decay channel
@@ -512,6 +525,26 @@ struct HfTaskB0Reduced {
           isSignal,
           ptMother);
       }
+      if constexpr (withDecayTypeCheck) {
+        if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::PartlyRecoDecay)) {
+          float candidateMlScoreSig = -1;
+          if constexpr (withB0Ml) {
+            candidateMlScoreSig = candidate.mlProbB0ToDPi();
+          }
+          hfRedB0McCheck(
+            invMassD,
+            ptD,
+            invMassB0,
+            ptCandB0,
+            candidateMlScoreSig,
+            candidate.pdgCodeBeautyMother(),
+            candidate.pdgCodeCharmMother(),
+            candidate.pdgCodeProng0(),
+            candidate.pdgCodeProng1(),
+            candidate.pdgCodeProng2(),
+            candidate.pdgCodeProng3());
+        }
+      }
     }
   }
 
@@ -565,7 +598,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, false, false>(candidate, candidatesD);
+      fillCand<false, false, false, false>(candidate, candidatesD);
     } // candidate loop
   }   // processData
   PROCESS_SWITCH(HfTaskB0Reduced, processData, "Process data without ML scores for B0 and D daughter", true);
@@ -581,7 +614,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, true, false>(candidate, candidatesD);
+      fillCand<false, false, true, false>(candidate, candidatesD);
     } // candidate loop
   }   // processDataWithDmesMl
   PROCESS_SWITCH(HfTaskB0Reduced, processDataWithDmesMl, "Process data with(out) ML scores for D daughter (B0)", false);
@@ -597,7 +630,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, false, true>(candidate, candidatesD);
+      fillCand<false, false, false, true>(candidate, candidatesD);
     } // candidate loop
   }   // processDataWithB0Ml
   PROCESS_SWITCH(HfTaskB0Reduced, processDataWithB0Ml, "Process data with(out) ML scores for B0 (D daughter)", false);
@@ -615,7 +648,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, false, false>(candidate, candidatesD);
+      fillCand<true, false, false, false>(candidate, candidatesD);
     } // rec
 
     // MC gen. level
@@ -624,6 +657,29 @@ struct HfTaskB0Reduced {
     } // gen
   }   // processMc
   PROCESS_SWITCH(HfTaskB0Reduced, processMc, "Process MC without ML scores for B0 and D daughter", false);
+
+  void processMcWithDecayTypeCheck(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s, aod::HfMcCheckB0s>> const& candidates,
+                                   aod::HfMcGenRedB0s const& mcParticles,
+                                   aod::HfRed3Prongs const& candidatesD,
+                                   TracksPion const&)
+  {
+    // MC rec
+    for (const auto& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<true, true, false, false>(candidate, candidatesD);
+    } // rec
+
+    // MC gen. level
+    for (const auto& particle : mcParticles) {
+      fillCandMcGen(particle);
+    } // gen
+  }   // processMc
+  PROCESS_SWITCH(HfTaskB0Reduced, processMcWithDecayTypeCheck, "Process MC with decay type check and without ML scores for B0 and D daughter", false);
 
   void processMcWithDmesMl(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfRedB0DpMls, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s>> const& candidates,
                            aod::HfMcGenRedB0s const& mcParticles,
@@ -638,7 +694,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, true, false>(candidate, candidatesD);
+      fillCand<true, false, true, false>(candidate, candidatesD);
     } // rec
 
     // MC gen. level
@@ -661,7 +717,7 @@ struct HfTaskB0Reduced {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, false, true>(candidate, candidatesD);
+      fillCand<true, false, false, true>(candidate, candidatesD);
     } // rec
 
     // MC gen. level
@@ -670,6 +726,29 @@ struct HfTaskB0Reduced {
     } // gen
   }   // processMcWithB0Ml
   PROCESS_SWITCH(HfTaskB0Reduced, processMcWithB0Ml, "Process MC with(out) ML scores for B0 (D daughter)", false);
+
+  void processMcWithB0MlAndDecayTypeCheck(soa::Filtered<soa::Join<aod::HfRedCandB0, aod::HfMlB0ToDPi, aod::HfSelB0ToDPi, aod::HfMcRecRedB0s, aod::HfMcCheckB0s>> const& candidates,
+                                          aod::HfMcGenRedB0s const& mcParticles,
+                                          aod::HfRed3Prongs const& candidatesD,
+                                          TracksPion const&)
+  {
+    // MC rec
+    for (const auto& candidate : candidates) {
+      if (!TESTBIT(candidate.hfflag(), hf_cand_b0::DecayType::B0ToDPi)) {
+        continue;
+      }
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yB0(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<true, true, false, true>(candidate, candidatesD);
+    } // rec
+
+    // MC gen. level
+    for (const auto& particle : mcParticles) {
+      fillCandMcGen(particle);
+    } // gen
+  }   // processMc
+  PROCESS_SWITCH(HfTaskB0Reduced, processMcWithB0MlAndDecayTypeCheck, "Process MC with decay type check and with(out) ML scores for B0 (D daughter)", false);
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
Ciao @fgrosa !

I implemented more checks for the partly reconstructed decays (where the 4 prongs have a common B mother, and where prongs 0,1 and 2 possibly have a common charm mother). This way, we'll be able to understand what is hiding inside the partly reco decay contribution in the B0 invariant mass distribution, and see if it is due to the MC generator config and/or if there is something else.

Modifications:
- in DPi creator: add a `checkDecayTypeMc` configurable to store PDG codes of beauty mother, charm mother, and prongs
- in B0 creator: add a new `process` function filling a new table with these PDG codes for B0 candidates
- in B0 selector: nothing new
- in B0 task: 2 new `process` functions so one can access these "MC checks" information with and without B0 ML selection + a new AOD table that can be saved in order to access PDG codes and invariant mass distributions of D meson and B mother