### PR TITLE
PWGUD/sgExclusivePhi

### DIFF
--- a/PWGUD/Tasks/CMakeLists.txt
+++ b/PWGUD/Tasks/CMakeLists.txt
@@ -129,3 +129,12 @@ o2physics_add_dpl_workflow(inclusive-phikstar-sd
                            PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::DGPIDSelector
                            COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(sg-exclusive-phi
+                           SOURCES sgExclusivePhi.cxx
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::DGPIDSelector
+                           COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(upc-pion-analysis
+                           SOURCES upcPionAnalysis.cxx
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::DGPIDSelector
+                           COMPONENT_NAME Analysis)

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -617,7 +617,7 @@ struct sgExclusivePhi {
             }
           }
         } // end of two tracks only loop
-      } // vertex cut
+      }   // vertex cut
 
       if (allTracksAreKaonsBandPID.size() == 2) {
 
@@ -639,11 +639,10 @@ struct sgExclusivePhi {
         double dEdx = onlyKaonBandPID[0].tpcSignal();
         registry.fill(HIST("hdEdxKaon9"), momentum, dEdx);
 
-        auto ksize = allTracksAreITSonlyAndFourITSclusters.size();
-        registry.fill(HIST("hTracksITSonly"), ksize);
+        // auto ksize = allTracksAreITSonlyAndFourITSclusters.size();
+        registry.fill(HIST("hTracksITSonly"), allTracksAreITSonlyAndFourITSclusters.size());
 
-        TLorentzVector reallyPhi[ksize];
-        for (int kaon = 0; kaon < ksize; kaon++) {
+        for (int kaon = 0; kaon < allTracksAreITSonlyAndFourITSclusters.size(); kaon++) {
 
           int clusterSize[7];
           double averageClusterSize = 0.;
@@ -654,17 +653,18 @@ struct sgExclusivePhi {
           averageClusterSize /= 7.;
           registry.fill(HIST("hClusterSizeOnlyITS"), averageClusterSize);
 
-          reallyPhi[kaon] += allTracksAreKaonsBandPID[0];
-          reallyPhi[kaon] += allTracksAreITSonlyAndFourITSclusters[kaon];
-          registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].M(), reallyPhi[kaon].Pt());
-          registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].Pt());
-          if (reallyPhi[kaon].Pt() < 0.2) {
-            registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].M());
+          TLorentzVector reallyPhi;
+          reallyPhi += allTracksAreKaonsBandPID[0];
+          reallyPhi += allTracksAreITSonlyAndFourITSclusters[kaon];
+          registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon"), reallyPhi.M(), reallyPhi.Pt());
+          registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon"), reallyPhi.Pt());
+          if (reallyPhi.Pt() < 0.2) {
+            registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon"), reallyPhi.M());
           }
         }
       } // Kaon Band
-    } // double gap
-  } // end of process
+    }   // double gap
+  }     // end of process
 
 }; // end of struct
 

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -162,10 +162,6 @@ struct sgExclusivePhi {
       hSelectionCounter2->GetXaxis()->SetBinLabel(i + 1, SelectionCuts2[i].Data());
     }
 
-    // TString SelectionCuts[15] = {"NoSelection", "GAPcondition", "PVtracks", "TPCcrossrow", "|nsigmaka|<2", "doublegap", "two tracks", "Phi-peak", "pt<0.2 GeV/c"};
-
-    // now we can set BinLabel in histogram Registry
-
     registry.add("hMassPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
     registry.add("hMassPtPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
     registry.add("hMassPhiWrongMomentumWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1D, {{400, 0., 4.}});
@@ -244,7 +240,6 @@ struct sgExclusivePhi {
   using UDCollisionsFull = soa::Join<aod::UDCollisions, aod::SGCollisions, aod::UDCollisionsSels, aod::UDZdcsReduced>;
   //__________________________________________________________________________
   // Main process
-  // void process(UDCollisions::iterator const& collision, udtracksfull const& tracks)
   void process(UDCollisionsFull::iterator const& collision, udtracksfull const& tracks)
   {
     registry.fill(HIST("hSelectionCounter"), 0);
@@ -259,7 +254,6 @@ struct sgExclusivePhi {
     registry.fill(HIST("posy"), collision.posY());
     registry.fill(HIST("posz"), collision.posZ());
     int truegapSide = sgSelector.trueGap(collision, FV0_cut, FT0A_cut, FT0C_cut, ZDC_cut);
-    // int truegapSide = sgSelector.trueGap(collision, FV0_cut, ZDC_cut);
     registry.fill(HIST("GapSide"), gapSide);
     registry.fill(HIST("TrueGapSide"), truegapSide);
     gapSide = truegapSide;

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -8,6 +8,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+//
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
@@ -17,15 +18,13 @@
 #include "TLorentzVector.h"
 #include "Common/DataModel/PIDResponse.h"
 #include "PWGUD/Core/SGSelector.h"
+
 using std::array;
 using namespace std;
 using namespace o2;
 using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
-#define mpion 0.1396   // mass of pion
-#define mkaon 0.493696 // mass of kaon
-// #define mmuon 0.1057 // mass of muon
 
 /// \brief Exclusive phi without PID
 /// \author Simone Ragoni, Creighton
@@ -248,8 +247,6 @@ struct sgExclusivePhi {
     if (gapSide < 0 || gapSide > 2)
       return;
 
-    // registry.fill(HIST("hSelectionCounter"), 1);
-
     registry.fill(HIST("posx"), collision.posX());
     registry.fill(HIST("posy"), collision.posY());
     registry.fill(HIST("posz"), collision.posZ());
@@ -289,7 +286,6 @@ struct sgExclusivePhi {
         registry.fill(HIST("hITSCluster"), trk.itsNCls());
         registry.fill(HIST("hChi2ITSTrkSegment"), trk.itsChi2NCl());
 
-        // double momentum = TMath::Sqrt(trk.px() * trk.px() + trk.py() * trk.py() + trk.pz() * trk.pz());
         double dEdx = trk.tpcSignal();
         registry.fill(HIST("hdEdx"), trk.tpcInnerParam() / trk.sign(), dEdx);
 
@@ -324,14 +320,8 @@ struct sgExclusivePhi {
         onlyKaonTracks.push_back(kaon);
         onlyKaonSigma.push_back(nSigmaKa);
         rawKaonTracks.push_back(trk);
-        // registry.fill(HIST("hdEdxKaon"), momentum, dEdx);
-        // registry.fill(HIST("hSelectionCounter"), 4);
 
       } // trk loop
-
-      // registry.fill(HIST("hTracksKaons"), rawKaonTracks.size());
-      // Creating phis using Kaon PID
-      // registry.fill(HIST("hSelectionCounter"), 5);
 
       if (onlyKaonTracks.size() == 2) {
         registry.fill(HIST("hSelectionCounter"), 7);
@@ -394,20 +384,14 @@ struct sgExclusivePhi {
         registry.fill(HIST("hSelectionCounter2"), 1);
         registry.fill(HIST("hTracks"), t.size());
 
-        /* if(t.itsNCls() < 4) {
-         continue;
-         }*/
-
         double momentum = TMath::Sqrt(t.px() * t.px() + t.py() * t.py() + t.pz() * t.pz());
         double dEdx = t.tpcSignal();
-
-        // registry.fill(HIST("hMomentum"), momentum);
 
         int clusterSize[7];
         double averageClusterSize = 0.;
         for (int i = 0; i < 7; i++) { // info stored in 4 bits
           clusterSize[i] = (((1 << 4) - 1) & (t.itsClusterSizes() >> 4 * i));
-          averageClusterSize += (double)clusterSize[i];
+          averageClusterSize += static_cast<double>(clusterSize[i]);
         }
         averageClusterSize /= 7.;
         registry.fill(HIST("hClusterSizeAllTracks"), averageClusterSize);
@@ -422,10 +406,6 @@ struct sgExclusivePhi {
         }
         registry.fill(HIST("hSelectionCounter2"), 3);
         registry.fill(HIST("hdEdxKaon5"), t.tpcInnerParam() / t.sign(), dEdx);
-
-        /* if (momentum > 0.2) {
-         continue;
-         }*/
 
         if (t.pt() > 0.180) {
           continue;
@@ -659,16 +639,17 @@ struct sgExclusivePhi {
         double dEdx = onlyKaonBandPID[0].tpcSignal();
         registry.fill(HIST("hdEdxKaon9"), momentum, dEdx);
 
-        registry.fill(HIST("hTracksITSonly"), allTracksAreITSonlyAndFourITSclusters.size());
+        auto ksize = allTracksAreITSonlyAndFourITSclusters.size();
+        registry.fill(HIST("hTracksITSonly"), ksize);
 
-        TLorentzVector reallyPhi[allTracksAreITSonlyAndFourITSclusters.size()];
-        for (int kaon = 0; kaon < allTracksAreITSonlyAndFourITSclusters.size(); kaon++) {
+        TLorentzVector reallyPhi[ksize];
+        for (int kaon = 0; kaon < ksize; kaon++) {
 
           int clusterSize[7];
           double averageClusterSize = 0.;
           for (int i = 0; i < 7; i++) { // info stored in 4 bits
             clusterSize[i] = (((1 << 4) - 1) & (onlyITS[kaon].itsClusterSizes() >> 4 * i));
-            averageClusterSize += (double)clusterSize[i];
+            averageClusterSize += static_cast<double>(clusterSize[i]);
           }
           averageClusterSize /= 7.;
           registry.fill(HIST("hClusterSizeOnlyITS"), averageClusterSize);
@@ -681,8 +662,7 @@ struct sgExclusivePhi {
             registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].M());
           }
         }
-      }
-
+      } // Kaon Band
     } // double gap
   } // end of process
 

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -1,0 +1,701 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "iostream"
+#include "PWGUD/DataModel/UDTables.h"
+#include <TString.h>
+#include "TLorentzVector.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "PWGUD/Core/SGSelector.h"
+using std::array;
+using namespace std;
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+#define mpion 0.1396   // mass of pion
+#define mkaon 0.493696 // mass of kaon
+// #define mmuon 0.1057 // mass of muon
+
+/// \brief Exclusive phi without PID
+/// \author Simone Ragoni, Creighton
+/// \author Anisa Khatun, Kansas University
+/// \date 14/2/2024
+
+struct sgExclusivePhi {
+  SGSelector sgSelector;
+  Configurable<float> FV0_cut{"FV0", 100., "FV0A threshold"};
+  Configurable<float> FT0A_cut{"FT0A", 200., "FT0A threshold"};
+  Configurable<float> FT0C_cut{"FT0C", 100., "FT0C threshold"};
+  Configurable<float> ZDC_cut{"ZDC", 10., "ZDC threshold"};
+  Configurable<float> gap_Side{"gap", 2, "gap selection"};
+  // defining histograms using histogram registry
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  //_____________________________________________________________________________
+  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
+                                 TLorentzVector pionNegative,
+                                 TLorentzVector possibleRhoZero)
+  {
+
+    Double_t HalfSqrtSnn = 2680.;
+    Double_t MassOfLead208 = 193.6823;
+    Double_t MomentumBeam = TMath::Sqrt(HalfSqrtSnn * HalfSqrtSnn * 208 * 208 - MassOfLead208 * MassOfLead208);
+
+    TLorentzVector pProjCM(0., 0., -MomentumBeam, HalfSqrtSnn * 208); // projectile
+    TLorentzVector pTargCM(0., 0., MomentumBeam, HalfSqrtSnn * 208);  // target
+
+    TVector3 beta = (-1. / possibleRhoZero.E()) * possibleRhoZero.Vect();
+    TLorentzVector pPi1Dipion = pionPositive;
+    TLorentzVector pPi2Dipion = pionNegative;
+    TLorentzVector pProjDipion = pProjCM;
+    TLorentzVector pTargDipion = pTargCM;
+
+    pPi1Dipion.Boost(beta);
+    pPi2Dipion.Boost(beta);
+    pProjDipion.Boost(beta);
+    pTargDipion.Boost(beta);
+
+    TVector3 zaxis = (possibleRhoZero.Vect()).Unit();
+
+    Double_t CosThetaHE = zaxis.Dot((pPi1Dipion.Vect()).Unit());
+    return CosThetaHE;
+  }
+  //------------------------------------------------------------------------------------------------------
+  Double_t PhiHelicityFrame(TLorentzVector muonPositive, TLorentzVector muonNegative, TLorentzVector possibleJPsi)
+  {
+
+    // Half of the energy per pair of the colliding nucleons.
+    Double_t HalfSqrtSnn = 2680.;
+    Double_t MassOfLead208 = 193.6823;
+    Double_t MomentumBeam = TMath::Sqrt(HalfSqrtSnn * HalfSqrtSnn * 208 * 208 - MassOfLead208 * MassOfLead208);
+
+    TLorentzVector pProjCM(0., 0., -MomentumBeam, HalfSqrtSnn * 208); // projectile
+    TLorentzVector pTargCM(0., 0., MomentumBeam, HalfSqrtSnn * 208);  // target
+
+    // Translate the dimuon parameters in the dimuon rest frame
+    TVector3 beta = (-1. / possibleJPsi.E()) * possibleJPsi.Vect();
+    TLorentzVector pMu1Dimu = muonPositive;
+    TLorentzVector pMu2Dimu = muonNegative;
+    TLorentzVector pProjDimu = pProjCM;
+    TLorentzVector pTargDimu = pTargCM;
+    pMu1Dimu.Boost(beta);
+    pMu2Dimu.Boost(beta);
+    pProjDimu.Boost(beta);
+    pTargDimu.Boost(beta);
+
+    // Axes
+    TVector3 zaxis = (possibleJPsi.Vect()).Unit();
+    TVector3 yaxis = ((pProjDimu.Vect()).Cross(pTargDimu.Vect())).Unit();
+    TVector3 xaxis = (yaxis.Cross(zaxis)).Unit();
+    //
+    // --- Calculation of the azimuthal angle (Helicity)
+    //
+    Double_t phi = TMath::ATan2((pMu1Dimu.Vect()).Dot(yaxis), (pMu1Dimu.Vect()).Dot(xaxis));
+    return phi;
+  }
+  //-----------------------------------------------------------------------------------------------------------------------
+  void init(o2::framework::InitContext&)
+  {
+    auto hSelectionCounter = registry.add<TH1>("hSelectionCounter", "hSelectionCounter;;NEvents", HistType::kTH1I, {{12, 0., 12.}});
+    TString SelectionCuts[12] = {"NoSelection", "Trackloop", "PVtracks", "|nsigmaka|<3", "|nsigmapi|>3", "|nsigmael|>3", "|nsigmamu|>3", "two tracks", "Phi-peak", "pt<0.2 GeV/c", "pt>0.2 GeV/c"};
+
+    for (int i = 0; i < 12; i++) {
+      hSelectionCounter->GetXaxis()->SetBinLabel(i + 1, SelectionCuts[i].Data());
+    }
+
+    registry.add("GapSide", "Gap Side; Entries", kTH1F, {{4, -1.5, 2.5}});
+    registry.add("TrueGapSide", "Gap Side; Entries", kTH1F, {{4, -1.5, 2.5}});
+
+    registry.add("posx", "Vertex position in x", kTH1F, {{100, -0.5, 0.5}});
+    registry.add("posy", "Vertex position in y", kTH1F, {{100, -0.5, 0.5}});
+    registry.add("posz", "Vertex position in z", kTH1F, {{1000, -100., 100.}});
+
+    registry.add("hTracks", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hTracksITSonly", "N_{tracks ITS only}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hITSCluster", "N_{cluster}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hChi2ITSTrkSegment", "N_{cluster}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hTPCCluster", "N_{cluster}", kTH1F, {{200, -0.5, 199.5}});
+    registry.add("hTracksKaons", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hdEdx", "p vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon1", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon2", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon3", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon4", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon5", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon6", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon7", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon8", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+    registry.add("hdEdxKaon9", "p_{#ka} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {1000, 0.0, 2000.0}});
+
+    registry.add("hNsigEvsKa1", "NSigmaKa(t1) vs NSigmaKa (t2);n#sigma_{1};n#sigma_{2}", kTH2F, {{100, 0., 1000.}, {100, 0., 1000}});
+    registry.add("hNsigEvsKa2", "NSigmaKa(t1) vs NSigmaKa (t2);n#sigma_{1};n#sigma_{2}", kTH2F, {{100, 0., 1000.}, {100, 0., 1000}});
+    registry.add("hMomentum", "p_{#ka};#it{p_{trk}}, GeV/c;", kTH1F, {{100, 0., 3.}});
+    registry.add("hClusterSizeAllTracks", "ClusterSizeAllTracks;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeMomentumCut", "ClusterSizeMomentumCut;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeOnlyIdentifiedKaons", "ClusterSizeOnlyIdentifiedKaons;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeOnlyITS", "ClusterSizeOnlyITS;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hEta1", "#eta_{#ka};#it{#eta_{trk}}, GeV/c;", kTH1F, {{100, -2., 2.}});
+    registry.add("hEta2", "#eta_{#ka};#it{#eta_{trk}}, GeV/c;", kTH1F, {{100, -2., 2.}});
+    registry.add("hPtPhi", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("hRapidityPhi", "Rapidity;#it{y_{KK}};", kTH1F, {{100, -2., 2.}});
+    registry.add("hMassPhi", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("hMassPhiIncoherent", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+
+    registry.add("hMassPtPhi", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+
+    auto hSelectionCounter2 = registry.add<TH1>("hSelectionCounter2", "hSelectionCounter;;NEvents", HistType::kTH1I, {{12, 0., 12.}});
+    TString SelectionCuts2[12] = {"NoSelection", "Trackloop", "PVtracks", "|nTPCCluster|<50", " track pt<0.180 GeV/c", "Kaon Band", "ITSCluster<6", "two tracks", "Phi-peak", "pt<0.2 GeV/c", "pt>0.2 GeV/c"};
+
+    for (int i = 0; i < 12; i++) {
+      hSelectionCounter2->GetXaxis()->SetBinLabel(i + 1, SelectionCuts2[i].Data());
+    }
+
+    // TString SelectionCuts[15] = {"NoSelection", "GAPcondition", "PVtracks", "TPCcrossrow", "|nsigmaka|<2", "doublegap", "two tracks", "Phi-peak", "pt<0.2 GeV/c"};
+
+    // now we can set BinLabel in histogram Registry
+
+    registry.add("hMassPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("hMassPtPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("hMassPhiWrongMomentumWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1D, {{400, 0., 4.}});
+
+    // Phi peak region
+    registry.add("PHI/hPtPhiWithoutPID", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PHI/hMassVsPt", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("PHI/hRapidityPhiWithoutPID", "Rapidity;#it{y_{KK}};", kTH1F, {{100, -2., 2.}});
+    registry.add("PHI/hCosThetaPhiWithoutPID", "CosTheta;cos(#theta);", kTH1F, {{100, -2., 2.}});
+    registry.add("PHI/hPhiPhiWithoutPID", "Phi;#varphi;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PHI/hPtKaonVsKaon", "Pt1 vs Pt2;p_{T};p_{T};", kTH2F, {{100, 0., 3.}, {100, 0., 3.}});
+    registry.add("PHI/hCostheta_Phi", "Phi vs Costheta;#it{#phi};#it{Cos#Theta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {100, -2, 2}});
+    registry.add("PHI/hMassPhiWithoutPIDPionHypothesis", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1D, {{400, 0., 4.}});
+    registry.add("PHI/hPtPhiWithoutPIDPionHypothesis", "Pt;#it{p_{t}}, GeV/c;", kTH1D, {{500, 0., 5.}});
+
+    // DIfferent phi topologies, 2 identified kaons, 1 identified kaon + 1 ITS track with correct selections and 4 ITS clusters
+    registry.add("KaonBandPHI/hMassPtPhiIdentifiedKaons", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPhiIdentifiedKaons", "Raw Inv.M;#it{M_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hPtPhiIdentifiedKaons", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
+
+    registry.add("PHI/hMassLike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHI/hMassUnlike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHI/hlikePt", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PHI/hUnlikePt", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PHI/hCoherentPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHI/hInCoherentPhiWithoutPID", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHI/hCoherentMassLike", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHI/hInCoherentMassLike", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+
+    // High Mass region
+    registry.add("PHIHIGH/hPtPhiWithoutPID1", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PHIHIGH/hMassVsPt1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("PHIHIGH/hRapidityPhiWithoutPID1", "Rapidity;#it{y_{KK}};", kTH1F, {{100, -2., 2.}});
+    registry.add("PHIHIGH/hCosThetaPhiWithoutPID1", "CosTheta;cos(#theta);", kTH1F, {{100, -2., 2.}});
+    registry.add("PHIHIGH/hPhiPhiWithoutPID1", "Phi;#varphi;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PHIHIGH/hPtKaonVsKaon1", "Pt1 vs Pt2;p_{T};p_{T};", kTH2F, {{100, 0., 3.}, {100, 0., 3.}});
+    registry.add("PHIHIGH/hCostheta_Phi1", "Phi vs Costheta;#it{#phi};#it{Cos#Theta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {100, -2, 2}});
+    registry.add("PHIHIGH/hMassPhiWithoutPIDPionHypothesis1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1D, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hPtPhiWithoutPIDPionHypothesis1", "Pt;#it{p_{t}}, GeV/c;", kTH1D, {{500, 0., 5.}});
+
+    registry.add("PHIHIGH/hMassLike1", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hMassUnlike1", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hlikePt1", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hUnlikePt1", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hCoherentPhiWithoutPID1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hInCoherentPhiWithoutPID1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hCoherentMassLike1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHIHIGH/hInCoherentMassLike1", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+
+    // Low Mass region
+    registry.add("PHILOW/hPtPhiWithoutPID2", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PHILOW/hMassVsPt2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("PHILOW/hRapidityPhiWithoutPID2", "Rapidity;#it{y_{KK}};", kTH1F, {{100, -2., 2.}});
+    registry.add("PHILOW/hCosThetaPhiWithoutPID2", "CosTheta;cos(#theta);", kTH1F, {{100, -2., 2.}});
+    registry.add("PHILOW/hPhiPhiWithoutPID2", "Phi;#varphi;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PHILOW/hPtKaonVsKaon2", "Pt1 vs Pt2;p_{T};p_{T};", kTH2F, {{100, 0., 3.}, {100, 0., 3.}});
+    registry.add("PHILOW/hCostheta_Phi2", "Phi vs Costheta;#it{#phi};#it{Cos#Theta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {100, -2, 2}});
+    registry.add("PHILOW/hMassPhiWithoutPIDPionHypothesis2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1D, {{400, 0., 4.}});
+    registry.add("PHILOW/hPtPhiWithoutPIDPionHypothesis2", "Pt;#it{p_{t}}, GeV/c;", kTH1D, {{500, 0., 5.}});
+
+    registry.add("PHILOW/hMassLike2", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hMassUnlike2", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hlikePt2", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hUnlikePt2", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hCoherentPhiWithoutPID2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hInCoherentPhiWithoutPID2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hCoherentMassLike2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+    registry.add("PHILOW/hInCoherentMassLike2", "Raw Inv.M;#it{m_{KK}}, GeV/c^{2};", kTH1F, {{400, 0., 4.}});
+  }
+
+  using udtracks = soa::Join<aod::UDTracks, aod::UDTracksExtra, aod::UDTracksPID>;
+  using udtracksfull = soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags>;
+  using UDCollisionsFull = soa::Join<aod::UDCollisions, aod::SGCollisions, aod::UDCollisionsSels, aod::UDZdcsReduced>;
+  //__________________________________________________________________________
+  // Main process
+  // void process(UDCollisions::iterator const& collision, udtracksfull const& tracks)
+  void process(UDCollisionsFull::iterator const& collision, udtracksfull const& tracks)
+  {
+    registry.fill(HIST("hSelectionCounter"), 0);
+
+    int gapSide = collision.gapSide();
+    if (gapSide < 0 || gapSide > 2)
+      return;
+
+    // registry.fill(HIST("hSelectionCounter"), 1);
+
+    registry.fill(HIST("posx"), collision.posX());
+    registry.fill(HIST("posy"), collision.posY());
+    registry.fill(HIST("posz"), collision.posZ());
+    int truegapSide = sgSelector.trueGap(collision, FV0_cut, FT0A_cut, FT0C_cut, ZDC_cut);
+    // int truegapSide = sgSelector.trueGap(collision, FV0_cut, ZDC_cut);
+    registry.fill(HIST("GapSide"), gapSide);
+    registry.fill(HIST("TrueGapSide"), truegapSide);
+    gapSide = truegapSide;
+
+    if (gapSide == gap_Side) {
+      TLorentzVector phi, phiWithoutPID, phiWithKaonPID, phiWrongMomentaWithoutPID, phiWithoutPIDPionHypothesis; // lorentz vectors of tracks and the mother
+
+      // ===================================
+      // Task for phi WITH PID FROM TPC
+      // ===================================
+      // Here the tracks are allowed to have
+      // at most 30 TPC clusters
+      // TPC PID is then possible, although
+      // not truly reliable
+      // NB: from MC simulations coherent
+      // phi SHOULD NOT leave clusters
+      // in the TPC at all
+      std::vector<TLorentzVector> onlyKaonTracks;
+      std::vector<float> onlyKaonSigma;
+      std::vector<decltype(tracks.begin())> rawKaonTracks;
+
+      for (auto trk : tracks) {
+        registry.fill(HIST("hSelectionCounter"), 1);
+        if (!trk.isPVContributor()) {
+          continue;
+        }
+        registry.fill(HIST("hSelectionCounter"), 2);
+
+        int NFindable = trk.tpcNClsFindable();
+        int NMinusFound = trk.tpcNClsFindableMinusFound();
+        int NCluster = NFindable - NMinusFound;
+        registry.fill(HIST("hTPCCluster"), NCluster);
+        registry.fill(HIST("hITSCluster"), trk.itsNCls());
+        registry.fill(HIST("hChi2ITSTrkSegment"), trk.itsChi2NCl());
+
+        // double momentum = TMath::Sqrt(trk.px() * trk.px() + trk.py() * trk.py() + trk.pz() * trk.pz());
+        double dEdx = trk.tpcSignal();
+        registry.fill(HIST("hdEdx"), trk.tpcInnerParam() / trk.sign(), dEdx);
+
+        TLorentzVector kaon;
+        kaon.SetXYZM(trk.px(), trk.py(), trk.pz(), o2::constants::physics::MassKaonCharged);
+        auto nSigmaKa = trk.tpcNSigmaKa();
+        auto nSigmaEl = trk.tpcNSigmaEl();
+        auto nSigmaPi = trk.tpcNSigmaPi();
+        auto nSigmaMu = trk.tpcNSigmaMu();
+
+        // if((nSigmaKa * nSigmaKa + nSigmaKa * nSigmaKa) > 9.) continue;
+        if (fabs(nSigmaKa) > 3.)
+          continue;
+        registry.fill(HIST("hSelectionCounter"), 3);
+        registry.fill(HIST("hdEdxKaon1"), trk.tpcInnerParam() / trk.sign(), dEdx);
+        // if((nSigmaEl * nSigmaEl + nSigmaEl * nSigmaEl) < 9.) continue;
+        if (fabs(nSigmaPi) < 3.)
+          continue;
+        registry.fill(HIST("hSelectionCounter"), 4);
+        registry.fill(HIST("hdEdxKaon2"), trk.tpcInnerParam() / trk.sign(), dEdx);
+        // if((nSigmaPi * nSigmaPi + nSigmaPi * nSigmaPi) < 9.) continue;
+        if (fabs(nSigmaEl) < 3.)
+          continue;
+        registry.fill(HIST("hSelectionCounter"), 5);
+        registry.fill(HIST("hdEdxKaon3"), trk.tpcInnerParam() / trk.sign(), dEdx);
+        // if((nSigmaMu * nSigmaMu + nSigmaMu * nSigmaMu) < 9.) continue;
+        if (fabs(nSigmaMu) < 3.)
+          continue;
+        registry.fill(HIST("hSelectionCounter"), 6);
+        registry.fill(HIST("hdEdxKaon4"), trk.tpcInnerParam() / trk.sign(), dEdx);
+
+        onlyKaonTracks.push_back(kaon);
+        onlyKaonSigma.push_back(nSigmaKa);
+        rawKaonTracks.push_back(trk);
+        // registry.fill(HIST("hdEdxKaon"), momentum, dEdx);
+        // registry.fill(HIST("hSelectionCounter"), 4);
+
+      } // trk loop
+
+      // registry.fill(HIST("hTracksKaons"), rawKaonTracks.size());
+      // Creating phis using Kaon PID
+      // registry.fill(HIST("hSelectionCounter"), 5);
+
+      if (onlyKaonTracks.size() == 2) {
+        registry.fill(HIST("hSelectionCounter"), 7);
+
+        for (auto kaon : onlyKaonTracks) {
+          phi += kaon;
+        }
+
+        registry.fill(HIST("hdEdxKaon"), rawKaonTracks[0].tpcInnerParam() / rawKaonTracks[0].sign(), rawKaonTracks[1].tpcSignal());
+        registry.fill(HIST("hNsigEvsKa1"), rawKaonTracks[0].tpcSignal(), rawKaonTracks[1].tpcSignal());
+        registry.fill(HIST("hMassPtPhi"), phi.M(), phi.Pt());
+        registry.fill(HIST("hRapidityPhi"), phi.Rapidity());
+
+        if (rawKaonTracks[0].sign() != rawKaonTracks[1].sign()) {
+          if ((phi.M() > 0.98) && (phi.M() < 1.05)) {
+            registry.fill(HIST("hSelectionCounter"), 8);
+            registry.fill(HIST("hPtPhi"), phi.Pt());
+
+            if (phi.Pt() < 0.2) {
+              registry.fill(HIST("hMassPhi"), phi.M());
+              registry.fill(HIST("hSelectionCounter"), 9);
+            }
+
+            if (phi.Pt() > 0.2) {
+              registry.fill(HIST("hMassPhiIncoherent"), phi.M());
+              registry.fill(HIST("hSelectionCounter"), 10);
+            }
+          }
+        }
+      }
+
+      // ===================================
+      // Task for phi WITHOUT PID
+      // ===================================
+
+      // ====================================
+      // Selections for events to be stored
+      // ------------------------------------
+      // - PV: only PV contributors
+      // - only two PV contributors
+      // - both PV have t.hasITS() ON
+      // - only ITS tracks
+      //_____________________________________
+      // Create kaons WITHOUT PID
+      std::vector<decltype(tracks.begin())> onlyTwoTracks;
+      std::vector<decltype(tracks.begin())> onlyKaonBandPID;
+      std::vector<decltype(tracks.begin())> onlyITS;
+      std::vector<TLorentzVector> allTracksAreKaons;
+      std::vector<TLorentzVector> allTracksArePions;
+      std::vector<TLorentzVector> allTracksAreKaonsWrongMomentum;
+      std::vector<TLorentzVector> allTracksAreKaonsBandPID;
+      std::vector<TLorentzVector> allTracksAreITSonlyAndFourITSclusters;
+
+      int counter = 0;
+      for (auto t : tracks) {
+        registry.fill(HIST("hSelectionCounter2"), 0);
+        if (!t.isPVContributor()) {
+          continue;
+        }
+        registry.fill(HIST("hSelectionCounter2"), 1);
+        registry.fill(HIST("hTracks"), t.size());
+
+        /* if(t.itsNCls() < 4) {
+         continue;
+         }*/
+
+        double momentum = TMath::Sqrt(t.px() * t.px() + t.py() * t.py() + t.pz() * t.pz());
+        double dEdx = t.tpcSignal();
+
+        // registry.fill(HIST("hMomentum"), momentum);
+
+        int clusterSize[7];
+        double averageClusterSize = 0.;
+        for (int i = 0; i < 7; i++) { // info stored in 4 bits
+          clusterSize[i] = (((1 << 4) - 1) & (t.itsClusterSizes() >> 4 * i));
+          averageClusterSize += (double)clusterSize[i];
+        }
+        averageClusterSize /= 7.;
+        registry.fill(HIST("hClusterSizeAllTracks"), averageClusterSize);
+
+        int NFindable = t.tpcNClsFindable();
+        int NMinusFound = t.tpcNClsFindableMinusFound();
+        int NCluster = NFindable - NMinusFound;
+        // registry.fill(HIST("hTPCCluster"), NCluster);
+
+        if (NCluster > 50) {
+          continue;
+        }
+        registry.fill(HIST("hSelectionCounter2"), 3);
+        registry.fill(HIST("hdEdxKaon5"), t.tpcInnerParam() / t.sign(), dEdx);
+
+        /* if (momentum > 0.2) {
+         continue;
+         }*/
+
+        if (t.pt() > 0.180) {
+          continue;
+        }
+
+        registry.fill(HIST("hSelectionCounter2"), 4);
+        registry.fill(HIST("hMomentum"), momentum);
+        registry.fill(HIST("hdEdxKaon6"), t.tpcInnerParam() / t.sign(), dEdx);
+        registry.fill(HIST("hClusterSizeMomentumCut"), averageClusterSize);
+
+        onlyTwoTracks.push_back(t);
+
+        TLorentzVector a;
+        a.SetXYZM(t.px(), t.py(), t.pz(), o2::constants::physics::MassKaonCharged);
+        TLorentzVector b;
+        b.SetXYZM(t.px(), t.py(), t.pz(), o2::constants::physics::MassElectron);
+        TLorentzVector a2;
+        a2.SetXYZM(-1. * t.px(), -1. * t.py(), -1. * t.pz(), o2::constants::physics::MassKaonCharged);
+
+        allTracksAreKaons.push_back(a);
+        allTracksArePions.push_back(b);
+
+        if (counter < 1) {
+          allTracksAreKaonsWrongMomentum.push_back(a);
+        } else {
+          allTracksAreKaonsWrongMomentum.push_back(a2);
+        }
+        counter += 1;
+
+        bool kaonBand = false;
+        if ((momentum > 0.180) && (momentum < 0.220) && (dEdx > 300)) {
+          kaonBand = true;
+        } else if ((momentum > 0.220) && (momentum < 0.300) && (dEdx > 180)) {
+          kaonBand = true;
+        } else if ((momentum > 0.300) && (momentum < 0.500) && (dEdx > 110)) {
+          kaonBand = true;
+        }
+
+        if (kaonBand == true) {
+          registry.fill(HIST("hSelectionCounter2"), 5);
+          allTracksAreKaonsBandPID.push_back(a);
+          onlyKaonBandPID.push_back(t);
+          registry.fill(HIST("hdEdxKaon7"), t.tpcInnerParam() / t.sign(), dEdx);
+          registry.fill(HIST("hClusterSizeOnlyIdentifiedKaons"), averageClusterSize);
+        }
+
+        if (NFindable < 1 && t.itsNCls() < 7) {
+          // if((NCluster==0) && (t.itsNCls() == 4)){
+          allTracksAreITSonlyAndFourITSclusters.push_back(a);
+          onlyITS.push_back(t);
+          registry.fill(HIST("hdEdxKaon8"), t.tpcInnerParam() / t.sign(), dEdx);
+          registry.fill(HIST("hSelectionCounter2"), 6);
+        }
+
+      } // track loop
+
+      //_____________________________________
+      // Creating phis and saving all the information
+      // in the case that there are ONLY 2 PV
+
+      if ((collision.posZ() < -10) || (collision.posZ() > 10)) {
+        if (allTracksAreKaons.size() == 2) {
+          registry.fill(HIST("hSelectionCounter2"), 7);
+          for (auto kaon : allTracksAreKaons) {
+            phiWithoutPID += kaon;
+          }
+          registry.fill(HIST("hTracksKaons"), allTracksAreKaons.size());
+          // kaon mass hypothesis with wrong momentum for one track
+          for (auto kaon : allTracksAreKaonsWrongMomentum) {
+            phiWrongMomentaWithoutPID += kaon;
+          }
+          // pion mass hypothesis
+          for (auto pion : allTracksArePions) {
+            phiWithoutPIDPionHypothesis += pion;
+          }
+
+          registry.fill(HIST("hNsigEvsKa2"), onlyTwoTracks[0].tpcSignal(), onlyTwoTracks[1].tpcSignal());
+          registry.fill(HIST("hEta1"), allTracksAreKaons[0].Eta());
+          registry.fill(HIST("hEta2"), allTracksAreKaons[1].Eta());
+
+          auto costhetaPhi = CosThetaHelicityFrame(allTracksAreKaons[0], allTracksAreKaons[1], phiWithoutPID);
+          auto phiPhi = 1. * TMath::Pi() + PhiHelicityFrame(allTracksAreKaons[0], allTracksAreKaons[1], phiWithoutPID);
+
+          // All invariant mass region
+          registry.fill(HIST("hMassPhiWithoutPID"), phiWithoutPID.M());
+          registry.fill(HIST("hMassPtPhiWithoutPID"), phiWithoutPID.M(), phiWithoutPID.Pt());
+          registry.fill(HIST("hMassPhiWrongMomentumWithoutPID"), phiWrongMomentaWithoutPID.M());
+
+          // Phi peak region
+          if ((phiWithoutPID.M() > 0.98) && (phiWithoutPID.M() < 1.05)) {
+            registry.fill(HIST("PHI/hPtPhiWithoutPID"), phiWithoutPID.Pt());
+            registry.fill(HIST("PHI/hMassVsPt"), phiWithoutPID.M(), phiWithoutPID.Pt());
+            registry.fill(HIST("PHI/hRapidityPhiWithoutPID"), phiWithoutPID.Rapidity());
+            registry.fill(HIST("PHI/hPtKaonVsKaon"), allTracksAreKaons[0].Pt(), allTracksAreKaons[1].Pt());
+
+            registry.fill(HIST("PHI/hPtPhiWithoutPIDPionHypothesis"), phiWithoutPIDPionHypothesis.Pt());
+            registry.fill(HIST("PHI/hMassPhiWithoutPIDPionHypothesis"), phiWithoutPIDPionHypothesis.M());
+
+            // unlike-sign
+            if (onlyTwoTracks[0].sign() != onlyTwoTracks[1].sign()) {
+              registry.fill(HIST("hSelectionCounter2"), 8);
+              registry.fill(HIST("PHI/hCosThetaPhiWithoutPID"), costhetaPhi);
+              registry.fill(HIST("PHI/hPhiPhiWithoutPID"), phiPhi);
+              registry.fill(HIST("PHI/hCostheta_Phi"), phiPhi, costhetaPhi);
+              registry.fill(HIST("PHI/hUnlikePt"), phiWithoutPID.Pt());
+              registry.fill(HIST("PHI/hMassUnlike"), phiWithoutPID.M());
+              if (phiWithoutPID.Pt() < 0.2) {
+                registry.fill(HIST("hSelectionCounter2"), 9);
+                registry.fill(HIST("PHI/hCoherentPhiWithoutPID"), phiWithoutPID.M());
+              }
+              if (phiWithoutPID.Pt() > 0.2) {
+                registry.fill(HIST("hSelectionCounter2"), 10);
+                registry.fill(HIST("PHI/hInCoherentPhiWithoutPID"), phiWithoutPID.M());
+              }
+            }
+
+            // Likesign quantities
+            if (onlyTwoTracks[0].sign() == onlyTwoTracks[1].sign()) {
+              registry.fill(HIST("PHI/hMassLike"), phiWithoutPID.M());
+              registry.fill(HIST("PHI/hlikePt"), phiWithoutPID.Pt());
+
+              if (phiWithoutPID.Pt() < 0.2) {
+                registry.fill(HIST("PHI/hCoherentMassLike"), phiWithoutPID.M());
+              }
+              if (phiWithoutPID.Pt() > 0.2) {
+                registry.fill(HIST("PHI/hInCoherentMassLike"), phiWithoutPID.M());
+              }
+            }
+          } // Mass cut
+
+          // Side band above phi mass region
+          if (phiWithoutPID.M() > 1.05) {
+
+            registry.fill(HIST("PHIHIGH/hPtPhiWithoutPID1"), phiWithoutPID.Pt());
+            registry.fill(HIST("PHIHIGH/hMassVsPt1"), phiWithoutPID.M(), phiWithoutPID.Pt());
+            registry.fill(HIST("PHIHIGH/hRapidityPhiWithoutPID1"), phiWithoutPID.Rapidity());
+
+            registry.fill(HIST("PHIHIGH/hPtKaonVsKaon1"), allTracksAreKaons[0].Pt(), allTracksAreKaons[1].Pt());
+            registry.fill(HIST("PHIHIGH/hPtPhiWithoutPIDPionHypothesis1"), phiWithoutPIDPionHypothesis.Pt());
+            registry.fill(HIST("PHIHIGH/hMassPhiWithoutPIDPionHypothesis1"), phiWithoutPIDPionHypothesis.M());
+
+            // unlike-sign
+            if (onlyTwoTracks[0].sign() != onlyTwoTracks[1].sign()) {
+              registry.fill(HIST("PHIHIGH/hCosThetaPhiWithoutPID1"), costhetaPhi);
+              registry.fill(HIST("PHIHIGH/hPhiPhiWithoutPID1"), phiPhi);
+              registry.fill(HIST("PHIHIGH/hCostheta_Phi1"), phiPhi, costhetaPhi);
+
+              registry.fill(HIST("PHIHIGH/hUnlikePt1"), phiWithoutPID.Pt());
+              registry.fill(HIST("PHIHIGH/hMassUnlike1"), phiWithoutPID.M());
+              if (phiWithoutPID.Pt() < 0.2) {
+                registry.fill(HIST("PHIHIGH/hCoherentPhiWithoutPID1"), phiWithoutPID.M());
+              }
+              if (phiWithoutPID.Pt() > 0.2) {
+                registry.fill(HIST("PHIHIGH/hInCoherentPhiWithoutPID1"), phiWithoutPID.M());
+              }
+            }
+
+            // Like sign
+            if (onlyTwoTracks[0].sign() == onlyTwoTracks[1].sign()) {
+              // Likesign quantities
+              registry.fill(HIST("PHIHIGH/hMassLike1"), phiWithoutPID.M());
+              registry.fill(HIST("PHIHIGH/hlikePt1"), phiWithoutPID.Pt());
+
+              if (phiWithoutPID.Pt() < 0.2) {
+                registry.fill(HIST("PHIHIGH/hCoherentMassLike1"), phiWithoutPID.M());
+              }
+              if (phiWithoutPID.Pt() > 0.2) {
+                registry.fill(HIST("PHIHIGH/hInCoherentMassLike1"), phiWithoutPID.M());
+              }
+            }
+          }
+
+          // Side band below phi mass region
+          if (phiWithoutPID.M() < 0.98) {
+            registry.fill(HIST("PHILOW/hPtPhiWithoutPID2"), phiWithoutPID.Pt());
+            registry.fill(HIST("PHILOW/hMassVsPt2"), phiWithoutPID.M(), phiWithoutPID.Pt());
+            registry.fill(HIST("PHILOW/hRapidityPhiWithoutPID2"), phiWithoutPID.Rapidity());
+
+            registry.fill(HIST("PHILOW/hPtKaonVsKaon2"), allTracksAreKaons[0].Pt(), allTracksAreKaons[1].Pt());
+
+            registry.fill(HIST("PHILOW/hPtPhiWithoutPIDPionHypothesis2"), phiWithoutPIDPionHypothesis.Pt());
+            registry.fill(HIST("PHILOW/hMassPhiWithoutPIDPionHypothesis2"), phiWithoutPIDPionHypothesis.M());
+
+            // unlike-sign
+            registry.fill(HIST("PHILOW/hCosThetaPhiWithoutPID2"), costhetaPhi);
+            registry.fill(HIST("PHILOW/hPhiPhiWithoutPID2"), phiPhi);
+            registry.fill(HIST("PHILOW/hCostheta_Phi2"), phiPhi, costhetaPhi);
+            registry.fill(HIST("PHILOW/hUnlikePt2"), phiWithoutPID.Pt());
+            registry.fill(HIST("PHILOW/hMassUnlike2"), phiWithoutPID.M());
+            if (phiWithoutPID.Pt() < 0.2) {
+              registry.fill(HIST("PHILOW/hCoherentPhiWithoutPID2"), phiWithoutPID.M());
+            }
+            if (phiWithoutPID.Pt() > 0.2) {
+              registry.fill(HIST("PHILOW/hInCoherentPhiWithoutPID2"), phiWithoutPID.M());
+            }
+            // like-sign
+            if (onlyTwoTracks[0].sign() == onlyTwoTracks[1].sign()) {
+              // Likesign quantities
+              registry.fill(HIST("PHI/hMassLike2"), phiWithoutPID.M());
+              registry.fill(HIST("PHI/hlikePt2"), phiWithoutPID.Pt());
+
+              if (phiWithoutPID.Pt() < 0.2) {
+                registry.fill(HIST("PHI/hCoherentMassLike2"), phiWithoutPID.M());
+              }
+
+              if (phiWithoutPID.Pt() > 0.2) {
+                registry.fill(HIST("PHI/hInCoherentMassLike2"), phiWithoutPID.M());
+              }
+            }
+          }
+        } // end of two tracks only loop
+      } // vertex cut
+
+      if (allTracksAreKaonsBandPID.size() == 2) {
+
+        TLorentzVector reallyPhi;
+        for (auto kaon : allTracksAreKaonsBandPID) {
+          reallyPhi += kaon;
+        }
+
+        registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaons"), reallyPhi.M(), reallyPhi.Pt());
+        if (reallyPhi.Pt() < 0.2) {
+          registry.fill(HIST("KanonBandPHI/hMassPhiIdentifiedKaons"), reallyPhi.M());
+        }
+        registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaons"), reallyPhi.Pt());
+      }
+
+      if (allTracksAreKaonsBandPID.size() == 1) {
+
+        double momentum = TMath::Sqrt(onlyKaonBandPID[0].px() * onlyKaonBandPID[0].px() + onlyKaonBandPID[0].py() * onlyKaonBandPID[0].py() + onlyKaonBandPID[0].pz() * onlyKaonBandPID[0].pz());
+        double dEdx = onlyKaonBandPID[0].tpcSignal();
+        registry.fill(HIST("hdEdxKaon9"), momentum, dEdx);
+
+        registry.fill(HIST("hTracksITSonly"), allTracksAreITSonlyAndFourITSclusters.size());
+
+        TLorentzVector reallyPhi[allTracksAreITSonlyAndFourITSclusters.size()];
+        for (int kaon = 0; kaon < allTracksAreITSonlyAndFourITSclusters.size(); kaon++) {
+
+          int clusterSize[7];
+          double averageClusterSize = 0.;
+          for (int i = 0; i < 7; i++) { // info stored in 4 bits
+            clusterSize[i] = (((1 << 4) - 1) & (onlyITS[kaon].itsClusterSizes() >> 4 * i));
+            averageClusterSize += (double)clusterSize[i];
+          }
+          averageClusterSize /= 7.;
+          registry.fill(HIST("hClusterSizeOnlyITS"), averageClusterSize);
+
+          reallyPhi[kaon] += allTracksAreKaonsBandPID[0];
+          reallyPhi[kaon] += allTracksAreITSonlyAndFourITSclusters[kaon];
+          registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].M(), reallyPhi[kaon].Pt());
+          registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].Pt());
+          if (reallyPhi[kaon].Pt() < 0.2) {
+            registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon"), reallyPhi[kaon].M());
+          }
+        }
+      }
+
+    } // double gap
+  } // end of process
+
+}; // end of struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<sgExclusivePhi>(cfgc)};
+}

--- a/PWGUD/Tasks/upcPionAnalysis.cxx
+++ b/PWGUD/Tasks/upcPionAnalysis.cxx
@@ -1,0 +1,782 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "iostream"
+#include "PWGUD/DataModel/UDTables.h"
+#include <TString.h>
+#include "TLorentzVector.h"
+#include "PWGUD/Core/SGSelector.h"
+using namespace std;
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+/// \brief  UPC pion study
+/// \author Anisa Khatun
+/// \date 11.11.2022
+
+struct upcPionAnalysis {
+  SGSelector sgSelector;
+  Configurable<float> FV0_cut{"FV0", 100., "FV0A threshold"};
+  Configurable<float> FT0A_cut{"FT0A", 200., "FT0A threshold"};
+  Configurable<float> FT0C_cut{"FT0C", 100., "FT0C threshold"};
+  Configurable<float> ZDC_cut{"ZDC", 10., "ZDC threshold"};
+  Configurable<float> gap_Side{"gap", 2, "gap selection"};
+  // defining histograms using histogram registry
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  //_____________________________________________________________________________
+  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
+                                 TLorentzVector pionNegative,
+                                 TLorentzVector possibleRhoZero)
+  {
+
+    Double_t HalfSqrtSnn = 2680.;
+    Double_t MassOfLead208 = 193.6823;
+    Double_t MomentumBeam = TMath::Sqrt(HalfSqrtSnn * HalfSqrtSnn * 208 * 208 - MassOfLead208 * MassOfLead208);
+
+    TLorentzVector pProjCM(0., 0., -MomentumBeam, HalfSqrtSnn * 208); // projectile
+    TLorentzVector pTargCM(0., 0., MomentumBeam, HalfSqrtSnn * 208);  // target
+
+    TVector3 beta = (-1. / possibleRhoZero.E()) * possibleRhoZero.Vect();
+    TLorentzVector pPi1Dipion = pionPositive;
+    TLorentzVector pPi2Dipion = pionNegative;
+    TLorentzVector pProjDipion = pProjCM;
+    TLorentzVector pTargDipion = pTargCM;
+
+    pPi1Dipion.Boost(beta);
+    pPi2Dipion.Boost(beta);
+    pProjDipion.Boost(beta);
+    pTargDipion.Boost(beta);
+
+    TVector3 zaxis = (possibleRhoZero.Vect()).Unit();
+
+    Double_t CosThetaHE = zaxis.Dot((pPi1Dipion.Vect()).Unit());
+    return CosThetaHE;
+  }
+  //------------------------------------------------------------------------------------------------------
+  Double_t PhiHelicityFrame(TLorentzVector piPositive, TLorentzVector piNegative, TLorentzVector possibleRho)
+  {
+
+    // Half of the energy per pair of the colliding nucleons.
+    Double_t HalfSqrtSnn = 2680.;
+    Double_t MassOfLead208 = 193.6823;
+    Double_t MomentumBeam = TMath::Sqrt(HalfSqrtSnn * HalfSqrtSnn * 208 * 208 - MassOfLead208 * MassOfLead208);
+
+    TLorentzVector pProjCM(0., 0., -MomentumBeam, HalfSqrtSnn * 208); // projectile
+    TLorentzVector pTargCM(0., 0., MomentumBeam, HalfSqrtSnn * 208);  // target
+
+    // Translate the dipion parameters in the dipion rest frame
+    TVector3 beta = (-1. / possibleRho.E()) * possibleRho.Vect();
+    TLorentzVector pPi1Dipi = piPositive;
+    TLorentzVector pPi2Dipi = piNegative;
+    TLorentzVector pProjDipi = pProjCM;
+    TLorentzVector pTargDipi = pTargCM;
+    pPi1Dipi.Boost(beta);
+    pPi2Dipi.Boost(beta);
+    pProjDipi.Boost(beta);
+    pTargDipi.Boost(beta);
+
+    // Axes
+    TVector3 zaxis = (possibleRho.Vect()).Unit();
+    TVector3 yaxis = ((pProjDipi.Vect()).Cross(pTargDipi.Vect())).Unit();
+    TVector3 xaxis = (yaxis.Cross(zaxis)).Unit();
+    //
+    // --- Calculation of the azimuthal angle (Helicity)
+    //
+    Double_t phi = TMath::ATan2((pPi1Dipi.Vect()).Dot(yaxis), (pPi1Dipi.Vect()).Dot(xaxis));
+    return phi;
+  }
+  //____________________________________________________________________________________________
+  float momentum(float px, float py, float pz)
+  // Just a simple function to return momentum
+  {
+    return std::sqrt(px * px + py * py + pz * pz);
+  }
+
+  //______________________________________________________________________________________________________
+  float eta(float px, float py, float pz)
+  // Just a simple function to return pseudorapidity
+  {
+    float arg = -2.; // outside valid range for std::atanh
+    float mom = momentum(px, py, pz);
+    if (mom != 0)
+      arg = pz / mom;
+    if (-1. < arg && arg < 1.)
+      return std::atanh(arg); // definition of eta
+    return -999.;
+  }
+
+  //-----------------------------------------------------------------------------------------------------------------------
+  void init(o2::framework::InitContext&)
+  {
+
+    registry.add("GapSide", "Gap Side; Entries", kTH1F, {{4, -1.5, 2.5}});
+    registry.add("TrueGapSide", "Gap Side; Entries", kTH1F, {{4, -1.5, 2.5}});
+
+    auto hSelectionCounter = registry.add<TH1>("hSelectionCounter", "hSelectionCounter;;NEvents", HistType::kTH1I, {{10, 0., 10.}});
+
+    TString SelectionCuts[7] = {"NoSelection", "2pioncandidates", "tpcNClsCrossedRows", "opposite_charge", "|nsigmapi|<3", "nsigmael", "track_momenta>0.3GeV/c"};
+    // now we can set BinLabel in histogram Registry
+
+    for (int i = 0; i < 7; i++) {
+      hSelectionCounter->GetXaxis()->SetBinLabel(i + 1, SelectionCuts[i].Data());
+    }
+
+    registry.add("hTracks", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("hTracksPions", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("h2TracksPions", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("h4TracksPions", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("h6TracksPions", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+    registry.add("h8TracksPions", "N_{tracks}", kTH1F, {{100, -0.5, 99.5}});
+
+    registry.add("hMassLike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{1000, 0., 20.}});
+    registry.add("hMassUnlike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{1000, 0., 20.}});
+    registry.add("hMassUnlikeCoherent", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{1000, 0., 20.}});
+    registry.add("hdEdx", "p vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {100, 0.0, 200.0}});
+    registry.add("hdEdxPion", "p_{#pi} vs dE/dx Signal", kTH2F, {{100, 0.0, 3.0}, {100, 0.0, 200.0}});
+
+    registry.add("hNsigPi1vsPi2", "NSigmaPi(t1) vs NSigmapi (t2);n#sigma_{1};n#sigma_{2}", kTH2F, {{100, -15., 15.}, {100, -15., 15}});
+    registry.add("hNsigEl1vsEl2", "NSigmaEl(t1) vs NSigmaEl (t2);n#sigma_{1};n#sigma_{2}", kTH2F, {{100, -15., 15.}, {100, -15., 15}});
+    registry.add("hNsigPivsPt1", "Pt vs NSigmaPi (t1);#it{p_{t}}, GeV/c;n#sigma_{#pi}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+    registry.add("hNsigPivsPt2", "Pt vs NSigmaPi (t2);#it{p_{t}}, GeV/c;n#sigma_{#pi}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+    registry.add("hNsigElvsPt1", "Pt vs NSigmaEl (t1);#it{p_{t}}, GeV/c;n#sigma_{#e}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+    registry.add("hNsigElvsPt2", "Pt vs NSigmaEl (t2);#it{p_{t}}, GeV/c;n#sigma_{#e}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+    registry.add("hNsigMuvsPt1", "Pt vs NSigmaMu (t1);#it{p_{t}}, GeV/c;n#sigma_{#pi}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+    registry.add("hNsigMuvsPt2", "Pt vs NSigmaMu (t2);#it{p_{t}}, GeV/c;n#sigma_{#pi}", kTH2F, {{100, 0., 2.5}, {100, -15., 15}});
+
+    registry.add("hEta_t1", "Eta of t1;#it{#eta};", kTH1F, {{100, -5., 5.}});
+    registry.add("hEta_t2", "Eta of t2;#it{#eta};", kTH1F, {{100, -5., 5.}});
+
+    registry.add("hCharge", "Charge;#it{charge};", kTH1F, {{500, -10., 10.}});
+    registry.add("hPtsingle_track1", "Pt t1;#it{p_{t}}, GeV/c;", kTH1F, {{600, 0., 3.}});
+    registry.add("hPtsingle_track2", "Pt t2;#it{p_{t}}, GeV/c;", kTH1F, {{600, 0., 3.}});
+    registry.add("hP1", "P vs TPC signal;#it{P_{track}}, GeV/c; signal_{TPC} t1", kTH2F, {{100, 0., 2.}, {300, 0, 150}});
+    registry.add("hTPCsig", "TPC signal;signal_{TPC} t2; signal_{TPC} t2", kTH2F, {{300, 0., 150.}, {300, 0, 150}});
+    registry.add("hP2", "P vs TPC signal;#it{P_{track}}, GeV/c; signal_{TPC} t1", kTH2F, {{100, 0., 2.}, {300, 0, 150}});
+    registry.add("hTPCsig1", "TPC signal;signal_{TPC} t2; signal_{TPC} t2", kTH2F, {{300, 0., 150.}, {300, 0, 150}});
+    registry.add("hCostheta_Phi", "Phi vs Costheta;#it{#phi};#it{Cos#Theta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {120, -1, 1}});
+
+    registry.add("hMass", "Raw Inv.M;#it{M_{#pi#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMassFourPions", "Raw Inv.M;#it{M_{4#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMassSixPions", "Raw Inv.M;#it{M_{6#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMassEightPions", "Raw Inv.M;#it{M_{8#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMassFourPionsRightSign", "Raw Inv.M;#it{M_{4#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMassSixPionsRightSign", "Raw Inv.M;#it{M_{6#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+    registry.add("hMass8PionsRightSign", "Raw Inv.M;#it{M_{8#pi}} (GeV/c^{2});", kTH1D, {{1000, 0., 10.}});
+
+    registry.add("hPhiEtaFourPionsRightSign", "Phi vs Eta;#it{#phi};#it{#eta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {120, -2, 2}});
+    registry.add("hPhiEtaSixPionsRightSign", "Phi vs Eta;#it{#phi};#it{#eta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {120, -2, 2}});
+    registry.add("hPhiEta8PionsRightSign", "Phi vs Eta;#it{#phi};#it{#eta};", kTH2F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}, {120, -2, 2}});
+
+    registry.add("hPt", "Pt;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt4Pion", "Pt1;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt6Pion", "Pt2;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt8Pion", "Pt2;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt4PionRightSign", "Pt1;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt6PionRightSign", "Pt2;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+    registry.add("hPt8PionRightSign", "Pt2;#it{p_{t}}, GeV/c;", kTH1D, {{1000, 0., 10.}});
+
+    registry.add("hEta", "Eta;#it{#eta};", kTH1F, {{500, -10., 10.}});
+    registry.add("hEta4Pion", "Eta of four pion;#it{#eta};", kTH1F, {{100, -5., 5.}});
+    registry.add("hEta6Pion", "Eta of six pion;#it{#eta};", kTH1F, {{100, -5., 5.}});
+    registry.add("hEta8Pion", "Eta of six pion;#it{#eta};", kTH1F, {{100, -5., 5.}});
+
+    registry.add("hRap", "Rapidity;#it{y};", kTH1F, {{500, -10., 10.}});
+    registry.add("hRap4Pion", "Rapidity;#it{y};", kTH1F, {{500, -10., 10.}});
+    registry.add("hRap6Pion", "Rapidity;#it{y};", kTH1F, {{500, -10., 10.}});
+    registry.add("hRap8pion", "Rapidity;#it{y};", kTH1F, {{500, -10., 10.}});
+
+    registry.add("hPhi", "Phi;#it{#Phi};", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("hPhi4Pion", "Phi;#it{#Phi};", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("hPhi6Pion", "Phi;#it{#Phi};", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("hPhi8Pion", "Phi;#it{#Phi};", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+
+    registry.add("hCostheta", "Costheta;#it{Cos#Theta};", kTH1F, {{100, -1., 1.}});
+    registry.add("hCostheta4Pion", "Costheta;#it{Cos#Theta};", kTH1F, {{100, -1., 1.}});
+    registry.add("hCostheta6Pion", "Costheta;#it{Cos#Theta};", kTH1F, {{100, -1., 1.}});
+    registry.add("hCostheta8Pion", "Costheta;#it{Cos#Theta};", kTH1F, {{100, -1., 1.}});
+
+    registry.add("hMPt", "Inv.M vs Pt;M, GeV/c^{2};#it{P_{t}}, GeV/c;", kTH2F, {{100, 0., 10.}, {100, 0., 10.}});
+    registry.add("hMPt1", "Inv.M vs Pt;M, GeV/c^{2};#it{P_{t}}, GeV/c;", kTH2F, {{100, 0., 10.}, {100, 0., 10.}});
+    registry.add("hMPt2", "Inv.M vs Pt;M, GeV/c^{2};#it{P_{t}}, GeV/c;", kTH2F, {{100, 0., 10.}, {100, 0., 10.}});
+    registry.add("hMPt3", "Inv.M vs Pt;M, GeV/c^{2};#it{P_{t}}, GeV/c;", kTH2F, {{100, 0., 20.}, {100, 0., 10.}});
+
+    registry.add("Ang/hMassCosTheta_0", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_1", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_2", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_3", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_4", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_5", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_6", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_7", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_8", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_9", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_10", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_11", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_12", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_13", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_14", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_15", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassCosTheta_16", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+
+    registry.add("Ang/hMassPhi_0", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_1", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_2", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_3", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_4", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_5", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_6", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_7", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_8", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_9", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_10", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_11", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+    registry.add("Ang/hMassPhi_12", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+
+    /* registry.add("Ang2/hMassCosTheta_0", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_1", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_2", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_3", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_4", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_5", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_6", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_7", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_8", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_9", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_10", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_11", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_12", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_13", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_14", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_15", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassCosTheta_16", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+
+     registry.add("Ang2/hMassPhi_0", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_1", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_2", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_3", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_4", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_5", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_6", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_7", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_8", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_9", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_10", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_11", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});
+     registry.add("Ang2/hMassPhi_12", "Raw Inv.M; M_{#pi#pi} (GeV/c^{2});", kTH1D, {{100, 0., 2.}});*/
+  }
+
+  using udtracks = soa::Join<aod::UDTracks, aod::UDTracksExtra, aod::UDTracksPID>;
+  using udtracksfull = soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags>;
+  using UDCollisionsFull = soa::Join<aod::UDCollisions, aod::SGCollisions, aod::UDCollisionsSels, aod::UDZdcsReduced>;
+  //__________________________________________________________________________
+  // Main process
+  void process(UDCollisionsFull::iterator const& collision, udtracksfull const& tracks)
+  {
+    registry.fill(HIST("hSelectionCounter"), 0);
+
+    int gapSide = collision.gapSide();
+    if (gapSide < 0 || gapSide > 2)
+      return;
+
+    // int truegapSide = sgSelector.trueGap(collision, FV0_cut, ZDC_cut);
+    int truegapSide = sgSelector.trueGap(collision, FV0_cut, FT0A_cut, FT0C_cut, ZDC_cut);
+    registry.fill(HIST("GapSide"), gapSide);
+    registry.fill(HIST("TrueGapSide"), truegapSide);
+    gapSide = truegapSide;
+
+    if (gapSide == gap_Side) {
+      //_____________________________________
+      // Create pions and apply TPC Pion PID
+      std::vector<TLorentzVector> allTracks;
+      std::vector<TLorentzVector> onlyPionTracks;
+      std::vector<float> onlyPionSigma;
+      std::vector<decltype(tracks.begin())> rawPionTracks;
+      TLorentzVector p;
+      registry.fill(HIST("hTracks"), tracks.size());
+
+      float sign = 1.;
+      for (auto t : tracks) {
+        if (!t.isPVContributor()) {
+          continue;
+        }
+
+        // double momentum = TMath::Sqrt(t.px() * t.px() + t.py() * t.py() + t.pz() * t.pz());
+        double dEdx = t.tpcSignal();
+
+        if (TMath::Abs(eta(t.px(), t.py(), t.pz()) > 0.9)) {
+          continue;
+        }
+
+        if (t.pt() < 0.1) {
+          continue;
+        }
+
+        registry.fill(HIST("hdEdx"), t.tpcInnerParam() / t.sign(), dEdx);
+        TLorentzVector a;
+        a.SetXYZM(t.px(), t.py(), t.pz(), o2::constants::physics::MassPionCharged);
+        allTracks.push_back(a);
+        auto nSigmaPi = t.tpcNSigmaPi();
+
+        if (fabs(nSigmaPi) < 5.) {
+          onlyPionTracks.push_back(a);
+          onlyPionSigma.push_back(nSigmaPi);
+          rawPionTracks.push_back(t);
+          sign *= t.sign();
+          registry.fill(HIST("hdEdxPion"), t.tpcInnerParam() / t.sign(), dEdx);
+        }
+      }
+      registry.fill(HIST("hTracksPions"), onlyPionTracks.size());
+      //_____________________________________
+      // Creating rhos
+      for (auto pion : onlyPionTracks) {
+        p += pion;
+      }
+      //_____________________________________
+      // Four pions analysis
+      if (onlyPionTracks.size() == 4) {
+
+        // if ((onlyPionTracks[0].Eta() > -0.9) && (onlyPionTracks[1].Eta() > -0.9) && (onlyPionTracks[2].Eta() > -0.9) && (onlyPionTracks[3].Eta()> -0.9)) {
+        //   if ((onlyPionTracks[0].Eta() < 0.9) && (onlyPionTracks[1].Eta() < 0.9) && (onlyPionTracks[2].Eta() < 0.9) && (onlyPionTracks[3].Eta()< 0.9)) {
+        //     if ((onlyPionTracks[0].P() > 0.2) && (onlyPionTracks[1].P() > 0.2) && (onlyPionTracks[2].P() > 0.2) && (onlyPionTracks[3].P()> 0.2)) {
+
+        registry.fill(HIST("hEta_t1"), onlyPionTracks[0].Eta());
+        registry.fill(HIST("hEta_t2"), onlyPionTracks[1].Eta());
+
+        // Quality Control
+        registry.fill(HIST("h2TracksPions"), onlyPionTracks.size());
+        registry.fill(HIST("hNsigPi1vsPi2"), rawPionTracks[0].tpcNSigmaPi(), rawPionTracks[1].tpcNSigmaPi());
+        registry.fill(HIST("hNsigEl1vsEl2"), rawPionTracks[2].tpcNSigmaPi(), rawPionTracks[3].tpcNSigmaPi());
+        registry.fill(HIST("hNsigPivsPt1"), onlyPionTracks[0].Pt(), rawPionTracks[0].tpcNSigmaPi());
+        registry.fill(HIST("hNsigPivsPt2"), onlyPionTracks[1].Pt(), rawPionTracks[1].tpcNSigmaPi());
+        registry.fill(HIST("hNsigElvsPt1"), onlyPionTracks[2].Pt(), rawPionTracks[2].tpcNSigmaPi());
+        registry.fill(HIST("hNsigElvsPt2"), onlyPionTracks[3].Pt(), rawPionTracks[3].tpcNSigmaPi());
+
+        registry.fill(HIST("hNsigMuvsPt1"), onlyPionTracks[0].Pt(), rawPionTracks[0].tpcNSigmaMu());
+        registry.fill(HIST("hNsigMuvsPt2"), onlyPionTracks[1].Pt(), rawPionTracks[1].tpcNSigmaMu());
+
+        registry.fill(HIST("hPtsingle_track1"), onlyPionTracks[0].Pt());
+        registry.fill(HIST("hPtsingle_track2"), onlyPionTracks[1].Pt());
+        registry.fill(HIST("hP1"), onlyPionTracks[0].P(), rawPionTracks[0].tpcSignal());
+        registry.fill(HIST("hTPCsig"), rawPionTracks[0].tpcSignal(), rawPionTracks[1].tpcSignal());
+        registry.fill(HIST("hP2"), onlyPionTracks[2].P(), rawPionTracks[2].tpcSignal());
+        registry.fill(HIST("hTPCsig1"), rawPionTracks[2].tpcSignal(), rawPionTracks[3].tpcSignal());
+
+        bool isRightSign = ((rawPionTracks[0].sign()) * (rawPionTracks[1].sign()) * (rawPionTracks[2].sign()) * (rawPionTracks[3].sign())) == 1;
+
+        TLorentzVector piplus, piminus;
+        if (rawPionTracks[0].sign() > 0) {
+          piplus = onlyPionTracks[0];
+        } else {
+          piminus = onlyPionTracks[0];
+        }
+        if (rawPionTracks[1].sign() < 0) {
+          piminus = onlyPionTracks[1];
+        } else {
+          piplus = onlyPionTracks[1];
+        }
+        if (rawPionTracks[2].sign() > 0) {
+          piplus = onlyPionTracks[2];
+        } else {
+          piminus = onlyPionTracks[2];
+        }
+        if (rawPionTracks[3].sign() < 0) {
+          piminus = onlyPionTracks[3];
+        } else {
+          piplus = onlyPionTracks[3];
+        }
+
+        auto costheta = CosThetaHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hCostheta4Pion"), costheta);
+        auto phihel = 1. * TMath::Pi() + PhiHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hPhi4Pion"), phihel);
+
+        if (p.Rapidity() > -0.9 && p.Rapidity() < 0.9) {
+
+          if (!isRightSign) {
+            registry.fill(HIST("hMassFourPions"), p.M());
+            registry.fill(HIST("hPt4Pion"), p.Pt());
+          }
+
+          if (isRightSign) {
+            registry.fill(HIST("hCharge"), sign);
+            registry.fill(HIST("h4TracksPions"), onlyPionTracks.size());
+            if (p.Pt() < 0.15) {
+              registry.fill(HIST("hMassFourPionsRightSign"), p.M());
+            }
+            if ((p.M() > 0.8) && (p.M() < 2.5)) {
+              registry.fill(HIST("hPt4PionRightSign"), p.Pt());
+            }
+            registry.fill(HIST("hMPt1"), p.M(), p.Pt());
+            registry.fill(HIST("hRap4Pion"), p.Rapidity());
+            registry.fill(HIST("hEta4Pion"), p.Eta());
+            for (auto pion : onlyPionTracks) {
+              registry.fill(HIST("hPhiEtaFourPionsRightSign"), pion.Phi(), pion.Eta());
+            }
+
+            // Invariant mass in angular bins
+            /* if (p.Pt() < 0.2) {
+                 if (costheta > -1. && costheta < -0.7) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_0"), p.M());
+                 }
+                 if (costheta > -0.7 && costheta < -0.55) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_1"), p.M());
+                 }
+                 if (costheta > -0.55 && costheta < -0.45) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_2"), p.M());
+                 }
+                 if (costheta > -0.45 && costheta < -0.35) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_3"), p.M());
+                 }
+                 if (costheta > -0.35 && costheta < -0.25) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_4"), p.M());
+                 }
+                 if (costheta > -0.25 && costheta < -0.15) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_5"), p.M());
+                 }
+                 if (costheta > -0.15 && costheta < -0.05) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_6"), p.M());
+                 }
+                 if (costheta > -0.05 && costheta < 0.) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_7"), p.M());
+                 }
+                 if (costheta > 0. && costheta < 0.05) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_8"), p.M());
+                 }
+                 if (costheta > 0.05 && costheta < 0.15) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_9"), p.M());
+                 }
+                 if (costheta > 0.15 && costheta < 0.25) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_10"), p.M());
+                 }
+                 if (costheta > 0.25 && costheta < 0.35) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_11"), p.M());
+                 }
+                 if (costheta > 0.35 && costheta < 0.45) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_12"), p.M());
+                 }
+                 if (costheta > 0.45 && costheta < 0.55) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_13"), p.M());
+                 }
+                 if (costheta > 0.55 && costheta < 0.7) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_14"), p.M());
+                 }
+                 if (costheta > 0.7 && costheta < 1.) {
+                     registry.fill(HIST("Ang2/hMassCosTheta_15"), p.M());
+                 }
+
+                 if (phihel > 2. * TMath::Pi() / 12. * 0. && phihel < 2. * TMath::Pi() / 12. * 1.) {
+                     registry.fill(HIST("Ang2/hMassPhi_0"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 1. && phihel < 2. * TMath::Pi() / 12. * 2.) {
+                     registry.fill(HIST("Ang2/hMassPhi_1"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 2. && phihel < 2. * TMath::Pi() / 12. * 3.) {
+                     registry.fill(HIST("Ang2/hMassPhi_2"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 3. && phihel < 2. * TMath::Pi() / 12. * 4.) {
+                     registry.fill(HIST("Ang2/hMassPhi_3"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 4. && phihel < 2. * TMath::Pi() / 12. * 5.) {
+                     registry.fill(HIST("Ang2/hMassPhi_4"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 5. && phihel < 2. * TMath::Pi() / 12. * 6.) {
+                     registry.fill(HIST("Ang2/hMassPhi_5"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 6. && phihel < 2. * TMath::Pi() / 12. * 7.) {
+                     registry.fill(HIST("Ang2/hMassPhi_6"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 7. && phihel < 2. * TMath::Pi() / 12. * 8.) {
+                     registry.fill(HIST("Ang2/hMassPhi_7"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 8. && phihel < 2. * TMath::Pi() / 12. * 9.) {
+                     registry.fill(HIST("Ang2/hMassPhi_8"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 9. && phihel < 2. * TMath::Pi() / 12. * 10.) {
+                     registry.fill(HIST("Ang2/hMassPhi_9"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 10. && phihel < 2. * TMath::Pi() / 12. * 11.) {
+                     registry.fill(HIST("Ang2/hMassPhi_10"), p.M());
+                 }
+                 if (phihel > 2. * TMath::Pi() / 12. * 11. && phihel < 2. * TMath::Pi() / 12. * 12.) {
+                     registry.fill(HIST("Ang2/hMassPhi_11"), p.M());
+                   }
+                }//end of angular distribution mass plots*/
+          }
+        }
+      }
+      //_____________________________________
+      // Six pions analysis
+      if (onlyPionTracks.size() == 6) {
+
+        int signSum = 0;
+        TLorentzVector piplus, piminus;
+        for (auto rawPion : rawPionTracks) {
+          if (rawPion.sign() > 0) {
+            signSum += 1;
+            piplus = onlyPionTracks[0];
+            piplus = onlyPionTracks[1];
+            piplus = onlyPionTracks[2];
+            piplus = onlyPionTracks[3];
+            piplus = onlyPionTracks[4];
+            piplus = onlyPionTracks[5];
+
+          } else if (rawPion.sign() < 0) {
+            signSum -= 1;
+            piminus = onlyPionTracks[0];
+            piminus = onlyPionTracks[1];
+            piminus = onlyPionTracks[2];
+            piminus = onlyPionTracks[3];
+            piminus = onlyPionTracks[4];
+            piminus = onlyPionTracks[5];
+          }
+        }
+
+        auto costheta = CosThetaHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hCostheta6Pion"), costheta);
+        auto phihel = 1. * TMath::Pi() + PhiHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hPhi6Pion"), phihel);
+
+        if (p.Rapidity() > -0.9 && p.Rapidity() < 0.9) {
+          if (signSum != 0) {
+            registry.fill(HIST("hMassSixPions"), p.M());
+            registry.fill(HIST("hPt6Pion"), p.Pt());
+          }
+
+          if (signSum == 0) {
+            registry.fill(HIST("h6TracksPions"), onlyPionTracks.size());
+            if (p.Pt() < 0.15) {
+              registry.fill(HIST("hMassSixPionsRightSign"), p.M());
+            }
+            registry.fill(HIST("hMPt2"), p.M(), p.Pt());
+            registry.fill(HIST("hRap6Pion"), p.Rapidity());
+            registry.fill(HIST("hEta6Pion"), p.Eta());
+            registry.fill(HIST("hPt6PionRightSign"), p.Pt());
+            for (auto pion : onlyPionTracks) {
+              registry.fill(HIST("hPhiEtaSixPionsRightSign"), pion.Phi(), pion.Eta());
+            }
+          }
+        }
+      }
+      //_____________________________________
+      // Eight pions analysis
+      if (onlyPionTracks.size() == 8) {
+        TLorentzVector piplus, piminus;
+        int signSum = 0;
+        for (auto rawPion : rawPionTracks) {
+          if (rawPion.sign() > 0) {
+            signSum += 1;
+            piplus = onlyPionTracks[0];
+            piplus = onlyPionTracks[1];
+            piplus = onlyPionTracks[2];
+            piplus = onlyPionTracks[3];
+            piplus = onlyPionTracks[4];
+            piplus = onlyPionTracks[5];
+            piplus = onlyPionTracks[6];
+            piplus = onlyPionTracks[7];
+
+          } else if (rawPion.sign() < 0) {
+            signSum -= 1;
+            piminus = onlyPionTracks[0];
+            piminus = onlyPionTracks[1];
+            piminus = onlyPionTracks[2];
+            piminus = onlyPionTracks[3];
+            piminus = onlyPionTracks[4];
+            piminus = onlyPionTracks[5];
+            piminus = onlyPionTracks[6];
+            piminus = onlyPionTracks[7];
+          }
+        }
+
+        auto costheta = CosThetaHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hCostheta8Pion"), costheta);
+        auto phihel = 1. * TMath::Pi() + PhiHelicityFrame(piplus, piminus, p);
+        registry.fill(HIST("hPhi8Pion"), phihel);
+
+        if (p.Rapidity() > -0.9 && p.Rapidity() < 0.9) {
+          if (signSum != 0) {
+            registry.fill(HIST("hMassEightPions"), p.M());
+            registry.fill(HIST("hPt8Pion"), p.Pt());
+          }
+          if (signSum == 0) {
+            registry.fill(HIST("h8TracksPions"), onlyPionTracks.size());
+            if (p.Pt() < 0.15) {
+              registry.fill(HIST("hMass8PionsRightSign"), p.M());
+            }
+            registry.fill(HIST("hPt8PionRightSign"), p.Pt());
+            registry.fill(HIST("hMPt3"), p.M(), p.Pt());
+            registry.fill(HIST("hRap8pion"), p.Rapidity());
+            registry.fill(HIST("hEta8Pion"), p.Eta());
+            for (auto pion : onlyPionTracks) {
+              registry.fill(HIST("hPhiEta8PionsRightSign"), pion.Phi(), pion.Eta());
+            }
+          }
+        }
+      }
+      //_____________________________________
+      // CUTS
+
+      if (onlyPionTracks.size() != 2) {
+        return;
+      }
+      if ((onlyPionSigma[0] * onlyPionSigma[0] + onlyPionSigma[1] * onlyPionSigma[1]) > 25) {
+        return;
+      }
+
+      if (onlyPionTracks[0].P() < 0.3 || onlyPionTracks[1].P() < 0.3) {
+        return;
+      }
+      if (p.Rapidity() < -0.9 || p.Rapidity() > 0.9) {
+        return;
+      }
+      if (rawPionTracks[0].sign() == rawPionTracks[1].sign()) {
+        registry.fill(HIST("hMassLike"), p.M());
+        return;
+      }
+      registry.fill(HIST("hMassUnlike"), p.M());
+
+      TLorentzVector tplus, tminus;
+      if (rawPionTracks[0].sign() > 0) {
+        tplus = onlyPionTracks[0];
+      } else {
+        tminus = onlyPionTracks[0];
+      }
+      if (rawPionTracks[1].sign() < 0) {
+        tminus = onlyPionTracks[1];
+      } else {
+        tplus = onlyPionTracks[1];
+      }
+
+      //______________________________
+
+      registry.fill(HIST("hPt"), p.Pt());
+      registry.fill(HIST("hMass"), p.M());
+      registry.fill(HIST("hEta"), p.Eta());
+      registry.fill(HIST("hRap"), p.Rapidity());
+      // registry.fill(HIST("hPhi"),  p.Phi());
+      registry.fill(HIST("hMPt"), p.M(), p.Pt());
+
+      if (p.Pt() < 0.2) {
+        registry.fill(HIST("hMassUnlikeCoherent"), p.M());
+      }
+
+      //____________________________
+      // Polarisation of two pions
+      if (p.Pt() < 0.2) {
+
+        auto costheta = CosThetaHelicityFrame(tplus, tminus, p);
+        registry.fill(HIST("hCostheta"), costheta);
+        auto phihel = 1. * TMath::Pi() + PhiHelicityFrame(tplus, tminus, p);
+        registry.fill(HIST("hPhi"), phihel);
+        registry.fill(HIST("hCostheta_Phi"), phihel, costheta);
+
+        if (costheta > -1. && costheta < -0.7) {
+          registry.fill(HIST("Ang/hMassCosTheta_0"), p.M());
+        }
+        if (costheta > -0.7 && costheta < -0.55) {
+          registry.fill(HIST("Ang/hMassCosTheta_1"), p.M());
+        }
+        if (costheta > -0.55 && costheta < -0.45) {
+          registry.fill(HIST("Ang/hMassCosTheta_2"), p.M());
+        }
+        if (costheta > -0.45 && costheta < -0.35) {
+          registry.fill(HIST("Ang/hMassCosTheta_3"), p.M());
+        }
+        if (costheta > -0.35 && costheta < -0.25) {
+          registry.fill(HIST("Ang/hMassCosTheta_4"), p.M());
+        }
+        if (costheta > -0.25 && costheta < -0.15) {
+          registry.fill(HIST("Ang/hMassCosTheta_5"), p.M());
+        }
+        if (costheta > -0.15 && costheta < -0.05) {
+          registry.fill(HIST("Ang/hMassCosTheta_6"), p.M());
+        }
+        if (costheta > -0.05 && costheta < 0.) {
+          registry.fill(HIST("Ang/hMassCosTheta_7"), p.M());
+        }
+        if (costheta > 0. && costheta < 0.05) {
+          registry.fill(HIST("Ang/hMassCosTheta_8"), p.M());
+        }
+        if (costheta > 0.05 && costheta < 0.15) {
+          registry.fill(HIST("Ang/hMassCosTheta_9"), p.M());
+        }
+        if (costheta > 0.15 && costheta < 0.25) {
+          registry.fill(HIST("Ang/hMassCosTheta_10"), p.M());
+        }
+        if (costheta > 0.25 && costheta < 0.35) {
+          registry.fill(HIST("Ang/hMassCosTheta_11"), p.M());
+        }
+        if (costheta > 0.35 && costheta < 0.45) {
+          registry.fill(HIST("Ang/hMassCosTheta_12"), p.M());
+        }
+        if (costheta > 0.45 && costheta < 0.55) {
+          registry.fill(HIST("Ang/hMassCosTheta_13"), p.M());
+        }
+        if (costheta > 0.55 && costheta < 0.7) {
+          registry.fill(HIST("Ang/hMassCosTheta_14"), p.M());
+        }
+        if (costheta > 0.7 && costheta < 1.) {
+          registry.fill(HIST("Ang/hMassCosTheta_15"), p.M());
+        }
+
+        if (phihel > 2. * TMath::Pi() / 12. * 0. && phihel < 2. * TMath::Pi() / 12. * 1.) {
+          registry.fill(HIST("Ang/hMassPhi_0"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 1. && phihel < 2. * TMath::Pi() / 12. * 2.) {
+          registry.fill(HIST("Ang/hMassPhi_1"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 2. && phihel < 2. * TMath::Pi() / 12. * 3.) {
+          registry.fill(HIST("Ang/hMassPhi_2"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 3. && phihel < 2. * TMath::Pi() / 12. * 4.) {
+          registry.fill(HIST("Ang/hMassPhi_3"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 4. && phihel < 2. * TMath::Pi() / 12. * 5.) {
+          registry.fill(HIST("Ang/hMassPhi_4"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 5. && phihel < 2. * TMath::Pi() / 12. * 6.) {
+          registry.fill(HIST("Ang/hMassPhi_5"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 6. && phihel < 2. * TMath::Pi() / 12. * 7.) {
+          registry.fill(HIST("Ang/hMassPhi_6"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 7. && phihel < 2. * TMath::Pi() / 12. * 8.) {
+          registry.fill(HIST("Ang/hMassPhi_7"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 8. && phihel < 2. * TMath::Pi() / 12. * 9.) {
+          registry.fill(HIST("Ang/hMassPhi_8"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 9. && phihel < 2. * TMath::Pi() / 12. * 10.) {
+          registry.fill(HIST("Ang/hMassPhi_9"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 10. && phihel < 2. * TMath::Pi() / 12. * 11.) {
+          registry.fill(HIST("Ang/hMassPhi_10"), p.M());
+        }
+        if (phihel > 2. * TMath::Pi() / 12. * 11. && phihel < 2. * TMath::Pi() / 12. * 12.) {
+          registry.fill(HIST("Ang/hMassPhi_11"), p.M());
+        }
+      }
+    } // double gap
+  } // end of process
+
+}; // end of struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<upcPionAnalysis>(cfgc)};
+}

--- a/PWGUD/Tasks/upcPionAnalysis.cxx
+++ b/PWGUD/Tasks/upcPionAnalysis.cxx
@@ -315,7 +315,6 @@ struct upcPionAnalysis {
           continue;
         }
 
-        // double momentum = TMath::Sqrt(t.px() * t.px() + t.py() * t.py() + t.pz() * t.pz());
         double dEdx = t.tpcSignal();
 
         if (TMath::Abs(eta(t.px(), t.py(), t.pz()) > 0.9)) {
@@ -349,10 +348,6 @@ struct upcPionAnalysis {
       //_____________________________________
       // Four pions analysis
       if (onlyPionTracks.size() == 4) {
-
-        // if ((onlyPionTracks[0].Eta() > -0.9) && (onlyPionTracks[1].Eta() > -0.9) && (onlyPionTracks[2].Eta() > -0.9) && (onlyPionTracks[3].Eta()> -0.9)) {
-        //   if ((onlyPionTracks[0].Eta() < 0.9) && (onlyPionTracks[1].Eta() < 0.9) && (onlyPionTracks[2].Eta() < 0.9) && (onlyPionTracks[3].Eta()< 0.9)) {
-        //     if ((onlyPionTracks[0].P() > 0.2) && (onlyPionTracks[1].P() > 0.2) && (onlyPionTracks[2].P() > 0.2) && (onlyPionTracks[3].P()> 0.2)) {
 
         registry.fill(HIST("hEta_t1"), onlyPionTracks[0].Eta());
         registry.fill(HIST("hEta_t2"), onlyPionTracks[1].Eta());

--- a/PWGUD/Tasks/upcPionAnalysis.cxx
+++ b/PWGUD/Tasks/upcPionAnalysis.cxx
@@ -766,7 +766,7 @@ struct upcPionAnalysis {
         }
       }
     } // double gap
-  } // end of process
+  }   // end of process
 
 }; // end of struct
 


### PR DESCRIPTION
The exclusivephi is task adapted for SG derive data with additional checks with z-vertex and kaon bands.
A task to analyse pions in UPC is added.