### PR TITLE
Fix PID selections on the negative track of Lambda

### DIFF
--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -26,7 +26,6 @@
 #include <cmath>
 #include <array>
 #include <cstdlib>
-#include <Math/Vector4D.h>
 
 #include <TFile.h>
 #include <TH2F.h>

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <array>
 #include <cstdlib>
+#include <Math/Vector4D.h>
 
 #include <TFile.h>
 #include <TH2F.h>

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -207,8 +207,8 @@ struct derivedlambdakzeroanalysis {
       maskTrackProperties = maskTrackProperties | (1 << selNegGoodTPCTrack);
       // TPC signal is available: ask for negative track PID
       maskK0ShortSpecific = maskK0ShortSpecific | (1 << selTPCPIDNegativePion);
-      maskLambdaSpecific = maskLambdaSpecific | (1 << selTPCPIDNegativeProton);
-      maskAntiLambdaSpecific = maskAntiLambdaSpecific | (1 << selTPCPIDNegativePion);
+      maskLambdaSpecific = maskLambdaSpecific | (1 << selTPCPIDNegativePion);
+      maskAntiLambdaSpecific = maskAntiLambdaSpecific | (1 << selTPCPIDNegativeProton);
     }
 
     // Primary particle selection, central to analysis


### PR DESCRIPTION
Fix PID selections on the negative track of Lambda and anti-Lambda to match the expected PID (pion for the Lambda, proton for the anti-Lambda)