### PR TITLE
PWGCF: FemtoUniverse -- applied globalIndex on V0 daughters for mixed events only

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -181,8 +181,8 @@ class FemtoUniverseDetaDphiStar
 
       bool pass = false;
       for (int i = 0; i < 2; i++) {
-        auto indexOfDaughter = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part2.globalIndex():part2.index()) - 2 + i;
-        //auto indexOfDaughter = part2.globalIndex() - 2 + i;
+        auto indexOfDaughter = (ChosenEventType == femtoUniverseContainer::EventType::mixed ? part2.globalIndex() : part2.index()) - 2 + i;
+        // auto indexOfDaughter = part2.globalIndex() - 2 + i;
         auto daughter = particles.begin() + indexOfDaughter;
         auto deta = part1.eta() - daughter.eta();
         auto dphiAvg = AveragePhiStar(part1, *daughter, i);
@@ -218,10 +218,10 @@ class FemtoUniverseDetaDphiStar
 
       bool pass = false;
       for (int i = 0; i < 2; i++) {
-        auto indexOfDaughterpart1 = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part1.globalIndex():part1.index()) - 2 + i;
-        auto indexOfDaughterpart2 = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part2.globalIndex():part2.index()) - 2 + i;
-        //auto indexOfDaughterpart1 = part1.globalIndex() - 2 + i;
-        //auto indexOfDaughterpart2 = part2.globalIndex() - 2 + i;
+        auto indexOfDaughterpart1 = (ChosenEventType == femtoUniverseContainer::EventType::mixed ? part1.globalIndex() : part1.index()) - 2 + i;
+        auto indexOfDaughterpart2 = (ChosenEventType == femtoUniverseContainer::EventType::mixed ? part2.globalIndex() : part2.index()) - 2 + i;
+        // auto indexOfDaughterpart1 = part1.globalIndex() - 2 + i;
+        // auto indexOfDaughterpart2 = part2.globalIndex() - 2 + i;
         auto daughterpart1 = particles.begin() + indexOfDaughterpart1;
         auto daughterpart2 = particles.begin() + indexOfDaughterpart2;
         auto deta = daughterpart1.eta() - daughterpart2.eta();

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -181,7 +181,8 @@ class FemtoUniverseDetaDphiStar
 
       bool pass = false;
       for (int i = 0; i < 2; i++) {
-        auto indexOfDaughter = part2.globalIndex() - 2 + i;
+        auto indexOfDaughter = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part2.globalIndex():part2.index()) - 2 + i;
+        //auto indexOfDaughter = part2.globalIndex() - 2 + i;
         auto daughter = particles.begin() + indexOfDaughter;
         auto deta = part1.eta() - daughter.eta();
         auto dphiAvg = AveragePhiStar(part1, *daughter, i);
@@ -217,8 +218,10 @@ class FemtoUniverseDetaDphiStar
 
       bool pass = false;
       for (int i = 0; i < 2; i++) {
-        auto indexOfDaughterpart1 = part1.globalIndex() - 2 + i;
-        auto indexOfDaughterpart2 = part2.globalIndex() - 2 + i;
+        auto indexOfDaughterpart1 = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part1.globalIndex():part1.index()) - 2 + i;
+        auto indexOfDaughterpart2 = (ChosenEventType == femtoUniverseContainer::EventType::mixed?part2.globalIndex():part2.index()) - 2 + i;
+        //auto indexOfDaughterpart1 = part1.globalIndex() - 2 + i;
+        //auto indexOfDaughterpart2 = part2.globalIndex() - 2 + i;
         auto daughterpart1 = particles.begin() + indexOfDaughterpart1;
         auto daughterpart2 = particles.begin() + indexOfDaughterpart2;
         auto deta = daughterpart1.eta() - daughterpart2.eta();

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -214,8 +214,8 @@ struct femtoUniversePairTaskTrackV0Extended {
 
     /// Histogramming same event
     for (auto& part : groupPartsTwo) {
-      const auto& posChild = parts.iteratorAt(part.globalIndex() - 2);
-      const auto& negChild = parts.iteratorAt(part.globalIndex() - 1);
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
       /// Daughters that do not pass this condition are not selected
       if (!IsParticleTPC(posChild, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild, V0ChildTable[ConfV0Type1][1]))
         continue;
@@ -257,8 +257,8 @@ struct femtoUniversePairTaskTrackV0Extended {
       /// PID using stored binned nsigma
       if (!IsParticleCombined(p1, ConfTrackChoicePartOne))
         continue;
-      const auto& posChild = parts.iteratorAt(p2.globalIndex() - 2);
-      const auto& negChild = parts.iteratorAt(p2.globalIndex() - 1);
+      const auto& posChild = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild = parts.iteratorAt(p2.index() - 1);
 
       /// Daughters that do not pass this condition are not selected
       if (!IsParticleTPC(posChild, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild, V0ChildTable[ConfV0Type1][1]))
@@ -282,8 +282,8 @@ struct femtoUniversePairTaskTrackV0Extended {
 
     /// Histogramming same event
     for (auto& part : groupPartsTwo) {
-      const auto& posChild = parts.iteratorAt(part.globalIndex() - 2);
-      const auto& negChild = parts.iteratorAt(part.globalIndex() - 1);
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
 
       /// Check daughters of first V0 particle
       if (IsParticleTPC(posChild, V0ChildTable[ConfV0Type1][0]) && IsParticleTPC(negChild, V0ChildTable[ConfV0Type1][1])) {
@@ -310,14 +310,14 @@ struct femtoUniversePairTaskTrackV0Extended {
           continue;
         }
       }
-      const auto& posChild1 = parts.iteratorAt(p1.globalIndex() - 2);
-      const auto& negChild1 = parts.iteratorAt(p1.globalIndex() - 1);
+      const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
+      const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
       /// Daughters that do not pass this condition are not selected
       if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
         continue;
 
-      const auto& posChild2 = parts.iteratorAt(p2.globalIndex() - 2);
-      const auto& negChild2 = parts.iteratorAt(p2.globalIndex() - 1);
+      const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
       /// Daughters that do not pass this condition are not selected
       if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
         continue;


### PR DESCRIPTION
-isClosePair for track-V0 and V0-V0 now checks for mixed events and then applies globalIndex for V0 daughters
-Task also applies globalIndex for V0 daughters in case of mixed events only