### PR TITLE
PWGHF: Lc task: Remove the redundant Configurable and keep using the Filter

### DIFF
--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -282,7 +282,7 @@ struct HfTaskLc {
     }
   }
 
-  template <bool applyMl, typename CandType>
+  template <bool fillMl, typename CandType>
   void processData(aod::Collision const& collision,
                    CandType const& candidates,
                    aod::TracksWDca const& tracks)
@@ -367,7 +367,7 @@ struct HfTaskLc {
         if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
           massLc = hfHelper.invMassLcToPKPi(candidate);
 
-          if constexpr (applyMl) {
+          if constexpr (fillMl) {
 
             if (candidate.mlProbLcToPKPi().size() == 3) {
 
@@ -384,7 +384,7 @@ struct HfTaskLc {
         if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
           massLc = hfHelper.invMassLcToPiKP(candidate);
 
-          if constexpr (applyMl) {
+          if constexpr (fillMl) {
 
             if (candidate.mlProbLcToPiKP().size() == 3) {
 
@@ -419,7 +419,7 @@ struct HfTaskLc {
   PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process Data with the ML method", false);
 
   /// Fills MC histograms.
-  template <bool applyMl, typename CandType>
+  template <bool fillMl, typename CandType>
   void processMc(CandType const& candidates,
                  soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& mcParticles,
                  aod::TracksWMc const&)
@@ -579,7 +579,7 @@ struct HfTaskLc {
           if ((candidate.isSelLcToPKPi() >= selectionFlagLc) && pdgCodeProng0 == kProton) {
             massLc = hfHelper.invMassLcToPKPi(candidate);
 
-            if constexpr (applyMl) {
+            if constexpr (fillMl) {
 
               if (candidate.mlProbLcToPKPi().size() == 3) {
 
@@ -596,7 +596,7 @@ struct HfTaskLc {
           if ((candidate.isSelLcToPiKP() >= selectionFlagLc) && pdgCodeProng0 == kPiPlus) {
             massLc = hfHelper.invMassLcToPiKP(candidate);
 
-            if constexpr (applyMl) {
+            if constexpr (fillMl) {
 
               if (candidate.mlProbLcToPiKP().size() == 3) {
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -660,7 +660,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processMcStd, "Process MC with the standard method", false);
 
-  void processMcWithMl(LcCandidatesMlMc const& selectedLcCandidatesMcMl,
+  void processMcWithMl(LcCandidatesMlMc const& selectedLcCandidatesMlMc,
                        soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& mcParticles,
                        aod::TracksWMc const& tracksWithMc)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -378,7 +378,7 @@ struct HfTaskLc {
             /// Fill the ML outputScores and variables of candidate
             registry.get<THnSparse>(HIST("hnLcVarsWithBdt"))->Fill(massLc, pt, nTracks, outputBkg, outputPrompt, outputFD, 0);
           } else {
-            registry.get<THnSparse>(HIST("hnLcVars"))->Fill(massLc, pt, ptProng0, ptProng1, ptProng2, nTracks, chi2PCA, decayLength, decayLengthXY, cpa, cpaXY, outputBkg, outputFD, 0);
+            registry.get<THnSparse>(HIST("hnLcVars"))->Fill(massLc, pt, nTracks, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, 0);
           }
         }
         if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
@@ -590,7 +590,7 @@ struct HfTaskLc {
               /// Fill the ML outputScores and variables of candidate (todo: add multiplicity)
               registry.get<THnSparse>(HIST("hnLcVarsWithBdt"))->Fill(massLc, pt, 0, outputBkg, outputPrompt, outputFD, originType);
             } else {
-              registry.get<THnSparse>(HIST("hnLcVars"))->Fill(massLc, pt, ptProng0, ptProng1, ptProng2, 0, chi2PCA, decayLength, decayLengthXY, cpa, cpaXY, outputBkg, outputFD, originType);
+              registry.get<THnSparse>(HIST("hnLcVars"))->Fill(massLc, pt, 0, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, originType);
             }
           }
           if ((candidate.isSelLcToPiKP() >= selectionFlagLc) && pdgCodeProng0 == kPiPlus) {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -664,7 +664,7 @@ struct HfTaskLc {
                        soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& mcParticles,
                        aod::TracksWMc const& tracksWithMc)
   {
-    processMc<true>(selectedLcCandidatesMcMl, mcParticles, tracksWithMc);
+    processMc<true>(selectedLcCandidatesMlMc, mcParticles, tracksWithMc);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method", false);
 };


### PR DESCRIPTION
-  remove the redundant Configurable "applyML" 
-  replace the "Partition" with "Filter"
- Fixes https://github.com/AliceO2Group/O2Physics/pull/5040