### PR TITLE
Restore isReconstructed flag

### DIFF
--- a/PWGLF/TableProducer/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/nucleiSpectra.cxx
@@ -455,7 +455,7 @@ struct nucleiSpectra {
       spectra.fill(HIST("hTpcSignalDataSelected"), correctedTpcInnerParam * track.sign(), track.tpcSignal());
       spectra.fill(HIST("hTofSignalData"), correctedTpcInnerParam, beta);
       beta = std::min(1.f - 1.e-6f, std::max(1.e-4f, beta)); /// sometimes beta > 1 or < 0, to be checked
-      uint16_t flag = static_cast<uint16_t>((track.pidForTracking() & 0xF) << 12);
+      uint16_t flag = static_cast<uint16_t>((track.pidForTracking() & 0xF) << 12) | kIsReconstructed;
       if (track.hasTOF()) {
         flag |= kHasTOF;
       }


### PR DESCRIPTION
The number of TPC clusters could be used instead, but it's good to restore if for sake of backward compatibility