### PR TITLE
PWGHF: Fix MC check to get charm mother information

### DIFF
--- a/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorDplusPiReduced.cxx
@@ -433,13 +433,9 @@ struct HfDataCreatorDplusPiReduced {
                   pdgCodeProng3 = particleProng1.pdgCode();
                   // look for common c-hadron mother among prongs 0, 1 and 2
                   for (const auto& cHadronMotherHypo : cHadronMotherHypos) {
-                    int8_t depthMax = 1;
-                    if (cHadronMotherHypo == Pdg::kDStar) {
-                      depthMax = 2;
-                    }
-                    int index0CharmMother = RecoDecay::getMother(particlesMc, particleProng0, cHadronMotherHypo, true, &sign, depthMax);
-                    int index1CharmMother = RecoDecay::getMother(particlesMc, particleProng1, cHadronMotherHypo, true, &sign, depthMax);
-                    int index2CharmMother = RecoDecay::getMother(particlesMc, particleProng2, cHadronMotherHypo, true, &sign, depthMax);
+                    int index0CharmMother = RecoDecay::getMother(particlesMc, particleProng0, cHadronMotherHypo, true, &sign, 2);
+                    int index1CharmMother = RecoDecay::getMother(particlesMc, particleProng1, cHadronMotherHypo, true, &sign, 2);
+                    int index2CharmMother = RecoDecay::getMother(particlesMc, particleProng2, cHadronMotherHypo, true, &sign, 2);
                     if (index0CharmMother > -1 && index1CharmMother > -1 && index2CharmMother > -1) {
                       if (index0CharmMother == index1CharmMother && index1CharmMother == index2CharmMother) {
                         pdgCodeCharmMother = particlesMc.rawIteratorAt(index0CharmMother).pdgCode();

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -92,6 +92,7 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_b0_lite::PtGen);
 
 DECLARE_SOA_TABLE(HfRedB0McCheck, "AOD", "HFREDB0MCCHECK", //! Table with MC decay type check
+                  hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_b0_lite::MProng0,
                   hf_cand_b0_lite::PtProng0,
                   hf_cand_b0_lite::M,
@@ -526,24 +527,23 @@ struct HfTaskB0Reduced {
           ptMother);
       }
       if constexpr (withDecayTypeCheck) {
-        if (TESTBIT(flagMcMatchRec, hf_cand_b0::DecayTypeMc::PartlyRecoDecay)) {
-          float candidateMlScoreSig = -1;
-          if constexpr (withB0Ml) {
-            candidateMlScoreSig = candidate.mlProbB0ToDPi();
-          }
-          hfRedB0McCheck(
-            invMassD,
-            ptD,
-            invMassB0,
-            ptCandB0,
-            candidateMlScoreSig,
-            candidate.pdgCodeBeautyMother(),
-            candidate.pdgCodeCharmMother(),
-            candidate.pdgCodeProng0(),
-            candidate.pdgCodeProng1(),
-            candidate.pdgCodeProng2(),
-            candidate.pdgCodeProng3());
+        float candidateMlScoreSig = -1;
+        if constexpr (withB0Ml) {
+          candidateMlScoreSig = candidate.mlProbB0ToDPi();
         }
+        hfRedB0McCheck(
+          flagMcMatchRec,
+          invMassD,
+          ptD,
+          invMassB0,
+          ptCandB0,
+          candidateMlScoreSig,
+          candidate.pdgCodeBeautyMother(),
+          candidate.pdgCodeCharmMother(),
+          candidate.pdgCodeProng0(),
+          candidate.pdgCodeProng1(),
+          candidate.pdgCodeProng2(),
+          candidate.pdgCodeProng3());
       }
     }
   }


### PR DESCRIPTION
Hello again @fgrosa 

Thanks for reviewing and merging the PR #4723 so quickly :) and sorry, but I just realized that:
- the D mesons can decay into phi mesons then decaying into pions and kaons ([config file](https://github.com/AliceO2Group/O2DPG/blob/master/MC/config/PWGHF/pythia8/generator/pythia8_charmtriggers_with_Bforced_decay.cfg)) so the `maxDepth` set in the `getMother` function should be `2` for all the D meson hypothesis (and not only D*)
- it might be better to fill the MC check table without this selection on `flagMcMatchRec` so that one could access each component (pure signal, B0->Ds Pi, partly reco decay, ...) in the invariant mass distribution.