### PR TITLE
PWGHF: add generated eta information for charm baryon

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1092,6 +1092,7 @@ DECLARE_SOA_COLUMN(DebugGenLambda, debugGenLambda, int8_t);
 DECLARE_SOA_COLUMN(OriginRec, originRec, int8_t);
 DECLARE_SOA_COLUMN(OriginGen, originGen, int8_t);
 DECLARE_SOA_COLUMN(PtCharmBaryonGen, ptCharmBaryonGen, float);
+DECLARE_SOA_COLUMN(EtaCharmBaryonGen, etaCharmBaryonGen, float);
 
 // mapping of decay types
 enum DecayType { DecayToXiPi = 0,
@@ -1138,7 +1139,7 @@ DECLARE_SOA_TABLE(HfToXiPiMCRec, "AOD", "HFTOXIPIMCREC", //!
 
 // table with results of generator level MC matching
 DECLARE_SOA_TABLE(HfToXiPiMCGen, "AOD", "HFTOXIPIMCGEN", //!
-                  hf_cand_toxipi::FlagMcMatchGen, hf_cand_toxipi::DebugGenCharmBar, hf_cand_toxipi::DebugGenXi, hf_cand_toxipi::DebugGenLambda, hf_cand_toxipi::PtCharmBaryonGen, hf_cand_toxipi::OriginGen);
+                  hf_cand_toxipi::FlagMcMatchGen, hf_cand_toxipi::DebugGenCharmBar, hf_cand_toxipi::DebugGenXi, hf_cand_toxipi::DebugGenLambda, hf_cand_toxipi::PtCharmBaryonGen, hf_cand_toxipi::EtaCharmBaryonGen, hf_cand_toxipi::OriginGen);
 
 // specific chic candidate properties
 namespace hf_cand_chic

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -517,7 +517,7 @@ struct HfCandidateCreatorToXiPiMc {
         }
       }
 
-      rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, etaCharmBaryon, origin);
+      rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
     }
   } // close process
   PROCESS_SWITCH(HfCandidateCreatorToXiPiMc, processMc, "Process MC", false);

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -463,7 +463,7 @@ struct HfCandidateCreatorToXiPiMc {
     // Match generated particles.
     for (const auto& particle : mcParticles) {
       ptCharmBaryonGen = -999.;
-      etaCharmBaryon = -999.;
+      etaCharmBaryonGen = -999.;
       flag = 0;
       sign = -9;
       debugGenCharmBar = 0;
@@ -475,7 +475,7 @@ struct HfCandidateCreatorToXiPiMc {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
-          etaCharmBaryon = particle.eta();
+          etaCharmBaryonGen = particle.eta();
           // Xi -> Lambda pi
           auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
           if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
@@ -498,7 +498,7 @@ struct HfCandidateCreatorToXiPiMc {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
-          etaCharmBaryon = particle.eta();
+          etaCharmBaryonGen = particle.eta();
           // Xi- -> Lambda pi
           auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
           if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -354,6 +354,7 @@ struct HfCandidateCreatorToXiPiMc {
                  aod::McParticles const& mcParticles)
   {
     float ptCharmBaryonGen = -999.;
+    float etaCharmBaryonGen = -999.;
     int indexRec = -1;
     int indexRecCharmBaryon = -1;
     int8_t sign = -9;
@@ -462,6 +463,7 @@ struct HfCandidateCreatorToXiPiMc {
     // Match generated particles.
     for (const auto& particle : mcParticles) {
       ptCharmBaryonGen = -999.;
+      etaCharmBaryon = -999.;
       flag = 0;
       sign = -9;
       debugGenCharmBar = 0;
@@ -473,6 +475,7 @@ struct HfCandidateCreatorToXiPiMc {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
+          etaCharmBaryon = particle.eta();
           // Xi -> Lambda pi
           auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
           if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
@@ -495,6 +498,7 @@ struct HfCandidateCreatorToXiPiMc {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
+          etaCharmBaryon = particle.eta();
           // Xi- -> Lambda pi
           auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
           if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
@@ -513,7 +517,7 @@ struct HfCandidateCreatorToXiPiMc {
         }
       }
 
-      rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, origin);
+      rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, etaCharmBaryon, origin);
     }
   } // close process
   PROCESS_SWITCH(HfCandidateCreatorToXiPiMc, processMc, "Process MC", false);


### PR DESCRIPTION
Add information about charm baryon generated eta (needed for offline analysis) in the MC table produced by candidateCreatorToXiPi