### PR TITLE
DPG: Fix compilation warnings

### DIFF
--- a/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
+++ b/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
@@ -488,26 +488,31 @@ struct TagTwoProngDisplacedVertices {
         if (std::abs(track.tofNSigmaPi()) < trackNumSigmaTof) {
           return true;
         }
+        break;
       }
       case aod::tagandprobe::TagChannels::DsOrDplusToKKPi: {
         if (std::abs(track.tofNSigmaKa()) < trackNumSigmaTof) {
           return true;
         }
+        break;
       }
       case aod::tagandprobe::TagChannels::DstarPlusToDzeroPi: {
         if ((track.signed1Pt() > 0 && std::abs(track.tofNSigmaPi()) < trackNumSigmaTof) || (track.signed1Pt() < 0 && std::abs(track.tofNSigmaKa()) < trackNumSigmaTof)) {
           return true;
         }
+        break;
       }
       case aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi: {
         if ((track.signed1Pt() < 0 && std::abs(track.tofNSigmaPi()) < trackNumSigmaTof) || (track.signed1Pt() > 0 && std::abs(track.tofNSigmaKa()) < trackNumSigmaTof)) {
           return true;
         }
+        break;
       }
       case aod::tagandprobe::TagChannels::DstarToDzeroToKK: {
         if (std::abs(track.tofNSigmaKa()) < trackNumSigmaTof) {
           return true;
         }
+        break;
       }
     }
     return false;


### PR DESCRIPTION
`implicit-fallthrough`
@fgrosa , I suppose that you want to check only the condition for the given `channel` and not continue to other checks if the condition is not satisfied, right?