### PR TITLE
DPL Analysis: PWGJE: avoid including data model in ROOT dictionary

### DIFF
--- a/PWGJE/Core/JetDerivedDataUtilities.h
+++ b/PWGJE/Core/JetDerivedDataUtilities.h
@@ -19,7 +19,7 @@
 
 #include <string>
 
-#include "Common/DataModel/EventSelection.h"
+#include "Common/CCDB/TriggerAliases.h"
 #include "PWGJE/Core/JetFinder.h"
 
 namespace jetderiveddatautilities


### PR DESCRIPTION
It is generally not recommended to expose heavily templated data model to rootcling because it adds compilation time and can break on some platforms due to older libstd++. In this case, it blocks https://github.com/AliceO2Group/AliceO2/pull/12724. 