### PR TITLE
PWGHF: D-h correlation analysis: post processing macros

### DIFF
--- a/PWGHF/HFC/Macros/AnalysisExecution.sh
+++ b/PWGHF/HFC/Macros/AnalysisExecution.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Create the output directory
+OUTDIR="Output_AnalysisExecution"
+if [ ! -d "$OUTDIR" ]; then
+    mkdir Output_AnalysisExecution
+fi
+
+# Correlation extraction
+root -b -l <<EOF &> Output_AnalysisExecution/stdoutExtractCorrel.log
+Printf("[INFO] EXTRACT CORRELATIONS");
+.L DhCorrelationExtraction.cxx+
+.x ExtractOutputCorrel.C("config_CorrAnalysis_DsToKKPi.json")
+.q
+EOF
+
+# Correlation fit
+root -b -l <<EOF &> Output_AnalysisExecution/stdoutFitCorrel.log
+Printf("[INFO] FIT CORRELATIONS");
+.L DhCorrelationFitter.cxx+
+.x FitCorrel.C("config_CorrAnalysis_DsToKKPi.json")
+.q
+EOF

--- a/PWGHF/HFC/Macros/DhCorrelationExtraction.cxx
+++ b/PWGHF/HFC/Macros/DhCorrelationExtraction.cxx
@@ -1,0 +1,553 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationExtraction.cxx
+/// \brief class for D-h correlation extraction
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#include "DhCorrelationExtraction.h"
+
+DhCorrelationExtraction::DhCorrelationExtraction() : // default constructor
+                                                     fFileMass(0x0),
+                                                     fFileSE(0x0),
+                                                     fFileME(0x0),
+                                                     fDirMass(0x0),
+                                                     fDirSE(0x0),
+                                                     fDirME(0x0),
+                                                     fCorrectedCorrHisto(0x0),
+                                                     fDmesonSpecies(kDsToKKPi),
+                                                     fDmesonLabel("Ds"),
+                                                     fNpools(9),
+                                                     fDeltaEtaMin(-1.),
+                                                     fDeltaEtaMax(1.),
+                                                     fCorrectPoolsSeparately(kTRUE),
+                                                     fSubtractSoftPiME(kFALSE),
+                                                     fFileNameSE(""),
+                                                     fFileNameME(""),
+                                                     fDirNameSE(""),
+                                                     fDirNameME(""),
+                                                     fMassHistoNameSgn(""),
+                                                     fMassHistoNameBkg(""),
+                                                     fMassHistoNameSBs(""),
+                                                     fSECorrelSignalRegionName(""),
+                                                     fSECorrelSidebandsName(""),
+                                                     fMECorrelSignalRegionName(""),
+                                                     fMECorrelSidebandsName(""),
+                                                     fBkgScaleFactor(1.),
+                                                     fSgnYieldNorm(1.),
+                                                     fRebin2Dhisto(kFALSE),
+                                                     fRebinAxisDeltaEta(1),
+                                                     fRebinAxisDeltaPhi(1),
+                                                     fDebug(0)
+{
+}
+
+DhCorrelationExtraction::DhCorrelationExtraction(const DhCorrelationExtraction& source) : // copy constructor
+                                                                                          fFileMass(source.fFileMass),
+                                                                                          fFileSE(source.fFileSE),
+                                                                                          fFileME(source.fFileME),
+                                                                                          fDirMass(source.fDirMass),
+                                                                                          fDirSE(source.fDirSE),
+                                                                                          fDirME(source.fDirME),
+                                                                                          fCorrectedCorrHisto(source.fCorrectedCorrHisto),
+                                                                                          fDmesonSpecies(source.fDmesonSpecies),
+                                                                                          fDmesonLabel(source.fDmesonLabel),
+                                                                                          fNpools(source.fNpools),
+                                                                                          fDeltaEtaMin(source.fDeltaEtaMin),
+                                                                                          fDeltaEtaMax(source.fDeltaEtaMax),
+                                                                                          fCorrectPoolsSeparately(source.fCorrectPoolsSeparately),
+                                                                                          fSubtractSoftPiME(source.fSubtractSoftPiME),
+                                                                                          fFileNameSE(source.fFileNameSE),
+                                                                                          fFileNameME(source.fFileNameME),
+                                                                                          fDirNameSE(source.fDirNameSE),
+                                                                                          fDirNameME(source.fDirNameME),
+                                                                                          fMassHistoNameSgn(source.fMassHistoNameSgn),
+                                                                                          fMassHistoNameBkg(source.fMassHistoNameBkg),
+                                                                                          fMassHistoNameSBs(source.fMassHistoNameSBs),
+                                                                                          fSECorrelSignalRegionName(source.fSECorrelSignalRegionName),
+                                                                                          fSECorrelSidebandsName(source.fSECorrelSidebandsName),
+                                                                                          fMECorrelSignalRegionName(source.fMECorrelSignalRegionName),
+                                                                                          fMECorrelSidebandsName(source.fMECorrelSidebandsName),
+                                                                                          fBkgScaleFactor(source.fBkgScaleFactor),
+                                                                                          fSgnYieldNorm(source.fSgnYieldNorm),
+                                                                                          fRebin2Dhisto(source.fRebin2Dhisto),
+                                                                                          fRebinAxisDeltaEta(source.fRebinAxisDeltaEta),
+                                                                                          fRebinAxisDeltaPhi(source.fRebinAxisDeltaPhi),
+                                                                                          fDebug(source.fDebug)
+{
+}
+
+DhCorrelationExtraction::~DhCorrelationExtraction()
+// destructor
+{
+}
+
+Bool_t DhCorrelationExtraction::SetDmesonSpecie(DmesonSpecie k)
+{
+
+  if (k < 0 || k > 3) {
+    printf("[ERROR] D meson specie not correctly set!\n");
+    return kFALSE;
+  } else if (k == 0)
+    fDmesonLabel = "Dzero";
+  else if (k == 1)
+    fDmesonLabel = "Dplus";
+  else if (k == 2)
+    fDmesonLabel = "Ds";
+  else
+    fDmesonLabel = "Dstar";
+
+  fDmesonSpecies = k;
+  return kTRUE;
+}
+
+Bool_t DhCorrelationExtraction::ExtractCorrelations(Double_t PtCandMin, Double_t PtCandMax, Double_t PtHadMin, Double_t PtHadMax, TString codeName)
+{
+
+  if (fSubtractSoftPiME) {
+    printf("[INFO] Fake softPi subtraction in ME via extraction code is enabled!\n");
+  }
+
+  if (!fCorrectPoolsSeparately)
+    fNpools = 1; // single histogram with integrated pools
+
+  // Histograms definition
+  TH2D* hSE_Sign[fNpools];
+  TH2D* hME_Sign[fNpools];
+  TH2D* hME_Sign_SoftPi[fNpools];
+  TH2D* hSE_Sideb[fNpools];
+  TH2D* hME_Sideb[fNpools];
+  TH2D* hME_Sideb_SoftPi[fNpools];
+
+  TH2D* hCorr_Sign[fNpools];
+  TH2D* hCorr_Sideb[fNpools];
+
+  TH2D* h2D_Sign;
+  TH2D* h2D_Sideb;
+  TH2D* h2D_Subtr;
+
+  TH1D* h1D_Sign;
+  TH1D* h1D_Sideb;
+  TH1D* h1D_Subtr;
+  TH1D* h1D_SubtrNorm;
+
+  // if (fIntegratePtBins && iBinPtHad>0) continue;
+
+  for (int iPool = 0; iPool < fNpools; iPool++) {
+
+    // Retrieve 2D plots for SE and ME, signal and bkg regions, for each pTbin and pool
+    hSE_Sign[iPool] = GetCorrelHisto(kSE, kSign, iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax);
+    hME_Sign[iPool] = GetCorrelHisto(kME, kSign, iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax);
+    hSE_Sideb[iPool] = GetCorrelHisto(kSE, kSideb, iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax);
+    hME_Sideb[iPool] = GetCorrelHisto(kME, kSideb, iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax);
+
+    hSE_Sign[iPool]->Sumw2();
+    hME_Sign[iPool]->Sumw2();
+    hSE_Sideb[iPool]->Sumw2();
+    hME_Sideb[iPool]->Sumw2();
+
+    // rebin axes deltaEta and deltaPhi
+    if (fRebin2Dhisto) {
+      hSE_Sign[iPool]->Rebin2D(fRebinAxisDeltaEta, fRebinAxisDeltaPhi); // Xaxis: deltaEta, Yaxis: deltaPhi
+      hSE_Sideb[iPool]->Rebin2D(fRebinAxisDeltaEta, fRebinAxisDeltaPhi);
+      hME_Sign[iPool]->Rebin2D(fRebinAxisDeltaEta, fRebinAxisDeltaPhi);
+      hME_Sideb[iPool]->Rebin2D(fRebinAxisDeltaEta, fRebinAxisDeltaPhi);
+      if (fSubtractSoftPiME) {
+        hME_Sideb_SoftPi[iPool]->Rebin2D(fRebinAxisDeltaEta, fRebinAxisDeltaPhi);
+      }
+    }
+
+    if (fDebug >= 1) {
+      TCanvas* c = new TCanvas(Form("cSEME_Original_%d_%1.1fto%1.1f", iPool, PtHadMin, PtHadMax), Form("cSEME_Original_%s_pool%d_PtCand%.0fto%.0f_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax), 100, 100, 1600, 900);
+      c->Divide(2, 2);
+      c->cd(1);
+      hSE_Sign[iPool]->SetMinimum(0);
+      hSE_Sign[iPool]->Draw("lego2");
+      c->cd(2);
+      hME_Sign[iPool]->SetMinimum(0);
+      hME_Sign[iPool]->Draw("lego2");
+      c->cd(3);
+      hSE_Sideb[iPool]->SetMinimum(0);
+      hSE_Sideb[iPool]->Draw("lego2");
+      c->cd(4);
+      hME_Sideb[iPool]->SetMinimum(0);
+      hME_Sideb[iPool]->Draw("lego2");
+      c->SaveAs(Form("Output_CorrelationExtraction_%s_png/CorrSEandME_Original_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+      c->SaveAs(Form("Output_CorrelationExtraction_%s_Root/CorrSEandME_Original_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+    }
+
+    // Scale bkg plots by ratio of signal region/sidebands
+    hSE_Sideb[iPool]->Scale(fBkgScaleFactor);
+    hME_Sideb[iPool]->Scale(fBkgScaleFactor);
+    hSE_Sideb[iPool]->SetEntries(hSE_Sideb[iPool]->GetEntries() * fBkgScaleFactor);
+    hME_Sideb[iPool]->SetEntries(hME_Sideb[iPool]->GetEntries() * fBkgScaleFactor);
+
+    if (fSubtractSoftPiME) {
+      hME_Sideb_SoftPi[iPool]->Scale(fBkgScaleFactor);
+      hME_Sideb_SoftPi[iPool]->SetEntries(hME_Sideb_SoftPi[iPool]->GetEntries() * fBkgScaleFactor);
+    }
+
+    // Normalize ME plots for the entries in (deltaEta, deltaPhi) = (0, 0)
+    NormalizeMEplot(hME_Sign[iPool], hME_Sign_SoftPi[iPool]);
+    NormalizeMEplot(hME_Sideb[iPool], hME_Sideb_SoftPi[iPool]);
+
+    // Apply Event Mixing Correction
+    hCorr_Sign[iPool] = (TH2D*)hSE_Sign[iPool]->Clone(Form("hCorr_Sign_Pool%d", iPool));
+    hCorr_Sign[iPool]->Sumw2();
+    hCorr_Sign[iPool]->Divide(hME_Sign[iPool]);
+
+    hCorr_Sideb[iPool] = (TH2D*)hSE_Sideb[iPool]->Clone(Form("hCorr_Sideb_Pool%d", iPool));
+    hCorr_Sideb[iPool]->Sumw2();
+    hCorr_Sideb[iPool]->Divide(hME_Sideb[iPool]);
+
+    Double_t N_SEsign = 0, N_SEsideb = 0, N_sign = 0, N_sideb = 0;
+    for (int i = 1; i <= hCorr_Sign[iPool]->GetXaxis()->GetNbins(); i++) {
+      for (int j = 1; j <= hCorr_Sign[iPool]->GetYaxis()->GetNbins(); j++) {
+        N_SEsign += hSE_Sign[iPool]->GetBinContent(i, j);
+        N_SEsideb += hSE_Sideb[iPool]->GetBinContent(i, j);
+        N_sign += hCorr_Sign[iPool]->GetBinContent(i, j);
+        N_sideb += hCorr_Sideb[iPool]->GetBinContent(i, j);
+      }
+    }
+    hSE_Sign[iPool]->SetEntries(N_SEsign);
+    hSE_Sideb[iPool]->SetEntries(N_SEsideb);
+    hCorr_Sign[iPool]->SetEntries(N_sign);
+    hCorr_Sideb[iPool]->SetEntries(N_sideb);
+
+    if (fDebug >= 1) {
+      TCanvas* c = new TCanvas(Form("cSEME_%d_%1.1fto%1.1f", iPool, PtHadMin, PtHadMax), Form("cSEME_%s_pool%d_PtCand%.0fto%.0f_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), iPool, PtCandMin, PtCandMax, PtHadMin, PtHadMax), 100, 100, 1600, 900);
+      c->Divide(3, 2);
+      c->cd(1);
+      hSE_Sign[iPool]->SetMinimum(0);
+      hSE_Sign[iPool]->Draw("lego2");
+      c->cd(2);
+      hME_Sign[iPool]->SetMinimum(0);
+      hME_Sign[iPool]->Draw("lego2");
+      c->cd(3);
+      hCorr_Sign[iPool]->SetMinimum(0);
+      hCorr_Sign[iPool]->Draw("lego2");
+      c->cd(4);
+      hSE_Sideb[iPool]->SetMinimum(0);
+      hSE_Sideb[iPool]->Draw("lego2");
+      c->cd(5);
+      hME_Sideb[iPool]->SetMinimum(0);
+      hME_Sideb[iPool]->Draw("lego2");
+      c->cd(6);
+      hCorr_Sideb[iPool]->SetMinimum(0);
+      hCorr_Sideb[iPool]->Draw("lego2");
+      c->SaveAs(Form("Output_CorrelationExtraction_%s_png/CorrSEandME_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+      c->SaveAs(Form("Output_CorrelationExtraction_%s_Root/CorrSEandME_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+    }
+
+    // Pools integration
+    if (iPool == 0) {
+      h2D_Sign = (TH2D*)hCorr_Sign[0]->Clone("h2D_Sign");
+      h2D_Sideb = (TH2D*)hCorr_Sideb[0]->Clone("h2D_Sideb");
+      h2D_Sign->Sumw2();
+      h2D_Sideb->Sumw2();
+    } else {
+      h2D_Sign->Add(hCorr_Sign[iPool]);
+      h2D_Sideb->Add(hCorr_Sideb[iPool]);
+    }
+  } // end pool loop
+
+  // Draw 2D plots (Signal region and Sidebands)
+  TCanvas* c2D = new TCanvas(Form("c2D_IntPools_PtHad%.0fto%.0f", PtHadMin, PtHadMax), Form("c2D_%s_IntPools_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), PtHadMin, PtHadMax), 100, 100, 1500, 800);
+  SetTH2HistoStyle(h2D_Sign, Form("Signal region, %.0f < p^{%s}_{T} < %.0f GeV/c, %.0f < p^{assoc}_{T} < %.0f GeV/c", PtCandMin, fDmesonLabel.Data(), PtCandMax, PtHadMin, PtHadMax), "#Delta#eta", "#Delta#phi [rad]", "entries", 1.6, 1.6, 1.6, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04);
+  SetTH2HistoStyle(h2D_Sideb, Form("Sideband region, %.0f < p^{%s}_{T} < %.0f GeV/c, %.0f < p^{assoc}_{T} < %.0f GeV/c", PtCandMin, fDmesonLabel.Data(), PtCandMax, PtHadMin, PtHadMax), "#Delta#eta", "#Delta#phi [rad]", "#frac{Y_{Bkg}}{Y_{SB}} entries", 1.6, 1.6, 1.6, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04);
+  c2D->Divide(2, 1);
+  c2D->cd(1);
+  h2D_Sign->SetMinimum(0);
+  h2D_Sign->Draw("lego2");
+  c2D->cd(2);
+  h2D_Sideb->SetMinimum(0);
+  h2D_Sideb->Draw("lego2");
+  c2D->SaveAs(Form("Output_CorrelationExtraction_%s_png/h2D_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+  c2D->SaveAs(Form("Output_CorrelationExtraction_%s_Root/h2D_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+
+  // Bkg subtraction (2D plot)
+  TCanvas* c2D_Sub = new TCanvas(Form("c2D_Subtr_IntPools_PtHAd%.0fto%.0f", PtHadMin, PtHadMax), Form("c2D_%s_Subtr_IntPools_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), PtHadMin, PtHadMax), 100, 100, 1500, 800);
+  h2D_Subtr = (TH2D*)h2D_Sign->Clone("h2D_Subtr");
+  h2D_Subtr->Sumw2();
+  h2D_Subtr->Add(h2D_Sideb, -1);
+  h2D_Subtr->SetEntries(h2D_Sign->GetEntries() - h2D_Sideb->GetEntries());
+  h2D_Subtr->SetTitle("Signal region after sideb. subt. corr. - 2D");
+  h2D_Subtr->Draw("lego2");
+  c2D_Sub->SaveAs(Form("Output_CorrelationExtraction_%s_png/h2D_%s_Subtr_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+  c2D_Sub->SaveAs(Form("Output_CorrelationExtraction_%s_Root/h2D_%s_Subtr_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+
+  // 1D projection
+  h1D_Sign = (TH1D*)h2D_Sign->ProjectionY("h1D_Sign"); // projection on deltaPhi axis
+  h1D_Sideb = (TH1D*)h2D_Sideb->ProjectionY("h1D_Sideb");
+  h1D_Sign->SetTitle("Signal region correlations");
+  h1D_Sideb->SetTitle("Sidebands correlations");
+  h1D_Sign->Scale(1. / h1D_Sign->GetXaxis()->GetBinWidth(1));
+  h1D_Sideb->Scale(1. / h1D_Sideb->GetXaxis()->GetBinWidth(1));
+
+  // Bkg subtraction (1D plot)
+  h1D_Subtr = (TH1D*)h1D_Sign->Clone("h1D_Subtr");
+  h1D_Subtr->Sumw2();
+  h1D_Subtr->Add(h1D_Sideb, -1);
+  h1D_Subtr->SetEntries(h1D_Sign->GetEntries() - h1D_Sideb->GetEntries());
+  h1D_Subtr->SetTitle("Signal region after sideb. subt. corr.");
+
+  // Draw 1D plots (Signal region, Sidebands, S-SB (subtr.))
+  TCanvas* c1D = new TCanvas(Form("c1D_IntPools_%.0fto%.0f", PtHadMin, PtHadMax), Form("c1D_%s_IntPools_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), PtHadMin, PtHadMax), 100, 100, 1600, 500);
+  c1D->Divide(3, 1);
+  c1D->cd(1);
+  h1D_Sign->Draw();
+  c1D->cd(2);
+  h1D_Sideb->Draw();
+  c1D->cd(3);
+  h1D_Subtr->Draw();
+  c1D->SaveAs(Form("Output_CorrelationExtraction_%s_png/h1D_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+  c1D->SaveAs(Form("Output_CorrelationExtraction_%s_Root/h1D_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+
+  // Apply normalization to number of triggers
+  h1D_SubtrNorm = (TH1D*)h1D_Subtr->Clone("h1D_SubtrNorm");
+  h1D_SubtrNorm->Sumw2();
+  h1D_SubtrNorm->Scale(1. / fSgnYieldNorm);
+  h1D_SubtrNorm->SetTitle("Signal region after sideb. subt. corr. - Normalized to # of triggers");
+
+  fCorrectedCorrHisto = (TH1D*)h1D_SubtrNorm->Clone(Form("hCorrectedCorr_PtCand%.0fto%.0f_PtAssoc%.0fto%.0f", PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+
+  // Draw 1D plots (Signal region, normalized)
+  TCanvas* cFinal = new TCanvas(Form("cFinal_%.0fto%.0f", PtHadMin, PtHadMax), Form("cFinal_%s_IntPools_PtAssoc%.0fto%.0f", fDmesonLabel.Data(), PtHadMin, PtHadMax), 100, 100, 1200, 700);
+  h1D_SubtrNorm->Draw();
+  cFinal->SaveAs(Form("Output_CorrelationExtraction_%s_png/AzimCorrDistr_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.png", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+  cFinal->SaveAs(Form("Output_CorrelationExtraction_%s_Root/AzimCorrDistr_%s_Canvas_PtCand%.0fto%.0f_PoolInt_PtAssoc%.0fto%.0f.root", codeName.Data(), fDmesonLabel.Data(), PtCandMin, PtCandMax, PtHadMin, PtHadMax));
+
+  return kTRUE;
+}
+
+Bool_t DhCorrelationExtraction::ReadInputSEandME()
+{
+
+  fFileSE = TFile::Open(fFileNameSE.Data());
+  if (!fFileSE) {
+    std::cout << "[ERROR] File " << fFileNameSE << " cannot be opened! check your file path!";
+    return kFALSE;
+  }
+
+  fFileME = TFile::Open(fFileNameME.Data());
+  if (!fFileME) {
+    std::cout << "[ERROR] File " << fFileNameME << " cannot be opened! check your file path!";
+    return kFALSE;
+  }
+
+  fDirSE = (TDirectoryFile*)fFileSE->Get(fDirNameSE.Data());
+  fDirME = (TDirectoryFile*)fFileME->Get(fDirNameME.Data());
+
+  std::cout << "===================== " << std::endl;
+  std::cout << "Read inputs SE and ME" << std::endl;
+  std::cout << "TFile SE    = " << fFileNameSE << std::endl;
+  std::cout << "TFile ME    = " << fFileNameME << std::endl;
+  std::cout << "TDir SE    = " << fDirNameSE << std::endl;
+  std::cout << "TDir ME    = " << fDirNameME << std::endl;
+  std::cout << "===================== " << std::endl;
+  std::cout << " " << std::endl;
+
+  return kTRUE;
+}
+
+Bool_t DhCorrelationExtraction::ReadInputInvMass()
+{
+
+  fFileMass = TFile::Open(fFileNameMass.Data());
+  if (!fFileMass) {
+    std::cout << "[ERROR] File " << fFileNameMass << " cannot be opened! check your file path!";
+    return kFALSE;
+  }
+
+  std::cout << "===================== " << std::endl;
+  std::cout << "Read inputs inv. mass" << std::endl;
+  std::cout << "TFile Mass    = " << fFileNameMass << std::endl;
+  std::cout << "Histo Sgn Yield	   = " << fMassHistoNameSgn << std::endl;
+  std::cout << "Histo Bkg Yield	   = " << fMassHistoNameBkg << std::endl;
+  std::cout << "Histo SBs Yield	   = " << fMassHistoNameSBs << std::endl;
+  std::cout << "===================== " << std::endl;
+  std::cout << " " << std::endl;
+
+  return kTRUE;
+}
+
+TH2D* DhCorrelationExtraction::GetCorrelHisto(Int_t SEorME, Int_t SorSB, Int_t pool, Double_t PtCandMin, Double_t PtCandMax, Double_t PtHadMin, Double_t PtHadMax)
+{
+  // TODO: Subtraction of softpion
+  TH2D* h2D = new TH2D(); // pointer to be returned
+
+  THnSparseD* hSparse = 0x0;
+
+  if (SEorME == kSE) { // Same Event
+    if (SorSB == kSign) {
+      hSparse = (THnSparseD*)fDirSE->Get(fSECorrelSignalRegionName.Data());
+    } else {
+      hSparse = (THnSparseD*)fDirSE->Get(fSECorrelSidebandsName.Data());
+    }
+  } else { // Mixed Event
+    if (SorSB == kSign) {
+      hSparse = (THnSparseD*)fDirME->Get(fMECorrelSignalRegionName.Data());
+    } else {
+      hSparse = (THnSparseD*)fDirME->Get(fMECorrelSidebandsName.Data());
+    }
+  }
+  Int_t binExtPtCandMin = (Int_t)hSparse->GetAxis(2)->FindBin(PtCandMin + 0.01); // axis2: ptCand, the 0.01 to avoid bin edges!
+  Int_t binExtPtCandMax = (Int_t)hSparse->GetAxis(2)->FindBin(PtCandMax - 0.01);
+  Int_t binExtPtHadMin = (Int_t)hSparse->GetAxis(3)->FindBin(PtHadMin + 0.01); // axis3: ptHad
+  Int_t binExtPtHadMax = (Int_t)hSparse->GetAxis(3)->FindBin(PtHadMax - 0.01);
+  Int_t binExtPoolMin;
+  Int_t binExtPoolMax;
+  if (fCorrectPoolsSeparately) {
+    binExtPoolMin = (Int_t)hSparse->GetAxis(4)->FindBin(pool + 1.01); // axis4: pool bin
+    binExtPoolMax = (Int_t)hSparse->GetAxis(4)->FindBin(pool + 1.99);
+  } else { // merge all pools in one
+    binExtPoolMin = 1;
+    binExtPoolMax = (Int_t)hSparse->GetAxis(4)->GetNbins();
+    // cout << "binExtPoolMax:" << binExtPoolMax <<endl;
+  }
+  // possibility to select a certain eta region
+  Int_t binExtEtaMin = (Int_t)hSparse->GetAxis(1)->FindBin(fDeltaEtaMin + 0.0001);
+  Int_t binExtEtaMax = (Int_t)hSparse->GetAxis(1)->FindBin(fDeltaEtaMax - 0.0001);
+  if (binExtEtaMax > hSparse->GetAxis(1)->GetNbins())
+    binExtEtaMax = hSparse->GetAxis(1)->GetNbins();
+  if (binExtEtaMin < 1)
+    binExtEtaMin = 1;
+
+  hSparse->GetAxis(1)->SetRange(binExtEtaMin, binExtEtaMax);       // axis1: deltaEta
+  hSparse->GetAxis(2)->SetRange(binExtPtCandMin, binExtPtCandMax); // axis2: ptCand
+  hSparse->GetAxis(3)->SetRange(binExtPtHadMin, binExtPtHadMax);   // axis3: ptHad
+  // hSparse -> GetAxis(4) -> SetRange(binExtPoolMin, binExtPoolMax); // axis4: pool bin
+
+  h2D = (TH2D*)hSparse->Projection(0, 1); // axis0: deltaPhi, axis1: deltaEta
+  if (SEorME == kSE) {                    // Same Event
+    if (SorSB == kSign) {
+      h2D->SetName(Form("hCorr_SE_Sig_2D_PtCandBin%d_PtHadBin%d_iPool%d", binExtPtCandMin, binExtPtHadMin, pool));
+    } else {
+      h2D->SetName(Form("hCorr_SE_Sideb_2D_PtCandBin%d_PtHadBin%d_iPool%d", binExtPtCandMin, binExtPtHadMin, pool));
+    }
+  } else { // Mixed Event
+    if (SorSB == kSign) {
+      h2D->SetName(Form("hCorr_ME_Sig_2D_PtCandBin%d_PtHadBin%d_iPool%d", binExtPtCandMin, binExtPtHadMin, pool));
+    } else {
+      h2D->SetName(Form("hCorr_ME_Sideb_2D_PtCandBin%d_PtHadBin%d_iPool%d", binExtPtCandMin, binExtPtHadMin, pool));
+    }
+  }
+
+  return h2D;
+}
+
+void DhCorrelationExtraction::GetSignalAndBackgroundForNorm(Double_t PtCandMin, Double_t PtCandMax)
+{
+
+  // using results obtained from HFInvariantMassFitter.cxx class
+  TH1F* hMassFitSgnYield = (TH1F*)fFileMass->Get(fMassHistoNameSgn.Data());
+  TH1F* hMassFitBkgYield = (TH1F*)fFileMass->Get(fMassHistoNameBkg.Data());
+  TH1F* hMassFitSBsYield = (TH1F*)fFileMass->Get(fMassHistoNameSBs.Data());
+
+  Int_t PtCandBin = hMassFitSgnYield->FindBin(PtCandMin + 0.01);
+  if (PtCandBin != hMassFitSgnYield->FindBin(PtCandMax - 0.01))
+    std::cout << "[ERROR] Pt bin in invariant mass histogram not univocally defined " << std::endl;
+
+  Float_t SgnYield = hMassFitSgnYield->GetBinContent(PtCandBin);
+  Float_t BkgYield = hMassFitBkgYield->GetBinContent(PtCandBin);
+  Float_t SBsYield = hMassFitSBsYield->GetBinContent(PtCandBin);
+
+  std::cout << "================================= " << std::endl;
+  std::cout << "Getting invariant mass parameters " << std::endl;
+  std::cout << "Pt cand " << PtCandMin << " - " << PtCandMax << std::endl;
+  std::cout << "Signal yield    = " << SgnYield << std::endl;
+  std::cout << "Bkg yield    = " << BkgYield << std::endl;
+  std::cout << "Sideband yield    = " << SBsYield << std::endl;
+  std::cout << "================================= " << std::endl;
+  std::cout << " " << std::endl;
+
+  SetSignalYieldforNorm(SgnYield);
+  SetBkgScaleFactor(BkgYield / SBsYield);
+
+  return;
+}
+
+void DhCorrelationExtraction::NormalizeMEplot(TH2D*& histoME, TH2D*& histoMEsoftPi)
+{
+
+  Double_t bin0phi = histoME->GetYaxis()->FindBin(0.);
+  Double_t bin0eta = histoME->GetXaxis()->FindBin(0.);
+
+  // evaluate the normalization (from ALL tracks, including possible fake softpions) -> **histoME indeed includes bin1+bin2 of THnSparse, i.e. all the tracks**
+  Double_t factorNorm = 0;
+  for (int in = -1; in <= 0; in++)
+    factorNorm += histoME->GetBinContent(bin0phi + in, bin0eta);
+  for (int in = -1; in <= 0; in++)
+    factorNorm += histoME->GetBinContent(bin0phi + in, bin0eta - 1);
+  factorNorm /= 4.;
+
+  if (fSubtractSoftPiME)
+    histoME->Add(histoMEsoftPi, -1); // remove the tracks compatible with soft pion (if requested)
+
+  // apply the normalization
+  histoME->Scale(1. / factorNorm);
+
+  return;
+}
+
+void DhCorrelationExtraction::SetTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+                                               Style_t markerStyle, Color_t markerColor, Double_t markerSize,
+                                               Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset,
+                                               Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hLabelXaxisSize, Float_t hLabelYaxisSize,
+                                               Bool_t centerXaxisTitle, Bool_t centerYaxisTitle)
+{
+
+  histo->SetTitle(hTitle.Data());
+  histo->GetXaxis()->SetTitle(hXaxisTitle.Data());
+  histo->GetYaxis()->SetTitle(hYaxisTitle.Data());
+  histo->SetMarkerStyle(markerStyle);
+  histo->SetMarkerColor(markerColor);
+  histo->SetMarkerSize(markerSize);
+  histo->SetLineColor(lineColor);
+  histo->SetLineWidth(lineWidth);
+  histo->GetXaxis()->SetTitleOffset(hTitleXaxisOffset);
+  histo->GetYaxis()->SetTitleOffset(hTitleYaxisOffset);
+  histo->GetXaxis()->SetTitleSize(hTitleXaxisSize);
+  histo->GetYaxis()->SetTitleSize(hTitleYaxisSize);
+  histo->GetXaxis()->SetLabelSize(hLabelXaxisSize);
+  histo->GetYaxis()->SetLabelSize(hLabelYaxisSize);
+  histo->GetXaxis()->CenterTitle(centerXaxisTitle);
+  histo->GetYaxis()->CenterTitle(centerYaxisTitle);
+
+  return;
+}
+
+void DhCorrelationExtraction::SetTH2HistoStyle(TH2D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, TString hZaxisTitle,
+                                               Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset, Float_t hTitleZaxisOffset,
+                                               Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hTitleZaxisSize,
+                                               Float_t hLabelXaxisSize, Float_t hLabelYaxisSize, Float_t hLabelZaxisSize,
+                                               Bool_t centerXaxisTitle, Bool_t centerYaxisTitle)
+{
+
+  histo->SetTitle(hTitle.Data());
+  histo->GetXaxis()->SetTitle(hXaxisTitle.Data());
+  histo->GetYaxis()->SetTitle(hYaxisTitle.Data());
+  histo->GetZaxis()->SetTitle(hZaxisTitle.Data());
+  histo->GetXaxis()->SetTitleOffset(hTitleXaxisOffset);
+  histo->GetYaxis()->SetTitleOffset(hTitleYaxisOffset);
+  histo->GetZaxis()->SetTitleOffset(hTitleZaxisOffset);
+  histo->GetXaxis()->SetTitleSize(hTitleXaxisSize);
+  histo->GetYaxis()->SetTitleSize(hTitleYaxisSize);
+  histo->GetZaxis()->SetTitleSize(hTitleZaxisSize);
+  histo->GetXaxis()->SetLabelSize(hLabelXaxisSize);
+  histo->GetYaxis()->SetLabelSize(hLabelYaxisSize);
+  histo->GetZaxis()->SetLabelSize(hLabelZaxisSize);
+  histo->GetXaxis()->CenterTitle(centerXaxisTitle);
+  histo->GetYaxis()->CenterTitle(centerYaxisTitle);
+
+  return;
+}

--- a/PWGHF/HFC/Macros/DhCorrelationExtraction.h
+++ b/PWGHF/HFC/Macros/DhCorrelationExtraction.h
@@ -1,0 +1,143 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationExtraction.h
+/// \brief class for D-h correlation extraction
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#ifndef DHCORRELATIONEXTRACTION_H_
+#define DHCORRELATIONEXTRACTION_H_
+
+#include <iostream>
+#include "TObject.h"
+#include "TMath.h"
+#include "TFile.h"
+#include "TDirectoryFile.h"
+#include "TList.h"
+#include "TCanvas.h"
+#include "TPaveText.h"
+#include "TLegend.h"
+#include "TSystem.h"
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TH3D.h"
+#include "TF1.h"
+#include "THnSparse.h"
+#include "TVector.h"
+
+class DhCorrelationExtraction : public TObject
+{
+
+ public:
+  enum DmesonSpecie { kD0toKpi = 0,
+                      kDplusKpipi,
+                      kDsToKKPi,
+                      kDStarD0pi };
+  enum selectAnalysisType { kSE,
+                            kME };
+  enum selectInvMassRegion { kSign,
+                             kSideb };
+
+  DhCorrelationExtraction(); // default constructor
+  DhCorrelationExtraction(const DhCorrelationExtraction& source);
+  virtual ~DhCorrelationExtraction();
+
+  /// Methods to set the input configuration
+  // Input files, directories and histograms
+  Bool_t SetDmesonSpecie(DmesonSpecie k);
+  void SetInputFilenameMass(TString filenameMass) { fFileNameMass = filenameMass; }
+  void SetInputFilenameSE(TString filenameSE) { fFileNameSE = filenameSE; }
+  void SetInputFilenameME(TString filenameME) { fFileNameME = filenameME; }
+  void SetDirNameSE(TString dirNameSE) { fDirNameSE = dirNameSE; }
+  void SetDirNameME(TString dirNameME) { fDirNameME = dirNameME; }
+  void SetMassHistoNameSgn(TString massHistoNameSgn) { fMassHistoNameSgn = massHistoNameSgn; }
+  void SetMassHistoNameBkg(TString massHistoNameBkg) { fMassHistoNameBkg = massHistoNameBkg; }
+  void SetMassHistoNameSBs(TString massHistoNameSBs) { fMassHistoNameSBs = massHistoNameSBs; }
+  void SetSECorrelHistoSignalName(TString correlNameSigSE) { fSECorrelSignalRegionName = correlNameSigSE; }
+  void SetSECorrelHistoSidebandName(TString correlNameSbSE) { fSECorrelSidebandsName = correlNameSbSE; }
+  void SetMECorrelHistoSignalName(TString correlNameSigME) { fMECorrelSignalRegionName = correlNameSigME; }
+  void SetMECorrelHistoSidebandName(TString correlNameSbME) { fMECorrelSidebandsName = correlNameSbME; }
+
+  // Input conditions: PtCand, PtHad, PoolBins
+  void SetNpools(Int_t npools) { fNpools = npools; }
+  void SetCorrectPoolsSeparately(Bool_t usePools) { fCorrectPoolsSeparately = usePools; }
+  void SetDeltaEtaRange(Double_t etaLow = -1., Double_t etaHigh = 1)
+  {
+    fDeltaEtaMin = etaLow;
+    fDeltaEtaMax = etaHigh;
+  }
+  void SetSubtractSoftPiInMEdistr(Bool_t subtractSoftPiME) { fSubtractSoftPiME = subtractSoftPiME; }
+  void SetBkgScaleFactor(Double_t scaleFactor) { fBkgScaleFactor = scaleFactor; }
+  void SetSignalYieldforNorm(Double_t sgnYield) { fSgnYieldNorm = sgnYield; }
+  void SetRebin2DcorrelHisto(Int_t rebinDeltaEta, Int_t rebinDeltaPhi)
+  {
+    fRebin2Dhisto = kTRUE;
+    fRebinAxisDeltaEta = rebinDeltaEta;
+    fRebinAxisDeltaPhi = rebinDeltaPhi;
+  }
+  void GetSignalAndBackgroundForNorm(Double_t PtCandMin, Double_t PtCandMax);
+  void NormalizeMEplot(TH2D*& histoME, TH2D*& histoMEsoftPi);
+  void SetDebugLevel(Int_t debug) { fDebug = debug; }
+
+  /// Analysis methods
+  TH2D* GetCorrelHisto(Int_t SEorME, Int_t SorSB, Int_t pool, Double_t PtCandMin, Double_t PtCandMax, Double_t PtHadMin, Double_t PtHadMax);
+  Bool_t ReadInputSEandME();
+  Bool_t ReadInputInvMass();
+  Bool_t ExtractCorrelations(Double_t PtCandMin, Double_t PtCandMax, Double_t PtHadMin, Double_t PtHadMax, TString codeName);
+  TH1D* GetCorrectedCorrHisto() { return fCorrectedCorrHisto; }
+
+  /// Histogram style
+  void SetTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, Style_t markerStyle = kFullCircle, Color_t markerColor = kRed + 1, Double_t markerSize = 1.4, Color_t lineColor = kRed + 1, Int_t lineWidth = 3, Float_t hTitleXaxisOffset = 1.0, Float_t hTitleYaxisOffset = 1.0, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
+  void SetTH2HistoStyle(TH2D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, TString hZaxisTitle, Float_t hTitleXaxisOffset = 1.8, Float_t hTitleYaxisOffset = 1.8, Float_t hTitleZaxisOffset = 1.2, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hTitleZaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Float_t hLabelZaxisSize = 0.060, Bool_t centerXaxisTitle = true, Bool_t centerYaxisTitle = true);
+
+ private:
+  TFile* fFileMass; // file containing the mass histograms
+  TFile* fFileSE;   // file containing the Same Event (SE) output
+  TFile* fFileME;   // file containing the Mixed Event (ME) output
+
+  TDirectoryFile* fDirMass; // TDirectory for mass histos
+  TDirectoryFile* fDirSE;   // TDirectory for SE info
+  TDirectoryFile* fDirME;   // TDirectory for ME info
+
+  TH1D* fCorrectedCorrHisto; // Corrected correlation histogram
+
+  DmesonSpecie fDmesonSpecies;       // D meson specie
+  TString fDmesonLabel;              // D meson label
+  TString fFileNameMass;             // File cntaining inv. mass histograms
+  TString fFileNameSE;               // File contaning Same Event (SE) output
+  TString fFileNameME;               // File contaning Mixed Event (ME) output
+  TString fDirNameSE;                // Directory in the file containing SE output
+  TString fDirNameME;                // Directory in the file containing ME output
+  TString fMassHistoNameSgn;         // Inv. mass histo name signal yield
+  TString fMassHistoNameBkg;         // Inv. mass histo name background yield
+  TString fMassHistoNameSBs;         // Inv. mass histo name sideband yield
+  TString fSECorrelSignalRegionName; // THnSparse name containing SE output for signal region
+  TString fSECorrelSidebandsName;    // THnSparse name containing SE output for sideband region
+  TString fMECorrelSignalRegionName; // THnSparse name containing ME output for signal region
+  TString fMECorrelSidebandsName;    // THnSparse name containing ME output for sideband region
+
+  Int_t fNpools;            // number of pools used for the ME correction
+  Int_t fRebinAxisDeltaEta; // rebin deltaEta axis
+  Int_t fRebinAxisDeltaPhi; // rebin deltaPhi axis
+  Int_t fDebug;             // debug level
+
+  Double_t fDeltaEtaMin;    // deltaEta min value
+  Double_t fDeltaEtaMax;    // deltaEta max value
+  Double_t fBkgScaleFactor; // Bkg/SB factor to scale correlation plots obtained in the sideband region
+  Double_t fSgnYieldNorm;   // Signal yield (used for normalize correlation plots after bkg subtraction)
+
+  Bool_t fCorrectPoolsSeparately; // Possibility to do the ME correction pool-by-pool (kTRUE) or merging all pools (kFALSE)
+  Bool_t fSubtractSoftPiME;       // Soft pion subtraction (for D0 case)
+  Bool_t fRebin2Dhisto;           // Flag to rebin the 2D correlation plots
+};
+
+#endif // DHCORRELATIONEXTRACTION_H_

--- a/PWGHF/HFC/Macros/DhCorrelationFitter.cxx
+++ b/PWGHF/HFC/Macros/DhCorrelationFitter.cxx
@@ -1,0 +1,581 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationFitter.cxx
+/// \brief class for for performing the fit of azimuthal correlations
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#include <TMath.h>
+#include <TFile.h>
+#include <TCanvas.h>
+#include <TH1F.h>
+#include <TF1.h>
+#include <TF2.h>
+#include <TMatrixD.h>
+#include <TFitResult.h>
+#include <TFitResultPtr.h>
+#include <Riostream.h>
+#include <TBufferFile.h>
+#include <TROOT.h>
+#include <TStyle.h>
+#include <TPaveText.h>
+#include <TPaveLabel.h>
+#include <TVirtualPad.h>
+#include <TMath.h>
+#include <TLatex.h>
+#include <TColor.h>
+#include <TClass.h>
+#include <sstream>
+#include <TVirtualFitter.h>
+#include <TMinuit.h>
+#include "DhCorrelationFitter.h"
+
+DhCorrelationFitter::DhCorrelationFitter() : // default constructor
+                                             fIsReflected(kFALSE),
+                                             fTypeOfFitFunc(kConstwoGaus),
+                                             fFixBase(0),
+                                             fFixMean(0),
+                                             fMinCandPt(0.),
+                                             fMaxCandPt(99.),
+                                             fMinAssoPt(0.),
+                                             fMaxAssoPt(99.),
+                                             fNpars(0),
+                                             fExtParsVals(0x0),
+                                             fExtParsLowBounds(0x0),
+                                             fExtParsUppBounds(0x0),
+                                             fUseExternalPars(kFALSE),
+                                             fNbasleinePoints(0),
+                                             fBinsBaseline(0x0),
+                                             fHist(0x0),
+                                             fMinCorr(0),
+                                             fMaxCorr(0),
+                                             fBaseline(0.),
+                                             fErrBaseline(0.),
+                                             fFit(0x0),
+                                             fGausNS(0x0),
+                                             fGausAS(0x0),
+                                             fPed(0x0),
+                                             fNSyieldBinCount(0.),
+                                             fErrNSyieldBinCount(0.),
+                                             fASyieldBinCount(0.),
+                                             fErrASyieldBinCount(0.)
+{
+}
+
+DhCorrelationFitter::DhCorrelationFitter(TH1F* histoToFit, Double_t min, Double_t max) : // standard constructor
+                                                                                         fIsReflected(kFALSE),
+                                                                                         fTypeOfFitFunc(kConstwoGaus),
+                                                                                         fFixBase(0),
+                                                                                         fFixMean(0),
+                                                                                         fMinCandPt(0.),
+                                                                                         fMaxCandPt(99.),
+                                                                                         fMinAssoPt(0.),
+                                                                                         fMaxAssoPt(99.),
+                                                                                         fNpars(0),
+                                                                                         fExtParsVals(0x0),
+                                                                                         fExtParsLowBounds(0x0),
+                                                                                         fExtParsUppBounds(0x0),
+                                                                                         fUseExternalPars(kFALSE),
+                                                                                         fNbasleinePoints(0),
+                                                                                         fBinsBaseline(0x0),
+                                                                                         fHist(0x0),
+                                                                                         fMinCorr(0.),
+                                                                                         fMaxCorr(0.),
+                                                                                         fBaseline(0.),
+                                                                                         fErrBaseline(0.),
+                                                                                         fFit(0x0),
+                                                                                         fGausNS(0x0),
+                                                                                         fGausAS(0x0),
+                                                                                         fPed(0x0),
+                                                                                         fNSyieldBinCount(0.),
+                                                                                         fErrNSyieldBinCount(0.),
+                                                                                         fASyieldBinCount(0.),
+                                                                                         fErrASyieldBinCount(0.)
+{
+  fHist = histoToFit;
+  fMinCorr = min;
+  fMaxCorr = max;
+}
+
+DhCorrelationFitter::DhCorrelationFitter(const DhCorrelationFitter& source) : // copy constructor
+                                                                              fIsReflected(source.fIsReflected),
+                                                                              fTypeOfFitFunc(source.fTypeOfFitFunc),
+                                                                              fFixBase(source.fFixBase),
+                                                                              fFixMean(source.fFixMean),
+                                                                              fMinCandPt(source.fMinCandPt),
+                                                                              fMaxCandPt(source.fMaxCandPt),
+                                                                              fMinAssoPt(source.fMinAssoPt),
+                                                                              fMaxAssoPt(source.fMaxAssoPt),
+                                                                              fNpars(source.fNpars),
+                                                                              fExtParsVals(source.fExtParsVals),
+                                                                              fExtParsLowBounds(source.fExtParsLowBounds),
+                                                                              fExtParsUppBounds(source.fExtParsUppBounds),
+                                                                              fUseExternalPars(source.fUseExternalPars),
+                                                                              fNbasleinePoints(source.fNbasleinePoints),
+                                                                              fBinsBaseline(source.fBinsBaseline),
+                                                                              fHist(source.fHist),
+                                                                              fMinCorr(source.fMinCorr),
+                                                                              fMaxCorr(source.fMaxCorr),
+                                                                              fBaseline(source.fBaseline),
+                                                                              fErrBaseline(source.fErrBaseline),
+                                                                              fFit(source.fFit),
+                                                                              fGausNS(source.fGausNS),
+                                                                              fGausAS(source.fGausAS),
+                                                                              fPed(source.fPed),
+                                                                              fNSyieldBinCount(source.fNSyieldBinCount),
+                                                                              fErrNSyieldBinCount(source.fErrNSyieldBinCount),
+                                                                              fASyieldBinCount(source.fASyieldBinCount),
+                                                                              fErrASyieldBinCount(source.fErrASyieldBinCount)
+{
+}
+
+DhCorrelationFitter::~DhCorrelationFitter()
+// destructor
+{
+  Info("DhCorrelationFitter.cxx", "Destructor is calling");
+
+  if (fHist) {
+    delete fHist;
+    fHist = 0;
+  }
+  if (fFit) {
+    delete fFit;
+    fFit = 0;
+  }
+  if (fGausNS) {
+    delete fGausNS;
+    fGausNS = 0;
+  }
+  // if (fGausNS2) {delete fGausNS2; fGausNS2 = 0;}
+  if (fPed) {
+    delete fPed;
+    fPed = 0;
+  }
+}
+
+DhCorrelationFitter& DhCorrelationFitter::operator=(const DhCorrelationFitter& cfit)
+// assignment operator
+{
+  if (&cfit == this)
+    return *this;
+
+  fIsReflected = cfit.fIsReflected;
+  fTypeOfFitFunc = cfit.fTypeOfFitFunc;
+  fFixBase = cfit.fFixBase;
+  fFixMean = cfit.fFixMean;
+  fMinCandPt = cfit.fMinCandPt;
+  fMaxCandPt = cfit.fMaxCandPt;
+  fMinAssoPt = cfit.fMinAssoPt;
+  fMaxAssoPt = cfit.fMaxAssoPt;
+  fNpars = cfit.fNpars;
+  fExtParsVals = cfit.fExtParsVals;
+  fExtParsLowBounds = cfit.fExtParsLowBounds;
+  fExtParsUppBounds = cfit.fExtParsUppBounds;
+  fUseExternalPars = cfit.fUseExternalPars;
+  fNbasleinePoints = cfit.fNbasleinePoints;
+  fBinsBaseline = cfit.fBinsBaseline;
+  fHist = cfit.fHist;
+  fMinCorr = cfit.fMinCorr;
+  fMaxCorr = cfit.fMaxCorr;
+  fBaseline = cfit.fBaseline;
+  fErrBaseline = cfit.fErrBaseline;
+  fFit = cfit.fFit;
+  fGausNS = cfit.fGausNS;
+  fGausAS = cfit.fGausAS;
+  fPed = cfit.fPed;
+  fNSyieldBinCount = cfit.fNSyieldBinCount;
+  fErrNSyieldBinCount = cfit.fErrNSyieldBinCount;
+  fASyieldBinCount = cfit.fASyieldBinCount;
+  fErrASyieldBinCount = cfit.fErrASyieldBinCount;
+
+  return *this;
+}
+
+void DhCorrelationFitter::SetExternalValsAndBounds(Int_t nPars, Double_t* vals, Double_t* lowBounds, Double_t* uppBounds)
+{
+
+  fNpars = nPars;
+
+  fExtParsVals = new Double_t[fNpars];
+  fExtParsLowBounds = new Double_t[fNpars];
+  fExtParsUppBounds = new Double_t[fNpars];
+
+  for (int i = 0; i < fNpars; i++) {
+    fExtParsVals[i] = vals[i];
+    fExtParsLowBounds[i] = lowBounds[i];
+    fExtParsUppBounds[i] = uppBounds[i];
+  }
+
+  return;
+}
+
+void DhCorrelationFitter::Fitting(Bool_t drawSplitTerm, Bool_t useExternalPars)
+{
+  // -> fFixBase = 0 : baseline free
+  //             = 1 : fix the baseline to the minimum of the histogram
+  //             < 0 : fix the baseline to the weighted average of the abs(fFixBaseline) lower points
+  //             = 2 : zyam at pi/2. Fix the baseline averaging the 2 points around +-pi/2 value
+  //             = 3 : fix the baseline to the weighted average of the points passed through the function SetPointsForBaseline()
+  //
+  // -> fFixMean = 0 : NS & AS mean free
+  //             = 1 : NS mean fixed to 0, AS mean free
+  //             = 2 : AS mean fixed to pi, NS mean free
+  //             = 3 : NS mean fixed to 0, AS mean to pi
+
+  if (useExternalPars)
+    fUseExternalPars = kTRUE;
+
+  if (fFixBase != 0 && fFixBase != 6) {
+    Printf("[INFO] DhCorrelationFitter::Fitting, Finding baseline");
+    FindBaseline();
+  }
+  Printf("[INFO] DhCorrelationFitter::Fitting, Setting Function");
+  SetFitFunction();
+
+  if (fFixBase != 0) {
+    fFit->FixParameter(0, fBaseline);
+  }
+  if (fFixMean == 1 || fFixMean == 3) {
+    fFit->FixParameter(2, 0.);
+  }
+  if (fFixMean == 2 || fFixMean == 3) {
+    if (fTypeOfFitFunc != 0)
+      fFit->FixParameter(5, TMath::Pi());
+  }
+  Printf("[INFO] DhCorrelationFitter::Fitting, Fitting");
+  TVirtualFitter::SetMaxIterations(20000);
+  TFitResultPtr fitptr = fHist->Fit(fFit, "RIMES", "", fMinCorr, fMaxCorr);
+  TMatrixD cor = fitptr->GetCorrelationMatrix();
+  TMatrixD cov = fitptr->GetCovarianceMatrix();
+  printf("[INFO] Correlation Matrix - The final one! \n");
+  cor.Print();
+  gMinuit->mnmatu(1);
+  printf("[INFO] Covariance Matrix - The final one! \n");
+  cov.Print();
+  if (fFixBase == 0) {
+    fBaseline = fFit->GetParameter(0);
+    fErrBaseline = fFit->GetParError(0);
+  }
+  Printf("[INFO] DhCorrelationFitter::Fitting, Calculating yields with BC");
+  CalculateYieldsAboveBaseline();
+  fHist->SetTitle(";#Delta#varphi (rad); #frac{1}{N_{D}}#frac{dN^{assoc}}{d#Delta#varphi} (rad^{-1})");
+  Printf("[INFO] DhCorrelationFitter::Fitting, Now drawing, if requested");
+  SetSingleTermsForDrawing(drawSplitTerm);
+}
+
+void DhCorrelationFitter::SetFitFunction()
+{
+  // -> fitFunc = 1: const+ G NS + G AS (w/o periodicity)
+  //            = 2: const+ G NS + G AS  (w/ periodicity)
+  //            = 3: const+ yieldNS*[fact*(G NS)+(1- fact)*(G2 NS)] + yieldAS*(G AS)  (w/ periodicity)
+  //            = 4: const +yieldNS*(G NS) + yieldAS*[fact*(G AS)+(1- fact)*(G2 AS)]   (w/ periodicity)
+  //            = 5: v2 modulation (no gaussian terms)
+  //            = 6: v2 modulation + G NS + G AS  (w/ periodicity)
+  //            = 7: const+ GenG NS + G AS  (w/ periodicity)
+  //            = 8: const+ GenG fixBeta NS + G AS  (w/ periodicity)
+  //            = 9: const+ GenG constrBeta NS + G AS  (w/ periodicity)
+
+  if (fFit) {
+    delete fFit;
+    delete fGausNS;
+    // delete fGausNS2;
+    delete fGausAS;
+    // delete fGausAS2;
+    delete fPed;
+  }
+  switch (fTypeOfFitFunc) {
+    case 1:
+      fFit = new TF1("ConstwoGaus", "[0]+[1]/TMath::Sqrt(2.*TMath::Pi())/[3]*TMath::Exp(-(x-[2])*(x-[2])/2./([3]*[3]))+[4]/TMath::Sqrt(2.*TMath::Pi())/[6]*TMath::Exp(-(x-[5])*(x-[5])/2./([6]*[6]))", fMinCorr, fMaxCorr);
+      fGausNS = new TF1("fGausNS", "[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-[1])*(x-[1])/2./([2]*[2]))", fMinCorr, fMaxCorr);
+      fGausAS = new TF1("fGausAS", "[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-[1])*(x-[1])/2./([2]*[2]))", fMinCorr, fMaxCorr);
+      fPed = new TF1("fPed", "[0]", fMinCorr, fMaxCorr);
+
+      if (!fUseExternalPars) {
+        fFit->SetParLimits(0, 0, 9999.);
+        fFit->SetParLimits(1, 0, 999.);
+        fFit->SetParLimits(2, -1, 1);
+        fFit->SetParLimits(3, 0, 3.14 / 3.);
+        fFit->SetParLimits(4, 0, 999.);
+        fFit->SetParLimits(5, 2., 4);
+        fFit->SetParLimits(6, 0, 3.14 / 2.);
+
+        fFit->SetParameter(0, 3);
+        fFit->SetParameter(1, 2);
+        fFit->SetParameter(2, 0.);
+        fFit->SetParameter(3, 0.3);
+        fFit->SetParameter(4, 2);
+        fFit->SetParameter(5, 3.14);
+        fFit->SetParameter(6, 0.3);
+
+      } else {
+        for (int i = 0; i < fNpars; i++) {
+          fFit->SetParameter(i, fExtParsVals[i]);
+          fFit->SetParLimits(i, fExtParsLowBounds[i], fExtParsUppBounds[i]);
+        }
+      }
+
+      fFit->SetParName(0, "ped");
+      fFit->SetParName(1, "NS Y");
+      fFit->SetParName(2, "NS mean");
+      fFit->SetParName(3, "NS #sigma");
+      fFit->SetParName(4, "AS Y");
+      fFit->SetParName(5, "AS mean");
+      fFit->SetParName(6, "AS #sigma");
+
+      break;
+
+    case 2:
+      fFit = new TF1("TwoGausPeriodicity", "[0]+[1]/TMath::Sqrt(2.*TMath::Pi())/[3]*TMath::Exp(-(x-[2])*(x-[2])/2./([3]*[3]))+[4]/TMath::Sqrt(2.*TMath::Pi())/[6]*TMath::Exp(-(x-[5])*(x-[5])/2./([6]*[6]))+[1]/TMath::Sqrt(2.*TMath::Pi())/[3]*TMath::Exp(-(x-2.*TMath::Pi()-[2])*(x-2.*TMath::Pi()-[2])/2./([3]*[3]))+[1]/TMath::Sqrt(2.*TMath::Pi())/[3]*TMath::Exp(-(x+2.*TMath::Pi()-[2])*(x+2.*TMath::Pi()-[2])/2./([3]*[3]))+[4]/TMath::Sqrt(2.*TMath::Pi())/[6]*TMath::Exp(-(x+2.*TMath::Pi()-[5])*(x+2.*TMath::Pi()-[5])/2./([6]*[6]))+[4]/TMath::Sqrt(2.*TMath::Pi())/[6]*TMath::Exp(-(x-2.*TMath::Pi()-[5])*(x-2.*TMath::Pi()-[5])/2./([6]*[6]))", fMinCorr, fMaxCorr);
+      fGausNS = new TF1("fGausNSper", "[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-[1])*(x-[1])/2./([2]*[2]))+[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-2.*TMath::Pi()-[1])*(x-2.*TMath::Pi()-[1])/2./([2]*[2]))+[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x+2.*TMath::Pi()-[1])*(x+2.*TMath::Pi()-[1])/2./([2]*[2]))", fMinCorr, fMaxCorr);
+      fGausAS = new TF1("fGausASper", "[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-[1])*(x-[1])/2./([2]*[2]))+[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-2.*TMath::Pi()-[1])*(x-2.*TMath::Pi()-[1])/2./([2]*[2]))+[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x+2.*TMath::Pi()-[1])*(x+2.*TMath::Pi()-[1])/2./([2]*[2]))", fMinCorr, fMaxCorr);
+      fPed = new TF1("fPed", "[0]", fMinCorr, fMaxCorr);
+
+      if (!fUseExternalPars) {
+        fFit->SetParLimits(0, 0., 999.);
+        fFit->SetParLimits(1, 0, 999.);
+        fFit->SetParLimits(2, -0.55, 0.55);
+        fFit->SetParLimits(3, 0, 3.14 / 3.);
+        fFit->SetParLimits(4, 0, 999.);
+        fFit->SetParLimits(5, 2.85, 3.55);
+        fFit->SetParLimits(6, 0, 3.14 / 2.);
+
+        fFit->SetParameter(0, 0.6);
+        fFit->SetParameter(1, 3);
+        fFit->SetParameter(2, 0.);
+        fFit->SetParameter(3, 0.3);
+        fFit->SetParameter(4, 2);
+        fFit->SetParameter(5, TMath::Pi());
+        fFit->SetParameter(6, 0.3);
+
+      } else {
+        for (int i = 0; i < fNpars; i++) {
+          fFit->SetParameter(i, fExtParsVals[i]);
+          fFit->SetParLimits(i, fExtParsLowBounds[i], fExtParsUppBounds[i]);
+        }
+      }
+
+      fFit->SetParName(0, "ped");
+      fFit->SetParName(1, "NS Y");
+      fFit->SetParName(2, "NS mean");
+      fFit->SetParName(3, "NS #sigma");
+      fFit->SetParName(4, "AS Y");
+      fFit->SetParName(5, "AS mean");
+      fFit->SetParName(6, "AS #sigma");
+
+      break;
+  }
+}
+
+void DhCorrelationFitter::SetPointsForBaseline(Int_t nBaselinePoints, Int_t* binsBaseline)
+{
+
+  fNbasleinePoints = nBaselinePoints;
+
+  fBinsBaseline = new Int_t[fNbasleinePoints];
+
+  for (int i = 0; i < fNbasleinePoints; i++) {
+    fBinsBaseline[i] = binsBaseline[i];
+  }
+
+  return;
+}
+
+Double_t DhCorrelationFitter::FindBaseline()
+{
+
+  // baseline free
+  if (fFixBase == 0) {
+    Printf("[INFO] DhCorrelationFitter::FindBasline(). The baseline option is set to free baseline: now the full fit will be done. Beware!");
+    Fitting(); // TODO: not sure
+    return fBaseline;
+  }
+
+  // fix the baseline to the minimum of the histogram
+  if (fFixBase == 1) {
+    Double_t min = 1.e10;
+    Int_t iBin = -1;
+    for (Int_t j = 1; j <= fHist->GetNbinsX(); j++) {
+      if (fHist->GetBinContent(j) < min) {
+        min = fHist->GetBinContent(j);
+        iBin = j;
+      }
+    }
+    fBaseline = min;
+    fErrBaseline = fHist->GetBinError(iBin);
+
+    return fBaseline;
+  }
+
+  // fix the baseline to the weighted average of the abs(fFixBaseline) lower points
+  if (fFixBase < 0) {
+    Int_t npointsAv = TMath::Abs(fFixBase);
+    Int_t* ind = new Int_t[fHist->GetNbinsX()];
+    Float_t* hval = new Float_t[fHist->GetNbinsX()];
+    for (Int_t k = 1; k <= fHist->GetNbinsX(); k++) {
+      hval[k - 1] = fHist->GetBinContent(k);
+    }
+    Double_t errAv = 0., Av = 0.;
+    TMath::Sort(fHist->GetNbinsX(), hval, ind, kFALSE); //  KFALSE -> increasing order
+    // Average of abs(fFixBase) lower points
+    for (Int_t k = 0; k < npointsAv; k++) {
+      if (fHist->GetBinError(ind[k] + 1) == 0.) // in case of null entries which induce a crash. Could bias the basline in upward direction!
+      {
+        printf("[WARNING] Null entries found in histogram to be fit! These points are been excluded from baseline evaluation...\n");
+        npointsAv++;
+        continue;
+      }
+      Av += fHist->GetBinContent(ind[k] + 1) / (fHist->GetBinError(ind[k] + 1) * fHist->GetBinError(ind[k] + 1));
+      errAv += 1. / (fHist->GetBinError(ind[k] + 1) * fHist->GetBinError(ind[k] + 1));
+    }
+    Av /= errAv;
+    errAv = TMath::Sqrt(1. / errAv);
+    printf("[RESULT] Average fBaseline: %.3f +- %.3f", Av, errAv);
+    fBaseline = Av;
+    fErrBaseline = errAv;
+    return fBaseline;
+  }
+
+  // zyam at pi/2. Fix the baseline averaging the 2 points around +-pi/2 value
+  if (fFixBase == 2) {
+    Double_t errAv = 0., Av = 0.;
+    Int_t binPhi = fHist->FindBin(TMath::Pi() / 2.);
+    Av += fHist->GetBinContent(binPhi) / (fHist->GetBinError(binPhi) * fHist->GetBinError(binPhi));
+    errAv += 1. / (fHist->GetBinError(binPhi) * fHist->GetBinError(binPhi));
+    if (!fIsReflected) {
+      binPhi = fHist->FindBin(-TMath::Pi() / 2.);
+      if (binPhi < 1)
+        binPhi = 1;
+      Av += fHist->GetBinContent(binPhi) / (fHist->GetBinError(binPhi) * fHist->GetBinError(binPhi));
+      errAv += 1. / (fHist->GetBinError(binPhi) * fHist->GetBinError(binPhi));
+    } else {
+      printf("[INFO] Reflected histo: only the point at +pi/2 used to evaluate baseline");
+    }
+    Av /= errAv;
+    errAv = TMath::Sqrt(1. / errAv);
+    printf("[RESULT] Average fBaseline: %.3f +- %.3f \n", Av, errAv);
+    fBaseline = Av;
+    fErrBaseline = errAv;
+
+    return fBaseline;
+  }
+
+  // fix the baseline to the weighted average of the points passed through the function SetPointsForBaseline()
+  if (fFixBase == 3) {
+    if (fNbasleinePoints == 0) {
+      printf("[ERROR] No baseline points set for the baseline evaluation, SetPointsForBaseline(Int_t nBaselinePoints, Double_t* valsBaseline). Returning -1");
+      return -1;
+    }
+    Double_t errAv = 0., Av = 0.;
+    for (int i = 0; i < fNbasleinePoints; i++) {
+      Av += fHist->GetBinContent(fBinsBaseline[i]) / (fHist->GetBinError(fBinsBaseline[i]) * fHist->GetBinError(fBinsBaseline[i]));
+      errAv += 1. / (fHist->GetBinError(fBinsBaseline[i]) * fHist->GetBinError(fBinsBaseline[i]));
+    }
+    Av /= errAv;
+    errAv = TMath::Sqrt(1. / errAv);
+    printf("[RESULT] Average fBaseline: %.3f +- %.3f \n", Av, errAv);
+    fBaseline = Av;
+    fErrBaseline = errAv;
+
+    return fBaseline;
+  }
+
+  Printf("[ERROR] DhCorrelationFitter::FindBaseline - WRONG BASELINE OPTION SET. Returning -1");
+  return -1.;
+}
+
+void DhCorrelationFitter::CalculateYieldsAboveBaseline()
+{
+
+  fNSyieldBinCount = 0;
+  fErrNSyieldBinCount = 0;
+  fASyieldBinCount = 0;
+  fErrASyieldBinCount = 0;
+  cout << "[RESULT] Baseline: " << fBaseline << " +- " << fErrBaseline << endl;
+  Int_t binMinNS = fHist->FindBin(-1.5); // slightly more than -pi/2
+  if (binMinNS < 1)
+    binMinNS = 1;                              // with this, it is ok even in the case of a reflected fHist (range 0 - pi)
+  Int_t binMaxNS = fHist->FindBin(1.5);        // slightly less than +pi/2
+  Int_t binMinAS = fHist->FindBin(1.6);        // slightly more than +pi/2
+  Int_t binMaxAS = fHist->FindBin(3.14 + 1.5); // slightly less than +3pi/2
+  if (binMaxAS > fHist->GetNbinsX())
+    binMaxNS = fHist->GetNbinsX(); // with this, it is ok even in the case of a reflected fHist (range 0 - pi) TODO: maybe binMaxAS
+  // Near Side Yield from bin counting
+  for (Int_t bmNS = binMinNS; bmNS <= binMaxNS; bmNS++) {
+    fNSyieldBinCount += (fHist->GetBinContent(bmNS) - fBaseline) * fHist->GetBinWidth(bmNS);
+    fErrNSyieldBinCount += (fHist->GetBinError(bmNS) * fHist->GetBinError(bmNS)) * fHist->GetBinWidth(bmNS) * fHist->GetBinWidth(bmNS);
+  }
+  fErrNSyieldBinCount = TMath::Sqrt(fErrNSyieldBinCount);
+
+  // Away Side Yield from bin counting
+  for (Int_t bmAS = binMinAS; bmAS <= binMaxAS; bmAS++) {
+    fASyieldBinCount += (fHist->GetBinContent(bmAS) - fBaseline) * fHist->GetBinWidth(bmAS);
+    fErrASyieldBinCount += (fHist->GetBinError(bmAS) * fHist->GetBinError(bmAS)) * fHist->GetBinWidth(bmAS) * fHist->GetBinWidth(bmAS);
+  }
+  fErrASyieldBinCount = TMath::Sqrt(fErrASyieldBinCount);
+
+  printf("[RESULT] Bin counting results: NS Yield = %.3f +- %.3f \n[RESULT] Bin counting results: AS Yield: %.3f +- %.3f \n", fNSyieldBinCount, fErrNSyieldBinCount, fASyieldBinCount, fErrASyieldBinCount);
+
+  return;
+}
+
+void DhCorrelationFitter::SetSingleTermsForDrawing(Bool_t draw)
+{
+  Double_t* par = 0;
+  if (fTypeOfFitFunc == 1 || fTypeOfFitFunc == 2) {
+    par = new Double_t[7];
+  } else {
+    Printf("[ERROR] DhCorrelationFitter::SetSingleTermsForDrawing, wrong type of function");
+    return;
+  }
+
+  fFit->GetParameters(par);
+  fFit->SetLineWidth(4);
+
+  fPed->SetParameter(0, par[0]);
+  fPed->SetLineColor(6); // pink
+  fPed->SetLineStyle(9);
+  fPed->SetLineWidth(4);
+
+  fGausNS->SetParameter(0, par[1]);
+  fGausNS->SetParameter(1, par[2]);
+  fGausNS->SetParameter(2, par[3]);
+  fGausAS->SetParameter(0, par[4]);
+  fGausAS->SetParameter(1, par[5]);
+  fGausAS->SetParameter(2, par[6]);
+
+  fGausNS->SetLineStyle(9);
+  fGausNS->SetLineColor(kBlue);
+  fGausAS->SetLineStyle(9);
+  fGausAS->SetLineColor(kGreen);
+  fGausNS->SetLineWidth(4);
+  fGausAS->SetLineWidth(4);
+
+  TPaveText* pvStatTests1 = new TPaveText(0.51, 0.58, 0.85, 0.90, "NDC");
+  pvStatTests1->SetFillStyle(0);
+  pvStatTests1->SetTextSize(0.035);
+  pvStatTests1->SetBorderSize(0);
+  TText *t0, *t1, *t2, *t3, *t4, *t5, *t6;
+  t0 = pvStatTests1->AddText(0., 1.00, Form("#chi^{2}/ndf = %.1f/%d ", fFit->GetChisquare(), fFit->GetNDF()));
+  t1 = pvStatTests1->AddText(0., 0.80, Form("Ped = %.3f#pm%.3f ", fBaseline, fErrBaseline));
+  t2 = pvStatTests1->AddText(0., 0.65, Form("NS Y = %.3f#pm%.3f ", fFit->GetParameter("NS Y"), fFit->GetParError(fFit->GetParNumber("NS Y"))));
+  t3 = pvStatTests1->AddText(0., 0.50, Form("NS #sigma = %.3f#pm%.3f ", fFit->GetParameter("NS #sigma"), fFit->GetParError(fFit->GetParNumber("NS #sigma"))));
+  t4 = pvStatTests1->AddText(0., 0.35, Form("AS Y = %.3f#pm%.3f ", fFit->GetParameter("AS Y"), fFit->GetParError(fFit->GetParNumber("AS Y"))));
+  t5 = pvStatTests1->AddText(0., 0.20, Form("AS #sigma = %.3f#pm%.3f ", fFit->GetParameter("AS #sigma"), fFit->GetParError(fFit->GetParNumber("AS #sigma"))));
+
+  if (draw) {
+    fFit->Draw("same");
+    fPed->Draw("same");
+    fGausAS->Draw("same");
+    fGausNS->Draw("same");
+    pvStatTests1->Draw("same");
+  }
+}

--- a/PWGHF/HFC/Macros/DhCorrelationFitter.h
+++ b/PWGHF/HFC/Macros/DhCorrelationFitter.h
@@ -1,0 +1,129 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationFitter.h
+/// \brief class for for performing the fit of azimuthal correlations
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#ifndef DHCORRELATIONFITTER_H_
+#define DHCORRELATIONFITTER_H_
+
+#include <TFile.h>
+#include <TH1F.h>
+#include <TCanvas.h>
+#include <TLatex.h>
+
+class DhCorrelationFitter
+{
+
+ public:
+  enum FunctionType { kConstwoGaus = 1,
+                      kTwoGausPeriodicity = 2 };
+
+  /// Constructors
+  DhCorrelationFitter();
+  DhCorrelationFitter(TH1F* histoToFit, Double_t min, Double_t max);
+  virtual ~DhCorrelationFitter();
+  DhCorrelationFitter(const DhCorrelationFitter& source);
+  DhCorrelationFitter& operator=(const DhCorrelationFitter& cfit);
+
+  /// Setters
+  void SetHistoIsReflected(Bool_t isrefl) { fIsReflected = isrefl; }
+  void SetFuncType(FunctionType fitType) { fTypeOfFitFunc = fitType; }
+  void SetFixBaseline(Int_t fixBase) { fFixBase = fixBase; }
+  void SetFixMean(Int_t fixMean) { fFixMean = fixMean; }
+  void SetPtRanges(Double_t PtCandMin, Double_t PtCandMax, Double_t PtAssocMin, Double_t PtAssocMax)
+  {
+    fMinCandPt = PtCandMin;
+    fMaxCandPt = PtCandMax;
+    fMinAssoPt = PtAssocMin;
+    fMaxAssoPt = PtAssocMax;
+  }
+  void SetExternalValsAndBounds(Int_t nPars, Double_t* vals, Double_t* lowBounds, Double_t* uppBounds);
+  void SetPointsForBaseline(Int_t nBaselinePoints, Int_t* binsBaseline);
+
+  /// Functions for fitting
+  void Fitting(Bool_t drawSplitTerm = kTRUE, Bool_t useExternalPars = kFALSE);
+  void SetFitFunction();
+  void CalculateYieldsAboveBaseline();
+  void SetSingleTermsForDrawing(Bool_t draw);
+  Double_t FindBaseline();
+
+  /// Getters
+  Double_t GetNSSigma() { return fFit->GetParameter("NS #sigma"); } // TODO: case kConstThreeGausPeriodicity
+  Double_t GetASSigma() { return fFit->GetParameter("AS #sigma"); } // TODO: case kConstThreeGausPeriodicity
+  Double_t GetNSYield() { return fFit->GetParameter("NS Y"); }
+  Double_t GetASYield() { return fFit->GetParameter("AS Y"); }
+  Double_t GetBeta() { return fFit->GetParameter(7); }
+  Double_t GetPedestal() { return fBaseline; }
+  Double_t Getv2hadron() { return fFit->GetParameter("v_{2} hadron"); }
+  Double_t Getv2Dmeson() { return fFit->GetParameter("v_{2} D meson"); }
+  Double_t GetNSSigmaError() { return fFit->GetParError(fFit->GetParNumber("NS #sigma")); } // TODO: case kConstThreeGausPeriodicity
+  Double_t GetASSigmaError() { return fFit->GetParError(fFit->GetParNumber("AS #sigma")); } // TODO: case kConstThreeGausPeriodicityAS
+  Double_t GetNSYieldError() { return fFit->GetParError(fFit->GetParNumber("NS Y")); }
+  Double_t GetASYieldError() { return fFit->GetParError(fFit->GetParNumber("AS Y")); }
+  Double_t GetBetaError() { return fFit->GetParError(7); }
+  Double_t GetPedestalError() { return fErrBaseline; }
+  Double_t Getv2hadronError() { return fFit->GetParError(fFit->GetParNumber("v_{2} hadron")); }
+  Double_t Getv2DmesonError() { return fFit->GetParError(fFit->GetParNumber("v_{2} D meson")); }
+  Double_t GetBinCountingNSYield() { return fNSyieldBinCount; }
+  Double_t GetBinCountingASYield() { return fASyieldBinCount; }
+  Double_t GetBinCountingNSYieldErr() { return fErrNSyieldBinCount; }
+  Double_t GetBinCountingASYieldErr() { return fErrASyieldBinCount; }
+  TF1* GetFitFunction()
+  {
+    if (!fFit) {
+      printf("[ERROR] DhCorrelationFitter::GetFitFunction, No fit function");
+      return NULL;
+    }
+    return fFit;
+  }
+
+ private:
+  TH1F* fHist; // 1D azimuthal correlation histogram
+
+  TF1* fFit;    // Total fit function
+  TF1* fGausNS; // Near-Side (NS) Gaussian
+  TF1* fGausAS; // Away-Side (AS) Gaussian
+  TF1* fPed;    // Baseline function
+
+  Bool_t fIsReflected;
+  Bool_t fUseExternalPars; // To use external fit parameters initial values and bounds
+
+  FunctionType fTypeOfFitFunc; // Type of fit function
+
+  Int_t fFixBase;         // Fix baseline or keep it as free parameter (see Fitting())
+  Int_t fFixMean;         // Fix means or keep them as free parameters (see Fitting())
+  Int_t fNpars;           // Number of parameters of the fit function
+  Int_t fNbasleinePoints; // Number of points passed as inputs for the baseline estimation
+
+  Int_t* fBinsBaseline; // Bin values for calculating the baseline
+
+  Double_t fMinCorr;            // Min value of correlation histogram
+  Double_t fMaxCorr;            // Max value of correlation histogram
+  Double_t fMinCandPt;          // Min pt value of candidate
+  Double_t fMaxCandPt;          // Max pt value of candidate
+  Double_t fMinAssoPt;          // Min pt value of assoc. particles
+  Double_t fMaxAssoPt;          // Max pt value of assoc. particles
+  Double_t fBaseline;           // Baseline value
+  Double_t fErrBaseline;        // Baseline error
+  Double_t fNSyieldBinCount;    // NS Yield from bin counting
+  Double_t fErrNSyieldBinCount; // NS Yield error from bin counting
+  Double_t fASyieldBinCount;    // AS Yield from bin counting
+  Double_t fErrASyieldBinCount; // AS Yield error from bin counting
+
+  Double_t* fExtParsVals;      // Fit parameters initial values
+  Double_t* fExtParsLowBounds; // Fit parameters lower bounds
+  Double_t* fExtParsUppBounds; // Fit parameters upper bounds
+};
+
+#endif // DHCORRELATIONFITTER_H_

--- a/PWGHF/HFC/Macros/ExtractOutputCorrel.C
+++ b/PWGHF/HFC/Macros/ExtractOutputCorrel.C
@@ -1,0 +1,195 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationExtraction.cxx
+/// \brief class for D-h correlation extraction
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#include "DhCorrelationExtraction.h"
+#include <TROOT.h>
+#include <TStyle.h>
+#include "Riostream.h"
+#include <rapidjson/document.h>
+#include <rapidjson/filereadstream.h>
+
+using namespace std;
+using namespace rapidjson;
+
+template <typename ValueType>
+void readArray(const Value& jsonArray, vector<ValueType>& output)
+{
+  for (auto it = jsonArray.Begin(); it != jsonArray.End(); it++) {
+    auto value = it->template Get<ValueType>();
+    output.emplace_back(value);
+  }
+}
+
+void parseStringArray(const Value& jsonArray, vector<string>& output)
+{
+  size_t arrayLength = jsonArray.Size();
+  for (size_t i = 0; i < arrayLength; i++) {
+    if (jsonArray[i].IsString()) {
+      output.emplace_back(jsonArray[i].GetString());
+    }
+  }
+}
+
+void SetInputCorrelNames(DhCorrelationExtraction* plotter, TString pathFileMass, TString pathFileSE, TString pathFileME, TString dirSE, TString dirME, TString histoNameCorrSignal, TString histoNameCorrSideba);
+void SetInputHistoInvMassNames(DhCorrelationExtraction* plotter, vector<string> inputMassNames);
+
+void ExtractOutputCorrel(TString cfgFileName = "config_CorrAnalysis.json")
+{
+  // gStyle -> SetOptStat(0);
+  gStyle->SetPadLeftMargin(0.15);
+  gStyle->SetPadBottomMargin(0.15);
+  gStyle->SetFrameLineWidth(2);
+  gStyle->SetLineWidth(2);
+  gStyle->SetCanvasDefH(1126);
+  gStyle->SetCanvasDefW(1840);
+
+  // Load config
+  FILE* configFile = fopen(cfgFileName.Data(), "r");
+  Document config;
+  char readBuffer[65536];
+  FileReadStream is(configFile, readBuffer, sizeof(readBuffer));
+  config.ParseStream(is);
+  fclose(configFile);
+
+  string CodeNameAnalysis = config["CodeName"].GetString();
+  gSystem->Exec(Form("rm -rf Output_CorrelationExtraction_%s_Root/ Output_CorrelationExtraction_%s_png/", CodeNameAnalysis.data(), CodeNameAnalysis.data()));
+  gSystem->Exec(Form("mkdir Output_CorrelationExtraction_%s_Root/ Output_CorrelationExtraction_%s_png/", CodeNameAnalysis.data(), CodeNameAnalysis.data()));
+
+  string pathFileSE = config["pathFileSE"].GetString();
+  string pathFileME = config["pathFileME"].GetString();
+  string pathFileMass = config["pathFileMass"].GetString();
+
+  string dirSE = config["InputDirSE"].GetString();
+  string dirME = config["InputDirME"].GetString();
+  string histoNameCorrSignal = config["InputHistoCorrSignalName"].GetString();
+  string histoNameCorrSideba = config["InputHistoCorrSidebaName"].GetString();
+
+  vector<string> InputHistoMassName;
+
+  const Value& inputMassNames = config["InputHistoMassName"];
+  parseStringArray(inputMassNames, InputHistoMassName);
+
+  cout << InputHistoMassName[0].data() << endl;
+  cout << InputHistoMassName[1].data() << endl;
+  cout << InputHistoMassName[2].data() << endl;
+
+  vector<double> binsPtCandIntervals;
+  vector<double> binsPtHadIntervals;
+  vector<double> deltaEtaInterval;
+
+  const Value& PtCandValue = config["binsPtCandIntervals"];
+  readArray(PtCandValue, binsPtCandIntervals);
+
+  const Value& PtHadValue = config["binsPtHadIntervals"];
+  readArray(PtHadValue, binsPtHadIntervals);
+
+  const Value& deltaEtaValue = config["deltaEtaInterval"];
+  readArray(deltaEtaValue, deltaEtaInterval);
+  double deltaEtaMin = deltaEtaInterval[0];
+  double deltaEtaMax = deltaEtaInterval[1];
+
+  int specie = config["DmesonSpecie"].GetInt();
+
+  int npools = config["NumberOfPools"].GetInt();
+  bool poolByPool = config["CorrectPoolsSeparately"].GetBool();
+
+  std::cout << "=========================== " << std::endl;
+  std::cout << "Input variables from config" << std::endl;
+  std::cout << "deltaEtaMin    = " << deltaEtaMin << std::endl;
+  std::cout << "deltaEtaMax    = " << deltaEtaMax << std::endl;
+  std::cout << "DmesonSpecie    = " << specie << std::endl;
+  std::cout << "nPools    = " << npools << std::endl;
+  std::cout << "poolByPool    = " << poolByPool << std::endl;
+  std::cout << "=========================== " << std::endl;
+  std::cout << " " << std::endl;
+
+  const int nBinsPtCand = binsPtCandIntervals.size() - 1;
+  const int nBinsPtHad = binsPtHadIntervals.size() - 1;
+
+  TH1D* hCorrectedCorrel[nBinsPtCand][nBinsPtHad];
+
+  // Create and set the correlation plotter class
+  DhCorrelationExtraction* plotter = new DhCorrelationExtraction();
+
+  Bool_t flagSpecie = plotter->SetDmesonSpecie(static_cast<DhCorrelationExtraction::DmesonSpecie>(specie));
+  plotter->SetNpools(npools);
+  plotter->SetCorrectPoolsSeparately(poolByPool); // kTRUE = pool.by-pool extraction and correction; kFALSE = merged ME pools
+  plotter->SetDeltaEtaRange(deltaEtaMin, deltaEtaMax);
+  plotter->SetSubtractSoftPiInMEdistr(kFALSE);
+  plotter->SetRebin2DcorrelHisto(2, 2); // Xaxis: deltaEta, Yaxis: deltaPhi
+  plotter->SetDebugLevel(1);
+
+  if (!flagSpecie)
+    cout << "[ERROR] Wrong D meson flag" << endl;
+
+  // Set the input file config
+  SetInputCorrelNames(plotter, pathFileMass, pathFileSE, pathFileME, dirSE, dirME, histoNameCorrSignal, histoNameCorrSideba);
+  SetInputHistoInvMassNames(plotter, InputHistoMassName);
+  Bool_t readSEandME = plotter->ReadInputSEandME();
+  Bool_t readInvMass = plotter->ReadInputInvMass();
+  if (readSEandME)
+    cout << "Files SE and ME read correctly" << endl;
+  if (readInvMass)
+    cout << "Files inv. mass read correctly" << endl;
+
+  // Loop over candidate pt and assoc. particle pt
+  for (int iBinPtCand = 0; iBinPtCand < nBinsPtCand; iBinPtCand++) {
+    plotter->GetSignalAndBackgroundForNorm(binsPtCandIntervals[iBinPtCand], binsPtCandIntervals[iBinPtCand + 1]);
+    for (int iBinPtHad = 0; iBinPtHad < nBinsPtHad; iBinPtHad++) {
+      plotter->ExtractCorrelations(binsPtCandIntervals[iBinPtCand], binsPtCandIntervals[iBinPtCand + 1], binsPtHadIntervals[iBinPtHad], binsPtHadIntervals[iBinPtHad + 1], CodeNameAnalysis);
+      hCorrectedCorrel[iBinPtCand][iBinPtHad] = (TH1D*)plotter->GetCorrectedCorrHisto();
+    }
+  }
+
+  // output file
+  TFile* outFile = new TFile(Form("Output_CorrelationExtraction_%s_Root/ExtractCorrelationsResults.root", CodeNameAnalysis.data()), "RECREATE");
+  outFile->cd();
+  for (int iBinPtCand = 0; iBinPtCand < nBinsPtCand; iBinPtCand++) {
+    for (int iBinPtHad = 0; iBinPtHad < nBinsPtHad; iBinPtHad++) {
+      hCorrectedCorrel[iBinPtCand][iBinPtHad]->Write();
+    }
+  }
+  outFile->Close();
+
+  return;
+}
+
+void SetInputCorrelNames(DhCorrelationExtraction* plotter, TString pathFileMass, TString pathFileSE, TString pathFileME, TString dirSE, TString dirME, TString histoNameCorrSignal, TString histoNameCorrSideba)
+{
+
+  // paths
+  plotter->SetInputFilenameMass(pathFileMass.Data());
+  plotter->SetInputFilenameSE(pathFileSE.Data());
+  plotter->SetInputFilenameME(pathFileME.Data());
+  plotter->SetDirNameSE(dirSE.Data());
+  plotter->SetDirNameME(dirME.Data());
+  plotter->SetSECorrelHistoSignalName(histoNameCorrSignal.Data());
+  plotter->SetSECorrelHistoSidebandName(histoNameCorrSideba.Data());
+  plotter->SetMECorrelHistoSignalName(histoNameCorrSignal.Data());
+  plotter->SetMECorrelHistoSidebandName(histoNameCorrSideba.Data());
+
+  return;
+}
+
+void SetInputHistoInvMassNames(DhCorrelationExtraction* plotter, vector<string> inputMassNames)
+{ // to use if sgn and bkg extraction is done apart
+
+  plotter->SetMassHistoNameSgn(inputMassNames[0].data());
+  plotter->SetMassHistoNameBkg(inputMassNames[1].data());
+  plotter->SetMassHistoNameSBs(inputMassNames[2].data());
+
+  return;
+}

--- a/PWGHF/HFC/Macros/FitCorrel.C
+++ b/PWGHF/HFC/Macros/FitCorrel.C
@@ -1,0 +1,194 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DhCorrelationExtraction.cxx
+/// \brief class for D-h correlation extraction
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+/// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>
+
+#include "DhCorrelationFitter.h"
+#include <TROOT.h>
+#include <TStyle.h>
+#include "Riostream.h"
+#include <rapidjson/document.h>
+#include <rapidjson/filereadstream.h>
+
+using namespace std;
+using namespace rapidjson;
+
+template <typename ValueType>
+void readArray(const Value& jsonArray, vector<ValueType>& output)
+{
+  for (auto it = jsonArray.Begin(); it != jsonArray.End(); it++) {
+    auto value = it->template Get<ValueType>();
+    output.emplace_back(value);
+  }
+}
+
+void SetTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+                      Style_t markerStyle, Color_t markerColor, Double_t markerSize,
+                      Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset = 1., Float_t hTitleYaxisOffset = 1.,
+                      Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060,
+                      Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
+
+void FitCorrel(TString cfgFileName = "config_CorrAnalysis.json")
+{
+  gStyle->SetOptStat(0);
+  gStyle->SetPadLeftMargin(0.15);
+  gStyle->SetPadBottomMargin(0.15);
+  gStyle->SetFrameLineWidth(2);
+  gStyle->SetLineWidth(2);
+  gStyle->SetCanvasDefH(1126);
+  gStyle->SetCanvasDefW(1840);
+
+  // Load config
+  FILE* configFile = fopen(cfgFileName.Data(), "r");
+  Document config;
+  char readBuffer[65536];
+  FileReadStream is(configFile, readBuffer, sizeof(readBuffer));
+  config.ParseStream(is);
+  fclose(configFile);
+
+  string CodeNameAnalysis = config["CodeName"].GetString();
+  gSystem->Exec(Form("rm -rf Output_CorrelationFitting_%s_Root/ Output_CorrelationFitting_%s_png/", CodeNameAnalysis.data(), CodeNameAnalysis.data()));
+  gSystem->Exec(Form("mkdir Output_CorrelationFitting_%s_Root/ Output_CorrelationFitting_%s_png/", CodeNameAnalysis.data(), CodeNameAnalysis.data()));
+
+  const TString inFileName = Form("Output_CorrelationExtraction_%s_Root/ExtractCorrelationsResults.root", CodeNameAnalysis.data());
+
+  vector<double> binsPtCandIntervals;
+  vector<double> binsPtHadIntervals;
+
+  const Value& PtCandValue = config["binsPtCandIntervals"];
+  readArray(PtCandValue, binsPtCandIntervals);
+
+  const Value& PtHadValue = config["binsPtHadIntervals"];
+  readArray(PtHadValue, binsPtHadIntervals);
+
+  int fitFunc = config["FitFunction"].GetInt();
+  int fixBase = config["FixBaseline"].GetInt();
+  int fixMean = config["FixMean"].GetInt();
+
+  std::cout << "=========================== " << std::endl;
+  std::cout << "Input variables from config" << std::endl;
+  std::cout << "FitFunction    = " << fitFunc << std::endl;
+  std::cout << "FixBaseline    = " << fixBase << std::endl;
+  std::cout << "FixMean    = " << fixMean << std::endl;
+  std::cout << "=========================== " << std::endl;
+  std::cout << " " << std::endl;
+
+  // TODO: reflections
+  bool refl = false;
+
+  const int nBinsPtCand = binsPtCandIntervals.size() - 1;
+  const int nBinsPtHad = binsPtHadIntervals.size() - 1;
+
+  // Input file
+  TFile* inFile = new TFile(inFileName.Data());
+
+  // Canvas
+  TCanvas* CanvasCorrPhi[nBinsPtHad];
+
+  // Histograms
+  TH1D* hCorrPhi[nBinsPtCand][nBinsPtHad];
+
+  int nBinsPhi;
+  double baselineFromThreePoints[nBinsPtCand][nBinsPtHad], baselineFromThreePointsError[nBinsPtCand][nBinsPtHad];
+
+  // DhCorrelationFitter
+  const double fMin{-0.5 * TMath::Pi()}, fMax{1.5 * TMath::Pi()}; // limits for the fitting function
+  DhCorrelationFitter* corrFitter[nBinsPtHad][nBinsPtCand];
+
+  // Input parameters for fitting
+  const int npars{8}; // PED     NSY  NSM    NSW    ASY   ASM     ASW   BETA
+  Double_t vals[npars] = {3., 2., 0., 0.5, 2., 3.14, 0.3, 2.};
+  Double_t lowBounds[npars] = {0., 0., -1., 0., 0., 2., 0., 0.5};
+  Double_t uppBounds[npars] = {9999., 999., 1., 3.14 / 3., 999., 4., 3.14 / 2., 3.5};
+
+  const int nBaselinePoints{8};
+  Int_t pointsForBaseline[nBaselinePoints] = {1, 2, 13, 14, 15, 16, 31, 32};
+
+  // extract TH1D and prepare fit
+  for (int iBinPtCand = 0; iBinPtCand < nBinsPtCand; iBinPtCand++) {
+    for (int iBinPtHad = 0; iBinPtHad < nBinsPtHad; iBinPtHad++) {
+      hCorrPhi[iBinPtCand][iBinPtHad] = (TH1D*)inFile->Get(Form("hCorrectedCorr_PtCand%.0fto%.0f_PtAssoc%.0fto%.0f", binsPtCandIntervals[iBinPtCand], binsPtCandIntervals[iBinPtCand + 1], binsPtHadIntervals[iBinPtHad], binsPtHadIntervals[iBinPtHad + 1]));
+
+      corrFitter[iBinPtHad][iBinPtCand] = new DhCorrelationFitter((TH1F*)hCorrPhi[iBinPtCand][iBinPtHad], fMin, fMax);
+      corrFitter[iBinPtHad][iBinPtCand]->SetHistoIsReflected(refl);
+      corrFitter[iBinPtHad][iBinPtCand]->SetFuncType(static_cast<DhCorrelationFitter::FunctionType>(fitFunc));
+      corrFitter[iBinPtHad][iBinPtCand]->SetFixBaseline(fixBase);
+      corrFitter[iBinPtHad][iBinPtCand]->SetPointsForBaseline(nBaselinePoints, pointsForBaseline);
+
+      corrFitter[iBinPtHad][iBinPtCand]->SetFixMean(fixMean);
+      corrFitter[iBinPtHad][iBinPtCand]->SetPtRanges(binsPtCandIntervals[iBinPtCand], binsPtCandIntervals[iBinPtCand + 1], binsPtHadIntervals[iBinPtHad], binsPtHadIntervals[iBinPtHad + 1]);
+      corrFitter[iBinPtHad][iBinPtCand]->SetExternalValsAndBounds(npars, vals, lowBounds, uppBounds); // these are starting points and limits...
+    }
+  }
+
+  // Plots and fit
+  for (int iBinPtHad = 0; iBinPtHad < nBinsPtHad; iBinPtHad++) {
+    CanvasCorrPhi[iBinPtHad] = new TCanvas(Form("CanvasCorrPhi_PtBinAssoc%d", iBinPtHad + 1), Form("CorrPhiDs_PtBinAssoc%d", iBinPtHad + 1));
+    if (nBinsPtCand <= 4) {
+      CanvasCorrPhi[iBinPtHad]->Divide(2, 2);
+    }
+    if (nBinsPtCand > 4 && nBinsPtCand <= 6) {
+      CanvasCorrPhi[iBinPtHad]->Divide(2, 3);
+    }
+    for (int iBinPtCand = 0; iBinPtCand < nBinsPtCand; iBinPtCand++) {
+      SetTH1HistoStyle(hCorrPhi[iBinPtCand][iBinPtHad], "", "#Delta#phi [rad]", "#frac{1}{N_{D_{s}}}#frac{dN^{assoc}}{d#Delta#phi} [rad^{-1}]", kFullCircle, kRed + 1, 1.4, kRed + 1, 3);
+
+      CanvasCorrPhi[iBinPtHad]->cd(iBinPtCand + 1);
+      hCorrPhi[iBinPtCand][iBinPtHad]->Draw();
+
+      // Fit
+      corrFitter[iBinPtHad][iBinPtCand]->Fitting(kTRUE, kTRUE); // the first term is for drawing the fit functions, the second argument is useExternalParams
+
+      TF1* fFit = corrFitter[iBinPtHad][iBinPtCand]->GetFitFunction();
+
+      // Title of the histogram
+      TPaveText* pttext = new TPaveText(0.15, 0.9, 0.85, 0.95, "NDC");
+      pttext->SetFillStyle(0);
+      pttext->SetBorderSize(0);
+      TText* tpT = pttext->AddText(0., 0.8, Form("%.0f < p_{T}^{D_{s}} < %.0f GeV/c, p_{T}^{assoc} > 0.3 GeV/c", binsPtCandIntervals[iBinPtCand], binsPtCandIntervals[iBinPtCand + 1]));
+      pttext->Draw("same");
+    }
+    CanvasCorrPhi[iBinPtHad]->SaveAs(Form("Output_CorrelationFitting_%s_png/CorrPhi_PtBinAssoc%d.png", CodeNameAnalysis.data(), iBinPtHad + 1));
+    CanvasCorrPhi[iBinPtHad]->SaveAs(Form("Output_CorrelationFitting_%s_Root/CorrPhi_PtBinAssoc%d.root", CodeNameAnalysis.data(), iBinPtHad + 1));
+  }
+
+  return;
+}
+
+void SetTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+                      Style_t markerStyle, Color_t markerColor, Double_t markerSize,
+                      Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset = 1., Float_t hTitleYaxisOffset = 1.,
+                      Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060,
+                      Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false)
+{
+
+  histo->SetTitle(hTitle.Data());
+  histo->GetXaxis()->SetTitle(hXaxisTitle.Data());
+  histo->GetYaxis()->SetTitle(hYaxisTitle.Data());
+  histo->SetMarkerStyle(markerStyle);
+  histo->SetMarkerColor(markerColor);
+  histo->SetMarkerSize(markerSize);
+  histo->SetLineColor(lineColor);
+  histo->SetLineWidth(lineWidth);
+  histo->GetXaxis()->SetTitleOffset(hTitleXaxisOffset);
+  histo->GetYaxis()->SetTitleOffset(hTitleYaxisOffset);
+  histo->GetXaxis()->SetTitleSize(hTitleXaxisSize);
+  histo->GetYaxis()->SetTitleSize(hTitleYaxisSize);
+  histo->GetXaxis()->SetLabelSize(hLabelXaxisSize);
+  histo->GetYaxis()->SetLabelSize(hLabelYaxisSize);
+  histo->GetXaxis()->CenterTitle(centerXaxisTitle);
+  histo->GetYaxis()->CenterTitle(centerYaxisTitle);
+
+  return;
+}

--- a/PWGHF/HFC/Macros/GetRawYields.C
+++ b/PWGHF/HFC/Macros/GetRawYields.C
@@ -1,0 +1,1124 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GetRawYields.C
+/// \brief Macro for fitting charm nesons and invariant-mass spectra
+///
+/// \author Grazia Luparello <gluparel@cern.ch>
+
+#if !defined(__CINT__) || defined(__CLING__)
+
+#include <string>
+#include <vector>
+
+// if .h file not found, please include your local rapidjson/document.h and rapidjson/filereadstream.h here
+#include <rapidjson/document.h>
+#include <rapidjson/filereadstream.h>
+
+#include "TROOT.h"
+#include "Riostream.h"
+#include "TH1.h"
+#include "TF1.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TFile.h"
+#include "TGaxis.h"
+#include "TDatabasePDG.h"
+#include "TH2F.h"
+#include "HFMassFitter.h"
+
+#endif
+
+using namespace std;
+using namespace rapidjson;
+
+enum { kDplus,
+       kD0,
+       kDs,
+       kLcToPKPi,
+       kLcToPK0s,
+       kDstar };
+
+//__________________________________________________________________________________________________________________
+int GetRawYields(bool isMC = false, TString infilename = "AnalysisResults.root", TString inDirectory = "hf-correlator-ds-hadrons", TString invMassHistoName2D = "hMassDsVsPt", TString refFileName = "", TString cfgfilename = "config_massfitter.json", TString outFileName = "RawYieldsDsToPKPi.root", bool doSideband = false);
+double SingleGaus(double* m, double* pars);
+double DoublePeakSingleGaus(double* x, double* pars);
+double DoubleGaus(double* m, double* pars);
+double DoublePeakDoubleGaus(double* m, double* pars);
+double DoubleGausSigmaRatio(double* m, double* pars);
+void SetHistoStyle(TH1* histo, int color = kBlack, double markersize = 1.);
+void SetStyle();
+void DivideCanvas(TCanvas* c, int nPtBins);
+TH1D* RebinHisto(TH1* hOrig, Int_t reb, Int_t firstUse = -1);
+
+//__________________________________________________________________________________________________________________
+template <typename ValueType>
+void readArray(const Value& jsonArray, vector<ValueType>& output)
+{
+  for (auto it = jsonArray.Begin(); it != jsonArray.End(); it++) {
+    auto value = it->template Get<ValueType>();
+    output.emplace_back(value);
+  }
+}
+//__________________________________________________________________________________________________________________
+int GetRawYields(bool isMC, TString infilename, TString inDirectory, TString invMassHistoName2D, TString refFileName, TString cfgfilename, TString outFileName, bool doSideband)
+{
+  SetStyle();
+
+  //=======================
+  // LOAD CONFIGURATION FROM JSON FILE
+  FILE* configFile = fopen(cfgfilename.Data(), "r");
+
+  Document config;
+  char readBuffer[65536];
+  FileReadStream is(configFile, readBuffer, sizeof(readBuffer));
+  config.ParseStream(is);
+  fclose(configFile);
+
+  TString ParticleName = config["Particle"].GetString();
+  cout << "Particle to be analysed" << ParticleName << endl;
+
+  int particle;
+  if (ParticleName == "Dplus") {
+    particle = kDplus;
+  } else if (ParticleName == "Ds") {
+    particle = kDs;
+  } else if (ParticleName == "D0") {
+    particle = kD0;
+  } else if (ParticleName == "LcToPKPi") {
+    particle = kLcToPKPi;
+  } else if (ParticleName == "LcToPK0s") {
+    particle = kLcToPK0s;
+  } else if (ParticleName == "Dstar") {
+    particle = kDstar;
+  } else {
+    cerr << "ERROR: only Dplus, Ds, D0, Dstar and Lc are supported! Exit";
+    return -1;
+  }
+
+  vector<double> PtMin;
+  vector<double> PtMax;
+  vector<double> MassMin;
+  vector<double> MassMax;
+  vector<double> Rebin;
+  vector<int> bkgFuncConfig;
+  vector<int> sgnFuncConfig;
+  vector<int> fixSigma;
+  vector<double> fixSigmaManually;
+  vector<int> fixMean;
+  vector<double> fixMeanManually;
+  vector<int> InclSecPeak;     // For Ds only
+  vector<double> SigmaSecPeak; // For Ds only
+  vector<double> MinSBLeft;
+  vector<double> MaxSBLeft;
+  vector<double> MinSBRight;
+  vector<double> MaxSBRight;
+
+  const Value& ptMinValue = config["PtMin"];
+  readArray(ptMinValue, PtMin);
+
+  cout << "Number of PtBins for fit = " << PtMin.size() << endl;
+  const unsigned int nPtBins = PtMin.size();
+
+  const Value& ptMaxValue = config["PtMax"];
+  readArray(ptMaxValue, PtMax);
+  if (PtMax.size() != nPtBins) {
+    cout << "ERROR: size of the vector PtMax is different from the size of vector PtMin" << endl;
+    return -1;
+  }
+
+  const Value& massMinValue = config["MassMin"];
+  readArray(massMinValue, MassMin);
+  if (MassMin.size() != nPtBins) {
+    cout << "ERROR: size of the vector MassMin is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  const Value& massMaxValue = config["MassMax"];
+  readArray(massMaxValue, MassMax);
+  if (MassMax.size() != nPtBins) {
+    cout << "ERROR: size of the vector MassMax is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  const Value& optFixSigma = config["FixSigma"];
+  readArray(optFixSigma, fixSigma);
+  if (fixSigma.size() == 1)
+    fixSigma.assign(PtMin.size(), fixSigma[0]);
+  if (fixSigma.size() != nPtBins) {
+    cout << "ERROR: size of the vector fixSigma is different from the number of PtBins. You have to correct the length of the vector in the config file or use just one entry" << endl;
+    return -1;
+  }
+
+  const Value& fixSigmaManual = config["FixSigmaManual"];
+  readArray(fixSigmaManual, fixSigmaManually);
+  if (fixSigmaManually.size() != 0 && fixSigmaManually.size() != nPtBins) {
+    cout << "ERROR: size of the vector fixSigmaManual is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  string infilenameSigma = config["SigmaFile"].GetString();
+  bool fixSigmaRatio = config["FixSigmaRatio"].GetBool(); // used only if SgnFunc=k2GausSigmaRatioPar
+  string infilenameSigmaRatio = config["SigmaRatioFile"].GetString();
+
+  bool isSigmaMultFromUnc = false;
+  double sigmaMult = 1.;
+  double sigmaMultFromConfig = config["SigmaMultFactor"].GetDouble();
+  if (sigmaMultFromConfig != 0)
+    sigmaMult = sigmaMultFromConfig;
+
+  string sigmaMultFromUnc = config["SigmaMultFactorUnc"].GetString();
+  if (sigmaMultFromUnc != "" && (sigmaMultFromUnc == "MinusUnc" || sigmaMultFromUnc == "PlusUnc")) {
+    cout << sigmaMultFromUnc << endl;
+    isSigmaMultFromUnc = true;
+  }
+
+  const Value& optFixMean = config["FixMean"];
+  readArray(optFixMean, fixMean);
+  if (fixMean.size() == 1)
+    fixMean.assign(PtMin.size(), fixMean[0]);
+  if (fixMean.size() != nPtBins) {
+    cout << "ERROR: size of the vector fixMean is different from the number of PtBins. You have to correct the length of the vector in the config file or use just one entry" << endl;
+    return -1;
+  }
+
+  const Value& fixMeanManual = config["FixMeanManual"];
+  readArray(fixMeanManual, fixMeanManually);
+  if (fixMeanManually.size() != 0 && fixMeanManually.size() != nPtBins) {
+    cout << "ERROR: size of the vector fixMean is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  string meanFile = config["MeanFile"].GetString();
+  bool boundMean = config["BoundMean"].GetBool();
+
+  bool enableRefl = config["EnableRefl"].GetBool();
+  bool UseLikelihood = config["UseLikelihood"].GetBool();
+
+  const Value& rebinValue = config["Rebin"];
+  readArray(rebinValue, Rebin);
+  if (Rebin.size() != nPtBins) {
+    cout << "ERROR: size of the vector Rebin is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  const Value& optInclSecPeak = config["InclSecPeak"];
+  readArray(optInclSecPeak, InclSecPeak);
+  if (InclSecPeak.size() == 1)
+    InclSecPeak.assign(PtMin.size(), InclSecPeak[0]);
+  if (InclSecPeak.size() != nPtBins) {
+    cout << "ERROR: size of the vector InclSecPeak is different from the number of PtBins. You have to correct the length of the vector in the config file or use just one entry" << endl;
+    return -1;
+  }
+  string infilenameSigmaSecPeak = config["SigmaFileSecPeak"].GetString();
+
+  const Value& sigmaSecPeak = config["SigmaSecPeak"];
+  readArray(sigmaSecPeak, SigmaSecPeak);
+  if (SigmaSecPeak.size() != 0 && SigmaSecPeak.size() != nPtBins) {
+    cout << "ERROR: size of the vector MassMax is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  double sigmaMultSecPeak = config["SigmaMultFactorSecPeak"].GetDouble();
+  bool fixSigmaToFirstPeak = config["FixSigmaToFirstPeak"].GetBool();
+
+  if (doSideband) {
+    const Value& minSBL = config["MinSidebandLeft"];
+    readArray(minSBL, MinSBLeft);
+    if (MinSBLeft.size() != nPtBins) {
+      cout << "ERROR: size of the vector MinSBLeft is different from the number of PtBins" << endl;
+      return -1;
+    }
+
+    const Value& maxSBL = config["MaxSidebandLeft"];
+    readArray(maxSBL, MaxSBLeft);
+    if (MaxSBLeft.size() != nPtBins) {
+      cout << "ERROR: size of the vector MaxSBLeft is different from the number of PtBins" << endl;
+      return -1;
+    }
+
+    const Value& minSBR = config["MinSidebandRight"];
+    readArray(minSBR, MinSBRight);
+    if (MinSBRight.size() != nPtBins) {
+      cout << "ERROR: size of the vector MinSBRight is different from the number of PtBins" << endl;
+      return -1;
+    }
+
+    const Value& maxSBR = config["MaxSidebandRight"];
+    readArray(maxSBR, MaxSBRight);
+    if (MaxSBRight.size() != nPtBins) {
+      cout << "ERROR: size of the vector MaxSBRight is different from the number of PtBins" << endl;
+      return -1;
+    }
+  }
+
+  const Value& bkgFuncValue = config["BkgFunc"];
+  readArray(bkgFuncValue, bkgFuncConfig);
+  if (bkgFuncConfig.size() != nPtBins) {
+    cout << "ERROR: size of the vector bkgFuncConfig is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  const Value& sgnFuncValue = config["SgnFunc"];
+  readArray(sgnFuncValue, sgnFuncConfig);
+  if (sgnFuncConfig.size() != nPtBins) {
+    cout << "ERROR: size of the vector signFuncConfig is different from the number of PtBins" << endl;
+    return -1;
+  }
+
+  // const unsigned int nPtBins = PtMin.size();
+  int BkgFunc[nPtBins], SgnFunc[nPtBins], degPol[nPtBins];
+  double PtLims[nPtBins + 1];
+  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
+    PtLims[iPt] = PtMin[iPt];
+    PtLims[iPt + 1] = PtMax[iPt];
+
+    degPol[iPt] = -1;
+    if (bkgFuncConfig[iPt] == HFMassFitter::kExpo)
+      BkgFunc[iPt] = HFMassFitter::kExpo;
+    else if (bkgFuncConfig[iPt] == HFMassFitter::kLin)
+      BkgFunc[iPt] = HFMassFitter::kLin;
+    else if (bkgFuncConfig[iPt] == HFMassFitter::kPol2)
+      BkgFunc[iPt] = HFMassFitter::kPol2;
+    else if (bkgFuncConfig[iPt] == 6) // Pol3
+    {
+      BkgFunc[iPt] = 6;
+      degPol[iPt] = 3;
+      if (PtMin.size() > 1 && InclSecPeak[iPt] == 1) {
+        cerr << "Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!" << endl;
+        return -1;
+      }
+    } else if (bkgFuncConfig[iPt] == 7) // Pol3
+    {
+      BkgFunc[iPt] = 6;
+      degPol[iPt] = 4;
+      if (PtMin.size() > 1 && InclSecPeak[iPt] == 1) {
+        cerr << "Pol3 and Pol4 fits work only with one bin if you have the secondary peak! Exit!" << endl;
+        return -1;
+      }
+    } else if (bkgFuncConfig[iPt] == HFMassFitter::kPow)
+      BkgFunc[iPt] = HFMassFitter::kPow;
+    else if (bkgFuncConfig[iPt] == HFMassFitter::kPowEx)
+      BkgFunc[iPt] = HFMassFitter::kPowEx;
+    else {
+      cerr << "ERROR: only kExpo, kLin, kPol2, kPol3, and kPol4, kPow and kPowEx background functions supported! Exit" << endl;
+      return -1;
+    }
+
+    if (sgnFuncConfig[iPt] == HFMassFitter::kGaus)
+      SgnFunc[iPt] = HFMassFitter::kGaus;
+    else if (sgnFuncConfig[iPt] == HFMassFitter::k2Gaus)
+      SgnFunc[iPt] = HFMassFitter::k2Gaus;
+    else if (sgnFuncConfig[iPt] == HFMassFitter::k2GausSigmaRatioPar)
+      SgnFunc[iPt] = HFMassFitter::k2GausSigmaRatioPar;
+    else {
+      cerr << "ERROR: only kGaus, k2Gaus and k2GausSigmaRatioPar signal functions supported! Exit" << endl;
+      return -1;
+    }
+  }
+
+  //=======================
+  TString massaxistit = "";
+  if (particle == kDplus)
+    massaxistit = "#it{M}(K#pi#pi) (GeV/#it{c}^{2})";
+  else if (particle == kD0)
+    massaxistit = "#it{M}(K#pi) (GeV/#it{c}^{2})";
+  else if (particle == kDs)
+    massaxistit = "#it{M}(KK#pi) (GeV/#it{c}^{2})";
+  else if (particle == kLcToPKPi)
+    massaxistit = "#it{M}(pK#pi) (GeV/#it{c}^{2})";
+  else if (particle == kLcToPK0s)
+    massaxistit = "#it{M}(pK^{0}_{s}) (GeV/#it{c}^{2})";
+  else if (particle == kDstar)
+    massaxistit = "#it{M}(pi^{+}) (GeV/#it{c}^{2})";
+
+  //=======================
+  // Load Invariant Mass Histogram from train output
+  auto infile = TFile::Open(infilename.Data());
+  if (!infile || !infile->IsOpen())
+    return -1;
+  TFile* infileref = NULL;
+  if (enableRefl) {
+    infileref = TFile::Open(refFileName.Data());
+    if (!infileref || !infileref->IsOpen())
+      return -1;
+  }
+  TDirectoryFile* dir = (TDirectoryFile*)infile->Get(inDirectory.Data());
+  TH2F* hMassVsPt = (TH2F*)dir->Get(invMassHistoName2D.Data());
+  hMassVsPt->Draw();
+
+  TH1F* hMassSig[nPtBins];
+  TH1F* hMassRef[nPtBins];
+  TH1F* hMass[nPtBins];
+  TH1F* hEv = NULL; // TO BE ADDED
+
+  TH1F* hPtAxis = (TH1F*)hMassVsPt->ProjectionY("hMassVsPt_py"); // prima _px
+  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
+    Int_t binExtPtMin = hPtAxis->FindBin(PtMin[iPt] + 0.001);
+    Int_t binExtPtMax = hPtAxis->FindBin(PtMax[iPt] - 0.001);
+    hMass[iPt] = (TH1F*)hMassVsPt->ProjectionX(Form("hMass_binPt%d", iPt), binExtPtMin, binExtPtMax);
+    if (enableRefl) {
+      // TO BE CHECKED WITH REF FILES
+      hMassRef[iPt] = static_cast<TH1F*>(infileref->Get(Form("hVarReflMass_%0.f_%0.f", PtMin[iPt] * 10, PtMax[iPt] * 10)));
+      hMassSig[iPt] = static_cast<TH1F*>(infileref->Get(Form("hFDMass_%0.f_%0.f", PtMin[iPt] * 10, PtMax[iPt] * 10)));
+      hMassSig[iPt]->Add(static_cast<TH1F*>(infileref->Get(Form("hPromptMass_%0.f_%0.f", PtMin[iPt] * 10, PtMax[iPt] * 10))));
+    }
+    hMass[iPt]->SetDirectory(0);
+    SetHistoStyle(hMass[iPt]);
+  }
+  // infile ->Close();
+
+  //=======================
+  // DEFINE OUTPUT HISTOS
+  auto hRawYields = new TH1D("hRawYields", ";#it{p}_{T} (GeV/#it{c});raw yield", nPtBins, PtLims);
+  auto hRawYieldsSigma = new TH1D("hRawYieldsSigma", ";#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})", nPtBins, PtLims);
+  auto hRawYieldsSigmaRatio = new TH1D("hRawYieldsSigmaRatio", ";#it{p}_{T} (GeV/#it{c});ratio #sigma_{1}/#sigma_{2}", nPtBins, PtLims);
+  auto hRawYieldsSigma2 = new TH1D("hRawYieldsSigma2", ";#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})", nPtBins, PtLims);
+  auto hRawYieldsMean = new TH1D("hRawYieldsMean", ";#it{p}_{T} (GeV/#it{c});mean (GeV/#it{c}^{2})", nPtBins, PtLims);
+  auto hRawYieldsFracGaus2 = new TH1D("hRawYieldsFracGaus2", ";#it{p}_{T} (GeV/#it{c});second-gaussian fraction", nPtBins, PtLims);
+  auto hRawYieldsSignificance = new TH1D("hRawYieldsSignificance", ";#it{p}_{T} (GeV/#it{c});significance (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsSoverB = new TH1D("hRawYieldsSoverB", ";#it{p}_{T} (GeV/#it{c});S/B (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsSignal = new TH1D("hRawYieldsSignal", ";#it{p}_{T} (GeV/#it{c});Signal (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsBkg = new TH1D("hRawYieldsBkg", ";#it{p}_{T} (GeV/#it{c});Background (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsChiSquare = new TH1D("hRawYieldsChiSquare", ";#it{p}_{T} (GeV/#it{c});#chi^{2}/#it{ndf}", nPtBins, PtLims);
+  auto hRawYieldsSecondPeak = new TH1D("hRawYieldsSecondPeak", ";#it{p}_{T} (GeV/#it{c});raw yield second peak", nPtBins, PtLims);
+  auto hRawYieldsMeanSecondPeak = new TH1D("hRawYieldsMeanSecondPeak", ";#it{p}_{T} (GeV/#it{c});mean second peak (GeV/#it{c}^{2})", nPtBins, PtLims);
+  auto hRawYieldsSigmaSecondPeak = new TH1D("hRawYieldsSigmaSecondPeak", ";#it{p}_{T} (GeV/#it{c});width second peak (GeV/#it{c}^{2})", nPtBins, PtLims);
+  auto hRawYieldsSignificanceSecondPeak = new TH1D("hRawYieldsSignificanceSecondPeak", ";#it{p}_{T} (GeV/#it{c});signficance second peak (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsSigmaRatioSecondFirstPeak = new TH1D("hRawYieldsSigmaRatioSecondFirstPeak", ";#it{p}_{T} (GeV/#it{c});width second peak / width first peak", nPtBins, PtLims);
+  auto hRawYieldsSoverBSecondPeak = new TH1D("hRawYieldsSoverBSecondPeak", ";#it{p}_{T} (GeV/#it{c});S/B second peak (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsSignalSecondPeak = new TH1D("hRawYieldsSignalSecondPeak", ";#it{p}_{T} (GeV/#it{c});Signal second peak (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsBkgSecondPeak = new TH1D("hRawYieldsBkgSecondPeak", ";#it{p}_{T} (GeV/#it{c});Background second peak (3#sigma)", nPtBins, PtLims);
+  auto hRawYieldsTrue = new TH1D("hRawYieldsTrue", ";#it{p}_{T} (GeV/#it{c});true signal", nPtBins, PtLims);
+  auto hRawYieldsSecondPeakTrue = new TH1D("hRawYieldsSecondPeakTrue", ";#it{p}_{T} (GeV/#it{c});true signal second peak", nPtBins, PtLims);
+  auto hRelDiffRawYieldsFitTrue = new TH1D("hRelDiffRawYieldsFitTrue", ";#it{p}_{T} (GeV/#it{c}); (Y_{fit} - Y_{true}) / Y_{true}", nPtBins, PtLims);
+  auto hRelDiffRawYieldsSecondPeakFitTrue = new TH1D("hRelDiffRawYieldsSecondPeakFitTrue", ";#it{p}_{T} (GeV/#it{c});(Y_{fit} - Y_{true}) / Y_{true} second peak", nPtBins, PtLims);
+  auto hBackgroundSidebands = new TH1D("hBackgroundSideband", ";#it{p}_{T} (GeV/#it{c});Background sideband", nPtBins, PtLims);
+
+  SetHistoStyle(hRawYields);
+  SetHistoStyle(hRawYieldsSigma);
+  SetHistoStyle(hRawYieldsSigma2);
+  SetHistoStyle(hRawYieldsMean);
+  SetHistoStyle(hRawYieldsFracGaus2);
+  SetHistoStyle(hRawYieldsSignificance);
+  SetHistoStyle(hRawYieldsSoverB);
+  SetHistoStyle(hRawYieldsSignal);
+  SetHistoStyle(hRawYieldsBkg);
+  SetHistoStyle(hRawYieldsChiSquare);
+  SetHistoStyle(hRawYieldsSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsMeanSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsSigmaSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsSignificanceSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsSigmaRatioSecondFirstPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsSoverBSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsSignalSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsBkgSecondPeak, kRed + 1);
+  SetHistoStyle(hRawYieldsTrue);
+  SetHistoStyle(hRawYieldsSecondPeakTrue, kRed + 1);
+  SetHistoStyle(hRelDiffRawYieldsFitTrue);
+  SetHistoStyle(hRelDiffRawYieldsSecondPeakFitTrue, kRed + 1);
+  SetHistoStyle(hRawYieldsSigmaRatio, kRed + 1);
+  SetHistoStyle(hBackgroundSidebands, kRed + 1);
+
+  //=======================
+  // READ HISTOS TO FIX VALUES - Note that also the possibility to manually define the fixed values in the config file
+  TH1D* hSigmaToFix = NULL;
+  if (accumulate(fixSigma.begin(), fixSigma.end(), 0) > 0 && infilenameSigma.compare("")) {
+    auto infileSigma = TFile::Open(infilenameSigma.data());
+    if (!infileSigma)
+      return -2;
+    hSigmaToFix = static_cast<TH1D*>(infileSigma->Get("hRawYieldsSigma"));
+    hSigmaToFix->SetDirectory(0);
+    if (static_cast<unsigned int>(hSigmaToFix->GetNbinsX()) != nPtBins)
+      cout << "WARNING: Different number of bins for this analysis and histo for fix sigma" << endl;
+    infileSigma->Close();
+  }
+
+  TH1D* hSigmaToFix1 = NULL;
+  TH1D* hSigmaToFix2 = NULL;
+  if (fixSigmaRatio) {
+    std::cout << "Load sigma ratio from file " << infilenameSigmaRatio.data() << std::endl;
+    auto infileSigmaRatio = TFile::Open(infilenameSigmaRatio.data());
+    if (!infileSigmaRatio)
+      return -2;
+    hSigmaToFix1 = static_cast<TH1D*>(infileSigmaRatio->Get("hRawYieldsSigma"));
+    hSigmaToFix1->SetDirectory(0);
+    if (static_cast<unsigned int>(hSigmaToFix1->GetNbinsX()) != nPtBins)
+      cout << "WARNING: Different number of bins for this analysis and histo for fix sigma ratio" << endl;
+
+    hSigmaToFix2 = static_cast<TH1D*>(infileSigmaRatio->Get("hRawYieldsSigma2"));
+    hSigmaToFix2->SetDirectory(0);
+    if (static_cast<unsigned int>(hSigmaToFix2->GetNbinsX()) != nPtBins)
+      cout << "WARNING: Different number of bins for this analysis and histo for fix sigma ratio" << endl;
+
+    infileSigmaRatio->Close();
+  }
+
+  TH1D* hMeanToFix = NULL;
+  if (accumulate(fixMean.begin(), fixMean.end(), 0) > 0 && meanFile.compare("")) {
+    auto infileMean = TFile::Open(meanFile.data());
+    if (!infileMean)
+      return -3;
+    hMeanToFix = static_cast<TH1D*>(infileMean->Get("hRawYieldsMean"));
+    hMeanToFix->SetDirectory(0);
+    if (static_cast<unsigned int>(hMeanToFix->GetNbinsX()) != nPtBins)
+      cout << "WARNING: Different number of bins for this analysis and histo for fix mean" << endl;
+    infileMean->Close();
+  }
+
+  TH1D* hSigmaFirstPeakMC = NULL;
+  TH1D* hSigmaToFixSecPeak = NULL;
+
+  /*
+  //TO BE UNDERSTOOD
+  bool InclSecPeakGlobal = false;
+  for(int isp:InclSecPeak){
+      if(isp != 0){
+          InclSecPeakGlobal = true;
+          break;
+      }
+  }
+
+  TFile *infileSigmaSecPeak = NULL;
+  if(InclSecPeakGlobal){
+      infileSigmaSecPeak = TFile::Open(infilenameSigmaSecPeak.data());
+  }
+  if(!infileSigmaSecPeak && fixSigmaToFirstPeak)
+      return -2;
+  if(infileSigmaSecPeak) {
+      hSigmaFirstPeakMC = static_cast<TH1D*>(infileSigmaSecPeak->Get("hRawYieldsSigma"));
+      hSigmaToFixSecPeak = static_cast<TH1D*>(infileSigmaSecPeak->Get("hRawYieldsSigmaSecondPeak"));
+      hSigmaFirstPeakMC->SetDirectory(0);
+      hSigmaToFixSecPeak->SetDirectory(0);
+      if(static_cast<unsigned int>(hSigmaFirstPeakMC->GetNbinsX()) != nPtBins ||
+         static_cast<unsigned int>(hSigmaToFixSecPeak->GetNbinsX()) != nPtBins)
+          cout << "WARNING: Different number of bins for this analysis and histos for fix sigma" << endl;
+      infileSigmaSecPeak->Close();
+}*/
+
+  //=======================
+  // FIT HISTOS
+  double massDplus = TDatabasePDG::Instance()->GetParticle(411)->Mass();
+  double massDs = TDatabasePDG::Instance()->GetParticle(431)->Mass();
+  double massD0 = TDatabasePDG::Instance()->GetParticle(421)->Mass();
+  double massLc = TDatabasePDG::Instance()->GetParticle(4122)->Mass();
+  double dmassDstar = TDatabasePDG::Instance()->GetParticle(413)->Mass() - TDatabasePDG::Instance()->GetParticle(421)->Mass();
+  double massForFit = -1.;
+
+  if (particle == kDplus)
+    massForFit = massDplus;
+  else if (particle == kDs)
+    massForFit = massDs;
+  else if (particle == kD0)
+    massForFit = massD0;
+  else if (particle == kLcToPKPi || particle == kLcToPK0s)
+    massForFit = massLc;
+  else if (particle == kDstar)
+    massForFit = dmassDstar;
+
+  TH1F* hMassForFit[nPtBins];
+  TH1F* hMassForRel[nPtBins];
+  TH1F* hMassForSig[nPtBins];
+
+  //=======================
+  // SET UP CANVAS
+  int canvSize[2] = {1920, 1080};
+  if (nPtBins == 1) {
+    canvSize[0] = 500;
+    canvSize[1] = 500;
+  }
+
+  int nMaxCanvases = 20; // do not put more than 20 bins per canvas to make them visible
+  const int nCanvases = ceil((float)nPtBins / nMaxCanvases);
+  TCanvas *cMass[nCanvases], *cResiduals[nCanvases];
+  for (int iCanv = 0; iCanv < nCanvases; iCanv++) {
+    int nPads = (nCanvases == 1) ? nPtBins : nMaxCanvases;
+    cMass[iCanv] = new TCanvas(Form("cMass%d", iCanv), Form("cMass%d", iCanv), canvSize[0], canvSize[1]);
+    DivideCanvas(cMass[iCanv], nPads);
+    cResiduals[iCanv] = new TCanvas(Form("cResiduals%d", iCanv), Form("cResiduals%d", iCanv), canvSize[0], canvSize[1]);
+    DivideCanvas(cResiduals[iCanv], nPads);
+  }
+
+  //=======================
+  // LOOP on Pt BINS
+  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
+
+    int iCanv = floor((float)iPt / nMaxCanvases);
+
+    hMassForFit[iPt] = reinterpret_cast<TH1F*>(RebinHisto(hMass[iPt], Rebin[iPt]));
+    TString pttitle = Form("%0.1f < #it{p}_{T} < %0.1f GeV/#it{c}", PtMin[iPt], PtMax[iPt]);
+    hMassForFit[iPt]->SetTitle(Form("%s;%s;Counts per %0.f MeV/#it{c}^{2}", pttitle.Data(), massaxistit.Data(), hMassForFit[iPt]->GetBinWidth(1) * 1000));
+    hMassForFit[iPt]->SetName(Form("MassForFit%d", iPt));
+    if (enableRefl) {
+      hMassForRel[iPt] = reinterpret_cast<TH1F*>(RebinHisto(hMassRef[iPt], Rebin[iPt]));
+      hMassForSig[iPt] = reinterpret_cast<TH1F*>(RebinHisto(hMassSig[iPt], Rebin[iPt]));
+    }
+    double markerSize = 1.;
+    if (nPtBins > 15)
+      markerSize = 0.5;
+    SetHistoStyle(hMassForFit[iPt], kBlack, markerSize);
+
+    if (isMC) {                                                            // MC
+      int parRawYield = 0, parMean = 1., parSigma1 = 2, parSigmaRatio = 3; // always the same
+      int parSigma2 = -1, parFrac2Gaus = -1, parRawYieldSecPeak = -1, parMeanSecPeak = -1, parSigmaSecPeak = -1;
+      TF1* massFunc = NULL;
+      if (SgnFunc[iPt] == HFMassFitter::kGaus) {
+        if (!(InclSecPeak[iPt] == 1 && particle == kDs)) {
+          // if(!(InclSecPeak && particle==kDs)) {
+          massFunc = new TF1(Form("massFunc%d", iPt), SingleGaus, MassMin[iPt], MassMax[iPt], 3);
+          massFunc->SetParameters(hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massForFit, 0.010);
+        } else {
+          massFunc = new TF1(Form("massFunc%d", iPt), DoublePeakSingleGaus, MassMin[iPt], MassMax[iPt], 6);
+          massFunc->SetParameters(hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massForFit, 0.010, hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massDplus, 0.010);
+          parRawYieldSecPeak = 3;
+          parMeanSecPeak = 4;
+          parSigmaSecPeak = 5;
+        }
+      } else if (SgnFunc[iPt] == HFMassFitter::k2Gaus) {
+        parSigma2 = 3;
+        parFrac2Gaus = 4;
+        if (!(InclSecPeak[iPt] == 1 && particle == kDs)) {
+          massFunc = new TF1(Form("massFunc%d", iPt), DoubleGaus, MassMin[iPt], MassMax[iPt], 5);
+          massFunc->SetParameters(hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massForFit, 0.010, 0.030, 0.9);
+        } else {
+          massFunc = new TF1(Form("massFunc%d", iPt), DoublePeakDoubleGaus, MassMin[iPt], MassMax[iPt], 8);
+          massFunc->SetParameters(hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massForFit, 0.010, 0.030, 0.9, hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1), massDplus, 0.010);
+          parRawYieldSecPeak = 5;
+          parMeanSecPeak = 6;
+          parSigmaSecPeak = 7;
+        }
+      } else if (SgnFunc[iPt] == HFMassFitter::k2GausSigmaRatioPar) {
+        massFunc = new TF1(Form("massFunc%d", iPt), DoubleGausSigmaRatio, MassMin[iPt], MassMax[iPt], 5);
+        massFunc->SetParameters(hMassForFit[iPt]->Integral() * hMassForFit[iPt]->GetBinWidth(1),
+                                massForFit, 0.010, 2, 0.5);
+        massFunc->SetParLimits(3, 1, 1e6);
+        massFunc->SetParLimits(4, 0, 1);
+      }
+
+      if (nPtBins > 1)
+        cMass[iCanv]->cd(iPt - nMaxCanvases * iCanv + 1);
+      else
+        cMass[iCanv]->cd();
+      hMassForFit[iPt]->Fit(massFunc, "E"); // fit with chi2
+
+      double rawyield = massFunc->GetParameter(parRawYield);
+      double rawyielderr = massFunc->GetParError(parRawYield);
+      double sigma = massFunc->GetParameter(parSigma1);
+      double sigmaerr = massFunc->GetParError(parSigma1);
+      double mean = massFunc->GetParameter(parMean);
+      double meanerr = massFunc->GetParError(parMean);
+      double redchi2 = massFunc->GetChisquare() / massFunc->GetNDF();
+
+      hRawYields->SetBinContent(iPt + 1, rawyield);
+      hRawYields->SetBinError(iPt + 1, rawyielderr);
+      hRawYieldsSigma->SetBinContent(iPt + 1, sigma);
+      hRawYieldsSigma->SetBinError(iPt + 1, sigmaerr);
+      hRawYieldsMean->SetBinContent(iPt + 1, mean);
+      hRawYieldsMean->SetBinError(iPt + 1, meanerr);
+      hRawYieldsChiSquare->SetBinContent(iPt + 1, redchi2);
+      hRawYieldsChiSquare->SetBinError(iPt + 1, 0.);
+
+      hRawYieldsTrue->SetBinContent(iPt + 1, hMassForFit[iPt]->Integral());
+      hRawYieldsTrue->SetBinError(iPt + 1, TMath::Sqrt(hMassForFit[iPt]->Integral()));
+      hRelDiffRawYieldsFitTrue->SetBinContent(iPt + 1, rawyield - hMassForFit[iPt]->Integral());
+      hRelDiffRawYieldsFitTrue->SetBinError(iPt + 1, TMath::Sqrt(rawyielderr * rawyielderr + hMassForFit[iPt]->Integral()));
+
+      if (InclSecPeak[iPt] == 1 && particle == kDs) {
+        double rawyieldSecPeak = massFunc->GetParameter(parRawYieldSecPeak);
+        double rawyieldSecPeakerr = massFunc->GetParError(parRawYieldSecPeak);
+        double sigmasecondpeak = massFunc->GetParameter(parSigmaSecPeak);
+        double sigmasecondpeakerr = massFunc->GetParError(parSigmaSecPeak);
+        double meansecondpeak = massFunc->GetParameter(parMeanSecPeak);
+        double meansecondpeakerr = massFunc->GetParError(parMeanSecPeak);
+        hRawYieldsSecondPeak->SetBinContent(iPt + 1, rawyieldSecPeak);
+        hRawYieldsSecondPeak->SetBinError(iPt + 1, rawyieldSecPeakerr);
+        hRawYieldsMeanSecondPeak->SetBinContent(iPt + 1, meansecondpeak);
+        hRawYieldsMeanSecondPeak->SetBinError(iPt + 1, meansecondpeakerr);
+        hRawYieldsSigmaSecondPeak->SetBinContent(iPt + 1, sigmasecondpeak);
+        hRawYieldsSigmaSecondPeak->SetBinError(iPt + 1, sigmasecondpeakerr);
+        hRawYieldsSigmaRatioSecondFirstPeak->SetBinContent(iPt + 1, sigmasecondpeak / sigma);
+        hRawYieldsSigmaRatioSecondFirstPeak->SetBinError(iPt + 1, TMath::Sqrt(sigmaerr * sigmaerr / (sigma * sigma) + sigmasecondpeakerr * sigmasecondpeakerr / (sigmasecondpeak * sigmasecondpeak)) * sigmasecondpeak / sigma); // neglected correlation between parameters
+
+        hRawYieldsSecondPeakTrue->SetBinContent(iPt + 1, rawyield);
+        hRelDiffRawYieldsSecondPeakFitTrue->SetBinContent(iPt + 1, rawyield);
+      }
+      if (SgnFunc[iPt] == HFMassFitter::k2Gaus) {
+        double sigma2 = massFunc->GetParameter(parSigma2);
+        double sigma2err = massFunc->GetParError(parSigma2);
+        double frac2gaus = massFunc->GetParameter(parFrac2Gaus);
+        double frac2gauserr = massFunc->GetParError(parFrac2Gaus);
+        hRawYieldsSigma2->SetBinContent(iPt + 1, sigma2);
+        hRawYieldsSigma2->SetBinError(iPt + 1, sigma2err);
+        hRawYieldsFracGaus2->SetBinContent(iPt + 1, frac2gaus);
+        hRawYieldsFracGaus2->SetBinError(iPt + 1, frac2gauserr);
+      } else if (SgnFunc[iPt] == HFMassFitter::k2GausSigmaRatioPar) {
+        double sigmaRatio1_2 = massFunc->GetParameter(parSigmaRatio);
+        double sigmaRatio1_2err = massFunc->GetParError(parSigmaRatio);
+        double sigma2 = sigma / sigmaRatio1_2;
+        double sigma2err = 0; // todo: add error propagation (correlation?)
+        hRawYieldsSigmaRatio->SetBinContent(iPt + 1, sigmaRatio1_2);
+        hRawYieldsSigmaRatio->SetBinError(iPt + 1, sigmaRatio1_2err);
+        hRawYieldsSigma2->SetBinContent(iPt + 1, sigma2);
+        hRawYieldsSigma2->SetBinError(iPt + 1, sigma2err);
+      }
+    } else { // data
+      auto massFitter = new HFMassFitter(hMassForFit[iPt], MassMin[iPt], MassMax[iPt], BkgFunc[iPt], SgnFunc[iPt]);
+      if (degPol[iPt] > 0)
+        massFitter->SetPolDegreeForBackgroundFit(degPol[iPt]);
+      if (UseLikelihood)
+        massFitter->SetUseLikelihoodFit();
+      if (fixMean[iPt]) {
+        if (hMeanToFix != NULL)
+          massFitter->SetFixGaussianMean(hMeanToFix->GetBinContent(iPt + 1));
+        else
+          massFitter->SetFixGaussianMean(fixMeanManually[iPt]);
+      }
+      if (boundMean)
+        massFitter->SetBoundGaussianMean(massForFit, MassMin[iPt], MassMax[iPt]);
+      else
+        massFitter->SetInitialGaussianMean(massForFit);
+      if (fixSigma[iPt]) {
+        if (!isSigmaMultFromUnc)
+          if (hSigmaToFix)
+            massFitter->SetFixGaussianSigma(hSigmaToFix->GetBinContent(iPt + 1) * sigmaMult);
+          else
+            massFitter->SetFixGaussianSigma(fixSigmaManually[iPt]);
+        else {
+          if (sigmaMultFromUnc == "MinusUnc")
+            massFitter->SetFixGaussianSigma(hSigmaToFix->GetBinContent(iPt + 1) - hSigmaToFix->GetBinError(iPt + 1));
+          else if (sigmaMultFromUnc == "PlusUnc")
+            massFitter->SetFixGaussianSigma(hSigmaToFix->GetBinContent(iPt + 1) + hSigmaToFix->GetBinError(iPt + 1));
+          else
+            cout << "WARNING: impossible to fix sigma! Wrong mult factor set in config file!" << endl;
+        }
+      } else {
+        if (hSigmaToFix)
+          massFitter->SetInitialGaussianSigma(hSigmaToFix->GetBinContent(iPt + 1) * sigmaMult);
+        else if (particle == kDstar)
+          massFitter->SetInitialGaussianSigma(0.001);
+        else
+          cout << "Initialise sigma" << endl;
+        massFitter->SetInitialGaussianSigma(0.008);
+      }
+      if (fixSigmaRatio) {
+        massFitter->SetFixRatio2GausSigma(
+          hSigmaToFix1->GetBinContent(iPt + 1) / hSigmaToFix2->GetBinContent(iPt + 1));
+      }
+      if (InclSecPeak[iPt] && particle == kDs) {
+        if (hSigmaToFixSecPeak) {
+          massFitter->IncludeSecondGausPeak(massDplus, false, hSigmaToFixSecPeak->GetBinContent(iPt + 1) * sigmaMultSecPeak, true);
+          if (fixSigmaToFirstPeak) {
+            // fix D+ peak to sigmaMC(D+)/sigmaMC(Ds+)*sigmaData(Ds+)
+            massFitter->MassFitter(false);
+            double sigmaFirstPeak = massFitter->GetSigma();
+            double sigmaRatioMC = hSigmaToFixSecPeak->GetBinContent(iPt + 1) / hSigmaFirstPeakMC->GetBinContent(iPt + 1);
+            massFitter->IncludeSecondGausPeak(massDplus, false, sigmaRatioMC * sigmaFirstPeak, true);
+          }
+        } else {
+          massFitter->IncludeSecondGausPeak(massDplus, false, SigmaSecPeak[iPt], true);
+        }
+      }
+
+      if (enableRefl) {
+        double rOverS = hMassForSig[iPt]->Integral(hMassForSig[iPt]->FindBin(MassMin[iPt] * 1.0001), hMassForSig[iPt]->FindBin(MassMax[iPt] * 0.999));
+        rOverS = hMassForRel[iPt]->Integral(hMassForRel[iPt]->FindBin(MassMin[iPt] * 1.0001), hMassForRel[iPt]->FindBin(MassMax[iPt] * 0.999)) / rOverS;
+        massFitter->SetFixReflOverS(rOverS);
+        massFitter->SetTemplateReflections(hMassRef[iPt], "2gaus", MassMin[iPt], MassMax[iPt]);
+      }
+
+      massFitter->MassFitter(false);
+
+      //=======================
+      // RETRIEVE FITTER PARAMETERS
+      double rawyield = massFitter->GetRawYield();
+      double rawyielderr = massFitter->GetRawYieldError();
+      double sigma = massFitter->GetSigma();
+      double sigmaerr = massFitter->GetSigmaUncertainty();
+      double mean = massFitter->GetMean();
+      double meanerr = massFitter->GetMeanUncertainty();
+      double redchi2 = massFitter->GetReducedChiSquare();
+      double signif = 0., signiferr = 0.;
+      double sgn = 0., sgnerr = 0.;
+      double bkg = 0., bkgerr = 0.;
+      massFitter->Significance(3, signif, signiferr);
+      massFitter->Signal(3, sgn, sgnerr);
+      massFitter->Background(3, bkg, bkgerr);
+
+      hRawYields->SetBinContent(iPt + 1, rawyield);
+      hRawYields->SetBinError(iPt + 1, rawyielderr);
+      hRawYieldsSigma->SetBinContent(iPt + 1, sigma);
+      hRawYieldsSigma->SetBinError(iPt + 1, sigmaerr);
+      hRawYieldsMean->SetBinContent(iPt + 1, mean);
+      hRawYieldsMean->SetBinError(iPt + 1, meanerr);
+      hRawYieldsSignificance->SetBinContent(iPt + 1, signif);
+      hRawYieldsSignificance->SetBinError(iPt + 1, signiferr);
+      hRawYieldsSoverB->SetBinContent(iPt + 1, sgn / bkg);
+      hRawYieldsSoverB->SetBinError(iPt + 1, sgn / bkg * TMath::Sqrt(sgnerr / sgn * sgnerr / sgn + bkgerr / bkg * bkgerr / bkg));
+      hRawYieldsSignal->SetBinContent(iPt + 1, sgn);
+      hRawYieldsSignal->SetBinError(iPt + 1, sgnerr);
+      hRawYieldsBkg->SetBinContent(iPt + 1, bkg);
+      hRawYieldsBkg->SetBinError(iPt + 1, bkgerr);
+      hRawYieldsChiSquare->SetBinContent(iPt + 1, redchi2);
+      hRawYieldsChiSquare->SetBinError(iPt + 1, 1.e-20);
+
+      /*            for(int iS = 0; iS < nMassWindows; iS++)
+            {
+                massFitter->Significance(nSigma4SandB[iS],signif,signiferr);
+                massFitter->Signal(nSigma4SandB[iS],sgn,sgnerr);
+                massFitter->Background(nSigma4SandB[iS],bkg,bkgerr);
+
+                hRawYieldsSignalDiffSigma[iS]->SetBinContent(iPt+1,sgn);
+                hRawYieldsSignalDiffSigma[iS]->SetBinError(iPt+1,sgnerr);
+                hRawYieldsBkgDiffSigma[iS]->SetBinContent(iPt+1,bkg);
+                hRawYieldsBkgDiffSigma[iS]->SetBinError(iPt+1,bkgerr);
+                hRawYieldsSoverBDiffSigma[iS]->SetBinContent(iPt+1,sgn/bkg);
+                hRawYieldsSoverBDiffSigma[iS]->SetBinError(iPt+1,sgn/bkg*TMath::Sqrt(sgnerr/sgn*sgnerr/sgn+bkgerr/bkg*bkgerr/bkg));
+                hRawYieldsSignifDiffSigma[iS]->SetBinContent(iPt+1,signif);
+                hRawYieldsSignifDiffSigma[iS]->SetBinError(iPt+1,signiferr);
+    }*/
+
+      TF1* fTotFunc = massFitter->GetMassFunc();
+      TF1* fBkgFunc = massFitter->GetBackgroundRecalcFunc();
+
+      double parFrac2Gaus = -1, parsecondsigma = -1;
+      if (SgnFunc[iPt] == HFMassFitter::k2Gaus) {
+        if (!(InclSecPeak[iPt] == 1 && particle == kDs)) {
+          parFrac2Gaus = fTotFunc->GetNpar() - 2;
+          parsecondsigma = fTotFunc->GetNpar() - 1;
+        } else {
+          parFrac2Gaus = fTotFunc->GetNpar() - 5;
+          parsecondsigma = fTotFunc->GetNpar() - 4;
+        }
+
+        double sigma2 = fTotFunc->GetParameter(parsecondsigma);
+        double sigma2err = fTotFunc->GetParError(parsecondsigma);
+        double frac2gaus = fTotFunc->GetParameter(parFrac2Gaus);
+        double frac2gauserr = fTotFunc->GetParError(parFrac2Gaus);
+        hRawYieldsSigma2->SetBinContent(iPt + 1, sigma2);
+        hRawYieldsSigma2->SetBinError(iPt + 1, sigma2err);
+        hRawYieldsFracGaus2->SetBinContent(iPt + 1, frac2gaus);
+        hRawYieldsFracGaus2->SetBinError(iPt + 1, frac2gauserr);
+      } else if (SgnFunc[iPt] == HFMassFitter::k2GausSigmaRatioPar) {
+        int parRatioSigma = fTotFunc->GetNpar() - 1;
+        double sigmaRatio1_2 = fTotFunc->GetParameter(parRatioSigma);
+        double sigmaRatio1_2err = fTotFunc->GetParError(parRatioSigma);
+        double sigma2 = sigma / sigmaRatio1_2;
+        double sigma2err = 0; // todo: add error propagation (correlation?)
+        hRawYieldsSigmaRatio->SetBinContent(iPt + 1, sigmaRatio1_2);
+        hRawYieldsSigmaRatio->SetBinError(iPt + 1, sigmaRatio1_2err);
+        hRawYieldsSigma2->SetBinContent(iPt + 1, sigma2);
+        hRawYieldsSigma2->SetBinError(iPt + 1, sigma2err);
+      }
+
+      if (InclSecPeak[iPt] == 1 && particle == kDs) {
+        int paryieldSecPeak = fTotFunc->GetNpar() - 3;
+        int parMeansecondpeak = fTotFunc->GetNpar() - 2;
+        int parSigmasecondpeak = fTotFunc->GetNpar() - 1;
+
+        double rawyieldSecPeak = fTotFunc->GetParameter(paryieldSecPeak) / hMassForFit[iPt]->GetBinWidth(1);
+        double rawyieldSecPeakerr = fTotFunc->GetParError(paryieldSecPeak) / hMassForFit[iPt]->GetBinWidth(1);
+        double meansecondpeak = fTotFunc->GetParameter(parMeansecondpeak);
+        double meansecondpeakerr = fTotFunc->GetParError(parMeansecondpeak);
+        double sigmasecondpeak = fTotFunc->GetParameter(parSigmasecondpeak);
+        double sigmasecondpeakerr = fTotFunc->GetParError(parSigmasecondpeak);
+
+        double bkgSecPeak = fBkgFunc->Integral(meansecondpeak - 3 * sigmasecondpeak, meansecondpeak + 3 * sigmasecondpeak) / hMassForFit[iPt]->GetBinWidth(1);
+        double bkgSecPeakerr = TMath::Sqrt(bkgSecPeak);
+        double signalSecPeak = fTotFunc->Integral(meansecondpeak - 3 * sigmasecondpeak, meansecondpeak + 3 * sigmasecondpeak) / hMassForFit[iPt]->GetBinWidth(1) - bkgSecPeak;
+        double signalSecPeakerr = TMath::Sqrt(signalSecPeak + bkgSecPeak);
+        double signifSecPeak = -1., signifSecPeakerr = -1.;
+        // AliVertexingHFUtils::ComputeSignificance(signalSecPeak,signalSecPeakerr,bkgSecPeak,bkgSecPeakerr,signifSecPeak,signifSecPeakerr);
+        // TO BE FIXED. At the moment there is no method to calc this sigificance.
+
+        hRawYieldsSecondPeak->SetBinContent(iPt + 1, rawyieldSecPeak);
+        hRawYieldsSecondPeak->SetBinError(iPt + 1, rawyieldSecPeakerr);
+        hRawYieldsMeanSecondPeak->SetBinContent(iPt + 1, meansecondpeak);
+        hRawYieldsMeanSecondPeak->SetBinError(iPt + 1, meansecondpeakerr);
+        hRawYieldsSigmaSecondPeak->SetBinContent(iPt + 1, sigmasecondpeak);
+        hRawYieldsSigmaSecondPeak->SetBinError(iPt + 1, sigmasecondpeakerr);
+        hRawYieldsSignificanceSecondPeak->SetBinContent(iPt + 1, signifSecPeak);
+        hRawYieldsSignificanceSecondPeak->SetBinError(iPt + 1, signifSecPeakerr);
+        hRawYieldsSigmaRatioSecondFirstPeak->SetBinContent(iPt + 1, sigmasecondpeak / sigma);
+        hRawYieldsSigmaRatioSecondFirstPeak->SetBinError(iPt + 1, TMath::Sqrt(sigmaerr * sigmaerr / (sigma * sigma) + sigmasecondpeakerr * sigmasecondpeakerr / (sigmasecondpeak * sigmasecondpeak)) * sigmasecondpeak / sigma); // neglected correlation between parameters
+        hRawYieldsSoverBSecondPeak->SetBinContent(iPt + 1, signalSecPeak / bkgSecPeak);
+        hRawYieldsSoverBSecondPeak->SetBinError(iPt + 1, signalSecPeak / bkgSecPeak * TMath::Sqrt(signalSecPeakerr / signalSecPeak * signalSecPeakerr / signalSecPeak + bkgSecPeakerr / bkgSecPeak * bkgSecPeakerr / bkgSecPeak));
+        hRawYieldsSignalSecondPeak->SetBinContent(iPt + 1, signalSecPeak);
+        hRawYieldsSignalSecondPeak->SetBinError(iPt + 1, signalSecPeakerr);
+        hRawYieldsBkgSecondPeak->SetBinContent(iPt + 1, bkgSecPeak);
+        hRawYieldsBkgSecondPeak->SetBinError(iPt + 1, bkgSecPeakerr);
+      }
+
+      if (doSideband) {
+        double bkgSB = fBkgFunc->Integral(MinSBLeft[iPt], MaxSBLeft[iPt]) / (Double_t)hMassForFit[iPt]->GetBinWidth(1) + fBkgFunc->Integral(MinSBRight[iPt], MaxSBRight[iPt]) / (Double_t)hMassForFit[iPt]->GetBinWidth(1);
+        double bkgSBErr = TMath::Sqrt(bkgSB);
+        // relative error evaluation: from histo
+
+        int minLeft = hMassForFit[iPt]->FindBin(MinSBLeft[iPt]);
+        int maxLeft = hMassForFit[iPt]->FindBin(MaxSBLeft[iPt]);
+        int minRight = hMassForFit[iPt]->FindBin(MinSBRight[iPt]);
+        int maxRight = hMassForFit[iPt]->FindBin(MaxSBRight[iPt]);
+
+        double intB = hMassForFit[iPt]->Integral(minLeft, maxLeft) + hMassForFit[iPt]->Integral(minRight, maxRight);
+        double sum2 = 0;
+        for (int i = minLeft; i <= maxLeft; i++) {
+          sum2 += hMassForFit[iPt]->GetBinError(i) * hMassForFit[iPt]->GetBinError(i);
+        }
+        for (int i = minRight; i <= maxRight; i++) {
+          sum2 += hMassForFit[iPt]->GetBinError(i) * hMassForFit[iPt]->GetBinError(i);
+        }
+        double intBerr = TMath::Sqrt(sum2);
+        double errbackground = intBerr / intB * bkgSB;
+        cout << "Check integrals bkg sidebands: " << fBkgFunc->Integral(MinSBLeft[iPt], MaxSBLeft[iPt]) / (Double_t)hMassForFit[iPt]->GetBinWidth(1) << " " << fBkgFunc->Integral(MinSBRight[iPt], MaxSBRight[iPt]) / (Double_t)hMassForFit[iPt]->GetBinWidth(1) << " " << intB << endl;
+        cout << "Check errors bkg sidebands: " << errbackground << "  " << bkgSBErr << endl;
+        hBackgroundSidebands->SetBinContent(iPt + 1, bkgSB);
+        hBackgroundSidebands->SetBinError(iPt + 1, bkgSBErr);
+      }
+
+      if (nPtBins > 1)
+        cMass[iCanv]->cd(iPt - nMaxCanvases * iCanv + 1);
+      else
+        cMass[iCanv]->cd();
+
+      hMassForFit[iPt]->GetYaxis()->SetRangeUser(hMassForFit[iPt]->GetMinimum() * 0.95, hMassForFit[iPt]->GetMaximum() * 1.2);
+      massFitter->DrawHere(gPad);
+
+      if (!isMC) {
+        // residuals
+        if (nPtBins > 1)
+          cResiduals[iCanv]->cd(iPt - nMaxCanvases * iCanv + 1);
+        else
+          cResiduals[iCanv]->cd();
+        massFitter->DrawHistoMinusFit(gPad);
+      }
+    }
+    cMass[iCanv]->Modified();
+    cMass[iCanv]->Update();
+    cResiduals[iCanv]->Modified();
+    cResiduals[iCanv]->Update();
+  }
+
+  // save output histos
+  TFile outFile(outFileName.Data(), "recreate");
+  for (int iCanv = 0; iCanv < nCanvases; iCanv++) {
+    cMass[iCanv]->Write();
+    if (!isMC)
+      cResiduals[iCanv]->Write();
+  }
+  for (unsigned int iPt = 0; iPt < nPtBins; iPt++)
+    hMass[iPt]->Write();
+  hRawYields->Write();
+  hRawYieldsSigma->Write();
+  hRawYieldsMean->Write();
+  hRawYieldsSignificance->Write();
+  hRawYieldsSoverB->Write();
+  hRawYieldsSignal->Write();
+  hRawYieldsBkg->Write();
+  hRawYieldsChiSquare->Write();
+  hRawYieldsSigma2->Write();
+  hRawYieldsFracGaus2->Write();
+  hRawYieldsSecondPeak->Write();
+  hRawYieldsMeanSecondPeak->Write();
+  hRawYieldsSigmaSecondPeak->Write();
+  hRawYieldsSignificanceSecondPeak->Write();
+  hRawYieldsSigmaRatioSecondFirstPeak->Write();
+  hRawYieldsSoverBSecondPeak->Write();
+  hRawYieldsSignalSecondPeak->Write();
+  hRawYieldsBkgSecondPeak->Write();
+  hRawYieldsTrue->Write();
+  hRawYieldsSecondPeakTrue->Write();
+  hRelDiffRawYieldsFitTrue->Write();
+  hRelDiffRawYieldsSecondPeakFitTrue->Write();
+  hRawYieldsSigmaRatio->Write();
+  hBackgroundSidebands->Write();
+  // hEv->Write();
+  if (!isMC) {
+    /*TDirectoryFile dir("SandBDiffNsigma", "SandBDiffNsigma");
+      dir.Write();
+      dir.cd();
+ for(int iS = 0; iS < nMassWindows; iS++)
+      {
+          hRawYieldsSignalDiffSigma[iS]->Write();
+          hRawYieldsBkgDiffSigma[iS]->Write();
+          hRawYieldsSoverBDiffSigma[iS]->Write();
+          hRawYieldsSignifDiffSigma[iS]->Write();
+    }
+      dir.Close();*/
+  }
+  outFile.Close();
+
+  outFileName.ReplaceAll(".root", ".pdf");
+  TString outFileNameRes = outFileName;
+  outFileNameRes.ReplaceAll(".pdf", "_Residuals.pdf");
+  for (int iCanv = 0; iCanv < nCanvases; iCanv++) {
+    if (iCanv == 0 && nCanvases > 1)
+      cMass[iCanv]->SaveAs(Form("%s[", outFileName.Data()));
+    cMass[iCanv]->SaveAs(outFileName.Data());
+    if (iCanv == nCanvases - 1 && nCanvases > 1)
+      cMass[iCanv]->SaveAs(Form("%s]", outFileName.Data()));
+
+    if (!isMC) {
+      if (iCanv == 0 && nCanvases > 1)
+        cResiduals[iCanv]->SaveAs(Form("%s[", outFileNameRes.Data()));
+      cResiduals[iCanv]->SaveAs(outFileNameRes.Data());
+      if (iCanv == nCanvases - 1 && nCanvases > 1)
+        cResiduals[iCanv]->SaveAs(Form("%s]", outFileNameRes.Data()));
+    }
+  }
+
+  return 0;
+}
+
+//__________________________________________________________________________________________________________________
+double SingleGaus(double* m, double* pars)
+{
+  double norm = pars[0], mean = pars[1], sigma = pars[2];
+
+  return norm * TMath::Gaus(m[0], mean, sigma, true);
+}
+
+//__________________________________________________________________________________________________________________
+double DoubleGaus(double* m, double* pars)
+{
+  double norm = pars[0], mean = pars[1], sigma1 = pars[2], sigma1_2 = pars[3], fg = pars[4];
+
+  return norm * ((1 - fg) * TMath::Gaus(m[0], mean, sigma1, true) + fg * TMath::Gaus(m[0], mean, sigma1_2, true));
+}
+
+//__________________________________________________________________________________________________________________
+double DoubleGausSigmaRatio(double* m, double* pars)
+{
+  double norm = pars[0], mean = pars[1], sigma1 = pars[2], sigma1OverSigma2 = pars[3], fg = pars[4];
+
+  return norm * ((1 - fg) * TMath::Gaus(m[0], mean, sigma1, true) + fg * TMath::Gaus(m[0], mean, sigma1 / sigma1OverSigma2, true));
+}
+
+//__________________________________________________________________________________________________________________
+double DoublePeakSingleGaus(double* m, double* pars)
+{
+  double norm1 = pars[0], mean1 = pars[1], sigma1 = pars[2]; // Ds peak
+  double norm2 = pars[3], mean2 = pars[4], sigma2 = pars[5]; // Dplus peak
+
+  return norm1 * TMath::Gaus(m[0], mean1, sigma1, true) + norm2 * TMath::Gaus(m[0], mean2, sigma2, true);
+}
+
+//__________________________________________________________________________________________________________________
+double DoublePeakDoubleGaus(double* m, double* pars)
+{
+  double norm1 = pars[0], mean = pars[1], sigma1 = pars[2], sigma1_2 = pars[3], fg = pars[4]; // Ds peak
+  double norm2 = pars[5], mean2 = pars[6], sigma2 = pars[7];                                  // Dplus peak
+
+  return norm1 * ((1 - fg) * TMath::Gaus(m[0], mean, sigma1, true) + fg * TMath::Gaus(m[0], mean, sigma1_2, true)) + norm2 * TMath::Gaus(m[0], mean2, sigma2, true);
+}
+
+//__________________________________________________________________________________________________________________
+void SetHistoStyle(TH1* histo, int color, double markersize)
+{
+  histo->SetStats(kFALSE);
+  histo->SetMarkerSize(markersize);
+  histo->SetMarkerStyle(20);
+  histo->SetLineWidth(2);
+  histo->SetMarkerColor(color);
+  histo->SetLineColor(color);
+}
+
+//__________________________________________________________________________________________________________________
+void DivideCanvas(TCanvas* c, int nPtBins)
+{
+  if (nPtBins < 2)
+    c->cd();
+  else if (nPtBins == 2 || nPtBins == 3)
+    c->Divide(nPtBins, 1);
+  else if (nPtBins == 4 || nPtBins == 6 || nPtBins == 8)
+    c->Divide(nPtBins / 2, 2);
+  else if (nPtBins == 5 || nPtBins == 7)
+    c->Divide((nPtBins + 1) / 2, 2);
+  else if (nPtBins == 9 || nPtBins == 12 || nPtBins == 15)
+    c->Divide(nPtBins / 3, 3);
+  else if (nPtBins == 10 || nPtBins == 11)
+    c->Divide(4, 3);
+  else if (nPtBins == 13 || nPtBins == 14)
+    c->Divide(5, 3);
+  else if (nPtBins > 15 && nPtBins <= 20 && nPtBins % 4 == 0)
+    c->Divide(nPtBins / 4, 4);
+  else if (nPtBins > 15 && nPtBins <= 20 && nPtBins % 4 != 0)
+    c->Divide(5, 4);
+  else if (nPtBins == 21)
+    c->Divide(7, 3);
+  else if (nPtBins > 21 && nPtBins <= 25)
+    c->Divide(5, 5);
+  else if (nPtBins > 25 && nPtBins % 2 == 0)
+    c->Divide(nPtBins / 2, 2);
+  else
+    c->Divide((nPtBins + 1) / 2, 2);
+}
+
+//__________________________________________________________________________________________________________________
+void SetStyle()
+{
+  gStyle->SetOptFit(0);
+  gStyle->SetOptStat(0);
+  gStyle->SetPadLeftMargin(0.12);
+  gStyle->SetPadBottomMargin(0.12);
+  gStyle->SetPadRightMargin(0.05);
+  gStyle->SetPadTopMargin(0.08);
+  gStyle->SetTitleOffset(1.4, "y");
+  gStyle->SetTitleOffset(1.2, "x");
+  gStyle->SetLegendBorderSize(0);
+  gStyle->SetPadTickX(1);
+  gStyle->SetPadTickY(1);
+  TGaxis::SetMaxDigits(3);
+}
+
+//__________________________________________________________________________________________________________________
+TH1D* RebinHisto(TH1* hOrig, Int_t reb, Int_t firstUse)
+{
+  /// Rebin histogram, from bin firstUse to lastUse
+  /// Use all bins if firstUse=-1
+  /// If ngroup is not an exact divider of the number of bins,
+  ///  the bin width is kept as reb*original width
+  ///  and the range of rebinned histogram is adapted
+
+  Int_t nBinOrig = hOrig->GetNbinsX();
+  Int_t firstBinOrig = 1;
+  Int_t lastBinOrig = nBinOrig;
+  Int_t nBinOrigUsed = nBinOrig;
+  Int_t nBinFinal = nBinOrig / reb;
+  if (firstUse >= 1) {
+    firstBinOrig = firstUse;
+    nBinFinal = (nBinOrig - firstUse + 1) / reb;
+    nBinOrigUsed = nBinFinal * reb;
+    lastBinOrig = firstBinOrig + nBinOrigUsed - 1;
+  } else {
+    Int_t exc = nBinOrigUsed % reb;
+    if (exc != 0) {
+      nBinOrigUsed -= exc;
+      lastBinOrig = firstBinOrig + nBinOrigUsed - 1;
+    }
+  }
+
+  printf("Rebin from %d bins to %d bins -- Used bins=%d in range %d-%d\n", nBinOrig, nBinFinal, nBinOrigUsed, firstBinOrig, lastBinOrig);
+  Float_t lowLim = hOrig->GetXaxis()->GetBinLowEdge(firstBinOrig);
+  Float_t hiLim = hOrig->GetXaxis()->GetBinUpEdge(lastBinOrig);
+  TH1D* hRebin = new TH1D(Form("%s-rebin", hOrig->GetName()), hOrig->GetTitle(), nBinFinal, lowLim, hiLim);
+  Int_t lastSummed = firstBinOrig - 1;
+  for (Int_t iBin = 1; iBin <= nBinFinal; iBin++) {
+    Float_t sum = 0.;
+    Float_t sume2 = 0.;
+    for (Int_t iOrigBin = 0; iOrigBin < reb; iOrigBin++) {
+      sum += hOrig->GetBinContent(lastSummed + 1);
+      sume2 += (hOrig->GetBinError(lastSummed + 1) * hOrig->GetBinError(lastSummed + 1));
+      lastSummed++;
+    }
+    hRebin->SetBinContent(iBin, sum);
+    hRebin->SetBinError(iBin, TMath::Sqrt(sume2));
+  }
+  return hRebin;
+}

--- a/PWGHF/HFC/Macros/HFMassFitter.cxx
+++ b/PWGHF/HFC/Macros/HFMassFitter.cxx
@@ -1,0 +1,1447 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HFMassFitter.cxx
+/// \brief HFMassFitter class
+///
+/// \author Grazia Luparello <gluparel@cern.ch>
+
+#include <TH1F.h>
+#include <TF1.h>
+#include <TMath.h>
+#include <TVirtualFitter.h>
+#include <TDatabasePDG.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+#include <TPaveText.h>
+#include <TFitResult.h>
+
+#include "HFMassFitter.h"
+
+/// \cond CLASSIMP
+ClassImp(HFMassFitter);
+/// \endcond
+
+//__________________________________________________________________________
+HFMassFitter::HFMassFitter() : TNamed(),
+                               fHistoInvMass(0x0),
+                               fMinMass(0),
+                               fMaxMass(5),
+                               fTypeOfFit4Bkg(kExpo),
+                               fPolDegreeBkg(4),
+                               fCurPolDegreeBkg(-1),
+                               fMassParticle(1.864),
+                               fTypeOfFit4Sgn(kGaus),
+                               fMass(1.865),
+                               fMassErr(0.),
+                               fSigmaSgn(0.012),
+                               fSigmaSgnErr(0.),
+                               fSigmaSgn2Gaus(0.012),
+                               fFixedMean(kFALSE),
+                               fBoundMean(kFALSE),
+                               fMassLowerLim(0),
+                               fMassUpperLim(0),
+                               fFixedSigma(kFALSE),
+                               fBoundSigma(kFALSE),
+                               fSigmaVar(0.012),
+                               fParSig(0.1),
+                               fFixedSigma2Gaus(kFALSE),
+                               fFixedRawYield(-1.),
+                               fFrac2Gaus(0.2),
+                               fFixedFrac2Gaus(kFALSE),
+                               fRatio2GausSigma(0.),
+                               fFixedRatio2GausSigma(kFALSE),
+                               fNParsSig(3),
+                               fNParsBkg(2),
+                               fOnlySideBands(kFALSE),
+                               fNSigma4SideBands(4.),
+                               fCheckSignalCountsAfterFirstFit(kTRUE),
+                               fFitOption("L,E"),
+                               fRawYield(0.),
+                               fRawYieldErr(0.),
+                               fSigFunc(0x0),
+                               fBkgFuncSb(0x0),
+                               fBkgFunc(0x0),
+                               fBkgFuncRefit(0x0),
+                               fReflections(kFALSE),
+                               fNParsRfl(0),
+                               fRflOverSig(0),
+                               fFixRflOverSig(kFALSE),
+                               fHistoTemplRfl(0x0),
+                               fSmoothRfl(kFALSE),
+                               fRawYieldHelp(0),
+                               fRflFunc(0x0),
+                               fBkRFunc(0x0),
+                               fSecondPeak(kFALSE),
+                               fNParsSec(0),
+                               fSecMass(-999.),
+                               fSecWidth(9999.),
+                               fFixSecMass(kFALSE),
+                               fFixSecWidth(kFALSE),
+                               fSecFunc(0x0),
+                               fTotFunc(0x0),
+                               fAcceptValidFit(kFALSE)
+{
+  /// default constructor
+}
+
+//__________________________________________________________________________
+HFMassFitter::HFMassFitter(const TH1F* histoToFit, Double_t minvalue, Double_t maxvalue, Int_t fittypeb, Int_t fittypes) : TNamed(),
+                                                                                                                           fHistoInvMass(0x0),
+                                                                                                                           fMinMass(minvalue),
+                                                                                                                           fMaxMass(maxvalue),
+                                                                                                                           fTypeOfFit4Bkg(fittypeb),
+                                                                                                                           fPolDegreeBkg(4),
+                                                                                                                           fCurPolDegreeBkg(-1),
+                                                                                                                           fMassParticle(1.864),
+                                                                                                                           fTypeOfFit4Sgn(fittypes),
+                                                                                                                           fMass(1.865),
+                                                                                                                           fMassErr(0.),
+                                                                                                                           fSigmaSgn(0.012),
+                                                                                                                           fSigmaSgnErr(0.),
+                                                                                                                           fSigmaSgn2Gaus(0.012),
+                                                                                                                           fFixedMean(kFALSE),
+                                                                                                                           fBoundMean(kFALSE),
+                                                                                                                           fMassLowerLim(0),
+                                                                                                                           fMassUpperLim(0),
+                                                                                                                           fFixedSigma(kFALSE),
+                                                                                                                           fBoundSigma(kFALSE),
+                                                                                                                           fSigmaVar(0.012),
+                                                                                                                           fParSig(0.1),
+                                                                                                                           fFixedSigma2Gaus(kFALSE),
+                                                                                                                           fFixedRawYield(-1.),
+                                                                                                                           fFrac2Gaus(0.2),
+                                                                                                                           fFixedFrac2Gaus(kFALSE),
+                                                                                                                           fRatio2GausSigma(0.),
+                                                                                                                           fFixedRatio2GausSigma(kFALSE),
+                                                                                                                           fNParsSig(3),
+                                                                                                                           fNParsBkg(2),
+                                                                                                                           fOnlySideBands(kFALSE),
+                                                                                                                           fNSigma4SideBands(4.),
+                                                                                                                           fCheckSignalCountsAfterFirstFit(kTRUE),
+                                                                                                                           fFitOption("L,E"),
+                                                                                                                           fRawYield(0.),
+                                                                                                                           fRawYieldErr(0.),
+                                                                                                                           fSigFunc(0x0),
+                                                                                                                           fBkgFuncSb(0x0),
+                                                                                                                           fBkgFunc(0x0),
+                                                                                                                           fBkgFuncRefit(0x0),
+                                                                                                                           fReflections(kFALSE),
+                                                                                                                           fNParsRfl(0),
+                                                                                                                           fRflOverSig(0),
+                                                                                                                           fFixRflOverSig(kFALSE),
+                                                                                                                           fHistoTemplRfl(0x0),
+                                                                                                                           fSmoothRfl(kFALSE),
+                                                                                                                           fRawYieldHelp(0),
+                                                                                                                           fRflFunc(0x0),
+                                                                                                                           fBkRFunc(0x0),
+                                                                                                                           fSecondPeak(kFALSE),
+                                                                                                                           fNParsSec(0),
+                                                                                                                           fSecMass(-999.),
+                                                                                                                           fSecWidth(9999.),
+                                                                                                                           fFixSecMass(kFALSE),
+                                                                                                                           fFixSecWidth(kFALSE),
+                                                                                                                           fSecFunc(0x0),
+                                                                                                                           fTotFunc(0x0),
+                                                                                                                           fAcceptValidFit(kFALSE)
+{
+  /// standard constructor
+  fHistoInvMass = (TH1F*)histoToFit->Clone("fHistoInvMass");
+  fHistoInvMass->SetDirectory(0);
+  SetNumberOfParams();
+}
+//_________________________________________________________________________
+HFMassFitter::~HFMassFitter()
+{
+
+  /// destructor
+
+  delete fSigFunc;
+  delete fBkgFunc;
+  delete fBkgFuncSb;
+  delete fBkgFuncRefit;
+  delete fHistoInvMass;
+  delete fRflFunc;
+  delete fBkRFunc;
+  delete fSecFunc;
+  delete fTotFunc;
+  delete fHistoTemplRfl;
+}
+//__________________________________________________________________________
+void HFMassFitter::SetNumberOfParams()
+{
+  /// Configure number of parameters of fit functions
+  ///
+
+  switch (fTypeOfFit4Bkg) {
+    case 0:
+      fNParsBkg = 2;
+      break;
+    case 1:
+      fNParsBkg = 2;
+      break;
+    case 2:
+      fNParsBkg = 3;
+      break;
+    case 3:
+      fNParsBkg = 1;
+      break;
+    case 4:
+      fNParsBkg = 2;
+      break;
+    case 5:
+      fNParsBkg = 2;
+      break;
+    case 6:
+      fNParsBkg = fPolDegreeBkg + 1;
+      break;
+    default:
+      cout << "Error in computing fNParsBkg: check fTypeOfFit4Bkg" << endl;
+      break;
+  }
+
+  switch (fTypeOfFit4Sgn) {
+    case 0:
+      fNParsSig = 3;
+      break;
+    case 1:
+      fNParsSig = 5;
+      break;
+    case 2:
+      fNParsSig = 5;
+      break;
+    default:
+      cout << "Error in computing fNParsSig: check fTypeOfFit4Sgn" << endl;
+      break;
+  }
+
+  if (fReflections)
+    fNParsRfl = 1;
+  else
+    fNParsRfl = 0;
+
+  if (fSecondPeak)
+    fNParsSec = 3;
+  else
+    fNParsSec = 0;
+}
+//__________________________________________________________________________
+Int_t HFMassFitter::MassFitter(Bool_t draw)
+{
+  /// Main function to fit the invariant mass distribution
+  /// returns 0 if the fit fails
+  /// returns 1 if the fit succeeds
+  /// returns 2 if there is no signal and the fit is performed with only background
+
+  TVirtualFitter::SetDefaultFitter("Minuit");
+
+  Double_t integralHisto = fHistoInvMass->Integral(fHistoInvMass->FindBin(fMinMass), fHistoInvMass->FindBin(fMaxMass), "width");
+
+  fOnlySideBands = kTRUE;
+  fBkgFuncSb = CreateBackgroundFitFunction("funcbkgsb", integralHisto);
+  Int_t status = -1;
+  Bool_t isFitValid = kFALSE;
+  printf("\n--- First fit with only background on the side bands - Exclusion region = %.2f sigma ---\n", fNSigma4SideBands);
+  if (fTypeOfFit4Bkg == 6) {
+    if (PrepareHighPolFit(fBkgFuncSb)) {
+      //   fHistoInvMass->GetListOfFunctions()->Add(fBkgFuncSb);
+      //   fHistoInvMass->GetFunction(fBkgFuncSb->GetName())->SetBit(1<<9,kTRUE);
+      status = 0;
+      isFitValid = kTRUE;
+    }
+  } else {
+    TFitResultPtr resultptr_bkg = fHistoInvMass->Fit("funcbkgsb", Form("R,S,%s,+,0", fFitOption.Data()));
+    status = (Int_t)resultptr_bkg;
+    isFitValid = resultptr_bkg->IsValid();
+  }
+  fBkgFuncSb->SetLineColor(kGray + 1);
+  if ((status != 0 && !fAcceptValidFit) || (fAcceptValidFit && !isFitValid)) {
+    printf("   ---> Failed first fit with only background, minuit status = %d\n", status);
+    return 0;
+  }
+
+  fOnlySideBands = kFALSE;
+  if (!fBkgFunc) {
+    fBkgFunc = CreateBackgroundFitFunction("funcbkg", integralHisto);
+    for (Int_t ipar = 0; ipar < fNParsBkg; ipar++)
+      fBkgFunc->SetParameter(ipar, fBkgFuncSb->GetParameter(ipar));
+  }
+  fBkgFunc->SetLineColor(kGray + 1);
+
+  printf("\n--- Estimate signal counts in the peak region ---\n");
+  Double_t estimSignal = CheckForSignal(fMass, fSigmaSgn);
+  Bool_t doFinalFit = kTRUE;
+  if (fCheckSignalCountsAfterFirstFit && estimSignal < 0.) {
+    if (draw)
+      DrawFit();
+    estimSignal = 0.;
+    doFinalFit = kFALSE;
+    printf("Abandon fit: no signal counts after first fit\n");
+  }
+
+  fRawYieldHelp = estimSignal; // needed for reflection normalization
+  if (!fBkgFuncRefit) {
+    fBkgFuncRefit = CreateBackgroundFitFunction("funcbkgrefit", integralHisto);
+    for (Int_t ipar = 0; ipar < fNParsBkg; ipar++)
+      fBkgFuncRefit->SetParameter(ipar, fBkgFunc->GetParameter(ipar));
+  }
+  fBkgFuncRefit->SetLineColor(2);
+  fSigFunc = CreateSignalFitFunction("fsigfit", estimSignal);
+  if (fSecondPeak) {
+    printf("   ---> Final fit includes a second inv. mass peak\n");
+    Double_t estimSec = CheckForSignal(fSecMass, fSecWidth);
+    fSecFunc = CreateSecondPeakFunction("fsecpeak", estimSec);
+  }
+  if (fReflections) {
+    printf("   ---> Final fit includes reflections\n");
+    fRflFunc = CreateReflectionFunction("freflect");
+    fBkRFunc = CreateBackgroundPlusReflectionFunction("fbkgrfl");
+  }
+  fTotFunc = CreateTotalFitFunction("funcmass");
+
+  if (doFinalFit) {
+    printf("\n--- Final fit with signal+background on the full range ---\n");
+    TFitResultPtr resultptr = fHistoInvMass->Fit("funcmass", Form("R,S,%s,+,0", fFitOption.Data()));
+    isFitValid = resultptr->IsValid();
+    status = (Int_t)resultptr;
+    printf("[HFMassFitter] final fit status %d\n", status);
+    printf("[HFMassFitter] IsValid() = %d\n", isFitValid);
+    if ((status != 0 && !fAcceptValidFit) || (fAcceptValidFit && !isFitValid)) {
+      printf("   ---> Failed fit with signal+background, minuit status = %d\n", status);
+      return 0;
+    }
+  }
+
+  for (Int_t ipar = 0; ipar < fNParsBkg; ipar++) {
+    fBkgFuncRefit->SetParameter(ipar, fTotFunc->GetParameter(ipar));
+    fBkgFuncRefit->SetParError(ipar, fTotFunc->GetParError(ipar));
+  }
+  for (Int_t ipar = 0; ipar < fNParsSig; ipar++) {
+    fSigFunc->SetParameter(ipar, fTotFunc->GetParameter(ipar + fNParsBkg));
+    fSigFunc->SetParError(ipar, fTotFunc->GetParError(ipar + fNParsBkg));
+  }
+  if (fSecondPeak) {
+    for (Int_t ipar = 0; ipar < fNParsSec; ipar++) {
+      fSecFunc->SetParameter(ipar, fTotFunc->GetParameter(ipar + fNParsBkg + fNParsSig));
+      fSecFunc->SetParError(ipar, fTotFunc->GetParError(ipar + fNParsBkg + fNParsSig));
+    }
+    fSecFunc->SetLineColor(kMagenta + 1);
+    fSecFunc->SetLineStyle(3);
+  }
+  if (fReflections) {
+    for (Int_t ipar = 0; ipar < fNParsRfl; ipar++) {
+      fRflFunc->SetParameter(ipar, fTotFunc->GetParameter(ipar + fNParsBkg + fNParsSig + fNParsSec));
+      fRflFunc->SetParError(ipar, fTotFunc->GetParError(ipar + fNParsBkg + fNParsSig + fNParsSec));
+      fBkRFunc->SetParameter(ipar + fNParsBkg, fTotFunc->GetParameter(ipar + fNParsBkg + fNParsSig + fNParsSec));
+      fBkRFunc->SetParError(ipar + fNParsBkg, fTotFunc->GetParError(ipar + fNParsBkg + fNParsSig + fNParsSec));
+    }
+    for (Int_t ipar = 0; ipar < fNParsBkg; ipar++) {
+      fBkRFunc->SetParameter(ipar, fTotFunc->GetParameter(ipar));
+      fBkRFunc->SetParError(ipar, fTotFunc->GetParError(ipar));
+    }
+    fRflFunc->SetLineColor(kGreen + 1);
+    fBkRFunc->SetLineColor(kRed + 1);
+    fBkRFunc->SetLineStyle(7);
+  }
+  fMass = fSigFunc->GetParameter(1);
+  fMassErr = fSigFunc->GetParError(1);
+  fSigmaSgn = fSigFunc->GetParameter(2);
+  fSigmaSgnErr = fSigFunc->GetParError(2);
+  fTotFunc->SetLineColor(4);
+  fRawYield = fTotFunc->GetParameter(fNParsBkg) / fHistoInvMass->GetBinWidth(1);
+  fRawYieldErr = fTotFunc->GetParError(fNParsBkg) / fHistoInvMass->GetBinWidth(1);
+  fRawYieldHelp = fRawYield;
+  if (draw)
+    DrawFit();
+  if (doFinalFit)
+    return 1;
+  else
+    return 2;
+}
+//______________________________________________________________________________
+void HFMassFitter::DrawFit()
+{
+  /// Steering method to draw the fit output
+  ///
+
+  TCanvas* c0 = new TCanvas("c0");
+  DrawHere(c0);
+}
+//______________________________________________________________________________
+void HFMassFitter::DrawHere(TVirtualPad* c, Double_t nsigma, Int_t writeFitInfo)
+{
+  /// Core method to draw the fit output
+  ///
+
+  gStyle->SetOptStat(0);
+  gStyle->SetCanvasColor(0);
+  gStyle->SetFrameFillColor(0);
+  c->cd();
+  fHistoInvMass->GetXaxis()->SetRangeUser(fMinMass, fMaxMass);
+  fHistoInvMass->SetMarkerStyle(20);
+  fHistoInvMass->SetMinimum(0.);
+  fHistoInvMass->Draw("PE");
+  if (fBkgFunc)
+    fBkgFunc->Draw("same");
+  if (fBkgFuncRefit)
+    fBkgFuncRefit->Draw("same");
+  if (fBkRFunc)
+    fBkRFunc->Draw("same");
+  if (fRflFunc)
+    fRflFunc->Draw("same");
+  if (fSecFunc)
+    fSecFunc->Draw("same");
+  if (fTotFunc)
+    fTotFunc->Draw("same");
+
+  if (writeFitInfo > 0) {
+    TPaveText* pinfos = new TPaveText(0.12, 0.65, 0.47, 0.89, "NDC");
+    TPaveText* pinfom = new TPaveText(0.6, 0.7, 1., .87, "NDC");
+    pinfos->SetBorderSize(0);
+    pinfos->SetFillStyle(0);
+    pinfom->SetBorderSize(0);
+    pinfom->SetFillStyle(0);
+    if (fTotFunc) {
+      pinfom->SetTextColor(kBlue);
+      for (Int_t ipar = 1; ipar < fNParsSig; ipar++) {
+        TString str = Form("%s = %.3f #pm %.3f", fTotFunc->GetParName(ipar + fNParsBkg), fTotFunc->GetParameter(ipar + fNParsBkg), fTotFunc->GetParError(ipar + fNParsBkg));
+        if (fTotFunc->GetParameter(fNParsBkg + fNParsSig - 2) < 0.2)
+          str = Form("%s = %.3f #pm %.3f", fTotFunc->GetParName(ipar + fNParsBkg), fTotFunc->GetParameter(ipar + fNParsBkg) * 1000, fTotFunc->GetParError(ipar + fNParsBkg) * 1000);
+        pinfom->AddText(str);
+      }
+      if (writeFitInfo >= 1)
+        pinfom->Draw();
+
+      Double_t bkg, errbkg;
+      Background(nsigma, bkg, errbkg);
+      Double_t signif, errsignif;
+      Significance(nsigma, signif, errsignif);
+
+      pinfos->AddText(Form("S = %.0f #pm %.0f ", fRawYield, fRawYieldErr));
+      pinfos->AddText(Form("B (%.0f#sigma) = %.0f #pm %.0f", nsigma, bkg, errbkg));
+      pinfos->AddText(Form("S/B (%.0f#sigma) = %.4g ", nsigma, fRawYield / bkg));
+      if (fRflFunc)
+        pinfos->AddText(Form("Refl/Sig =  %.3f #pm %.3f ", fRflFunc->GetParameter(0), fRflFunc->GetParError(0)));
+      pinfos->AddText(Form("Signif (%.0f#sigma) = %.1f #pm %.1f ", nsigma, signif, errsignif));
+      if (writeFitInfo >= 2)
+        pinfos->Draw();
+    }
+  }
+  c->Update();
+  return;
+}
+//______________________________________________________________________________
+void HFMassFitter::DrawHistoMinusFit(TVirtualPad* c, Int_t writeFitInfo)
+{
+  /// Core method to draw the fit output
+  ///
+
+  gStyle->SetOptStat(0);
+  gStyle->SetCanvasColor(0);
+  gStyle->SetFrameFillColor(0);
+  c->cd();
+  TH1F* hInvMassMinusFit = (TH1F*)fHistoInvMass->Clone(Form("%sMinusFit", fHistoInvMass->GetName()));
+  hInvMassMinusFit->Reset("ICEM");
+  Double_t ymin = 0;
+  Double_t ymax = 1;
+  for (Int_t jst = 1; jst <= fHistoInvMass->GetNbinsX(); jst++) {
+    Double_t integBkg = fBkgFuncRefit->Integral(fHistoInvMass->GetBinLowEdge(jst), fHistoInvMass->GetBinLowEdge(jst) + fHistoInvMass->GetBinWidth(jst)) / fHistoInvMass->GetBinWidth(jst);
+    hInvMassMinusFit->SetBinContent(jst, fHistoInvMass->GetBinContent(jst) - integBkg);
+    hInvMassMinusFit->SetBinError(jst, fHistoInvMass->GetBinError(jst));
+    if (hInvMassMinusFit->GetBinCenter(jst) > fMinMass && hInvMassMinusFit->GetBinCenter(jst) < fMaxMass) {
+      if (hInvMassMinusFit->GetBinContent(jst) + hInvMassMinusFit->GetBinError(jst) > ymax)
+        ymax = hInvMassMinusFit->GetBinContent(jst) + hInvMassMinusFit->GetBinError(jst);
+      if (hInvMassMinusFit->GetBinContent(jst) - hInvMassMinusFit->GetBinError(jst) < ymin)
+        ymin = hInvMassMinusFit->GetBinContent(jst) - hInvMassMinusFit->GetBinError(jst);
+    }
+  }
+  hInvMassMinusFit->GetXaxis()->SetRangeUser(fMinMass, fMaxMass);
+  hInvMassMinusFit->SetMarkerStyle(20);
+  hInvMassMinusFit->SetMinimum(ymin - 0.08 * TMath::Abs(ymin));
+  hInvMassMinusFit->SetMaximum(ymax + 0.08 * TMath::Abs(ymax));
+  hInvMassMinusFit->DrawCopy();
+  if (fSigFunc)
+    fSigFunc->Draw("same");
+  if (fRflFunc)
+    fRflFunc->Draw("same");
+  if (fSecFunc)
+    fSecFunc->Draw("same");
+  if (writeFitInfo > 0) {
+    TPaveText* pinfom = new TPaveText(0.15, 0.6, 0.48, .87, "NDC");
+    pinfom->SetBorderSize(0);
+    pinfom->SetFillStyle(0);
+    if (fTotFunc) {
+      for (Int_t ipar = 1; ipar < fNParsSig; ipar++) {
+        TString str = Form("%s = %.3f #pm %.3f", fTotFunc->GetParName(ipar + fNParsBkg), fTotFunc->GetParameter(ipar + fNParsBkg), fTotFunc->GetParError(ipar + fNParsBkg));
+        if (fTotFunc->GetParameter(fNParsBkg + fNParsSig - 2) < 0.2)
+          str = Form("%s = %.3f #pm %.3f", fTotFunc->GetParName(ipar + fNParsBkg), fTotFunc->GetParameter(ipar + fNParsBkg) * 1000, fTotFunc->GetParError(ipar + fNParsBkg) * 1000);
+        pinfom->AddText(str);
+      }
+      pinfom->AddText(Form("S = %.0f #pm %.0f ", fRawYield, fRawYieldErr));
+      if (fRflFunc)
+        pinfom->AddText(Form("Refl/Sig =  %.3f #pm %.3f ", fRflFunc->GetParameter(0), fRflFunc->GetParError(0)));
+      pinfom->Draw();
+    }
+  }
+  c->Update();
+  return;
+}
+//______________________________________________________________________________
+Double_t HFMassFitter::CheckForSignal(Double_t mean, Double_t sigma)
+{
+  /// Checks if there are signal counts above the background
+  ///   in the invariant mass region of the peak
+
+  Double_t minForSig = mean - 4. * sigma;
+  Double_t maxForSig = mean + 4. * sigma;
+  Int_t binForMinSig = fHistoInvMass->FindBin(minForSig);
+  Int_t binForMaxSig = fHistoInvMass->FindBin(maxForSig);
+  Double_t sum = 0.;
+  Double_t sumback = 0.;
+  fBkgFunc->Print();
+  for (Int_t ibin = binForMinSig; ibin <= binForMaxSig; ibin++) {
+    sum += fHistoInvMass->GetBinContent(ibin);
+    sumback += fBkgFunc->Eval(fHistoInvMass->GetBinCenter(ibin));
+  }
+  Double_t diffUnderPeak = (sum - sumback);
+  printf("   ---> IntegralUnderHisto=%f  IntegralUnderBkgFunc=%f   EstimatedSignal=%f\n", sum, sumback, diffUnderPeak);
+  if (diffUnderPeak / TMath::Sqrt(sum) < 1.) {
+    printf("   ---> (Tot-Bkg)/sqrt(Tot)=%f ---> Likely no signal\n", diffUnderPeak / TMath::Sqrt(sum));
+    return -1;
+  }
+  return diffUnderPeak * fHistoInvMass->GetBinWidth(1);
+}
+
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateBackgroundFitFunction(TString fname, Double_t integral)
+{
+  /// Creates the background fit fucntion
+  ///
+
+  SetNumberOfParams();
+  TF1* funcbkg = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4Bkg, fMinMass, fMaxMass, fNParsBkg, "HFMassFitter", "FitFunction4Bkg");
+  switch (fTypeOfFit4Bkg) {
+    case 0: // gaus+expo
+      funcbkg->SetParNames("BkgInt", "Slope");
+      funcbkg->SetParameters(integral, -2.);
+      break;
+    case 1:
+      funcbkg->SetParNames("BkgInt", "Slope");
+      funcbkg->SetParameters(integral, -100.);
+      break;
+    case 2:
+      funcbkg->SetParNames("BkgInt", "Coef1", "Coef2");
+      funcbkg->SetParameters(integral, -10., 5);
+      break;
+    case 3:
+      funcbkg->SetParNames("Const");
+      funcbkg->SetParameter(0, 0.);
+      funcbkg->FixParameter(0, 0.);
+      break;
+    case 4:
+      funcbkg->SetParNames("BkgInt", "Coef1");
+      funcbkg->SetParameters(integral, 0.5);
+      break;
+    case 5:
+      funcbkg->SetParNames("Coef1", "Coef2");
+      funcbkg->SetParameters(-10., 5.);
+      break;
+    case 6:
+      for (Int_t j = 0; j < fNParsBkg; j++) {
+        funcbkg->SetParName(j, Form("Coef%d", j));
+        funcbkg->SetParameter(j, 0);
+      }
+      funcbkg->SetParameter(0, integral);
+      break;
+    default:
+      cout << "Wrong choice of fTypeOfFit4Bkg" << fTypeOfFit4Bkg << endl;
+      delete funcbkg;
+      return 0x0;
+      break;
+  }
+  //  if(fFixToHistoIntegral) funcbkg->FixParameter(0,integral);
+  funcbkg->SetLineColor(kBlue + 3);
+  return funcbkg;
+}
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateSecondPeakFunction(TString fname, Double_t integsig)
+{
+  /// Creates a function for a gaussian peak in the background fit function
+  /// Can be used e.g. to include the D+->KKpi peak in the D_s inv. mass fit
+
+  TF1* funcsec = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4SecPeak, fMinMass, fMaxMass, 3, "HFMassFitter", "FitFunction4SecPeak");
+  funcsec->SetParameter(0, integsig);
+  funcsec->SetParameter(1, fSecMass);
+  if (fFixSecMass)
+    funcsec->FixParameter(1, fSecMass);
+  funcsec->SetParameter(2, fSecWidth);
+  if (fFixSecWidth)
+    funcsec->FixParameter(2, fSecWidth);
+  funcsec->SetParNames("SecPeakInt", "SecMean", "SecSigma");
+  return funcsec;
+}
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateReflectionFunction(TString fname)
+{
+  /// Creates a function for reflections contribution
+  /// in the D0->Kpi inv. mass distribution
+  TF1* funcrfl = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4Refl, fMinMass, fMaxMass, 1, "HFMassFitter", "FitFunction4Refl");
+  funcrfl->SetParameter(0, fRflOverSig);
+  funcrfl->SetParLimits(0, 0., 1.);
+  if (fFixRflOverSig)
+    funcrfl->FixParameter(0, fRflOverSig);
+  funcrfl->SetParNames("ReflOverS");
+  return funcrfl;
+}
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateBackgroundPlusReflectionFunction(TString fname)
+{
+  /// Creates the function with sum of background and reflections
+  ///
+  SetNumberOfParams();
+  Int_t totParams = fNParsBkg + fNParsRfl;
+  TF1* fbr = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4BkgAndRefl, fMinMass, fMaxMass, totParams, "HFMassFitter", "FitFunction4BkgAndRefl");
+  for (Int_t ipar = 0; ipar < fNParsBkg; ipar++) {
+    fbr->SetParameter(ipar, fBkgFunc->GetParameter(ipar));
+    fbr->SetParName(ipar, fBkgFunc->GetParName(ipar));
+  }
+  for (Int_t ipar = 0; ipar < fNParsRfl; ipar++) {
+    fbr->SetParameter(ipar + fNParsBkg, fRflFunc->GetParameter(ipar));
+    fbr->SetParName(ipar + fNParsBkg, fRflFunc->GetParName(ipar));
+    // par limits not set because this function is not used for fitting but only for drawing
+  }
+  return fbr;
+}
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateSignalFitFunction(TString fname, Double_t integsig)
+{
+  /// Creates the fit function for the signal peak
+  ///
+
+  SetNumberOfParams();
+  TF1* funcsig = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4Sgn, fMinMass, fMaxMass, fNParsSig, "HFMassFitter", "FitFunction4Sgn");
+  if (fTypeOfFit4Sgn == kGaus) {
+    funcsig->SetParameter(0, integsig);
+    if (fFixedRawYield > -0.1)
+      funcsig->FixParameter(0, fFixedRawYield);
+    funcsig->SetParameter(1, fMass);
+    if (fFixedMean)
+      funcsig->FixParameter(1, fMass);
+    if (fBoundMean)
+      funcsig->SetParLimits(1, fMassLowerLim, fMassUpperLim);
+    funcsig->SetParameter(2, fSigmaSgn);
+    if (fFixedSigma)
+      funcsig->FixParameter(2, fSigmaSgn);
+    if (fBoundSigma)
+      funcsig->SetParLimits(2, fSigmaVar * (1 - fParSig), fSigmaVar * (1 + fParSig));
+    funcsig->SetParNames("SgnInt", "Mean", "Sigma");
+  }
+  if (fTypeOfFit4Sgn == k2Gaus) {
+    funcsig->SetParameter(0, integsig);
+    if (fFixedRawYield > -0.1)
+      funcsig->FixParameter(0, fFixedRawYield);
+    funcsig->SetParameter(1, fMass);
+    if (fFixedMean)
+      funcsig->FixParameter(1, fMass);
+    if (fBoundMean)
+      funcsig->SetParLimits(1, fMassLowerLim, fMassUpperLim);
+    funcsig->SetParameter(2, fSigmaSgn);
+    funcsig->SetParLimits(2, 0.004, 0.05);
+    if (fFixedSigma)
+      funcsig->FixParameter(2, fSigmaSgn);
+    if (fBoundSigma)
+      funcsig->SetParLimits(2, fSigmaVar * (1 - fParSig), fSigmaVar * (1 + fParSig));
+    funcsig->SetParameter(3, fFrac2Gaus);
+    if (fFixedFrac2Gaus)
+      funcsig->FixParameter(3, fFrac2Gaus);
+    else
+      funcsig->SetParLimits(3, 0., 1.);
+    funcsig->SetParameter(4, fSigmaSgn2Gaus);
+    if (fFixedSigma2Gaus)
+      funcsig->FixParameter(4, fSigmaSgn2Gaus);
+    else
+      funcsig->SetParLimits(4, 0.004, 0.05);
+    funcsig->SetParNames("SgnInt", "Mean", "Sigma1", "Frac", "Sigma2");
+  }
+  if (fTypeOfFit4Sgn == k2GausSigmaRatioPar) {
+    funcsig->SetParameter(0, integsig);
+    if (fFixedRawYield > -0.1)
+      funcsig->FixParameter(0, fFixedRawYield);
+    funcsig->SetParameter(1, fMass);
+    if (fFixedMean)
+      funcsig->FixParameter(1, fMass);
+    if (fBoundMean)
+      funcsig->SetParLimits(1, fMassLowerLim, fMassUpperLim);
+    funcsig->SetParameter(2, fSigmaSgn);
+    funcsig->SetParLimits(2, 0.004, 0.05);
+    if (fFixedSigma)
+      funcsig->FixParameter(2, fSigmaSgn);
+    if (fBoundSigma)
+      funcsig->SetParLimits(2, fSigmaVar * (1 - fParSig), fSigmaVar * (1 + fParSig));
+    funcsig->SetParameter(3, fFrac2Gaus);
+    if (fFixedFrac2Gaus)
+      funcsig->FixParameter(3, fFrac2Gaus);
+    else
+      funcsig->SetParLimits(3, 0., 1.);
+    funcsig->SetParameter(4, fSigmaSgn2Gaus);
+    if (fFixedRatio2GausSigma)
+      funcsig->FixParameter(4, fRatio2GausSigma);
+    else
+      funcsig->SetParLimits(4, 0., 20.);
+    funcsig->SetParNames("SgnInt", "Mean", "Sigma1", "Frac", "RatioSigma12");
+  }
+  return funcsig;
+}
+
+//______________________________________________________________________________
+TF1* HFMassFitter::CreateTotalFitFunction(TString fname)
+{
+  /// Creates the total fit fucntion (signal+background+possible second peak)
+  ///
+
+  SetNumberOfParams();
+  Int_t totParams = fNParsBkg + fNParsRfl + fNParsSec + fNParsSig;
+  TF1* ftot = new TF1(fname.Data(), this, &HFMassFitter::FitFunction4Mass, fMinMass, fMaxMass, totParams, "HFMassFitter", "FitFunction4Mass");
+  for (Int_t ipar = 0; ipar < fNParsBkg; ipar++) {
+    ftot->SetParameter(ipar, fBkgFunc->GetParameter(ipar));
+    ftot->SetParName(ipar, fBkgFunc->GetParName(ipar));
+    // Double_t parmin,parmax;
+    // fBkgFunc->GetParLimits(ipar,parmin,parmax);
+    // ftot->SetParLimits(ipar,parmin,parmax);
+  }
+  for (Int_t ipar = 0; ipar < fNParsSig; ipar++) {
+    ftot->SetParameter(ipar + fNParsBkg, fSigFunc->GetParameter(ipar));
+    ftot->SetParName(ipar + fNParsBkg, fSigFunc->GetParName(ipar));
+    Double_t parmin, parmax;
+    fSigFunc->GetParLimits(ipar, parmin, parmax);
+    ftot->SetParLimits(ipar + fNParsBkg, parmin, parmax);
+  }
+  if (fSecondPeak && fSecFunc) {
+    for (Int_t ipar = 0; ipar < fNParsSec; ipar++) {
+      ftot->SetParameter(ipar + fNParsBkg + fNParsSig, fSecFunc->GetParameter(ipar));
+      ftot->SetParName(ipar + fNParsBkg + fNParsSig, fSecFunc->GetParName(ipar));
+      Double_t parmin, parmax;
+      fSecFunc->GetParLimits(ipar, parmin, parmax);
+      ftot->SetParLimits(ipar + fNParsBkg + fNParsSig, parmin, parmax);
+    }
+  }
+  if (fReflections && fRflFunc) {
+    for (Int_t ipar = 0; ipar < fNParsRfl; ipar++) {
+      ftot->SetParameter(ipar + fNParsBkg + fNParsSig + fNParsSec, fRflFunc->GetParameter(ipar));
+      ftot->SetParName(ipar + fNParsBkg + fNParsSig + fNParsSec, fRflFunc->GetParName(ipar));
+      Double_t parmin, parmax;
+      fRflFunc->GetParLimits(ipar, parmin, parmax);
+      ftot->SetParLimits(ipar + fNParsBkg + fNParsSig + fNParsSec, parmin, parmax);
+    }
+  }
+  return ftot;
+}
+//__________________________________________________________________________
+Double_t HFMassFitter::FitFunction4Bkg(Double_t* x, Double_t* par)
+{
+  /// Fit function for the background
+  ///
+
+  Double_t maxDeltaM = fNSigma4SideBands * fSigmaSgn;
+  if (fOnlySideBands && TMath::Abs(x[0] - fMass) < maxDeltaM) {
+    TF1::RejectPoint();
+    return 0;
+  }
+  if (fOnlySideBands && fSecondPeak && TMath::Abs(x[0] - fSecMass) < (fNSigma4SideBands * fSecWidth)) {
+    TF1::RejectPoint();
+    return 0;
+  }
+  Double_t total = 0;
+
+  switch (fTypeOfFit4Bkg) {
+    case 0:
+      // exponential
+      // exponential = A*exp(B*x) -> integral(exponential)=A/B*exp(B*x)](min,max)
+      //-> A = B*integral/(exp(B*max)-exp(B*min)) where integral can be written
+      // as integralTot- integralGaus (=par [2])
+      // Par:
+      //  * [0] = integralBkg;
+      //  * [1] = B;
+      // exponential = [1]*[0]/(exp([1]*max)-exp([1]*min))*exp([1]*x)
+      total = par[0] * par[1] / (TMath::Exp(par[1] * fMaxMass) - TMath::Exp(par[1] * fMinMass)) * TMath::Exp(par[1] * x[0]);
+      //    cout << Background function set to: exponential"<<endl;
+      break;
+    case 1:
+      // linear
+      // y=a+b*x -> integral = a(max-min)+1/2*b*(max^2-min^2) -> a = (integral-1/2*b*(max^2-min^2))/(max-min)=integral/(max-min)-1/2*b*(max+min)
+      //  * [0] = integralBkg;
+      //  * [1] = b;
+      total = par[0] / (fMaxMass - fMinMass) + par[1] * (x[0] - 0.5 * (fMaxMass + fMinMass));
+      //    cout<< "Background function set to: linear"<<endl;
+      break;
+    case 2:
+      // parabola
+      // y=a+b*x+c*x**2 -> integral = a(max-min) + 1/2*b*(max^2-min^2) +
+      //+ 1/3*c*(max^3-min^3) ->
+      // a = (integral-1/2*b*(max^2-min^2)-1/3*c*(max^3-min^3))/(max-min)
+      //  * [0] = integralBkg;
+      //  * [1] = b;
+      //  * [2] = c;
+      total = par[0] / (fMaxMass - fMinMass) + par[1] * (x[0] - 0.5 * (fMaxMass + fMinMass)) + par[2] * (x[0] * x[0] - 1 / 3. * (fMaxMass * fMaxMass * fMaxMass - fMinMass * fMinMass * fMinMass) / (fMaxMass - fMinMass));
+      //    cout << "Background function set to: polynomial"<<endl;
+      break;
+    case 3:
+      total = par[0];
+      break;
+    case 4:
+      // power function
+      // y=a(x-m_pi)^b -> integral = a/(b+1)*((max-m_pi)^(b+1)-(min-m_pi)^(b+1))
+      //
+      // a = integral*(b+1)/((max-m_pi)^(b+1)-(min-m_pi)^(b+1))
+      //  * [0] = integralBkg;
+      //  * [1] = b;
+      //  a(power function) = [0]*([1]+1)/((max-m_pi)^([1]+1)-(min-m_pi)^([1]+1))*(x-m_pi)^[1]
+      {
+        Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
+
+        total = par[0] * (par[1] + 1.) / (TMath::Power(fMaxMass - mpi, par[1] + 1.) - TMath::Power(fMinMass - mpi, par[1] + 1.)) * TMath::Power(x[0] - mpi, par[1]);
+        //    cout<<"Background function set to: powerlaw"<<endl;
+      }
+      break;
+    case 5:
+      // power function wit exponential
+      // y=a*Sqrt(x-m_pi)*exp(-b*(x-m_pi))
+      {
+        Double_t mpi = TDatabasePDG::Instance()->GetParticle(211)->Mass();
+
+        total = par[0] * TMath::Sqrt(x[0] - mpi) * TMath::Exp(-1. * par[1] * (x[0] - mpi));
+        //    cout << "Background function set to: wit exponential"<<endl;
+      }
+      break;
+    case 6:
+      // the following comment must be removed
+      //     // pol 3, following convention for pol 2
+      //     //y=a+b*x+c*x**2+d*x**3 -> integral = a(max-min) + 1/2*b*(max^2-min^2) +
+      //     //+ 1/3*c*(max^3-min^3) + 1/4 d * (max^4-min^4) ->
+      //     //a = (integral-1/2*b*(max^2-min^2)-1/3*c*(max^3-min^3) - 1/4 d * (max^4-min^4) )/(max-min)
+      //     // * [0] = integralBkg;
+      //     // * [1] = b;
+      //     // * [2] = c;
+      //     // * [3] = d;
+      {
+        total = par[0];
+        for (Int_t it = 1; it <= fPolDegreeBkg; it++) {
+          total += par[it] * TMath::Power(x[0] - fMassParticle, it) / TMath::Factorial(it);
+        }
+      }
+      break;
+  }
+  return total;
+}
+//_________________________________________________________________________
+Double_t HFMassFitter::FitFunction4Sgn(Double_t* x, Double_t* par)
+{
+  /// Fit function for the signal
+  ///
+
+  //  cout << "Signal function set to: Gaussian"<< endl;
+  Double_t sigval = 0;
+  Double_t g1 = 0;
+  Double_t g2 = 0;
+  switch (fTypeOfFit4Sgn) {
+    case 0:
+      // gaussian = A/(sigma*sqrt(2*pi))*exp(-(x-mean)^2/2/sigma^2)
+      // Par:
+      //  * [0] = integralSgn
+      //  * [1] = mean
+      //  * [2] = sigma
+      // gaussian = [0]/TMath::Sqrt(2.*TMath::Pi())/[2]*exp[-(x-[1])*(x-[1])/(2*[2]*[2])]
+      sigval = par[0] / TMath::Sqrt(2. * TMath::Pi()) / par[2] * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / par[2] / par[2]);
+      break;
+    case 1:
+      // double gaussian = A/(sigma*sqrt(2*pi))*exp(-(x-mean)^2/2/sigma^2)
+      // Par:
+      //  * [0] = integralSgn
+      //  * [1] = mean
+      //  * [2] = sigma1
+      //  * [3] = 2nd gaussian ratio
+      //  * [4] = deltaSigma
+      // gaussian = [0]/TMath::Sqrt(2.*TMath::Pi())/[2]*exp[-(x-[1])*(x-[1])/(2*[2]*[2])]
+      g1 = (1. - par[3]) / TMath::Sqrt(2. * TMath::Pi()) / par[2] * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / par[2] / par[2]);
+      g2 = par[3] / TMath::Sqrt(2. * TMath::Pi()) / par[4] * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / par[4] / par[4]);
+      sigval = par[0] * (g1 + g2);
+      break;
+    case 2:
+      // double gaussian = A/(sigma*sqrt(2*pi))*exp(-(x-mean)^2/2/sigma^2)
+      // Par:
+      //  * [0] = integralSgn
+      //  * [1] = mean
+      //  * [2] = sigma1
+      //  * [3] = 2nd gaussian ratio
+      //  * [4] = ratio sigma12
+      g1 = (1. - par[3]) / TMath::Sqrt(2. * TMath::Pi()) / par[2] * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / par[2] / par[2]);
+      g2 = par[3] / TMath::Sqrt(2. * TMath::Pi()) / (par[4] * par[2]) * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / (par[4] * par[2]) / (par[4] * par[2]));
+      sigval = par[0] * (g1 + g2);
+      break;
+  }
+  fRawYieldHelp = par[0] / fHistoInvMass->GetBinWidth(1);
+  return sigval;
+}
+//_________________________________________________________________________
+Double_t HFMassFitter::FitFunction4Refl(Double_t* x, Double_t* par)
+{
+  /// Fit function for reflections:
+  /// D0->Kpi decays with swapped mass assignment to pion and kaon decay tracks
+  if (!fHistoTemplRfl)
+    return 0;
+
+  Int_t bin = fHistoTemplRfl->FindBin(x[0]);
+  Double_t value = fHistoTemplRfl->GetBinContent(bin);
+  Int_t binmin = fHistoTemplRfl->FindBin(fMinMass * 1.00001);
+  Int_t binmax = fHistoTemplRfl->FindBin(fMaxMass * 0.99999);
+  Double_t norm = fHistoTemplRfl->Integral(binmin, binmax) * fHistoTemplRfl->GetBinWidth(bin);
+  if (TMath::Abs(value) < 1.e-14 && fSmoothRfl) { // very rough, assume a constant trend, much better would be a pol1 or pol2 over a broader range
+    value += fHistoTemplRfl->GetBinContent(bin - 1) + fHistoTemplRfl->GetBinContent(bin + 1);
+    value /= 3.;
+  }
+  return par[0] * value / norm * fRawYieldHelp * fHistoInvMass->GetBinWidth(1);
+}
+//_________________________________________________________________________
+Double_t HFMassFitter::FitFunction4BkgAndRefl(Double_t* x, Double_t* par)
+{
+  /// Fit fucntion with the sum of background and reflections
+  ///
+  Double_t bkg = FitFunction4Bkg(x, par);
+  Double_t refl = 0;
+  if (fReflections)
+    refl = FitFunction4Refl(x, &par[fNParsBkg]);
+  return bkg + refl;
+}
+//_________________________________________________________________________
+Double_t HFMassFitter::FitFunction4SecPeak(Double_t* x, Double_t* par)
+{
+  /// Fit function for a second gaussian peak
+  /// To be used, e.g., for D+->KKpi in the Ds mass spectrum
+
+  // gaussian = A/(sigma*sqrt(2*pi))*exp(-(x-mean)^2/2/sigma^2)
+  // Par:
+  //  * [0] = integralSgn
+  //  * [1] = mean
+  //  * [2] = sigma
+  Double_t secgaval = par[0] / TMath::Sqrt(2. * TMath::Pi()) / par[2] * TMath::Exp(-(x[0] - par[1]) * (x[0] - par[1]) / 2. / par[2] / par[2]);
+  return secgaval;
+}
+//_________________________________________________________________________
+Double_t HFMassFitter::FitFunction4Mass(Double_t* x, Double_t* par)
+{
+  /// Total fit function (signal+background+possible second peak)
+  ///
+
+  Double_t bkg = FitFunction4Bkg(x, par);
+  Double_t sig = FitFunction4Sgn(x, &par[fNParsBkg]);
+  Double_t sec = 0.;
+  if (fSecondPeak)
+    sec = FitFunction4SecPeak(x, &par[fNParsBkg + fNParsSig]);
+  Double_t refl = 0;
+  if (fReflections)
+    refl = FitFunction4Refl(x, &par[fNParsBkg + fNParsSig + fNParsSec]);
+  return bkg + sig + sec + refl;
+}
+
+//_________________________________________________________________________
+void HFMassFitter::Signal(Double_t nOfSigma, Double_t& signal, Double_t& errsignal) const
+{
+  /// Return signal integral in mean +- n sigma
+  ///
+
+  Double_t minMass = fMass - nOfSigma * fSigmaSgn;
+  Double_t maxMass = fMass + nOfSigma * fSigmaSgn;
+  Signal(minMass, maxMass, signal, errsignal);
+  return;
+}
+
+//_________________________________________________________________________
+void HFMassFitter::Signal(Double_t min, Double_t max, Double_t& signal, Double_t& errsignal) const
+{
+  /// Return signal integral in a range
+  ///
+
+  signal = fSigFunc->Integral(min, max) / (Double_t)fHistoInvMass->GetBinWidth(1);
+  errsignal = (fRawYieldErr / fRawYield) * signal; /*assume relative error is the same as for total integral*/
+  return;
+}
+
+//___________________________________________________________________________
+void HFMassFitter::Background(Double_t nOfSigma, Double_t& background, Double_t& errbackground) const
+{
+  /// Return background integral in mean +- n sigma
+  ///
+
+  Double_t minMass = fMass - nOfSigma * fSigmaSgn;
+  Double_t maxMass = fMass + nOfSigma * fSigmaSgn;
+  Background(minMass, maxMass, background, errbackground);
+  return;
+}
+//___________________________________________________________________________
+void HFMassFitter::Background(Double_t min, Double_t max, Double_t& background, Double_t& errbackground) const
+{
+  /// Return background integral in a range
+  ///
+
+  TF1* funcbkg = 0x0;
+  if (fBkgFuncRefit)
+    funcbkg = fBkgFuncRefit;
+  else if (fBkgFunc)
+    funcbkg = fBkgFunc;
+  if (!funcbkg) {
+    cout << "Bkg function not found!" << endl;
+    return;
+  }
+
+  Double_t intB = funcbkg->GetParameter(0);
+  Double_t intBerr = funcbkg->GetParError(0);
+
+  // relative error evaluation: from histo
+
+  Int_t leftBand = fHistoInvMass->FindBin(fMass - fNSigma4SideBands * fSigmaSgn);
+  Int_t rightBand = fHistoInvMass->FindBin(fMass + fNSigma4SideBands * fSigmaSgn);
+  intB = fHistoInvMass->Integral(1, leftBand) + fHistoInvMass->Integral(rightBand, fHistoInvMass->GetNbinsX());
+  Double_t sum2 = 0;
+  for (Int_t i = 1; i <= leftBand; i++) {
+    sum2 += fHistoInvMass->GetBinError(i) * fHistoInvMass->GetBinError(i);
+  }
+  for (Int_t i = rightBand; i <= fHistoInvMass->GetNbinsX(); i++) {
+    sum2 += fHistoInvMass->GetBinError(i) * fHistoInvMass->GetBinError(i);
+  }
+
+  intBerr = TMath::Sqrt(sum2);
+
+  background = funcbkg->Integral(min, max) / (Double_t)fHistoInvMass->GetBinWidth(1);
+  errbackground = intBerr / intB * background;
+
+  return;
+}
+//__________________________________________________________________________
+
+void HFMassFitter::Significance(Double_t nOfSigma, Double_t& significance, Double_t& errsignificance) const
+{
+  /// Return significance in mean +- n sigma
+  ///
+
+  Double_t minMass = fMass - nOfSigma * fSigmaSgn;
+  Double_t maxMass = fMass + nOfSigma * fSigmaSgn;
+  Significance(minMass, maxMass, significance, errsignificance);
+
+  return;
+}
+
+//__________________________________________________________________________
+
+void HFMassFitter::Significance(Double_t min, Double_t max, Double_t& significance, Double_t& errsignificance) const
+{
+  /// Return significance integral in a range
+  ///
+
+  Double_t background, errbackground;
+  Background(min, max, background, errbackground);
+
+  Double_t errSigSq = fRawYieldErr * fRawYieldErr;
+  Double_t errBkgSq = errbackground * errbackground;
+  Double_t sigPlusBkg = fRawYield + background;
+  if (sigPlusBkg > 0. && fRawYield > 0.) {
+    significance = fRawYield / TMath::Sqrt(fRawYield + background);
+    errsignificance = significance * TMath::Sqrt((errSigSq + errBkgSq) / (4. * sigPlusBkg * sigPlusBkg) + (background / sigPlusBkg) * errSigSq / fRawYield / fRawYield);
+  } else {
+    significance = 0.;
+    errsignificance = 0.;
+  }
+  return;
+}
+//________________________________________________________________________
+Bool_t HFMassFitter::PrepareHighPolFit(TF1* fback)
+{
+  /// Perform intermediate fit steps up to fPolDegreeBkg-1
+  /// in case of fit with a polynomial with degree > 2 (fTypeOfFit4Bkg=6)
+
+  Double_t estimatecent = 0.5 * (fHistoInvMass->GetBinContent(fHistoInvMass->FindBin(fMass - 3.5 * fSigmaSgn)) + fHistoInvMass->GetBinContent(fHistoInvMass->FindBin(fMass + 3.5 * fSigmaSgn)));              // just a first rough estimate
+  Double_t estimateslope = (fHistoInvMass->GetBinContent(fHistoInvMass->FindBin(fMass + 3.5 * fSigmaSgn)) - fHistoInvMass->GetBinContent(fHistoInvMass->FindBin(fMass - 3.5 * fSigmaSgn))) / (7 * fSigmaSgn); // first rough estimate
+
+  fCurPolDegreeBkg = 2;
+  TF1 *funcbkg, *funcPrev = 0x0;
+  while (fCurPolDegreeBkg <= fPolDegreeBkg) {
+    funcbkg = new TF1(Form("temp%d", fCurPolDegreeBkg), this, &HFMassFitter::BackFitFuncPolHelper, fMinMass, fMaxMass, fCurPolDegreeBkg + 1, "HFMassFitter", "BackFitFuncPolHelper");
+    if (funcPrev) {
+      for (Int_t j = 0; j < fCurPolDegreeBkg; j++) { // now is +1 degree w.r.t. previous fit funct
+        funcbkg->SetParameter(j, funcPrev->GetParameter(j));
+      }
+      delete funcPrev;
+    } else {
+      funcbkg->SetParameter(0, estimatecent);
+      funcbkg->SetParameter(1, estimateslope);
+    }
+    printf("   ---> Pre-fit of background with pol degree %d ---\n", fCurPolDegreeBkg);
+    fHistoInvMass->Fit(funcbkg, "REMN", "");
+    funcPrev = (TF1*)funcbkg->Clone("ftemp");
+    delete funcbkg;
+    fCurPolDegreeBkg++;
+  }
+
+  for (Int_t j = 0; j <= fPolDegreeBkg; j++) {
+    fback->SetParameter(j, funcPrev->GetParameter(j));
+    fback->SetParError(j, funcPrev->GetParError(j));
+  }
+  printf("   ---> Final background fit with pol degree %d ---\n", fPolDegreeBkg);
+  fHistoInvMass->Fit(fback, Form("R,%s,+,0", fFitOption.Data())); // THIS IS JUST TO SET NOT ONLY THE PARAMETERS BUT ALSO chi2, etc...
+
+  // The following lines might be useful for debugging
+  //   TCanvas *cDebug=new TCanvas();
+  //   cDebug->cd();
+  //   fHistoInvMass->Draw();
+  //   TString strout=Form("Test%d.root",(Int_t)fhistoInvMass->GetBinContent(fhistoInvMass->FindBin(fMass)));
+  //   cDebug->Print(strout.Data());
+  // delete cDebug;
+
+  delete funcPrev;
+  return kTRUE;
+}
+// _______________________________________________________________________
+Double_t HFMassFitter::BackFitFuncPolHelper(Double_t* x, Double_t* par)
+{
+  /// Helper function for polynomials with degree>2
+  ///
+
+  Double_t maxDeltaM = fNSigma4SideBands * fSigmaSgn;
+  if (fOnlySideBands && TMath::Abs(x[0] - fMass) < maxDeltaM) {
+    TF1::RejectPoint();
+    return 0;
+  }
+  Double_t back = par[0];
+  for (Int_t it = 1; it <= fCurPolDegreeBkg; it++) {
+    back += par[it] * TMath::Power(x[0] - fMassParticle, it) / TMath::Factorial(it);
+  }
+  return back;
+}
+// _______________________________________________________________________
+TH1F* HFMassFitter::SetTemplateReflections(const TH1* h, TString opt, Double_t minRange, Double_t maxRange)
+{
+  /// Method to create the reflection invariant mass distributions from MC templates
+  /// option could be:
+  ///    "template"                use MC histograms
+  ///    "1gaus" ot "singlegaus"   single gaussian function fit to MC templates
+  ///    "2gaus" ot "doublegaus"   double gaussian function fit to MC templates
+  ///    "pol3"                    3rd order polynomial fit to MC templates
+  ///    "pol6"                    6th order polynomial fit to MC templates
+
+  if (!h) {
+    fReflections = kFALSE;
+    return 0x0;
+  }
+  fHistoTemplRfl = (TH1F*)h->Clone("hTemplRfl");
+  opt.ToLower();
+  fReflections = kTRUE;
+  printf("\n--- Reflection templates from simulation ---\n");
+  if (opt.Contains("templ")) {
+    printf("   ---> Reflection contribution using directly the histogram from simulation\n");
+    return fHistoTemplRfl;
+  }
+
+  TF1* f = 0x0;
+  Bool_t isPoissErr = kTRUE;
+  Double_t xMinForFit = h->GetBinLowEdge(1);
+  Double_t xMaxForFit = h->GetXaxis()->GetBinUpEdge(h->GetNbinsX());
+  if (minRange >= 0 && maxRange >= 0) {
+    xMinForFit = TMath::Max(minRange, h->GetBinLowEdge(1));
+    xMaxForFit = TMath::Min(maxRange, h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
+  }
+  if (opt.EqualTo("1gaus") || opt.EqualTo("singlegaus")) {
+    printf("   ---> Reflection contribution from single-Gaussian fit to histogram from simulation\n");
+    f = new TF1("mygaus", "gaus", xMinForFit, xMaxForFit);
+    f->SetParameter(0, h->GetMaximum());
+    //    f->SetParLimits(0,0,100.*h->Integral());
+    f->SetParameter(1, 1.865);
+    f->SetParameter(2, 0.050);
+    fHistoTemplRfl->Fit(f, "REM0", ""); //,h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
+  } else if (opt.EqualTo("2gaus") || opt.EqualTo("doublegaus")) {
+    printf("   ---> Reflection contribution from double-Gaussian fit to histogram from simulation\n");
+    f = new TF1("my2gaus", "[0]*([3]/( TMath::Sqrt(2.*TMath::Pi())*[2])*TMath::Exp(-(x-[1])*(x-[1])/(2.*[2]*[2]))+(1.-[3])/( TMath::Sqrt(2.*TMath::Pi())*[5])*TMath::Exp(-(x-[4])*(x-[4])/(2.*[5]*[5])))", xMinForFit, xMaxForFit);
+    f->SetParameter(0, h->GetMaximum());
+    //    f->SetParLimits(0,0,100.*h->Integral());
+    f->SetParLimits(3, 0., 1.);
+    f->SetParameter(3, 0.5);
+    f->SetParameter(1, 1.84);
+    f->SetParameter(2, 0.050);
+    f->SetParameter(4, 1.88);
+    f->SetParameter(5, 0.050);
+    fHistoTemplRfl->Fit(f, "REM0", ""); //,h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
+  } else if (opt.EqualTo("pol3")) {
+    printf("   ---> Reflection contribution from pol3 fit to histogram from simulation\n");
+    f = new TF1("mypol3", "pol3", xMinForFit, xMaxForFit);
+    f->SetParameter(0, h->GetMaximum());
+    //    f->SetParLimits(0,0,100.*h->Integral());
+    // Hard to initialize the other parameters...
+    fHistoTemplRfl->Fit(f, "REM0", "");
+    //    Printf("We USED %d POINTS in the Fit",f->GetNumberFitPoints());
+  } else if (opt.EqualTo("pol6")) {
+    printf("   ---> Reflection contribution from pol6 fit to histogram from simulation\n");
+    f = new TF1("mypol6", "pol6", xMinForFit, xMaxForFit);
+    f->SetParameter(0, h->GetMaximum());
+    //    f->SetParLimits(0,0,100.*h->Integral());
+    // Hard to initialize the other parameters...
+    fHistoTemplRfl->Fit(f, "RLEMI0", ""); //,h->GetBinLowEdge(1),h->GetXaxis()->GetBinUpEdge(h->GetNbinsX()));
+  } else {
+    // no good option passed
+    printf("   ---> Bad option for reflection configuration -> reflections will not be included in the fit\n");
+    fReflections = kFALSE;
+    delete fHistoTemplRfl;
+    fHistoTemplRfl = 0x0;
+    return 0x0;
+  }
+
+  // Fill fHistoTemplRfl with values of fit function
+  if (f) {
+    for (Int_t j = 1; j <= fHistoTemplRfl->GetNbinsX(); j++) {
+      fHistoTemplRfl->SetBinContent(j, f->Integral(fHistoTemplRfl->GetBinLowEdge(j), fHistoTemplRfl->GetXaxis()->GetBinUpEdge(j)) / fHistoTemplRfl->GetBinWidth(j));
+      if (fHistoTemplRfl->GetBinContent(j) >= 0. && TMath::Abs(h->GetBinError(j) * h->GetBinError(j) - h->GetBinContent(j)) > 0.1 * h->GetBinContent(j))
+        isPoissErr = kFALSE;
+    }
+    for (Int_t j = 1; j <= fHistoTemplRfl->GetNbinsX(); j++) {
+      if (isPoissErr) {
+        if (fHistoTemplRfl->GetBinContent(j) > 0)
+          fHistoTemplRfl->SetBinError(j, TMath::Sqrt(fHistoTemplRfl->GetBinContent(j)));
+        else
+          fHistoTemplRfl->SetBinError(j, 0);
+      } else
+        fHistoTemplRfl->SetBinError(j, 0.001 * fHistoTemplRfl->GetBinContent(j));
+    }
+    fReflections = kTRUE;
+    return fHistoTemplRfl;
+  } else {
+    printf("   ---> Fit to MC template for reflection failed -> reflections will not be included in the fit\n");
+    fReflections = kFALSE;
+    delete fHistoTemplRfl;
+    fHistoTemplRfl = 0x0;
+    return 0x0;
+  }
+  return 0x0;
+}
+// _______________________________________________________________________
+Double_t HFMassFitter::GetRawYieldBinCounting(Double_t& errRyBC, Double_t nOfSigma, Int_t option, Int_t pdgCode) const
+{
+  /// Method to compute the signal using inv. mass histo bin counting
+  /// -> interface method to compute yield in nsigma range around peak
+  /// pdgCode: if==411,421,413,413 or 4122: range defined based on PDG mass
+  //           else (default) mean of gaussian fit
+
+  Double_t massVal = fMass;
+  switch (pdgCode) {
+    case 411:
+    case 421:
+    case 431:
+    case 4122:
+      massVal = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
+      break;
+    case 413:
+      massVal = TDatabasePDG::Instance()->GetParticle(pdgCode)->Mass();
+      massVal -= TDatabasePDG::Instance()->GetParticle(421)->Mass();
+      break;
+    default:
+      massVal = fMass;
+      break;
+  }
+
+  Double_t minMass = massVal - nOfSigma * fSigmaSgn;
+  Double_t maxMass = massVal + nOfSigma * fSigmaSgn;
+  return GetRawYieldBinCounting(errRyBC, minMass, maxMass, option);
+}
+// _______________________________________________________________________
+Double_t HFMassFitter::GetRawYieldBinCounting(Double_t& errRyBC, Double_t minMass, Double_t maxMass, Int_t option) const
+{
+  /// Method to compute the signal using inv. mass histo bin counting
+  /// after background subtraction from background fit function
+  ///   option=0: background fit function from 1st fit step (only side bands)
+  ///   option=1: background fit function from 2nd fit step (S+B)
+
+  Int_t minBinSum = fHistoInvMass->FindBin(minMass);
+  Int_t maxBinSum = fHistoInvMass->FindBin(maxMass);
+  if (minBinSum < 1) {
+    printf("Left range for bin counting smaller than allowed by histogram axis, setting it to the lower edge of the first histo bin\n");
+    minBinSum = 1;
+  }
+  if (maxBinSum > fHistoInvMass->GetNbinsX()) {
+    printf("Right range for bin counting larger than allowed by histogram axis, setting it to the upper edge of the last histo bin\n");
+    maxBinSum = fHistoInvMass->GetNbinsX();
+  }
+  Double_t cntSig = 0.;
+  Double_t cntErr = 0.;
+  errRyBC = 0;
+  TF1* fbackground = fBkgFunc;
+  if (option == 1)
+    fbackground = fBkgFuncRefit;
+  if (!fbackground)
+    return 0.;
+
+  for (Int_t jb = minBinSum; jb <= maxBinSum; jb++) {
+    Double_t cntTot = fHistoInvMass->GetBinContent(jb);
+    Double_t cntBkg = fbackground->Integral(fHistoInvMass->GetBinLowEdge(jb), fHistoInvMass->GetBinLowEdge(jb) + fHistoInvMass->GetBinWidth(jb)) / fHistoInvMass->GetBinWidth(jb);
+    Double_t cntRefl = 0;
+    if (option == 1 && fRflFunc)
+      cntRefl = fRflFunc->Integral(fHistoInvMass->GetBinLowEdge(jb), fHistoInvMass->GetBinLowEdge(jb) + fHistoInvMass->GetBinWidth(jb)) / fHistoInvMass->GetBinWidth(jb);
+    // Double_t cntBkg=fbackground->Eval(fHistoInvMass->GetBinCenter(jb));
+    Double_t cntSecPeak = 0;
+    if (option == 1 && fSecondPeak && fSecFunc)
+      cntSecPeak = fSecFunc->Integral(fHistoInvMass->GetBinLowEdge(jb), fHistoInvMass->GetBinLowEdge(jb) + fHistoInvMass->GetBinWidth(jb)) / fHistoInvMass->GetBinWidth(jb);
+    cntSig += (cntTot - cntBkg - cntRefl - cntSecPeak);
+    cntErr += (fHistoInvMass->GetBinError(jb) * fHistoInvMass->GetBinError(jb));
+  }
+  errRyBC = TMath::Sqrt(cntErr);
+  return cntSig;
+}
+
+// _______________________________________________________________________
+TH1F* HFMassFitter::GetResidualsAndPulls(TH1* hPulls, TH1* hResidualTrend, TH1* hPullsTrend, Double_t minrange, Double_t maxrange, Int_t option)
+{
+
+  /// fill and return the residual and pull histos
+
+  Int_t binmi = fHistoInvMass->FindBin(fMinMass * 1.001);
+  Int_t binma = fHistoInvMass->FindBin(fMaxMass * 0.9999);
+  if (maxrange > minrange) {
+    binmi = fHistoInvMass->FindBin(minrange * 1.001);
+    binma = fHistoInvMass->FindBin(maxrange * 0.9999);
+  }
+  if (hResidualTrend) {
+    // fHistoInvMass->Copy(hResidualTrend);
+    hResidualTrend->SetBins(fHistoInvMass->GetNbinsX(), fHistoInvMass->GetXaxis()->GetXmin(), fHistoInvMass->GetXaxis()->GetXmax());
+    hResidualTrend->SetName(Form("%s_residualTrend", fHistoInvMass->GetName()));
+    hResidualTrend->SetTitle(Form("%s  (Residuals)", fHistoInvMass->GetTitle()));
+    hResidualTrend->SetMarkerStyle(20);
+    hResidualTrend->SetMarkerSize(1.0);
+    hResidualTrend->Reset();
+  }
+  if (hPullsTrend) {
+    hPullsTrend->SetBins(fHistoInvMass->GetNbinsX(), fHistoInvMass->GetXaxis()->GetXmin(), fHistoInvMass->GetXaxis()->GetXmax());
+    hPullsTrend->Reset();
+    hPullsTrend->SetName(Form("%s_pullTrend", fHistoInvMass->GetName()));
+    hPullsTrend->SetTitle(Form("%s (Pulls)", fHistoInvMass->GetTitle()));
+    hPullsTrend->SetMarkerStyle(20);
+    hPullsTrend->SetMarkerSize(1.0);
+  }
+  if (hPulls) {
+    hPulls->SetName(Form("%s_pulls", fHistoInvMass->GetName()));
+    hPulls->SetTitle(Form("%s ; Pulls", fHistoInvMass->GetTitle()));
+    hPulls->SetBins(40, -10, 10);
+    hPulls->Reset();
+  }
+
+  Double_t res = -1.e-6, min = 1.e+12, max = -1.e+12;
+  TArrayD* arval = new TArrayD(binma - binmi + 1);
+  for (Int_t jst = 1; jst <= fHistoInvMass->GetNbinsX(); jst++) {
+    Double_t integFit = 0;
+    if (option == 0)
+      integFit = fTotFunc->Integral(fHistoInvMass->GetBinLowEdge(jst), fHistoInvMass->GetBinLowEdge(jst) + fHistoInvMass->GetBinWidth(jst));
+    else {
+      integFit = fBkgFuncRefit->Integral(fHistoInvMass->GetBinLowEdge(jst), fHistoInvMass->GetBinLowEdge(jst) + fHistoInvMass->GetBinWidth(jst));
+      if (option == 2)
+        integFit += fRflFunc->Integral(fHistoInvMass->GetBinLowEdge(jst), fHistoInvMass->GetBinLowEdge(jst) + fHistoInvMass->GetBinWidth(jst));
+    }
+    res = fHistoInvMass->GetBinContent(jst) - integFit / fHistoInvMass->GetBinWidth(jst);
+    if (jst >= binmi && jst <= binma) {
+      arval->AddAt(res, jst - binmi);
+      if (res < min)
+        min = res;
+      if (res > max)
+        max = res;
+    }
+    //      Printf("Res = %f from %f - %f",res,fHistoInvMass->GetBinContent(jst),fTotFunc->Integral(fHistoInvMass->GetBinLowEdge(jst),fHistoInvMass->GetBinLowEdge(jst)+fHistoInvMass->GetBinWidth(jst))/fHistoInvMass->GetBinWidth(jst));
+    if (hResidualTrend) {
+      hResidualTrend->SetBinContent(jst, res);
+      hResidualTrend->SetBinError(jst, fHistoInvMass->GetBinError(jst));
+    }
+    if (hPulls) {
+      if (jst >= binmi && jst <= binma)
+        hPulls->Fill(res / fHistoInvMass->GetBinError(jst));
+    }
+    if (hPullsTrend) {
+      hPullsTrend->SetBinContent(jst, res / fHistoInvMass->GetBinError(jst));
+      hPullsTrend->SetBinError(jst, 0.0001);
+    }
+  }
+  if (hResidualTrend) {
+    hResidualTrend->GetXaxis()->SetRange(binmi, binma);
+    if (option != 0) {
+      TF1* fgauss = new TF1("signalTermForRes", "[0]/TMath::Sqrt(2.*TMath::Pi())/[2]*TMath::Exp(-(x-[1])*(x-[1])/2./[2]/[2])", fHistoInvMass->GetBinLowEdge(1), fHistoInvMass->GetBinLowEdge(fHistoInvMass->GetNbinsX() + 1));
+      fgauss->SetParameter(0, fRawYield * fHistoInvMass->GetBinWidth(1));
+      fgauss->SetParameter(1, fMass);
+      fgauss->SetParameter(2, fSigmaSgn);
+      fgauss->SetLineColor(kBlue);
+      hResidualTrend->GetListOfFunctions()->Add(fgauss);
+    }
+  }
+  if (hPullsTrend) {
+    hPullsTrend->GetXaxis()->SetRange(binmi, binma);
+    hPullsTrend->SetMinimum(-7);
+    hPullsTrend->SetMaximum(+7);
+  }
+  if (TMath::Abs(min) > TMath::Abs(max))
+    max = min;
+
+  TH1F* hout = new TH1F(Form("%s_residuals", fHistoInvMass->GetName()), Form("%s ; residuals", fHistoInvMass->GetTitle()), 25, -TMath::Abs(max) * 1.5, TMath::Abs(max) * 1.5);
+  for (Int_t j = 0; j < binma - binmi + 1; j++) {
+    hout->Fill(arval->At(j));
+  }
+  hout->Sumw2();
+  hout->Fit("gaus", "LEM", "", -TMath::Abs(max) * 1.2, TMath::Abs(max) * 1.2);
+
+  if (hPulls) {
+    hPulls->Sumw2();
+    hPulls->Fit("gaus", "LEM", "", -3, 3);
+  }
+  delete arval;
+  return hout;
+}
+// _______________________________________________________________________
+TH1F* HFMassFitter::GetOverBackgroundResidualsAndPulls(TH1* hPulls, TH1* hResidualTrend, TH1* hPullsTrend, Double_t minrange, Double_t maxrange)
+{
+  ///
+  return GetResidualsAndPulls(hPulls, hResidualTrend, hPullsTrend, minrange, maxrange, 1);
+}
+// _______________________________________________________________________
+TH1F* HFMassFitter::GetOverBackgroundPlusReflResidualsAndPulls(TH1* hPulls, TH1* hResidualTrend, TH1* hPullsTrend, Double_t minrange, Double_t maxrange)
+{
+  ///
+  return GetResidualsAndPulls(hPulls, hResidualTrend, hPullsTrend, minrange, maxrange, 2);
+}
+
+// _______________________________________________________________________
+void HFMassFitter::PrintFunctions()
+{
+  /// dump the function parameters
+  ///
+  if (fBkgFunc) {
+    printf("--- Background function in 1st step fit to side bands ---\n");
+    fBkgFunc->Print();
+  }
+  if (fTotFunc) {
+    printf("--- Total fit function from 2nd step fit ---\n");
+    fTotFunc->Print();
+  }
+  if (fBkgFuncRefit) {
+    printf("--- Background function in 2nd step fit ---\n");
+    fBkgFuncRefit->Print();
+  }
+  if (fRflFunc) {
+    printf("--- Reflections ---\n");
+    fRflFunc->Print();
+  }
+  if (fBkRFunc) {
+    printf("--- Background + reflections ---\n");
+    fBkRFunc->Print();
+  }
+  if (fSecFunc) {
+    printf("--- Additional Gaussian peak ---\n");
+    fSecFunc->Print();
+  }
+}

--- a/PWGHF/HFC/Macros/HFMassFitter.h
+++ b/PWGHF/HFC/Macros/HFMassFitter.h
@@ -1,0 +1,321 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HFMassFitter.cxx
+/// \brief HFMassFitter class
+///
+/// \author Grazia Luparello <gluparel@cern.ch>
+
+#ifndef HFMASSFITTER_H
+#define HFMASSFITTER_H
+
+class TF1;
+class TH1F;
+
+using namespace std;
+
+class HFMassFitter : public TNamed
+{
+ public:
+  enum ETypeOfBkg { kExpo = 0,
+                    kLin = 1,
+                    kPol2 = 2,
+                    kNoBk = 3,
+                    kPow = 4,
+                    kPowEx = 5 };
+  enum ETypeOfSgn { kGaus = 0,
+                    k2Gaus = 1,
+                    k2GausSigmaRatioPar = 2 };
+  HFMassFitter();
+  HFMassFitter(const TH1F* histoToFit, Double_t minvalue, Double_t maxvalue, Int_t fittypeb = kExpo, Int_t fittypes = kGaus);
+  ~HFMassFitter();
+
+  void SetHistogramFit(const TH1F* histoToFit)
+  {
+    if (fHistoInvMass)
+      delete fHistoInvMass;
+    fHistoInvMass = (TH1F*)histoToFit->Clone("fHistoInvMass");
+    fHistoInvMass->SetDirectory(0);
+  }
+  void SetRangeFit(Double_t minvalue, Double_t maxvalue)
+  {
+    fMinMass = minvalue;
+    fMaxMass = maxvalue;
+  }
+  void SetFitFunctions(Int_t fittypeb, Int_t fittypes)
+  {
+    fTypeOfFit4Bkg = fittypeb;
+    fTypeOfFit4Sgn = fittypes;
+    SetNumberOfParams();
+  }
+  void SetSigmaLimit(Double_t sigmaVar, Double_t sigmalimit)
+  {
+    fSigmaVar = sigmaVar;
+    fParSig = sigmalimit;
+  }
+
+  void SetUseLikelihoodFit() { fFitOption = "L,E"; }
+  void SetUseLikelihoodWithWeightsFit() { fFitOption = "WL,E"; }
+  void SetUseChi2Fit() { fFitOption = "E"; }
+  void SetFitOption(TString opt) { fFitOption = opt.Data(); };
+  void SetParticlePdgMass(Double_t mass) { fMassParticle = mass; }
+  Double_t GetParticlePdgMass() { return fMassParticle; }
+  void SetPolDegreeForBackgroundFit(Int_t deg)
+  {
+    if (fTypeOfFit4Bkg != 6)
+      cout << "Fit type for background should be set to 6 to use higher order polynomials" << endl;
+    fPolDegreeBkg = deg;
+    SetNumberOfParams();
+  }
+  void SetInitialGaussianMean(Double_t mean) { fMass = mean; }
+  void SetInitialGaussianSigma(Double_t sigma) { fSigmaSgn = sigma; }
+  void SetInitialSecondGaussianSigma(Double_t sigma) { fSigmaSgn2Gaus = sigma; }
+  void SetInitialFrac2Gaus(Double_t frac) { fFrac2Gaus = frac; }
+  void SetInitialRatio2GausSigma(Double_t fracsigma) { fRatio2GausSigma = fracsigma; }
+  void SetFixGaussianMean(Double_t mean)
+  {
+    SetInitialGaussianMean(mean);
+    fFixedMean = kTRUE;
+  }
+  void SetBoundGaussianMean(Double_t mean, Double_t meanLowerLim, Double_t meanUpperLim)
+  {
+    if (!(meanLowerLim < mean && mean < meanUpperLim))
+      cout << "mass limits are not set correctly" << endl;
+    SetInitialGaussianMean(mean);
+    fMassLowerLim = meanLowerLim;
+    fMassUpperLim = meanUpperLim;
+    fBoundMean = kTRUE;
+  }
+
+  void SetFixGaussianSigma(Double_t sigma)
+  {
+    SetInitialGaussianSigma(sigma);
+    fFixedSigma = kTRUE;
+  }
+  void SetBoundGaussianSigma(Double_t sigma, Double_t sigmalimit)
+  {
+    SetInitialGaussianSigma(sigma);
+    SetSigmaLimit(sigma, sigmalimit);
+    fBoundSigma = kTRUE;
+    fFitOption = "L,E,B";
+  }
+  void SetFixSecondGaussianSigma(Double_t sigma)
+  {
+    if (fTypeOfFit4Sgn != k2Gaus)
+      cout << "Type of fit for signal should be set to k2Gaus to fix ratio between gaussians" << endl;
+    SetInitialSecondGaussianSigma(sigma);
+    fFixedSigma2Gaus = kTRUE;
+  }
+  void SetFixFrac2Gaus(Double_t frac)
+  {
+    if (fTypeOfFit4Sgn != k2Gaus && fTypeOfFit4Sgn != k2GausSigmaRatioPar)
+      cout << "Type of fit for background should be set to k2Gaus to fix relative integral of two gaussians" << endl;
+    SetInitialFrac2Gaus(frac);
+    fFixedFrac2Gaus = kTRUE;
+  }
+  void SetFixRatio2GausSigma(Double_t sigmafrac)
+  {
+    if (fTypeOfFit4Sgn != k2GausSigmaRatioPar)
+      cout << "Type of fit for background should be set to k2GausSigmaRatioPar to fix ratio between gaussian sigmas" << endl;
+    SetInitialRatio2GausSigma(sigmafrac);
+    fFixedRatio2GausSigma = kTRUE;
+  }
+  void SetFixSignalYield(Double_t yield)
+  {
+    fFixedRawYield = yield;
+  }
+  void SetNSigma4SideBands(Double_t ns = 4.)
+  {
+    fNSigma4SideBands = ns;
+  }
+  TH1F* SetTemplateReflections(const TH1* h, TString opt, Double_t minRange, Double_t maxRange);
+  void SetInitialReflOverS(Double_t rovers) { fRflOverSig = rovers; }
+  void SetFixReflOverS(Double_t rovers)
+  {
+    SetInitialReflOverS(rovers);
+    fFixRflOverSig = kTRUE;
+  }
+  void SetSmoothReflectionTemplate(Bool_t opt) { fSmoothRfl = opt; }
+
+  void IncludeSecondGausPeak(Double_t mass, Bool_t fixm, Double_t width, Bool_t fixw)
+  {
+    fSecondPeak = kTRUE;
+    fSecMass = mass;
+    fSecWidth = width;
+    fFixSecMass = fixm;
+    fFixSecWidth = fixw;
+  }
+  void SetCheckSignalCountsAfterFirstFit(Bool_t opt) { fCheckSignalCountsAfterFirstFit = opt; }
+
+  void SetAcceptValidFit() { fAcceptValidFit = kTRUE; }
+
+  Double_t GetRawYield() const { return fRawYield; }
+  Double_t GetRawYieldError() const { return fRawYieldErr; }
+  Double_t GetMean() const { return fMass; }
+  Double_t GetMeanUncertainty() const { return fMassErr; }
+  Double_t GetSigma() const { return fSigmaSgn; }
+  Double_t GetSigmaUncertainty() const { return fSigmaSgnErr; }
+  Double_t GetReflOverSig() const
+  {
+    if (fRflFunc)
+      return fRflFunc->GetParameter(0);
+    else
+      return 0;
+  }
+  Double_t GetReflOverSigUncertainty() const
+  {
+    if (fRflFunc)
+      return fRflFunc->GetParError(0);
+    else
+      return 0;
+  }
+  TF1* GetBackgroundFullRangeFunc() { return fBkgFunc; }
+  TF1* GetBackgroundRecalcFunc() { return fBkgFuncRefit; }
+  TF1* GetBkgPlusReflFunc() { return fBkRFunc; }
+  TF1* GetSignalFunc() { return fSigFunc; }
+  TF1* GetMassFunc() { return fTotFunc; }
+  TF1* GetSecondPeakFunc() { return fSecFunc; }
+  TF1* GetReflFunc() { return fRflFunc; }
+  Double_t GetChiSquare() const
+  {
+    if (fTotFunc)
+      return fTotFunc->GetChisquare();
+    else
+      return -1;
+  }
+  Double_t GetReducedChiSquare() const
+  {
+    if (fTotFunc)
+      return fTotFunc->GetChisquare() / fTotFunc->GetNDF();
+    else
+      return -1;
+  }
+  Double_t GetFitProbability() const
+  {
+    if (fTotFunc)
+      return fTotFunc->GetProb();
+    else
+      return -1;
+  }
+  TH1F* GetHistoClone() const
+  {
+    TH1F* hout = (TH1F*)fHistoInvMass->Clone(Form("%scloned", fHistoInvMass->GetName()));
+    return hout;
+  }
+  Double_t GetRawYieldBinCounting(Double_t& errRyBC, Double_t nSigma = 3., Int_t option = 0, Int_t pdgCode = 0) const;
+  Double_t GetRawYieldBinCounting(Double_t& errRyBC, Double_t minMass, Double_t maxMass, Int_t option = 0) const;
+  Int_t MassFitter(Bool_t draw = kTRUE);
+  Double_t FitFunction4Sgn(Double_t* x, Double_t* par);
+  Double_t FitFunction4Bkg(Double_t* x, Double_t* par);
+  Double_t FitFunction4Refl(Double_t* x, Double_t* par);
+  Double_t FitFunction4BkgAndRefl(Double_t* x, Double_t* par);
+  Double_t FitFunction4SecPeak(Double_t* x, Double_t* par);
+  Double_t FitFunction4Mass(Double_t* x, Double_t* par);
+  virtual void Signal(Double_t nOfSigma, Double_t& signal, Double_t& errsignal) const;
+  virtual void Signal(Double_t min, Double_t max, Double_t& signal, Double_t& errsignal) const;
+  void Background(Double_t nOfSigma, Double_t& background, Double_t& errbackground) const;
+  void Background(Double_t min, Double_t max, Double_t& background, Double_t& errbackground) const;
+  void DrawHere(TVirtualPad* c, Double_t nsigma = 3, Int_t writeFitInfo = 2);
+  void DrawHistoMinusFit(TVirtualPad* c, Int_t writeFitInfo = 1);
+  void Significance(Double_t nOfSigma, Double_t& significance, Double_t& errsignificance) const;
+  void Significance(Double_t min, Double_t max, Double_t& significance, Double_t& errsignificance) const;
+  // Function to compute the residuals histo-fit
+  //   option=0 -> use the total fit function (signal+background+reflections)
+  //   option=1 -> use only the background fit function (to isolate signal+reflections)
+  //   option=2 -> use background+reflection fit function (to isolate the signal line shape)
+  TH1F* GetResidualsAndPulls(TH1* hPulls = 0x0, TH1* hResidualTrend = 0x0, TH1* hPullsTrend = 0x0, Double_t minrange = 0, Double_t maxrange = -1, Int_t option = 0);
+  // Interface method to compute the residuals histo-fit function of the background
+  TH1F* GetOverBackgroundResidualsAndPulls(TH1* hPulls = 0x0, TH1* hResidualTrend = 0x0, TH1* hPullsTrend = 0x0, Double_t minrange = 0, Double_t maxrange = -1);
+  // Interface method to compute the residuals histo-(fit function of the background+reflections)
+  TH1F* GetOverBackgroundPlusReflResidualsAndPulls(TH1* hPulls = 0x0, TH1* hResidualTrend = 0x0, TH1* hPullsTrend = 0x0, Double_t minrange = 0, Double_t maxrange = -1);
+  void PrintFunctions();
+
+ private:
+  HFMassFitter(const HFMassFitter& source);
+  HFMassFitter& operator=(const HFMassFitter& source);
+
+  void SetNumberOfParams();
+  Double_t CheckForSignal(Double_t mean, Double_t sigma);
+  TF1* CreateBackgroundFitFunction(TString fname, Double_t integral);
+  TF1* CreateSignalFitFunction(TString fname, Double_t integral);
+  TF1* CreateSecondPeakFunction(TString fname, Double_t integral);
+  TF1* CreateReflectionFunction(TString fname);
+  TF1* CreateBackgroundPlusReflectionFunction(TString fname);
+  TF1* CreateTotalFitFunction(TString fname);
+  Bool_t PrepareHighPolFit(TF1* fback);
+  Double_t BackFitFuncPolHelper(Double_t* x, Double_t* par);
+
+  void DrawFit();
+
+  TH1F* fHistoInvMass;                    // histogram to fit
+  Double_t fMinMass;                      // lower mass limit
+  Double_t fMaxMass;                      // upper mass limit
+  Int_t fTypeOfFit4Bkg;                   // background fit func
+  Int_t fPolDegreeBkg;                    // degree of polynomial expansion for back fit (option 6 for back)
+  Int_t fCurPolDegreeBkg;                 // help variable
+  Double_t fMassParticle;                 // pdg value of particle mass
+  Int_t fTypeOfFit4Sgn;                   // signal fit func
+  Double_t fMass;                         // signal gaussian mean value
+  Double_t fMassErr;                      // unc on signal gaussian mean value
+  Double_t fMassLowerLim;                 // lower limit of the allowed mass range
+  Double_t fMassUpperLim;                 // upper limit of the allowed mass range
+  Bool_t fBoundMean;                      // switch for bound mean of gaussian
+  Double_t fSigmaSgn;                     // signal gaussian sigma
+  Double_t fSigmaSgnErr;                  // unc on signal gaussian sigma
+  Double_t fSigmaSgn2Gaus;                // signal second gaussian sigma in case of k2Gaus
+  Bool_t fFixedMean;                      // switch for fix mean of gaussian
+  Bool_t fFixedSigma;                     // switch for fix Sigma of gaussian
+  Bool_t fBoundSigma;                     // switch for bound Sigma of gaussian
+  Double_t fSigmaVar;                     // value of bound Sigma of gaussian
+  Double_t fParSig;                       // +/- range variation of bound Sigma of gaussian in %
+  Bool_t fFixedSigma2Gaus;                // switch for fix Sigma of second gaussian in case of k2Gaus
+  Double_t fFixedRawYield;                // initialization for wa yield
+  Double_t fFrac2Gaus;                    // initialization for fraction of 2nd gaussian in case of k2Gaus or k2GausSigmaRatioPar
+  Bool_t fFixedFrac2Gaus;                 // switch for fixed fraction of 2nd gaussian in case of k2Gaus or k2GausSigmaRatioPar
+  Double_t fRatio2GausSigma;              // initialization for ratio between two gaussian sigmas in case of k2GausSigmaRatioPar
+  Bool_t fFixedRatio2GausSigma;           // switch for fixed ratio between two gaussian sigmas in case of k2GausSigmaRatioPar
+  Int_t fNParsSig;                        // fit parameters in signal fit function
+  Int_t fNParsBkg;                        // fit parameters in background fit function
+  Bool_t fOnlySideBands;                  // kTRUE = only side bands considered
+  Double_t fNSigma4SideBands;             // number of sigmas to veto the signal peak
+  Bool_t fCheckSignalCountsAfterFirstFit; // switch for check after first fit
+  TString fFitOption;                     // L, LW or Chi2
+  Double_t fRawYield;                     // signal gaussian integral
+  Double_t fRawYieldErr;                  // err on signal gaussian integral
+  TF1* fSigFunc;                          // Signal fit function
+  TF1* fBkgFuncSb;                        // background fit function (1st step, side bands only)
+  TF1* fBkgFunc;                          // background fit function (1st step, extended in peak region)
+  TF1* fBkgFuncRefit;                     // background fit function (2nd step)
+  Bool_t fReflections;                    // flag use/not use reflections
+  Int_t fNParsRfl;                        // fit parameters in reflection fit function
+  Double_t fRflOverSig;                   // reflection/signal
+  Bool_t fFixRflOverSig;                  // switch for fix refl/signal
+  TH1F* fHistoTemplRfl;                   // histogram with reflection template
+  Bool_t fSmoothRfl;                      // switch for smoothing of reflection template
+  Double_t fRawYieldHelp;                 // internal variable for fit with reflections
+  TF1* fRflFunc;                          // fit function for reflections
+  TF1* fBkRFunc;                          // fit function for reflections
+  Bool_t fSecondPeak;                     // switch off/on second peak (for D+->KKpi in Ds)
+  Int_t fNParsSec;                        // fit parameters in 2nd peak fit function
+  Double_t fSecMass;                      // position of the 2nd peak
+  Double_t fSecWidth;                     // width of the 2nd peak
+  Bool_t fFixSecMass;                     // flag to fix the position of the 2nd peak
+  Bool_t fFixSecWidth;                    // flag to fix the width of the 2nd peak
+  TF1* fSecFunc;                          // fit function for second peak
+  TF1* fTotFunc;                          // total fit function
+  Bool_t fAcceptValidFit;                 // accept a fit when IsValid() gives true, nevertheless the status code
+
+  /// \cond CLASSIMP
+  ClassDef(HFMassFitter, 1); // class for invariant mass fit
+  /// \endcond
+};
+
+#endif

--- a/PWGHF/HFC/Macros/config_CorrAnalysis_DsToKKPi.json
+++ b/PWGHF/HFC/Macros/config_CorrAnalysis_DsToKKPi.json
@@ -1,0 +1,51 @@
+{
+  "CodeName": "Default",
+  "_CodeName": "Name to identify the analysis",
+  "pathFileSE": "~/cernbox/DsCorrelationAnalysis/MasterDegreeAnalysis/AnalysisResultsFinal.root",
+  "pathFileME": "~/cernbox/DsCorrelationAnalysis/MasterDegreeAnalysis/AnalysisResultsFinalME.root",
+  "pathFileMass": "/data/dataalice/scattar/RawYieldsDs.root",
+  "InputDirSE": "hf-task-correlation-ds-hadrons",
+  "InputDirME": "hf-task-correlation-ds-hadrons",
+  "InputHistoCorrSignalName": "hCorrel2DVsPtSignalRegion",
+  "InputHistoCorrSidebaName": "hCorrel2DVsPtSidebands",
+  "InputHistoMassName": [
+    "hRawYieldsSignal",
+    "hRawYieldsBkg",
+    "hBackgroundSideband"
+  ],
+  "_InputHistoMassName": [
+    "Sgn yield vs pt",
+    "Bkg yield vs pt",
+    "SBs yield vs pt"
+  ],
+  "binsPtCandIntervals": [
+    2.0,
+    3.0,
+    4.0,
+    5.0,
+    8.0,
+    16.0
+  ],
+  "binsPtHadIntervals": [
+    0.0,
+    11.0
+  ],
+  "deltaEtaInterval": [
+    -0.8,
+    0.8
+  ],
+  "DmesonSpecie": 2,
+  "_DmesonSpecie": [
+    "0 for kD0toKpi",
+    "1 for kDplusKpipi",
+    "2 for kDsToKKPi",
+    "3 for kDStarD0pi"
+  ],
+  "NumberOfPools": 9,
+  "_NumberOfPools": "Number of pools for the event mixing",
+  "CorrectPoolsSeparately": false,
+  "_CorrectPoolsSeparately": "true = pool-by-pool ME correction; false = merged-pools ME correction",
+  "FitFunction": 1,
+  "FixBaseline": 0,
+  "FixMean": 3
+}

--- a/PWGHF/HFC/Macros/config_massfitter_DsToKKPi.json
+++ b/PWGHF/HFC/Macros/config_massfitter_DsToKKPi.json
@@ -1,0 +1,148 @@
+{
+  "Particle": "Ds",
+  "_Particles": [
+    "Dplus",
+    "Ds",
+    "LcToPKPi",
+    "LcToPK0s",
+    "Dstar"
+  ],
+  "EnableRefl": false,
+  "FixSigma": [
+    0
+  ],
+  "SigmaFile": "",
+  "_SigmaFile": "fix sigma from file",
+  "FixSigmaManual": [
+  ],
+  "_FixSigmaManual": "fix sigma mannually",
+  "FixMean": [
+    0
+  ],
+  "MeanFile": "",
+  "_MeanFile": "fix mean from file",
+  "PtMin": [
+    2.0,
+    4.0,
+    6.0,
+    8.0,
+    12.0
+  ],
+  "PtMax": [
+    4.0,
+    6.0,
+    8.0,
+    12.0,
+    24.0
+  ],
+  "MassMin": [
+    1.75,
+    1.75,
+    1.75,
+    1.75,
+    1.75
+  ],
+  "MassMax": [
+    2.1,
+    2.1,
+    2.1,
+    2.1,
+    2.1
+  ],
+  "Rebin": [
+    3,
+    3,
+    3,
+    3,
+    3
+  ],
+  "InclSecPeak": [
+    1
+  ],
+  "SigmaSecPeak": [
+    0.012,
+    0.012,
+    0.012,
+    0.012,
+    0.012
+  ],
+  "SigmaMultSecPeak": [
+  ],
+  "SigmaFileSecPeak": "",
+  "SigmaMultFactorSecPeak": 1.0,
+  "FixSigmaToFirstPeak": false,
+  "UseLikelihood": true,
+  "_UseLikelihood": [
+    "true: likelihood fit",
+    "false: chi2 fit"
+  ],
+  "BkgFunc": [
+    2,
+    2,
+    2,
+    2,
+    2
+  ],
+  "_BkgFuncs": [
+    "0 for Expo",
+    "1 for Poly1",
+    "2 for Poly2",
+    "3 for Pow",
+    "4 for PowEx",
+    "5 for NoBkg",
+    "6 for Poly3",
+    "7 for Poly4"
+  ],
+  "SgnFunc": [
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "_SgnFuncs": [
+    "0 for SingleGaus",
+    "1 for DoubleGaus",
+    "2 for DoubleGausSigmaRatioPar"
+  ],
+  "BoundMean": false,
+  "_BoundMean": [
+    "false: Do not set limits on mean range",
+    "true: the mean is set to be between MassMin[i] and MassMax[i]"
+  ],
+  "FixSigmaRatio": false,
+  "SigmaRatioFile": "",
+  "SigmaMultFactorUnc": "",
+  "_SigmaMultFactorUnc": [
+    "MinusUnc",
+    "PlusUnc"
+  ],
+  "MinSidebandLeft": [
+    1.75,
+    1.75,
+    1.75,
+    1.75,
+    1.75
+  ],
+  "MaxSidebandLeft": [
+    1.8,
+    1.8,
+    1.8,
+    1.8,
+    1.8
+  ],
+  "MinSidebandRight": [
+    2.05,
+    2.05,
+    2.05,
+    2.05,
+    2.05
+  ], 
+  "MaxSidebandRight": [
+    2.1,
+    2.1,
+    2.1,
+    2.1,
+    2.1
+  ]
+}


### PR DESCRIPTION
Dear all,
This commit include the post processing macros for the D-h correlation analysis:
- Invariant mass analysis: GetRawYields.C, HFInvMassFitter.cxx, HFInvMassFitter.h (author @gluparel )
- Correlation extraction: ExtractOutputCorrel.C, DhCorrelationExtraction.cxx, DhCorrelationExtraction.h (authors: @scattaru, @skhade)
- Correlation fitter: FitCorrel.C, DhCorrelationFitter.cxx, DhCorrelationFitter.h (authors: @scattaru, @skhade)
- Configuration files: config_massfitter_DsToKKPi.json, config_CorrAnalysis_DsToKKPi.json
- Script for the analysis execution: AnalysisExecution.sh

Best regards,
Samuele