### PR TITLE
added new collision cuts

### DIFF
--- a/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
@@ -104,6 +104,9 @@ struct reso2initializer {
   Configurable<int> ConfEvtTriggerSel{"ConfEvtTriggerSel", 8, "Evt sel: trigger"};
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", true, "Evt sel: check for offline selection"};
   Configurable<bool> ConfEvtTFBorderCut{"ConfEvtTFBorderCut", false, "Evt sel: apply TF border cut"};
+  Configurable<bool> ConfEvtITSTPCmatching{"ConfEvtITSTPCmatching", false, "Evt sel: apply ITS-TPC matching"};
+  Configurable<bool> ConfEvtZvertexTimedifference{"ConfEvtZvertexTimedifference", false, "Evt sel: apply Z-vertex time difference"};
+  Configurable<bool> ConfEvtPileupRejection{"ConfEvtPileupRejection", false, "Evt sel: apply pileup rejection"};
   Configurable<bool> ConfEvtNoITSROBorderCut{"ConfEvtNoITSROBorderCut", false, "Evt sel: apply NoITSRO border cut"};
 
   Configurable<std::string> cfgMultName{"cfgMultName", "FT0M", "The name of multiplicity estimator"};
@@ -857,6 +860,9 @@ struct reso2initializer {
     }
     colCuts.init(&qaRegistry);
     colCuts.setApplyTFBorderCut(ConfEvtTFBorderCut);
+    colCuts.setApplyITSTPCmatching(ConfEvtITSTPCmatching);
+    colCuts.setApplyZvertexTimedifference(ConfEvtZvertexTimedifference);
+    colCuts.setApplyPileupRejection(ConfEvtPileupRejection);
     colCuts.setApplyNoITSROBorderCut(ConfEvtNoITSROBorderCut);
     if (!ConfBypassCCDB) {
       ccdb->setURL(ccdburl.value);

--- a/PWGLF/Utils/collisionCuts.h
+++ b/PWGLF/Utils/collisionCuts.h
@@ -48,6 +48,9 @@ class CollisonCuts
     mCheckOffline = checkOffline;
     mCheckIsRun3 = checkRun3;
     mApplyTFBorderCut = false;
+    mApplyITSTPCmatching = false;
+    mApplyZvertexTimedifference = false;
+    mApplyPileupRejection = false;
     mApplyNoITSROBorderCut = false;
   }
 
@@ -82,6 +85,15 @@ class CollisonCuts
   /// Set the time frame border cut
   void setApplyTFBorderCut(bool applyTFBorderCut) { mApplyTFBorderCut = applyTFBorderCut; }
 
+  /// Set the ITS-TPC matching cut
+  void setApplyITSTPCmatching(bool applyITSTPCmatching) { mApplyITSTPCmatching = applyITSTPCmatching; }
+
+  /// Set the Z-vertex time difference cut
+  void setApplyZvertexTimedifference(bool applyZvertexTimedifference) { mApplyZvertexTimedifference = applyZvertexTimedifference; }
+
+  /// Set the Pileup rejection
+  void setApplyPileupRejection(bool applyPileupRejection) { mApplyPileupRejection = applyPileupRejection; }
+
   /// Set the NoITSRO frame border cut
   void setApplyNoITSROBorderCut(bool applyNoITSROBorderCut) { mApplyNoITSROBorderCut = applyNoITSROBorderCut; }
 
@@ -103,6 +115,18 @@ class CollisonCuts
       }
       if (!col.selection_bit(aod::evsel::kNoTimeFrameBorder) && mApplyTFBorderCut) {
         LOGF(debug, "Time frame border cut failed");
+        return false;
+      }
+      if (!col.selection_bit(o2::aod::evsel::kIsVertexITSTPC) && mApplyITSTPCmatching) {
+        LOGF(debug, "ITS-TPC matching cut failed");
+        return false;
+      }
+      if (!col.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV) && mApplyZvertexTimedifference) {
+        LOGF(debug, "Z-vertex time difference cut failed");
+        return false;
+      }
+      if (!col.selection_bit(o2::aod::evsel::kNoSameBunchPileup) && mApplyPileupRejection) {
+        LOGF(debug, "Pileup rejection failed");
         return false;
       }
       if (!col.selection_bit(aod::evsel::kNoITSROFrameBorder) && mApplyNoITSROBorderCut) {
@@ -166,6 +190,9 @@ class CollisonCuts
   bool mCheckIsRun3 = false;                       ///< Check if running on Pilot Beam
   bool mInitialTriggerScan = false;                ///< Check trigger when the event is first selected
   bool mApplyTFBorderCut = false;                  ///< Apply time frame border cut
+  bool mApplyITSTPCmatching = false;               ///< selects collisions with at least one ITS-TPC track
+  bool mApplyZvertexTimedifference = false;        ///< removes collisions with large differences between z of PV by tracks and z of PV from FT0 A-C time difference.
+  bool mApplyPileupRejection = false;              ///< Pileup rejection
   bool mApplyNoITSROBorderCut = false;             ///< Apply NoITSRO frame border cut
   int mTrigger = kINT7;                            ///< Trigger to check for
   float mZvtxMax = 999.f;                          ///< Maximal deviation from nominal z-vertex (cm)


### PR DESCRIPTION
1. `kNoSameBunchPileup` : Pileup rejection
2. `kIsGoodZvtxFT0vsPV` : removes collisions with large differences between z of PV by tracks and z of PV from FT0 A-C time difference.
3. `kIsVertexITSTPC` : selects collisions with at least one ITS-TPC track