### PR TITLE
Common/LF: add some extras for QA of evsel based on PF info

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -53,7 +53,7 @@ DECLARE_SOA_COLUMN(MultMCNParticlesEta08, multMCNParticlesEta08, int); //!
 DECLARE_SOA_COLUMN(MultMCNParticlesEta05, multMCNParticlesEta05, int); //!
 
 // complementary / MultsExtra table
-DECLARE_SOA_COLUMN(MultPVTotalContributors, multPVTotalContributors, int); //!
+DECLARE_SOA_COLUMN(MultPVTotalContributors, multPVTotalContributors, int);   //!
 DECLARE_SOA_COLUMN(MultPVChi2, multPVChi2, float);                           //!
 DECLARE_SOA_COLUMN(MultCollisionTimeRes, multCollisionTimeRes, float);       //!
 DECLARE_SOA_COLUMN(MultRunNumber, multRunNumber, int);                       //!
@@ -69,7 +69,7 @@ DECLARE_SOA_COLUMN(MultNTracksHasTRD, multNTracksHasTRD, int); //!
 DECLARE_SOA_COLUMN(MultNTracksITSOnly, multNTracksITSOnly, int); //!
 DECLARE_SOA_COLUMN(MultNTracksTPCOnly, multNTracksTPCOnly, int); //!
 DECLARE_SOA_COLUMN(MultNTracksITSTPC, multNTracksITSTPC, int);   //!
-DECLARE_SOA_COLUMN(MultAllTracksTPCOnly, multAllTracksTPCOnly, int);   //!
+DECLARE_SOA_COLUMN(MultAllTracksTPCOnly, multAllTracksTPCOnly, int); //!
 DECLARE_SOA_COLUMN(MultAllTracksITSTPC, multAllTracksITSTPC, int);   //!
 
 DECLARE_SOA_COLUMN(BCNumber, bcNumber, int); //!
@@ -104,7 +104,7 @@ using Mult = Mults::iterator;
 DECLARE_SOA_TABLE(MultsExtra, "AOD", "MULTEXTRA", //!
                   mult::MultPVTotalContributors, mult::MultPVChi2, mult::MultCollisionTimeRes, mult::MultRunNumber, mult::MultPVz, mult::MultSel8,
                   mult::MultNTracksHasITS, mult::MultNTracksHasTPC, mult::MultNTracksHasTOF, mult::MultNTracksHasTRD,
-                  mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, 
+                  mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC,
                   mult::MultAllTracksTPCOnly, mult::MultAllTracksITSTPC,
                   mult::BCNumber);
 DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -53,7 +53,7 @@ DECLARE_SOA_COLUMN(MultMCNParticlesEta08, multMCNParticlesEta08, int); //!
 DECLARE_SOA_COLUMN(MultMCNParticlesEta05, multMCNParticlesEta05, int); //!
 
 // complementary / MultsExtra table
-DECLARE_SOA_COLUMN(MultPVTotalContributors, multPVTotalContributors, float); //!
+DECLARE_SOA_COLUMN(MultPVTotalContributors, multPVTotalContributors, int); //!
 DECLARE_SOA_COLUMN(MultPVChi2, multPVChi2, float);                           //!
 DECLARE_SOA_COLUMN(MultCollisionTimeRes, multCollisionTimeRes, float);       //!
 DECLARE_SOA_COLUMN(MultRunNumber, multRunNumber, int);                       //!
@@ -69,6 +69,8 @@ DECLARE_SOA_COLUMN(MultNTracksHasTRD, multNTracksHasTRD, int); //!
 DECLARE_SOA_COLUMN(MultNTracksITSOnly, multNTracksITSOnly, int); //!
 DECLARE_SOA_COLUMN(MultNTracksTPCOnly, multNTracksTPCOnly, int); //!
 DECLARE_SOA_COLUMN(MultNTracksITSTPC, multNTracksITSTPC, int);   //!
+DECLARE_SOA_COLUMN(MultAllTracksTPCOnly, multAllTracksTPCOnly, int);   //!
+DECLARE_SOA_COLUMN(MultAllTracksITSTPC, multAllTracksITSTPC, int);   //!
 
 DECLARE_SOA_COLUMN(BCNumber, bcNumber, int); //!
 
@@ -102,7 +104,9 @@ using Mult = Mults::iterator;
 DECLARE_SOA_TABLE(MultsExtra, "AOD", "MULTEXTRA", //!
                   mult::MultPVTotalContributors, mult::MultPVChi2, mult::MultCollisionTimeRes, mult::MultRunNumber, mult::MultPVz, mult::MultSel8,
                   mult::MultNTracksHasITS, mult::MultNTracksHasTPC, mult::MultNTracksHasTOF, mult::MultNTracksHasTRD,
-                  mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, mult::BCNumber);
+                  mult::MultNTracksITSOnly, mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, 
+                  mult::MultAllTracksTPCOnly, mult::MultAllTracksITSTPC,
+                  mult::BCNumber);
 DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!
                   evsel::Selection);                       // for derived data / QA studies
 using MultExtra = MultsExtra::iterator;

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -455,22 +455,22 @@ struct MultiplicityTableTaskIndexed {
                 nHasTRD++;
             };
 
-            int nAllTracksTPCOnly = 0; 
-            int nAllTracksITSTPC = 0; 
+            int nAllTracksTPCOnly = 0;
+            int nAllTracksITSTPC = 0;
             for (auto track : pvAllContribsGrouped) {
               if (track.hasITS()) {
                 nAllTracksITSTPC++;
-              }else{
+              } else {
                 nAllTracksTPCOnly++;
               }
             };
 
             int bcNumber = bc.globalBC() % 3564;
 
-            tableExtra(collision.numContrib(), collision.chi2(), collision.collisionTimeRes(), 
-            mRunNumber, collision.posZ(), collision.sel8(), 
-            nHasITS, nHasTPC, nHasTOF, nHasTRD, nITSonly, nTPConly, nITSTPC, 
-            nAllTracksTPCOnly, nAllTracksITSTPC, bcNumber);
+            tableExtra(collision.numContrib(), collision.chi2(), collision.collisionTimeRes(),
+                       mRunNumber, collision.posZ(), collision.sel8(),
+                       nHasITS, nHasTPC, nHasTOF, nHasTRD, nITSonly, nTPConly, nITSTPC,
+                       nAllTracksTPCOnly, nAllTracksITSTPC, bcNumber);
           } break;
           case kMultSelections: // Z equalized
           {

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -434,6 +434,7 @@ struct MultiplicityTableTaskIndexed {
             int nHasITS = 0, nHasTPC = 0, nHasTOF = 0, nHasTRD = 0;
             int nITSonly = 0, nTPConly = 0, nITSTPC = 0;
             const auto& pvAllContribsGrouped = pvAllContribTracksIU->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+            const auto& tpcTracksGrouped = tracksIUWithTPC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
             for (auto track : pvAllContribsGrouped) {
               if (track.hasITS()) {
@@ -454,9 +455,22 @@ struct MultiplicityTableTaskIndexed {
                 nHasTRD++;
             };
 
+            int nAllTracksTPCOnly = 0; 
+            int nAllTracksITSTPC = 0; 
+            for (auto track : pvAllContribsGrouped) {
+              if (track.hasITS()) {
+                nAllTracksITSTPC++;
+              }else{
+                nAllTracksTPCOnly++;
+              }
+            };
+
             int bcNumber = bc.globalBC() % 3564;
 
-            tableExtra(static_cast<float>(collision.numContrib()), collision.chi2(), collision.collisionTimeRes(), mRunNumber, collision.posZ(), collision.sel8(), nHasITS, nHasTPC, nHasTOF, nHasTRD, nITSonly, nTPConly, nITSTPC, bcNumber);
+            tableExtra(collision.numContrib(), collision.chi2(), collision.collisionTimeRes(), 
+            mRunNumber, collision.posZ(), collision.sel8(), 
+            nHasITS, nHasTPC, nHasTOF, nHasTRD, nITSonly, nTPConly, nITSTPC, 
+            nAllTracksTPCOnly, nAllTracksITSTPC, bcNumber);
           } break;
           case kMultSelections: // Z equalized
           {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -34,17 +34,17 @@ DECLARE_SOA_TABLE(StraCents, "AOD", "STRACENTS", //! centrality percentiles
                   cent::CentFT0C, cent::CentFV0A);
 DECLARE_SOA_TABLE(StraRawCents_000, "AOD", "STRARAWCENTS", //! debug information
                   mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, mult::MultNTracksPVeta1);
-DECLARE_SOA_TABLE_VERSIONED(StraRawCents_001, "AOD", "STRARAWCENTS", 1, //! debug information
-                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors 
-                            mult::MultNTracksPVeta1, // track multiplicities
-                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+DECLARE_SOA_TABLE_VERSIONED(StraRawCents_001, "AOD", "STRARAWCENTS", 1,     //! debug information
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors
+                            mult::MultNTracksPVeta1,                        // track multiplicities
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1,   // ZDC signals
                             mult::MultZEM2, mult::MultZPA, mult::MultZPC);
-DECLARE_SOA_TABLE_VERSIONED(StraRawCents_002, "AOD", "STRARAWCENTS", 2, //! debug information
-                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors 
-                            mult::MultNTracksPVeta1, // track multiplicities with eta cut for INEL>0
-                            mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, // track multiplicities, PV contribs, no eta cut
+DECLARE_SOA_TABLE_VERSIONED(StraRawCents_002, "AOD", "STRARAWCENTS", 2,            //! debug information
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A,        // FIT detectors
+                            mult::MultNTracksPVeta1,                               // track multiplicities with eta cut for INEL>0
+                            mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC,     // track multiplicities, PV contribs, no eta cut
                             mult::MultAllTracksTPCOnly, mult::MultAllTracksITSTPC, // track multiplicities, all, no eta cut
-                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1,          // ZDC signals
                             mult::MultZEM2, mult::MultZPA, mult::MultZPC);
 DECLARE_SOA_TABLE(StraEvSels, "AOD", "STRAEVSELS", //! event selection: sel8
                   evsel::Sel8, evsel::Selection);

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -35,8 +35,17 @@ DECLARE_SOA_TABLE(StraCents, "AOD", "STRACENTS", //! centrality percentiles
 DECLARE_SOA_TABLE(StraRawCents_000, "AOD", "STRARAWCENTS", //! debug information
                   mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, mult::MultNTracksPVeta1);
 DECLARE_SOA_TABLE_VERSIONED(StraRawCents_001, "AOD", "STRARAWCENTS", 1, //! debug information
-                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, mult::MultNTracksPVeta1,
-                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, mult::MultZEM2, mult::MultZPA, mult::MultZPC);
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors 
+                            mult::MultNTracksPVeta1, // track multiplicities
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+                            mult::MultZEM2, mult::MultZPA, mult::MultZPC);
+DECLARE_SOA_TABLE_VERSIONED(StraRawCents_002, "AOD", "STRARAWCENTS", 2, //! debug information
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors 
+                            mult::MultNTracksPVeta1, // track multiplicities with eta cut for INEL>0
+                            mult::MultNTracksTPCOnly, mult::MultNTracksITSTPC, // track multiplicities, PV contribs, no eta cut
+                            mult::MultAllTracksTPCOnly, mult::MultAllTracksITSTPC, // track multiplicities, all, no eta cut
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+                            mult::MultZEM2, mult::MultZPA, mult::MultZPC);
 DECLARE_SOA_TABLE(StraEvSels, "AOD", "STRAEVSELS", //! event selection: sel8
                   evsel::Sel8, evsel::Selection);
 DECLARE_SOA_TABLE(StraFT0AQVs, "AOD", "STRAFT0AQVS", //! t0a Qvec
@@ -50,7 +59,7 @@ DECLARE_SOA_TABLE(StraFV0AQVs, "AOD", "STRAFV0AQVS", //! v0a Qvec
 DECLARE_SOA_TABLE(StraStamps, "AOD", "STRASTAMPS", //! information for ID-ing mag field if needed
                   bc::RunNumber, timestamp::Timestamp);
 
-using StraRawCents = StraRawCents_001;
+using StraRawCents = StraRawCents_002;
 using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
 

--- a/PWGLF/TableProducer/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/strangederivedbuilder.cxx
@@ -166,6 +166,7 @@ struct strangederivedbuilder {
   Configurable<bool> fillRawFV0A{"fillRawFV0A", false, "Fill raw FV0A information for debug"};
   Configurable<bool> fillRawZDC{"fillRawZDC", false, "Fill raw ZDC information for debug"};
   Configurable<bool> fillRawNTracksEta1{"fillRawNTracksEta1", true, "Fill raw NTracks |eta|<1 information for debug"};
+  Configurable<bool> fillRawNTracksForCorrelation{"fillRawNTracksForCorrelation", true, "Fill raw NTracks for correlation cuts"};
 
   Configurable<bool> qaCentrality{"qaCentrality", false, "qa centrality flag: check base raw values"};
 
@@ -235,7 +236,7 @@ struct strangederivedbuilder {
     }
   }
 
-  void processCollisionsV0sOnly(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels> const& collisions, aod::V0Datas const& V0s, aod::BCsWithTimestamps const&)
+  void processCollisionsV0sOnly(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::MultsExtra> const& collisions, aod::V0Datas const& V0s, aod::BCsWithTimestamps const&)
   {
     for (const auto& collision : collisions) {
       const uint64_t collIdx = collision.globalIndex();
@@ -255,6 +256,10 @@ struct strangederivedbuilder {
                           collision.multFT0C() * static_cast<float>(fillRawFT0C),
                           collision.multFT0A() * static_cast<float>(fillRawFV0A),
                           collision.multNTracksPVeta1() * static_cast<int>(fillRawNTracksEta1),
+                          collision.multNTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multNTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
                           collision.multZNA() * static_cast<float>(fillRawZDC),
                           collision.multZNC() * static_cast<float>(fillRawZDC),
                           collision.multZEM1() * static_cast<float>(fillRawZDC),
@@ -268,7 +273,7 @@ struct strangederivedbuilder {
     }
   }
 
-  void processCollisions(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels> const& collisions, aod::V0Datas const& V0s, aod::CascDatas const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&)
+  void processCollisions(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::MultsExtra> const& collisions, aod::V0Datas const& V0s, aod::CascDatas const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&)
   {
     for (const auto& collision : collisions) {
       const uint64_t collIdx = collision.globalIndex();
@@ -301,6 +306,10 @@ struct strangederivedbuilder {
                           collision.multFT0C() * static_cast<float>(fillRawFT0C),
                           collision.multFT0A() * static_cast<float>(fillRawFV0A),
                           collision.multNTracksPVeta1() * static_cast<int>(fillRawNTracksEta1),
+                          collision.multNTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multNTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
                           collision.multZNA() * static_cast<float>(fillRawZDC),
                           collision.multZNC() * static_cast<float>(fillRawZDC),
                           collision.multZEM1() * static_cast<float>(fillRawZDC),
@@ -320,7 +329,7 @@ struct strangederivedbuilder {
     }
   }
 
-  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::MultsExtraMC> const& mcCollisions)
+  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels, aod::MultsExtra> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::MultsExtraMC> const& mcCollisions)
   {
     // ______________________________________________
     // fill all MC collisions, correlate via index later on
@@ -365,6 +374,10 @@ struct strangederivedbuilder {
                           collision.multFT0C() * static_cast<float>(fillRawFT0C),
                           collision.multFT0A() * static_cast<float>(fillRawFV0A),
                           collision.multNTracksPVeta1() * static_cast<int>(fillRawNTracksEta1),
+                          collision.multNTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multNTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksTPCOnly() * static_cast<int>(fillRawNTracksForCorrelation),
+                          collision.multAllTracksITSTPC() * static_cast<int>(fillRawNTracksForCorrelation),
                           collision.multZNA() * static_cast<float>(fillRawZDC),
                           collision.multZNC() * static_cast<float>(fillRawZDC),
                           collision.multZEM1() * static_cast<float>(fillRawZDC),


### PR DESCRIPTION
@lhusova @romainschotter following also a suggestion from @lhusova, this adds enough information for us to explore a correlation cut on Number of PV contributors and global (=ITSTPC, not necessarily PV contribs) tracks, just for a cross-check. 