### PR TITLE
PWGHF: fix loop over generated particles toXiPi

### DIFF
--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -291,7 +291,7 @@ struct EventSelectionQaTask {
 
     histos.add("hVtxFT0VsVtxCol", "", kTH2F, {axisVtxZ, axisVtxZ});                // FT0-vertex vs z-vertex from collisions
     histos.add("hVtxFT0MinusVtxCol", "", kTH1F, {axisVtxZ});                       // FT0-vertex minus z-vertex from collisions
-    histos.add("hVtxFT0MinusVtxColVsMultT0M", "", kTH1F, {axisVtxZ, axisMultT0M}); // FT0-vertex minus z-vertex from collisions vs multiplicity
+    histos.add("hVtxFT0MinusVtxColVsMultT0M", "", kTH2F, {axisVtxZ, axisMultT0M}); // FT0-vertex minus z-vertex from collisions vs multiplicity
 
     histos.add("hFoundBc", "", kTH1F, {axisBCs});            // distribution of found bcs (for ITS ROF studies)
     histos.add("hFoundBcTOF", "", kTH1F, {axisBCs});         // distribution of found bcs (TOF-matched vertex)

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -478,15 +478,23 @@ struct HfCandidateCreatorToXiPiMc {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
-          // Xi -> Lambda pi
-          auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
-          if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
-            debugGenXi = 1;
-            // Lambda -> p pi
-            auto v0MC = mcParticles.rawIteratorAt(cascMC.daughtersIds().front());
-            if (RecoDecay::isMatchedMCGen(mcParticles, v0MC, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
-              debugGenLambda = 1;
-              flag = sign * (1 << aod::hf_cand_toxipi::DecayType::OmegaczeroToXiPi);
+          for(const auto& daughterCharm : particle.daughters_as<aod::McParticles>()){
+            if(std::abs(daughterCharm.pdgCode()) != pdgCodeXiMinus){
+              continue;
+            }
+            // Xi -> Lambda pi
+            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
+              debugGenXi = 1;
+              for(const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()){
+                if(std::abs(daughterCascade.pdgCode()) != pdgCodeLambda){
+                  continue;
+                }
+                // Lambda -> p pi
+                if(RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
+                  debugGenLambda = 1;
+                  flag = sign * (1 << aod::hf_cand_toxipi::DecayType::OmegaczeroToXiPi);
+                }
+              }
             }
           }
         }
@@ -495,21 +503,30 @@ struct HfCandidateCreatorToXiPiMc {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true);
         }
       }
+
       if (matchXicMc) {
         //  Xic → Xi pi
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
-          // Xi- -> Lambda pi
-          auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
-          if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
-            debugGenXi = 1;
-            // Lambda -> p pi
-            auto v0MC = mcParticles.rawIteratorAt(cascMC.daughtersIds().front());
-            if (RecoDecay::isMatchedMCGen(mcParticles, v0MC, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
-              debugGenLambda = 1;
-              flag = sign * (1 << aod::hf_cand_toxipi::DecayType::XiczeroToXiPi);
+          for(const auto& daughterCharm : particle.daughters_as<aod::McParticles>()){
+            if(std::abs(daughterCharm.pdgCode()) != pdgCodeXiMinus){
+              continue;
+            }
+            // Xi -> Lambda pi
+            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
+              debugGenXi = 1;
+              for(const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()){
+                if(std::abs(daughterCascade.pdgCode()) != pdgCodeLambda){
+                  continue;
+                }
+                // Lambda -> p pi
+                if(RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
+                  debugGenLambda = 1;
+                  flag = sign * (1 << aod::hf_cand_toxipi::DecayType::XiczeroToXiPi);
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Fix loop over generated particles in candidateCreatorToXiPi: now at each step of the decay chain all the daughters are taken into account