### PR TITLE
PWGLF: add cascade TOF pid code

### DIFF
--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -409,24 +409,24 @@ struct cascadepid {
           histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade - d3d); // for debugging purposes
 
           if (cascade.dcaV0daughters() < qaV0DCADau && cascade.dcacascdaughters() < qaCascDCADau && cascade.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > qaV0CosPA && cascade.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > qaCascCosPA) {
-            if(cascade.sign()<0){
-              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+            if (cascade.sign() < 0) {
+              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
               }
-              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
               }
-            }else{
-              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+            } else {
+              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
               }
-              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -242,7 +242,7 @@ struct cascadepid {
       histos.add("h2dnegDeltaTimeAsXiPi", "h2dnegDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
       histos.add("h2dnegDeltaTimeAsXiPr", "h2dnegDeltaTimeAsXiPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
       histos.add("h2dbachDeltaTimeAsXiPi", "h2dbachDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      
+
       histos.add("h2dposDeltaTimeAsOmPi", "h2dposDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
       histos.add("h2dposDeltaTimeAsOmPr", "h2dposDeltaTimeAsOmPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
       histos.add("h2dnegDeltaTimeAsOmPi", "h2dnegDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
@@ -325,9 +325,9 @@ struct cascadepid {
         float velocityOm = velocity(cascTrack.getP(), o2::constants::physics::MassOmegaMinus);
         float velocityLa = velocity(std::hypot(cascade.pxlambda(), cascade.pylambda(), cascade.pzlambda()), o2::constants::physics::MassLambda);
 
-        // calculate daughter length to TOF intercept 
-        float lengthPositive = findInterceptLength(posTrack, d_bz); // FIXME: tofPosition ok? adjust?
-        float lengthNegative = findInterceptLength(negTrack, d_bz); // FIXME: tofPosition ok? adjust?
+        // calculate daughter length to TOF intercept
+        float lengthPositive = findInterceptLength(posTrack, d_bz);  // FIXME: tofPosition ok? adjust?
+        float lengthNegative = findInterceptLength(negTrack, d_bz);  // FIXME: tofPosition ok? adjust?
         float lengthBachelor = findInterceptLength(bachTrack, d_bz); // FIXME: tofPosition ok? adjust?
 
         // calculate mother lengths
@@ -336,8 +336,8 @@ struct cascadepid {
         const o2::math_utils::Point3D<float> collVtx{collision.posX(), collision.posY(), collision.posZ()};
         bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(collVtx, cascTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE);
         float d = -1.0f, d3d = 0.0f;
-        float linearToPV = std::hypot(cascade.x()-collision.posX(),cascade.y()-collision.posY(), cascade.z()-collision.posZ()); 
-        if(successPropag){
+        float linearToPV = std::hypot(cascade.x() - collision.posX(), cascade.y() - collision.posY(), cascade.z() - collision.posZ());
+        if (successPropag) {
           std::array<float, 3> cascCloseToPVPosition;
           cascTrack.getXYZGlo(cascCloseToPVPosition);
           o2::math_utils::CircleXYf_t trcCircleCascade;
@@ -345,49 +345,49 @@ struct cascadepid {
           cascTrack.getCircleParams(d_bz, trcCircleCascade, sna, csa);
 
           // calculate 2D distance between two points
-          d = std::hypot(cascade.x()-cascCloseToPVPosition[0],cascade.y()-cascCloseToPVPosition[1]); 
-          d3d = std::hypot(cascade.x()-cascCloseToPVPosition[0],cascade.y()-cascCloseToPVPosition[1], cascade.z()-cascCloseToPVPosition[2]); // cross-check variable
-          float sinThetaOverTwo = d/(2.0f*trcCircleCascade.rC);
-          lengthCascade = 2.0f*trcCircleCascade.rC*TMath::ASin(sinThetaOverTwo);
+          d = std::hypot(cascade.x() - cascCloseToPVPosition[0], cascade.y() - cascCloseToPVPosition[1]);
+          d3d = std::hypot(cascade.x() - cascCloseToPVPosition[0], cascade.y() - cascCloseToPVPosition[1], cascade.z() - cascCloseToPVPosition[2]); // cross-check variable
+          float sinThetaOverTwo = d / (2.0f * trcCircleCascade.rC);
+          lengthCascade = 2.0f * trcCircleCascade.rC * TMath::ASin(sinThetaOverTwo);
           lengthCascade *= sqrt(1.0f + cascTrack.getTgl() * cascTrack.getTgl());
         }
 
-        if(!successPropag){
+        if (!successPropag) {
           lengthCascade = linearToPV; // if propagation failed, use linear estimate (optional: actually do not define?)
         }
 
         // lambda, xi and omega flight time is always defined
-        float lambdaFlight = lengthV0/velocityLa;
-        float xiFlight = lengthCascade/velocityXi;
-        float omFlight = lengthCascade/velocityOm;
-        float posFlightPi = lengthPositive/velocityPositivePi;
-        float posFlightPr = lengthPositive/velocityPositivePr;
-        float negFlightPi = lengthNegative/velocityNegativePi;
-        float negFlightPr = lengthNegative/velocityNegativePr;
-        float bachFlightPi = lengthBachelor/velocityBachelorPi;
-        float bachFlightKa = lengthBachelor/velocityBachelorKa;
+        float lambdaFlight = lengthV0 / velocityLa;
+        float xiFlight = lengthCascade / velocityXi;
+        float omFlight = lengthCascade / velocityOm;
+        float posFlightPi = lengthPositive / velocityPositivePi;
+        float posFlightPr = lengthPositive / velocityPositivePr;
+        float negFlightPi = lengthNegative / velocityNegativePi;
+        float negFlightPr = lengthNegative / velocityNegativePr;
+        float bachFlightPi = lengthBachelor / velocityBachelorPi;
+        float bachFlightKa = lengthBachelor / velocityBachelorKa;
 
         // initialize delta-times (actual PID variables)
         float posDeltaTimeAsXiPi = -1e+6, posDeltaTimeAsXiPr = -1e+6;
-        float negDeltaTimeAsXiPi = -1e+6, negDeltaTimeAsXiPr = -1e+6; 
+        float negDeltaTimeAsXiPi = -1e+6, negDeltaTimeAsXiPr = -1e+6;
         float bachDeltaTimeAsXiPi = -1e+6;
         float posDeltaTimeAsOmPi = -1e+6, posDeltaTimeAsOmPr = -1e+6;
-        float negDeltaTimeAsOmPi = -1e+6, negDeltaTimeAsOmPr = -1e+6; 
-        float bachDeltaTimeAsOmKa = -1e+6; 
+        float negDeltaTimeAsOmPi = -1e+6, negDeltaTimeAsOmPr = -1e+6;
+        float bachDeltaTimeAsOmKa = -1e+6;
 
-        if( cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0 ){ 
+        if (cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0) {
           posDeltaTimeAsXiPi = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (xiFlight + lambdaFlight + posFlightPi);
           posDeltaTimeAsXiPr = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (xiFlight + lambdaFlight + posFlightPr);
           posDeltaTimeAsOmPi = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (omFlight + lambdaFlight + posFlightPi);
           posDeltaTimeAsOmPr = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (omFlight + lambdaFlight + posFlightPr);
         }
-        if( cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0 ){ 
+        if (cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0) {
           negDeltaTimeAsXiPi = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (xiFlight + lambdaFlight + negFlightPi);
           negDeltaTimeAsXiPr = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (xiFlight + lambdaFlight + negFlightPr);
           negDeltaTimeAsOmPi = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (omFlight + lambdaFlight + negFlightPi);
           negDeltaTimeAsOmPr = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (omFlight + lambdaFlight + negFlightPr);
         }
-        if( cascade.bachTOFSignal() > 0 && cascade.bachTOFEventTime() > 0 ){ 
+        if (cascade.bachTOFSignal() > 0 && cascade.bachTOFEventTime() > 0) {
           bachDeltaTimeAsXiPi = (cascade.bachTOFSignal() - cascade.bachTOFEventTime()) - (xiFlight + bachFlightPi);
           bachDeltaTimeAsOmKa = (cascade.bachTOFSignal() - cascade.bachTOFEventTime()) - (omFlight + bachFlightKa);
         }
@@ -397,10 +397,10 @@ struct cascadepid {
           posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa,
           0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f // no Nsigmas yet
         );
-  
+
         if (doQA) {
           // fill QA histograms for cross-checking
-          histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade-d3d); // for debugging purposes
+          histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade - d3d); // for debugging purposes
           histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
           histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
           histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -407,26 +407,26 @@ struct cascadepid {
           // fill QA histograms for cross-checking
           histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade - d3d); // for debugging purposes
 
-          if(cascade.dcaV0daughters()<qaV0DCADau && cascade.dcacascdaughters()<qaCascDCADau && cascade.v0cosPA(collision.posX(), collision.posY(), collision.posZ())>qaV0CosPA && cascade.casccosPA(collision.posX(), collision.posY(), collision.posZ())>qaCascCosPA){ 
+          if (cascade.dcaV0daughters() < qaV0DCADau && cascade.dcacascdaughters() < qaCascDCADau && cascade.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > qaV0CosPA && cascade.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > qaCascCosPA) {
 
-            if(cascade.sign()<0){
-              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+            if (cascade.sign() < 0) {
+              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
               }
-              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), posDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), negDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
               }
-            }else{
-              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+            } else {
+              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), negDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
               }
-              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), posDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), negDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
@@ -439,11 +439,11 @@ struct cascadepid {
   }
 };
 
-  Configurable<float> qaV0DCADau{"qaV0DCADau", 0.5, "DCA daughters (cm) for QA plots"};
-  Configurable<float> qaCascDCADau{"qaCascDCADau", 0.5, "DCA daughters (cm) for QA plots"};
-  Configurable<float> qaV0CosPA{"qaV0CosPA", 0.995, "CosPA for QA plots"};
-  Configurable<float> qaCascCosPA{"qaCascCosPA", 0.995, "CosPA for QA plots"};
-  Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
+Configurable<float> qaV0DCADau{"qaV0DCADau", 0.5, "DCA daughters (cm) for QA plots"};
+Configurable<float> qaCascDCADau{"qaCascDCADau", 0.5, "DCA daughters (cm) for QA plots"};
+Configurable<float> qaV0CosPA{"qaV0CosPA", 0.995, "CosPA for QA plots"};
+Configurable<float> qaCascCosPA{"qaCascCosPA", 0.995, "CosPA for QA plots"};
+Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -89,6 +89,7 @@ struct cascadepid {
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
+  ConfigurableAxis axisEta{"axisEta", {20, -1.0f, +1.0f}, "#eta"};
   ConfigurableAxis axisDeltaTime{"axisDeltaTime", {2000, -1000.0f, +1000.0f}, "delta-time (ps)"};
   ConfigurableAxis axisTime{"axisTime", {200, 0.0f, +20000.0f}, "T (ps)"};
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "p_{T} (GeV/c)"};
@@ -242,17 +243,17 @@ struct cascadepid {
     if (doQA) {
       // standard deltaTime values
       histos.add("hArcDebug", "hArcDebug", kTH2F, {axisPt, {500, -5.0f, 10.0f}});
-      histos.add("h2dposDeltaTimeAsXiPi", "h2dposDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dposDeltaTimeAsXiPr", "h2dposDeltaTimeAsXiPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dnegDeltaTimeAsXiPi", "h2dnegDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dnegDeltaTimeAsXiPr", "h2dnegDeltaTimeAsXiPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dbachDeltaTimeAsXiPi", "h2dbachDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsXiPi", "h2dposDeltaTimeAsXiPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsXiPr", "h2dposDeltaTimeAsXiPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsXiPi", "h2dnegDeltaTimeAsXiPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsXiPr", "h2dnegDeltaTimeAsXiPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dbachDeltaTimeAsXiPi", "h2dbachDeltaTimeAsXiPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
 
-      histos.add("h2dposDeltaTimeAsOmPi", "h2dposDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dposDeltaTimeAsOmPr", "h2dposDeltaTimeAsOmPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dnegDeltaTimeAsOmPi", "h2dnegDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dnegDeltaTimeAsOmPr", "h2dnegDeltaTimeAsOmPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dbachDeltaTimeAsOmKa", "h2dbachDeltaTimeAsOmKa", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsOmPi", "h2dposDeltaTimeAsOmPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsOmPr", "h2dposDeltaTimeAsOmPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsOmPi", "h2dnegDeltaTimeAsOmPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsOmPr", "h2dnegDeltaTimeAsOmPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dbachDeltaTimeAsOmKa", "h2dbachDeltaTimeAsOmKa", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
     }
   }
 
@@ -408,28 +409,27 @@ struct cascadepid {
           histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade - d3d); // for debugging purposes
 
           if (cascade.dcaV0daughters() < qaV0DCADau && cascade.dcacascdaughters() < qaCascDCADau && cascade.v0cosPA(collision.posX(), collision.posY(), collision.posZ()) > qaV0CosPA && cascade.casccosPA(collision.posX(), collision.posY(), collision.posZ()) > qaCascCosPA) {
-
-            if (cascade.sign() < 0) {
-              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
-                histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
-                histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);
-                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
+            if(cascade.sign()<0){
+              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPr);
+                histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPi);
+                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
               }
-              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
-                histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), posDeltaTimeAsOmPr);
-                histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), negDeltaTimeAsOmPi);
-                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPr);
+                histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPi);
+                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
               }
-            } else {
-              if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow) {
-                histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
-                histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), negDeltaTimeAsXiPr);
-                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
+            }else{
+              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPi);
+                histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPr);
+                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
               }
-              if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow) {
-                histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), posDeltaTimeAsOmPi);
-                histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), negDeltaTimeAsOmPr);
-                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPi);
+                histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPr);
+                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
               }
             }
           }

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -58,22 +58,8 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
 
-// use parameters + cov mat non-propagated, aux info + (extension propagated)
-using FullTracksExt = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksCov>;
-using FullTracksExtIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TOFEvTime, aod::TOFSignal>;
-using TracksWithExtra = soa::Join<aod::Tracks, aod::TracksExtra>;
-
-// For dE/dx association in pre-selection
-using TracksExtraWithPID = soa::Join<aod::TracksExtra, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTPCFullKa>;
-
-// For MC and dE/dx association
-using TracksExtraWithPIDandLabels = soa::Join<aod::TracksExtra, aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTPCFullHe, aod::McTrackLabels>;
-
-// Pre-selected V0s
-using TaggedCascades = soa::Join<aod::Cascades, aod::CascTags>;
-
-// For MC association in pre-selection
-using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
+// Cores with references and TOF pid
+using CascFullCores = soa::Join<aod::CascCores, aod::CascTOFs, aod::CascCollRefs>;
 
 struct cascadepid {
   // TOF pid for strangeness (recalculated with topology)
@@ -82,14 +68,14 @@ struct cascadepid {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
   // For manual sliceBy
-  Preslice<aod::CascDatas> perCollision = o2::aod::cascdata::collisionId;
+  Preslice<CascFullCores> perCollision = o2::aod::v0data::straCollisionId;
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // Operation and minimisation criteria
   Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
-  Configurable<float> tofPosition{"tofPosition", 370, "TOF position for tests"};
-  Configurable<bool> fillRawPID{"fillRawPID", true, "fill raw PID tables for debug/x-check"};
+  Configurable<float> tofPosition{"tofPosition", 377.934f, "TOF effective (inscribed) radius"};
+  Configurable<bool> doQA{"doQA", true, "create QA histos"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -98,73 +84,140 @@ struct cascadepid {
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
+  ConfigurableAxis axisDeltaTime{"axisDeltaTime", {2000, -1000.0f, +1000.0f}, "delta-time (ps)"};
+  ConfigurableAxis axisTime{"axisTime", {200, 0.0f, +20000.0f}, "T (ps)"};
+  ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "p_{T} (GeV/c)"};
+
   int mRunNumber;
   float d_bz;
   float maxSnp;  // max sine phi for propagation
   float maxStep; // max step size (cm) for propagation
 
-  /// function to calculate track length of this track up to a certain radius
+  /// function to calculate track length of this track up to a certain segment of a detector
+  /// to be used internally in another funcrtion that calculates length until it finds the proper one
+  /// warning: this could be optimised further for speed
   /// \param track the input track
-  /// \param radius the radius of the layer you're calculating the length to
+  /// \param x1 x of the first point of the detector segment
+  /// \param y1 y of the first point of the detector segment
+  /// \param x2 x of the first point of the detector segment
+  /// \param y2 y of the first point of the detector segment
   /// \param magneticField the magnetic field to use when propagating
-  float trackLength(o2::track::TrackParCov track, float radius, float magneticField)
+  float trackLengthToSegment(o2::track::TrackPar track, float x1, float y1, float x2, float y2, float magneticField)
   {
     // don't make use of the track parametrization
-    float length = -100;
+    float length = -104;
 
+    // causality protection
+    std::array<float, 3> mom;
+    track.getPxPyPzGlo(mom);
+    // get start point
+    std::array<float, 3> startPoint;
+    track.getXYZGlo(startPoint);
+
+    // better replaced with scalar momentum check later
+    // if (((x1 + x2) * mom[0] + (y1 + y2) * mom[1]) < 0.0f)
+    //   return -101;
+
+    // get circle X, Y please
     o2::math_utils::CircleXYf_t trcCircle;
     float sna, csa;
     track.getCircleParams(magneticField, trcCircle, sna, csa);
 
-    // distance between circle centers (one circle is at origin -> easy)
-    float centerDistance = std::hypot(trcCircle.xC, trcCircle.yC);
+    // Calculate necessary inner product
+    float segmentModulus = std::hypot(x2 - x1, y2 - y1);
+    float alongSegment = ((trcCircle.xC - x1) * (x2 - x1) + (trcCircle.yC - y1) * (y2 - y1)) / segmentModulus;
 
-    // condition of circles touching - if not satisfied returned length will be -100
-    if (centerDistance < trcCircle.rC + radius && centerDistance > fabs(trcCircle.rC - radius)) {
-      length = 0.0f;
+    // find point of closest approach between segment and circle center
+    float pcaX = (x2 - x1) * alongSegment / segmentModulus + x1;
+    float pcaY = (y2 - y1) * alongSegment / segmentModulus + y1;
 
-      // base radical direction
-      float ux = trcCircle.xC / centerDistance;
-      float uy = trcCircle.yC / centerDistance;
-      // calculate perpendicular vector (normalized) for +/- displacement
-      float vx = -uy;
-      float vy = +ux;
-      // calculate coordinate for radical line
-      float radical = (centerDistance * centerDistance - trcCircle.rC * trcCircle.rC + radius * radius) / (2.0f * centerDistance);
-      // calculate absolute displacement from center-to-center axis
-      float displace = (0.5f / centerDistance) * TMath::Sqrt(
-                                                   (-centerDistance + trcCircle.rC - radius) *
-                                                   (-centerDistance - trcCircle.rC + radius) *
-                                                   (-centerDistance + trcCircle.rC + radius) *
-                                                   (centerDistance + trcCircle.rC + radius));
+    float centerDistToPC = std::hypot(pcaX - trcCircle.xC, pcaY - trcCircle.yC);
 
-      // possible intercept points of track and TOF layer in 2D plane
-      float point1[2] = {radical * ux + displace * vx, radical * uy + displace * vy};
-      float point2[2] = {radical * ux - displace * vx, radical * uy - displace * vy};
+    // distance pca-to-intercept in multiples of segment modulus (for convenience)
+    if (centerDistToPC > trcCircle.rC)
+      return -103;
 
-      // decide on correct intercept point
-      std::array<float, 3> mom;
-      track.getPxPyPzGlo(mom);
-      float scalarProduct1 = point1[0] * mom[0] + point1[1] * mom[1];
-      float scalarProduct2 = point2[0] * mom[0] + point2[1] * mom[1];
+    float pcaToIntercept = TMath::Sqrt(TMath::Abs(trcCircle.rC * trcCircle.rC - centerDistToPC * centerDistToPC));
 
-      // get start point
-      std::array<float, 3> startPoint;
-      track.getXYZGlo(startPoint);
+    float interceptX1 = pcaX + (x2 - x1) / segmentModulus * pcaToIntercept;
+    float interceptY1 = pcaY + (y2 - y1) / segmentModulus * pcaToIntercept;
+    float interceptX2 = pcaX - (x2 - x1) / segmentModulus * pcaToIntercept;
+    float interceptY2 = pcaY - (y2 - y1) / segmentModulus * pcaToIntercept;
 
-      float cosAngle = -1000, modulus = -1000;
+    float scalarCheck1 = ((x2 - x1) * (interceptX1 - x1) + (y2 - y1) * (interceptY1 - y1)) / segmentModulus;
+    float scalarCheck2 = ((x2 - x1) * (interceptX2 - x1) + (y2 - y1) * (interceptY2 - y1)) / segmentModulus;
 
-      if (scalarProduct1 > scalarProduct2) {
-        modulus = std::hypot(point1[0] - trcCircle.xC, point1[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
-        cosAngle = (point1[0] - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (point1[1] - trcCircle.yC) * (startPoint[0] - trcCircle.yC);
-      } else {
-        modulus = std::hypot(point2[0] - trcCircle.xC, point2[1] - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
-        cosAngle = (point2[0] - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (point2[1] - trcCircle.yC) * (startPoint[0] - trcCircle.yC);
-      }
-      cosAngle /= modulus;
-      length = trcCircle.rC * TMath::ACos(cosAngle);
-      length *= sqrt(1.0f + track.getTgl() * track.getTgl());
+    float cosAngle1 = -1000, sinAngle1 = -1000, modulus1 = -1000;
+    float cosAngle2 = -1000, sinAngle2 = -1000, modulus2 = -1000;
+    float length1 = -1000, length2 = -1000;
+
+    modulus1 = std::hypot(interceptX1 - trcCircle.xC, interceptY1 - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
+    cosAngle1 = (interceptX1 - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (interceptY1 - trcCircle.yC) * (startPoint[1] - trcCircle.yC);
+    sinAngle1 = (interceptX1 - trcCircle.xC) * (startPoint[1] - trcCircle.yC) - (interceptY1 - trcCircle.yC) * (startPoint[0] - trcCircle.xC);
+    cosAngle1 /= modulus1;
+    sinAngle1 /= modulus1;
+    length1 = trcCircle.rC * TMath::ACos(cosAngle1);
+    length1 *= sqrt(1.0f + track.getTgl() * track.getTgl());
+
+    modulus2 = std::hypot(interceptX2 - trcCircle.xC, interceptY2 - trcCircle.yC) * std::hypot(startPoint[0] - trcCircle.xC, startPoint[1] - trcCircle.yC);
+    cosAngle2 = (interceptX2 - trcCircle.xC) * (startPoint[0] - trcCircle.xC) + (interceptY2 - trcCircle.yC) * (startPoint[1] - trcCircle.yC);
+    sinAngle2 = (interceptX2 - trcCircle.xC) * (startPoint[1] - trcCircle.yC) - (interceptY2 - trcCircle.yC) * (startPoint[0] - trcCircle.xC);
+    cosAngle2 /= modulus2;
+    sinAngle2 /= modulus2;
+    length2 = trcCircle.rC * TMath::ACos(cosAngle2);
+    length2 *= sqrt(1.0f + track.getTgl() * track.getTgl());
+
+    // rotate transverse momentum vector such that it is at intercepts
+    float angle1 = TMath::ACos(cosAngle1);
+    if (sinAngle1 < 0)
+      angle1 *= -1.0f;
+    float px1 = +TMath::Cos(angle1) * mom[0] + TMath::Sin(angle1) * mom[1];
+    float py1 = -TMath::Sin(angle1) * mom[0] + TMath::Cos(angle1) * mom[1];
+
+    float angle2 = TMath::ACos(cosAngle2);
+    if (sinAngle2 < 0)
+      angle2 *= -1.0f;
+    float px2 = +TMath::Cos(angle2) * mom[0] + TMath::Sin(angle2) * mom[1];
+    float py2 = -TMath::Sin(angle2) * mom[0] + TMath::Cos(angle2) * mom[1];
+
+    float midSegX = 0.5f * (x2 + x1);
+    float midSegY = 0.5f * (y2 + y1);
+
+    float scalarMomentumCheck1 = px1 * midSegX + py1 * midSegY;
+    float scalarMomentumCheck2 = px2 * midSegX + py2 * midSegY;
+
+    if (scalarCheck1 > 0.0f && scalarCheck1 < segmentModulus && scalarMomentumCheck1 > 0.0f) {
+      length = length1;
+      // X = interceptX1; Y = interceptY1;
     }
+    if (scalarCheck2 > 0.0f && scalarCheck2 < segmentModulus && scalarMomentumCheck2 > 0.0f) {
+      length = length2;
+      // X = interceptX2; Y = interceptY2;
+    }
+    return length;
+  }
+
+  /// function to calculate track length of this track up to a certain segmented detector
+  /// \param track the input track
+  /// \param magneticField the magnetic field to use when propagating
+  float findInterceptLength(o2::track::TrackPar track, float magneticField)
+  {
+    float length = 1e+6;
+    for (int iSeg = 0; iSeg < 18; iSeg++) {
+      // Detector segmentation loop
+      float segmentAngle = 20.0f / 180.0f * TMath::Pi();
+      float theta = static_cast<float>(iSeg) * 20.0f / 180.0f * TMath::Pi();
+      float halfWidth = tofPosition * TMath::Tan(0.5f * segmentAngle);
+      float x1 = TMath::Cos(theta) * (-halfWidth) + TMath::Sin(theta) * tofPosition;
+      float y1 = -TMath::Sin(theta) * (-halfWidth) + TMath::Cos(theta) * tofPosition;
+      float x2 = TMath::Cos(theta) * (+halfWidth) + TMath::Sin(theta) * tofPosition;
+      float y2 = -TMath::Sin(theta) * (+halfWidth) + TMath::Cos(theta) * tofPosition;
+      float thisLength = trackLengthToSegment(track, x1, y1, x2, y2, magneticField);
+      if (thisLength < length && thisLength > 0)
+        length = thisLength;
+    }
+    if (length > 1e+5)
+      length = -100; // force negative to avoid misunderstandings
     return length;
   }
 
@@ -179,11 +232,28 @@ struct cascadepid {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     ccdb->setFatalWhenNull(false);
+
+    // measured vs expected total time QA
+    if (doQA) {
+      // standard deltaTime values
+      histos.add("hArcDebug", "hArcDebug", kTH2F, {axisPt, {500, -5.0f, 10.0f}});
+      histos.add("h2dposDeltaTimeAsXiPi", "h2dposDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsXiPr", "h2dposDeltaTimeAsXiPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsXiPi", "h2dnegDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsXiPr", "h2dnegDeltaTimeAsXiPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dbachDeltaTimeAsXiPi", "h2dbachDeltaTimeAsXiPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      
+      histos.add("h2dposDeltaTimeAsOmPi", "h2dposDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dposDeltaTimeAsOmPr", "h2dposDeltaTimeAsOmPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsOmPi", "h2dnegDeltaTimeAsOmPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dnegDeltaTimeAsOmPr", "h2dnegDeltaTimeAsOmPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dbachDeltaTimeAsOmKa", "h2dbachDeltaTimeAsOmKa", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+    }
   }
 
-  void initCCDB(aod::BCsWithTimestamps::iterator const& bc)
+  void initCCDB(soa::Join<aod::StraCollisions, aod::StraStamps>::iterator const& collision)
   {
-    if (mRunNumber == bc.runNumber()) {
+    if (mRunNumber == collision.runNumber()) {
       return;
     }
 
@@ -195,11 +265,11 @@ struct cascadepid {
         grpmag.setL3Current(30000.f / (d_bz / 5.0f));
       }
       o2::base::Propagator::initFieldFromGRP(&grpmag);
-      mRunNumber = bc.runNumber();
+      mRunNumber = collision.runNumber();
       return;
     }
 
-    auto run3grp_timestamp = bc.timestamp();
+    auto run3grp_timestamp = collision.timestamp();
     o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
     o2::parameters::GRPMagField* grpmag = 0x0;
     if (grpo) {
@@ -217,7 +287,7 @@ struct cascadepid {
       d_bz = std::lround(5.f * grpmag->getL3Current() / 30000.f);
       LOG(info) << "Retrieved GRP for timestamp " << run3grp_timestamp << " with magnetic field of " << d_bz << " kZG";
     }
-    mRunNumber = bc.runNumber();
+    mRunNumber = collision.runNumber();
   }
 
   float velocity(float lMomentum, float lMass)
@@ -228,28 +298,121 @@ struct cascadepid {
     return 0.0299792458 * TMath::Sqrt(lA / (1 + lA));
   }
 
-  void process(aod::Collisions const& collisions, aod::CascDatas const& Cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::V0s const&)
+  void process(soa::Join<aod::StraCollisions, aod::StraStamps> const& collisions, CascFullCores const& Cascades)
   {
     for (const auto& collision : collisions) {
-      // Fire up CCDB
-      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
-      initCCDB(bc);
-      // Do analysis with collision-grouped cascades, retain full collision information
+      // Fire up CCDB - based on StraCollisions for derived analysis
+      initCCDB(collision);
+      // Do analysis with collision-grouped V0s, retain full collision information
       const uint64_t collIdx = collision.globalIndex();
       auto CascTable_thisCollision = Cascades.sliceBy(perCollision, collIdx);
       // cascade table sliced
       for (auto const& cascade : CascTable_thisCollision) {
-        // Track casting
-        auto bachTrack = cascade.bachelor_as<FullTracksExtIU>();
-        auto posTrack = cascade.posTrack_as<FullTracksExtIU>();
-        auto negTrack = cascade.negTrack_as<FullTracksExtIU>();
+        // initialize from positions and momenta as needed
+        o2::track::TrackPar posTrack = o2::track::TrackPar({cascade.xlambda(), cascade.ylambda(), cascade.zlambda()}, {cascade.pxpos(), cascade.pypos(), cascade.pzpos()}, +1);
+        o2::track::TrackPar negTrack = o2::track::TrackPar({cascade.xlambda(), cascade.ylambda(), cascade.zlambda()}, {cascade.pxneg(), cascade.pyneg(), cascade.pzneg()}, -1);
+        o2::track::TrackPar bachTrack = o2::track::TrackPar({cascade.x(), cascade.y(), cascade.z()}, {cascade.pxbach(), cascade.pybach(), cascade.pzbach()}, cascade.sign());
+        o2::track::TrackPar cascTrack = o2::track::TrackPar({cascade.x(), cascade.y(), cascade.z()}, {cascade.px(), cascade.py(), cascade.pz()}, cascade.sign());
 
-        // FIXME: TOF calculation: under construction, to follow
-        casctofpids(0.0f, 0.0f,
-                    posTrack.length(), negTrack.length(), bachTrack.length(),
-                    0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                    0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-                    0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        // start calculation: calculate velocities
+        float velocityPositivePr = velocity(posTrack.getP(), o2::constants::physics::MassProton);
+        float velocityPositivePi = velocity(posTrack.getP(), o2::constants::physics::MassPionCharged);
+        float velocityNegativePr = velocity(negTrack.getP(), o2::constants::physics::MassProton);
+        float velocityNegativePi = velocity(negTrack.getP(), o2::constants::physics::MassPionCharged);
+        float velocityBachelorPi = velocity(bachTrack.getP(), o2::constants::physics::MassPionCharged);
+        float velocityBachelorKa = velocity(bachTrack.getP(), o2::constants::physics::MassKaonCharged);
+        float velocityXi = velocity(cascTrack.getP(), o2::constants::physics::MassXiMinus);
+        float velocityOm = velocity(cascTrack.getP(), o2::constants::physics::MassOmegaMinus);
+        float velocityLa = velocity(std::hypot(cascade.pxlambda(), cascade.pylambda(), cascade.pzlambda()), o2::constants::physics::MassLambda);
+
+        // calculate daughter length to TOF intercept 
+        float lengthPositive = findInterceptLength(posTrack, d_bz); // FIXME: tofPosition ok? adjust?
+        float lengthNegative = findInterceptLength(negTrack, d_bz); // FIXME: tofPosition ok? adjust?
+        float lengthBachelor = findInterceptLength(bachTrack, d_bz); // FIXME: tofPosition ok? adjust?
+
+        // calculate mother lengths
+        float lengthV0 = std::hypot(cascade.xlambda() - cascade.x(), cascade.ylambda() - cascade.y(), cascade.zlambda() - cascade.z());
+        float lengthCascade = -1e+6;
+        const o2::math_utils::Point3D<float> collVtx{collision.posX(), collision.posY(), collision.posZ()};
+        bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(collVtx, cascTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE);
+        float d = -1.0f, d3d = 0.0f;
+        float linearToPV = std::hypot(cascade.x()-collision.posX(),cascade.y()-collision.posY(), cascade.z()-collision.posZ()); 
+        if(successPropag){
+          std::array<float, 3> cascCloseToPVPosition;
+          cascTrack.getXYZGlo(cascCloseToPVPosition);
+          o2::math_utils::CircleXYf_t trcCircleCascade;
+          float sna, csa;
+          cascTrack.getCircleParams(d_bz, trcCircleCascade, sna, csa);
+
+          // calculate 2D distance between two points
+          d = std::hypot(cascade.x()-cascCloseToPVPosition[0],cascade.y()-cascCloseToPVPosition[1]); 
+          d3d = std::hypot(cascade.x()-cascCloseToPVPosition[0],cascade.y()-cascCloseToPVPosition[1], cascade.z()-cascCloseToPVPosition[2]); // cross-check variable
+          float sinThetaOverTwo = d/(2.0f*trcCircleCascade.rC);
+          lengthCascade = 2.0f*trcCircleCascade.rC*TMath::ASin(sinThetaOverTwo);
+          lengthCascade *= sqrt(1.0f + cascTrack.getTgl() * cascTrack.getTgl());
+        }
+
+        if(!successPropag){
+          lengthCascade = linearToPV; // if propagation failed, use linear estimate (optional: actually do not define?)
+        }
+
+        // lambda, xi and omega flight time is always defined
+        float lambdaFlight = lengthV0/velocityLa;
+        float xiFlight = lengthCascade/velocityXi;
+        float omFlight = lengthCascade/velocityOm;
+        float posFlightPi = lengthPositive/velocityPositivePi;
+        float posFlightPr = lengthPositive/velocityPositivePr;
+        float negFlightPi = lengthNegative/velocityNegativePi;
+        float negFlightPr = lengthNegative/velocityNegativePr;
+        float bachFlightPi = lengthBachelor/velocityBachelorPi;
+        float bachFlightKa = lengthBachelor/velocityBachelorKa;
+
+        // initialize delta-times (actual PID variables)
+        float posDeltaTimeAsXiPi = -1e+6, posDeltaTimeAsXiPr = -1e+6;
+        float negDeltaTimeAsXiPi = -1e+6, negDeltaTimeAsXiPr = -1e+6; 
+        float bachDeltaTimeAsXiPi = -1e+6;
+        float posDeltaTimeAsOmPi = -1e+6, posDeltaTimeAsOmPr = -1e+6;
+        float negDeltaTimeAsOmPi = -1e+6, negDeltaTimeAsOmPr = -1e+6; 
+        float bachDeltaTimeAsOmKa = -1e+6; 
+
+        if( cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0 ){ 
+          posDeltaTimeAsXiPi = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (xiFlight + lambdaFlight + posFlightPi);
+          posDeltaTimeAsXiPr = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (xiFlight + lambdaFlight + posFlightPr);
+          posDeltaTimeAsOmPi = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (omFlight + lambdaFlight + posFlightPi);
+          posDeltaTimeAsOmPr = (cascade.posTOFSignal() - cascade.posTOFEventTime()) - (omFlight + lambdaFlight + posFlightPr);
+        }
+        if( cascade.posTOFSignal() > 0 && cascade.posTOFEventTime() > 0 ){ 
+          negDeltaTimeAsXiPi = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (xiFlight + lambdaFlight + negFlightPi);
+          negDeltaTimeAsXiPr = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (xiFlight + lambdaFlight + negFlightPr);
+          negDeltaTimeAsOmPi = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (omFlight + lambdaFlight + negFlightPi);
+          negDeltaTimeAsOmPr = (cascade.negTOFSignal() - cascade.negTOFEventTime()) - (omFlight + lambdaFlight + negFlightPr);
+        }
+        if( cascade.bachTOFSignal() > 0 && cascade.bachTOFEventTime() > 0 ){ 
+          bachDeltaTimeAsXiPi = (cascade.bachTOFSignal() - cascade.bachTOFEventTime()) - (xiFlight + bachFlightPi);
+          bachDeltaTimeAsOmKa = (cascade.bachTOFSignal() - cascade.bachTOFEventTime()) - (omFlight + bachFlightKa);
+        }
+
+        casctofpids(
+          posDeltaTimeAsXiPi, posDeltaTimeAsXiPr, negDeltaTimeAsXiPi, negDeltaTimeAsXiPr, bachDeltaTimeAsXiPi,
+          posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa,
+          0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f // no Nsigmas yet
+        );
+  
+        if (doQA) {
+          // fill QA histograms for cross-checking
+          histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade-d3d); // for debugging purposes
+          histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
+          histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
+          histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);
+          histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), negDeltaTimeAsXiPr);
+          histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
+
+          histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), posDeltaTimeAsOmPi);
+          histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), posDeltaTimeAsOmPr);
+          histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), negDeltaTimeAsOmPi);
+          histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), negDeltaTimeAsOmPr);
+          histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+        }
       }
     }
   }

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -76,6 +76,11 @@ struct cascadepid {
   Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
   Configurable<float> tofPosition{"tofPosition", 377.934f, "TOF effective (inscribed) radius"};
   Configurable<bool> doQA{"doQA", true, "create QA histos"};
+  Configurable<float> qaV0DCADau{"qaV0DCADau", 0.5, "DCA daughters (cm) for QA plots"};
+  Configurable<float> qaCascDCADau{"qaCascDCADau", 0.5, "DCA daughters (cm) for QA plots"};
+  Configurable<float> qaV0CosPA{"qaV0CosPA", 0.995, "CosPA for QA plots"};
+  Configurable<float> qaCascCosPA{"qaCascCosPA", 0.995, "CosPA for QA plots"};
+  Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -395,28 +400,50 @@ struct cascadepid {
         casctofpids(
           posDeltaTimeAsXiPi, posDeltaTimeAsXiPr, negDeltaTimeAsXiPi, negDeltaTimeAsXiPr, bachDeltaTimeAsXiPi,
           posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa,
-          0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f // no Nsigmas yet
+          0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f // no Nsigmas yet, note: could be fewer
         );
 
         if (doQA) {
           // fill QA histograms for cross-checking
           histos.fill(HIST("hArcDebug"), cascade.pt(), lengthCascade - d3d); // for debugging purposes
-          histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
-          histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
-          histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);
-          histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), negDeltaTimeAsXiPr);
-          histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
 
-          histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), posDeltaTimeAsOmPi);
-          histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), posDeltaTimeAsOmPr);
-          histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), negDeltaTimeAsOmPi);
-          histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), negDeltaTimeAsOmPr);
-          histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+          if(cascade.dcaV0daughters()<qaV0DCADau && cascade.dcacascdaughters()<qaCascDCADau && cascade.v0cosPA(collision.posX(), collision.posY(), collision.posZ())>qaV0CosPA && cascade.casccosPA(collision.posX(), collision.posY(), collision.posZ())>qaCascCosPA){ 
+
+            if(cascade.sign()<0){
+              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), posDeltaTimeAsXiPr);
+                histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), negDeltaTimeAsXiPi);
+                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
+              }
+              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), posDeltaTimeAsOmPr);
+                histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), negDeltaTimeAsOmPi);
+                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+              }
+            }else{
+              if(std::abs(cascade.mXi()-1.32171)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), posDeltaTimeAsXiPi);
+                histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), negDeltaTimeAsXiPr);
+                histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), bachDeltaTimeAsXiPi);
+              }
+              if(std::abs(cascade.mOmega()-1.67245)<qaMassWindow){
+                histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), posDeltaTimeAsOmPi);
+                histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), negDeltaTimeAsOmPr);
+                histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), bachDeltaTimeAsOmKa);
+              }
+            }
+          }
         }
       }
     }
   }
 };
+
+  Configurable<float> qaV0DCADau{"qaV0DCADau", 0.5, "DCA daughters (cm) for QA plots"};
+  Configurable<float> qaCascDCADau{"qaCascDCADau", 0.5, "DCA daughters (cm) for QA plots"};
+  Configurable<float> qaV0CosPA{"qaV0CosPA", 0.995, "CosPA for QA plots"};
+  Configurable<float> qaCascCosPA{"qaCascCosPA", 0.995, "CosPA for QA plots"};
+  Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -396,12 +396,12 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dProtonMeasuredVsExpected"),
                         (timeLambda + timePositivePr),
                         (v0.posTOFSignal() - v0.posTOFEventTime()));
-            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
-              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
+              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), deltaTimePositiveLambdaPr);
-              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), deltaTimePositiveLambdaPi);
-              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), deltaTimePositiveK0ShortPi);
             }
           }
@@ -410,12 +410,12 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dPionMeasuredVsExpected"),
                         (timeLambda + timeNegativePi),
                         (v0.negTOFSignal() - v0.negTOFEventTime()));
-            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
-              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
+              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), deltaTimeNegativeLambdaPi);
-              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), deltaTimeNegativeLambdaPr);
-              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), deltaTimeNegativeK0ShortPi);
             }
           }

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -397,12 +397,12 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dProtonMeasuredVsExpected"),
                         (timeLambda + timePositivePr),
                         (v0.posTOFSignal() - v0.posTOFEventTime()));
-            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
-              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
+              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), v0.eta(), deltaTimePositiveLambdaPr);
-              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), v0.eta(), deltaTimePositiveLambdaPi);
-              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), v0.eta(), deltaTimePositiveK0ShortPi);
             }
           }
@@ -411,12 +411,12 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dPionMeasuredVsExpected"),
                         (timeLambda + timeNegativePi),
                         (v0.negTOFSignal() - v0.negTOFEventTime()));
-            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
-              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
+              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), v0.eta(), deltaTimeNegativeLambdaPi);
-              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), v0.eta(), deltaTimeNegativeLambdaPr);
-              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
                 histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), v0.eta(), deltaTimeNegativeK0ShortPi);
             }
           }

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -389,7 +389,7 @@ struct lambdakzeropid {
         v0tofdebugs(timeLambda, timeK0Short, timePositivePr, timePositivePi, timeNegativePr, timeNegativePi);
 
         if (doQA) {
-          if (v0.posTOFSignal() > 0 && v0.posTOFEventTime() > 0){
+          if (v0.posTOFSignal() > 0 && v0.posTOFEventTime() > 0) {
             histos.fill(HIST("h2dProtonMeasuredVsExpected"),
                         (timeLambda + timePositivePr),
                         (v0.posTOFSignal() - v0.posTOFEventTime()));
@@ -398,7 +398,7 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), deltaTimePositiveK0ShortPi);
           }
 
-          if (v0.negTOFSignal() > 0 && v0.negTOFEventTime() > 0){
+          if (v0.negTOFSignal() > 0 && v0.negTOFEventTime() > 0) {
             histos.fill(HIST("h2dPionMeasuredVsExpected"),
                         (timeLambda + timeNegativePi),
                         (v0.negTOFSignal() - v0.negTOFEventTime()));

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -78,6 +78,9 @@ struct lambdakzeropid {
   Configurable<double> d_bz_input{"d_bz", -999, "bz field, -999 is automatic"};
   Configurable<float> tofPosition{"tofPosition", 377.934f, "TOF effective (inscribed) radius"};
   Configurable<bool> doQA{"doQA", true, "create QA histos"};
+  Configurable<float> qaDCADau{"qaDCADau", 0.5, "DCA daughters (cm) for QA plots"};
+  Configurable<float> qaCosPA{"qaCosPA", 0.999, "CosPA for QA plots"};
+  Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -393,18 +396,28 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dProtonMeasuredVsExpected"),
                         (timeLambda + timePositivePr),
                         (v0.posTOFSignal() - v0.posTOFEventTime()));
-            histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), deltaTimePositiveLambdaPi);
-            histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), deltaTimePositiveLambdaPr);
-            histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), deltaTimePositiveK0ShortPi);
+            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
+              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), deltaTimePositiveLambdaPr);
+              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), deltaTimePositiveLambdaPi);
+              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), deltaTimePositiveK0ShortPi);
+            }
           }
 
           if (v0.negTOFSignal() > 0 && v0.negTOFEventTime() > 0) {
             histos.fill(HIST("h2dPionMeasuredVsExpected"),
                         (timeLambda + timeNegativePi),
                         (v0.negTOFSignal() - v0.negTOFEventTime()));
-            histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), deltaTimeNegativeLambdaPi);
-            histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), deltaTimeNegativeLambdaPr);
-            histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), deltaTimeNegativeK0ShortPi);
+            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
+              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), deltaTimeNegativeLambdaPi);
+              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), deltaTimeNegativeLambdaPr);
+              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), deltaTimeNegativeK0ShortPi);
+            }
           }
           // delta lambda decay time
           histos.fill(HIST("h2dLambdaDeltaDecayTime"), v0.pt(), deltaDecayTimeLambda);

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -89,6 +89,7 @@ struct lambdakzeropid {
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
+  ConfigurableAxis axisEta{"axisEta", {20, -1.0f, +1.0f}, "#eta"};
   ConfigurableAxis axisDeltaTime{"axisDeltaTime", {2000, -1000.0f, +1000.0f}, "delta-time (ps)"};
   ConfigurableAxis axisTime{"axisTime", {200, 0.0f, +20000.0f}, "T (ps)"};
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "p_{T} (GeV/c)"};
@@ -247,12 +248,12 @@ struct lambdakzeropid {
       histos.add("h2dPionMeasuredVsExpected", "h2dPionMeasuredVsExpected", {HistType::kTH2F, {axisTime, axisTime}});
 
       // standard deltaTime values
-      histos.add("h2dDeltaTimePositiveLambdaPi", "h2dDeltaTimePositiveLambdaPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dDeltaTimeNegativeLambdaPi", "h2dDeltaTimeNegativeLambdaPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dDeltaTimePositiveLambdaPr", "h2dDeltaTimePositiveLambdaPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dDeltaTimeNegativeLambdaPr", "h2dDeltaTimeNegativeLambdaPr", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dDeltaTimePositiveK0ShortPi", "h2dDeltaTimePositiveK0ShortPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
-      histos.add("h2dDeltaTimeNegativeK0ShortPi", "h2dDeltaTimeNegativeK0ShortPi", {HistType::kTH2F, {axisPt, axisDeltaTime}});
+      histos.add("h2dDeltaTimePositiveLambdaPi", "h2dDeltaTimePositiveLambdaPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dDeltaTimeNegativeLambdaPi", "h2dDeltaTimeNegativeLambdaPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dDeltaTimePositiveLambdaPr", "h2dDeltaTimePositiveLambdaPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dDeltaTimeNegativeLambdaPr", "h2dDeltaTimeNegativeLambdaPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dDeltaTimePositiveK0ShortPi", "h2dDeltaTimePositiveK0ShortPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
+      histos.add("h2dDeltaTimeNegativeK0ShortPi", "h2dDeltaTimeNegativeK0ShortPi", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
 
       // delta lambda decay time
       histos.add("h2dLambdaDeltaDecayTime", "h2dLambdaDeltaDecayTime", {HistType::kTH2F, {axisPt, axisDeltaTime}});
@@ -396,13 +397,13 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dProtonMeasuredVsExpected"),
                         (timeLambda + timePositivePr),
                         (v0.posTOFSignal() - v0.posTOFEventTime()));
-            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
-              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), deltaTimePositiveLambdaPr);
-              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), deltaTimePositiveLambdaPi);
-              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), deltaTimePositiveK0ShortPi);
+            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
+              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveLambdaPr"), v0.pt(), v0.eta(), deltaTimePositiveLambdaPr);
+              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveLambdaPi"), v0.pt(), v0.eta(), deltaTimePositiveLambdaPi);
+              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimePositiveK0ShortPi"), v0.pt(), v0.eta(), deltaTimePositiveK0ShortPi);
             }
           }
 
@@ -410,13 +411,13 @@ struct lambdakzeropid {
             histos.fill(HIST("h2dPionMeasuredVsExpected"),
                         (timeLambda + timeNegativePi),
                         (v0.negTOFSignal() - v0.negTOFEventTime()));
-            if (v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau) {
-              if (std::abs(v0.mLambda() - 1.115683) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), deltaTimeNegativeLambdaPi);
-              if (std::abs(v0.mAntiLambda() - 1.115683) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), deltaTimeNegativeLambdaPr);
-              if (std::abs(v0.mK0Short() - 0.497) < qaMassWindow)
-                histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), deltaTimeNegativeK0ShortPi);
+            if(v0.v0cosPA() > qaCosPA && v0.dcaV0daughters() < qaDCADau){
+              if(std::abs(v0.mLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPi"), v0.pt(), v0.eta(), deltaTimeNegativeLambdaPi);
+              if(std::abs(v0.mAntiLambda()-1.115683)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeLambdaPr"), v0.pt(), v0.eta(), deltaTimeNegativeLambdaPr);
+              if(std::abs(v0.mK0Short()-0.497)<qaMassWindow)
+                histos.fill(HIST("h2dDeltaTimeNegativeK0ShortPi"), v0.pt(), v0.eta(), deltaTimeNegativeK0ShortPi);
             }
           }
           // delta lambda decay time


### PR DESCRIPTION
This PR: 
* corrects a small bug in the negative prong PID under the K0Short hypothesis (thanks @romainschotter for spotting!) 
* adds a cascade path for the TOF PID which may be of interest to @lhusova @ChiaraDeMartin95 @skundu692 @mpuccio 

As a side comment, this seems to perform better in Pb-Pb `pass2` than the first tests in `pass1` ([shown in the PAG](https://indico.cern.ch/event/1362697/contributions/5736690/attachments/2777839/4841421/DDChinellato-StrangenessTOF-01.pdf)). I'm testing a bit more. 

The next step, when I manage to find the time, is to calibrate the signals and store a calibration in the CCDB. This should allow for a direct Nsigma selection as well as an effective correction of energy loss at the lowest momentum, potentially increasing the usefulness of TOF pid in that case. 