### PR TITLE
PWGHF: reducing number of bins for ML scores in D0 output ThnSparse

### DIFF
--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -74,7 +74,7 @@ struct HfTaskD0 {
   Partition<D0CandidatesMlMc> selectedD0CandidatesMlMc = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
   Partition<D0CandidatesMlMcKF> selectedD0CandidatesMlMcKF = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
 
-  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {{100, 0.f, 1.f}, {100, 0.f, 1.f}, {120, 1.5848, 2.1848}, {360, 0., 36.}, {100, -5., 5.}, {3, -0.5, 2.5}, {4, -0.5, 3.5}}};
+  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {{50, 0.f, 1.f}, {50, 0.f, 1.f}, {120, 1.5848, 2.1848}, {360, 0., 36.}, {100, -5., 5.}, {3, -0.5, 2.5}, {4, -0.5, 3.5}}};
 
   HistogramRegistry registry{
     "registry",

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -216,7 +216,7 @@ struct HfTaskD0 {
       const AxisSpec thnAxisY{thnConfigAxisY, "y"};
       const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "Origin"};
       const AxisSpec thnAxisCandType{thnConfigAxisCandType, "D0 type"};
-      
+  
       registry.add("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type", "Thn for D0 candidates with BDT scores", HistType::kTHnSparseD, {thnAxisBkgScore, thnAxisNonPromptScore, thnAxisMass, thnAxisPt, thnAxisY, thnAxisOrigin, thnAxisCandType});
       registry.get<THnSparse>(HIST("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type"))->Sumw2();
     }

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -56,10 +56,10 @@ struct HfTaskD0 {
   ConfigurableAxis thnConfigAxisBkgScore{"thnConfigAxisBkgScore", {50, 0, 1}, "Bkg score bins"};
   ConfigurableAxis thnConfigAxisNonPromptScore{"thnConfigAxisNonPromptScore", {50, 0, 1}, "Non-prompt score bins"};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {120, 1.5848, 2.1848}, "Cand. inv-mass bins"};
-  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {50, 0, 50}, "Cand. pT bins"};
-  ConfigurableAxis thnConfigAxisRapidity{"thnConfigAxisRapidity", {100, -5, 5}, "Cand. rapidity bins"};
+  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {120, 0, 24}, "Cand. pT bins"};
+  ConfigurableAxis thnConfigAxisY{"thnConfigAxisY", {20, -1, 1}, "Cand. rapidity bins"};
   ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {3, -0.5, 2.5}, "Cand. origin type"};
-  ConfigurableAxis thnConfigAxisD0Type{"thnConfigAxisD0Type", {4, -0.5, 3.5}, "D0 type"};
+  ConfigurableAxis thnConfigAxisCandType{"thnConfigAxisCandType", {4, -0.5, 3.5}, "D0 type"};
 
   HfHelper hfHelper;
 
@@ -82,8 +82,6 @@ struct HfTaskD0 {
   Partition<D0CandidatesMlKF> selectedD0CandidatesMlKF = aod::hf_sel_candidate_d0::isSelD0 >= selectionFlagD0 || aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlagD0bar;
   Partition<D0CandidatesMlMc> selectedD0CandidatesMlMc = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
   Partition<D0CandidatesMlMcKF> selectedD0CandidatesMlMcKF = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
-
-  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {thnConfigAxisBkgScore, thnConfigAxisNonPromptScore, thnConfigAxisMass, thnConfigAxisPt, thnConfigAxisRapidity, thnConfigAxisOrigin, thnConfigAxisD0Type}};
 
   HistogramRegistry registry{
     "registry",
@@ -211,7 +209,15 @@ struct HfTaskD0 {
     registry.add("hDecLengthxyVsPtSig", "2-prong candidates;decay length xy (cm) vs #it{p}_{T} for signal;entries", {HistType::kTH2F, {{800, 0., 4.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
     if (applyMl) {
-      registry.add("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type", "2-prong candidates;BDT score bkg.;BDT score non-prompt;inv. mass (#pi K) (GeV/#it{c}^{2});#it{p}_{T};y;Origin;D0 Type;", hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type);
+      const AxisSpec thnAxisBkgScore{thnConfigAxisBkgScore, "BDT score bkg."};
+      const AxisSpec thnAxisNonPromptScore{thnConfigAxisNonPromptScore, "BDT score non-prompt."};
+      const AxisSpec thnAxisMass{thnConfigAxisMass, "inv. mass (#pi K) (GeV/#it{c}^{2})"};
+      const AxisSpec thnAxisPt{thnConfigAxisPt, "#it{p}_{T} (GeV/#it{c})"};
+      const AxisSpec thnAxisY{thnConfigAxisY, "y"};
+      const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "Origin"};
+      const AxisSpec thnAxisCandType{thnConfigAxisCandType, "D0 type"};
+      
+      registry.add("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type", "Thn for D0 candidates with BDT scores", HistType::kTHnSparseD, {thnAxisBkgScore, thnAxisNonPromptScore, thnAxisMass, thnAxisPt, thnAxisY, thnAxisOrigin, thnAxisCandType});
       registry.get<THnSparse>(HIST("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type"))->Sumw2();
     }
   }

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -49,8 +49,15 @@ struct HfTaskD0 {
   Configurable<int> selectionCand{"selectionCand", 1, "Selection Flag for conj. topol. selected candidates"};
   Configurable<int> selectionPid{"selectionPid", 1, "Selection Flag for reco PID candidates"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
+  Configurable<int> nBinsNonPromptScore{"nBinsNonPromptScore", 50, "Number of non-prompt score bins in output ThnSparse"};
+  Configurable<int> nBinsBkgScore{"nBinsBkgScore", 50, "Number of bkg score bins in output ThnSparse"};
+  Configurable<int> nBinsInvMass{"nBinsInvMass", 120, "Number of inv-mass bins in output ThnSparse"};
+  Configurable<int> nBinsPt{"nBinsPt", 360, "Number of pT bins in output ThnSparse"};
+  Configurable<double> ptCandMin{"ptCandMin", 0., "min. cand. pT in output ThnSparse"};
+  Configurable<double> ptCandMax{"ptCandMax", 50., "max. cand. pT in output ThnSparse"};
   // ML inference
   Configurable<bool> applyMl{"applyMl", false, "Flag to apply ML selections"};
+  
 
   HfHelper hfHelper;
 
@@ -74,7 +81,7 @@ struct HfTaskD0 {
   Partition<D0CandidatesMlMc> selectedD0CandidatesMlMc = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
   Partition<D0CandidatesMlMcKF> selectedD0CandidatesMlMcKF = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
 
-  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {{50, 0.f, 1.f}, {50, 0.f, 1.f}, {120, 1.5848, 2.1848}, {360, 0., 36.}, {100, -5., 5.}, {3, -0.5, 2.5}, {4, -0.5, 3.5}}};
+  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {{nBinsBkgScore, 0.f, 1.f}, {nBinsNonPromptScore, 0.f, 1.f}, {nBinsInvMass, 1.5848, 2.1848}, {nBinsPt, ptCandMin, ptCandMax}, {100, -5., 5.}, {3, -0.5, 2.5}, {4, -0.5, 3.5}}};
 
   HistogramRegistry registry{
     "registry",

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -49,14 +49,17 @@ struct HfTaskD0 {
   Configurable<int> selectionCand{"selectionCand", 1, "Selection Flag for conj. topol. selected candidates"};
   Configurable<int> selectionPid{"selectionPid", 1, "Selection Flag for reco PID candidates"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
-  Configurable<int> nBinsNonPromptScore{"nBinsNonPromptScore", 50, "Number of non-prompt score bins in output ThnSparse"};
-  Configurable<int> nBinsBkgScore{"nBinsBkgScore", 50, "Number of bkg score bins in output ThnSparse"};
-  Configurable<int> nBinsInvMass{"nBinsInvMass", 120, "Number of inv-mass bins in output ThnSparse"};
-  Configurable<int> nBinsPt{"nBinsPt", 360, "Number of pT bins in output ThnSparse"};
-  Configurable<double> ptCandMin{"ptCandMin", 0., "min. cand. pT in output ThnSparse"};
-  Configurable<double> ptCandMax{"ptCandMax", 50., "max. cand. pT in output ThnSparse"};
   // ML inference
   Configurable<bool> applyMl{"applyMl", false, "Flag to apply ML selections"};
+
+  // ThnSparse for ML outputScores and Vars
+  ConfigurableAxis thnConfigAxisBkgScore{"thnConfigAxisBkgScore", {50, 0, 1}, "Bkg score bins"};
+  ConfigurableAxis thnConfigAxisNonPromptScore{"thnConfigAxisNonPromptScore", {50, 0, 1}, "Non-prompt score bins"};
+  ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {120, 1.5848, 2.1848}, "Cand. inv-mass bins"};
+  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {50, 0, 50}, "Cand. pT bins"};
+  ConfigurableAxis thnConfigAxisRapidity{"thnConfigAxisRapidity", {100, -5, 5}, "Cand. rapidity bins"};
+  ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {3, -0.5, 2.5}, "Cand. origin type"};
+  ConfigurableAxis thnConfigAxisD0Type{"thnConfigAxisD0Type", {4, -0.5, 3.5}, "D0 type"};
 
   HfHelper hfHelper;
 
@@ -80,7 +83,7 @@ struct HfTaskD0 {
   Partition<D0CandidatesMlMc> selectedD0CandidatesMlMc = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
   Partition<D0CandidatesMlMcKF> selectedD0CandidatesMlMcKF = aod::hf_sel_candidate_d0::isRecoHfFlag >= selectionFlagHf;
 
-  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {{nBinsBkgScore, 0.f, 1.f}, {nBinsNonPromptScore, 0.f, 1.f}, {nBinsInvMass, 1.5848, 2.1848}, {nBinsPt, ptCandMin, ptCandMax}, {100, -5., 5.}, {3, -0.5, 2.5}, {4, -0.5, 3.5}}};
+  HistogramConfigSpec hTHnBdtScoreVsMassVsPtVsYVsOriginVsD0Type{HistType::kTHnSparseD, {thnConfigAxisBkgScore, thnConfigAxisNonPromptScore, thnConfigAxisMass, thnConfigAxisPt, thnConfigAxisRapidity, thnConfigAxisOrigin, thnConfigAxisD0Type}};
 
   HistogramRegistry registry{
     "registry",

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -57,7 +57,6 @@ struct HfTaskD0 {
   Configurable<double> ptCandMax{"ptCandMax", 50., "max. cand. pT in output ThnSparse"};
   // ML inference
   Configurable<bool> applyMl{"applyMl", false, "Flag to apply ML selections"};
-  
 
   HfHelper hfHelper;
 

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -216,7 +216,7 @@ struct HfTaskD0 {
       const AxisSpec thnAxisY{thnConfigAxisY, "y"};
       const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "Origin"};
       const AxisSpec thnAxisCandType{thnConfigAxisCandType, "D0 type"};
-  
+
       registry.add("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type", "Thn for D0 candidates with BDT scores", HistType::kTHnSparseD, {thnAxisBkgScore, thnAxisNonPromptScore, thnAxisMass, thnAxisPt, thnAxisY, thnAxisOrigin, thnAxisCandType});
       registry.get<THnSparse>(HIST("hBdtScoreVsMassVsPtVsYVsOriginVsD0Type"))->Sumw2();
     }


### PR DESCRIPTION
The number of bins for Bkg and FD score are reduced from 100 to 50, which allows us to able to create smaller AnalysisResults.root that can be merged on a large dataset. @atavirag 