### PR TITLE
PWGLF: TOF Nsigs for cascades + adjustments

### DIFF
--- a/PWGLF/DataModel/LFStrangenessPIDTables.h
+++ b/PWGLF/DataModel/LFStrangenessPIDTables.h
@@ -68,11 +68,11 @@ DECLARE_SOA_COLUMN(DeltaDecayTimeAntiLambda, deltaDecayTimeAntiLambda, float); /
 DECLARE_SOA_COLUMN(DeltaDecayTimeK0Short, deltaDecayTimeK0Short, float);       //! delta-decay time estimate from pion/pion from K0Short
 
 // n-sigmas
-DECLARE_SOA_COLUMN(TOFNSigmaLaPr, tofNSigmaLaPr, float); //! positive track NSigma from proton <- lambda expectation
-DECLARE_SOA_COLUMN(TOFNSigmaLaPi, tofNSigmaLaPi, float); //! negative track NSigma from pion <- lambda expectation
-DECLARE_SOA_COLUMN(TOFNSigmaALaPr, tofNSigmaALaPr, float); //! negative track NSigma from proton <- antilambda expectation
-DECLARE_SOA_COLUMN(TOFNSigmaALaPi, tofNSigmaALaPi, float); //! positive track NSigma from pion <- antilambda expectation
-DECLARE_SOA_COLUMN(TOFNSigmaK0PiPlus, tofNSigmaK0PiPlus, float); //! positive track NSigma from pion <- k0short expectation
+DECLARE_SOA_COLUMN(TOFNSigmaLaPr, tofNSigmaLaPr, float);           //! positive track NSigma from proton <- lambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaLaPi, tofNSigmaLaPi, float);           //! negative track NSigma from pion <- lambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaALaPr, tofNSigmaALaPr, float);         //! negative track NSigma from proton <- antilambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaALaPi, tofNSigmaALaPi, float);         //! positive track NSigma from pion <- antilambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaK0PiPlus, tofNSigmaK0PiPlus, float);   //! positive track NSigma from pion <- k0short expectation
 DECLARE_SOA_COLUMN(TOFNSigmaK0PiMinus, tofNSigmaK0PiMinus, float); //! negative track NSigma from pion <- k0short expectation
 
 // beta values
@@ -111,7 +111,7 @@ DECLARE_SOA_TABLE(V0TOFBetas, "AOD", "V0TOFBETA", // processed info table (for a
                   v0data::TofBetaLambda, v0data::TofBetaAntiLambda, v0data::TofBetaK0Short);
 
 DECLARE_SOA_TABLE(V0TOFNSigmas, "AOD", "V0TOFNSIGMA", // processed NSigma table (for analysis)
-                  v0data::TOFNSigmaLaPr, v0data::TOFNSigmaLaPi, 
+                  v0data::TOFNSigmaLaPr, v0data::TOFNSigmaLaPi,
                   v0data::TOFNSigmaALaPr, v0data::TOFNSigmaALaPi,
                   v0data::TOFNSigmaK0PiPlus, v0data::TOFNSigmaK0PiMinus);
 
@@ -142,12 +142,12 @@ DECLARE_SOA_COLUMN(NegTOFDeltaTOmPr, negTOFDeltaTOmPr, float);   //! negative tr
 DECLARE_SOA_COLUMN(BachTOFDeltaTOmPi, bachTOFDeltaTOmPi, float); //! bachelor track TOFDeltaT from pion <- omega expectation
 
 // n-sigmas
-DECLARE_SOA_COLUMN(TOFNSigmaXiLaPi, tofNSigmaXiLaPi, float);   //! meson track NSigma from pion <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(TOFNSigmaXiLaPr, tofNSigmaXiLaPr, float);   //! baryon track NSigma from proton <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(TOFNSigmaXiPi, tofNSigmaXiPi, float);   //! bachelor track NSigma from pion <- xi expectation
-DECLARE_SOA_COLUMN(TOFNSigmaOmLaPi, tofNSigmaOmLaPi, float);   //! meson track NSigma from pion <- lambda <- om expectation
-DECLARE_SOA_COLUMN(TOFNSigmaOmLaPr, tofNSigmaOmLaPr, float);   //! baryon track NSigma from proton <- lambda <- om expectation
-DECLARE_SOA_COLUMN(TOFNSigmaOmKa, tofNSigmaOmKa, float);   //! bachelor track NSigma from kaon <- om expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiLaPi, tofNSigmaXiLaPi, float); //! meson track NSigma from pion <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiLaPr, tofNSigmaXiLaPr, float); //! baryon track NSigma from proton <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiPi, tofNSigmaXiPi, float);     //! bachelor track NSigma from pion <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmLaPi, tofNSigmaOmLaPi, float); //! meson track NSigma from pion <- lambda <- om expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmLaPr, tofNSigmaOmLaPr, float); //! baryon track NSigma from proton <- lambda <- om expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmKa, tofNSigmaOmKa, float);     //! bachelor track NSigma from kaon <- om expectation
 } // namespace cascdata
 
 DECLARE_SOA_TABLE(CascTOFs, "AOD", "CascTOF", // raw information table (for debug, etc)

--- a/PWGLF/DataModel/LFStrangenessPIDTables.h
+++ b/PWGLF/DataModel/LFStrangenessPIDTables.h
@@ -67,13 +67,13 @@ DECLARE_SOA_COLUMN(DeltaDecayTimeLambda, deltaDecayTimeLambda, float);         /
 DECLARE_SOA_COLUMN(DeltaDecayTimeAntiLambda, deltaDecayTimeAntiLambda, float); //! delta-decay time estimate from pion/proton from AntiLambda
 DECLARE_SOA_COLUMN(DeltaDecayTimeK0Short, deltaDecayTimeK0Short, float);       //! delta-decay time estimate from pion/pion from K0Short
 
-// n-sigmas - unused as of now
-DECLARE_SOA_COLUMN(PosTOFNSigmaLaPi, posTOFNSigmaLaPi, float); //! positive track NSigma from pion <- lambda expectation
-DECLARE_SOA_COLUMN(PosTOFNSigmaLaPr, posTOFNSigmaLaPr, float); //! positive track NSigma from proton <- lambda expectation
-DECLARE_SOA_COLUMN(NegTOFNSigmaLaPi, negTOFNSigmaLaPi, float); //! negative track NSigma from pion <- lambda expectation
-DECLARE_SOA_COLUMN(NegTOFNSigmaLaPr, negTOFNSigmaLaPr, float); //! negative track NSigma from proton <- lambda expectation
-DECLARE_SOA_COLUMN(PosTOFNSigmaK0Pi, posTOFNSigmaK0Pi, float); //! positive track NSigma from pion <- k0short expectation
-DECLARE_SOA_COLUMN(NegTOFNSigmaK0Pi, negTOFNSigmaK0Pi, float); //! positive track NSigma from pion <- k0short expectation
+// n-sigmas
+DECLARE_SOA_COLUMN(TOFNSigmaLaPr, tofNSigmaLaPr, float); //! positive track NSigma from proton <- lambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaLaPi, tofNSigmaLaPi, float); //! negative track NSigma from pion <- lambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaALaPr, tofNSigmaALaPr, float); //! negative track NSigma from proton <- antilambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaALaPi, tofNSigmaALaPi, float); //! positive track NSigma from pion <- antilambda expectation
+DECLARE_SOA_COLUMN(TOFNSigmaK0PiPlus, tofNSigmaK0PiPlus, float); //! positive track NSigma from pion <- k0short expectation
+DECLARE_SOA_COLUMN(TOFNSigmaK0PiMinus, tofNSigmaK0PiMinus, float); //! negative track NSigma from pion <- k0short expectation
 
 // beta values
 DECLARE_SOA_COLUMN(TofBetaLambda, tofBetaLambda, float);         //! beta value with Lambda hypothesis
@@ -110,10 +110,10 @@ DECLARE_SOA_TABLE(V0TOFDebugs, "AOD", "V0TOFDEBUG", // table with intermediate i
 DECLARE_SOA_TABLE(V0TOFBetas, "AOD", "V0TOFBETA", // processed info table (for analysis)
                   v0data::TofBetaLambda, v0data::TofBetaAntiLambda, v0data::TofBetaK0Short);
 
-DECLARE_SOA_TABLE(V0TOFNSigmas, "AOD", "V0TOFNSIGMA", // processed info table (for analysis)
-                  v0data::PosTOFNSigmaLaPi, v0data::PosTOFNSigmaLaPr,
-                  v0data::NegTOFNSigmaLaPi, v0data::NegTOFNSigmaLaPr,
-                  v0data::PosTOFNSigmaK0Pi, v0data::NegTOFNSigmaK0Pi);
+DECLARE_SOA_TABLE(V0TOFNSigmas, "AOD", "V0TOFNSIGMA", // processed NSigma table (for analysis)
+                  v0data::TOFNSigmaLaPr, v0data::TOFNSigmaLaPi, 
+                  v0data::TOFNSigmaALaPr, v0data::TOFNSigmaALaPi,
+                  v0data::TOFNSigmaK0PiPlus, v0data::TOFNSigmaK0PiMinus);
 
 namespace cascdata
 {
@@ -142,16 +142,12 @@ DECLARE_SOA_COLUMN(NegTOFDeltaTOmPr, negTOFDeltaTOmPr, float);   //! negative tr
 DECLARE_SOA_COLUMN(BachTOFDeltaTOmPi, bachTOFDeltaTOmPi, float); //! bachelor track TOFDeltaT from pion <- omega expectation
 
 // n-sigmas
-DECLARE_SOA_COLUMN(PosNSigmaXiPi, posNSigmaXiPi, float);   //! positive track NSigma from pion <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(PosNSigmaXiPr, posNSigmaXiPr, float);   //! positive track NSigma from proton <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(NegNSigmaXiPi, negNSigmaXiPi, float);   //! negative track NSigma from pion <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(NegNSigmaXiPr, negNSigmaXiPr, float);   //! negative track NSigma from proton <- lambda <- xi expectation
-DECLARE_SOA_COLUMN(BachNSigmaXiPi, bachNSigmaXiPi, float); //! bachelor track NSigma from pion <- xi expectation
-DECLARE_SOA_COLUMN(PosNSigmaOmPi, posNSigmaOmPi, float);   //! positive track NSigma from pion <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(PosNSigmaOmPr, posNSigmaOmPr, float);   //! positive track NSigma from proton <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(NegNSigmaOmPi, negNSigmaOmPi, float);   //! negative track NSigma from pion <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(NegNSigmaOmPr, negNSigmaOmPr, float);   //! negative track NSigma from proton <- lambda <- omega expectation
-DECLARE_SOA_COLUMN(BachNSigmaOmKa, bachNSigmaOmKa, float); //! bachelor track NSigma from kaon <- omega expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiLaPi, tofNSigmaXiLaPi, float);   //! meson track NSigma from pion <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiLaPr, tofNSigmaXiLaPr, float);   //! baryon track NSigma from proton <- lambda <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaXiPi, tofNSigmaXiPi, float);   //! bachelor track NSigma from pion <- xi expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmLaPi, tofNSigmaOmLaPi, float);   //! meson track NSigma from pion <- lambda <- om expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmLaPr, tofNSigmaOmLaPr, float);   //! baryon track NSigma from proton <- lambda <- om expectation
+DECLARE_SOA_COLUMN(TOFNSigmaOmKa, tofNSigmaOmKa, float);   //! bachelor track NSigma from kaon <- om expectation
 } // namespace cascdata
 
 DECLARE_SOA_TABLE(CascTOFs, "AOD", "CascTOF", // raw information table (for debug, etc)
@@ -164,13 +160,10 @@ DECLARE_SOA_TABLE(CascTOFPIDs, "AOD", "CASCTOFPID", // processed information for
                   cascdata::BachTOFDeltaTXiPi,
                   cascdata::PosTOFDeltaTOmPi, cascdata::PosTOFDeltaTOmPr,
                   cascdata::NegTOFDeltaTOmPi, cascdata::NegTOFDeltaTOmPr,
-                  cascdata::BachTOFDeltaTOmPi,
-                  cascdata::PosNSigmaXiPi, cascdata::PosNSigmaXiPr,
-                  cascdata::NegNSigmaXiPi, cascdata::NegNSigmaXiPr,
-                  cascdata::BachNSigmaXiPi,
-                  cascdata::PosNSigmaOmPi, cascdata::PosNSigmaOmPr,
-                  cascdata::NegNSigmaOmPi, cascdata::NegNSigmaOmPr,
-                  cascdata::BachNSigmaOmKa);
+                  cascdata::BachTOFDeltaTOmPi);
+DECLARE_SOA_TABLE(CascTOFNSigmas, "AOD", "CascTOFNSigmas", // Nsigmas for cascades
+                  cascdata::TOFNSigmaXiLaPi, cascdata::TOFNSigmaXiLaPr, cascdata::TOFNSigmaXiPi,
+                  cascdata::TOFNSigmaOmLaPi, cascdata::TOFNSigmaOmLaPr, cascdata::TOFNSigmaOmKa);
 } // namespace o2::aod
 
 #endif // PWGLF_DATAMODEL_LFSTRANGENESSPIDTABLES_H_

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -501,7 +501,7 @@ struct cascadepid {
               nSigmaOmLaPi = (negDeltaTimeAsOmPi - hMeanNegOmPi->Interpolate(cascade.pt())) / hSigmaNegOmPi->Interpolate(cascade.pt());
             if (bachDeltaTimeAsOmKa > -1e+5) // kaon from OmegaMinus has signal
               nSigmaOmKa = (bachDeltaTimeAsOmKa - hMeanBachOmKa->Interpolate(cascade.pt())) / hSigmaBachOmKa->Interpolate(cascade.pt());
-          }else{
+          } else {
             if (posDeltaTimeAsXiPi > -1e+5) // proton from Lambda from XiMinus has signal
               nSigmaXiLaPi = (posDeltaTimeAsXiPi - hMeanPosXiPi->Interpolate(cascade.pt())) / hSigmaPosXiPi->Interpolate(cascade.pt());
             if (negDeltaTimeAsXiPr > -1e+5) // pion from Lambda from XiMinus has signal
@@ -528,7 +528,7 @@ struct cascadepid {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
-                if(doQANSigma){
+                if (doQANSigma) {
                   histos.fill(HIST("h2dNSigmaXiLaPi"), cascade.pt(), nSigmaXiLaPi);
                   histos.fill(HIST("h2dNSigmaXiLaPr"), cascade.pt(), nSigmaXiLaPr);
                   histos.fill(HIST("h2dNSigmaXiPi"), cascade.pt(), nSigmaXiPi);
@@ -538,7 +538,7 @@ struct cascadepid {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
-                if(doQANSigma){
+                if (doQANSigma) {
                   histos.fill(HIST("h2dNSigmaOmLaPi"), cascade.pt(), nSigmaOmLaPi);
                   histos.fill(HIST("h2dNSigmaOmLaPr"), cascade.pt(), nSigmaOmLaPr);
                   histos.fill(HIST("h2dNSigmaOmKa"), cascade.pt(), nSigmaOmKa);
@@ -549,7 +549,7 @@ struct cascadepid {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
-                if(doQANSigma){
+                if (doQANSigma) {
                   histos.fill(HIST("h2dNSigmaXiLaPi"), cascade.pt(), nSigmaXiLaPi);
                   histos.fill(HIST("h2dNSigmaXiLaPr"), cascade.pt(), nSigmaXiLaPr);
                   histos.fill(HIST("h2dNSigmaXiPi"), cascade.pt(), nSigmaXiPi);
@@ -559,7 +559,7 @@ struct cascadepid {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
-                if(doQANSigma){
+                if (doQANSigma) {
                   histos.fill(HIST("h2dNSigmaOmLaPi"), cascade.pt(), nSigmaOmLaPi);
                   histos.fill(HIST("h2dNSigmaOmLaPr"), cascade.pt(), nSigmaOmLaPr);
                   histos.fill(HIST("h2dNSigmaOmKa"), cascade.pt(), nSigmaOmKa);

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -64,7 +64,7 @@ using CascFullCores = soa::Join<aod::CascCores, aod::CascTOFs, aod::CascExtras, 
 
 struct cascadepid {
   // TOF pid for strangeness (recalculated with topology)
-  Produces<aod::CascTOFPIDs> casctofpids; // table with base info
+  Produces<aod::CascTOFPIDs> casctofpids;       // table with base info
   Produces<aod::CascTOFNSigmas> casctofnsigmas; // table with Nsigmas
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -420,8 +420,7 @@ struct cascadepid {
 
         casctofpids(
           posDeltaTimeAsXiPi, posDeltaTimeAsXiPr, negDeltaTimeAsXiPi, negDeltaTimeAsXiPr, bachDeltaTimeAsXiPi,
-          posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa
-        );
+          posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa);
 
         // go for Nsigma values if requested
         if (doNSigmas) {
@@ -433,7 +432,7 @@ struct cascadepid {
           float nSigmaOmKa = -1e+5;
 
           // Xi hypothesis ________________________
-          if (cascade.sign() < 0) { // XiMinus
+          if (cascade.sign() < 0) {         // XiMinus
             if (posDeltaTimeAsXiPr > -1e+5) // proton from Lambda from XiMinus has signal
               nSigmaXiLaPr = (posDeltaTimeAsXiPr - hMeanPosXiPr->Interpolate(cascade.pt())) / hSigmaPosXiPr->Interpolate(cascade.pt());
             if (negDeltaTimeAsXiPi > -1e+5) // pion from Lambda from XiMinus has signal

--- a/PWGLF/TableProducer/cascadepid.cxx
+++ b/PWGLF/TableProducer/cascadepid.cxx
@@ -85,6 +85,7 @@ struct cascadepid {
   Configurable<float> qaMassWindow{"qaMassWindow", 0.005, "Mass window around expected (in GeV/c2) for QA plots"};
   Configurable<float> qaTPCNSigma{"qaTPCNSigma", 5, "TPC N-sigma to apply for qa plots"};
   Configurable<bool> doNSigmas{"doNSigmas", false, "calculate TOF N-sigma"};
+  Configurable<bool> doQANSigma{"doQANSigma", false, "create QA of Nsigma histos"};
 
   // CCDB options
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -96,9 +97,9 @@ struct cascadepid {
 
   ConfigurableAxis axisEta{"axisEta", {20, -1.0f, +1.0f}, "#eta"};
   ConfigurableAxis axisDeltaTime{"axisDeltaTime", {2000, -1000.0f, +1000.0f}, "delta-time (ps)"};
+  ConfigurableAxis axisNSigma{"axisNSigma", {200, -10.0f, +10.0f}, "N(#sigma)"};
   ConfigurableAxis axisTime{"axisTime", {200, 0.0f, +20000.0f}, "T (ps)"};
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "p_{T} (GeV/c)"};
-
 
   bool nSigmaCalibLoaded;
   TList* nSigmaCalibObjects;
@@ -277,6 +278,16 @@ struct cascadepid {
       histos.add("h2dnegDeltaTimeAsOmPr", "h2dnegDeltaTimeAsOmPr", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
       histos.add("h2dbachDeltaTimeAsOmKa", "h2dbachDeltaTimeAsOmKa", {HistType::kTH3F, {axisPt, axisEta, axisDeltaTime}});
     }
+
+    if (doQANSigma) {
+      // standard NSigma values
+      histos.add("h2dNSigmaXiLaPi", "h2dNSigmaXiLaPi", {HistType::kTH2F, {axisPt, axisNSigma}});
+      histos.add("h2dNSigmaXiLaPr", "h2dNSigmaXiLaPr", {HistType::kTH2F, {axisPt, axisNSigma}});
+      histos.add("h2dNSigmaXiPi", "h2dNSigmaXiPi", {HistType::kTH2F, {axisPt, axisNSigma}});
+      histos.add("h2dNSigmaOmLaPi", "h2dNSigmaOmLaPi", {HistType::kTH2F, {axisPt, axisNSigma}});
+      histos.add("h2dNSigmaOmLaPr", "h2dNSigmaOmLaPr", {HistType::kTH2F, {axisPt, axisNSigma}});
+      histos.add("h2dNSigmaOmPi", "h2dNSigmaOmPi", {HistType::kTH2F, {axisPt, axisNSigma}});
+    }
   }
 
   void initCCDB(soa::Join<aod::StraCollisions, aod::StraStamps>::iterator const& collision)
@@ -344,15 +355,14 @@ struct cascadepid {
         hSigmaNegOmPr = reinterpret_cast<TH1*>(nSigmaCalibObjects->FindObject("hSigmaNegOmPr"));
         hSigmaBachOmKa = reinterpret_cast<TH1*>(nSigmaCalibObjects->FindObject("hSigmaBachOmKa"));
 
-        if (!hMeanPosXiPi || !hMeanPosXiPr || !hMeanNegXiPi || !hMeanNegXiPr || !hMeanBachXiPi) {
+        if (!hMeanPosXiPi || !hMeanPosXiPr || !hMeanNegXiPi || !hMeanNegXiPr || !hMeanBachXiPi)
           LOG(info) << "Problems finding xi mean histograms!";
-        if (!hMeanPosOmPi || !hMeanPosOmPr || !hMeanNegOmPi || !hMeanNegOmPr || !hMeanBachOmPi) {
+        if (!hMeanPosOmPi || !hMeanPosOmPr || !hMeanNegOmPi || !hMeanNegOmPr || !hMeanBachOmKa)
           LOG(info) << "Problems finding omega sigma histograms!";
-        if (!hSigmaPosXiPi || !hSigmaPosXiPr || !hSigmaNegXiPi || !hSigmaNegXiPr || !hSigmaBachXiPi) {
+        if (!hSigmaPosXiPi || !hSigmaPosXiPr || !hSigmaNegXiPi || !hSigmaNegXiPr || !hSigmaBachXiPi)
           LOG(info) << "Problems finding xi sigma histograms!";
-        if (!hSigmaPosOmPi || !hSigmaPosOmPr || !hSigmaNegOmPi || !hSigmaNegOmPr || !hSigmaBachOmPi) {
+        if (!hSigmaPosOmPi || !hSigmaPosOmPr || !hSigmaNegOmPi || !hSigmaNegOmPr || !hSigmaBachOmKa)
           LOG(info) << "Problems finding omega sigma histograms!";
-        }
       }
     }
     mRunNumber = collision.runNumber();
@@ -468,15 +478,15 @@ struct cascadepid {
           posDeltaTimeAsXiPi, posDeltaTimeAsXiPr, negDeltaTimeAsXiPi, negDeltaTimeAsXiPr, bachDeltaTimeAsXiPi,
           posDeltaTimeAsOmPi, posDeltaTimeAsOmPr, negDeltaTimeAsOmPi, negDeltaTimeAsOmPr, bachDeltaTimeAsOmKa);
 
+        float nSigmaXiLaPr = -1e+6;
+        float nSigmaXiLaPi = -1e+6;
+        float nSigmaXiPi = -1e+6;
+        float nSigmaOmLaPr = -1e+6;
+        float nSigmaOmLaPi = -1e+6;
+        float nSigmaOmKa = -1e+6;
+
         // go for Nsigma values if requested
         if (doNSigmas) {
-          float nSigmaXiLaPr = -1e+6;
-          float nSigmaXiLaPi = -1e+6;
-          float nSigmaXiPi = -1e+6;
-          float nSigmaOmLaPr = -1e+6;
-          float nSigmaOmLaPi = -1e+6;
-          float nSigmaOmKa = -1e+6;
-
           // Xi hypothesis ________________________
           if (cascade.sign() < 0) {         // XiMinus
             if (posDeltaTimeAsXiPr > -1e+5) // proton from Lambda from XiMinus has signal
@@ -518,22 +528,42 @@ struct cascadepid {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
+                if(doQANSigma){
+                  histos.fill(HIST("h2dNSigmaXiLaPi"), cascade.pt(), nSigmaXiLaPi);
+                  histos.fill(HIST("h2dNSigmaXiLaPr"), cascade.pt(), nSigmaXiLaPr);
+                  histos.fill(HIST("h2dNSigmaXiPi"), cascade.pt(), nSigmaXiPi);
+                }
               }
               if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow && fabs(pTra.tpcNSigmaPr()) < qaTPCNSigma && fabs(nTra.tpcNSigmaPi()) < qaTPCNSigma && fabs(bTra.tpcNSigmaKa()) < qaTPCNSigma) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
+                if(doQANSigma){
+                  histos.fill(HIST("h2dNSigmaOmLaPi"), cascade.pt(), nSigmaOmLaPi);
+                  histos.fill(HIST("h2dNSigmaOmLaPr"), cascade.pt(), nSigmaOmLaPr);
+                  histos.fill(HIST("h2dNSigmaOmKa"), cascade.pt(), nSigmaOmKa);
+                }
               }
             } else {
               if (std::abs(cascade.mXi() - 1.32171) < qaMassWindow && fabs(pTra.tpcNSigmaPi()) < qaTPCNSigma && fabs(nTra.tpcNSigmaPr()) < qaTPCNSigma && fabs(bTra.tpcNSigmaPi()) < qaTPCNSigma) {
                 histos.fill(HIST("h2dposDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsXiPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsXiPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsXiPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsXiPi"), cascade.pt(), cascade.eta(), bachDeltaTimeAsXiPi);
+                if(doQANSigma){
+                  histos.fill(HIST("h2dNSigmaXiLaPi"), cascade.pt(), nSigmaXiLaPi);
+                  histos.fill(HIST("h2dNSigmaXiLaPr"), cascade.pt(), nSigmaXiLaPr);
+                  histos.fill(HIST("h2dNSigmaXiPi"), cascade.pt(), nSigmaXiPi);
+                }
               }
               if (std::abs(cascade.mOmega() - 1.67245) < qaMassWindow && fabs(pTra.tpcNSigmaPi()) < qaTPCNSigma && fabs(nTra.tpcNSigmaPr()) < qaTPCNSigma && fabs(bTra.tpcNSigmaKa()) < qaTPCNSigma) {
                 histos.fill(HIST("h2dposDeltaTimeAsOmPi"), cascade.pt(), cascade.eta(), posDeltaTimeAsOmPi);
                 histos.fill(HIST("h2dnegDeltaTimeAsOmPr"), cascade.pt(), cascade.eta(), negDeltaTimeAsOmPr);
                 histos.fill(HIST("h2dbachDeltaTimeAsOmKa"), cascade.pt(), cascade.eta(), bachDeltaTimeAsOmKa);
+                if(doQANSigma){
+                  histos.fill(HIST("h2dNSigmaOmLaPi"), cascade.pt(), nSigmaOmLaPi);
+                  histos.fill(HIST("h2dNSigmaOmLaPr"), cascade.pt(), nSigmaOmLaPr);
+                  histos.fill(HIST("h2dNSigmaOmKa"), cascade.pt(), nSigmaOmKa);
+                }
               }
             }
           }

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -528,8 +528,8 @@ struct lambdakzeropid {
             nSigmaNegativeK0ShortPi = (deltaTimeNegativeK0ShortPi - hMeanNegK0Pi->Interpolate(v0.pt())) / hSigmaNegK0Pi->Interpolate(v0.pt());
 
           v0tofnsigmas(
-            nSigmaPositiveLambdaPr, nSigmaNegativeLambdaPi, 
-            nSigmaNegativeLambdaPr, nSigmaPositiveLambdaPi, 
+            nSigmaPositiveLambdaPr, nSigmaNegativeLambdaPi,
+            nSigmaNegativeLambdaPr, nSigmaPositiveLambdaPi,
             nSigmaPositiveK0ShortPi, nSigmaNegativeK0ShortPi);
         }
 

--- a/PWGLF/TableProducer/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/lambdakzeropid.cxx
@@ -528,8 +528,8 @@ struct lambdakzeropid {
             nSigmaNegativeK0ShortPi = (deltaTimeNegativeK0ShortPi - hMeanNegK0Pi->Interpolate(v0.pt())) / hSigmaNegK0Pi->Interpolate(v0.pt());
 
           v0tofnsigmas(
-            nSigmaPositiveLambdaPi, nSigmaPositiveLambdaPr,
-            nSigmaNegativeLambdaPi, nSigmaNegativeLambdaPr,
+            nSigmaPositiveLambdaPr, nSigmaNegativeLambdaPi, 
+            nSigmaNegativeLambdaPr, nSigmaPositiveLambdaPi, 
             nSigmaPositiveK0ShortPi, nSigmaNegativeK0ShortPi);
         }
 

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -576,18 +576,18 @@ struct derivedlambdakzeroanalysis {
 
     // TOF PID in NSigma
     // Positive track
-    if (fabs(v0.posTOFNSigmaLaPr()) < TofPidNsigmaCutLaPr)
+    if (fabs(v0.tofNSigmaLaPr()) < TofPidNsigmaCutLaPr)
       bitset(bitMap, selTOFNSigmaPositiveProtonLambda);
-    if (fabs(v0.posTOFNSigmaLaPi()) < TofPidNsigmaCutLaPi)
+    if (fabs(v0.tofNSigmaALaPi()) < TofPidNsigmaCutLaPi)
       bitset(bitMap, selTOFNSigmaPositivePionLambda);
-    if (fabs(v0.posTOFNSigmaK0Pi()) < TofPidNsigmaCutK0Pi)
+    if (fabs(v0.tofNSigmaK0PiPlus()) < TofPidNsigmaCutK0Pi)
       bitset(bitMap, selTOFNSigmaPositivePionK0Short);
     // Negative track
-    if (fabs(v0.negTOFNSigmaLaPr()) < TofPidNsigmaCutLaPr)
+    if (fabs(v0.tofNSigmaALaPr()) < TofPidNsigmaCutLaPr)
       bitset(bitMap, selTOFNSigmaNegativeProtonLambda);
-    if (fabs(v0.negTOFNSigmaLaPi()) < TofPidNsigmaCutLaPi)
+    if (fabs(v0.tofNSigmaLaPi()) < TofPidNsigmaCutLaPi)
       bitset(bitMap, selTOFNSigmaNegativePionLambda);
-    if (fabs(v0.negTOFNSigmaK0Pi()) < TofPidNsigmaCutK0Pi)
+    if (fabs(v0.tofNSigmaK0PiMinus()) < TofPidNsigmaCutK0Pi)
       bitset(bitMap, selTOFNSigmaNegativePionK0Short);
 
     // ITS only tag


### PR DESCRIPTION
* adjust NSigma getters to conform to usual convention of PID getters, i.e. `[detector]NSigma[species]` with extra `[A](...)[Z]` ordering for decay chains, with `[Z]` being the last state:
   * `tofNSigmaLaPi`: negative pion from Lambda decay
   * `tofNSigmaLaPr`: proton from Lambda decay 
   * `tofNSigmaALaPi`: positive pion from AntiLambda decay 
   * `tofNSigmaALaPr`: antiproton from AntiLambda decay 
   * `tofNSigmaK0PiPlus`: positive pion from K0 decay 
   * `tofNSigmaK0PiMinus`: negative pion from K0 decay
   * `tofNSigmaXiLaPi`: negative pion from lambda from XiMinus decay (for matter, adjust automatically to positive pion from AntiLambda in case cascade sign is positive / antimatter)
   * `tofNSigmaXiLaPr`: proton from lambda from XiMinus decay (for matter, adjust automatically to antiproton from AntiLambda in case cascade sign is positive / antimatter)
   * `tofNSigmaXiPi`: negative pion (bachelor) from XiMinus decay (for matter, adjust automatically to positive pion from XiPlus decay in case cascade sign is positive / antimatter)
   * `tofNSigmaOmLaPi`: negative pion from lambda from XiMinus decay (for matter, adjust automatically to positive pion from AntiLambda in case cascade sign is positive / antimatter)
   * `tofNSigmaOmLaPr`: proton from lambda from XiMinus decay (for matter, adjust automatically to antiproton from AntiLambda in case cascade sign is positive / antimatter)
   * `tofNSigmaOmKa`: negative pion (bachelor) from XiMinus decay (for matter, adjust automatically to positive kaon from OmegaPlus decay in case cascade sign is positive / antimatter)
* creates an Nsigma processing path for Cascades 

@njacazio can you please check this naming scheme to see if this conforms to something that is as close as possible to the usual NSigma naming schemes? Note that I have to preserve the full decay history hypotheses, so many getters are needed. The only simplification happens in the cascade case, where the sign of the cascade helps in deciding which prong to require the proton or pion hypothesis for. 

@mfaggin (can't find Iouri here I fear): I'll try to present this work also in the upcoming DPG AOT Tracks meeting as I think it would be a good opportunity, so here's a heads-up in case you want to / have the time to look a bit into the code and interface choices. Thanks :-D