### PR TITLE
PWGMM: Mult: add reduced data model and a task

### DIFF
--- a/PWGMM/Mult/DataModel/ReducedTables.h
+++ b/PWGMM/Mult/DataModel/ReducedTables.h
@@ -1,0 +1,250 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef PWGMM_MULT_DATAMODEL_REDUCEDTABLES_H_
+#define PWGMM_MULT_DATAMODEL_REDUCEDTABLES_H_
+#include "Framework/AnalysisDataModel.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+namespace o2::aod
+{
+
+#define BCcols o2::soa::Index<>,\
+               bc::RunNumber
+
+// Reduced BCs as a root index
+DECLARE_SOA_TABLE(RBCs, "AOD", "RBC",
+                  BCcols,
+                  soa::Marker<1>
+                  );
+DECLARE_SOA_TABLE(StoredRBCs, "AOD1", "RBC",
+                  BCcols,
+                  soa::Marker<2>
+                  );
+
+namespace rcol {
+DECLARE_SOA_INDEX_COLUMN(RBC, rbc);
+}
+
+#define Ccols o2::soa::Index<>,\
+              rcol::RBCId,\
+              collision::PosX,\
+              collision::PosY,\
+              collision::PosZ,\
+              collision::CollisionTimeRes,\
+              mult::MultFT0A,\
+              mult::MultFT0C,\
+              mult::MultFDDA,\
+              mult::MultFDDC,\
+              mult::MultZNA,\
+              mult::MultZNC,\
+              mult::MultNTracksPV,\
+              mult::MultNTracksPVeta1,\
+              mult::MultNTracksPVetaHalf
+
+
+#define CCcols cent::CentFV0A,\
+               cent::CentFT0M,\
+               cent::CentFT0A,\
+               cent::CentFT0C,\
+               cent::CentFDDM,\
+               cent::CentNTPV
+
+// Reduced Collisions
+DECLARE_SOA_TABLE(RCollisions, "AOD", "RCOLLS",
+                  Ccols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRCollisions, "AOD1", "RCOLLS",
+                  Ccols,
+                  soa::Marker<2>
+                  )
+
+DECLARE_SOA_TABLE(RCents, "AOD", "RCENTS",
+                  CCcols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRCents, "AOD1", "RCENTS",
+                  CCcols,
+                  soa::Marker<2>
+                  )
+
+// Reduced tracks (is this needed?)
+namespace rtrack {
+DECLARE_SOA_INDEX_COLUMN(RCollision, rcollision);
+DECLARE_SOA_COLUMN(Weight, weight, float);
+}
+#define Tcols o2::soa::Index<>,\
+              rtrack::RCollisionId,\
+              rtrack::Weight,\
+              track::Pt,\
+              track::P,\
+              track::Eta,\
+              track::Phi,\
+              track::DcaXY,\
+              track::DcaZ
+
+DECLARE_SOA_TABLE(RTracks, "AOD", "RTRK",
+                  Tcols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRTracks, "AOD1", "RTRK",
+                  Tcols,
+                  soa::Marker<2>
+                  )
+
+#define TFcols o2::soa::Index<>,\
+               rtrack::RCollisionId,\
+               rtrack::Weight,\
+               fwdtrack::Pt,\
+               fwdtrack::P,\
+               fwdtrack::Eta,\
+               fwdtrack::Phi,\
+               fwdtrack::FwdDcaX,\
+               fwdtrack::FwdDcaY
+
+DECLARE_SOA_TABLE(RFTracks, "AOD", "RFTRK",
+                  TFcols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRFTracks, "AOD1", "RFTRK",
+                  TFcols,
+                  soa::Marker<2>
+                  )
+
+// Reduced MC collisions
+namespace rmccol {
+DECLARE_SOA_COLUMN(Weight, weight, float);
+}
+#define MCCcols o2::soa::Index<>,\
+                rcol::RBCId,\
+                rmccol::Weight,\
+                mccollision::PosX,\
+                mccollision::PosY,\
+                mccollision::PosZ,\
+                mccollision::ImpactParameter,\
+                mult::MultMCFT0A,\
+                mult::MultMCFT0C,\
+                mult::MultMCNParticlesEta05,\
+                mult::MultMCNParticlesEta10
+
+DECLARE_SOA_TABLE(RMCCollisions, "AOD", "RMCCOLS",
+                  MCCcols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRMCCollisions, "AOD1", "RMCCOLS",
+                  MCCcols,
+                  soa::Marker<2>
+                  )
+
+// Extra MC tables
+namespace rhepmc {
+DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollison);
+}
+#define HMCcols rhepmc::RMCCollisionId,\
+                hepmcxsection::XsectGen,\
+                hepmcxsection::PtHard,\
+                hepmcxsection::NMPI,\
+                hepmcxsection::ProcessId,\
+                hepmcpdfinfo::Id1,\
+                hepmcpdfinfo::Id2,\
+                hepmcpdfinfo::PdfId1,\
+                hepmcpdfinfo::PdfId2,\
+                hepmcpdfinfo::X1,\
+                hepmcpdfinfo::X2,\
+                hepmcpdfinfo::ScalePdf,\
+                hepmcpdfinfo::Pdf1,\
+                hepmcpdfinfo::Pdf2
+
+DECLARE_SOA_TABLE(RHepMCinfos, "AOD", "RHMCI",
+                  HMCcols,
+                  soa::Marker<1>
+                  );
+DECLARE_SOA_TABLE(StoredRHepMCinfos, "AOD1", "RHMCI",
+                  HMCcols,
+                  soa::Marker<2>
+                  );
+
+#define HMCHIcols rhepmc::RMCCollisionId,\
+                  hepmcheavyion::NcollHard,\
+                  hepmcheavyion::NpartProj,\
+                  hepmcheavyion::NpartTarg,\
+                  hepmcheavyion::Ncoll,\
+                  hepmcheavyion::ImpactParameter,\
+                  hepmcheavyion::EventPlaneAngle,\
+                  hepmcheavyion::SigmaInelNN,\
+                  hepmcheavyion::Centrality
+
+DECLARE_SOA_TABLE(RHepMCHI, "AOD", "RHMCHI",
+                  HMCHIcols,
+                  soa::Marker<1>
+                  );
+DECLARE_SOA_TABLE(StoredRHepMCHI, "AOD1", "RHMCHI",
+                  HMCHIcols,
+                  soa::Marker<2>
+                  );
+
+namespace rparticle {
+DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollision);
+}
+
+// Reduced MC particles (is this needed?)
+#define RMCPcols o2::soa::Index<>,\
+                 rparticle::RMCCollisionId,\
+                 mcparticle::PdgCode,\
+                 mcparticle::MothersIds,\
+                 mcparticle::DaughtersIdSlice,\
+                 mcparticle::Pt,\
+                 mcparticle::P,\
+                 mcparticle::Eta,\
+                 mcparticle::Y,\
+                 mcparticle::Phi,\
+                 mcparticle::E,\
+                 mcparticle::Weight
+
+DECLARE_SOA_TABLE(RMCParticles, "AOD", "RMCPART",
+                  RMCPcols,
+                  soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRMCParticles, "AOD1", "RMCPART",
+                  RMCPcols,
+                  soa::Marker<2>
+                  )
+
+// label tables
+namespace rlabels {
+DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollision);
+DECLARE_SOA_INDEX_COLUMN(RMCParticle, rmcparticle);
+}
+DECLARE_SOA_TABLE(RMCTrackLabels, "AOD", "RMCTRKL",
+                  rlabels::RMCParticleId, soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRMCTrackLabels, "AOD1", "RMCTRKL",
+                  rlabels::RMCParticleId, soa::Marker<2>
+                  )
+
+DECLARE_SOA_TABLE(RMCColLabels, "AOD", "RMCCOLL",
+                  rlabels::RMCCollisionId, soa::Marker<1>
+                  )
+DECLARE_SOA_TABLE(StoredRMCColLabels, "AOD1", "RMCCOLL",
+                  rlabels::RMCCollisionId, soa::Marker<2>
+                  )
+}
+namespace o2::soa {
+DECLARE_EQUIVALENT_FOR_INDEX(aod::RBCs, aod::StoredRBCs);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::RCollisions, aod::StoredRCollisions);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::RMCCollisions, aod::StoredRMCCollisions);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::RMCParticles, aod::StoredRMCParticles);
+}
+#endif // PWGMM_MULT_DATAMODEL_REDUCEDTABLES_H_

--- a/PWGMM/Mult/DataModel/ReducedTables.h
+++ b/PWGMM/Mult/DataModel/ReducedTables.h
@@ -20,231 +20,215 @@
 namespace o2::aod
 {
 
-#define BCcols o2::soa::Index<>,\
+#define BCcols o2::soa::Index<>, \
                bc::RunNumber
 
 // Reduced BCs as a root index
 DECLARE_SOA_TABLE(RBCs, "AOD", "RBC",
                   BCcols,
-                  soa::Marker<1>
-                  );
+                  soa::Marker<1>);
 DECLARE_SOA_TABLE(StoredRBCs, "AOD1", "RBC",
                   BCcols,
-                  soa::Marker<2>
-                  );
+                  soa::Marker<2>);
 
-namespace rcol {
+namespace rcol
+{
 DECLARE_SOA_INDEX_COLUMN(RBC, rbc);
 }
 
-#define Ccols o2::soa::Index<>,\
-              rcol::RBCId,\
-              collision::PosX,\
-              collision::PosY,\
-              collision::PosZ,\
-              collision::CollisionTimeRes,\
-              mult::MultFT0A,\
-              mult::MultFT0C,\
-              mult::MultFDDA,\
-              mult::MultFDDC,\
-              mult::MultZNA,\
-              mult::MultZNC,\
-              mult::MultNTracksPV,\
-              mult::MultNTracksPVeta1,\
+#define Ccols o2::soa::Index<>,            \
+              rcol::RBCId,                 \
+              collision::PosX,             \
+              collision::PosY,             \
+              collision::PosZ,             \
+              collision::CollisionTimeRes, \
+              mult::MultFT0A,              \
+              mult::MultFT0C,              \
+              mult::MultFDDA,              \
+              mult::MultFDDC,              \
+              mult::MultZNA,               \
+              mult::MultZNC,               \
+              mult::MultNTracksPV,         \
+              mult::MultNTracksPVeta1,     \
               mult::MultNTracksPVetaHalf
 
-
-#define CCcols cent::CentFV0A,\
-               cent::CentFT0M,\
-               cent::CentFT0A,\
-               cent::CentFT0C,\
-               cent::CentFDDM,\
+#define CCcols cent::CentFV0A, \
+               cent::CentFT0M, \
+               cent::CentFT0A, \
+               cent::CentFT0C, \
+               cent::CentFDDM, \
                cent::CentNTPV
 
 // Reduced Collisions
 DECLARE_SOA_TABLE(RCollisions, "AOD", "RCOLLS",
                   Ccols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRCollisions, "AOD1", "RCOLLS",
                   Ccols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
 DECLARE_SOA_TABLE(RCents, "AOD", "RCENTS",
                   CCcols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRCents, "AOD1", "RCENTS",
                   CCcols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
 // Reduced tracks (is this needed?)
-namespace rtrack {
+namespace rtrack
+{
 DECLARE_SOA_INDEX_COLUMN(RCollision, rcollision);
 DECLARE_SOA_COLUMN(Weight, weight, float);
-}
-#define Tcols o2::soa::Index<>,\
-              rtrack::RCollisionId,\
-              rtrack::Weight,\
-              track::Pt,\
-              track::P,\
-              track::Eta,\
-              track::Phi,\
-              track::DcaXY,\
+} // namespace rtrack
+#define Tcols o2::soa::Index<>,     \
+              rtrack::RCollisionId, \
+              rtrack::Weight,       \
+              track::Pt,            \
+              track::P,             \
+              track::Eta,           \
+              track::Phi,           \
+              track::DcaXY,         \
               track::DcaZ
 
 DECLARE_SOA_TABLE(RTracks, "AOD", "RTRK",
                   Tcols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRTracks, "AOD1", "RTRK",
                   Tcols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
-#define TFcols o2::soa::Index<>,\
-               rtrack::RCollisionId,\
-               rtrack::Weight,\
-               fwdtrack::Pt,\
-               fwdtrack::P,\
-               fwdtrack::Eta,\
-               fwdtrack::Phi,\
-               fwdtrack::FwdDcaX,\
+#define TFcols o2::soa::Index<>,     \
+               rtrack::RCollisionId, \
+               rtrack::Weight,       \
+               fwdtrack::Pt,         \
+               fwdtrack::P,          \
+               fwdtrack::Eta,        \
+               fwdtrack::Phi,        \
+               fwdtrack::FwdDcaX,    \
                fwdtrack::FwdDcaY
 
 DECLARE_SOA_TABLE(RFTracks, "AOD", "RFTRK",
                   TFcols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRFTracks, "AOD1", "RFTRK",
                   TFcols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
 // Reduced MC collisions
-namespace rmccol {
+namespace rmccol
+{
 DECLARE_SOA_COLUMN(Weight, weight, float);
 }
-#define MCCcols o2::soa::Index<>,\
-                rcol::RBCId,\
-                rmccol::Weight,\
-                mccollision::PosX,\
-                mccollision::PosY,\
-                mccollision::PosZ,\
-                mccollision::ImpactParameter,\
-                mult::MultMCFT0A,\
-                mult::MultMCFT0C,\
-                mult::MultMCNParticlesEta05,\
+#define MCCcols o2::soa::Index<>,             \
+                rcol::RBCId,                  \
+                rmccol::Weight,               \
+                mccollision::PosX,            \
+                mccollision::PosY,            \
+                mccollision::PosZ,            \
+                mccollision::ImpactParameter, \
+                mult::MultMCFT0A,             \
+                mult::MultMCFT0C,             \
+                mult::MultMCNParticlesEta05,  \
                 mult::MultMCNParticlesEta10
 
 DECLARE_SOA_TABLE(RMCCollisions, "AOD", "RMCCOLS",
                   MCCcols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRMCCollisions, "AOD1", "RMCCOLS",
                   MCCcols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
 // Extra MC tables
-namespace rhepmc {
+namespace rhepmc
+{
 DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollison);
 }
-#define HMCcols rhepmc::RMCCollisionId,\
-                hepmcxsection::XsectGen,\
-                hepmcxsection::PtHard,\
-                hepmcxsection::NMPI,\
-                hepmcxsection::ProcessId,\
-                hepmcpdfinfo::Id1,\
-                hepmcpdfinfo::Id2,\
-                hepmcpdfinfo::PdfId1,\
-                hepmcpdfinfo::PdfId2,\
-                hepmcpdfinfo::X1,\
-                hepmcpdfinfo::X2,\
-                hepmcpdfinfo::ScalePdf,\
-                hepmcpdfinfo::Pdf1,\
+#define HMCcols rhepmc::RMCCollisionId,   \
+                hepmcxsection::XsectGen,  \
+                hepmcxsection::PtHard,    \
+                hepmcxsection::NMPI,      \
+                hepmcxsection::ProcessId, \
+                hepmcpdfinfo::Id1,        \
+                hepmcpdfinfo::Id2,        \
+                hepmcpdfinfo::PdfId1,     \
+                hepmcpdfinfo::PdfId2,     \
+                hepmcpdfinfo::X1,         \
+                hepmcpdfinfo::X2,         \
+                hepmcpdfinfo::ScalePdf,   \
+                hepmcpdfinfo::Pdf1,       \
                 hepmcpdfinfo::Pdf2
 
 DECLARE_SOA_TABLE(RHepMCinfos, "AOD", "RHMCI",
                   HMCcols,
-                  soa::Marker<1>
-                  );
+                  soa::Marker<1>);
 DECLARE_SOA_TABLE(StoredRHepMCinfos, "AOD1", "RHMCI",
                   HMCcols,
-                  soa::Marker<2>
-                  );
+                  soa::Marker<2>);
 
-#define HMCHIcols rhepmc::RMCCollisionId,\
-                  hepmcheavyion::NcollHard,\
-                  hepmcheavyion::NpartProj,\
-                  hepmcheavyion::NpartTarg,\
-                  hepmcheavyion::Ncoll,\
-                  hepmcheavyion::ImpactParameter,\
-                  hepmcheavyion::EventPlaneAngle,\
-                  hepmcheavyion::SigmaInelNN,\
+#define HMCHIcols rhepmc::RMCCollisionId,         \
+                  hepmcheavyion::NcollHard,       \
+                  hepmcheavyion::NpartProj,       \
+                  hepmcheavyion::NpartTarg,       \
+                  hepmcheavyion::Ncoll,           \
+                  hepmcheavyion::ImpactParameter, \
+                  hepmcheavyion::EventPlaneAngle, \
+                  hepmcheavyion::SigmaInelNN,     \
                   hepmcheavyion::Centrality
 
 DECLARE_SOA_TABLE(RHepMCHI, "AOD", "RHMCHI",
                   HMCHIcols,
-                  soa::Marker<1>
-                  );
+                  soa::Marker<1>);
 DECLARE_SOA_TABLE(StoredRHepMCHI, "AOD1", "RHMCHI",
                   HMCHIcols,
-                  soa::Marker<2>
-                  );
+                  soa::Marker<2>);
 
-namespace rparticle {
+namespace rparticle
+{
 DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollision);
 }
 
 // Reduced MC particles (is this needed?)
-#define RMCPcols o2::soa::Index<>,\
-                 rparticle::RMCCollisionId,\
-                 mcparticle::PdgCode,\
-                 mcparticle::MothersIds,\
-                 mcparticle::DaughtersIdSlice,\
-                 mcparticle::Pt,\
-                 mcparticle::P,\
-                 mcparticle::Eta,\
-                 mcparticle::Y,\
-                 mcparticle::Phi,\
-                 mcparticle::E,\
+#define RMCPcols o2::soa::Index<>,             \
+                 rparticle::RMCCollisionId,    \
+                 mcparticle::PdgCode,          \
+                 mcparticle::MothersIds,       \
+                 mcparticle::DaughtersIdSlice, \
+                 mcparticle::Pt,               \
+                 mcparticle::P,                \
+                 mcparticle::Eta,              \
+                 mcparticle::Y,                \
+                 mcparticle::Phi,              \
+                 mcparticle::E,                \
                  mcparticle::Weight
 
 DECLARE_SOA_TABLE(RMCParticles, "AOD", "RMCPART",
                   RMCPcols,
-                  soa::Marker<1>
-                  )
+                  soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRMCParticles, "AOD1", "RMCPART",
                   RMCPcols,
-                  soa::Marker<2>
-                  )
+                  soa::Marker<2>)
 
 // label tables
-namespace rlabels {
+namespace rlabels
+{
 DECLARE_SOA_INDEX_COLUMN(RMCCollision, rmccollision);
 DECLARE_SOA_INDEX_COLUMN(RMCParticle, rmcparticle);
-}
+} // namespace rlabels
 DECLARE_SOA_TABLE(RMCTrackLabels, "AOD", "RMCTRKL",
-                  rlabels::RMCParticleId, soa::Marker<1>
-                  )
+                  rlabels::RMCParticleId, soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRMCTrackLabels, "AOD1", "RMCTRKL",
-                  rlabels::RMCParticleId, soa::Marker<2>
-                  )
+                  rlabels::RMCParticleId, soa::Marker<2>)
 
 DECLARE_SOA_TABLE(RMCColLabels, "AOD", "RMCCOLL",
-                  rlabels::RMCCollisionId, soa::Marker<1>
-                  )
+                  rlabels::RMCCollisionId, soa::Marker<1>)
 DECLARE_SOA_TABLE(StoredRMCColLabels, "AOD1", "RMCCOLL",
-                  rlabels::RMCCollisionId, soa::Marker<2>
-                  )
-}
-namespace o2::soa {
+                  rlabels::RMCCollisionId, soa::Marker<2>)
+} // namespace o2::aod
+namespace o2::soa
+{
 DECLARE_EQUIVALENT_FOR_INDEX(aod::RBCs, aod::StoredRBCs);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::RCollisions, aod::StoredRCollisions);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::RMCCollisions, aod::StoredRMCCollisions);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::RMCParticles, aod::StoredRMCParticles);
-}
+} // namespace o2::soa
 #endif // PWGMM_MULT_DATAMODEL_REDUCEDTABLES_H_

--- a/PWGMM/Mult/TableProducer/CMakeLists.txt
+++ b/PWGMM/Mult/TableProducer/CMakeLists.txt
@@ -14,6 +14,11 @@ o2physics_add_dpl_workflow(particles-to-tracks
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(reducer
+                    SOURCES reducer.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(track-propagation
                     SOURCES trackPropagation.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2::ReconstructionDataFormats O2::DetectorsCommonDataFormats

--- a/PWGMM/Mult/TableProducer/reducer.cxx
+++ b/PWGMM/Mult/TableProducer/reducer.cxx
@@ -1,0 +1,187 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <random>
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+
+#include "ReducedTables.h"
+
+#include "Framework/runDataProcessing.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+static constexpr float defparams[1][7] = {{0.142664,	1.40302,	2.61158,	1.20139,	5.24992,	2.16384,	0.871307}};
+
+struct Reducer {
+  using BCs = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
+  using MCCollisions = soa::Join<aod::McCollisions, aod::HepMCXSections, aod::HepMCPdfInfos, aod::MultsExtraMC>;
+  using Collisions = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::FT0Mults, aod::FDDMults, aod::ZDCMults, aod::PVMults>;
+  using Particles = aod::McParticles;
+  using Tracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::McTrackLabels>;
+
+  Produces<aod::StoredRBCs> rbcs;
+  Produces<aod::StoredRMCCollisions> rmcc;
+  Produces<aod::StoredRMCColLabels> rmcl;
+  Produces<aod::StoredRCollisions> rc;
+  Produces<aod::StoredRHepMCinfos> rhepmci;
+
+  Configurable<float> reductionFactor{"reduction-factor", 1.e-4, "Reduction factor"};
+  Configurable<LabeledArray<float>> params{"params", {defparams[0], 1, 7, {"pars"}, {"0bin", "l", "a", "n1", "p1", "n2", "p2"}}, "Multiplicity distribution parameterization"};
+
+  Preslice<aod::Collisions> cperBC = aod::collision::bcId;
+  Preslice<aod::McCollisions> mccperBC = aod::mccollision::bcId;
+  Preslice<aod::McParticles> perMCc = aod::mcparticle::mcCollisionId;
+  Preslice<aod::Tracks> perC = aod::track::collisionId;
+
+  std::mt19937 randomgen;
+
+  std::vector<int64_t> usedMCCs;
+  std::vector<int64_t> usedLabels;
+  std::vector<float> weights;
+
+  double NormalizedDoubleNBD(double x)
+  {
+    // <n> = (p[2,4]^2)
+    // k = (1+p[3,5]^2), k >= 1 -> smaller standar deviation, peak is pronounced
+    // p[6] - normalization
+    // alpha = p[1]^2 / ( 1 + p[1]^2), relative weight, 0 < alpha < 1
+
+    return params->get((int)0, 6) *
+           ( params->get((int)0, 1) * params->get((int)0, 1) / ( 1. + params->get((int)0, 1) * params->get((int)0, 1) ) *                 //alpha
+           // 	       v1 +
+            1. / ( x * TMath::Beta ( x, ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) ) ) * TMath::Power ( ( params->get((int)0, 2) * params->get((int)0, 2) ) / ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) + ( params->get((int)0, 2) * params->get((int)0, 2) ) ), x ) * TMath::Power ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) / ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) + ( params->get((int)0, 2) * params->get((int)0, 2) ) ) , ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) ) +
+            1. / ( 1 + params->get((int)0, 1) * params->get((int)0, 1) ) *                              // 1 - alpha
+           // 		   v2 );
+            1. / ( x * TMath::Beta ( x, ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) ) ) * TMath::Power ( ( params->get((int)0, 4) * params->get((int)0, 4) ) / ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) + ( params->get((int)0, 4) * params->get((int)0, 4) ) ), x ) * TMath::Power ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) / ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) + ( params->get((int)0, 4) * params->get((int)0, 4) ) ) , ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) ) );
+  }
+
+  void init(InitContext const&)
+  {
+    std::random_device randomdevice;
+    randomgen.seed(randomdevice());
+    LOGP(info, ">>> Starting with params: {}, {}, {}, {}, {}, {}, {}", params->get((int)0, int(0)), params->get((int)0, 1), params->get((int)0, 2),
+         params->get((int)0, 3), params->get((int)0, 4), params->get((int)0, 5), params->get((int)0, 6));
+  }
+
+  template <typename MCC>
+  void checkSampling(MCC const& mccollisions)
+  {
+    weights.clear();
+    weights.resize(mccollisions.size());
+    std::fill(weights.begin(), weights.end(), (float)-1.);
+    auto i = 0;
+    LOGP(info, ">>> {} MC collisions for BC", mccollisions.size());
+    for (auto& mcc : mccollisions) {
+      auto value = (mcc.multMCNParticlesEta10() == 0) ? params->get((int)0, (int)0) : NormalizedDoubleNBD((double)mcc.multMCNParticlesEta10());
+      LOGP(info, ">>> {} value for reduction (threshold {})", value, (float)reductionFactor);
+      if (value < reductionFactor) {
+        // if the fraction of events at this multiplicity is less than reduction factor, keep the event as is
+        weights[i] = 1.f;
+        LOGP(info, ">>> keeping with weight {}", weights[i]);
+      } else {
+        // if the fraction of events at this multiplicity is greater than the reduction factor, randomly discard it or add with the weight
+        std::uniform_real_distribution<float> d(0, value);
+        auto r = d(randomgen);
+        LOGP(info, ">>> die roll: {}", r);
+        if (r > reductionFactor) {
+          // dicard
+          LOGP(info, ">>> discarding");
+        } else {
+          // keep
+          weights[i] = value / reductionFactor;
+          LOGP(info, ">>> keeping with weight {}", weights[i]);
+        }
+      }
+      ++i;
+    }
+  }
+
+  void process(BCs::iterator const& bc,
+               MCCollisions const& mccollisions,
+               Collisions const& collisions)
+  {
+    usedMCCs.clear();
+    usedLabels.clear();
+    // if BC has no collisions, skip it
+    if (mccollisions.size() == 0) {
+      return;
+    }
+    checkSampling(mccollisions);
+    // if all events are discarded, skip the BC
+    if (std::all_of(weights.begin(), weights.end(), [](auto const& x){ return x < 0; })) {
+      return;
+    }
+    // keep the BC
+    rbcs(bc.runNumber());
+    auto bcId = rbcs.lastIndex();
+    auto i = 0;
+    // check MC events
+    for (auto& mcc : mccollisions) {
+      // skip discarded events
+      if (weights[i] < 0) {
+        ++i;
+        continue;
+      }
+      rmcc(bcId, weights[i], mcc.posX(), mcc.posY(), mcc.posZ(), mcc.impactParameter(), mcc.multMCFT0A(), mcc.multMCFT0C(), mcc.multMCNParticlesEta05(), mcc.multMCNParticlesEta10());
+      rhepmci(rmcc.lastIndex(), mcc.xsectGen(), mcc.ptHard(), mcc.nMPI(), mcc.processId(), mcc.id1(), mcc.id2(), mcc.pdfId1(), mcc.pdfId2(), mcc.x1(), mcc.x2(), mcc.scalePdf(), mcc.pdf1(), mcc.pdf2());
+      // remember used events so that the index relation can be preserved
+      usedMCCs.push_back(mcc.globalIndex());
+      usedLabels.push_back(rmcc.lastIndex());
+      ++i;
+    }
+    i = 0;
+    // check Reco events
+    for (auto& c : collisions) {
+      // discard fake events
+      if (!c.has_mcCollision()) {
+        ++i;
+        continue;
+      }
+      // discard events for which MC event was discarded
+      auto pos = std::find(usedMCCs.begin(), usedMCCs.end(), c.mcCollisionId());
+      if (pos == usedMCCs.end()) {
+        ++i;
+        continue;
+      }
+      rc(bcId, c.posX(), c.posY(), c.posZ(), c.collisionTimeRes(), c.multFT0A(), c.multFT0C(), c.multFDDA(), c.multFDDC(), c.multZNA(), c.multZNC(), c.multNTracksPV(), c.multNTracksPVeta1(), c.multNTracksPVetaHalf());
+      rmcl(usedLabels[std::distance(usedMCCs.begin(), pos)]);
+      ++i;
+    }
+  }
+
+};
+
+struct ReducerTest {
+  HistogramRegistry r{
+    "Common",
+    {
+     {"ReconstructedMultiplicity", " ; N_{trk}", {HistType::kTH1F, {{301, -0.5, 300.5}}}}, //
+     {"GeneratedMultiplicity", " ; N_{particles}", {HistType::kTH1F, {{301, -0.5, 300.5}}}} //
+    }//
+  };
+
+  void process(aod::StoredRMCCollisions const& mccollisions, soa::Join<aod::StoredRCollisions, aod::StoredRMCColLabels> const& collisions)
+  {
+    for (auto& c : collisions) {
+        r.fill(HIST("ReconstructedMultiplicity"), c.multNTracksPVeta1(), c.rmccollision_as<aod::StoredRMCCollisions>().weight());
+    }
+    for (auto& c : mccollisions) {
+        r.fill(HIST("GeneratedMultiplicity"), c.multMCNParticlesEta10(), c.weight());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return {adaptAnalysisTask<Reducer>(cfgc), adaptAnalysisTask<ReducerTest>(cfgc)};
+}

--- a/PWGMM/Mult/TableProducer/reducer.cxx
+++ b/PWGMM/Mult/TableProducer/reducer.cxx
@@ -58,10 +58,10 @@ struct Reducer {
 
     return params->get((int)0, 6) *
            (params->get((int)0, 1) * params->get((int)0, 1) / (1. + params->get((int)0, 1) * params->get((int)0, 1)) * // alpha
-            // v1 +
+                                                                                                                       // v1 +
               1. / (x * TMath::Beta(x, (1. + params->get((int)0, 3) * params->get((int)0, 3)))) * TMath::Power((params->get((int)0, 2) * params->get((int)0, 2)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), x) * TMath::Power((1. + params->get((int)0, 3) * params->get((int)0, 3)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), (1. + params->get((int)0, 3) * params->get((int)0, 3))) +
             1. / (1 + params->get((int)0, 1) * params->get((int)0, 1)) * // 1 - alpha
-            // v2 );
+                                                                         // v2 );
               1. / (x * TMath::Beta(x, (1. + params->get((int)0, 5) * params->get((int)0, 5)))) * TMath::Power((params->get((int)0, 4) * params->get((int)0, 4)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), x) * TMath::Power((1. + params->get((int)0, 5) * params->get((int)0, 5)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), (1. + params->get((int)0, 5) * params->get((int)0, 5))));
   }
 

--- a/PWGMM/Mult/TableProducer/reducer.cxx
+++ b/PWGMM/Mult/TableProducer/reducer.cxx
@@ -20,7 +20,7 @@
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-static constexpr float defparams[1][7] = {{0.142664,	1.40302,	2.61158,	1.20139,	5.24992,	2.16384,	0.871307}};
+static constexpr float defparams[1][7] = {{0.142664, 1.40302, 2.61158, 1.20139, 5.24992, 2.16384, 0.871307}};
 
 struct Reducer {
   using BCs = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
@@ -57,12 +57,12 @@ struct Reducer {
     // alpha = p[1]^2 / ( 1 + p[1]^2), relative weight, 0 < alpha < 1
 
     return params->get((int)0, 6) *
-           ( params->get((int)0, 1) * params->get((int)0, 1) / ( 1. + params->get((int)0, 1) * params->get((int)0, 1) ) *                 //alpha
-           // 	       v1 +
-            1. / ( x * TMath::Beta ( x, ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) ) ) * TMath::Power ( ( params->get((int)0, 2) * params->get((int)0, 2) ) / ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) + ( params->get((int)0, 2) * params->get((int)0, 2) ) ), x ) * TMath::Power ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) / ( ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) + ( params->get((int)0, 2) * params->get((int)0, 2) ) ) , ( 1. + params->get((int)0, 3) * params->get((int)0, 3) ) ) +
-            1. / ( 1 + params->get((int)0, 1) * params->get((int)0, 1) ) *                              // 1 - alpha
-           // 		   v2 );
-            1. / ( x * TMath::Beta ( x, ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) ) ) * TMath::Power ( ( params->get((int)0, 4) * params->get((int)0, 4) ) / ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) + ( params->get((int)0, 4) * params->get((int)0, 4) ) ), x ) * TMath::Power ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) / ( ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) + ( params->get((int)0, 4) * params->get((int)0, 4) ) ) , ( 1. + params->get((int)0, 5) * params->get((int)0, 5) ) ) );
+           (params->get((int)0, 1) * params->get((int)0, 1) / (1. + params->get((int)0, 1) * params->get((int)0, 1)) * // alpha
+              // 	       v1 +
+              1. / (x * TMath::Beta(x, (1. + params->get((int)0, 3) * params->get((int)0, 3)))) * TMath::Power((params->get((int)0, 2) * params->get((int)0, 2)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), x) * TMath::Power((1. + params->get((int)0, 3) * params->get((int)0, 3)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), (1. + params->get((int)0, 3) * params->get((int)0, 3))) +
+            1. / (1 + params->get((int)0, 1) * params->get((int)0, 1)) * // 1 - alpha
+                                                                         // 		   v2 );
+              1. / (x * TMath::Beta(x, (1. + params->get((int)0, 5) * params->get((int)0, 5)))) * TMath::Power((params->get((int)0, 4) * params->get((int)0, 4)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), x) * TMath::Power((1. + params->get((int)0, 5) * params->get((int)0, 5)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), (1. + params->get((int)0, 5) * params->get((int)0, 5))));
   }
 
   void init(InitContext const&)
@@ -118,7 +118,7 @@ struct Reducer {
     }
     checkSampling(mccollisions);
     // if all events are discarded, skip the BC
-    if (std::all_of(weights.begin(), weights.end(), [](auto const& x){ return x < 0; })) {
+    if (std::all_of(weights.begin(), weights.end(), [](auto const& x) { return x < 0; })) {
       return;
     }
     // keep the BC
@@ -158,25 +158,24 @@ struct Reducer {
       ++i;
     }
   }
-
 };
 
 struct ReducerTest {
   HistogramRegistry r{
     "Common",
     {
-     {"ReconstructedMultiplicity", " ; N_{trk}", {HistType::kTH1F, {{301, -0.5, 300.5}}}}, //
-     {"GeneratedMultiplicity", " ; N_{particles}", {HistType::kTH1F, {{301, -0.5, 300.5}}}} //
-    }//
+      {"ReconstructedMultiplicity", " ; N_{trk}", {HistType::kTH1F, {{301, -0.5, 300.5}}}},  //
+      {"GeneratedMultiplicity", " ; N_{particles}", {HistType::kTH1F, {{301, -0.5, 300.5}}}} //
+    }                                                                                        //
   };
 
   void process(aod::StoredRMCCollisions const& mccollisions, soa::Join<aod::StoredRCollisions, aod::StoredRMCColLabels> const& collisions)
   {
     for (auto& c : collisions) {
-        r.fill(HIST("ReconstructedMultiplicity"), c.multNTracksPVeta1(), c.rmccollision_as<aod::StoredRMCCollisions>().weight());
+      r.fill(HIST("ReconstructedMultiplicity"), c.multNTracksPVeta1(), c.rmccollision_as<aod::StoredRMCCollisions>().weight());
     }
     for (auto& c : mccollisions) {
-        r.fill(HIST("GeneratedMultiplicity"), c.multMCNParticlesEta10(), c.weight());
+      r.fill(HIST("GeneratedMultiplicity"), c.multMCNParticlesEta10(), c.weight());
     }
   }
 };

--- a/PWGMM/Mult/TableProducer/reducer.cxx
+++ b/PWGMM/Mult/TableProducer/reducer.cxx
@@ -58,10 +58,10 @@ struct Reducer {
 
     return params->get((int)0, 6) *
            (params->get((int)0, 1) * params->get((int)0, 1) / (1. + params->get((int)0, 1) * params->get((int)0, 1)) * // alpha
-              // 	       v1 +
+            // v1 +
               1. / (x * TMath::Beta(x, (1. + params->get((int)0, 3) * params->get((int)0, 3)))) * TMath::Power((params->get((int)0, 2) * params->get((int)0, 2)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), x) * TMath::Power((1. + params->get((int)0, 3) * params->get((int)0, 3)) / ((1. + params->get((int)0, 3) * params->get((int)0, 3)) + (params->get((int)0, 2) * params->get((int)0, 2))), (1. + params->get((int)0, 3) * params->get((int)0, 3))) +
             1. / (1 + params->get((int)0, 1) * params->get((int)0, 1)) * // 1 - alpha
-                                                                         // 		   v2 );
+            // v2 );
               1. / (x * TMath::Beta(x, (1. + params->get((int)0, 5) * params->get((int)0, 5)))) * TMath::Power((params->get((int)0, 4) * params->get((int)0, 4)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), x) * TMath::Power((1. + params->get((int)0, 5) * params->get((int)0, 5)) / ((1. + params->get((int)0, 5) * params->get((int)0, 5)) + (params->get((int)0, 4) * params->get((int)0, 4))), (1. + params->get((int)0, 5) * params->get((int)0, 5))));
   }
 


### PR DESCRIPTION
* Reduced data model with collision, MC collision, track and particles information
* Task that produces collision and MC collision sampled trees

This is a task to create sampled trees of collision multiplicity information. Tail of multiplicity distribution is kept as is, while the bulk of the collisions are randomly discarded according to configured threshold. The rest are added with corresponding weight. The trees are intended to be small in size and used for ML studies. 