### PR TITLE
Incorporated the electrons and muons also to the PID QC

### DIFF
--- a/PWGCF/TableProducer/dptdptfilter.cxx
+++ b/PWGCF/TableProducer/dptdptfilter.cxx
@@ -570,6 +570,9 @@ struct DptDptFilterTracks {
   Configurable<o2::analysis::TrackSelectionPIDCfg> cfgElectronPIDSelection{"elpidsel",
                                                                            {},
                                                                            "PID criteria for electrons"};
+  Configurable<o2::analysis::TrackSelectionPIDCfg> cfgMuonPIDSelection{"mupidsel",
+                                                                       {},
+                                                                       "PID criteria for muons"};
 
   OutputObj<TList> fOutput{"DptDptFilterTracksInfo", OutputObjHandlingPolicy::AnalysisObject};
   PIDSpeciesSelection pidselector;
@@ -661,10 +664,11 @@ struct DptDptFilterTracks {
         }
       }
     };
+    insertInPIDselector(cfgElectronPIDSelection, 0);
+    insertInPIDselector(cfgMuonPIDSelection, 1);
     insertInPIDselector(cfgPionPIDSelection, 2);
     insertInPIDselector(cfgKaonPIDSelection, 3);
     insertInPIDselector(cfgProtonPIDSelection, 4);
-    insertInPIDselector(cfgElectronPIDSelection, 0);
 
     /* create the output list which will own the task histograms */
     TList* fOutputList = new TList();

--- a/PWGCF/TableProducer/dptdptfilter.h
+++ b/PWGCF/TableProducer/dptdptfilter.h
@@ -833,6 +833,7 @@ struct PIDSpeciesSelection {
   const char* getHadName() { return hadname; }
   const char* getHadTitle() { return hadtitle; }
   const char* getHadFName() { return hadfname; }
+  bool isSpeciesBeingSelected(uint8_t sp) { return std::find(species.begin(), species.end(), sp) != species.end(); }
   void storePIDAdjustments(TList* lst)
   {
     auto storedetectorwithcharge = [&](auto& detectorstore, auto detectorname, auto charge) {
@@ -949,10 +950,10 @@ struct PIDSpeciesSelection {
       return ((config->mPThreshold > 0.0) && (config->mPThreshold < track.p()));
     };
     auto isA = [&](auto& config, uint8_t sp) {
-      if (aboveThreshold(config)) {
-        if (track.hasTOF()) {
-          return closeToTPCTOF(config, sp) && awayFromTPCTOF(config, sp);
-        } else {
+      if (track.hasTOF()) {
+        return closeToTPCTOF(config, sp) && awayFromTPCTOF(config, sp);
+      } else {
+        if (aboveThreshold(config)) {
           if (config->mRequireTOF) {
             return false;
           }
@@ -991,14 +992,7 @@ struct PIDSpeciesSelection {
       }
     };
 
-    /* let's start discarding garbage */
-    if (track.hasTOF()) {
-      if (track.beta() < 0.42) {
-        return -127;
-      }
-    }
-
-    /* now adjust the nsigmas values if appropriate */
+    /* adjust the nsigmas values if appropriate */
     adjustnsigmas();
 
     /* let's first check the exclusion from the analysis */

--- a/PWGCF/Tasks/dptdptcorrelations.cxx
+++ b/PWGCF/Tasks/dptdptcorrelations.cxx
@@ -771,8 +771,8 @@ struct DptDptCorrelationsTask {
     {
       /* self configure the desired species */
       o2::analysis::dptdptfilter::PIDSpeciesSelection pidselector;
-      std::vector<std::string> cfgnames = {"pipidsel", "kapidsel", "prpidsel"};
-      std::vector<uint8_t> spids = {2, 3, 4};
+      std::vector<std::string> cfgnames = {"elpidsel", "mupidsel", "pipidsel", "kapidsel", "prpidsel"};
+      std::vector<uint8_t> spids = {0, 1, 2, 3, 4};
       for (uint i = 0; i < cfgnames.size(); ++i) {
         auto includeIt = [&pidselector, &initContext](int spid, auto name) {
           bool mUseIt = false;

--- a/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
@@ -609,7 +609,7 @@ struct DptDptEfficiencyAndQc {
   std::vector<HistogramRegistry*> registrybank{&registry_one, &registry_two, &registry_three, &registry_four, &registry_five,
                                                &registry_six, &registry_seven, &registry_eight, &registry_nine, &registry_ten};
   std::vector<HistogramRegistry*> pidregistrybank{&registry_pidone, &registry_pidtwo, &registry_pidthree, &registry_pidfour, &registry_pidfive,
-                                               &registry_pidsix, &registry_pidseven, &registry_pideight, &registry_pidnine, &registry_pidten};
+                                                  &registry_pidsix, &registry_pidseven, &registry_pideight, &registry_pidnine, &registry_pidten};
 
   Configurable<bool> inCentralityClasses{"usecentrality", false, "Perform the task using centrality/multiplicity classes. Default value: false"};
 

--- a/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/efficiencyAndQc.cxx
@@ -63,11 +63,11 @@ std::vector<std::string> tnames;   ///< the track names
 
 static const std::vector<o2::track::PID::ID> allmainspecies{o2::track::PID::Electron, o2::track::PID::Muon, o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton};
 static const std::vector<std::string> allmainspnames{"ElectronP", "ElectronM", "MuonP", "MuonM", "PionP", "PionM", "KaonP", "KaonM", "ProtonP", "ProtonM"};
+static const std::vector<std::string> allmainsptitles{"e^{#plus}", "e^{#minus}", "#mu^{#plus}", "#mu^{#minus}", "#pi^{#plus}", "#pi^{#minus}", "K^{#plus}", "K^{#minus}", "p", "#bar{p}"};
 static const std::vector<o2::track::PID::ID> mainspecies{o2::track::PID::Pion, o2::track::PID::Kaon, o2::track::PID::Proton};
 static const std::vector<std::string> mainspnames{"PionP", "PionM", "KaonP", "KaonM", "ProtonP", "ProtonM"};
-static const std::vector<int> pdgcodes = {11, 13, 211, 321, 2212};
 static const std::vector<std::string> mainsptitles{"#pi^{#plus}", "#pi^{#minus}", "K^{#plus}", "K^{#minus}", "p", "#bar{p}"};
-static const std::vector<std::string> allmainsptitles{"e^{#plus}", "e^{#minus}", "#mu^{#plus}", "#mu^{#minus}", "#pi^{#plus}", "#pi^{#minus}", "K^{#plus}", "K^{#minus}", "p", "#bar{p}"};
+static const std::vector<int> pdgcodes = {11, 13, 211, 321, 2212};
 } // namespace efficiencyandqatask
 
 /* the QA data collecting engine */
@@ -294,9 +294,9 @@ struct QADataCollectingEngine {
           h->Fill(track.eta(), track.pt());
         }
       };
-      bool hasits = track.hasITS() && ((track.trackCutFlag() & trackSelectionITS) == trackSelectionITS) && ((track.trackCutFlag() & trackSelectionDCA) == trackSelectionDCA);
-      bool hastpc = track.hasTPC() && ((track.trackCutFlag() & trackSelectionTPC) == trackSelectionTPC) && ((track.trackCutFlag() & trackSelectionDCA) == trackSelectionDCA);
-      bool hastof = track.hasTOF() && ((track.trackCutFlag() & trackSelectionDCA) == trackSelectionDCA);
+      bool hasits = track.hasITS() && TrackSelectionFlags::checkFlag(track.trackCutFlag(), trackSelectionITS) && TrackSelectionFlags::checkFlag(track.trackCutFlag(), trackSelectionDCA);
+      bool hastpc = track.hasTPC() && TrackSelectionFlags::checkFlag(track.trackCutFlag(), trackSelectionTPC);
+      bool hastof = track.hasTOF();
 
       fhITS_NCls_vs_PtB->Fill(track.pt(), track.itsNCls());
       fhITS_Chi2NCls_vs_PtB->Fill(track.pt(), track.itsChi2NCl());
@@ -596,8 +596,20 @@ struct DptDptEfficiencyAndQc {
   HistogramRegistry registry_eight{"registry_eight", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry registry_nine{"registry_nine", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry registry_ten{"registry_ten", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidone{"pidregistry_one", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidtwo{"pidregistry_two", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidthree{"pidregistry_three", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidfour{"pidregistry_four", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidfive{"pidregistry_five", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidsix{"pidregistry_six", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidseven{"pidregistry_seven", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pideight{"pidregistry_eight", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidnine{"pidregistry_nine", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registry_pidten{"pidregistry_ten", {}, OutputObjHandlingPolicy::AnalysisObject};
   std::vector<HistogramRegistry*> registrybank{&registry_one, &registry_two, &registry_three, &registry_four, &registry_five,
                                                &registry_six, &registry_seven, &registry_eight, &registry_nine, &registry_ten};
+  std::vector<HistogramRegistry*> pidregistrybank{&registry_pidone, &registry_pidtwo, &registry_pidthree, &registry_pidfour, &registry_pidfive,
+                                               &registry_pidsix, &registry_pidseven, &registry_pideight, &registry_pidnine, &registry_pidten};
 
   Configurable<bool> inCentralityClasses{"usecentrality", false, "Perform the task using centrality/multiplicity classes. Default value: false"};
 
@@ -627,8 +639,8 @@ struct DptDptEfficiencyAndQc {
 
       /* configuring the involved species */
       o2::analysis::dptdptfilter::PIDSpeciesSelection pidselector;
-      std::vector<std::string> cfgnames = {"pipidsel", "kapidsel", "prpidsel"};
-      std::vector<uint8_t> spids = {2, 3, 4};
+      std::vector<std::string> cfgnames = {"elpidsel", "mupidsel", "pipidsel", "kapidsel", "prpidsel"};
+      std::vector<uint8_t> spids = {0, 1, 2, 3, 4};
       for (uint i = 0; i < cfgnames.size(); ++i) {
         auto includeIt = [&pidselector, &initContext](int spid, auto name) {
           bool mUseIt = false;
@@ -699,22 +711,22 @@ struct DptDptEfficiencyAndQc {
       }
       /* in reverse order for proper order in results file */
       for (uint i = 0; i < ncmranges; ++i) {
-        auto initializeCEInstance = [&](auto dce, auto name) {
+        auto initializeCEInstance = [&](auto dce, auto name, auto& registry) {
           /* crete the output list for the passed centrality/multiplicity range */
           /* init the data collection instance */
-          dce->template init<kReco>(*registrybank[i], name.Data());
+          dce->template init<kReco>(registry, name.Data());
           if (doprocessGeneratorLevelNotStored) {
-            dce->template init<kGen>(*registrybank[i], name.Data());
+            dce->template init<kGen>(registry, name.Data());
           }
         };
-        auto buildQACEInstance = [&initializeCEInstance](float min, float max) {
+        auto buildQACEInstance = [&](float min, float max) {
           auto* dce = new QADataCollectingEngine();
-          initializeCEInstance(dce, TString::Format("EfficiencyAndQaData-%d-%d", static_cast<int>(min), static_cast<int>(max)));
+          initializeCEInstance(dce, TString::Format("EfficiencyAndQaData-%d-%d", static_cast<int>(min), static_cast<int>(max)), *registrybank[i]);
           return dce;
         };
-        auto buildPidCEInstance = [&initializeCEInstance](float min, float max) {
+        auto buildPidCEInstance = [&](float min, float max) {
           auto* dce = new PidDataCollectingEngine();
-          initializeCEInstance(dce, TString::Format("EfficiencyAndQaData-%d-%d", static_cast<int>(min), static_cast<int>(max)));
+          initializeCEInstance(dce, TString::Format("EfficiencyAndPidData-%d-%d", static_cast<int>(min), static_cast<int>(max)), *pidregistrybank[i]);
           return dce;
         };
         /* in reverse order for proper order in results file */


### PR DESCRIPTION
Also
- if there is TOF, always use it although the threshold were not reached (this should not make necessary to discard the garbage below a certain beta)
- the filters for the different matching now exclude the DCA cut