### PR TITLE
PWGHF: Add columns of impact parameter z for daughters of 2-prong and 3-prong candidates

### DIFF
--- a/PWGHF/Core/HfMlResponseD0ToKPi.h
+++ b/PWGHF/Core/HfMlResponseD0ToKPi.h
@@ -81,11 +81,11 @@ enum class InputFeaturesD0ToKPi : uint8_t {
   decayLengthXY,
   decayLengthNormalised,
   decayLengthXYNormalised,
-  impactParameterNormalised0,
+  impactParameterXYNormalised0,
   ptProng0,
   ptProng1,
-  impactParameter0,
-  impactParameter1,
+  impactParameterXY0,
+  impactParameterXY1,
   impactParameterZ0,
   impactParameterZ1,
   nSigTpcPi0,
@@ -139,10 +139,10 @@ class HfMlResponseD0ToKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_D0(decayLengthXYNormalised);
         CHECK_AND_FILL_VEC_D0(ptProng0);
         CHECK_AND_FILL_VEC_D0(ptProng1);
-        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameter0, impactParameter0);
-        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameter1, impactParameter1);
-        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterZ0, impactParameterZ0);
-        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterZ1, impactParameterZ1);
+        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterXY0, impactParameter0);
+        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterXY1, impactParameter1);
+        CHECK_AND_FILL_VEC_D0(impactParameterZ0);
+        CHECK_AND_FILL_VEC_D0(impactParameterZ1);
         // TPC PID variables
         CHECK_AND_FILL_VEC_D0_FULL(prong0, nSigTpcPi0, tpcNSigmaPi);
         CHECK_AND_FILL_VEC_D0_FULL(prong0, nSigTpcKa0, tpcNSigmaKa);
@@ -183,8 +183,8 @@ class HfMlResponseD0ToKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_D0(decayLengthXYNormalised),
       FILL_MAP_D0(ptProng0),
       FILL_MAP_D0(ptProng1),
-      FILL_MAP_D0(impactParameter0),
-      FILL_MAP_D0(impactParameter1),
+      FILL_MAP_D0(impactParameterXY0),
+      FILL_MAP_D0(impactParameterXY1),
       FILL_MAP_D0(impactParameterZ0),
       FILL_MAP_D0(impactParameterZ1),
       // TPC PID variables

--- a/PWGHF/Core/HfMlResponseD0ToKPi.h
+++ b/PWGHF/Core/HfMlResponseD0ToKPi.h
@@ -86,6 +86,8 @@ enum class InputFeaturesD0ToKPi : uint8_t {
   ptProng1,
   impactParameter0,
   impactParameter1,
+  impactParameterZ0,
+  impactParameterZ1,
   nSigTpcPi0,
   nSigTpcKa0,
   nSigTofPi0,
@@ -139,6 +141,8 @@ class HfMlResponseD0ToKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_D0(ptProng1);
         CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameter0, impactParameter0);
         CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameter1, impactParameter1);
+        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterZ0, impactParameterZ0);
+        CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterZ1, impactParameterZ1);
         // TPC PID variables
         CHECK_AND_FILL_VEC_D0_FULL(prong0, nSigTpcPi0, tpcNSigmaPi);
         CHECK_AND_FILL_VEC_D0_FULL(prong0, nSigTpcKa0, tpcNSigmaKa);
@@ -181,6 +185,8 @@ class HfMlResponseD0ToKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_D0(ptProng1),
       FILL_MAP_D0(impactParameter0),
       FILL_MAP_D0(impactParameter1),
+      FILL_MAP_D0(impactParameterZ0),
+      FILL_MAP_D0(impactParameterZ1),
       // TPC PID variables
       FILL_MAP_D0(nSigTpcPi0),
       FILL_MAP_D0(nSigTpcKa0),

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -58,6 +58,9 @@ enum class InputFeaturesDplusToPiKPi : uint8_t {
   impactParameterXY0,
   impactParameterXY1,
   impactParameterXY2,
+  impactParameterZ0,
+  impactParameterZ1,
+  impactParameterZ2,
   decayLength,
   decayLengthXY,
   decayLengthNormalised,
@@ -115,6 +118,9 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ0, impactParameterZ0);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ1, impactParameterZ1);
+        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ2, impactParameterZ2);
         CHECK_AND_FILL_VEC_DPLUS(decayLength);
         CHECK_AND_FILL_VEC_DPLUS(decayLengthXY);
         CHECK_AND_FILL_VEC_DPLUS(decayLengthNormalised);
@@ -161,6 +167,9 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_DPLUS(impactParameterXY0),
       FILL_MAP_DPLUS(impactParameterXY1),
       FILL_MAP_DPLUS(impactParameterXY2),
+      FILL_MAP_DPLUS(impactParameterZ0),
+      FILL_MAP_DPLUS(impactParameterZ1),
+      FILL_MAP_DPLUS(impactParameterZ2),
       FILL_MAP_DPLUS(decayLength),
       FILL_MAP_DPLUS(decayLengthXY),
       FILL_MAP_DPLUS(decayLengthNormalised),

--- a/PWGHF/Core/HfMlResponseDplusToPiKPi.h
+++ b/PWGHF/Core/HfMlResponseDplusToPiKPi.h
@@ -118,9 +118,9 @@ class HfMlResponseDplusToPiKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterXY2, impactParameter2);
-        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ0, impactParameterZ0);
-        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ1, impactParameterZ1);
-        CHECK_AND_FILL_VEC_DPLUS_FULL(candidate, impactParameterZ2, impactParameterZ2);
+        CHECK_AND_FILL_VEC_DPLUS(impactParameterZ0);
+        CHECK_AND_FILL_VEC_DPLUS(impactParameterZ1);
+        CHECK_AND_FILL_VEC_DPLUS(impactParameterZ2);
         CHECK_AND_FILL_VEC_DPLUS(decayLength);
         CHECK_AND_FILL_VEC_DPLUS(decayLengthXY);
         CHECK_AND_FILL_VEC_DPLUS(decayLengthNormalised);

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -146,9 +146,9 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY2, impactParameter2);
-        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ0, impactParameterZ0);
-        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ1, impactParameterZ1);
-        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ2, impactParameterZ2);
+        CHECK_AND_FILL_VEC_DS(impactParameterZ0);
+        CHECK_AND_FILL_VEC_DS(impactParameterZ1);
+        CHECK_AND_FILL_VEC_DS(impactParameterZ2);
         // TPC PID variables
         CHECK_AND_FILL_VEC_DS_FULL(prong0, nSigTpcPi0, tpcNSigmaPi);
         CHECK_AND_FILL_VEC_DS_FULL(prong1, nSigTpcPi1, tpcNSigmaPi);

--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -86,6 +86,9 @@ enum class InputFeaturesDsToKKPi : uint8_t {
   impactParameterXY0,
   impactParameterXY1,
   impactParameterXY2,
+  impactParameterZ0,
+  impactParameterZ1,
+  impactParameterZ2,
   nSigTpcPi0,
   nSigTpcPi1,
   nSigTpcPi2,
@@ -143,6 +146,9 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ0, impactParameterZ0);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ1, impactParameterZ1);
+        CHECK_AND_FILL_VEC_DS_FULL(candidate, impactParameterZ2, impactParameterZ2);
         // TPC PID variables
         CHECK_AND_FILL_VEC_DS_FULL(prong0, nSigTpcPi0, tpcNSigmaPi);
         CHECK_AND_FILL_VEC_DS_FULL(prong1, nSigTpcPi1, tpcNSigmaPi);

--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -130,9 +130,9 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY2, impactParameter2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ0, impactParameterZ0);
-        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ1, impactParameterZ1);
-        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ2, impactParameterZ2);
+        CHECK_AND_FILL_VEC_LCTOPKPI(impactParameterZ0);
+        CHECK_AND_FILL_VEC_LCTOPKPI(impactParameterZ1);
+        CHECK_AND_FILL_VEC_LCTOPKPI(impactParameterZ2);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLength);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLengthXY);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLengthXYNormalised);

--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -63,6 +63,9 @@ enum class InputFeaturesLcToPKPi : uint8_t {
   impactParameterXY0,
   impactParameterXY1,
   impactParameterXY2,
+  impactParameterZ0,
+  impactParameterZ1,
+  impactParameterZ2,
   decayLength,
   decayLengthXY,
   decayLengthXYNormalised,
@@ -127,6 +130,9 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ0, impactParameterZ0);
+        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ1, impactParameterZ1);
+        CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, impactParameterZ2, impactParameterZ2);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLength);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLengthXY);
         CHECK_AND_FILL_VEC_LCTOPKPI(decayLengthXYNormalised);
@@ -180,6 +186,9 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_LCTOPKPI(impactParameterXY0),
       FILL_MAP_LCTOPKPI(impactParameterXY1),
       FILL_MAP_LCTOPKPI(impactParameterXY2),
+      FILL_MAP_LCTOPKPI(impactParameterZ0),
+      FILL_MAP_LCTOPKPI(impactParameterZ1),
+      FILL_MAP_LCTOPKPI(impactParameterZ2),
       FILL_MAP_LCTOPKPI(decayLength),
       FILL_MAP_LCTOPKPI(decayLengthXY),
       FILL_MAP_LCTOPKPI(decayLengthXYNormalised),

--- a/PWGHF/Core/HfMlResponseXicToPKPi.h
+++ b/PWGHF/Core/HfMlResponseXicToPKPi.h
@@ -57,6 +57,9 @@ enum class InputFeaturesXicToPKPi : uint8_t {
   impactParameterXY0,
   impactParameterXY1,
   impactParameterXY2,
+  impactParameterZ0,
+  impactParameterZ1,
+  impactParameterZ2,
   decayLength,
   decayLengthXY,
   decayLengthXYNormalised,
@@ -122,6 +125,9 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ0, impactParameterZ0);
+        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ1, impactParameterZ1);
+        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ2, impactParameterZ2);
         CHECK_AND_FILL_VEC_XIC(decayLength);
         CHECK_AND_FILL_VEC_XIC(decayLengthXY);
         CHECK_AND_FILL_VEC_XIC(decayLengthXYNormalised);
@@ -175,6 +181,9 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_XIC(impactParameterXY0),
       FILL_MAP_XIC(impactParameterXY1),
       FILL_MAP_XIC(impactParameterXY2),
+      FILL_MAP_XIC(impactParameterZ0),
+      FILL_MAP_XIC(impactParameterZ1),
+      FILL_MAP_XIC(impactParameterZ2),
       FILL_MAP_XIC(decayLength),
       FILL_MAP_XIC(decayLengthXY),
       FILL_MAP_XIC(decayLengthXYNormalised),

--- a/PWGHF/Core/HfMlResponseXicToPKPi.h
+++ b/PWGHF/Core/HfMlResponseXicToPKPi.h
@@ -125,9 +125,9 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY0, impactParameter0);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY1, impactParameter1);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterXY2, impactParameter2);
-        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ0, impactParameterZ0);
-        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ1, impactParameterZ1);
-        CHECK_AND_FILL_VEC_XIC_FULL(candidate, impactParameterZ2, impactParameterZ2);
+        CHECK_AND_FILL_VEC_XIC(impactParameterZ0);
+        CHECK_AND_FILL_VEC_XIC(impactParameterZ1);
+        CHECK_AND_FILL_VEC_XIC(impactParameterZ2);
         CHECK_AND_FILL_VEC_XIC(decayLength);
         CHECK_AND_FILL_VEC_XIC(decayLengthXY);
         CHECK_AND_FILL_VEC_XIC(decayLengthXYNormalised);

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -441,6 +441,10 @@ DECLARE_SOA_COLUMN(ImpactParameter0, impactParameter0, float);                  
 DECLARE_SOA_COLUMN(ErrorImpactParameter0, errorImpactParameter0, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised0, impactParameterNormalised0, //!
                            [](float dca, float err) -> float { return dca / err; });
+DECLARE_SOA_COLUMN(ImpactParameterZ0, impactParameterZ0, float);                     //!
+DECLARE_SOA_COLUMN(ErrorImpactParameterZ0, errorImpactParameterZ0, float);           //!
+DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterZNormalised0, impactParameterZNormalised0, //!
+                           [](float dca, float err) -> float { return dca / err; });
 DECLARE_SOA_COLUMN(PxProng1, pxProng1, float); //!
 DECLARE_SOA_COLUMN(PyProng1, pyProng1, float); //!
 DECLARE_SOA_COLUMN(PzProng1, pzProng1, float); //!
@@ -454,6 +458,10 @@ DECLARE_SOA_COLUMN(ImpactParameter1, impactParameter1, float);                  
 DECLARE_SOA_COLUMN(ErrorImpactParameter1, errorImpactParameter1, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised1, impactParameterNormalised1, //!
                            [](float dca, float err) -> float { return dca / err; });
+DECLARE_SOA_COLUMN(ImpactParameterZ1, impactParameterZ1, float);                     //!
+DECLARE_SOA_COLUMN(ErrorImpactParameterZ1, errorImpactParameterZ1, float);           //!
+DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterZNormalised1, impactParameterZNormalised1, //!
+                           [](float dca, float err) -> float { return dca / err; });
 DECLARE_SOA_COLUMN(PxProng2, pxProng2, float); //!
 DECLARE_SOA_COLUMN(PyProng2, pyProng2, float); //!
 DECLARE_SOA_COLUMN(PzProng2, pzProng2, float); //!
@@ -466,6 +474,10 @@ DECLARE_SOA_DYNAMIC_COLUMN(PVectorProng2, pVectorProng2, //!
 DECLARE_SOA_COLUMN(ImpactParameter2, impactParameter2, float);                     //!
 DECLARE_SOA_COLUMN(ErrorImpactParameter2, errorImpactParameter2, float);           //!
 DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterNormalised2, impactParameterNormalised2, //!
+                           [](float dca, float err) -> float { return dca / err; });
+DECLARE_SOA_COLUMN(ImpactParameterZ2, impactParameterZ2, float);                     //!
+DECLARE_SOA_COLUMN(ErrorImpactParameterZ2, errorImpactParameterZ2, float);           //!
+DECLARE_SOA_DYNAMIC_COLUMN(ImpactParameterZNormalised2, impactParameterZNormalised2, //!
                            [](float dca, float err) -> float { return dca / err; });
 DECLARE_SOA_COLUMN(NProngsContributorsPV, nProngsContributorsPV, uint8_t); //! number of prongs contributing to the primary-vertex reconstruction
 // candidate properties
@@ -583,6 +595,8 @@ DECLARE_SOA_TABLE(HfCand2ProngBase, "AOD", "HFCAND2PBASE", //!
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1,
+                  hf_cand::ImpactParameterZ0, hf_cand::ImpactParameterZ1,
+                  hf_cand::ErrorImpactParameterZ0, hf_cand::ErrorImpactParameterZ1,
                   hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_cand::NProngsContributorsPV,
                   hf_track_index::HFflag,
                   /* dynamic columns */
@@ -846,6 +860,8 @@ DECLARE_SOA_TABLE(HfCand3ProngBase, "AOD", "HFCAND3PBASE", //!
                   hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2,
                   hf_cand::ImpactParameter0, hf_cand::ImpactParameter1, hf_cand::ImpactParameter2,
                   hf_cand::ErrorImpactParameter0, hf_cand::ErrorImpactParameter1, hf_cand::ErrorImpactParameter2,
+                  hf_cand::ImpactParameterZ0, hf_cand::ImpactParameterZ1, hf_cand::ImpactParameterZ2,
+                  hf_cand::ErrorImpactParameterZ0, hf_cand::ErrorImpactParameterZ1, hf_cand::ErrorImpactParameterZ2,
                   hf_track_index::Prong0Id, hf_track_index::Prong1Id, hf_track_index::Prong2Id, hf_cand::NProngsContributorsPV,
                   hf_track_index::HFflag,
                   /* dynamic columns */

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -288,6 +288,8 @@ struct HfCandidateCreator2Prong {
                        pvec1[0], pvec1[1], pvec1[2],
                        impactParameter0.getY(), impactParameter1.getY(),
                        std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()),
+                       impactParameter0.getZ(), impactParameter1.getZ(),
+                       std::sqrt(impactParameter0.getSigmaZ2()), std::sqrt(impactParameter1.getSigmaZ2()),
                        rowTrackIndexProng2.prong0Id(), rowTrackIndexProng2.prong1Id(), nProngsContributorsPV,
                        rowTrackIndexProng2.hfflag());
 
@@ -431,6 +433,7 @@ struct HfCandidateCreator2Prong {
                        kfNegKaon.GetPx(), kfNegKaon.GetPy(), kfNegKaon.GetPz(),
                        impactParameter0XY, impactParameter1XY,
                        errImpactParameter0XY, errImpactParameter1XY,
+                       0.0, 0.0, 0.0, 0.0,
                        rowTrackIndexProng2.prong0Id(), rowTrackIndexProng2.prong1Id(), nProngsContributorsPV,
                        rowTrackIndexProng2.hfflag());
       rowCandidateKF(topolChi2PerNdfD0,

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -433,7 +433,8 @@ struct HfCandidateCreator2Prong {
                        kfNegKaon.GetPx(), kfNegKaon.GetPy(), kfNegKaon.GetPz(),
                        impactParameter0XY, impactParameter1XY,
                        errImpactParameter0XY, errImpactParameter1XY,
-                       0.0, 0.0, 0.0, 0.0,
+                       0.f, 0.f,
+                       0.f, 0.f,
                        rowTrackIndexProng2.prong0Id(), rowTrackIndexProng2.prong1Id(), nProngsContributorsPV,
                        rowTrackIndexProng2.hfflag());
       rowCandidateKF(topolChi2PerNdfD0,

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -294,6 +294,8 @@ struct HfCandidateCreator3Prong {
                        pvec2[0], pvec2[1], pvec2[2],
                        impactParameter0.getY(), impactParameter1.getY(), impactParameter2.getY(),
                        std::sqrt(impactParameter0.getSigmaY2()), std::sqrt(impactParameter1.getSigmaY2()), std::sqrt(impactParameter2.getSigmaY2()),
+                       impactParameter0.getZ(), impactParameter1.getZ(), impactParameter2.getZ(),
+                       std::sqrt(impactParameter0.getSigmaZ2()), std::sqrt(impactParameter1.getSigmaZ2()), std::sqrt(impactParameter2.getSigmaZ2()),
                        rowTrackIndexProng3.prong0Id(), rowTrackIndexProng3.prong1Id(), rowTrackIndexProng3.prong2Id(), nProngsContributorsPV,
                        rowTrackIndexProng3.hfflag());
 


### PR DESCRIPTION
Also changed the name of impact parameter features in the HfMlResponseD0ToKPi  to explicitly be impactparameterXY