### PR TITLE
PWGHF: Use `pVector` instead of `std::array{px, py, pz}`

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -337,8 +337,8 @@ struct HfFilter { // Main struct for HF triggers
         auto trackParNeg = getTrackPar(trackNeg);
         o2::gpu::gpustd::array<float, 2> dcaPos{trackPos.dcaXY(), trackPos.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaNeg{trackNeg.dcaXY(), trackNeg.dcaZ()};
-        std::array<float, 3> pVecPos{trackPos.px(), trackPos.py(), trackPos.pz()};
-        std::array<float, 3> pVecNeg{trackNeg.px(), trackNeg.py(), trackNeg.pz()};
+        std::array<float, 3> pVecPos{trackPos.pVector()};
+        std::array<float, 3> pVecNeg{trackNeg.pVector()};
         if (trackPos.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParPos, 2.f, noMatCorr, &dcaPos);
           getPxPyPz(trackParPos, pVecPos);
@@ -406,7 +406,7 @@ struct HfFilter { // Main struct for HF triggers
 
           auto trackParThird = getTrackPar(track);
           o2::gpu::gpustd::array<float, 2> dcaThird{track.dcaXY(), track.dcaZ()};
-          std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
+          std::array<float, 3> pVecThird = {track.pVector()};
           if (track.collisionId() != thisCollId) {
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParThird, 2.f, noMatCorr, &dcaThird);
             getPxPyPz(trackParThird, pVecThird);
@@ -448,7 +448,7 @@ struct HfFilter { // Main struct for HF triggers
                     }
                     auto trackParFourth = getTrackPar(trackB);
                     o2::gpu::gpustd::array<float, 2> dcaFourth{trackB.dcaXY(), trackB.dcaZ()};
-                    std::array<float, 3> pVecFourth = {trackB.px(), trackB.py(), trackB.pz()};
+                    std::array<float, 3> pVecFourth = {trackB.pVector()};
                     if (trackB.collisionId() != thisCollId) {
                       o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFourth, 2.f, noMatCorr, &dcaFourth);
                       getPxPyPz(trackParFourth, pVecFourth);
@@ -560,7 +560,7 @@ struct HfFilter { // Main struct for HF triggers
 
                   auto trackParBachelor = getTrackPar(trackBachelor);
                   o2::gpu::gpustd::array<float, 2> dcaBachelor{trackBachelor.dcaXY(), trackBachelor.dcaZ()};
-                  std::array<float, 3> pVecBachelor = {trackBachelor.px(), trackBachelor.py(), trackBachelor.pz()};
+                  std::array<float, 3> pVecBachelor = {trackBachelor.pVector()};
                   if (trackBachelor.collisionId() != thisCollId) {
                     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParBachelor, 2.f, noMatCorr, &dcaBachelor);
                     getPxPyPz(trackParBachelor, pVecBachelor);
@@ -676,9 +676,9 @@ struct HfFilter { // Main struct for HF triggers
         o2::gpu::gpustd::array<float, 2> dcaFirst{trackFirst.dcaXY(), trackFirst.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaSecond{trackSecond.dcaXY(), trackSecond.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaThird{trackThird.dcaXY(), trackThird.dcaZ()};
-        std::array<float, 3> pVecFirst = {trackFirst.px(), trackFirst.py(), trackFirst.pz()};
-        std::array<float, 3> pVecSecond = {trackSecond.px(), trackSecond.py(), trackSecond.pz()};
-        std::array<float, 3> pVecThird = {trackThird.px(), trackThird.py(), trackThird.pz()};
+        std::array<float, 3> pVecFirst = trackFirst.pVector();
+        std::array<float, 3> pVecSecond = trackSecond.pVector();
+        std::array<float, 3> pVecThird = trackThird.pVector();
         if (trackFirst.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFirst, 2.f, noMatCorr, &dcaFirst);
           getPxPyPz(trackParFirst, pVecFirst);
@@ -801,7 +801,7 @@ struct HfFilter { // Main struct for HF triggers
 
           auto trackParFourth = getTrackPar(track);
           o2::gpu::gpustd::array<float, 2> dcaFourth{track.dcaXY(), track.dcaZ()};
-          std::array<float, 3> pVecFourth = {track.px(), track.py(), track.pz()};
+          std::array<float, 3> pVecFourth = track.pVector();
           if (track.collisionId() != thisCollId) {
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFourth, 2.f, noMatCorr, &dcaFourth);
             getPxPyPz(trackParFourth, pVecFourth);
@@ -884,7 +884,7 @@ struct HfFilter { // Main struct for HF triggers
               // select soft pion candidates
               auto trackParSoftPi = getTrackPar(trackSoftPi);
               o2::gpu::gpustd::array<float, 2> dcaSoftPi{trackSoftPi.dcaXY(), trackSoftPi.dcaZ()};
-              std::array<float, 3> pVecSoftPi = {trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz()};
+              std::array<float, 3> pVecSoftPi = trackSoftPi.pVector();
               if (trackSoftPi.collisionId() != thisCollId) {
                 // This is a track reassociated to this PV by the track-to-collision-associator
                 // Let's propagate this track to it, and calculate dcaXY, dcaZ
@@ -1093,7 +1093,7 @@ struct HfFilter { // Main struct for HF triggers
                 // select soft pion candidates
                 auto trackParSoftPi = getTrackPar(trackSoftPi);
                 o2::gpu::gpustd::array<float, 2> dcaSoftPi{trackSoftPi.dcaXY(), trackSoftPi.dcaZ()};
-                std::array<float, 3> pVecSoftPi = {trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz()};
+                std::array<float, 3> pVecSoftPi = trackSoftPi.pVector();
                 if (trackSoftPi.collisionId() != thisCollId) {
                   // This is a track reassociated to this PV by the track-to-collision-associator
                   // Let's propagate this track to it, and calculate dcaXY, dcaZ
@@ -1112,8 +1112,8 @@ struct HfFilter { // Main struct for HF triggers
                     /// and keep it only if it is in the correct mass range
 
                     float massSigmaCPKPi{-999.}, massSigmaCPiKP{-999.}, deltaMassXicResoPKPi{-999.}, deltaMassXicResoPiKP{-999.};
-                    std::array<float, 3> pVecPiPosK0s = {posTrack.px(), posTrack.py(), posTrack.pz()};
-                    std::array<float, 3> pVecPiNegK0s = {negTrack.px(), negTrack.py(), negTrack.pz()};
+                    std::array<float, 3> pVecPiPosK0s = posTrack.pVector();
+                    std::array<float, 3> pVecPiNegK0s = negTrack.pVector();
                     float ptSigmaCKaon = RecoDecay::pt(pVecSigmaC, pVecPiPosK0s, pVecPiNegK0s);
                     if (ptSigmaCKaon > cutsPtDeltaMassCharmReso->get(2u, 10u)) {
                       if (TESTBIT(whichSigmaC, 0)) {
@@ -1201,7 +1201,7 @@ struct HfFilter { // Main struct for HF triggers
             getPxPyPz(trackParCasc, pVecCascade);
 
             auto trackParBachelor = getTrackPar(track);
-            std::array<float, 3> pVecBachelor = {track.px(), track.py(), track.pz()};
+            std::array<float, 3> pVecBachelor = track.pVector();
             if (track.collisionId() != thisCollId) {
               o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParBachelor, 2.f, noMatCorr, &dcaInfo);
               getPxPyPz(trackParBachelor, pVecBachelor);

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -341,8 +341,8 @@ struct HfFilter { // Main struct for HF triggers
         auto trackParNeg = getTrackPar(trackNeg);
         o2::gpu::gpustd::array<float, 2> dcaPos{trackPos.dcaXY(), trackPos.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaNeg{trackNeg.dcaXY(), trackNeg.dcaZ()};
-        std::array<float, 3> pVecPos{trackPos.px(), trackPos.py(), trackPos.pz()};
-        std::array<float, 3> pVecNeg{trackNeg.px(), trackNeg.py(), trackNeg.pz()};
+        std::array<float, 3> pVecPos{trackPos.pVector()};
+        std::array<float, 3> pVecNeg{trackNeg.pVector()};
         if (trackPos.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParPos, 2.f, noMatCorr, &dcaPos);
           getPxPyPz(trackParPos, pVecPos);
@@ -410,7 +410,7 @@ struct HfFilter { // Main struct for HF triggers
 
           auto trackParThird = getTrackPar(track);
           o2::gpu::gpustd::array<float, 2> dcaThird{track.dcaXY(), track.dcaZ()};
-          std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
+          std::array<float, 3> pVecThird = track.pVector();
           if (track.collisionId() != thisCollId) {
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParThird, 2.f, noMatCorr, &dcaThird);
             getPxPyPz(trackParThird, pVecThird);
@@ -452,7 +452,7 @@ struct HfFilter { // Main struct for HF triggers
                     }
                     auto trackParFourth = getTrackPar(trackB);
                     o2::gpu::gpustd::array<float, 2> dcaFourth{trackB.dcaXY(), trackB.dcaZ()};
-                    std::array<float, 3> pVecFourth = {trackB.px(), trackB.py(), trackB.pz()};
+                    std::array<float, 3> pVecFourth = trackB.pVector();
                     if (trackB.collisionId() != thisCollId) {
                       o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFourth, 2.f, noMatCorr, &dcaFourth);
                       getPxPyPz(trackParFourth, pVecFourth);
@@ -581,7 +581,7 @@ struct HfFilter { // Main struct for HF triggers
 
                 auto trackParBachelor = getTrackPar(trackBachelor);
                 o2::gpu::gpustd::array<float, 2> dcaBachelor{trackBachelor.dcaXY(), trackBachelor.dcaZ()};
-                std::array<float, 3> pVecBachelor = {trackBachelor.px(), trackBachelor.py(), trackBachelor.pz()};
+                std::array<float, 3> pVecBachelor = trackBachelor.pVector();
                 if (trackBachelor.collisionId() != thisCollId) {
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParBachelor, 2.f, noMatCorr, &dcaBachelor);
                   getPxPyPz(trackParBachelor, pVecBachelor);
@@ -698,9 +698,9 @@ struct HfFilter { // Main struct for HF triggers
         o2::gpu::gpustd::array<float, 2> dcaFirst{trackFirst.dcaXY(), trackFirst.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaSecond{trackSecond.dcaXY(), trackSecond.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaThird{trackThird.dcaXY(), trackThird.dcaZ()};
-        std::array<float, 3> pVecFirst = {trackFirst.px(), trackFirst.py(), trackFirst.pz()};
-        std::array<float, 3> pVecSecond = {trackSecond.px(), trackSecond.py(), trackSecond.pz()};
-        std::array<float, 3> pVecThird = {trackThird.px(), trackThird.py(), trackThird.pz()};
+        std::array<float, 3> pVecFirst = trackFirst.pVector();
+        std::array<float, 3> pVecSecond = trackSecond.pVector();
+        std::array<float, 3> pVecThird = trackThird.pVector();
         if (trackFirst.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFirst, 2.f, noMatCorr, &dcaFirst);
           getPxPyPz(trackParFirst, pVecFirst);
@@ -823,7 +823,7 @@ struct HfFilter { // Main struct for HF triggers
 
           auto trackParFourth = getTrackPar(track);
           o2::gpu::gpustd::array<float, 2> dcaFourth{track.dcaXY(), track.dcaZ()};
-          std::array<float, 3> pVecFourth = {track.px(), track.py(), track.pz()};
+          std::array<float, 3> pVecFourth = track.pVector();
           if (track.collisionId() != thisCollId) {
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFourth, 2.f, noMatCorr, &dcaFourth);
             getPxPyPz(trackParFourth, pVecFourth);
@@ -905,7 +905,7 @@ struct HfFilter { // Main struct for HF triggers
               // select soft pion candidates
               auto trackParSoftPi = getTrackPar(trackSoftPi);
               o2::gpu::gpustd::array<float, 2> dcaSoftPi{trackSoftPi.dcaXY(), trackSoftPi.dcaZ()};
-              std::array<float, 3> pVecSoftPi = {trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz()};
+              std::array<float, 3> pVecSoftPi = trackSoftPi.pVector();
               if (trackSoftPi.collisionId() != thisCollId) {
                 // This is a track reassociated to this PV by the track-to-collision-associator
                 // Let's propagate this track to it, and calculate dcaXY, dcaZ
@@ -1123,7 +1123,7 @@ struct HfFilter { // Main struct for HF triggers
                 // select soft pion candidates
                 auto trackParSoftPi = getTrackPar(trackSoftPi);
                 o2::gpu::gpustd::array<float, 2> dcaSoftPi{trackSoftPi.dcaXY(), trackSoftPi.dcaZ()};
-                std::array<float, 3> pVecSoftPi = {trackSoftPi.px(), trackSoftPi.py(), trackSoftPi.pz()};
+                std::array<float, 3> pVecSoftPi = trackSoftPi.pVector();
                 if (trackSoftPi.collisionId() != thisCollId) {
                   // This is a track reassociated to this PV by the track-to-collision-associator
                   // Let's propagate this track to it, and calculate dcaXY, dcaZ
@@ -1142,8 +1142,8 @@ struct HfFilter { // Main struct for HF triggers
                     /// and keep it only if it is in the correct mass range
 
                     float massSigmaCPKPi{-999.}, massSigmaCPiKP{-999.}, deltaMassXicResoPKPi{-999.}, deltaMassXicResoPiKP{-999.};
-                    std::array<float, 3> pVecPiPosK0s = {posTrack.px(), posTrack.py(), posTrack.pz()};
-                    std::array<float, 3> pVecPiNegK0s = {negTrack.px(), negTrack.py(), negTrack.pz()};
+                    std::array<float, 3> pVecPiPosK0s = posTrack.pVector();
+                    std::array<float, 3> pVecPiNegK0s = negTrack.pVector();
                     float ptSigmaCKaon = RecoDecay::pt(pVecSigmaC, pVecPiPosK0s, pVecPiNegK0s);
                     if (ptSigmaCKaon > cutsPtDeltaMassCharmReso->get(2u, 10u)) {
                       if (TESTBIT(whichSigmaC, 0)) {
@@ -1227,7 +1227,7 @@ struct HfFilter { // Main struct for HF triggers
             getPxPyPz(trackParCasc, pVecCascade);
 
             auto trackParBachelor = getTrackPar(track);
-            std::array<float, 3> pVecBachelor = {track.px(), track.py(), track.pz()};
+            std::array<float, 3> pVecBachelor = track.pVector();
             if (track.collisionId() != thisCollId) {
               o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParBachelor, 2.f, noMatCorr, &dcaInfo);
               getPxPyPz(trackParBachelor, pVecBachelor);

--- a/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
+++ b/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
@@ -161,8 +161,8 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         auto trackParNeg = getTrackPar(trackNeg);
         o2::gpu::gpustd::array<float, 2> dcaPos{trackPos.dcaXY(), trackPos.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaNeg{trackNeg.dcaXY(), trackNeg.dcaZ()};
-        std::array<float, 3> pVecPos{trackPos.px(), trackPos.py(), trackPos.pz()};
-        std::array<float, 3> pVecNeg{trackNeg.px(), trackNeg.py(), trackNeg.pz()};
+        std::array<float, 3> pVecPos{trackPos.pVector()};
+        std::array<float, 3> pVecNeg{trackNeg.pVector()};
         if (trackPos.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParPos, 2.f, noMatCorr, &dcaPos);
           getPxPyPz(trackParPos, pVecPos);
@@ -216,7 +216,7 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
 
           auto trackParThird = getTrackPar(track);
           o2::gpu::gpustd::array<float, 2> dcaThird{track.dcaXY(), track.dcaZ()};
-          std::array<float, 3> pVecThird = {track.px(), track.py(), track.pz()};
+          std::array<float, 3> pVecThird = track.pVector();
           if (track.collisionId() != thisCollId) {
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParThird, 2.f, noMatCorr, &dcaThird);
             getPxPyPz(trackParThird, pVecThird);
@@ -268,9 +268,9 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
         o2::gpu::gpustd::array<float, 2> dcaFirst{trackFirst.dcaXY(), trackFirst.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaSecond{trackSecond.dcaXY(), trackSecond.dcaZ()};
         o2::gpu::gpustd::array<float, 2> dcaThird{trackThird.dcaXY(), trackThird.dcaZ()};
-        std::array<float, 3> pVecFirst = {trackFirst.px(), trackFirst.py(), trackFirst.pz()};
-        std::array<float, 3> pVecSecond = {trackSecond.px(), trackSecond.py(), trackSecond.pz()};
-        std::array<float, 3> pVecThird = {trackThird.px(), trackThird.py(), trackThird.pz()};
+        std::array<float, 3> pVecFirst = trackFirst.pVector();
+        std::array<float, 3> pVecSecond = trackSecond.pVector();
+        std::array<float, 3> pVecThird = trackThird.pVector();
         if (trackFirst.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFirst, 2.f, noMatCorr, &dcaFirst);
           getPxPyPz(trackParFirst, pVecFirst);

--- a/EventFiltering/PWGHF/HFFilterPrepareMLSamples.cxx
+++ b/EventFiltering/PWGHF/HFFilterPrepareMLSamples.cxx
@@ -100,8 +100,8 @@ struct HfFilterPrepareMlSamples { // Main struct
       auto trackParNeg = getTrackPar(trackNeg);
       o2::gpu::gpustd::array<float, 2> dcaPos{trackPos.dcaXY(), trackPos.dcaZ()};
       o2::gpu::gpustd::array<float, 2> dcaNeg{trackNeg.dcaXY(), trackNeg.dcaZ()};
-      std::array<float, 3> pVecPos{trackPos.px(), trackPos.py(), trackPos.pz()};
-      std::array<float, 3> pVecNeg{trackNeg.px(), trackNeg.py(), trackNeg.pz()};
+      std::array<float, 3> pVecPos{trackPos.pVector()};
+      std::array<float, 3> pVecNeg{trackNeg.pVector()};
       if (trackPos.collisionId() != thisCollId) {
         o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParPos, 2.f, noMatCorr, &dcaPos);
         getPxPyPz(trackParPos, pVecPos);
@@ -162,9 +162,9 @@ struct HfFilterPrepareMlSamples { // Main struct
       o2::gpu::gpustd::array<float, 2> dcaFirst{trackFirst.dcaXY(), trackFirst.dcaZ()};
       o2::gpu::gpustd::array<float, 2> dcaSecond{trackSecond.dcaXY(), trackSecond.dcaZ()};
       o2::gpu::gpustd::array<float, 2> dcaThird{trackThird.dcaXY(), trackThird.dcaZ()};
-      std::array<float, 3> pVecFirst{trackFirst.px(), trackFirst.py(), trackFirst.pz()};
-      std::array<float, 3> pVecSecond{trackSecond.px(), trackSecond.py(), trackSecond.pz()};
-      std::array<float, 3> pVecThird{trackThird.px(), trackThird.py(), trackThird.pz()};
+      std::array<float, 3> pVecFirst{trackFirst.pVector()};
+      std::array<float, 3> pVecSecond{trackSecond.pVector()};
+      std::array<float, 3> pVecThird{trackThird.pVector()};
       if (trackFirst.collisionId() != thisCollId) {
         o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFirst, 2.f, noMatCorr, &dcaFirst);
         getPxPyPz(trackParFirst, pVecFirst);

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
@@ -119,7 +119,7 @@ struct HfCandidateCreatorChic {
       hCPAJpsi->Fill(jpsiCand.cpa());
       // create Jpsi track to pass to DCA fitter; use cand table + rebuild vertex
       const std::array<float, 3> vertexJpsi = {jpsiCand.xSecondaryVertex(), jpsiCand.ySecondaryVertex(), jpsiCand.zSecondaryVertex()};
-      std::array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
+      std::array<float, 3> pvecJpsi = jpsiCand.pVector();
       auto prong0 = jpsiCand.prong0_as<aod::TracksWCov>();
       auto prong1 = jpsiCand.prong1_as<aod::TracksWCov>();
       auto prong0TrackParCov = getTrackParCov(prong0);

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorChic.cxx
@@ -253,7 +253,7 @@ struct HfCandidateCreatorChicMc {
         if (indexMother > -1 && indexMotherGamma == indexMother && candidate.prong1().mcparticle().pdgCode() == kGamma) {
           auto particleMother = mcParticles.rawIteratorAt(indexMother);
           hEphotonMatched->Fill(candidate.prong1().e());
-          hMassEMatched->Fill(sqrt(candidate.prong1().px() * candidate.prong1().px() + candidate.prong1().py() * candidate.prong1().py() + candidate.prong1().pz() * candidate.prong1().pz()));
+          hMassEMatched->Fill(RecoDecay::p(candidate.pVectorProng1()));
           if (particleMother.has_daughters()) {
             std::vector<int> arrAllDaughtersIndex;
             RecoDecay::getDaughters(particleMother, &arrAllDaughtersIndex, std::array{static_cast<int>(kGamma), static_cast<int>(Pdg::kJPsi)}, 1);

--- a/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
+++ b/PWGHF/ALICE3/TableProducer/candidateCreatorX.cxx
@@ -136,7 +136,7 @@ struct HfCandidateCreatorX {
       hCPAJpsi->Fill(jpsiCand.cpa());
       // create Jpsi track to pass to DCA fitter; use cand table + rebuild vertex
       const std::array<float, 3> vertexJpsi = {jpsiCand.xSecondaryVertex(), jpsiCand.ySecondaryVertex(), jpsiCand.zSecondaryVertex()};
-      std::array<float, 3> pvecJpsi = {jpsiCand.px(), jpsiCand.py(), jpsiCand.pz()};
+      std::array<float, 3> pvecJpsi = jpsiCand.pVector();
       auto prong0 = jpsiCand.prong0_as<aod::TracksWCov>();
       auto prong1 = jpsiCand.prong1_as<aod::TracksWCov>();
       auto prong0TrackParCov = getTrackParCov(prong0);

--- a/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
@@ -153,9 +153,9 @@ struct HfTreeCreatorChicToJpsiGamma {
     // int indexCand = 0;
     rowCandidateFull.reserve(candidates.size());
     for (const auto& candidate : candidates) {
-      std::array<float, 3> pvecChic = {candidate.px(), candidate.py(), candidate.pz()};
-      std::array<float, 3> pvecJpsi = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-      std::array<float, 3> pvecGamma = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+      std::array<float, 3> pvecChic = candidate.pVector();
+      std::array<float, 3> pvecJpsi = candidate.pVectorProng0();
+      std::array<float, 3> pvecGamma = candidate.pVectorProng1();
       auto pchic = RecoDecay::p(pvecChic);
       auto pjpsi = RecoDecay::p(pvecJpsi);
       auto pl1 = std::abs(RecoDecay::dotProd(pvecChic, pvecJpsi)) / pchic;

--- a/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorChicToJpsiGamma.cxx
@@ -217,7 +217,7 @@ struct HfTreeCreatorChicToJpsiGamma {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massChic),
+          RecoDecay::y(particle.pVector(), massChic),
           0., // put here the jpsi mass
           particle.flagMcMatchGen(),
           particle.originMcGen());

--- a/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
+++ b/PWGHF/ALICE3/TableProducer/treeCreatorXToJpsiPiPi.cxx
@@ -249,7 +249,7 @@ struct HfTreeCreatorXToJpsiPiPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massX),
+          RecoDecay::y(particle.pVector(), massX),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/ALICE3/Tasks/taskChic.cxx
+++ b/PWGHF/ALICE3/Tasks/taskChic.cxx
@@ -204,7 +204,7 @@ struct HfTaskChicMc {
     for (const auto& particle : mcParticles) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
         auto mchic = o2::constants::physics::MassChiC1; // chi_c1(1p)
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, mchic)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), mchic)) > yCandMax) {
           continue;
         }
 

--- a/PWGHF/ALICE3/Tasks/taskD0Alice3Barrel.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0Alice3Barrel.cxx
@@ -142,11 +142,11 @@ struct HfTaskD0Alice3Barrel {
 
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0)) > 4.0) {
+        if (std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0);
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskD0Alice3Forward.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0Alice3Forward.cxx
@@ -70,11 +70,11 @@ struct HfTaskD0Alice3Forward {
 
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0)) > 4.0) {
+        if (std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0);
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskD0ParametrizedPid.cxx
+++ b/PWGHF/ALICE3/Tasks/taskD0ParametrizedPid.cxx
@@ -118,11 +118,11 @@ struct HfTaskD0ParametrizedPid {
       float maxFiducialY = 0.8;
       float minFiducialY = -0.8;
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
-        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0)) > 4.0) {
+        if (std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0);
         registry.fill(HIST("hGenPtVsY"), ptGen, std::abs(yGen));
         if (ptGen < 5.0) {
           maxFiducialY = -0.2 / 15 * ptGen * ptGen + 1.9 / 15 * ptGen + 0.5;

--- a/PWGHF/ALICE3/Tasks/taskJpsi.cxx
+++ b/PWGHF/ALICE3/Tasks/taskJpsi.cxx
@@ -256,7 +256,7 @@ struct HfTaskJpsiMc {
         registry.fill(HIST("hChi2PCASig"), candidate.chi2PCA(), candidate.pt());
         registry.fill(HIST("hCtSig"), hfHelper.ctJpsi(candidate), candidate.pt());
         registry.fill(HIST("hYSig"), hfHelper.yJpsi(candidate), candidate.pt());
-        registry.fill(HIST("hYGenSig"), RecoDecay::y(std::array{particleMother.px(), particleMother.py(), particleMother.pz()}, o2::constants::physics::MassJPsi), particleMother.pt());
+        registry.fill(HIST("hYGenSig"), RecoDecay::y(particleMother.pVector(), o2::constants::physics::MassJPsi), particleMother.pt());
 
       } else {
         registry.fill(HIST("hPtRecBg"), candidate.pt());

--- a/PWGHF/ALICE3/Tasks/taskJpsi.cxx
+++ b/PWGHF/ALICE3/Tasks/taskJpsi.cxx
@@ -280,12 +280,12 @@ struct HfTaskJpsiMc {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassJPsi)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassJPsi)) > yCandMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
-        registry.fill(HIST("hYGen"), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassJPsi), particle.pt());
+        registry.fill(HIST("hYGen"), RecoDecay::y(particle.pVector(), o2::constants::physics::MassJPsi), particle.pt());
         // registry.fill(HIST("hPtGenProng0"), particle.daughter0_as<McParticlesHf>().pt(), particle.pt());
         // registry.fill(HIST("hPtGenProng1"), particle.daughter1_as<McParticlesHf>().pt(), particle.pt());
       }

--- a/PWGHF/ALICE3/Tasks/taskLcAlice3.cxx
+++ b/PWGHF/ALICE3/Tasks/taskLcAlice3.cxx
@@ -138,11 +138,11 @@ struct HfTaskLcAlice3 {
 
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
-        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus)) > 4.0) {
+        if (std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus)) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskLcParametrizedPid.cxx
+++ b/PWGHF/ALICE3/Tasks/taskLcParametrizedPid.cxx
@@ -118,11 +118,11 @@ struct HfTaskLcParametrizedPid {
 
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
-        if (std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus)) > 4.0) {
+        if (std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus)) > 4.0) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         registry.fill(HIST("hMassGen"), ptGen, std::abs(yGen));
       }
     }

--- a/PWGHF/ALICE3/Tasks/taskX.cxx
+++ b/PWGHF/ALICE3/Tasks/taskX.cxx
@@ -210,7 +210,7 @@ struct HfTaskXMc {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (particle.flagMcMatchGen() == 1 << decayMode) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassX3872)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassX3872)) > yCandMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -417,7 +417,8 @@ DECLARE_SOA_TABLE(HfRedVzeros, "AOD", "HFREDVZERO", //! Table with V0 candidate 
                   hf_reso_cand_reduced::Cpa,
                   hf_reso_cand_reduced::Dca,
                   hf_reso_cand_reduced::Radius,
-                  hf_reso_cand_reduced::V0Type);
+                  hf_reso_cand_reduced::V0Type,
+                  mcparticle::PVector<hf_reso_cand_reduced::Px, hf_reso_cand_reduced::Py, hf_reso_cand_reduced::Pz>);
 
 DECLARE_SOA_TABLE(HfRed3PrNoTrks, "AOD", "HFRED3PRNOTRK", //! Table with 3 prong candidate information for resonances reduced workflow
                   o2::soa::Index<>,
@@ -428,7 +429,8 @@ DECLARE_SOA_TABLE(HfRed3PrNoTrks, "AOD", "HFRED3PRNOTRK", //! Table with 3 prong
                   hf_reso_cand_reduced::Px,
                   hf_reso_cand_reduced::Py,
                   hf_reso_cand_reduced::Pz,
-                  hf_reso_cand_reduced::DType);
+                  hf_reso_cand_reduced::DType,
+                  mcparticle::PVector<hf_reso_cand_reduced::Px, hf_reso_cand_reduced::Py, hf_reso_cand_reduced::Pz>);
 
 DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Resonance candidate information for resonances reduced workflow
                   o2::soa::Index<>,

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -129,7 +129,8 @@ DECLARE_SOA_TABLE(HfRedTrackBases, "AOD", "HFREDTRACKBASE", //! Table with track
                   HFTRACKPAR_COLUMNS,
                   aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
                   aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
-                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>,
+                  aod::track::PVector<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha, aod::track::Tgl>);
 
 DECLARE_SOA_TABLE(HfRedTracksCov, "AOD", "HFREDTRACKCOV", //! Table with track covariance information for reduced workflow
                   soa::Index<>,
@@ -172,7 +173,8 @@ DECLARE_SOA_TABLE(HfRed2Prongs, "AOD", "HFRED2PRONG", //! Table with 2prong cand
                   hf_charm_cand_reduced::InvMassD0, hf_charm_cand_reduced::InvMassD0Bar,
                   aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
                   aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
-                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>,
+                  aod::track::PVector<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha, aod::track::Tgl>);
 
 DECLARE_SOA_TABLE(HfRed2ProngsCov, "AOD", "HFRED2PRONGSCOV", //! Table with 2prong candidate covariance for reduced workflow
                   o2::soa::Index<>,
@@ -198,7 +200,8 @@ DECLARE_SOA_TABLE(HfRed3Prongs, "AOD", "HFRED3PRONG", //! Table with 3prong cand
                   hf_charm_cand_reduced::InvMass,
                   aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
                   aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
-                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>);
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>,
+                  aod::track::PVector<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha, aod::track::Tgl>);
 
 DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3prong candidate covariance for reduced workflow
                   o2::soa::Index<>,

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -117,7 +117,7 @@ struct HfCandidateCreatorB0Reduced {
 
     for (const auto& candD : candsDThisColl) {
       auto trackParCovD = getTrackParCov(candD);
-      std::array<float, 3> pVecD = {candD.px(), candD.py(), candD.pz()};
+      std::array<float, 3> pVecD = candD.pVector();
 
       for (const auto& trackPion : tracksPionThisCollision) {
         // this track is among daughters
@@ -126,7 +126,7 @@ struct HfCandidateCreatorB0Reduced {
         }
 
         auto trackParCovPi = getTrackParCov(trackPion);
-        std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+        std::array<float, 3> pVecPion = trackPion.pVector();
 
         // compute invariant mass square and apply selection
         auto invMass2DPi = RecoDecay::m2(std::array{pVecD, pVecPion}, std::array{massD, massPi});

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -124,12 +124,12 @@ struct HfCandidateCreatorBplusReduced {
       auto candsDThisColl = candsD.sliceBy(candsDPerCollision, thisCollId);
       for (const auto& candD0 : candsDThisColl) {
         auto trackParCovD = getTrackParCov(candD0);
-        std::array<float, 3> pVecD0 = {candD0.px(), candD0.py(), candD0.pz()};
+        std::array<float, 3> pVecD0 = candD0.pVector();
 
         auto tracksPionThisCollision = tracksPion.sliceBy(tracksPionPerCollision, thisCollId);
         for (const auto& trackPion : tracksPionThisCollision) {
           auto trackParCovPi = getTrackParCov(trackPion);
-          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          std::array<float, 3> pVecPion = trackPion.pVector();
 
           // compute invariant mass square and apply selection
           auto invMass2D0Pi = RecoDecay::m2(std::array{pVecD0, pVecPion}, std::array{massD0, massPi});

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -175,7 +175,7 @@ struct HfCandidateCreatorCharmResoReduced {
         registry.fill(HIST("hSelections"), 1 + Selections::DSel);
       }
       float invMassD = candD.invMass();
-      std::array<float, 3> pVecD = {candD.px(), candD.py(), candD.pz()};
+      std::array<float, 3> pVecD = candD.pVector();
       float ptD = RecoDecay::pt(pVecD);
       ;
       // loop on V0 candidates
@@ -190,7 +190,7 @@ struct HfCandidateCreatorCharmResoReduced {
         }
         float invMassReso{0.};
         float invMassV0{0.};
-        std::array<float, 3> pVecV0 = {candV0.px(), candV0.py(), candV0.pz()};
+        std::array<float, 3> pVecV0 = candV0.pVector();
         float ptV0 = RecoDecay::pt(pVecV0);
         float ptReso = RecoDecay::pt(RecoDecay::sumOfVec(pVecV0, pVecD));
         switch (channel) {

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -485,8 +485,8 @@ struct HfDataCreatorCharmHadPiReduced {
       o2::track::TrackParCov trackParCov1 = getTrackParCov(charmHadDauTracks[1]);
       o2::track::TrackParCov trackParCov2{};
 
-      std::array<float, 3> pVec0 = {charmHadDauTracks[0].px(), charmHadDauTracks[0].py(), charmHadDauTracks[0].pz()};
-      std::array<float, 3> pVec1 = {charmHadDauTracks[1].px(), charmHadDauTracks[1].py(), charmHadDauTracks[1].pz()};
+      std::array<float, 3> pVec0 = charmHadDauTracks[0].pVector();
+      std::array<float, 3> pVec1 = charmHadDauTracks[1].pVector();
       std::array<float, 3> pVec2{};
 
       auto dca0 = o2::dataformats::DCA(charmHadDauTracks[0].dcaXY(), charmHadDauTracks[0].dcaZ(), charmHadDauTracks[0].cYY(), charmHadDauTracks[0].cZY(), charmHadDauTracks[0].cZZ());
@@ -505,7 +505,7 @@ struct HfDataCreatorCharmHadPiReduced {
       if constexpr (decChannel == DecayChannel::B0ToDminusPi) {
         charmHadDauTracks.push_back(candC.template prong2_as<TTracks>());
         trackParCov2 = getTrackParCov(charmHadDauTracks[2]);
-        pVec2 = std::array{charmHadDauTracks[2].px(), charmHadDauTracks[2].py(), charmHadDauTracks[2].pz()};
+        pVec2 = charmHadDauTracks[2].pVector();
         auto dca2 = o2::dataformats::DCA(charmHadDauTracks[2].dcaXY(), charmHadDauTracks[2].dcaZ(), charmHadDauTracks[2].cYY(), charmHadDauTracks[2].cZY(), charmHadDauTracks[2].cZZ());
 
         if (charmHadDauTracks[2].collisionId() != thisCollId) {
@@ -551,7 +551,7 @@ struct HfDataCreatorCharmHadPiReduced {
         // apply selections on pion tracks
         auto trackParCovPion = getTrackParCov(trackPion);
         o2::gpu::gpustd::array<float, 2> dcaPion{trackPion.dcaXY(), trackPion.dcaZ()};
-        std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+        std::array<float, 3> pVecPion = trackPion.pVector();
         if (trackPion.collisionId() != thisCollId) {
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCovPion, 2.f, noMatCorr, &dcaPion);
           getPxPyPz(trackParCovPion, pVecPion);

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -733,7 +733,7 @@ struct HfDataCreatorCharmHadPiReduced {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
         rowHfB0McGenReduced(flag, ptParticle, yParticle, etaParticle,
@@ -766,7 +766,7 @@ struct HfDataCreatorCharmHadPiReduced {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
         rowHfBpMcGenReduced(flag, ptParticle, yParticle, etaParticle,

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -723,7 +723,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massB);
+        auto yParticle = RecoDecay::y(particle.pVector(), massB);
         auto etaParticle = particle.eta();
 
         std::array<float, 2> ptProngs;
@@ -756,7 +756,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, massB);
+        auto yParticle = RecoDecay::y(particle.pVector(), massB);
         auto etaParticle = particle.eta();
 
         std::array<float, 2> ptProngs;

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -271,7 +271,7 @@ struct HfTaskB0 {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_b0::DecayType::B0ToDPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassB0);
+        auto yParticle = RecoDecay::y(particle.pVector(), o2::constants::physics::MassB0);
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskB0.cxx
+++ b/PWGHF/D2H/Tasks/taskB0.cxx
@@ -283,7 +283,7 @@ struct HfTaskB0 {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -339,7 +339,7 @@ struct HfTaskB0Reduced {
     auto invMassD = candD.invMass();
     std::array<float, 3> posPv{candidate.posX(), candidate.posY(), candidate.posZ()};
     std::array<float, 3> posSvD{candD.xSecondaryVertex(), candD.ySecondaryVertex(), candD.zSecondaryVertex()};
-    std::array<float, 3> momD{candD.px(), candD.py(), candD.pz()};
+    std::array<float, 3> momD{candD.pVector()};
     auto cospD = RecoDecay::cpa(posPv, posSvD, momD);
     auto cospXyD = RecoDecay::cpaXY(posPv, posSvD, momD);
     auto decLenD = RecoDecay::distance(posPv, posSvD);

--- a/PWGHF/D2H/Tasks/taskBplus.cxx
+++ b/PWGHF/D2H/Tasks/taskBplus.cxx
@@ -262,7 +262,7 @@ struct HfTaskBplus {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_bplus::DecayType::BplusToD0Pi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassBPlus);
+        auto yParticle = RecoDecay::y(particle.pVector(), o2::constants::physics::MassBPlus);
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskBplus.cxx
+++ b/PWGHF/D2H/Tasks/taskBplus.cxx
@@ -272,7 +272,7 @@ struct HfTaskBplus {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -216,7 +216,7 @@ struct HfTaskBplusReduced {
       auto candD0 = candidate.prong0_as<aod::HfRed2Prongs>();
       std::array<float, 3> posPv{candidate.posX(), candidate.posY(), candidate.posZ()};
       std::array<float, 3> posSvD{candD0.xSecondaryVertex(), candD0.ySecondaryVertex(), candD0.zSecondaryVertex()};
-      std::array<float, 3> momD{candD0.px(), candD0.py(), candD0.pz()};
+      std::array<float, 3> momD{candD0.pVector()};
       auto cospD0 = RecoDecay::cpa(posPv, posSvD, momD);
       auto decLenD0 = RecoDecay::distance(posPv, posSvD);
 

--- a/PWGHF/D2H/Tasks/taskBs.cxx
+++ b/PWGHF/D2H/Tasks/taskBs.cxx
@@ -268,7 +268,7 @@ struct HfTaskBs {
       if (TESTBIT(std::abs(particle.flagMcMatchGen()), hf_cand_bs::DecayTypeMc::BsToDsPiToKKPiPi)) {
 
         auto ptParticle = particle.pt();
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassBS);
+        auto yParticle = RecoDecay::y(particle.pVector(), o2::constants::physics::MassBS);
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskBs.cxx
+++ b/PWGHF/D2H/Tasks/taskBs.cxx
@@ -280,7 +280,7 @@ struct HfTaskBs {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -636,7 +636,7 @@ struct TaskPolarisationCharmHadrons {
           pzCharmHad = candidate.pz();
         }
         massDau = massProton; // (*)
-        rapidity = RecoDecay::y(std::array{pxCharmHad, pyCharmHad, pzCharmHad}, massLc);
+        rapidity = RecoDecay::y(candidate.pVector(), massLc);
 
         /// mass-hypothesis-dependent variables
         if (iMass == charm_polarisation::MassHyposLcToPKPi::PKPi && candidate.isSelLcToPKPi() >= selectionFlagLcToPKPi) {

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -327,7 +327,7 @@ struct HfTaskD0 {
         auto indexMother = RecoDecay::getMother(mcParticles, candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>(), o2::constants::physics::Pdg::kD0, true);
         auto particleMother = mcParticles.rawIteratorAt(indexMother);
         auto ptGen = particleMother.pt();                                                                                                    // gen. level pT
-        auto yGen = RecoDecay::y(particleMother.pVector(), o2::constants::physics::MassD0); // gen. level y
+        auto yGen = RecoDecay::y(particleMother.pVector(), o2::constants::physics::MassD0);                                                  // gen. level y
         registry.fill(HIST("hPtGenSig"), ptGen);                                                                                             // gen. level pT
         auto ptRec = candidate.pt();
         auto yRec = hfHelper.yD0(candidate);

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -485,11 +485,11 @@ struct HfTaskD0 {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
-        if (yCandGenMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0)) > yCandGenMax) {
+        if (yCandGenMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > yCandGenMax) {
           continue;
         }
         auto ptGen = particle.pt();
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0);
         registry.fill(HIST("hPtGen"), ptGen);
         registry.fill(HIST("hPtVsYGen"), ptGen, yGen);
         if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -327,7 +327,7 @@ struct HfTaskD0 {
         auto indexMother = RecoDecay::getMother(mcParticles, candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>(), o2::constants::physics::Pdg::kD0, true);
         auto particleMother = mcParticles.rawIteratorAt(indexMother);
         auto ptGen = particleMother.pt();                                                                                                    // gen. level pT
-        auto yGen = RecoDecay::y(std::array{particleMother.px(), particleMother.py(), particleMother.pz()}, o2::constants::physics::MassD0); // gen. level y
+        auto yGen = RecoDecay::y(particleMother.pVector(), o2::constants::physics::MassD0); // gen. level y
         registry.fill(HIST("hPtGenSig"), ptGen);                                                                                             // gen. level pT
         auto ptRec = candidate.pt();
         auto yRec = hfHelper.yD0(candidate);

--- a/PWGHF/D2H/Tasks/taskDplus.cxx
+++ b/PWGHF/D2H/Tasks/taskDplus.cxx
@@ -245,7 +245,7 @@ struct HfTaskDplus {
   void fillHistoMCGen(const T2& particle)
   {
     auto ptGen = particle.pt();
-    auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDPlus);
+    auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassDPlus);
     registry.fill(HIST("hPtGen"), ptGen);
     registry.fill(HIST("hPtVsYGen"), ptGen, yGen);
     if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
@@ -322,7 +322,7 @@ struct HfTaskDplus {
     }
     // MC gen.
     for (const auto& particle : mcParticles) {
-      auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDPlus);
+      auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassDPlus);
       if ((yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) || (std::abs(particle.flagMcMatchGen()) != 1 << aod::hf_cand_3prong::DecayType::DplusToPiKPi)) {
         continue;
       }

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -545,7 +545,7 @@ struct HfTaskDs {
           auto y = 0;
 
           if (particle.flagMcDecayChanGen() == decayChannel) {
-            y = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDS);
+            y = RecoDecay::y(particle.pVector(), o2::constants::physics::MassDS);
             if (yCandGenMax >= 0. && std::abs(y) > yCandGenMax) {
               continue;
             }
@@ -560,7 +560,7 @@ struct HfTaskDs {
               std::get<TH1_ptr>(histosPtr[DataType::McDsNonPrompt]["hEtaGen"])->Fill(particle.eta()); // gen. level pT
             }
           } else if (fillDplusMc) {
-            y = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDPlus);
+            y = RecoDecay::y(particle.pVector(), o2::constants::physics::MassDPlus);
             if (yCandGenMax >= 0. && std::abs(y) > yCandGenMax) {
               continue;
             }

--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -255,7 +255,7 @@ struct HfTaskDstarToD0Pi {
       if (TESTBIT(std::abs(mcParticle.flagMcMatchGen()), aod::hf_cand_dstar::DecayType::DstarToD0Pi)) { // MC Matching is successful at Generator Level
         auto ptGen = mcParticle.pt();
         // auto yGen = mcParticle.y(); // Can we use this definition?
-        auto yGen = RecoDecay::y(std::array{mcParticle.px(), mcParticle.py(), mcParticle.pz()}, o2::constants::physics::MassDStar);
+        auto yGen = RecoDecay::y(mcParticle.pVector(), o2::constants::physics::MassDStar);
         if (yCandDstarGenMax >= 0. && std::abs(yGen) > yCandDstarGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskLb.cxx
+++ b/PWGHF/D2H/Tasks/taskLb.cxx
@@ -257,7 +257,7 @@ struct HfTaskLbMc {
         for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskLb.cxx
+++ b/PWGHF/D2H/Tasks/taskLb.cxx
@@ -247,7 +247,7 @@ struct HfTaskLbMc {
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << hf_cand_lb::DecayType::LbToLcPi) {
 
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaB0);
+        auto yParticle = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaB0);
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -617,7 +617,7 @@ struct HfTaskLc {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
-        auto yGen = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus);
+        auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskSigmac.cxx
+++ b/PWGHF/D2H/Tasks/taskSigmac.cxx
@@ -542,7 +542,7 @@ struct HfTaskSigmac {
          OR
          consider the new parametrization of the fiducial acceptance (to be seen for reco signal in MC)
       */
-      if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassSigmaC0)) > yCandMax) {
+      if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassSigmaC0)) > yCandMax) {
         continue;
       }
 

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -509,7 +509,7 @@ struct HfTaskXic {
         for (const auto& daught : particle.daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>()) {
           ptProngs[counter] = daught.pt();
           etaProngs[counter] = daught.eta();
-          yProngs[counter] = RecoDecay::y(std::array{daught.px(), daught.py(), daught.pz()}, pdg->Mass(daught.pdgCode()));
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
           counter++;
         }
 

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -497,7 +497,7 @@ struct HfTaskXic {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::XicToPKPi) {
-        auto yParticle = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCPlus);
+        auto yParticle = RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCPlus);
         if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskXicc.cxx
+++ b/PWGHF/D2H/Tasks/taskXicc.cxx
@@ -264,13 +264,13 @@ struct HfTaskXiccMc {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_xicc::DecayType::XiccToXicPi) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCCPlusPlus)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCCPlusPlus)) > yCandMax) {
           continue;
         }
         registry.fill(HIST("hPtGen"), particle.pt());
         registry.fill(HIST("hEtaGen"), particle.eta());
-        registry.fill(HIST("hYGen"), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCCPlusPlus));
-        registry.fill(HIST("hPtvsEtavsYGen"), particle.pt(), particle.eta(), RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCCPlusPlus));
+        registry.fill(HIST("hYGen"), RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCCPlusPlus));
+        registry.fill(HIST("hPtvsEtavsYGen"), particle.pt(), particle.eta(), RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCCPlusPlus));
       }
     } // end of loop of MC particles
   }   // end of process function

--- a/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
@@ -401,7 +401,7 @@ struct HfCorrelatorD0D0bar {
       if (std::abs(particle1.pdgCode()) != Pdg::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassD0);
+      double yD = RecoDecay::y(particle1.pVector(), MassD0);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -424,7 +424,7 @@ struct HfCorrelatorD0D0bar {
         if (particle2.pdgCode() != Pdg::kD0Bar) { // check that inner particle is D0bar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassD0Bar)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassD0Bar)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -499,7 +499,7 @@ struct HfCorrelatorD0D0bar {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassCharm);
+      double yC = RecoDecay::y(particle1.pVector(), MassCharm);
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -523,7 +523,7 @@ struct HfCorrelatorD0D0bar {
         if (particle2.pdgCode() != PDG_t::kCharmBar) { // check that inner particle is a cbar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassCharmBar)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassCharmBar)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
@@ -402,7 +402,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
       if (std::abs(particle1.pdgCode()) != Pdg::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassD0);
+      double yD = RecoDecay::y(particle1.pVector(), MassD0);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -425,7 +425,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (particle2.pdgCode() != Pdg::kD0Bar) { // check that inner particle is D0bar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassD0Bar)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassD0Bar)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -500,7 +500,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassCharm);
+      double yC = RecoDecay::y(particle1.pVector(), MassCharm);
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -524,7 +524,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (particle2.pdgCode() != PDG_t::kCharmBar) { // check that inner particle is a cbar
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassCharmBar)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassCharmBar)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -150,7 +150,7 @@ struct HfCorrelatorD0HadronsSelection {
       if (std::abs(particle1.pdgCode()) != Pdg::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassD0);
+      double yD = RecoDecay::y(particle1.pVector(), MassD0);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -355,7 +355,7 @@ struct HfCorrelatorD0Hadrons {
         // ========== soft pion removal ===================================================
         double invMassDstar1 = 0., invMassDstar2 = 0.;
         bool isSoftPiD0 = false, isSoftPiD0bar = false;
-        auto pSum2 = RecoDecay::p2(candidate1.px() + track.px(), candidate1.py() + track.py(), candidate1.pz() + track.pz());
+        auto pSum2 = RecoDecay::p2(candidate1.pVector(), track.pVector());
         auto ePion = track.energy(massPi);
         invMassDstar1 = std::sqrt((ePiK + ePion) * (ePiK + ePion) - pSum2);
         invMassDstar2 = std::sqrt((eKPi + ePion) * (eKPi + ePion) - pSum2);
@@ -508,7 +508,7 @@ struct HfCorrelatorD0Hadrons {
         // ===== soft pion removal ===================================================
         double invMassDstar1 = 0, invMassDstar2 = 0;
         bool isSoftPiD0 = false, isSoftPiD0bar = false;
-        auto pSum2 = RecoDecay::p2(candidate1.px() + track.px(), candidate1.py() + track.py(), candidate1.pz() + track.pz());
+        auto pSum2 = RecoDecay::p2(candidate1.pVector(), track.pVector());
         auto ePion = track.energy(massPi);
         invMassDstar1 = std::sqrt((ePiK + ePion) * (ePiK + ePion) - pSum2);
         invMassDstar2 = std::sqrt((eKPi + ePion) * (eKPi + ePion) - pSum2);
@@ -576,7 +576,7 @@ struct HfCorrelatorD0Hadrons {
       if (std::abs(particle1.pdgCode()) != Pdg::kD0) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassD0);
+      double yD = RecoDecay::y(particle1.pVector(), MassD0);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -666,7 +666,7 @@ struct HfCorrelatorD0Hadrons {
         auto eKPi = RecoDecay::e(t1.pVectorProng0(), massK) + RecoDecay::e(t1.pVectorProng1(), massPi);
         double invMassDstar1 = 0., invMassDstar2 = 0.;
         bool isSoftPiD0 = false, isSoftPiD0bar = false;
-        auto pSum2 = RecoDecay::p2(t1.px() + t2.px(), t1.py() + t2.py(), t1.pz() + t2.pz());
+        auto pSum2 = RecoDecay::p2(t1.pVector(), t2.pVector());
         auto ePion = t2.energy(massPi);
         invMassDstar1 = std::sqrt((ePiK + ePion) * (ePiK + ePion) - pSum2);
         invMassDstar2 = std::sqrt((eKPi + ePion) * (eKPi + ePion) - pSum2);
@@ -730,7 +730,7 @@ struct HfCorrelatorD0Hadrons {
         auto eKPi = RecoDecay::e(t1.pVectorProng0(), massK) + RecoDecay::e(t1.pVectorProng1(), massPi);
         double invMassDstar1 = 0., invMassDstar2 = 0.;
         bool isSoftPiD0 = false, isSoftPiD0bar = false;
-        auto pSum2 = RecoDecay::p2(t1.px() + t2.px(), t1.py() + t2.py(), t1.pz() + t2.pz());
+        auto pSum2 = RecoDecay::p2(t1.pVector(), t2.pVector());
         auto ePion = t2.energy(massPi);
         invMassDstar1 = std::sqrt((ePiK + ePion) * (ePiK + ePion) - pSum2);
         invMassDstar2 = std::sqrt((eKPi + ePion) * (eKPi + ePion) - pSum2);
@@ -838,7 +838,7 @@ struct HfCorrelatorD0Hadrons {
           continue;
         }
 
-        double yD = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, MassD0);
+        double yD = RecoDecay::y(t1.pVector(), MassD0);
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusDminus.cxx
@@ -384,7 +384,7 @@ struct HfCorrelatorDplusDminus {
       if (std::abs(particle1.pdgCode()) != Pdg::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassDPlus);
+      double yD = RecoDecay::y(particle1.pVector(), MassDPlus);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -407,7 +407,7 @@ struct HfCorrelatorDplusDminus {
         if (particle2.pdgCode() != -Pdg::kDPlus) { // check that inner particle is a Dminus
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassDPlus)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassDPlus)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {
@@ -481,7 +481,7 @@ struct HfCorrelatorDplusDminus {
         continue;
       }
       counterCCbarBeforeEtasel++; // count c or cbar (before kinematic selection)
-      double yC = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassCharm);
+      double yC = RecoDecay::y(particle1.pVector(), MassCharm);
       if (yCandMax >= 0. && std::abs(yC) > yCandMax) {
         continue;
       }
@@ -505,7 +505,7 @@ struct HfCorrelatorDplusDminus {
         if (particle2.pdgCode() != PDG_t::kCharmBar) {
           continue;
         }
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle2.px(), particle2.py(), particle2.pz()}, MassCharmBar)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle2.pVector(), MassCharmBar)) > yCandMax) {
           continue;
         }
         if (ptCandMin >= 0. && particle2.pt() < ptCandMin) {

--- a/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
@@ -131,7 +131,7 @@ struct HfCorrelatorDplusHadronsDplusSelection {
       if (std::abs(particle1.pdgCode()) != Pdg::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassDPlus);
+      double yD = RecoDecay::y(particle1.pVector(), MassDPlus);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -456,7 +456,7 @@ struct HfCorrelatorDplusHadrons {
       if (std::abs(particle1.pdgCode()) != Pdg::kDPlus) {
         continue;
       }
-      double yD = RecoDecay::y(std::array{particle1.px(), particle1.py(), particle1.pz()}, MassDPlus);
+      double yD = RecoDecay::y(particle1.pVector(), MassDPlus);
       if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
         continue;
       }
@@ -583,7 +583,7 @@ struct HfCorrelatorDplusHadrons {
           continue;
         }
 
-        double yD = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, MassDPlus);
+        double yD = RecoDecay::y(t1.pVector(), MassDPlus);
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -126,7 +126,7 @@ struct HfCorrelatorDsHadronsSelCollision {
         if (std::abs(particle.pdgCode()) != Pdg::kDS) {
           continue;
         }
-        double yD = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, MassDS);
+        double yD = RecoDecay::y(particle.pVector(), MassDS);
         if (std::abs(yD) > yCandMax || particle.pt() < ptCandMin) {
           continue;
         }
@@ -719,7 +719,7 @@ struct HfCorrelatorDsHadrons {
         continue;
       }
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::DsToKKPi) {
-        double yD = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, MassDS); // TODO
+        double yD = RecoDecay::y(particle.pVector(), MassDS); // TODO
         if (yCandGenMax >= 0. && std::abs(yD) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -598,7 +598,7 @@ struct HfCorrelatorDsHadrons {
         hCandidates->Fill(kCandidateStepMcGenAll, mcParticle.pt(), multiplicity, mcParticle.originMcGen());
         if (std::abs(mcParticle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::DsToKKPi) {
           hCandidates->Fill(kCandidateStepMcGenDsToKKPi, mcParticle.pt(), multiplicity, mcParticle.originMcGen());
-          auto yDs = RecoDecay::y(std::array{mcParticle.px(), mcParticle.py(), mcParticle.pz()}, o2::constants::physics::MassDS);
+          auto yDs = RecoDecay::y(mcParticle.pVector(), o2::constants::physics::MassDS);
           if (std::abs(yDs) <= yCandGenMax) {
             hCandidates->Fill(kCandidateStepMcCandInAcceptance, mcParticle.pt(), multiplicity, mcParticle.originMcGen());
           }

--- a/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
@@ -154,7 +154,7 @@ struct HfCorrelatorLcHadronsSelection {
       if (std::abs(particle.pdgCode()) != Pdg::kLambdaCPlus) {
         continue;
       }
-      double yL = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, MassLambdaCPlus);
+      double yL = RecoDecay::y(particle.pVector(), MassLambdaCPlus);
       if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
         continue;
       }
@@ -520,7 +520,7 @@ struct HfCorrelatorLcHadrons {
         continue;
       }
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
-        double yL = RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, MassLambdaCPlus);
+        double yL = RecoDecay::y(particle.pVector(), MassLambdaCPlus);
         if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
           continue;
         }

--- a/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcHadrons.cxx
@@ -673,7 +673,7 @@ struct HfCorrelatorLcHadrons {
           continue;
         }
 
-        double yL = RecoDecay::y(std::array{t1.px(), t1.py(), t1.pz()}, MassLambdaCPlus);
+        double yL = RecoDecay::y(t1.pVector(), MassLambdaCPlus);
         if (yCandMax >= 0. && std::abs(yL) > yCandMax) {
           continue;
         }

--- a/PWGHF/TableProducer/candidateCreatorB0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorB0.cxx
@@ -201,9 +201,9 @@ struct HfCandidateCreatorB0 {
         auto trackParCov1 = getTrackParCov(track1);
         auto trackParCov2 = getTrackParCov(track2);
 
-        std::array<float, 3> pVec0 = {track0.px(), track0.py(), track0.pz()};
-        std::array<float, 3> pVec1 = {track1.px(), track1.py(), track1.pz()};
-        std::array<float, 3> pVec2 = {track2.px(), track2.py(), track2.pz()};
+        std::array<float, 3> pVec0 = track0.pVector();
+        std::array<float, 3> pVec1 = track1.pVector();
+        std::array<float, 3> pVec2 = track2.pVector();
 
         auto dca0 = o2::dataformats::DCA(track0.dcaXY(), track0.dcaZ(), track0.cYY(), track0.cZY(), track0.cZZ());
         auto dca1 = o2::dataformats::DCA(track1.dcaXY(), track1.dcaZ(), track1.cYY(), track1.cZY(), track1.cZZ());
@@ -273,7 +273,7 @@ struct HfCandidateCreatorB0 {
           }
 
           hPtPion->Fill(trackPion.pt());
-          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          std::array<float, 3> pVecPion = trackPion.pVector();
           auto trackParCovPi = getTrackParCov(trackPion);
 
           // ---------------------------------

--- a/PWGHF/TableProducer/candidateCreatorBs.cxx
+++ b/PWGHF/TableProducer/candidateCreatorBs.cxx
@@ -181,9 +181,9 @@ struct HfCandidateCreatorBs {
         auto trackParCov1 = getTrackParCov(track1);
         auto trackParCov2 = getTrackParCov(track2);
 
-        std::array<float, 3> pVec0 = {track0.px(), track0.py(), track0.pz()};
-        std::array<float, 3> pVec1 = {track1.px(), track1.py(), track1.pz()};
-        std::array<float, 3> pVec2 = {track2.px(), track2.py(), track2.pz()};
+        std::array<float, 3> pVec0 = track0.pVector();
+        std::array<float, 3> pVec1 = track1.pVector();
+        std::array<float, 3> pVec2 = track2.pVector();
 
         auto dca0 = o2::dataformats::DCA(track0.dcaXY(), track0.dcaZ(), track0.cYY(), track0.cZY(), track0.cZZ());
         auto dca1 = o2::dataformats::DCA(track1.dcaXY(), track1.dcaZ(), track1.cYY(), track1.cZY(), track1.cZZ());
@@ -254,7 +254,7 @@ struct HfCandidateCreatorBs {
             continue;
           }
 
-          std::array<float, 3> pVecPion = {trackPion.px(), trackPion.py(), trackPion.pz()};
+          std::array<float, 3> pVecPion = trackPion.pVector();
           auto trackParCovPi = getTrackParCov(trackPion);
 
           // ---------------------------------

--- a/PWGHF/TableProducer/candidateCreatorLb.cxx
+++ b/PWGHF/TableProducer/candidateCreatorLb.cxx
@@ -159,8 +159,8 @@ struct HfCandidateCreatorLb {
       trackParVar1.propagateTo(secondaryVertex[0], bz);
       trackParVar2.propagateTo(secondaryVertex[0], bz);
 
-      std::array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
-      std::array<float, 3> pvecLc = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
+      std::array<float, 3> pvecpK = RecoDecay::pVec(track0.pVector(), track1.pVector());
+      std::array<float, 3> pvecLc = RecoDecay::pVec(pvecpK, track2.pVector());
       auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
       auto trackLc = o2::dataformats::V0(df3.getPCACandidatePos(), pvecLc, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 

--- a/PWGHF/TableProducer/candidateCreatorXicc.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicc.cxx
@@ -131,8 +131,8 @@ struct HfCandidateCreatorXicc {
       trackParVar1.propagateTo(secondaryVertex[0], bz);
       trackParVar2.propagateTo(secondaryVertex[0], bz);
 
-      std::array<float, 3> pvecpK = {track0.px() + track1.px(), track0.py() + track1.py(), track0.pz() + track1.pz()};
-      std::array<float, 3> pvecxic = {pvecpK[0] + track2.px(), pvecpK[1] + track2.py(), pvecpK[2] + track2.pz()};
+      std::array<float, 3> pvecpK = RecoDecay::pVec(track0.pVector(), track1.pVector());
+      std::array<float, 3> pvecxic = RecoDecay::pVec(pvecpK, track2.pVector());
       auto trackpK = o2::dataformats::V0(df3.getPCACandidatePos(), pvecpK, df3.calcPCACovMatrixFlat(), trackParVar0, trackParVar1);
       auto trackxic = o2::dataformats::V0(df3.getPCACandidatePos(), pvecxic, df3.calcPCACovMatrixFlat(), trackpK, trackParVar2);
 

--- a/PWGHF/TableProducer/candidateSelectorLcPidMl.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLcPidMl.cxx
@@ -250,9 +250,9 @@ struct HfCandidateSelectorLcPidMl {
         continue;
       }
 
-      std::array<float, 3> pVecPos1 = {trackPos1.px(), trackPos1.py(), trackPos1.pz()};
-      std::array<float, 3> pVecNeg = {trackNeg.px(), trackNeg.py(), trackNeg.pz()};
-      std::array<float, 3> pVecPos2 = {trackPos2.px(), trackPos2.py(), trackPos2.pz()};
+      std::array<float, 3> pVecPos1 = trackPos1.pVector();
+      std::array<float, 3> pVecNeg = trackNeg.pVector();
+      std::array<float, 3> pVecPos2 = trackPos2.pVector();
       const float massPi = o2::constants::physics::MassPiPlus;
       const float massK = o2::constants::physics::MassKPlus;
       const float massProton = o2::constants::physics::MassProton;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2137,7 +2137,7 @@ struct HfTrackIndexSkimCreator {
         bool sel3ProngStatusPos1 = TESTBIT(isSelProngPos1, CandidateType::Cand3Prong);
 
         auto trackParVarPos1 = getTrackParCov(trackPos1);
-        std::array<float, 3> pVecTrackPos1{trackPos1.px(), trackPos1.py(), trackPos1.pz()};
+        std::array<float, 3> pVecTrackPos1{trackPos1.pVector()};
         o2::gpu::gpustd::array<float, 2> dcaInfoPos1{trackPos1.dcaXY(), trackPos1.dcaZ()};
         if (thisCollId != trackPos1.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos1, 2.f, noMatCorr, &dcaInfoPos1);
@@ -2155,7 +2155,7 @@ struct HfTrackIndexSkimCreator {
           bool sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
 
           auto trackParVarNeg1 = getTrackParCov(trackNeg1);
-          std::array<float, 3> pVecTrackNeg1{trackNeg1.px(), trackNeg1.py(), trackNeg1.pz()};
+          std::array<float, 3> pVecTrackNeg1{trackNeg1.pVector()};
           o2::gpu::gpustd::array<float, 2> dcaInfoNeg1{trackNeg1.dcaXY(), trackNeg1.dcaZ()};
           if (thisCollId != trackNeg1.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg1, 2.f, noMatCorr, &dcaInfoNeg1);
@@ -2390,11 +2390,11 @@ struct HfTrackIndexSkimCreator {
 
               auto trackPos2 = trackIndexPos2.template track_as<TTracks>();
               auto trackParVarPos2 = getTrackParCov(trackPos2);
-              std::array<float, 3> pVecTrackPos2{trackPos2.px(), trackPos2.py(), trackPos2.pz()};
               o2::gpu::gpustd::array<float, 2> dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
+                std::array<float, 3> pVecTrackPos2{trackPos2.pVector()};
                 if (thisCollId != trackPos2.collisionId()) { // this is not the "default" collision for this track and we still did not re-propagate it, we have to re-propagate it
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos2, 2.f, noMatCorr, &dcaInfoPos2);
                   getPxPyPz(trackParVarPos2, pVecTrackPos2);
@@ -2634,11 +2634,11 @@ struct HfTrackIndexSkimCreator {
 
               auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
               auto trackParVarNeg2 = getTrackParCov(trackNeg2);
-              std::array<float, 3> pVecTrackNeg2{trackNeg2.px(), trackNeg2.py(), trackNeg2.pz()};
               o2::gpu::gpustd::array<float, 2> dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
+                std::array<float, 3> pVecTrackNeg2{trackNeg2.pVector()};
                 if (thisCollId != trackNeg2.collisionId()) { // this is not the "default" collision for this track and we still did not re-propagate it, we have to re-propagate it
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg2, 2.f, noMatCorr, &dcaInfoNeg2);
                   getPxPyPz(trackParVarNeg2, pVecTrackNeg2);
@@ -2867,10 +2867,10 @@ struct HfTrackIndexSkimCreator {
                   continue;
                 }
                 auto trackPos2 = trackIndexPos2.template track_as<TTracks>();
-                auto trackParVarPos2 = getTrackParCov(trackPos2);
-                std::array<float, 3> pVecTrackPos2{trackPos2.px(), trackPos2.py(), trackPos2.pz()};
-                o2::gpu::gpustd::array<float, 2> dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
+                std::array<float, 3> pVecTrackPos2{trackPos2.pVector()};
                 if (thisCollId != trackPos2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
+                  auto trackParVarPos2 = getTrackParCov(trackPos2);
+                  o2::gpu::gpustd::array<float, 2> dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos2, 2.f, noMatCorr, &dcaInfoPos2);
                   getPxPyPz(trackParVarPos2, pVecTrackPos2);
                 }
@@ -2904,10 +2904,10 @@ struct HfTrackIndexSkimCreator {
                   continue;
                 }
                 auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
-                auto trackParVarNeg2 = getTrackParCov(trackNeg2);
-                std::array<float, 3> pVecTrackNeg2{trackNeg2.px(), trackNeg2.py(), trackNeg2.pz()};
-                o2::gpu::gpustd::array<float, 2> dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
+                std::array<float, 3> pVecTrackNeg2{trackNeg2.pVector()};
                 if (thisCollId != trackNeg2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
+                  auto trackParVarNeg2 = getTrackParCov(trackNeg2);
+                  o2::gpu::gpustd::array<float, 2> dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg2, 2.f, noMatCorr, &dcaInfoNeg2);
                   getPxPyPz(trackParVarNeg2, pVecTrackNeg2);
                 }
@@ -3191,7 +3191,7 @@ struct HfTrackIndexSkimCreatorCascades {
 
           // invariant-mass cut: we do it here, before updating the momenta of bach and V0 during the fitting to save CPU
           // TODO: but one should better check that the value here and after the fitter do not change significantly!!!
-          double mass2K0sP = RecoDecay::m(std::array{std::array{bach.px(), bach.py(), bach.pz()}, momentumV0}, std::array{massP, massK0s});
+          double mass2K0sP = RecoDecay::m(std::array{bach.pVector(), momentumV0}, std::array{massP, massK0s});
           if ((cutInvMassCascLc >= 0.) && (std::abs(mass2K0sP - massLc) > cutInvMassCascLc)) {
             continue;
           }

--- a/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorB0ToDPi.cxx
@@ -367,7 +367,7 @@ struct HfTreeCreatorB0ToDPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassB0),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassB0),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
+++ b/PWGHF/TableProducer/treeCreatorBplusToD0Pi.cxx
@@ -325,7 +325,7 @@ struct HfTreeCreatorBplusToD0Pi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassBPlus),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassBPlus),
           particle.flagMcMatchGen(),
           particle.globalIndex());
       }

--- a/PWGHF/TableProducer/treeCreatorBsToDsPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorBsToDsPi.cxx
@@ -357,7 +357,7 @@ struct HfTreeCreatorBsToDsPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassBS),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassBS),
           particle.flagMcMatchGen());
       }
     }

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -493,7 +493,7 @@ struct HfTreeCreatorD0ToKPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassD0),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0),
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           particle.globalIndex());

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -478,7 +478,7 @@ struct HfTreeCreatorDplusToPiKPi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDPlus),
+        RecoDecay::y(particle.pVector(), o2::constants::physics::MassDPlus),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -565,7 +565,7 @@ struct HfTreeCreatorDsToKKPi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDS),
+        RecoDecay::y(particle.pVector(), o2::constants::physics::MassDS),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDstarToD0Pi.cxx
@@ -518,7 +518,7 @@ struct HfTreeCreatorDstarToD0Pi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassDStar),
+        RecoDecay::y(particle.pVector(), o2::constants::physics::MassDStar),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToK0sP.cxx
@@ -388,7 +388,7 @@ struct HfTreeCreatorLcToK0sP {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()},
+          RecoDecay::y(particle.pVector(),
                        o2::constants::physics::MassLambdaCPlus),
           particle.flagMcMatchGen(),
           particle.originMcGen());

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -471,7 +471,7 @@ struct HfTreeCreatorLcToPKPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus),
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           particle.globalIndex());

--- a/PWGHF/TableProducer/treeCreatorOmegacSt.cxx
+++ b/PWGHF/TableProducer/treeCreatorOmegacSt.cxx
@@ -683,8 +683,8 @@ struct HfTreeCreatorOmegacSt {
                 }
 
                 // MC-based mass
-                momenta[0] = {mother.px(), mother.py(), mother.pz()};
-                momenta[1] = {mcpart.px(), mcpart.py(), mcpart.pz()};
+                momenta[0] = mother.pVector();
+                momenta[1] = mcpart.pVector();
                 registry.fill(HIST("hMassOmegacGen"), RecoDecay::m(momenta, masses));
               }
             }

--- a/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToPKPi.cxx
@@ -511,7 +511,7 @@ struct HfTreeCreatorXicToPKPi {
         particle.pt(),
         particle.eta(),
         particle.phi(),
-        RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCPlus),
+        RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCPlus),
         particle.flagMcMatchGen(),
         particle.originMcGen());
     }

--- a/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXiccToPKPiPi.cxx
@@ -270,7 +270,7 @@ struct HfTreeCreatorXiccToPKPiPi {
           particle.pt(),
           particle.eta(),
           particle.phi(),
-          RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassXiCCPlusPlus),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCCPlusPlus),
           particle.flagMcMatchGen(),
           particle.originMcGen());
       }

--- a/PWGHF/Tasks/taskLcCentrality.cxx
+++ b/PWGHF/Tasks/taskLcCentrality.cxx
@@ -183,7 +183,7 @@ struct HfTaskLcCentralityMc {
     // MC gen.
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
-        if (yCandMax >= 0. && std::abs(RecoDecay::y(std::array{particle.px(), particle.py(), particle.pz()}, o2::constants::physics::MassLambdaCPlus)) > yCandMax) {
+        if (yCandMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus)) > yCandMax) {
           continue;
         }
         auto ptGen = particle.pt();


### PR DESCRIPTION
- Simplifies code by using `pVector` columns from `Tracks`, `McParticles` and `ReducedDataModel.h` tables instead of 
explicitly constructing arrays from `px`, `py`, `pz`.
- Simplifies calculations with momenta, using proper `RecoDecay` functions.
- Limits the scope of some local variables in `trackIndexSkimCreator.cxx`.

Requires:
- https://github.com/AliceO2Group/AliceO2/pull/12991
- https://github.com/AliceO2Group/AliceO2/pull/13043