### PR TITLE
[PWGCF - FemtoDream]: Including MC collision table

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -68,7 +68,7 @@ DECLARE_SOA_TABLE(FDDownSample, "AOD", "FDDOWNSAMPLE",
 
 namespace femtodreamMCcollision
 {
-DECLARE_SOA_COLUMN(MultMCgenPartEta08, multMCgenPartEta08, int);       //! Multiplicity of the event as given by the generator in |eta|<0.8
+DECLARE_SOA_COLUMN(MultMCgenPartEta08, multMCgenPartEta08, int); //! Multiplicity of the event as given by the generator in |eta|<0.8
 }
 
 DECLARE_SOA_TABLE(FDMCCollisions, "AOD", "FDMCCOLLISION",
@@ -81,7 +81,6 @@ namespace mcfdcolllabel
 DECLARE_SOA_INDEX_COLUMN(FDMCCollision, fdMCCollision); //! MC collision for femtodreamcollision
 }
 DECLARE_SOA_TABLE(FDMCCollLabels, "AOD", "FDMCCollLabel", mcfdcolllabel::FDMCCollisionId);
-
 
 /// FemtoDreamTrack
 namespace femtodreamparticle

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -66,6 +66,23 @@ DECLARE_SOA_TABLE(FDColMasks, "AOD", "FDCOLMASK",
 DECLARE_SOA_TABLE(FDDownSample, "AOD", "FDDOWNSAMPLE",
                   femtodreamcollision::Downsample);
 
+namespace femtodreamMCcollision
+{
+DECLARE_SOA_COLUMN(MultMCgenPartEta08, multMCgenPartEta08, int);       //! Multiplicity of the event as given by the generator in |eta|<0.8
+}
+
+DECLARE_SOA_TABLE(FDMCCollisions, "AOD", "FDMCCOLLISION",
+                  o2::soa::Index<>,
+                  femtodreamMCcollision::MultMCgenPartEta08);
+using FDMCCollision = FDMCCollisions::iterator;
+
+namespace mcfdcolllabel
+{
+DECLARE_SOA_INDEX_COLUMN(FDMCCollision, fdMCCollision); //! MC collision for femtodreamcollision
+}
+DECLARE_SOA_TABLE(FDMCCollLabels, "AOD", "FDMCCollLabel", mcfdcolllabel::FDMCCollisionId);
+
+
 /// FemtoDreamTrack
 namespace femtodreamparticle
 {

--- a/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
@@ -42,7 +42,7 @@ class FemtoDreamEventHisto
     mHistogramRegistry->add("Event/hMultPercentileVsZvtx", "; Multiplicity Percentile (FT0M); vtx_{z} (cm)", kTH2F, {{110, 0, 110}, {300, -12.5, 12.5}});
 
     if (isMC) {
-      mHistogramRegistry->add("Event_MC/hMultPercentileVsGenMult08", "; Multiplicity Percentile (FT0M); generated MC multiplicity (#eta<0.8)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
+      mHistogramRegistry->add("Event_MC/hGenMult08VsMultPercentile", "; generated MC multiplicity (#eta<0.8); Multiplicity Percentile (FT0M)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
     }
   }
 
@@ -62,7 +62,7 @@ class FemtoDreamEventHisto
 
       if constexpr (isMC) {
         if (col.has_fdMCCollision()) {
-          mHistogramRegistry->fill(HIST("Event_MC/hMultPercentileVsGenMult08"), col.fdMCCollision().multMCgenPartEta08(), col.multV0M());
+          mHistogramRegistry->fill(HIST("Event_MC/hGenMult08VsMultPercentile"), col.fdMCCollision().multMCgenPartEta08(), col.multV0M());
         }
       }
     }

--- a/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
@@ -31,7 +31,7 @@ class FemtoDreamEventHisto
   virtual ~FemtoDreamEventHisto() = default;
   /// Initializes histograms for the task
   /// \param registry Histogram registry to be passed
-  void init(HistogramRegistry* registry)
+  void init(HistogramRegistry* registry, bool isMC)
   {
     mHistogramRegistry = registry;
     mHistogramRegistry->add("Event/hZvtx", "; vtx_{z} (cm); Entries", kTH1F, {{300, -12.5, 12.5}});
@@ -40,12 +40,16 @@ class FemtoDreamEventHisto
     mHistogramRegistry->add("Event/hMultNTrVsZvtx", "; Multiplicity (MultNtr); vtx_{z} (cm)", kTH2F, {{200, 0, 200}, {300, -12.5, 12.5}});
     mHistogramRegistry->add("Event/hMultNTrVsMultPercentile", "; Multiplicity (MultNtr); Multiplicity Percentile (FT0M)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
     mHistogramRegistry->add("Event/hMultPercentileVsZvtx", "; Multiplicity Percentile (FT0M); vtx_{z} (cm)", kTH2F, {{110, 0, 110}, {300, -12.5, 12.5}});
+
+    if (isMC){
+      mHistogramRegistry->add("Event_MC/hMultPercentileVsGenMult08", "; Multiplicity Percentile (FT0M); generated MC multiplicity (#eta<0.8)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
+    }
   }
 
   /// Some basic QA of the event
   /// \tparam T type of the collision
   /// \param col Collision
-  template <typename T>
+  template <bool isMC, typename T>
   void fillQA(T const& col)
   {
     if (mHistogramRegistry) {
@@ -55,6 +59,12 @@ class FemtoDreamEventHisto
       mHistogramRegistry->fill(HIST("Event/hMultNTrVsZvtx"), col.multNtr(), col.posZ());
       mHistogramRegistry->fill(HIST("Event/hMultNTrVsMultPercentile"), col.multNtr(), col.multV0M());
       mHistogramRegistry->fill(HIST("Event/hMultPercentileVsZvtx"), col.multV0M(), col.posZ());
+
+      if constexpr(isMC){
+        if (col.has_fdMCCollision()){
+          mHistogramRegistry->fill(HIST("Event_MC/hMultPercentileVsGenMult08"), col.fdMCCollision().multMCgenPartEta08(), col.multV0M());
+        }
+      }
     }
   }
 

--- a/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamEventHisto.h
@@ -41,7 +41,7 @@ class FemtoDreamEventHisto
     mHistogramRegistry->add("Event/hMultNTrVsMultPercentile", "; Multiplicity (MultNtr); Multiplicity Percentile (FT0M)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
     mHistogramRegistry->add("Event/hMultPercentileVsZvtx", "; Multiplicity Percentile (FT0M); vtx_{z} (cm)", kTH2F, {{110, 0, 110}, {300, -12.5, 12.5}});
 
-    if (isMC){
+    if (isMC) {
       mHistogramRegistry->add("Event_MC/hMultPercentileVsGenMult08", "; Multiplicity Percentile (FT0M); generated MC multiplicity (#eta<0.8)", kTH2F, {{200, 0, 200}, {110, 0, 110}});
     }
   }
@@ -60,8 +60,8 @@ class FemtoDreamEventHisto
       mHistogramRegistry->fill(HIST("Event/hMultNTrVsMultPercentile"), col.multNtr(), col.multV0M());
       mHistogramRegistry->fill(HIST("Event/hMultPercentileVsZvtx"), col.multV0M(), col.posZ());
 
-      if constexpr(isMC){
-        if (col.has_fdMCCollision()){
+      if constexpr (isMC) {
+        if (col.has_fdMCCollision()) {
           mHistogramRegistry->fill(HIST("Event_MC/hMultPercentileVsGenMult08"), col.fdMCCollision().multMCgenPartEta08(), col.multV0M());
         }
       }

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -45,10 +45,11 @@ using namespace o2::analysis::femtoDream;
 namespace o2::aod
 {
 
-using FemtoFullCollision =
-  soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms>::iterator;
+using FemtoFullCollision = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms>::iterator;
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::McCollisionLabels>::iterator;
 using FemtoFullCollision_noCent_MC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
+using FemtoFullMCgenCollisions = soa::Join<aod::McCollisions, MultsExtraMC>;
+using FemtoFullMCgenCollision = FemtoFullMCgenCollisions::iterator;
 
 using FemtoFullTracks =
   soa::Join<aod::FullTracks, aod::TracksDCA,
@@ -72,6 +73,8 @@ int getRowDaughters(int daughID, T const& vecID)
 struct femtoDreamProducerTask {
 
   Produces<aod::FDCollisions> outputCollision;
+  Produces<aod::FDMCCollisions> outputMCCollision;
+  Produces<aod::FDMCCollLabels> outputCollsMCLabels;
   Produces<aod::FDParticles> outputParts;
   Produces<aod::FDMCParticles> outputPartsMC;
   Produces<aod::FDExtParticles> outputDebugParts;
@@ -354,7 +357,18 @@ struct femtoDreamProducerTask {
       }
     }
   }
-
+  
+  template <typename CollisionType>
+  void fillMCCollision(CollisionType const& col)
+  {
+    if (col.has_mcCollision()){
+      auto genMCcol = col.template mcCollision_as<aod::FemtoFullMCgenCollisions>();
+      outputMCCollision(genMCcol.multMCNParticlesEta08());
+      outputCollsMCLabels(outputMCCollision.lastIndex());
+    } else {
+      outputCollsMCLabels(-1);
+    }
+  }
   template <bool isMC, bool useCentrality, typename V0Type, typename TrackType, typename CollisionType>
   void fillCollisionsAndTracksAndV0(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
   {
@@ -392,6 +406,9 @@ struct femtoDreamProducerTask {
     }
 
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
+    if constexpr (isMC) {
+      fillMCCollision(col);
+    } 
 
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
@@ -530,7 +547,7 @@ struct femtoDreamProducerTask {
   void processMC(aod::FemtoFullCollisionMC const& col,
                  aod::BCsWithTimestamps const&,
                  soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                 aod::McCollisions const&,
+                 aod::FemtoFullMCgenCollisions const&,
                  aod::McParticles const&,
                  soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
   {
@@ -544,7 +561,7 @@ struct femtoDreamProducerTask {
   void processMC_noCentrality(aod::FemtoFullCollision_noCent_MC const& col,
                               aod::BCsWithTimestamps const&,
                               soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                              aod::McCollisions const&,
+                              aod::FemtoFullMCgenCollisions const&,
                               aod::McParticles const&,
                               soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s) /// \todo with FilteredFullV0s
   {

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -357,11 +357,11 @@ struct femtoDreamProducerTask {
       }
     }
   }
-  
+
   template <typename CollisionType>
   void fillMCCollision(CollisionType const& col)
   {
-    if (col.has_mcCollision()){
+    if (col.has_mcCollision()) {
       auto genMCcol = col.template mcCollision_as<aod::FemtoFullMCgenCollisions>();
       outputMCCollision(genMCcol.multMCNParticlesEta08());
       outputCollsMCLabels(outputMCCollision.lastIndex());
@@ -408,7 +408,7 @@ struct femtoDreamProducerTask {
     outputCollision(vtxZ, mult, multNtr, spher, mMagField);
     if constexpr (isMC) {
       fillMCCollision(col);
-    } 
+    }
 
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugV0.cxx
@@ -79,7 +79,7 @@ struct femtoDreamDebugV0 {
 
   void init(InitContext&)
   {
-    eventHisto.init(&EventRegistry);
+    eventHisto.init(&EventRegistry, false);
     posChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
     negChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
     V0Histos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0TempFitVarMomentumBins, ConfDummy, ConfDummy, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
@@ -89,7 +89,7 @@ struct femtoDreamDebugV0 {
   void process(o2::aod::FDCollision const& col, FemtoFullParticles const& parts)
   {
     auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<false>(col);
     for (auto& part : groupPartsOne) {
       if (!part.has_children()) {
         continue;

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -80,12 +80,12 @@ struct femtoDreamPairTaskTrackTrack {
   using FilteredCollisions = soa::Filtered<FDCollisions>;
   using FilteredCollision = FilteredCollisions::iterator;
   using FilteredMCCollisions = soa::Filtered<soa::Join<aod::FDCollisions, aod::FDMCCollLabels>>;
-  using FilteredMCCollision = FilteredMCCollisions::iterator; 
-  
+  using FilteredMCCollision = FilteredMCCollisions::iterator;
+
   using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
-  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>; 
-  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator; 
+  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
+  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
 
   femtodreamcollision::BitMaskType BitMask = -1;
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -79,8 +79,14 @@ struct femtoDreamPairTaskTrackTrack {
 
   using FilteredCollisions = soa::Filtered<FDCollisions>;
   using FilteredCollision = FilteredCollisions::iterator;
+  using FilteredMCCollisions = soa::Filtered<soa::Join<aod::FDCollisions, aod::FDMCCollLabels>>;
+  using FilteredMCCollision = FilteredMCCollisions::iterator; 
+  
   using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
+  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>; 
+  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator; 
+
   femtodreamcollision::BitMaskType BitMask = -1;
 
   /// Track 1
@@ -216,7 +222,7 @@ struct femtoDreamPairTaskTrackTrack {
     if (Option.RandomizePair.value) {
       random = new TRandom3(0);
     }
-    eventHisto.init(&qaRegistry);
+    eventHisto.init(&qaRegistry, Option.IsMC);
     trackHistoPartOne.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
     if (!Option.SameSpecies) {
       trackHistoPartTwo.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track2.PDGCode);
@@ -286,10 +292,10 @@ struct femtoDreamPairTaskTrackTrack {
     }
   };
 
-  template <typename CollisionType>
+  template <bool isMC, typename CollisionType>
   void fillCollision(CollisionType col)
   {
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<isMC>(col);
   }
 
   /// This function processes the same event and takes care of all the histogramming
@@ -358,7 +364,7 @@ struct femtoDreamPairTaskTrackTrack {
   /// \param parts subscribe to the femtoDreamParticleTable
   void processSameEvent(FilteredCollision& col, o2::aod::FDParticles& parts)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceTrk2 = PartitionTrk2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     if (SliceTrk1.size() == 0 && SliceTrk2.size() == 0) {
@@ -379,7 +385,7 @@ struct femtoDreamPairTaskTrackTrack {
         return;
       }
     }
-    fillCollision(col);
+    fillCollision<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceTrk2 = PartitionTrk2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<false>(SliceTrk1, SliceTrk2, parts, col);
@@ -390,10 +396,12 @@ struct femtoDreamPairTaskTrackTrack {
   /// \param col subscribe to the collision table (Monte Carlo Reconstructed reconstructed)
   /// \param parts subscribe to joined table FemtoDreamParticles and FemtoDreamMCLables to access Monte Carlo truth
   /// \param FemtoDreamMCParticles subscribe to the Monte Carlo truth table
-  void processSameEventMC(FilteredCollision& col, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+  void processSameEventMC(FilteredMCCollision& col,
+                          o2::aod::FDMCCollisions&,
+                          soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                           o2::aod::FDMCParticles&)
   {
-    fillCollision(col);
+    fillCollision<true>(col);
     auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceMCTrk2 = PartitionMCTrk2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     if (SliceMCTrk1.size() == 0 && SliceMCTrk2.size() == 0) {
@@ -403,7 +411,7 @@ struct femtoDreamPairTaskTrackTrack {
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackTrack, processSameEventMC, "Enable processing same event for Monte Carlo", false);
 
-  void processSameEventMCMasked(FilteredMaskedCollision& col, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
+  void processSameEventMCMasked(FilteredMaskedMCCollision& col, o2::aod::FDMCCollisions&, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                                 o2::aod::FDMCParticles&)
   {
     if (Option.SameSpecies.value) {
@@ -415,7 +423,7 @@ struct femtoDreamPairTaskTrackTrack {
         return;
       }
     }
-    fillCollision(col);
+    fillCollision<true>(col);
     auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceMCTrk2 = PartitionMCTrk2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<true>(SliceMCTrk1, SliceMCTrk2, parts, col);
@@ -539,7 +547,7 @@ struct femtoDreamPairTaskTrackTrack {
   /// @param cols subscribe to the collisions table (Monte Carlo Reconstructed reconstructed)
   /// @param parts subscribe to joined table FemtoDreamParticles and FemtoDreamMCLables to access Monte Carlo truth
   /// @param FemtoDreamMCParticles subscribe to the Monte Carlo truth table
-  void processMixedEventMC(FilteredCollisions& cols, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts, o2::aod::FDMCParticles&)
+  void processMixedEventMC(FilteredMCCollisions& cols, o2::aod::FDMCCollisions&, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts, o2::aod::FDMCParticles&)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:
@@ -557,7 +565,7 @@ struct femtoDreamPairTaskTrackTrack {
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackTrack, processMixedEventMC, "Enable processing mixed events MC", false);
 
-  void processMixedEventMCMasked(FilteredMaskedCollisions& cols, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts, o2::aod::FDMCParticles&)
+  void processMixedEventMCMasked(FilteredMaskedMCCollisions& cols, o2::aod::FDMCCollisions&, soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts, o2::aod::FDMCParticles&)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -206,7 +206,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   void init(InitContext& context)
   {
-    eventHisto.init(&qaRegistry, ConfOptIsMC);
+    eventHisto.init(&qaRegistry, Option.IsMC);
     // void init(HistogramRegistry* registry,
     //    T& MomentumBins, T& tempFitVarBins, T& NsigmaTPCBins, T& NsigmaTOFBins, T& NsigmaTPCTOFBins, T& InvMassBins,
     //    bool isMC, int pdgCode, bool isDebug = false)

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -69,10 +69,11 @@ struct femtoDreamPairTaskTrackV0 {
   Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
   Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
 
-  using FilteredCollisions = soa::Filtered<FDCollisions>;
-  using FilteredCollision = FilteredCollisions::iterator;
   using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
+  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>; 
+  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator; 
+
   femtodreamcollision::BitMaskType BitMask = -1;
 
   /// Particle 1 (track)
@@ -205,7 +206,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   void init(InitContext& context)
   {
-    eventHisto.init(&qaRegistry);
+    eventHisto.init(&qaRegistry, ConfOptIsMC);
     // void init(HistogramRegistry* registry,
     //    T& MomentumBins, T& tempFitVarBins, T& NsigmaTPCBins, T& NsigmaTOFBins, T& NsigmaTPCTOFBins, T& InvMassBins,
     //    bool isMC, int pdgCode, bool isDebug = false)
@@ -332,19 +333,19 @@ struct femtoDreamPairTaskTrackV0 {
     if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
     }
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<false>(SliceTrk1, SliceV02, parts, col);
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", true);
 
-  void processSameEventMCMasked(FilteredMaskedCollision const& col, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
+  void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
   {
     if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
     }
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<true>(col);
     auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col);
@@ -410,7 +411,7 @@ struct femtoDreamPairTaskTrackV0 {
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMasked, "Enable processing mixed events with masks", true);
 
-  void processMixedEventMCMasked(FilteredMaskedCollisions const& cols, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
+  void processMixedEventMCMasked(FilteredMaskedMCCollisions const& cols, o2::aod::FDMCCollisions&, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -71,8 +71,8 @@ struct femtoDreamPairTaskTrackV0 {
 
   using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
-  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>; 
-  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator; 
+  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
+  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
 
   femtodreamcollision::BitMaskType BitMask = -1;
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamTripletTaskTrackTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamTripletTaskTrackTrackTrack.cxx
@@ -124,7 +124,7 @@ struct femtoDreamTripletTaskTrackTrackTrack {
   void init(InitContext& context)
   {
 
-    eventHisto.init(&qaRegistry);
+    eventHisto.init(&qaRegistry, false);
     trackHistoSelectedParts.init(&qaRegistry, ConfBinmultTempFit, ConfDummy, ConfTempFitVarpTBins, ConfDummy, ConfDummy, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePart);
     trackHistoALLSelectedParts.init(&qaRegistry, ConfBinmultTempFit, ConfDummy, ConfTempFitVarpTBins, ConfDummy, ConfDummy, ConfTempFitVarBins, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePart);
 
@@ -184,11 +184,11 @@ struct femtoDreamTripletTaskTrackTrackTrack {
     }
   }
 
-  template <typename CollisionType>
+  template <bool isMC, typename CollisionType>
   void fillCollision(CollisionType col)
   {
     ThreeBodyQARegistry.fill(HIST("TripletTaskQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtr()}));
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<isMC>(col);
   }
 
   /// This function processes the same event and takes care of all the histogramming
@@ -245,7 +245,7 @@ struct femtoDreamTripletTaskTrackTrackTrack {
   void processSameEvent(o2::aod::FDCollision& col,
                         o2::aod::FDParticles& parts)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedParts = SelectedParts->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedParts) {
       trackHistoALLSelectedParts.fillQA<false, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -263,7 +263,7 @@ struct femtoDreamTripletTaskTrackTrackTrack {
   /// \param parts subscribe to the femtoDreamParticleTable
   void processSameEventMasked(MaskedCollision& col, o2::aod::FDParticles& parts)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedParts = SelectedParts->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedParts) {
       trackHistoALLSelectedParts.fillQA<false, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -283,7 +283,7 @@ struct femtoDreamTripletTaskTrackTrackTrack {
                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                           o2::aod::FDMCParticles&)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedParts = SelectedPartsMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedParts) {
       trackHistoALLSelectedParts.fillQA<true, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -303,7 +303,7 @@ struct femtoDreamTripletTaskTrackTrackTrack {
                                 soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                                 o2::aod::FDMCParticles&)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedParts = SelectedPartsMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedParts) {
       trackHistoALLSelectedParts.fillQA<true, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());

--- a/PWGCF/FemtoDream/Tasks/femtoDreamTripletTaskTrackTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamTripletTaskTrackTrackV0.cxx
@@ -173,7 +173,7 @@ struct femtoDreamTripletTaskTrackTrackV0 {
   void init(InitContext& context)
   {
 
-    eventHisto.init(&qaRegistry);
+    eventHisto.init(&qaRegistry, false);
     trackHistoSelectedParts.init(&qaRegistry, ConfDummy, ConfDummy, ConfTempFitVarpTBins, ConfDummy, ConfDummy, ConfTempFitVarBinsTrack, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePart);
     trackHistoALLSelectedParts.init(&qaRegistry, ConfDummy, ConfDummy, ConfTempFitVarpTBins, ConfDummy, ConfDummy, ConfTempFitVarBinsTrack, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfIsMC, ConfPDGCodePart);
     particleHistoSelectedV0s.init(&qaRegistry, ConfDummy, ConfDummy, ConfTempFitVarpTV0Bins, ConfDummy, ConfDummy, ConfTempFitVarBinsV0, ConfDummy, ConfDummy, ConfDummy, ConfDummy, ConfInvMassBins, ConfIsMC, ConfPDGCodeV0);
@@ -262,11 +262,11 @@ struct femtoDreamTripletTaskTrackTrackV0 {
     }
   }
 
-  template <typename CollisionType>
+  template <bool isMC, typename CollisionType>
   void fillCollision(CollisionType col)
   {
     ThreeBodyQARegistry.fill(HIST("TripletTaskQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtr()}));
-    eventHisto.fillQA(col);
+    eventHisto.fillQA<isMC>(col);
   }
 
   /// This function processes the same event and takes care of all the histogramming
@@ -350,7 +350,7 @@ struct femtoDreamTripletTaskTrackTrackV0 {
   void processSameEvent(o2::aod::FDCollision& col,
                         o2::aod::FDParticles& parts)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedTracks = SelectedParts->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedTracks) {
       trackHistoALLSelectedParts.fillQA<false, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -381,7 +381,7 @@ struct femtoDreamTripletTaskTrackTrackV0 {
   /// \param parts subscribe to the femtoDreamParticleTable
   void processSameEventMasked(MaskedCollision& col, o2::aod::FDParticles& parts)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedTracks = SelectedParts->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedTracks) {
       trackHistoALLSelectedParts.fillQA<false, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -415,7 +415,7 @@ struct femtoDreamTripletTaskTrackTrackV0 {
                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                           o2::aod::FDMCParticles&)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedTracks = SelectedPartsMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedTracks) {
       trackHistoALLSelectedParts.fillQA<true, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -449,7 +449,7 @@ struct femtoDreamTripletTaskTrackTrackV0 {
                                 soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                                 o2::aod::FDMCParticles&)
   {
-    fillCollision(col);
+    fillCollision<false>(col);
     auto thegroupSelectedTracks = SelectedPartsMC->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     for (auto& part : thegroupSelectedTracks) {
       trackHistoALLSelectedParts.fillQA<true, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());


### PR DESCRIPTION
A new table is added containing MC truth information for collisions. It
can be linked to the reconstruction table via a new index table. The
procedure is similar to the previously implemented table for MC true
information for particles

New tables:
- FDMCCollisions: Contains MC truth information (for now only the number
  of produced paricles in |eta| < 0.8
- FDMCCollLabels: Linkable with FDCollisions to access the
  FDMCCollisions table