### PR TITLE
PWGHF: Ds-h correlations, Adding DCA and nTPCcrossedRowa for tracking efficiency and selection systematics

### DIFF
--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -118,17 +118,20 @@ DECLARE_SOA_TABLE(LcHadronRecoInfo, "AOD", "LCHRECOINFO", //! Lc-Hadrons pairs R
 // definition of columns and tables for Ds-Hadron correlation pairs
 namespace hf_correlation_ds_hadron
 {
-DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);                  //! DeltaPhi between Ds and Hadrons
-DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);                  //! DeltaEta between Ds and Hadrons
-DECLARE_SOA_COLUMN(PtD, ptD, float);                            //! Transverse momentum of Ds
-DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);                  //! Transverse momentum of Hadron
-DECLARE_SOA_COLUMN(MD, mD, float);                              //! Invariant mass of Ds
-DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);              //! ML background score for Ds selection
-DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);        //! ML prompt score for Ds selection
-DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                      //! Pool Bin for the MixedEvent
-DECLARE_SOA_COLUMN(IsSignal, isSignal, bool);                   //! Used in MC-Rec, Ds Signal
-DECLARE_SOA_COLUMN(IsPrompt, isPrompt, bool);                   //! Used in MC-Rec, Ds Prompt or Non-Prompt
-DECLARE_SOA_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, bool); //! Used in MC-Rec, primary associated particles
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);                             //! DeltaPhi between Ds and Hadrons
+DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);                             //! DeltaEta between Ds and Hadrons
+DECLARE_SOA_COLUMN(PtD, ptD, float);                                       //! Transverse momentum of Ds
+DECLARE_SOA_COLUMN(PtHadron, ptHadron, float);                             //! Transverse momentum of Hadron
+DECLARE_SOA_COLUMN(MD, mD, float);                                         //! Invariant mass of Ds
+DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);                         //! ML background score for Ds selection
+DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);                   //! ML prompt score for Ds selection
+DECLARE_SOA_COLUMN(TrackDcaXY, trackDcaXY, float);                         //! DCA xy of the track
+DECLARE_SOA_COLUMN(TrackDcaZ, trackDcaZ, float);                           //! DCA z of the track
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                                 //! Pool Bin for the MixedEvent
+DECLARE_SOA_COLUMN(TrackTPCNClsCrossedRows, trackTPCNClsCrossedRows, int); //! Number of crossed TPC Rows
+DECLARE_SOA_COLUMN(IsSignal, isSignal, bool);                              //! Used in MC-Rec, Ds Signal
+DECLARE_SOA_COLUMN(IsPrompt, isPrompt, bool);                              //! Used in MC-Rec, Ds Prompt or Non-Prompt
+DECLARE_SOA_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, bool);            //! Used in MC-Rec, primary associated particles
 } // namespace hf_correlation_ds_hadron
 
 DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Information
@@ -155,6 +158,11 @@ DECLARE_SOA_TABLE(DsCandRecoInfo, "AOD", "DSCANDRECOINFO", //! Ds candidates Rec
                   aod::hf_correlation_ds_hadron::PtD,
                   aod::hf_correlation_ds_hadron::MlScorePrompt,
                   aod::hf_correlation_ds_hadron::MlScoreBkg);
+
+DECLARE_SOA_TABLE(TrackRecoInfo, "AOD", "TRACKRECOINFO", //! Tracks Reconstructed Information
+                  aod::hf_correlation_ds_hadron::TrackDcaXY,
+                  aod::hf_correlation_ds_hadron::TrackDcaZ,
+                  aod::hf_correlation_ds_hadron::TrackTPCNClsCrossedRows);
 
 // definition of columns and tables for Dplus properties
 namespace hf_dplus_meson

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -55,7 +55,7 @@ struct HfTaskCorrelationDsHadrons {
   ConfigurableAxis binsPoolBin{"binsPoolBin", {9, 0., 9.}, "PoolBin"};
 
   using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo>;
-  using DsHadronPairFullWithMl = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo, aod::DsHadronMlInfo, aod::entryTrackRecoInfo>;
+  using DsHadronPairFullWithMl = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo, aod::DsHadronMlInfo, aod::TrackRecoInfo>;
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -31,6 +31,9 @@ using namespace o2::framework::expressions;
 /// Ds-Hadron correlation pair filling task, from pair tables - for real data and data-like analysis (i.e. reco-level w/o matching request via MC truth)
 struct HfTaskCorrelationDsHadrons {
   Configurable<bool> applyEfficiency{"applyEfficiency", false, "Flag for applying efficiency weights"};
+  Configurable<int> nTpcCrossedRaws{"nTpcCrossedRaws", 70, "Number of crossed TPC Rows"};
+  Configurable<float> dcaXYTrackMax{"dcaXYTrackMax", 1., "max. DCA_xy of tracks"};
+  Configurable<float> dcaZTrackMax{"dcaZTrackMax", 1., "max. DCA_z of tracks"};
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> binsPtHadron{"binsPtHadron", std::vector<double>{0.3, 2., 4., 8., 12., 50.}, "pT bin limits for assoc particle efficiency"};
   Configurable<std::vector<double>> mlOutputPrompt{"mlScorePrompt", {0.5, 0.5, 0.5, 0.5}, "Machine learning scores for prompt"};
@@ -52,7 +55,7 @@ struct HfTaskCorrelationDsHadrons {
   ConfigurableAxis binsPoolBin{"binsPoolBin", {9, 0., 9.}, "PoolBin"};
 
   using DsHadronPairFull = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo>;
-  using DsHadronPairFullWithMl = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo, aod::DsHadronMlInfo>;
+  using DsHadronPairFullWithMl = soa::Join<aod::DsHadronPair, aod::DsHadronRecoInfo, aod::DsHadronGenInfo, aod::DsHadronMlInfo, aod::entryTrackRecoInfo>;
 
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
@@ -132,10 +135,16 @@ struct HfTaskCorrelationDsHadrons {
       float massD = pairEntry.mD();
       float bdtScorePrompt = pairEntry.mlScorePrompt();
       float bdtScoreBkg = pairEntry.mlScoreBkg();
+      float trackDcaXY = pairEntry.trackDcaXY();
+      float trackDcaZ = pairEntry.trackDcaZ();
+      int trackTpcCrossedRows = pairEntry.trackTPCNClsCrossedRows();
       int poolBin = pairEntry.poolBin();
       int ptBinD = o2::analysis::findBin(binsPtD, ptD);
 
       if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
+      if (trackDcaXY > dcaXYTrackMax || trackDcaZ > dcaZTrackMax || trackTpcCrossedRows < nTpcCrossedRaws) {
         continue;
       }
       double efficiencyWeight = 1.;
@@ -161,7 +170,7 @@ struct HfTaskCorrelationDsHadrons {
   PROCESS_SWITCH(HfTaskCorrelationDsHadrons, processData, "Process data", true);
 
   /// D-Hadron correlation pair filling task, from pair tables - for MC reco-level analysis (candidates matched to true signal only, but also bkg sources are studied)
-  void processMcRec(DsHadronPairFull const& pairEntries)
+  void processMcRec(DsHadronPairFullWithMl const& pairEntries)
   {
     for (const auto& pairEntry : pairEntries) {
       // define variables for widely used quantities
@@ -170,11 +179,22 @@ struct HfTaskCorrelationDsHadrons {
       float ptD = pairEntry.ptD();
       float ptHadron = pairEntry.ptHadron();
       float massD = pairEntry.mD();
+      float bdtScorePrompt = pairEntry.mlScorePrompt();
+      float bdtScoreBkg = pairEntry.mlScoreBkg();
+      float trackDcaXY = pairEntry.trackDcaXY();
+      float trackDcaZ = pairEntry.trackDcaZ();
+      int trackTpcCrossedRows = pairEntry.trackTPCNClsCrossedRows();
       int poolBin = pairEntry.poolBin();
       int statusDsPrompt = static_cast<int>(pairEntry.isPrompt());
       int ptBinD = o2::analysis::findBin(binsPtD, ptD);
       bool isPhysicalPrimary = pairEntry.isPhysicalPrimary();
 
+      if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
+      if (trackDcaXY > dcaXYTrackMax || trackDcaZ > dcaZTrackMax || trackTpcCrossedRows < nTpcCrossedRaws) {
+        continue;
+      }
       double efficiencyWeight = 1.;
       if (applyEfficiency) {
         efficiencyWeight = 1. / (efficiencyD->at(o2::analysis::findBin(binsPtEfficiencyD, ptD)) * efficiencyHad->at(o2::analysis::findBin(binsPtEfficiencyHad, ptHadron)));
@@ -234,10 +254,16 @@ struct HfTaskCorrelationDsHadrons {
       float massD = pairEntry.mD();
       float bdtScorePrompt = pairEntry.mlScorePrompt();
       float bdtScoreBkg = pairEntry.mlScoreBkg();
+      float trackDcaXY = pairEntry.trackDcaXY();
+      float trackDcaZ = pairEntry.trackDcaZ();
+      int trackTpcCrossedRows = pairEntry.trackTPCNClsCrossedRows();
       int poolBin = pairEntry.poolBin();
       int ptBinD = o2::analysis::findBin(binsPtD, ptD);
 
       if (bdtScorePrompt < mlOutputPrompt->at(ptBinD) || bdtScoreBkg > mlOutputBkg->at(ptBinD)) {
+        continue;
+      }
+      if (trackDcaXY > dcaXYTrackMax || trackDcaZ > dcaZTrackMax || trackTpcCrossedRows < nTpcCrossedRaws) {
         continue;
       }
       double efficiencyWeight = 1.;


### PR DESCRIPTION
Dear all,
I have added a new table in order to store the information on track dcaXY , dcaZ and nTPCcrossedRows in order to evaluate the systematic uncertainties on the tracking efficiency and the secondary particle contamination. Let me know for any comment.

Best regards,
Samuele