### PR TITLE
PWGHF: add selection on generated PV z position in creators

### DIFF
--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -677,8 +677,8 @@ struct HfCandidateCreator2ProngExpressions {
         for (const auto& option : device.options) {
           if (option.name.compare("zPvPosMax") == 0) {
             zPvPosMax = option.defaultValue.get<float>();
+            break;
           }
-          break;
         }
         break;
       }

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -685,7 +685,8 @@ struct HfCandidateCreator2ProngExpressions {
 
   /// Performs MC matching.
   void processMc(aod::TracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& mcParticles,
+                 aod::McCollisions const&)
   {
     rowCandidateProng2->bindExternalIndices(&tracks);
 
@@ -697,6 +698,7 @@ struct HfCandidateCreator2ProngExpressions {
     // Match reconstructed candidates.
     // Spawned table can be used directly
     for (const auto& candidate : *rowCandidateProng2) {
+
       flag = 0;
       origin = 0;
       auto arrayDaughters = std::array{candidate.prong0_as<aod::TracksWMc>(), candidate.prong1_as<aod::TracksWMc>()};

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -671,14 +671,16 @@ struct HfCandidateCreator2ProngExpressions {
   // inspect for which zPvPosMax cut was set for reconstructed
   void init(InitContext& initContext)
   {
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-2prong") == 0) {
         for (const auto& option : device.options) {
           if (option.name.compare("zPvPosMax") == 0) {
             zPvPosMax = option.defaultValue.get<float>();
           }
+          break;
         }
+        break;
       }
     }
   }

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -504,7 +504,8 @@ struct HfCandidateCreator3ProngExpressions {
 
   /// Performs MC matching.
   void processMc(aod::TracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& mcParticles,
+                 aod::McCollisions const&)
   {
     rowCandidateProng3->bindExternalIndices(&tracks);
 

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -476,7 +476,7 @@ struct HfCandidateCreator3ProngExpressions {
   {
 
     // inspect for which particle species the candidates were created and which zPvPosMax cut was set for reconstructed
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-3prong") == 0) {
         for (const auto& option : device.options) {
@@ -492,6 +492,7 @@ struct HfCandidateCreator3ProngExpressions {
             zPvPosMax = option.defaultValue.get<float>();
           }
         }
+        break;
       }
     }
 

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -470,11 +470,12 @@ struct HfCandidateCreator3ProngExpressions {
   bool createDs{false};
   bool createLc{false};
   bool createXic{false};
+  float zPvPosMax{1000.f};
 
   void init(InitContext& initContext)
   {
 
-    // inspect for which particle species the candidates were created
+    // inspect for which particle species the candidates were created and which zPvPosMax cut was set for reconstructed
     auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-3prong") == 0) {
@@ -487,6 +488,8 @@ struct HfCandidateCreator3ProngExpressions {
             createLc = option.defaultValue.get<bool>();
           } else if (option.name.compare("createXic") == 0) {
             createXic = option.defaultValue.get<bool>();
+          } else if (option.name.compare("zPvPosMax") == 0) {
+            zPvPosMax = option.defaultValue.get<float>();
           }
         }
       }
@@ -617,6 +620,13 @@ struct HfCandidateCreator3ProngExpressions {
       origin = 0;
       channel = 0;
       arrDaughIndex.clear();
+
+      auto mcCollision = particle.mcCollision();
+      float zPv = mcCollision.posZ();
+      if (zPv < -zPvPosMax || zPv > zPvPosMax) { // to avoid counting particles in collisions with Zvtx larger than the maximum, we do not match them
+        rowMcMatchGen(flag, origin, channel);
+        continue;
+      }
 
       // D± → π± K∓ π±
       if (createDplus) {

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -451,7 +451,7 @@ struct HfCandidateCreatorCascadeMc {
   // inspect for which zPvPosMax cut was set for reconstructed
   void init(InitContext& initContext)
   {
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-cascade") == 0) {
         for (const auto& option : device.options) {
@@ -459,6 +459,7 @@ struct HfCandidateCreatorCascadeMc {
             zPvPosMax = option.defaultValue.get<float>();
           }
         }
+        break;
       }
     }
   }

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -464,7 +464,8 @@ struct HfCandidateCreatorCascadeMc {
   }
 
   void processMc(MyTracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& mcParticles,
+                 aod::McCollisions const&)
   {
     int8_t sign = 0;
     int8_t origin = 0;

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -457,6 +457,7 @@ struct HfCandidateCreatorCascadeMc {
         for (const auto& option : device.options) {
           if (option.name.compare("zPvPosMax") == 0) {
             zPvPosMax = option.defaultValue.get<float>();
+            break;
           }
         }
         break;

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -22,6 +22,7 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
 #include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
 #include "ReconstructionDataFormats/DCA.h"
 #include "ReconstructionDataFormats/V0.h"
 
@@ -445,6 +446,22 @@ struct HfCandidateCreatorCascadeMc {
 
   using MyTracksWMc = soa::Join<aod::TracksWCov, aod::McTrackLabels>;
 
+  float zPvPosMax{1000.f};
+
+  // inspect for which zPvPosMax cut was set for reconstructed
+  void init(InitContext& initContext) {
+    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    for (const DeviceSpec& device : workflows.devices) {
+      if (device.name.compare("hf-candidate-creator-cascade") == 0) {
+        for (const auto& option : device.options) {
+          if (option.name.compare("zPvPosMax") == 0) {
+            zPvPosMax = option.defaultValue.get<float>();
+          }
+        }
+      }
+    }
+  }
+
   void processMc(MyTracksWMc const& tracks,
                  aod::McParticles const& mcParticles)
   {
@@ -493,6 +510,14 @@ struct HfCandidateCreatorCascadeMc {
     // Match generated particles.
     for (const auto& particle : mcParticles) {
       origin = 0;
+
+      auto mcCollision = particle.mcCollision();
+      float zPv = mcCollision.posZ();
+      if (zPv < -zPvPosMax || zPv > zPvPosMax) { // to avoid counting particles in collisions with Zvtx larger than the maximum, we do not match them
+        rowMcMatchGen(sign, origin);
+        continue;
+      }
+
       // checking if I have a Lc --> K0S + p
       RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kLambdaCPlus, std::array{+kProton, +kK0Short}, false, &sign, 2);
       if (sign == 0) { // now check for anti-Lc

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -528,6 +528,7 @@ struct HfCandidateCreatorDstarExpressions {
         for (const auto& option : device.options) {
           if (option.name.compare("zPvPosMax") == 0) {
             zPvPosMax = option.defaultValue.get<float>();
+            break;
           }
         }
         break;

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -24,6 +24,7 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
 // O2Physics
 #include "Common/Core/trackUtilities.h"
 // PWGHF
@@ -516,7 +517,21 @@ struct HfCandidateCreatorDstarExpressions {
   Produces<aod::HfCandDstarMcRec> rowsMcMatchRecDstar;
   Produces<aod::HfCandDstarMcGen> rowsMcMatchGenDstar;
 
-  void init(InitContext const&) {}
+  float zPvPosMax{1000.f};
+
+  // inspect for which zPvPosMax cut was set for reconstructed
+  void init(InitContext& initContext) {
+    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    for (const DeviceSpec& device : workflows.devices) {
+      if (device.name.compare("hf-candidate-creator-dstar") == 0) {
+        for (const auto& option : device.options) {
+          if (option.name.compare("zPvPosMax") == 0) {
+            zPvPosMax = option.defaultValue.get<float>();
+          }
+        }
+      }
+    }
+  }
 
   /// Perform MC Matching.
   void processMc(aod::TracksWMc const& tracks,
@@ -575,6 +590,14 @@ struct HfCandidateCreatorDstarExpressions {
       flagD0 = 0;
       originDstar = 0;
       originD0 = 0;
+
+      auto mcCollision = particle.mcCollision();
+      float zPv = mcCollision.posZ();
+      if (zPv < -zPvPosMax || zPv > zPvPosMax) { // to avoid counting particles in collisions with Zvtx larger than the maximum, we do not match them
+        rowsMcMatchGenDstar(flagDstar, originDstar);
+        rowsMcMatchGenD0(flagD0, originD0);
+        continue;
+      }
 
       // D*± → D0(bar) π±
       if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDStar, std::array{+kPiPlus, +kPiPlus, -kKPlus}, true, &signDstar, 2)) {

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -536,7 +536,8 @@ struct HfCandidateCreatorDstarExpressions {
 
   /// Perform MC Matching.
   void processMc(aod::TracksWMc const& tracks,
-                 aod::McParticles const& mcParticles)
+                 aod::McParticles const& mcParticles,
+                 aod::McCollisions const&)
   {
     rowsCandidateD0->bindExternalIndices(&tracks);
     rowsCandidateDstar->bindExternalIndices(&tracks);

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -522,7 +522,7 @@ struct HfCandidateCreatorDstarExpressions {
   // inspect for which zPvPosMax cut was set for reconstructed
   void init(InitContext& initContext)
   {
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-dstar") == 0) {
         for (const auto& option : device.options) {
@@ -530,6 +530,7 @@ struct HfCandidateCreatorDstarExpressions {
             zPvPosMax = option.defaultValue.get<float>();
           }
         }
+        break;
       }
     }
   }

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -24,6 +24,7 @@
 #include "DetectorsVertexing/PVertexer.h"      // for dca recalculation
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
 
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/trackUtilities.h"
@@ -385,8 +386,21 @@ struct HfCandidateSigmac0plusplusMc {
   using LambdacMc = soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>;
   // using LambdacMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
 
+  float zPvPosMax{1000.f};
+
   /// @brief init function
-  void init(InitContext const&) {}
+  void init(InitContext& initContext) {
+    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    for (const DeviceSpec& device : workflows.devices) {
+      if (device.name.compare("hf-candidate-creator-3prong") == 0) { // here we assume that the hf-candidate-creator-3prong is in the workflow
+        for (const auto& option : device.options) {
+          if (option.name.compare("zPvPosMax") == 0) {
+            zPvPosMax = option.defaultValue.get<float>();
+          }
+        }
+      }
+    }
+  }
 
   /// @brief dummy process function, to be run on data
   /// @param
@@ -468,6 +482,13 @@ struct HfCandidateSigmac0plusplusMc {
     for (const auto& particle : mcParticles) {
       flag = 0;
       origin = 0;
+
+      auto mcCollision = particle.mcCollision();
+      float zPv = mcCollision.posZ();
+      if (zPv < -zPvPosMax || zPv > zPvPosMax) { // to avoid counting particles in collisions with Zvtx larger than the maximum, we do not match them
+        rowMCMatchScGen(flag, origin);
+        continue;
+      }
 
       /// 3 levels:
       ///   1. Σc0 → Λc+ π-,+

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -391,7 +391,7 @@ struct HfCandidateSigmac0plusplusMc {
   /// @brief init function
   void init(InitContext& initContext)
   {
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
+    const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-3prong") == 0) { // here we assume that the hf-candidate-creator-3prong is in the workflow
         for (const auto& option : device.options) {
@@ -399,6 +399,7 @@ struct HfCandidateSigmac0plusplusMc {
             zPvPosMax = option.defaultValue.get<float>();
           }
         }
+        break;
       }
     }
   }

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -397,6 +397,7 @@ struct HfCandidateSigmac0plusplusMc {
         for (const auto& option : device.options) {
           if (option.name.compare("zPvPosMax") == 0) {
             zPvPosMax = option.defaultValue.get<float>();
+            break;
           }
         }
         break;

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -412,7 +412,8 @@ struct HfCandidateSigmac0plusplusMc {
   /// @param mcParticles table of generated particles
   void processMc(aod::McParticles const& mcParticles,
                  aod::TracksWMc const& tracks,
-                 LambdacMc const& candsLc /*, const LambdacMcGen&*/)
+                 LambdacMc const& candsLc /*, const LambdacMcGen&*/,
+                 aod::McCollisions const&)
   {
 
     // Match reconstructed candidates.


### PR DESCRIPTION
This PR implements the selection on the generated PV z position. In order to avoid human mistakes, the same value used in the reconstructed part is retrieved by the workflow of the reconstructed part. Not yet implemented for the XiPi creator because no event selection is present for the XiPi creator for the reconstructed part (@ZFederica let me know if you want me to include it).