### PR TITLE
Common | PWGHF: Take flavour oscillation into account at MC reco and gen levels

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -47,6 +47,8 @@ class RecoDecay
                     Prompt,
                     NonPrompt };
 
+  const uint8_t PdgStatusCodeAfterFlavourOscillation = 92;
+
   // Auxiliary functions
 
   /// Sums numbers.
@@ -581,7 +583,7 @@ class RecoDecay
       stage--;
     }
     if (sign) {
-      *sign = sgn;
+      *sign = particle.getGenStatusCode() != PdgStatusCodeAfterFlavourOscillation ? sgn : -sgn; // take possible flavour oscillation of B0(s) into account
     }
 
     return indexMother;
@@ -796,6 +798,7 @@ class RecoDecay
                              std::vector<int>* listIndexDaughters = nullptr)
   {
     // Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
+    bool flagFlavourOscillation = false; // true if the B0(s) mother flavour oscillated
     int8_t sgn = 0; // 1 if the expected mother is particle, -1 if antiparticle (w.r.t. PDGParticle)
     if (sign) {
       *sign = sgn;
@@ -841,6 +844,10 @@ class RecoDecay
       for (auto indexDaughterI : arrAllDaughtersIndex) {
         auto candidateDaughterI = particlesMC.rawIteratorAt(indexDaughterI - particlesMC.offset()); // ith daughter particle
         auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();                                  // PDG code of the ith daughter
+        if (!flagFlavourOscillation && candidateDaughterI.getGenStatusCode() == PdgStatusCodeAfterFlavourOscillation) {
+          flagFlavourOscillation = true; // flag flavour oscillation of B0(s)
+          sgn = -sgn;                    // select the sign of the mother after flavour oscillation
+        }
         // Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);
         bool isPDGFound = false; // Is the PDG code of this daughter among the remaining expected PDG codes?
         for (std::size_t iProngCp = 0; iProngCp < N; ++iProngCp) {

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -308,7 +308,7 @@ struct HfDataCreatorCharmHadPiReduced {
 
     if constexpr (decChannel == DecayChannel::B0ToDminusPi) {
       // B0 → D- π+ → (π- K+ π-) π+
-      auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
+      auto indexRec = RecoDecay::getMatchedMCRec<true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kB0, std::array{-kPiPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
       if (indexRec > -1) {
         // D- → π- K+ π-
         // Printf("Checking D- → π- K+ π-");
@@ -332,7 +332,7 @@ struct HfDataCreatorCharmHadPiReduced {
       if (checkDecayTypeMc) {
         // B0 → Ds- π+ → (K- K+ π-) π+
         if (!flag) {
-          indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kB0, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
+          indexRec = RecoDecay::getMatchedMCRec<true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kB0, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
           if (indexRec > -1) {
             // Ds- → K- K+ π-
             indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, -Pdg::kDS, std::array{-kKPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
@@ -678,11 +678,11 @@ struct HfDataCreatorCharmHadPiReduced {
       int8_t flag{0};
       if constexpr (decayChannel == DecayChannel::B0ToDminusPi) {
         // B0 → D- π+
-        if (RecoDecay::isMatchedMCGen(particlesMc, particle, Pdg::kB0, std::array{-static_cast<int>(Pdg::kDPlus), +kPiPlus}, true)) {
+        if (RecoDecay::isMatchedMCGen<true>(particlesMc, particle, Pdg::kB0, std::array{-static_cast<int>(Pdg::kDPlus), +kPiPlus}, true)) {
           // Match D- -> π- K+ π-
           auto candCMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
           // Printf("Checking D- -> π- K+ π-");
-          if (RecoDecay::isMatchedMCGen(particlesMc, candCMC, -static_cast<int>(Pdg::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign)) {
+          if (RecoDecay::isMatchedMCGen(particlesMc, candCMC, -static_cast<int>(Pdg::kDPlus), std::array{-kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2)) {
             flag = sign * BIT(hf_cand_b0::DecayType::B0ToDPi);
           }
         }


### PR DESCRIPTION
Hello @vkucera ! Here is my proposition to take B0(s) oscillation into account.

---------------------------------------

**The "issue" in a nutshell**

Let's suppose we aim at reconstructing the decay channel `B0bar -> D+ Pi-`. Currently, the code (at MC reco and gen levels) perfectly allows to do so by checking this decay channel with a set of pdg code signs `(-1 -> +1 -1)`. However, if B0 flavour oscillation occured, we actually have `B0 -> B0bar -> D+ Pi-`.
Here comes the "issue": in the genealogy of the decay products, the `B0bar` mother does not appear (when oscillation occurs), only the `B0` appears. In other words, the beauty meson after oscillation is "not seen" and one can only retrieve the pdg code of the beauty meson before oscillation, which of course leads to a rejection of the candidate as we look for `B0bar -> D+ Pi-` with a sign set `(-1 -> +1 -1)` while we only "see" `B0 -> D+ Pi-` with a sign set `(+1 -> +1 -1)`.
_Note: the problem lies in the sign of the beauty mother pdg code_

---------------------------------------

**The "fix" proposition in a nutshell**

Thanks to [Pythia status code](https://pythia.org/latest-manual/ParticleProperties.html), one can know if a decay product comes from an oscillated `B0(s)`, if so its code is equal to `92`.
So, in `RecoDecay.h`, we added a way to spot possible oscillation via this status code. If oscillation is indeed spotted, we swap the sign of the beauty mother.

Example: we have `B0 -> [B0bar "not seen"] -> D+ Pi-` but look for `B0bar -> D+ Pi-`
- without the functionality included in this PR, the B0 candidate is flagged as background (even though it is actually signal with flavour oscillation) 
- with the functionality included in this PR, if oscillation is spotted (thanks to the status code of the Dmeson and/or the bachelor pion), we swap the pdg code sign of the beauty mother (`B0` -> `B0bar`) and we then have `B0bar -> D+ Pi-`, which is exactly what we are looking for -> the B0bar candidate is flagged as signal

---------------------------------------

**Some safeties**

The code added in this PR is embedded in `template booleans` and such booleans are set to `false` by default so all the other decay channels calling the functions modified here in `RecoDecay.h` don't get affected. These booleans are only activated for the `B0` decay channel for the moment.
Tests were performed on the 3prong candidate creator, that is calling `getMatchedMcRec` and `isMatchedMcGen`: the output is indeed not affected by the code added in this PR.