### PR TITLE
EventFiltering,PWGHF: Move HFFilter ML application one step before

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -19,8 +19,6 @@
 /// \author Biao Zhang <biao.zhang@cern.ch>, CCNU
 /// \author Federica Zanone <federica.zanone@cern.ch>, Heidelberg University
 
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h> // needed for HFFilterHelpers, to be fixed
-
 #include "CommonConstants/PhysicsConstants.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPMagField.h"
@@ -96,19 +94,13 @@ struct HfFilter { // Main struct for HF triggers
   Configurable<LabeledArray<float>> cutsXiBachelor{"cutsXiBachelor", {cutsCharmBaryons[0], 1, 4, labelsEmpty, labelsColumnsCharmBaryons}, "Selections for charm baryons (Xi+Pi and Xi+Ka)"};
   Configurable<LabeledArray<double>> cutsTrackCharmBaryonBachelor{"cutsTrackCharmBaryonBachelor", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for charm-baryon bachelor candidates"};
 
-  // parameters for ML application with ONNX
-  Configurable<bool> applyML{"applyML", false, "Flag to enable or disable ML application"};
+  // parameters for ML application
   Configurable<std::vector<double>> pTBinsBDT{"pTBinsBDT", std::vector<double>{hf_cuts_bdt_multiclass::vecBinsPt}, "track pT bin limits for BDT cut"};
 
-  Configurable<std::string> onnxFileD0ToKPiConf{"onnxFileD0ToKPiConf", "XGBoostModel.onnx", "ONNX file for ML model for D0 candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreD0ToKPi{"thresholdBDTScoreD0ToKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D0 candidates"};
-  Configurable<std::string> onnxFileDPlusToPiKPiConf{"onnxFileDPlusToPiKPiConf", "", "ONNX file for ML model for D+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDPlusToPiKPi{"thresholdBDTScoreDPlusToPiKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D+ candidates"};
-  Configurable<std::string> onnxFileDSToPiKKConf{"onnxFileDSToPiKKConf", "", "ONNX file for ML model for Ds+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDSToPiKK{"thresholdBDTScoreDSToPiKK", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Ds+ candidates"};
-  Configurable<std::string> onnxFileLcToPiKPConf{"onnxFileLcToPiKPConf", "", "ONNX file for ML model for Lc+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreLcToPiKP{"thresholdBDTScoreLcToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Lc+ candidates"};
-  Configurable<std::string> onnxFileXicToPiKPConf{"onnxFileXicToPiKPConf", "", "ONNX file for ML model for Xic+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreXicToPiKP{"thresholdBDTScoreXicToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Xic+ candidates"};
 
   Configurable<bool> acceptBdtBkgOnly{"acceptBdtBkgOnly", true, "Enable / disable selection based on BDT bkg score only"};
@@ -117,9 +109,6 @@ struct HfFilter { // Main struct for HF triggers
   o2::ccdb::CcdbApi ccdbApi;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::string> mlModelPathCCDB{"mlModelPathCCDB", "Analysis/PWGHF/ML/HFTrigger/", "Path on CCDB"};
-  Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB. Exceptions: > 0 for the specific timestamp, 0 gets the run dependent timestamp"};
-  Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
   int currentRun{0}; // needed to detect if the run changed and trigger update of calibrations etc.
 
   // TPC PID calibrations
@@ -135,8 +124,7 @@ struct HfFilter { // Main struct for HF triggers
   // parameter for Optimisation Tree
   Configurable<bool> applyOptimisation{"applyOptimisation", false, "Flag to enable or disable optimisation"};
 
-  // array of ONNX config and BDT thresholds
-  std::array<std::string, kNCharmParticles> onnxFiles;
+  // array of BDT thresholds
   std::array<LabeledArray<double>, kNCharmParticles> thresholdBDTScores;
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
@@ -155,18 +143,6 @@ struct HfFilter { // Main struct for HF triggers
   std::array<std::shared_ptr<TH2>, kNV0> hArmPod{};
   std::shared_ptr<TH2> hV0Selected;
   std::shared_ptr<TH1> hMassXi;
-
-  // ONNX
-  std::array<std::shared_ptr<Ort::Experimental::Session>, kNCharmParticles> sessionML = {nullptr, nullptr, nullptr, nullptr, nullptr};
-  std::array<std::vector<std::vector<int64_t>>, kNCharmParticles> inputShapesML{};
-  std::array<Ort::Env, kNCharmParticles> envML = {
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-d0-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-dplus-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-ds-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-lc-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-xic-triggers"}};
-  std::array<Ort::SessionOptions, kNCharmParticles> sessionOptions{Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions()};
-  std::array<int, kNCharmParticles> dataTypeML{};
 
   // material correction for track propagation
   o2::base::MatLayerCylSet* lut;
@@ -213,7 +189,7 @@ struct HfFilter { // Main struct for HF triggers
         hCharmHighPt[iCharmPart] = registry.add<TH1>(Form("f%sHighPt", charmParticleNames[iCharmPart].data()), Form("#it{p}_{T} distribution of triggered high-#it{p}_{T} %s candidates;#it{p}_{T} (GeV/#it{c});counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {ptAxis});
         hCharmProtonKstarDistr[iCharmPart] = registry.add<TH1>(Form("f%sProtonKstarDistr", charmParticleNames[iCharmPart].data()), Form("#it{k}* distribution of triggered p#minus%s pairs;#it{k}* (GeV/#it{c});counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {kstarAxis});
         hMassVsPtC[iCharmPart] = registry.add<TH2>(Form("fMassVsPt%s", charmParticleNames[iCharmPart].data()), Form("#it{M} vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", charmParticleNames[iCharmPart].data()), HistType::kTH2F, {ptAxis, massAxisC[iCharmPart]});
-        if (applyML && activateQA > 1) {
+        if (activateQA > 1) {
           hBDTScoreBkg[iCharmPart] = registry.add<TH1>(Form("f%sBDTScoreBkgDistr", charmParticleNames[iCharmPart].data()), Form("BDT background score distribution for %s;BDT background score;counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {bdtAxis});
           hBDTScorePrompt[iCharmPart] = registry.add<TH1>(Form("f%sBDTScorePromptDistr", charmParticleNames[iCharmPart].data()), Form("BDT prompt score distribution for %s;BDT prompt score;counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {bdtAxis});
           hBDTScoreNonPrompt[iCharmPart] = registry.add<TH1>(Form("f%sBDTScoreNonPromptDistr", charmParticleNames[iCharmPart].data()), Form("BDT nonprompt score distribution for %s;BDT nonprompt score;counts", charmParticleNames[iCharmPart].data()), HistType::kTH1F, {bdtAxis});
@@ -277,50 +253,28 @@ struct HfFilter { // Main struct for HF triggers
     ccdbApi.init(url);
     lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>("GLO/Param/MatLUT"));
 
-    thresholdBDTScores = {
-      thresholdBDTScoreD0ToKPi,
-      thresholdBDTScoreDPlusToPiKPi,
-      thresholdBDTScoreDSToPiKK,
-      thresholdBDTScoreLcToPiKP,
-      thresholdBDTScoreXicToPiKP};
-
-    onnxFiles = {
-      onnxFileD0ToKPiConf,
-      onnxFileDPlusToPiKPiConf,
-      onnxFileDSToPiKKConf,
-      onnxFileLcToPiKPConf,
-      onnxFileXicToPiKPConf};
-
-    // init ONNX runtime session
-    if (applyML && (!loadModelsFromCCDB || timestampCCDB != 0)) {
-      for (auto iCharmPart{0}; iCharmPart < kNCharmParticles; ++iCharmPart) {
-        if (onnxFiles[iCharmPart] != "") {
-          sessionML[iCharmPart].reset(helper.initONNXSession(onnxFiles[iCharmPart], charmParticleNames[iCharmPart], envML[iCharmPart], sessionOptions[iCharmPart], inputShapesML[iCharmPart], dataTypeML[iCharmPart], loadModelsFromCCDB, ccdbApi, mlModelPathCCDB.value, timestampCCDB));
-        }
-      }
-    }
-    // safety for optimisation tree
-    if (applyOptimisation && !applyML) {
-      LOG(fatal) << "Can't apply optimisation if ML is not applied.";
-    }
+    thresholdBDTScores = {thresholdBDTScoreD0ToKPi, thresholdBDTScoreDPlusToPiKPi, thresholdBDTScoreDSToPiKK, thresholdBDTScoreLcToPiKP, thresholdBDTScoreXicToPiKP};
   }
 
   using BigTracksMCPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::McTrackLabels>;
   using BigTracksPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr>;
   using CollsWithEvSel = soa::Join<aod::Collisions, aod::EvSels>;
 
+  using Hf2ProngsWithMl = soa::Join<aod::Hf2Prongs, aod::Hf2ProngMlProbs>;
+  using Hf3ProngsWithMl = soa::Join<aod::Hf3Prongs, aod::Hf3ProngMlProbs>;
+
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::V0Datas> v0sPerCollision = aod::v0data::collisionId;
-  Preslice<aod::Hf2Prongs> hf2ProngPerCollision = aod::track_association::collisionId;
-  Preslice<aod::Hf3Prongs> hf3ProngPerCollision = aod::track_association::collisionId;
+  Preslice<Hf2ProngsWithMl> hf2ProngPerCollision = aod::track_association::collisionId;
+  Preslice<Hf3ProngsWithMl> hf3ProngPerCollision = aod::track_association::collisionId;
   Preslice<aod::CascDatas> cascPerCollision = aod::cascdata::collisionId;
 
   void process(CollsWithEvSel const& collisions,
                aod::BCsWithTimestamps const&,
                aod::V0Datas const& theV0s,
                aod::CascDatas const& cascades,
-               aod::Hf2Prongs const& cand2Prongs,
-               aod::Hf3Prongs const& cand3Prongs,
+               Hf2ProngsWithMl const& cand2Prongs,
+               Hf3ProngsWithMl const& cand3Prongs,
                aod::TrackAssoc const& trackIndices,
                BigTracksPID const& tracks)
   {
@@ -340,15 +294,6 @@ struct HfFilter { // Main struct for HF triggers
       }
 
       auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-
-      if (applyML && (loadModelsFromCCDB && timestampCCDB == 0) && !sessionML[kD0]) {
-        for (auto iCharmPart{0}; iCharmPart < kNCharmParticles; ++iCharmPart) {
-          if (onnxFiles[iCharmPart] != "") {
-            sessionML[iCharmPart].reset(helper.initONNXSession(onnxFiles[iCharmPart], charmParticleNames[iCharmPart], envML[iCharmPart], sessionOptions[iCharmPart], inputShapesML[iCharmPart], dataTypeML[iCharmPart], loadModelsFromCCDB, ccdbApi, mlModelPathCCDB.value, bc.timestamp()));
-          }
-        }
-      }
-
       // needed for track propagation
       if (currentRun != bc.runNumber()) {
         o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", bc.timestamp());
@@ -400,45 +345,24 @@ struct HfFilter { // Main struct for HF triggers
           getPxPyPz(trackParNeg, pVecNeg);
         }
 
-        bool isSignalTagged{true}, isCharmTagged{true}, isBeautyTagged{true};
-
         // apply ML models
-        int tagBDT = 0;
-        float scoresToFill[3] = {-1., -1., -1.};
-        if (applyML && onnxFiles[kD0] != "") {
-          isSignalTagged = false;
-          isCharmTagged = false;
-          isBeautyTagged = false;
+        std::vector<float> scores{};
+        scores.insert(scores.end(), cand2Prong.mlProbSkimD0ToKPi().begin(), cand2Prong.mlProbSkimD0ToKPi().end());
+        if (scores.size() != 3) {
+          scores.resize(3);
+          scores[0] = 2.;
+          scores[1] = -1.;
+          scores[2] = -1.;
+        }
+        auto tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
+        bool isCharmTagged = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
+        bool isBeautyTagged = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
+        bool isSignalTagged = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isCharmTagged || isBeautyTagged);
 
-          // TODO: add more feature configurations
-          std::vector<float> inputFeaturesD0{trackParPos.getPt(), dcaPos[0], dcaPos[1], trackParNeg.getPt(), dcaNeg[0], dcaNeg[1]};
-          std::vector<double> inputFeaturesDoD0{trackParPos.getPt(), dcaPos[0], dcaPos[1], trackParNeg.getPt(), dcaNeg[0], dcaNeg[1]};
-
-          if (dataTypeML[kD0] == 1) {
-            auto scores = helper.predictONNX(inputFeaturesD0, sessionML[kD0], inputShapesML[kD0]);
-            tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
-            for (int iScore{0}; iScore < 3; ++iScore) {
-              scoresToFill[iScore] = scores[iScore];
-            }
-          } else if (dataTypeML[kD0] == 11) {
-            auto scores = helper.predictONNX(inputFeaturesDoD0, sessionML[kD0], inputShapesML[kD0]);
-            tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
-            for (int iScore{0}; iScore < 3; ++iScore) {
-              scoresToFill[iScore] = scores[iScore];
-            }
-          } else {
-            LOG(fatal) << "Error running model inference for D0: Unexpected input data type.";
-          }
-
-          if (applyML && activateQA > 1) {
-            hBDTScoreBkg[kD0]->Fill(scoresToFill[0]);
-            hBDTScorePrompt[kD0]->Fill(scoresToFill[1]);
-            hBDTScoreNonPrompt[kD0]->Fill(scoresToFill[2]);
-          }
-
-          isCharmTagged = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
-          isBeautyTagged = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
-          isSignalTagged = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isCharmTagged || isBeautyTagged);
+        if (activateQA > 1) {
+          hBDTScoreBkg[kD0]->Fill(scores[0]);
+          hBDTScorePrompt[kD0]->Fill(scores[1]);
+          hBDTScoreNonPrompt[kD0]->Fill(scores[2]);
         }
 
         if (!isSignalTagged) {
@@ -449,7 +373,7 @@ struct HfFilter { // Main struct for HF triggers
         auto pt2Prong = RecoDecay::pt(pVec2Prong);
 
         if (applyOptimisation) {
-          optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scoresToFill[0], scoresToFill[1], scoresToFill[2]);
+          optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scores[0], scores[1], scores[2]);
         }
 
         auto selD0 = helper.isSelectedD0InMassRange(pVecPos, pVecNeg, pt2Prong, preselD0, activateQA, hMassVsPtC[kD0]);
@@ -495,7 +419,7 @@ struct HfFilter { // Main struct for HF triggers
                 keepEvent[kBeauty3P] = true;
                 // fill optimisation tree for D0
                 if (applyOptimisation) {
-                  optimisationTreeBeauty(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scoresToFill[0], scoresToFill[1], scoresToFill[2], dcaThird[0]);
+                  optimisationTreeBeauty(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scores[0], scores[1], scores[2], dcaThird[0]);
                 }
                 if (activateQA) {
                   hMassVsPtB[kBplus]->Fill(ptCand, massCand);
@@ -534,7 +458,7 @@ struct HfFilter { // Main struct for HF triggers
                         keepEvent[kBeauty3P] = true;
                         // fill optimisation tree for D0
                         if (applyOptimisation) {
-                          optimisationTreeBeauty(thisCollId, 413, pt2Prong, scoresToFill[0], scoresToFill[1], scoresToFill[2], dcaFourth[0]); // pdgCode of D*(2010)+: 413
+                          optimisationTreeBeauty(thisCollId, 413, pt2Prong, scores[0], scores[1], scores[2], dcaFourth[0]); // pdgCode of D*(2010)+: 413
                         }
                         if (activateQA) {
                           auto pVecBeauty4Prong = RecoDecay::pVec(pVec2Prong, pVecThird, pVecFourth);
@@ -555,7 +479,7 @@ struct HfFilter { // Main struct for HF triggers
             if (isProton) {
               float relativeMomentum = helper.computeRelativeMomentum(pVecThird, pVec2Prong, massD0);
               if (applyOptimisation) {
-                optimisationTreeFemto(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scoresToFill[0], scoresToFill[1], scoresToFill[2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr());
+                optimisationTreeFemto(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scores[0], scores[1], scores[2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr());
               }
               if (relativeMomentum < femtoMaxRelativeMomentum) {
                 keepEvent[kFemto2P] = true;
@@ -785,50 +709,33 @@ struct HfFilter { // Main struct for HF triggers
         std::array<int8_t, kNCharmParticles - 1> isCharmTagged = is3Prong;
         std::array<int8_t, kNCharmParticles - 1> isBeautyTagged = is3Prong;
 
-        float scoresToFill[kNCharmParticles - 1][3];
-        for (int i = 0; i < kNCharmParticles - 1; i++) {
-          std::fill_n(scoresToFill[i], 3, -1);
-        } // initialize BDT scores array outside ML loop
-        // apply ML models
-        if (applyML) {
-          isSignalTagged = std::array<int8_t, kNCharmParticles - 1>{0};
-          isCharmTagged = std::array<int8_t, kNCharmParticles - 1>{0};
-          isBeautyTagged = std::array<int8_t, kNCharmParticles - 1>{0};
+        std::array<std::vector<float>, kNCharmParticles - 1> scores{};
+        scores[0].insert(scores[0].end(), cand3Prong.mlProbSkimDplusToPiKPi().begin(), cand3Prong.mlProbSkimDplusToPiKPi().end());
+        scores[1].insert(scores[1].end(), cand3Prong.mlProbSkimDsToKKPi().begin(), cand3Prong.mlProbSkimDsToKKPi().end());
+        scores[2].insert(scores[2].end(), cand3Prong.mlProbSkimLcToPKPi().begin(), cand3Prong.mlProbSkimLcToPKPi().end());
+        scores[3].insert(scores[3].end(), cand3Prong.mlProbSkimXicToPKPi().begin(), cand3Prong.mlProbSkimXicToPKPi().end());
 
-          // TODO: add more feature configurations
-          std::vector<float> inputFeatures{trackParFirst.getPt(), dcaFirst[0], dcaFirst[1], trackParSecond.getPt(), dcaSecond[0], dcaSecond[1], trackParThird.getPt(), dcaThird[0], dcaThird[1]};
-          std::vector<double> inputFeaturesD{trackParFirst.getPt(), dcaFirst[0], dcaFirst[1], trackParSecond.getPt(), dcaSecond[0], dcaSecond[1], trackParThird.getPt(), dcaThird[0], dcaThird[1]};
-          for (auto iCharmPart{0}; iCharmPart < kNCharmParticles - 1; ++iCharmPart) {
-            if (!is3Prong[iCharmPart] || onnxFiles[iCharmPart + 1] == "") {
-              continue;
-            }
+        for (auto iCharmPart{0}; iCharmPart < kNCharmParticles - 1; ++iCharmPart) {
+          if (!is3Prong[iCharmPart]) { // we immediately skip if it was not selected for a given 3-prong species
+            continue;
+          }
 
-            int tagBDT = 0;
-            if (dataTypeML[iCharmPart + 1] == 1) {
-              auto scores = helper.predictONNX(inputFeatures, sessionML[iCharmPart + 1], inputShapesML[iCharmPart + 1]);
-              tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[iCharmPart + 1]);
-              for (int iScore{0}; iScore < 3; ++iScore) {
-                scoresToFill[iCharmPart][iScore] = scores[iScore];
-              }
-            } else if (dataTypeML[iCharmPart + 1] == 11) {
-              auto scores = helper.predictONNX(inputFeaturesD, sessionML[iCharmPart + 1], inputShapesML[iCharmPart + 1]);
-              tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[iCharmPart + 1]);
-              for (int iScore{0}; iScore < 3; ++iScore) {
-                scoresToFill[iCharmPart][iScore] = scores[iScore];
-              }
-            } else {
-              LOG(error) << "Error running model inference for " << charmParticleNames[iCharmPart + 1].data() << ": Unexpected input data type.";
-            }
+          if (scores[iCharmPart].size() != 3) {
+            scores[iCharmPart].resize(3);
+            scores[iCharmPart][0] = 2.;
+            scores[iCharmPart][1] = -1.;
+            scores[iCharmPart][2] = -1.;
+          }
+          auto tagBDT = helper.isBDTSelected(scores[iCharmPart], thresholdBDTScores[iCharmPart + 1]);
 
-            isCharmTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
-            isBeautyTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
-            isSignalTagged[iCharmPart] = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isCharmTagged[iCharmPart] || isBeautyTagged[iCharmPart]);
+          isCharmTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
+          isBeautyTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
+          isSignalTagged[iCharmPart] = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isCharmTagged[iCharmPart] || isBeautyTagged[iCharmPart]);
 
-            if (activateQA > 1) {
-              hBDTScoreBkg[iCharmPart + 1]->Fill(scoresToFill[iCharmPart][0]);
-              hBDTScorePrompt[iCharmPart + 1]->Fill(scoresToFill[iCharmPart][1]);
-              hBDTScoreNonPrompt[iCharmPart + 1]->Fill(scoresToFill[iCharmPart][2]);
-            }
+          if (activateQA > 1) {
+            hBDTScoreBkg[iCharmPart + 1]->Fill(scores[iCharmPart][0]);
+            hBDTScorePrompt[iCharmPart + 1]->Fill(scores[iCharmPart][1]);
+            hBDTScoreNonPrompt[iCharmPart + 1]->Fill(scores[iCharmPart][2]);
           }
         }
 
@@ -848,25 +755,25 @@ struct HfFilter { // Main struct for HF triggers
         if (is3Prong[0]) {
           is3ProngInMass[0] = helper.isSelectedDplusInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, activateQA, hMassVsPtC[kDplus]);
           if (applyOptimisation) {
-            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kDPlus, pt3Prong, scoresToFill[0][0], scoresToFill[0][1], scoresToFill[0][2]);
+            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kDPlus, pt3Prong, scores[0][0], scores[0][1], scores[0][2]);
           }
         }
         if (is3Prong[1]) {
           is3ProngInMass[1] = helper.isSelectedDsInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, is3Prong[1], activateQA, hMassVsPtC[kDs]);
           if (applyOptimisation) {
-            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kDS, pt3Prong, scoresToFill[1][0], scoresToFill[1][1], scoresToFill[1][2]);
+            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kDS, pt3Prong, scores[1][0], scores[1][1], scores[1][2]);
           }
         }
         if (is3Prong[2]) {
           is3ProngInMass[2] = helper.isSelectedLcInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, is3Prong[2], activateQA, hMassVsPtC[kLc]);
           if (applyOptimisation) {
-            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kLambdaCPlus, pt3Prong, scoresToFill[2][0], scoresToFill[2][1], scoresToFill[2][2]);
+            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kLambdaCPlus, pt3Prong, scores[2][0], scores[2][1], scores[2][2]);
           }
         }
         if (is3Prong[3]) {
           is3ProngInMass[3] = helper.isSelectedXicInMassRange(pVecFirst, pVecThird, pVecSecond, pt3Prong, is3Prong[3], activateQA, hMassVsPtC[kXic]);
           if (applyOptimisation) {
-            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kXiCPlus, pt3Prong, scoresToFill[3][0], scoresToFill[3][1], scoresToFill[3][2]);
+            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kXiCPlus, pt3Prong, scores[3][0], scores[3][1], scores[3][2]);
           }
         }
 
@@ -910,7 +817,7 @@ struct HfFilter { // Main struct for HF triggers
                 if (std::fabs(massCandB - massBeautyHypos[iHypo]) <= deltaMassHypos[iHypo]) {
                   keepEvent[kBeauty4P] = true;
                   if (applyOptimisation) {
-                    optimisationTreeBeauty(thisCollId, charmParticleID[iHypo], pt3Prong, scoresToFill[iHypo][0], scoresToFill[iHypo][1], scoresToFill[iHypo][2], dcaFourth[0]);
+                    optimisationTreeBeauty(thisCollId, charmParticleID[iHypo], pt3Prong, scores[iHypo][0], scores[iHypo][1], scores[iHypo][2], dcaFourth[0]);
                   }
                   if (activateQA) {
                     auto pVecBeauty4Prong = RecoDecay::pVec(pVec3Prong, pVecFourth);
@@ -929,7 +836,7 @@ struct HfFilter { // Main struct for HF triggers
               if (isCharmTagged[iHypo] && enableFemtoChannels->get(0u, iHypo + 1) && (TESTBIT(is3ProngInMass[iHypo], 0) || TESTBIT(is3ProngInMass[iHypo], 1) || !requireCharmMassForFemto)) {
                 float relativeMomentum = helper.computeRelativeMomentum(pVecFourth, pVec3Prong, massCharmHypos[iHypo]);
                 if (applyOptimisation) {
-                  optimisationTreeFemto(thisCollId, charmParticleID[iHypo], pt3Prong, scoresToFill[iHypo][0], scoresToFill[iHypo][1], scoresToFill[iHypo][2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr());
+                  optimisationTreeFemto(thisCollId, charmParticleID[iHypo], pt3Prong, scores[iHypo][0], scores[iHypo][1], scores[iHypo][2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr());
                 }
                 if (relativeMomentum < femtoMaxRelativeMomentum) {
                   keepEvent[kFemto3P] = true;

--- a/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
+++ b/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
@@ -15,8 +15,6 @@
 ///
 /// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
 
-#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h> // needed for HFFilterHelpers, to be fixed
-
 #include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DataFormatsParameters/GRPObject.h"
@@ -45,21 +43,16 @@ using namespace o2::framework::expressions;
 
 struct HfFilterCharmHadronSignals { // Main struct for HF triggers
 
-  Configurable<bool> applyEventSelection{"applyEventSelection", false, "flag to enable event selection (sel8 + Zvt)"};
+  Configurable<bool> applyEventSelection{"applyEventSelection", true, "flag to enable event selection (sel8 + Zvt)"};
+  Configurable<bool> applyTimeFrameBorderCut{"applyTimeFrameBorderCut", true, "flag to enable time-frame border cut"};
 
-  // parameters for ML application with ONNX
-  Configurable<bool> applyML{"applyML", false, "Flag to enable or disable ML application"};
+  // parameters for ML application
   Configurable<std::vector<double>> pTBinsBDT{"pTBinsBDT", std::vector<double>{hf_cuts_bdt_multiclass::vecBinsPt}, "track pT bin limits for BDT cut"};
 
-  Configurable<std::string> onnxFileD0ToKPiConf{"onnxFileD0ToKPiConf", "XGBoostModel.onnx", "ONNX file for ML model for D0 candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreD0ToKPi{"thresholdBDTScoreD0ToKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D0 candidates"};
-  Configurable<std::string> onnxFileDPlusToPiKPiConf{"onnxFileDPlusToPiKPiConf", "", "ONNX file for ML model for D+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDPlusToPiKPi{"thresholdBDTScoreDPlusToPiKPi", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of D+ candidates"};
-  Configurable<std::string> onnxFileDSToPiKKConf{"onnxFileDSToPiKKConf", "", "ONNX file for ML model for Ds+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreDSToPiKK{"thresholdBDTScoreDSToPiKK", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Ds+ candidates"};
-  Configurable<std::string> onnxFileLcToPiKPConf{"onnxFileLcToPiKPConf", "", "ONNX file for ML model for Lc+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreLcToPiKP{"thresholdBDTScoreLcToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Lc+ candidates"};
-  Configurable<std::string> onnxFileXicToPiKPConf{"onnxFileXicToPiKPConf", "", "ONNX file for ML model for Xic+ candidates"};
   Configurable<LabeledArray<double>> thresholdBDTScoreXicToPiKP{"thresholdBDTScoreXicToPiKP", {hf_cuts_bdt_multiclass::cuts[0], hf_cuts_bdt_multiclass::nBinsPt, hf_cuts_bdt_multiclass::nCutBdtScores, hf_cuts_bdt_multiclass::labelsPt, hf_cuts_bdt_multiclass::labelsCutBdt}, "Threshold values for BDT output scores of Xic+ candidates"};
   Configurable<std::string> paramCharmMassShape{"paramCharmMassShape", "2023_pass3", "Parametrisation of charm-hadron mass shape (options: 2023_pass3)"};
   Configurable<float> numSigmaDeltaMassCharmHad{"numSigmaDeltaMassCharmHad", 2.5, "Number of sigma for charm-hadron delta mass cut in B and D resonance triggers"};
@@ -73,26 +66,11 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
   Configurable<LabeledArray<double>> cutsTrackBeauty3Prong{"cutsTrackBeauty3Prong", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 3-prong beauty candidates"};
 
   // CCDB configuration
-  o2::ccdb::CcdbApi ccdbApi;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::string> mlModelPathCCDB{"mlModelPathCCDB", "Analysis/PWGHF/ML/HFTrigger/", "Path on CCDB"};
-  Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB. Exceptions: > 0 for the specific timestamp, 0 gets the run dependent timestamp"};
-  Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
-  int currentRun{0}; // needed to get proper magnetic field
+  int currentRun{0}; // needed to detect if the run changed and trigger update of calibrations etc.
 
-  // ONNX
-  std::array<std::shared_ptr<Ort::Experimental::Session>, kNCharmParticles> sessionML = {nullptr, nullptr, nullptr, nullptr, nullptr};
-  std::array<std::vector<std::vector<int64_t>>, kNCharmParticles> inputShapesML{};
-  std::array<Ort::Env, kNCharmParticles> envML = {
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-d0-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-dplus-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-ds-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-lc-triggers"},
-    Ort::Env{ORT_LOGGING_LEVEL_ERROR, "ml-model-xic-triggers"}};
-  std::array<Ort::SessionOptions, kNCharmParticles> sessionOptions{Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions(), Ort::SessionOptions()};
-  std::array<int, kNCharmParticles> dataTypeML{};
-  std::array<std::string, kNCharmParticles> onnxFiles;
+  // array of BDT thresholds
   std::array<LabeledArray<double>, kNCharmParticles> thresholdBDTScores;
 
   ConfigurableAxis pvContributorsAxis{"pvContributorsAxis", {250, 0.f, 250.f}, "PV contributors"};
@@ -128,46 +106,28 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
     ccdb->setLocalObjectValidityChecking();
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
 
-    thresholdBDTScores = {
-      thresholdBDTScoreD0ToKPi,
-      thresholdBDTScoreDPlusToPiKPi,
-      thresholdBDTScoreDSToPiKK,
-      thresholdBDTScoreLcToPiKP,
-      thresholdBDTScoreXicToPiKP};
-
-    onnxFiles = {
-      onnxFileD0ToKPiConf,
-      onnxFileDPlusToPiKPiConf,
-      onnxFileDSToPiKKConf,
-      onnxFileLcToPiKPConf,
-      onnxFileXicToPiKPConf};
-
-    // init ONNX runtime session
-    if (applyML && (!loadModelsFromCCDB || timestampCCDB != 0)) {
-      for (auto iCharmPart{0}; iCharmPart < kNCharmParticles; ++iCharmPart) {
-        if (onnxFiles[iCharmPart] != "") {
-          sessionML[iCharmPart].reset(helper.initONNXSession(onnxFiles[iCharmPart], charmParticleNames[iCharmPart], envML[iCharmPart], sessionOptions[iCharmPart], inputShapesML[iCharmPart], dataTypeML[iCharmPart], loadModelsFromCCDB, ccdbApi, mlModelPathCCDB.value, timestampCCDB));
-        }
-      }
-    }
+    thresholdBDTScores = {thresholdBDTScoreD0ToKPi, thresholdBDTScoreDPlusToPiKPi, thresholdBDTScoreDSToPiKK, thresholdBDTScoreLcToPiKP, thresholdBDTScoreXicToPiKP};
   }
 
   using CollsWithEvSelAndMult = soa::Join<aod::Collisions, aod::EvSels, aod::Mults>;
   using BigTracksPID = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr>;
 
+  using Hf2ProngsWithMl = soa::Join<aod::Hf2Prongs, aod::Hf2ProngMlProbs>;
+  using Hf3ProngsWithMl = soa::Join<aod::Hf3Prongs, aod::Hf3ProngMlProbs>;
+
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
-  Preslice<aod::Hf2Prongs> hf2ProngPerCollision = aod::track_association::collisionId;
-  Preslice<aod::Hf3Prongs> hf3ProngPerCollision = aod::track_association::collisionId;
+  Preslice<Hf2ProngsWithMl> hf2ProngPerCollision = aod::track_association::collisionId;
+  Preslice<Hf3ProngsWithMl> hf3ProngPerCollision = aod::track_association::collisionId;
 
   void process(CollsWithEvSelAndMult const& collisions,
                aod::BCsWithTimestamps const&,
-               aod::Hf2Prongs const& cand2Prongs,
-               aod::Hf3Prongs const& cand3Prongs,
+               Hf2ProngsWithMl const& cand2Prongs,
+               Hf3ProngsWithMl const& cand3Prongs,
                aod::TrackAssoc const& trackIndices,
                BigTracksPID const& tracks)
   {
     for (const auto& collision : collisions) {
-      if (applyEventSelection && (!collision.sel8() || std::fabs(collision.posZ()) > 11.f)) { // safety margin for Zvtx
+      if (applyEventSelection && (!collision.sel8() || std::fabs(collision.posZ()) > 11.f || (!collision.selection_bit(aod::evsel::kNoTimeFrameBorder) && applyTimeFrameBorderCut))) { // safety margin for Zvtx
         continue;
       }
 
@@ -175,15 +135,6 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
 
       auto thisCollId = collision.globalIndex();
       auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-
-      if (applyML && (loadModelsFromCCDB && timestampCCDB == 0) && !sessionML[kD0]) {
-        for (auto iCharmPart{0}; iCharmPart < kNCharmParticles; ++iCharmPart) {
-          if (onnxFiles[iCharmPart] != "") {
-            sessionML[iCharmPart].reset(helper.initONNXSession(onnxFiles[iCharmPart], charmParticleNames[iCharmPart], envML[iCharmPart], sessionOptions[iCharmPart], inputShapesML[iCharmPart], dataTypeML[iCharmPart], loadModelsFromCCDB, ccdbApi, mlModelPathCCDB.value, bc.timestamp()));
-          }
-        }
-      }
-
       // needed for track propagation
       if (currentRun != bc.runNumber()) {
         o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", bc.timestamp());
@@ -222,31 +173,17 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         }
 
         // apply ML models
-        int tagBDT = 0;
-        float scoresToFill[3] = {-1., -1., -1.};
-        if (applyML && onnxFiles[kD0] != "") {
-          std::vector<float> inputFeaturesD0{trackParPos.getPt(), dcaPos[0], dcaPos[1], trackParNeg.getPt(), dcaNeg[0], dcaNeg[1]};
-          std::vector<double> inputFeaturesDoD0{trackParPos.getPt(), dcaPos[0], dcaPos[1], trackParNeg.getPt(), dcaNeg[0], dcaNeg[1]};
-
-          if (dataTypeML[kD0] == 1) {
-            auto scores = helper.predictONNX(inputFeaturesD0, sessionML[kD0], inputShapesML[kD0]);
-            tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
-            for (int iScore{0}; iScore < 3; ++iScore) {
-              scoresToFill[iScore] = scores[iScore];
-            }
-          } else if (dataTypeML[kD0] == 11) {
-            auto scores = helper.predictONNX(inputFeaturesDoD0, sessionML[kD0], inputShapesML[kD0]);
-            tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
-            for (int iScore{0}; iScore < 3; ++iScore) {
-              scoresToFill[iScore] = scores[iScore];
-            }
-          } else {
-            LOG(fatal) << "Error running model inference for D0: Unexpected input data type.";
-          }
-
-          if (!TESTBIT(tagBDT, RecoDecay::OriginType::None)) { // if not signal, we skip
-            continue;
-          }
+        std::vector<float> scores{};
+        scores.insert(scores.end(), cand2Prong.mlProbSkimD0ToKPi().begin(), cand2Prong.mlProbSkimD0ToKPi().end());
+        if (scores.size() != 3) {
+          scores.resize(3);
+          scores[0] = 2.;
+          scores[1] = -1.;
+          scores[2] = -1.;
+        }
+        auto tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
+        if (!TESTBIT(tagBDT, RecoDecay::OriginType::None)) {
+          continue;
         }
 
         auto pVec2Prong = RecoDecay::pVec(pVecPos, pVecNeg);
@@ -257,10 +194,10 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         auto invMassD0bar = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massKa, massPi});
         // fill THnSparse
         if (TESTBIT(preselD0, 0)) { // D0
-          registry.fill(HIST("hDzeroToKPi"), invMassD0, pt2Prong, yD0, phi2Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1], scoresToFill[2]);
+          registry.fill(HIST("hDzeroToKPi"), invMassD0, pt2Prong, yD0, phi2Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1], scores[2]);
         }
         if (TESTBIT(preselD0, 1)) { // D0bar
-          registry.fill(HIST("hDzeroToKPi"), invMassD0bar, pt2Prong, yD0, phi2Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1], scoresToFill[2]);
+          registry.fill(HIST("hDzeroToKPi"), invMassD0bar, pt2Prong, yD0, phi2Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1], scores[2]);
         }
 
         // we build D* here, as done in the HFFilter.cxx
@@ -300,9 +237,9 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
             auto phiDstar = RecoDecay::phi(pVecDstar[0], pVecDstar[1]);
             auto yDstar = RecoDecay::y(pVecDstar, massDStar);
             if (minDeltaMassDstar <= massDiffDstar && massDiffDstar <= maxDeltaMassDstar) {
-              registry.fill(HIST("hDstarToDzeroPi"), massDiffDstar, ptDstar, yDstar, phiDstar, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1], scoresToFill[2]); // for D* we store the BDT output scores of the D0
+              registry.fill(HIST("hDstarToDzeroPi"), massDiffDstar, ptDstar, yDstar, phiDstar, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1], scores[2]); // for D* we store the BDT output scores of the D0
               if (TESTBIT(isTrackSelected, kSoftPionForBeauty)) {
-                registry.fill(HIST("hDstarToDzeroPiForBeauty"), massDiffDstar, ptDstar, yDstar, phiDstar, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1], scoresToFill[2]); // for D* we store the BDT output scores of the D0
+                registry.fill(HIST("hDstarToDzeroPiForBeauty"), massDiffDstar, ptDstar, yDstar, phiDstar, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1], scores[2]); // for D* we store the BDT output scores of the D0
               }
             }
           }
@@ -364,45 +301,27 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         }
 
         std::array<int8_t, kNCharmParticles - 1> isSignalTagged = is3Prong;
-        std::array<int8_t, kNCharmParticles - 1> isCharmTagged = is3Prong;
-        std::array<int8_t, kNCharmParticles - 1> isBeautyTagged = is3Prong;
-        float scoresToFill[kNCharmParticles - 1][3];
-        for (int i = 0; i < kNCharmParticles - 1; i++) {
-          std::fill_n(scoresToFill[i], 3, -1);
-        } // initialize BDT scores array outside ML loop
-        if (applyML) {
-          isSignalTagged = std::array<int8_t, kNCharmParticles - 1>{0};
-          isCharmTagged = std::array<int8_t, kNCharmParticles - 1>{0};
-          isBeautyTagged = std::array<int8_t, kNCharmParticles - 1>{0};
 
-          std::vector<float> inputFeatures{trackParFirst.getPt(), dcaFirst[0], dcaFirst[1], trackParSecond.getPt(), dcaSecond[0], dcaSecond[1], trackParThird.getPt(), dcaThird[0], dcaThird[1]};
-          std::vector<double> inputFeaturesD{trackParFirst.getPt(), dcaFirst[0], dcaFirst[1], trackParSecond.getPt(), dcaSecond[0], dcaSecond[1], trackParThird.getPt(), dcaThird[0], dcaThird[1]};
-          for (auto iCharmPart{0}; iCharmPart < kNCharmParticles - 1; ++iCharmPart) {
-            if (!is3Prong[iCharmPart] || onnxFiles[iCharmPart + 1] == "") {
-              continue;
-            }
+        std::array<std::vector<float>, kNCharmParticles - 1> scores{};
+        scores[0].insert(scores[0].end(), cand3Prong.mlProbSkimDplusToPiKPi().begin(), cand3Prong.mlProbSkimDplusToPiKPi().end());
+        scores[1].insert(scores[1].end(), cand3Prong.mlProbSkimDsToKKPi().begin(), cand3Prong.mlProbSkimDsToKKPi().end());
+        scores[2].insert(scores[2].end(), cand3Prong.mlProbSkimLcToPKPi().begin(), cand3Prong.mlProbSkimLcToPKPi().end());
+        scores[3].insert(scores[3].end(), cand3Prong.mlProbSkimXicToPKPi().begin(), cand3Prong.mlProbSkimXicToPKPi().end());
 
-            int tagBDT = 0;
-            if (dataTypeML[iCharmPart + 1] == 1) {
-              auto scores = helper.predictONNX(inputFeatures, sessionML[iCharmPart + 1], inputShapesML[iCharmPart + 1]);
-              tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[iCharmPart + 1]);
-              for (int iScore{0}; iScore < 3; ++iScore) {
-                scoresToFill[iCharmPart][iScore] = scores[iScore];
-              }
-            } else if (dataTypeML[iCharmPart + 1] == 11) {
-              auto scores = helper.predictONNX(inputFeaturesD, sessionML[iCharmPart + 1], inputShapesML[iCharmPart + 1]);
-              tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[iCharmPart + 1]);
-              for (int iScore{0}; iScore < 3; ++iScore) {
-                scoresToFill[iCharmPart][iScore] = scores[iScore];
-              }
-            } else {
-              LOG(error) << "Error running model inference for " << charmParticleNames[iCharmPart + 1].data() << ": Unexpected input data type.";
-            }
-
-            isSignalTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::None);
-            isCharmTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
-            isBeautyTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
+        for (auto iCharmPart{0}; iCharmPart < kNCharmParticles - 1; ++iCharmPart) {
+          if (!is3Prong[iCharmPart]) { // we immediately skip if it was not selected for a given 3-prong species
+            continue;
           }
+
+          if (scores[iCharmPart].size() != 3) {
+            scores[iCharmPart].resize(3);
+            scores[iCharmPart][0] = 2.;
+            scores[iCharmPart][1] = -1.;
+            scores[iCharmPart][2] = -1.;
+          }
+          auto tagBDT = helper.isBDTSelected(scores[iCharmPart], thresholdBDTScores[iCharmPart + 1]);
+
+          isSignalTagged[iCharmPart] = TESTBIT(tagBDT, RecoDecay::OriginType::None);
         }
 
         if (!std::accumulate(isSignalTagged.begin(), isSignalTagged.end(), 0)) {
@@ -415,28 +334,28 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         if (is3Prong[0]) { // D+
           auto yDplus = RecoDecay::y(pVec3Prong, massDPlus);
           auto invMassDplus = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird}, std::array{massPi, massKa, massPi});
-          registry.fill(HIST("hDplusToKPiPi"), invMassDplus, pt3Prong, yDplus, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[0][1], scoresToFill[0][2]);
+          registry.fill(HIST("hDplusToKPiPi"), invMassDplus, pt3Prong, yDplus, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[0][1], scores[0][2]);
         }
         if (is3Prong[1]) { // Ds+
           auto yDs = RecoDecay::y(pVec3Prong, massDs);
           if (TESTBIT(is3Prong[1], 0)) {
             auto invMassDsToKKPi = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird}, std::array{massKa, massKa, massPi});
-            registry.fill(HIST("hDsToKKPi"), invMassDsToKKPi, pt3Prong, yDs, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1][1], scoresToFill[1][2]);
+            registry.fill(HIST("hDsToKKPi"), invMassDsToKKPi, pt3Prong, yDs, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1][1], scores[1][2]);
           }
           if (TESTBIT(is3Prong[1], 1)) {
             auto invMassDsToPiKK = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird}, std::array{massPi, massKa, massKa});
-            registry.fill(HIST("hDsToKKPi"), invMassDsToPiKK, pt3Prong, yDs, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[1][1], scoresToFill[1][2]);
+            registry.fill(HIST("hDsToKKPi"), invMassDsToPiKK, pt3Prong, yDs, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[1][1], scores[1][2]);
           }
         }
         if (is3Prong[2]) { // Lc+
           auto yLc = RecoDecay::y(pVec3Prong, massLc);
           if (TESTBIT(is3Prong[2], 0)) {
             auto invMassLcToPKPi = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird}, std::array{massProton, massKa, massPi});
-            registry.fill(HIST("hLcToPKPi"), invMassLcToPKPi, pt3Prong, yLc, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[2][1], scoresToFill[2][2]);
+            registry.fill(HIST("hLcToPKPi"), invMassLcToPKPi, pt3Prong, yLc, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[2][1], scores[2][2]);
           }
           if (TESTBIT(is3Prong[2], 1)) {
             auto invMassLcToPiKP = RecoDecay::m(std::array{pVecFirst, pVecSecond, pVecThird}, std::array{massPi, massKa, massProton});
-            registry.fill(HIST("hLcToPKPi"), invMassLcToPiKP, pt3Prong, yLc, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scoresToFill[2][1], scoresToFill[2][2]);
+            registry.fill(HIST("hLcToPKPi"), invMassLcToPiKP, pt3Prong, yLc, phi3Prong, collision.posZ(), collision.numContrib(), collision.multFT0M(), scores[2][1], scores[2][2]);
           }
         }
       } // end 3-prong loop

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -268,6 +268,12 @@ DECLARE_SOA_COLUMN(FlagDsToKKPi, flagDsToKKPi, uint8_t);         //!
 DECLARE_SOA_COLUMN(FlagXicToPKPi, flagXicToPKPi, uint8_t);       //!
 
 DECLARE_SOA_COLUMN(FlagDstarToD0Pi, flagDstarToD0Pi, uint8_t); //!
+
+DECLARE_SOA_COLUMN(MlProbSkimD0ToKPi, mlProbSkimD0ToKPi, std::vector<float>);           //! ML probabilities (background, prompt, non-prompt) for D0->Kpi
+DECLARE_SOA_COLUMN(MlProbSkimDplusToPiKPi, mlProbSkimDplusToPiKPi, std::vector<float>); //! ML probabilities (background, prompt, non-prompt) for D+->Kpipi
+DECLARE_SOA_COLUMN(MlProbSkimDsToKKPi, mlProbSkimDsToKKPi, std::vector<float>);         //! ML probabilities (background, prompt, non-prompt) for Ds->KKpi
+DECLARE_SOA_COLUMN(MlProbSkimLcToPKPi, mlProbSkimLcToPKPi, std::vector<float>);         //! ML probabilities (background, prompt, non-prompt) for Lc->pKpi
+DECLARE_SOA_COLUMN(MlProbSkimXicToPKPi, mlProbSkimXicToPKPi, std::vector<float>);       //! ML probabilities (background, prompt, non-prompt) for Xic->pKpi
 } // namespace hf_track_index
 
 DECLARE_SOA_TABLE(Hf2Prongs_000, "AOD", "HF2PRONG", //! Table for HF 2 prong candidates (Run 2 converted format)
@@ -366,6 +372,15 @@ DECLARE_SOA_TABLE(HfCutStatus3Prong, "AOD", "HFCUTSTATUS3P", //!
 
 DECLARE_SOA_TABLE(HfCutStatusDstar, "AOD", "HFCUTSTATUSDST", //!
                   hf_track_index::FlagDstarToD0Pi);
+
+DECLARE_SOA_TABLE(Hf2ProngMlProbs, "AOD", "HF2PRONGMLPROB", //! Table for ML scores of HF 2 prong candidates
+                  hf_track_index::MlProbSkimD0ToKPi);
+
+DECLARE_SOA_TABLE(Hf3ProngMlProbs, "AOD", "HF3PRONGMLPROB", //! Table for ML scores of HF 3 prong candidates
+                  hf_track_index::MlProbSkimDplusToPiKPi,
+                  hf_track_index::MlProbSkimLcToPKPi,
+                  hf_track_index::MlProbSkimDsToKKPi,
+                  hf_track_index::MlProbSkimXicToPKPi);
 
 namespace hf_pv_refit
 {

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 o2physics_add_dpl_workflow(track-index-skim-creator
                     SOURCES trackIndexSkimCreator.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing O2::DCAFitter O2Physics::AnalysisCCDB
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing O2::DCAFitter O2Physics::AnalysisCCDB O2Physics::MLCore
                     COMPONENT_NAME Analysis)
 
 # Helpers

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1427,7 +1427,7 @@ struct HfTrackIndexSkimCreator {
       const std::vector<std::string> mlModelPathCcdb2Prongs = {mlModelPathCCDB.value + "D0"};
       const std::array<std::vector<std::string>, kN3ProngDecays> mlModelPathCcdb3Prongs = {std::vector<std::string>{mlModelPathCCDB.value + "Dplus"}, std::vector<std::string>{mlModelPathCCDB.value + "Lc"}, std::vector<std::string>{mlModelPathCCDB.value + "Ds"}, std::vector<std::string>{mlModelPathCCDB.value + "Xic"}};
       const std::vector<double> ptBinsMl = {0., 1.e10};
-      const std::vector<int> cutDirMl = {o2::cuts_ml::CutDirection::CutSmaller, o2::cuts_ml::CutDirection::CutGreater, o2::cuts_ml::CutDirection::CutGreater};
+      const std::vector<int> cutDirMl = {o2::cuts_ml::CutDirection::CutGreater, o2::cuts_ml::CutDirection::CutSmaller, o2::cuts_ml::CutDirection::CutSmaller};
       const std::array<LabeledArray<double>, kN3ProngDecays> thresholdMlScore3Prongs = {thresholdMlScoreDplusToPiKPi, thresholdMlScoreLcToPiKP, thresholdMlScoreDsToPiKK, thresholdMlScoreXicToPiKP};
       
       // initialise 2-prong ML response


### PR DESCRIPTION
In this PR I moved the application of the ML models needed for the `HFFilter.cxx` in the `trackIndexSkimCreator`.
A cut on the ML scores can be applied already in the `trackIndexSkimCreator`, but the scores of the candidates passing the selections are also stored in an output table to further apply selections in the subsequent steps (needed for instance to separate prompt and non-prompt candidates).