### PR TITLE
PWGHF: Replace cos3PiK with its absolute value in HfMlResponseDsToKKPi

### DIFF
--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -308,10 +308,22 @@ class HfHelper
   }
 
   template <typename T>
+  auto absCos3PiKDsToKKPi(const T& candidate)
+  {
+    return std::abs(cos3PiKDsToKKPi(candidate));
+  }
+
+  template <typename T>
   auto cos3PiKDsToPiKK(const T& candidate)
   {
     auto cosPiK = cosPiKPhiRestFrame(candidate, 1);
     return cosPiK * cosPiK * cosPiK;
+  }
+
+  template <typename T>
+  auto absCos3PiKDsToPiKK(const T& candidate)
+  {
+    return std::abs(cos3PiKDsToPiKK(candidate));
   }
 
   // Λc± → p± K∓ π±

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -98,7 +98,7 @@ enum class InputFeaturesDsToKKPi : uint8_t {
   nSigTpcTofKa0,
   nSigTpcTofKa1,
   nSigTpcTofKa2,
-  cos3PiK,
+  absCos3PiK,
   deltaMassPhi
 };
 
@@ -159,7 +159,7 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(prong2, nSigTpcTofKa2, tpcTofNSigmaKa);
 
         // Ds specific variables
-        CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, cos3PiK, cos3PiKDsToKKPi, cos3PiKDsToPiKK);
+        CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, absCos3PiK, absCos3PiKDsToKKPi, absCos3PiKDsToPiKK);
         CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, deltaMassPhi, deltaMassPhiDsToKKPi, deltaMassPhiDsToPiKK);
       }
     }
@@ -203,7 +203,7 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_DS(nSigTpcTofKa2),
 
       // Ds specific variables
-      FILL_MAP_DS(cos3PiK),
+      FILL_MAP_DS(absCos3PiK),
       FILL_MAP_DS(deltaMassPhi)};
   }
 };

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -258,7 +258,7 @@ struct HfTaskDs {
       }
     }
     registry.fill(HIST("hCos3PiK"), hfHelper.cos3PiKDsToKKPi(candidate), pt);
-    registry.fill(HIST("hAbsCos3PiK"), std::abs(hfHelper.cos3PiKDsToKKPi(candidate)), pt);
+    registry.fill(HIST("hAbsCos3PiK"), hfHelper.absCos3PiKDsToKKPi(candidate), pt);
     registry.fill(HIST("hDeltaMassPhi"), hfHelper.deltaMassPhiDsToKKPi(candidate), pt);
     registry.fill(HIST("hMassKK"), hfHelper.massKKPairDsToKKPi(candidate), pt);
     return;
@@ -288,7 +288,7 @@ struct HfTaskDs {
       }
     }
     registry.fill(HIST("hCos3PiK"), hfHelper.cos3PiKDsToPiKK(candidate), pt);
-    registry.fill(HIST("hAbsCos3PiK"), std::abs(hfHelper.cos3PiKDsToPiKK(candidate)), pt);
+    registry.fill(HIST("hAbsCos3PiK"), hfHelper.absCos3PiKDsToPiKK(candidate), pt);
     registry.fill(HIST("hDeltaMassPhi"), hfHelper.deltaMassPhiDsToPiKK(candidate), pt);
     registry.fill(HIST("hMassKK"), hfHelper.massKKPairDsToPiKK(candidate), pt);
     return;

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -212,7 +212,7 @@ struct HfCandidateSelectorDsToKKPi {
     if (hfHelper.deltaMassPhiDsToKKPi(candidate) > cuts->get(pTBin, "deltaM Phi")) {
       return false;
     }
-    if (std::abs(hfHelper.cos3PiKDsToKKPi(candidate)) < cuts->get(pTBin, "cos^3 theta_PiK")) {
+    if (hfHelper.absCos3PiKDsToKKPi(candidate) < cuts->get(pTBin, "cos^3 theta_PiK")) {
       return false;
     }
     return true;
@@ -241,7 +241,7 @@ struct HfCandidateSelectorDsToKKPi {
     if (hfHelper.deltaMassPhiDsToPiKK(candidate) > cuts->get(pTBin, "deltaM Phi")) {
       return false;
     }
-    if (std::abs(hfHelper.cos3PiKDsToPiKK(candidate)) < cuts->get(pTBin, "cos^3 theta_PiK")) {
+    if (hfHelper.absCos3PiKDsToPiKK(candidate) < cuts->get(pTBin, "cos^3 theta_PiK")) {
       return false;
     }
     return true;

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -307,11 +307,11 @@ struct HfTreeCreatorDsToKKPi {
     if constexpr (massHypo == 0) {
       invMassDs = hfHelper.invMassDsToKKPi(candidate);
       deltaMassPhiKK = hfHelper.deltaMassPhiDsToKKPi(candidate);
-      absCos3PiKDs = std::abs(hfHelper.cos3PiKDsToKKPi(candidate));
+      absCos3PiKDs = hfHelper.absCos3PiKDsToKKPi(candidate);
     } else if constexpr (massHypo == 1) {
       invMassDs = hfHelper.invMassDsToPiKK(candidate);
       deltaMassPhiKK = hfHelper.deltaMassPhiDsToPiKK(candidate);
-      absCos3PiKDs = std::abs(hfHelper.cos3PiKDsToPiKK(candidate));
+      absCos3PiKDs = hfHelper.absCos3PiKDsToPiKK(candidate);
     }
 
     auto prong0 = candidate.template prong0_as<TracksWPid>();


### PR DESCRIPTION
This PR replaces the cos3PiK variable in the HfMlResponseDsToKKPi with its absolute value. This is to avoid confusion as the non-absolute value is not included in the Ds tree creator, and one cannot train a model using it as a feature