### PR TITLE
PWGHF: Add MC collision tables in self-contained derived format

### DIFF
--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -500,10 +500,10 @@ DECLARE_SOA_TABLE(Hf3PMcs, "AOD", "HF3PMC", //! Table with MC candidate info
 // MC particle columns
 namespace hf_mc_particle
 {
-DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
-DECLARE_SOA_INDEX_COLUMN(HfD0McCollBase, hfD0McCollBase);             //! collision index pointing to the derived MC collision table for D0 candidates
-DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);                 //! MC collision of this particle
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                   //! MC particle
+DECLARE_SOA_INDEX_COLUMN(HfD0McCollBase, hfD0McCollBase);           //! collision index pointing to the derived MC collision table for D0 candidates
+DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);           //! collision index pointing to the derived MC collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! particle origin, generator level
 DECLARE_SOA_COLUMN(FlagMcDecayChanGen, flagMcDecayChanGen, int8_t); //! resonant decay channel flag, generator level

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -29,6 +29,11 @@
 
 namespace o2::aod
 {
+constexpr uint MarkerD0 = 1;
+constexpr uint Marker3P = 2;
+constexpr uint MarkerD0Stored = 10;
+constexpr uint Marker3PStored = 20;
+
 // ================
 // Collision tables
 // ================
@@ -58,14 +63,16 @@ DECLARE_SOA_TABLE(HfD0CollBases, "AOD", "HFD0COLLBASE", //! Table with basic col
                   hf_coll_base::CentFT0C,
                   hf_coll_base::CentFT0M,
                   hf_coll_base::CentFV0A,
-                  hf_coll_base::MultZeqNTracksPV);
-// hf_coll_base::IsEventReject,
-// bc::RunNumber,
+                  hf_coll_base::MultZeqNTracksPV,
+                  // hf_coll_base::IsEventReject,
+                  // bc::RunNumber,
+                  soa::Marker<MarkerD0>);
 
 using HfD0CollBase = HfD0CollBases::iterator;
 
 DECLARE_SOA_TABLE(HfD0CollIds, "AOD", "HFD0COLLID", //! Table with global indices for collisions
-                  hf_cand::CollisionId);
+                  hf_cand::CollisionId,
+                  soa::Marker<MarkerD0>);
 
 // 3-prong decays
 
@@ -82,13 +89,13 @@ DECLARE_SOA_TABLE(Hf3PCollBases, "AOD", "HF3PCOLLBASE", //! Table with basic col
                   hf_coll_base::MultZeqNTracksPV,
                   // hf_coll_base::IsEventReject,
                   // bc::RunNumber,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 
 using Hf3PCollBase = Hf3PCollBases::iterator;
 
 DECLARE_SOA_TABLE(Hf3PCollIds, "AOD", "HF3PCOLLID", //! Table with global indices for collisions
                   hf_cand::CollisionId,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 
 // ===================
 // MC collision tables
@@ -108,7 +115,7 @@ DECLARE_SOA_TABLE(HfD0McCollBases, "AOD", "HFD0MCCOLLBASE", //! Table with basic
                   mccollision::PosX,
                   mccollision::PosY,
                   mccollision::PosZ,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0>);
 
 using HfD0McCollBase = HfD0McCollBases::iterator;
 
@@ -122,7 +129,7 @@ DECLARE_SOA_TABLE(Hf3PMcCollBases, "AOD", "HF3PMCCOLLBASE", //! Table with basic
                   mccollision::PosX,
                   mccollision::PosY,
                   mccollision::PosZ,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 
 using Hf3PMcCollBase = Hf3PMcCollBases::iterator;
 
@@ -303,7 +310,8 @@ DECLARE_SOA_TABLE(HfD0Bases, "AOD", "HFD0BASE", //! Table with basic candidate p
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<MarkerD0>);
 
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
@@ -336,7 +344,8 @@ DECLARE_SOA_TABLE(HfD0Pars, "AOD", "HFD0PAR", //! Table with candidate propertie
                   hf_cand_par::NSigTpcTofPi1,
                   hf_cand_par::NSigTpcTofKa1,
                   hf_cand_par::MaxNormalisedDeltaIP,
-                  hf_cand_par::ImpactParameterProduct);
+                  hf_cand_par::ImpactParameterProduct,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0ParEs, "AOD", "HFD0PARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
@@ -360,22 +369,27 @@ DECLARE_SOA_TABLE(HfD0ParEs, "AOD", "HFD0PARE", //! Table with additional candid
                   hf_cand::ErrorImpactParameter0,
                   hf_cand::ErrorImpactParameter1,
                   hf_cand_par::CosThetaStar,
-                  hf_cand_par::Ct);
+                  hf_cand_par::Ct,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0Sels, "AOD", "HFD0SEL", //! Table with candidate selection flags
-                  hf_cand_sel::CandidateSelFlag);
+                  hf_cand_sel::CandidateSelFlag,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0Mls, "AOD", "HFD0ML", //! Table with candidate selection ML scores
-                  hf_cand_mc::MlScores);
+                  hf_cand_mc::MlScores,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0Ids, "AOD", "HFD0ID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
                   hf_track_index::Prong0Id,
-                  hf_track_index::Prong1Id);
+                  hf_track_index::Prong1Id,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0Mcs, "AOD", "HFD0MC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
-                  hf_cand_mc::OriginMcRec);
+                  hf_cand_mc::OriginMcRec,
+                  soa::Marker<MarkerD0>);
 
 // 3-prong decays
 
@@ -390,7 +404,8 @@ DECLARE_SOA_TABLE(Hf3PBases, "AOD", "HF3PBASE", //! Table with basic candidate p
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<Marker3P>);
 
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
@@ -428,7 +443,8 @@ DECLARE_SOA_TABLE(Hf3PPars, "AOD", "HF3PPAR", //! Table with candidate propertie
                   hf_cand_par::NSigTofPi2,
                   hf_cand_par::NSigTofPr2,
                   hf_cand_par::NSigTpcTofPi2,
-                  hf_cand_par::NSigTpcTofPr2);
+                  hf_cand_par::NSigTpcTofPr2,
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PParEs, "AOD", "HF3PPARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
@@ -455,26 +471,29 @@ DECLARE_SOA_TABLE(Hf3PParEs, "AOD", "HF3PPARE", //! Table with additional candid
                   hf_cand::ErrorImpactParameter0,
                   hf_cand::ErrorImpactParameter1,
                   hf_cand::ErrorImpactParameter2,
-                  hf_cand_par::Ct);
+                  hf_cand_par::Ct,
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PSels, "AOD", "HF3PSEL", //! Table with candidate selection flags
                   hf_cand_sel::CandidateSelFlag,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PMls, "AOD", "HF3PML", //! Table with candidate selection ML scores
                   hf_cand_mc::MlScores,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PIds, "AOD", "HF3PID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,
-                  hf_track_index::Prong2Id);
+                  hf_track_index::Prong2Id,
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PMcs, "AOD", "HF3PMC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec,
-                  hf_cand_mc::IsCandidateSwapped);
+                  hf_cand_mc::IsCandidateSwapped,
+                  soa::Marker<Marker3P>);
 
 // ==================
 // MC particle tables
@@ -506,11 +525,13 @@ DECLARE_SOA_TABLE(HfD0PBases, "AOD", "HFD0PBASE", //! Table with MC particle inf
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<MarkerD0>);
 
 DECLARE_SOA_TABLE(HfD0PIds, "AOD", "HFD0PID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
-                  hf_mc_particle::McParticleId);
+                  hf_mc_particle::McParticleId,
+                  soa::Marker<MarkerD0>);
 
 // 3-prong decays
 
@@ -526,12 +547,13 @@ DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle inf
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<Marker3P>);
 
 DECLARE_SOA_TABLE(Hf3PPIds, "AOD", "HF3PPID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
                   hf_mc_particle::McParticleId,
-                  soa::Marker<2>);
+                  soa::Marker<Marker3P>);
 } // namespace o2::aod
 
 #endif // PWGHF_DATAMODEL_DERIVEDTABLES_H_

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -155,7 +155,7 @@ DECLARE_SOA_TABLE(Hf3PMcCollBases, "AOD", "HF3PMCCOLLBASE", //! Table with basic
 
 using Hf3PMcCollBase = Hf3PMcCollBases::iterator;
 
-DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table with basic MC collision info
+DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table with basic MC collision info (stored version)
                   o2::soa::Index<>,
                   mccollision::PosX,
                   mccollision::PosY,
@@ -163,6 +163,12 @@ DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table wit
                   soa::Marker<3>);
 
 using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
+
+DECLARE_SOA_TABLE(Hf3PMcCollIds, "AOD", "HF3PMCCOLLID", //! Table with indices pointing to the derived collision table
+                  hf_mc_coll::Hf3PCollBaseIds);
+
+DECLARE_SOA_TABLE(StoredHf3PMcCollIds, "AOD1", "HF3PMCCOLLID", //! Table with indices pointing to the derived collision table (stored version)
+                  hf_mc_coll::StoredHf3PCollBaseIds);
 
 // ================
 // Candidate tables

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -28,6 +28,10 @@
 
 namespace o2::aod
 {
+// ================
+// Collision tables
+// ================
+
 // Basic collision properties
 namespace hf_coll_base
 {
@@ -127,6 +131,21 @@ DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global
                   hf_cand::CollisionId,
                   soa::Marker<3>);
 
+// ===================
+// MC collision tables
+// ===================
+
+// MC collision columns
+namespace hf_mc_coll
+{
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Hf3PCollBase, hf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
+DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
+} // namespace hf_mc_coll
+
+// DO (TODO)
+
+// 3-prong decays
+
 DECLARE_SOA_TABLE(Hf3PMcCollBases, "AOD", "HF3PMCCOLLBASE", //! Table with basic MC collision info
                   o2::soa::Index<>,
                   mccollision::PosX,
@@ -145,6 +164,10 @@ DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table wit
 
 using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
 
+// ================
+// Candidate tables
+// ================
+
 // Basic candidate properties
 namespace hf_cand_base
 {
@@ -157,6 +180,8 @@ DECLARE_SOA_COLUMN(M, m, float);                                  //! invariant 
 DECLARE_SOA_COLUMN(Phi, phi, float);                              //! azimuth
 DECLARE_SOA_COLUMN(Pt, pt, float);                                //! transverse momentum
 
+/// Helper functions for dynamic columns
+/// \todo Move to RecoDecayPtEtaPhi
 namespace functions_pt_eta_phi
 {
 /// px as a function of pT, phi
@@ -289,22 +314,13 @@ namespace hf_cand_sel
 DECLARE_SOA_COLUMN(CandidateSelFlag, candidateSelFlag, int8_t); //! bitmap of the selected candidate type
 }
 
-// MC flags
+// Candidate MC columns
 namespace hf_cand_mc
 {
-DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
-DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
-DECLARE_SOA_ARRAY_INDEX_COLUMN(Hf3PCollBase, hf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
-DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);         //! flag for reconstruction level matching
-DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               //! particle origin, reconstruction level
-DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! particle origin, generator level
 DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t); //! swapping of the prongs order
 DECLARE_SOA_COLUMN(FlagMcDecayChanRec, flagMcDecayChanRec, int8_t); //! resonant decay channel flag, reconstruction level
-DECLARE_SOA_COLUMN(FlagMcDecayChanGen, flagMcDecayChanGen, int8_t); //! resonant decay channel flag, generator level
 DECLARE_SOA_COLUMN(MlScoreBkg, mlScoreBkg, float);                  //! ML score for background class
 DECLARE_SOA_COLUMN(MlScorePrompt, mlScorePrompt, float);            //! ML score for prompt class
 DECLARE_SOA_COLUMN(MlScoreNonPrompt, mlScoreNonPrompt, float);      //! ML score for non-prompt class
@@ -484,42 +500,6 @@ DECLARE_SOA_TABLE(HfD0Mcs, "AOD", "HFD0MC", //! Table with MC candidate info
 DECLARE_SOA_TABLE(StoredHfD0Mcs, "AOD1", "HFD0MC", //! Table with MC candidate info (stored version)
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec,
-                  soa::Marker<1>);
-
-DECLARE_SOA_TABLE(HfD0PBases, "AOD", "HFD0PBASE", //! Table with MC particle info
-                  o2::soa::Index<>,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_cand_mc::FlagMcMatchGen,
-                  hf_cand_mc::OriginMcGen,
-                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
-
-DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC particle info (stored version)
-                  o2::soa::Index<>,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_cand_mc::FlagMcMatchGen,
-                  hf_cand_mc::OriginMcGen,
-                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
-
-DECLARE_SOA_TABLE(HfD0PIds, "AOD", "HFD0PID", //! Table with global indices for MC particles
-                  hf_cand_mc::McCollisionId,
-                  hf_cand_mc::McParticleId);
-
-DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles (stored version)
-                  hf_cand_mc::McCollisionId,
-                  hf_cand_mc::McParticleId,
                   soa::Marker<1>);
 
 // 3-prong decays
@@ -719,14 +699,70 @@ DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate i
                   hf_cand_mc::IsCandidateSwapped,
                   soa::Marker<1>);
 
-DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle info
+// ==================
+// MC particle tables
+// ==================
+
+// MC particle columns
+namespace hf_mc_particle
+{
+DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
+DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
+DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! particle origin, generator level
+DECLARE_SOA_COLUMN(FlagMcDecayChanGen, flagMcDecayChanGen, int8_t); //! resonant decay channel flag, generator level
+} // namespace hf_mc_particle
+
+// D0
+
+DECLARE_SOA_TABLE(HfD0PBases, "AOD", "HFD0PBASE", //! Table with MC particle info
                   o2::soa::Index<>,
-                  hf_cand_mc::Hf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
-                  hf_cand_mc::FlagMcMatchGen,
-                  hf_cand_mc::OriginMcGen,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
+                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
+
+DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC particle info (stored version)
+                  o2::soa::Index<>,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
+                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(HfD0PIds, "AOD", "HFD0PID", //! Table with global indices for MC particles
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId);
+
+DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles (stored version)
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId,
+                  soa::Marker<1>);
+
+// 3-prong decays
+
+DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle info
+                  o2::soa::Index<>,
+                  hf_mc_particle::Hf3PMcCollBaseId,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
                   hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
@@ -735,12 +771,12 @@ DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle inf
 
 DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC particle info (stored version)
                   o2::soa::Index<>,
-                  hf_cand_mc::StoredHf3PMcCollBaseId,
+                  hf_mc_particle::StoredHf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
-                  hf_cand_mc::FlagMcMatchGen,
-                  hf_cand_mc::OriginMcGen,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
                   hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
@@ -749,13 +785,13 @@ DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC parti
                   soa::Marker<1>);
 
 DECLARE_SOA_TABLE(Hf3PPIds, "AOD", "HF3PPID", //! Table with global indices for MC particles
-                  hf_cand_mc::McCollisionId,
-                  hf_cand_mc::McParticleId,
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId,
                   soa::Marker<2>);
 
 DECLARE_SOA_TABLE(StoredHf3PPIds, "AOD1", "HF3PPID", //! Table with global indices for MC particles (stored version)
-                  hf_cand_mc::McCollisionId,
-                  hf_cand_mc::McParticleId,
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId,
                   soa::Marker<3>);
 } // namespace o2::aod
 

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -31,8 +31,6 @@ namespace o2::aod
 {
 constexpr uint MarkerD0 = 1;
 constexpr uint Marker3P = 2;
-constexpr uint MarkerD0Stored = 10;
-constexpr uint Marker3PStored = 20;
 
 // ================
 // Collision tables

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -97,10 +97,23 @@ DECLARE_SOA_TABLE(Hf3PCollIds, "AOD", "HF3PCOLLID", //! Table with global indice
 // MC collision columns
 namespace hf_mc_coll
 {
+DECLARE_SOA_ARRAY_INDEX_COLUMN(HfD0CollBase, hfD0CollBases); //! collision index array pointing to the derived collision table for D0 candidates
 DECLARE_SOA_ARRAY_INDEX_COLUMN(Hf3PCollBase, hf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
 } // namespace hf_mc_coll
 
-// DO (TODO)
+// DO
+
+DECLARE_SOA_TABLE(HfD0McCollBases, "AOD", "HFD0MCCOLLBASE", //! Table with basic MC collision info
+                  o2::soa::Index<>,
+                  mccollision::PosX,
+                  mccollision::PosY,
+                  mccollision::PosZ,
+                  soa::Marker<1>);
+
+using HfD0McCollBase = HfD0McCollBases::iterator;
+
+DECLARE_SOA_TABLE(HfD0McCollIds, "AOD", "HFD0MCCOLLID", //! Table with indices pointing to the derived collision table
+                  hf_mc_coll::HfD0CollBaseIds);
 
 // 3-prong decays
 
@@ -472,6 +485,7 @@ namespace hf_mc_particle
 {
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
+DECLARE_SOA_INDEX_COLUMN(HfD0McCollBase, hfD0McCollBase);             //! collision index pointing to the derived MC collision table for D0 candidates
 DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! particle origin, generator level
@@ -482,6 +496,7 @@ DECLARE_SOA_COLUMN(FlagMcDecayChanGen, flagMcDecayChanGen, int8_t); //! resonant
 
 DECLARE_SOA_TABLE(HfD0PBases, "AOD", "HFD0PBASE", //! Table with MC particle info
                   o2::soa::Index<>,
+                  hf_mc_particle::HfD0McCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -127,6 +127,24 @@ DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global
                   hf_cand::CollisionId,
                   soa::Marker<3>);
 
+DECLARE_SOA_TABLE(Hf3PMcCollBases, "AOD", "HF3PMCCOLLBASE", //! Table with basic MC collision info
+                  o2::soa::Index<>,
+                  mccollision::PosX,
+                  mccollision::PosY,
+                  mccollision::PosZ,
+                  soa::Marker<2>);
+
+using Hf3PMcCollBase = Hf3PMcCollBases::iterator;
+
+DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table with basic MC collision info
+                  o2::soa::Index<>,
+                  mccollision::PosX,
+                  mccollision::PosY,
+                  mccollision::PosZ,
+                  soa::Marker<3>);
+
+using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
+
 // Basic candidate properties
 namespace hf_cand_base
 {

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -9,8 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file DerivedTables.h.h
+/// \file DerivedTables.h
 /// \brief Definitions of derived tables produced by derived-data creators
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
 
 #ifndef PWGHF_DATAMODEL_DERIVEDTABLES_H_
 #define PWGHF_DATAMODEL_DERIVEDTABLES_H_
@@ -63,29 +64,8 @@ DECLARE_SOA_TABLE(HfD0CollBases, "AOD", "HFD0COLLBASE", //! Table with basic col
 
 using HfD0CollBase = HfD0CollBases::iterator;
 
-DECLARE_SOA_TABLE(StoredHfD0CollBases, "AOD1", "HFD0COLLBASE", //! Table with basic collision info (stored version)
-                  o2::soa::Index<>,
-                  collision::PosX,
-                  collision::PosY,
-                  collision::PosZ,
-                  collision::NumContrib,
-                  hf_coll_base::CentFT0A,
-                  hf_coll_base::CentFT0C,
-                  hf_coll_base::CentFT0M,
-                  hf_coll_base::CentFV0A,
-                  hf_coll_base::MultZeqNTracksPV,
-                  // hf_coll_base::IsEventReject,
-                  // bc::RunNumber,
-                  soa::Marker<1>);
-
-using StoredHfD0CollBase = StoredHfD0CollBases::iterator;
-
 DECLARE_SOA_TABLE(HfD0CollIds, "AOD", "HFD0COLLID", //! Table with global indices for collisions
                   hf_cand::CollisionId);
-
-DECLARE_SOA_TABLE(StoredHfD0CollIds, "AOD1", "HFD0COLLID", //! Table with global indices for collisions (stored version)
-                  hf_cand::CollisionId,
-                  soa::Marker<1>);
 
 // 3-prong decays
 
@@ -106,30 +86,9 @@ DECLARE_SOA_TABLE(Hf3PCollBases, "AOD", "HF3PCOLLBASE", //! Table with basic col
 
 using Hf3PCollBase = Hf3PCollBases::iterator;
 
-DECLARE_SOA_TABLE(StoredHf3PCollBases, "AOD1", "HF3PCOLLBASE", //! Table with basic collision info (stored version)
-                  o2::soa::Index<>,
-                  collision::PosX,
-                  collision::PosY,
-                  collision::PosZ,
-                  collision::NumContrib,
-                  hf_coll_base::CentFT0A,
-                  hf_coll_base::CentFT0C,
-                  hf_coll_base::CentFT0M,
-                  hf_coll_base::CentFV0A,
-                  hf_coll_base::MultZeqNTracksPV,
-                  // hf_coll_base::IsEventReject,
-                  // bc::RunNumber,
-                  soa::Marker<3>);
-
-using StoredHf3PCollBase = StoredHf3PCollBases::iterator;
-
 DECLARE_SOA_TABLE(Hf3PCollIds, "AOD", "HF3PCOLLID", //! Table with global indices for collisions
                   hf_cand::CollisionId,
                   soa::Marker<2>);
-
-DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global indices for collisions (stored version)
-                  hf_cand::CollisionId,
-                  soa::Marker<3>);
 
 // ===================
 // MC collision tables
@@ -139,7 +98,6 @@ DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global
 namespace hf_mc_coll
 {
 DECLARE_SOA_ARRAY_INDEX_COLUMN(Hf3PCollBase, hf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
-DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
 } // namespace hf_mc_coll
 
 // DO (TODO)
@@ -155,20 +113,8 @@ DECLARE_SOA_TABLE(Hf3PMcCollBases, "AOD", "HF3PMCCOLLBASE", //! Table with basic
 
 using Hf3PMcCollBase = Hf3PMcCollBases::iterator;
 
-DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table with basic MC collision info (stored version)
-                  o2::soa::Index<>,
-                  mccollision::PosX,
-                  mccollision::PosY,
-                  mccollision::PosZ,
-                  soa::Marker<3>);
-
-using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
-
 DECLARE_SOA_TABLE(Hf3PMcCollIds, "AOD", "HF3PMCCOLLID", //! Table with indices pointing to the derived collision table
                   hf_mc_coll::Hf3PCollBaseIds);
-
-DECLARE_SOA_TABLE(StoredHf3PMcCollIds, "AOD1", "HF3PMCCOLLID", //! Table with indices pointing to the derived collision table (stored version)
-                  hf_mc_coll::StoredHf3PCollBaseIds);
 
 // ================
 // Candidate tables
@@ -178,9 +124,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcCollIds, "AOD1", "HF3PMCCOLLID", //! Table with in
 namespace hf_cand_base
 {
 DECLARE_SOA_INDEX_COLUMN(HfD0CollBase, hfD0CollBase);             //! collision index pointing to the derived collision table for D0 candidates
-DECLARE_SOA_INDEX_COLUMN(StoredHfD0CollBase, storedHfD0CollBase); //! collision index pointing to the derived collision table for D0 candidates
 DECLARE_SOA_INDEX_COLUMN(Hf3PCollBase, hf3PCollBase);             //! collision index pointing to the derived collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBase); //! collision index pointing to the derived collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(Eta, eta, float);                              //! pseudorapidity
 DECLARE_SOA_COLUMN(M, m, float);                                  //! invariant mass
 DECLARE_SOA_COLUMN(Phi, phi, float);                              //! azimuth
@@ -348,20 +292,6 @@ DECLARE_SOA_TABLE(HfD0Bases, "AOD", "HFD0BASE", //! Table with basic candidate p
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
 
-DECLARE_SOA_TABLE(StoredHfD0Bases, "AOD1", "HFD0BASE", //! Table with basic candidate properties used in the analyses (stored version)
-                  o2::soa::Index<>,
-                  hf_cand_base::StoredHfD0CollBaseId,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_cand_base::M,
-                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
-
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
 // XY: CpaXY, DecayLengthXY, ErrorDecayLengthXY
@@ -395,36 +325,6 @@ DECLARE_SOA_TABLE(HfD0Pars, "AOD", "HFD0PAR", //! Table with candidate propertie
                   hf_cand_par::MaxNormalisedDeltaIP,
                   hf_cand_par::ImpactParameterProduct);
 
-DECLARE_SOA_TABLE(StoredHfD0Pars, "AOD1", "HFD0PAR", //! Table with candidate properties used for selection (stored version)
-                  hf_cand::Chi2PCA,
-                  hf_cand_par::Cpa,
-                  hf_cand_par::CpaXY,
-                  hf_cand_par::DecayLength,
-                  hf_cand_par::DecayLengthXY,
-                  hf_cand_par::DecayLengthNormalised,
-                  hf_cand_par::DecayLengthXYNormalised,
-                  hf_cand_par::PtProng0,
-                  hf_cand_par::PtProng1,
-                  hf_cand::ImpactParameter0,
-                  hf_cand::ImpactParameter1,
-                  hf_cand_par::ImpactParameterNormalised0,
-                  hf_cand_par::ImpactParameterNormalised1,
-                  hf_cand_par::NSigTpcPi0,
-                  hf_cand_par::NSigTpcKa0,
-                  hf_cand_par::NSigTofPi0,
-                  hf_cand_par::NSigTofKa0,
-                  hf_cand_par::NSigTpcTofPi0,
-                  hf_cand_par::NSigTpcTofKa0,
-                  hf_cand_par::NSigTpcPi1,
-                  hf_cand_par::NSigTpcKa1,
-                  hf_cand_par::NSigTofPi1,
-                  hf_cand_par::NSigTofKa1,
-                  hf_cand_par::NSigTpcTofPi1,
-                  hf_cand_par::NSigTpcTofKa1,
-                  hf_cand_par::MaxNormalisedDeltaIP,
-                  hf_cand_par::ImpactParameterProduct,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(HfD0ParEs, "AOD", "HFD0PARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
                   collision::PosY,
@@ -449,64 +349,20 @@ DECLARE_SOA_TABLE(HfD0ParEs, "AOD", "HFD0PARE", //! Table with additional candid
                   hf_cand_par::CosThetaStar,
                   hf_cand_par::Ct);
 
-DECLARE_SOA_TABLE(StoredHfD0ParEs, "AOD1", "HFD0PARE", //! Table with additional candidate properties used for selection (stored version)
-                  collision::PosX,
-                  collision::PosY,
-                  collision::PosZ,
-                  hf_cand::XSecondaryVertex,
-                  hf_cand::YSecondaryVertex,
-                  hf_cand::ZSecondaryVertex,
-                  hf_cand::ErrorDecayLength,
-                  hf_cand::ErrorDecayLengthXY,
-                  hf_cand::KfTopolChi2OverNdf,
-                  hf_cand_par::RSecondaryVertex,
-                  hf_cand_par::PProng0,
-                  hf_cand_par::PProng1,
-                  hf_cand::PxProng0,
-                  hf_cand::PyProng0,
-                  hf_cand::PzProng0,
-                  hf_cand::PxProng1,
-                  hf_cand::PyProng1,
-                  hf_cand::PzProng1,
-                  hf_cand::ErrorImpactParameter0,
-                  hf_cand::ErrorImpactParameter1,
-                  hf_cand_par::CosThetaStar,
-                  hf_cand_par::Ct,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(HfD0Sels, "AOD", "HFD0SEL", //! Table with candidate selection flags
                   hf_cand_sel::CandidateSelFlag);
 
-DECLARE_SOA_TABLE(StoredHfD0Sels, "AOD1", "HFD0SEL", //! Table with candidate selection flags (stored version)
-                  hf_cand_sel::CandidateSelFlag,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(HfD0Mls, "AOD", "HFD0ML", //! Table with candidate selection ML scores
                   hf_cand_mc::MlScores);
-
-DECLARE_SOA_TABLE(StoredHfD0Mls, "AOD1", "HFD0ML", //! Table with candidate selection ML scores (stored version)
-                  hf_cand_mc::MlScores,
-                  soa::Marker<1>);
 
 DECLARE_SOA_TABLE(HfD0Ids, "AOD", "HFD0ID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id);
 
-DECLARE_SOA_TABLE(StoredHfD0Ids, "AOD1", "HFD0ID", //! Table with global indices for candidates (stored version)
-                  hf_cand::CollisionId,
-                  hf_track_index::Prong0Id,
-                  hf_track_index::Prong1Id,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(HfD0Mcs, "AOD", "HFD0MC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec);
-
-DECLARE_SOA_TABLE(StoredHfD0Mcs, "AOD1", "HFD0MC", //! Table with MC candidate info (stored version)
-                  hf_cand_mc::FlagMcMatchRec,
-                  hf_cand_mc::OriginMcRec,
-                  soa::Marker<1>);
 
 // 3-prong decays
 
@@ -522,20 +378,6 @@ DECLARE_SOA_TABLE(Hf3PBases, "AOD", "HF3PBASE", //! Table with basic candidate p
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
-
-DECLARE_SOA_TABLE(StoredHf3PBases, "AOD1", "HF3PBASE", //! Table with basic candidate properties used in the analyses (stored version)
-                  o2::soa::Index<>,
-                  hf_cand_base::StoredHf3PCollBaseId,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_cand_base::M,
-                  hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
 
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
@@ -575,41 +417,6 @@ DECLARE_SOA_TABLE(Hf3PPars, "AOD", "HF3PPAR", //! Table with candidate propertie
                   hf_cand_par::NSigTpcTofPi2,
                   hf_cand_par::NSigTpcTofPr2);
 
-DECLARE_SOA_TABLE(StoredHf3PPars, "AOD1", "HF3PPAR", //! Table with candidate properties used for selection (stored version)
-                  hf_cand::Chi2PCA,
-                  hf_cand::NProngsContributorsPV,
-                  hf_cand_par::Cpa,
-                  hf_cand_par::CpaXY,
-                  hf_cand_par::DecayLength,
-                  hf_cand_par::DecayLengthXY,
-                  hf_cand_par::DecayLengthNormalised,
-                  hf_cand_par::DecayLengthXYNormalised,
-                  hf_cand_par::PtProng0,
-                  hf_cand_par::PtProng1,
-                  hf_cand_par::PtProng2,
-                  hf_cand::ImpactParameter0,
-                  hf_cand::ImpactParameter1,
-                  hf_cand::ImpactParameter2,
-                  hf_cand_par::ImpactParameterNormalised0,
-                  hf_cand_par::ImpactParameterNormalised1,
-                  hf_cand_par::ImpactParameterNormalised2,
-                  hf_cand_par::NSigTpcPi0,
-                  hf_cand_par::NSigTpcPr0,
-                  hf_cand_par::NSigTofPi0,
-                  hf_cand_par::NSigTofPr0,
-                  hf_cand_par::NSigTpcTofPi0,
-                  hf_cand_par::NSigTpcTofPr0,
-                  hf_cand_par::NSigTpcKa1,
-                  hf_cand_par::NSigTofKa1,
-                  hf_cand_par::NSigTpcTofKa1,
-                  hf_cand_par::NSigTpcPi2,
-                  hf_cand_par::NSigTpcPr2,
-                  hf_cand_par::NSigTofPi2,
-                  hf_cand_par::NSigTofPr2,
-                  hf_cand_par::NSigTpcTofPi2,
-                  hf_cand_par::NSigTpcTofPr2,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(Hf3PParEs, "AOD", "HF3PPARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
                   collision::PosY,
@@ -637,49 +444,13 @@ DECLARE_SOA_TABLE(Hf3PParEs, "AOD", "HF3PPARE", //! Table with additional candid
                   hf_cand::ErrorImpactParameter2,
                   hf_cand_par::Ct);
 
-DECLARE_SOA_TABLE(StoredHf3PParEs, "AOD1", "HF3PPARE", //! Table with additional candidate properties used for selection (stored version)
-                  collision::PosX,
-                  collision::PosY,
-                  collision::PosZ,
-                  hf_cand::XSecondaryVertex,
-                  hf_cand::YSecondaryVertex,
-                  hf_cand::ZSecondaryVertex,
-                  hf_cand::ErrorDecayLength,
-                  hf_cand::ErrorDecayLengthXY,
-                  hf_cand_par::RSecondaryVertex,
-                  hf_cand_par::PProng0,
-                  hf_cand_par::PProng1,
-                  hf_cand_par::PProng2,
-                  hf_cand::PxProng0,
-                  hf_cand::PyProng0,
-                  hf_cand::PzProng0,
-                  hf_cand::PxProng1,
-                  hf_cand::PyProng1,
-                  hf_cand::PzProng1,
-                  hf_cand::PxProng2,
-                  hf_cand::PyProng2,
-                  hf_cand::PzProng2,
-                  hf_cand::ErrorImpactParameter0,
-                  hf_cand::ErrorImpactParameter1,
-                  hf_cand::ErrorImpactParameter2,
-                  hf_cand_par::Ct,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(Hf3PSels, "AOD", "HF3PSEL", //! Table with candidate selection flags
                   hf_cand_sel::CandidateSelFlag,
                   soa::Marker<2>);
 
-DECLARE_SOA_TABLE(StoredHf3PSels, "AOD1", "HF3PSEL", //! Table with candidate selection flags (stored version)
-                  hf_cand_sel::CandidateSelFlag,
-                  soa::Marker<3>);
-
 DECLARE_SOA_TABLE(Hf3PMls, "AOD", "HF3PML", //! Table with candidate selection ML scores
                   hf_cand_mc::MlScores,
                   soa::Marker<2>);
-
-DECLARE_SOA_TABLE(StoredHf3PMls, "AOD1", "HF3PML", //! Table with candidate selection ML scores (stored version)
-                  hf_cand_mc::MlScores,
-                  soa::Marker<3>);
 
 DECLARE_SOA_TABLE(Hf3PIds, "AOD", "HF3PID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
@@ -687,23 +458,10 @@ DECLARE_SOA_TABLE(Hf3PIds, "AOD", "HF3PID", //! Table with global indices for ca
                   hf_track_index::Prong1Id,
                   hf_track_index::Prong2Id);
 
-DECLARE_SOA_TABLE(StoredHf3PIds, "AOD1", "HF3PID", //! Table with global indices for candidates (stored version)
-                  hf_cand::CollisionId,
-                  hf_track_index::Prong0Id,
-                  hf_track_index::Prong1Id,
-                  hf_track_index::Prong2Id,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(Hf3PMcs, "AOD", "HF3PMC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec,
                   hf_cand_mc::IsCandidateSwapped);
-
-DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate info (stored version)
-                  hf_cand_mc::FlagMcMatchRec,
-                  hf_cand_mc::OriginMcRec,
-                  hf_cand_mc::IsCandidateSwapped,
-                  soa::Marker<1>);
 
 // ==================
 // MC particle tables
@@ -715,7 +473,6 @@ namespace hf_mc_particle
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
 DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! particle origin, generator level
 DECLARE_SOA_COLUMN(FlagMcDecayChanGen, flagMcDecayChanGen, int8_t); //! resonant decay channel flag, generator level
@@ -736,28 +493,9 @@ DECLARE_SOA_TABLE(HfD0PBases, "AOD", "HFD0PBASE", //! Table with MC particle inf
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
 
-DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC particle info (stored version)
-                  o2::soa::Index<>,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_mc_particle::FlagMcMatchGen,
-                  hf_mc_particle::OriginMcGen,
-                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(HfD0PIds, "AOD", "HFD0PID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
                   hf_mc_particle::McParticleId);
-
-DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles (stored version)
-                  hf_mc_particle::McCollisionId,
-                  hf_mc_particle::McParticleId,
-                  soa::Marker<1>);
 
 // 3-prong decays
 
@@ -775,30 +513,10 @@ DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle inf
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>);
 
-DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC particle info (stored version)
-                  o2::soa::Index<>,
-                  hf_mc_particle::StoredHf3PMcCollBaseId,
-                  hf_cand_base::Pt,
-                  hf_cand_base::Eta,
-                  hf_cand_base::Phi,
-                  hf_mc_particle::FlagMcMatchGen,
-                  hf_mc_particle::OriginMcGen,
-                  hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
-                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
-
 DECLARE_SOA_TABLE(Hf3PPIds, "AOD", "HF3PPID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
                   hf_mc_particle::McParticleId,
                   soa::Marker<2>);
-
-DECLARE_SOA_TABLE(StoredHf3PPIds, "AOD1", "HF3PPID", //! Table with global indices for MC particles (stored version)
-                  hf_mc_particle::McCollisionId,
-                  hf_mc_particle::McParticleId,
-                  soa::Marker<3>);
 } // namespace o2::aod
 
 #endif // PWGHF_DATAMODEL_DERIVEDTABLES_H_

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -152,6 +152,8 @@ DECLARE_SOA_INDEX_COLUMN(HfD0CollBase, hfD0CollBase);             //! collision 
 DECLARE_SOA_INDEX_COLUMN(StoredHfD0CollBase, storedHfD0CollBase); //! collision index pointing to the derived collision table for D0 candidates
 DECLARE_SOA_INDEX_COLUMN(Hf3PCollBase, hf3PCollBase);             //! collision index pointing to the derived collision table for 3-prong candidates
 DECLARE_SOA_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBase); //! collision index pointing to the derived collision table for 3-prong candidates
+DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
 DECLARE_SOA_COLUMN(Eta, eta, float);                              //! pseudorapidity
@@ -717,6 +719,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate i
 
 DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle info
                   o2::soa::Index<>,
+                  hf_cand_base::Hf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
@@ -730,6 +733,7 @@ DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle inf
 
 DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC particle info (stored version)
                   o2::soa::Index<>,
+                  hf_cand_base::Hf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,

--- a/PWGHF/DataModel/DerivedTables.h
+++ b/PWGHF/DataModel/DerivedTables.h
@@ -152,10 +152,6 @@ DECLARE_SOA_INDEX_COLUMN(HfD0CollBase, hfD0CollBase);             //! collision 
 DECLARE_SOA_INDEX_COLUMN(StoredHfD0CollBase, storedHfD0CollBase); //! collision index pointing to the derived collision table for D0 candidates
 DECLARE_SOA_INDEX_COLUMN(Hf3PCollBase, hf3PCollBase);             //! collision index pointing to the derived collision table for 3-prong candidates
 DECLARE_SOA_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBase); //! collision index pointing to the derived collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
-DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
-DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
 DECLARE_SOA_COLUMN(Eta, eta, float);                              //! pseudorapidity
 DECLARE_SOA_COLUMN(M, m, float);                                  //! invariant mass
 DECLARE_SOA_COLUMN(Phi, phi, float);                              //! azimuth
@@ -296,6 +292,12 @@ DECLARE_SOA_COLUMN(CandidateSelFlag, candidateSelFlag, int8_t); //! bitmap of th
 // MC flags
 namespace hf_cand_mc
 {
+DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);               //! MC collision of this particle
+DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);                 //! MC particle
+DECLARE_SOA_INDEX_COLUMN(Hf3PMcCollBase, hf3PMcCollBase);             //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Hf3PCollBase, hf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
+DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);         //! flag for reconstruction level matching
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         //! flag for generator level matching
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               //! particle origin, reconstruction level
@@ -326,7 +328,7 @@ DECLARE_SOA_TABLE(HfD0Bases, "AOD", "HFD0BASE", //! Table with basic candidate p
 
 DECLARE_SOA_TABLE(StoredHfD0Bases, "AOD1", "HFD0BASE", //! Table with basic candidate properties used in the analyses (stored version)
                   o2::soa::Index<>,
-                  hf_cand_base::HfD0CollBaseId,
+                  hf_cand_base::StoredHfD0CollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
@@ -512,12 +514,12 @@ DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC parti
                   soa::Marker<1>);
 
 DECLARE_SOA_TABLE(HfD0PIds, "AOD", "HFD0PID", //! Table with global indices for MC particles
-                  hf_cand_base::McCollisionId,
-                  hf_cand_base::McParticleId);
+                  hf_cand_mc::McCollisionId,
+                  hf_cand_mc::McParticleId);
 
 DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles (stored version)
-                  hf_cand_base::McCollisionId,
-                  hf_cand_base::McParticleId,
+                  hf_cand_mc::McCollisionId,
+                  hf_cand_mc::McParticleId,
                   soa::Marker<1>);
 
 // 3-prong decays
@@ -537,7 +539,7 @@ DECLARE_SOA_TABLE(Hf3PBases, "AOD", "HF3PBASE", //! Table with basic candidate p
 
 DECLARE_SOA_TABLE(StoredHf3PBases, "AOD1", "HF3PBASE", //! Table with basic candidate properties used in the analyses (stored version)
                   o2::soa::Index<>,
-                  hf_cand_base::Hf3PCollBaseId,
+                  hf_cand_base::StoredHf3PCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
@@ -719,7 +721,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate i
 
 DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle info
                   o2::soa::Index<>,
-                  hf_cand_base::Hf3PMcCollBaseId,
+                  hf_cand_mc::Hf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
@@ -733,7 +735,7 @@ DECLARE_SOA_TABLE(Hf3PPBases, "AOD", "HF3PPBASE", //! Table with MC particle inf
 
 DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC particle info (stored version)
                   o2::soa::Index<>,
-                  hf_cand_base::Hf3PMcCollBaseId,
+                  hf_cand_mc::StoredHf3PMcCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,
@@ -747,13 +749,13 @@ DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC parti
                   soa::Marker<1>);
 
 DECLARE_SOA_TABLE(Hf3PPIds, "AOD", "HF3PPID", //! Table with global indices for MC particles
-                  hf_cand_base::McCollisionId,
-                  hf_cand_base::McParticleId,
+                  hf_cand_mc::McCollisionId,
+                  hf_cand_mc::McParticleId,
                   soa::Marker<2>);
 
 DECLARE_SOA_TABLE(StoredHf3PPIds, "AOD1", "HF3PPID", //! Table with global indices for MC particles (stored version)
-                  hf_cand_base::McCollisionId,
-                  hf_cand_base::McParticleId,
+                  hf_cand_mc::McCollisionId,
+                  hf_cand_mc::McParticleId,
                   soa::Marker<3>);
 } // namespace o2::aod
 

--- a/PWGHF/DataModel/DerivedTablesStored.h
+++ b/PWGHF/DataModel/DerivedTablesStored.h
@@ -10,8 +10,13 @@
 // or submit itself to any jurisdiction.
 
 /// \file DerivedTablesStored.h
-/// \brief Definitions of stored versions of derived tables produced by derived-data creators
+/// \brief Definitions of stored versions of derived tables produced by derived-data creators (defined in DerivedTables.h)
 /// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+/// \note Things to check when comparing with DerivedTables.h:
+///       - Prefix "Stored" in table definitions
+///       - Prefix "Stored" in names of index columns pointing to derived tables
+///       - Origin AOD1
+///       - Incremented Marker number
 
 #ifndef PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_
 #define PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_

--- a/PWGHF/DataModel/DerivedTablesStored.h
+++ b/PWGHF/DataModel/DerivedTablesStored.h
@@ -29,6 +29,8 @@ namespace o2::aod
 // Collision tables
 // ================
 
+// D0
+
 DECLARE_SOA_TABLE(StoredHfD0CollBases, "AOD1", "HFD0COLLBASE", //! Table with basic collision info
                   o2::soa::Index<>,
                   collision::PosX,
@@ -80,10 +82,23 @@ DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global
 // MC collision columns
 namespace hf_mc_coll
 {
+DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHfD0CollBase, storedHfD0CollBases); //! collision index array pointing to the derived collision table for D0 candidates
 DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
 } // namespace hf_mc_coll
 
-// DO (TODO)
+// DO
+
+DECLARE_SOA_TABLE(StoredHfD0McCollBases, "AOD1", "HFD0MCCOLLBASE", //! Table with basic MC collision info
+                  o2::soa::Index<>,
+                  mccollision::PosX,
+                  mccollision::PosY,
+                  mccollision::PosZ,
+                  soa::Marker<3>);
+
+using StoredHfD0McCollBase = StoredHfD0McCollBases::iterator;
+
+DECLARE_SOA_TABLE(StoredHfD0McCollIds, "AOD1", "HFD0MCCOLLID", //! Table with indices pointing to the derived collision table
+                  hf_mc_coll::StoredHfD0CollBaseIds);
 
 // 3-prong decays
 
@@ -92,7 +107,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table wit
                   mccollision::PosX,
                   mccollision::PosY,
                   mccollision::PosZ,
-                  soa::Marker<3>);
+                  soa::Marker<4>);
 
 using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
 
@@ -315,6 +330,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate i
 // MC particle columns
 namespace hf_mc_particle
 {
+DECLARE_SOA_INDEX_COLUMN(StoredHfD0McCollBase, storedHfD0McCollBase); //! collision index pointing to the derived MC collision table for D0 candidates
 DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
 } // namespace hf_mc_particle
 
@@ -322,6 +338,7 @@ DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collis
 
 DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC particle info
                   o2::soa::Index<>,
+                  hf_mc_particle::StoredHfD0McCollBaseId,
                   hf_cand_base::Pt,
                   hf_cand_base::Eta,
                   hf_cand_base::Phi,

--- a/PWGHF/DataModel/DerivedTablesStored.h
+++ b/PWGHF/DataModel/DerivedTablesStored.h
@@ -1,0 +1,360 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DerivedTablesStored.h
+/// \brief Definitions of stored versions of derived tables produced by derived-data creators
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#ifndef PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_
+#define PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_
+
+#include "PWGHF/DataModel/DerivedTables.h"
+
+namespace o2::aod
+{
+// ================
+// Collision tables
+// ================
+
+DECLARE_SOA_TABLE(StoredHfD0CollBases, "AOD1", "HFD0COLLBASE", //! Table with basic collision info
+                  o2::soa::Index<>,
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  collision::NumContrib,
+                  hf_coll_base::CentFT0A,
+                  hf_coll_base::CentFT0C,
+                  hf_coll_base::CentFT0M,
+                  hf_coll_base::CentFV0A,
+                  hf_coll_base::MultZeqNTracksPV,
+                  // hf_coll_base::IsEventReject,
+                  // bc::RunNumber,
+                  soa::Marker<1>);
+
+using StoredHfD0CollBase = StoredHfD0CollBases::iterator;
+
+DECLARE_SOA_TABLE(StoredHfD0CollIds, "AOD1", "HFD0COLLID", //! Table with global indices for collisions
+                  hf_cand::CollisionId,
+                  soa::Marker<1>);
+
+// 3-prong decays
+
+DECLARE_SOA_TABLE(StoredHf3PCollBases, "AOD1", "HF3PCOLLBASE", //! Table with basic collision info
+                  o2::soa::Index<>,
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  collision::NumContrib,
+                  hf_coll_base::CentFT0A,
+                  hf_coll_base::CentFT0C,
+                  hf_coll_base::CentFT0M,
+                  hf_coll_base::CentFV0A,
+                  hf_coll_base::MultZeqNTracksPV,
+                  // hf_coll_base::IsEventReject,
+                  // bc::RunNumber,
+                  soa::Marker<3>);
+
+using StoredHf3PCollBase = StoredHf3PCollBases::iterator;
+
+DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global indices for collisions
+                  hf_cand::CollisionId,
+                  soa::Marker<3>);
+
+// ===================
+// MC collision tables
+// ===================
+
+// MC collision columns
+namespace hf_mc_coll
+{
+DECLARE_SOA_ARRAY_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBases); //! collision index array pointing to the derived collision table for 3-prong candidates
+} // namespace hf_mc_coll
+
+// DO (TODO)
+
+// 3-prong decays
+
+DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table with basic MC collision info
+                  o2::soa::Index<>,
+                  mccollision::PosX,
+                  mccollision::PosY,
+                  mccollision::PosZ,
+                  soa::Marker<3>);
+
+using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
+
+DECLARE_SOA_TABLE(StoredHf3PMcCollIds, "AOD1", "HF3PMCCOLLID", //! Table with indices pointing to the derived collision table
+                  hf_mc_coll::StoredHf3PCollBaseIds);
+
+// ================
+// Candidate tables
+// ================
+
+// Basic candidate properties
+namespace hf_cand_base
+{
+DECLARE_SOA_INDEX_COLUMN(StoredHfD0CollBase, storedHfD0CollBase); //! collision index pointing to the derived collision table for D0 candidates
+DECLARE_SOA_INDEX_COLUMN(StoredHf3PCollBase, storedHf3PCollBase); //! collision index pointing to the derived collision table for 3-prong candidates
+} // namespace hf_cand_base
+
+// D0
+
+DECLARE_SOA_TABLE(StoredHfD0Bases, "AOD1", "HFD0BASE", //! Table with basic candidate properties used in the analyses
+                  o2::soa::Index<>,
+                  hf_cand_base::StoredHfD0CollBaseId,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_cand_base::M,
+                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<1>);
+
+// candidates for removal:
+// PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
+// XY: CpaXY, DecayLengthXY, ErrorDecayLengthXY
+// normalised: DecayLengthNormalised, DecayLengthXYNormalised, ImpactParameterNormalised0
+DECLARE_SOA_TABLE(StoredHfD0Pars, "AOD1", "HFD0PAR", //! Table with candidate properties used for selection
+                  hf_cand::Chi2PCA,
+                  hf_cand_par::Cpa,
+                  hf_cand_par::CpaXY,
+                  hf_cand_par::DecayLength,
+                  hf_cand_par::DecayLengthXY,
+                  hf_cand_par::DecayLengthNormalised,
+                  hf_cand_par::DecayLengthXYNormalised,
+                  hf_cand_par::PtProng0,
+                  hf_cand_par::PtProng1,
+                  hf_cand::ImpactParameter0,
+                  hf_cand::ImpactParameter1,
+                  hf_cand_par::ImpactParameterNormalised0,
+                  hf_cand_par::ImpactParameterNormalised1,
+                  hf_cand_par::NSigTpcPi0,
+                  hf_cand_par::NSigTpcKa0,
+                  hf_cand_par::NSigTofPi0,
+                  hf_cand_par::NSigTofKa0,
+                  hf_cand_par::NSigTpcTofPi0,
+                  hf_cand_par::NSigTpcTofKa0,
+                  hf_cand_par::NSigTpcPi1,
+                  hf_cand_par::NSigTpcKa1,
+                  hf_cand_par::NSigTofPi1,
+                  hf_cand_par::NSigTofKa1,
+                  hf_cand_par::NSigTpcTofPi1,
+                  hf_cand_par::NSigTpcTofKa1,
+                  hf_cand_par::MaxNormalisedDeltaIP,
+                  hf_cand_par::ImpactParameterProduct,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0ParEs, "AOD1", "HFD0PARE", //! Table with additional candidate properties used for selection
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  hf_cand::XSecondaryVertex,
+                  hf_cand::YSecondaryVertex,
+                  hf_cand::ZSecondaryVertex,
+                  hf_cand::ErrorDecayLength,
+                  hf_cand::ErrorDecayLengthXY,
+                  hf_cand::KfTopolChi2OverNdf,
+                  hf_cand_par::RSecondaryVertex,
+                  hf_cand_par::PProng0,
+                  hf_cand_par::PProng1,
+                  hf_cand::PxProng0,
+                  hf_cand::PyProng0,
+                  hf_cand::PzProng0,
+                  hf_cand::PxProng1,
+                  hf_cand::PyProng1,
+                  hf_cand::PzProng1,
+                  hf_cand::ErrorImpactParameter0,
+                  hf_cand::ErrorImpactParameter1,
+                  hf_cand_par::CosThetaStar,
+                  hf_cand_par::Ct,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0Sels, "AOD1", "HFD0SEL", //! Table with candidate selection flags
+                  hf_cand_sel::CandidateSelFlag,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0Mls, "AOD1", "HFD0ML", //! Table with candidate selection ML scores
+                  hf_cand_mc::MlScores,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0Ids, "AOD1", "HFD0ID", //! Table with global indices for candidates
+                  hf_cand::CollisionId,
+                  hf_track_index::Prong0Id,
+                  hf_track_index::Prong1Id,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0Mcs, "AOD1", "HFD0MC", //! Table with MC candidate info
+                  hf_cand_mc::FlagMcMatchRec,
+                  hf_cand_mc::OriginMcRec,
+                  soa::Marker<1>);
+
+// 3-prong decays
+
+DECLARE_SOA_TABLE(StoredHf3PBases, "AOD1", "HF3PBASE", //! Table with basic candidate properties used in the analyses
+                  o2::soa::Index<>,
+                  hf_cand_base::StoredHf3PCollBaseId,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_cand_base::M,
+                  hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<1>);
+
+// candidates for removal:
+// PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
+// XY: CpaXY, DecayLengthXY, ErrorDecayLengthXY
+// normalised: DecayLengthNormalised, DecayLengthXYNormalised, ImpactParameterNormalised0
+DECLARE_SOA_TABLE(StoredHf3PPars, "AOD1", "HF3PPAR", //! Table with candidate properties used for selection
+                  hf_cand::Chi2PCA,
+                  hf_cand::NProngsContributorsPV,
+                  hf_cand_par::Cpa,
+                  hf_cand_par::CpaXY,
+                  hf_cand_par::DecayLength,
+                  hf_cand_par::DecayLengthXY,
+                  hf_cand_par::DecayLengthNormalised,
+                  hf_cand_par::DecayLengthXYNormalised,
+                  hf_cand_par::PtProng0,
+                  hf_cand_par::PtProng1,
+                  hf_cand_par::PtProng2,
+                  hf_cand::ImpactParameter0,
+                  hf_cand::ImpactParameter1,
+                  hf_cand::ImpactParameter2,
+                  hf_cand_par::ImpactParameterNormalised0,
+                  hf_cand_par::ImpactParameterNormalised1,
+                  hf_cand_par::ImpactParameterNormalised2,
+                  hf_cand_par::NSigTpcPi0,
+                  hf_cand_par::NSigTpcPr0,
+                  hf_cand_par::NSigTofPi0,
+                  hf_cand_par::NSigTofPr0,
+                  hf_cand_par::NSigTpcTofPi0,
+                  hf_cand_par::NSigTpcTofPr0,
+                  hf_cand_par::NSigTpcKa1,
+                  hf_cand_par::NSigTofKa1,
+                  hf_cand_par::NSigTpcTofKa1,
+                  hf_cand_par::NSigTpcPi2,
+                  hf_cand_par::NSigTpcPr2,
+                  hf_cand_par::NSigTofPi2,
+                  hf_cand_par::NSigTofPr2,
+                  hf_cand_par::NSigTpcTofPi2,
+                  hf_cand_par::NSigTpcTofPr2,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHf3PParEs, "AOD1", "HF3PPARE", //! Table with additional candidate properties used for selection
+                  collision::PosX,
+                  collision::PosY,
+                  collision::PosZ,
+                  hf_cand::XSecondaryVertex,
+                  hf_cand::YSecondaryVertex,
+                  hf_cand::ZSecondaryVertex,
+                  hf_cand::ErrorDecayLength,
+                  hf_cand::ErrorDecayLengthXY,
+                  hf_cand_par::RSecondaryVertex,
+                  hf_cand_par::PProng0,
+                  hf_cand_par::PProng1,
+                  hf_cand_par::PProng2,
+                  hf_cand::PxProng0,
+                  hf_cand::PyProng0,
+                  hf_cand::PzProng0,
+                  hf_cand::PxProng1,
+                  hf_cand::PyProng1,
+                  hf_cand::PzProng1,
+                  hf_cand::PxProng2,
+                  hf_cand::PyProng2,
+                  hf_cand::PzProng2,
+                  hf_cand::ErrorImpactParameter0,
+                  hf_cand::ErrorImpactParameter1,
+                  hf_cand::ErrorImpactParameter2,
+                  hf_cand_par::Ct,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHf3PSels, "AOD1", "HF3PSEL", //! Table with candidate selection flags
+                  hf_cand_sel::CandidateSelFlag,
+                  soa::Marker<3>);
+
+DECLARE_SOA_TABLE(StoredHf3PMls, "AOD1", "HF3PML", //! Table with candidate selection ML scores
+                  hf_cand_mc::MlScores,
+                  soa::Marker<3>);
+
+DECLARE_SOA_TABLE(StoredHf3PIds, "AOD1", "HF3PID", //! Table with global indices for candidates
+                  hf_cand::CollisionId,
+                  hf_track_index::Prong0Id,
+                  hf_track_index::Prong1Id,
+                  hf_track_index::Prong2Id,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate info
+                  hf_cand_mc::FlagMcMatchRec,
+                  hf_cand_mc::OriginMcRec,
+                  hf_cand_mc::IsCandidateSwapped,
+                  soa::Marker<1>);
+
+// ==================
+// MC particle tables
+// ==================
+
+// MC particle columns
+namespace hf_mc_particle
+{
+DECLARE_SOA_INDEX_COLUMN(StoredHf3PMcCollBase, storedHf3PMcCollBase); //! collision index pointing to the derived MC collision table for 3-prong candidates
+} // namespace hf_mc_particle
+
+// D0
+
+DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC particle info
+                  o2::soa::Index<>,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
+                  hf_cand_base::d0::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId,
+                  soa::Marker<1>);
+
+// 3-prong decays
+
+DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC particle info
+                  o2::soa::Index<>,
+                  hf_mc_particle::StoredHf3PMcCollBaseId,
+                  hf_cand_base::Pt,
+                  hf_cand_base::Eta,
+                  hf_cand_base::Phi,
+                  hf_mc_particle::FlagMcMatchGen,
+                  hf_mc_particle::OriginMcGen,
+                  hf_cand_base::lc::Y<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::Px<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
+                  hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
+                  soa::Marker<1>);
+
+DECLARE_SOA_TABLE(StoredHf3PPIds, "AOD1", "HF3PPID", //! Table with global indices for MC particles
+                  hf_mc_particle::McCollisionId,
+                  hf_mc_particle::McParticleId,
+                  soa::Marker<3>);
+} // namespace o2::aod
+
+#endif // PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_

--- a/PWGHF/DataModel/DerivedTablesStored.h
+++ b/PWGHF/DataModel/DerivedTablesStored.h
@@ -15,8 +15,8 @@
 /// \note Things to check when comparing with DerivedTables.h:
 ///       - Prefix "Stored" in table definitions
 ///       - Prefix "Stored" in names of index columns pointing to derived tables
+///       - Suffix "Stored" in Marker name
 ///       - Origin AOD1
-///       - Incremented Marker number
 
 #ifndef PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_
 #define PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_
@@ -44,13 +44,13 @@ DECLARE_SOA_TABLE(StoredHfD0CollBases, "AOD1", "HFD0COLLBASE", //! Table with ba
                   hf_coll_base::MultZeqNTracksPV,
                   // hf_coll_base::IsEventReject,
                   // bc::RunNumber,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 using StoredHfD0CollBase = StoredHfD0CollBases::iterator;
 
 DECLARE_SOA_TABLE(StoredHfD0CollIds, "AOD1", "HFD0COLLID", //! Table with global indices for collisions
                   hf_cand::CollisionId,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 // 3-prong decays
 
@@ -67,13 +67,13 @@ DECLARE_SOA_TABLE(StoredHf3PCollBases, "AOD1", "HF3PCOLLBASE", //! Table with ba
                   hf_coll_base::MultZeqNTracksPV,
                   // hf_coll_base::IsEventReject,
                   // bc::RunNumber,
-                  soa::Marker<3>);
+                  soa::Marker<Marker3PStored>);
 
 using StoredHf3PCollBase = StoredHf3PCollBases::iterator;
 
 DECLARE_SOA_TABLE(StoredHf3PCollIds, "AOD1", "HF3PCOLLID", //! Table with global indices for collisions
                   hf_cand::CollisionId,
-                  soa::Marker<3>);
+                  soa::Marker<Marker3PStored>);
 
 // ===================
 // MC collision tables
@@ -93,7 +93,7 @@ DECLARE_SOA_TABLE(StoredHfD0McCollBases, "AOD1", "HFD0MCCOLLBASE", //! Table wit
                   mccollision::PosX,
                   mccollision::PosY,
                   mccollision::PosZ,
-                  soa::Marker<3>);
+                  soa::Marker<MarkerD0Stored>);
 
 using StoredHfD0McCollBase = StoredHfD0McCollBases::iterator;
 
@@ -107,7 +107,7 @@ DECLARE_SOA_TABLE(StoredHf3PMcCollBases, "AOD1", "HF3PMCCOLLBASE", //! Table wit
                   mccollision::PosX,
                   mccollision::PosY,
                   mccollision::PosZ,
-                  soa::Marker<4>);
+                  soa::Marker<Marker3PStored>);
 
 using StoredHf3PMcCollBase = StoredHf3PMcCollBases::iterator;
 
@@ -139,7 +139,7 @@ DECLARE_SOA_TABLE(StoredHfD0Bases, "AOD1", "HFD0BASE", //! Table with basic cand
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
@@ -173,7 +173,7 @@ DECLARE_SOA_TABLE(StoredHfD0Pars, "AOD1", "HFD0PAR", //! Table with candidate pr
                   hf_cand_par::NSigTpcTofKa1,
                   hf_cand_par::MaxNormalisedDeltaIP,
                   hf_cand_par::ImpactParameterProduct,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0ParEs, "AOD1", "HFD0PARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
@@ -198,26 +198,26 @@ DECLARE_SOA_TABLE(StoredHfD0ParEs, "AOD1", "HFD0PARE", //! Table with additional
                   hf_cand::ErrorImpactParameter1,
                   hf_cand_par::CosThetaStar,
                   hf_cand_par::Ct,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0Sels, "AOD1", "HFD0SEL", //! Table with candidate selection flags
                   hf_cand_sel::CandidateSelFlag,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0Mls, "AOD1", "HFD0ML", //! Table with candidate selection ML scores
                   hf_cand_mc::MlScores,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0Ids, "AOD1", "HFD0ID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0Mcs, "AOD1", "HFD0MC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 // 3-prong decays
 
@@ -233,7 +233,7 @@ DECLARE_SOA_TABLE(StoredHf3PBases, "AOD1", "HF3PBASE", //! Table with basic cand
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 // candidates for removal:
 // PxProng0, PyProng0, PzProng0,... (same for 1, 2), we can keep Pt, Eta, Phi instead
@@ -272,7 +272,7 @@ DECLARE_SOA_TABLE(StoredHf3PPars, "AOD1", "HF3PPAR", //! Table with candidate pr
                   hf_cand_par::NSigTofPr2,
                   hf_cand_par::NSigTpcTofPi2,
                   hf_cand_par::NSigTpcTofPr2,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PParEs, "AOD1", "HF3PPARE", //! Table with additional candidate properties used for selection
                   collision::PosX,
@@ -300,28 +300,28 @@ DECLARE_SOA_TABLE(StoredHf3PParEs, "AOD1", "HF3PPARE", //! Table with additional
                   hf_cand::ErrorImpactParameter1,
                   hf_cand::ErrorImpactParameter2,
                   hf_cand_par::Ct,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PSels, "AOD1", "HF3PSEL", //! Table with candidate selection flags
                   hf_cand_sel::CandidateSelFlag,
-                  soa::Marker<3>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PMls, "AOD1", "HF3PML", //! Table with candidate selection ML scores
                   hf_cand_mc::MlScores,
-                  soa::Marker<3>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PIds, "AOD1", "HF3PID", //! Table with global indices for candidates
                   hf_cand::CollisionId,
                   hf_track_index::Prong0Id,
                   hf_track_index::Prong1Id,
                   hf_track_index::Prong2Id,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PMcs, "AOD1", "HF3PMC", //! Table with MC candidate info
                   hf_cand_mc::FlagMcMatchRec,
                   hf_cand_mc::OriginMcRec,
                   hf_cand_mc::IsCandidateSwapped,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 // ==================
 // MC particle tables
@@ -349,12 +349,12 @@ DECLARE_SOA_TABLE(StoredHfD0PBases, "AOD1", "HFD0PBASE", //! Table with MC parti
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 DECLARE_SOA_TABLE(StoredHfD0PIds, "AOD1", "HFD0PID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
                   hf_mc_particle::McParticleId,
-                  soa::Marker<1>);
+                  soa::Marker<MarkerD0Stored>);
 
 // 3-prong decays
 
@@ -371,12 +371,12 @@ DECLARE_SOA_TABLE(StoredHf3PPBases, "AOD1", "HF3PPBASE", //! Table with MC parti
                   hf_cand_base::Py<hf_cand_base::Pt, hf_cand_base::Phi>,
                   hf_cand_base::Pz<hf_cand_base::Pt, hf_cand_base::Eta>,
                   hf_cand_base::P<hf_cand_base::Pt, hf_cand_base::Eta>,
-                  soa::Marker<1>);
+                  soa::Marker<Marker3PStored>);
 
 DECLARE_SOA_TABLE(StoredHf3PPIds, "AOD1", "HF3PPID", //! Table with global indices for MC particles
                   hf_mc_particle::McCollisionId,
                   hf_mc_particle::McParticleId,
-                  soa::Marker<3>);
+                  soa::Marker<Marker3PStored>);
 } // namespace o2::aod
 
 #endif // PWGHF_DATAMODEL_DERIVEDTABLESSTORED_H_

--- a/PWGHF/DataModel/DerivedTablesStored.h
+++ b/PWGHF/DataModel/DerivedTablesStored.h
@@ -25,6 +25,9 @@
 
 namespace o2::aod
 {
+constexpr uint MarkerD0Stored = 10;
+constexpr uint Marker3PStored = 20;
+
 // ================
 // Collision tables
 // ================

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -73,7 +73,7 @@ struct HfDerivedDataCreatorD0ToKPi {
   HfHelper hfHelper;
   SliceCache cache;
   std::map<int, std::vector<int>> matchedCollisions; // indices of derived reconstructed collisions matched to the global indices of MC collisions
-  std::map<int, bool> hasMcParticles; // flags for MC collisions with HF particles
+  std::map<int, bool> hasMcParticles;                // flags for MC collisions with HF particles
 
   using CollisionsWCentMult = soa::Join<aod::Collisions, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
   using CollisionsWMcCentMult = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -58,14 +58,14 @@ struct HfDerivedDataCreatorD0ToKPi {
   Configurable<bool> fillCandidateParE{"fillCandidateParE", true, "Fill candidate extended parameters"};
   Configurable<bool> fillCandidateSel{"fillCandidateSel", true, "Fill candidate selection flags"};
   Configurable<bool> fillCandidateMl{"fillCandidateMl", true, "Fill candidate selection ML scores"};
-  Configurable<bool> fillCandidateId{"fillCandidateId", true, "Fill candidate indices"};
+  Configurable<bool> fillCandidateId{"fillCandidateId", true, "Fill original indices from the candidate table"};
   Configurable<bool> fillCandidateMc{"fillCandidateMc", true, "Fill candidate MC info"};
   Configurable<bool> fillCollBase{"fillCollBase", true, "Fill collision base properties"};
-  Configurable<bool> fillCollId{"fillCollId", true, "Fill collision indices"};
+  Configurable<bool> fillCollId{"fillCollId", true, "Fill original collision indices"};
   Configurable<bool> fillMcCollBase{"fillMcCollBase", true, "Fill MC collision base properties"};
-  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill MC collision indices"};
+  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill indices of saved derived reconstructed collisions matched to saved derived MC collisions"};
   Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill MC particle properties"};
-  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill MC particle indices"};
+  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill original MC indices"};
   // Parameters for production of training samples
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -34,6 +34,7 @@ using namespace o2::framework::expressions;
 
 /// Writes the full information in an output TTree
 struct HfDerivedDataCreatorD0ToKPi {
+  // Candidates
   Produces<o2::aod::HfD0Bases> rowCandidateBase;
   Produces<o2::aod::HfD0Pars> rowCandidatePar;
   Produces<o2::aod::HfD0ParEs> rowCandidateParE;
@@ -41,8 +42,13 @@ struct HfDerivedDataCreatorD0ToKPi {
   Produces<o2::aod::HfD0Mls> rowCandidateMl;
   Produces<o2::aod::HfD0Ids> rowCandidateId;
   Produces<o2::aod::HfD0Mcs> rowCandidateMc;
+  // Collisions
   Produces<o2::aod::HfD0CollBases> rowCollBase;
   Produces<o2::aod::HfD0CollIds> rowCollId;
+  // MC collisions
+  Produces<o2::aod::HfD0McCollBases> rowMcCollBase;
+  Produces<o2::aod::HfD0McCollIds> rowMcCollId;
+  // MC particles
   Produces<o2::aod::HfD0PBases> rowParticleBase;
   Produces<o2::aod::HfD0PIds> rowParticleId;
 
@@ -56,16 +62,21 @@ struct HfDerivedDataCreatorD0ToKPi {
   Configurable<bool> fillCandidateMc{"fillCandidateMc", true, "Fill candidate MC info"};
   Configurable<bool> fillCollBase{"fillCollBase", true, "Fill collision base properties"};
   Configurable<bool> fillCollId{"fillCollId", true, "Fill collision indices"};
-  Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill particle properties"};
-  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill particle indices"};
+  Configurable<bool> fillMcCollBase{"fillMcCollBase", true, "Fill MC collision base properties"};
+  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill MC collision indices"};
+  Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill MC particle properties"};
+  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill MC particle indices"};
   // Parameters for production of training samples
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
 
   HfHelper hfHelper;
   SliceCache cache;
+  std::map<int, std::vector<int>> mappingCollisions; // indices of derived reconstructed collisions matched to the global indices of MC collisions
+  std::map<int, bool> hasMcParticles; // flags for MC collisions with HF particles
 
   using CollisionsWCentMult = soa::Join<aod::Collisions, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
+  using CollisionsWMcCentMult = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
   using TracksWPid = soa::Join<aod::Tracks, aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa>;
   using SelectedCandidates = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
   using SelectedCandidatesKf = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfCand2ProngKF, aod::HfSelD0>>;
@@ -76,6 +87,7 @@ struct HfDerivedDataCreatorD0ToKPi {
   using SelectedCandidatesMcMl = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec, aod::HfSelD0, aod::HfMlD0>>;
   using SelectedCandidatesMcKfMl = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfCand2ProngKF, aod::HfCand2ProngMcRec, aod::HfSelD0, aod::HfMlD0>>;
   using MatchedGenCandidatesMc = soa::Filtered<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>;
+  using TypeMcCollisions = aod::McCollisions;
 
   Filter filterSelectCandidates = aod::hf_sel_candidate_d0::isSelD0 >= 1 || aod::hf_sel_candidate_d0::isSelD0bar >= 1;
   Filter filterMcGenMatching = nabs(aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
@@ -88,6 +100,7 @@ struct HfDerivedDataCreatorD0ToKPi {
   Preslice<SelectedCandidatesKfMl> candidatesKfMlPerCollision = aod::hf_cand::collisionId;
   Preslice<SelectedCandidatesMcMl> candidatesMcMlPerCollision = aod::hf_cand::collisionId;
   Preslice<SelectedCandidatesMcKfMl> candidatesMcKfMlPerCollision = aod::hf_cand::collisionId;
+  Preslice<MatchedGenCandidatesMc> mcParticlesPerMcCollision = aod::mcparticle::mcCollisionId;
 
   // trivial partitions for all candidates to allow "->sliceByCached" inside processCandidates
   Partition<SelectedCandidates> candidatesAll = aod::hf_sel_candidate_d0::isSelD0 >= 0;
@@ -125,8 +138,9 @@ struct HfDerivedDataCreatorD0ToKPi {
     }
   };
 
-  template <typename T>
-  void fillTablesCollision(const T& collision, int /*isEventReject*/, int /*runNumber*/)
+  template <bool isMC, typename T>
+  // void fillTablesCollision(const T& collision, int isEventReject, int runNumber)
+  void fillTablesCollision(const T& collision)
   {
     if (fillCollBase) {
       rowCollBase(
@@ -146,10 +160,33 @@ struct HfDerivedDataCreatorD0ToKPi {
       rowCollId(
         collision.globalIndex());
     }
+    if constexpr (isMC) {
+      if (fillMcCollId && collision.has_mcCollision()) {
+        // Save rowCollBase.lastIndex() at key collision.mcCollisionId()
+        LOGF(debug, "Rec. collision %d: Filling derived-collision index %d for MC collision %d", collision.globalIndex(), rowCollBase.lastIndex(), collision.mcCollisionId());
+        mappingCollisions[collision.mcCollisionId()].push_back(rowCollBase.lastIndex()); // [] inserts an empty element if it does not exist
+      }
+    }
+  }
+
+  template <typename T>
+  void fillTablesMcCollision(const T& mcCollision)
+  {
+    if (fillMcCollBase) {
+      rowMcCollBase(
+        mcCollision.posX(),
+        mcCollision.posY(),
+        mcCollision.posZ());
+    }
+    if (fillMcCollId) {
+      // Fill the table with the vector of indices of derived reconstructed collisions matched to mcCollision.globalIndex()
+      rowMcCollId(
+        mappingCollisions[mcCollision.globalIndex()]);
+    }
   }
 
   template <typename T, typename U>
-  auto fillTablesCandidate(const T& candidate, const U& prong0, const U& prong1, int candFlag, double invMass, double cosThetaStar, double topoChi2,
+  void fillTablesCandidate(const T& candidate, const U& prong0, const U& prong1, int candFlag, double invMass, double cosThetaStar, double topoChi2,
                            double ct, int8_t flagMc, int8_t origin, const std::vector<float>& mlScores)
   {
     if (fillCandidateBase) {
@@ -241,6 +278,7 @@ struct HfDerivedDataCreatorD0ToKPi {
   {
     if (fillParticleBase) {
       rowParticleBase(
+        rowMcCollBase.lastIndex(),
         particle.pt(),
         particle.eta(),
         particle.phi(),
@@ -261,6 +299,11 @@ struct HfDerivedDataCreatorD0ToKPi {
                          aod::BCs const&)
   {
     // Fill collision properties
+    if constexpr (isMc) {
+      if (fillMcCollId) {
+        mappingCollisions.clear();
+      }
+    }
     auto sizeTableColl = collisions.size();
     reserveTable(rowCollBase, fillCollBase, sizeTableColl);
     reserveTable(rowCollId, fillCollId, sizeTableColl);
@@ -268,11 +311,20 @@ struct HfDerivedDataCreatorD0ToKPi {
       auto thisCollId = collision.globalIndex();
       auto candidatesThisColl = candidates->sliceByCached(aod::hf_cand::collisionId, thisCollId, cache); // FIXME
       auto sizeTableCand = candidatesThisColl.size();
-      // skip collisions without HF candidates
-      if (sizeTableCand == 0) {
+      LOGF(debug, "Rec. collision %d has %d candidates", thisCollId, sizeTableCand);
+      // Skip collisions without HF candidates (and without HF particles if saving indices of reconstructed collisions matched to MC collisions)
+      bool mcCollisionHasMcParticles{false};
+      if constexpr (isMc) {
+        mcCollisionHasMcParticles = fillMcCollId && collision.has_mcCollision() && hasMcParticles[collision.mcCollisionId()];
+        LOGF(debug, "Rec. collision %d has MC collision %d with MC particles? %s", thisCollId, collision.mcCollisionId(), mcCollisionHasMcParticles ? "yes" : "no");
+      }
+      if (sizeTableCand == 0 && (!fillMcCollId || !mcCollisionHasMcParticles)) {
+        LOGF(debug, "Skipping rec. collision %d", thisCollId);
         continue;
       }
-      fillTablesCollision(collision, 0, collision.bc().runNumber());
+      LOGF(debug, "Filling rec. collision %d at derived index %d", thisCollId, rowCollBase.lastIndex() + 1);
+      // fillTablesCollision(collision, 0, collision.bc().runNumber());
+      fillTablesCollision<isMc>(collision);
 
       // Fill candidate properties
       reserveTable(rowCandidateBase, fillCandidateBase, sizeTableCand);
@@ -336,18 +388,51 @@ struct HfDerivedDataCreatorD0ToKPi {
     }
   }
 
-  template <typename ParticleType>
-  void processMcParticles(ParticleType const& mcParticles)
+  template <typename CollisionType, typename ParticleType>
+  void preProcessMcCollisions(CollisionType const& mcCollisions,
+                              ParticleType const& mcParticles)
   {
-    // Fill MC particle properties
-    auto sizeTablePart = mcParticles.size();
-    reserveTable(rowParticleBase, fillParticleBase, sizeTablePart);
-    reserveTable(rowParticleId, fillParticleId, sizeTablePart);
-    for (const auto& particle : mcParticles) {
-      if (!TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+    if (!fillMcCollId) {
+      return;
+    }
+    hasMcParticles.clear();
+    // Fill MC collision flags
+    for (const auto& mcCollision : mcCollisions) {
+      auto thisMcCollId = mcCollision.globalIndex();
+      auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);
+      LOGF(debug, "MC collision %d has %d MC particles (preprocess)", thisMcCollId, particlesThisMcColl.size());
+      hasMcParticles[thisMcCollId] = (particlesThisMcColl.size() > 0);
+    }
+  }
+
+  template <typename CollisionType, typename ParticleType>
+  void processMcParticles(CollisionType const& mcCollisions,
+                          ParticleType const& mcParticles)
+  {
+    // Fill MC collision properties
+    auto sizeTableMcColl = mcCollisions.size();
+    reserveTable(rowMcCollBase, fillMcCollBase, sizeTableMcColl);
+    reserveTable(rowMcCollId, fillMcCollId, sizeTableMcColl);
+    for (const auto& mcCollision : mcCollisions) {
+      auto thisMcCollId = mcCollision.globalIndex();
+      auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);
+      auto sizeTablePart = particlesThisMcColl.size();
+      LOGF(debug, "MC collision %d has %d MC particles", thisMcCollId, sizeTablePart);
+      // Skip MC collisions without HF particles (and without reconstructed HF candidates if saving indices of reconstructed collisions)
+      LOGF(debug, "MC collision %d has %d saved derived rec. collisions", thisMcCollId, mappingCollisions[thisMcCollId].size());
+      if (sizeTablePart == 0 && (!fillMcCollId || mappingCollisions[thisMcCollId].empty())) {
+        LOGF(debug, "Skipping MC collision %d", thisMcCollId);
         continue;
       }
-      fillTablesParticle(particle, o2::constants::physics::MassD0);
+      LOGF(debug, "Filling MC collision %d at derived index %d", thisMcCollId, rowMcCollBase.lastIndex() + 1);
+      fillTablesMcCollision(mcCollision);
+
+      // Fill MC particle properties
+      reserveTable(rowParticleBase, fillParticleBase, sizeTablePart);
+      reserveTable(rowParticleId, fillParticleId, sizeTablePart);
+      for (const auto& particle : mcParticles) {
+        fillTablesParticle(particle, o2::constants::physics::MassD0);
+      }
     }
   }
 
@@ -369,69 +454,81 @@ struct HfDerivedDataCreatorD0ToKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processDataWithKFParticle, "Process data with KFParticle", false);
 
-  void processMcWithDCAFitterSig(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterSig(CollisionsWMcCentMult const& collisions,
                                  SelectedCandidatesMc const&,
+                                 TypeMcCollisions const& mcCollisions,
                                  MatchedGenCandidatesMc const& mcParticles,
                                  TracksWPid const& tracks,
                                  aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, false, true, false, true>(collisions, candidatesMcSig, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterSig, "Process MC with DCAFitterN only for signals", false);
 
-  void processMcWithDCAFitterBkg(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterBkg(CollisionsWMcCentMult const& collisions,
                                  SelectedCandidatesMc const&,
+                                 TypeMcCollisions const& mcCollisions,
                                  MatchedGenCandidatesMc const& mcParticles,
                                  TracksWPid const& tracks,
                                  aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, false, true, true, false>(collisions, candidatesMcBkg, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterBkg, "Process MC with DCAFitterN only for background", false);
 
-  void processMcWithDCAFitterAll(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterAll(CollisionsWMcCentMult const& collisions,
                                  SelectedCandidatesMc const&,
+                                 TypeMcCollisions const& mcCollisions,
                                  MatchedGenCandidatesMc const& mcParticles,
                                  TracksWPid const& tracks,
                                  aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, false, true, false, false>(collisions, candidatesMcAll, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterAll, "Process MC with DCAFitterN", false);
 
-  void processMcWithKFParticleSig(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleSig(CollisionsWMcCentMult const& collisions,
                                   SelectedCandidatesMcKf const&,
+                                  TypeMcCollisions const& mcCollisions,
                                   MatchedGenCandidatesMc const& mcParticles,
                                   TracksWPid const& tracks,
                                   aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, false, true, false, true>(collisions, candidatesMcKfSig, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleSig, "Process MC with KFParticle only for signals", false);
 
-  void processMcWithKFParticleBkg(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleBkg(CollisionsWMcCentMult const& collisions,
                                   SelectedCandidatesMcKf const&,
+                                  TypeMcCollisions const& mcCollisions,
                                   MatchedGenCandidatesMc const& mcParticles,
                                   TracksWPid const& tracks,
                                   aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, false, true, true, false>(collisions, candidatesMcKfBkg, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleBkg, "Process MC with KFParticle only for background", false);
 
-  void processMcWithKFParticleAll(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleAll(CollisionsWMcCentMult const& collisions,
                                   SelectedCandidatesMcKf const&,
+                                  TypeMcCollisions const& mcCollisions,
                                   MatchedGenCandidatesMc const& mcParticles,
                                   TracksWPid const& tracks,
                                   aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, false, true, false, false>(collisions, candidatesMcKfAll, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleAll, "Process MC with KFParticle", false);
 
@@ -455,69 +552,81 @@ struct HfDerivedDataCreatorD0ToKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processDataWithKFParticleMl, "Process data with KFParticle and ML", false);
 
-  void processMcWithDCAFitterMlSig(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterMlSig(CollisionsWMcCentMult const& collisions,
                                    SelectedCandidatesMcMl const&,
+                                   TypeMcCollisions const& mcCollisions,
                                    MatchedGenCandidatesMc const& mcParticles,
                                    TracksWPid const& tracks,
                                    aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, true, true, false, true>(collisions, candidatesMcMlSig, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterMlSig, "Process MC with DCAFitterN and ML only for signals", false);
 
-  void processMcWithDCAFitterMlBkg(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterMlBkg(CollisionsWMcCentMult const& collisions,
                                    SelectedCandidatesMcMl const&,
+                                   TypeMcCollisions const& mcCollisions,
                                    MatchedGenCandidatesMc const& mcParticles,
                                    TracksWPid const& tracks,
                                    aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, true, true, true, false>(collisions, candidatesMcMlBkg, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterMlBkg, "Process MC with DCAFitterN and ML only for background", false);
 
-  void processMcWithDCAFitterMlAll(CollisionsWCentMult const& collisions,
+  void processMcWithDCAFitterMlAll(CollisionsWMcCentMult const& collisions,
                                    SelectedCandidatesMcMl const&,
+                                   TypeMcCollisions const& mcCollisions,
                                    MatchedGenCandidatesMc const& mcParticles,
                                    TracksWPid const& tracks,
                                    aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::DCAFitter, true, true, false, false>(collisions, candidatesMcMlAll, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithDCAFitterMlAll, "Process MC with DCAFitterN and ML", false);
 
-  void processMcWithKFParticleMlSig(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleMlSig(CollisionsWMcCentMult const& collisions,
                                     SelectedCandidatesMcKfMl const&,
+                                    TypeMcCollisions const& mcCollisions,
                                     MatchedGenCandidatesMc const& mcParticles,
                                     TracksWPid const& tracks,
                                     aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, true, true, false, true>(collisions, candidatesMcKfMlSig, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleMlSig, "Process MC with KFParticle and ML only for signals", false);
 
-  void processMcWithKFParticleMlBkg(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleMlBkg(CollisionsWMcCentMult const& collisions,
                                     SelectedCandidatesMcKfMl const&,
+                                    TypeMcCollisions const& mcCollisions,
                                     MatchedGenCandidatesMc const& mcParticles,
                                     TracksWPid const& tracks,
                                     aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, true, true, true, false>(collisions, candidatesMcKfMlBkg, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleMlBkg, "Process MC with KFParticle and ML only for background", false);
 
-  void processMcWithKFParticleMlAll(CollisionsWCentMult const& collisions,
+  void processMcWithKFParticleMlAll(CollisionsWMcCentMult const& collisions,
                                     SelectedCandidatesMcKfMl const&,
+                                    TypeMcCollisions const& mcCollisions,
                                     MatchedGenCandidatesMc const& mcParticles,
                                     TracksWPid const& tracks,
                                     aod::BCs const& bcs)
   {
+    preProcessMcCollisions(mcCollisions, mcParticles);
     processCandidates<aod::hf_cand::VertexerType::KfParticle, true, true, false, false>(collisions, candidatesMcKfMlAll, tracks, bcs);
-    processMcParticles(mcParticles);
+    processMcParticles(mcCollisions, mcParticles);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorD0ToKPi, processMcWithKFParticleMlAll, "Process MC with KFParticle and ML", false);
 };

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -335,7 +335,7 @@ struct HfDerivedDataCreatorD0ToKPi {
       if constexpr (isMc) {
         reserveTable(rowCandidateMc, fillCandidateMc, sizeTableCand);
       }
-      int8_t flagMcRec, origin;
+      int8_t flagMcRec = 0, origin = 0;
       for (const auto& candidate : candidatesThisColl) {
         if constexpr (isMc) {
           flagMcRec = candidate.flagMcMatchRec();
@@ -356,9 +356,6 @@ struct HfDerivedDataCreatorD0ToKPi {
               continue;
             }
           }
-        } else {
-          flagMcRec = 0;
-          origin = 0;
         }
         auto prong0 = candidate.template prong0_as<TracksWPid>();
         auto prong1 = candidate.template prong1_as<TracksWPid>();
@@ -430,7 +427,7 @@ struct HfDerivedDataCreatorD0ToKPi {
       // Fill MC particle properties
       reserveTable(rowParticleBase, fillParticleBase, sizeTablePart);
       reserveTable(rowParticleId, fillParticleId, sizeTablePart);
-      for (const auto& particle : mcParticles) {
+      for (const auto& particle : particlesThisMcColl) {
         fillTablesParticle(particle, o2::constants::physics::MassD0);
       }
     }

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -73,7 +73,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   HfHelper hfHelper;
   SliceCache cache;
   std::map<int, std::vector<int>> matchedCollisions; // indices of derived reconstructed collisions matched to the global indices of MC collisions
-  std::map<int, bool> hasMcParticles; // flags for MC collisions with HF particles
+  std::map<int, bool> hasMcParticles;                // flags for MC collisions with HF particles
 
   using CollisionsWCentMult = soa::Join<aod::Collisions, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
   using CollisionsWMcCentMult = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -58,14 +58,14 @@ struct HfDerivedDataCreatorLcToPKPi {
   Configurable<bool> fillCandidateParE{"fillCandidateParE", true, "Fill candidate extended parameters"};
   Configurable<bool> fillCandidateSel{"fillCandidateSel", true, "Fill candidate selection flags"};
   Configurable<bool> fillCandidateMl{"fillCandidateMl", true, "Fill candidate selection ML scores"};
-  Configurable<bool> fillCandidateId{"fillCandidateId", true, "Fill candidate indices"};
+  Configurable<bool> fillCandidateId{"fillCandidateId", true, "Fill original indices from the candidate table"};
   Configurable<bool> fillCandidateMc{"fillCandidateMc", true, "Fill candidate MC info"};
   Configurable<bool> fillCollBase{"fillCollBase", true, "Fill collision base properties"};
-  Configurable<bool> fillCollId{"fillCollId", true, "Fill collision indices"};
+  Configurable<bool> fillCollId{"fillCollId", true, "Fill original collision indices"};
   Configurable<bool> fillMcCollBase{"fillMcCollBase", true, "Fill MC collision base properties"};
-  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill MC collision indices"};
+  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill indices of saved derived reconstructed collisions matched to saved derived MC collisions"};
   Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill MC particle properties"};
-  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill MC particle indices"};
+  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill original MC indices"};
   // Parameters for production of training samples
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -148,7 +148,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
 
   template <typename T, typename U>
-  auto fillTablesCandidate(const T& candidate, const U& prong0, const U& prong1, const U& prong2, int candFlag, double invMass,
+  void fillTablesCandidate(const T& candidate, const U& prong0, const U& prong1, const U& prong2, int candFlag, double invMass,
                            double ct, int8_t flagMc, int8_t origin, int8_t swapping, const std::vector<float>& mlScores)
   {
     if (fillCandidateBase) {

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -74,6 +74,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   SliceCache cache;
 
   using CollisionsWCentMult = soa::Join<aod::Collisions, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
+  using CollisionsWMcCentMult = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
   using TracksWPid = soa::Join<aod::Tracks, aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr>;
   using SelectedCandidates = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc>>;
   using SelectedCandidatesMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfCand3ProngMcRec, aod::HfSelLc>>;
@@ -118,7 +119,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     }
   };
 
-  template <typename T>
+  template <bool isMC, typename T>
   // void fillTablesCollision(const T& collision, int isEventReject, int runNumber)
   void fillTablesCollision(const T& collision)
   {
@@ -140,19 +141,25 @@ struct HfDerivedDataCreatorLcToPKPi {
       rowCollId(
         collision.globalIndex());
     }
+    if constexpr (isMC) {
+      if (fillMcCollId) {
+        // Save pair (collision.mcCollisionId(), rowCollBase.lastIndex())
+      }
+    }
   }
 
   template <typename T>
-  void fillTablesMcCollision(const T& collision)
+  void fillTablesMcCollision(const T& mcCollision)
   {
     if (fillMcCollBase) {
       rowMcCollBase(
-        collision.posX(),
-        collision.posY(),
-        collision.posZ());
+        mcCollision.posX(),
+        mcCollision.posY(),
+        mcCollision.posZ());
     }
     if (fillMcCollId) {
-      std::vector<int> ids{};
+      std::vector<int> ids;
+      // Fill vector of collision indices matched to mcCollision.globalIndex()
       rowMcCollId(
         ids);
     }
@@ -294,7 +301,7 @@ struct HfDerivedDataCreatorLcToPKPi {
         continue;
       }
       // fillTablesCollision(collision, 0, collision.bc().runNumber());
-      fillTablesCollision(collision);
+      fillTablesCollision<isMc>(collision);
 
       // Fill candidate properties
       reserveTable(rowCandidateBase, fillCandidateBase, sizeTableCand);
@@ -385,7 +392,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processData, "Process data", true);
 
-  void processMcSig(CollisionsWCentMult const& collisions,
+  void processMcSig(CollisionsWMcCentMult const& collisions,
                     SelectedCandidatesMc const&,
                     TypeMcCollisions const& mcCollisions,
                     MatchedGenCandidatesMc const& mcParticles,
@@ -397,7 +404,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processMcSig, "Process MC only for signals", false);
 
-  void processMcBkg(CollisionsWCentMult const& collisions,
+  void processMcBkg(CollisionsWMcCentMult const& collisions,
                     SelectedCandidatesMc const&,
                     TypeMcCollisions const& mcCollisions,
                     MatchedGenCandidatesMc const& mcParticles,
@@ -409,7 +416,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processMcBkg, "Process MC only for background", false);
 
-  void processMcAll(CollisionsWCentMult const& collisions,
+  void processMcAll(CollisionsWMcCentMult const& collisions,
                     SelectedCandidatesMc const&,
                     TypeMcCollisions const& mcCollisions,
                     MatchedGenCandidatesMc const& mcParticles,
@@ -432,7 +439,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processDataMl, "Process data with ML", false);
 
-  void processMcMlSig(CollisionsWCentMult const& collisions,
+  void processMcMlSig(CollisionsWMcCentMult const& collisions,
                       SelectedCandidatesMcMl const&,
                       TypeMcCollisions const& mcCollisions,
                       MatchedGenCandidatesMc const& mcParticles,
@@ -444,7 +451,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processMcMlSig, "Process MC with ML only for signals", false);
 
-  void processMcMlBkg(CollisionsWCentMult const& collisions,
+  void processMcMlBkg(CollisionsWMcCentMult const& collisions,
                       SelectedCandidatesMcMl const&,
                       TypeMcCollisions const& mcCollisions,
                       MatchedGenCandidatesMc const& mcParticles,
@@ -456,7 +463,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   }
   PROCESS_SWITCH(HfDerivedDataCreatorLcToPKPi, processMcMlBkg, "Process MC with ML only for background", false);
 
-  void processMcMlAll(CollisionsWCentMult const& collisions,
+  void processMcMlAll(CollisionsWMcCentMult const& collisions,
                       SelectedCandidatesMcMl const&,
                       TypeMcCollisions const& mcCollisions,
                       MatchedGenCandidatesMc const& mcParticles,

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -34,6 +34,7 @@ using namespace o2::framework::expressions;
 
 /// Writes the full information in an output TTree
 struct HfDerivedDataCreatorLcToPKPi {
+  // Candidates
   Produces<o2::aod::Hf3PBases> rowCandidateBase;
   Produces<o2::aod::Hf3PPars> rowCandidatePar;
   Produces<o2::aod::Hf3PParEs> rowCandidateParE;
@@ -41,9 +42,13 @@ struct HfDerivedDataCreatorLcToPKPi {
   Produces<o2::aod::Hf3PMls> rowCandidateMl;
   Produces<o2::aod::Hf3PIds> rowCandidateId;
   Produces<o2::aod::Hf3PMcs> rowCandidateMc;
+  // Collisions
   Produces<o2::aod::Hf3PCollBases> rowCollBase;
   Produces<o2::aod::Hf3PCollIds> rowCollId;
+  // MC collisions
   Produces<o2::aod::Hf3PMcCollBases> rowMcCollBase;
+  Produces<o2::aod::Hf3PMcCollIds> rowMcCollId;
+  // MC particles
   Produces<o2::aod::Hf3PPBases> rowParticleBase;
   Produces<o2::aod::Hf3PPIds> rowParticleId;
 
@@ -58,8 +63,9 @@ struct HfDerivedDataCreatorLcToPKPi {
   Configurable<bool> fillCollBase{"fillCollBase", true, "Fill collision base properties"};
   Configurable<bool> fillCollId{"fillCollId", true, "Fill collision indices"};
   Configurable<bool> fillMcCollBase{"fillMcCollBase", true, "Fill MC collision base properties"};
-  Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill particle properties"};
-  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill particle indices"};
+  Configurable<bool> fillMcCollId{"fillMcCollId", true, "Fill MC collision indices"};
+  Configurable<bool> fillParticleBase{"fillParticleBase", true, "Fill MC particle properties"};
+  Configurable<bool> fillParticleId{"fillParticleId", true, "Fill MC particle indices"};
   // Parameters for production of training samples
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
@@ -144,6 +150,11 @@ struct HfDerivedDataCreatorLcToPKPi {
         collision.posX(),
         collision.posY(),
         collision.posZ());
+    }
+    if (fillMcCollId) {
+      std::vector<int> ids{};
+      rowMcCollId(
+        ids);
     }
   }
 

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -358,9 +358,6 @@ struct HfDerivedDataCreatorLcToPKPi {
       reserveTable(rowParticleBase, fillParticleBase, sizeTablePart);
       reserveTable(rowParticleId, fillParticleId, sizeTablePart);
       for (const auto& particle : particlesThisMcColl) {
-        if (!TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_3prong::DecayType::LcToPKPi)) {
-          continue;
-        }
         fillTablesParticle(particle, o2::constants::physics::MassLambdaCPlus);
       }
     }

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -356,6 +356,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     // Fill MC collision properties
     auto sizeTableMcColl = mcCollisions.size();
     reserveTable(rowMcCollBase, fillMcCollBase, sizeTableMcColl);
+    reserveTable(rowMcCollId, fillMcCollId, sizeTableMcColl);
     for (const auto& mcCollision : mcCollisions) {
       auto thisMcCollId = mcCollision.globalIndex();
       auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -250,6 +250,7 @@ struct HfDerivedDataCreatorLcToPKPi {
   {
     if (fillParticleBase) {
       rowParticleBase(
+        rowMcCollBase.lastIndex(),
         particle.pt(),
         particle.eta(),
         particle.phi(),

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -146,6 +146,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     if constexpr (isMC) {
       if (fillMcCollId && collision.has_mcCollision()) {
         // Save rowCollBase.lastIndex() at key collision.mcCollisionId()
+        LOGF(debug, "Rec. collision %d: Filling derived-collision index %d for MC collision %d", collision.globalIndex(), rowCollBase.lastIndex(), collision.mcCollisionId());
         mappingCollisions[collision.mcCollisionId()].push_back(rowCollBase.lastIndex()); // [] inserts an empty element if it does not exist
       }
     }
@@ -303,14 +304,18 @@ struct HfDerivedDataCreatorLcToPKPi {
       auto thisCollId = collision.globalIndex();
       auto candidatesThisColl = candidates->sliceByCached(aod::hf_cand::collisionId, thisCollId, cache); // FIXME
       auto sizeTableCand = candidatesThisColl.size();
+      LOGF(debug, "Rec. collision %d has %d candidates", thisCollId, sizeTableCand);
       // Skip collisions without HF candidates (and without HF particles if saving indices of reconstructed collisions matched to MC collisions)
       bool mcCollisionHasMcParticles{false};
       if constexpr (isMc) {
         mcCollisionHasMcParticles = fillMcCollId && collision.has_mcCollision() && hasMcParticles[collision.mcCollisionId()];
+        LOGF(debug, "Rec. collision %d has MC collision %d with MC particles? %s", thisCollId, collision.mcCollisionId(), mcCollisionHasMcParticles ? "yes" : "no");
       }
       if (sizeTableCand == 0 && (!fillMcCollId || !mcCollisionHasMcParticles)) {
+        LOGF(debug, "Skipping rec. collision %d", thisCollId);
         continue;
       }
+      LOGF(debug, "Filling rec. collision %d at derived index %d", thisCollId, rowCollBase.lastIndex() + 1);
       // fillTablesCollision(collision, 0, collision.bc().runNumber());
       fillTablesCollision<isMc>(collision);
 
@@ -379,6 +384,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     for (const auto& mcCollision : mcCollisions) {
       auto thisMcCollId = mcCollision.globalIndex();
       auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);
+      LOGF(debug, "MC collision %d has %d MC particles (preprocess)", thisMcCollId, particlesThisMcColl.size());
       hasMcParticles[thisMcCollId] = (particlesThisMcColl.size() > 0);
     }
   }
@@ -395,10 +401,14 @@ struct HfDerivedDataCreatorLcToPKPi {
       auto thisMcCollId = mcCollision.globalIndex();
       auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);
       auto sizeTablePart = particlesThisMcColl.size();
+      LOGF(debug, "MC collision %d has %d MC particles", thisMcCollId, sizeTablePart);
       // Skip MC collisions without HF particles (and without reconstructed HF candidates if saving indices of reconstructed collisions)
+      LOGF(debug, "MC collision %d has %d saved derived rec. collisions", thisMcCollId, mappingCollisions[thisMcCollId].size());
       if (sizeTablePart == 0 && (!fillMcCollId || mappingCollisions[thisMcCollId].empty())) {
+        LOGF(debug, "Skipping MC collision %d", thisMcCollId);
         continue;
       }
+      LOGF(debug, "Filling MC collision %d at derived index %d", thisMcCollId, rowMcCollBase.lastIndex() + 1);
       fillTablesMcCollision(mcCollision);
 
       // Fill MC particle properties

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -72,7 +72,7 @@ struct HfDerivedDataCreatorLcToPKPi {
 
   HfHelper hfHelper;
   SliceCache cache;
-  std::map<int, std::vector<int>> mappingCollisions; // indices of derived reconstructed collisions matched to the global indices of MC collisions
+  std::map<int, std::vector<int>> matchedCollisions; // indices of derived reconstructed collisions matched to the global indices of MC collisions
   std::map<int, bool> hasMcParticles; // flags for MC collisions with HF particles
 
   using CollisionsWCentMult = soa::Join<aod::Collisions, aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::PVMultZeqs>;
@@ -147,7 +147,7 @@ struct HfDerivedDataCreatorLcToPKPi {
       if (fillMcCollId && collision.has_mcCollision()) {
         // Save rowCollBase.lastIndex() at key collision.mcCollisionId()
         LOGF(debug, "Rec. collision %d: Filling derived-collision index %d for MC collision %d", collision.globalIndex(), rowCollBase.lastIndex(), collision.mcCollisionId());
-        mappingCollisions[collision.mcCollisionId()].push_back(rowCollBase.lastIndex()); // [] inserts an empty element if it does not exist
+        matchedCollisions[collision.mcCollisionId()].push_back(rowCollBase.lastIndex()); // [] inserts an empty element if it does not exist
       }
     }
   }
@@ -164,7 +164,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     if (fillMcCollId) {
       // Fill the table with the vector of indices of derived reconstructed collisions matched to mcCollision.globalIndex()
       rowMcCollId(
-        mappingCollisions[mcCollision.globalIndex()]);
+        matchedCollisions[mcCollision.globalIndex()]);
     }
   }
 
@@ -294,7 +294,7 @@ struct HfDerivedDataCreatorLcToPKPi {
     // Fill collision properties
     if constexpr (isMc) {
       if (fillMcCollId) {
-        mappingCollisions.clear();
+        matchedCollisions.clear();
       }
     }
     auto sizeTableColl = collisions.size();
@@ -305,7 +305,7 @@ struct HfDerivedDataCreatorLcToPKPi {
       auto candidatesThisColl = candidates->sliceByCached(aod::hf_cand::collisionId, thisCollId, cache); // FIXME
       auto sizeTableCand = candidatesThisColl.size();
       LOGF(debug, "Rec. collision %d has %d candidates", thisCollId, sizeTableCand);
-      // Skip collisions without HF candidates (and without HF particles if saving indices of reconstructed collisions matched to MC collisions)
+      // Skip collisions without HF candidates (and without HF particles in matched MC collisions if saving indices of reconstructed collisions matched to MC collisions)
       bool mcCollisionHasMcParticles{false};
       if constexpr (isMc) {
         mcCollisionHasMcParticles = fillMcCollId && collision.has_mcCollision() && hasMcParticles[collision.mcCollisionId()];
@@ -402,9 +402,9 @@ struct HfDerivedDataCreatorLcToPKPi {
       auto particlesThisMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, thisMcCollId);
       auto sizeTablePart = particlesThisMcColl.size();
       LOGF(debug, "MC collision %d has %d MC particles", thisMcCollId, sizeTablePart);
-      // Skip MC collisions without HF particles (and without reconstructed HF candidates if saving indices of reconstructed collisions)
-      LOGF(debug, "MC collision %d has %d saved derived rec. collisions", thisMcCollId, mappingCollisions[thisMcCollId].size());
-      if (sizeTablePart == 0 && (!fillMcCollId || mappingCollisions[thisMcCollId].empty())) {
+      // Skip MC collisions without HF particles (and without HF candidates in matched reconstructed collisions if saving indices of reconstructed collisions matched to MC collisions)
+      LOGF(debug, "MC collision %d has %d saved derived rec. collisions", thisMcCollId, matchedCollisions[thisMcCollId].size());
+      if (sizeTablePart == 0 && (!fillMcCollId || matchedCollisions[thisMcCollId].empty())) {
         LOGF(debug, "Skipping MC collision %d", thisMcCollId);
         continue;
       }

--- a/PWGJE/Core/JetHFUtilities.h
+++ b/PWGJE/Core/JetHFUtilities.h
@@ -38,6 +38,7 @@
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 #include "PWGHF/DataModel/DerivedTables.h"
+#include "PWGHF/DataModel/DerivedTablesStored.h"
 
 #include "PWGJE/Core/FastJetUtilities.h"
 #include "PWGJE/Core/JetDerivedDataUtilities.h"
@@ -620,7 +621,7 @@ void fillD0CandidateMcTable(T const& candidate, U& D0PBaseTable, int32_t& D0Cand
 template <typename T, typename U>
 void fillLcCandidateMcTable(T const& candidate, U& LcPBaseTable, int32_t& LcCandidateTableIndex)
 {
-  LcPBaseTable(candidate.pt(), candidate.eta(), candidate.phi(), candidate.flagMcMatchGen(), candidate.originMcGen());
+  LcPBaseTable(candidate.hf3PMcCollBaseId(), candidate.pt(), candidate.eta(), candidate.phi(), candidate.flagMcMatchGen(), candidate.originMcGen());
   LcCandidateTableIndex = LcPBaseTable.lastIndex();
 }
 

--- a/PWGJE/Core/JetHFUtilities.h
+++ b/PWGJE/Core/JetHFUtilities.h
@@ -615,7 +615,7 @@ void fillCandidateTable(T const& candidate, int32_t collisionIndex, U& HFBaseTab
 template <typename T, typename U>
 void fillD0CandidateMcTable(T const& candidate, U& D0PBaseTable, int32_t& D0CandidateTableIndex)
 {
-  D0PBaseTable(candidate.pt(), candidate.eta(), candidate.phi(), candidate.flagMcMatchGen(), candidate.originMcGen());
+  D0PBaseTable(candidate.hfD0McCollBaseId(), candidate.pt(), candidate.eta(), candidate.phi(), candidate.flagMcMatchGen(), candidate.originMcGen());
   D0CandidateTableIndex = D0PBaseTable.lastIndex();
 }
 template <typename T, typename U>


### PR DESCRIPTION
Add derived tables for MC collision properties.

- Derived MC particles point to derived MC collisions.
- Derived MC collisions can point to derived reconstructed collisions if `fillMcCollId`:
  - If `!fillMcCollId`:
    - Reconstructed collision is stored if it has selected HF candidates.
    - MC collision is stored if it has selected HF MC particles.
  - If `fillMcCollId`:
    - Reconstructed collision is stored if it has selected HF candidates or if its matched MC collision has selected HF MC particles.
    - MC collision is stored if it has selected HF MC particles or if it is matched to a stored reconstructed collision.
- Re-organise and split data models for standard derived tables and stored derived tables for better maintenance.

FYI @nzardosh @qgp @DelloStritto 