### PR TITLE
PWGHF: Modify the muon cuts and histograms in HFL muon source task

### DIFF
--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -65,11 +65,9 @@ struct HfTaskSingleMuonSource {
   Configurable<int> mcMaskSelection{"mcMaskSelection", 0, "McMask for correct match, valid values are 0 and 128"};
   Configurable<int> trackType{"trackType", 0, "Muon track type, validated values are 0, 1, 2, 3 and 4"};
 
-  double pDcaMin = 324.0; // p*DCA maximum value for small Rabs
   double pDcaMax = 594.0; // p*DCA maximum value for large Rabs
-  double rAbsMin = 17.6;  // R at absorber end minimum value
+  double rAbsMin = 26.5;  // R at absorber end minimum value
   double rAbsMax = 89.5;  // R at absorber end maximum value
-  double rAbsMid = 26.5;  // R at absorber end split point for different p*DCA selections
   double etaLow = -3.6;   // low edge of eta acceptance
   double etaUp = -2.5;    // up edge of eta acceptance
   double edgeZ = 10.0;    // edge of event position Z
@@ -96,16 +94,16 @@ struct HfTaskSingleMuonSource {
     AxisSpec axisDCA{5000, 0., 5., "DCA (cm)"};
     AxisSpec axisChi2{500, 0., 100., "#chi^{2} of MCH-MFT matching"};
     AxisSpec axisPt{200, 0., 100., "#it{p}_{T,reco} (GeV/#it{c})"};
-    AxisSpec axisEta{250, -5., 0., "#it{#eta}"};
+    AxisSpec axisDeltaPt{1000, -50., 50., "#Delta #it{p}_{T} (GeV/#it{c})"};
 
     HistogramConfigSpec h2PtDCA{HistType::kTH2F, {axisPt, axisDCA}};
     HistogramConfigSpec h2PtChi2{HistType::kTH2F, {axisPt, axisChi2}};
-    HistogramConfigSpec h2PtEta{HistType::kTH2F, {axisPt, axisEta}};
+    HistogramConfigSpec h2PtDeltaPt{HistType::kTH2F, {axisPt, axisDeltaPt}};
 
     for (const auto& src : muonSources) {
       registry.add(Form("h2%sPtDCA", src.Data()), "", h2PtDCA);
       registry.add(Form("h2%sPtChi2", src.Data()), "", h2PtChi2);
-      registry.add(Form("h2%sPtEta", src.Data()), "", h2PtEta);
+      registry.add(Form("h2%sPtDeltaPt", src.Data()), "", h2PtDeltaPt);
     }
   }
 
@@ -237,39 +235,45 @@ struct HfTaskSingleMuonSource {
   void fillHistograms(const McMuons::iterator& muon)
   {
     const auto mask(getMask(muon));
-    const auto pt(muon.pt()), chi2(muon.chi2MatchMCHMFT()), eta(muon.eta());
+    const auto pt(muon.pt()), chi2(muon.chi2MatchMCHMFT());
     const auto dca(RecoDecay::sqrtSumOfSquares(muon.fwdDcaX(), muon.fwdDcaY()));
+
+    if (!muon.has_matchMCHTrack()) {
+      return;
+    }
+    const auto muonType3 = muon.matchMCHTrack_as<McMuons>();
+    const auto deltaPt = muonType3.pt() - pt;
 
     singleMuonSource(pt, dca, mask);
 
     if (isBeautyDecayMu(mask)) {
       registry.fill(HIST("h2BeautyDecayMuPtDCA"), pt, dca);
       registry.fill(HIST("h2BeautyDecayMuPtChi2"), pt, chi2);
-      registry.fill(HIST("h2BeautyDecayMuPtEta"), pt, eta);
+      registry.fill(HIST("h2BeautyDecayMuPtDeltaPt"), pt, deltaPt);
     } else if (isNonpromptCharmMu(mask)) {
       registry.fill(HIST("h2NonpromptCharmMuPtDCA"), pt, dca);
       registry.fill(HIST("h2NonpromptCharmMuPtChi2"), pt, chi2);
-      registry.fill(HIST("h2NonpromptCharmMuPtEta"), pt, eta);
+      registry.fill(HIST("h2NonpromptCharmMuPtDeltaPt"), pt, deltaPt);
     } else if (isPromptCharmMu(mask)) {
       registry.fill(HIST("h2PromptCharmMuPtDCA"), pt, dca);
       registry.fill(HIST("h2PromptCharmMuPtChi2"), pt, chi2);
-      registry.fill(HIST("h2PromptCharmMuPtEta"), pt, eta);
+      registry.fill(HIST("h2PromptCharmMuPtDeltaPt"), pt, deltaPt);
     } else if (isLightDecayMu(mask)) {
       registry.fill(HIST("h2LightDecayMuPtDCA"), pt, dca);
       registry.fill(HIST("h2LightDecayMuPtChi2"), pt, chi2);
-      registry.fill(HIST("h2LightDecayMuPtEta"), pt, eta);
+      registry.fill(HIST("h2LightDecayMuPtDeltaPt"), pt, deltaPt);
     } else if (isSecondaryMu(mask)) {
       registry.fill(HIST("h2SecondaryMuPtDCA"), pt, dca);
       registry.fill(HIST("h2SecondaryMuPtChi2"), pt, chi2);
-      registry.fill(HIST("h2SecondaryMuPtEta"), pt, eta);
+      registry.fill(HIST("h2SecondaryMuPtDeltaPt"), pt, deltaPt);
     } else if (isHadron(mask)) {
       registry.fill(HIST("h2HadronPtDCA"), pt, dca);
       registry.fill(HIST("h2HadronPtChi2"), pt, chi2);
-      registry.fill(HIST("h2HadronPtEta"), pt, eta);
+      registry.fill(HIST("h2HadronPtDeltaPt"), pt, deltaPt);
     } else if (isUnidentified(mask)) {
       registry.fill(HIST("h2UnidentifiedPtDCA"), pt, dca);
       registry.fill(HIST("h2UnidentifiedPtChi2"), pt, chi2);
-      registry.fill(HIST("h2UnidentifiedPtEta"), pt, eta);
+      registry.fill(HIST("h2UnidentifiedPtDeltaPt"), pt, deltaPt);
     }
   }
 
@@ -300,10 +304,7 @@ struct HfTaskSingleMuonSource {
       if ((rAbs >= rAbsMax) || (rAbs < rAbsMin)) {
         continue;
       }
-      if ((rAbs < rAbsMid) && (pDca >= pDcaMin)) {
-        continue;
-      }
-      if ((rAbs >= rAbsMid) && (pDca >= pDcaMax)) {
+      if (pDca >= pDcaMax) {
         continue;
       }
       if ((muon.chi2() >= 1e6) || (muon.chi2() < 0)) {


### PR DESCRIPTION
Replace the pT-eta histograms to the Delta pT-pT histograms, and tighten the Rabs cut for muon source separation task.