### PR TITLE
PWGDQ: tableReader: fix pair histogram filling

### DIFF
--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -1137,7 +1137,7 @@ struct AnalysisSameEventPairing {
             }
           }      // end loop (pair cuts)
         } else { // end if (filter bits)
-          iCut++;
+          iCut = iCut + 1 + fPairCuts.size();
         }
       } // end loop (cuts)
     }   // end loop over pairs


### PR DESCRIPTION
Dear DQ code experts,
it seems to me that for the same event pairing the filling of the histograms in lines https://github.com/AliceO2Group/O2Physics/blob/da70ecf75cb1484c9343e5c08445e9f097fe274f/PWGDQ/Tasks/tableReader.cxx#L1094-L1142 seems to get mixed up. E.g. sometimes I get more entries in histograms with pair cuts than in the corresponding histogram without pair cuts.
I think it should be fixed in line 1140, where the variable `iCut` is not shifted by the correct amount.

Sorry in case I'm missing something super obvious...