### PR TITLE
PWGLF: add missing 'IU' in run 3 process function

### DIFF
--- a/PWGLF/Tasks/Strangeness/cascadeanalysisMC.cxx
+++ b/PWGLF/Tasks/Strangeness/cascadeanalysisMC.cxx
@@ -442,7 +442,7 @@ struct cascadeAnalysisMC {
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun2VsMultiplicity, "Process Run 2 data vs multiplicity", false);
 
-  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::McParticles const&)
+  void processRun3WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, FullTracksExtIUWithPID const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 3 event selection criteria
@@ -451,13 +451,13 @@ struct cascadeAnalysisMC {
     }
     // fill cascade information with tracksIU typecast (Run 3)
     for (auto& casc : Cascades) {
-      int lPIDvalue = checkCascadeTPCPID<FullTracksExtWithPID>(casc);
+      int lPIDvalue = checkCascadeTPCPID<FullTracksExtIUWithPID>(casc);
       processCascadeCandidate<FullTracksExtIUWithPID>(casc, collision.posX(), collision.posY(), collision.posZ(), -999, lPIDvalue);
     }
   }
   PROCESS_SWITCH(cascadeAnalysisMC, processRun3WithPID, "Process Run 3 data  with PID", false);
 
-  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, aod::McParticles const&)
+  void processRun2WithPID(soa::Join<aod::Collisions, aod::EvSels>::iterator const& collision, soa::Filtered<LabeledCascades> const& Cascades, aod::V0sLinked const&, FullTracksExtWithPID const&, aod::McParticles const&)
   // process function subscribing to Run 3-like analysis objects
   {
     // Run 2 event selection criteria


### PR DESCRIPTION
Also subscribe to tracks table in the "withPID" process functions, both for run 2 and run 3