### PR TITLE
[PWGDQ] Fix bug for Q-vector normalisation

### DIFF
--- a/PWGDQ/Tasks/dqFlow.cxx
+++ b/PWGDQ/Tasks/dqFlow.cxx
@@ -358,9 +358,9 @@ struct DQEventQvector {
     }
 
     // Define quantities needed for the different eta regions
-    uint8_t nentriesN = 0.0;
-    uint8_t nentriesP = 0.0;
-    uint8_t nentriesFull = 0.0;
+    int nentriesN = 0;
+    int nentriesP = 0;
+    int nentriesFull = 0;
     complex<double> Q1vecN;
     complex<double> Q1vecP;
     complex<double> Q1vecFull;


### PR DESCRIPTION
Fix bug of Q-vector normalisation coming from the insufficient size of type `uint8_t`