### PR TITLE
Standardise scalers reporting in LF

### DIFF
--- a/EventFiltering/PWGLF/filterf1proton.cxx
+++ b/EventFiltering/PWGLF/filterf1proton.cxx
@@ -130,8 +130,8 @@ struct filterf1proton {
   Configurable<double> cMaxRelMom{"cMaxRelMom", 0.5, "Relative momentum cut"};
 
   // Histogram
+  OutputObj<TH1D> hProcessedEvents{TH1D("hProcessedEvents", ";; Number of events", 3, 0.0f, 3.0f)};
   HistogramRegistry qaRegistry{"QAHistos", {
-                                             {"hEventstat", "hEventstat", {HistType::kTH1F, {{3, 0.0f, 3.0f}}}},
                                              {"hInvMassf1", "hInvMassf1", {HistType::kTH2F, {{400, 1.1f, 1.9f}, {100, 0.0f, 10.0f}}}},
                                              {"hInvMassf1Like", "hInvMassf1Like", {HistType::kTH2F, {{400, 1.1f, 1.9f}, {100, 0.0f, 10.0f}}}},
                                              {"hInvMassf1kstar", "hInvMassf1kstar", {HistType::kTH3F, {{400, 1.1f, 1.9f}, {100, 0.0f, 10.0f}, {8, 0.0f, 0.8f}}}},
@@ -158,6 +158,9 @@ struct filterf1proton {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    hProcessedEvents->GetXaxis()->SetBinLabel(1, "All events");
+    hProcessedEvents->GetXaxis()->SetBinLabel(2, "Events with F1");
+    hProcessedEvents->GetXaxis()->SetBinLabel(3, aod::filtering::TriggerEventF1Proton::columnLabel());
   }
 
   template <typename T>
@@ -643,12 +646,12 @@ struct filterf1proton {
         }
       }
     }
-    qaRegistry.fill(HIST("hEventstat"), 0.5);
+    hProcessedEvents->Fill(0.5);
     if (numberF1 > 0) {
-      qaRegistry.fill(HIST("hEventstat"), 1.5);
+      hProcessedEvents->Fill(1.5);
     }
     if (keepEventF1Proton) {
-      qaRegistry.fill(HIST("hEventstat"), 2.5);
+      hProcessedEvents->Fill(2.5);
     }
     tags(keepEventF1Proton);
   }

--- a/EventFiltering/PWGLF/strangenessFilter.cxx
+++ b/EventFiltering/PWGLF/strangenessFilter.cxx
@@ -68,7 +68,7 @@ struct strangenessFilter {
   HistogramRegistry QAHistosTriggerParticles{"QAHistosTriggerParticles", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
   HistogramRegistry QAHistosStrangenessTracking{"QAHistosStrangenessTracking", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
   HistogramRegistry EventsvsMultiplicity{"EventsvsMultiplicity", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
-  OutputObj<TH1F> hProcessedEvents{TH1F("hProcessedEvents", "Strangeness - event filtered; Event counter; Number of events", 13, -1., 12.)};
+  OutputObj<TH1D> hProcessedEvents{TH1D("hProcessedEvents", "Strangeness - event filtered;; Number of events", 13, -1., 12.)};
   OutputObj<TH1F> hCandidate{TH1F("hCandidate", "; Candidate pass selection; Number of events", 30, 0., 30.)};
   OutputObj<TH1F> hEvtvshMinPt{TH1F("hEvtvshMinPt", " Number of h-Xi events with pT_h higher than thrd; hadrons with p_{T}>bincenter (GeV/c); Number of events", 11, 0., 11.)};
   OutputObj<TH1F> hhXiPairsvsPt{TH1F("hhXiPairsvsPt", "pt distributions of Xi in events with a trigger particle; #it{p}_{T} (GeV/c); Number of Xi", 100, 0., 10.)};
@@ -180,18 +180,19 @@ struct strangenessFilter {
     mTrackSelector.SetMaxDcaXY(1.f);
     mTrackSelector.SetMaxDcaZ(2.f);
 
-    hProcessedEvents->GetXaxis()->SetBinLabel(2, "Events processed");
+    hProcessedEvents->GetXaxis()->SetBinLabel(1, "Events processed");
+    hProcessedEvents->GetXaxis()->SetBinLabel(2, "Event selection");
     hProcessedEvents->GetXaxis()->SetBinLabel(3, "Events w/ high-#it{p}_{T} hadron");
-    hProcessedEvents->GetXaxis()->SetBinLabel(4, "#Omega");
-    hProcessedEvents->GetXaxis()->SetBinLabel(5, "high-#it{p}_{T} hadron - #Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(6, "2#Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(7, "3#Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(8, "4#Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(9, "#Xi-YN");
-    hProcessedEvents->GetXaxis()->SetBinLabel(10, "#Omega high radius");
+    hProcessedEvents->GetXaxis()->SetBinLabel(4, aod::filtering::Omega::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(5, aod::filtering::hadronXi::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(6, aod::filtering::DoubleXi::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(7, aod::filtering::TripleXi::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(8, aod::filtering::QuadrupleXi::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(9, aod::filtering::SingleXiYN::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(10, aod::filtering::OmegaLargeRadius::columnLabel());
     hProcessedEvents->GetXaxis()->SetBinLabel(11, "#Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(12, "trk. #Xi");
-    hProcessedEvents->GetXaxis()->SetBinLabel(13, "trk. #Omega");
+    hProcessedEvents->GetXaxis()->SetBinLabel(12, aod::filtering::TrackedXi::columnLabel());
+    hProcessedEvents->GetXaxis()->SetBinLabel(13, aod::filtering::TrackedOmega::columnLabel());
 
     hCandidate->GetXaxis()->SetBinLabel(1, "All");
     hCandidate->GetXaxis()->SetBinLabel(2, "Has_V0");


### PR DESCRIPTION
This is an example to be followed by the other PWGs to enable automatic verification of the consistency of the scalers with the CEFP reporting