### PR TITLE
PWGHF: Fill DplusPi McRec table after correlated bkg checks

### DIFF
--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -326,7 +326,6 @@ struct HfDataCreatorCharmHadPiReduced {
           motherPt = particleMother.pt();
         }
       }
-      rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, debug, motherPt);
 
       // additional checks for correlated backgrounds
       if (checkDecayTypeMc) {
@@ -396,6 +395,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         rowHfDPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
       }
+      rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, debug, motherPt);
     } else if constexpr (decChannel == DecayChannel::BplusToD0barPi) {
       // B+ → D0(bar) π+ → (K+ π-) π+
       auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, Pdg::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);


### PR DESCRIPTION
Hello @fgrosa !

I found another bug :)

We need to fill the DplusPi McRec table after the decay type checks, otherwise the `flag` value is not updated.