### PR TITLE
MegaLinter: Upload artifacts with formatted files

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -26,7 +26,7 @@ DISABLE_ERRORS_LINTERS: # If errors are found by these linters, they will be con
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
 GITHUB_COMMENT_REPORTER: false
-UPDATED_SOURCES_REPORTER: false
+UPDATED_SOURCES_REPORTER: true
 PRINT_ALPACA: false # Don't print ASCII alpaca in the log
 PRINT_ALL_FILES: true # Print all processed files
 FLAVOR_SUGGESTIONS: false # Don't show suggestions about different MegaLinter flavors


### PR DESCRIPTION
Enable uploading artifacts with formatted files https://megalinter.io/latest/reporters/UpdatedSourcesReporter/

MegaLinter first runs the formatting and then the rest of linters. If those linters find errors, the line numbers they report in the log refer to the formatted files, not to the committed files.
The artifacts allow to download the formatted files and find the exact location reported by the linters.