### PR TITLE
PWGHF: Adding utility function for single track cut on min/max dcaxy

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -54,6 +54,9 @@ struct HfCandidateSelectorDplusToPiKPi {
   // topological cuts
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_dplus_to_pi_k_pi::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_dplus_to_pi_k_pi::cuts[0], hf_cuts_dplus_to_pi_k_pi::nBinsPt, hf_cuts_dplus_to_pi_k_pi::nCutVars, hf_cuts_dplus_to_pi_k_pi::labelsPt, hf_cuts_dplus_to_pi_k_pi::labelsCutVar}, "Dplus candidate selection per pT bin"};
+  // DCAxy selections
+  Configurable<LabeledArray<double>> cutsSingleTrack{"cutsSingleTrack", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections"};
+  Configurable<std::vector<double>> binsPtTrack{"binsPtTrack", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for DCA XY pT-dependent cut"};
   // QA switch
   Configurable<bool> activateQA{"activateQA", false, "Flag to enable QA histogram"};
   // ML inference
@@ -161,7 +164,24 @@ struct HfCandidateSelectorDplusToPiKPi {
     if (std::abs(candidate.maxNormalisedDeltaIP()) > cuts->get(pTBin, "max normalized deltaIP")) {
       return false;
     }
+    if (!isSelectedCandidateDcaXY(candidate)) {
+      return false;
+    }
     return true;
+  }
+
+  /// Single-track cuts
+  /// \param candidate is the Ds candidate
+  /// \return true if all the prongs pass the selections
+  template <typename T1>
+  bool isSelectedCandidateDcaXY(const T1& candidate)
+  {
+    if (isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng0(), candidate.impactParameter0()) &&
+        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng1(), candidate.impactParameter1()) &&
+        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng2(), candidate.impactParameter2())) {
+      return true;
+    }
+    return false;
   }
 
   /// Apply PID selection

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -176,12 +176,9 @@ struct HfCandidateSelectorDplusToPiKPi {
   template <typename T1>
   bool isSelectedCandidateDcaXY(const T1& candidate)
   {
-    if (isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng0(), candidate.impactParameter0()) &&
-        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng1(), candidate.impactParameter1()) &&
-        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng2(), candidate.impactParameter2())) {
-      return true;
-    }
-    return false;
+    return (isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng0(), candidate.impactParameter0()) &&
+            isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng1(), candidate.impactParameter1()) &&
+            isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng2(), candidate.impactParameter2()));
   }
 
   /// Apply PID selection

--- a/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDsToKKPi.cxx
@@ -123,34 +123,14 @@ struct HfCandidateSelectorDsToKKPi {
   }
 
   /// Single-track cuts
-  /// \param trackPt is the prong pT
-  /// \param dcaXY is the prong dcaXY
-  /// \return true if track passes all cuts
-  bool isSelectedTrackDcaXY(const float& trackPt, const float& dcaXY)
-  {
-    auto pTBinTrack = findBin(binsPtTrack, trackPt);
-    if (pTBinTrack == -1) {
-      return false;
-    }
-
-    if (std::abs(dcaXY) < cutsSingleTrack->get(pTBinTrack, "min_dcaxytoprimary")) {
-      return false; // minimum DCAxy
-    }
-    if (std::abs(dcaXY) > cutsSingleTrack->get(pTBinTrack, "max_dcaxytoprimary")) {
-      return false; // maximum DCAxy
-    }
-    return true;
-  }
-
-  /// Single-track cuts
   /// \param candidate is the Ds candidate
   /// \return true if all the prongs pass the selections
   template <typename T1>
   bool isSelectedCandidateDcaXY(const T1& candidate)
   {
-    if (isSelectedTrackDcaXY(candidate.ptProng0(), candidate.impactParameter0()) &&
-        isSelectedTrackDcaXY(candidate.ptProng1(), candidate.impactParameter1()) &&
-        isSelectedTrackDcaXY(candidate.ptProng2(), candidate.impactParameter2())) {
+    if (isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng0(), candidate.impactParameter0()) &&
+        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng1(), candidate.impactParameter1()) &&
+        isSelectedTrackDcaXY(binsPtTrack, cutsSingleTrack, candidate.ptProng2(), candidate.impactParameter2())) {
       return true;
     }
     return false;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -458,27 +458,6 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     return flag;
   }
 
-  /// Single-track cuts for 2-prongs, 3-prongs, bachelor+V0, bachelor+cascade decays
-  /// \param trackPt is the track pt
-  /// \param dca is a 2-element array with dca in transverse and longitudinal directions
-  /// \param candType is the flag to decide which cuts to be applied (either for 2-prong, 3-prong, bachelor+V0 or bachelor+cascade decays)
-  /// \return true if track passes all cuts
-  bool isSelectedTrackDCA(const float& trackPt, const std::array<float, 2>& dca, const int candType)
-  {
-    auto pTBinTrack = findBin(binsPtTrack, trackPt);
-    if (pTBinTrack == -1) {
-      return false;
-    }
-
-    if (std::abs(dca[0]) < cutsSingleTrack[candType].get(pTBinTrack, "min_dcaxytoprimary")) {
-      return false; // minimum DCAxy
-    }
-    if (std::abs(dca[0]) > cutsSingleTrack[candType].get(pTBinTrack, "max_dcaxytoprimary")) {
-      return false; // maximum DCAxy
-    }
-    return true;
-  }
-
   /// Single-track cuts for 2-prongs or 3-prongs
   /// \param hfTrack is a track
   /// \param trackPt is the track pt
@@ -657,7 +636,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     iCut = 5;
     if (statusProng > 0) {
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; ++iCandType) {
-        if (TESTBIT(statusProng, iCandType) && !isSelectedTrackDCA(trackPt, dca, iCandType)) {
+        if (TESTBIT(statusProng, iCandType) && !isSelectedTrackDcaXY(binsPtTrack, &cutsSingleTrack[iCandType], trackPt, dca[0])) {
           CLRBIT(statusProng, iCandType);
           if (fillHistograms) {
             registry.fill(HIST("hRejTracks"), (nCuts + 1) * iCandType + iCut);

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -36,6 +36,27 @@ int findBin(T1 const& binsPt, T2 value)
   }
   return std::distance(binsPt->begin(), std::upper_bound(binsPt->begin(), binsPt->end(), value)) - 1;
 }
+
+/// Single-track cut on DCAxy
+/// \param trackPt is the prong pT
+/// \param dcaXY is the prong dcaXY
+/// \return true if track passes all cuts
+template <typename T1, typename T2>
+bool isSelectedTrackDcaXY(T1 const& binsPtTrack, T2 const& cutsSingleTrack, const float& trackPt, const float& dcaXY)
+{
+  auto pTBinTrack = findBin(binsPtTrack, trackPt);
+  if (pTBinTrack == -1) {
+    return false;
+  }
+  if (std::abs(dcaXY) < cutsSingleTrack->get(pTBinTrack, "min_dcaxytoprimary")) {
+    return false; // minimum DCAxy
+  }
+  if (std::abs(dcaXY) > cutsSingleTrack->get(pTBinTrack, "max_dcaxytoprimary")) {
+    return false; // maximum DCAxy
+  }
+  return true;
+}
+
 } // namespace o2::analysis
 
 #endif // PWGHF_UTILS_UTILSANALYSIS_H_

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -38,20 +38,22 @@ int findBin(T1 const& binsPt, T2 value)
 }
 
 /// Single-track cut on DCAxy
-/// \param trackPt is the prong pT
+/// \param binsPt pT bins
+/// \param cuts cut configuration
+/// \param pt is the prong pT
 /// \param dcaXY is the prong dcaXY
 /// \return true if track passes all cuts
 template <typename T1, typename T2>
-bool isSelectedTrackDcaXY(T1 const& binsPtTrack, T2 const& cutsSingleTrack, const float& trackPt, const float& dcaXY)
+bool isSelectedTrackDcaXY(T1 const& binsPt, T2 const& cuts, const float pt, const float dcaXY)
 {
-  auto pTBinTrack = findBin(binsPtTrack, trackPt);
-  if (pTBinTrack == -1) {
+  auto binPt = findBin(binsPt, pt);
+  if (binPt == -1) {
     return false;
   }
-  if (std::abs(dcaXY) < cutsSingleTrack->get(pTBinTrack, "min_dcaxytoprimary")) {
+  if (std::abs(dcaXY) < cuts->get(binPt, "min_dcaxytoprimary")) {
     return false; // minimum DCAxy
   }
-  if (std::abs(dcaXY) > cutsSingleTrack->get(pTBinTrack, "max_dcaxytoprimary")) {
+  if (std::abs(dcaXY) > cuts->get(binPt, "max_dcaxytoprimary")) {
     return false; // maximum DCAxy
   }
   return true;


### PR DESCRIPTION
This PR contains a utility function for the track's DCA selection. 

- The selection is added in the `candidateSelectorDplusToPiKPi.cxx`
- The utility function is applied in the `candidateSelectorDsToKKPi.cxx` and  `trackIndexSkimCreator.cxx`