### PR TITLE
PWGLF: V0 builder preselector optimization

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -586,9 +586,9 @@ enum v0bit {
   bitdEdxNegProton,
   bitdEdxNegHelium3,
 
-  // Mixed bits 
-  bitdEdxPosPionOrITSOnly, 
-  bitdEdxNegPionOrITSOnly, 
+  // Mixed bits
+  bitdEdxPosPionOrITSOnly,
+  bitdEdxNegPionOrITSOnly,
 
   // Monte Carlo Association bits
   bitTrueGamma,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -565,85 +565,81 @@ using V0Linked = V0sLinked::iterator;
 // helper for building
 namespace v0tag
 {
-namespace enums{
-  enum v0bit { 
-               // Track quality 
-               bitTrackPosGoodTPC,
-               bitTrackPosGoodITSOnly,
-               bitTrackPosGoodTPCorITSOnly,
-               bitTrackNegGoodTPC,
-               bitTrackNegGoodITSOnly,
-               bitTrackNegGoodTPCorITSOnly,
+namespace enums
+{
+enum v0bit {
+  // Track quality
+  bitTrackPosGoodTPC,
+  bitTrackPosGoodITSOnly,
+  bitTrackPosGoodTPCorITSOnly,
+  bitTrackNegGoodTPC,
+  bitTrackNegGoodITSOnly,
+  bitTrackNegGoodTPCorITSOnly,
 
-               // dEdx compatibility bits
-               bitdEdxPosElectron,
-               bitdEdxPosPion,
-               bitdEdxPosProton,
-               bitdEdxPosHelium3,
-               bitdEdxNegElectron,
-               bitdEdxNegPion,
-               bitdEdxNegProton,
-               bitdEdxNegHelium3,
+  // dEdx compatibility bits
+  bitdEdxPosElectron,
+  bitdEdxPosPion,
+  bitdEdxPosProton,
+  bitdEdxPosHelium3,
+  bitdEdxNegElectron,
+  bitdEdxNegPion,
+  bitdEdxNegProton,
+  bitdEdxNegHelium3,
 
-               // Monte Carlo Association bits
-               bitTrueGamma,
-               bitTrueK0Short,
-               bitTrueLambda,
-               bitTrueAntiLambda,
-               bitTrueHypertriton,
-               bitTrueAntiHypertriton,
+  // Monte Carlo Association bits
+  bitTrueGamma,
+  bitTrueK0Short,
+  bitTrueLambda,
+  bitTrueAntiLambda,
+  bitTrueHypertriton,
+  bitTrueAntiHypertriton,
 
-               // cascade use bits
-               bitUsedInCascade,
-               bitUsedInTrackedCascade };
+  // cascade use bits
+  bitUsedInCascade,
+  bitUsedInTrackedCascade
+};
 }
 
 DECLARE_SOA_COLUMN(IsInteresting, isInteresting, bool); //! global selector (keep legacy behaviour)
 
 // dynamic columns to keep legacy behaviour of compound dEdx selectors
 DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxGamma, isdEdxGamma, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron))) == 
-                           ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron)); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxK0Short, isdEdxK0Short, //! 
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion))) == 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion)); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxLambda, isdEdxLambda, //! 
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion))) == 
-                           ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion)); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiLambda, isdEdxAntiLambda, //! 
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton))) == 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton)); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxHypertriton, isdEdxHypertriton, //! 
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion))) == 
-                           ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion)); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiHypertriton, isdEdxAntiHypertriton, //! 
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3))) == 
-                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3)); });
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron))) ==
+                                                                      ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxK0Short, isdEdxK0Short, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion))) ==
+                                                                      ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxLambda, isdEdxLambda, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion))) ==
+                                                                      ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiLambda, isdEdxAntiLambda, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton))) ==
+                                                                      ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxHypertriton, isdEdxHypertriton, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion))) ==
+                                                                      ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiHypertriton, isdEdxAntiHypertriton, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap &
+                                                                       ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3))) ==
+                                                                      ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3)); });
 
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueGamma, isTrueGamma, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueGamma)) == (1 << enums::bitTrueGamma); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueK0Short, isTrueK0Short, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueK0Short)) == (1 << enums::bitTrueK0Short); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueLambda, isTrueLambda, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueLambda)) == (1 << enums::bitTrueLambda); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiLambda, isTrueAntiLambda, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueAntiLambda)) == (1 << enums::bitTrueAntiLambda); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueHypertriton, isTrueHypertriton, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueHypertriton)) == (1 << enums::bitTrueHypertriton); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiHypertriton, isTrueAntiHypertriton, //! 
-                           [](uint32_t selectionMap) -> bool { 
-                            return (selectionMap & (1 << enums::bitTrueAntiHypertriton)) == (1 << enums::bitTrueAntiHypertriton); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueGamma, isTrueGamma, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueGamma)) == (1 << enums::bitTrueGamma); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueK0Short, isTrueK0Short, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueK0Short)) == (1 << enums::bitTrueK0Short); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueLambda, isTrueLambda, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueLambda)) == (1 << enums::bitTrueLambda); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiLambda, isTrueAntiLambda, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueAntiLambda)) == (1 << enums::bitTrueAntiLambda); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueHypertriton, isTrueHypertriton, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueHypertriton)) == (1 << enums::bitTrueHypertriton); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiHypertriton, isTrueAntiHypertriton, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueAntiHypertriton)) == (1 << enums::bitTrueAntiHypertriton); });
 
 DECLARE_SOA_COLUMN(Tag, tag, uint32_t); // pack according to enums
 } // namespace v0tag
@@ -665,8 +661,7 @@ DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
                   v0tag::IsTrueLambda<v0tag::Tag>,
                   v0tag::IsTrueAntiLambda<v0tag::Tag>,
                   v0tag::IsTrueHypertriton<v0tag::Tag>,
-                  v0tag::IsTrueAntiHypertriton<v0tag::Tag>
-                  );
+                  v0tag::IsTrueAntiHypertriton<v0tag::Tag>);
 
 namespace kfcascdata
 {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -565,45 +565,108 @@ using V0Linked = V0sLinked::iterator;
 // helper for building
 namespace v0tag
 {
-// Global bool
-DECLARE_SOA_COLUMN(IsInteresting, isInteresting, bool); //! will this be built or not?
+namespace enums{
+  enum v0bit { 
+               // Track quality 
+               bitTrackPosGoodTPC,
+               bitTrackPosGoodITSOnly,
+               bitTrackPosGoodTPCorITSOnly,
+               bitTrackNegGoodTPC,
+               bitTrackNegGoodITSOnly,
+               bitTrackNegGoodTPCorITSOnly,
 
-// MC association bools
-DECLARE_SOA_COLUMN(IsTrueGamma, isTrueGamma, bool);                     //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueK0Short, isTrueK0Short, bool);                 //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueLambda, isTrueLambda, bool);                   //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueAntiLambda, isTrueAntiLambda, bool);           //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueHypertriton, isTrueHypertriton, bool);         //! PDG checked correctly in MC
-DECLARE_SOA_COLUMN(IsTrueAntiHypertriton, isTrueAntiHypertriton, bool); //! PDG checked correctly in MC
+               // dEdx compatibility bits
+               bitdEdxPosElectron,
+               bitdEdxPosPion,
+               bitdEdxPosProton,
+               bitdEdxPosHelium3,
+               bitdEdxNegElectron,
+               bitdEdxNegPion,
+               bitdEdxNegProton,
+               bitdEdxNegHelium3,
 
-// dE/dx compatibility bools
-DECLARE_SOA_COLUMN(IsdEdxGamma, isdEdxGamma, bool);                     //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsdEdxK0Short, isdEdxK0Short, bool);                 //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsdEdxLambda, isdEdxLambda, bool);                   //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsdEdxAntiLambda, isdEdxAntiLambda, bool);           //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsdEdxHypertriton, isdEdxHypertriton, bool);         //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsdEdxAntiHypertriton, isdEdxAntiHypertriton, bool); //! compatible with dE/dx hypotheses
+               // Monte Carlo Association bits
+               bitTrueGamma,
+               bitTrueK0Short,
+               bitTrueLambda,
+               bitTrueAntiLambda,
+               bitTrueHypertriton,
+               bitTrueAntiHypertriton,
 
-// used in cascades (potentially useful in general, make available as tags)
-DECLARE_SOA_COLUMN(IsFromCascade, isFromCascade, bool);               //! compatible with dE/dx hypotheses
-DECLARE_SOA_COLUMN(IsFromTrackedCascade, isFromTrackedCascade, bool); //! compatible with dE/dx hypotheses
+               // cascade use bits
+               bitUsedInCascade,
+               bitUsedInTrackedCascade };
+}
+
+DECLARE_SOA_COLUMN(IsInteresting, isInteresting, bool); //! global selector (keep legacy behaviour)
+
+// dynamic columns to keep legacy behaviour of compound dEdx selectors
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxGamma, isdEdxGamma, //!
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron))) == 
+                           ((1 << enums::bitdEdxPosElectron) | (1 << enums::bitdEdxNegElectron)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxK0Short, isdEdxK0Short, //! 
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion))) == 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxLambda, isdEdxLambda, //! 
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion))) == 
+                           ((1 << enums::bitdEdxPosProton) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiLambda, isdEdxAntiLambda, //! 
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton))) == 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegProton)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxHypertriton, isdEdxHypertriton, //! 
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion))) == 
+                           ((1 << enums::bitdEdxPosHelium3) | (1 << enums::bitdEdxNegPion)); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiHypertriton, isdEdxAntiHypertriton, //! 
+                           [](uint32_t selectionMap) -> bool { return (selectionMap & 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3))) == 
+                           ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3)); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueGamma, isTrueGamma, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueGamma)) == (1 << enums::bitTrueGamma); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueK0Short, isTrueK0Short, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueK0Short)) == (1 << enums::bitTrueK0Short); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueLambda, isTrueLambda, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueLambda)) == (1 << enums::bitTrueLambda); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiLambda, isTrueAntiLambda, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueAntiLambda)) == (1 << enums::bitTrueAntiLambda); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueHypertriton, isTrueHypertriton, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueHypertriton)) == (1 << enums::bitTrueHypertriton); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiHypertriton, isTrueAntiHypertriton, //! 
+                           [](uint32_t selectionMap) -> bool { 
+                            return (selectionMap & (1 << enums::bitTrueAntiHypertriton)) == (1 << enums::bitTrueAntiHypertriton); });
+
+DECLARE_SOA_COLUMN(Tag, tag, uint32_t); // pack according to enums
 } // namespace v0tag
 DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
                   v0tag::IsInteresting,
-                  v0tag::IsTrueGamma,
-                  v0tag::IsTrueK0Short,
-                  v0tag::IsTrueLambda,
-                  v0tag::IsTrueAntiLambda,
-                  v0tag::IsTrueHypertriton,
-                  v0tag::IsTrueAntiHypertriton,
-                  v0tag::IsdEdxGamma,
-                  v0tag::IsdEdxK0Short,
-                  v0tag::IsdEdxLambda,
-                  v0tag::IsdEdxAntiLambda,
-                  v0tag::IsdEdxHypertriton,
-                  v0tag::IsdEdxAntiHypertriton,
-                  v0tag::IsFromCascade,
-                  v0tag::IsFromTrackedCascade);
+                  v0tag::Tag,
+
+                  // Dynamic composite
+                  v0tag::IsdEdxGamma<v0tag::Tag>,
+                  v0tag::IsdEdxK0Short<v0tag::Tag>,
+                  v0tag::IsdEdxLambda<v0tag::Tag>,
+                  v0tag::IsdEdxAntiLambda<v0tag::Tag>,
+                  v0tag::IsdEdxHypertriton<v0tag::Tag>,
+                  v0tag::IsdEdxAntiHypertriton<v0tag::Tag>,
+
+                  // true flags
+                  v0tag::IsTrueGamma<v0tag::Tag>,
+                  v0tag::IsTrueK0Short<v0tag::Tag>,
+                  v0tag::IsTrueLambda<v0tag::Tag>,
+                  v0tag::IsTrueAntiLambda<v0tag::Tag>,
+                  v0tag::IsTrueHypertriton<v0tag::Tag>,
+                  v0tag::IsTrueAntiHypertriton<v0tag::Tag>
+                  );
 
 namespace kfcascdata
 {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -632,40 +632,19 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsdEdxAntiHypertriton, isdEdxAntiHypertriton, //!
                                                                        ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3))) ==
                                                                       ((1 << enums::bitdEdxPosPion) | (1 << enums::bitdEdxNegHelium3)); });
 
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueGamma, isTrueGamma, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueGamma)) == (1 << enums::bitTrueGamma); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueK0Short, isTrueK0Short, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueK0Short)) == (1 << enums::bitTrueK0Short); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueLambda, isTrueLambda, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueLambda)) == (1 << enums::bitTrueLambda); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiLambda, isTrueAntiLambda, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueAntiLambda)) == (1 << enums::bitTrueAntiLambda); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueHypertriton, isTrueHypertriton, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueHypertriton)) == (1 << enums::bitTrueHypertriton); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsTrueAntiHypertriton, isTrueAntiHypertriton, //!
-                           [](uint32_t selectionMap) -> bool { return (selectionMap & (1 << enums::bitTrueAntiHypertriton)) == (1 << enums::bitTrueAntiHypertriton); });
-
-DECLARE_SOA_COLUMN(Tag, tag, uint32_t); // pack according to enums
+DECLARE_SOA_BITMAP_COLUMN(Tag, tag, 32);
 } // namespace v0tag
 DECLARE_SOA_TABLE(V0Tags, "AOD", "V0TAGS",
                   v0tag::IsInteresting,
                   v0tag::Tag,
 
-                  // Dynamic composite
+                  // Dynamic composite: two bits checked
                   v0tag::IsdEdxGamma<v0tag::Tag>,
                   v0tag::IsdEdxK0Short<v0tag::Tag>,
                   v0tag::IsdEdxLambda<v0tag::Tag>,
                   v0tag::IsdEdxAntiLambda<v0tag::Tag>,
                   v0tag::IsdEdxHypertriton<v0tag::Tag>,
-                  v0tag::IsdEdxAntiHypertriton<v0tag::Tag>,
-
-                  // true flags
-                  v0tag::IsTrueGamma<v0tag::Tag>,
-                  v0tag::IsTrueK0Short<v0tag::Tag>,
-                  v0tag::IsTrueLambda<v0tag::Tag>,
-                  v0tag::IsTrueAntiLambda<v0tag::Tag>,
-                  v0tag::IsTrueHypertriton<v0tag::Tag>,
-                  v0tag::IsTrueAntiHypertriton<v0tag::Tag>);
+                  v0tag::IsdEdxAntiHypertriton<v0tag::Tag>);
 
 namespace kfcascdata
 {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -586,6 +586,10 @@ enum v0bit {
   bitdEdxNegProton,
   bitdEdxNegHelium3,
 
+  // Mixed bits 
+  bitdEdxPosPionOrITSOnly, 
+  bitdEdxNegPionOrITSOnly, 
+
   // Monte Carlo Association bits
   bitTrueGamma,
   bitTrueK0Short,

--- a/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
+++ b/PWGLF/TableProducer/hStrangeCorrelationFilter.cxx
@@ -32,6 +32,7 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::aod::v0tag::enums; // for the selectiom bits
 
 #define bitcheck(var, nbit) ((var) & (1 << (nbit)))
 
@@ -380,7 +381,7 @@ struct hstrangecorrelationfilter {
       ) {
         assocV0(v0.collisionId(), v0.globalIndex(),
                 compatibleK0Short, compatibleLambda, compatibleAntiLambda,
-                origV0entry.isTrueK0Short(), origV0entry.isTrueLambda(), origV0entry.isTrueAntiLambda(),
+                origV0entry.tag_bit(bitTrueK0Short), origV0entry.tag_bit(bitTrueLambda), origV0entry.tag_bit(bitTrueAntiLambda),
                 massRegK0Short, massRegLambda, massRegAntiLambda);
       }
     }

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -1077,7 +1077,7 @@ struct lambdakzeroPreselector {
   // for bit-packed maps
   std::vector<uint32_t> selectionMask;
 
-  // selection masks set up at ::Init time 
+  // selection masks set up at ::Init time
   uint32_t selectionK0Short;
   uint32_t selectionLambda;
   uint32_t selectionAntiLambda;
@@ -1087,7 +1087,7 @@ struct lambdakzeroPreselector {
 
   void init(InitContext const&)
   {
-    // initalise selection criteria 
+    // initalise selection criteria
     selectionK0Short = 0;
     selectionLambda = 0;
     selectionAntiLambda = 0;
@@ -1097,54 +1097,54 @@ struct lambdakzeroPreselector {
 
     //_____________________________________
     // TPC Quality requirements
-    if( dTPCNCrossedRows > 0 ){ // if it's stated that there is a TPC requirement, set masks accordingly
-      selectionK0Short = selectionK0Short | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-      selectionGamma = selectionGamma | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-      if(!dPreselectOnlyBaryons){ 
-        selectionLambda = selectionLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-        selectionAntiLambda = selectionAntiLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-        selectionHypertriton = selectionHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-        selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC); 
-      }else{
+    if (dTPCNCrossedRows > 0) { // if it's stated that there is a TPC requirement, set masks accordingly
+      selectionK0Short = selectionK0Short | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+      selectionGamma = selectionGamma | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+      if (!dPreselectOnlyBaryons) {
+        selectionLambda = selectionLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+        selectionAntiLambda = selectionAntiLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+        selectionHypertriton = selectionHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+        selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPC);
+      } else {
         // if preselection only affects baryons, accept also mesonic daughter via ITS only (with min ITS clu = minITSCluITSOnly)
-        selectionLambda = selectionLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPCorITSOnly); 
-        selectionAntiLambda = selectionAntiLambda | (1 << bitTrackPosGoodTPCorITSOnly) | (1 << bitTrackNegGoodTPC); 
-        selectionHypertriton = selectionHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPCorITSOnly); 
-        selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitTrackPosGoodTPCorITSOnly) | (1 << bitTrackNegGoodTPC); 
+        selectionLambda = selectionLambda | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPCorITSOnly);
+        selectionAntiLambda = selectionAntiLambda | (1 << bitTrackPosGoodTPCorITSOnly) | (1 << bitTrackNegGoodTPC);
+        selectionHypertriton = selectionHypertriton | (1 << bitTrackPosGoodTPC) | (1 << bitTrackNegGoodTPCorITSOnly);
+        selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitTrackPosGoodTPCorITSOnly) | (1 << bitTrackNegGoodTPC);
       }
     }
 
     //_____________________________________
     // TPC PID requirements
-    selectionK0Short = selectionK0Short | (1 << bitdEdxPosPion) | (1 << bitdEdxNegPion); 
-    selectionGamma = selectionGamma | (1 << bitdEdxPosElectron) | (1 << bitdEdxNegElectron); 
-    if(!dPreselectOnlyBaryons){ 
-      selectionLambda = selectionLambda | (1 << bitdEdxPosProton) | (1 << bitdEdxNegPion); 
-      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxPosPion) | (1 << bitdEdxNegProton); 
-      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3) | (1 << bitdEdxNegPion); 
-      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxPosPion) | (1 << bitdEdxNegHelium3); 
-    }else{
+    selectionK0Short = selectionK0Short | (1 << bitdEdxPosPion) | (1 << bitdEdxNegPion);
+    selectionGamma = selectionGamma | (1 << bitdEdxPosElectron) | (1 << bitdEdxNegElectron);
+    if (!dPreselectOnlyBaryons) {
+      selectionLambda = selectionLambda | (1 << bitdEdxPosProton) | (1 << bitdEdxNegPion);
+      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxPosPion) | (1 << bitdEdxNegProton);
+      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3) | (1 << bitdEdxNegPion);
+      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxPosPion) | (1 << bitdEdxNegHelium3);
+    } else {
       // if preselection only affects baryons, accept also mesonic daughter via ITS only (with min ITS clu = minITSCluITSOnly)
-      selectionLambda = selectionLambda | (1 << bitdEdxPosProton); 
-      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxNegProton); 
-      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3); 
-      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxNegHelium3); 
+      selectionLambda = selectionLambda | (1 << bitdEdxPosProton);
+      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxNegProton);
+      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3);
+      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxNegHelium3);
     }
 
-    if(doprocessBuildMCAssociated || doprocessBuildValiddEdxMCAssociated){
-      selectionK0Short = selectionK0Short | (dIfMCgenerateK0Short << bitTrueK0Short); 
-      selectionLambda = selectionLambda | (dIfMCgenerateLambda << bitTrueLambda); 
-      selectionAntiLambda = selectionAntiLambda | (dIfMCgenerateAntiLambda << bitTrueAntiLambda); 
-      selectionGamma = selectionGamma | (dIfMCgenerateGamma << bitTrueGamma); 
-      selectionHypertriton = selectionHypertriton | (dIfMCgenerateHypertriton << bitTrueHypertriton); 
-      selectionAntiHypertriton = selectionAntiHypertriton | (dIfMCgenerateAntiHypertriton << bitTrueAntiHypertriton); 
+    if (doprocessBuildMCAssociated || doprocessBuildValiddEdxMCAssociated) {
+      selectionK0Short = selectionK0Short | (dIfMCgenerateK0Short << bitTrueK0Short);
+      selectionLambda = selectionLambda | (dIfMCgenerateLambda << bitTrueLambda);
+      selectionAntiLambda = selectionAntiLambda | (dIfMCgenerateAntiLambda << bitTrueAntiLambda);
+      selectionGamma = selectionGamma | (dIfMCgenerateGamma << bitTrueGamma);
+      selectionHypertriton = selectionHypertriton | (dIfMCgenerateHypertriton << bitTrueHypertriton);
+      selectionAntiHypertriton = selectionAntiHypertriton | (dIfMCgenerateAntiHypertriton << bitTrueAntiHypertriton);
     }
 
     uint32_t globalSelection = 0; // for master switches
-    if(doprocessSkipV0sNotUsedInCascades) 
-      globalSelection = globalSelection | (1 << bitUsedInCascade); 
-    if(doprocessSkipV0sNotUsedInTrackedCascades) 
-      globalSelection = globalSelection | (1 << bitUsedInTrackedCascade); 
+    if (doprocessSkipV0sNotUsedInCascades)
+      globalSelection = globalSelection | (1 << bitUsedInCascade);
+    if (doprocessSkipV0sNotUsedInTrackedCascades)
+      globalSelection = globalSelection | (1 << bitUsedInTrackedCascade);
 
     selectionK0Short = selectionK0Short | globalSelection;
     selectionLambda = selectionLambda | globalSelection;
@@ -1229,14 +1229,14 @@ struct lambdakzeroPreselector {
     auto lPosTrack = lV0Candidate.template posTrack_as<TTrackTo>();
 
     // dEdx check with LF PID
-    bitsetvalue(maskElement, bitdEdxPosElectron, (TMath::Abs(lPosTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxPosPion, (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxPosProton, (TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxPosHelium3, (TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxNegElectron, (TMath::Abs(lNegTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxNegPion, (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxNegProton, (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow)); 
-    bitsetvalue(maskElement, bitdEdxNegHelium3, (TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow)); 
+    bitsetvalue(maskElement, bitdEdxPosElectron, (TMath::Abs(lPosTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxPosPion, (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxPosProton, (TMath::Abs(lPosTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxPosHelium3, (TMath::Abs(lPosTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxNegElectron, (TMath::Abs(lNegTrack.tpcNSigmaEl()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxNegPion, (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxNegProton, (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow));
+    bitsetvalue(maskElement, bitdEdxNegHelium3, (TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow));
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// Initialization of mask vectors if uninitialized
@@ -1258,7 +1258,7 @@ struct lambdakzeroPreselector {
   void checkAndFinalize()
   {
     int preselectorStatistics[7]; // faster
-    for(int ii=0; ii<7; ii++)
+    for (int ii = 0; ii < 7; ii++)
       preselectorStatistics[ii] = 0;
     // parse + publish tag table now
     for (int ii = 0; ii < selectionMask.size(); ii++) {
@@ -1269,7 +1269,7 @@ struct lambdakzeroPreselector {
       bool inGa = (selectionMask[ii] & selectionGamma) == selectionGamma;
       bool inHyp = (selectionMask[ii] & selectionHypertriton) == selectionHypertriton;
       bool inAntiHy = (selectionMask[ii] & selectionAntiHypertriton) == selectionAntiHypertriton;
-      bool inAny = inK0S || inLam || inAnLam || inGa || inHyp || inAntiHy; 
+      bool inAny = inK0S || inLam || inAnLam || inGa || inHyp || inAntiHy;
 
       preselectorStatistics[0] += static_cast<int>(inK0S);
       preselectorStatistics[1] += static_cast<int>(inLam);

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -781,8 +781,8 @@ struct lambdakzeroBuilder {
     // check if user requested to correlate mass requirement with TPC PID
     // (useful for data volume reduction)
     bool dEdxK0Short = V0.isdEdxK0Short() || !massWindowWithTPCPID;
-    bool dEdxLambda = (V0.isdEdxLambda() || (V0.isdEdxPosProton() && !negTrack.hasTPC())) || !massWindowWithTPCPID;
-    bool dEdxAntiLambda = (V0.isdEdxAntiLambda() || (V0.isdEdxNegProton() && !posTrack.hasTPC())) || !massWindowWithTPCPID;
+    bool dEdxLambda = (V0.isdEdxLambda() || (V0.tag_bit(bitdEdxPosProton) && !negTrack.hasTPC())) || !massWindowWithTPCPID;
+    bool dEdxAntiLambda = (V0.isdEdxAntiLambda() || (V0.tag_bit(bitdEdxNegProton) && !posTrack.hasTPC())) || !massWindowWithTPCPID;
 
     // check proper lifetime if asked for
     bool passML2P_K0Short = lML2P_K0Short < lifetimecut->get("lifetimecutK0S") || lifetimecut->get("lifetimecutK0S") > 1000;
@@ -814,34 +814,34 @@ struct lambdakzeroBuilder {
 
       // Fill basic mass histograms
       if (TMath::Abs(RecoDecay::eta(std::array{px, py, pz})) < 0.5) {
-        if ((V0.isdEdxGamma() || dEdxUnchecked) && (V0.isTrueGamma() || mcUnchecked))
+        if ((V0.isdEdxGamma() || dEdxUnchecked) && (V0.tag_bit(bitTrueGamma) || mcUnchecked))
           registry.fill(HIST("h2dGammaMass"), lPt, lGammaMass);
-        if ((V0.isdEdxK0Short() || dEdxUnchecked) && (V0.isTrueK0Short() || mcUnchecked))
+        if ((V0.isdEdxK0Short() || dEdxUnchecked) && (V0.tag_bit(bitTrueK0Short) || mcUnchecked))
           registry.fill(HIST("h2dK0ShortMass"), lPt, v0candidate.k0ShortMass);
-        if ((V0.isdEdxLambda() || dEdxUnchecked) && (V0.isTrueLambda() || mcUnchecked))
+        if ((V0.isdEdxLambda() || dEdxUnchecked) && (V0.tag_bit(bitTrueLambda) || mcUnchecked))
           registry.fill(HIST("h2dLambdaMass"), lPt, v0candidate.lambdaMass);
-        if ((V0.isdEdxAntiLambda() || dEdxUnchecked) && (V0.isTrueAntiLambda() || mcUnchecked))
+        if ((V0.isdEdxAntiLambda() || dEdxUnchecked) && (V0.tag_bit(bitTrueAntiLambda) || mcUnchecked))
           registry.fill(HIST("h2dAntiLambdaMass"), lPt, v0candidate.antiLambdaMass);
-        if ((V0.isdEdxHypertriton() || dEdxUnchecked) && (V0.isTrueHypertriton() || mcUnchecked))
+        if ((V0.isdEdxHypertriton() || dEdxUnchecked) && (V0.tag_bit(bitTrueHypertriton) || mcUnchecked))
           registry.fill(HIST("h2dHypertritonMass"), lPtHy, lHypertritonMass);
-        if ((V0.isdEdxAntiHypertriton() || dEdxUnchecked) && (V0.isTrueAntiHypertriton() || mcUnchecked))
+        if ((V0.isdEdxAntiHypertriton() || dEdxUnchecked) && (V0.tag_bit(bitTrueAntiHypertriton) || mcUnchecked))
           registry.fill(HIST("h2dAntiHypertritonMass"), lPtAnHy, lAntiHypertritonMass);
       }
 
       // Fill ITS cluster maps with specific mass cuts
-      if (TMath::Abs(lGammaMass - 0.0) < dQAGammaMassWindow && ((V0.isdEdxGamma() || dEdxUnchecked) && (V0.isTrueGamma() || mcUnchecked))) {
+      if (TMath::Abs(lGammaMass - 0.0) < dQAGammaMassWindow && ((V0.isdEdxGamma() || dEdxUnchecked) && (V0.tag_bit(bitTrueGamma) || mcUnchecked))) {
         registry.fill(HIST("h2dITSCluMap_Gamma"), static_cast<float>(posTrack.itsClusterMap()), static_cast<float>(negTrack.itsClusterMap()), v0candidate.V0radius);
         registry.fill(HIST("h2dXIU_Gamma"), static_cast<float>(posTrack.x()), static_cast<float>(negTrack.x()), v0candidate.V0radius);
       }
-      if (TMath::Abs(v0candidate.k0ShortMass - 0.497) < dQAK0ShortMassWindow && ((V0.isdEdxK0Short() || dEdxUnchecked) && (V0.isTrueK0Short() || mcUnchecked))) {
+      if (TMath::Abs(v0candidate.k0ShortMass - 0.497) < dQAK0ShortMassWindow && ((V0.isdEdxK0Short() || dEdxUnchecked) && (V0.tag_bit(bitTrueK0Short) || mcUnchecked))) {
         registry.fill(HIST("h2dITSCluMap_K0Short"), static_cast<float>(posTrack.itsClusterMap()), static_cast<float>(negTrack.itsClusterMap()), v0candidate.V0radius);
         registry.fill(HIST("h2dXIU_K0Short"), static_cast<float>(posTrack.x()), static_cast<float>(negTrack.x()), v0candidate.V0radius);
       }
-      if (TMath::Abs(v0candidate.lambdaMass - 1.116) < dQALambdaMassWindow && ((V0.isdEdxLambda() || dEdxUnchecked) && (V0.isTrueLambda() || mcUnchecked))) {
+      if (TMath::Abs(v0candidate.lambdaMass - 1.116) < dQALambdaMassWindow && ((V0.isdEdxLambda() || dEdxUnchecked) && (V0.tag_bit(bitTrueLambda) || mcUnchecked))) {
         registry.fill(HIST("h2dITSCluMap_Lambda"), static_cast<float>(posTrack.itsClusterMap()), static_cast<float>(negTrack.itsClusterMap()), v0candidate.V0radius);
         registry.fill(HIST("h2dXIU_Lambda"), static_cast<float>(posTrack.x()), static_cast<float>(negTrack.x()), v0candidate.V0radius);
       }
-      if (TMath::Abs(v0candidate.antiLambdaMass - 1.116) < dQALambdaMassWindow && ((V0.isdEdxAntiLambda() || dEdxUnchecked) && (V0.isTrueAntiLambda() || mcUnchecked))) {
+      if (TMath::Abs(v0candidate.antiLambdaMass - 1.116) < dQALambdaMassWindow && ((V0.isdEdxAntiLambda() || dEdxUnchecked) && (V0.tag_bit(bitTrueAntiLambda) || mcUnchecked))) {
         registry.fill(HIST("h2dITSCluMap_AntiLambda"), static_cast<float>(posTrack.itsClusterMap()), static_cast<float>(negTrack.itsClusterMap()), v0candidate.V0radius);
         registry.fill(HIST("h2dXIU_AntiLambda"), static_cast<float>(posTrack.x()), static_cast<float>(negTrack.x()), v0candidate.V0radius);
       }
@@ -883,7 +883,7 @@ struct lambdakzeroBuilder {
 
       // let's just use tagged, cause we can
       if (!posTrack.hasITS() && !posTrack.hasTRD() && !posTrack.hasTOF() && !negTrack.hasITS() && !negTrack.hasTRD() && !negTrack.hasTOF()) {
-        if (V0.isTrueGamma()) {
+        if (V0.tag_bit(bitTrueGamma)) {
           registry.fill(HIST("h2d_pcm_DCAXY_True"), lPt, std::hypot(dcaInfo[0], dcaInfo[1]));
           registry.fill(HIST("h2d_pcm_DCACHI2_True"), lPt, fitter.getChi2AtPCACandidate());
           registry.fill(HIST("h2d_pcm_DeltaDistanceRadii_True"), lPt, centerDistance - trcCircle1.rC - trcCircle2.rC);

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -781,8 +781,8 @@ struct lambdakzeroBuilder {
     // check if user requested to correlate mass requirement with TPC PID
     // (useful for data volume reduction)
     bool dEdxK0Short = V0.isdEdxK0Short() || !massWindowWithTPCPID;
-    bool dEdxLambda = V0.isdEdxLambda() || !massWindowWithTPCPID;
-    bool dEdxAntiLambda = V0.isdEdxAntiLambda() || !massWindowWithTPCPID;
+    bool dEdxLambda = (V0.isdEdxLambda() || (V0.isdEdxPosProton() && !negTrack.hasTPC())) || !massWindowWithTPCPID;
+    bool dEdxAntiLambda = (V0.isdEdxAntiLambda() || (V0.isdEdxNegProton() && !posTrack.hasTPC())) || !massWindowWithTPCPID;
 
     // check proper lifetime if asked for
     bool passML2P_K0Short = lML2P_K0Short < lifetimecut->get("lifetimecutK0S") || lifetimecut->get("lifetimecutK0S") > 1000;

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -1125,10 +1125,10 @@ struct lambdakzeroPreselector {
       selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxPosPion) | (1 << bitdEdxNegHelium3);
     } else {
       // if preselection only affects baryons, accept also mesonic daughter via ITS only (with min ITS clu = minITSCluITSOnly)
-      selectionLambda = selectionLambda | (1 << bitdEdxPosProton);
-      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxNegProton);
-      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3);
-      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxNegHelium3);
+      selectionLambda = selectionLambda | (1 << bitdEdxPosProton) | (1 << bitdEdxNegPionOrITSOnly);
+      selectionAntiLambda = selectionAntiLambda | (1 << bitdEdxNegProton) | (1 << bitdEdxPosPionOrITSOnly);
+      selectionHypertriton = selectionHypertriton | (1 << bitdEdxPosHelium3) | (1 << bitdEdxNegPionOrITSOnly);
+      selectionAntiHypertriton = selectionAntiHypertriton | (1 << bitdEdxNegHelium3) | (1 << bitdEdxPosPionOrITSOnly);
     }
 
     if (doprocessBuildMCAssociated || doprocessBuildValiddEdxMCAssociated) {
@@ -1237,6 +1237,9 @@ struct lambdakzeroPreselector {
     bitsetvalue(maskElement, bitdEdxNegPion, (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow));
     bitsetvalue(maskElement, bitdEdxNegProton, (TMath::Abs(lNegTrack.tpcNSigmaPr()) < ddEdxPreSelectionWindow));
     bitsetvalue(maskElement, bitdEdxNegHelium3, (TMath::Abs(lNegTrack.tpcNSigmaHe()) < ddEdxPreSelectionWindow));
+
+    bitsetvalue(maskElement, bitdEdxPosPionOrITSOnly, (!lPosTrack.hasTPC() && lPosTrack.itsNCls() >= minITSCluITSOnly || (TMath::Abs(lPosTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow)));
+    bitsetvalue(maskElement, bitdEdxNegPionOrITSOnly, (!lNegTrack.hasTPC() && lNegTrack.itsNCls() >= minITSCluITSOnly || (TMath::Abs(lNegTrack.tpcNSigmaPi()) < ddEdxPreSelectionWindow)));
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// Initialization of mask vectors if uninitialized


### PR DESCRIPTION
This PR re-arranges the pre-selector logic of the V0 builder such that it is geared towards faster processing, also based on observations discussed with @ZFederica and @fgrosa regarding the less than ideal speed of the V0 builer in special use cases. The new pre-selector logic uses bitmask checking for a significant reduction of `if` calls and comparisons when processing `aod::V0s` candidates (before distance minimization calls)

Since this is a relatively non-trivial change of a key component used in many analyses, some further testing will be done before merging.