### PR TITLE
Common: RecoDecay: Consider only particles coming from decay process when matching

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -645,10 +645,8 @@ class RecoDecay
       // for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
       //   printf(" ");
       // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
-      // check if the particle comes from a decay process
-      if (particle.getProcess() == TMCProcess::kPDecay) {
-        list->push_back(particle.globalIndex());
-      }
+      // check if the particle comes from a decay process   
+      list->push_back(particle.globalIndex());
       return;
     }
     // If we are here, we have to follow the daughter tree.
@@ -745,6 +743,12 @@ class RecoDecay
         }
         // Get the list of actual final daughters.
         getDaughters(particleMother, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
+        // remove daughters not coming from the decay process
+        for(int j=0; j<static_cast<int>(arrAllDaughtersIndex.size()); j++){
+          if(particlesMC.rawIteratorAt(arrAllDaughtersIndex[j] - particlesMC.offset()).getProcess() != TMCProcess::kPDecay){
+            arrAllDaughtersIndex.erase(arrAllDaughtersIndex.begin() + j);
+          }
+        }
         // printf("MC Rec: Mother %d has %d final daughters:", indexMother, arrAllDaughtersIndex.size());
         // for (auto i : arrAllDaughtersIndex) {
         //   printf(" %d", i);
@@ -860,6 +864,7 @@ class RecoDecay
       }
       // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
       for (const auto& dau : candidate.template daughters_as<T>()) {
+        //printf("Daughter production process is %i", dau.getProcess());
         if (dau.getProcess() == TMCProcess::kPDecay) {
           dauCounter++;
         }
@@ -870,6 +875,12 @@ class RecoDecay
       }
       // Get the list of actual final daughters.
       getDaughters(candidate, &arrAllDaughtersIndex, arrPDGDaughters, depthMax);
+      // remove daughters not coming from the decay process
+      for(int j=0; j<static_cast<int>(arrAllDaughtersIndex.size()); j++){
+        if(particlesMC.rawIteratorAt(arrAllDaughtersIndex[j] - particlesMC.offset()).getProcess() != TMCProcess::kPDecay){
+          arrAllDaughtersIndex.erase(arrAllDaughtersIndex.begin() + j);
+        }
+      }
       // printf("MC Gen: Mother %ld has %ld final daughters:", candidate.globalIndex(), arrAllDaughtersIndex.size());
       // for (auto i : arrAllDaughtersIndex) {
       //   printf(" %d", i);

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -24,7 +24,6 @@
 #include <vector>    // std::vector
 
 #include "CommonConstants/MathConstants.h"
-#include "Framework/AnalysisDataModel.h"
 #include "TMCProcess.h" // for VMC Particle Production Process
 
 /// Base class for calculating properties of reconstructed decays

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -644,8 +644,7 @@ class RecoDecay
       // printf("getDaughters: ");
       // for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
       //   printf(" ");
-      // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
-      // check if the particle comes from a decay process   
+      // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle); 
       list->push_back(particle.globalIndex());
       return;
     }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -24,6 +24,7 @@
 #include <vector>    // std::vector
 
 #include "CommonConstants/MathConstants.h"
+#include "Framework/AnalysisDataModel.h"
 #include "TMCProcess.h" // for VMC Particle Production Process
 
 /// Base class for calculating properties of reconstructed decays

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -24,7 +24,6 @@
 #include <vector>    // std::vector
 
 #include "CommonConstants/MathConstants.h"
-#include "TMCProcess.h" // for VMC Particle Production Process
 
 /// Base class for calculating properties of reconstructed decays
 ///
@@ -645,9 +644,8 @@ class RecoDecay
       // for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
       //   printf(" ");
       // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
-      printf("Daughter production process is %i\n", particle.getProcess());
-      printf("Daughter pdg code is %i\n", particle.pdgCode());
-      if(particle.getProcess() == TMCProcess::kPDecay){
+
+      if(particle.getProcess() == 4){
         list->push_back(particle.globalIndex());
       }
       
@@ -712,7 +710,7 @@ class RecoDecay
       }
       auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
       // check if the daughter candidate comes from a decay process
-      if (particleI.getProcess() != TMCProcess::kPDecay) {
+      if (particleI.getProcess() != 4) {
         return -1;
       }
       arrDaughtersIndex[iProng] = particleI.globalIndex();

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -862,8 +862,8 @@ class RecoDecay
         return false;
       }
       // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-      for (const auto& dau : candidate.template daughters_as<T>()) {
-        // printf("Daughter production process is %i", dau.getProcess());
+      for (const auto& dau : candidate.template daughters_as<typename std::decay_t<U>::parent_t>()) {
+        printf("Daughter production process is %i", dau.getProcess());
         if (dau.getProcess() == TMCProcess::kPDecay) {
           dauCounter++;
         }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -23,8 +23,9 @@
 #include <utility>   // std::move
 #include <vector>    // std::vector
 
-#include "CommonConstants/MathConstants.h"
 #include "TMCProcess.h" // for VMC Particle Production Process
+#include "CommonConstants/MathConstants.h"
+
 
 /// Base class for calculating properties of reconstructed decays
 ///
@@ -596,6 +597,7 @@ class RecoDecay
   }
 
   /// Gets the complete list of indices of final-state daughters of an MC particle.
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \param particle  MC particle
   /// \param list  vector where the indices of final-state daughters will be added
   /// \param arrPDGFinal  array of PDG codes of particles to be considered final if found
@@ -615,6 +617,7 @@ class RecoDecay
       return;
     }
     if constexpr (checkProcess) {
+      // If the particle is neither the original particle nor coming from a decay, we do nothing and exit.
       if (stage != 0 && particle.getProcess() != TMCProcess::kPDecay && particle.getProcess() != TMCProcess::kPPrimary) { // decay products of HF hadrons are labeled as kPPrimary
         return;
       }
@@ -674,6 +677,7 @@ class RecoDecay
   /// \param acceptAntiParticles  switch to accept the antiparticle version of the expected decay
   /// \param sign  antiparticle indicator of the found mother w.r.t. PDGMother; 1 if particle, -1 if antiparticle, 0 if mother not found
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return index of the mother particle if the mother and daughters are correct, -1 otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, std::size_t N, typename T, typename U>
   static int getMatchedMCRec(const T& particlesMC,
@@ -793,6 +797,7 @@ class RecoDecay
   /// \param PDGParticle  expected particle PDG code
   /// \param acceptAntiParticles  switch to accept the antiparticle
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return true if PDG code of the particle is correct, false otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, typename T, typename U>
   static int isMatchedMCGen(const T& particlesMC,
@@ -814,6 +819,7 @@ class RecoDecay
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \param listIndexDaughters  vector of indices of found daughter
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, std::size_t N, typename T, typename U>
   static bool isMatchedMCGen(const T& particlesMC,

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -24,6 +24,7 @@
 #include <vector>    // std::vector
 
 #include "CommonConstants/MathConstants.h"
+#include "TMCProcess.h" // for VMC Particle Production Process
 
 /// Base class for calculating properties of reconstructed decays
 ///
@@ -677,7 +678,7 @@ class RecoDecay
                              bool acceptAntiParticles = false,
                              int8_t* sign = nullptr,
                              int depthMax = 1,
-                             bool checkProcess = true)
+                             bool checkProcess = false)
   {
     // Printf("MC Rec: Expected mother PDG: %d", PDGMother);
     int8_t coefFlavourOscillation = 1;     // 1 if no B0(s) flavour oscillation occured, -1 else
@@ -707,10 +708,6 @@ class RecoDecay
         return -1;
       }
       auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
-      // check if the daughter candidate comes from a decay process
-      if (checkProcess && particleI.getProcess() != 4) {
-        return -1;
-      }
       arrDaughtersIndex[iProng] = particleI.globalIndex();
       // Get the list of daughter indices from the mother of the first prong.
       if (iProng == 0) {
@@ -754,6 +751,9 @@ class RecoDecay
       // Check daughter's PDG code.
       auto PDGParticleI = particleI.pdgCode(); // PDG code of the ith daughter
       // Printf("MC Rec: Daughter %d PDG: %d", iProng, PDGParticleI);
+      if(checkProcess && particleI.getProcess() != TMCProcess::kPDecay){                                   // production process of the ith daughter
+        continue;
+      }   
       bool isPDGFound = false; // Is the PDG code of this daughter among the remaining expected PDG codes?
       for (std::size_t iProngCp = 0; iProngCp < N; ++iProngCp) {
         if (PDGParticleI == coefFlavourOscillation * sgn * arrPDGDaughters[iProngCp]) {
@@ -788,7 +788,7 @@ class RecoDecay
                             int PDGParticle,
                             bool acceptAntiParticles = false,
                             int8_t* sign = nullptr,
-                            bool checkProcess = true)
+                            bool checkProcess = false)
   {
     std::array<int, 0> arrPDGDaughters;
     return isMatchedMCGen<acceptFlavourOscillation>(particlesMC, candidate, PDGParticle, std::move(arrPDGDaughters), acceptAntiParticles, sign, checkProcess);
@@ -814,7 +814,7 @@ class RecoDecay
                              int8_t* sign = nullptr,
                              int depthMax = 1,
                              std::vector<int>* listIndexDaughters = nullptr,
-                             bool checkProcess = true)
+                             bool checkProcess = false)
   {
     // Printf("MC Gen: Expected particle PDG: %d", PDGParticle);
     int8_t coefFlavourOscillation = 1; // 1 if no B0(s) flavour oscillation occured, -1 else
@@ -863,7 +863,7 @@ class RecoDecay
       for (auto indexDaughterI : arrAllDaughtersIndex) {
         auto candidateDaughterI = particlesMC.rawIteratorAt(indexDaughterI - particlesMC.offset()); // ith daughter particle
         auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();                                  // PDG code of the ith daughter   
-        if(checkProcess && candidateDaughterI.getProcess() != 4){                                   // production process of the ith daughter
+        if(checkProcess && candidateDaughterI.getProcess() != TMCProcess::kPDecay){                                   // production process of the ith daughter
           continue;
         }                       
         // Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -614,10 +614,6 @@ class RecoDecay
       // Printf("getDaughters: Error: No list!");
       return;
     }
-    // check if the particle comes from a decay process
-    if (particle.getProcess() != kPDecay) {
-      return;
-    }
     bool isFinal = false;                     // Flag to indicate the end of recursion
     if (depthMax > -1 && stage >= depthMax) { // Maximum depth has been reached (or exceeded).
       isFinal = true;
@@ -649,7 +645,10 @@ class RecoDecay
       // for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
       //   printf(" ");
       // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
-      list->push_back(particle.globalIndex());
+      // check if the particle comes from a decay process
+      if(particle.getProcess() == kPDecay){
+        list->push_back(particle.globalIndex());
+      }
       return;
     }
     // If we are here, we have to follow the daughter tree.

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -719,7 +719,6 @@ class RecoDecay
       if (iProng == 0) {
         // Get the mother index and its sign.
         // PDG code of the first daughter's mother determines whether the expected mother is a particle or antiparticle.
-        //FIX!
         indexMother = getMother(particlesMC, particleI, PDGMother, acceptAntiParticles, &sgn, depthMax);
         // Check whether mother was found.
         if (indexMother <= -1) {

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -646,7 +646,7 @@ class RecoDecay
       //   printf(" ");
       // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
       // check if the particle comes from a decay process
-      if (particle.getProcess() == kPDecay) {
+      if (particle.getProcess() == TMCProcess::kPDecay) {
         list->push_back(particle.globalIndex());
       }
       return;
@@ -711,7 +711,7 @@ class RecoDecay
       }
       auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
       // check if the daughter candidate comes from a decay process
-      if (particleI.getProcess() != kPDecay) {
+      if (particleI.getProcess() != TMCProcess::kPDecay) {
         return -1;
       }
       arrDaughtersIndex[iProng] = particleI.globalIndex();
@@ -733,9 +733,9 @@ class RecoDecay
           // Printf("MC Rec: Rejected: bad daughter index range: %d-%d", particleMother.daughtersIds().front(), particleMother.daughtersIds().back());
           return -1;
         }
-        // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-        for (const auto& dau : particleMother.template daughters_as<o2::aod::McParticles>()) {
-          if (dau.getProcess() == kPDecay) {
+        // Check that the number of direct daughters coming from the decay is not larger than the number of expected final daughters.
+        for (const auto& dau : particleMother.template daughters_as<T>()) {
+          if (dau.getProcess() == TMCProcess::kPDecay) {
             dauCounter++;
           }
         }
@@ -859,8 +859,8 @@ class RecoDecay
         return false;
       }
       // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-      for (const auto& dau : candidate.template daughters_as<o2::aod::McParticles>()) {
-        if (dau.getProcess() == kPDecay) {
+      for (const auto& dau : candidate.template daughters_as<T>()) {
+        if (dau.getProcess() == TMCProcess::kPDecay) {
           dauCounter++;
         }
       }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -669,6 +669,7 @@ class RecoDecay
   }
 
   /// Checks whether the reconstructed decay candidate is the expected decay.
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \param particlesMC  table with MC particles
   /// \param arrDaughters  array of candidate daughters
   /// \param PDGMother  expected mother PDG code
@@ -676,7 +677,6 @@ class RecoDecay
   /// \param acceptAntiParticles  switch to accept the antiparticle version of the expected decay
   /// \param sign  antiparticle indicator of the found mother w.r.t. PDGMother; 1 if particle, -1 if antiparticle, 0 if mother not found
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
-  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return index of the mother particle if the mother and daughters are correct, -1 otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, std::size_t N, typename T, typename U>
   static int getMatchedMCRec(const T& particlesMC,
@@ -791,12 +791,12 @@ class RecoDecay
   }
 
   /// Checks whether the MC particle is the expected one.
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \param particlesMC  table with MC particles
   /// \param candidate  candidate MC particle
   /// \param PDGParticle  expected particle PDG code
   /// \param acceptAntiParticles  switch to accept the antiparticle
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
-  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return true if PDG code of the particle is correct, false otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, typename T, typename U>
   static int isMatchedMCGen(const T& particlesMC,
@@ -810,6 +810,7 @@ class RecoDecay
   }
 
   /// Check whether the MC particle is the expected one and whether it decayed via the expected decay channel.
+  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \param particlesMC  table with MC particles
   /// \param candidate  candidate MC particle
   /// \param PDGParticle  expected particle PDG code
@@ -818,7 +819,6 @@ class RecoDecay
   /// \param sign  antiparticle indicator of the candidate w.r.t. PDGParticle; 1 if particle, -1 if antiparticle, 0 if not matched
   /// \param depthMax  maximum decay tree level to check; Daughters up to this level will be considered. If -1, all levels are considered.
   /// \param listIndexDaughters  vector of indices of found daughter
-  /// \param checkProcess  switch to accept only decay daughters by checking the production process of MC particles
   /// \return true if PDG codes of the particle and its daughters are correct, false otherwise
   template <bool acceptFlavourOscillation = false, bool checkProcess = false, std::size_t N, typename T, typename U>
   static bool isMatchedMCGen(const T& particlesMC,

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -644,9 +644,7 @@ class RecoDecay
       // for (int i = 0; i < stage; i++) // Indent to make the tree look nice.
       //   printf(" ");
       // printf("Stage %d: Adding %d (PDG %d) as final daughter.\n", stage, index, PDGParticle);
-
       list->push_back(particle.globalIndex());
-      
       return;
     }
     // If we are here, we have to follow the daughter tree.
@@ -738,15 +736,6 @@ class RecoDecay
         //   printf(" %d", i);
         // }
         // printf("\n");
-        //  Check whether the number of actual final daughters is equal to the number of expected final daughters (i.e. the number of provided prongs).
-
-        /*
-        if (arrAllDaughtersIndex.size() != N) {
-          // Printf("MC Rec: Rejected: incorrect number of final daughters: %ld (expected %ld)", arrAllDaughtersIndex.size(), N);
-          return -1;
-        }
-        */
-
       }
       // Check that the daughter is in the list of final daughters.
       // (Check that the daughter is not a stepdaughter, i.e. particle pointing to the mother while not being its daughter.)
@@ -860,15 +849,6 @@ class RecoDecay
       //   printf(" %d", i);
       // }
       // printf("\n");
-      //  Check whether the number of final daughters is equal to the required number.
-
-      /*
-      if (arrAllDaughtersIndex.size() != N) {
-        // Printf("MC Gen: Rejected: incorrect number of final daughters: %ld (expected %ld)", arrAllDaughtersIndex.size(), N);
-        return false;
-      }
-      */
-
       if constexpr (acceptFlavourOscillation) {
         // Loop over decay candidate prongs to spot possible oscillation decay product
         for (auto indexDaughterI : arrAllDaughtersIndex) {

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -734,7 +734,7 @@ class RecoDecay
           return -1;
         }
         // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-        for (const auto& dau : particleMother.daughters_as<aod::McParticles>()) {
+        for (const auto& dau : particleMother.template daughters_as<aod::McParticles>()) {
           if (dau.getProcess() == kPDecay) {
             dauCounter++;
           }
@@ -859,7 +859,7 @@ class RecoDecay
         return false;
       }
       // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-      for (const auto& dau : candidate.daughters_as<aod::McParticles>()) {
+      for (const auto& dau : candidate.template daughters_as<aod::McParticles>()) {
         if (dau.getProcess() == kPDecay) {
           dauCounter++;
         }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -734,7 +734,7 @@ class RecoDecay
           return -1;
         }
         // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-        for (const auto& dau : particleMother.template daughters_as<aod::McParticles>()) {
+        for (const auto& dau : particleMother.template daughters_as<o2::aod::McParticles>()) {
           if (dau.getProcess() == kPDecay) {
             dauCounter++;
           }
@@ -859,7 +859,7 @@ class RecoDecay
         return false;
       }
       // Check that the number of direct daughters coming from the dacay is not larger than the number of expected final daughters.
-      for (const auto& dau : candidate.template daughters_as<aod::McParticles>()) {
+      for (const auto& dau : candidate.template daughters_as<o2::aod::McParticles>()) {
         if (dau.getProcess() == kPDecay) {
           dauCounter++;
         }

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -22,7 +22,6 @@
 #include <cmath>     // std::abs, std::sqrt
 #include <utility>   // std::move
 #include <vector>    // std::vector
-#include <iostream>
 
 #include "CommonConstants/MathConstants.h"
 #include "TMCProcess.h" // for VMC Particle Production Process

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -710,15 +710,16 @@ class RecoDecay
         return -1;
       }
       auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
-      // check if the daughter comes from the decay process of the mother
+      // check if the daughter candidate comes from a decay process
       if (particleI.getProcess() != kPDecay) {
-        continue;
+        return -1;
       }
       arrDaughtersIndex[iProng] = particleI.globalIndex();
       // Get the list of daughter indices from the mother of the first prong.
       if (iProng == 0) {
         // Get the mother index and its sign.
         // PDG code of the first daughter's mother determines whether the expected mother is a particle or antiparticle.
+        //FIX!
         indexMother = getMother(particlesMC, particleI, PDGMother, acceptAntiParticles, &sgn, depthMax);
         // Check whether mother was found.
         if (indexMother <= -1) {

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -22,6 +22,7 @@
 #include <cmath>     // std::abs, std::sqrt
 #include <utility>   // std::move
 #include <vector>    // std::vector
+#include <iostream>
 
 #include "CommonConstants/MathConstants.h"
 #include "TMCProcess.h" // for VMC Particle Production Process
@@ -733,6 +734,10 @@ class RecoDecay
         //   printf(" %d", i);
         // }
         // printf("\n");
+        if (!checkProcess && arrAllDaughtersIndex.size() != N) {
+          // Printf("MC Rec: Rejected: incorrect number of final daughters: %ld (expected %ld)", arrAllDaughtersIndex.size(), N);
+          return -1;
+        }
       }
       // Check that the daughter is in the list of final daughters.
       // (Check that the daughter is not a stepdaughter, i.e. particle pointing to the mother while not being its daughter.)
@@ -849,6 +854,11 @@ class RecoDecay
       //   printf(" %d", i);
       // }
       // printf("\n");
+      //  Check whether the number of final daughters is equal to the required number.
+      if (!checkProcess && arrAllDaughtersIndex.size() != N) {
+        // Printf("MC Gen: Rejected: incorrect number of final daughters: %ld (expected %ld)", arrAllDaughtersIndex.size(), N);
+        return false;
+      }
       if constexpr (acceptFlavourOscillation) {
         // Loop over decay candidate prongs to spot possible oscillation decay product
         for (auto indexDaughterI : arrAllDaughtersIndex) {
@@ -863,7 +873,7 @@ class RecoDecay
       for (auto indexDaughterI : arrAllDaughtersIndex) {
         auto candidateDaughterI = particlesMC.rawIteratorAt(indexDaughterI - particlesMC.offset()); // ith daughter particle
         auto PDGCandidateDaughterI = candidateDaughterI.pdgCode();                                  // PDG code of the ith daughter
-        if (checkProcess && candidateDaughterI.getProcess() != TMCProcess::kPDecay) {               // production process of the ith daughter
+        if (checkProcess && candidateDaughterI.getProcess() != TMCProcess::kPDecay) {             // production process of the ith daughter
           continue;
         }
         // Printf("MC Gen: Daughter %d PDG: %d", indexDaughterI, PDGCandidateDaughterI);

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -355,6 +355,8 @@ struct HfCandidateCreatorToXiPiMc {
     int indexRec = -1;
     int indexRecCharmBaryon = -1;
     int8_t sign = -9;
+    int8_t signCasc = -9;
+    int8_t signV0 = -9;
     int8_t flag = 0;
     int8_t origin = 0; // to be used for prompt/non prompt
     int8_t debug = 0;
@@ -391,20 +393,20 @@ struct HfCandidateCreatorToXiPiMc {
       // Omegac matching
       if (matchOmegacMc) {
         // Omegac → pi pi pi p
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeOmegac0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3);
+        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeOmegac0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3, true);
         indexRecCharmBaryon = indexRec;
         if (indexRec == -1) {
           debug = 1;
         }
         if (indexRec > -1) {
           // Xi- → pi pi p
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2);
+          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2, true);
           if (indexRec == -1) {
             debug = 2;
           }
           if (indexRec > -1) {
             // Lambda → p pi
-            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1);
+            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1, true);
             if (indexRec == -1) {
               debug = 3;
             }
@@ -424,20 +426,20 @@ struct HfCandidateCreatorToXiPiMc {
       // Xic matching
       if (matchXicMc) {
         // Xic → pi pi pi p
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeXic0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3);
+        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeXic0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3, true);
         indexRecCharmBaryon = indexRec;
         if (indexRec == -1) {
           debug = 1;
         }
         if (indexRec > -1) {
           // Xi- → pi pi p
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2);
+          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2, true);
           if (indexRec == -1) {
             debug = 2;
           }
           if (indexRec > -1) {
             // Lambda → p pi
-            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1);
+            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1, true);
             if (indexRec == -1) {
               debug = 3;
             }
@@ -468,13 +470,15 @@ struct HfCandidateCreatorToXiPiMc {
       etaCharmBaryonGen = -999.;
       flag = 0;
       sign = -9;
+      signCasc = -9;
+      signV0 = -9;
       debugGenCharmBar = 0;
       debugGenXi = 0;
       debugGenLambda = 0;
       origin = RecoDecay::OriginType::None;
       if (matchOmegacMc) {
         //  Omegac → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, true)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
@@ -483,14 +487,14 @@ struct HfCandidateCreatorToXiPiMc {
               continue;
             }
             // Xi -> Lambda pi
-            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
+            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true, &signCasc, 1, nullptr, true)) {
               debugGenXi = 1;
               for (const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()) {
                 if (std::abs(daughterCascade.pdgCode()) != pdgCodeLambda) {
                   continue;
                 }
                 // Lambda -> p pi
-                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
+                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1, nullptr, true)) {
                   debugGenLambda = 1;
                   flag = sign * (1 << aod::hf_cand_toxipi::DecayType::OmegaczeroToXiPi);
                 }
@@ -506,7 +510,7 @@ struct HfCandidateCreatorToXiPiMc {
 
       if (matchXicMc) {
         //  Xic → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
+        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, true)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
@@ -515,14 +519,14 @@ struct HfCandidateCreatorToXiPiMc {
               continue;
             }
             // Xi -> Lambda pi
-            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
+            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true, &signCasc, 1, nullptr, true)) {
               debugGenXi = 1;
               for (const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()) {
                 if (std::abs(daughterCascade.pdgCode()) != pdgCodeLambda) {
                   continue;
                 }
                 // Lambda -> p pi
-                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
+                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1, nullptr, true)) {
                   debugGenLambda = 1;
                   flag = sign * (1 << aod::hf_cand_toxipi::DecayType::XiczeroToXiPi);
                 }

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -393,20 +393,20 @@ struct HfCandidateCreatorToXiPiMc {
       // Omegac matching
       if (matchOmegacMc) {
         // Omegac → pi pi pi p
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeOmegac0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3, true);
+        indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughters, pdgCodeOmegac0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3);
         indexRecCharmBaryon = indexRec;
         if (indexRec == -1) {
           debug = 1;
         }
         if (indexRec > -1) {
           // Xi- → pi pi p
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2, true);
+          indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &signCasc, 2);
           if (indexRec == -1) {
             debug = 2;
           }
           if (indexRec > -1) {
             // Lambda → p pi
-            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1);
             if (indexRec == -1) {
               debug = 3;
             }
@@ -426,20 +426,20 @@ struct HfCandidateCreatorToXiPiMc {
       // Xic matching
       if (matchXicMc) {
         // Xic → pi pi pi p
-        indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, pdgCodeXic0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3, true);
+        indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughters, pdgCodeXic0, std::array{pdgCodePiPlus, pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 3);
         indexRecCharmBaryon = indexRec;
         if (indexRec == -1) {
           debug = 1;
         }
         if (indexRec > -1) {
           // Xi- → pi pi p
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &sign, 2, true);
+          indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughtersCasc, pdgCodeXiMinus, std::array{pdgCodePiMinus, pdgCodeProton, pdgCodePiMinus}, true, &signCasc, 2);
           if (indexRec == -1) {
             debug = 2;
           }
           if (indexRec > -1) {
             // Lambda → p pi
-            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &sign, 1, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true>(mcParticles, arrayDaughtersV0, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1);
             if (indexRec == -1) {
               debug = 3;
             }
@@ -470,15 +470,13 @@ struct HfCandidateCreatorToXiPiMc {
       etaCharmBaryonGen = -999.;
       flag = 0;
       sign = -9;
-      signCasc = -9;
-      signV0 = -9;
       debugGenCharmBar = 0;
       debugGenXi = 0;
       debugGenLambda = 0;
       origin = RecoDecay::OriginType::None;
       if (matchOmegacMc) {
         //  Omegac → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, false)) {
+        if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
@@ -487,14 +485,14 @@ struct HfCandidateCreatorToXiPiMc {
               continue;
             }
             // Xi -> Lambda pi
-            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true, &signCasc, 1, nullptr, true)) {
+            if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
               debugGenXi = 1;
               for (const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()) {
                 if (std::abs(daughterCascade.pdgCode()) != pdgCodeLambda) {
                   continue;
                 }
                 // Lambda -> p pi
-                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1, nullptr, true)) {
+                if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
                   debugGenLambda = 1;
                   flag = sign * (1 << aod::hf_cand_toxipi::DecayType::OmegaczeroToXiPi);
                 }
@@ -510,7 +508,7 @@ struct HfCandidateCreatorToXiPiMc {
 
       if (matchXicMc) {
         //  Xic → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, false)) {
+        if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
@@ -519,14 +517,14 @@ struct HfCandidateCreatorToXiPiMc {
               continue;
             }
             // Xi -> Lambda pi
-            if (RecoDecay::isMatchedMCGen(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true, &signCasc, 1, nullptr, true)) {
+            if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, daughterCharm, pdgCodeXiMinus, std::array{pdgCodeLambda, pdgCodePiMinus}, true)) {
               debugGenXi = 1;
               for (const auto& daughterCascade : daughterCharm.daughters_as<aod::McParticles>()) {
                 if (std::abs(daughterCascade.pdgCode()) != pdgCodeLambda) {
                   continue;
                 }
                 // Lambda -> p pi
-                if (RecoDecay::isMatchedMCGen(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true, &signV0, 1, nullptr, true)) {
+                if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, daughterCascade, pdgCodeLambda, std::array{pdgCodeProton, pdgCodePiMinus}, true)) {
                   debugGenLambda = 1;
                   flag = sign * (1 << aod::hf_cand_toxipi::DecayType::XiczeroToXiPi);
                 }

--- a/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorToXiPi.cxx
@@ -478,7 +478,7 @@ struct HfCandidateCreatorToXiPiMc {
       origin = RecoDecay::OriginType::None;
       if (matchOmegacMc) {
         //  Omegac → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, true)) {
+        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeOmegac0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, false)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();
@@ -510,7 +510,7 @@ struct HfCandidateCreatorToXiPiMc {
 
       if (matchXicMc) {
         //  Xic → Xi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, true)) {
+        if (RecoDecay::isMatchedMCGen(mcParticles, particle, pdgCodeXic0, std::array{pdgCodeXiMinus, pdgCodePiPlus}, true, &sign, 1, nullptr, false)) {
           debugGenCharmBar = 1;
           ptCharmBaryonGen = particle.pt();
           etaCharmBaryonGen = particle.eta();


### PR DESCRIPTION
Check the production process of particles when doing the MC matching (both rec and gen) so that only particles coming from the decay are taken into account. This is optional and can be controlled using the parameter checkProcess, which is by default false (so the default behaviour is not changed wrt the current version of O2Physics).
In particular the check on the process is done using the function `getProcess()`, that returns `kPDecay` for particles produced in a decay this function. This check is implemented inside `getMatchedMcRec` and `isMatchedMcGen`. Inside these functions the checks on the number of daughters have been removed because they do not allow to properly take into account only the desiderd daughters. 
