### PR TITLE
Remove unused constant kHighFv0Flat

### DIFF
--- a/EventFiltering/PWGMM/multFilter.cxx
+++ b/EventFiltering/PWGMM/multFilter.cxx
@@ -39,7 +39,6 @@ float meanMultV0A = 0.f;
 struct multFilter {
   enum { kHighTrackMult = 0,
          kHighFv0Mult,
-         kHighFv0Flat,
          kHighFt0Mult,
          kHighFt0Flat,
          kHighFt0cFv0Mult,


### PR DESCRIPTION
This was causing a bug in the interface with the CEFP by increasing the size of the keepEvent array and shifting the bits by 1