### PR TITLE
beta-gamma cutoff, enable flags per species for NN

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -102,6 +102,16 @@ struct tpcPid {
   Configurable<int> pidTr{"pid-tr", -1, {"Produce PID information for the Triton mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
   Configurable<int> pidHe{"pid-he", -1, {"Produce PID information for the Helium3 mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
   Configurable<int> pidAl{"pid-al", -1, {"Produce PID information for the Alpha mass hypothesis, overrides the automatic setup: the corresponding table can be set off (0) or on (1)"}};
+  Configurable<int> useNetworkEl{"useNetworkEl", 1, {"Switch for applying neural network on the electron mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkMu{"useNetworkMu", 1, {"Switch for applying neural network on the muon mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkPi{"useNetworkPi", 1, {"Switch for applying neural network on the pion mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkKa{"useNetworkKa", 1, {"Switch for applying neural network on the kaon mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkPr{"useNetworkPr", 1, {"Switch for applying neural network on the proton mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkDe{"useNetworkDe", 1, {"Switch for applying neural network on the deuteron mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkTr{"useNetworkTr", 1, {"Switch for applying neural network on the triton mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkHe{"useNetworkHe", 1, {"Switch for applying neural network on the helium3 mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<int> useNetworkAl{"useNetworkAl", 1, {"Switch for applying neural network on the alpha mass hypothesis (if network enabled) (set to 0 to disable)"}};
+  Configurable<float> networkBetaGammaCutoff{"networkBetaGammaCutoff", 0.45, {"Lower value of beta-gamma to override the NN application"}};
 
   // Paramatrization configuration
   bool useCCDBParam = false;
@@ -202,11 +212,11 @@ struct tpcPid {
     }
   }
 
-  Partition<Trks> notTPCStandaloneTracks = ((aod::track::itsClusterSizes > (uint32_t)0) || (aod::track::trdPattern > (uint8_t)0) || (aod::track::tofExpMom > 0.f && aod::track::tofChi2 > 0.f)); // To count number of tracks for use in NN array
+  Partition<Trks> notTPCStandaloneTracks = (aod::track::tpcNClsFindable > (uint8_t)0) && ((aod::track::itsClusterSizes > (uint32_t)0) || (aod::track::trdPattern > (uint8_t)0) || (aod::track::tofExpMom > 0.f && aod::track::tofChi2 > 0.f)); // To count number of tracks for use in NN array
   Partition<Trks> tracksWithTPC = (aod::track::tpcNClsFindable > (uint8_t)0);
 
   void process(Coll const& collisions, Trks const& tracks,
-               aod::BCsWithTimestamps const&)
+               aod::BCsWithTimestamps const& bcs)
   {
 
     const uint64_t outTable_size = tracks.size();
@@ -233,7 +243,7 @@ struct tpcPid {
     if (useNetworkCorrection) {
       auto start_network_total = std::chrono::high_resolution_clock::now();
       if (autofetchNetworks) {
-        auto bc = collisions.iteratorAt(0).bc_as<aod::BCsWithTimestamps>();
+        auto bc = bcs.begin();
         // Initialise correct TPC response object before NN setup (for NCl normalisation)
         if (useCCDBParam && ccdbTimestamp.value == 0 && !ccdb->isCachedObjectValid(ccdbPath.value, bc.timestamp())) { // Updating parametrisation only if the initial timestamp is 0
           if (recoPass.value == "") {
@@ -297,7 +307,7 @@ struct tpcPid {
           track_properties[counter_track_props + 1] = trk.tgl();
           track_properties[counter_track_props + 2] = trk.signed1Pt();
           track_properties[counter_track_props + 3] = o2::track::pid_constants::sMasses[i];
-          track_properties[counter_track_props + 4] = collisions.iteratorAt(trk.collisionId()).multTPC() / 11000.;
+          track_properties[counter_track_props + 4] = trk.has_collision() ? collisions.iteratorAt(trk.collisionId()).multTPC() / 11000. : 1.; // Dummy value in case no associated collision
           track_properties[counter_track_props + 5] = std::sqrt(nNclNormalization / trk.tpcNClsFound());
           counter_track_props += input_dimensions;
         }
@@ -346,7 +356,7 @@ struct tpcPid {
         }
       }
       // Check and fill enabled tables
-      auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracksForNet_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid) {
+      auto makeTable = [&trk, &collisions, &network_prediction, &count_tracks, &tracksForNet_size, this](const Configurable<int>& flag, auto& table, const o2::track::PID::ID pid, bool speciesApplicationFlag) {
         if (flag.value != 1) {
           return;
         }
@@ -361,13 +371,14 @@ struct tpcPid {
           }
         }
         auto expSignal = response->GetExpectedSignal(trk, pid);
-        auto expSigma = response->GetExpectedSigma(collisions.iteratorAt(trk.collisionId()), trk, pid);
-        if (expSignal < 0. || expSigma < 0.) { // skip if expected signal invalid
+        auto expSigma = trk.has_collision() ? response->GetExpectedSigma(collisions.iteratorAt(trk.collisionId()), trk, pid) : 0.07 * expSignal; // use default sigma value of 7% if no collision information to estimate resolution
+        if (expSignal < 0. || expSigma < 0.) {                                                                                                   // skip if expected signal invalid
           table(aod::pidtpc_tiny::binning::underflowBin);
           return;
         }
+        float bg = trk.tpcInnerParam() / o2::track::pid_constants::sMasses[pid]; // estimated beta-gamma for network cutoff
 
-        if (useNetworkCorrection) {
+        if (useNetworkCorrection && speciesApplicationFlag && trk.has_collision() && bg > networkBetaGammaCutoff) {
 
           // Here comes the application of the network. The output--dimensions of the network dtermine the application: 1: mean, 2: sigma, 3: sigma asymmetric
           // For now only the option 2: sigma will be used. The other options are kept if there would be demand later on
@@ -389,15 +400,15 @@ struct tpcPid {
         }
       };
 
-      makeTable(pidEl, tablePIDEl, o2::track::PID::Electron);
-      makeTable(pidMu, tablePIDMu, o2::track::PID::Muon);
-      makeTable(pidPi, tablePIDPi, o2::track::PID::Pion);
-      makeTable(pidKa, tablePIDKa, o2::track::PID::Kaon);
-      makeTable(pidPr, tablePIDPr, o2::track::PID::Proton);
-      makeTable(pidDe, tablePIDDe, o2::track::PID::Deuteron);
-      makeTable(pidTr, tablePIDTr, o2::track::PID::Triton);
-      makeTable(pidHe, tablePIDHe, o2::track::PID::Helium3);
-      makeTable(pidAl, tablePIDAl, o2::track::PID::Alpha);
+      makeTable(pidEl, tablePIDEl, o2::track::PID::Electron, useNetworkEl);
+      makeTable(pidMu, tablePIDMu, o2::track::PID::Muon, useNetworkMu);
+      makeTable(pidPi, tablePIDPi, o2::track::PID::Pion, useNetworkPi);
+      makeTable(pidKa, tablePIDKa, o2::track::PID::Kaon, useNetworkKa);
+      makeTable(pidPr, tablePIDPr, o2::track::PID::Proton, useNetworkPr);
+      makeTable(pidDe, tablePIDDe, o2::track::PID::Deuteron, useNetworkDe);
+      makeTable(pidTr, tablePIDTr, o2::track::PID::Triton, useNetworkTr);
+      makeTable(pidHe, tablePIDHe, o2::track::PID::Helium3, useNetworkHe);
+      makeTable(pidAl, tablePIDAl, o2::track::PID::Alpha, useNetworkAl);
 
       if (trk.hasTPC() && (!skipTPCOnly || trk.hasITS() || trk.hasTRD() || trk.hasTOF())) {
         count_tracks++; // Increment network track counter only if (not skipping TPConly) or (is not TPConly)


### PR DESCRIPTION
Addresses several issues that popped up with NN application in trigger selection:

- impose (configurable) cutoff in expected beta-gamma to remove artifacts reported by PWG-CF in very low-momentum antiprotons where network extrapolation causes issues (below this value only BB is used, betagamma >0.45 is set as a conservative default ) - plots below are expected dE/dx and nsigma for protons, (left) without the betagamma cutoff and (right) with the cutoff
![image](https://github.com/AliceO2Group/O2Physics/assets/28785553/3ae486a3-6ac9-4ac6-926d-16bd401641b0)
![image](https://github.com/AliceO2Group/O2Physics/assets/28785553/828f5e7b-8149-44af-b409-ec00efb68d8e)
- add protections for case where the collision table is not populated (CCDB timestamp request now only references the collision table if the track is explicitly associated to a collision, and from the BC table directly otherwise. Also disables NN correction for tracks with no associated collision, as the application uses info from the collision table)
- add configurable flags to allow per-species disabling of NN application - default value is 1 for each species, and should be set to 0 for each species where it should be disabled (the global "useNetworkCorrection" still rules here and does not apply at all if set to 0, regardless of the species switches)

pinging for info: @wiechula @ChSonnabend @mpuccio @lietava 