### PR TITLE
PWGHF: fix Lc polarization

### DIFF
--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -82,7 +82,7 @@ struct TaskPolarisationCharmHadrons {
   // ConfigurableAxis configThnAxisCent{"configThnAxisCent", {102, -1., 101.}, "centrality (%)"};
 
   Filter filterSelectDstarCandidates = aod::hf_sel_candidate_dstar::isSelDstarToD0Pi == selectionFlagDstarToD0Pi;
-  Filter filterSelectLcToPKPiCandidates = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLcToPKPi || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLcToPKPi);
+  Filter filterSelectLcToPKPiCandidates = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLcToPKPi) || (aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLcToPKPi);
 
   HfHelper hfHelper;
   HistogramRegistry registry{"registry", {}};

--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -82,7 +82,7 @@ struct TaskPolarisationCharmHadrons {
   // ConfigurableAxis configThnAxisCent{"configThnAxisCent", {102, -1., 101.}, "centrality (%)"};
 
   Filter filterSelectDstarCandidates = aod::hf_sel_candidate_dstar::isSelDstarToD0Pi == selectionFlagDstarToD0Pi;
-  Filter filterSelectLcToPKPiCandidates = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLcToPKPi) || (aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLcToPKPi);
+  Filter filterSelectLcToPKPiCandidates = (aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLcToPKPi || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLcToPKPi);
 
   HfHelper hfHelper;
   HistogramRegistry registry{"registry", {}};
@@ -173,6 +173,7 @@ struct TaskPolarisationCharmHadrons {
           pxDau = candidate.pxProng0();
           pyDau = candidate.pyProng0();
           pzDau = candidate.pzProng0();
+          invMassCharmHad = hfHelper.invMassLcToPKPi(candidate);
           invMassCharmHadForSparse = hfHelper.invMassLcToPKPi(candidate);
           if constexpr (withMl) {
             if (candidate.mlProbLcToPKPi().size() == 3) {
@@ -188,6 +189,7 @@ struct TaskPolarisationCharmHadrons {
           pxDau = candidate.pxProng2();
           pyDau = candidate.pyProng2();
           pzDau = candidate.pzProng2();
+          invMassCharmHad = hfHelper.invMassLcToPiKP(candidate);
           invMassCharmHadForSparse = hfHelper.invMassLcToPiKP(candidate);
           if constexpr (withMl) {
             if (candidate.mlProbLcToPiKP().size() == 3) {
@@ -198,9 +200,12 @@ struct TaskPolarisationCharmHadrons {
               outputMl[2] = candidate.mlProbLcToPiKP()[2];
             }
           }
+        } else {
+          // NB: no need to check cases in which candidate.isSelLcToPKPi() and candidate.isSelLcToPiKP() are both false, because they are rejected already by the Filter
+          // ... but we need to put this protections here!
+          // Otherwise, a candidate selected as pKpi only has invMassCharmHad==0 when iMass == charm_polarisation::MassHyposLcToPKPi::PiKP and viceversa
+          continue;
         }
-
-        // NB: no need to check cases in which candidate.isSelLcToPKPi() and candidate.isSelLcToPiKP() are both false, because they are rejected already by the Filter
 
         // hypothesis-independent variables
         pxCharmHad = candidate.px();


### PR DESCRIPTION
- inv. mass used for 4-vector calculation was always at 0 by mistake
- add protection due to double mass hypotheses