### PR TITLE
PWGLF: add found tag in findable exercise

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -703,12 +703,12 @@ DECLARE_SOA_TABLE(V0MCRefs, "AOD", "V0MCREF", //! index table when using AO2Ds
 using V0sLinked = soa::Join<V0s, V0DataLink>;
 using V0Linked = V0sLinked::iterator;
 
-namespace v0data 
+namespace v0data
 {
 DECLARE_SOA_COLUMN(IsFound, isFound, bool); //! is this FindableV0 actually in the V0s table?
 }
 
-// Major bypass for simultaneous found vs findable study 
+// Major bypass for simultaneous found vs findable study
 DECLARE_SOA_TABLE(FindableV0s, "AOD", "FindableV0", //! Will store findable
                   o2::soa::Index<>, v0::CollisionId,
                   v0::PosTrackId, v0::NegTrackId,
@@ -718,7 +718,7 @@ DECLARE_SOA_TABLE(FindableV0s, "AOD", "FindableV0", //! Will store findable
                   v0::IsCollinearV0<v0::V0Type>,
                   o2::soa::Marker<1>);
 
-DECLARE_SOA_TABLE(V0FoundTags, "AOD", "V0FoundTag", //! found or not? 
+DECLARE_SOA_TABLE(V0FoundTags, "AOD", "V0FoundTag", //! found or not?
                   v0data::IsFound);
 
 using FindableV0sLinked = soa::Join<FindableV0s, V0DataLink>;
@@ -1260,16 +1260,16 @@ using CascadeLinked = CascadesLinked::iterator;
 using KFCascadesLinked = soa::Join<Cascades, KFCascDataLink>;
 using KFCascadeLinked = KFCascadesLinked::iterator;
 
-namespace cascdata 
+namespace cascdata
 {
-DECLARE_SOA_INDEX_COLUMN(FindableV0, findableV0);                                   //! V0 index
-DECLARE_SOA_COLUMN(IsFound, isFound, bool); //! is this FindableCascade actually in the Cascades table?
-}
+DECLARE_SOA_INDEX_COLUMN(FindableV0, findableV0); //! V0 index
+DECLARE_SOA_COLUMN(IsFound, isFound, bool);       //! is this FindableCascade actually in the Cascades table?
+} // namespace cascdata
 
 DECLARE_SOA_TABLE(FindableCascades, "AOD", "FINDABLECASCS", //! Run 3 cascade table
-                            o2::soa::Index<>, cascade::CollisionId, cascdata::FindableV0Id, cascade::BachelorId, o2::soa::Marker<1>);
+                  o2::soa::Index<>, cascade::CollisionId, cascdata::FindableV0Id, cascade::BachelorId, o2::soa::Marker<1>);
 
-DECLARE_SOA_TABLE(CascFoundTags, "AOD", "CascFoundTag", //! found or not? 
+DECLARE_SOA_TABLE(CascFoundTags, "AOD", "CascFoundTag", //! found or not?
                   cascdata::IsFound);
 
 using FindableCascadesLinked = soa::Join<FindableCascades, CascDataLink>;

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -1262,11 +1262,12 @@ using KFCascadeLinked = KFCascadesLinked::iterator;
 
 namespace cascdata 
 {
+DECLARE_SOA_INDEX_COLUMN(FindableV0, findableV0);                                   //! V0 index
 DECLARE_SOA_COLUMN(IsFound, isFound, bool); //! is this FindableCascade actually in the Cascades table?
 }
 
 DECLARE_SOA_TABLE(FindableCascades, "AOD", "FINDABLECASCS", //! Run 3 cascade table
-                            o2::soa::Index<>, cascade::CollisionId, cascade::V0Id, cascade::BachelorId, o2::soa::Marker<1>);
+                            o2::soa::Index<>, cascade::CollisionId, cascdata::FindableV0Id, cascade::BachelorId, o2::soa::Marker<1>);
 
 DECLARE_SOA_TABLE(CascFoundTags, "AOD", "CascFoundTag", //! found or not? 
                   cascdata::IsFound);

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -693,12 +693,15 @@ namespace v0data
 DECLARE_SOA_INDEX_COLUMN(V0Data, v0Data);                         //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN(V0fCData, v0fCData);                     //! Index to V0Data entry
 DECLARE_SOA_INDEX_COLUMN_FULL(V0MC, v0MC, int, V0MCCores, "_MC"); //!
+DECLARE_SOA_INDEX_COLUMN(V0MCCore, v0MCCore);
 } // namespace v0data
 
 DECLARE_SOA_TABLE(V0DataLink, "AOD", "V0DATALINK", //! Joinable table with V0s which links to V0Data which is not produced for all entries
                   o2::soa::Index<>, v0data::V0DataId, v0data::V0fCDataId);
 DECLARE_SOA_TABLE(V0MCRefs, "AOD", "V0MCREF", //! index table when using AO2Ds
                   o2::soa::Index<>, v0data::V0MCId);
+DECLARE_SOA_TABLE(V0CoreMCLabels, "AOD", "V0COREMCLABEL", //! optional table to refer to V0MCCores if not joinable
+                  o2::soa::Index<>, v0data::V0MCCoreId);
 
 using V0sLinked = soa::Join<V0s, V0DataLink>;
 using V0Linked = V0sLinked::iterator;

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -703,6 +703,27 @@ DECLARE_SOA_TABLE(V0MCRefs, "AOD", "V0MCREF", //! index table when using AO2Ds
 using V0sLinked = soa::Join<V0s, V0DataLink>;
 using V0Linked = V0sLinked::iterator;
 
+namespace v0data 
+{
+DECLARE_SOA_COLUMN(IsFound, isFound, bool); //! is this FindableV0 actually in the V0s table?
+}
+
+// Major bypass for simultaneous found vs findable study 
+DECLARE_SOA_TABLE(FindableV0s, "AOD", "FindableV0", //! Will store findable
+                  o2::soa::Index<>, v0::CollisionId,
+                  v0::PosTrackId, v0::NegTrackId,
+                  v0::V0Type,
+                  v0::IsStandardV0<v0::V0Type>,
+                  v0::IsPhotonV0<v0::V0Type>,
+                  v0::IsCollinearV0<v0::V0Type>,
+                  o2::soa::Marker<1>);
+
+DECLARE_SOA_TABLE(V0FoundTags, "AOD", "V0FoundTag", //! found or not? 
+                  v0data::IsFound);
+
+using FindableV0sLinked = soa::Join<FindableV0s, V0DataLink>;
+using FindableV0Linked = FindableV0sLinked::iterator;
+
 // helper for building
 namespace v0tag
 {
@@ -1238,6 +1259,20 @@ using CascadesLinked = soa::Join<Cascades, CascDataLink>;
 using CascadeLinked = CascadesLinked::iterator;
 using KFCascadesLinked = soa::Join<Cascades, KFCascDataLink>;
 using KFCascadeLinked = KFCascadesLinked::iterator;
+
+namespace cascdata 
+{
+DECLARE_SOA_COLUMN(IsFound, isFound, bool); //! is this FindableCascade actually in the Cascades table?
+}
+
+DECLARE_SOA_TABLE(FindableCascades, "AOD", "FINDABLECASCS", //! Run 3 cascade table
+                            o2::soa::Index<>, cascade::CollisionId, cascade::V0Id, cascade::BachelorId, o2::soa::Marker<1>);
+
+DECLARE_SOA_TABLE(CascFoundTags, "AOD", "CascFoundTag", //! found or not? 
+                  cascdata::IsFound);
+
+using FindableCascadesLinked = soa::Join<FindableCascades, CascDataLink>;
+using FindableCascadeLinked = FindableCascadesLinked::iterator;
 
 namespace casctag
 {

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -1904,7 +1904,7 @@ struct cascadeBuilder {
       buildStrangenessTables<FullTracksExtIU>(CascadeTable_thisCollision);
     }
   }
-  PROCESS_SWITCH(cascadeBuilder, processFindableRun3, "Produce Run 3 findable cascade tables", true);
+  PROCESS_SWITCH(cascadeBuilder, processFindableRun3, "Produce Run 3 findable cascade tables", false);
 
   void processRun3withKFParticle(aod::Collisions const& collisions, soa::Filtered<TaggedCascades> const& cascades, FullTracksExtIU const&, aod::BCsWithTimestamps const&, aod::V0s const&)
   {

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -1525,7 +1525,8 @@ struct cascadeBuilder {
   }
 
   template <class TTrackTo, typename TV0Index, typename TCascade>
-  void processCascadeCandidate(TV0Index const& v0index, TCascade const& cascade){
+  void processCascadeCandidate(TV0Index const& v0index, TCascade const& cascade)
+  {
     bool validCascadeCandidate = false;
     if (v0index.has_v0Data()) {
       // this V0 passed both standard V0 and cascade V0 selections
@@ -1549,17 +1550,17 @@ struct cascadeBuilder {
             cascadecandidate.positiveId, cascadecandidate.negativeId,
             cascadecandidate.bachelorId, cascade.collisionId());
     cascdata(cascadecandidate.charge, cascadecandidate.mXi, cascadecandidate.mOmega,
-              cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
-              cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
-              cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
-              cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
-              cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
-              cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
-              cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
-              cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
-              cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
-              cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
-              cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
+             cascadecandidate.pos[0], cascadecandidate.pos[1], cascadecandidate.pos[2],
+             cascadecandidate.v0pos[0], cascadecandidate.v0pos[1], cascadecandidate.v0pos[2],
+             cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
+             cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
+             cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
+             cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
+             cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
+             cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
+             cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
+             cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
+             cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available
     if (createCascTrackXs) {
       cascTrackXs(cascadecandidate.positiveX, cascadecandidate.negativeX, cascadecandidate.bachelorX);
     }
@@ -1599,7 +1600,7 @@ struct cascadeBuilder {
     for (auto& cascade : cascades) {
       // de-reference from V0 pool, either specific for cascades or general
       // use templatizing to avoid code duplication
-      
+
       auto v0index = cascade.template v0_as<aod::V0sLinked>();
       processCascadeCandidate<TTrackTo>(v0index, cascade);
     }
@@ -1615,7 +1616,7 @@ struct cascadeBuilder {
     for (auto& cascade : cascades) {
       // de-reference from V0 pool, either specific for cascades or general
       // use templatizing to avoid code duplication
-      
+
       auto v0index = cascade.template findableV0_as<aod::FindableV0sLinked>();
       processCascadeCandidate<TTrackTo>(v0index, cascade);
     }
@@ -2007,7 +2008,7 @@ struct cascadePreselector {
 
   void init(InitContext const&)
   {
-    //check settings and stop if not viable
+    // check settings and stop if not viable
     if (doprocessBuildAll == false && doprocessBuildMCAssociated == false && doprocessBuildValiddEdx == false && doprocessBuildValiddEdxMCAssociated == false && doprocessBuildFindable == false) {
       LOGF(fatal, "No processBuild function enabled. Please choose one.");
     }
@@ -2344,7 +2345,7 @@ struct cascadeLinkBuilder {
     }
   }
 
-    // build Cascade -> CascData link table
+  // build Cascade -> CascData link table
   void processFindable(aod::FindableCascades const& casctable, aod::CascDatas const& cascdatatable)
   {
     std::vector<int> lIndices;

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -107,27 +107,29 @@ struct cascademcbuilder {
 
                 // if we got to this level, it means the mother particle exists and is the same
                 // now we have to go one level up and compare to the bachelor mother too
-                for (auto& lV0Mother : lNegMother.template mothers_as<aod::McParticles>()) {
-                  for (auto& lBachMother : lMCBachTrack.template mothers_as<aod::McParticles>()) {
-                    if (lV0Mother == lBachMother) {
-                      lLabel = lV0Mother.globalIndex();
-                      pdgCode = lV0Mother.pdgCode();
-                      isPhysicalPrimary = lV0Mother.isPhysicalPrimary();
-                      xmc = lMCBachTrack.vx();
-                      ymc = lMCBachTrack.vy();
-                      zmc = lMCBachTrack.vz();
-                      px = lV0Mother.px();
-                      py = lV0Mother.py();
-                      pz = lV0Mother.pz();
-                      if (lV0Mother.has_mothers()) {
-                        for (auto& lV0GrandMother : lV0Mother.template mothers_as<aod::McParticles>()) {
-                          pdgCodeMother = lV0GrandMother.pdgCode();
-                          lMotherLabel = lV0GrandMother.globalIndex();
+                if (lNegMother.has_mothers() && lMCBachTrack.has_mothers()) {
+                  for (auto& lV0Mother : lNegMother.template mothers_as<aod::McParticles>()) {
+                    for (auto& lBachMother : lMCBachTrack.template mothers_as<aod::McParticles>()) {
+                      if (lV0Mother == lBachMother) {
+                        lLabel = lV0Mother.globalIndex();
+                        pdgCode = lV0Mother.pdgCode();
+                        isPhysicalPrimary = lV0Mother.isPhysicalPrimary();
+                        xmc = lMCBachTrack.vx();
+                        ymc = lMCBachTrack.vy();
+                        zmc = lMCBachTrack.vz();
+                        px = lV0Mother.px();
+                        py = lV0Mother.py();
+                        pz = lV0Mother.pz();
+                        if (lV0Mother.has_mothers()) {
+                          for (auto& lV0GrandMother : lV0Mother.template mothers_as<aod::McParticles>()) {
+                            pdgCodeMother = lV0GrandMother.pdgCode();
+                            lMotherLabel = lV0GrandMother.globalIndex();
+                          }
                         }
                       }
                     }
-                  }
-                } // end conditional V0-bach pair
+                  } // end conditional V0-bach pair
+                } // end has mothers
               }   // end neg = pos mother conditional
             }
           } // end loop neg/pos mothers

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -56,7 +56,8 @@ struct cascademcbuilder {
   void init(InitContext const&) {}
 
   template <typename TCascadeTable>
-  void generateCascadeMCinfo(TCascadeTable cascTable){
+  void generateCascadeMCinfo(TCascadeTable cascTable)
+  {
     for (auto& casc : cascTable) {
       int pdgCode = -1, pdgCodeMother = -1;
       int pdgCodePositive = -1, pdgCodeNegative = -1, pdgCodeBachelor = -1, pdgCodeV0 = -1;
@@ -129,7 +130,7 @@ struct cascademcbuilder {
                       }
                     }
                   } // end conditional V0-bach pair
-                } // end has mothers
+                }   // end has mothers
               }   // end neg = pos mother conditional
             }
           } // end loop neg/pos mothers

--- a/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
@@ -62,11 +62,12 @@ using namespace o2::framework::expressions;
 using std::array;
 using namespace ROOT::Math;
 
+// WARNING: the cascade findable uses findable V0s as well 
 using LabeledTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels>;
-using LabeledFullV0s = soa::Join<aod::V0s, aod::McFullV0Labels>;
+using LabeledFullV0s = soa::Join<aod::FindableV0s, aod::McFullV0Labels>;
 
 struct cascademcfinder {
-  Produces<aod::Cascades> cascades;
+  Produces<aod::FindableCascades> cascades;
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 

--- a/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
@@ -62,7 +62,7 @@ using namespace o2::framework::expressions;
 using std::array;
 using namespace ROOT::Math;
 
-// WARNING: the cascade findable uses findable V0s as well 
+// WARNING: the cascade findable uses findable V0s as well
 using LabeledTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels>;
 using LabeledFullV0s = soa::Join<aod::FindableV0s, aod::McFullV0Labels>;
 

--- a/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
@@ -56,7 +56,6 @@
 #include <TPDGCode.h>
 #include <TDatabasePDG.h>
 
-
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;

--- a/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
@@ -24,6 +24,11 @@
 //    david.dobrigkeit.chinellato@cern.ch
 //
 
+#include <Math/Vector4D.h>
+#include <cmath>
+#include <array>
+#include <cstdlib>
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -40,7 +45,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Centrality.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "CCDB/BasicCCDBManager.h"
 
@@ -49,12 +53,9 @@
 #include <TH1F.h>
 #include <TH2F.h>
 #include <TProfile.h>
-#include <Math/Vector4D.h>
 #include <TPDGCode.h>
 #include <TDatabasePDG.h>
-#include <cmath>
-#include <array>
-#include <cstdlib>
+
 
 using namespace o2;
 using namespace o2::framework;
@@ -90,8 +91,8 @@ struct cascademcfinder {
   void init(InitContext&)
   {
     // initialize histograms
-    const AxisSpec axisNTimesCollRecoed{(int)10, -0.5f, +9.5f, ""};
-    const AxisSpec axisPt{(int)100, +0.0f, +10.0f, "p_{T} (GeV/c)"};
+    const AxisSpec axisNTimesCollRecoed{static_cast<int>(10), -0.5f, +9.5f, ""};
+    const AxisSpec axisPt{static_cast<int>(100), +0.0f, +10.0f, "p_{T} (GeV/c)"};
 
     histos.add("hNTimesCollRecoed", "hNTimesCollRecoed", kTH1F, {axisNTimesCollRecoed});
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
@@ -1363,7 +1363,7 @@ struct lambdakzeroPreselector {
 
   void init(InitContext const&)
   {
-    //check settings and stop if not viable
+    // check settings and stop if not viable
     if (doprocessBuildAll == false && doprocessBuildMCAssociated == false && doprocessBuildValiddEdx == false && doprocessBuildValiddEdxMCAssociated == false && doprocessBuildFindable == false) {
       LOGF(fatal, "No processBuild function enabled. Please choose one.");
     }

--- a/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
@@ -90,6 +90,7 @@ using TracksExtraWithPIDandLabels = soa::Join<aod::TracksExtra, aod::pidTPCFullE
 
 // Pre-selected V0s
 using TaggedV0s = soa::Join<aod::V0s, aod::V0Tags>;
+using TaggedFindableV0s = soa::Join<aod::FindableV0s, aod::V0Tags>;
 
 // For MC association in pre-selection
 using LabeledTracksExtra = soa::Join<aod::TracksExtra, aod::McTrackLabels>;
@@ -1283,6 +1284,20 @@ struct lambdakzeroBuilder {
     buildStrangenessTables<FullTracksExtIU>(V0s);
   }
   PROCESS_SWITCH(lambdakzeroBuilder, processRun3, "Produce Run 3 V0 tables", true);
+
+  void processFindableRun3(aod::Collisions const& collisions, soa::Filtered<TaggedFindableV0s> const& V0s, FullTracksExtIU const&, aod::BCsWithTimestamps const& bcs)
+  {
+    statisticsRegistry.eventCounter += collisions.size();
+    // Fire up CCDB
+    auto bc = collisions.size() ? collisions.begin().bc_as<aod::BCsWithTimestamps>() : bcs.begin();
+    if (!bcs.size()) {
+      LOGF(warn, "No BC found, skipping this DF.");
+      return;
+    }
+    initCCDB(bc);
+    buildStrangenessTables<FullTracksExtIU>(V0s);
+  }
+  PROCESS_SWITCH(lambdakzeroBuilder, processFindableRun3, "Produce Run 3 V0 tables with all findable candidates", true);
 };
 
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -1342,6 +1357,16 @@ struct lambdakzeroPreselector {
 
   void init(InitContext const&)
   {
+    //check settings and stop if not viable
+    if (doprocessBuildAll == false && doprocessBuildMCAssociated == false && doprocessBuildValiddEdx == false && doprocessBuildValiddEdxMCAssociated == false && doprocessBuildFindable == false) {
+      LOGF(fatal, "No processBuild function enabled. Please choose one.");
+    }
+    
+    if (static_cast<int>(doprocessBuildAll) + static_cast<int>(doprocessBuildMCAssociated) + static_cast<int>(doprocessBuildValiddEdx)
+  + static_cast<int>(doprocessBuildValiddEdxMCAssociated) + static_cast<int>(doprocessBuildFindable)) {
+      LOGF(fatal, "More than one processBuild function enabled. Please choose only one.");
+    }
+
     auto h = histos.add<TH1>("hPreselectorStatistics", "hPreselectorStatistics", kTH1D, {{6, -0.5f, 5.5f}});
     h->GetXaxis()->SetBinLabel(1, "All");
     h->GetXaxis()->SetBinLabel(2, "Tracks OK");
@@ -1581,6 +1606,16 @@ struct lambdakzeroPreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  /// This process function ensures that all findable V0s are built.
+  void processBuildFindable(aod::FindableV0s const& v0table, aod::TracksExtra const&)
+  {
+    initializeMasks(v0table.size());
+    for (auto const& v0 : v0table) {
+      checkTrackQuality<aod::TracksExtra>(v0, selectionMask[v0.globalIndex()], true);
+    }
+    checkAndFinalize();
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function checks for the use of V0s in cascades
   /// They are then marked appropriately; the user could then operate
   /// the lambdakzerobuilder to construct only those V0s.
@@ -1609,6 +1644,7 @@ struct lambdakzeroPreselector {
   PROCESS_SWITCH(lambdakzeroPreselector, processBuildMCAssociated, "Switch to build MC-associated V0s", false);
   PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdx, "Switch to build V0s with dE/dx preselection", false);
   PROCESS_SWITCH(lambdakzeroPreselector, processBuildValiddEdxMCAssociated, "Switch to build MC-associated V0s with dE/dx preselection", false);
+  PROCESS_SWITCH(lambdakzeroPreselector, processBuildFindable, "Switch to build findable V0s. Requires lambdakzeromcfinder", false);
   /// skippers options (choose one in addition to a processBuild if you like)
   PROCESS_SWITCH(lambdakzeroPreselector, processSkipV0sNotUsedInCascades, "skip all V0s not used in cascades", false);
   PROCESS_SWITCH(lambdakzeroPreselector, processSkipV0sNotUsedInTrackedCascades, "skip all V0s not used in tracked cascades", false);
@@ -1623,7 +1659,7 @@ struct lambdakzeroV0DataLinkBuilder {
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   // build V0 -> V0Data link table
-  void process(aod::V0s const& v0table, aod::V0Datas const& v0datatable, aod::V0fCDatas const& v0fcdatatable)
+  void processFound(aod::V0s const& v0table, aod::V0Datas const& v0datatable, aod::V0fCDatas const& v0fcdatatable)
   {
     std::vector<int> lIndices, lfCIndices;
     lIndices.reserve(v0table.size());
@@ -1643,6 +1679,24 @@ struct lambdakzeroV0DataLinkBuilder {
     }
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  // build V0Findable -> V0Data link table
+  void processFindable(aod::FindableV0s const& v0table, aod::V0Datas const& v0datatable)
+  {
+    std::vector<int> lIndices;
+    lIndices.reserve(v0table.size());
+    for (int ii = 0; ii < v0table.size(); ii++) {
+      lIndices[ii] = -1;
+    }
+    for (auto& v0data : v0datatable) {
+      lIndices[v0data.v0Id()] = v0data.globalIndex();
+    }
+    for (int ii = 0; ii < v0table.size(); ii++) {
+      v0dataLink(lIndices[ii], -1);
+    }
+  }
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  PROCESS_SWITCH(lambdakzeroV0DataLinkBuilder, processFound, "process found V0s (default)", true);
+  PROCESS_SWITCH(lambdakzeroV0DataLinkBuilder, processFindable, "process findable V0s", false);
 };
 
 // Extends the v0data table with expression columns

--- a/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
@@ -529,11 +529,17 @@ struct lambdakzeroBuilder {
       LOGF(info, "LUT load done!");
     }
 
-    if (doprocessRun2 == false && doprocessRun3 == false) {
-      LOGF(fatal, "Neither processRun2 nor processRun3 enabled. Please choose one.");
+    if (doprocessRun2 == false && doprocessRun3 == false && doprocessFindableRun3 == false) {
+      LOGF(fatal, "Neither processRun2 nor processRun3 nor processFindableRun3 enabled. Please choose one.");
     }
     if (doprocessRun2 == true && doprocessRun3 == true) {
       LOGF(fatal, "Cannot enable processRun2 and processRun3 at the same time. Please choose one.");
+    }
+    if (doprocessRun2 == true && doprocessFindableRun3 == true) {
+      LOGF(fatal, "Cannot enable processRun2 and processFindableRun3 at the same time. Please choose one.");
+    }
+    if (doprocessRun3 == true && doprocessFindableRun3 == true) {
+      LOGF(fatal, "Cannot enable processRun3 and processFindableRun3 at the same time. Please choose one.");
     }
 
     if (d_UseAutodetectMode) {
@@ -1297,7 +1303,7 @@ struct lambdakzeroBuilder {
     initCCDB(bc);
     buildStrangenessTables<FullTracksExtIU>(V0s);
   }
-  PROCESS_SWITCH(lambdakzeroBuilder, processFindableRun3, "Produce Run 3 V0 tables with all findable candidates", true);
+  PROCESS_SWITCH(lambdakzeroBuilder, processFindableRun3, "Produce Run 3 V0 tables with all findable candidates", false);
 };
 
 //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -1361,11 +1367,11 @@ struct lambdakzeroPreselector {
     if (doprocessBuildAll == false && doprocessBuildMCAssociated == false && doprocessBuildValiddEdx == false && doprocessBuildValiddEdxMCAssociated == false && doprocessBuildFindable == false) {
       LOGF(fatal, "No processBuild function enabled. Please choose one.");
     }
-    
-    if (static_cast<int>(doprocessBuildAll) + static_cast<int>(doprocessBuildMCAssociated) + static_cast<int>(doprocessBuildValiddEdx)
-  + static_cast<int>(doprocessBuildValiddEdxMCAssociated) + static_cast<int>(doprocessBuildFindable)) {
-      LOGF(fatal, "More than one processBuild function enabled. Please choose only one.");
-    }
+    LOGF(info, "Process function processBuildAll status: %i", static_cast<int>(doprocessBuildAll));
+    LOGF(info, "Process function doprocessBuildMCAssociated status: %i", static_cast<int>(doprocessBuildMCAssociated));
+    LOGF(info, "Process function doprocessBuildValiddEdx status: %i", static_cast<int>(doprocessBuildValiddEdx));
+    LOGF(info, "Process function doprocessBuildValiddEdxMCAssociated status: %i", static_cast<int>(doprocessBuildValiddEdxMCAssociated));
+    LOGF(info, "Process function doprocessBuildFindable status: %i", static_cast<int>(doprocessBuildFindable));
 
     auto h = histos.add<TH1>("hPreselectorStatistics", "hPreselectorStatistics", kTH1D, {{6, -0.5f, 5.5f}});
     h->GetXaxis()->SetBinLabel(1, "All");

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -158,6 +158,11 @@ struct lambdakzeromcbuilder {
           thisInfo.isPhysicalPrimary, thisInfo.xyz[0], thisInfo.xyz[1], thisInfo.xyz[2],
           thisInfo.posP[0], thisInfo.posP[1], thisInfo.posP[2],
           thisInfo.negP[0], thisInfo.negP[1], thisInfo.negP[2]);
+        
+        // n.b. placing the interlink index here allows for the writing of 
+        //      code that is agnostic with respect to the joinability of 
+        //      V0Cores and V0MCCores (always dereference -> safe)
+        v0CoreMCLabels(v0.globalIndex()); // interlink index 
       }
       // ---] Asymmetric populate [---
       // in this approach, V0Cores will NOT be joinable with V0MCCores.

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -51,28 +51,29 @@ struct lambdakzeromcbuilder {
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(InitContext const&) {
-    if(populateV0MCCoresAsymmetric){ 
+  void init(InitContext const&)
+  {
+    if (populateV0MCCoresAsymmetric) {
       LOGF(info, "Asymmetric V0MCCores filling enabled!");
     }
-    if(populateV0MCCoresSymmetric){ 
+    if (populateV0MCCoresSymmetric) {
       LOGF(info, "Symmetric V0MCCores filling enabled!");
     }
-    if(populateV0MCCoresAsymmetric && populateV0MCCoresSymmetric){ 
+    if (populateV0MCCoresAsymmetric && populateV0MCCoresSymmetric) {
       LOGF(fatal, "Error in configuration: please select only one out of populateV0MCCoresAsymmetric and populateV0MCCoresSymmetric! Crashing!");
     }
 
     // for storing basic statistics
-    histos.add("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{10,-0.5,9.5f}});
+    histos.add("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{10, -0.5, 9.5f}});
   }
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   // Helper struct to contain V0MCCore information prior to filling
-  struct mcV0info{
+  struct mcV0info {
     int label;
     int motherLabel;
-    int pdgCode; 
-    int pdgCodeMother; 
+    int pdgCode;
+    int pdgCodeMother;
     int pdgCodePositive;
     int pdgCodeNegative;
     bool isPhysicalPrimary;
@@ -147,7 +148,7 @@ struct lambdakzeromcbuilder {
       // and it might use more disk space unnecessarily.
       if (populateV0MCCoresSymmetric) {
         v0mccores(
-          thisInfo.label, thisInfo.pdgCode, 
+          thisInfo.label, thisInfo.pdgCode,
           thisInfo.pdgCodeMother, thisInfo.pdgCodePositive, thisInfo.pdgCodeNegative,
           thisInfo.isPhysicalPrimary, thisInfo.xyz[0], thisInfo.xyz[1], thisInfo.xyz[2],
           thisInfo.posP[0], thisInfo.posP[1], thisInfo.posP[2],
@@ -155,21 +156,21 @@ struct lambdakzeromcbuilder {
       }
       // ---] Asymmetric populate [---
       // in this approach, V0Cores will NOT be joinable with V0MCCores.
-      // an additional reference to V0MCCore that IS joinable with V0Cores 
+      // an additional reference to V0MCCore that IS joinable with V0Cores
       // will be provided to the user.
       if (populateV0MCCoresAsymmetric) {
         int thisV0MCCoreIndex = -1;
         // step 1: check if this element is already provided in the table
         //         using the packedIndices variable calculated above
-        for(uint32_t ii=0; ii<mcV0infos.size(); ii++){ 
-          if(thisInfo.packedTrackIndices == mcV0infos[ii].packedTrackIndices){
-            thisV0MCCoreIndex = ii; 
+        for (uint32_t ii = 0; ii < mcV0infos.size(); ii++) {
+          if (thisInfo.packedTrackIndices == mcV0infos[ii].packedTrackIndices) {
+            thisV0MCCoreIndex = ii;
             histos.fill(HIST("hBuildingStatistics"), 3.0f); // found
-            break; // this exists already in list
+            break;                                          // this exists already in list
           }
         }
-        if(thisV0MCCoreIndex<0){ 
-          // this V0MCCore does not exist yet. Create it and reference it 
+        if (thisV0MCCoreIndex < 0) {
+          // this V0MCCore does not exist yet. Create it and reference it
           histos.fill(HIST("hBuildingStatistics"), 4.0f); // new
           thisV0MCCoreIndex = mcV0infos.size();
           mcV0infos.push_back(thisInfo);
@@ -180,9 +181,9 @@ struct lambdakzeromcbuilder {
 
     // now populate V0MCCores if in asymmetric mode
     if (populateV0MCCoresAsymmetric) {
-      for( auto info : mcV0infos ){
+      for (auto info : mcV0infos) {
         v0mccores(
-          info.label, info.pdgCode, 
+          info.label, info.pdgCode,
           info.pdgCodeMother, info.pdgCodePositive, info.pdgCodeNegative,
           info.isPhysicalPrimary, info.xyz[0], info.xyz[1], info.xyz[2],
           info.posP[0], info.posP[1], info.posP[2],

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -44,23 +44,62 @@ using std::array;
 struct lambdakzeromcbuilder {
   Produces<aod::McV0Labels> v0labels; // MC labels for V0s
   Produces<aod::V0MCCores> v0mccores; // optionally aggregate information from MC side for posterior analysis (derived data)
+  Produces<aod::V0CoreMCLabels> v0CoreMCLabels; // interlink V0Cores -> V0MCCores in asymmetric mode
 
-  Configurable<bool> populateV0MCCores{"populateV0MCCores", false, "populate V0MCCores table for derived data analysis"};
+  Configurable<bool> populateV0MCCoresSymmetric{"populateV0MCCoresSymmetric", false, "populate V0MCCores table for derived data analysis, keep V0MCCores joinable with V0Cores"};
+  Configurable<bool> populateV0MCCoresAsymmetric{"populateV0MCCoresAsymmetric", false, "populate V0MCCores table for derived data analysis, create V0Cores -> V0MCCores interlink. Saves only labeled V0s."};
 
-  void init(InitContext const&) {}
+  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext const&) {
+    if(populateV0MCCoresAsymmetric){ 
+      LOGF(info, "Asymmetric V0MCCores filling enabled!");
+    }
+    if(populateV0MCCoresSymmetric){ 
+      LOGF(info, "Symmetric V0MCCores filling enabled!");
+    }
+    if(populateV0MCCoresAsymmetric && populateV0MCCoresSymmetric){ 
+      LOGF(fatal, "Error in configuration: please select only one out of populateV0MCCoresAsymmetric and populateV0MCCoresSymmetric! Crashing!");
+    }
+
+    // for storing basic statistics
+    histos.add("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{2,-0.5,1.5f}});
+  }
+
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+  // Helper struct to contain V0MCCore information prior to filling
+  struct mcV0info{
+    int label;
+    int motherLabel;
+    int pdgCode; 
+    int pdgCodeMother; 
+    int pdgCodePositive;
+    int pdgCodeNegative;
+    bool isPhysicalPrimary;
+    std::array<float, 3> xyz;
+    std::array<float, 3> posP;
+    std::array<float, 3> negP;
+    uint64_t packedTrackIndices;
+  };
+  mcV0info thisInfo;
+  //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+
+  // prong index combiner
+  uint64_t combineProngIndices(uint32_t low, uint32_t high)
+  {
+    return (((uint64_t)high) << 32) | ((uint64_t)low);
+  }
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   // build V0 labels
   void process(aod::V0Datas const& v0table, aod::McTrackLabels const&, aod::McParticles const& /*particlesMC*/)
   {
-    for (auto& v0 : v0table) {
-      int lLabel = -1, lMotherLabel = -1;
-      int pdgCode = -1, pdgCodeMother = -1, pdgCodePositive = -1, pdgCodeNegative = -1;
-      bool isPhysicalPrimary = false;
-      float xmc = -999.0f, ymc = -999.0f, zmc = -999.0f;
-      float pxposmc = -999.0f, pyposmc = -999.0f, pzposmc = -999.0f;
-      float pxnegmc = -999.0f, pynegmc = -999.0f, pznegmc = -999.0f;
+    // to be used if using the populateV0MCCoresAsymmetric mode, kept empty otherwise
+    std::vector<mcV0info> mcV0infos; // V0MCCore information
+    uint64_t packedIndices;
 
+    for (auto& v0 : v0table) {
+      packedIndices = combineProngIndices(v0.negTrackId(), v0.posTrackId());
       auto lNegTrack = v0.negTrack_as<aod::McTrackLabels>();
       auto lPosTrack = v0.posTrack_as<aod::McTrackLabels>();
 
@@ -69,29 +108,29 @@ struct lambdakzeromcbuilder {
       if (lNegTrack.has_mcParticle() && lPosTrack.has_mcParticle()) {
         auto lMCNegTrack = lNegTrack.mcParticle_as<aod::McParticles>();
         auto lMCPosTrack = lPosTrack.mcParticle_as<aod::McParticles>();
-        pdgCodePositive = lMCPosTrack.pdgCode();
-        pdgCodeNegative = lMCNegTrack.pdgCode();
-        pxposmc = lMCPosTrack.px();
-        pyposmc = lMCPosTrack.py();
-        pzposmc = lMCPosTrack.pz();
-        pxnegmc = lMCNegTrack.px();
-        pynegmc = lMCNegTrack.py();
-        pznegmc = lMCNegTrack.pz();
+        thisInfo.pdgCodePositive = lMCPosTrack.pdgCode();
+        thisInfo.pdgCodeNegative = lMCNegTrack.pdgCode();
+        thisInfo.posP[0] = lMCPosTrack.px();
+        thisInfo.posP[1] = lMCPosTrack.py();
+        thisInfo.posP[2] = lMCPosTrack.pz();
+        thisInfo.negP[0] = lMCNegTrack.px();
+        thisInfo.negP[1] = lMCNegTrack.py();
+        thisInfo.negP[2] = lMCNegTrack.pz();
         if (lMCNegTrack.has_mothers() && lMCPosTrack.has_mothers()) {
           for (auto& lNegMother : lMCNegTrack.mothers_as<aod::McParticles>()) {
             for (auto& lPosMother : lMCPosTrack.mothers_as<aod::McParticles>()) {
               if (lNegMother.globalIndex() == lPosMother.globalIndex()) {
-                lLabel = lNegMother.globalIndex();
+                thisInfo.label = lNegMother.globalIndex();
                 // acquire information
-                xmc = lMCPosTrack.vx();
-                ymc = lMCPosTrack.vy();
-                zmc = lMCPosTrack.vz();
-                pdgCode = lNegMother.pdgCode();
-                isPhysicalPrimary = lNegMother.isPhysicalPrimary();
+                thisInfo.xyz[0] = lMCPosTrack.vx();
+                thisInfo.xyz[1] = lMCPosTrack.vy();
+                thisInfo.xyz[2] = lMCPosTrack.vz();
+                thisInfo.pdgCode = lNegMother.pdgCode();
+                thisInfo.isPhysicalPrimary = lNegMother.isPhysicalPrimary();
                 if (lNegMother.has_mothers()) {
                   for (auto& lNegGrandMother : lNegMother.mothers_as<aod::McParticles>()) {
-                    pdgCodeMother = lNegGrandMother.pdgCode();
-                    lMotherLabel = lNegGrandMother.globalIndex();
+                    thisInfo.pdgCodeMother = lNegGrandMother.pdgCode();
+                    thisInfo.motherLabel = lNegGrandMother.globalIndex();
                   }
                 }
               }
@@ -101,15 +140,58 @@ struct lambdakzeromcbuilder {
       } // end association check
       // Construct label table (note: this will be joinable with V0Datas!)
       v0labels(
-        lLabel, lMotherLabel);
-      if (populateV0MCCores) {
+        thisInfo.label, thisInfo.motherLabel);
+
+      // ---] Symmetric populate [---
+      // in this approach, V0Cores will be joinable with V0MCCores.
+      // this is the most pedagogical approach, but it is also more limited
+      // and it might use more disk space unnecessarily.
+      if (populateV0MCCoresSymmetric) {
         v0mccores(
-          lLabel, pdgCode, pdgCodeMother, pdgCodePositive, pdgCodeNegative,
-          isPhysicalPrimary, xmc, ymc, zmc,
-          pxposmc, pyposmc, pzposmc,
-          pxnegmc, pynegmc, pznegmc);
+          thisInfo.label, thisInfo.pdgCode, 
+          thisInfo.pdgCodeMother, thisInfo.pdgCodePositive, thisInfo.pdgCodeNegative,
+          thisInfo.isPhysicalPrimary, thisInfo.xyz[0], thisInfo.xyz[1], thisInfo.xyz[2],
+          thisInfo.posP[0], thisInfo.posP[1], thisInfo.posP[2],
+          thisInfo.negP[0], thisInfo.negP[1], thisInfo.negP[2]);
+      }
+      // ---] Asymmetric populate [---
+      // in this approach, V0Cores will NOT be joinable with V0MCCores.
+      // an additional reference to V0MCCore that IS joinable with V0Cores 
+      // will be provided to the user.
+      if (populateV0MCCoresAsymmetric) {
+        int thisV0MCCoreIndex = -1;
+        // step 1: check if this element is already provided in the table
+        //         using the packedIndices variable calculated above
+        for(uint32_t ii=0; ii<mcV0infos.size(); ii++){ 
+          if(packedIndices == mcV0infos[ii].packedTrackIndices){
+            thisV0MCCoreIndex = ii; 
+            break; // this exists already in list
+          }
+        }
+        if(thisV0MCCoreIndex<0){ 
+          // this V0MCCore does not exist yet. Create it and reference it 
+          thisV0MCCoreIndex = mcV0infos.size();
+          mcV0infos.push_back(thisInfo);
+        }
+        v0CoreMCLabels(thisV0MCCoreIndex); // interlink index
       }
     }
+
+    // now populate V0MCCores if in asymmetric mode
+    if (populateV0MCCoresAsymmetric) {
+      for( auto info : mcV0infos ){
+        v0mccores(
+          info.label, info.pdgCode, 
+          info.pdgCodeMother, info.pdgCodePositive, info.pdgCodeNegative,
+          info.isPhysicalPrimary, info.xyz[0], info.xyz[1], info.xyz[2],
+          info.posP[0], info.posP[1], info.posP[2],
+          info.negP[0], info.negP[1], info.negP[2]);
+      }
+    }
+
+    // collect operating parameters
+    histos.fill(HIST("hBuildingStatistics"), 0.0f, v0table.size());
+    histos.fill(HIST("hBuildingStatistics"), 1.0f, mcV0infos.size());
   }
 };
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -158,11 +158,11 @@ struct lambdakzeromcbuilder {
           thisInfo.isPhysicalPrimary, thisInfo.xyz[0], thisInfo.xyz[1], thisInfo.xyz[2],
           thisInfo.posP[0], thisInfo.posP[1], thisInfo.posP[2],
           thisInfo.negP[0], thisInfo.negP[1], thisInfo.negP[2]);
-        
-        // n.b. placing the interlink index here allows for the writing of 
-        //      code that is agnostic with respect to the joinability of 
+
+        // n.b. placing the interlink index here allows for the writing of
+        //      code that is agnostic with respect to the joinability of
         //      V0Cores and V0MCCores (always dereference -> safe)
-        v0CoreMCLabels(v0.globalIndex()); // interlink index 
+        v0CoreMCLabels(v0.globalIndex()); // interlink index
       }
       // ---] Asymmetric populate [---
       // in this approach, V0Cores will NOT be joinable with V0MCCores.

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -64,7 +64,7 @@ struct lambdakzeromcbuilder {
     }
 
     // for storing basic statistics
-    auto h = histos.add<TH1>("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{4,-0.5,3.5f}});
+    auto h = histos.add<TH1>("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{4, -0.5, 3.5f}});
     h->GetXaxis()->SetBinLabel(1, "V0Cores population");
     h->GetXaxis()->SetBinLabel(2, "V0MCCores population");
     h->GetXaxis()->SetBinLabel(3, "x check: duplicates");
@@ -167,15 +167,15 @@ struct lambdakzeromcbuilder {
         int thisV0MCCoreIndex = -1;
         // step 1: check if this element is already provided in the table
         //         using the packedIndices variable calculated above
-        for(uint32_t ii=0; ii<mcV0infos.size(); ii++){ 
-          if(thisInfo.packedMcParticleIndices == mcV0infos[ii].packedMcParticleIndices && mcV0infos[ii].packedMcParticleIndices > 0){
-            thisV0MCCoreIndex = ii; 
+        for (uint32_t ii = 0; ii < mcV0infos.size(); ii++) {
+          if (thisInfo.packedMcParticleIndices == mcV0infos[ii].packedMcParticleIndices && mcV0infos[ii].packedMcParticleIndices > 0) {
+            thisV0MCCoreIndex = ii;
             histos.fill(HIST("hBuildingStatistics"), 2.0f); // found
-            break; // this exists already in list
+            break;                                          // this exists already in list
           }
         }
-        if(thisV0MCCoreIndex<0){ 
-          // this V0MCCore does not exist yet. Create it and reference it 
+        if (thisV0MCCoreIndex < 0) {
+          // this V0MCCore does not exist yet. Create it and reference it
           histos.fill(HIST("hBuildingStatistics"), 3.0f); // new
           thisV0MCCoreIndex = mcV0infos.size();
           mcV0infos.push_back(thisInfo);

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -63,7 +63,7 @@ struct lambdakzeromcbuilder {
     }
 
     // for storing basic statistics
-    histos.add("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{2,-0.5,1.5f}});
+    histos.add("hBuildingStatistics", "hBuildingStatistics", kTH1F, {{10,-0.5,9.5f}});
   }
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -96,10 +96,9 @@ struct lambdakzeromcbuilder {
   {
     // to be used if using the populateV0MCCoresAsymmetric mode, kept empty otherwise
     std::vector<mcV0info> mcV0infos; // V0MCCore information
-    uint64_t packedIndices;
 
     for (auto& v0 : v0table) {
-      packedIndices = combineProngIndices(v0.negTrackId(), v0.posTrackId());
+      thisInfo.packedTrackIndices = combineProngIndices(v0.negTrackId(), v0.posTrackId());
       auto lNegTrack = v0.negTrack_as<aod::McTrackLabels>();
       auto lPosTrack = v0.posTrack_as<aod::McTrackLabels>();
 
@@ -163,13 +162,15 @@ struct lambdakzeromcbuilder {
         // step 1: check if this element is already provided in the table
         //         using the packedIndices variable calculated above
         for(uint32_t ii=0; ii<mcV0infos.size(); ii++){ 
-          if(packedIndices == mcV0infos[ii].packedTrackIndices){
+          if(thisInfo.packedTrackIndices == mcV0infos[ii].packedTrackIndices){
             thisV0MCCoreIndex = ii; 
+            histos.fill(HIST("hBuildingStatistics"), 3.0f); // found
             break; // this exists already in list
           }
         }
         if(thisV0MCCoreIndex<0){ 
           // this V0MCCore does not exist yet. Create it and reference it 
+          histos.fill(HIST("hBuildingStatistics"), 4.0f); // new
           thisV0MCCoreIndex = mcV0infos.size();
           mcV0infos.push_back(thisInfo);
         }

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcfinder.cxx
@@ -178,9 +178,8 @@ struct lambdakzeromcfinder {
   {
     int nPosReco = 0;
     int nNegReco = 0;
-    const int maxReco = 20;
-    int trackIndexPositive[maxReco];
-    int trackIndexNegative[maxReco];
+    int trackIndexPositive[20];
+    int trackIndexNegative[20];
 
     int positivePdg = 211;
     int negativePdg = -211;

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcfinder.cxx
@@ -68,7 +68,7 @@ using LabeledTracks = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLab
 using FullMcParticles = soa::Join<aod::McParticles, aod::ParticlesToTracks>;
 
 struct lambdakzeromcfinder {
-  Produces<aod::V0s> v0;
+  Produces<aod::FindableV0s> v0;
   Produces<aod::McFullV0Labels> fullv0labels;
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -218,8 +218,8 @@ struct strangederivedbuilder {
 
     histos.add("h2dNVerticesVsCentrality", "h2dNVerticesVsCentrality", kTH2D, {axisCentrality, axisNVertices});
 
-    if( doprocessV0FoundTags || doprocessCascFoundTags){
-    histos.add("hFoundTagsCounters", "hFoundTagsCounters", kTH1D, {{4, -0.5f, 3.5f}});
+    if (doprocessV0FoundTags || doprocessCascFoundTags) {
+      histos.add("hFoundTagsCounters", "hFoundTagsCounters", kTH1D, {{4, -0.5f, 3.5f}});
     }
 
     // for QA and test purposes
@@ -794,7 +794,7 @@ struct strangederivedbuilder {
 
   uint64_t combineProngIndices(uint32_t low, uint32_t high)
   {
-      return (((uint64_t) high) << 32) | ((uint64_t) low);
+    return (((uint64_t)high) << 32) | ((uint64_t)low);
   }
 
   void processV0FoundTags(aod::V0s const& foundV0s, aod::V0Datas const& findableV0s, aod::FindableV0s const& /* added to avoid troubles */)
@@ -803,7 +803,7 @@ struct strangederivedbuilder {
     histos.fill(HIST("hFoundTagsCounters"), 1.0f, findableV0s.size());
 
     // pack the found V0s in a long long
-    std::vector<uint64_t> foundV0sPacked; 
+    std::vector<uint64_t> foundV0sPacked;
     foundV0sPacked.reserve(foundV0s.size());
     for (auto const& foundV0 : foundV0s) {
       foundV0sPacked[foundV0.globalIndex()] = combineProngIndices(foundV0.posTrackId(), foundV0.negTrackId());
@@ -812,8 +812,8 @@ struct strangederivedbuilder {
     bool hasBeenFound = false;
     for (auto const& findableV0 : findableV0s) {
       uint64_t indexPack = combineProngIndices(findableV0.posTrackId(), findableV0.negTrackId());
-      for(uint32_t ic=0; ic<foundV0s.size(); ic++){ 
-        if(indexPack==foundV0sPacked[ic]) { 
+      for (uint32_t ic = 0; ic < foundV0s.size(); ic++) {
+        if (indexPack == foundV0sPacked[ic]) {
           hasBeenFound = true;
           break;
         }
@@ -825,7 +825,7 @@ struct strangederivedbuilder {
   using uint128_t = __uint128_t;
   uint128_t combineProngIndices128(uint32_t pos, uint32_t neg, uint32_t bach)
   {
-      return (((uint128_t) pos) << 64) | (((uint128_t) neg) << 32) | ((uint128_t) bach);
+    return (((uint128_t)pos) << 64) | (((uint128_t)neg) << 32) | ((uint128_t)bach);
   }
 
   void processCascFoundTags(aod::Cascades const& foundCascades, aod::CascDatas const& findableCascades, aod::V0s const&, aod::FindableCascades const& /* added to avoid troubles */)
@@ -834,7 +834,7 @@ struct strangederivedbuilder {
     histos.fill(HIST("hFoundTagsCounters"), 3.0f, findableCascades.size());
 
     // pack the found V0s in a long long
-    std::vector<uint128_t> foundCascadesPacked; 
+    std::vector<uint128_t> foundCascadesPacked;
     foundCascadesPacked.reserve(foundCascades.size());
     for (auto const& foundCascade : foundCascades) {
       auto v0 = foundCascade.v0();
@@ -844,8 +844,8 @@ struct strangederivedbuilder {
     bool hasBeenFound = false;
     for (auto const& findableCascade : findableCascades) {
       uint128_t indexPack = combineProngIndices128(findableCascade.posTrackId(), findableCascade.negTrackId(), findableCascade.bachelorId());
-      for(uint32_t ic=0; ic<foundCascades.size(); ic++){ 
-        if(indexPack==foundCascadesPacked[ic]) { 
+      for (uint32_t ic = 0; ic < foundCascades.size(); ic++) {
+        if (indexPack == foundCascadesPacked[ic]) {
           hasBeenFound = true;
           break;
         }

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -218,7 +218,7 @@ struct strangederivedbuilder {
 
     histos.add("h2dNVerticesVsCentrality", "h2dNVerticesVsCentrality", kTH2D, {axisCentrality, axisNVertices});
 
-    if( doprocessV0FoundTags || doprocessCascFoundTags){
+    if (doprocessV0FoundTags || doprocessCascFoundTags) {
       auto h = histos.add<TH1>("hFoundTagsCounters", "hFoundTagsCounters", kTH1D, {{6, -0.5f, 5.5f}});
       h->GetXaxis()->SetBinLabel(1, "Found V0s");
       h->GetXaxis()->SetBinLabel(2, "Findable V0s");

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -218,8 +218,14 @@ struct strangederivedbuilder {
 
     histos.add("h2dNVerticesVsCentrality", "h2dNVerticesVsCentrality", kTH2D, {axisCentrality, axisNVertices});
 
-    if (doprocessV0FoundTags || doprocessCascFoundTags) {
-      histos.add("hFoundTagsCounters", "hFoundTagsCounters", kTH1D, {{4, -0.5f, 3.5f}});
+    if( doprocessV0FoundTags || doprocessCascFoundTags){
+      auto h = histos.add<TH1>("hFoundTagsCounters", "hFoundTagsCounters", kTH1D, {{6, -0.5f, 5.5f}});
+      h->GetXaxis()->SetBinLabel(1, "Found V0s");
+      h->GetXaxis()->SetBinLabel(2, "Findable V0s");
+      h->GetXaxis()->SetBinLabel(3, "Findable & found V0s");
+      h->GetXaxis()->SetBinLabel(4, "Found Cascades");
+      h->GetXaxis()->SetBinLabel(5, "Findable Cascades");
+      h->GetXaxis()->SetBinLabel(6, "Findable & found Cascades");
     }
 
     // for QA and test purposes
@@ -815,6 +821,7 @@ struct strangederivedbuilder {
       for (uint32_t ic = 0; ic < foundV0s.size(); ic++) {
         if (indexPack == foundV0sPacked[ic]) {
           hasBeenFound = true;
+          histos.fill(HIST("hFoundTagsCounters"), 2.0f);
           break;
         }
       }
@@ -830,8 +837,8 @@ struct strangederivedbuilder {
 
   void processCascFoundTags(aod::Cascades const& foundCascades, aod::CascDatas const& findableCascades, aod::V0s const&, aod::FindableCascades const& /* added to avoid troubles */)
   {
-    histos.fill(HIST("hFoundTagsCounters"), 2.0f, foundCascades.size());
-    histos.fill(HIST("hFoundTagsCounters"), 3.0f, findableCascades.size());
+    histos.fill(HIST("hFoundTagsCounters"), 3.0f, foundCascades.size());
+    histos.fill(HIST("hFoundTagsCounters"), 4.0f, findableCascades.size());
 
     // pack the found V0s in a long long
     std::vector<uint128_t> foundCascadesPacked;
@@ -847,6 +854,7 @@ struct strangederivedbuilder {
       for (uint32_t ic = 0; ic < foundCascades.size(); ic++) {
         if (indexPack == foundCascadesPacked[ic]) {
           hasBeenFound = true;
+          histos.fill(HIST("hFoundTagsCounters"), 5.0f);
           break;
         }
       }


### PR DESCRIPTION
@lhusova @romainschotter with this PR, we can generate an extra flag in the findable derived data that is able to tell us easily if each and every "findable" candidate was actually found correctly. The ratio of found/findable is therefore viable within a single derived dataset with all findable, adding extra debug capabilities as we can more easily and reliably calculate the combined global tracking + svertexing efficiency... 

I will still test this before declaring it ready to merge. The changes necessary for this were a bit more complicated than I originally expected... 