### PR TITLE
PWGDQ/EM add recalculation of DCA param of TrackToCollAssoc tracks

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -689,7 +689,7 @@ class VarManager : public TObject
   static void FillTrack(T const& track, float* values = nullptr);
   template <uint32_t fillMap, typename T, typename C>
   static void FillTrackCollision(T const& track, C const& collision, float* values = nullptr);
-  template <uint32_t fillMap, typename T, typename C,typename M>
+  template <uint32_t fillMap, typename T, typename C, typename M>
   static void FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, float* values = nullptr);
   template <typename U, typename T>
   static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
@@ -1667,8 +1667,6 @@ void VarManager::FillTrackCollisionMatCorr(T const& track, C const& collision, M
     // trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, fgMagField, &dca);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, materialCorr, &dca);
     getPxPyPz(trackPar, pVec);
-    cout << __LINE__ << " COUT LINE::VarManager track.pt() = " << track.pt() << endl;
-    cout << __LINE__ << " COUT LINE::VarManager trackPar.getPt() = " << trackPar.getPt() << endl << endl;
 
     values[kTrackDCAxy] = dca[0];
     values[kTrackDCAz] = dca[1];

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -689,8 +689,8 @@ class VarManager : public TObject
   static void FillTrack(T const& track, float* values = nullptr);
   template <uint32_t fillMap, typename T, typename C>
   static void FillTrackCollision(T const& track, C const& collision, float* values = nullptr);
-  template <uint32_t fillMap, typename T, typename C, typename M>
-  static void FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, float* values = nullptr);
+  template <uint32_t fillMap, typename T, typename C, typename M, typename P>
+  static void FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, P const& propagator, float* values = nullptr);
   template <typename U, typename T>
   static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
   template <uint32_t fillMap, typename T1, typename T2, typename C>
@@ -1654,8 +1654,8 @@ void VarManager::FillTrackCollision(T const& track, C const& collision, float* v
   }
 }
 
-template <uint32_t fillMap, typename T, typename C, typename M>
-void VarManager::FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, float* values)
+template <uint32_t fillMap, typename T, typename C, typename M, typename P>
+void VarManager::FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, P const& propagator, float* values)
 {
   if (!values) {
     values = fgValues;

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1665,7 +1665,7 @@ void VarManager::FillTrackCollisionMatCorr(T const& track, C const& collision, M
     std::array<float, 2> dca{1e10f, 1e10f};
     std::array<float, 3> pVec = {track.px(), track.py(), track.pz()};
     // trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, fgMagField, &dca);
-    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, materialCorr, &dca);
+    propagator->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, materialCorr, &dca);
     getPxPyPz(trackPar, pVec);
 
     values[kTrackDCAxy] = dca[0];

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -689,6 +689,8 @@ class VarManager : public TObject
   static void FillTrack(T const& track, float* values = nullptr);
   template <uint32_t fillMap, typename T, typename C>
   static void FillTrackCollision(T const& track, C const& collision, float* values = nullptr);
+  template <uint32_t fillMap, typename T, typename C,typename M>
+  static void FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, float* values = nullptr);
   template <typename U, typename T>
   static void FillTrackMC(const U& mcStack, T const& track, float* values = nullptr);
   template <uint32_t fillMap, typename T1, typename T2, typename C>
@@ -1637,6 +1639,36 @@ void VarManager::FillTrackCollision(T const& track, C const& collision, float* v
     auto trackPar = getTrackPar(track);
     std::array<float, 2> dca{1e10f, 1e10f};
     trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, fgMagField, &dca);
+
+    values[kTrackDCAxy] = dca[0];
+    values[kTrackDCAz] = dca[1];
+
+    if constexpr ((fillMap & ReducedTrackBarrelCov) > 0 || (fillMap & TrackCov) > 0) {
+      if (fgUsedVars[kTrackDCAsigXY]) {
+        values[kTrackDCAsigXY] = dca[0] / std::sqrt(track.cYY());
+      }
+      if (fgUsedVars[kTrackDCAsigZ]) {
+        values[kTrackDCAsigZ] = dca[1] / std::sqrt(track.cZZ());
+      }
+    }
+  }
+}
+
+template <uint32_t fillMap, typename T, typename C, typename M>
+void VarManager::FillTrackCollisionMatCorr(T const& track, C const& collision, M const& materialCorr, float* values)
+{
+  if (!values) {
+    values = fgValues;
+  }
+  if constexpr ((fillMap & ReducedTrackBarrel) > 0 || (fillMap & TrackDCA) > 0) {
+    auto trackPar = getTrackPar(track);
+    std::array<float, 2> dca{1e10f, 1e10f};
+    std::array<float, 3> pVec = {track.px(), track.py(), track.pz()};
+    // trackPar.propagateParamToDCA({collision.posX(), collision.posY(), collision.posZ()}, fgMagField, &dca);
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, materialCorr, &dca);
+    getPxPyPz(trackPar, pVec);
+    cout << __LINE__ << " COUT LINE::VarManager track.pt() = " << track.pt() << endl;
+    cout << __LINE__ << " COUT LINE::VarManager trackPar.getPt() = " << trackPar.getPt() << endl << endl;
 
     values[kTrackDCAxy] = dca[0];
     values[kTrackDCAz] = dca[1];

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -284,7 +284,7 @@ struct DQBarrelTrackSelection {
 
       VarManager::FillTrack<TTrackFillMap>(track);
       // compute quantities which depend on the associated collision, such as DCA
-      if (fPropTrack) {
+      if (fPropTrack && (track.collisionId() != collision.globalIndex())) {
         VarManager::FillTrackCollisionMatCorr<TTrackFillMap>(track, collision, noMatCorr, o2::base::Propagator::Instance());
       }
       if (fConfigQA) {


### PR DESCRIPTION
This PR Draft has not been tested yet!!!

Adapt `track selection` to perform a recalculation of the DCA parameter.

Following the example of the `TableReader_withAssoc` using
`VarManager::FillTrackCollision<TTrackFillMap>(track, collision);`
and the `void runMuonSelection()` function.

So far no flag has been introduced to select this recalculation.

@rbailhac @dsekihat @hscheid  I would appreciate if you could have a first look at this.
I'm not sure if this implementation is the way to go, but I tried to follow other examples.
