### PR TITLE
[PWGMM] Change the type of histograms in trackPropagation.cxx

### DIFF
--- a/PWGMM/Mult/TableProducer/trackPropagation.cxx
+++ b/PWGMM/Mult/TableProducer/trackPropagation.cxx
@@ -93,8 +93,8 @@ struct AmbiguousTrackPropagation {
       registry.add({"TracksDCAXY", " ; DCA_{XY} (cm)", {HistType::kTH1F, {DCAxyAxis}}});
       registry.add({"ReassignedDCAXY", " ; DCA_{XY} (cm)", {HistType::kTH1F, {DCAxyAxis}}});
       registry.add({"TracksOrigDCAXY", " ; DCA_{XY} (wrt orig coll) (cm)", {HistType::kTH1F, {DCAxyAxis}}});
-      registry.add({"TracksAmbDegree", " ; N_{coll}^{comp}", {HistType::kTH1I, {{41, -0.5, 40.5}}}});
-      registry.add({"TrackIsAmb", " ; isAmbiguous", {HistType::kTH1I, {{2, -0.5, 1.5}}}});
+      registry.add({"TracksAmbDegree", " ; N_{coll}^{comp}", {HistType::kTH1D, {{41, -0.5, 40.5}}}});
+      registry.add({"TrackIsAmb", " ; isAmbiguous", {HistType::kTH1D, {{2, -0.5, 1.5}}}});
     }
   }
 


### PR DESCRIPTION
This will allow the bin entries to go up to 2^53, instead of 2.147E9