### PR TITLE
PWGCF: add final event selection bit to FemtoDream

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
@@ -94,7 +94,9 @@ class FemtoDreamCollisionSelection
         return false;
       }
       // all checks additional to sel8 are pending to be included in sel8, check them explicitly now and remove them once they have been added to sel8
-      if (mAddCheckOffline && (!col.selection_bit(aod::evsel::kNoTimeFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoITSROFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoSameBunchPileup) || !col.selection_bit(o2::aod::evsel::kIsVertexITSTPC))) {
+      // kIsGoodZvtxFT0vsPV can be a dangerous cut because the default event selection value is rather tight
+      // Remeber to open the cut (~4cm) with custom event selection task on hyperloop
+      if (mAddCheckOffline && (!col.selection_bit(aod::evsel::kNoTimeFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoITSROFrameBorder) || !col.selection_bit(o2::aod::evsel::kNoSameBunchPileup) || !col.selection_bit(o2::aod::evsel::kIsVertexITSTPC) || !col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV))) {
         return false;
       }
     } else {

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -85,7 +85,6 @@ struct femtoDreamProducerTask {
 
   /// Event cuts
   FemtoDreamCollisionSelection colCuts;
-  Configurable<bool> ConfEvtUseTPCmult{"ConfEvtUseTPCmult", false, "Use multiplicity based on the number of tracks with TPC information"};
   Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
   Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", true, "Evt sel: check for trigger"};
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", kINT7, "Evt sel: trigger"};
@@ -373,9 +372,6 @@ struct femtoDreamProducerTask {
     } else {
       mult = 1; // multiplicity percentile is know in Run 2
       multNtr = col.multTracklets();
-    }
-    if (ConfEvtUseTPCmult) {
-      multNtr = col.multTPC();
     }
 
     colCuts.fillQA(col, mult);


### PR DESCRIPTION
This PR contains two fixes:
- There is an upper limit on configurables that can be declared in a task. With the last PR this limit was hit and not detected locally. Remove the configurable on using the TPC only charge track multiplicity since it has not been used in the past.
- Add one more advertised event selection bit kIsGoodZvtxFT0vsPV. After discussion with Igor, it is safe to include as long as one increases the limit set in the event selection task to a more reasonable value (like 4 instead of 1).