### PR TITLE
PWGHF: make uniform event selection

### DIFF
--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -31,6 +31,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 
@@ -90,21 +91,8 @@ struct HfCandidateCreator2Prong {
   double massKPi{0.};
   double bz{0.};
 
-  OutputObj<TH1F> hMass2{TH1F("hMass2", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", 500, 0., 5.)};
-  OutputObj<TH1F> hCovPVXX{TH1F("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH1F> hCovPVYY{TH1F("hCovPVYY", "2-prong candidates;YY element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVYY{TH1F("hCovSVYY", "2-prong candidates;YY element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH1F> hCovPVXZ{TH1F("hCovPVXZ", "2-prong candidates;XZ element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, -1.e-4, 1.e-4)};
-  OutputObj<TH1F> hCovSVXZ{TH1F("hCovSVXZ", "2-prong candidates;XZ element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, -1.e-4, 0.2)};
-  OutputObj<TH1F> hCovPVZZ{TH1F("hCovPVZZ", "2-prong candidates;ZZ element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVZZ{TH1F("hCovSVZZ", "2-prong candidates;ZZ element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH2F> hDcaXYProngs{TH2F("hDcaXYProngs", "DCAxy of 2-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
-  OutputObj<TH2F> hDcaZProngs{TH2F("hDcaZProngs", "DCAz of 2-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
-  OutputObj<TH1F> hVertexerType{TH1F("hVertexerType", "Use KF or DCAFitterN;Vertexer type;entries", 2, -0.5, 1.5)}; // See o2::aod::hf_cand::VertexerType
-  OutputObj<TH1D> hCollisions{TH1D("hCollisions", "HF event counter", ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f)};
-  OutputObj<TH1D> hPosZBeforeEvSel{TH1D("hPosZBeforeEvSel", "PV position Z before ev. selection;posZ (cm);entries", 400, -20, 20)};
-  OutputObj<TH1D> hPosZAfterEvSel{TH1D("hPosZAfterEvSel", "PV position Z after ev. selection;posZ (cm);entries", 400, -20, 20)};
+  std::shared_ptr<TH1> hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel;
+  HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
   {
@@ -135,11 +123,31 @@ struct HfCandidateCreator2Prong {
       }
     }
 
+    // histograms
+    registry.add("hMass2", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.6, 2.1}}});
+    registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hCovPVYY", "2-prong candidates;YY element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVYY", "2-prong candidates;YY element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hCovPVXZ", "2-prong candidates;XZ element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, -1.e-4, 1.e-4}}});
+    registry.add("hCovSVXZ", "2-prong candidates;XZ element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, -1.e-4, 0.2}}});
+    registry.add("hCovPVZZ", "2-prong candidates;ZZ element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVZZ", "2-prong candidates;ZZ element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hDcaXYProngs", "DCAxy of 2-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
+    registry.add("hDcaZProngs", "DCAz of 2-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
+    registry.add("hVertexerType", "Use KF or DCAFitterN;Vertexer type;entries", {HistType::kTH1D, {{2, -0.5, 1.5}}}); // See o2::aod::hf_cand::VertexerType
+    hCollisions = registry.add<TH1>("hCollisions", "HF event counter;;entries", {HistType::kTH1D, {{ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f}}});
+    hPosZBeforeEvSel = registry.add<TH1>("hPosZBeforeEvSel", "all events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosZAfterEvSel = registry.add<TH1>("hPosZAfterEvSel", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosXAfterEvSel = registry.add<TH1>("hPosXAfterEvSel", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hPosYAfterEvSel = registry.add<TH1>("hPosYAfterEvSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hNumPvContributorsAfterSel = registry.add<TH1>("hNumPvContributorsAfterSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{500, -0.5, 499.5}}});
+
     massPi = MassPiPlus;
     massK = MassKPlus;
 
     if (std::accumulate(doprocessDF.begin(), doprocessDF.end(), 0) == 1) {
-      hVertexerType->Fill(aod::hf_cand::VertexerType::DCAFitter);
+      registry.fill(HIST("hVertexerType"), aod::hf_cand::VertexerType::DCAFitter);
       // Configure DCAFitterN
       // df.setBz(bz);
       df.setPropagateToPCA(propagateToPCA);
@@ -151,7 +159,7 @@ struct HfCandidateCreator2Prong {
       df.setWeightedFinalPCA(useWeightedFinalPCA);
     }
     if (std::accumulate(doprocessKF.begin(), doprocessKF.end(), 0) == 1) {
-      hVertexerType->Fill(aod::hf_cand::VertexerType::KfParticle);
+      registry.fill(HIST("hVertexerType"), aod::hf_cand::VertexerType::KfParticle);
     }
 
     ccdb->setURL(ccdbUrl);
@@ -161,7 +169,7 @@ struct HfCandidateCreator2Prong {
     runNumber = 0;
 
     /// collision monitoring
-    setLabelHistoEvSel(hCollisions.object);
+    setLabelHistoEvSel(hCollisions);
   }
 
   template <bool doPvRefit, o2::aod::hf_collision_centrality::CentralityEstimator centEstimator, typename Coll, typename CandType, typename TTracks>
@@ -175,7 +183,8 @@ struct HfCandidateCreator2Prong {
 
       /// reject candidates not satisfying the event selections
       auto collision = rowTrackIndexProng2.template collision_as<Coll>();
-      const auto rejectionMask = getHfCollisionRejectionMask<centEstimator>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, centEstimator>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
       if (rejectionMask != 0) {
         /// at least one event selection not satisfied --> reject the candidate
         continue;
@@ -207,10 +216,10 @@ struct HfCandidateCreator2Prong {
       const auto& secondaryVertex = df.getPCACandidate();
       auto chi2PCA = df.getChi2AtPCACandidate();
       auto covMatrixPCA = df.calcPCACovMatrixFlat();
-      hCovSVXX->Fill(covMatrixPCA[0]); // FIXME: Calculation of errorDecayLength(XY) gives wrong values without this line.
-      hCovSVYY->Fill(covMatrixPCA[2]);
-      hCovSVXZ->Fill(covMatrixPCA[3]);
-      hCovSVZZ->Fill(covMatrixPCA[5]);
+      registry.fill(HIST("hCovSVXX"), covMatrixPCA[0]); // FIXME: Calculation of errorDecayLength(XY) gives wrong values without this line.
+      registry.fill(HIST("hCovSVYY"), covMatrixPCA[2]);
+      registry.fill(HIST("hCovSVXZ"), covMatrixPCA[3]);
+      registry.fill(HIST("hCovSVZZ"), covMatrixPCA[5]);
       auto trackParVar0 = df.getTrack(0);
       auto trackParVar1 = df.getTrack(1);
 
@@ -240,18 +249,18 @@ struct HfCandidateCreator2Prong {
         primaryVertex.setSigmaZ2(rowTrackIndexProng2.pvRefitSigmaZ2());
         covMatrixPV = primaryVertex.getCov();
       }
-      hCovPVXX->Fill(covMatrixPV[0]);
-      hCovPVYY->Fill(covMatrixPV[2]);
-      hCovPVXZ->Fill(covMatrixPV[3]);
-      hCovPVZZ->Fill(covMatrixPV[5]);
+      registry.fill(HIST("hCovPVXX"), covMatrixPV[0]);
+      registry.fill(HIST("hCovPVYY"), covMatrixPV[2]);
+      registry.fill(HIST("hCovPVXZ"), covMatrixPV[3]);
+      registry.fill(HIST("hCovPVZZ"), covMatrixPV[5]);
       o2::dataformats::DCA impactParameter0;
       o2::dataformats::DCA impactParameter1;
       trackParVar0.propagateToDCA(primaryVertex, bz, &impactParameter0);
       trackParVar1.propagateToDCA(primaryVertex, bz, &impactParameter1);
-      hDcaXYProngs->Fill(track0.pt(), impactParameter0.getY() * toMicrometers);
-      hDcaXYProngs->Fill(track1.pt(), impactParameter1.getY() * toMicrometers);
-      hDcaZProngs->Fill(track0.pt(), impactParameter0.getZ() * toMicrometers);
-      hDcaZProngs->Fill(track1.pt(), impactParameter1.getZ() * toMicrometers);
+      registry.fill(HIST("hDcaXYProngs"), track0.pt(), impactParameter0.getY() * toMicrometers);
+      registry.fill(HIST("hDcaXYProngs"), track1.pt(), impactParameter1.getY() * toMicrometers);
+      registry.fill(HIST("hDcaZProngs"), track0.pt(), impactParameter0.getZ() * toMicrometers);
+      registry.fill(HIST("hDcaZProngs"), track1.pt(), impactParameter1.getZ() * toMicrometers);
 
       // get uncertainty of the decay length
       double phi, theta;
@@ -287,8 +296,8 @@ struct HfCandidateCreator2Prong {
         auto arrayMomenta = std::array{pvec0, pvec1};
         massPiK = RecoDecay::m(arrayMomenta, std::array{massPi, massK});
         massKPi = RecoDecay::m(arrayMomenta, std::array{massK, massPi});
-        hMass2->Fill(massPiK);
-        hMass2->Fill(massKPi);
+        registry.fill(HIST("hMass2"), massPiK);
+        registry.fill(HIST("hMass2"), massKPi);
       }
     }
   }
@@ -304,7 +313,8 @@ struct HfCandidateCreator2Prong {
 
       /// reject candidates in collisions not satisfying the event selections
       auto collision = rowTrackIndexProng2.template collision_as<Coll>();
-      const auto rejectionMask = getHfCollisionRejectionMask<centEstimator>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, centEstimator>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
       if (rejectionMask != 0) {
         /// at least one event selection not satisfied --> reject the candidate
         continue;
@@ -340,10 +350,10 @@ struct HfCandidateCreator2Prong {
       }
       kfpVertex.GetCovarianceMatrix(covMatrixPV);
       KFParticle KFPV(kfpVertex);
-      hCovPVXX->Fill(covMatrixPV[0]);
-      hCovPVYY->Fill(covMatrixPV[2]);
-      hCovPVXZ->Fill(covMatrixPV[3]);
-      hCovPVZZ->Fill(covMatrixPV[5]);
+      registry.fill(HIST("hCovPVXX"), covMatrixPV[0]);
+      registry.fill(HIST("hCovPVYY"), covMatrixPV[2]);
+      registry.fill(HIST("hCovPVXZ"), covMatrixPV[3]);
+      registry.fill(HIST("hCovPVZZ"), covMatrixPV[5]);
 
       KFPTrack kfpTrack0 = createKFPTrackFromTrack(track0);
       KFPTrack kfpTrack1 = createKFPTrackFromTrack(track1);
@@ -355,18 +365,18 @@ struct HfCandidateCreator2Prong {
 
       float impactParameter0XY = 0., errImpactParameter0XY = 0., impactParameter1XY = 0., errImpactParameter1XY = 0.;
       if (!kfPosPion.GetDistanceFromVertexXY(KFPV, impactParameter0XY, errImpactParameter0XY)) {
-        hDcaXYProngs->Fill(track0.pt(), impactParameter0XY * toMicrometers);
-        hDcaZProngs->Fill(track0.pt(), std::sqrt(kfPosPion.GetDistanceFromVertex(KFPV) * kfPosPion.GetDistanceFromVertex(KFPV) - impactParameter0XY * impactParameter0XY) * toMicrometers);
+        registry.fill(HIST("hDcaXYProngs"), track0.pt(), impactParameter0XY * toMicrometers);
+        registry.fill(HIST("hDcaZProngs"), track0.pt(), std::sqrt(kfPosPion.GetDistanceFromVertex(KFPV) * kfPosPion.GetDistanceFromVertex(KFPV) - impactParameter0XY * impactParameter0XY) * toMicrometers);
       } else {
-        hDcaXYProngs->Fill(track0.pt(), -999.);
-        hDcaZProngs->Fill(track0.pt(), -999.);
+        registry.fill(HIST("hDcaXYProngs"), track0.pt(), -999.f);
+        registry.fill(HIST("hDcaZProngs"), track0.pt(), -999.f);
       }
       if (!kfNegPion.GetDistanceFromVertexXY(KFPV, impactParameter1XY, errImpactParameter1XY)) {
-        hDcaXYProngs->Fill(track1.pt(), impactParameter1XY * toMicrometers);
-        hDcaZProngs->Fill(track1.pt(), std::sqrt(kfNegPion.GetDistanceFromVertex(KFPV) * kfNegPion.GetDistanceFromVertex(KFPV) - impactParameter1XY * impactParameter1XY) * toMicrometers);
+        registry.fill(HIST("hDcaXYProngs"), track1.pt(), impactParameter1XY * toMicrometers);
+        registry.fill(HIST("hDcaZProngs"), track1.pt(), std::sqrt(kfPosPion.GetDistanceFromVertex(KFPV) * kfPosPion.GetDistanceFromVertex(KFPV) - impactParameter1XY * impactParameter1XY) * toMicrometers);
       } else {
-        hDcaXYProngs->Fill(track1.pt(), -999.);
-        hDcaZProngs->Fill(track1.pt(), -999.);
+        registry.fill(HIST("hDcaXYProngs"), track1.pt(), -999.f);
+        registry.fill(HIST("hDcaZProngs"), track1.pt(), -999.f);
       }
 
       KFParticle kfCandD0;
@@ -381,10 +391,11 @@ struct HfCandidateCreator2Prong {
       auto massD0 = kfCandD0.GetMass();
       auto massD0bar = kfCandD0bar.GetMass();
 
-      hCovSVXX->Fill(kfCandD0.Covariance(0, 0));
-      hCovSVYY->Fill(kfCandD0.Covariance(1, 1));
-      hCovSVXZ->Fill(kfCandD0.Covariance(2, 0));
-      hCovSVZZ->Fill(kfCandD0.Covariance(2, 2));
+      registry.fill(HIST("hCovSVXX"), kfCandD0.Covariance(0, 0));
+      registry.fill(HIST("hCovSVYY"), kfCandD0.Covariance(1, 1));
+      registry.fill(HIST("hCovSVXZ"), kfCandD0.Covariance(2, 0));
+      registry.fill(HIST("hCovSVZZ"), kfCandD0.Covariance(2, 2));
+
       auto covMatrixSV = kfCandD0.CovarianceMatrix();
 
       double phi, theta;
@@ -426,8 +437,8 @@ struct HfCandidateCreator2Prong {
 
       // fill histograms
       if (fillHistograms) {
-        hMass2->Fill(massD0);
-        hMass2->Fill(massD0bar);
+        registry.fill(HIST("hMass2"), massD0);
+        registry.fill(HIST("hMass2"), massD0bar);
       }
     }
   }
@@ -583,10 +594,11 @@ struct HfCandidateCreator2Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::None>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::None>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -599,10 +611,11 @@ struct HfCandidateCreator2Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0C>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0C>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -615,10 +628,11 @@ struct HfCandidateCreator2Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0M>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0M>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -20,6 +20,7 @@
 #include "CommonConstants/PhysicsConstants.h"
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/RunningWorkflowInfo.h"
 #include "ReconstructionDataFormats/DCA.h"
@@ -88,20 +89,8 @@ struct HfCandidateCreator3Prong {
   // filter candidates
   Filter filterSelected3Prongs = (createDplus && (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi))) != static_cast<uint8_t>(0)) || (createDs && (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(BIT(aod::hf_cand_3prong::DecayType::DsToKKPi))) != static_cast<uint8_t>(0)) || (createLc && (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(BIT(aod::hf_cand_3prong::DecayType::LcToPKPi))) != static_cast<uint8_t>(0)) || (createXic && (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(BIT(aod::hf_cand_3prong::DecayType::XicToPKPi))) != static_cast<uint8_t>(0));
 
-  OutputObj<TH1F> hMass3{TH1F("hMass3", "3-prong candidates;inv. mass (#pi K #pi) (GeV/#it{c}^{2});entries", 500, 1.6, 2.1)};
-  OutputObj<TH1F> hCovPVXX{TH1F("hCovPVXX", "3-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVXX{TH1F("hCovSVXX", "3-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH1F> hCovPVYY{TH1F("hCovPVYY", "3-prong candidates;YY element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVYY{TH1F("hCovSVYY", "3-prong candidates;YY element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH1F> hCovPVXZ{TH1F("hCovPVXZ", "3-prong candidates;XZ element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, -1.e-4, 1.e-4)};
-  OutputObj<TH1F> hCovSVXZ{TH1F("hCovSVXZ", "3-prong candidates;XZ element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, -1.e-4, 0.2)};
-  OutputObj<TH1F> hCovPVZZ{TH1F("hCovPVZZ", "3-prong candidates;ZZ element of cov. matrix of prim. vtx. position (cm^{2});entries", 100, 0., 1.e-4)};
-  OutputObj<TH1F> hCovSVZZ{TH1F("hCovSVZZ", "3-prong candidates;ZZ element of cov. matrix of sec. vtx. position (cm^{2});entries", 100, 0., 0.2)};
-  OutputObj<TH2F> hDcaXYProngs{TH2F("hDcaXYProngs", "DCAxy of 3-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
-  OutputObj<TH2F> hDcaZProngs{TH2F("hDcaZProngs", "DCAz of 3-prong candidates;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", 100, 0., 20., 200, -500., 500.)};
-  OutputObj<TH1D> hCollisions{TH1D("hCollisions", "HF event counter", ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f)};
-  OutputObj<TH1D> hPosZBeforeEvSel{TH1D("hPosZBeforeEvSel", "PV position Z before ev. selection;posZ (cm);entries", 400, -20, 20)};
-  OutputObj<TH1D> hPosZAfterEvSel{TH1D("hPosZAfterEvSel", "PV position Z after ev. selection;posZ (cm);entries", 400, -20, 20)};
+  std::shared_ptr<TH1> hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel;
+  HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
   {
@@ -134,6 +123,25 @@ struct HfCandidateCreator3Prong {
       LOGP(fatal, "At least one particle specie should be enabled for the creation.");
     }
 
+    // histograms
+    registry.add("hMass3", "3-prong candidates;inv. mass (#pi K #pi) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 1.6, 2.1}}});
+    registry.add("hCovPVXX", "3-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVXX", "3-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hCovPVYY", "3-prong candidates;YY element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVYY", "3-prong candidates;YY element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hCovPVXZ", "3-prong candidates;XZ element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, -1.e-4, 1.e-4}}});
+    registry.add("hCovSVXZ", "3-prong candidates;XZ element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, -1.e-4, 0.2}}});
+    registry.add("hCovPVZZ", "3-prong candidates;ZZ element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVZZ", "3-prong candidates;ZZ element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hDcaXYProngs", "DCAxy of 3-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
+    registry.add("hDcaZProngs", "DCAz of 3-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
+    hCollisions = registry.add<TH1>("hCollisions", "HF event counter;;entries", {HistType::kTH1D, {{ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f}}});
+    hPosZBeforeEvSel = registry.add<TH1>("hPosZBeforeEvSel", "all events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosZAfterEvSel = registry.add<TH1>("hPosZAfterEvSel", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosXAfterEvSel = registry.add<TH1>("hPosXAfterEvSel", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hPosYAfterEvSel = registry.add<TH1>("hPosYAfterEvSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hNumPvContributorsAfterSel = registry.add<TH1>("hNumPvContributorsAfterSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{500, -0.5, 499.5}}});
+
     massPi = MassPiPlus;
     massK = MassKPlus;
 
@@ -154,7 +162,7 @@ struct HfCandidateCreator3Prong {
     runNumber = 0;
 
     /// collision monitoring
-    setLabelHistoEvSel(hCollisions.object);
+    setLabelHistoEvSel(hCollisions);
   }
 
   template <bool doPvRefit = false, o2::aod::hf_collision_centrality::CentralityEstimator centEstimator, typename Coll, typename Cand>
@@ -168,7 +176,8 @@ struct HfCandidateCreator3Prong {
 
       /// reject candidates in collisions not satisfying the event selections
       auto collision = rowTrackIndexProng3.template collision_as<Coll>();
-      const auto rejectionMask = getHfCollisionRejectionMask<centEstimator>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, centEstimator>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
       if (rejectionMask != 0) {
         /// at least one event selection not satisfied --> reject the candidate
         continue;
@@ -202,10 +211,10 @@ struct HfCandidateCreator3Prong {
       const auto& secondaryVertex = df.getPCACandidate();
       auto chi2PCA = df.getChi2AtPCACandidate();
       auto covMatrixPCA = df.calcPCACovMatrixFlat();
-      hCovSVXX->Fill(covMatrixPCA[0]); // FIXME: Calculation of errorDecayLength(XY) gives wrong values without this line.
-      hCovSVYY->Fill(covMatrixPCA[2]);
-      hCovSVXZ->Fill(covMatrixPCA[3]);
-      hCovSVZZ->Fill(covMatrixPCA[5]);
+      registry.fill(HIST("hCovSVXX"), covMatrixPCA[0]); // FIXME: Calculation of errorDecayLength(XY) gives wrong values without this line.
+      registry.fill(HIST("hCovSVYY"), covMatrixPCA[2]);
+      registry.fill(HIST("hCovSVXZ"), covMatrixPCA[3]);
+      registry.fill(HIST("hCovSVZZ"), covMatrixPCA[5]);
       trackParVar0 = df.getTrack(0);
       trackParVar1 = df.getTrack(1);
       trackParVar2 = df.getTrack(2);
@@ -238,22 +247,22 @@ struct HfCandidateCreator3Prong {
         primaryVertex.setSigmaZ2(rowTrackIndexProng3.pvRefitSigmaZ2());
         covMatrixPV = primaryVertex.getCov();
       }
-      hCovPVXX->Fill(covMatrixPV[0]);
-      hCovPVYY->Fill(covMatrixPV[2]);
-      hCovPVXZ->Fill(covMatrixPV[3]);
-      hCovPVZZ->Fill(covMatrixPV[5]);
+      registry.fill(HIST("hCovPVXX"), covMatrixPV[0]);
+      registry.fill(HIST("hCovPVYY"), covMatrixPV[2]);
+      registry.fill(HIST("hCovPVXZ"), covMatrixPV[3]);
+      registry.fill(HIST("hCovPVZZ"), covMatrixPV[5]);
       o2::dataformats::DCA impactParameter0;
       o2::dataformats::DCA impactParameter1;
       o2::dataformats::DCA impactParameter2;
       trackParVar0.propagateToDCA(primaryVertex, bz, &impactParameter0);
       trackParVar1.propagateToDCA(primaryVertex, bz, &impactParameter1);
       trackParVar2.propagateToDCA(primaryVertex, bz, &impactParameter2);
-      hDcaXYProngs->Fill(track0.pt(), impactParameter0.getY() * toMicrometers);
-      hDcaXYProngs->Fill(track1.pt(), impactParameter1.getY() * toMicrometers);
-      hDcaXYProngs->Fill(track2.pt(), impactParameter2.getY() * toMicrometers);
-      hDcaZProngs->Fill(track0.pt(), impactParameter0.getZ() * toMicrometers);
-      hDcaZProngs->Fill(track1.pt(), impactParameter1.getZ() * toMicrometers);
-      hDcaZProngs->Fill(track2.pt(), impactParameter2.getZ() * toMicrometers);
+      registry.fill(HIST("hDcaXYProngs"), track0.pt(), impactParameter0.getY() * toMicrometers);
+      registry.fill(HIST("hDcaXYProngs"), track1.pt(), impactParameter1.getY() * toMicrometers);
+      registry.fill(HIST("hDcaXYProngs"), track2.pt(), impactParameter2.getY() * toMicrometers);
+      registry.fill(HIST("hDcaZProngs"), track0.pt(), impactParameter0.getZ() * toMicrometers);
+      registry.fill(HIST("hDcaZProngs"), track1.pt(), impactParameter1.getZ() * toMicrometers);
+      registry.fill(HIST("hDcaZProngs"), track2.pt(), impactParameter2.getZ() * toMicrometers);
 
       // get uncertainty of the decay length
       double phi, theta;
@@ -292,7 +301,7 @@ struct HfCandidateCreator3Prong {
         // calculate invariant mass
         auto arrayMomenta = std::array{pvec0, pvec1, pvec2};
         massPiKPi = RecoDecay::m(std::move(arrayMomenta), std::array{massPi, massK, massPi});
-        hMass3->Fill(massPiKPi);
+        registry.fill(HIST("hMass3"), massPiKPi);
       }
     }
   }
@@ -388,10 +397,11 @@ struct HfCandidateCreator3Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::None>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::None>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -404,10 +414,11 @@ struct HfCandidateCreator3Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0C>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0C>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -420,10 +431,11 @@ struct HfCandidateCreator3Prong {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0M>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0M>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -85,6 +85,7 @@ struct HfCandidateCreatorDstar {
   AxisSpec ptAxis = {100, 0., 2.0, "#it{p}_{T} (GeV/#it{c}"};
   AxisSpec dcaAxis = {200, -500., 500., "#it{d}_{xy,z} (#mum)"};
 
+  std::shared_ptr<TH1> hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel;
   HistogramRegistry registry{
     "registry",
     {{"Refit/hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}}},
@@ -106,10 +107,6 @@ struct HfCandidateCreatorDstar {
      {"QA/hPtD0Prong1", "D^{0} candidates' prong1", {HistType::kTH1F, {ptAxis}}},
      {"QA/hPtD0", "D^{0} candidates", {HistType::kTH1F, {ptAxis}}},
      {"QA/hPtDstar", "D* candidates", {HistType::kTH1F, {ptAxis}}}}};
-
-  OutputObj<TH1D> hCollisions{TH1D("hCollisions", "HF event counter", ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f)};
-  OutputObj<TH1D> hPosZBeforeEvSel{TH1D("hPosZBeforeEvSel", "PV position Z before ev. selection;posZ (cm);entries", 400, -20, 20)};
-  OutputObj<TH1D> hPosZAfterEvSel{TH1D("hPosZAfterEvSel", "PV position Z after ev. selection;posZ (cm);entries", 400, -20, 20)};
 
   /// @brief This function initializes the ccdb setting, vertex fitter and runs function MatLayerCylSet::rectifyPtrFromFile(..args..)
   void init(InitContext const&)
@@ -138,6 +135,14 @@ struct HfCandidateCreatorDstar {
       }
     }
 
+    // histograms (evSel)
+    hCollisions = registry.add<TH1>("EvSel/hCollisions", "HF event counter;;entries", {HistType::kTH1D, {{ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f}}});
+    hPosZBeforeEvSel = registry.add<TH1>("EvSel/hPosZBeforeEvSel", "all events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosZAfterEvSel = registry.add<TH1>("EvSel/hPosZAfterEvSel", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{400, -20., 20.}}});
+    hPosXAfterEvSel = registry.add<TH1>("EvSel/hPosXAfterEvSel", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hPosYAfterEvSel = registry.add<TH1>("EvSel/hPosYAfterEvSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+    hNumPvContributorsAfterSel = registry.add<TH1>("EvSel/hNumPvContributorsAfterSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{500, -0.5, 499.5}}});
+
     // LOG(info) << "Init Function Invoked";
     massPi = MassPiPlus;
     massK = MassKPlus;
@@ -159,7 +164,7 @@ struct HfCandidateCreatorDstar {
     bz = 0;
 
     /// collision monitoring
-    setLabelHistoEvSel(hCollisions.object);
+    setLabelHistoEvSel(hCollisions);
   }
 
   /// @brief function for secondary vertex reconstruction and candidate creator
@@ -184,7 +189,8 @@ struct HfCandidateCreatorDstar {
 
       /// reject candidates in collisions not satisfying the event selections
       auto collision = rowTrackIndexDstar.template collision_as<Coll>();
-      const auto rejectionMask = getHfCollisionRejectionMask<centEstimator>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, centEstimator>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
       if (rejectionMask != 0) {
         /// at least one event selection not satisfied --> reject the candidate
         continue;
@@ -439,10 +445,11 @@ struct HfCandidateCreatorDstar {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::None>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::None>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -455,10 +462,11 @@ struct HfCandidateCreatorDstar {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0C>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0C>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }
@@ -471,10 +479,11 @@ struct HfCandidateCreatorDstar {
     for (const auto& collision : collisions) {
 
       /// bitmask with event. selection info
-      const auto rejectionMask = getHfCollisionRejectionMask<CentralityEstimator::FT0M>(collision, centralityMin, centralityMax, useSel8Trigger, maxPvPosZ, useTimeFrameBorderCut);
+      float centrality{-1.f};
+      const auto rejectionMask = getHfCollisionRejectionMask<true, CentralityEstimator::FT0M>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, -maxPvPosZ, maxPvPosZ, 0, -1.f);
 
       /// monitor the satisfied event selections
-      monitorCollision(collision, rejectionMask, hCollisions.object, hPosZBeforeEvSel.object, hPosZAfterEvSel.object);
+      monitorCollision(collision, rejectionMask, hCollisions, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel);
 
     } /// end loop over collisions
   }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -94,10 +94,6 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
   Produces<aod::HfSelCollision> rowSelectedCollision;
 
   Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
-  Configurable<float> xVertexMin{"xVertexMin", -100., "min. x of primary vertex [cm]"};
-  Configurable<float> xVertexMax{"xVertexMax", 100., "max. x of primary vertex [cm]"};
-  Configurable<float> yVertexMin{"yVertexMin", -100., "min. y of primary vertex [cm]"};
-  Configurable<float> yVertexMax{"yVertexMax", 100., "max. y of primary vertex [cm]"};
   Configurable<float> zVertexMin{"zVertexMin", -100., "min. z of primary vertex [cm]"};
   Configurable<float> zVertexMax{"zVertexMax", 100., "max. z of primary vertex [cm]"};
   Configurable<int> nContribMin{"nContribMin", 0, "min. number of contributors to primary-vertex reconstruction"};
@@ -112,6 +108,8 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
 
   int triggerClass;
 
+  // QA histos
+  std::shared_ptr<TH1> hEvents, hPrimVtxZBeforeSel, hPrimVtxZAfterSel, hPrimVtxXAfterSel, hPrimVtxYAfterSel, hNContributorsAfterSel;
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
@@ -124,152 +122,41 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
     triggerClass = std::distance(aliasLabels, std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data()));
 
     if (fillHistograms) {
-      constexpr int kNBinsEvents = 2 + EventRejection::NEventRejection;
-      std::string labels[kNBinsEvents];
-      labels[0] = "processed";
-      labels[1] = "selected";
-      labels[2 + EventRejection::Trigger] = "rej. trigger";
-      labels[2 + EventRejection::TimeFrameBorderCut] = "rej. time-frame border";
-      labels[2 + EventRejection::PositionX] = "rej. #it{x}";
-      labels[2 + EventRejection::PositionY] = "rej. #it{y}";
-      labels[2 + EventRejection::PositionZ] = "rej. #it{z}";
-      labels[2 + EventRejection::NContrib] = "rej. # of contributors";
-      labels[2 + EventRejection::Chi2] = "rej. #it{#chi}^{2}";
-      labels[2 + EventRejection::Centrality] = "rej. centrality";
-      AxisSpec axisEvents = {kNBinsEvents, 0.5, kNBinsEvents + 0.5, ""};
-      registry.add("hEvents", "Events;;entries", HistType::kTH1F, {axisEvents});
-      for (int iBin = 0; iBin < kNBinsEvents; iBin++) {
-        registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
-      }
+      AxisSpec axisEvents = {ValuesEvSel::NEvSel, -0.5f, static_cast<float>(ValuesEvSel::NEvSel) - 0.5f, ""};
+      hEvents = registry.add<TH1>("hEvents", "Events;;entries", HistType::kTH1F, {axisEvents});
+      setLabelHistoEvSel(hEvents);
+
       // primary vertex histograms
-      registry.add("hNContributors", "Number of PV contributors;entries", {HistType::kTH1F, {axisNumContributors}});
-      registry.add("hPrimVtxX", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -0.5, 0.5}}});
-      registry.add("hPrimVtxY", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -0.5, 0.5}}});
-      registry.add("hPrimVtxZ", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1F, {{200, -20., 20.}}});
+      hPrimVtxZBeforeSel = registry.add<TH1>("hPrimVtxZBeforeSel", "all events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -20., 20.}}});
+      hPrimVtxZAfterSel = registry.add<TH1>("hPrimVtxZAfterSel", "selected events;#it{z}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -20., 20.}}});
+      hPrimVtxXAfterSel = registry.add<TH1>("hPrimVtxXAfterSel", "selected events;#it{x}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+      hPrimVtxYAfterSel = registry.add<TH1>("hPrimVtxYAfterSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {{200, -0.5, 0.5}}});
+      hNContributorsAfterSel = registry.add<TH1>("hNContributorsAfterSel", "selected events;#it{y}_{prim. vtx.} (cm);entries", {HistType::kTH1D, {axisNumContributors}});
 
       if (doprocessTrigAndCentFT0ASel || doprocessTrigAndCentFT0CSel || doprocessTrigAndCentFT0MSel || doprocessTrigAndCentFV0ASel) {
         AxisSpec axisCentrality{200, 0., 100., "centrality percentile"};
-        registry.add("hCentralitySelected", "Centrality percentile of selected events; centrality percentile;entries", {HistType::kTH1F, {axisCentrality}});
-        registry.add("hCentralityRejected", "Centrality percentile of rejected events; centrality percentile;entries", {HistType::kTH1F, {axisCentrality}});
-      }
-    }
-  }
-
-  /// Primary-vertex selection
-  /// \param collision  collision table row
-  /// \param statusCollision  bit map with rejection results
-  template <typename Col>
-  void selectVertex(const Col& collision, int& statusCollision)
-  {
-    if (fillHistograms) {
-      registry.fill(HIST("hNContributors"), collision.numContrib());
-    }
-
-    // x position
-    if (collision.posX() < xVertexMin || collision.posX() > xVertexMax) {
-      SETBIT(statusCollision, EventRejection::PositionX);
-      if (fillHistograms) {
-        registry.fill(HIST("hEvents"), 3 + EventRejection::PositionX);
-      }
-    }
-    // y position
-    if (collision.posY() < yVertexMin || collision.posY() > yVertexMax) {
-      SETBIT(statusCollision, EventRejection::PositionY);
-      if (fillHistograms) {
-        registry.fill(HIST("hEvents"), 3 + EventRejection::PositionY);
-      }
-    }
-    // z position
-    if (collision.posZ() < zVertexMin || collision.posZ() > zVertexMax) {
-      SETBIT(statusCollision, EventRejection::PositionZ);
-      if (fillHistograms) {
-        registry.fill(HIST("hEvents"), 3 + EventRejection::PositionZ);
-      }
-    }
-    // number of contributors
-    if (collision.numContrib() < nContribMin) {
-      SETBIT(statusCollision, EventRejection::NContrib);
-      if (fillHistograms) {
-        registry.fill(HIST("hEvents"), 3 + EventRejection::NContrib);
-      }
-    }
-    // chi^2
-    if (chi2Max > 0. && collision.chi2() > chi2Max) {
-      SETBIT(statusCollision, EventRejection::Chi2);
-      if (fillHistograms) {
-        registry.fill(HIST("hEvents"), 3 + EventRejection::Chi2);
+        registry.add("hCentralitySelected", "Centrality percentile of selected events; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
+        registry.add("hCentralityRejected", "Centrality percentile of rejected events; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
       }
     }
   }
 
   /// Collision selection
   /// \param collision  collision table with
-  template <bool applyTrigSel, int centEstimator, typename Col>
+  template <bool applyTrigSel, o2::aod::hf_collision_centrality::CentralityEstimator centEstimator, typename Col>
   void selectCollision(const Col& collision)
   {
-    int statusCollision = 0;
-
-    // processed events
-    if (fillHistograms) {
-      registry.fill(HIST("hEvents"), 1);
-    }
-
-    // trigger selection
-    if constexpr (applyTrigSel) {
-      if ((!useSel8Trigger && !collision.alias_bit(triggerClass)) || (useSel8Trigger && !collision.sel8())) {
-        SETBIT(statusCollision, EventRejection::Trigger);
-        if (fillHistograms) {
-          registry.fill(HIST("hEvents"), 3 + EventRejection::Trigger);
-        }
-      }
-
-      if (useTimeFrameBorderCut && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
-        SETBIT(statusCollision, EventRejection::TimeFrameBorderCut);
-        if (fillHistograms) {
-          registry.fill(HIST("hEvents"), 3 + EventRejection::TimeFrameBorderCut);
-        }
-      }
-    }
-
     float centrality = -1.;
-    if constexpr (centEstimator != CentralityEstimator::None) {
-      if constexpr (centEstimator == CentralityEstimator::FT0A) {
-        centrality = collision.centFT0A();
-      } else if constexpr (centEstimator == CentralityEstimator::FT0C) {
-        centrality = collision.centFT0C();
-      } else if constexpr (centEstimator == CentralityEstimator::FT0M) {
-        centrality = collision.centFT0M();
-      } else if constexpr (centEstimator == CentralityEstimator::FV0A) {
-        centrality = collision.centFV0A();
-      } else {
-        LOGP(fatal, "Centrality estimator not set!");
-      }
-      if (centrality < centralityMin || centrality > centralityMax) {
-        SETBIT(statusCollision, EventRejection::Centrality);
-        if (fillHistograms) {
-          registry.fill(HIST("hEvents"), 3 + EventRejection::Centrality);
-        }
-      }
-    }
+    const auto statusCollision = getHfCollisionRejectionMask<applyTrigSel, centEstimator>(collision, centrality, centralityMin, centralityMax, useSel8Trigger, useTimeFrameBorderCut, zVertexMin, zVertexMax, nContribMin, chi2Max);
 
-    // vertex selection
-    selectVertex(collision, statusCollision);
-
-    // selected events
     if (fillHistograms) {
-      if (statusCollision == 0) {
-        registry.fill(HIST("hEvents"), 2);
-        registry.fill(HIST("hPrimVtxX"), collision.posX());
-        registry.fill(HIST("hPrimVtxY"), collision.posY());
-        registry.fill(HIST("hPrimVtxZ"), collision.posZ());
-        if constexpr (centEstimator != CentralityEstimator::None) {
+      monitorCollision(collision, statusCollision, hEvents, hPrimVtxZBeforeSel, hPrimVtxZAfterSel, hPrimVtxXAfterSel, hPrimVtxYAfterSel, hNContributorsAfterSel);
+      // additional centrality histos
+      if constexpr (centEstimator != o2::aod::hf_collision_centrality::None) {
+        if (statusCollision == 0) {
           registry.fill(HIST("hCentralitySelected"), centrality);
-        }
-      } else {
-        if constexpr (centEstimator != CentralityEstimator::None) {
-          if (TESTBIT(statusCollision, EventRejection::Centrality)) {
-            registry.fill(HIST("hCentralityRejected"), centrality);
-          }
+        } else if (statusCollision == BIT(EventRejection::Centrality)) { // rejected by centrality only
+          registry.fill(HIST("hCentralityRejected"), centrality);
         }
       }
     }


### PR DESCRIPTION
Hi @mfaggin, @vkucera, as promised I modified the track-index-skim creator using the event selection utilities developed for the creators. The main changes are:
- I removed the possibility to apply selections on the PV position in X and Y in the `trackIndexSkimCreator` (I do not see why we should do it)
- I changed the counter histogram in the `trackIndexSkimCreator` to match the one in the creators
- I added few steps in the monitoring (adding also chi2 and min number of contributors cuts) and moved the `Zvtx` at the end of the selections (to have the `Zvtx` cut efficiency only for selected events)
- I moved to the `HistogramRegistry` in the creators