### PR TITLE
PWGCF: Generic JQVectors class for JCorran

### DIFF
--- a/PWGCF/JCorran/Core/JFFlucAnalysis.cxx
+++ b/PWGCF/JCorran/Core/JFFlucAnalysis.cxx
@@ -335,7 +335,7 @@ TComplex JFFlucAnalysis::Q(int n, int p)
 {
   // Return QvectorQC
   // Q{-n, p} = Q{n, p}*
-  return n >= 0 ? QvectorQC[n][p] : C(QvectorQC[-n][p]);
+  return n >= 0 ? pqvecs->QvectorQC[n][p] : C(pqvecs->QvectorQC[-n][p]);
 }
 
 TComplex JFFlucAnalysis::Two(int n1, int n2)
@@ -355,11 +355,11 @@ TComplex JFFlucAnalysis::Four(int n1, int n2, int n3, int n4)
 void JFFlucAnalysis::UserExec(Option_t* popt)
 {
   for (UInt_t ih = 2; ih < kNH; ih++) {
-    fh_cos_n_phi[ih][fCBin]->Fill(QvectorQC[ih][1].Re() / QvectorQC[0][1].Re());
-    fh_sin_n_phi[ih][fCBin]->Fill(QvectorQC[ih][1].Im() / QvectorQC[0][1].Re());
+    fh_cos_n_phi[ih][fCBin]->Fill(pqvecs->QvectorQC[ih][1].Re() / pqvecs->QvectorQC[0][1].Re());
+    fh_sin_n_phi[ih][fCBin]->Fill(pqvecs->QvectorQC[ih][1].Im() / pqvecs->QvectorQC[0][1].Re());
     //
     //
-    Double_t psi = QvectorQC[ih][1].Theta();
+    Double_t psi = pqvecs->QvectorQC[ih][1].Theta();
     fh_psi_n[ih][fCBin]->Fill(psi);
     fh_cos_n_psi_n[ih][fCBin]->Fill(TMath::Cos((Double_t)ih * psi));
     fh_sin_n_psi_n[ih][fCBin]->Fill(TMath::Sin((Double_t)ih * psi));
@@ -372,7 +372,7 @@ void JFFlucAnalysis::UserExec(Option_t* popt)
   TComplex ncorr[kNH][nKL];
   TComplex ncorr2[kNH][nKL][kcNH][nKL];
 
-  const TComplex(*pQq)[kNH][nKL] = QvectorQCgap;
+  const TComplex(*pQq)[kNH][nKL] = pqvecs->QvectorQCgap;
 
   for (UInt_t i = 0; i < 2; ++i) {
     if ((subeventMask & (1 << i)) == 0)
@@ -531,7 +531,7 @@ void JFFlucAnalysis::UserExec(Option_t* popt)
   if (flags & kFlucEbEWeighting) {
     event_weight_four = Four(0, 0, 0, 0).Re();
     event_weight_two = Two(0, 0).Re();
-    event_weight_two_gap = (QvectorQCgap[kSubA][0][1] * QvectorQCgap[kSubB][0][1]).Re();
+    event_weight_two_gap = (pqvecs->QvectorQCgap[kSubA][0][1] * pqvecs->QvectorQCgap[kSubB][0][1]).Re();
   }
 
   for (UInt_t ih = 2; ih < kNH; ih++) {
@@ -544,7 +544,7 @@ void JFFlucAnalysis::UserExec(Option_t* popt)
     TComplex sctwo = Two(ih, -ih) / Two(0, 0).Re();
     fh_SC_with_QC_2corr[ih][fCBin]->Fill(sctwo.Re(), event_weight_two);
 
-    TComplex sctwoGap = (QvectorQCgap[kSubA][ih][1] * TComplex::Conjugate(QvectorQCgap[kSubB][ih][1])) / (QvectorQCgap[kSubA][0][1] * QvectorQCgap[kSubB][0][1]).Re();
+    TComplex sctwoGap = (pqvecs->QvectorQCgap[kSubA][ih][1] * TComplex::Conjugate(pqvecs->QvectorQCgap[kSubB][ih][1])) / (pqvecs->QvectorQCgap[kSubA][0][1] * pqvecs->QvectorQCgap[kSubB][0][1]).Re();
     fh_SC_with_QC_2corr_gap[ih][fCBin]->Fill(sctwoGap.Re(), event_weight_two_gap);
   }
 }

--- a/PWGCF/JCorran/Core/JQVectors.h
+++ b/PWGCF/JCorran/Core/JQVectors.h
@@ -1,0 +1,89 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+/// \author Dong Jo Kim (djkim@jyu.fi)
+/// \author Jasper Parkkila (jparkkil@cern.ch)
+/// \since Sep 2022
+
+#ifndef PWGCF_JCORRAN_CORE_JQVECTORS_H_
+#define PWGCF_JCORRAN_CORE_JQVECTORS_H_
+
+#include <experimental/type_traits>
+#include <TMath.h>
+
+template <class Q, UInt_t nh, UInt_t nk>
+class JQVectorsGapBase
+{
+ public:
+  JQVectorsGapBase() {}
+  virtual ~JQVectorsGapBase() {}
+  Q QvectorQCgap[2][nh][nk];
+};
+
+class JQVectorsEmptyBase
+{
+ public:
+  //
+};
+
+template <class Q, UInt_t nh, UInt_t nk, bool gap>
+class JQVectors : public std::conditional_t<gap, JQVectorsGapBase<Q, nh, nk>, JQVectorsEmptyBase>
+{
+ public:
+  JQVectors() {}
+  ~JQVectors() {}
+
+  template <class T>
+  using hasWeightNUA = decltype(std::declval<T&>().weightNUA());
+  template <class T>
+  using hasWeightEff = decltype(std::declval<T&>().weightEff());
+
+  template <class JInputClass>
+  inline void Calculate(JInputClass& inputInst, float etamax, float etamin)
+  {
+    // calculate Q-vector for QC method ( no subgroup )
+    for (UInt_t ih = 0; ih < nh; ++ih) {
+      for (UInt_t ik = 0; ik < nk; ++ik) {
+        QvectorQC[ih][ik] = Q(0, 0);
+        if constexpr (gap) {
+          for (UInt_t isub = 0; isub < 2; ++isub)
+            this->QvectorQCgap[isub][ih][ik] = Q(0, 0);
+        }
+      }
+    }
+    for (auto& track : inputInst) {
+      if (track.eta() < -etamax || track.eta() > etamax)
+        continue;
+
+      UInt_t isub = (UInt_t)(track.eta() > 0.0);
+      for (UInt_t ih = 0; ih < nh; ++ih) {
+        Double_t tf = 1.0;
+        for (UInt_t ik = 0; ik < nk; ++ik) {
+          Q q(tf * TMath::Cos(ih * track.phi()), tf * TMath::Sin(ih * track.phi()));
+          QvectorQC[ih][ik] += q;
+
+          if constexpr (gap) {
+            if (TMath::Abs(track.eta()) > etamin)
+              this->QvectorQCgap[isub][ih][ik] += q;
+          }
+
+          using JInputClassIter = typename JInputClass::iterator;
+          if constexpr (std::experimental::is_detected<hasWeightNUA, const JInputClassIter>::value)
+            tf /= track.weightNUA();
+          if constexpr (std::experimental::is_detected<hasWeightEff, const JInputClassIter>::value)
+            tf /= track.weightEff();
+        }
+      }
+    }
+  }
+  Q QvectorQC[nh][nk];
+};
+
+#endif // PWGCF_JCORRAN_CORE_JQVECTORS_H_

--- a/PWGCF/JCorran/Tasks/jflucAnalysisTask.cxx
+++ b/PWGCF/JCorran/Tasks/jflucAnalysisTask.cxx
@@ -184,7 +184,8 @@ struct jflucAnalysisTask {
   {
     pcf->Init();
     pcf->FillQA(tracks);
-    pcf->CalculateQvectorsQC(tracks);
+    qvecs.Calculate(tracks, etamin, etamax);
+    pcf->SetJQVectors(&qvecs);
     const auto& edges = AxisSpec(axisMultiplicity).binEdges;
     for (UInt_t i = 0, n = AxisSpec(axisMultiplicity).getNbins(); i < n; ++i)
       if (collision.multiplicity() < edges[i + 1]) {
@@ -221,6 +222,7 @@ struct jflucAnalysisTask {
   }
   PROCESS_SWITCH(jflucAnalysisTask, processCFDerivedCorrected, "Process CF derived data with corrections", false);
 
+  JFFlucAnalysis::JQVectorsT qvecs;
   JFFlucAnalysis* pcf;
 };
 


### PR DESCRIPTION
The Q-vector calculation code is moved from JFlucAnalysis to a shared header, so that other analyses under JCorran can take advantage of it. At the same time, the class is further templated to be more flexible under different requirements.