### PR TITLE
Common: create a MC Collision tool for MC context

### DIFF
--- a/Common/DataModel/McCollisionExtra.h
+++ b/Common/DataModel/McCollisionExtra.h
@@ -26,7 +26,7 @@ DECLARE_SOA_COLUMN(BestCollisionIndex, bestCollisionIndex, int); //! stores N ti
 DECLARE_SOA_COLUMN(BestCollisionCentFT0C, bestCollisionCentFT0C, float); //! stores best FT0C centrality
 
 // collision MC context (neighbours contain PoI?)
-DECLARE_SOA_COLUMN(ForwardCollisionMap, forwardCollisionMap, uint32_t); //! stores bitmap telling if PoI found in collisions after this one (bits forward in time)
+DECLARE_SOA_COLUMN(ForwardCollisionMap, forwardCollisionMap, uint32_t);   //! stores bitmap telling if PoI found in collisions after this one (bits forward in time)
 DECLARE_SOA_COLUMN(BackwardCollisionMap, backwardCollisionMap, uint32_t); //! stores bitmap telling if PoI found in collisions before this one (bits backward in time)
 } // namespace mccollisionprop
 DECLARE_SOA_TABLE(McCollsExtra, "AOD", "MCCOLLSEXTRA",

--- a/Common/DataModel/McCollisionExtra.h
+++ b/Common/DataModel/McCollisionExtra.h
@@ -23,10 +23,16 @@ namespace mccollisionprop
 {
 DECLARE_SOA_COLUMN(NumRecoCollision, numRecoCollision, int);     //! stores N times this PV was recoed
 DECLARE_SOA_COLUMN(BestCollisionIndex, bestCollisionIndex, int); //! stores N times this PV was recoed
-DECLARE_SOA_COLUMN(BestCollisionCentFT0C, bestCollisionCentFT0C, float); //! stores N times this PV was recoed
+DECLARE_SOA_COLUMN(BestCollisionCentFT0C, bestCollisionCentFT0C, float); //! stores best FT0C centrality
+
+// collision MC context (neighbours contain PoI?)
+DECLARE_SOA_COLUMN(ForwardCollisionMap, forwardCollisionMap, uint32_t); //! stores bitmap telling if PoI found in collisions after this one (bits forward in time)
+DECLARE_SOA_COLUMN(BackwardCollisionMap, backwardCollisionMap, uint32_t); //! stores bitmap telling if PoI found in collisions before this one (bits backward in time)
 } // namespace mccollisionprop
 DECLARE_SOA_TABLE(McCollsExtra, "AOD", "MCCOLLSEXTRA",
                   mccollisionprop::NumRecoCollision, mccollisionprop::BestCollisionIndex, mccollisionprop::BestCollisionCentFT0C);
+DECLARE_SOA_TABLE(McCollContexts, "AOD", "MCCOLLCONTEXT",
+                  mccollisionprop::ForwardCollisionMap, mccollisionprop::BackwardCollisionMap);
 } // namespace o2::aod
 
 #endif // COMMON_DATAMODEL_MCCOLLISIONEXTRA_H_

--- a/Common/TableProducer/mcCollsExtra.cxx
+++ b/Common/TableProducer/mcCollsExtra.cxx
@@ -63,7 +63,7 @@ struct mcCollisionExtra {
   Configurable<bool> pdgCodeAbsolute{"pdgCodeAbsolute", true, "if true, accept +/- pdgCodeOfInterest"};
   Configurable<float> poiEtaWindow{"poiEtaWindow", 0.8, "PDG code requirement within this eta window"};
 
-    // For manual sliceBy
+  // For manual sliceBy
   Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
 
   template <typename T>
@@ -109,11 +109,11 @@ struct mcCollisionExtra {
       bool PoIpresent = false;
       auto mcParticles = mcParticlesUngrouped.sliceBy(perMcCollision, mcCollision.globalIndex());
       for (auto& mcParticle : mcParticles) {
-        if( std::abs(mcParticle.eta())<poiEtaWindow){
-          if(mcParticle.pdgCode() == pdgCodeOfInterest){
+        if (std::abs(mcParticle.eta()) < poiEtaWindow) {
+          if (mcParticle.pdgCode() == pdgCodeOfInterest) {
             PoIpresent = true;
           }
-          if(mcParticle.pdgCode() == -pdgCodeOfInterest && pdgCodeAbsolute){
+          if (mcParticle.pdgCode() == -pdgCodeOfInterest && pdgCodeAbsolute) {
             PoIpresent = true;
           }
         }
@@ -125,26 +125,25 @@ struct mcCollisionExtra {
     auto sortedIndices = sort_indices(mcCollisionTimes);
     for (auto& collision : collisions) {
       uint16_t forwardHistory = 0, backwardHistory = 0;
-      if(!collision.has_mcCollision()) {
+      if (!collision.has_mcCollision()) {
         mcCollContexts(forwardHistory, backwardHistory);
         continue;
       }
-      auto mcCollision = collision.mcCollision(); 
+      auto mcCollision = collision.mcCollision();
       auto iter = std::find(sortedIndices.begin(), sortedIndices.end(), mcCollision.index());
-      if (iter != sortedIndices.end())  
-      { 
-        int index = iter - sortedIndices.begin(); 
-        for(int iMcColl=index+1; iMcColl<index+17;iMcColl++){
-          if(iMcColl>=sortedIndices.size())
+      if (iter != sortedIndices.end()) {
+        int index = iter - sortedIndices.begin();
+        for (int iMcColl = index + 1; iMcColl < index + 17; iMcColl++) {
+          if (iMcColl >= sortedIndices.size())
             continue;
-          if(mcCollisionHasPoI[sortedIndices[iMcColl]]) 
-            bitset(forwardHistory,iMcColl-index-1);
+          if (mcCollisionHasPoI[sortedIndices[iMcColl]])
+            bitset(forwardHistory, iMcColl - index - 1);
         }
-        for(int iMcColl=index-1; iMcColl>index-17;iMcColl--){
-          if(iMcColl<=0)
+        for (int iMcColl = index - 1; iMcColl > index - 17; iMcColl--) {
+          if (iMcColl <= 0)
             continue;
-          if(mcCollisionHasPoI[sortedIndices[iMcColl]]) 
-            bitset(backwardHistory,index+1-iMcColl);
+          if (mcCollisionHasPoI[sortedIndices[iMcColl]])
+            bitset(backwardHistory, index + 1 - iMcColl);
         }
       }
       mcCollContexts(forwardHistory, backwardHistory);

--- a/Common/TableProducer/mcCollsExtra.cxx
+++ b/Common/TableProducer/mcCollsExtra.cxx
@@ -51,8 +51,30 @@ using std::array;
 
 using FullCollisions = soa::Join<aod::McCollisionLabels, aod::Collisions, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::FT0Mults>;
 
+// simple checkers
+#define bitset(var, nbit) ((var) |= (1 << (nbit)))
+#define bitcheck(var, nbit) ((var) & (1 << (nbit)))
+
 struct mcCollisionExtra {
   Produces<aod::McCollsExtra> mcCollsExtra;
+  Produces<aod::McCollContexts> mcCollContexts; // collision context with respect to its neighbours
+
+  Configurable<int> pdgCodeOfInterest{"pdgCodeOfInterest", 3312, "PDG Code of interest"};
+  Configurable<bool> pdgCodeAbsolute{"pdgCodeAbsolute", true, "if true, accept +/- pdgCodeOfInterest"};
+  Configurable<float> poiEtaWindow{"poiEtaWindow", 0.8, "PDG code requirement within this eta window"};
+
+    // For manual sliceBy
+  Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+
+  template <typename T>
+  std::vector<std::size_t> sort_indices(const std::vector<T>& v)
+  {
+    std::vector<std::size_t> idx(v.size());
+    std::iota(idx.begin(), idx.end(), 0);
+    std::stable_sort(idx.begin(), idx.end(),
+                     [&v](std::size_t i1, std::size_t i2) { return v[i1] < v[i2]; });
+    return idx;
+  }
 
   void processNoCentrality(aod::McCollision const& mcCollision, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions)
   {
@@ -79,9 +101,59 @@ struct mcCollisionExtra {
     }
     mcCollsExtra(collisions.size(), bestCollisionIndex, bestCollisionCentFT0C);
   }
+  void processMcContexts(aod::McCollisions const& mcCollisions, aod::McParticles const& mcParticlesUngrouped, FullCollisions const& collisions)
+  {
+    std::vector<float> mcCollisionTimes;
+    std::vector<bool> mcCollisionHasPoI;
+    for (auto& mcCollision : mcCollisions) {
+      bool PoIpresent = false;
+      auto mcParticles = mcParticlesUngrouped.sliceBy(perMcCollision, mcCollision.globalIndex());
+      for (auto& mcParticle : mcParticles) {
+        if( std::abs(mcParticle.eta())<poiEtaWindow){
+          if(mcParticle.pdgCode() == pdgCodeOfInterest){
+            PoIpresent = true;
+          }
+          if(mcParticle.pdgCode() == -pdgCodeOfInterest && pdgCodeAbsolute){
+            PoIpresent = true;
+          }
+        }
+      }
+      mcCollisionTimes.emplace_back(mcCollision.t());
+      mcCollisionHasPoI.emplace_back(PoIpresent);
+    }
+    // sort mcCollisions according to time
+    auto sortedIndices = sort_indices(mcCollisionTimes);
+    for (auto& collision : collisions) {
+      uint16_t forwardHistory = 0, backwardHistory = 0;
+      if(!collision.has_mcCollision()) {
+        mcCollContexts(forwardHistory, backwardHistory);
+        continue;
+      }
+      auto mcCollision = collision.mcCollision(); 
+      auto iter = std::find(sortedIndices.begin(), sortedIndices.end(), mcCollision.index());
+      if (iter != sortedIndices.end())  
+      { 
+        int index = iter - sortedIndices.begin(); 
+        for(int iMcColl=index+1; iMcColl<index+17;iMcColl++){
+          if(iMcColl>=sortedIndices.size())
+            continue;
+          if(mcCollisionHasPoI[sortedIndices[iMcColl]]) 
+            bitset(forwardHistory,iMcColl-index-1);
+        }
+        for(int iMcColl=index-1; iMcColl>index-17;iMcColl--){
+          if(iMcColl<=0)
+            continue;
+          if(mcCollisionHasPoI[sortedIndices[iMcColl]]) 
+            bitset(backwardHistory,index+1-iMcColl);
+        }
+      }
+      mcCollContexts(forwardHistory, backwardHistory);
+    }
+  }
 
   PROCESS_SWITCH(mcCollisionExtra, processNoCentrality, "process as if real data", false);
   PROCESS_SWITCH(mcCollisionExtra, processWithCentrality, "process as if real data", true);
+  PROCESS_SWITCH(mcCollisionExtra, processMcContexts, "process mc collision contexts", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
This is a first test of a tool that tags collisions according to the properties of their MC neighbours. It is meant such that we can properly calculate MC efficiencies given a certain specific-case gap configuration, taking into account also that the gap itself could contain a particle of interest (e.g. consider the Xi case). 

The basic rationale is to decompose the issues we see in the gap triggering "microscopically" isolating collisions for which the neighbours have or don't have a particle of interest, and to be able to calculate efficiencies in each of the various possibilites. Related to JIRA ticket [3702](https://its.cern.ch/jira/browse/O2-3702); tagging also @ercolessi @nepeivodaRS @ChiaraDeMartin95 