### PR TITLE
PWGCF: Update femtodream

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -1,4 +1,3 @@
-// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //
@@ -139,6 +138,9 @@ class FemtoDreamParticleHisto
     mHistogramRegistry->add((folderName + folderSuffix + "/hPDG").c_str(), "; PDG; Entries", kTH1I, {{6001, -3000.5, 3000.5}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hOrigin_MC").c_str(), "; Origin; Entries", kTH1I, {{7, -0.5, 6.5}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hNoMCtruthCounter").c_str(), "; Counter; Entries", kTH1I, {{1, -0.5, 0.5}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hPt_DiffTruthReco").c_str(), "; p^{truth}_{T}; (p^{reco}_{T} - p^{truth}_{T}) / p^{truth}_{T}", kTH2F, {tempFitVarpTAxis, {200, -1, 1}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hEta_DiffTruthReco").c_str(), "; #eta^{truth}; #eta^{reco} - #eta^{truth}", kTH2F, {{200, -1, 1}, {200, -1, 1}});
+    mHistogramRegistry->add((folderName + folderSuffix + "/hPhi_DiffTruthReco").c_str(), "; #varphi^{truth}; #varphi^{reco} - #varphi^{truth}", kTH2F, {{720, 0, TMath::TwoPi()}, {200, -1, 1}});
 
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
       /// Track histograms
@@ -398,6 +400,12 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPDG"), pdgcode);
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hOrigin_MC"), mctruthorigin);
 
+      auto MCpart = part.fdMCParticle();
+
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_DiffTruthReco"), MCpart.pt(), (part.pt() - MCpart.pt()) / MCpart.pt());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hEta_DiffTruthReco"), MCpart.eta(), (part.eta() - MCpart.eta()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPhi_DiffTruthReco"), MCpart.phi(), (part.phi() - MCpart.phi()));
+
       if (abs(pdgcode) == mPDG) { // fill this histogramm only for TRUE protons (independently of their origin) for the track purity estimation
         mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST("_MC/hPt_ReconNoFake"), part.pt());
       }
@@ -564,7 +572,6 @@ class FemtoDreamParticleHisto
   template <bool isMC, bool isDebug, typename Tpart>
   void fillQA(Tpart const& part, aod::femtodreamparticle::MomentumType MomemtumType, const int mult, const float cent, bool correlatedPlots = false)
   {
-    std::string tempFitVarName;
     if (mHistogramRegistry) {
       fillQA_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(part, mult);
       if constexpr (isDebug) {

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -1,3 +1,4 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -319,8 +319,8 @@ struct femoDreamCollisionMasker {
   }
 
   // make bitmask for a track for two body task
-  template <typename T, typename R>
-  void MaskForTrack(T& BitSet, CollisionMasks::Parts P, R& track)
+  template <typename T, typename R, typename S>
+  void MaskForTrack(T& BitSet, CollisionMasks::Parts P, R& track, S& counter)
   {
     if (track.partType() != static_cast<uint8_t>(femtodreamparticle::kTrack)) {
       return;
@@ -349,10 +349,12 @@ struct femoDreamCollisionMasker {
         if (track.p() <= TrackPIDThreshold.at(P).at(index)) {
           if ((track.pidcut() & TrackPIDTPCBits.at(P).at(index)) == TrackPIDTPCBits.at(P).at(index) && ((track.pidcut() & TrackPIDTPCBitsReject.at(P).at(index)) == 0u)) {
             BitSet.at(P).set(index);
+            counter.at(P).at(index)++;
           }
         } else {
           if ((track.pidcut() & TrackPIDTPCTOFBits.at(P).at(index)) == TrackPIDTPCTOFBits.at(P).at(index)) {
             BitSet.at(P).set(index);
+            counter.at(P).at(index)++;
           }
         }
       }
@@ -527,20 +529,39 @@ struct femoDreamCollisionMasker {
     // create a bit mask for particle one, particle two and particle three
     std::array<std::bitset<8 * sizeof(femtodreamcollision::BitMaskType)>, CollisionMasks::kNParts> Mask = {{0}};
 
+    // array to keep track of found particles
+    std::array<std::array<int, 8 * sizeof(femtodreamcollision::BitMaskType)>, CollisionMasks::kNParts> FoundParts = {{{0}}};
+
     switch (TaskFinder) {
       case CollisionMasks::kTrackTrack:
         // pair-track-track task
         // create mask for track 1 and track 2
         for (auto const& part : parts) {
-          MaskForTrack(Mask, CollisionMasks::kPartOne, part);
-          MaskForTrack(Mask, CollisionMasks::kPartTwo, part);
+          MaskForTrack(Mask, CollisionMasks::kPartOne, part, FoundParts);
+          MaskForTrack(Mask, CollisionMasks::kPartTwo, part, FoundParts);
         }
+        // check if SameSpecies option is set
+        // if so, only set the bit for kPartTwo to true if there are at least to tracks in the collision that pass the selections
+        // this allows to select only events with at least two particles for the mixing
+        for (size_t index = 0; index < TrackSameSpecies.size(); index++) {
+          if (TrackSameSpecies.at(index) == true) {
+            Mask.at(CollisionMasks::kPartTwo).reset(index);
+            // LOG(warn) <<  "reset mask";
+            //        LOG(warn) << Mask.at(CollisionMasks::kPartTwo).to_string();
+            if (FoundParts.at(CollisionMasks::kPartOne).at(index) >= 2) {
+              Mask.at(CollisionMasks::kPartTwo).set(index);
+              // LOG(warn) <<  "set mask";
+              //        LOG(warn) << Mask.at(CollisionMasks::kPartTwo).to_string();
+            }
+          }
+        }
+
         break;
       case CollisionMasks::kTrackV0:
         // pair-track-v0 task
         // create mask for track 1 and v0 2
         for (auto const& part : parts) {
-          MaskForTrack(Mask, CollisionMasks::kPartOne, part);
+          MaskForTrack(Mask, CollisionMasks::kPartOne, part, FoundParts);
           MaskForV0(Mask, CollisionMasks::kPartTwo, part, parts);
         }
         break;

--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -191,7 +191,9 @@ struct femoDreamCollisionMasker {
         counter++;
         TaskFinder = CollisionMasks::kTrackV0;
         for (auto const& option : device.options) {
-          if (option.name.compare(std::string("Track1.CutBit")) == 0) {
+          if (option.name.compare(std::string("Option.DCACutPtDep")) == 0) {
+            TrackDCACutPtDep.push_back(option.defaultValue.get<bool>());
+          } else if (option.name.compare(std::string("Track1.CutBit")) == 0) {
             TrackCutBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
           } else if (option.name.compare(std::string("Track1.TPCBit")) == 0) {
             TrackPIDTPCBits.at(CollisionMasks::kPartOne).push_back(option.defaultValue.get<femtodreamparticle::cutContainerType>());
@@ -332,7 +334,7 @@ struct femoDreamCollisionMasker {
           track.eta() < FilterEtaMin.at(P).at(index) || track.eta() > FilterEtaMax.at(P).at(index)) {
         // check if we apply pt dependend dca cut
         if (TrackDCACutPtDep.at(index)) {
-          if (std::abs(track.tempFitVar()) > 0.0105f * (0.035 / std::pow(track.pt(), 1.1))) {
+          if (std::fabs(track.tempFitVar()) > 0.0105f * (0.035f / std::pow(track.pt(), 1.1f))) {
             continue;
           }
         } else {
@@ -542,20 +544,15 @@ struct femoDreamCollisionMasker {
         }
         // check if SameSpecies option is set
         // if so, only set the bit for kPartTwo to true if there are at least to tracks in the collision that pass the selections
-        // this allows to select only events with at least two particles for the mixing
+        // this allows to (optionally) select only events with at least two particles for the mixing
         for (size_t index = 0; index < TrackSameSpecies.size(); index++) {
           if (TrackSameSpecies.at(index) == true) {
             Mask.at(CollisionMasks::kPartTwo).reset(index);
-            // LOG(warn) <<  "reset mask";
-            //        LOG(warn) << Mask.at(CollisionMasks::kPartTwo).to_string();
             if (FoundParts.at(CollisionMasks::kPartOne).at(index) >= 2) {
               Mask.at(CollisionMasks::kPartTwo).set(index);
-              // LOG(warn) <<  "set mask";
-              //        LOG(warn) << Mask.at(CollisionMasks::kPartTwo).to_string();
             }
           }
         }
-
         break;
       case CollisionMasks::kTrackV0:
         // pair-track-v0 task
@@ -578,7 +575,7 @@ struct femoDreamCollisionMasker {
         break;
       // TODO: add all supported pair/triplet tasks
       default:
-        LOG(fatal) << "No femtodream pair task found!";
+        LOG(fatal) << "No femtodream task found!";
     }
     // fill bitmask for each collision
     Masks(static_cast<femtodreamcollision::BitMaskType>(Mask.at(CollisionMasks::kPartOne).to_ulong()),

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -512,7 +512,7 @@ struct femtoDreamPairTaskTrackTrack {
       if (Option.SameSpecies.value && Option.MixEventWithPairs.value) {
         // in case of mixing the same species and events that contain pairs, check for bitmask of particle two
         // when same species is set to true the bit of particle two is only set if the event contains at least two selected particles
-        Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo,BitMask) && aod::femtodreamcollision::downsample == true;
+        Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
         PartitionMaskedCol1.bindTable(cols);
         MixEvents(PartitionMaskedCol1);
       } else if (Option.SameSpecies.value && !Option.MixEventWithPairs.value) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -88,7 +88,7 @@ struct femtoDreamPairTaskTrackTrack {
   using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
   using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
 
-  femtodreamcollision::BitMaskType BitMask = -1;
+  femtodreamcollision::BitMaskType BitMask = 0;
 
   /// Track 1
   struct : ConfigurableGroup {
@@ -107,27 +107,29 @@ struct femtoDreamPairTaskTrackTrack {
   } Track1;
 
   /// Partition for particle 1
-  Partition<aod::FDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                              (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
-                                              ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
-                                              (aod::femtodreamparticle::pt > Track1.PtMin) &&
-                                              (aod::femtodreamparticle::pt < Track1.PtMax) &&
-                                              (aod::femtodreamparticle::eta > Track1.EtaMin) &&
-                                              (aod::femtodreamparticle::eta < Track1.EtaMax) &&
-                                              ifnode(Option.DCACutPtDep, nabs(aod::femtodreamparticle::tempFitVar) < 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)),
-                                                     (aod::femtodreamparticle::tempFitVar > Track1.TempFitVarMin) &&
-                                                       (aod::femtodreamparticle::tempFitVar < Track1.TempFitVarMax));
+  Partition<aod::FDParticles> PartitionTrk1 =
+    (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+    (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+    ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+    (aod::femtodreamparticle::pt >= Track1.PtMin) &&
+    (aod::femtodreamparticle::pt <= Track1.PtMax) &&
+    (aod::femtodreamparticle::eta >= Track1.EtaMin) &&
+    (aod::femtodreamparticle::eta <= Track1.EtaMax) &&
+    ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+           ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+            (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
 
-  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                                            (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
-                                                                            ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
-                                                                            (aod::femtodreamparticle::pt > Track1.PtMin) &&
-                                                                            (aod::femtodreamparticle::pt < Track1.PtMax) &&
-                                                                            (aod::femtodreamparticle::eta > Track1.EtaMin) &&
-                                                                            (aod::femtodreamparticle::eta < Track1.EtaMax) &&
-                                                                            ifnode(Option.DCACutPtDep, nabs(aod::femtodreamparticle::tempFitVar) < 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)),
-                                                                                   (aod::femtodreamparticle::tempFitVar > Track1.TempFitVarMin) &&
-                                                                                     (aod::femtodreamparticle::tempFitVar < Track1.TempFitVarMax));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> PartitionMCTrk1 =
+    (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+    (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+    ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+    (aod::femtodreamparticle::pt >= Track1.PtMin) &&
+    (aod::femtodreamparticle::pt <= Track1.PtMax) &&
+    (aod::femtodreamparticle::eta >= Track1.EtaMin) &&
+    (aod::femtodreamparticle::eta < Track1.EtaMax) &&
+    ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+           ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+            (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
@@ -149,27 +151,29 @@ struct femtoDreamPairTaskTrackTrack {
   } Track2;
 
   /// Partition for track 2
-  Partition<aod::FDParticles> PartitionTrk2 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                              (ncheckbit(aod::femtodreamparticle::cut, Track2.CutBit)) &&
-                                              ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track2.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCBit) && ((aod::femtodreamparticle::pidcut & Track2.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCTOFBit)) &&
-                                              (aod::femtodreamparticle::pt > Track2.PtMin) &&
-                                              (aod::femtodreamparticle::pt < Track2.PtMax) &&
-                                              (aod::femtodreamparticle::eta > Track2.EtaMin) &&
-                                              (aod::femtodreamparticle::eta < Track2.EtaMax) &&
-                                              ifnode(Option.DCACutPtDep, nabs(aod::femtodreamparticle::tempFitVar) < 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)),
-                                                     (aod::femtodreamparticle::tempFitVar > Track2.TempFitVarMin) &&
-                                                       (aod::femtodreamparticle::tempFitVar < Track2.TempFitVarMax));
+  Partition<aod::FDParticles> PartitionTrk2 =
+    (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+    (ncheckbit(aod::femtodreamparticle::cut, Track2.CutBit)) &&
+    ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track2.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCBit) && ((aod::femtodreamparticle::pidcut & Track2.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCTOFBit)) &&
+    (aod::femtodreamparticle::pt >= Track2.PtMin) &&
+    (aod::femtodreamparticle::pt <= Track2.PtMax) &&
+    (aod::femtodreamparticle::eta >= Track2.EtaMin) &&
+    (aod::femtodreamparticle::eta <= Track2.EtaMax) &&
+    ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+           ((aod::femtodreamparticle::tempFitVar >= Track2.TempFitVarMin) &&
+            (aod::femtodreamparticle::tempFitVar <= Track2.TempFitVarMax)));
 
-  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> PartitionMCTrk2 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                                            (ncheckbit(aod::femtodreamparticle::cut, Track2.CutBit)) &&
-                                                                            ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track2.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCBit) && ((aod::femtodreamparticle::pidcut & Track2.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCTOFBit)) &&
-                                                                            (aod::femtodreamparticle::pt > Track2.PtMin) &&
-                                                                            (aod::femtodreamparticle::pt < Track2.PtMax) &&
-                                                                            (aod::femtodreamparticle::eta > Track2.EtaMin) &&
-                                                                            (aod::femtodreamparticle::eta < Track2.EtaMax) &&
-                                                                            ifnode(Option.DCACutPtDep, nabs(aod::femtodreamparticle::tempFitVar) < 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)),
-                                                                                   (aod::femtodreamparticle::tempFitVar > Track2.TempFitVarMin) &&
-                                                                                     (aod::femtodreamparticle::tempFitVar < Track2.TempFitVarMax));
+  Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> PartitionMCTrk2 =
+    (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+    (ncheckbit(aod::femtodreamparticle::cut, Track2.CutBit)) &&
+    ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track2.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCBit) && ((aod::femtodreamparticle::pidcut & Track2.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track2.TPCTOFBit)) &&
+    (aod::femtodreamparticle::pt >= Track2.PtMin) &&
+    (aod::femtodreamparticle::pt <= Track2.PtMax) &&
+    (aod::femtodreamparticle::eta > Track2.EtaMin) &&
+    (aod::femtodreamparticle::eta < Track2.EtaMax) &&
+    ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+           ((aod::femtodreamparticle::tempFitVar >= Track2.TempFitVarMin) &&
+            (aod::femtodreamparticle::tempFitVar <= Track2.TempFitVarMax)));
 
   /// Histogramming for track 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 2> trackHistoPartTwo;
@@ -388,7 +392,7 @@ struct femtoDreamPairTaskTrackTrack {
         return;
       }
     } else {
-      if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
         return;
       }
     }
@@ -460,7 +464,7 @@ struct femtoDreamPairTaskTrackTrack {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType& cols, PartType& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    if (!Option.SameSpecies.value && !Option.MixEventWithPairs) {
+    if (!Option.SameSpecies.value && !Option.MixEventWithPairs.value) {
       // If the two particles are not the same species and the events which are mixed should contain at least one particle of interest, create two paritition of collisions that contain at least one of the two particle of interest and mix them
       // Make sure there is a check that we do not mix a event with itself in case it contains both partilces
       Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
@@ -470,13 +474,14 @@ struct femtoDreamPairTaskTrackTrack {
       // use *Partition.mFiltered when passing the partition to mixing object
       // there is an issue when the partition is passed directly
       // workaround for now, change back once it is fixed
-      for (auto const& [collision1, collision2] : combinations(soa::CombinationsFullIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
+      for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
         // make sure that tracks in the same events are not mixed
         if (collision1.globalIndex() == collision2.globalIndex()) {
           continue;
         }
         auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
         auto SliceTrk2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+
         for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceTrk2))) {
           if (Option.CPROn.value) {
             if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
@@ -487,34 +492,39 @@ struct femtoDreamPairTaskTrackTrack {
         }
       }
     } else {
-      // Option 2: The two particles are not the same species and we do not mix event with pairs, in this case we only need to define one partition of collision and make self combinations
-      // Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask  && (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask&& aod::femtodreamcollision::downsample == true;
-      Partition<CollisionType> PartitionMaskedCol1 =
-        (ifnode(Option.SameSpecies && Option.MixEventWithPairs, (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask, false) ||
-         ifnode(Option.SameSpecies && !Option.MixEventWithPairs, (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask, false) ||
-         ifnode(!Option.SameSpecies && Option.MixEventWithPairs, (aod::femtodreamcollision::bitmaskTrackOne & BitMask && (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask), false)) &&
-        aod::femtodreamcollision::downsample == true;
-      PartitionMaskedCol1.bindTable(cols);
-      // use *Partition.mFiltered when passing the partition to mixing object
-      // there is an issue when the partition is passed directly
-      // workaround for now, change back once it is fixed
-      for (auto const& [collision1, collision2] : selfCombinations(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol1.mFiltered)) {
-        // selfCombinations policy should not allow for same events to be mixed
-        // print a warning to be on the safe side
-        if (collision1.globalIndex() == collision2.globalIndex()) {
-          LOG(warn) << "Global Collision index " << collision1.globalIndex() << " clashing!";
-          continue;
-        }
-        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-        auto SliceTrk2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
-        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceTrk2))) {
-          if (Option.CPROn.value) {
-            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
-              continue;
+      // In the other case where the two particles are not the same species and we do not mix event with pairs,  we only need to define one partition of collisions and make self combinations
+
+      // define a lambda function for the mixing with selfCombinations policy
+      auto MixEvents = [policy, &part1, &part2, parts, this](auto& partition) {
+        for (auto const& [collision1, collision2] : selfCombinations(policy, Mixing.Depth.value, -1, *partition.mFiltered, *partition.mFiltered)) {
+          auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+          auto SliceTrk2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+          for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceTrk2))) {
+            if (Option.CPROn.value) {
+              if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+                continue;
+              }
             }
+            mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D.value, Option.ExtendedPlots.value, Option.SmearingByOrigin.value);
           }
-          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.SmearingByOrigin);
         }
+      };
+      if (Option.SameSpecies.value && Option.MixEventWithPairs.value) {
+        // in case of mixing the same species and events that contain pairs, check for bitmask of particle two
+        // when same species is set to true the bit of particle two is only set if the event contains at least two selected particles
+        Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo,BitMask) && aod::femtodreamcollision::downsample == true;
+        PartitionMaskedCol1.bindTable(cols);
+        MixEvents(PartitionMaskedCol1);
+      } else if (Option.SameSpecies.value && !Option.MixEventWithPairs.value) {
+        // in case of mixing the same species and events that contain at least one selected paritcle, check for bitmask of particle one
+        Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && aod::femtodreamcollision::downsample == true;
+        PartitionMaskedCol1.bindTable(cols);
+        MixEvents(PartitionMaskedCol1);
+      } else if (!Option.SameSpecies.value && Option.MixEventWithPairs.value) {
+        // in case of mixing different species and events that contain a pair of selected paritcles, check for both bitmasks of paritcle one and particle two
+        Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
+        PartitionMaskedCol1.bindTable(cols);
+        MixEvents(PartitionMaskedCol1);
       }
     }
   }

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -54,6 +54,8 @@ struct femtoDreamPairTaskTrackV0 {
     Configurable<bool> CPRPlotPerRadii{"Option.CPRPlotPerRadii", false, "Plot CPR per radii"};
     Configurable<float> CPRdeltaPhiMax{"Option.CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
     Configurable<float> CPRdeltaEtaMax{"Option.CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+    Configurable<bool> DCACutPtDep{"Option.DCACutPtDep", false, "Use pt dependent dca cut"};
+    Configurable<bool> MixEventWithPairs{"Option.MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
     Configurable<bool> smearingByOrigin{"Option.smearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption. Use with care!"};
     ConfigurableAxis Dummy{"Option.Dummy", {1, 0, 1}, "Dummy axis"};
   } Option;
@@ -74,7 +76,7 @@ struct femtoDreamPairTaskTrackV0 {
   using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
   using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
 
-  femtodreamcollision::BitMaskType BitMask = -1;
+  femtodreamcollision::BitMaskType BitMask = 1;
 
   /// Particle 1 (track)
   struct : ConfigurableGroup {
@@ -96,8 +98,9 @@ struct femtoDreamPairTaskTrackV0 {
   Filter trackPtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt < Track1.PtMax, true);
   Filter trackEtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta > Track1.EtaMin, true);
   Filter trackEtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta < Track1.EtaMax, true);
-  Filter trackTempFitVarFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar > Track1.TempFitVarMin, true);
-  Filter trackTempFitVarFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar < Track1.TempFitVarMax, true);
+  Filter trackTempFitVarFilterUp = !Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar > Track1.TempFitVarMin, true);
+  Filter trackTempFitVarFilterLow = !Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar < Track1.TempFitVarMax, true);
+  Filter trackTempFitVarFilterPtDep = Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)), true);
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
@@ -330,7 +333,7 @@ struct femtoDreamPairTaskTrackV0 {
 
   void processSameEventMasked(FilteredMaskedCollision const& col, FilteredFDParticles const& parts)
   {
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
     }
     eventHisto.fillQA<false>(col);
@@ -355,40 +358,77 @@ struct femtoDreamPairTaskTrackV0 {
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
-    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask && aod::femtodreamcollision::downsample == true;
-    PartitionMaskedCol1.bindTable(cols);
-    PartitionMaskedCol2.bindTable(cols);
 
-    // use *Partition.mFiltered when passing the partition to mixing object
-    // there is an issue when the partition is passed directly
-    // workaround for now, change back once it is fixed
-    for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
-      // make sure that tracks in same events are not mixed
-      if (collision1.globalIndex() == collision2.globalIndex()) {
-        continue;
-      }
-      auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-      auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
-      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
-        const auto& posChild = parts.iteratorAt(p2.index() - 2);
-        const auto& negChild = parts.iteratorAt(p2.index() - 1);
-        // check cuts on V0 children
-        if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
-            ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
-            ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
-            ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
+    if (Option.MixEventWithPairs.value) {
+      Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
+      PartitionMaskedCol.bindTable(cols);
+      // use *Partition.mFiltered when passing the partition to mixing object
+      // there is an issue when the partition is passed directly
+      // workaround for now, change back once it is fixed
+      for (auto const& [collision1, collision2] : selfCombinations(policy, Mixing.Depth.value, -1, *PartitionMaskedCol.mFiltered, *PartitionMaskedCol.mFiltered)) {
+        // make sure that tracks in same events are not mixed
+        if (collision1.globalIndex() == collision2.globalIndex()) {
           continue;
         }
-        if (Option.CPROn.value) {
-          if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+          const auto& posChild = parts.iteratorAt(p2.index() - 2);
+          const auto& negChild = parts.iteratorAt(p2.index() - 1);
+          // check cuts on V0 children
+          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
             continue;
           }
+          if (Option.CPROn.value) {
+            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+              continue;
+            }
+          }
+          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+            continue;
+          }
+          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
         }
-        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+      }
+    } else {
+      Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && aod::femtodreamcollision::downsample == true;
+      Partition<CollisionType> PartitionMaskedCol2 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
+      PartitionMaskedCol1.bindTable(cols);
+      PartitionMaskedCol2.bindTable(cols);
+
+      // use *Partition.mFiltered when passing the partition to mixing object
+      // there is an issue when the partition is passed directly
+      // workaround for now, change back once it is fixed
+      for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
+        // make sure that tracks in same events are not mixed
+        if (collision1.globalIndex() == collision2.globalIndex()) {
           continue;
         }
-        mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+          const auto& posChild = parts.iteratorAt(p2.index() - 2);
+          const auto& negChild = parts.iteratorAt(p2.index() - 1);
+          // check cuts on V0 children
+          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
+            continue;
+          }
+          if (Option.CPROn.value) {
+            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+              continue;
+            }
+          }
+          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+            continue;
+          }
+          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+        }
       }
     }
   }


### PR DESCRIPTION
- Add the option to only select collisions that contain a particle pair in the track-track and track-v0 pair task
- Add option for pT dependent DCAxy cut in pair track-v0 task
- Add debug histogram to plot the difference between pT, eta, and phi of generated and reconstructed particle