### PR TITLE
Making more flexible the efficiency and QA task

### DIFF
--- a/PWGCF/Tasks/dptdptcorrelations.cxx
+++ b/PWGCF/Tasks/dptdptcorrelations.cxx
@@ -711,17 +711,17 @@ struct DptDptCorrelationsTask {
     }
 
     /* self configure the binning */
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxbins", zvtxbins);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxmin", zvtxlow);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxmax", zvtxup);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTbins", ptbins);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTmin", ptlow);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTmax", ptup);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtabins", etabins);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtamin", etalow);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtamax", etaup);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPhibins", phibins);
-    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPhibinshift", phibinshift);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxbins", zvtxbins, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxmin", zvtxlow, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mZVtxmax", zvtxup, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTbins", ptbins, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTmin", ptlow, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPTmax", ptup, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtabins", etabins, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtamin", etalow, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mEtamax", etaup, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPhibins", phibins, false);
+    getTaskOptionValue(initContext, "dpt-dpt-filter", "binning.mPhibinshift", phibinshift, false);
     philow = 0.0f;
     phiup = constants::math::TwoPI;
     processpairs = cfgProcessPairs.value;
@@ -772,8 +772,8 @@ struct DptDptCorrelationsTask {
         auto includeIt = [&pidselector, &initContext](int spid, auto name) {
           bool mUseIt = false;
           bool mExcludeIt = false;
-          if (getTaskOptionValue(initContext, "dpt-dpt-filter-tracks", TString::Format("%s.mUseIt", name.c_str()).Data(), mUseIt) &&
-              getTaskOptionValue(initContext, "dpt-dpt-filter-tracks", TString::Format("%s.mExclude", name.c_str()).Data(), mExcludeIt)) {
+          if (getTaskOptionValue(initContext, "dpt-dpt-filter-tracks", TString::Format("%s.mUseIt", name.c_str()).Data(), mUseIt, false) &&
+              getTaskOptionValue(initContext, "dpt-dpt-filter-tracks", TString::Format("%s.mExclude", name.c_str()).Data(), mExcludeIt, false)) {
             if (mUseIt && !mExcludeIt) {
               auto cfg = new o2::analysis::TrackSelectionPIDCfg();
               cfg->mUseIt = true;
@@ -810,7 +810,7 @@ struct DptDptCorrelationsTask {
 
       /* self configure the centrality/multiplicity ranges */
       std::string centspec;
-      if (getTaskOptionValue(initContext, "dpt-dpt-filter", "centralities", centspec)) {
+      if (getTaskOptionValue(initContext, "dpt-dpt-filter", "centralities", centspec, false)) {
         LOGF(info, "Got the centralities specification: %s", centspec.c_str());
         auto tokens = TString(centspec.c_str()).Tokenize(",");
         ncmranges = tokens->GetEntries();

--- a/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <CCDB/BasicCCDBManager.h>
 #include "ReconstructionDataFormats/PID.h"
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/TableHelper.h"
@@ -32,6 +33,13 @@ using namespace o2::framework;
 using namespace o2::soa;
 using namespace o2::framework::expressions;
 
+#define ADDHISTOGRAM(thetype, thedirectory, thename, thetitle, thekind, thebinning...) \
+  registry.add<thetype>(TString::Format("%s/%s", thedirectory, thename).Data(), thetitle, thekind, thebinning)
+#define FORMATSTRING(theformat, theparams...) TString::Format(theformat, theparams).Data()
+#define DIRECTORYSTRING(thedirectoryfmt, thedirectorypars...) FORMATSTRING(thedirectoryfmt, thedirectorypars)
+#define HNAMESTRING(thehnamefmt, thehnamepars...) FORMATSTRING(thehnamefmt, thehnamepars)
+#define HTITLESTRING(thehtitlefmt, thehtitlepars...) FORMATSTRING(thehtitlefmt, thehtitlepars)
+
 namespace efficiencyandqatask
 {
 // initialized during self configuration
@@ -45,7 +53,7 @@ int zvtxbins = 0;
 float zvtxlow = 0.0f;
 float zvtxup = 0.0f;
 
-/// \enum KindOfProcess
+/// \enum KindOfProcessQA
 /// \brief The kind of processing for templating the procedures
 enum KindOfProcess {
   kReco = 0, ///< processing over reconstructed particles/tracks
@@ -71,7 +79,6 @@ static const std::vector<std::string> mainsptitles{"#pi^{#plus}", "#pi^{#minus}"
 /* the QA data collecting engine */
 struct QADataCollectingEngine {
   size_t nsp = efficiencyandqatask::tnames.size();
-  size_t nmainsp = mainspnames.size();
 
   //===================================================
   // The QA output objects
@@ -125,27 +132,8 @@ struct QADataCollectingEngine {
   std::vector<std::shared_ptr<TH2>> fhTPC_CrossedRows_vs_PtA{nsp, nullptr};
   std::vector<std::shared_ptr<TH2>> fhTPC_CrossedRowsOverFindableCls_vs_PtA{nsp, nullptr};
   std::vector<std::shared_ptr<TH2>> fhTPC_Chi2NCls_vs_PtA{nsp, nullptr};
-  /* PID histograms */
-  /* before and after */
-  std::vector<std::shared_ptr<TH2>> fhTPCdEdxSignalVsP{2, nullptr};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhTPCdEdxSignalDiffVsP{2, {nmainsp, nullptr}};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhTPCnSigmasVsP{2, {nmainsp, nullptr}};
-  std::vector<std::shared_ptr<TH2>> fhTOFSignalVsP{2, nullptr};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhTOFSignalDiffVsP{2, {nmainsp, nullptr}};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhTOFnSigmasVsP{2, {nmainsp, nullptr}};
-  std::vector<std::shared_ptr<TH2>> fhPvsTOFSqMass{2, nullptr};
-  std::vector<std::vector<std::shared_ptr<TH3>>> fhTPCTOFSigmaVsP{2, {nmainsp, nullptr}};
-  /* PID histograms */
-  /* only after track selection */
-  std::vector<std::shared_ptr<TH2>> fhIdTPCdEdxSignalVsP{nsp, nullptr};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhIdTPCdEdxSignalDiffVsP{nsp, {nsp, nullptr}};
-  std::vector<std::shared_ptr<TH2>> fhIdTPCnSigmasVsP{nsp, nullptr};
-  std::vector<std::shared_ptr<TH2>> fhIdTOFSignalVsP{nsp, nullptr};
-  std::vector<std::vector<std::shared_ptr<TH2>>> fhIdTOFSignalDiffVsP{nsp, {nsp, nullptr}};
-  std::vector<std::shared_ptr<TH2>> fhIdTOFnSigmasVsP{nsp, nullptr};
-  std::vector<std::shared_ptr<TH2>> fhIdPvsTOFSqMass{nsp, nullptr};
 
-  template <bool processpid, efficiencyandqatask::KindOfProcess kind>
+  template <efficiencyandqatask::KindOfProcess kind>
   void init(HistogramRegistry& registry, const char* dirname)
   {
     using namespace efficiencyandqatask;
@@ -161,16 +149,6 @@ struct QADataCollectingEngine {
     const AxisSpec tpcFractionAxis{100, 0, 1, "fraction"};
     const AxisSpec tpcXRowsOverFindClsAxis{60, 0.7, 1.3, "fraction"};
     const AxisSpec tpcCh2Axis{100, 0, 10, "#Chi^{2}/Cls TPC"};
-    const AxisSpec dEdxAxis{200, 0.0, 200.0, "dE/dx (au)"};
-    AxisSpec pidPAxis{150, 0.1, 5.0, "#it{p} (GeV/#it{c})"};
-    pidPAxis.makeLogarithmic();
-
-#define ADDHISTOGRAM(thetype, thedirectory, thename, thetitle, thekind, thebinning...) \
-  registry.add<thetype>(TString::Format("%s/%s", thedirectory, thename).Data(), thetitle, thekind, thebinning)
-#define FORMATSTRING(theformat, theparams...) TString::Format(theformat, theparams).Data()
-#define DIRECTORYSTRING(thedirectoryfmt, thedirectorypars...) FORMATSTRING(thedirectoryfmt, thedirectorypars)
-#define HNAMESTRING(thehnamefmt, thehnamepars...) FORMATSTRING(thehnamefmt, thehnamepars)
-#define HTITLESTRING(thehtitlefmt, thehtitlepars...) FORMATSTRING(thehtitlefmt, thehtitlepars)
 
     /* the reconstructed and generated levels histograms */
     std::string recogen = (kind == kReco) ? "Reco" : "Gen";
@@ -211,48 +189,6 @@ struct QADataCollectingEngine {
         fhPt_vs_EtaItsTofA[isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "Efficiency", "Reco"), HNAMESTRING("ptItsTof_%s", tnames[isp].c_str()), HTITLESTRING("ITS&TOF %s tracks", tnames[isp].c_str()), kTH2F, {etaAxis, ptAxis});
         fhPt_vs_EtaTpcTofA[isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "Efficiency", "Reco"), HNAMESTRING("ptTpcTof_%s", tnames[isp].c_str()), HTITLESTRING("TPC&TOF %s tracks", tnames[isp].c_str()), kTH2F, {etaAxis, ptAxis});
         fhPt_vs_EtaItsTpcTofA[isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "Efficiency", "Reco"), HNAMESTRING("ptItsTpcTof_%s", tnames[isp].c_str()), HTITLESTRING("ITS&TPC&TOF %s tracks", tnames[isp].c_str()), kTH2F, {etaAxis, ptAxis});
-      }
-      /* PID histograms */
-      if constexpr (processpid) {
-        /* only if the PID information is present */
-        std::vector<std::string> whenname{"Before", "After"};
-        char whenprefix[2]{'B', 'A'};
-        std::vector<std::string> whentitle{"before", ""};
-        for (uint ix = 0; ix < whenname.size(); ++ix) {
-          fhTPCdEdxSignalVsP[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                HNAMESTRING("tpcSignalVsP%c", whenprefix[ix]),
-                                                HTITLESTRING("TPC dE/dx signal %s", whentitle[ix].c_str()), kTH2F, {pidPAxis, dEdxAxis});
-          fhTOFSignalVsP[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                            HNAMESTRING("tofSignalVsP%c", whenprefix[ix]),
-                                            HTITLESTRING("TOF signal %s", whentitle[ix].c_str()),
-                                            kTH2F, {pidPAxis, {200, 0.0, 1.1, "#beta"}});
-          fhPvsTOFSqMass[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                            HNAMESTRING("tofPvsMassSq%c", whenprefix[ix]),
-                                            HTITLESTRING("Momentum versus #it{m}^{2} %s", whentitle[ix].c_str()),
-                                            kTH2F, {{140, 0.0, 1.4, "#it{m}^{2} ((GeV/c^{2})^{2})"}, pidPAxis});
-          for (uint isp = 0; isp < nmainsp; ++isp) {
-            fhTPCdEdxSignalDiffVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                           HNAMESTRING("tpcSignalDiffVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
-                                                           HTITLESTRING("TPC dE/dx to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
-                                                           kTH2F, {pidPAxis, {400, -200.0, 200.0, FORMATSTRING("dE/dx - <dE/dx>_{%s}", mainsptitles[isp].c_str())}});
-            fhTPCnSigmasVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                    HNAMESTRING("tpcNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
-                                                    HTITLESTRING("TPC n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
-                                                    kTH2F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TPC}^{%s}", mainsptitles[isp].c_str())}});
-            fhTOFSignalDiffVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                       HNAMESTRING("tofSignalDiffVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
-                                                       HTITLESTRING("#Delta^{TOF_{%s}} %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
-                                                       kTH2F, {pidPAxis, {200, -1000.0, 1000.0, FORMATSTRING("t-t_{ev}-t_{exp_{%s}} (ps)", mainsptitles[isp].c_str())}});
-            fhTOFnSigmasVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                    HNAMESTRING("tofNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
-                                                    HTITLESTRING("TOF n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
-                                                    kTH2F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TOF}^{%s}", mainsptitles[isp].c_str())}});
-            fhTPCTOFSigmaVsP[ix][isp] = ADDHISTOGRAM(TH3, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
-                                                     HNAMESTRING("toftpcNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
-                                                     HTITLESTRING("n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
-                                                     kTH3F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TPC}^{%s}", mainsptitles[isp].c_str())}, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TOF}^{%s}", mainsptitles[isp].c_str())}});
-          }
-        }
       }
     } else {
       for (uint isp = 0; isp < nsp; ++isp) {
@@ -313,6 +249,178 @@ struct QADataCollectingEngine {
     }
   }
 
+  template <efficiencyandqatask::KindOfProcess kind, typename TrackObject>
+  void processTrack(float zvtx, TrackObject const& track)
+  {
+    using namespace efficiencyandqatask;
+
+    fhPtB[kind]->Fill(track.pt());
+    fhPt_vs_EtaB[kind]->Fill(track.eta(), track.pt());
+    fhPt_vs_ZvtxB[kind]->Fill(zvtx, track.pt());
+    if (!(track.trackacceptedid() < 0)) {
+      fhPtA[kind][track.trackacceptedid()]->Fill(track.pt());
+      fhPt_vs_EtaA[kind][track.trackacceptedid()]->Fill(track.eta(), track.pt());
+      fhPt_vs_ZvtxA[kind][track.trackacceptedid()]->Fill(zvtx, track.pt());
+    }
+    if constexpr (kind == kReco) {
+      bool hasits = track.hasITS();
+      bool hastpc = track.hasTPC();
+      bool hastof = track.hasTOF();
+
+      fhITS_NCls_vs_PtB->Fill(track.pt(), track.itsNCls());
+      fhITS_Chi2NCls_vs_PtB->Fill(track.pt(), track.itsChi2NCl());
+      fhTPC_FindableNCls_vs_PtB->Fill(track.pt(), track.tpcNClsFindable());
+      fhTPC_FoundNCls_vs_PtB->Fill(track.pt(), track.tpcNClsFound());
+      fhTPC_SharedNCls_vs_PtB->Fill(track.pt(), track.tpcNClsShared());
+      fhTPC_FractionSharedCls_vs_PtB->Fill(track.pt(), track.tpcFractionSharedCls());
+      fhTPC_CrossedRows_vs_PtB->Fill(track.pt(), track.tpcNClsCrossedRows());
+      fhTPC_CrossedRowsOverFindableCls_vs_PtB->Fill(track.pt(), track.tpcCrossedRowsOverFindableCls());
+      fhTPC_Chi2NCls_vs_PtB->Fill(track.pt(), track.tpcChi2NCl());
+
+      if (!(track.trackacceptedid() < 0)) {
+        fhITS_NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.itsNCls());
+        fhITS_Chi2NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.itsChi2NCl());
+        fhTPC_FindableNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsFindable());
+        fhTPC_FoundNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsFound());
+        fhTPC_SharedNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsShared());
+        fhTPC_FractionSharedCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcFractionSharedCls());
+        fhTPC_CrossedRows_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsCrossedRows());
+        fhTPC_CrossedRowsOverFindableCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcCrossedRowsOverFindableCls());
+        fhTPC_Chi2NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcChi2NCl());
+        /* efficiency histograms */
+        auto fillhisto = [&track](auto& h, bool cond) {
+          if (cond) {
+            h->Fill(track.eta(), track.pt());
+          }
+        };
+        fillhisto(fhPt_vs_EtaItsA[track.trackacceptedid()], hasits);
+        fillhisto(fhPt_vs_EtaTpcA[track.trackacceptedid()], hastpc);
+        fillhisto(fhPt_vs_EtaItsTpcA[track.trackacceptedid()], hasits && hastpc);
+        fillhisto(fhPt_vs_EtaItsTofA[track.trackacceptedid()], hasits && hastof);
+        fillhisto(fhPt_vs_EtaTpcTofA[track.trackacceptedid()], hastpc && hastof);
+        fillhisto(fhPt_vs_EtaItsTpcTofA[track.trackacceptedid()], hasits && hastpc && hastof);
+        /* the detector / generator combined level */
+        if constexpr (framework::has_type_v<aod::mctracklabel::McParticleId, typename TrackObject::all_columns>) {
+          /* get the associated MC particle we are sure it does exist because the track was accepted */
+          const auto& mcparticle = track.template mcParticle_as<soa::Join<aod::McParticles, aod::DptDptCFGenTracksInfo>>();
+
+          /* TODO: what if the id of the generated is not the same as the id of the reconstructed */
+          bool isprimary = mcparticle.isPhysicalPrimary();
+          bool issecdecay = !isprimary && (mcparticle.getProcess() == 4);
+          bool isfrommaterial = !isprimary && !issecdecay;
+          auto fillhisto = [](auto& h, float pt, float eta, bool cond1, bool cond2) {
+            if (cond1 && cond2) {
+              h->Fill(eta, pt);
+            }
+          };
+          std::vector<float> t_pt = {track.pt(), mcparticle.pt()};
+          std::vector<float> t_eta = {track.eta(), mcparticle.eta()};
+          for (uint ix = 0; ix < t_pt.size(); ++ix) {
+            fillhisto(fhPt_vs_EtaPrimItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, isprimary);
+            fillhisto(fhPt_vs_EtaPrimItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, isprimary);
+            fillhisto(fhPt_vs_EtaPrimItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, isprimary);
+            fillhisto(fhPt_vs_EtaSecItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, issecdecay);
+            fillhisto(fhPt_vs_EtaSecItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, issecdecay);
+            fillhisto(fhPt_vs_EtaSecItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, issecdecay);
+            fillhisto(fhPt_vs_EtaMatItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, isfrommaterial);
+            fillhisto(fhPt_vs_EtaMatItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, isfrommaterial);
+            fillhisto(fhPt_vs_EtaMatItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, isfrommaterial);
+          }
+        }
+      }
+    }
+    if constexpr (kind == kGen) {
+      if (!(track.trackacceptedid() < 0)) {
+        /* pure generator level */
+        if (track.isPhysicalPrimary()) {
+          fhPt_vs_EtaPrimA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
+        } else if (track.getProcess() == 4) {
+          fhPt_vs_EtaSecA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
+        } else {
+          fhPt_vs_EtaMatA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
+        }
+      }
+    }
+  }
+};
+
+/* the PID data collecting engine */
+struct PidDataCollectingEngine {
+  size_t nsp = efficiencyandqatask::tnames.size();
+  size_t nmainsp = mainspnames.size();
+
+  /* PID histograms */
+  /* before and after */
+  std::vector<std::shared_ptr<TH2>> fhTPCdEdxSignalVsP{2, nullptr};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhTPCdEdxSignalDiffVsP{2, {nmainsp, nullptr}};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhTPCnSigmasVsP{2, {nmainsp, nullptr}};
+  std::vector<std::shared_ptr<TH2>> fhTOFSignalVsP{2, nullptr};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhTOFSignalDiffVsP{2, {nmainsp, nullptr}};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhTOFnSigmasVsP{2, {nmainsp, nullptr}};
+  std::vector<std::shared_ptr<TH2>> fhPvsTOFSqMass{2, nullptr};
+  std::vector<std::vector<std::shared_ptr<TH3>>> fhTPCTOFSigmaVsP{2, {nmainsp, nullptr}};
+  /* PID histograms */
+  /* only after track selection */
+  std::vector<std::shared_ptr<TH2>> fhIdTPCdEdxSignalVsP{nsp, nullptr};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhIdTPCdEdxSignalDiffVsP{nsp, {nsp, nullptr}};
+  std::vector<std::shared_ptr<TH2>> fhIdTPCnSigmasVsP{nsp, nullptr};
+  std::vector<std::shared_ptr<TH2>> fhIdTOFSignalVsP{nsp, nullptr};
+  std::vector<std::vector<std::shared_ptr<TH2>>> fhIdTOFSignalDiffVsP{nsp, {nsp, nullptr}};
+  std::vector<std::shared_ptr<TH2>> fhIdTOFnSigmasVsP{nsp, nullptr};
+  std::vector<std::shared_ptr<TH2>> fhIdPvsTOFSqMass{nsp, nullptr};
+
+  template <efficiencyandqatask::KindOfProcess kind>
+  void init(HistogramRegistry& registry, const char* dirname)
+  {
+    using namespace efficiencyandqatask;
+
+    const AxisSpec dEdxAxis{200, 0.0, 200.0, "dE/dx (au)"};
+    AxisSpec pidPAxis{150, 0.1, 5.0, "#it{p} (GeV/#it{c})"};
+    pidPAxis.makeLogarithmic();
+
+    if constexpr (kind == kReco) {
+      /* PID histograms */
+      std::vector<std::string> whenname{"Before", "After"};
+      char whenprefix[2]{'B', 'A'};
+      std::vector<std::string> whentitle{"before", ""};
+      for (uint ix = 0; ix < whenname.size(); ++ix) {
+        fhTPCdEdxSignalVsP[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                              HNAMESTRING("tpcSignalVsP%c", whenprefix[ix]),
+                                              HTITLESTRING("TPC dE/dx signal %s", whentitle[ix].c_str()), kTH2F, {pidPAxis, dEdxAxis});
+        fhTOFSignalVsP[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                          HNAMESTRING("tofSignalVsP%c", whenprefix[ix]),
+                                          HTITLESTRING("TOF signal %s", whentitle[ix].c_str()),
+                                          kTH2F, {pidPAxis, {200, 0.0, 1.1, "#beta"}});
+        fhPvsTOFSqMass[ix] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                          HNAMESTRING("tofPvsMassSq%c", whenprefix[ix]),
+                                          HTITLESTRING("Momentum versus #it{m}^{2} %s", whentitle[ix].c_str()),
+                                          kTH2F, {{140, 0.0, 1.4, "#it{m}^{2} ((GeV/c^{2})^{2})"}, pidPAxis});
+        for (uint isp = 0; isp < nmainsp; ++isp) {
+          fhTPCdEdxSignalDiffVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                                         HNAMESTRING("tpcSignalDiffVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
+                                                         HTITLESTRING("TPC dE/dx to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
+                                                         kTH2F, {pidPAxis, {400, -200.0, 200.0, FORMATSTRING("dE/dx - <dE/dx>_{%s}", mainsptitles[isp].c_str())}});
+          fhTPCnSigmasVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                                  HNAMESTRING("tpcNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
+                                                  HTITLESTRING("TPC n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
+                                                  kTH2F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TPC}^{%s}", mainsptitles[isp].c_str())}});
+          fhTOFSignalDiffVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                                     HNAMESTRING("tofSignalDiffVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
+                                                     HTITLESTRING("#Delta^{TOF_{%s}} %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
+                                                     kTH2F, {pidPAxis, {200, -1000.0, 1000.0, FORMATSTRING("t-t_{ev}-t_{exp_{%s}} (ps)", mainsptitles[isp].c_str())}});
+          fhTOFnSigmasVsP[ix][isp] = ADDHISTOGRAM(TH2, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                                  HNAMESTRING("tofNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
+                                                  HTITLESTRING("TOF n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
+                                                  kTH2F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TOF}^{%s}", mainsptitles[isp].c_str())}});
+          fhTPCTOFSigmaVsP[ix][isp] = ADDHISTOGRAM(TH3, DIRECTORYSTRING("%s/%s/%s", dirname, "PID", whenname[ix].c_str()),
+                                                   HNAMESTRING("toftpcNSigmasVsP%c_%s", whenprefix[ix], mainspnames[isp].c_str()),
+                                                   HTITLESTRING("n#sigma to the %s line %s", mainsptitles[isp].c_str(), whentitle[ix].c_str()),
+                                                   kTH3F, {pidPAxis, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TPC}^{%s}", mainsptitles[isp].c_str())}, {120, -6.0, 6.0, FORMATSTRING("n#sigma_{TOF}^{%s}", mainsptitles[isp].c_str())}});
+        }
+      }
+    }
+  }
+
   template <o2::track::PID::ID id, typename TrackObject>
   void fillSpeciesPID(uint ix, TrackObject const& track)
   {
@@ -346,109 +454,18 @@ struct QADataCollectingEngine {
         break;
       }
     }
-    fillSpeciesPID<o2::track::PID::Pion>(0, track);
-    fillSpeciesPID<o2::track::PID::Kaon>(1, track);
-    fillSpeciesPID<o2::track::PID::Proton>(2, track);
   }
 
-  template <bool processpid, efficiencyandqatask::KindOfProcess kind, typename TrackListObject>
-  void processTracks(float zvtx, TrackListObject const& passedtracks)
+  template <efficiencyandqatask::KindOfProcess kind, typename TrackObject>
+  void processTrack(TrackObject const& track)
   {
     using namespace efficiencyandqatask;
 
-    for (auto& track : passedtracks) {
-      fhPtB[kind]->Fill(track.pt());
-      fhPt_vs_EtaB[kind]->Fill(track.eta(), track.pt());
-      fhPt_vs_ZvtxB[kind]->Fill(zvtx, track.pt());
-      if (!(track.trackacceptedid() < 0)) {
-        fhPtA[kind][track.trackacceptedid()]->Fill(track.pt());
-        fhPt_vs_EtaA[kind][track.trackacceptedid()]->Fill(track.eta(), track.pt());
-        fhPt_vs_ZvtxA[kind][track.trackacceptedid()]->Fill(zvtx, track.pt());
-      }
-      if constexpr (kind == kReco) {
-        bool hasits = track.hasITS();
-        bool hastpc = track.hasTPC();
-        bool hastof = track.hasTOF();
-
-        fhITS_NCls_vs_PtB->Fill(track.pt(), track.itsNCls());
-        fhITS_Chi2NCls_vs_PtB->Fill(track.pt(), track.itsChi2NCl());
-        fhTPC_FindableNCls_vs_PtB->Fill(track.pt(), track.tpcNClsFindable());
-        fhTPC_FoundNCls_vs_PtB->Fill(track.pt(), track.tpcNClsFound());
-        fhTPC_SharedNCls_vs_PtB->Fill(track.pt(), track.tpcNClsShared());
-        fhTPC_FractionSharedCls_vs_PtB->Fill(track.pt(), track.tpcFractionSharedCls());
-        fhTPC_CrossedRows_vs_PtB->Fill(track.pt(), track.tpcNClsCrossedRows());
-        fhTPC_CrossedRowsOverFindableCls_vs_PtB->Fill(track.pt(), track.tpcCrossedRowsOverFindableCls());
-        fhTPC_Chi2NCls_vs_PtB->Fill(track.pt(), track.tpcChi2NCl());
-
-        if constexpr (processpid) {
-          /* only if PID information is available */
-          fillPID(track);
-        }
-
-        if (!(track.trackacceptedid() < 0)) {
-          fhITS_NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.itsNCls());
-          fhITS_Chi2NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.itsChi2NCl());
-          fhTPC_FindableNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsFindable());
-          fhTPC_FoundNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsFound());
-          fhTPC_SharedNCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsShared());
-          fhTPC_FractionSharedCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcFractionSharedCls());
-          fhTPC_CrossedRows_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcNClsCrossedRows());
-          fhTPC_CrossedRowsOverFindableCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcCrossedRowsOverFindableCls());
-          fhTPC_Chi2NCls_vs_PtA[track.trackacceptedid()]->Fill(track.pt(), track.tpcChi2NCl());
-          /* efficiency histograms */
-          auto fillhisto = [&track](auto& h, bool cond) {
-            if (cond) {
-              h->Fill(track.eta(), track.pt());
-            }
-          };
-          fillhisto(fhPt_vs_EtaItsA[track.trackacceptedid()], hasits);
-          fillhisto(fhPt_vs_EtaTpcA[track.trackacceptedid()], hastpc);
-          fillhisto(fhPt_vs_EtaItsTpcA[track.trackacceptedid()], hasits && hastpc);
-          fillhisto(fhPt_vs_EtaItsTofA[track.trackacceptedid()], hasits && hastof);
-          fillhisto(fhPt_vs_EtaTpcTofA[track.trackacceptedid()], hastpc && hastof);
-          fillhisto(fhPt_vs_EtaItsTpcTofA[track.trackacceptedid()], hasits && hastpc && hastof);
-          /* the detector / generator combined level */
-          if constexpr (framework::has_type_v<aod::mctracklabel::McParticleId, typename TrackListObject::iterator::all_columns>) {
-            /* get the associated MC particle we are sure it does exist because the track was accepted */
-            const auto& mcparticle = track.template mcParticle_as<soa::Join<aod::McParticles, aod::DptDptCFGenTracksInfo>>();
-
-            /* TODO: what if the id of the generated is not the same as the id of the reconstructed */
-            bool isprimary = mcparticle.isPhysicalPrimary();
-            bool issecdecay = !isprimary && (mcparticle.getProcess() == 4);
-            bool isfrommaterial = !isprimary && !issecdecay;
-            auto fillhisto = [](auto& h, float pt, float eta, bool cond1, bool cond2) {
-              if (cond1 && cond2) {
-                h->Fill(eta, pt);
-              }
-            };
-            std::vector<float> t_pt = {track.pt(), mcparticle.pt()};
-            std::vector<float> t_eta = {track.eta(), mcparticle.eta()};
-            for (uint ix = 0; ix < t_pt.size(); ++ix) {
-              fillhisto(fhPt_vs_EtaPrimItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, isprimary);
-              fillhisto(fhPt_vs_EtaPrimItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, isprimary);
-              fillhisto(fhPt_vs_EtaPrimItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, isprimary);
-              fillhisto(fhPt_vs_EtaSecItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, issecdecay);
-              fillhisto(fhPt_vs_EtaSecItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, issecdecay);
-              fillhisto(fhPt_vs_EtaSecItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, issecdecay);
-              fillhisto(fhPt_vs_EtaMatItsA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits, isfrommaterial);
-              fillhisto(fhPt_vs_EtaMatItsTpcA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastpc, isfrommaterial);
-              fillhisto(fhPt_vs_EtaMatItsTpcTofA[ix][track.trackacceptedid()], t_pt[ix], t_eta[ix], hasits && hastof, isfrommaterial);
-            }
-          }
-        }
-      }
-      if constexpr (kind == kGen) {
-        if (!(track.trackacceptedid() < 0)) {
-          /* pure generator level */
-          if (track.isPhysicalPrimary()) {
-            fhPt_vs_EtaPrimA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
-          } else if (track.getProcess() == 4) {
-            fhPt_vs_EtaSecA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
-          } else {
-            fhPt_vs_EtaMatA[track.trackacceptedid()]->Fill(track.eta(), track.pt());
-          }
-        }
-      }
+    if constexpr (kind == kReco) {
+      fillPID(track);
+      fillSpeciesPID<o2::track::PID::Pion>(0, track);
+      fillSpeciesPID<o2::track::PID::Kaon>(1, track);
+      fillSpeciesPID<o2::track::PID::Proton>(2, track);
     }
   }
 };
@@ -461,9 +478,10 @@ struct DptDptEfficiencyAndQc {
   float* fCentMultMax = nullptr;
 
   /* the data collecting engine instances */
-  QADataCollectingEngine** dataCE;
+  QADataCollectingEngine** qaDataCE;
+  PidDataCollectingEngine** pidDataCE;
 
-  /* this is a nightmare but not other way found to overcome the histogram registry limit */
+  /* the histogram registries */
   HistogramRegistry registry_one{"registry_one", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry registry_two{"registry_two", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry registry_three{"registry_three", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -477,9 +495,12 @@ struct DptDptEfficiencyAndQc {
   std::vector<HistogramRegistry*> registrybank{&registry_one, &registry_two, &registry_three, &registry_four, &registry_five,
                                                &registry_six, &registry_seven, &registry_eight, &registry_nine, &registry_ten};
 
+  Configurable<bool> inCentralityClasses{"usecentrality", false, "Perform the task using centrality/multiplicity classes. Default value: false"};
+
   void init(o2::framework::InitContext& initContext)
   {
     using namespace efficiencyandqatask;
+
     /* Self configuration: requires dptdptfilter task in the workflow */
     {
       /* the binning */
@@ -531,7 +552,7 @@ struct DptDptEfficiencyAndQc {
 
       /* create the data collecting engine instances according to the configured centrality/multiplicity ranges */
       std::string centspec;
-      if (getTaskOptionValue(initContext, "dpt-dpt-filter", "centralities", centspec, false)) {
+      if (inCentralityClasses.value && getTaskOptionValue(initContext, "dpt-dpt-filter", "centralities", centspec, false)) {
         LOGF(info, "Got the centralities specification: %s", centspec.c_str());
         auto tokens = TString(centspec.c_str()).Tokenize(",");
         ncmranges = tokens->GetEntries();
@@ -553,9 +574,13 @@ struct DptDptEfficiencyAndQc {
         fCentMultMin[0] = 0.0f;
         fCentMultMax[0] = 100.0f;
       }
-      dataCE = new QADataCollectingEngine*[ncmranges];
+      bool doPidAnalysis = doprocessDetectorLevelNotStored || doprocessReconstructedNotStored;
+      qaDataCE = new QADataCollectingEngine*[ncmranges];
+      if (doPidAnalysis) {
+        pidDataCE = new PidDataCollectingEngine*[ncmranges];
+      }
       std::string recogen;
-      if (!doprocessReconstructedNotStored && !doprocessDetectorLevelNotStored) {
+      if (!(doprocessReconstructedNotStored || doprocessReconstructedNotStoredNoPID) && !(doprocessDetectorLevelNotStored || doprocessDetectorLevelNotStoredNoPID)) {
         LOGF(fatal, "Neither reco nor detector level not configured. Please, fix it!");
       }
       if (ncmranges > registrybank.size()) {
@@ -566,18 +591,26 @@ struct DptDptEfficiencyAndQc {
         auto initializeCEInstance = [&](auto dce, auto name) {
           /* crete the output list for the passed centrality/multiplicity range */
           /* init the data collection instance */
-          dce->template init<true, kReco>(*registrybank[i], name.Data());
+          dce->template init<kReco>(*registrybank[i], name.Data());
           if (doprocessGeneratorLevelNotStored) {
-            dce->template init<true, kGen>(*registrybank[i], name.Data());
+            dce->template init<kGen>(*registrybank[i], name.Data());
           }
         };
-        auto buildCEInstance = [&initializeCEInstance](float min, float max) {
-          QADataCollectingEngine* dce = new QADataCollectingEngine();
+        auto buildQACEInstance = [&initializeCEInstance](float min, float max) {
+          auto* dce = new QADataCollectingEngine();
+          initializeCEInstance(dce, TString::Format("EfficiencyAndQaData-%d-%d", static_cast<int>(min), static_cast<int>(max)));
+          return dce;
+        };
+        auto buildPidCEInstance = [&initializeCEInstance](float min, float max) {
+          auto* dce = new PidDataCollectingEngine();
           initializeCEInstance(dce, TString::Format("EfficiencyAndQaData-%d-%d", static_cast<int>(min), static_cast<int>(max)));
           return dce;
         };
         /* in reverse order for proper order in results file */
-        dataCE[ncmranges - i - 1] = buildCEInstance(fCentMultMin[ncmranges - i - 1], fCentMultMax[ncmranges - i - 1]);
+        qaDataCE[ncmranges - i - 1] = buildQACEInstance(fCentMultMin[ncmranges - i - 1], fCentMultMax[ncmranges - i - 1]);
+        if (doPidAnalysis) {
+          pidDataCE[ncmranges - i - 1] = buildPidCEInstance(fCentMultMin[ncmranges - i - 1], fCentMultMax[ncmranges - i - 1]);
+        }
       }
       for (uint i = 0; i < ncmranges; ++i) {
         LOGF(info, " centrality/multipliicty range: %d, low limit: %0.2f, up limit: %0.2f", i, fCentMultMin[i], fCentMultMax[i]);
@@ -589,30 +622,39 @@ struct DptDptEfficiencyAndQc {
   template <typename FilteredCollision>
   int getDCEindex(FilteredCollision collision)
   {
-    int ixDCE = -1;
-    float cm = collision.centmult();
-    for (uint i = 0; i < ncmranges; ++i) {
-      if (cm < fCentMultMax[i]) {
-        ixDCE = i;
-        break;
+    if (!inCentralityClasses.value) {
+      return 0;
+    } else {
+      int ixDCE = -1;
+      float cm = collision.centmult();
+      for (uint i = 0; i < ncmranges; ++i) {
+        if (cm < fCentMultMax[i]) {
+          ixDCE = i;
+          break;
+        }
       }
-    }
-    if (!(ixDCE < 0)) {
-      if (cm < fCentMultMin[ixDCE]) {
-        ixDCE = -1;
+      if (!(ixDCE < 0)) {
+        if (cm < fCentMultMin[ixDCE]) {
+          ixDCE = -1;
+        }
       }
+      return ixDCE;
     }
-    return ixDCE;
   }
 
-  template <efficiencyandqatask::KindOfProcess kind, typename FilterdCollision, typename PassedTracks>
+  template <bool dopid, efficiencyandqatask::KindOfProcess kind, typename FilterdCollision, typename PassedTracks>
   void processTracks(FilterdCollision const& collision, PassedTracks const& tracks)
   {
     using namespace efficiencyandqatask;
 
     int ixDCE = getDCEindex(collision);
     if (!(ixDCE < 0)) {
-      dataCE[ixDCE]->processTracks<true, kind>(collision.posZ(), tracks);
+      for (auto& track : tracks) {
+        qaDataCE[ixDCE]->processTrack<kind>(collision.posZ(), track);
+        if constexpr (dopid) {
+          pidDataCE[ixDCE]->processTrack<kind>(track);
+        }
+      }
     }
   }
 
@@ -625,7 +667,7 @@ struct DptDptEfficiencyAndQc {
   {
     using namespace efficiencyandqatask;
 
-    processTracks<kReco>(collision, tracks);
+    processTracks<true, kReco>(collision, tracks);
   }
   PROCESS_SWITCH(DptDptEfficiencyAndQc, processReconstructedNotStored, "Process reconstructed efficiency and QA for not stored derived data", false);
 
@@ -635,18 +677,87 @@ struct DptDptEfficiencyAndQc {
   {
     using namespace efficiencyandqatask;
 
-    processTracks<kReco>(collision, tracks);
+    processTracks<true, kReco>(collision, tracks);
   }
-  PROCESS_SWITCH(DptDptEfficiencyAndQc, processDetectorLevelNotStored, "Process MC detector level efficiency and QA for not stored derived data", true);
+  PROCESS_SWITCH(DptDptEfficiencyAndQc, processDetectorLevelNotStored, "Process MC detector level efficiency and QA for not stored derived data", false);
 
   void processGeneratorLevelNotStored(soa::Filtered<soa::Join<aod::McCollisions, aod::DptDptCFGenCollisionsInfo>>::iterator const& collision,
                                       soa::Join<aod::McParticles, aod::DptDptCFGenTracksInfo>& particles)
   {
     using namespace efficiencyandqatask;
 
-    processTracks<kGen>(collision, particles);
+    processTracks<false, kGen>(collision, particles);
   }
   PROCESS_SWITCH(DptDptEfficiencyAndQc, processGeneratorLevelNotStored, "Process MC generator level efficiency and QA for not stored derived data", true);
+
+  void processReconstructedNotStoredNoPID(soa::Filtered<soa::Join<aod::Collisions, aod::DptDptCFCollisionsInfo>>::iterator const& collision, soa::Join<aod::FullTracks, aod::DptDptCFTracksInfo>& tracks)
+  {
+    using namespace efficiencyandqatask;
+
+    processTracks<false, kReco>(collision, tracks);
+  }
+  PROCESS_SWITCH(DptDptEfficiencyAndQc, processReconstructedNotStoredNoPID, "Process reconstructed efficiency and QA for not stored derived data", false);
+
+  void processDetectorLevelNotStoredNoPID(soa::Filtered<soa::Join<aod::Collisions, aod::DptDptCFCollisionsInfo>>::iterator const& collision,
+                                          soa::Join<aod::FullTracks, aod::DptDptCFTracksInfo, aod::McTrackLabels>& tracks,
+                                          soa::Join<aod::McParticles, aod::DptDptCFGenTracksInfo> const&)
+  {
+    using namespace efficiencyandqatask;
+
+    processTracks<false, kReco>(collision, tracks);
+  }
+  PROCESS_SWITCH(DptDptEfficiencyAndQc, processDetectorLevelNotStoredNoPID, "Process MC detector level efficiency and QA for not stored derived data", true);
+};
+
+using BCsWithTimestamps = soa::Join<aod::BCs, aod::Timestamps>;
+
+struct checkTimestamp {
+
+  o2::ccdb::CcdbApi ccdb_api;
+  int mRunNumber;
+  ULong64_t runsor = 0;
+  ULong64_t runeor = 0;
+  std::shared_ptr<TH2> hTimeStampDiffNegative = nullptr;
+  std::shared_ptr<TH2> hTimeStampDiffPositive = nullptr;
+
+  Configurable<std::string> ccdburl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext&)
+  {
+    LOG(info) << "Initializing check timestamp task";
+    AxisSpec diffAxis{1000, 0.0001, 10000, "time (s)"};
+    diffAxis.makeLogarithmic();
+
+    hTimeStampDiffNegative = registry.add<TH2>("DiffNegative", "Time before SOR (s)", kTH2F, {{1, 0, 1, "Run number"}, diffAxis});
+    hTimeStampDiffPositive = registry.add<TH2>("DiffPositive", "Time after EOR (s)", kTH2F, {{1, 0, 1, "Run number"}, diffAxis});
+    ccdb_api.init(ccdburl);
+  }
+
+  void process(aod::Collisions const& collisions, BCsWithTimestamps const&)
+  {
+    for (auto const& collision : collisions) {
+      /* check the previous run number */
+      auto bc = collision.bc_as<BCsWithTimestamps>();
+      if (bc.runNumber() != mRunNumber) {
+        LOGF(info, "timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
+        mRunNumber = bc.runNumber();
+
+        // read SOR and EOR timestamps from RCT CCDB via utility function
+        auto soreor = o2::ccdb::BasicCCDBManager::getRunDuration(ccdb_api, mRunNumber, false);
+        runeor = soreor.second;
+        runsor = soreor.first;
+      }
+      if (bc.timestamp() < runsor || runeor < bc.timestamp()) {
+        /* we go a wrong timestamp let's convert the out of run time to seconds */
+        if (bc.timestamp() < runsor) {
+          hTimeStampDiffNegative->Fill(mRunNumber, (runsor - bc.timestamp()) / 1000);
+        } else {
+          hTimeStampDiffPositive->Fill(mRunNumber, (bc.timestamp() - runeor) / 1000);
+        }
+      }
+    }
+  }
 };
 
 //****************************************************************************************
@@ -657,6 +768,7 @@ struct DptDptEfficiencyAndQc {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<DptDptEfficiencyAndQc>(cfgc)};
+    adaptAnalysisTask<DptDptEfficiencyAndQc>(cfgc),
+    adaptAnalysisTask<checkTimestamp>(cfgc)};
   return workflow;
 }


### PR DESCRIPTION
Now it is feasible to order it with PID info collection or without it as well as within multiplicity classes or just MB

Additionally
- removing the self-configuration logging
- introducing the timestamp checking task