### PR TITLE
PWGHF: Ds-h correlations, minor adjustments in assoc particle efficiency evaluation

### DIFF
--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -123,26 +123,38 @@ DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);                  //! DeltaEta bet
 DECLARE_SOA_COLUMN(PtD, ptD, float);                            //! Transverse momentum of Ds
 DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);                  //! Transverse momentum of Hadron
 DECLARE_SOA_COLUMN(MD, mD, float);                              //! Invariant mass of Ds
+DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);              //! ML background score for Ds selection
+DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);        //! ML prompt score for Ds selection
 DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                      //! Pool Bin for the MixedEvent
 DECLARE_SOA_COLUMN(IsSignal, isSignal, bool);                   //! Used in MC-Rec, Ds Signal
 DECLARE_SOA_COLUMN(IsPrompt, isPrompt, bool);                   //! Used in MC-Rec, Ds Prompt or Non-Prompt
 DECLARE_SOA_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, bool); //! Used in MC-Rec, primary associated particles
 } // namespace hf_correlation_ds_hadron
 
-DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informations
+DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Information
                   aod::hf_correlation_ds_hadron::DeltaPhi,
                   aod::hf_correlation_ds_hadron::DeltaEta,
                   aod::hf_correlation_ds_hadron::PtD,
                   aod::hf_correlation_ds_hadron::PtHadron,
                   aod::hf_correlation_ds_hadron::PoolBin);
 
-DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Informations
+DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Information
                   aod::hf_correlation_ds_hadron::MD,
                   aod::hf_correlation_ds_hadron::IsSignal);
 
-DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Informations
+DECLARE_SOA_TABLE(DsHadronGenInfo, "AOD", "DSHGENINFO", //! Ds-Hadrons pairs Generated Information
                   aod::hf_correlation_ds_hadron::IsPrompt,
                   aod::hf_correlation_ds_hadron::IsPhysicalPrimary);
+
+DECLARE_SOA_TABLE(DsHadronMlInfo, "AOD", "DSHMLINFO", //! Ds-Hadrons pairs Machine Learning Information
+                  aod::hf_correlation_ds_hadron::MlScorePrompt,
+                  aod::hf_correlation_ds_hadron::MlScoreBkg);
+
+DECLARE_SOA_TABLE(DsCandRecoInfo, "AOD", "DSCANDRECOINFO", //! Ds candidates Reconstructed Information
+                  aod::hf_correlation_ds_hadron::MD,
+                  aod::hf_correlation_ds_hadron::PtD,
+                  aod::hf_correlation_ds_hadron::MlScorePrompt,
+                  aod::hf_correlation_ds_hadron::MlScoreBkg);
 
 // definition of columns and tables for Dplus properties
 namespace hf_dplus_meson

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -622,7 +622,7 @@ struct HfCorrelatorDsHadrons {
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcCandEfficiency, "Process MC for calculating candidate reconstruction efficiency", false);
 
   /// Ds-Hadron correlation - for calculating associated particle tracking efficiency using MC reco-level analysis
-  void processMcTrackEfficiency(soa::Join<aod::Collisions, aod::FT0Mults> const&,
+  void processMcTrackEfficiency(soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels> const&,
                                 soa::Join<aod::McCollisions, aod::MultsExtraMC> const&,
                                 CandDsMcGen const& mcParticles,
                                 TracksWithMc const& tracksData)
@@ -652,7 +652,10 @@ struct HfCorrelatorDsHadrons {
         if (!track.isGlobalTrackWoDCA()) {
           continue;
         }
-        auto collision = track.template collision_as<soa::Join<aod::Collisions, aod::FT0Mults>>();
+        auto collision = track.template collision_as<soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels>>();
+        if (!collision.sel8()) {
+          continue;
+        }
         multiplicity = collision.multFT0M();
         posZ = collision.posZ();
         registry.fill(HIST("hZVtx"), posZ);

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -50,7 +50,8 @@ using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFT0
 struct HfCorrelatorDsHadronsSelCollision {
   Produces<aod::DmesonSelection> collisionsWithSelDs;
 
-  Configurable<bool> doSelCollision{"doSelCollision", true, "Select collisions with at least one Ds"};
+  Configurable<bool> useSel8{"useSel8", true, "Flag for applying sel8 for collision selection"};
+  Configurable<bool> doSelDsCollision{"doSelDsCollision", true, "Select collisions with at least one Ds"};
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
   Configurable<float> ptCandMin{"ptCandMin", 1., "min. cand. pT"};
@@ -58,6 +59,7 @@ struct HfCorrelatorDsHadronsSelCollision {
   SliceCache cache;
   HfHelper hfHelper;
 
+  using SelCollisions = soa::Join<aod::Collisions, aod::EvSels>;
   using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi>>;
   using CandDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;
   using CandDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
@@ -65,44 +67,50 @@ struct HfCorrelatorDsHadronsSelCollision {
   Filter dsFilter = ((o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << aod::hf_cand_3prong::DecayType::DsToKKPi)) != static_cast<uint8_t>(0)) && (aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs);
 
   /// Code to select collisions with at least one Ds meson - for real data and data-like analysis
-  void processDsSelCollisionsData(aod::Collision const& collision,
+  void processDsSelCollisionsData(SelCollisions::iterator const& collision,
                                   CandDsData const& candidates)
   {
     bool isDsFound = false;
-    if (doSelCollision) {
-      if (candidates.size() > 0) {
-        for (const auto& candidate : candidates) {
-          if (std::abs(hfHelper.yDs(candidate)) > yCandMax || candidate.pt() < ptCandMin) {
-            continue;
-          }
-          isDsFound = true;
-          break;
+    bool isSel8 = false;
+    if (doSelDsCollision) {
+      for (const auto& candidate : candidates) {
+        if (std::abs(hfHelper.yDs(candidate)) > yCandMax || candidate.pt() < ptCandMin) {
+          continue;
         }
+        isDsFound = true;
+        break;
       }
     } else {
       isDsFound = true;
+    }
+    if (useSel8) {
+      isSel8 = collision.sel8();
+      isDsFound = isDsFound && isSel8;
     }
     collisionsWithSelDs(isDsFound);
   }
   PROCESS_SWITCH(HfCorrelatorDsHadronsSelCollision, processDsSelCollisionsData, "Process Ds Collision Selection Data", true);
 
   /// Code to select collisions with at least one Ds meson - for MC reco-level analysis
-  void processDsSelCollisionsMcRec(aod::Collision const& collision,
+  void processDsSelCollisionsMcRec(SelCollisions::iterator const& collision,
                                    CandDsMcReco const& candidates)
   {
     bool isDsFound = false;
-    if (doSelCollision) {
-      if (candidates.size() > 0) {
-        for (const auto& candidate : candidates) {
-          if (std::abs(hfHelper.yDs(candidate)) > yCandMax || candidate.pt() < ptCandMin) {
-            continue;
-          }
-          isDsFound = true;
-          break;
+    bool isSel8 = false;
+    if (doSelDsCollision) {
+      for (const auto& candidate : candidates) {
+        if (std::abs(hfHelper.yDs(candidate)) > yCandMax || candidate.pt() < ptCandMin) {
+          continue;
         }
+        isDsFound = true;
+        break;
       }
     } else {
       isDsFound = true;
+    }
+    if (useSel8) {
+      isSel8 = collision.sel8();
+      isDsFound = isDsFound && isSel8;
     }
     collisionsWithSelDs(isDsFound);
   }
@@ -113,7 +121,7 @@ struct HfCorrelatorDsHadronsSelCollision {
                                    CandDsMcGen const& mcParticles)
   {
     bool isDsFound = false;
-    if (doSelCollision) {
+    if (doSelDsCollision) {
       for (const auto& particle : mcParticles) {
         if (std::abs(particle.pdgCode()) != Pdg::kDS) {
           continue;
@@ -138,11 +146,13 @@ struct HfCorrelatorDsHadrons {
   Produces<aod::DsHadronPair> entryDsHadronPair;
   Produces<aod::DsHadronRecoInfo> entryDsHadronRecoInfo;
   Produces<aod::DsHadronGenInfo> entryDsHadronGenInfo;
+  Produces<aod::DsHadronMlInfo> entryDsHadronMlInfo;
+  Produces<aod::DsCandRecoInfo> entryDsCandRecoInfo;
 
   Configurable<int> selectionFlagDs{"selectionFlagDs", 7, "Selection Flag for Ds"};
   Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "Number of events mixed in ME process"};
+  Configurable<bool> useSel8ForTrackEff{"useSel8ForTrackEff", true, "Flag for applying sel8 for collision selection"};
   Configurable<bool> applyEfficiency{"applyEfficiency", true, "Flag for applying D-meson efficiency weights"};
-  Configurable<bool> fillSystematics{"fillSystematics", false, "Flag for filling THnSparse for systematics"};
   Configurable<float> yCandMax{"yCandMax", 0.8, "max. cand. rapidity"};
   Configurable<float> yCandGenMax{"yCandGenMax", 0.5, "max. gen. cand. rapidity"};
   Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. eta of tracks"};
@@ -188,15 +198,15 @@ struct HfCorrelatorDsHadrons {
                         kAssocTrackStepFake,
                         kAssocTrackNSteps };
 
-  using SelCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::DmesonSelection>>; // collisionFilter applied
-  using SelCollisionsWithDsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::DmesonSelection>>;                      // collisionFilter applied
-  using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi>>;                // flagDsFilter applied
-  using CandDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfCand3ProngMcRec>>;         // flagDsFilter applied
-  using CandDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;                                              // flagDsFilter applied
-  using MyTracksData = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection>>;                                  // trackFilter applied
-  using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, o2::aod::McTrackLabels>>;          // trackFilter applied
+  using SelCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::DmesonSelection>>;            // collisionFilter applied
+  using SelCollisionsWithDsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::DmesonSelection>>;                                 // collisionFilter applied
+  using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi>>;                           // flagDsFilter applied
+  using CandDsMcReco = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi, aod::HfCand3ProngMcRec>>; // flagDsFilter applied
+  using CandDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;                                                         // flagDsFilter applied
+  using MyTracksData = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection>>;                                             // trackFilter applied
+  using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, o2::aod::McTrackLabels>>;                     // trackFilter applied
 
-  Filter collisionFilter = aod::hf_selection_dmeson_collision::dmesonSel == true && o2::aod::evsel::sel8 == true;
+  Filter collisionFilter = aod::hf_selection_dmeson_collision::dmesonSel == true;
   Filter flagDsFilter = ((o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << aod::hf_cand_3prong::DecayType::DsToKKPi)) != static_cast<uint8_t>(0)) && (aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs);
   Filter trackFilter = (nabs(aod::track::eta) < etaTrackMax) && (aod::track::pt > ptTrackMin) && (aod::track::pt < ptTrackMax) && (nabs(aod::track::dcaXY) < dcaXYTrackMax) && (nabs(aod::track::dcaZ) < dcaZTrackMax);
 
@@ -377,17 +387,24 @@ struct HfCorrelatorDsHadrons {
       if (applyEfficiency) {
         efficiencyWeightD = 1. / efficiencyD->at(o2::analysis::findBin(binsPtEfficiencyD, candidate.pt()));
       }
+      std::vector<float> outputMl = {-1., -1., -1.};
       fillHisto(candidate);
       if (candidate.isSelDsToKKPi() >= selectionFlagDs) {
         fillHistoKKPi(candidate, efficiencyWeightD);
-      }
-      if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
+        for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+          outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
+        }
+        entryDsCandRecoInfo(hfHelper.invMassDsToKKPi(candidate), candidate.pt(), outputMl[0], outputMl[2]);
+      } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
         fillHistoPiKK(candidate, efficiencyWeightD);
+        for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+          outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
+        }
+        entryDsCandRecoInfo(hfHelper.invMassDsToPiKK(candidate), candidate.pt(), outputMl[0], outputMl[2]);
       }
       if (candidate.isSelDsToKKPi() >= selectionFlagDs && candidate.isSelDsToPiKK() >= selectionFlagDs) {
         registry.fill(HIST("hCountSelectionStatusDsToKKPiAndToPiKK"), 0.);
       }
-      std::vector<float> outputMl = {-1., -1., -1.};
 
       // Ds-Hadron correlation dedicated section
       for (const auto& track : tracks) {
@@ -409,12 +426,7 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToKKPi(candidate), false);
           entryDsHadronGenInfo(false, false);
-          if (fillSystematics) {
-            for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
-              outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
-            }
-            registry.fill(HIST("hCorrelSystematics"), getDeltaPhi(track.phi(), candidate.phi()), track.eta() - candidate.eta(), candidate.pt(), track.pt(), hfHelper.invMassDsToKKPi(candidate), outputMl[0], outputMl[2]);
-          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
           entryDsHadronPair(getDeltaPhi(track.phi(), candidate.phi()),
                             track.eta() - candidate.eta(),
@@ -423,12 +435,7 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToPiKK(candidate), false);
           entryDsHadronGenInfo(false, false);
-          if (fillSystematics) {
-            for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
-              outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
-            }
-            registry.fill(HIST("hCorrelSystematics"), getDeltaPhi(track.phi(), candidate.phi()), track.eta() - candidate.eta(), candidate.pt(), track.pt(), hfHelper.invMassDsToPiKK(candidate), outputMl[0], outputMl[2]);
-          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         }
       } // end track loop
     }   // end candidate loop
@@ -499,6 +506,7 @@ struct HfCorrelatorDsHadrons {
           registry.fill(HIST("hSelectionStatusDsToPiKKMcRec"), candidate.isSelDsToPiKK());
         }
       }
+      std::vector<float> outputMl = {-1., -1., -1.};
 
       // Ds-Hadron correlation dedicated section
       // if the candidate is selected as Ds, search for Hadron and evaluate correlations
@@ -519,6 +527,10 @@ struct HfCorrelatorDsHadrons {
                             track.pt(),
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToKKPi(candidate), isDsSignal);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
+          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
           if (track.has_mcParticle()) {
             auto mcParticle = track.template mcParticle_as<aod::McParticles>();
             isPhysicalPrimary = mcParticle.isPhysicalPrimary();
@@ -541,6 +553,10 @@ struct HfCorrelatorDsHadrons {
                             track.pt(),
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToPiKK(candidate), isDsSignal);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
+          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
           if (track.has_mcParticle()) {
             auto mcParticle = track.template mcParticle_as<aod::McParticles>();
             isPhysicalPrimary = mcParticle.isPhysicalPrimary();
@@ -653,7 +669,7 @@ struct HfCorrelatorDsHadrons {
           continue;
         }
         auto collision = track.template collision_as<soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels>>();
-        if (!collision.sel8()) {
+        if (useSel8ForTrackEff && !collision.sel8()) {
           continue;
         }
         multiplicity = collision.multFT0M();
@@ -749,12 +765,7 @@ struct HfCorrelatorDsHadrons {
       registry.fill(HIST("hMultFT0M"), collision.multFT0M());
       registry.fill(HIST("hZVtx"), collision.posZ());
     }
-    for (const auto& candidate : candidates) {
-      if (std::abs(hfHelper.yDs(candidate)) > yCandMax || candidate.pt() < ptCandMin || candidate.pt() > ptCandMax) {
-        continue;
-      }
-      fillHisto(candidate);
-    }
+
     auto tracksTuple = std::make_tuple(candidates, tracks);
     Pair<SelCollisionsWithDs, CandDsData, MyTracksData, BinningType> pairData{corrBinning, numberEventsMixed, -1, collisions, tracksTuple, &cache};
 
@@ -762,6 +773,7 @@ struct HfCorrelatorDsHadrons {
       if (tracks1.size() == 0) {
         continue;
       }
+
       // LOGF(info, "Mixed event collisions: Index = (%d, %d), tracks Size: (%d, %d), Z Vertex: (%f, %f), Pool Bin: (%d, %d)", c1.globalIndex(), c2.globalIndex(), tracks1.size(), tracks2.size(), c1.posZ(), c2.posZ(), corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFT0M())), corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFT0M())));
       int poolBin = corrBinning.getBin(std::make_tuple(c2.posZ(), c2.multFT0M()));
       int poolBinDs = corrBinning.getBin(std::make_tuple(c1.posZ(), c1.multFT0M()));
@@ -788,12 +800,10 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToKKPi(cand), false);
           entryDsHadronGenInfo(false, false);
-          if (fillSystematics) {
-            for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
-              outputMl[iclass] = cand.mlProbDsToKKPi()[classMl->at(iclass)];
-            }
-            registry.fill(HIST("hCorrelSystematics"), getDeltaPhi(pAssoc.phi(), cand.phi()), pAssoc.eta() - cand.eta(), cand.pt(), pAssoc.pt(), hfHelper.invMassDsToKKPi(cand), outputMl[0], outputMl[2]);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = cand.mlProbDsToKKPi()[classMl->at(iclass)];
           }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         } else if (cand.isSelDsToPiKK() >= selectionFlagDs) {
           // LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d), PiKK", cand.index(), pAssoc.index(), c1.index(), c2.index(), cand.collision().index(), pAssoc.collision().index());
           entryDsHadronPair(getDeltaPhi(pAssoc.phi(), cand.phi()),
@@ -803,12 +813,10 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToPiKK(cand), false);
           entryDsHadronGenInfo(false, false);
-          if (fillSystematics) {
-            for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
-              outputMl[iclass] = cand.mlProbDsToPiKK()[classMl->at(iclass)];
-            }
-            registry.fill(HIST("hCorrelSystematics"), getDeltaPhi(pAssoc.phi(), cand.phi()), pAssoc.eta() - cand.eta(), cand.pt(), pAssoc.pt(), hfHelper.invMassDsToPiKK(cand), outputMl[0], outputMl[2]);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = cand.mlProbDsToPiKK()[classMl->at(iclass)];
           }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         }
       }
     }
@@ -856,6 +864,7 @@ struct HfCorrelatorDsHadrons {
         if (!pAssoc.isGlobalTrackWoDCA()) {
           continue;
         }
+        std::vector<float> outputMl = {-1., -1., -1.};
         // prompt and non-prompt division
         isDsPrompt = candidate.originMcRec() == RecoDecay::OriginType::Prompt;
         // Ds Signal
@@ -869,6 +878,10 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToKKPi(candidate), isDsSignal);
           entryDsHadronGenInfo(isDsPrompt, false);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
+          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
           entryDsHadronPair(getDeltaPhi(pAssoc.phi(), candidate.phi()),
                             pAssoc.eta() - candidate.eta(),
@@ -877,6 +890,10 @@ struct HfCorrelatorDsHadrons {
                             poolBin);
           entryDsHadronRecoInfo(hfHelper.invMassDsToPiKK(candidate), isDsSignal);
           entryDsHadronGenInfo(isDsPrompt, false);
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
+          }
+          entryDsHadronMlInfo(outputMl[0], outputMl[2]);
         }
       }
     }

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -33,6 +33,8 @@ struct HfTaskCorrelationDsHadrons {
   Configurable<bool> applyEfficiency{"applyEfficiency", false, "Flag for applying efficiency weights"};
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> binsPtHadron{"binsPtHadron", std::vector<double>{0.3, 2., 4., 8., 12., 50.}, "pT bin limits for assoc particle efficiency"};
+  Configurable<std::vector<double>> mlOutputPrompt{"mlScorePrompt", {0.5, 0.5, 0.5, 0.5}, "Machine learning scores for prompt"};
+  Configurable<std::vector<double>> mlOutputBkg{"mlScoreBkg", {0.5, 0.5, 0.5, 0.5}, "Machine learning scores for bkg"};
   Configurable<std::vector<double>> binsPtEfficiencyD{"binsPtEfficiencyD", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for D-meson efficiency"};
   Configurable<std::vector<double>> binsPtEfficiencyHad{"binsPtEfficiencyHad", std::vector<double>{0.3, 2., 4., 8., 12., 50.}, "pT bin limits for associated particle efficiency"};
   Configurable<std::vector<double>> efficiencyD{"efficiencyD", {1., 1., 1., 1., 1., 1.}, "efficiency values for Ds meson"};
@@ -43,24 +45,32 @@ struct HfTaskCorrelationDsHadrons {
   Configurable<std::vector<double>> sidebandLeftOuter{"sidebandLeftOuter", {1.9040, 1.9040, 1.9040, 1.9040, 1.9040, 1.9040, 1.9040, 1.9040}, "Outer values of left sideband vs pT"};
   Configurable<std::vector<double>> sidebandRightInner{"sidebandRightInner", {2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000}, "Inner values of right sideband vs pT"};
   Configurable<std::vector<double>> sidebandRightOuter{"sidebandRightOuter", {2.0320, 2.0320, 2.0320, 2.0320, 2.0320, 2.0320, 2.0320, 2.0320}, "Outer values of right sideband vs pT"};
+  ConfigurableAxis binsMassD{"binsMassD", {200, 1.7, 2.25}, "inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2})"};
+  ConfigurableAxis binsBdtScore{"binsBdtScore", {100, 0., 1.}, "Bdt output scores"};
   ConfigurableAxis binsEta{"binsEta", {100, -2., 2.}, "#it{#eta}"};
   ConfigurableAxis binsPhi{"binsPhi", {64, -PIHalf, 3. * PIHalf}, "#it{#varphi}"};
   ConfigurableAxis binsPoolBin{"binsPoolBin", {9, 0., 9.}, "PoolBin"};
 
   using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo>;
+  using DsHadronPairFullWithMl = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo, aod::DsHadronMlInfo>;
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {
+    AxisSpec axisMassD = {binsMassD, "inv. mass (K^{#pm}K^{-}#pi^{+}) (GeV/#it{c}^{2})"};
     AxisSpec axisDetlaEta = {binsEta, "#it{#eta}^{Hadron}-#it{#eta}^{D}"};
     AxisSpec axisDetlaPhi = {binsPhi, "#it{#varphi}^{Hadron}-#it{#varphi}^{D} (rad)"};
     AxisSpec axisPtD = {(std::vector<double>)binsPtD, "#it{p}_{T}^{D} (GeV/#it{c})"};
     AxisSpec axisPtHadron = {(std::vector<double>)binsPtHadron, "#it{p}_{T}^{Hadron} (GeV/#it{c})"};
     AxisSpec axisPoolBin = {binsPoolBin, "poolBin"};
+    AxisSpec axisBdtScore = {binsBdtScore, "Bdt score"};
     AxisSpec axisDsPrompt = {2, -0.5, 1.5, "Prompt Ds"};
 
     // Histograms for data analysis
+    registry.add("hMassDsVsPt", "Ds candidates massVsPt", {HistType::kTH2F, {{axisMassD}, {axisPtD}}});
+    registry.add("hBdtScorePrompt", "Ds BDT prompt score", {HistType::kTH1F, {axisBdtScore}});
+    registry.add("hBdtScoreBkg", "Ds BDT bkg score", {HistType::kTH1F, {axisBdtScore}});
     registry.add("hDeltaEtaPtIntSignalRegion", "Ds-h deltaEta signal region", {HistType::kTH1F, {axisDetlaEta}});
     registry.add("hDeltaPhiPtIntSignalRegion", "Ds-h deltaPhi signal region", {HistType::kTH1F, {axisDetlaPhi}});
     registry.add("hCorrel2DVsPtSignalRegion", "Ds-h correlations signal region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
@@ -91,22 +101,48 @@ struct HfTaskCorrelationDsHadrons {
     registry.get<THnSparse>(HIST("hCorrel2DVsPtMcGenPromptDivision"))->Sumw2();
   }
 
-  void processData(DsHadronPairFull const& pairEntries)
+  void processData(DsHadronPairFullWithMl const& pairEntries,
+                   aod::DsCandRecoInfo const& candidates)
   {
-    for (const auto& pairEntry : pairEntries) {
-      // define variables for widely used quantities
-      double deltaPhi = pairEntry.deltaPhi();
-      double deltaEta = pairEntry.deltaEta();
-      double ptD = pairEntry.ptD();
-      double ptHadron = pairEntry.ptHadron();
-      int poolBin = pairEntry.poolBin();
-      double massD = pairEntry.mD();
+    for (const auto& candidate : candidates) {
+      float massD = candidate.mD();
+      float ptD = candidate.ptD();
+      float bdtScorePrompt = candidate.mlScorePrompt();
+      float bdtScoreBkg = candidate.mlScoreBkg();
       int ptBinD = o2::analysis::findBin(binsPtD, ptD);
 
+      if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
+      double efficiencyWeightD = 1.;
+      if (applyEfficiency) {
+        efficiencyWeightD = 1. / efficiencyD->at(o2::analysis::findBin(binsPtEfficiencyD, ptD));
+      }
+      registry.fill(HIST("hMassDsVsPt"), massD, ptD, efficiencyWeightD);
+      registry.fill(HIST("hBdtScorePrompt"), bdtScorePrompt);
+      registry.fill(HIST("hBdtScoreBkg"), bdtScoreBkg);
+    }
+
+    for (const auto& pairEntry : pairEntries) {
+      // define variables for widely used quantities
+      float deltaPhi = pairEntry.deltaPhi();
+      float deltaEta = pairEntry.deltaEta();
+      float ptD = pairEntry.ptD();
+      float ptHadron = pairEntry.ptHadron();
+      float massD = pairEntry.mD();
+      float bdtScorePrompt = pairEntry.mlScorePrompt();
+      float bdtScoreBkg = pairEntry.mlScoreBkg();
+      int poolBin = pairEntry.poolBin();
+      int ptBinD = o2::analysis::findBin(binsPtD, ptD);
+
+      if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
       double efficiencyWeight = 1.;
       if (applyEfficiency) {
         efficiencyWeight = 1. / (efficiencyD->at(o2::analysis::findBin(binsPtEfficiencyD, ptD)) * efficiencyHad->at(o2::analysis::findBin(binsPtEfficiencyHad, ptHadron)));
       }
+
       // in signal region
       if (massD > signalRegionInner->at(ptBinD) && massD < signalRegionOuter->at(ptBinD)) {
         registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
@@ -129,15 +165,15 @@ struct HfTaskCorrelationDsHadrons {
   {
     for (const auto& pairEntry : pairEntries) {
       // define variables for widely used quantities
-      double deltaPhi = pairEntry.deltaPhi();
-      double deltaEta = pairEntry.deltaEta();
-      double ptD = pairEntry.ptD();
-      double ptHadron = pairEntry.ptHadron();
+      float deltaPhi = pairEntry.deltaPhi();
+      float deltaEta = pairEntry.deltaEta();
+      float ptD = pairEntry.ptD();
+      float ptHadron = pairEntry.ptHadron();
+      float massD = pairEntry.mD();
       int poolBin = pairEntry.poolBin();
-      double massD = pairEntry.mD();
       int statusDsPrompt = static_cast<int>(pairEntry.isPrompt());
-      bool isPhysicalPrimary = pairEntry.isPhysicalPrimary();
       int ptBinD = o2::analysis::findBin(binsPtD, ptD);
+      bool isPhysicalPrimary = pairEntry.isPhysicalPrimary();
 
       double efficiencyWeight = 1.;
       if (applyEfficiency) {
@@ -172,10 +208,10 @@ struct HfTaskCorrelationDsHadrons {
   {
     for (const auto& pairEntry : pairEntries) {
       // define variables for widely used quantities
-      double deltaPhi = pairEntry.deltaPhi();
-      double deltaEta = pairEntry.deltaEta();
-      double ptD = pairEntry.ptD();
-      double ptHadron = pairEntry.ptHadron();
+      float deltaPhi = pairEntry.deltaPhi();
+      float deltaEta = pairEntry.deltaEta();
+      float ptD = pairEntry.ptD();
+      float ptHadron = pairEntry.ptHadron();
       int poolBin = pairEntry.poolBin();
       int statusDsPrompt = static_cast<int>(pairEntry.isPrompt());
 
@@ -186,6 +222,45 @@ struct HfTaskCorrelationDsHadrons {
     }
   }
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processMcGen, "Process MC Gen mode", false);
+
+  void processDataME(DsHadronPairFullWithMl const& pairEntries)
+  {
+    for (const auto& pairEntry : pairEntries) {
+      // define variables for widely used quantities
+      float deltaPhi = pairEntry.deltaPhi();
+      float deltaEta = pairEntry.deltaEta();
+      float ptD = pairEntry.ptD();
+      float ptHadron = pairEntry.ptHadron();
+      float massD = pairEntry.mD();
+      float bdtScorePrompt = pairEntry.mlScorePrompt();
+      float bdtScoreBkg = pairEntry.mlScoreBkg();
+      int poolBin = pairEntry.poolBin();
+      int ptBinD = o2::analysis::findBin(binsPtD, ptD);
+
+      if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
+      double efficiencyWeight = 1.;
+      if (applyEfficiency) {
+        efficiencyWeight = 1. / (efficiencyD->at(o2::analysis::findBin(binsPtEfficiencyD, ptD)) * efficiencyHad->at(o2::analysis::findBin(binsPtEfficiencyHad, ptHadron)));
+      }
+
+      // in signal region
+      if (massD > signalRegionInner->at(ptBinD) && massD < signalRegionOuter->at(ptBinD)) {
+        registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSignalRegion"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSignalRegion"), deltaPhi, efficiencyWeight);
+      }
+      // in sideband region
+      if ((massD > sidebandLeftOuter->at(ptBinD) && massD < sidebandLeftInner->at(ptBinD)) ||
+          (massD > sidebandRightInner->at(ptBinD) && massD < sidebandRightOuter->at(ptBinD))) {
+        registry.fill(HIST("hCorrel2DVsPtSidebands"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
+        registry.fill(HIST("hDeltaEtaPtIntSidebands"), deltaEta, efficiencyWeight);
+        registry.fill(HIST("hDeltaPhiPtIntSidebands"), deltaPhi, efficiencyWeight);
+      }
+    }
+  }
+  PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processDataME, "Process data ME", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -148,12 +148,12 @@ struct HfTaskCorrelationDsHadrons {
         registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRec"), deltaPhi, deltaEta, ptD, ptHadron, poolBin, efficiencyWeight);
         registry.fill(HIST("hDeltaEtaPtIntSignalRegionMcRec"), deltaEta, efficiencyWeight);
         registry.fill(HIST("hDeltaPhiPtIntSignalRegionMcRec"), deltaPhi, efficiencyWeight);
-        if (isPhysicalPrimary) {
-          registry.fill(HIST("hCorrel2DVsPtPhysicalPrimaryMcRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
-        }
         // prompt and non-prompt division
         if (pairEntry.isSignal()) {
           registry.fill(HIST("hCorrel2DVsPtSignalRegionMcRecPromptDivision"), deltaPhi, deltaEta, ptD, ptHadron, statusDsPrompt, poolBin, efficiencyWeight);
+          if (isPhysicalPrimary) {
+            registry.fill(HIST("hCorrel2DVsPtPhysicalPrimaryMcRec"), deltaPhi, deltaEta, ptD, ptHadron, efficiencyWeight);
+          }
         }
       }
       // in sideband region


### PR DESCRIPTION
Dear all,
- I've fixed the evaluation of associated particle efficiency requiring to use only particles coming from sel8 events for the reconstructed part (numerator). 
- I've fixed the secondary particle contamination evaluation requiring that the Ds meson used to build the correlations is a real signal candidate.

Let me know if there are any comments,
Best regards,
Samuele