### PR TITLE
modifing randomness mechanism in a pair rel. momentum calculation

### DIFF
--- a/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
@@ -254,7 +254,8 @@ struct FemtoCorrelations {
           SEhistos_1D[multBin][kTbin]->Fill(Pair->GetKstar()); // close pair rejection and fillig the SE histo
 
           if (_fill3dCF) {
-            TVector3 qLCMS = Pair->GetQLCMS();
+            std::mt19937 mt(std::chrono::steady_clock::now().time_since_epoch().count());
+            TVector3 qLCMS = std::pow(-1, (mt() % 2)) * Pair->GetQLCMS(); // introducing randomness to the pair order ([first, second]); important only for 3D because if there are any sudden order/correlation in the tables, it could couse unwanted asymmetries in the final 3d rel. momentum distributions; irrelevant in 1D case because the absolute value of the rel.momentum is taken
             SEhistos_3D[multBin][kTbin]->Fill(qLCMS.X(), qLCMS.Y(), qLCMS.Z());
           }
         }
@@ -301,14 +302,16 @@ struct FemtoCorrelations {
             mThistos[multBin][kTbin]->Fill(Pair->GetMt()); // test
 
             if (_fill3dCF) {
-              TVector3 qLCMS = Pair->GetQLCMS();
+              std::mt19937 mt(std::chrono::steady_clock::now().time_since_epoch().count());
+              TVector3 qLCMS = std::pow(-1, (mt() % 2)) * Pair->GetQLCMS(); // introducing randomness to the pair order ([first, second]); important only for 3D because if there are any sudden order/correlation in the tables, it could couse unwanted asymmetries in the final 3d rel. momentum distributions; irrelevant in 1D case because the absolute value of the rel.momentum is taken
               SEhistos_3D[multBin][kTbin]->Fill(qLCMS.X(), qLCMS.Y(), qLCMS.Z());
             }
           } else {
             MEhistos_1D[multBin][kTbin]->Fill(Pair->GetKstar());
 
             if (_fill3dCF) {
-              TVector3 qLCMS = Pair->GetQLCMS();
+              std::mt19937 mt(std::chrono::steady_clock::now().time_since_epoch().count());
+              TVector3 qLCMS = std::pow(-1, (mt() % 2)) * Pair->GetQLCMS(); // introducing randomness to the pair order ([first, second]); important only for 3D because if there are any sudden order/correlation in the tables, it could couse unwanted asymmetries in the final 3d rel. momentum distributions; irrelevant in 1D case because the absolute value of the rel.momentum is taken
               MEhistos_3D[multBin][kTbin]->Fill(qLCMS.X(), qLCMS.Y(), qLCMS.Z());
               qLCMSvskStar[multBin][kTbin]->Fill(qLCMS.X(), qLCMS.Y(), qLCMS.Z(), Pair->GetKstar());
             }
@@ -412,11 +415,6 @@ struct FemtoCorrelations {
           int centBin = std::floor((i->first).second);
           MultHistos[centBin]->Fill(col1->mult());
 
-          if (_fill3dCF) { // shuffling is important only for 3D because if there are any sudden order/correlation in the tables, it could couse unwanted asymmetries in the final 3d rel. momentum distributions; irrelevant in 1D case because the absolute value of the rel.momentum is taken
-            std::mt19937 gen(std::chrono::steady_clock::now().time_since_epoch().count());
-            std::shuffle(selectedtracks_1[col1->index()].begin(), selectedtracks_1[col1->index()].end(), gen);
-          }
-
           mixTracks(selectedtracks_1[col1->index()], centBin); // mixing SE identical
 
           for (int indx2 = indx1 + 1; indx2 < EvPerBin; indx2++) { // nested loop for all the combinations of collisions in a chosen mult/vertex bin
@@ -448,11 +446,6 @@ struct FemtoCorrelations {
 
           int centBin = std::floor((i->first).second);
           MultHistos[centBin]->Fill(col1->mult());
-
-          if (_fill3dCF) {
-            std::mt19937 gen(std::chrono::steady_clock::now().time_since_epoch().count());
-            std::shuffle(selectedtracks_1[col1->index()].begin(), selectedtracks_1[col1->index()].end(), gen);
-          }
 
           mixTracks<0>(selectedtracks_1[col1->index()], selectedtracks_2[col1->index()], centBin); // mixing SE non-identical, in <> brackets: 0 -- SE; 1 -- ME
 


### PR DESCRIPTION
Dear @victor-gonzalez ,

In this commit we're trying to improve the randomness mechanism for a pair assignment. In case of 3d we're sensitive to the projections of the relative momentum (in 1d we take an abs. value -- irrelevant). In principle pairs must be the same but the pair order [particle1, particle2] must be random. The pairing has a pattern and in order to eliminate it we used shuffling before, this time we just randomly choose the sign of the momenta difference p1 - p2 I.e. order. We expect it to be a more correct way of eliminating any patterns. Could you please approve this commit? Thank you.

Sincerely yours, Gleb.