### PR TITLE
PWGHF: Fix mistakenly removed parameters

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -344,7 +344,8 @@ struct HfCandidateCreatorB0Expressions {
 
   void init(InitContext const&) {}
 
-  void processMc(aod::TracksWMc const&,
+  void processMc(aod::HfCand3Prong const&,
+                 aod::TracksWMc const&,
                  aod::McParticles const& mcParticles,
                  aod::HfCandB0Prongs const& candsB0)
   {

--- a/PWGHF/TableProducer/candidateCreatorBplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBplus.cxx
@@ -344,7 +344,8 @@ struct HfCandidateCreatorBplusExpressions {
 
   void init(InitContext const&) {}
 
-  void processMc(aod::TracksWMc const&,
+  void processMc(aod::HfCand2Prong const&,
+                 aod::TracksWMc const&,
                  aod::McParticles const& mcParticles,
                  aod::HfCandBplusProngs const& candsBplus)
   {


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/AliceO2Group/O2Physics/pull/5648