### PR TITLE
Common/PWGLF: coll assoc + mult debug extras

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -45,8 +45,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsInelGt0, isInelGt0, //! is INEL > 0
 DECLARE_SOA_DYNAMIC_COLUMN(IsInelGt1, isInelGt1, //! is INEL > 1
                            [](int multPveta1) -> bool { return multPveta1 > 1; });
 // MC
-DECLARE_SOA_COLUMN(MultMCFT0A, multMCFT0A, int);                   //!
-DECLARE_SOA_COLUMN(MultMCFT0C, multMCFT0C, int);                   //!
+DECLARE_SOA_COLUMN(MultMCFT0A, multMCFT0A, int);                       //!
+DECLARE_SOA_COLUMN(MultMCFT0C, multMCFT0C, int);                       //!
 DECLARE_SOA_COLUMN(MultMCNParticlesEta10, multMCNParticlesEta10, int); //!
 DECLARE_SOA_COLUMN(MultMCNParticlesEta08, multMCNParticlesEta08, int); //!
 DECLARE_SOA_COLUMN(MultMCNParticlesEta05, multMCNParticlesEta05, int); //!

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -104,7 +104,7 @@ DECLARE_SOA_TABLE(MultsExtra, "AOD", "MULTEXTRA", //!
                   mult::MultNTracksHasITS, mult::MultNTracksHasTPC, mult::MultNTracksHasTOF, mult::MultNTracksHasTRD,
                   mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, mult::BCNumber);
 DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!
-                  evsel::Selection); // for derived data / QA studies
+                  evsel::Selection);                       // for derived data / QA studies
 using MultExtra = MultsExtra::iterator;
 DECLARE_SOA_TABLE(MultsExtraMC, "AOD", "MULTEXTRAMC", //! Table for the MC information
                   mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<1>);

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -45,9 +45,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsInelGt0, isInelGt0, //! is INEL > 0
 DECLARE_SOA_DYNAMIC_COLUMN(IsInelGt1, isInelGt1, //! is INEL > 1
                            [](int multPveta1) -> bool { return multPveta1 > 1; });
 // MC
-DECLARE_SOA_COLUMN(MultMCFT0A, multMCFT0A, float);                   //!
-DECLARE_SOA_COLUMN(MultMCFT0C, multMCFT0C, float);                   //!
-DECLARE_SOA_COLUMN(MultMCNTracksPVeta1, multMCNTracksPVeta1, float); //!
+DECLARE_SOA_COLUMN(MultMCFT0A, multMCFT0A, int);                   //!
+DECLARE_SOA_COLUMN(MultMCFT0C, multMCFT0C, int);                   //!
+DECLARE_SOA_COLUMN(MultMCNParticlesEta10, multMCNParticlesEta10, int); //!
+DECLARE_SOA_COLUMN(MultMCNParticlesEta08, multMCNParticlesEta08, int); //!
+DECLARE_SOA_COLUMN(MultMCNParticlesEta05, multMCNParticlesEta05, int); //!
 
 // complementary / MultsExtra table
 DECLARE_SOA_COLUMN(MultPVTotalContributors, multPVTotalContributors, float); //!
@@ -102,7 +104,7 @@ DECLARE_SOA_TABLE(MultsExtra, "AOD", "MULTEXTRA", //!
                   mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, mult::BCNumber);
 using MultExtra = MultsExtra::iterator;
 DECLARE_SOA_TABLE(MultsExtraMC, "AOD", "MULTEXTRAMC", //! Table for the MC information
-                  mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNTracksPVeta1);
+                  mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<1>);
 using MultExtraMC = MultsExtraMC::iterator;
 
 namespace multZeq

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -12,6 +12,7 @@
 #define O2_ANALYSIS_MULTIPLICITY_H_
 
 #include "Framework/AnalysisDataModel.h"
+#include "Common/DataModel/EventSelection.h"
 
 namespace o2::aod
 {
@@ -102,6 +103,8 @@ DECLARE_SOA_TABLE(MultsExtra, "AOD", "MULTEXTRA", //!
                   mult::MultPVTotalContributors, mult::MultPVChi2, mult::MultCollisionTimeRes, mult::MultRunNumber, mult::MultPVz, mult::MultSel8,
                   mult::MultNTracksHasITS, mult::MultNTracksHasTPC, mult::MultNTracksHasTOF, mult::MultNTracksHasTRD,
                   mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, mult::BCNumber);
+DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!
+                  evsel::Selection); // for derived data / QA studies
 using MultExtra = MultsExtra::iterator;
 DECLARE_SOA_TABLE(MultsExtraMC, "AOD", "MULTEXTRAMC", //! Table for the MC information
                   mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<1>);

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -493,24 +493,24 @@ struct MultiplicityTableTaskIndexed {
     int multBarrelEta08 = 0;
     int multBarrelEta10 = 0;
     for (auto const& mcPart : mcParticles) {
-      if(!mcPart.isPhysicalPrimary())
+      if (!mcPart.isPhysicalPrimary())
         continue;
 
-      if(std::abs(mcPart.eta())<1.0){ 
-        multBarrelEta10++; 
-        if(std::abs(mcPart.eta())<0.8){
-          multBarrelEta08++; 
-          if(std::abs(mcPart.eta())<0.5){
-          multBarrelEta05++; 
+      if (std::abs(mcPart.eta()) < 1.0) {
+        multBarrelEta10++;
+        if (std::abs(mcPart.eta()) < 0.8) {
+          multBarrelEta08++;
+          if (std::abs(mcPart.eta()) < 0.5) {
+            multBarrelEta05++;
           }
         }
       }
-      if(-3.3 < mcPart.eta() && mcPart.eta() < -2.1 )
-        multFT0C++; 
-      if(3.5 < mcPart.eta() && mcPart.eta() < 4.9 )
-        multFT0A++; 
+      if (-3.3 < mcPart.eta() && mcPart.eta() < -2.1)
+        multFT0C++;
+      if (3.5 < mcPart.eta() && mcPart.eta() < 4.9)
+        multFT0A++;
     }
-    tableExtraMc( multFT0A, multFT0C, multBarrelEta05, multBarrelEta08, multBarrelEta10);
+    tableExtraMc(multFT0A, multFT0C, multBarrelEta05, multBarrelEta08, multBarrelEta10);
   }
 
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", false);

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -9,10 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ConfigParamSpec.h"
-
-using namespace o2;
-using namespace o2::framework;
-
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -21,6 +17,11 @@ using namespace o2::framework;
 #include "Common/DataModel/Multiplicity.h"
 #include "TableHelper.h"
 #include "iostream"
+#include "Framework/ASoAHelpers.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
 
 static constexpr int kFV0Mults = 0;
 static constexpr int kFT0Mults = 1;
@@ -207,7 +208,6 @@ struct MultiplicityTableTaskIndexed {
     tableTpc(multTPC);
     tablePv(multNContribs, multNContribsEta1, multNContribsEtaHalf);
   }
-  PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", false);
 
   using Run3Tracks = soa::Join<aod::TracksIU, aod::TracksExtra>;
   Partition<Run3Tracks> tracksIUWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
@@ -478,7 +478,44 @@ struct MultiplicityTableTaskIndexed {
       }
     }
   }
+
+  // one loop better than multiple sliceby calls
+  // FIT FT0C: -3.3 < η < -2.1
+  // FOT FT0A:  3.5 < η <  4.9
+  Filter mcParticleFilter = (aod::mcparticle::eta < 4.9f) && (aod::mcparticle::eta > -3.3f);
+  using mcParticlesFiltered = soa::Filtered<aod::McParticles>;
+
+  void processMC(aod::McCollision const& mcCollision, mcParticlesFiltered const& mcParticles)
+  {
+    int multFT0A = 0;
+    int multFT0C = 0;
+    int multBarrelEta05 = 0;
+    int multBarrelEta08 = 0;
+    int multBarrelEta10 = 0;
+    for (auto const& mcPart : mcParticles) {
+      if(!mcPart.isPhysicalPrimary())
+        continue;
+
+      if(std::abs(mcPart.eta())<1.0){ 
+        multBarrelEta10++; 
+        if(std::abs(mcPart.eta())<0.8){
+          multBarrelEta08++; 
+          if(std::abs(mcPart.eta())<0.5){
+          multBarrelEta05++; 
+          }
+        }
+      }
+      if(-3.3 < mcPart.eta() && mcPart.eta() < -2.1 )
+        multFT0C++; 
+      if(3.5 < mcPart.eta() && mcPart.eta() < 4.9 )
+        multFT0A++; 
+    }
+    tableExtraMc( multFT0A, multFT0C, multBarrelEta05, multBarrelEta08, multBarrelEta10);
+  }
+
+  PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun2, "Produce Run 2 multiplicity tables", false);
   PROCESS_SWITCH(MultiplicityTableTaskIndexed, processRun3, "Produce Run 3 multiplicity tables", true);
+  PROCESS_SWITCH(MultiplicityTableTaskIndexed, processMC, "Produce MC multiplicity tables", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -31,9 +31,10 @@ static constexpr int kTrackletMults = 4;
 static constexpr int kTPCMults = 5;
 static constexpr int kPVMults = 6;
 static constexpr int kMultsExtra = 7;
-static constexpr int kMultZeqs = 8;
-static constexpr int kMultsExtraMC = 9;
-static constexpr int nTables = 10;
+static constexpr int kMultSelections = 8;
+static constexpr int kMultZeqs = 9;
+static constexpr int kMultsExtraMC = 10;
+static constexpr int nTables = 11;
 static constexpr int nParameters = 1;
 static const std::vector<std::string> tableNames{"FV0Mults",
                                                  "FT0Mults",
@@ -43,10 +44,11 @@ static const std::vector<std::string> tableNames{"FV0Mults",
                                                  "TPCMults",
                                                  "PVMults",
                                                  "MultsExtra",
+                                                 "MultSelections",
                                                  "MultZeqs",
                                                  "MultsExtraMC"};
 static const std::vector<std::string> parameterNames{"Enable"};
-static const int defaultParameters[nTables][nParameters]{{-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}};
+static const int defaultParameters[nTables][nParameters]{{-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}};
 
 struct MultiplicityTableTaskIndexed {
   SliceCache cache;
@@ -58,6 +60,7 @@ struct MultiplicityTableTaskIndexed {
   Produces<aod::TPCMults> tableTpc;
   Produces<aod::PVMults> tablePv;
   Produces<aod::MultsExtra> tableExtra;
+  Produces<aod::MultSelections> multSelections;
   Produces<aod::MultZeqs> tableMultZeq;
   Produces<aod::MultsExtraMC> tableExtraMc;
 
@@ -454,6 +457,10 @@ struct MultiplicityTableTaskIndexed {
             int bcNumber = bc.globalBC() % 3564;
 
             tableExtra(static_cast<float>(collision.numContrib()), collision.chi2(), collision.collisionTimeRes(), mRunNumber, collision.posZ(), collision.sel8(), nHasITS, nHasTPC, nHasTOF, nHasTRD, nITSonly, nTPConly, nITSTPC, bcNumber);
+          } break;
+          case kMultSelections: // Z equalized
+          {
+            multSelections(collision.selection_raw());
           } break;
           case kMultZeqs: // Z equalized
           {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -55,8 +55,8 @@ using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
 
 //______________________________________________________
-// for correlating information with MC 
-// also allows for collision association cross-checks 
+// for correlating information with MC
+// also allows for collision association cross-checks
 DECLARE_SOA_TABLE(StraMCCollisions, "AOD", "STRAMCCOLLISION", //! MC collision properties
                   o2::soa::Index<>, mccollision::PosX, mccollision::PosY, mccollision::PosZ,
                   mccollision::ImpactParameter);
@@ -149,7 +149,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras,
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                        //!
 DECLARE_SOA_INDEX_COLUMN(StraMCCollision, straMCCollision);                                    //!
 DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                          //!
-} 
+} // namespace v0data
 //______________________________________________________
 // intermezzo: define StraCollRefs, then carry on
 DECLARE_SOA_TABLE(StraCollLabels, "AOD", "STRACOLLLABELS", //! optional table to refer back to a MC collision

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -22,6 +22,7 @@
 
 namespace o2::aod
 {
+
 //______________________________________________________
 // Collision declarations for derived data analysis
 // this is optional but will ensure full flexibility
@@ -52,6 +53,17 @@ DECLARE_SOA_TABLE(StraStamps, "AOD", "STRASTAMPS", //! information for ID-ing ma
 using StraRawCents = StraRawCents_001;
 using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
+
+//______________________________________________________
+// for correlating information with MC 
+// also allows for collision association cross-checks 
+DECLARE_SOA_TABLE(StraMCCollisions, "AOD", "STRAMCCOLLISION", //! MC collision properties
+                  o2::soa::Index<>, mccollision::PosX, mccollision::PosY, mccollision::PosZ,
+                  mccollision::ImpactParameter);
+DECLARE_SOA_TABLE(StraMCCollMults, "AOD", "STRAMCCOLLMULTS", //! MC collision multiplicities
+                  mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<2>);
+
+using StraMCCollision = StraMCCollisions::iterator;
 
 namespace dautrack
 {
@@ -135,8 +147,16 @@ DECLARE_SOA_INDEX_COLUMN(V0, v0);                                       //!
 DECLARE_SOA_INDEX_COLUMN_FULL(PosTrackExtra, posTrackExtra, int, DauTrackExtras, "_PosExtra"); //!
 DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras, "_NegExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                        //!
+DECLARE_SOA_INDEX_COLUMN(StraMCCollision, straMCCollision);                                    //!
 DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                          //!
-
+} 
+//______________________________________________________
+// intermezzo: define StraCollRefs, then carry on
+DECLARE_SOA_TABLE(StraCollLabels, "AOD", "STRACOLLLABELS", //! optional table to refer back to a MC collision
+                  o2::soa::Index<>, v0data::StraMCCollisionId, o2::soa::Marker<1>);
+//______________________________________________________
+namespace v0data
+{
 //______________________________________________________
 // REGULAR COLUMNS FOR V0CORES
 // General V0 properties: position, momentum
@@ -497,6 +517,9 @@ DECLARE_SOA_TABLE(V0MCCores, "AOD", "V0MCCORE", //! MC properties of the V0 for 
                   v0data::PxPosMC, v0data::PyPosMC, v0data::PzPosMC,
                   v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC);
 
+DECLARE_SOA_TABLE(V0MCCollRefs, "AOD", "V0MCCOLLREF", //! refers MC candidate back to proper MC Collision
+                  o2::soa::Index<>, v0data::StraMCCollisionId, o2::soa::Marker<2>);
+
 DECLARE_SOA_TABLE(GeK0Short, "AOD", "GeK0Short", v0data::GeneratedK0Short);
 DECLARE_SOA_TABLE(GeLambda, "AOD", "GeLambda", v0data::GeneratedLambda);
 DECLARE_SOA_TABLE(GeAntiLambda, "AOD", "GeAntiLambda", v0data::GeneratedAntiLambda);
@@ -596,6 +619,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(NegTrackExtra, negTrackExtra, int, DauTrackExtras,
 DECLARE_SOA_INDEX_COLUMN_FULL(BachTrackExtra, bachTrackExtra, int, DauTrackExtras, "_BachExtra");          //!
 DECLARE_SOA_INDEX_COLUMN_FULL(StrangeTrackExtra, strangeTrackExtra, int, DauTrackExtras, "_StrangeExtra"); //!
 DECLARE_SOA_INDEX_COLUMN(StraCollision, straCollision);                                                    //!
+DECLARE_SOA_INDEX_COLUMN(StraMCCollision, straMCCollision);                                                //!
 DECLARE_SOA_INDEX_COLUMN(MotherMCPart, motherMCPart);                                                      //!
 
 //______________________________________________________
@@ -954,6 +978,9 @@ DECLARE_SOA_TABLE(CascMCCores, "AOD", "CASCMCCORE", //! bachelor-baryon correlat
                   cascdata::PxNegMC, cascdata::PyNegMC, cascdata::PzNegMC,
                   cascdata::PxBachMC, cascdata::PyBachMC, cascdata::PzBachMC,
                   cascdata::PxMC, cascdata::PyMC, cascdata::PzMC);
+
+DECLARE_SOA_TABLE(CascMCCollRefs, "AOD", "CASCMCCOLLREF", //! refers MC candidate back to proper MC Collision
+                  o2::soa::Index<>, cascdata::StraMCCollisionId, o2::soa::Marker<3>);
 
 DECLARE_SOA_TABLE(GeXiMinus, "AOD", "GeXiMinus", cascdata::GeneratedXiMinus);
 DECLARE_SOA_TABLE(GeXiPlus, "AOD", "GeXiPlus", cascdata::GeneratedXiPlus);

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -38,7 +38,7 @@ DECLARE_SOA_TABLE_VERSIONED(StraRawCents_001, "AOD", "STRARAWCENTS", 1, //! debu
                             mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, mult::MultNTracksPVeta1,
                             mult::MultZNA, mult::MultZNC, mult::MultZEM1, mult::MultZEM2, mult::MultZPA, mult::MultZPC);
 DECLARE_SOA_TABLE(StraEvSels, "AOD", "STRAEVSELS", //! event selection: sel8
-                  evsel::Sel8);
+                  evsel::Sel8, evsel::Selection);
 DECLARE_SOA_TABLE(StraFT0AQVs, "AOD", "STRAFT0AQVS", //! t0a Qvec
                   qvec::QvecFT0ARe, qvec::QvecFT0AIm, qvec::SumAmplFT0A);
 DECLARE_SOA_TABLE(StraFT0CQVs, "AOD", "STRAFT0CQVS", //! t0c Qvec

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -68,17 +68,17 @@ struct strangederivedbuilder {
   //__________________________________________________
   // fundamental building blocks of derived data
   Produces<aod::StraCollision> strangeColl;      // characterises collisions
-  Produces<aod::StraCollLabels> strangeCollLabels;      // characterises collisions
-  Produces<aod::StraMCCollisions> strangeMCColl;      // characterises collisions / MC
-  Produces<aod::StraMCCollMults> strangeMCMults;      // characterises collisions / MC mults
+  Produces<aod::StraCollLabels> strangeCollLabels; // characterises collisions
+  Produces<aod::StraMCCollisions> strangeMCColl;   // characterises collisions / MC
+  Produces<aod::StraMCCollMults> strangeMCMults;   // characterises collisions / MC mults
   Produces<aod::StraCents> strangeCents;         // characterises collisions / centrality
   Produces<aod::StraRawCents> strangeRawCents;   // characterises collisions / centrality
   Produces<aod::StraEvSels> strangeEvSels;       // characterises collisions / sel8 selection
   Produces<aod::StraStamps> strangeStamps;       // provides timestamps, run numbers
   Produces<aod::V0CollRefs> v0collref;           // references collisions from V0s
-  Produces<aod::V0MCCollRefs> v0mccollref;           // references collisions from V0s
+  Produces<aod::V0MCCollRefs> v0mccollref;       // references collisions from V0s
   Produces<aod::CascCollRefs> casccollref;       // references collisions from cascades
-  Produces<aod::CascMCCollRefs> cascmccollref;           // references collisions from V0s
+  Produces<aod::CascMCCollRefs> cascmccollref;   // references collisions from V0s
   Produces<aod::KFCascCollRefs> kfcasccollref;   // references collisions from KF cascades
   Produces<aod::TraCascCollRefs> tracasccollref; // references collisions from tracked cascades
 
@@ -326,8 +326,8 @@ struct strangederivedbuilder {
     // fill all MC collisions, correlate via index later on
     for (const auto& mccollision : mcCollisions) {
       strangeMCColl(mccollision.posX(), mccollision.posY(), mccollision.posZ(), mccollision.impactParameter());
-      strangeMCMults(mccollision.multMCFT0A(), mccollision.multMCFT0C(), 
-                     mccollision.multMCNParticlesEta05(), 
+      strangeMCMults(mccollision.multMCFT0A(), mccollision.multMCFT0C(),
+                     mccollision.multMCNParticlesEta05(),
                      mccollision.multMCNParticlesEta08(),
                      mccollision.multMCNParticlesEta10());
     }
@@ -382,19 +382,19 @@ struct strangederivedbuilder {
       for (int i = 0; i < TraCascTable_thisColl.size(); i++)
         tracasccollref(strangeColl.lastIndex());
 
-      //populate MC collision references 
+      // populate MC collision references
       for (const auto& v0 : V0Table_thisColl) {
-        uint32_t indMCColl = -1; 
-        if( v0.has_mcParticle()){
-          auto mcParticle = v0.mcParticle(); 
+        uint32_t indMCColl = -1;
+        if (v0.has_mcParticle()) {
+          auto mcParticle = v0.mcParticle();
           indMCColl = mcParticle.mcCollisionId();
         }
         v0collref(indMCColl);
       }
       for (const auto& casc : CascTable_thisColl) {
-        uint32_t indMCColl = -1; 
-        if( casc.has_mcParticle()){
-          auto mcParticle = casc.mcParticle(); 
+        uint32_t indMCColl = -1;
+        if (casc.has_mcParticle()) {
+          auto mcParticle = casc.mcParticle();
           indMCColl = mcParticle.mcCollisionId();
         }
         casccollref(indMCColl);

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -68,12 +68,17 @@ struct strangederivedbuilder {
   //__________________________________________________
   // fundamental building blocks of derived data
   Produces<aod::StraCollision> strangeColl;      // characterises collisions
+  Produces<aod::StraCollLabels> strangeCollLabels;      // characterises collisions
+  Produces<aod::StraMCCollisions> strangeMCColl;      // characterises collisions / MC
+  Produces<aod::StraMCCollMults> strangeMCMults;      // characterises collisions / MC mults
   Produces<aod::StraCents> strangeCents;         // characterises collisions / centrality
   Produces<aod::StraRawCents> strangeRawCents;   // characterises collisions / centrality
   Produces<aod::StraEvSels> strangeEvSels;       // characterises collisions / sel8 selection
   Produces<aod::StraStamps> strangeStamps;       // provides timestamps, run numbers
   Produces<aod::V0CollRefs> v0collref;           // references collisions from V0s
+  Produces<aod::V0MCCollRefs> v0mccollref;           // references collisions from V0s
   Produces<aod::CascCollRefs> casccollref;       // references collisions from cascades
+  Produces<aod::CascMCCollRefs> cascmccollref;           // references collisions from V0s
   Produces<aod::KFCascCollRefs> kfcasccollref;   // references collisions from KF cascades
   Produces<aod::TraCascCollRefs> tracasccollref; // references collisions from tracked cascades
 
@@ -312,6 +317,88 @@ struct strangederivedbuilder {
         kfcasccollref(strangeColl.lastIndex());
       for (int i = 0; i < TraCascTable_thisColl.size(); i++)
         tracasccollref(strangeColl.lastIndex());
+    }
+  }
+
+  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::MultsExtraMC> const& mcCollisions)
+  {
+    // ______________________________________________
+    // fill all MC collisions, correlate via index later on
+    for (const auto& mccollision : mcCollisions) {
+      strangeMCColl(mccollision.posX(), mccollision.posY(), mccollision.posZ(), mccollision.impactParameter());
+      strangeMCMults(mccollision.multMCFT0A(), mccollision.multMCFT0C(), 
+                     mccollision.multMCNParticlesEta05(), 
+                     mccollision.multMCNParticlesEta08(),
+                     mccollision.multMCNParticlesEta10());
+    }
+
+    // ______________________________________________
+    for (const auto& collision : collisions) {
+      const uint64_t collIdx = collision.globalIndex();
+
+      float centrality = collision.centFT0C();
+      if (qaCentrality) {
+        auto hRawCentrality = histos.get<TH1>(HIST("hRawCentrality"));
+        centrality = hRawCentrality->GetBinContent(hRawCentrality->FindBin(collision.multFT0C()));
+      }
+
+      auto V0Table_thisColl = V0s.sliceBy(V0perCollision, collIdx);
+      auto CascTable_thisColl = Cascades.sliceBy(CascperCollision, collIdx);
+      auto KFCascTable_thisColl = KFCascades.sliceBy(KFCascperCollision, collIdx);
+      auto TraCascTable_thisColl = TraCascades.sliceBy(TraCascperCollision, collIdx);
+      bool strange = V0Table_thisColl.size() > 0 ||
+                     CascTable_thisColl.size() > 0 ||
+                     KFCascTable_thisColl.size() > 0 ||
+                     TraCascTable_thisColl.size() > 0;
+      // casc table sliced
+      if (strange || fillEmptyCollisions) {
+        strangeColl(collision.posX(), collision.posY(), collision.posZ());
+        strangeCollLabels(collision.mcCollisionId());
+        strangeCents(collision.centFT0M(), collision.centFT0A(),
+                     centrality, collision.centFV0A());
+        strangeEvSels(collision.sel8());
+        auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+        strangeStamps(bc.runNumber(), bc.timestamp());
+
+        if (fillRawFT0C || fillRawFT0C || fillRawFV0A || fillRawNTracksEta1 || fillRawZDC) {
+          strangeRawCents(collision.multFT0A() * static_cast<float>(fillRawFT0A),
+                          collision.multFT0C() * static_cast<float>(fillRawFT0C),
+                          collision.multFT0A() * static_cast<float>(fillRawFV0A),
+                          collision.multNTracksPVeta1() * static_cast<int>(fillRawNTracksEta1),
+                          collision.multZNA() * static_cast<float>(fillRawZDC),
+                          collision.multZNC() * static_cast<float>(fillRawZDC),
+                          collision.multZEM1() * static_cast<float>(fillRawZDC),
+                          collision.multZEM2() * static_cast<float>(fillRawZDC),
+                          collision.multZPA() * static_cast<float>(fillRawZDC),
+                          collision.multZPC() * static_cast<float>(fillRawZDC));
+        }
+      }
+      for (int i = 0; i < V0Table_thisColl.size(); i++)
+        v0collref(strangeColl.lastIndex());
+      for (int i = 0; i < CascTable_thisColl.size(); i++)
+        casccollref(strangeColl.lastIndex());
+      for (int i = 0; i < KFCascTable_thisColl.size(); i++)
+        kfcasccollref(strangeColl.lastIndex());
+      for (int i = 0; i < TraCascTable_thisColl.size(); i++)
+        tracasccollref(strangeColl.lastIndex());
+
+      //populate MC collision references 
+      for (const auto& v0 : V0Table_thisColl) {
+        uint32_t indMCColl = -1; 
+        if( v0.has_mcParticle()){
+          auto mcParticle = v0.mcParticle(); 
+          indMCColl = mcParticle.mcCollisionId();
+        }
+        v0collref(indMCColl);
+      }
+      for (const auto& casc : CascTable_thisColl) {
+        uint32_t indMCColl = -1; 
+        if( casc.has_mcParticle()){
+          auto mcParticle = casc.mcParticle(); 
+          indMCColl = mcParticle.mcCollisionId();
+        }
+        casccollref(indMCColl);
+      }
     }
   }
 
@@ -675,6 +762,7 @@ struct strangederivedbuilder {
 
   PROCESS_SWITCH(strangederivedbuilder, processCollisionsV0sOnly, "Produce collisions (V0s only)", true);
   PROCESS_SWITCH(strangederivedbuilder, processCollisions, "Produce collisions (V0s + casc)", true);
+  PROCESS_SWITCH(strangederivedbuilder, processCollisionsMC, "Produce collisions (V0s + casc)", false);
   PROCESS_SWITCH(strangederivedbuilder, processTrackExtrasV0sOnly, "Produce track extra information (V0s only)", true);
   PROCESS_SWITCH(strangederivedbuilder, processTrackExtras, "Produce track extra information (V0s + casc)", true);
   PROCESS_SWITCH(strangederivedbuilder, processStrangeMothers, "Produce tables with mother info for V0s + casc", true);

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -356,7 +356,7 @@ struct strangederivedbuilder {
         strangeCollLabels(collision.mcCollisionId());
         strangeCents(collision.centFT0M(), collision.centFT0A(),
                      centrality, collision.centFV0A());
-        strangeEvSels(collision.sel8());
+        strangeEvSels(collision.sel8(), collision.selection_raw());
         auto bc = collision.bc_as<aod::BCsWithTimestamps>();
         strangeStamps(bc.runNumber(), bc.timestamp());
 

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -246,7 +246,7 @@ struct strangederivedbuilder {
         strangeColl(collision.posX(), collision.posY(), collision.posZ());
         strangeCents(collision.centFT0M(), collision.centFT0A(),
                      collision.centFT0C(), collision.centFV0A());
-        strangeEvSels(collision.sel8());
+        strangeEvSels(collision.sel8(), collision.selection_raw());
         auto bc = collision.bc_as<aod::BCsWithTimestamps>();
         strangeStamps(bc.runNumber(), bc.timestamp());
 
@@ -292,7 +292,7 @@ struct strangederivedbuilder {
         strangeColl(collision.posX(), collision.posY(), collision.posZ());
         strangeCents(collision.centFT0M(), collision.centFT0A(),
                      centrality, collision.centFV0A());
-        strangeEvSels(collision.sel8());
+        strangeEvSels(collision.sel8(), collision.selection_raw());
         auto bc = collision.bc_as<aod::BCsWithTimestamps>();
         strangeStamps(bc.runNumber(), bc.timestamp());
 


### PR DESCRIPTION
@romainschotter @lhusova This pull request:
* modifies the multiplicity data model for some extra MC QA by adding MC multiplicities that are joinable with `mcCollisions`. 
* In the LF derived data, it provides base functionality for linking `StraCollisions` to mc collisions and `V0MCCores/CascMCCores` to mc collisions. In doing so, it allows for the use of derived data to cross-check collision association for both V0s and Cascades in the analysis of Pb-Pb 