### PR TITLE
fixed the low entries in the ME background 

### DIFF
--- a/PWGLF/Tasks/Resonances/KshortKshort.cxx
+++ b/PWGLF/Tasks/Resonances/KshortKshort.cxx
@@ -21,6 +21,7 @@
 #include <TMath.h>
 #include <TObjArray.h>
 #include <TPDGCode.h>
+#include "TF1.h"
 
 #include <array>
 #include <cmath>
@@ -60,20 +61,26 @@ struct strangeness_tutorial {
 
   Configurable<bool> QAv0{"QAv0", false, "QAv0"};
   Configurable<bool> QAPID{"QAPID", false, "QAPID"};
+  Configurable<bool> QAv0_daughters{"QAv0_daughters", false, "QA of v0 daughters"};
   Configurable<bool> inv_mass1D{"inv_mass1D", false, "1D invariant mass histograms"};
   Configurable<bool> DCAv0topv{"DCAv0topv", false, "DCA V0 to PV"};
   Configurable<bool> armcut{"armcut", true, "arm cut"};
-  Configurable<bool> timFrameEvsel{"timFrameEvsel", false, "TPC Time frame boundary cut"};
 
   // Configurable for event selection
   Configurable<float> cutzvertex{"cutzvertex", 10.0f, "Accepted z-vertex range (cm)"};
   Configurable<float> cfgETAcut{"cfgETAcut", 0.8f, "Track ETA cut"};
+  Configurable<bool> timFrameEvsel{"timFrameEvsel", false, "TPC Time frame boundary cut"};
+  Configurable<bool> piluprejection{"piluprejection", false, "Pileup rejection"};
+  Configurable<bool> goodzvertex{"goodzvertex", false, "removes collisions with large differences between z of PV by tracks and z of PV from FT0 A-C time difference."};
+  Configurable<bool> itstpctracks{"itstpctracks", false, "selects collisions with at least one ITS-TPC track,"};
+  Configurable<bool> additionalEvsel{"additionalEvsel", false, "Additional event selcection"};
 
   // Configurable parameters for V0 selection
   Configurable<float> ConfV0DCADaughMax{"ConfV0DCADaughMax", 1.0f, "DCA b/w V0 daughters"};
   Configurable<float> v0setting_dcapostopv{"v0setting_dcapostopv", 0.06, "DCA Pos To PV"};
   Configurable<float> v0setting_dcanegtopv{"v0setting_dcanegtopv", 0.06, "DCA Neg To PV"};
   Configurable<double> cMaxV0DCA{"cMaxV0DCA", 1, "DCA V0 to PV"};
+  // Configurable<bool> isStandarv0{"isStandarv0", false, "Standard V0"};
   // Configurable<float> ConfDaughDCAMin{"ConfDaughDCAMin", 0.06f, "V0 Daugh sel:  Max. DCA Daugh to PV (cm)"}; // same as DCA pos to pv and neg to pv
 
   Configurable<float> ConfV0PtMin{"ConfV0PtMin", 0.f, "Minimum transverse momentum of V0"};
@@ -81,16 +88,20 @@ struct strangeness_tutorial {
   Configurable<float> ConfV0TranRadV0Min{"ConfV0TranRadV0Min", 0.5f, "Minimum transverse radius"};
   Configurable<float> ConfV0TranRadV0Max{"ConfV0TranRadV0Max", 200.f, "Maximum transverse radius"};
   Configurable<double> cMaxV0LifeTime{"cMaxV0LifeTime", 15, "Maximum V0 life time"};
-  Configurable<double> cSigmaMassKs0{"cSigmaMassKs0", 4, "n Sigma cut on KS0 mass"};
+  Configurable<double> cSigmaMassKs0{"cSigmaMassKs0", 4, "n Sigma cut on Ks0 mass (Mass (Ks) - cSigmaMassKs0*cWidthKs0)"};
   Configurable<double> cWidthKs0{"cWidthKs0", 0.005, "Width of KS0"};
   Configurable<float> ConfDaughEta{"ConfDaughEta", 0.8f, "V0 Daugh sel: max eta"};
   Configurable<float> ConfDaughTPCnclsMin{"ConfDaughTPCnclsMin", 70.f, "V0 Daugh sel: Min. nCls TPC"};
   Configurable<float> ConfDaughPIDCuts{"ConfDaughPIDCuts", 5, "PID selections for KS0 daughters"};
+  Configurable<float> Confarmcut{"Confarmcut", 0.2f, "Armenteros cut"};
+  Configurable<float> ConfKsrapidity{"ConfKsrapidity", 0.5f, "Rapidity cut on K0s"};
+  // Configurable<float> lowmasscutks0{"lowmasscutks0", 0.497 - 4 * 0.005, "Low mass cut on K0s"};
+  // Configurable<float> highmasscutks0{"highmasscutks0", 0.497 + 4 * 0.005, "High mass cut on K0s"};
 
   // Configurable for track selection and multiplicity
   Configurable<float> cfgPTcut{"cfgPTcut", 0.2f, "Track PT cut"};
   Configurable<int> cfgNmixedEvents{"cfgNmixedEvents", 5, "Number of mixed events"};
-  Configurable<bool> cfgMultFOTM{"cfgMultFOTM", true, "Use FOTM multiplicity if pp else use 0 here for PbPb"};
+  Configurable<bool> cfgMultFOTM{"cfgMultFOTM", true, "Use FOTM multiplicity if pp else use 0 here for PbPb (FT0C)"};
   ConfigurableAxis binsCent{"binsCent", {VARIABLE_WIDTH, 0., 5., 10., 30., 50., 70., 100., 110., 150.}, "Binning of the centrality axis"};
 
   // Other cuts on Ks and glueball
@@ -100,9 +111,6 @@ struct strangeness_tutorial {
   Configurable<float> competingcascrejlambdaanti{"competingcascrejlambdaanti", 4.3, "rejecting competing cascade anti-lambda"};
   Configurable<int> tpcCrossedrows{"tpcCrossedrows", 70, "TPC crossed rows"};
   Configurable<float> tpcCrossedrowsOverfcls{"tpcCrossedrowsOverfcls", 0.8, "TPC crossed rows over findable clusters"};
-  Configurable<bool> piluprejection{"piluprejection", false, "Pileup rejection"};
-  Configurable<bool> goodzvertex{"goodzvertex", false, "removes collisions with large differences between z of PV by tracks and z of PV from FT0 A-C time difference."};
-  Configurable<bool> itstpctracks{"itstpctracks", false, "selects collisions with at least one ITS-TPC track,"};
 
   // Mass and pT axis as configurables
   Configurable<float> cPtMin{"cPtMin", 0.0f, "Minimum pT"};
@@ -114,6 +122,13 @@ struct strangeness_tutorial {
   Configurable<float> ksMassMin{"ksMassMin", 0.45f, "Minimum mass of K0s"};
   Configurable<float> ksMassMax{"ksMassMax", 0.55f, "Maximum mass of K0s"};
   Configurable<int> ksMassBins{"ksMassBins", 200, "Number of mass bins for K0s"};
+
+  // Event selection cuts - Alex (Temporary, need to fix!)
+  TF1* fMultPVCutLow = nullptr;
+  TF1* fMultPVCutHigh = nullptr;
+  TF1* fMultCutLow = nullptr;
+  TF1* fMultCutHigh = nullptr;
+  TF1* fMultMultPVCut = nullptr;
 
   void init(InitContext const&)
   {
@@ -136,16 +151,35 @@ struct strangeness_tutorial {
     }
     hglue.add("h3glueInvMassDS", "h3glueInvMassDS", kTHnSparseF, {multiplicityAxis, ptAxis, glueballMassAxis}, true);
     hglue.add("h3glueInvMassME", "h3glueInvMassME", kTHnSparseF, {multiplicityAxis, ptAxis, glueballMassAxis}, true);
+    hglue.add("heventscheck", "heventscheck", kTH1F, {{9, 0, 9}});
 
     // K0s topological/PID cuts
     if (QAv0) {
       // Invariant Mass
-      rKzeroShort.add("hMassK0Shortbefore", "hMassK0Shortbefore", kTH2F, {K0ShortMassAxis, ptAxis});
-      rKzeroShort.add("hMassK0ShortSelected", "hMassK0ShortSelected", kTH2F, {K0ShortMassAxis, ptAxis});
-      // Topological cuts
-      rKzeroShort.add("hDCAV0Daughters", "hDCAV0Daughters", {HistType::kTH1F, {{55, 0.0f, 2.2f}}});
-      rKzeroShort.add("hV0CosPA", "hV0CosPA", {HistType::kTH1F, {{100, 0.95f, 1.f}}});
+      rKzeroShort.add("hMassK0Shortbefore", "hMassK0Shortbefore", kTHnSparseF, {K0ShortMassAxis, ptAxis});
+      rKzeroShort.add("hMassK0ShortSelected", "hMassK0ShortSelected", kTHnSparseF, {K0ShortMassAxis, ptAxis});
+      // Topological histograms (after the selection)
+      rKzeroShort.add("hDCAV0Daughters", "DCA between v0 daughters", {HistType::kTH1F, {{60, -3.0f, 3.0f}}});
+      rKzeroShort.add("hV0CosPA", "hV0CosPA", {HistType::kTH1F, {{100, 0.96f, 1.1f}}});
       rKzeroShort.add("hLT", "hLT", {HistType::kTH1F, {{100, 0.0f, 50.0f}}});
+      rKzeroShort.add("Mass_lambda", "Mass under lambda hypothesis", kTH1F, {glueballMassAxis});
+      rKzeroShort.add("mass_AntiLambda", "Mass under anti-lambda hypothesis", kTH1F, {glueballMassAxis});
+      rKzeroShort.add("mass_Gamma", "Mass under Gamma hypothesis", kTH1F, {glueballMassAxis});
+      // rKzeroShort.add("mass_Hypertriton", "Mass under hypertriton hypothesis", kTH1F, {glueballMassAxis});
+      // rKzeroShort.add("mass_AnitHypertriton", "Mass under anti-hypertriton hypothesis", kTH1F, {glueballMassAxis});
+      rKzeroShort.add("rapidity", "Rapidity distribution", kTH1F, {{100, -1.0f, 1.0f}});
+      rKzeroShort.add("hv0radius", "hv0radius", kTH1F, {{100, 0.0f, 200.0f}});
+      rKzeroShort.add("hDCApostopv", "DCA positive daughter to PV", kTH1F, {{1000, -10.0f, 10.0f}});
+      rKzeroShort.add("hDCAnegtopv", "DCA negative daughter to PV", kTH1F, {{1000, -10.0f, 10.0f}});
+      rKzeroShort.add("hDCAv0topv", "DCA V0 to PV", kTH1F, {{60, -3.0f, 3.0f}});
+      rKzeroShort.add("halpha", "Armenteros alpha", kTH1F, {{100, -5.0f, 5.0f}});
+      rKzeroShort.add("hqtarm", "qtarm", kTH1F, {{100, 0.0f, 1.0f}});
+      rKzeroShort.add("hpsipair", "psi pair angle", kTH1F, {{100, -5.0f, 5.0f}});
+
+      // // Topological histograms (before the selection)
+      // rKzeroShort.add("hDCAV0Daughters_before", "DCA between v0 daughters before the selection", {HistType::kTH1F, {{60, -3.0f, 3.0f}}});
+      // rKzeroShort.add("hV0CosPA_before", "hV0CosPA_before", {HistType::kTH1F, {{200, 0.91f, 1.1f}}});
+      // rKzeroShort.add("hLT_before", "hLT_before", {HistType::kTH1F, {{100, 0.0f, 50.0f}}});
     }
     if (QAPID) {
       rKzeroShort.add("hNSigmaPosPionK0s_before", "hNSigmaPosPionK0s_before", {HistType::kTH2F, {{ptAxis}, {100, -5.f, 5.f}}});
@@ -153,28 +187,58 @@ struct strangeness_tutorial {
       rKzeroShort.add("hNSigmaNegPionK0s_before", "hNSigmaNegPionK0s_before", {HistType::kTH2F, {{ptAxis}, {100, -5.f, 5.f}}});
       rKzeroShort.add("hNSigmaNegPionK0s_after", "hNSigmaNegPionK0s_after", {HistType::kTH2F, {{ptAxis}, {100, -5.f, 5.f}}});
     }
+    if (QAv0_daughters) {
+      rKzeroShort.add("negative_pt", "Negative daughter pT", kTH1F, {ptAxis});
+      rKzeroShort.add("positive_pt", "Positive daughter pT", kTH1F, {ptAxis});
+      rKzeroShort.add("negative_eta", "Negative daughter eta", kTH1F, {{100, -1.0f, 1.0f}});
+      rKzeroShort.add("positive_eta", "Positive daughter eta", kTH1F, {{100, -1.0f, 1.0f}});
+      rKzeroShort.add("negative_phi", "Negative daughter phi", kTH1F, {{70, 0.0f, 7.0f}});
+      rKzeroShort.add("positive_phi", "Positive daughter phi", kTH1F, {{70, 0.0f, 7.0f}});
+    }
+  }
+
+  template <typename Collision>
+  bool eventselection(Collision const& collision, const float& multiplicity)
+  {
+    if (!collision.sel8()) {
+      return false;
+    }
+    if (timFrameEvsel && (!collision.selection_bit(aod::evsel::kNoTimeFrameBorder) || !collision.selection_bit(aod::evsel::kNoITSROFrameBorder))) {
+      return false;
+    }
+    if (piluprejection && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
+      return false;
+    }
+    if (goodzvertex && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
+      return false;
+    }
+    if (itstpctracks && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
+      return false;
+    }
+    // if (collision.alias_bit(kTVXinTRD)) {
+    //   // TRD triggered
+    //   // return 0;
+    // }
+    auto multNTracksPV = collision.multNTracksPV();
+    if (additionalEvsel && multNTracksPV < fMultPVCutLow->Eval(multiplicity)) {
+      return false;
+    }
+    if (additionalEvsel && multNTracksPV > fMultPVCutHigh->Eval(multiplicity)) {
+      return false;
+    }
+    // if (multTrk < fMultCutLow->Eval(multiplicity))
+    //  return 0;
+    // if (multTrk > fMultCutHigh->Eval(multiplicity))
+    //  return 0;
+    // if (multTrk > fMultMultPVCut->Eval(multNTracksPV))
+    //  return 0;
+    return true;
   }
 
   template <typename Collision, typename V0>
   bool SelectionV0(Collision const& collision, V0 const& candidate,
                    float /*multiplicity*/)
   {
-    if (QAv0) {
-      rKzeroShort.fill(HIST("hMassK0Shortbefore"), candidate.mK0Short(), candidate.pt());
-    }
-
-    if (!DCAv0topv && fabs(candidate.dcav0topv()) > cMaxV0DCA) {
-      return false;
-    }
-
-    if (rapidityks && TMath::Abs(candidate.yK0Short()) >= 0.5) {
-      return false;
-    }
-
-    if (masslambda && TMath::Abs(candidate.mLambda() - candidate.mK0Short()) >= competingcascrejlambda && TMath::Abs(candidate.mAntiLambda() - candidate.mK0Short()) >= competingcascrejlambdaanti) {
-      return false;
-    }
-
     const float qtarm = candidate.qtarm();
     const float alph = candidate.alpha();
     float arm = qtarm / alph;
@@ -187,6 +251,42 @@ struct strangeness_tutorial {
     float lowmasscutks0 = 0.497 - cWidthKs0 * cSigmaMassKs0;
     float highmasscutks0 = 0.497 + cWidthKs0 * cSigmaMassKs0;
     // float decayLength = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * RecoDecay::sqrtSumOfSquares(candidate.px(), candidate.py(), candidate.pz());
+
+    if (QAv0) {
+      rKzeroShort.fill(HIST("hMassK0Shortbefore"), candidate.mK0Short(), candidate.pt());
+      rKzeroShort.fill(HIST("hLT"), CtauK0s);
+      rKzeroShort.fill(HIST("hDCAV0Daughters"), candidate.dcaV0daughters());
+      rKzeroShort.fill(HIST("hV0CosPA"), candidate.v0cosPA());
+      rKzeroShort.fill(HIST("Mass_lambda"), candidate.mLambda());
+      rKzeroShort.fill(HIST("mass_AntiLambda"), candidate.mAntiLambda());
+      rKzeroShort.fill(HIST("mass_Gamma"), candidate.mGamma());
+      // rKzeroShort.fill(HIST("mass_Hypertriton"), candidate.mHypertriton());
+      // rKzeroShort.fill(HIST("mass_AnitHypertriton"), candidate.mAntiHypertriton());
+      rKzeroShort.fill(HIST("rapidity"), candidate.yK0Short());
+      rKzeroShort.fill(HIST("hv0radius"), candidate.v0radius());
+      rKzeroShort.fill(HIST("hDCApostopv"), candidate.dcapostopv());
+      rKzeroShort.fill(HIST("hDCAnegtopv"), candidate.dcanegtopv());
+      rKzeroShort.fill(HIST("hDCAv0topv"), candidate.dcav0topv());
+      rKzeroShort.fill(HIST("halpha"), candidate.alpha());
+      rKzeroShort.fill(HIST("hqtarm"), candidate.qtarm());
+      rKzeroShort.fill(HIST("hpsipair"), candidate.psipair());
+    }
+
+    if (!DCAv0topv && fabs(candidate.dcav0topv()) > cMaxV0DCA) {
+      return false;
+    }
+
+    if (rapidityks && TMath::Abs(candidate.yK0Short()) >= ConfKsrapidity) {
+      return false;
+    }
+
+    if (masslambda && TMath::Abs(candidate.mLambda() - candidate.mK0Short()) >= competingcascrejlambda && TMath::Abs(candidate.mAntiLambda() - candidate.mK0Short()) >= competingcascrejlambdaanti) {
+      return false;
+    }
+
+    // if (isStandarv0 && candidate.isStandardV0 == 0) {
+    //   return false;
+    // }
 
     if (pT < ConfV0PtMin) {
       return false;
@@ -206,15 +306,12 @@ struct strangeness_tutorial {
     if (fabs(CtauK0s) > cMaxV0LifeTime || candidate.mK0Short() < lowmasscutks0 || candidate.mK0Short() > highmasscutks0) {
       return false;
     }
-    if (!armcut && arm < 0.2) {
+    if (!armcut && arm < Confarmcut) {
       return false;
     }
 
     if (QAv0) {
       rKzeroShort.fill(HIST("hMassK0ShortSelected"), candidate.mK0Short(), candidate.pt());
-      rKzeroShort.fill(HIST("hLT"), CtauK0s);
-      rKzeroShort.fill(HIST("hDCAV0Daughters"), candidate.dcaV0daughters());
-      rKzeroShort.fill(HIST("hV0CosPA"), candidate.v0cosPA());
     }
     return true;
   }
@@ -268,6 +365,12 @@ struct strangeness_tutorial {
       // }
     }
 
+    if (QAv0_daughters) {
+      (charge == 1) ? rKzeroShort.fill(HIST("positive_pt"), track.pt()) : rKzeroShort.fill(HIST("negative_pt"), track.pt());
+      (charge == 1) ? rKzeroShort.fill(HIST("positive_eta"), track.eta()) : rKzeroShort.fill(HIST("negative_eta"), track.eta());
+      (charge == 1) ? rKzeroShort.fill(HIST("positive_phi"), track.phi()) : rKzeroShort.fill(HIST("negative_phi"), track.phi());
+    }
+
     return true;
   }
 
@@ -282,7 +385,7 @@ struct strangeness_tutorial {
 
   // Defining the type of the daughter tracks
   using DaughterTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTOFFullPi>;
-  using EventCandidates = soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::FT0Mults, aod::MultZeqs, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>>;
+  using EventCandidates = soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::FT0Mults, aod::FV0Mults, aod::MultZeqs, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::Mults>>;
   using TrackCandidates = soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection, aod::TracksExtra, aod::TracksDCA, aod::pidTPCFullPi, aod::pidTOFFullPi>>;
   using V0TrackCandidate = aod::V0Datas;
 
@@ -292,34 +395,27 @@ struct strangeness_tutorial {
 
   void processSE(EventCandidates::iterator const& collision, TrackCandidates const& /*tracks*/, aod::V0Datas const& V0s)
   {
+    hglue.fill(HIST("heventscheck"), 0.5);
     const double massK0s = TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass();
-    if (!collision.sel8()) {
-      return;
-    }
-    if (timFrameEvsel && (!collision.selection_bit(aod::evsel::kNoTimeFrameBorder) || !collision.selection_bit(aod::evsel::kNoITSROFrameBorder))) {
-      return;
-    }
-    if (piluprejection && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-      return;
-    }
-    if (goodzvertex && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
-      return;
-    }
-    if (itstpctracks && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
-      return;
-    }
-
     float multiplicity = 0.0f;
     if (cfgMultFOTM) {
       multiplicity = collision.centFT0M();
     } else {
       multiplicity = collision.centFT0C();
     }
+    if (!eventselection(collision, multiplicity)) {
+      return;
+    }
+
+    hglue.fill(HIST("heventscheck"), 1.5);
 
     rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
     rEventSelection.fill(HIST("hmultiplicity"), multiplicity);
 
     for (auto& [v1, v2] : combinations(CombinationsStrictlyUpperIndexPolicy(V0s, V0s))) {
+
+      hglue.fill(HIST("heventscheck"), 2.5);
+
       if (v1.size() == 0 || v2.size() == 0) {
         continue;
       }
@@ -360,6 +456,8 @@ struct strangeness_tutorial {
         continue;
       }
 
+      hglue.fill(HIST("heventscheck"), 3.5);
+
       TLorentzVector lv1, lv2, lv3;
       lv1.SetPtEtaPhiM(v1.pt(), v1.eta(), v1.phi(), massK0s);
       lv2.SetPtEtaPhiM(v2.pt(), v2.eta(), v2.phi(), massK0s);
@@ -382,48 +480,36 @@ struct strangeness_tutorial {
   using BinningTypeCentralityM = ColumnBinningPolicy<aod::collision::PosZ, aod::cent::CentFT0M>;
   using BinningTypeVertexContributor = ColumnBinningPolicy<aod::collision::PosZ, aod::cent::CentFT0C>;
   ConfigurableAxis mevz = {"mevz", {10, -10., 10.}, "mixed event vertex z binning"};
-  ConfigurableAxis memult = {"memult", {2, 0., 110.}, "mixed event multiplicity binning"};
-  BinningTypeVertexContributor binningOnPositions1{{mevz, memult}, true};
-  BinningTypeCentralityM binningOnPositions2{{mevz, memult}, true};
+  ConfigurableAxis memult = {"memult", {2000, 0, 10000}, "mixed event multiplicity binning"};
 
-  SameKindPair<EventCandidates, V0TrackCandidate, BinningTypeVertexContributor> pair1{binningOnPositions1, cfgNmixedEvents, -1, &cache}; // for PbPb
-  SameKindPair<EventCandidates, V0TrackCandidate, BinningTypeCentralityM> pair2{binningOnPositions2, cfgNmixedEvents, -1, &cache};       // for pp
-
-  void processME(EventCandidates const& /*collisions*/, TrackCandidates const& /*tracks*/, V0TrackCandidate const& /*v0s*/)
+  void processME(EventCandidates const& collisions, TrackCandidates const& /*tracks*/, V0TrackCandidate const& v0s)
   {
+    hglue.fill(HIST("heventscheck"), 4.5);
+
     const double massK0s = TDatabasePDG::Instance()->GetParticle(kK0Short)->Mass();
+    auto tracksTuple = std::make_tuple(v0s);
+    BinningTypeVertexContributor binningOnPositions1{{mevz, memult}, true};
+    BinningTypeCentralityM binningOnPositions2{{mevz, memult}, true};
+
+    SameKindPair<EventCandidates, V0TrackCandidate, BinningTypeVertexContributor> pair1{binningOnPositions1, cfgNmixedEvents, -1, collisions, tracksTuple, &cache}; // for PbPb
+    SameKindPair<EventCandidates, V0TrackCandidate, BinningTypeCentralityM> pair2{binningOnPositions2, cfgNmixedEvents, -1, collisions, tracksTuple, &cache};       // for pp
+
     if (cfgMultFOTM) {
       for (auto& [c1, tracks1, c2, tracks2] : pair2) // two different centrality c1 and c2 and tracks corresponding to them
       {
-
-        if (!c1.sel8()) {
-          continue;
-        }
-        if (!c2.sel8()) {
-          continue;
-        }
-
-        if (timFrameEvsel && (!c1.selection_bit(aod::evsel::kNoTimeFrameBorder) || !c2.selection_bit(aod::evsel::kNoTimeFrameBorder) || !c1.selection_bit(aod::evsel::kNoITSROFrameBorder) || !c2.selection_bit(aod::evsel::kNoITSROFrameBorder))) {
-          continue;
-        }
-
-        if (piluprejection && !c1.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          continue;
-        }
-        if (piluprejection && !c2.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          continue;
-        }
-        if (goodzvertex && (!c1.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV) || !c2.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV))) {
-          continue;
-        }
-        if (itstpctracks && (!c1.selection_bit(o2::aod::evsel::kIsVertexITSTPC) || !c2.selection_bit(o2::aod::evsel::kIsVertexITSTPC))) {
-          continue;
-        }
+        hglue.fill(HIST("heventscheck"), 5.5);
 
         float multiplicity = 0.0f;
         multiplicity = c1.centFT0M();
 
-        for (auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(tracks1, tracks2))) {
+        if (!eventselection(c1, multiplicity) || !eventselection(c2, multiplicity)) {
+          continue;
+        }
+        hglue.fill(HIST("heventscheck"), 6.5);
+
+        for (auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
+          hglue.fill(HIST("heventscheck"), 7.5);
+
           if (t1.size() == 0 || t2.size() == 0) {
             continue;
           }
@@ -461,6 +547,8 @@ struct strangeness_tutorial {
             continue;
           }
 
+          hglue.fill(HIST("heventscheck"), 8.5);
+
           TLorentzVector lv1, lv2, lv3;
           lv1.SetPtEtaPhiM(t1.pt(), t1.eta(), t1.phi(), massK0s);
           lv2.SetPtEtaPhiM(t2.pt(), t2.eta(), t2.phi(), massK0s);
@@ -476,35 +564,14 @@ struct strangeness_tutorial {
     } else {
       for (auto& [c1, tracks1, c2, tracks2] : pair1) // two different centrality c1 and c2 and tracks corresponding to them
       {
-
-        if (!c1.sel8()) {
-          continue;
-        }
-        if (!c2.sel8()) {
-          continue;
-        }
-
-        if (timFrameEvsel && (!c1.selection_bit(aod::evsel::kNoTimeFrameBorder) || !c2.selection_bit(aod::evsel::kNoTimeFrameBorder) || !c1.selection_bit(aod::evsel::kNoITSROFrameBorder) || !c2.selection_bit(aod::evsel::kNoITSROFrameBorder))) {
-          continue;
-        }
-
-        if (piluprejection && !c1.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          continue;
-        }
-        if (piluprejection && !c2.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          continue;
-        }
-        if (goodzvertex && (!c1.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV) || !c2.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV))) {
-          continue;
-        }
-        if (itstpctracks && (!c1.selection_bit(o2::aod::evsel::kIsVertexITSTPC) || !c2.selection_bit(o2::aod::evsel::kIsVertexITSTPC))) {
-          continue;
-        }
-
         float multiplicity = 0.0f;
         multiplicity = c1.centFT0C();
 
-        for (auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(tracks1, tracks2))) {
+        if (!eventselection(c1, multiplicity) || !eventselection(c2, multiplicity)) {
+          continue;
+        }
+
+        for (auto& [t1, t2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(tracks1, tracks2))) {
           if (t1.size() == 0 || t2.size() == 0) {
             continue;
           }


### PR DESCRIPTION
…upper index policy I used for the ME background, but since in the event mixing tracks are coming from the different events, we do not need to exclude the (1,2) and (2,1) pairs in case of Ks Ks