### PR TITLE
[PWGDQ]adding FTOC Centrality in MixingLibrary

### DIFF
--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -42,6 +42,31 @@ void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible
     mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
   }
 
+  if (!nameStr.compare("CentralityFT0C1")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 20.0f, 40.0f, 60.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+  if (!nameStr.compare("CentralityFT0C2")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 40.0f, 60.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+  if (!nameStr.compare("CentralityFT0C3")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 70.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+  if (!nameStr.compare("CentralityFT0C4")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+  if (!nameStr.compare("CentralityFT0C5")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 5.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+  if (!nameStr.compare("CentralityFT0C6")) {
+    std::vector<float> fCentFT0CLimsHashing = {0.0f, 2.5f, 5.0f, 7.5f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+  }
+
   if (!nameStr.compare("Vtx1")) {
     std::vector<float> fZLimsHashing = {-10.0f, 0.0f, 10.0f};
     mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);

--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -15,7 +15,6 @@
 
 void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible)
 {
-
   std::string nameStr = mixingVarible;
   if (!nameStr.compare("Centrality1")) {
     std::vector<float> fCentLimsHashing = {0.0f, 20.0f, 40.0f, 60.0f, 90.0f};

--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -10,7 +10,6 @@
 // or submit itself to any jurisdiction.
 //
 // Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
-//
 #include "PWGDQ/Core/MixingLibrary.h"
 
 void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible)

--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 //
 // Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
+//
 #include "PWGDQ/Core/MixingLibrary.h"
 
 void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible)

--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -41,7 +41,6 @@ void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible
     std::vector<float> fCentLimsHashing = {0.0f, 2.5f, 5.0f, 7.5f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
     mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
   }
-
   if (!nameStr.compare("CentralityFT0C1")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 20.0f, 40.0f, 60.0f, 90.0f};
     mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
@@ -66,7 +65,6 @@ void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 2.5f, 5.0f, 7.5f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
     mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
   }
-
   if (!nameStr.compare("Vtx1")) {
     std::vector<float> fZLimsHashing = {-10.0f, 0.0f, 10.0f};
     mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);


### PR DESCRIPTION
FTOC Centrality is added as mixing variable for event mixing.