### PR TITLE
CCDB: do not include AnalysisHelpers.h in ROOT dictionaries

### DIFF
--- a/Common/CCDB/ctpRateFetcher.cxx
+++ b/Common/CCDB/ctpRateFetcher.cxx
@@ -22,10 +22,7 @@
 
 namespace o2
 {
-
-using framework::Service;
-
-double ctpRateFetcher::fetch(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
+double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
 {
   if (sourceName.find("ZNC") != std::string::npos) {
     if (runNumber < 544448) {
@@ -48,7 +45,7 @@ double ctpRateFetcher::fetch(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t
   return -1.;
 }
 
-double ctpRateFetcher::fetchCTPratesClasses(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType)
+double ctpRateFetcher::fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType)
 {
   getCTPscalers(ccdb, timeStamp, runNumber);
   getCTPconfig(ccdb, timeStamp, runNumber);
@@ -71,7 +68,7 @@ double ctpRateFetcher::fetchCTPratesClasses(Service<o2::ccdb::BasicCCDBManager>&
   return pileUpCorrection(rate.second);
 }
 
-double ctpRateFetcher::fetchCTPratesInputs(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, int input)
+double ctpRateFetcher::fetchCTPratesInputs(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, int input)
 {
   getCTPscalers(ccdb, timeStamp, runNumber);
   getLHCIFdata(ccdb, timeStamp, runNumber);
@@ -85,7 +82,7 @@ double ctpRateFetcher::fetchCTPratesInputs(Service<o2::ccdb::BasicCCDBManager>& 
   }
 }
 
-void ctpRateFetcher::getCTPscalers(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber)
+void ctpRateFetcher::getCTPscalers(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber)
 {
   if (runNumber == mRunNumber && mScalers != nullptr) {
     return;
@@ -99,7 +96,7 @@ void ctpRateFetcher::getCTPscalers(Service<o2::ccdb::BasicCCDBManager>& ccdb, ui
   mScalers->convertRawToO2();
 }
 
-void ctpRateFetcher::getLHCIFdata(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber)
+void ctpRateFetcher::getLHCIFdata(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber)
 {
   if (runNumber == mRunNumber && mLHCIFdata != nullptr) {
     return;
@@ -111,7 +108,7 @@ void ctpRateFetcher::getLHCIFdata(Service<o2::ccdb::BasicCCDBManager>& ccdb, uin
   }
 }
 
-void ctpRateFetcher::getCTPconfig(Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber)
+void ctpRateFetcher::getCTPconfig(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber)
 {
   if (runNumber == mRunNumber && mConfig != nullptr) {
     return;

--- a/Common/CCDB/ctpRateFetcher.h
+++ b/Common/CCDB/ctpRateFetcher.h
@@ -15,7 +15,6 @@
 #include <string>
 
 #include "CCDB/BasicCCDBManager.h"
-#include "Framework/AnalysisHelpers.h"
 
 namespace o2
 {
@@ -35,14 +34,14 @@ class ctpRateFetcher
 {
  public:
   ctpRateFetcher() = default;
-  double fetch(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, std::string sourceName);
+  double fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName);
 
  private:
-  void getCTPconfig(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber);
-  void getCTPscalers(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber);
-  void getLHCIFdata(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber);
-  double fetchCTPratesInputs(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, int input);
-  double fetchCTPratesClasses(framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType = 1);
+  void getCTPconfig(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
+  void getCTPscalers(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
+  void getLHCIFdata(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
+  double fetchCTPratesInputs(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, int input);
+  double fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType = 1);
   double pileUpCorrection(double rate);
 
   int mRunNumber = -1;


### PR DESCRIPTION
Hello @mpuccio
This removes include of `AnalysisHelpers.h` as to not expose ASoA stuff to root cling - it breaks on c++20 features on linux - unblocking https://github.com/AliceO2Group/AliceO2/pull/12724.

Instead of `Service` wrapper the fetcher functions can use bare pointer. As I understand this is not used in O2Physics, but in QC? One would have to change the invocations to use the pointer from the service (accessible directly as `.service`).