### PR TITLE
PWGCF: add new event selection bits to FemtoDream producer

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
@@ -41,13 +41,14 @@ class FemtoDreamCollisionSelection
   /// \param checkTrigger whether or not to check for the trigger alias
   /// \param trig Requested trigger alias
   /// \param checkOffline whether or not to check for offline selection criteria
-  void setCuts(float zvtxMax, bool checkTrigger, int trig, bool checkOffline, bool checkRun3)
+  void setCuts(float zvtxMax, bool checkTrigger, int trig, bool checkOffline, bool addCheckOffline, bool checkRun3)
   {
     mCutsSet = true;
     mZvtxMax = zvtxMax;
     mCheckTrigger = checkTrigger;
     mTrigger = static_cast<triggerAliases>(trig);
     mCheckOffline = checkOffline;
+    mAddCheckOffline = addCheckOffline;
     mCheckIsRun3 = checkRun3;
   }
 
@@ -85,16 +86,15 @@ class FemtoDreamCollisionSelection
   bool isSelectedCollision(C const& col)
   {
 
-    // remove events at the border of the time frame
-    if (!col.selection_bit(aod::evsel::kNoTimeFrameBorder)) {
-      return false;
-    }
-
     if (std::abs(col.posZ()) > mZvtxMax) {
       return false;
     }
     if (mCheckIsRun3) {
       if (mCheckOffline && !col.sel8()) {
+        return false;
+      }
+      // all checks additional to sel8 are pending to be included in sel8, check them explicitly now and remove them once they have been added to sel8
+      if (mAddCheckOffline && (!col.selection_bit(aod::evsel::kNoTimeFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoITSROFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoSameBunchPileup) || !col.selection_bit(o2::aod::evsel::kIsVertexITSTPC))) {
         return false;
       }
     } else {
@@ -173,6 +173,7 @@ class FemtoDreamCollisionSelection
   bool mCutsSet = false;                           ///< Protection against running without cuts
   bool mCheckTrigger = false;                      ///< Check for trigger
   bool mCheckOffline = false;                      ///< Check for offline criteria (might change)
+  bool mAddCheckOffline = false;                   ///< Additional check for offline criteria (added to sel8 soon)
   bool mCheckIsRun3 = false;                       ///< Check if running on Pilot Beam
   triggerAliases mTrigger = kINT7;                 ///< Trigger to check for
   float mZvtxMax = 999.f;                          ///< Maximal deviation from nominal z-vertex (cm)

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -76,6 +76,7 @@ struct femtoDreamProducerReducedTask {
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+  Configurable<bool> ConfEvtAddOfflineCheck{"ConfEvtAddOfflineCheck", false, "Evt sel: additional checks for offline selection (not part of sel8 yet)"};
 
   Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
 
@@ -113,7 +114,7 @@ struct femtoDreamProducerReducedTask {
     int CutBits = 8 * sizeof(o2::aod::femtodreamparticle::cutContainerType);
     Registry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
 
-    colCuts.setCuts(ConfEvtZvtx.value, ConfEvtTriggerCheck.value, ConfEvtTriggerSel.value, ConfEvtOfflineCheck.value, ConfIsRun3.value);
+    colCuts.setCuts(ConfEvtZvtx.value, ConfEvtTriggerCheck.value, ConfEvtTriggerSel.value, ConfEvtOfflineCheck.value, ConfEvtAddOfflineCheck.value, ConfIsRun3.value);
     colCuts.init(&qaRegistry);
 
     trackCuts.setSelection(ConfTrkCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -90,6 +90,7 @@ struct femtoDreamProducerTask {
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
+  Configurable<bool> ConfEvtAddOfflineCheck{"ConfEvtAddOfflineCheck", false, "Evt sel: additional checks for offline selection (not part of sel8 yet)"};
   Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", true, "Activate filling of V0 into femtodream tables"};
 
   Configurable<bool> ConfTrkRejectNotPropagated{"ConfTrkRejectNotPropagated", false, "True: reject not propagated tracks"};
@@ -167,7 +168,7 @@ struct femtoDreamProducerTask {
     TrackRegistry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
     V0Registry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
 
-    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, ConfIsRun3);
+    colCuts.setCuts(ConfEvtZvtx.value, ConfEvtTriggerCheck.value, ConfEvtTriggerSel.value, ConfEvtOfflineCheck.value, ConfEvtAddOfflineCheck.value, ConfIsRun3.value);
     colCuts.init(&qaRegistry);
 
     trackCuts.setSelection(ConfTrkCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);


### PR DESCRIPTION
New event selection bits have been added to the central event selection task here PR https://github.com/AliceO2Group/O2Physics/pull/5411

In this PR they are added to the FemtoDream producer task. All the checks added are pending to be included in sel8 selection. Once this has been done, these additional checks can be removed again.