### PR TITLE
PWGEM/PhotonMeson: Add event selection cutstring and calo readout configurable

### DIFF
--- a/PWGEM/PhotonMeson/Core/CutsLibrary.cxx
+++ b/PWGEM/PhotonMeson/Core/CutsLibrary.cxx
@@ -44,7 +44,7 @@ EMEventCut* o2::aod::pwgem::photon::eventcuts::GetCut(const char* cutName)
   if (!nameStr.compare("minbias")) {
     cut->SetRequireFT0AND(true);
     cut->SetZvtxRange(-10.f, +10.f);
-    cut->SetRequireNoTFB(true);
+    cut->SetRequireNoTFB(false);
     cut->SetRequireNoITSROFB(false);
     return cut;
   }
@@ -54,6 +54,22 @@ EMEventCut* o2::aod::pwgem::photon::eventcuts::GetCut(const char* cutName)
     cut->SetZvtxRange(-1e+10, +1e+10);
     cut->SetRequireNoTFB(false);
     cut->SetRequireNoITSROFB(false);
+    return cut;
+  }
+
+  if (!nameStr.compare("minbias_notfb")) {
+    cut->SetRequireFT0AND(true);
+    cut->SetZvtxRange(-10.f, +10.f);
+    cut->SetRequireNoTFB(true);
+    cut->SetRequireNoITSROFB(false);
+    return cut;
+  }
+
+  if (!nameStr.compare("minbias_notfb_noitsrofb")) {
+    cut->SetRequireFT0AND(true);
+    cut->SetZvtxRange(-10.f, +10.f);
+    cut->SetRequireNoTFB(true);
+    cut->SetRequireNoITSROFB(true);
     return cut;
   }
 

--- a/PWGEM/PhotonMeson/Core/EMEventCut.h
+++ b/PWGEM/PhotonMeson/Core/EMEventCut.h
@@ -41,16 +41,16 @@ class EMEventCut : public TNamed
   template <typename T>
   bool IsSelected(T const& collision) const
   {
-    if (!IsSelected(collision, EMEventCuts::kFT0AND)) {
+    if (mRequireFT0AND && !IsSelected(collision, EMEventCuts::kFT0AND)) {
       return false;
     }
     if (!IsSelected(collision, EMEventCuts::kZvtx)) {
       return false;
     }
-    if (!IsSelected(collision, EMEventCuts::kNoTFB)) {
+    if (mRequireNoTFB && !IsSelected(collision, EMEventCuts::kNoTFB)) {
       return false;
     }
-    if (!IsSelected(collision, EMEventCuts::kNoITSROFB)) {
+    if (mRequireNoITSROFB && !IsSelected(collision, EMEventCuts::kNoITSROFB)) {
       return false;
     }
     return true;

--- a/PWGEM/PhotonMeson/TableProducer/createEMReducedEvent.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createEMReducedEvent.cxx
@@ -42,6 +42,8 @@ struct CreateEMEvent {
   Produces<o2::aod::EMReducedEventsMult> event_mult;
   Produces<o2::aod::EMReducedEventsCent> event_cent;
 
+  Configurable<bool> requireCaloReadout{"requireCaloReadout", true, "Require calorimeters readout when analyzing EMCal/PHOS"};
+
   enum class EMEventType : int {
     kEvent = 0,
     kEvent_Cent = 1,
@@ -80,8 +82,8 @@ struct CreateEMEvent {
       // LOGF(info, "collision-loop | bc.globalIndex() = %d, ncolls_per_bc = %d", bc.globalIndex(), map_ncolls_per_bc[bc.globalIndex()]);
       registry.fill(HIST("hEventCounter"), 1);
 
-      bool is_phoscpv_readout = collision.alias_bit(kTVXinPHOS);
-      bool is_emc_readout = collision.alias_bit(kTVXinEMC);
+      bool is_phoscpv_readout = (!requireCaloReadout || collision.alias_bit(kTVXinPHOS));
+      bool is_emc_readout = (!requireCaloReadout || collision.alias_bit(kTVXinEMC));
 
       if (collision.sel8()) {
         registry.fill(HIST("hEventCounter"), 2);

--- a/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
@@ -80,9 +80,9 @@ struct emcalQC {
     reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(1, "all cols");
     reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(2, "sel8");
     reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(3, "emc readout");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(5, "1+ Contributor");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(6, "z<10cm");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(7, "unique col");
+    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(4, "1+ Contributor");
+    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(5, "z<10cm");
+    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(6, "unique col");
 
     o2::aod::pwgem::photon::histogram::AddHistClass(fMainList, "Cluster");
     THashList* list_cluster = reinterpret_cast<THashList*>(fMainList->FindObject("Cluster"));


### PR DESCRIPTION
- Add minbias_noTBForROFCut event cutstring for MB events without ITSROF or TBF restrictions
- Query event cut settings (NoTFB and ITFROFB) in EMEventCut.h
- Add requireCaloReadout configurable to circumvent trigger requirement (wrong in certain MCs)
- Fix bin labels in emcQC task