### PR TITLE
PWGHF: Add the NumberOfCluster in MFT information in the outputs of HFL single muon source task

### DIFF
--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -246,7 +246,7 @@ struct HfTaskSingleMuonSource {
     const auto muonType3 = muon.matchMCHTrack_as<McMuons>();
     const auto deltaPt = muonType3.pt() - pt;
 
-    if(!muon.has_matchMFTTrack()) {
+    if (!muon.has_matchMFTTrack()) {
       return;
     }
     const auto mft = muon.matchMFTTrack_as<McMFTs>();

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -33,7 +33,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using MyCollisions = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels>;
 using McMuons = soa::Join<aod::FwdTracks, aod::McFwdTrackLabels, aod::FwdTracksDCA>;
-using McMFTs = soa::Join<aod::MFTTracks, aod::MFTTrackLabels>;
+using McMFTs = soa::Join<aod::MFTTracks, aod::McMFTTrackLabels>;
 
 namespace
 {


### PR DESCRIPTION
The change is temporary, and aims to check the Number of cluster dependence for each kind of global tracks. Once the MFT information is available in DQ's table-maker-MC, this change will be recovered.