### PR TITLE
PWGCF: Fix in FemtoDream producer

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamObjectSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamObjectSelection.h
@@ -84,14 +84,14 @@ class FemtoDreamObjectSelection
       case (femtoDreamSelection::SelectionType::kUpperLimit):
       case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
         std::sort(sels.begin(), sels.end(), [](FemtoDreamSelection<selValDataType, selVariable> a, FemtoDreamSelection<selValDataType, selVariable> b) {
-          return a.getSelectionValue() > b.getSelectionValue();
+          return a.getSelectionValue() >= b.getSelectionValue();
         });
         break;
       case (femtoDreamSelection::SelectionType::kLowerLimit):
       case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
       case (femtoDreamSelection::SelectionType::kEqual):
         std::sort(sels.begin(), sels.end(), [](FemtoDreamSelection<selValDataType, selVariable> a, FemtoDreamSelection<selValDataType, selVariable> b) {
-          return a.getSelectionValue() < b.getSelectionValue();
+          return a.getSelectionValue() <= b.getSelectionValue();
         });
         break;
     }
@@ -126,14 +126,14 @@ class FemtoDreamObjectSelection
         switch (sel.getSelectionType()) {
           case (femtoDreamSelection::SelectionType::kUpperLimit):
           case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
-            if (minimalSel < sel.getSelectionValue()) {
+            if (minimalSel <= sel.getSelectionValue()) {
               minimalSel = sel.getSelectionValue();
             }
             break;
           case (femtoDreamSelection::SelectionType::kLowerLimit):
           case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
           case (femtoDreamSelection::SelectionType::kEqual):
-            if (minimalSel > sel.getSelectionValue()) {
+            if (minimalSel >= sel.getSelectionValue()) {
               minimalSel = sel.getSelectionValue();
             }
             break;

--- a/PWGCF/FemtoDream/Core/femtoDreamSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamSelection.h
@@ -82,14 +82,14 @@ class FemtoDreamSelection
   {
     switch (mSelType) {
       case (femtoDreamSelection::SelectionType::kUpperLimit):
-        return (observable < mSelVal);
+        return (observable <= mSelVal);
       case (femtoDreamSelection::SelectionType::kAbsUpperLimit):
-        return (std::abs(observable) < mSelVal);
+        return (std::abs(observable) <= mSelVal);
         break;
       case (femtoDreamSelection::SelectionType::kLowerLimit):
-        return (observable > mSelVal);
+        return (observable >= mSelVal);
       case (femtoDreamSelection::SelectionType::kAbsLowerLimit):
-        return (std::abs(observable) > mSelVal);
+        return (std::abs(observable) >= mSelVal);
         break;
       case (femtoDreamSelection::SelectionType::kEqual):
         /// \todo can the comparison be done a bit nicer?


### PR DESCRIPTION
So far the upper/lower bounds were not included in the selection. Hence, for example, if one sets the lower bound of ITS clusters to 5, only tracks with at least 6 clusters are selected.