### PR TITLE
V0: use collinear fit from DCAFitter

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -390,8 +390,10 @@ DECLARE_SOA_DYNAMIC_COLUMN(PositivePhi, positivephi, //! positive daughter phi
 
 DECLARE_SOA_DYNAMIC_COLUMN(IsStandardV0, isStandardV0, //! is standard V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 0); });
-DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonTPConly, isPhotonTPConly, //! is photon V0
+DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonTPConly, isPhotonTPConly, //! is tpc-only photon V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 1); });
+DECLARE_SOA_DYNAMIC_COLUMN(IsCollinear, isCollinear, //! is collinear V0
+                           [](uint8_t V0Type) -> bool { return V0Type & (1 << 2); });
 } // namespace v0data
 
 DECLARE_SOA_TABLE(V0Indices, "AOD", "V0INDEX", //! index table when using AO2Ds

--- a/PWGLF/TableProducer/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/lambdakzerobuilder.cxx
@@ -664,6 +664,7 @@ struct lambdakzeroBuilder {
     //---/---/---/
     // Move close to minima
     int nCand = 0;
+    fitter.setCollinear(V0.isCollinearV0());
     try {
       nCand = fitter.process(lPositiveTrack, lNegativeTrack);
     } catch (...) {


### PR DESCRIPTION
For photons the position is better resolved using a specialized collinear method in DCAFitter.