### PR TITLE
PWGLF: Resonance framework hotfix for run3 study

### DIFF
--- a/PWGLF/TableProducer/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/LFResonanceInitializer.cxx
@@ -179,7 +179,7 @@ struct reso2initializer {
                                                     || (nabs(aod::mcparticle::pdgCode) == 123314)  // Xi(1820)0
                                                     || (nabs(aod::mcparticle::pdgCode) == 123324); // Xi(1820)-0
 
-  using ResoEvents = soa::Join<aod::Collisions, aod::EvSels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0Cs, aod::CentFT0As, aod::CentRun2V0Ms>;
+  using ResoEvents = soa::Join<aod::Collisions, aod::EvSels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0Cs, aod::CentFT0As>;
   using ResoRun2Events = soa::Join<aod::Collisions, aod::EvSels, aod::CentRun2V0Ms>;
   using ResoEventsMC = soa::Join<ResoEvents, aod::McCollisionLabels>;
   using ResoRun2EventsMC = soa::Join<ResoEvents, aod::McCollisionLabels>;
@@ -953,7 +953,7 @@ struct reso2initializer {
 
     fillTracks<false>(collision, tracks);
   }
-  PROCESS_SWITCH(reso2initializer, processTrackDataRun2, "Process for data", true);
+  PROCESS_SWITCH(reso2initializer, processTrackDataRun2, "Process for data", false);
 
   void processTrackEPData(soa::Filtered<soa::Join<ResoEvents, aod::Qvectors>>::iterator const& collision,
                           soa::Filtered<ResoTracks> const& tracks,


### PR DESCRIPTION
I had to remove CentV0MRun2s from run3 events and disable the process for run2 by default.