### PR TITLE
Common/PWGHF: fix smearing of sigmaYZ cov. matrix term in TrackTuner, and add protection.

### DIFF
--- a/Common/TableProducer/trackPropagation.cxx
+++ b/Common/TableProducer/trackPropagation.cxx
@@ -182,8 +182,8 @@ struct TrackPropagation {
       // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
       if (track.trackType() == aod::track::TrackIU && track.x() < minPropagationRadius) {
         if constexpr (isMc && fillCovMat) { /// track tuner ok only if cov. matrix is used
-          trackTunedTracks->Fill(1);        // all tracks
           if (useTrackTuner) {
+            trackTunedTracks->Fill(1);        // all tracks
             // call track propagator
             // this function reads many many things
             //  - reads track params

--- a/Common/TableProducer/trackPropagation.cxx
+++ b/Common/TableProducer/trackPropagation.cxx
@@ -60,7 +60,7 @@ struct TrackPropagation {
   // for TrackTuner only (MC smearing)
   Configurable<bool> useTrackTuner{"useTrackTuner", false, "Apply Improver/DCA corrections to MC"};
   Configurable<std::string> trackTunerParams{"trackTunerParams", "debugInfo=0|updateTrackCovMat=1|updateCurvature=0|updatePulls=0|isInputFileFromCCDB=1|pathInputFile=Users/m/mfaggin/test/inputsTrackTuner/PbPb2022|nameInputFile=trackTuner_DataLHC22sPass5_McLHC22l1b2_run529397.root|usePvRefitCorrections=0|oneOverPtCurrent=0|oneOverPtUpgr=0", "TrackTuner parameter initialization (format: <name>=<value>|<name>=<value>)"};
-  OutputObj<TH1D> trackTunedTracks{TH1D("trackTunedTracks", "", 3, 0.5, 3.5), OutputObjHandlingPolicy::AnalysisObject};
+  OutputObj<TH1D> trackTunedTracks{TH1D("trackTunedTracks", "", 4, 0.5, 4.5), OutputObjHandlingPolicy::AnalysisObject};
 
   using TracksIUWithMc = soa::Join<aod::StoredTracksIU, aod::McTrackLabels, aod::TracksCovIU>;
 
@@ -109,6 +109,7 @@ struct TrackPropagation {
       trackTunedTracks->GetXaxis()->SetBinLabel(1, "all tracks");
       trackTunedTracks->GetXaxis()->SetBinLabel(2, "tracks tuned (no negative detXY)");
       trackTunedTracks->GetXaxis()->SetBinLabel(3, "untouched tracks due to negative detXY");
+      trackTunedTracks->GetXaxis()->SetBinLabel(4, "original detXY<0");
     }
   }
 

--- a/Common/TableProducer/trackPropagation.cxx
+++ b/Common/TableProducer/trackPropagation.cxx
@@ -60,7 +60,7 @@ struct TrackPropagation {
   // for TrackTuner only (MC smearing)
   Configurable<bool> useTrackTuner{"useTrackTuner", false, "Apply Improver/DCA corrections to MC"};
   Configurable<std::string> trackTunerParams{"trackTunerParams", "debugInfo=0|updateTrackCovMat=1|updateCurvature=0|updatePulls=0|isInputFileFromCCDB=1|pathInputFile=Users/m/mfaggin/test/inputsTrackTuner/PbPb2022|nameInputFile=trackTuner_DataLHC22sPass5_McLHC22l1b2_run529397.root|usePvRefitCorrections=0|oneOverPtCurrent=0|oneOverPtUpgr=0", "TrackTuner parameter initialization (format: <name>=<value>|<name>=<value>)"};
-  OutputObj<TH1D> trackTunedTracks{TH1D("trackTunedTracks", "", 1, 0.5, 1.5), OutputObjHandlingPolicy::AnalysisObject};
+  OutputObj<TH1D> trackTunedTracks{TH1D("trackTunedTracks", "", 3, 0.5, 3.5), OutputObjHandlingPolicy::AnalysisObject};
 
   using TracksIUWithMc = soa::Join<aod::StoredTracksIU, aod::McTrackLabels, aod::TracksCovIU>;
 
@@ -106,6 +106,9 @@ struct TrackPropagation {
       std::string outputStringParams = trackTunerObj.configParams(trackTunerParams);
       trackTunerObj.getDcaGraphs();
       trackTunedTracks->SetTitle(outputStringParams.c_str());
+      trackTunedTracks->GetXaxis()->SetBinLabel(1, "all tracks");
+      trackTunedTracks->GetXaxis()->SetBinLabel(2, "tracks tuned (no negative detXY)");
+      trackTunedTracks->GetXaxis()->SetBinLabel(3, "untouched tracks due to negative detXY");
     }
   }
 
@@ -178,6 +181,7 @@ struct TrackPropagation {
       // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
       if (track.trackType() == aod::track::TrackIU && track.x() < minPropagationRadius) {
         if constexpr (isMc && fillCovMat) { /// track tuner ok only if cov. matrix is used
+          trackTunedTracks->Fill(1);        // all tracks
           if (useTrackTuner) {
             // call track propagator
             // this function reads many many things
@@ -187,9 +191,9 @@ struct TrackPropagation {
               // LOG(info) << " MC particle exists... ";
               // LOG(info) << "Inside trackPropagation: before calling tuneTrackParams trackParCov.getY(): " << trackParCov.getY();
               auto mcParticle = track.mcParticle();
-              trackTunerObj.tuneTrackParams(mcParticle, mTrackParCov, matCorr, &mDcaInfoCov);
+              trackTunerObj.tuneTrackParams(mcParticle, mTrackParCov, matCorr, &mDcaInfoCov, trackTunedTracks);
               // LOG(info) << "Inside trackPropagation: after calling tuneTrackParams trackParCov.getY(): " << trackParCov.getY();
-              trackTunedTracks->Fill(1);
+              // trackTunedTracks->Fill(1);
             }
           }
         }

--- a/Common/TableProducer/trackPropagation.cxx
+++ b/Common/TableProducer/trackPropagation.cxx
@@ -183,7 +183,7 @@ struct TrackPropagation {
       if (track.trackType() == aod::track::TrackIU && track.x() < minPropagationRadius) {
         if constexpr (isMc && fillCovMat) { /// track tuner ok only if cov. matrix is used
           if (useTrackTuner) {
-            trackTunedTracks->Fill(1);        // all tracks
+            trackTunedTracks->Fill(1); // all tracks
             // call track propagator
             // this function reads many many things
             //  - reads track params

--- a/Common/Tools/TrackTuner.h
+++ b/Common/Tools/TrackTuner.h
@@ -330,8 +330,8 @@ struct TrackTuner {
     }
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  void tuneTrackParams(T1 const& mcparticle, T2& trackParCov, T3 const& matCorr, T4 dcaInfoCov)
+  template <typename T1, typename T2, typename T3, typename T4, typename H>
+  void tuneTrackParams(T1 const& mcparticle, T2& trackParCov, T3 const& matCorr, T4 dcaInfoCov, H hQA)
   {
 
     double ptMC = mcparticle.pt();
@@ -533,6 +533,10 @@ struct TrackTuner {
     double sigma1PtTgl = 0.0;
     double sigma1Pt2 = 0.0;
 
+    double sigmaY2orig = trackParCov.getSigmaY2();
+    double sigmaZYorig = trackParCov.getSigmaZY();
+    double sigmaZ2orig = trackParCov.getSigmaZ2();
+
     if (updateTrackCovMat) {
       //       if(sd0rpo>0.)            covar[0]*=(sd0rpn/sd0rpo)*(sd0rpn/sd0rpo);//yy
       sigmaY2 = trackParCov.getSigmaY2();
@@ -543,7 +547,7 @@ struct TrackTuner {
       //       if(sd0zo>0. && sd0rpo>0.)covar[1]*=(sd0rpn/sd0rpo)*(sd0zn/sd0zo);//yz
       sigmaZY = trackParCov.getSigmaZY();
       if (dcaZResCurrent > 0. && dcaXYResCurrent > 0.)
-        sigmaZY *= ((dcaXYResUpgr / dcaXYResCurrent) * (dcaXYResUpgr / dcaXYResCurrent));
+        sigmaZY *= ((dcaXYResUpgr / dcaXYResCurrent) * (dcaZResUpgr / dcaZResCurrent));
       trackParCov.setCov(sigmaZY, 1);
 
       //       if(sd0zo>0.)             covar[2]*=(sd0zn/sd0zo)*(sd0zn/sd0zo);//zz
@@ -617,7 +621,7 @@ struct TrackTuner {
       trackParCov.setCov(sigmaY2, 0);
 
       // covar[1]*=pullcorr;//yz
-      sigmaZY *= ratioDCAxyPulls;
+      sigmaZY *= (ratioDCAxyPulls * ratioDCAzPulls);
       trackParCov.setCov(sigmaZY, 1);
 
       sigmaZ2 *= (ratioDCAzPulls * ratioDCAzPulls);
@@ -643,6 +647,30 @@ struct TrackTuner {
 
       sigma1PtZ *= ratioDCAzPulls;
       trackParCov.setCov(sigma1PtZ, 11);
+    }
+
+    /// sanity check for track covariance matrix element
+    /// see https://github.com/AliceO2Group/AliceO2/blob/66de30958153cd7badf522150e8554f9fcf975ff/Common/DCAFitter/include/DCAFitter/DCAFitterN.h#L38-L54
+    double detYZ = sigmaY2 * sigmaZ2 - sigmaZY * sigmaZY;
+    if (detYZ < 0) {
+      /// restore the original values for these elements, since in this case the cov. matrix gets ill-defined
+      if (debugInfo) {
+        LOG(info) << "\n>>> ILL DEFINED COV. MATRIX <<<";
+        LOG(info) << "    sigmaY2 = " << sigmaY2;
+        LOG(info) << "    sigmaZY = " << sigmaZY;
+        LOG(info) << "    sigmaZ2 = " << sigmaZ2;
+        LOG(info) << "    The product (sigmaY2*sigmaZ2 - sigmaZY*sigmaZY) = " << detYZ << " is negative. Restoring the original sigmaY2, sigmaZY, sigmaZ2 cov. matrix elements:";
+        LOG(info) << "    sigmaY2orig = " << sigmaY2orig;
+        LOG(info) << "    sigmaZYorig = " << sigmaZYorig;
+        LOG(info) << "    sigmaZ2orig = " << sigmaZ2orig;
+      }
+      trackParCov.setCov(sigmaY2orig, 0);
+      trackParCov.setCov(sigmaZYorig, 1);
+      trackParCov.setCov(sigmaZ2orig, 2);
+
+      hQA->Fill(3);
+    } else {
+      hQA->Fill(2);
     }
   }
 


### PR DESCRIPTION
Fix in the smearing of out-of-diagonal term `sigmaZY` of the track cov. matrix in the `trackTuner`.
Error found running on derived data on HF trigger MC (`LHC22b1a`, `LHC22b1b`) on Hyperloop and enabling the `candidateCreator3Prong`.

In few cases the code was throwing the `invalid track covariance` error, triggered by [this](https://github.com/AliceO2Group/AliceO2/blob/66de30958153cd7badf522150e8554f9fcf975ff/Common/DCAFitter/include/DCAFitter/DCAFitterN.h#L38-L54), i.e. when the `detXY` is negative.
By fixing the `sigmaZY`, and adding a protection that restores the original `sigmaY2`, `sigmaZ2` and `sigmaZY` values in case of `detYZ = sigmaY2 * sigmaZ2 - sigmaZY * sigmaZY < 0` after the smearing, the `candidateCreator3Prong` worked with both `updateTrackCovMat=1` and `updatePulls=1`. The `hQA` histogram has been added to monitor how frequently these pathologic cases happen, but now they seem very rare (see below).

Tagging @phymanshu and @arossi81 , as well as @fgrosa and @DelloStritto for their knowledge.

![photo_2024-02-28_18-34-46](https://github.com/AliceO2Group/O2Physics/assets/28501912/aa212ca1-6288-4995-964e-1b030b39eb83)
