### PR TITLE
Apply the same pT dependent DCAxy cut on DCAz

### DIFF
--- a/PWGCF/TableProducer/dptdptfilter.cxx
+++ b/PWGCF/TableProducer/dptdptfilter.cxx
@@ -515,7 +515,7 @@ struct DptDptFilterTracks {
   std::string cfgCCDBPeriod{"LHC22o"};
 
   Configurable<bool> cfgFullDerivedData{"fullderiveddata", false, "Produce the full derived data for external storage. Default false"};
-  Configurable<int> cfgTrackType{"trktype", 4, "Type of selected tracks: 0 = no selection;1 = Run2 global tracks FB96;3 = Run3 tracks;4 = Run3 tracks MM sel;5 = Run2 TPC only tracks;7 = Run 3 TPC only tracks;30-33 = any/two on 3 ITS,any/all in 7 ITS;40-43 same as 30-33 w tighter DCAxy. Default 4"};
+  Configurable<int> cfgTrackType{"trktype", 4, "Type of selected tracks: 0 = no selection;1 = Run2 global tracks FB96;3 = Run3 tracks;4 = Run3 tracks MM sel;5 = Run2 TPC only tracks;7 = Run 3 TPC only tracks;30-33 = any/two on 3 ITS,any/all in 7 ITS;40-43 same as 30-33 w tighter DCAxy;50-53 w tighter pT DCAz. Default 4"};
   Configurable<o2::analysis::CheckRangeCfg> cfgTraceDCAOutliers{"trackdcaoutliers", {false, 0.0, 0.0}, "Track the generator level DCAxy outliers: false/true, low dcaxy, up dcaxy. Default {false,0.0,0.0}"};
   Configurable<float> cfgTraceOutOfSpeciesParticles{"trackoutparticles", false, "Track the particles which are not e,mu,pi,K,p: false/true. Default false"};
   Configurable<int> cfgRecoIdMethod{"recoidmethod", 0, "Method for identifying reconstructed tracks: 0 No PID, 1 PID, 2 mcparticle, 3 mcparticle only primaries. Default 0"};

--- a/PWGCF/TableProducer/dptdptfilter.h
+++ b/PWGCF/TableProducer/dptdptfilter.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <locale>
 #include <sstream>
+#include <functional>
 #include <map>
 
 #include "ReconstructionDataFormats/PID.h"
@@ -135,6 +136,7 @@ static constexpr o2::aod::track::TrackSelectionFlags::flagtype trackSelectionDCA
   o2::aod::track::TrackSelectionFlags::kDCAz | o2::aod::track::TrackSelectionFlags::kDCAxy;
 
 int tracktype = 1;
+std::function<float(float)> maxDcaZPtDep{}; // max dca in z axis as function of pT
 
 std::vector<TrackSelection*> trackFilters = {};
 bool dca2Dcut = false;
@@ -237,6 +239,22 @@ inline void initializeTrackSelection(const TrackSelectionTuneCfg& tune)
     } break;
     case 43: { /* Run 3 global track: kAll on all 7 layers of ITS, tighter DCAxy */
       trackFilters.push_back(new TrackSelection(getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSall7Layers, TrackSelection::GlobalTrackRun3DCAxyCut::ppPass3)));
+    } break;
+    case 50: { /* Run 3 global track: kAny on 3 IB layers of ITS, tighter DCAxy, tighter pT dep DCAz */
+      trackFilters.push_back(new TrackSelection(getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSibAny, TrackSelection::GlobalTrackRun3DCAxyCut::ppPass3)));
+      maxDcaZPtDep = [](float pt) { return 0.004f + 0.013f / pt; };
+    } break;
+    case 51: { /* Run 3 global track: kTwo on 3 IB layers of ITS, tighter DCAxy, tighter pT dep DCAz */
+      trackFilters.push_back(new TrackSelection(getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSibTwo, TrackSelection::GlobalTrackRun3DCAxyCut::ppPass3)));
+      maxDcaZPtDep = [](float pt) { return 0.004f + 0.013f / pt; };
+    } break;
+    case 52: { /* Run 3 global track: kAny on all 7 layers of ITS, tighter DCAxy, tighter pT dep DCAz */
+      trackFilters.push_back(new TrackSelection(getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSallAny, TrackSelection::GlobalTrackRun3DCAxyCut::ppPass3)));
+      maxDcaZPtDep = [](float pt) { return 0.004f + 0.013f / pt; };
+    } break;
+    case 53: { /* Run 3 global track: kAll on all 7 layers of ITS, tighter DCAxy, tighter pT dep DCAz */
+      trackFilters.push_back(new TrackSelection(getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSall7Layers, TrackSelection::GlobalTrackRun3DCAxyCut::ppPass3)));
+      maxDcaZPtDep = [](float pt) { return 0.004f + 0.013f / pt; };
     } break;
     default:
       break;
@@ -776,15 +794,31 @@ inline bool matchTrackType(TrackObject const& track)
   } else {
     for (auto filter : trackFilters) {
       if (filter->IsSelected(track)) {
-        if (dca2Dcut) {
-          if (track.dcaXY() * track.dcaXY() / maxDCAxy / maxDCAxy + track.dcaZ() * track.dcaZ() / maxDCAz / maxDCAz > 1) {
-            return false;
+        /* additional track cuts if needed */
+        auto checkDca2Dcut = [&](auto const& track) {
+          if (dca2Dcut) {
+            if (track.dcaXY() * track.dcaXY() / maxDCAxy / maxDCAxy + track.dcaZ() * track.dcaZ() / maxDCAz / maxDCAz > 1) {
+              return false;
+            } else {
+              return true;
+            }
           } else {
             return true;
           }
-        } else {
-          return true;
+        };
+        auto checkDcaZcut = [&](auto const& track) {
+          return ((maxDcaZPtDep) ? abs(track.dcaZ()) <= maxDcaZPtDep(track.pt()) : true);
+        };
+
+        /* tight pT dependent DCAz cut */
+        if (!checkDcaZcut(track)) {
+          return false;
         }
+        /* 2D DCA xy-o-z cut */
+        if (!checkDca2Dcut(track)) {
+          return false;
+        }
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
This only apply, for the time being, to the pass3 variety of the global tracks selection