### PR TITLE
PWGHF: correlatorDsHadrons, correct getDeltaPhi

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -38,7 +38,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 /// Returns deltaPhi value in range [-pi/2., 3.*pi/2], typically used for correlation studies
-double getDeltaPhi(double phiD, double phiHadron)
+double getDeltaPhi(double phiHadron, double phiD)
 {
   return RecoDecay::constrainAngle(phiHadron - phiD, -PIHalf);
 }


### PR DESCRIPTION
Dear all,
Just corrected the order of members passed to getDeltaPhi function

Cheers,
Samuele