### PR TITLE
Fix logic and reporting of table auto-enabling

### DIFF
--- a/Common/Core/TableHelper.cxx
+++ b/Common/Core/TableHelper.cxx
@@ -68,7 +68,6 @@ void enableFlagIfTableRequired(o2::framework::InitContext& initContext, const st
     LOG(info) << "Auto-enabling table: " + table;
     return;
   }
-  flag = false;
   LOG(info) << "Table disabled and not required: " + table;
 }
 
@@ -89,8 +88,13 @@ void enableFlagIfTableRequired(o2::framework::InitContext& initContext, const st
       LOG(info) << "Auto-enabling table: " + table;
       return;
     }
-    LOG(info) << "Table disabled but required: " + table;
+    LOG(warn) << "Table disabled but required: " + table;
+  } else {
+    if (flag < 0) {
+      flag = 0;
+      LOG(info) << "Auto-disabling table: " + table;
+      return;
+    }
+    LOG(info) << "Table disabled and not required: " + table;
   }
-  flag = 0;
-  LOG(info) << "Table disabled and not required: " + table;
 }


### PR DESCRIPTION
Current problematic behaviour:

- `if (required && flag == 0)`:
  - info "Table disabled but required" (correct, but should be at least warning if not error or fatal)
  - `flag = 0` (redundant)
  - info "Table disabled and not required" (incorrect)
- `if (!required && flag == 0)`:
  - `flag = 0` (redundant)
  - info "Table disabled and not required" (correct)
- `if (!required && flag < 0)`:
  - `flag = 0` (correct)
  - info "Table disabled and not required" ("disabled" is misleading when referring to -1)
 
Expected behaviour:

- `if (required && flag == 0)`:
  - warn "Table disabled but required"
- `if (!required && flag == 0)`:
  - info "Table disabled and not required"
- `if (!required && flag < 0)`:
  - `flag = 0`
  - info "Auto-disabling table"

Also in the `bool flag` version, setting `flag = false` is redundant.

@njacazio please check.