### PR TITLE
PWGLF: Include event correction

### DIFF
--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -33,6 +33,20 @@ namespace o2::aod
 /// Resonance Collisions
 namespace resocollision
 {
+enum {
+  kECbegin = 0,
+  kINEL = 1,
+  kINEL10,
+  kINELg0,
+  kINELg010,
+  kTrig,
+  kINELg0Trig,
+  kINELg010Trig,
+  kSel,
+  kINELg0Sel,
+  kINELg010Sel,
+  kECend,
+};
 DECLARE_SOA_COLUMN(Cent, cent, float);             //! Centrality (Multiplicity) percentile (Default: FT0M)
 DECLARE_SOA_COLUMN(Spherocity, spherocity, float); //! Spherocity of the event
 DECLARE_SOA_COLUMN(EvtPl, evtPl, float);           //! Second harmonic event plane
@@ -40,6 +54,12 @@ DECLARE_SOA_COLUMN(EvtPlResAB, evtPlResAB, float); //! Second harmonic event pla
 DECLARE_SOA_COLUMN(EvtPlResAC, evtPlResAC, float); //! Second harmonic event plane resolution of A-C sub events
 DECLARE_SOA_COLUMN(EvtPlResBC, evtPlResBC, float); //! Second harmonic event plane resolution of B-C sub events
 DECLARE_SOA_COLUMN(BMagField, bMagField, float);   //! Magnetic field
+// MC
+DECLARE_SOA_COLUMN(IsVtxIn10, isVtxIn10, bool);               //! Vtx10
+DECLARE_SOA_COLUMN(IsINELgt0, isINELgt0, bool);               //! INEL>0
+DECLARE_SOA_COLUMN(IsInSel8, isInSel8, bool);                 //! InSel8
+DECLARE_SOA_COLUMN(IsInAfterAllCuts, isInAfterAllCuts, bool); //! InAfterAllCuts
+
 } // namespace resocollision
 DECLARE_SOA_TABLE(ResoCollisions, "AOD", "RESOCOL",
                   o2::soa::Index<>,
@@ -56,6 +76,13 @@ DECLARE_SOA_TABLE(ResoCollisions, "AOD", "RESOCOL",
                   resocollision::BMagField,
                   timestamp::Timestamp);
 using ResoCollision = ResoCollisions::iterator;
+
+DECLARE_SOA_TABLE(ResoMCCollisions, "AOD", "RESOMCCOL",
+                  resocollision::IsVtxIn10,
+                  resocollision::IsINELgt0,
+                  resocollision::IsInSel8,
+                  resocollision::IsInAfterAllCuts);
+using ResoMCCollision = ResoMCCollisions::iterator;
 
 // Resonance Daughters
 // inspired from PWGCF/DataModel/FemtoDerived.h

--- a/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
@@ -46,17 +46,6 @@ using namespace o2::soa;
 
 /// Initializer for the resonance candidate producers
 struct reso2initializer {
-  enum {
-    kECbegin = 0,
-    kINEL = 1,
-    kINEL10,
-    kINELg0,
-    kINELg010,
-    kTrig,
-    kINELg0Trig,
-    kINELg010Trig,
-    kECend,
-  };
   SliceCache cache;
   float cXiMass;
   int mRunNumber;
@@ -66,6 +55,7 @@ struct reso2initializer {
   Service<o2::framework::O2DatabasePDG> pdg;
 
   Produces<aod::ResoCollisions> resoCollisions;
+  Produces<aod::ResoMCCollisions> resoMCCollisions;
   Produces<aod::ResoTracks> reso2trks;
   Produces<aod::ResoV0s> reso2v0s;
   Produces<aod::ResoCascades> reso2cascades;
@@ -94,8 +84,7 @@ struct reso2initializer {
   Configurable<int> trackSphMin{"trackSphMin", 10, "Number of tracks for Spherocity Calculation"};
 
   // EventCorrection for MC
-  ConfigurableAxis binsCent{"binsCent", {VARIABLE_WIDTH, 0., 0.01, 0.1, 1.0, 5.0, 10., 15., 20., 30., 40., 50., 70., 100.0, 105.}, "Binning of the centrality axis"};
-  ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -20, -15, -10, -7, -5, -3, -2, -1, 0, 1, 2, 3, 5, 7, 10, 15, 20}, "Mixing bins - z-vertex"};
+  ConfigurableAxis binsCent{"binsCent", {VARIABLE_WIDTH, 0., 0.01, 0.1, 1.0, 5.0, 10., 15., 20., 30., 40., 50., 60., 70., 80., 90., 100.0, 105.}, "Binning of the centrality axis"};
 
   /// Event cuts
   o2::analysis::CollisonCuts colCuts;
@@ -159,7 +148,6 @@ struct reso2initializer {
                        ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
   Filter tpcPIDFilter = nabs(aod::pidtpc::tpcNSigmaPi) < pidnSigmaPreSelectionCut || nabs(aod::pidtpc::tpcNSigmaKa) < pidnSigmaPreSelectionCut || nabs(aod::pidtpc::tpcNSigmaPr) < pidnSigmaPreSelectionCut; // TPC
   Filter trackEtaFilter = nabs(aod::track::eta) < cfgCutEta;                                                                                                                                                 // Eta cut
-  Filter collisionFilter = nabs(aod::collision::posZ) < ConfEvtZvtx;
 
   EventPlaneHelper helperEP;
 
@@ -336,6 +324,24 @@ struct reso2initializer {
         qaRegistry.fill(HIST("hGoodMCCascIndices"), 0.5);
     }
     return true;
+  }
+
+  // Check if the collision is INEL>0
+  template <typename MCColl, typename MCPart>
+  bool IsTrueINEL0(MCColl const& mccoll, MCPart const& mcparts)
+  {
+    for (auto& mcparticle : mcparts) {
+      if (!mcparticle.isPhysicalPrimary())
+        continue;
+      auto p = pdg->GetParticle(mcparticle.pdgCode());
+      if (p != nullptr) {
+        if (std::abs(p->Charge()) >= 3) {
+          if (std::abs(mcparticle.eta()) < 1)
+            return true;
+        }
+      }
+    }
+    return false;
   }
 
   // Centralicity estimator selection
@@ -825,6 +831,42 @@ struct reso2initializer {
     }
   }
 
+  template <bool isRun2, typename MCCol, typename MCPart>
+  void fillMCCollision(MCCol const& mccol, MCPart const& mcparts)
+  {
+    auto centrality = 0.0;
+    if constexpr (!isRun2)
+      centrality = CentEst(mccol);
+    else
+      centrality = mccol.centRun2V0M();
+    bool inVtx10 = (abs(mccol.mcCollision().posZ()) > 10.) ? false : true;
+    bool isTrueINELgt0 = IsTrueINEL0(mccol, mcparts);
+    bool isSel8 = mccol.sel8();
+    bool isSelected = colCuts.isSelected(mccol);
+    resoMCCollisions(inVtx10, isTrueINELgt0, isSel8, isSelected);
+
+    // QA for Trigger efficiency
+    qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINEL);
+    if (inVtx10)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINEL10);
+    if (isTrueINELgt0)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg0);
+    if (inVtx10 && isTrueINELgt0)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg010);
+    if (isSel8)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kTrig);
+    if (isSel8 && isTrueINELgt0)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg0Trig);
+    if (isSel8 && isTrueINELgt0 && inVtx10)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg010Trig);
+    if (isSelected)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kSel);
+    if (isSelected && isTrueINELgt0)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg0Sel);
+    if (isSelected && isTrueINELgt0 && inVtx10)
+      qaRegistry.fill(HIST("Event/hMCEventIndices"), centrality, aod::resocollision::kINELg010Sel);
+  }
+
   void init(InitContext&)
   {
     cXiMass = pdg->GetParticle(3312)->Mass();
@@ -844,18 +886,19 @@ struct reso2initializer {
     }
 
     // Check if we are running multiple processes at the same time
-    int nProcesses = doprocessTrackDataRun2 + doprocessTrackV0DataRun2 + doprocessTrackV0CascDataRun2 +
-                     doprocessMCGenCountRun2 + doprocessTrackMCRun2 + doprocessTrackV0MCRun2 +
-                     doprocessTrackV0CascMCRun2;
+    int nProcesses = doprocessTrackData + doprocessTrackV0Data + doprocessTrackV0CascData +
+                     doprocessTrackMC + doprocessTrackV0MC + doprocessTrackV0CascMC + doprocessTrackEPData +
+                     doprocessTrackDataRun2 + doprocessTrackV0DataRun2 + doprocessTrackV0CascDataRun2 +
+                     doprocessTrackMCRun2 + doprocessTrackV0MCRun2 + doprocessTrackV0CascMCRun2;
 
     if (nProcesses > 1) {
       LOG(fatal) << "Multiple processes are not supported at the same time";
     }
 
     // Case selector based on the process.
-    if (doprocessTrackDataRun2 || doprocessTrackV0DataRun2 || doprocessTrackV0CascDataRun2 || doprocessMCGenCountRun2 || doprocessTrackMCRun2 || doprocessTrackV0MCRun2 || doprocessTrackV0CascMCRun2) {
+    if (doprocessTrackDataRun2 || doprocessTrackV0DataRun2 || doprocessTrackV0CascDataRun2 || doprocessTrackMCRun2 || doprocessTrackV0MCRun2 || doprocessTrackV0CascMCRun2) {
       colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, false);
-    } else if (doprocessTrackData || doprocessTrackV0Data || doprocessTrackV0CascData || doprocessMCGenCount || doprocessTrackMC || doprocessTrackV0MC || doprocessTrackV0CascMC || doprocessTrackEPData) {
+    } else if (doprocessTrackData || doprocessTrackV0Data || doprocessTrackV0CascData || doprocessTrackMC || doprocessTrackV0MC || doprocessTrackV0CascMC || doprocessTrackEPData) {
       colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtTriggerSel, ConfEvtOfflineCheck, true);
     }
     colCuts.init(&qaRegistry);
@@ -874,6 +917,11 @@ struct reso2initializer {
     }
 
     // QA histograms
+    if (doprocessTrackMCRun2 || doprocessTrackV0MCRun2 || doprocessTrackV0CascMCRun2 || doprocessTrackMC || doprocessTrackV0MC || doprocessTrackV0CascMC) {
+      AxisSpec centAxis = {binsCent, "Centrality (%)"};
+      AxisSpec idxMCAxis = {16, -0.5, 15.5, "Index"};
+      qaRegistry.add("Event/hMCEventIndices", "hMCEventIndices", kTH2D, {centAxis, idxMCAxis});
+    }
     AxisSpec idxAxis = {8, 0, 8, "Index"};
     if (ConfFillQA) {
       qaRegistry.add("hGoodTrackIndices", "hGoodTrackIndices", kTH1F, {idxAxis});
@@ -883,14 +931,6 @@ struct reso2initializer {
       qaRegistry.add("hGoodCascIndices", "hGoodCascIndices", kTH1F, {idxAxis});
       qaRegistry.add("hGoodMCCascIndices", "hGoodMCCascIndices", kTH1F, {idxAxis});
       qaRegistry.add("Phi", "#phi distribution", kTH1F, {{65, -0.1, 6.4}});
-    }
-    // MC histograms
-    if (doprocessMCGenCount) {
-      AxisSpec EvtClassAxis = {kECend - 1, +kECbegin + 0.5, +kECend - 0.5, "", "event class"};
-      AxisSpec ZAxis = {CfgVtxBins, "zaxis"};
-      AxisSpec CentAxis = {binsCent, "centrality"};
-      qaRegistry.add("Event/totalEventGenMC", "totalEventGenMC", {HistType::kTHnSparseF, {EvtClassAxis}});
-      qaRegistry.add("Event/hgenzvtx", "evntclass; zvtex", {HistType::kTHnSparseF, {EvtClassAxis, ZAxis, CentAxis}});
     }
   }
 
@@ -938,7 +978,7 @@ struct reso2initializer {
     LOGF(info, "Bz set to %f for run: ", d_bz, mRunNumber);
   }
 
-  void processTrackData(soa::Filtered<ResoEvents>::iterator const& collision,
+  void processTrackData(ResoEvents::iterator const& collision,
                         soa::Filtered<ResoTracks> const& tracks,
                         aod::BCsWithTimestamps const&)
   {
@@ -955,7 +995,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackData, "Process for data", true);
 
-  void processTrackDataRun2(soa::Filtered<ResoRun2Events>::iterator const& collision,
+  void processTrackDataRun2(ResoRun2Events::iterator const& collision,
                             soa::Filtered<ResoTracks> const& tracks,
                             aod::BCsWithTimestamps const&)
   {
@@ -972,7 +1012,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackDataRun2, "Process for data", false);
 
-  void processTrackEPData(soa::Filtered<soa::Join<ResoEvents, aod::Qvectors>>::iterator const& collision,
+  void processTrackEPData(soa::Join<ResoEvents, aod::Qvectors>::iterator const& collision,
                           soa::Filtered<ResoTracks> const& tracks,
                           aod::BCsWithTimestamps const&)
   {
@@ -989,117 +1029,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackEPData, "Process for data and ep ana", false);
 
-  PresliceUnsorted<ResoEventsMC> perMcCol = aod::mccollisionlabel::mcCollisionId;
-  void processMCGenCount(aod::McCollisions const& mccollisions, aod::McParticles const& mcParticles, ResoEventsMC const& mcCols)
-  {
-    // Mainly referenced from dndeta_hi task in PWG-MM PAG-Multiplicity (Beomkyu Kim)
-    for (auto& mcCollision : mccollisions) { // Gen MC Event loop
-      auto particles = mcParticles.sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache);
-      std::vector<Bool_t> bevtc(kECend, false);
-      bevtc[kINEL] = true;
-      auto posZ = mcCollision.posZ();
-      if (std::abs(posZ) < 10)
-        bevtc[kINEL10] = true;
-      for (auto& particle : particles) {
-        if (!particle.isPhysicalPrimary())
-          continue;
-        auto kp = pdg->GetParticle(particle.pdgCode());
-        if (kp != nullptr) {
-          if (std::abs(kp->Charge()) >= 3) {    // 3 quarks
-            if (std::abs(particle.eta()) < 1) { // INEL>0 definition
-              bevtc[kINELg0] = true;
-              break;
-            }
-          }
-        }
-      }
-      if (bevtc[kINELg0] && bevtc[kINEL10])
-        bevtc[kINELg010] = true;
-
-      for (auto ievtc = 1u; ievtc < kECend; ievtc++) {
-        if (bevtc[ievtc])
-          qaRegistry.fill(HIST("Event/totalEventGenMC"), Double_t(ievtc));
-      }
-
-      auto collisionsample = mcCols.sliceBy(perMcCol, mcCollision.globalIndex());
-      float cent = -1.0;
-      if (collisionsample.size() != 1) { // Prevent no reconstructed collision case
-        cent = -1;
-      } else {
-        for (auto& collision : collisionsample) {
-          cent = CentEst(collision);
-          if (collision.sel8())
-            bevtc[kTrig] = true;
-        }
-      }
-      if (bevtc[kTrig] && bevtc[kINELg0])
-        bevtc[kINELg0Trig] = true;
-      if (bevtc[kINELg0Trig] && bevtc[kINEL10])
-        bevtc[kINELg010Trig] = true;
-      for (auto ievtc = 1u; ievtc < kECend; ievtc++) {
-        if (bevtc[ievtc])
-          qaRegistry.fill(HIST("Event/hgenzvtx"), Double_t(ievtc), posZ, cent);
-      }
-    }
-  }
-  PROCESS_SWITCH(reso2initializer, processMCGenCount, "Process for MC", false);
-
-  PresliceUnsorted<ResoRun2EventsMC> perMcColRun2 = aod::mccollisionlabel::mcCollisionId;
-  void processMCGenCountRun2(aod::McCollisions const& mccollisions, aod::McParticles const& mcParticles, ResoRun2EventsMC const& mcCols)
-  {
-    // Mainly referenced from dndeta_hi task in PWG-MM PAG-Multiplicity (Beomkyu Kim)
-    for (auto& mcCollision : mccollisions) { // Gen MC Event loop
-      auto particles = mcParticles.sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache);
-      std::vector<Bool_t> bevtc(kECend, false);
-      bevtc[kINEL] = true;
-      auto posZ = mcCollision.posZ();
-      if (std::abs(posZ) < 10)
-        bevtc[kINEL10] = true;
-      for (auto& particle : particles) {
-        if (!particle.isPhysicalPrimary())
-          continue;
-        auto kp = pdg->GetParticle(particle.pdgCode());
-        if (kp != nullptr) {
-          if (std::abs(kp->Charge()) >= 3) {    // 3 quarks
-            if (std::abs(particle.eta()) < 1) { // INEL>0 definition
-              bevtc[kINELg0] = true;
-              break;
-            }
-          }
-        }
-      }
-      if (bevtc[kINELg0] && bevtc[kINEL10])
-        bevtc[kINELg010] = true;
-
-      for (auto ievtc = 1u; ievtc < kECend; ievtc++) {
-        if (bevtc[ievtc])
-          qaRegistry.fill(HIST("Event/totalEventGenMC"), Double_t(ievtc));
-      }
-
-      auto collisionsample = mcCols.sliceBy(perMcColRun2, mcCollision.globalIndex());
-      float cent = -1.0;
-      if (collisionsample.size() != 1) { // Prevent no reconstructed collision case
-        cent = -1;
-      } else {
-        for (auto& collision : collisionsample) {
-          cent = CentEst(collision);
-          if (collision.sel7())
-            bevtc[kTrig] = true;
-        }
-      }
-      if (bevtc[kTrig] && bevtc[kINELg0])
-        bevtc[kINELg0Trig] = true;
-      if (bevtc[kINELg0Trig] && bevtc[kINEL10])
-        bevtc[kINELg010Trig] = true;
-      for (auto ievtc = 1u; ievtc < kECend; ievtc++) {
-        if (bevtc[ievtc])
-          qaRegistry.fill(HIST("Event/hgenzvtx"), Double_t(ievtc), posZ, cent);
-      }
-    }
-  }
-  PROCESS_SWITCH(reso2initializer, processMCGenCountRun2, "Process for MC", false);
-
-  void processTrackV0Data(soa::Filtered<ResoEvents>::iterator const& collision,
+  void processTrackV0Data(ResoEvents::iterator const& collision,
                           soa::Filtered<ResoTracks> const& tracks,
                           ResoV0s const& V0s,
                           aod::BCsWithTimestamps const&)
@@ -1118,7 +1048,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0Data, "Process for data", false);
 
-  void processTrackV0DataRun2(soa::Filtered<ResoRun2Events>::iterator const& collision,
+  void processTrackV0DataRun2(ResoRun2Events::iterator const& collision,
                               soa::Filtered<ResoTracks> const& tracks,
                               ResoV0s const& V0s,
                               aod::BCsWithTimestamps const&)
@@ -1137,7 +1067,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0DataRun2, "Process for data", false);
 
-  void processTrackV0CascData(soa::Filtered<ResoEvents>::iterator const& collision,
+  void processTrackV0CascData(ResoEvents::iterator const& collision,
                               soa::Filtered<ResoTracks> const& tracks,
                               ResoV0s const& V0s,
                               ResoCascades const& Cascades,
@@ -1158,7 +1088,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0CascData, "Process for data", false);
 
-  void processTrackV0CascDataRun2(soa::Filtered<ResoRun2Events>::iterator const& collision,
+  void processTrackV0CascDataRun2(ResoRun2Events::iterator const& collision,
                                   soa::Filtered<ResoTracks> const& tracks,
                                   ResoV0s const& V0s,
                                   ResoCascades const& Cascades,
@@ -1180,17 +1110,16 @@ struct reso2initializer {
   PROCESS_SWITCH(reso2initializer, processTrackV0CascDataRun2, "Process for data", false);
 
   Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
-  void processTrackMC(soa::Filtered<soa::Join<ResoEvents, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackMC(soa::Join<ResoEvents, aod::McCollisionLabels>::iterator const& collision,
                       aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                       aod::McParticles const& mcParticles, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQA(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<false>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);
@@ -1201,18 +1130,36 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackMC, "Process for MC", false);
 
+  void processTrackEPMC(soa::Join<ResoEvents, aod::Qvectors, aod::McCollisionLabels>::iterator const& collision,
+                        aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
+                        aod::McParticles const& mcParticles, aod::BCsWithTimestamps const&)
+  {
+    auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
+    initCCDB(bc);
+    colCuts.fillQA(collision);
+
+    resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), GetEvtPl(collision), GetEvtPlRes(collision, EvtPlDetId, EvtPlRefAId), GetEvtPlRes(collision, EvtPlDetId, EvtPlRefBId), GetEvtPlRes(collision, EvtPlRefAId, EvtPlRefBId), d_bz, bc.timestamp());
+    fillMCCollision<false>(collision, mcParticles);
+
+    // Loop over tracks
+    fillTracks<false>(collision, tracks);
+    // Loop over all MC particles
+    auto mcParts = selectedMCParticles->sliceBy(perMcCollision, collision.mcCollision().globalIndex());
+    fillMCParticles(mcParts, mcParticles);
+  }
+  PROCESS_SWITCH(reso2initializer, processTrackEPMC, "Process for MC and ep ana", false);
+
   Preslice<aod::McParticles> perMcCollisionRun2 = aod::mcparticle::mcCollisionId;
-  void processTrackMCRun2(soa::Filtered<soa::Join<ResoRun2Events, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackMCRun2(soa::Join<ResoRun2Events, aod::McCollisionLabels>::iterator const& collision,
                           aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                           aod::McParticles const& mcParticles, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQARun2(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), collision.centRun2V0M(), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<true>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);
@@ -1223,18 +1170,17 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackMCRun2, "Process for MC", false);
 
-  void processTrackV0MC(soa::Filtered<soa::Join<ResoEvents, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackV0MC(soa::Join<ResoEvents, aod::McCollisionLabels>::iterator const& collision,
                         aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                         ResoV0sMC const& V0s,
                         aod::McParticles const& mcParticles, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQA(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<false>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);
@@ -1246,18 +1192,17 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0MC, "Process for MC", false);
 
-  void processTrackV0MCRun2(soa::Filtered<soa::Join<ResoRun2Events, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackV0MCRun2(soa::Join<ResoRun2Events, aod::McCollisionLabels>::iterator const& collision,
                             aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                             ResoV0sMC const& V0s,
                             aod::McParticles const& mcParticles, aod::BCsWithTimestamps const&)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQARun2(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), collision.centRun2V0M(), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<true>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);
@@ -1269,7 +1214,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0MCRun2, "Process for MC", false);
 
-  void processTrackV0CascMC(soa::Filtered<soa::Join<ResoEvents, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackV0CascMC(soa::Join<ResoEvents, aod::McCollisionLabels>::iterator const& collision,
                             aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                             ResoV0sMC const& V0s,
                             ResoCascadesMC const& Cascades,
@@ -1277,11 +1222,10 @@ struct reso2initializer {
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQA(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), CentEst(collision), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<false>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);
@@ -1295,7 +1239,7 @@ struct reso2initializer {
   }
   PROCESS_SWITCH(reso2initializer, processTrackV0CascMC, "Process for MC", false);
 
-  void processTrackV0CascMCRun2(soa::Filtered<soa::Join<ResoRun2Events, aod::McCollisionLabels>>::iterator const& collision,
+  void processTrackV0CascMCRun2(soa::Join<ResoRun2Events, aod::McCollisionLabels>::iterator const& collision,
                                 aod::McCollisions const&, soa::Filtered<ResoTracksMC> const& tracks,
                                 ResoV0sMC const& V0s,
                                 ResoCascadesMC const& Cascades,
@@ -1303,11 +1247,10 @@ struct reso2initializer {
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>(); /// adding timestamp to access magnetic field later
     initCCDB(bc);
-    if (!colCuts.isSelected(collision))
-      return;
     colCuts.fillQARun2(collision);
 
     resoCollisions(0, collision.posX(), collision.posY(), collision.posZ(), collision.centRun2V0M(), ComputeSpherocity(tracks, trackSphMin, trackSphDef), 0., 0., 0., 0., d_bz, bc.timestamp());
+    fillMCCollision<true>(collision, mcParticles);
 
     // Loop over tracks
     fillTracks<true>(collision, tracks);

--- a/PWGLF/Tasks/Resonances/k892analysis.cxx
+++ b/PWGLF/Tasks/Resonances/k892analysis.cxx
@@ -40,6 +40,8 @@ struct k892analysis {
   Preslice<aod::Tracks> perCollision = aod::track::collisionId;
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
+  using ResoMCCols = soa::Join<aod::ResoCollisions, aod::ResoMCCollisions>;
+
   ///// Configurables
   /// Histograms
   ConfigurableAxis binsPt{"binsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
@@ -103,6 +105,7 @@ struct k892analysis {
     AxisSpec centAxis = {binsCent, "V0M (%)"};
     AxisSpec dcaxyAxis = {cDCABins, 0.0, 3.0, "DCA_{#it{xy}} (cm)"};
     AxisSpec dcazAxis = {cDCABins, 0.0, 3.0, "DCA_{#it{xy}} (cm)"};
+    AxisSpec mcLabelAxis = {4, -0.5, 3.5, "MC Label"};
     AxisSpec ptAxis = {binsPt, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec ptAxisQA = {binsPtQA, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec invMassAxis = {cInvMassBins, cInvMassStart, cInvMassEnd, "Invariant Mass (GeV/#it{c}^2)"};
@@ -182,10 +185,10 @@ struct k892analysis {
       histos.add("QAMCTrue/TPC_Nsigmaka_all", "TPC NSigma for Kaon;#it{p}_{T} (GeV/#it{c});#sigma_{TPC}^{Kaon};", {HistType::kTH3F, {centAxis, ptAxisQA, pidQAAxis}});
       histos.add("h3Reck892invmass", "Invariant mass of Reconstructed MC K(892)0", kTH3F, {centAxis, ptAxis, invMassAxis});
       histos.add("h3Reck892invmassAnti", "Invariant mass of Reconstructed MC Anti-K(892)0", kTH3F, {centAxis, ptAxis, invMassAxis});
-      histos.add("k892Gen", "pT distribution of True MC K(892)0", kTH2D, {ptAxis, centAxis});
-      histos.add("k892GenAnti", "pT distribution of True MC Anti-K(892)0", kTH2D, {ptAxis, centAxis});
-      histos.add("k892Rec", "pT distribution of Reconstructed MC K(892)0", kTH2D, {ptAxis, centAxis});
-      histos.add("k892RecAnti", "pT distribution of Reconstructed MC Anti-K(892)0", kTH2D, {ptAxis, centAxis});
+      histos.add("k892Gen", "pT distribution of True MC K(892)0", kTH3F, {mcLabelAxis, ptAxis, centAxis});
+      histos.add("k892GenAnti", "pT distribution of True MC Anti-K(892)0", kTH3F, {mcLabelAxis, ptAxis, centAxis});
+      histos.add("k892Rec", "pT distribution of Reconstructed MC K(892)0", kTH2F, {ptAxis, centAxis});
+      histos.add("k892RecAnti", "pT distribution of Reconstructed MC Anti-K(892)0", kTH2F, {ptAxis, centAxis});
       histos.add("k892Recinvmass", "Inv mass distribution of Reconstructed MC Phi", kTH1F, {invMassAxis});
     }
     // Print output histograms statistics
@@ -506,36 +509,48 @@ struct k892analysis {
   }
   PROCESS_SWITCH(k892analysis, processDataLight, "Process Event for data", false);
 
-  void processMCLight(aod::ResoCollision& collision,
+  void processMCLight(ResoMCCols::iterator const& collision,
                       soa::Join<aod::ResoTracks, aod::ResoMCTracks> const& resotracks)
   {
+    if (!collision.isInAfterAllCuts()) // MC event selection
+      return;
     fillHistograms<true, false>(collision, resotracks, resotracks);
   }
   PROCESS_SWITCH(k892analysis, processMCLight, "Process Event for MC (Reconstructed)", false);
 
-  void processMCTrue(aod::ResoCollision& collision, aod::ResoMCParents& resoParents)
+  void processMCTrue(ResoMCCols::iterator const& collision, aod::ResoMCParents& resoParents)
   {
     auto multiplicity = collision.cent();
-    for (auto& part : resoParents) {  // loop over all pre-filtered MC particles
-      if (abs(part.pdgCode()) != 313) // K892(0)
+    for (auto& part : resoParents) { // loop over all pre-filtered MC particles
+      if (abs(part.pdgCode()) != 313 || abs(part.y()) >= 0.5)
         continue;
-      if (abs(part.y()) >= 0.5) { // rapidity cut
+      bool pass1 = abs(part.daughterPDG1()) == 211 || abs(part.daughterPDG2()) == 211;
+      bool pass2 = abs(part.daughterPDG1()) == 321 || abs(part.daughterPDG2()) == 321;
+
+      if (!pass1 || !pass2)
         continue;
+
+      if (collision.isVtxIn10()) // INEL10
+      {
+        if (part.pdgCode() > 0)
+          histos.fill(HIST("k892Gen"), 0, part.pt(), multiplicity);
+        else
+          histos.fill(HIST("k892GenAnti"), 0, part.pt(), multiplicity);
       }
-      bool pass1 = false;
-      bool pass2 = false;
-      if (abs(part.daughterPDG1()) == 321 || abs(part.daughterPDG2()) == 321) { // At least one decay to Kaon
-        pass2 = true;
+      if (collision.isVtxIn10() && collision.isInSel8()) // INEL>10, vtx10
+      {
+        if (part.pdgCode() > 0)
+          histos.fill(HIST("k892Gen"), 1, part.pt(), multiplicity);
+        else
+          histos.fill(HIST("k892GenAnti"), 1, part.pt(), multiplicity);
       }
-      if (abs(part.daughterPDG1()) == 211 || abs(part.daughterPDG2()) == 211) { // At least one decay to Pion
-        pass1 = true;
+      if (collision.isInAfterAllCuts()) // after all event selection
+      {
+        if (part.pdgCode() > 0)
+          histos.fill(HIST("k892Gen"), 2, part.pt(), multiplicity);
+        else
+          histos.fill(HIST("k892GenAnti"), 2, part.pt(), multiplicity);
       }
-      if (!pass1 || !pass2) // If we have both decay products
-        continue;
-      if (part.pdgCode() > 0)
-        histos.fill(HIST("k892Gen"), part.pt(), multiplicity);
-      else
-        histos.fill(HIST("k892GenAnti"), part.pt(), multiplicity);
     }
   }
   PROCESS_SWITCH(k892analysis, processMCTrue, "Process Event for MC (Generated)", false);


### PR DESCRIPTION
It introduces a new table `ResoMCCollisions` to keep the MC event flags.

Resoinitializer now saves the event correction histogram `hMCEventIndices` when we run the MC process.

The analyser can get the event correction factor, such as trigger efficiency from this.

Similarly, the signal loss correction factor can be calculated.