### PR TITLE
refactor: Update flag from kIsReconstructed to kHasTRD

### DIFF
--- a/PWGLF/TableProducer/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/nucleiSpectra.cxx
@@ -199,7 +199,7 @@ struct nucleiSpectra {
     kHe3 = BIT(3),
     kHe4 = BIT(4),
     kHasTOF = BIT(5),
-    kIsReconstructed = BIT(6),
+    kHasTRD = BIT(6),
     kIsAmbiguous = BIT(7), /// just a placeholder now
     kPositive = BIT(8),
     kIsPhysicalPrimary = BIT(9), /// MC flags starting from the second half of the short
@@ -482,6 +482,9 @@ struct nucleiSpectra {
       uint16_t flag = static_cast<uint16_t>((track.pidForTracking() & 0xF) << 12);
       if (track.hasTOF()) {
         flag |= kHasTOF;
+      }
+      if (track.hasTRD()) {
+        flag |= kHasTRD;
       }
       if (!iC) {
         flag |= kPositive;


### PR DESCRIPTION
Adds a new flag to indicate if a track has TRD information. The flag was updated
to better reflect the presence of TRD data and improve clarity in the code.