### PR TITLE
PWGHF: Add workflow for producing combined TPC+TOF NSigma

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -177,27 +177,27 @@ DECLARE_SOA_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, float); //! Combined NSigma s
 
 // Extension of per particle tables
 DECLARE_SOA_TABLE(TracksPidFullElS, "AOD", "PIDFULLELS", //! Table of the TPC & TOF Combined NSigma for electron
-                                pid_tpc_tof_static_full::TpcTofNSigmaEl);
+                  pid_tpc_tof_static_full::TpcTofNSigmaEl);
 DECLARE_SOA_TABLE(TracksPidFullMuS, "AOD", "PIDFULLMUS", //! Table of the TPC & TOF Combined NSigma for muon
-                                pid_tpc_tof_static_full::TpcTofNSigmaMu);
+                  pid_tpc_tof_static_full::TpcTofNSigmaMu);
 DECLARE_SOA_TABLE(TracksPidFullPiS, "AOD", "PIDFULLPIS", //! Table of the TPC & TOF Combined NSigma for pion
-                                pid_tpc_tof_static_full::TpcTofNSigmaPi);
+                  pid_tpc_tof_static_full::TpcTofNSigmaPi);
 DECLARE_SOA_TABLE(TracksPidFullKaS, "AOD", "PIDFULLKAS", //! Table of the TPC & TOF Combined NSigma for kaon
-                                pid_tpc_tof_static_full::TpcTofNSigmaKa);
+                  pid_tpc_tof_static_full::TpcTofNSigmaKa);
 DECLARE_SOA_TABLE(TracksPidFullPrS, "AOD", "PIDFULLPRS", //! Table of the TPC & TOF Combined NSigma for proton
-                                pid_tpc_tof_static_full::TpcTofNSigmaPr);
+                  pid_tpc_tof_static_full::TpcTofNSigmaPr);
 
 // Extension of per particle tables
 DECLARE_SOA_TABLE(TracksPidTinyElS, "AOD", "PIDTINYELS", //! Table of the TPC & TOF Combined NSigma for electron
-                                pid_tpc_tof_static_tiny::TpcTofNSigmaEl);
+                  pid_tpc_tof_static_tiny::TpcTofNSigmaEl);
 DECLARE_SOA_TABLE(TracksPidTinyMuS, "AOD", "PIDTINYMUS", //! Table of the TPC & TOF Combined NSigma for muon
-                                pid_tpc_tof_static_tiny::TpcTofNSigmaMu);
+                  pid_tpc_tof_static_tiny::TpcTofNSigmaMu);
 DECLARE_SOA_TABLE(TracksPidTinyPiS, "AOD", "PIDTINYPIS", //! Table of the TPC & TOF Combined NSigma for pion
-                                pid_tpc_tof_static_tiny::TpcTofNSigmaPi);
+                  pid_tpc_tof_static_tiny::TpcTofNSigmaPi);
 DECLARE_SOA_TABLE(TracksPidTinyKaS, "AOD", "PIDTINYKAS", //! Table of the TPC & TOF Combined NSigma for kaon
-                                pid_tpc_tof_static_tiny::TpcTofNSigmaKa);
+                  pid_tpc_tof_static_tiny::TpcTofNSigmaKa);
 DECLARE_SOA_TABLE(TracksPidTinyPrS, "AOD", "PIDTINYPRS", //! Table of the TPC & TOF Combined NSigma for proton
-                                pid_tpc_tof_static_tiny::TpcTofNSigmaPr);
+                  pid_tpc_tof_static_tiny::TpcTofNSigmaPr);
 
 namespace hf_sel_collision
 {

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -155,6 +155,50 @@ DECLARE_SOA_EXTENDED_TABLE_USER(TracksPidTinyKaExt, TracksPidTinyKa, "PIDTINYKAE
 DECLARE_SOA_EXTENDED_TABLE_USER(TracksPidTinyPrExt, TracksPidTinyPr, "PIDTINYPREXT", //! Table of the TPC & TOF combined binned NSigma for proton
                                 pid_tpc_tof_tiny::TpcTofNSigmaPr);
 
+namespace pid_tpc_tof_static_full
+{
+// Combined TPC and TOF NSigma
+DECLARE_SOA_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, float); //! Combined NSigma separation with the TPC & TOF detectors for electron
+DECLARE_SOA_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, float); //! Combined NSigma separation with the TPC & TOF detectors for muon
+DECLARE_SOA_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, float); //! Combined NSigma separation with the TPC & TOF detectors for kaon
+DECLARE_SOA_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, float); //! Combined NSigma separation with the TPC & TOF detectors for proton
+} // namespace pid_tpc_tof_static_full
+
+namespace pid_tpc_tof_static_tiny
+{
+// Combined TPC and TOF NSigma
+DECLARE_SOA_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, float); //! Combined NSigma separation with the TPC & TOF detectors for electron
+DECLARE_SOA_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, float); //! Combined NSigma separation with the TPC & TOF detectors for muon
+DECLARE_SOA_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, float); //! Combined NSigma separation with the TPC & TOF detectors for kaon
+DECLARE_SOA_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, float); //! Combined NSigma separation with the TPC & TOF detectors for proton
+} // namespace pid_tpc_tof_static_tiny
+
+// Extension of per particle tables
+DECLARE_SOA_TABLE(TracksPidFullElS, "AOD", "PIDFULLELS", //! Table of the TPC & TOF Combined NSigma for electron
+                                pid_tpc_tof_static_full::TpcTofNSigmaEl);
+DECLARE_SOA_TABLE(TracksPidFullMuS, "AOD", "PIDFULLMUS", //! Table of the TPC & TOF Combined NSigma for muon
+                                pid_tpc_tof_static_full::TpcTofNSigmaMu);
+DECLARE_SOA_TABLE(TracksPidFullPiS, "AOD", "PIDFULLPIS", //! Table of the TPC & TOF Combined NSigma for pion
+                                pid_tpc_tof_static_full::TpcTofNSigmaPi);
+DECLARE_SOA_TABLE(TracksPidFullKaS, "AOD", "PIDFULLKAS", //! Table of the TPC & TOF Combined NSigma for kaon
+                                pid_tpc_tof_static_full::TpcTofNSigmaKa);
+DECLARE_SOA_TABLE(TracksPidFullPrS, "AOD", "PIDFULLPRS", //! Table of the TPC & TOF Combined NSigma for proton
+                                pid_tpc_tof_static_full::TpcTofNSigmaPr);
+
+// Extension of per particle tables
+DECLARE_SOA_TABLE(TracksPidTinyElS, "AOD", "PIDTINYELS", //! Table of the TPC & TOF Combined NSigma for electron
+                                pid_tpc_tof_static_tiny::TpcTofNSigmaEl);
+DECLARE_SOA_TABLE(TracksPidTinyMuS, "AOD", "PIDTINYMUS", //! Table of the TPC & TOF Combined NSigma for muon
+                                pid_tpc_tof_static_tiny::TpcTofNSigmaMu);
+DECLARE_SOA_TABLE(TracksPidTinyPiS, "AOD", "PIDTINYPIS", //! Table of the TPC & TOF Combined NSigma for pion
+                                pid_tpc_tof_static_tiny::TpcTofNSigmaPi);
+DECLARE_SOA_TABLE(TracksPidTinyKaS, "AOD", "PIDTINYKAS", //! Table of the TPC & TOF Combined NSigma for kaon
+                                pid_tpc_tof_static_tiny::TpcTofNSigmaKa);
+DECLARE_SOA_TABLE(TracksPidTinyPrS, "AOD", "PIDTINYPRS", //! Table of the TPC & TOF Combined NSigma for proton
+                                pid_tpc_tof_static_tiny::TpcTofNSigmaPr);
+
 namespace hf_sel_collision
 {
 DECLARE_SOA_COLUMN(WhyRejectColl, whyRejectColl, int); //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -160,7 +160,7 @@ namespace pid_tpc_tof_static_full
 // Combined TPC and TOF NSigma
 DECLARE_SOA_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, float); //! Combined NSigma separation with the TPC & TOF detectors for electron
 DECLARE_SOA_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, float); //! Combined NSigma separation with the TPC & TOF detectors for muon
-DECLARE_SOA_COLUMN(TpcTofNSigmaPiS, tpcTofNSigmaPiS, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
 DECLARE_SOA_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, float); //! Combined NSigma separation with the TPC & TOF detectors for kaon
 DECLARE_SOA_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, float); //! Combined NSigma separation with the TPC & TOF detectors for proton
 } // namespace pid_tpc_tof_static_full
@@ -181,7 +181,7 @@ DECLARE_SOA_TABLE(TracksPidFullElS, "AOD", "PIDFULLELS", //! Table of the TPC & 
 DECLARE_SOA_TABLE(TracksPidFullMuS, "AOD", "PIDFULLMUS", //! Table of the TPC & TOF Combined NSigma for muon
                   pid_tpc_tof_static_full::TpcTofNSigmaMu);
 DECLARE_SOA_TABLE(TracksPidFullPiS, "AOD", "PIDFULLPIS", //! Table of the TPC & TOF Combined NSigma for pion
-                  pid_tpc_tof_static_full::TpcTofNSigmaPiS);
+                  pid_tpc_tof_static_full::TpcTofNSigmaPi);
 DECLARE_SOA_TABLE(TracksPidFullKaS, "AOD", "PIDFULLKAS", //! Table of the TPC & TOF Combined NSigma for kaon
                   pid_tpc_tof_static_full::TpcTofNSigmaKa);
 DECLARE_SOA_TABLE(TracksPidFullPrS, "AOD", "PIDFULLPRS", //! Table of the TPC & TOF Combined NSigma for proton

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -160,7 +160,7 @@ namespace pid_tpc_tof_static_full
 // Combined TPC and TOF NSigma
 DECLARE_SOA_COLUMN(TpcTofNSigmaEl, tpcTofNSigmaEl, float); //! Combined NSigma separation with the TPC & TOF detectors for electron
 DECLARE_SOA_COLUMN(TpcTofNSigmaMu, tpcTofNSigmaMu, float); //! Combined NSigma separation with the TPC & TOF detectors for muon
-DECLARE_SOA_COLUMN(TpcTofNSigmaPi, tpcTofNSigmaPi, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
+DECLARE_SOA_COLUMN(TpcTofNSigmaPiS, tpcTofNSigmaPiS, float); //! Combined NSigma separation with the TPC & TOF detectors for pion
 DECLARE_SOA_COLUMN(TpcTofNSigmaKa, tpcTofNSigmaKa, float); //! Combined NSigma separation with the TPC & TOF detectors for kaon
 DECLARE_SOA_COLUMN(TpcTofNSigmaPr, tpcTofNSigmaPr, float); //! Combined NSigma separation with the TPC & TOF detectors for proton
 } // namespace pid_tpc_tof_static_full
@@ -181,7 +181,7 @@ DECLARE_SOA_TABLE(TracksPidFullElS, "AOD", "PIDFULLELS", //! Table of the TPC & 
 DECLARE_SOA_TABLE(TracksPidFullMuS, "AOD", "PIDFULLMUS", //! Table of the TPC & TOF Combined NSigma for muon
                   pid_tpc_tof_static_full::TpcTofNSigmaMu);
 DECLARE_SOA_TABLE(TracksPidFullPiS, "AOD", "PIDFULLPIS", //! Table of the TPC & TOF Combined NSigma for pion
-                  pid_tpc_tof_static_full::TpcTofNSigmaPi);
+                  pid_tpc_tof_static_full::TpcTofNSigmaPiS);
 DECLARE_SOA_TABLE(TracksPidFullKaS, "AOD", "PIDFULLKAS", //! Table of the TPC & TOF Combined NSigma for kaon
                   pid_tpc_tof_static_full::TpcTofNSigmaKa);
 DECLARE_SOA_TABLE(TracksPidFullPrS, "AOD", "PIDFULLPRS", //! Table of the TPC & TOF Combined NSigma for proton

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -16,8 +16,15 @@ o2physics_add_dpl_workflow(track-index-skim-creator
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing O2::DCAFitter O2Physics::AnalysisCCDB
                     COMPONENT_NAME Analysis)
 
+# Helpers
+
 o2physics_add_dpl_workflow(refit-pv-dummy
                     SOURCES refitPvDummy.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(pid-creator
+                    SOURCES pidCreator.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -421,6 +421,13 @@ struct HfCandidateSelectorD0 {
     processSel<aod::hf_cand::VertexerType::KfParticle>(candidates, tracks);
   }
   PROCESS_SWITCH(HfCandidateSelectorD0, processWithKFParticle, "process candidates selection with KFParticle", false);
+
+  void processTest(soa::Join<aod::TracksPidEl, aod::TracksPidFullElS> const& tracks)
+  // void processTest(aod::TracksPidFullElS const& tracks)
+  {
+    LOGF(info, "TracksPidFullElS size: %d", tracks.size());
+  }
+  PROCESS_SWITCH(HfCandidateSelectorD0, processTest, "process El PID", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -422,12 +422,15 @@ struct HfCandidateSelectorD0 {
   }
   PROCESS_SWITCH(HfCandidateSelectorD0, processWithKFParticle, "process candidates selection with KFParticle", false);
 
-  void processTest(soa::Join<aod::TracksPidEl, aod::TracksPidFullElS> const& tracks)
-  // void processTest(aod::TracksPidFullElS const& tracks)
+  void processTest(soa::Join<aod::TracksPidPi, aod::TracksPidFullPiS, aod::TracksPidPiExt> const& tracks)
   {
-    LOGF(info, "TracksPidFullElS size: %d", tracks.size());
+    LOGF(info, "TracksPidFullPi size: %d", tracks.size());
+    for (auto const& track : tracks) {
+      if (std::abs(track.tpcTofNSigmaPi() - track.tpcTofNSigmaPiS()) > 1.e-9)
+        LOGF(fatal, "TpcTofNSigmaPi = %g %g\n", track.tpcTofNSigmaPi(), track.tpcTofNSigmaPiS());
+    }
   }
-  PROCESS_SWITCH(HfCandidateSelectorD0, processTest, "process El PID", false);
+  PROCESS_SWITCH(HfCandidateSelectorD0, processTest, "process PID", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/TableProducer/candidateSelectorD0.cxx
+++ b/PWGHF/TableProducer/candidateSelectorD0.cxx
@@ -421,16 +421,6 @@ struct HfCandidateSelectorD0 {
     processSel<aod::hf_cand::VertexerType::KfParticle>(candidates, tracks);
   }
   PROCESS_SWITCH(HfCandidateSelectorD0, processWithKFParticle, "process candidates selection with KFParticle", false);
-
-  void processTest(soa::Join<aod::TracksPidPi, aod::TracksPidFullPiS, aod::TracksPidPiExt> const& tracks)
-  {
-    LOGF(info, "TracksPidFullPi size: %d", tracks.size());
-    for (auto const& track : tracks) {
-      if (std::abs(track.tpcTofNSigmaPi() - track.tpcTofNSigmaPiS()) > 1.e-9)
-        LOGF(fatal, "TpcTofNSigmaPi = %g %g\n", track.tpcTofNSigmaPi(), track.tpcTofNSigmaPiS());
-    }
-  }
-  PROCESS_SWITCH(HfCandidateSelectorD0, processTest, "process PID", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -93,23 +93,23 @@ struct HfPidCreator {
   void processDummy(aod::Collisions const&) {}
   PROCESS_SWITCH(HfPidCreator, processDummy, "Process nothing", true);
 
-  // Macro for declaring process functions per species
-  #define PROCESS_PID(_Species_) \
-  void processFull##_Species_(aod::TracksPid##_Species_ const& tracks) \
-  { \
-    for (const auto& track : tracks) { \
-      tracksPidFull##_Species_##S(combineNSigma<false>(track.tpcNSigma##_Species_(), track.tofNSigma##_Species_())); \
-    } \
-  } \
-  PROCESS_SWITCH(HfPidCreator, processFull##_Species_, "Process full "#_Species_, false); \
- \
-  void processTiny##_Species_(aod::TracksPidTiny##_Species_ const& tracks) \
-  { \
-    for (const auto& track : tracks) { \
+// Macro for declaring process functions per species
+#define PROCESS_PID(_Species_)                                                                                                \
+  void processFull##_Species_(aod::TracksPid##_Species_ const& tracks)                                                        \
+  {                                                                                                                           \
+    for (const auto& track : tracks) {                                                                                        \
+      tracksPidFull##_Species_##S(combineNSigma<false>(track.tpcNSigma##_Species_(), track.tofNSigma##_Species_()));          \
+    }                                                                                                                         \
+  }                                                                                                                           \
+  PROCESS_SWITCH(HfPidCreator, processFull##_Species_, "Process full " #_Species_, false);                                    \
+                                                                                                                              \
+  void processTiny##_Species_(aod::TracksPidTiny##_Species_ const& tracks)                                                    \
+  {                                                                                                                           \
+    for (const auto& track : tracks) {                                                                                        \
       tracksPidTiny##_Species_##S(combineNSigma<true>(track.tpcNSigmaStore##_Species_(), track.tofNSigmaStore##_Species_())); \
-    } \
-  } \
-  PROCESS_SWITCH(HfPidCreator, processTiny##_Species_, "Process tiny "#_Species_, false);
+    }                                                                                                                         \
+  }                                                                                                                           \
+  PROCESS_SWITCH(HfPidCreator, processTiny##_Species_, "Process tiny " #_Species_, false);
 
   // Declare process functions for all species.
   PROCESS_PID(El)
@@ -118,7 +118,7 @@ struct HfPidCreator {
   PROCESS_PID(Ka)
   PROCESS_PID(Pr)
 
-  #undef PROCESS_PID
+#undef PROCESS_PID
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file pidCreator.cxx
+/// \brief Workflow to produce tables with TPC+TOF combined n sigma
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+#include "Common/Core/TableHelper.h"
+#include "Common/DataModel/PIDResponse.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+struct HfPidCreator {
+  Produces<aod::TracksPidFullElS> tracksPidFullElS;
+  Produces<aod::TracksPidTinyElS> tracksPidTinyElS;
+
+  static constexpr float defaultNSigmaTolerance = .1f;
+  static constexpr float defaultNSigma = -999.f + defaultNSigmaTolerance; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h
+
+  template <typename TSwitch>
+  void checkTableSwitch(InitContext& initContext, const std::string& table, const TSwitch& doprocess)
+  {
+    auto isNeeded = isTableRequiredInWorkflow(initContext, table);
+    if (isNeeded && !doprocess.value) {
+      LOGF(fatal, "Table %s is needed but not requested. Enable the corresponding process function!", table);
+    }
+    if (!isNeeded && doprocess.value) {
+      LOGF(warn, "Table %s is requested but not needed. Disable the corresponding process function!", table);
+    }
+  }
+
+  void init(InitContext& initContext)
+  {
+    checkTableSwitch(initContext, "TracksPidFullElS", doprocessFullEl);
+    checkTableSwitch(initContext, "TracksPidTinyElS", doprocessTinyEl);
+  }
+
+  /// Function to combine TPC and TOF NSigma
+  /// \param tiny switch between full and tiny (binned) PID tables
+  /// \param tpcNSigma is the (binned) NSigma separation in TPC (if tiny = true)
+  /// \param tofNSigma is the (binned) NSigma separation in TOF (if tiny = true)
+  /// \return combined NSigma of TPC and TOF
+  template <bool tiny, typename T1>
+  T1 combineNSigma(T1 tpcNSigma, T1 tofNSigma)
+  {
+    if constexpr (tiny) {
+      tpcNSigma *= aod::pidtpc_tiny::binning::bin_width;
+      tofNSigma *= aod::pidtof_tiny::binning::bin_width;
+    }
+    if ((tpcNSigma > defaultNSigma) && (tofNSigma > defaultNSigma)) { // TPC and TOF
+      return std::sqrt(.5f * (tpcNSigma * tpcNSigma + tofNSigma * tofNSigma));
+    }
+    if (tpcNSigma > defaultNSigma) { // only TPC
+      return std::abs(tpcNSigma);
+    }
+    if (tofNSigma > defaultNSigma) { // only TOF
+      return std::abs(tofNSigma);
+    }
+    return tofNSigma; // no TPC nor TOF
+  }
+
+  void processDummy(aod::Collisions const&) {}
+  PROCESS_SWITCH(HfPidCreator, processDummy, "Process nothing", true);
+
+  void processFullEl(aod::TracksPidEl const& tracks)
+  {
+    for (const auto& track : tracks) {
+      tracksPidFullElS(combineNSigma<false>(track.tpcNSigmaEl(), track.tofNSigmaEl()));
+    }
+  }
+  PROCESS_SWITCH(HfPidCreator, processFullEl, "Process full El ", false);
+
+  void processTinyEl(aod::TracksPidTinyEl const& tracks)
+  {
+    for (const auto& track : tracks) {
+      tracksPidTinyElS(combineNSigma<true>(track.tpcNSigmaStoreEl(), track.tofNSigmaStoreEl()));
+    }
+  }
+  PROCESS_SWITCH(HfPidCreator, processTinyEl, "Process tiny El", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfPidCreator>(cfgc)};
+}

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -40,6 +40,10 @@ struct HfPidCreator {
   static constexpr float defaultNSigmaTolerance = .1f;
   static constexpr float defaultNSigma = -999.f + defaultNSigmaTolerance; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h
 
+  /// Function to check whether the process function flag matches the need for filling the table
+  /// \param initContext  workflow context (argument of the init function)
+  /// \param table  name of the table
+  /// \param doprocess  process function flag
   template <typename TSwitch>
   void checkTableSwitch(InitContext& initContext, const std::string& table, const TSwitch& doprocess)
   {
@@ -54,6 +58,7 @@ struct HfPidCreator {
 
   void init(InitContext& initContext)
   {
+    // Check whether the right process functions are enabled.
     checkTableSwitch(initContext, "TracksPidFullElS", doprocessFullEl);
     checkTableSwitch(initContext, "TracksPidTinyElS", doprocessTinyEl);
     checkTableSwitch(initContext, "TracksPidFullMuS", doprocessFullMu);

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -28,6 +28,14 @@ using namespace o2::framework;
 struct HfPidCreator {
   Produces<aod::TracksPidFullElS> tracksPidFullElS;
   Produces<aod::TracksPidTinyElS> tracksPidTinyElS;
+  Produces<aod::TracksPidFullMuS> tracksPidFullMuS;
+  Produces<aod::TracksPidTinyMuS> tracksPidTinyMuS;
+  Produces<aod::TracksPidFullPiS> tracksPidFullPiS;
+  Produces<aod::TracksPidTinyPiS> tracksPidTinyPiS;
+  Produces<aod::TracksPidFullKaS> tracksPidFullKaS;
+  Produces<aod::TracksPidTinyKaS> tracksPidTinyKaS;
+  Produces<aod::TracksPidFullPrS> tracksPidFullPrS;
+  Produces<aod::TracksPidTinyPrS> tracksPidTinyPrS;
 
   static constexpr float defaultNSigmaTolerance = .1f;
   static constexpr float defaultNSigma = -999.f + defaultNSigmaTolerance; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h
@@ -48,6 +56,14 @@ struct HfPidCreator {
   {
     checkTableSwitch(initContext, "TracksPidFullElS", doprocessFullEl);
     checkTableSwitch(initContext, "TracksPidTinyElS", doprocessTinyEl);
+    checkTableSwitch(initContext, "TracksPidFullMuS", doprocessFullMu);
+    checkTableSwitch(initContext, "TracksPidTinyMuS", doprocessTinyMu);
+    checkTableSwitch(initContext, "TracksPidFullPiS", doprocessFullPi);
+    checkTableSwitch(initContext, "TracksPidTinyPiS", doprocessTinyPi);
+    checkTableSwitch(initContext, "TracksPidFullKaS", doprocessFullKa);
+    checkTableSwitch(initContext, "TracksPidTinyKaS", doprocessTinyKa);
+    checkTableSwitch(initContext, "TracksPidFullPrS", doprocessFullPr);
+    checkTableSwitch(initContext, "TracksPidTinyPrS", doprocessTinyPr);
   }
 
   /// Function to combine TPC and TOF NSigma
@@ -77,6 +93,7 @@ struct HfPidCreator {
   void processDummy(aod::Collisions const&) {}
   PROCESS_SWITCH(HfPidCreator, processDummy, "Process nothing", true);
 
+  // Macro for declaring process functions per species
   #define PROCESS_PID(_Species_) \
   void processFull##_Species_(aod::TracksPid##_Species_ const& tracks) \
   { \
@@ -94,7 +111,12 @@ struct HfPidCreator {
   } \
   PROCESS_SWITCH(HfPidCreator, processTiny##_Species_, "Process tiny "#_Species_, false);
 
+  // Declare process functions for all species.
   PROCESS_PID(El)
+  PROCESS_PID(Mu)
+  PROCESS_PID(Pi)
+  PROCESS_PID(Ka)
+  PROCESS_PID(Pr)
 
   #undef PROCESS_PID
 };

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -44,15 +44,17 @@ struct HfPidCreator {
   /// \param initContext  workflow context (argument of the init function)
   /// \param table  name of the table
   /// \param doprocess  process function flag
-  template <typename TSwitch>
-  void checkTableSwitch(InitContext& initContext, const std::string& table, const TSwitch& doprocess)
+  template <typename TFlag>
+  void checkTableSwitch(InitContext& initContext, const std::string& table, TFlag& doprocess)
   {
     auto isNeeded = isTableRequiredInWorkflow(initContext, table);
     if (isNeeded && !doprocess.value) {
       LOGF(fatal, "Table %s is needed but not requested. Enable the corresponding process function!", table);
     }
     if (!isNeeded && doprocess.value) {
-      LOGF(warn, "Table %s is requested but not needed. Disable the corresponding process function!", table);
+      LOGF(warn, "Table %s is requested but not needed. Disabling the corresponding process function!", table);
+      // NOTE: This does not remove the input table subscription from the context! The input table is still considered consumed.
+      doprocess.value = false;
     }
   }
 

--- a/PWGHF/TableProducer/pidCreator.cxx
+++ b/PWGHF/TableProducer/pidCreator.cxx
@@ -77,21 +77,26 @@ struct HfPidCreator {
   void processDummy(aod::Collisions const&) {}
   PROCESS_SWITCH(HfPidCreator, processDummy, "Process nothing", true);
 
-  void processFullEl(aod::TracksPidEl const& tracks)
-  {
-    for (const auto& track : tracks) {
-      tracksPidFullElS(combineNSigma<false>(track.tpcNSigmaEl(), track.tofNSigmaEl()));
-    }
-  }
-  PROCESS_SWITCH(HfPidCreator, processFullEl, "Process full El ", false);
+  #define PROCESS_PID(_Species_) \
+  void processFull##_Species_(aod::TracksPid##_Species_ const& tracks) \
+  { \
+    for (const auto& track : tracks) { \
+      tracksPidFull##_Species_##S(combineNSigma<false>(track.tpcNSigma##_Species_(), track.tofNSigma##_Species_())); \
+    } \
+  } \
+  PROCESS_SWITCH(HfPidCreator, processFull##_Species_, "Process full "#_Species_, false); \
+ \
+  void processTiny##_Species_(aod::TracksPidTiny##_Species_ const& tracks) \
+  { \
+    for (const auto& track : tracks) { \
+      tracksPidTiny##_Species_##S(combineNSigma<true>(track.tpcNSigmaStore##_Species_(), track.tofNSigmaStore##_Species_())); \
+    } \
+  } \
+  PROCESS_SWITCH(HfPidCreator, processTiny##_Species_, "Process tiny "#_Species_, false);
 
-  void processTinyEl(aod::TracksPidTinyEl const& tracks)
-  {
-    for (const auto& track : tracks) {
-      tracksPidTinyElS(combineNSigma<true>(track.tpcNSigmaStoreEl(), track.tofNSigmaStoreEl()));
-    }
-  }
-  PROCESS_SWITCH(HfPidCreator, processTinyEl, "Process tiny El", false);
+  PROCESS_PID(El)
+
+  #undef PROCESS_PID
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
Workflow to produce tables with combined TPC+TOF sigmas in static columns instead of extended tables with expression columns.
Rationale: Extended tables have to be spawned. Spawning cannot be conditional (yet) so it is not possible to produce extended tables for different particle species only when needed. Spawning needed tables inside different selector workflows makes it impossible to run these workflows together because of the conflicting table production.

Implementation in this PR:

- Produce normal tables with static columns for all particle species and table types (full, tiny).
- Run one process function per table to isolate subscriptions to parent PID tables (which automatically enable their filling by the PID task).
- Automatically disable process functions enabled for not needed tables. (This prevent the process function from running but it does not remove the input table subscription from the context! The input table is still considered consumed and will be produced by the PID task anyway. It is therefore still important to set the process switches correctly to avoid wasting resources.)
- Throw fatal for process functions disabled for needed tables. (Cannot be enabled.)
