### PR TITLE
PWGLF: Fix bool check (double-negative...)

### DIFF
--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -715,12 +715,12 @@ struct derivedlambdakzeroanalysis {
     }
     histos.fill(HIST("hEventSelection"), 2 /* vertex-Z selected */);
 
-    if (rejectITSROFBorder && collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
+    if (rejectITSROFBorder && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
       return;
     }
     histos.fill(HIST("hEventSelection"), 3 /* Not at ITS ROF border */);
 
-    if (rejectTFBorder && collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
+    if (rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
       return;
     }
     histos.fill(HIST("hEventSelection"), 4 /* Not at TF border */);
@@ -767,12 +767,12 @@ struct derivedlambdakzeroanalysis {
     }
     histos.fill(HIST("hEventSelection"), 2 /* vertex-Z selected */);
 
-    if (rejectITSROFBorder && collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
+    if (rejectITSROFBorder && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
       return;
     }
     histos.fill(HIST("hEventSelection"), 3 /* Not at ITS ROF border */);
 
-    if (rejectTFBorder && collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
+    if (rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
       return;
     }
     histos.fill(HIST("hEventSelection"), 4 /* Not at TF border */);


### PR DESCRIPTION
@romainschotter I'm on fire! On fire with bugs! Here, I did not notice the bool from EvSel is actually a "NOT at border" and rejected everything "NOT at border". Now it's correct: I'm rejecting events that are NOT NOT at border... Phew. 