### PR TITLE
PWGCF:FemtoUniverse - corrections in D0 analysis

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -264,7 +264,7 @@ class FemtoUniverseDetaDphiStar
         } else if (ChosenEventType == femtoUniverseContainer::EventType::same) {
           indexOfDaughter = part2.index() - 2 + i;
         }
-        
+
         auto daughter = particles.begin() + indexOfDaughter;
         auto deta = part1.eta() - daughter.eta();
         auto dphiAvg = AveragePhiStar(part1, *daughter, i); // auto dphiAvg = CalculateDphiStar(part1, *daughter);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -258,7 +258,13 @@ class FemtoUniverseDetaDphiStar
 
       bool pass = false;
       for (int i = 0; i < 2; i++) {
-        auto indexOfDaughter = part2.index() - 2 + i;
+        auto indexOfDaughter = 0;
+        if (ChosenEventType == femtoUniverseContainer::EventType::mixed) {
+          indexOfDaughter = part2.globalIndex() - 2 + i;
+        } else if (ChosenEventType == femtoUniverseContainer::EventType::same) {
+          indexOfDaughter = part2.index() - 2 + i;
+        }
+        
         auto daughter = particles.begin() + indexOfDaughter;
         auto deta = part1.eta() - daughter.eta();
         auto dphiAvg = AveragePhiStar(part1, *daughter, i); // auto dphiAvg = CalculateDphiStar(part1, *daughter);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h
@@ -109,10 +109,11 @@ class FemtoUniversePairCleaner
       // Getting D0 (part2) children
       const auto& posChild = particles.iteratorAt(part2.index() - 2);
       const auto& negChild = particles.iteratorAt(part2.index() - 1);
-      if (part1.globalIndex() == posChild.globalIndex() || part1.globalIndex() == negChild.globalIndex()) {
-        return false;
+
+      if (part1.globalIndex() != posChild.globalIndex() && part1.globalIndex() != negChild.globalIndex()) {
+        return true;
       }
-      return part1.globalIndex() != part2.globalIndex();
+      return false;
     } else if constexpr (mPartOneType == o2::aod::femtouniverseparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtouniverseparticle::ParticleType::kPhi) {
       /// Track-Phi combination part1 is Phi and part 2 is hadron
       if (part1.partType() != o2::aod::femtouniverseparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtouniverseparticle::ParticleType::kPhi) {

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -74,10 +74,10 @@ double wrapDeltaPhi0PI(double phiD, double phiDbar)
 {
   double deltaPhi = 0.0;
   deltaPhi = RecoDecay::constrainAngle(phiDbar - phiD, 0.0);
-  if(deltaPhi < 0.) {
+  if (deltaPhi < 0.) {
     deltaPhi = deltaPhi + o2::constants::math::TwoPI;
   }
-  if(deltaPhi > o2::constants::math::TwoPI) {
+  if (deltaPhi > o2::constants::math::TwoPI) {
     deltaPhi = o2::constants::math::TwoPI - deltaPhi;
   }
   return deltaPhi;
@@ -461,7 +461,7 @@ struct femtoUniversePairTaskTrackD0 {
         if (cand2.mLambda() > 0.0f && cand2.mAntiLambda() < 0.0f) {
           continue;
         }
-        //deltaPhi = getDeltaPhi(cand1.phi(), cand2.phi());
+        // deltaPhi = getDeltaPhi(cand1.phi(), cand2.phi());
         deltaPhi = wrapDeltaPhi0PI(cand1.phi(), cand2.phi());
         deltaEta = cand2.eta() - cand1.eta();
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -68,6 +68,21 @@ double getDeltaPhi(double phiD, double phiDbar)
   return RecoDecay::constrainAngle(phiDbar - phiD, -o2::constants::math::PIHalf);
 }
 
+/// Returns deltaPhi value within the range [0, pi]
+///
+double wrapDeltaPhi0PI(double phiD, double phiDbar)
+{
+  double deltaPhi = 0.0;
+  deltaPhi = RecoDecay::constrainAngle(phiDbar - phiD, 0.0);
+  if(deltaPhi < 0.) {
+    deltaPhi = deltaPhi + o2::constants::math::TwoPI;
+  }
+  if(deltaPhi > o2::constants::math::TwoPI) {
+    deltaPhi = o2::constants::math::TwoPI - deltaPhi;
+  }
+  return deltaPhi;
+}
+
 struct femtoUniversePairTaskTrackD0 {
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
@@ -355,12 +370,12 @@ struct femtoUniversePairTaskTrackD0 {
     registry.add("hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {ConfInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hMassVsPtFinerBinning", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {ConfInvMassFinerBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hInvMassVsPtOnlyD0D0bar", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {ConfInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hDeltaPhiSigSig", "SxS correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{50, -0.5 * o2::constants::math::PI, 1.5 * o2::constants::math::PI}}});
-    registry.add("hDeltaPhiD0BgD0barSig", "B(D0)x S(D0bar) correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{50, -0.5 * o2::constants::math::PI, 1.5 * o2::constants::math::PI}}});
-    registry.add("hDeltaPhiD0SigD0barBg", "S(D0)x B(D0bar) correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{50, -0.5 * o2::constants::math::PI, 1.5 * o2::constants::math::PI}}});
-    registry.add("hDeltaPhiBgBg", "BxB correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{50, -0.5 * o2::constants::math::PI, 1.5 * o2::constants::math::PI}}});
+    registry.add("hDeltaPhiSigSig", "SxS correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{14, 0.0, o2::constants::math::PI}}});
+    registry.add("hDeltaPhiD0BgD0barSig", "B(D0)x S(D0bar) correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{14, 0.0, o2::constants::math::PI}}});
+    registry.add("hDeltaPhiD0SigD0barBg", "S(D0)x B(D0bar) correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{14, 0.0, o2::constants::math::PI}}});
+    registry.add("hDeltaPhiBgBg", "BxB correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{14, 0.0, o2::constants::math::PI}}});
     registry.add("hPtCand1VsPtCand2", "2-prong candidates;#it{p}_{T} (GeV/#it{c});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("hDeltaEtaDeltaPhi", "2-prong candidates;#Delta #eta;#Delta #varphi (rad)", {HistType::kTH2F, {{29, -2., 2.}, {29, -0.5 * o2::constants::math::PI, 1.5 * o2::constants::math::PI}}});
+    registry.add("hDeltaEtaDeltaPhi", "2-prong candidates;#Delta #eta;#Delta #varphi (rad)", {HistType::kTH2F, {{29, -2., 2.}, {29, 0.0, o2::constants::math::PI}}});
   }
 
   template <typename CollisionType>
@@ -446,7 +461,8 @@ struct femtoUniversePairTaskTrackD0 {
         if (cand2.mLambda() > 0.0f && cand2.mAntiLambda() < 0.0f) {
           continue;
         }
-        deltaPhi = getDeltaPhi(cand1.phi(), cand2.phi());
+        //deltaPhi = getDeltaPhi(cand1.phi(), cand2.phi());
+        deltaPhi = wrapDeltaPhi0PI(cand1.phi(), cand2.phi());
         deltaEta = cand2.eta() - cand1.eta();
 
         // General histograms


### PR DESCRIPTION
I've changed the following things:

- getting the index of the daughter particle of the charm meson,
- pair cleaning,
- new function to wrap deltaPhi to 0-PI range,
- binning in the angular correlation histograms.