### PR TITLE
[PWGDQ] Added filter bits for muon and barrel tracks to keep track whether muon propagation and TPC postcalib have been applied at skimming time

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -128,19 +128,19 @@ class VarManager : public TObject
   };
 
   enum BarrelTrackFilteringBits {
-    kIsConversionLeg = 0,           // electron from conversions
-    kIsK0sLeg,                      // pion from K0s
-    kIsLambdaLeg,                   // proton or pion from Lambda
-    kIsALambdaLeg,                  // proton or pion from anti-Lambda  
-    kIsOmegaLeg,                    // kaon from Omega baryon decay
-    kDalitzBits = 5,                // first bit for Dalitz tagged tracks 
-    kBarrelUserCutsBits = 13,       // first bit for user track cuts
-    kIsTPCPostcalibrated = 63       // tracks were postcalibrated for the TPC PID
+    kIsConversionLeg = 0,     // electron from conversions
+    kIsK0sLeg,                // pion from K0s
+    kIsLambdaLeg,             // proton or pion from Lambda
+    kIsALambdaLeg,            // proton or pion from anti-Lambda
+    kIsOmegaLeg,              // kaon from Omega baryon decay
+    kDalitzBits = 5,          // first bit for Dalitz tagged tracks
+    kBarrelUserCutsBits = 13, // first bit for user track cuts
+    kIsTPCPostcalibrated = 63 // tracks were postcalibrated for the TPC PID
   };
 
   enum MuonTrackFilteringBits {
-    kMuonUserCutsBits = 0,        // first bit for user muon cuts
-    kMuonIsPropagated = 7         // whether the muon was propagated already
+    kMuonUserCutsBits = 0, // first bit for user muon cuts
+    kMuonIsPropagated = 7  // whether the muon was propagated already
   };
 
  public:
@@ -916,7 +916,7 @@ void VarManager::FillPropagateMuon(const T& muon, const C& collision, float* val
   }
 
   if constexpr ((fillMap & ReducedMuonCov) > 0) {
-    if (muon.filteringFlags() & (uint8_t(1) << VarManager::kMuonIsPropagated)) {  // the muon is already propagated, so nothing to do
+    if (muon.filteringFlags() & (uint8_t(1) << VarManager::kMuonIsPropagated)) { // the muon is already propagated, so nothing to do
       return;
     }
   }
@@ -1258,8 +1258,8 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kCharge] = track.sign();
 
     if constexpr ((fillMap & ReducedTrack) > 0 && !((fillMap & Pair) > 0)) {
-      //values[kIsGlobalTrack] = track.filteringFlags_bit(0);
-      //values[kIsGlobalTrackSDD] = track.filteringFlags_bit(1);
+      // values[kIsGlobalTrack] = track.filteringFlags_bit(0);
+      // values[kIsGlobalTrackSDD] = track.filteringFlags_bit(1);
       values[kIsAmbiguous] = track.isAmbiguous();
 
       values[kIsLegFromGamma] = track.filteringFlags_bit(VarManager::kIsConversionLeg);

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -127,6 +127,22 @@ class VarManager : public TObject
     kNMaxCandidateTypes
   };
 
+  enum BarrelTrackFilteringBits {
+    kIsConversionLeg = 0,           // electron from conversions
+    kIsK0sLeg,                      // pion from K0s
+    kIsLambdaLeg,                   // proton or pion from Lambda
+    kIsALambdaLeg,                  // proton or pion from anti-Lambda  
+    kIsOmegaLeg,                    // kaon from Omega baryon decay
+    kDalitzBits = 5,                // first bit for Dalitz tagged tracks 
+    kBarrelUserCutsBits = 13,       // first bit for user track cuts
+    kIsTPCPostcalibrated = 63       // tracks were postcalibrated for the TPC PID
+  }
+
+  enum MuonTrackFilteringBits {
+    kMuonUserCutsBits = 0,        // first bit for user muon cuts
+    kMuonIsPropagated = 7         // whether the muon was propagated already
+  }
+
  public:
   enum Variables {
     kNothing = -1,
@@ -897,6 +913,13 @@ void VarManager::FillPropagateMuon(const T& muon, const C& collision, float* val
   if (!values) {
     values = fgValues;
   }
+
+  if constexpr ((fillMap & ReducedMuonCov) > 0) {
+    if (muon.filteringFlags() & (uint8_t(1) << VarManager::kMuonIsPropagated)) {  // the muon is already propagated, so nothing to do
+      return;
+    }
+  }
+
   if constexpr ((fillMap & MuonCov) > 0 || (fillMap & ReducedMuonCov) > 0) {
     o2::dataformats::GlobalFwdTrack propmuon = PropagateMuon(muon, collision);
 
@@ -1234,20 +1257,20 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kCharge] = track.sign();
 
     if constexpr ((fillMap & ReducedTrack) > 0 && !((fillMap & Pair) > 0)) {
-      values[kIsGlobalTrack] = track.filteringFlags_bit(0);
-      values[kIsGlobalTrackSDD] = track.filteringFlags_bit(1);
+      //values[kIsGlobalTrack] = track.filteringFlags_bit(0);
+      //values[kIsGlobalTrackSDD] = track.filteringFlags_bit(1);
       values[kIsAmbiguous] = track.isAmbiguous();
 
-      values[kIsLegFromGamma] = track.filteringFlags_bit(2);
-      values[kIsLegFromK0S] = track.filteringFlags_bit(3);
-      values[kIsLegFromLambda] = track.filteringFlags_bit(4);
-      values[kIsLegFromAntiLambda] = track.filteringFlags_bit(5);
-      values[kIsLegFromOmega] = track.filteringFlags_bit(6);
+      values[kIsLegFromGamma] = track.filteringFlags_bit(VarManager::kIsConversionLeg);
+      values[kIsLegFromK0S] = track.filteringFlags_bit(VarManager::kIsK0sLeg);
+      values[kIsLegFromLambda] = track.filteringFlags_bit(VarManager::kIsLambdaLeg);
+      values[kIsLegFromAntiLambda] = track.filteringFlags_bit(VarManager::kIsALambdaLeg);
+      values[kIsLegFromOmega] = track.filteringFlags_bit(VarManager::kIsOmegaLeg);
 
       values[kIsProtonFromLambdaAndAntiLambda] = static_cast<bool>((values[kIsLegFromLambda] * track.sign() > 0) || (values[kIsLegFromAntiLambda] * (-track.sign()) > 0));
 
       for (int i = 0; i < 8; i++) {
-        values[kIsDalitzLeg + i] = track.filteringFlags_bit(7 + i);
+        values[kIsDalitzLeg + i] = track.filteringFlags_bit(VarManager::kDalitzBits + i);
       }
     }
   }
@@ -1408,6 +1431,12 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kTPCnSigmaKa] = track.tpcNSigmaKa();
     values[kTPCnSigmaPr] = track.tpcNSigmaPr();
 
+    bool isTPCCalibrated = false;
+    if constexpr ((fillMap & ReducedTrackBarrelPID) > 0) {
+      if (track.filteringFlags_bit(kIsTPCPostcalibrated)) {
+        isTPCCalibrated = true;
+      }
+    }
     // compute TPC postcalibrated electron nsigma based on calibration histograms from CCDB
     if (fgUsedVars[kTPCnSigmaEl_Corr] && fgRunTPCPostCalibration[0]) {
       TH3F* calibMean = reinterpret_cast<TH3F*>(fgCalibs[kTPCElectronMean]);
@@ -1425,7 +1454,11 @@ void VarManager::FillTrack(T const& track, float* values)
 
       double mean = calibMean->GetBinContent(binTPCncls, binPin, binEta);
       double width = calibSigma->GetBinContent(binTPCncls, binPin, binEta);
-      values[kTPCnSigmaEl_Corr] = (values[kTPCnSigmaEl] - mean) / width;
+      if (!isTPCCalibrated) {
+        values[kTPCnSigmaEl_Corr] = (values[kTPCnSigmaEl] - mean) / width;
+      } else {
+        values[kTPCnSigmaEl_Corr] = track.tpcNSigmaEl();
+      }
     }
     // compute TPC postcalibrated pion nsigma if required
     if (fgUsedVars[kTPCnSigmaPi_Corr] && fgRunTPCPostCalibration[1]) {
@@ -1444,7 +1477,11 @@ void VarManager::FillTrack(T const& track, float* values)
 
       double mean = calibMean->GetBinContent(binTPCncls, binPin, binEta);
       double width = calibSigma->GetBinContent(binTPCncls, binPin, binEta);
-      values[kTPCnSigmaPi_Corr] = (values[kTPCnSigmaPi] - mean) / width;
+      if (!isTPCCalibrated) {
+        values[kTPCnSigmaPi_Corr] = (values[kTPCnSigmaPi] - mean) / width;
+      } else {
+        values[kTPCnSigmaPi_Corr] = track.tpcNSigmaPi();
+      }
     }
     if (fgUsedVars[kTPCnSigmaKa_Corr] && fgRunTPCPostCalibration[2]) {
       TH3F* calibMean = reinterpret_cast<TH3F*>(fgCalibs[kTPCKaonMean]);
@@ -1462,7 +1499,11 @@ void VarManager::FillTrack(T const& track, float* values)
 
       double mean = calibMean->GetBinContent(binTPCncls, binPin, binEta);
       double width = calibSigma->GetBinContent(binTPCncls, binPin, binEta);
-      values[kTPCnSigmaKa_Corr] = (values[kTPCnSigmaKa] - mean) / width;
+      if (!isTPCCalibrated) {
+        values[kTPCnSigmaKa_Corr] = (values[kTPCnSigmaKa] - mean) / width;
+      } else {
+        values[kTPCnSigmaKa_Corr] = track.tpcNSigmaKa();
+      }
     }
     // compute TPC postcalibrated proton nsigma if required
     if (fgUsedVars[kTPCnSigmaPr_Corr] && fgRunTPCPostCalibration[3]) {
@@ -1481,7 +1522,11 @@ void VarManager::FillTrack(T const& track, float* values)
 
       double mean = calibMean->GetBinContent(binTPCncls, binPin, binEta);
       double width = calibSigma->GetBinContent(binTPCncls, binPin, binEta);
-      values[kTPCnSigmaPr_Corr] = (values[kTPCnSigmaPr] - mean) / width;
+      if (!isTPCCalibrated) {
+        values[kTPCnSigmaPr_Corr] = (values[kTPCnSigmaPr] - mean) / width;
+      } else {
+        values[kTPCnSigmaPr_Corr] = track.tpcNSigmaPr();
+      }
     }
     values[kTOFnSigmaEl] = track.tofNSigmaEl();
     values[kTOFnSigmaPi] = track.tofNSigmaPi();

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -136,12 +136,12 @@ class VarManager : public TObject
     kDalitzBits = 5,                // first bit for Dalitz tagged tracks 
     kBarrelUserCutsBits = 13,       // first bit for user track cuts
     kIsTPCPostcalibrated = 63       // tracks were postcalibrated for the TPC PID
-  }
+  };
 
   enum MuonTrackFilteringBits {
     kMuonUserCutsBits = 0,        // first bit for user muon cuts
     kMuonIsPropagated = 7         // whether the muon was propagated already
-  }
+  };
 
  public:
   enum Variables {
@@ -359,7 +359,7 @@ class VarManager : public TObject
     kIsDalitzLeg,             // Up to 8 dalitz selections
     kBarrelNAssocsInBunch,    // number of in bunch collision associations
     kBarrelNAssocsOutOfBunch, // number of out of bunch collision associations
-    kNBarrelTrackVariables = kIsDalitzLeg + 8,
+    kNBarrelTrackVariables,
 
     // Muon track variables
     kMuonNClusters,
@@ -784,12 +784,13 @@ class VarManager : public TObject
   VarManager& operator=(const VarManager& c);
   VarManager(const VarManager& c);
 
-  ClassDefNV(VarManager, 3)
+  ClassDef(VarManager, 3);
 };
 
 template <typename T, typename U, typename V>
 auto VarManager::getRotatedCovMatrixXX(const T& matrix, U phi, V theta)
 {
+  //
   auto cp = std::cos(phi);
   auto sp = std::sin(phi);
   auto ct = std::cos(theta);

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -444,6 +444,7 @@ struct TableMaker {
     eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
 
     uint64_t trackFilteringTag = 0;
+    uint8_t fwdFilteringTag = 0;
     uint8_t trackTempFilterMap = 0;
     int isAmbiguous = 0;
     if constexpr (static_cast<bool>(TTrackFillMap)) {
@@ -498,42 +499,48 @@ struct TableMaker {
         }
 
         // store filtering information
-        if (track.isGlobalTrack()) {
+        /*if (track.isGlobalTrack()) {
           trackFilteringTag |= (uint64_t(1) << 0); // BIT0: global track
         }
         if (track.isGlobalTrackSDD()) {
           trackFilteringTag |= (uint64_t(1) << 1); // BIT1: global track SSD
-        }
-        if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackV0Bits)) { // BIT2-6: V0Bits
-          trackFilteringTag |= (uint64_t(track.pidbit()) << 2);
+        }*/
+        if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackV0Bits)) { // BIT0-4: V0Bits
+          trackFilteringTag = uint64_t(track.pidbit());
           for (int iv0 = 0; iv0 < 5; iv0++) {
             if (track.pidbit() & (uint8_t(1) << iv0)) {
               (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(fTrackCuts.size() + static_cast<float>(iv0));
             }
           }
           if (fConfigIsOnlyforMaps) {
-            if (trackFilteringTag & (uint64_t(1) << 2)) { // for electron
+            if (trackFilteringTag & (uint64_t(1) << VarManager::kIsConversionLeg)) { // for electron
               fHistMan->FillHistClass("TrackBarrel_PostCalibElectron", VarManager::fgValues);
             }
-            if (trackFilteringTag & (uint64_t(1) << 3)) { // for pion
+            if (trackFilteringTag & (uint64_t(1) << VarManager::kIsK0sLeg)) { // for pion
               fHistMan->FillHistClass("TrackBarrel_PostCalibPion", VarManager::fgValues);
             }
-            if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 4)) * (track.sign()) > 0)) { // for proton from Lambda
+            if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << VarManager::kIsLambdaLeg)) * (track.sign()) > 0)) { // for proton from Lambda
               fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
             }
-            if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 5)) * (track.sign()) < 0)) { // for proton from AntiLambda
+            if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << VarManager::kIsALambdaLeg)) * (track.sign()) < 0)) { // for proton from AntiLambda
               fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
             }
           }
         }
         if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
-          trackFilteringTag |= (uint64_t(track.dalitzBits()) << 7); // BIT7-14: Dalitz
+          trackFilteringTag |= (uint64_t(track.dalitzBits()) << VarManager::kDalitzBits); // BIT5-12: Dalitz selection bits
         }
-        trackFilteringTag |= (uint64_t(trackTempFilterMap) << 15); // BIT15-...:  user track filters
+        trackFilteringTag |= (uint64_t(trackTempFilterMap) << VarManager::kBarrelUserCutsBits); // BIT13-20...:  user track filters
 
         if (fConfigSaveElectronSample) { // only save electron sample
-          if (!(trackFilteringTag & (uint64_t(1) << 2))) {
+          if (!(trackFilteringTag & (uint64_t(1) << VarManager::kIsConversionLeg))) {
             continue;
+          }
+        }
+
+        if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackPID)) {
+          if (fConfigComputeTPCpostCalib) {
+            trackFilteringTag |= (uint64_t(1) << VarManager::kIsTPCPostcalibrated);    // store the info on whether TPC pid is skimmed as postcalibrated
           }
         }
 
@@ -600,7 +607,7 @@ struct TableMaker {
         VarManager::FillTrack<gkMFTFillMap>(mft);
         fHistMan->FillHistClass("MftTracks", VarManager::fgValues);
 
-        trackMFT(event.lastIndex(), trackFilteringTag, mft.pt(), mft.eta(), mft.phi());
+        trackMFT(event.lastIndex(), fwdFilteringTag, mft.pt(), mft.eta(), mft.phi());
         trackMFTExtra(mft.mftClusterSizesAndTrackFlags(), mft.sign(), dcaX, dcaY, mft.nClusters());
       } // end of mft : mftTracks
 
@@ -624,7 +631,7 @@ struct TableMaker {
       std::map<int, int> newMFTMatchIndex;
 
       for (auto& muon : tracksMuon) {
-        trackFilteringTag = uint64_t(0);
+        fwdFilteringTag = uint64_t(0);
         VarManager::FillTrack<TMuonFillMap>(muon);
         if (fPropMuon) {
           VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
@@ -662,7 +669,7 @@ struct TableMaker {
             }
           }
         }
-        trackFilteringTag = uint64_t(0);
+        fwdFilteringTag = uint8_t(0);
         trackTempFilterMap = uint8_t(0);
 
         VarManager::FillTrack<TMuonFillMap>(muon);
@@ -693,7 +700,10 @@ struct TableMaker {
           continue;
         }
         // store the cut decisions
-        trackFilteringTag |= uint64_t(trackTempFilterMap); // BIT0-7:  user selection cuts
+        trackFilteringTag = trackTempFilterMap; // BIT0-7:  user selection cuts
+        if (fPropMuon) {
+          trackFilteringTag |= (uint8_t(1) << VarManager::kMuonIsPropagated);  // store the info on whether the muon is propagated or not
+        }
 
         // update the matching MCH/MFT index
         if (static_cast<int>(muon.trackType()) == 0 || static_cast<int>(muon.trackType()) == 2) { // MCH-MFT(2) or GLB(0) track

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -540,7 +540,7 @@ struct TableMaker {
 
         if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackPID)) {
           if (fConfigComputeTPCpostCalib) {
-            trackFilteringTag |= (uint64_t(1) << VarManager::kIsTPCPostcalibrated);    // store the info on whether TPC pid is skimmed as postcalibrated
+            trackFilteringTag |= (uint64_t(1) << VarManager::kIsTPCPostcalibrated); // store the info on whether TPC pid is skimmed as postcalibrated
           }
         }
 
@@ -702,7 +702,7 @@ struct TableMaker {
         // store the cut decisions
         trackFilteringTag = trackTempFilterMap; // BIT0-7:  user selection cuts
         if (fPropMuon) {
-          trackFilteringTag |= (uint8_t(1) << VarManager::kMuonIsPropagated);  // store the info on whether the muon is propagated or not
+          trackFilteringTag |= (uint8_t(1) << VarManager::kMuonIsPropagated); // store the info on whether the muon is propagated or not
         }
 
         // update the matching MCH/MFT index

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -210,7 +210,7 @@ struct TableMaker {
   std::map<uint32_t, uint32_t> fTrackIndexMap;            // key: old track global index, value: new track global index
   std::map<uint32_t, uint32_t> fFwdTrackIndexMap;         // key: fwd-track global index, value: new fwd-track global index
   std::map<uint32_t, uint32_t> fFwdTrackIndexMapReversed; // key: new fwd-track global index, value: fwd-track global index
-  std::map<uint32_t, uint8_t> fFwdTrackFilterMap;        // key: fwd-track global index, value: fwd-track filter map
+  std::map<uint32_t, uint8_t> fFwdTrackFilterMap;         // key: fwd-track global index, value: fwd-track filter map
   std::map<uint32_t, uint32_t> fMftIndexMap;              // key: MFT tracklet global index, value: new MFT tracklet global index
 
   // FIXME: For now, the skimming is done using the Common track-collision association task, which does not allow to use

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -210,7 +210,7 @@ struct TableMaker {
   std::map<uint32_t, uint32_t> fTrackIndexMap;            // key: old track global index, value: new track global index
   std::map<uint32_t, uint32_t> fFwdTrackIndexMap;         // key: fwd-track global index, value: new fwd-track global index
   std::map<uint32_t, uint32_t> fFwdTrackIndexMapReversed; // key: new fwd-track global index, value: fwd-track global index
-  std::map<uint32_t, uint64_t> fFwdTrackFilterMap;        // key: fwd-track global index, value: fwd-track filter map
+  std::map<uint32_t, uint8_t> fFwdTrackFilterMap;        // key: fwd-track global index, value: fwd-track filter map
   std::map<uint32_t, uint32_t> fMftIndexMap;              // key: MFT tracklet global index, value: new MFT tracklet global index
 
   // FIXME: For now, the skimming is done using the Common track-collision association task, which does not allow to use
@@ -581,29 +581,36 @@ struct TableMaker {
           }
         }
         if (fConfigIsOnlyforMaps) {
-          if (trackFilteringTag & (uint64_t(1) << 0)) { // for electron
+          if (trackFilteringTag & (uint64_t(1) << VarManager::kIsConversionLeg)) { // for electron
             fHistMan->FillHistClass("TrackBarrel_PostCalibElectron", VarManager::fgValues);
           }
-          if (trackFilteringTag & (uint64_t(1) << 1)) { // for pion
+          if (trackFilteringTag & (uint64_t(1) << VarManager::kIsK0sLeg)) { // for pion
             fHistMan->FillHistClass("TrackBarrel_PostCalibPion", VarManager::fgValues);
           }
-          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 2)) * (track.sign()) > 0)) { // for proton from Lambda
+          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << VarManager::kIsLambdaLeg)) * (track.sign()) > 0)) { // for proton from Lambda
             fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
           }
-          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << 3)) * (track.sign()) < 0)) { // for proton from AntiLambda
+          if ((static_cast<bool>(trackFilteringTag & (uint64_t(1) << VarManager::kIsALambdaLeg)) * (track.sign()) < 0)) { // for proton from AntiLambda
             fHistMan->FillHistClass("TrackBarrel_PostCalibProton", VarManager::fgValues);
           }
         }
         if (fConfigSaveElectronSample) { // only save electron sample
-          if (!(trackFilteringTag & (uint64_t(1) << 2))) {
+          if (!(trackFilteringTag & (uint64_t(1) << VarManager::kIsConversionLeg))) {
             continue;
           }
         }
       } // end if V0Bits
       if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::DalitzBits)) {
-        trackFilteringTag |= (uint64_t(track.dalitzBits()) << 5); // BIT5-12: Dalitz
+        trackFilteringTag |= (uint64_t(track.dalitzBits()) << VarManager::kDalitzBits); // BIT5-12: Dalitz
       }
-      trackFilteringTag |= (uint64_t(trackTempFilterMap) << 13); // BIT13-...:  user track filters
+      trackFilteringTag |= (uint64_t(trackTempFilterMap) << VarManager::kBarrelUserCutsBits); // BIT13-...:  user track filters
+
+      if constexpr (static_cast<bool>(TTrackFillMap & VarManager::ObjTypes::TrackPID)) {
+        if (fConfigComputeTPCpostCalib) {
+          trackFilteringTag |= (uint64_t(1) << VarManager::kIsTPCPostcalibrated);
+        }
+      }
+
       // write the track global index in the map for skimming (to make sure we have it just once)
       if (fTrackIndexMap.find(track.globalIndex()) == fTrackIndexMap.end()) {
         // NOTE: The collision ID that is written in the table is the one found in the first association for this track.
@@ -679,7 +686,7 @@ struct TableMaker {
     //     Muons are written only once, even if they constribute to more than one association,
     //         which means that in the case of multiple associations, the track parameters are wrong and should be computed again at analysis time.
 
-    uint64_t trackFilteringTag = uint64_t(0);
+    uint8_t trackFilteringTag = uint8_t(0);
     uint8_t trackTempFilterMap = uint8_t(0);
     fFwdTrackIndexMapReversed.clear();
 
@@ -689,7 +696,7 @@ struct TableMaker {
       // get the muon
       auto muon = assoc.template fwdtrack_as<TMuons>();
 
-      trackFilteringTag = uint64_t(0);
+      trackFilteringTag = uint8_t(0);
       VarManager::FillTrack<TMuonFillMap>(muon);
       // NOTE: If a muon is associated to multiple collisions, depending on the selections,
       //       it may be accepted for some associations and rejected for other
@@ -714,7 +721,7 @@ struct TableMaker {
       if (!trackTempFilterMap) {
         continue;
       }
-      trackFilteringTag |= uint64_t(trackTempFilterMap); // BIT0-7:  user selection cuts
+      trackFilteringTag = trackTempFilterMap; // BIT0-7:  user selection cuts
 
       // update the index map if this is a new muon (it can already exist in the map from a different collision association)
       if (fFwdTrackIndexMap.find(muon.globalIndex()) == fFwdTrackIndexMap.end()) {
@@ -764,10 +771,10 @@ struct TableMaker {
                 muon.trackTime(), muon.trackTimeRes());
       muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
       if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
-        muonCov(VarManager::fgValues[VarManager::kX], VarManager::fgValues[VarManager::kY], VarManager::fgValues[VarManager::kZ], VarManager::fgValues[VarManager::kPhi], VarManager::fgValues[VarManager::kTgl], muon.sign() / VarManager::fgValues[VarManager::kPt],
-                VarManager::fgValues[VarManager::kMuonCXX], VarManager::fgValues[VarManager::kMuonCXY], VarManager::fgValues[VarManager::kMuonCYY], VarManager::fgValues[VarManager::kMuonCPhiX], VarManager::fgValues[VarManager::kMuonCPhiY], VarManager::fgValues[VarManager::kMuonCPhiPhi],
-                VarManager::fgValues[VarManager::kMuonCTglX], VarManager::fgValues[VarManager::kMuonCTglY], VarManager::fgValues[VarManager::kMuonCTglPhi], VarManager::fgValues[VarManager::kMuonCTglTgl], VarManager::fgValues[VarManager::kMuonC1Pt2X], VarManager::fgValues[VarManager::kMuonC1Pt2Y],
-                VarManager::fgValues[VarManager::kMuonC1Pt2Phi], VarManager::fgValues[VarManager::kMuonC1Pt2Tgl], VarManager::fgValues[VarManager::kMuonC1Pt21Pt2]);
+        muonCov(muon.x(), muon.y(), muon.z(), muon.phi(), muon.tgl(), muon.sign() / muon.pt(),
+                muon.cXX(), muon.cXY(), muon.cYY(), muon.cPhiX(), muon.cPhiY(), muon.cPhiPhi(),
+                muon.cTglX(), muon.cTglY(), muon.cTglPhi(), muon.cTglTgl(), muon.c1PtX(), muon.c1PtY(),
+                muon.c1PtPhi(), muon.c1PtTgl(), muon.c1Pt21Pt2());
       }
     } // end loop over selected muons
   }   // end skimMuons

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -16,7 +16,7 @@ o2physics_add_dpl_workflow(table-reader
 
 o2physics_add_dpl_workflow(table-reader-with-assoc
                     SOURCES tableReader_withAssoc.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(efficiency

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -546,6 +546,9 @@ struct AnalysisMuonSelection {
     fCCDB->setCaching(true);
     fCCDB->setLocalObjectValidityChecking();
     fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      fCCDB->get<TGeoManager>(geoPath);
+    }
   }
 
   template <uint32_t TEventFillMap, uint32_t TMuonFillMap, typename TEvents, typename TMuons>
@@ -554,6 +557,7 @@ struct AnalysisMuonSelection {
     if (events.size() > 0 && fCurrentRun != events.begin().runNumber()) {
       o2::parameters::GRPMagField* grpmag = fCCDB->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, events.begin().timestamp());
       if (grpmag != nullptr) {
+        o2::base::Propagator::initFieldFromGRP(grpmag);
         VarManager::SetMagneticField(grpmag->getNominalL3Field());
       } else {
         LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", events.begin().timestamp());

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -505,6 +505,7 @@ struct AnalysisMuonSelection {
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
   Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<std::string> fConfigGeoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
 
@@ -547,7 +548,7 @@ struct AnalysisMuonSelection {
     fCCDB->setLocalObjectValidityChecking();
     fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
     if (!o2::base::GeometryManager::isGeometryLoaded()) {
-      fCCDB->get<TGeoManager>(geoPath);
+      fCCDB->get<TGeoManager>(fConfigGeoPath);
     }
   }
 


### PR DESCRIPTION
Additional changes:
1) Adding enum to define the bits from the filteringTagsfor the muon and barrel tracks
2) fixing the problem with initialized mag field in table-reader-with-assoc
3) In tableMaker_withAssoc, the skimmed fwd tracks are selected according to propagated track params, but the skimmed tracks written to disk will be unpropagated so that the propagation can be applied at analysis time.