### PR TITLE
PWGCF: Update FemtoDream

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <iostream>
 #include "Common/CCDB/TriggerAliases.h"
+#include "Common/DataModel/EventSelection.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/Logger.h"
 
@@ -83,6 +84,12 @@ class FemtoDreamCollisionSelection
   template <typename C>
   bool isSelectedCollision(C const& col)
   {
+
+    // remove events at the border of the time frame
+    if (!col.selection_bit(aod::evsel::kNoTimeFrameBorder)) {
+      return false;
+    }
+
     if (std::abs(col.posZ()) > mZvtxMax) {
       return false;
     }

--- a/PWGCF/FemtoDream/Core/femtoDreamContainer.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamContainer.h
@@ -25,11 +25,11 @@
 
 #include "Framework/HistogramRegistry.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamMath.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamUtils.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
 
 #include "Math/Vector4D.h"
 #include "TMath.h"
-#include "TDatabasePDG.h"
 
 using namespace o2::framework;
 
@@ -178,8 +178,8 @@ class FemtoDreamContainer
   /// \param pdg2 PDG code of particle two
   void setPDGCodes(const int pdg1, const int pdg2)
   {
-    mMassOne = TDatabasePDG::Instance()->GetParticle(pdg1)->Mass();
-    mMassTwo = TDatabasePDG::Instance()->GetParticle(pdg2)->Mass();
+    mMassOne = o2::analysis::femtoDream::getMass(pdg1);
+    mMassTwo = o2::analysis::femtoDream::getMass(pdg2);
     mPDGOne = pdg1;
     mPDGTwo = pdg2;
   }

--- a/PWGCF/FemtoDream/Core/femtoDreamUtils.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamUtils.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <algorithm>
 #include "Framework/ASoAHelpers.h"
+#include "CommonConstants/PhysicsConstants.h"
 #include "PWGCF/DataModel/FemtoDerived.h"
 
 namespace o2::analysis::femtoDream
@@ -98,7 +99,38 @@ bool isFullPIDSelected(aod::femtodreamparticle::cutContainerType const& pidCut,
   return pidSelection;
 };
 
-int checkDaughterType(o2::aod::femtodreamparticle::ParticleType partType, int motherPDG)
+/// function for getting the mass of a particle depending on the pdg code
+/// \param pdgCode pdg code of the particle
+/// \return mass of the particle
+inline float getMass(int pdgCode)
+{
+  // use this function instead of TDatabasePDG to return masses defined in the PhysicsConstants.h header
+  // this approach saves a lot of memory and important partilces like deuteron are missing in TDatabasePDG anyway
+  float Mass = 0;
+  // add new particles if necessary here
+  switch (std::abs(pdgCode)) {
+    case 211: // charged pions
+      Mass = o2::constants::physics::MassPiPlus;
+      break;
+    case 321: // charged kaon
+      Mass = o2::constants::physics::MassKPlus;
+      break;
+    case 2212: // proton
+      Mass = o2::constants::physics::MassProton;
+      break;
+    case 3122: // Lambda
+      Mass = o2::constants::physics::MassLambda;
+      break;
+    case 1000010020: // Deuteron
+      Mass = o2::constants::physics::MassDeuteron;
+      break;
+    default:
+      LOG(fatal) << "PDG code is not suppored";
+  }
+  return Mass;
+}
+
+inline int checkDaughterType(o2::aod::femtodreamparticle::ParticleType partType, int motherPDG)
 {
   int partOrigin = 0;
   if (partType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
@@ -137,7 +169,7 @@ int checkDaughterType(o2::aod::femtodreamparticle::ParticleType partType, int mo
 };
 
 template <typename T, typename R>
-bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
+inline bool containsNameValuePair(const std::vector<T>& myVector, const std::string& name, R value)
 {
   for (const auto& obj : myVector) {
     if (obj.name == name) {

--- a/PWGCF/FemtoDream/Core/femtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamV0Selection.h
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <TDatabasePDG.h> // FIXME
-
 #include "PWGCF/FemtoDream/Core/femtoDreamObjectSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h"
@@ -557,7 +555,7 @@ std::array<cutContainerType, 5>
   cutContainerType output = 0;
   size_t counter = 0;
 
-  auto lambdaMassNominal = TDatabasePDG::Instance()->GetParticle(3122)->Mass(); // FIXME: Get from the common header
+  auto lambdaMassNominal = o2::constants::physics::MassLambda;
   auto lambdaMassHypothesis = v0.mLambda();
   auto antiLambdaMassHypothesis = v0.mAntiLambda();
   auto diffLambda = abs(lambdaMassNominal - lambdaMassHypothesis);

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -27,7 +27,6 @@
 #include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/Configurable.h"
 #include "Framework/Expressions.h"
-#include "TDatabasePDG.h"
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h"


### PR DESCRIPTION
This PR addresses two issues:
- Remove TDataBasePDG to access particle masses in the particle pair tasks. TDataBasePDG has a large memory footprint and does not have the deuteron mass. Replace it with a switch statement and the masses defined in the PhysicsConstants.h header
- Add the time frame border cut to the collision selection of the producer.