### PR TITLE
 [PWGCF-FemtoDream]: Debug task MC

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -272,6 +272,12 @@ DECLARE_SOA_INDEX_COLUMN(FDMCParticle, fdMCParticle); //! MC particle for femtod
 } // namespace mcfdlabel
 DECLARE_SOA_TABLE(FDMCLabels, "AOD", "FDMCLabel", //! Table joinable to FemtoDreamParticle containing the MC labels
                   mcfdlabel::FDMCParticleId);
+namespace mcfdextlabel
+{
+DECLARE_SOA_INDEX_COLUMN(FDExtMCParticle, fdExtMCParticle); //! MC particle for femtodreamparticle
+} // namespace mcfdextlabel
+DECLARE_SOA_TABLE(FDExtMCLabels, "AOD", "FDExtMCLabel", //! Table joinable to FemtoDreamParticle containing the MC labels
+                  mcfdextlabel::FDExtMCParticleId);
 
 /// Hash
 namespace hash

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -194,13 +194,13 @@ struct femtoDreamProducerReducedTask {
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
       if (abs(pdgCode) == abs(ConfTrkPDGCode.value)) {
-        if (col.has_mcCollision() && (particleMC.mcCollisionId() != col.mcCollisionId())) {
+        if ((col.has_mcCollision() && (particleMC.mcCollisionId() != col.mcCollisionId())) || !col.has_mcCollision()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kWrongCollision;
         } else if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
-        } else if (motherparticleMC.producedByGenerator()) {
+        } else if (motherparticleMC.isPhysicalPrimary() && particleMC.getProcess() == 4) {
           particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
-        } else if (!particleMC.producedByGenerator()) {
+        } else if (particleMC.getGenStatusCode() == -1) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
         } else {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kElse;

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -77,6 +77,7 @@ struct femtoDreamProducerTask {
   Produces<aod::FDExtParticles> outputDebugParts;
   Produces<aod::FDMCLabels> outputPartsMCLabels;
   Produces<aod::FDExtMCParticles> outputDebugPartsMC;
+  Produces<aod::FDExtMCLabels> outputPartsExtMCLabels;
 
   Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   Configurable<bool> ConfIsRun3{"ConfIsRun3", false, "Running on Run3 or pilot"};
@@ -325,13 +326,13 @@ struct femtoDreamProducerTask {
       auto motherparticleMC = particleMC.template mothers_as<aod::McParticles>().front();
 
       if (abs(pdgCode) == abs(ConfTrkPDGCode.value)) {
-        if (col.has_mcCollision() && (particleMC.mcCollisionId() != col.mcCollisionId())) {
+        if ((col.has_mcCollision() && (particleMC.mcCollisionId() != col.mcCollisionId())) || !col.has_mcCollision()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kWrongCollision;
         } else if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kPrimary;
-        } else if (motherparticleMC.producedByGenerator()) {
+        } else if (motherparticleMC.isPhysicalPrimary() && particleMC.getProcess() == 4) {
           particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
-        } else if (!particleMC.producedByGenerator()) {
+        } else if (particleMC.getGenStatusCode() == -1) {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kMaterial;
         } else {
           particleOrigin = aod::femtodreamMCparticle::ParticleOriginMCTruth::kElse;
@@ -342,8 +343,13 @@ struct femtoDreamProducerTask {
 
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
+      outputPartsExtMCLabels(outputPartsMC.lastIndex());
+      if (ConfIsDebug) {
+        outputDebugPartsMC(motherparticleMC.pdgCode());
+      }
     } else {
       outputPartsMCLabels(-1);
+      outputPartsExtMCLabels(-1);
     }
   }
 

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -343,13 +343,15 @@ struct femtoDreamProducerTask {
 
       outputPartsMC(particleOrigin, pdgCode, particleMC.pt(), particleMC.eta(), particleMC.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
-      outputPartsExtMCLabels(outputPartsMC.lastIndex());
       if (ConfIsDebug) {
+        outputPartsExtMCLabels(outputPartsMC.lastIndex());
         outputDebugPartsMC(motherparticleMC.pdgCode());
       }
     } else {
       outputPartsMCLabels(-1);
-      outputPartsExtMCLabels(-1);
+      if (ConfIsDebug) {
+        outputPartsExtMCLabels(-1);
+      }
     }
   }
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugTrack.cxx
@@ -64,7 +64,7 @@ struct femtoDreamDebugTrack {
     ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= ConfTrk1_PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCBit), ncheckbit(aod::femtodreamparticle::pidcut, ConfTrk1_TPCTOFBit));
   Preslice<FemtoFullParticles> perColReco = aod::femtodreamparticle::fdCollisionId;
 
-  using FemtoFullParticlesMC = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>;
+  using FemtoFullParticlesMC = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels, aod::FDExtMCLabels>;
   Partition<FemtoFullParticlesMC> partsOneMC =
     (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
     ncheckbit(aod::femtodreamparticle::cut, ConfTrk1_CutBit) &&
@@ -110,7 +110,7 @@ struct femtoDreamDebugTrack {
   /// \param col subscribe to FemtoDreamCollision table
   /// \param parts subscribe to the joined table of FemtoDreamParticles and FemtoDreamMCLabels table
   /// \param FemtoDramMCParticles subscribe to the table containing the Monte Carlo Truth information
-  void processMC(o2::aod::FDCollision& col, FemtoFullParticlesMC& parts, o2::aod::FDMCParticles&)
+  void processMC(o2::aod::FDCollision& col, FemtoFullParticlesMC& parts, aod::FDMCParticles&, aod::FDExtMCParticles&)
   {
     auto groupPartsOne = partsOneMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     FillDebugHistos<true>(col, groupPartsOne);


### PR DESCRIPTION
- FDExtMCTable: Properly include the extended FemtoDream Table for
  additional information in the debug task (for now only the pdgCode
	  of the mothers is added)
	  for the mother particles is added)
- additonal histograms for the PDGcode of the Mother particle for each MCorigin (activated in the debug task)
- fix the categorization of MC origins in the producer task