### PR TITLE
DPL Analysis: prevent data model being exposed to rootcling

### DIFF
--- a/PWGEM/PhotonMeson/Utils/TrackSelection.h
+++ b/PWGEM/PhotonMeson/Utils/TrackSelection.h
@@ -212,7 +212,7 @@ inline bool isTPConly_ITSonly(TTrack const& track0, TTrack const& track1)
  * @param mc2 MCParticle 1
  * @return true if the mother particle is the expected type and the same for both
  */
-template <typename T, PDG_t motherType>
+template <PDG_t motherType, typename T>
 inline bool checkMCParticles(T const& mc1, T const& mc2)
 {
   if (abs(mc1.pdgCode()) != kElectron || abs(mc2.pdgCode()) != kElectron) {

--- a/PWGEM/PhotonMeson/Utils/TrackSelection.h
+++ b/PWGEM/PhotonMeson/Utils/TrackSelection.h
@@ -16,7 +16,6 @@
 #define PWGEM_PHOTONMESON_UTILS_TRACKSELECTION_H_
 
 #include "TPDGCode.h"
-#include "Framework/AnalysisDataModel.h"
 
 namespace o2::pwgem::photonmeson
 {
@@ -213,8 +212,8 @@ inline bool isTPConly_ITSonly(TTrack const& track0, TTrack const& track1)
  * @param mc2 MCParticle 1
  * @return true if the mother particle is the expected type and the same for both
  */
-template <PDG_t motherType>
-inline bool checkMCParticles(aod::McParticle const& mc1, aod::McParticle const& mc2)
+template <typename T, PDG_t motherType>
+inline bool checkMCParticles(T const& mc1, T const& mc2)
 {
   if (abs(mc1.pdgCode()) != kElectron || abs(mc2.pdgCode()) != kElectron) {
     return false;
@@ -225,10 +224,10 @@ inline bool checkMCParticles(aod::McParticle const& mc1, aod::McParticle const& 
   if (mc1.mothersIds()[0] != mc2.mothersIds()[0]) {
     return false;
   }
-  if (const auto& mothers = mc1.mothers_as<aod::McParticles>(); mothers.empty() || mothers.size() > 1) {
+  if (const auto& mothers = mc1.template mothers_as<typename T::parent_t>(); mothers.empty() || mothers.size() > 1) {
     return false;
   }
-  if (mc1.template mothers_first_as<aod::McParticles>().pdgCode() != motherType) {
+  if (mc1.template mothers_first_as<typename T::parent_t>().pdgCode() != motherType) {
     return false;
   }
   return true;


### PR DESCRIPTION
The include of `AnalysisDataModel.h` in a header, that is, in turn, included in ROOT dictionary, exposes some things to rootcling that it cannot chew. This removes the include and makes the template function more generic. Please consider reviewing this soon, as it blocks https://github.com/AliceO2Group/AliceO2/pull/12724. 