### PR TITLE
PWGHF: Reduce number of produced centrality tables in Ds task

### DIFF
--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -33,19 +33,15 @@ using namespace o2::framework::expressions;
 enum finalState { KKPi = 0,
                   PiKK };
 
-enum centEstimator { FT0A = 0,
-                     FT0C,
+enum centEstimator { FT0C = 0,
                      FT0M,
-                     FV0A,
-                     FDDM,
                      NTracksPV,
-                     kNMaxCentEstimators };
+                     NoCentEstimation};
 
 /// Ds± analysis task
 struct HfTaskDs {
   Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds/Dplus->PhiPi->KKpi, 2 for Ds/Dplus->K0*K->KKPi"};
   Configurable<bool> fillDplusMc{"fillDplusMc", true, "Switch to fill Dplus MC information"};
-  Configurable<int> centDetector{"centDetector", 2, "Detector for multiplicity estimation (FT0A: 0, FT0C: 1, FT0M: 2, FV0A: 3, FDDM:4, NTracksPV: 5)"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<std::vector<int>> classMl{"classMl", {0, 2, 3}, "Indexes of ML scores to be stored. Three indexes max."};
   Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
@@ -54,7 +50,9 @@ struct HfTaskDs {
 
   HfHelper hfHelper;
 
-  using CollisionsWithCent = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0As, aod::CentFT0Cs, aod::CentFT0Ms, aod::CentFV0As, aod::CentFDDMs, aod::CentNTPVs>;
+  using CollisionsWithFT0C = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs>;
+  using CollisionsWithFT0M = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
+  using CollisionsWithNTracksPV = soa::Join<aod::Collisions, aod::EvSels, aod::CentNTPVs>;
   using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>;
   using CandDsDataWithMl = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi>>;
   using CandDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;
@@ -104,17 +102,14 @@ struct HfTaskDs {
 
   void init(InitContext&)
   {
-    std::array<int, 8> processes = {doprocessDataWithCent, doprocessData, doprocessDataWithMlAndCent, doprocessDataWithMl,
-                                    doprocessMcWithCent, doprocessMc, doprocessMcWithMlAndCent, doprocessMcWithMl};
+    std::array<int, 16> processes = {doprocessDataWithCentFT0, doprocessDataWithCentFT0M, doprocessDataWithCentNTracksPV, doprocessData, doprocessDataWithMlAndCentFT0, doprocessDataWithMlAndCentFT0M, doprocessDataWithMlAndCentNTracksPV, doprocessDataWithMl, doprocessMcWithCentFT0, doprocessMcWithCentFT0M, doprocessMcWithCentNTracksPV, doprocessMc, doprocessMcWithMlAndCentFT0, doprocessMcWithMlAndCentFT0M, doprocessMcWithMlAndCentNTracksPV, doprocessMcWithMl};
+                             
     const int nProcesses = std::accumulate(processes.begin(), processes.end(), 0);
     if (nProcesses > 1) {
       LOGP(fatal, "Only one process function should be enabled at a time, please check your configuration");
     } else if (nProcesses == 0) {
       LOGP(fatal, "No process function enabled");
     }
-
-    if (centDetector < 0 || centDetector >= centEstimator::kNMaxCentEstimators)
-      LOG(warning) << "Centrality estimator not valid. Please choose between FT0A, FT0C, FT0M, FV0A, FDDM, NTracksPV. Fallback to FT0M";
 
     auto vbins = (std::vector<double>)binsPt;
     AxisSpec ptbins = {vbins, "#it{p}_{T} (GeV/#it{c})"};
@@ -123,9 +118,11 @@ struct HfTaskDs {
     AxisSpec MLbins = {100, 0., 1., "ML output"};
     AxisSpec centralitybins = {100, 0., 100., "Centrality"};
 
-    if (doprocessDataWithCent || doprocessMcWithCent) {
+    if (doprocessDataWithCentFT0 || doprocessDataWithCentFT0M || doprocessDataWithCentNTracksPV || 
+        doprocessMcWithCentFT0 || doprocessMcWithCentFT0M || doprocessMcWithCentNTracksPV) {
       registry.add("hSparseMass", "THn for Ds", HistType::kTHnSparseF, {massbins, ptbins, centralitybins});
-    } else if (doprocessDataWithMlAndCent || doprocessMcWithMlAndCent) {
+    } else if (doprocessDataWithMlAndCentFT0 || doprocessDataWithMlAndCentFT0M || doprocessDataWithMlAndCentNTracksPV || 
+               doprocessMcWithMlAndCentFT0 || doprocessMcWithMlAndCentFT0M || doprocessMcWithMlAndCentNTracksPV) {
       registry.add("hSparseMass", "THn for Ds", HistType::kTHnSparseF, {massbins, ptbins, centralitybins, MLbins, MLbins, MLbins});
     } else if (doprocessData || doprocessMc) {
       registry.add("hSparseMass", "THn for Ds", HistType::kTHnSparseF, {massbins, ptbins});
@@ -196,25 +193,15 @@ struct HfTaskDs {
   /// Evaluate multiplicity
   /// \param candidate is candidate
   /// \return multiplicity of the collision associated to the candidate
-  template <typename T1>
+  template <int centDetector, typename T1>
   int evaluateCentrality(const T1& candidate)
   {
-    switch (centDetector) {
-      case centEstimator::FT0A:
-        return candidate.template collision_as<CollisionsWithCent>().centFT0A();
-      case centEstimator::FT0C:
-        return candidate.template collision_as<CollisionsWithCent>().centFT0C();
-      case centEstimator::FT0M:
-        return candidate.template collision_as<CollisionsWithCent>().centFT0M();
-      case centEstimator::FV0A:
-        return candidate.template collision_as<CollisionsWithCent>().centFV0A();
-      case centEstimator::FDDM:
-        return candidate.template collision_as<CollisionsWithCent>().centFDDM();
-      case centEstimator::NTracksPV:
-        return candidate.template collision_as<CollisionsWithCent>().centNTPV();
-      default: // In case of invalid configuration use FT0M
-        return candidate.template collision_as<CollisionsWithCent>().centFT0M();
-    }
+    if constexpr (centDetector == centEstimator::FT0C)
+      return candidate.template collision_as<CollisionsWithFT0C>().centFT0C();
+    else if constexpr (centDetector == centEstimator::FT0M)
+      return candidate.template collision_as<CollisionsWithFT0M>().centFT0M();
+    else if constexpr (centDetector == centEstimator::NTracksPV)
+      return candidate.template collision_as<CollisionsWithNTracksPV>().centNTPV();
   }
 
   /// Fill histograms of quantities independent from the daugther-mass hypothesis
@@ -250,7 +237,7 @@ struct HfTaskDs {
 
   /// Fill histograms of quantities for the KKPi daugther-mass hypothesis
   /// \param candidate is candidate
-  template <bool useMl, bool fillCent, typename T1>
+  template <bool useMl, int centDetector, typename T1>
   void fillHistoKKPi(const T1& candidate)
   {
     auto pt = candidate.pt();
@@ -259,14 +246,14 @@ struct HfTaskDs {
       for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) { // TODO: add checks for classMl size
         outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
       }
-      if constexpr (fillCent) {
-        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality(candidate), outputMl[0], outputMl[1], outputMl[2]);
+      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality<centDetector>(candidate), outputMl[0], outputMl[1], outputMl[2]);
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, outputMl[0], outputMl[1], outputMl[2]);
       }
     } else {
-      if constexpr (fillCent) {
-        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality(candidate));
+      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality<centDetector>(candidate));
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt);
       }
@@ -280,7 +267,7 @@ struct HfTaskDs {
 
   /// Fill histograms of quantities for the PiKK daugther-mass hypothesis
   /// \param candidate is candidate
-  template <bool useMl, bool fillCent, typename T1>
+  template <bool useMl, int centDetector, typename T1>
   void fillHistoPiKK(const T1& candidate)
   {
     auto pt = candidate.pt();
@@ -289,14 +276,14 @@ struct HfTaskDs {
       for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) { // TODO: add checks for classMl size
         outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
       }
-      if constexpr (fillCent) {
-        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality(candidate), outputMl[0], outputMl[1], outputMl[2]);
+      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality<centDetector>(candidate), outputMl[0], outputMl[1], outputMl[2]);
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, outputMl[0], outputMl[1], outputMl[2]);
       }
     } else {
-      if constexpr (fillCent) {
-        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality(candidate));
+      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+        registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality<centDetector>(candidate));
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt);
       }
@@ -433,7 +420,7 @@ struct HfTaskDs {
     }
   }
 
-  template <int decayChannel, bool useMl, bool fillCent, typename CandsDs>
+  template <int decayChannel, int centDetector, bool useMl, typename CandsDs>
   void runDataAnalysis(CandsDs const& candidates)
   {
     for (const auto& candidate : candidates) {
@@ -442,9 +429,9 @@ struct HfTaskDs {
       }
       fillHisto(candidate);
       if constexpr (decayChannel == finalState::KKPi) { // KKPi
-        fillHistoKKPi<useMl, fillCent>(candidate);
+        fillHistoKKPi<useMl, centDetector>(candidate);
       } else if constexpr (decayChannel == finalState::PiKK) { // PiKK
-        fillHistoPiKK<useMl, fillCent>(candidate);
+        fillHistoPiKK<useMl, centDetector>(candidate);
       }
     }
   }
@@ -542,48 +529,102 @@ struct HfTaskDs {
     }
   }
 
-  void processDataWithCent(CollisionsWithCent const&,
-                           CandDsData const& candidates)
+  void processDataWithCentFT0( CollisionsWithFT0C const&,
+                                CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, false, true>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, false, true>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, false>(selectedDsToPiKKCandData);
   }
-  PROCESS_SWITCH(HfTaskDs, processDataWithCent, "Process data w/o ML information on Ds, with information on centrality", false);
+  PROCESS_SWITCH(HfTaskDs, processDataWithCentFT0, "Process data w/o ML information on Ds, with information on centrality from FT0C", false);
+
+  void processDataWithCentFT0M( CollisionsWithFT0M const&,
+                                CandDsData const& candidates)
+  {
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, false>(selectedDsToPiKKCandData);
+  }
+  PROCESS_SWITCH(HfTaskDs, processDataWithCentFT0M, "Process data w/o ML information on Ds, with information on centrality from FT0M", false);
+
+  void processDataWithCentNTracksPV(CollisionsWithNTracksPV const&,
+                                    CandDsData const& candidates)
+  {
+    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, false>(selectedDsToPiKKCandData);
+  }
+  PROCESS_SWITCH(HfTaskDs, processDataWithCentNTracksPV, "Process data w/o ML information on Ds, with information on centrality from NTracksPV", false);
 
   void processData(aod::Collisions const&,
                    CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, false, false>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, false, false>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, false>(selectedDsToPiKKCandData);
   }
   PROCESS_SWITCH(HfTaskDs, processData, "Process data w/o ML information on Ds, w/o information on centrality", true);
 
-  void processDataWithMlAndCent(CollisionsWithCent const&,
+  void processDataWithMlAndCentFT0(CollisionsWithFT0C const&,
                                 CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, true, true>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, true, true>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, true>(selectedDsToPiKKCandWithMlData);
   }
-  PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCent, "Process data with ML information on Ds, with information on centrality", false);
+  PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentFT0, "Process data with ML information on Ds, with information on centrality from FT0C", false);
+  
+  void processDataWithMlAndCentFT0M(CollisionsWithFT0M const&,
+                                CandDsDataWithMl const& candidates)
+  {
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, true>(selectedDsToPiKKCandWithMlData);
+  }
+  PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentFT0M, "Process data with ML information on Ds, with information on centrality from FT0M", false);
+
+  void processDataWithMlAndCentNTracksPV(CollisionsWithNTracksPV const&,
+                                CandDsDataWithMl const& candidates)
+  {
+    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlData);
+  }
+  PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentNTracksPV, "Process data with ML information on Ds, with information on centrality", false);
 
   void processDataWithMl(aod::Collisions const&,
                          CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, true, false>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, true, false>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, true>(selectedDsToPiKKCandWithMlData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithMl, "Process data with ML information on Ds, w/o information on centrality", false);
 
-  void processMcWithCent(CollisionsWithCent const&,
+  void processMcWithCentFT0(CollisionsWithFT0C const&,
                          CandDsMcReco const& candidates,
                          CandDsMcGen const& mcParticles,
                          aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, false, true>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, false, true>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, false>(selectedDsToPiKKCandMc);
   }
-  PROCESS_SWITCH(HfTaskDs, processMcWithCent, "Process MC w/o ML information on Ds, with information on centrality", false);
+  PROCESS_SWITCH(HfTaskDs, processMcWithCentFT0, "Process MC w/o ML information on Ds, with information on centrality from FT0C", false);
+
+  void processMcWithCentFT0M(CollisionsWithFT0M const&,
+                         CandDsMcReco const& candidates,
+                         CandDsMcGen const& mcParticles,
+                         aod::TracksWMc const&)
+  {
+    runMcAnalysis<false>(candidates, mcParticles);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, false>(selectedDsToPiKKCandMc);
+  }
+  PROCESS_SWITCH(HfTaskDs, processMcWithCentFT0M, "Process MC w/o ML information on Ds, with information on centrality from FT0M", false);
+
+  void processMcWithCentNTracksPV(CollisionsWithNTracksPV const&,
+                         CandDsMcReco const& candidates,
+                         CandDsMcGen const& mcParticles,
+                         aod::TracksWMc const&)
+  {
+    runMcAnalysis<false>(candidates, mcParticles);
+    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, false>(selectedDsToPiKKCandMc);
+  }
+  PROCESS_SWITCH(HfTaskDs, processMcWithCentNTracksPV, "Process MC w/o ML information on Ds, with information on centrality from NTracksPV", false);
 
   void processMc(aod::Collisions const&,
                  CandDsMcReco const& candidates,
@@ -591,21 +632,43 @@ struct HfTaskDs {
                  aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, false, false>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, false, false>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, false>(selectedDsToPiKKCandMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMc, "Process MC w/o ML information on Ds, w/o information on centrality", false);
 
-  void processMcWithMlAndCent(CollisionsWithCent const&,
+  void processMcWithMlAndCentFT0(CollisionsWithFT0C const&,
                               CandDsMcRecoWithMl const& candidates,
                               CandDsMcGen const& mcParticles,
                               aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, true, true>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, true, true>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, true>(selectedDsToPiKKCandWithMlMc);
   }
-  PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCent, "Process MC with ML information on Ds, with information on centrality", false);
+  PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentFT0, "Process MC with ML information on Ds, with information on centrality from FT0C", false);
+
+  void processMcWithMlAndCentFT0M(CollisionsWithFT0M const&,
+                              CandDsMcRecoWithMl const& candidates,
+                              CandDsMcGen const& mcParticles,
+                              aod::TracksWMc const&)
+  {
+    runMcAnalysis<true>(candidates, mcParticles);
+    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, true>(selectedDsToPiKKCandWithMlMc);
+  }
+  PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentFT0M, "Process MC with ML information on Ds, with information on centrality from FT0M", false);
+
+  void processMcWithMlAndCentNTracksPV(CollisionsWithNTracksPV const&,
+                              CandDsMcRecoWithMl const& candidates,
+                              CandDsMcGen const& mcParticles,
+                              aod::TracksWMc const&)
+  {
+    runMcAnalysis<true>(candidates, mcParticles);
+    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlMc);
+  }
+  PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentNTracksPV, "Process MC with ML information on Ds, with information on centrality from NTracksPV", false);
 
   void processMcWithMl(aod::Collisions const&,
                        CandDsMcRecoWithMl const& candidates,
@@ -613,8 +676,8 @@ struct HfTaskDs {
                        aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, true, false>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, true, false>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, true>(selectedDsToPiKKCandWithMlMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithMl, "Process MC with ML information on Ds, w/o information on centrality", false);
 };

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -45,7 +45,7 @@ struct HfTaskDs {
 
   HfHelper hfHelper;
 
-  using CentralityEstimator = CentralityEstimator;
+  using CentralityEstimator = o2::aod::hf_collision_centrality::CentralityEstimator;
 
   using CollisionsWithFT0C = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs>;
   using CollisionsWithFT0M = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -33,11 +33,6 @@ using namespace o2::framework::expressions;
 enum finalState { KKPi = 0,
                   PiKK };
 
-enum centEstimator { FT0C = 0,
-                     FT0M,
-                     NTracksPV,
-                     NoCentEstimation };
-
 /// Ds± analysis task
 struct HfTaskDs {
   Configurable<int> decayChannel{"decayChannel", 1, "Switch between decay channels: 1 for Ds/Dplus->PhiPi->KKpi, 2 for Ds/Dplus->K0*K->KKPi"};
@@ -196,11 +191,11 @@ struct HfTaskDs {
   template <int centDetector, typename T1>
   int evaluateCentrality(const T1& candidate)
   {
-    if constexpr (centDetector == centEstimator::FT0C)
+    if constexpr (centDetector == o2::aod::hf_collision_centrality::CentralityEstimator::FT0C)
       return candidate.template collision_as<CollisionsWithFT0C>().centFT0C();
-    else if constexpr (centDetector == centEstimator::FT0M)
+    else if constexpr (centDetector == o2::aod::hf_collision_centrality::CentralityEstimator::FT0M)
       return candidate.template collision_as<CollisionsWithFT0M>().centFT0M();
-    else if constexpr (centDetector == centEstimator::NTracksPV)
+    else if constexpr (centDetector == o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV)
       return candidate.template collision_as<CollisionsWithNTracksPV>().centNTPV();
   }
 
@@ -246,13 +241,13 @@ struct HfTaskDs {
       for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) { // TODO: add checks for classMl size
         outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
       }
-      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+      if constexpr (centDetector != o2::aod::hf_collision_centrality::CentralityEstimator::None) {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality<centDetector>(candidate), outputMl[0], outputMl[1], outputMl[2]);
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, outputMl[0], outputMl[1], outputMl[2]);
       }
     } else {
-      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+      if constexpr (centDetector != o2::aod::hf_collision_centrality::CentralityEstimator::None) {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt, evaluateCentrality<centDetector>(candidate));
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToKKPi(candidate), pt);
@@ -276,13 +271,13 @@ struct HfTaskDs {
       for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) { // TODO: add checks for classMl size
         outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
       }
-      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+      if constexpr (centDetector != o2::aod::hf_collision_centrality::CentralityEstimator::None) {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality<centDetector>(candidate), outputMl[0], outputMl[1], outputMl[2]);
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, outputMl[0], outputMl[1], outputMl[2]);
       }
     } else {
-      if constexpr (centDetector != centEstimator::NoCentEstimation) {
+      if constexpr (centDetector != o2::aod::hf_collision_centrality::CentralityEstimator::None) {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt, evaluateCentrality<centDetector>(candidate));
       } else {
         registry.fill(HIST("hSparseMass"), hfHelper.invMassDsToPiKK(candidate), pt);
@@ -532,64 +527,64 @@ struct HfTaskDs {
   void processDataWithCentFT0(CollisionsWithFT0C const&,
                               CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, false>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, false>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, false>(selectedDsToPiKKCandData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithCentFT0, "Process data w/o ML information on Ds, with information on centrality from FT0C", false);
 
   void processDataWithCentFT0M(CollisionsWithFT0M const&,
                                CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, false>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, false>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, false>(selectedDsToPiKKCandData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithCentFT0M, "Process data w/o ML information on Ds, with information on centrality from FT0M", false);
 
   void processDataWithCentNTracksPV(CollisionsWithNTracksPV const&,
                                     CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, false>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, false>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, false>(selectedDsToPiKKCandData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithCentNTracksPV, "Process data w/o ML information on Ds, with information on centrality from NTracksPV", false);
 
   void processData(aod::Collisions const&,
                    CandDsData const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, false>(selectedDsToKKPiCandData);
-    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, false>(selectedDsToPiKKCandData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::None, false>(selectedDsToKKPiCandData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::None, false>(selectedDsToPiKKCandData);
   }
   PROCESS_SWITCH(HfTaskDs, processData, "Process data w/o ML information on Ds, w/o information on centrality", true);
 
   void processDataWithMlAndCentFT0(CollisionsWithFT0C const&,
                                    CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, true>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, true>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, true>(selectedDsToPiKKCandWithMlData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentFT0, "Process data with ML information on Ds, with information on centrality from FT0C", false);
 
   void processDataWithMlAndCentFT0M(CollisionsWithFT0M const&,
                                     CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, true>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, true>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, true>(selectedDsToPiKKCandWithMlData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentFT0M, "Process data with ML information on Ds, with information on centrality from FT0M", false);
 
   void processDataWithMlAndCentNTracksPV(CollisionsWithNTracksPV const&,
                                          CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithMlAndCentNTracksPV, "Process data with ML information on Ds, with information on centrality", false);
 
   void processDataWithMl(aod::Collisions const&,
                          CandDsDataWithMl const& candidates)
   {
-    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, true>(selectedDsToKKPiCandWithMlData);
-    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, true>(selectedDsToPiKKCandWithMlData);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::None, true>(selectedDsToKKPiCandWithMlData);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::None, true>(selectedDsToPiKKCandWithMlData);
   }
   PROCESS_SWITCH(HfTaskDs, processDataWithMl, "Process data with ML information on Ds, w/o information on centrality", false);
 
@@ -599,8 +594,8 @@ struct HfTaskDs {
                             aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, false>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, false>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, false>(selectedDsToPiKKCandMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithCentFT0, "Process MC w/o ML information on Ds, with information on centrality from FT0C", false);
 
@@ -610,8 +605,8 @@ struct HfTaskDs {
                              aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, false>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, false>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, false>(selectedDsToPiKKCandMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithCentFT0M, "Process MC w/o ML information on Ds, with information on centrality from FT0M", false);
 
@@ -621,8 +616,8 @@ struct HfTaskDs {
                                   aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, false>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, false>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, false>(selectedDsToPiKKCandMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithCentNTracksPV, "Process MC w/o ML information on Ds, with information on centrality from NTracksPV", false);
 
@@ -632,8 +627,8 @@ struct HfTaskDs {
                  aod::TracksWMc const&)
   {
     runMcAnalysis<false>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, false>(selectedDsToKKPiCandMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, false>(selectedDsToPiKKCandMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::None, false>(selectedDsToKKPiCandMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::None, false>(selectedDsToPiKKCandMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMc, "Process MC w/o ML information on Ds, w/o information on centrality", false);
 
@@ -643,8 +638,8 @@ struct HfTaskDs {
                                  aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0C, true>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0C, true>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0C, true>(selectedDsToPiKKCandWithMlMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentFT0, "Process MC with ML information on Ds, with information on centrality from FT0C", false);
 
@@ -654,8 +649,8 @@ struct HfTaskDs {
                                   aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::FT0M, true>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::FT0M, true>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::FT0M, true>(selectedDsToPiKKCandWithMlMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentFT0M, "Process MC with ML information on Ds, with information on centrality from FT0M", false);
 
@@ -665,8 +660,8 @@ struct HfTaskDs {
                                        aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::NTracksPV, true>(selectedDsToPiKKCandWithMlMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithMlAndCentNTracksPV, "Process MC with ML information on Ds, with information on centrality from NTracksPV", false);
 
@@ -676,8 +671,8 @@ struct HfTaskDs {
                        aod::TracksWMc const&)
   {
     runMcAnalysis<true>(candidates, mcParticles);
-    runDataAnalysis<finalState::KKPi, centEstimator::NoCentEstimation, true>(selectedDsToKKPiCandWithMlMc);
-    runDataAnalysis<finalState::PiKK, centEstimator::NoCentEstimation, true>(selectedDsToPiKKCandWithMlMc);
+    runDataAnalysis<finalState::KKPi, o2::aod::hf_collision_centrality::CentralityEstimator::None, true>(selectedDsToKKPiCandWithMlMc);
+    runDataAnalysis<finalState::PiKK, o2::aod::hf_collision_centrality::CentralityEstimator::None, true>(selectedDsToPiKKCandWithMlMc);
   }
   PROCESS_SWITCH(HfTaskDs, processMcWithMl, "Process MC with ML information on Ds, w/o information on centrality", false);
 };

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -68,6 +68,7 @@ enum CentralityEstimator {
   FT0C,
   FT0M,
   FV0A,
+  NTracksPV,
   NCentralityEstimators
 };
 } // namespace hf_collision_centrality

--- a/PWGLF/Tasks/Nuspex/QCspectraTPC.cxx
+++ b/PWGLF/Tasks/Nuspex/QCspectraTPC.cxx
@@ -122,7 +122,7 @@ struct QCspectraTPC {
     histos.add("delta_p", "delta_p", HistType::kTH2F, {{axisPGlobal}, {axisDeltaP}});
   } // init loop end
   using CollisionCandidate = soa::Join<aod::Collisions, aod::EvSels /*, aod::CentFT0Cs*/>;
-  using TrackCandidates = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPr, aod::pidTPCFullDe>;
+  using TrackCandidates = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPr>;
 
   void process(CollisionCandidate::iterator const& collision, TrackCandidates const& tracks)
   {
@@ -155,9 +155,9 @@ struct QCspectraTPC {
       // if (track.tpcNClsCrossedRows() > minNCrossedRowsTPC) continue;
       // if (track.tpcChi2NCl() < maxChi2PerClusterTPC) continue;
       // if (track.itsChi2NCl() < maxChi2PerClusterITS) continue;
-      if (abs(track.dcaXY()) < cfgCutDCAXY)
+      if (abs(track.dcaXY()) > cfgCutDCAXY)
         continue;
-      if (abs(track.dcaZ()) < cfgCutDCAZ)
+      if (abs(track.dcaZ()) > cfgCutDCAZ)
         continue;
 
       histos.fill(HIST("etaHistogram"), track.eta());


### PR DESCRIPTION
Hello @fgrosa , as you suggested I have added new process functions to the Ds task, one for each centrality estimator.
This allows to produce less centrality tables and to get a faster processing of data