### PR TITLE
Common: fix forgotten line

### DIFF
--- a/Common/TableProducer/mcCollsExtra.cxx
+++ b/Common/TableProducer/mcCollsExtra.cxx
@@ -97,6 +97,7 @@ struct mcCollisionExtra {
       if (biggestNContribs < collision.numContrib()) {
         biggestNContribs = collision.numContrib();
         bestCollisionIndex = collision.globalIndex();
+        bestCollisionCentFT0C = .bestCollisionCentFT0C();
       }
     }
     mcCollsExtra(collisions.size(), bestCollisionIndex, bestCollisionCentFT0C);

--- a/Common/TableProducer/mcCollsExtra.cxx
+++ b/Common/TableProducer/mcCollsExtra.cxx
@@ -97,7 +97,7 @@ struct mcCollisionExtra {
       if (biggestNContribs < collision.numContrib()) {
         biggestNContribs = collision.numContrib();
         bestCollisionIndex = collision.globalIndex();
-        bestCollisionCentFT0C = .bestCollisionCentFT0C();
+        bestCollisionCentFT0C = collision.centFT0C();
       }
     }
     mcCollsExtra(collisions.size(), bestCollisionIndex, bestCollisionCentFT0C);


### PR DESCRIPTION
@romainschotter @lhusova I was looking at the wrong place for my bug. It was a silly mistake in an auxiliary tool. Now the decoding of generated histograms works fine!