### PR TITLE
RecoDecay: Add PtEtaPhi-based calculations

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -34,8 +34,7 @@
 /// - calculation of topological properties of secondary vertices
 /// - Monte Carlo matching of decays at track and particle level
 
-struct RecoDecay
-{
+struct RecoDecay {
   // mapping of charm-hadron origin type
   enum OriginType { None = 0,
                     Prompt,
@@ -989,8 +988,7 @@ struct RecoDecay
 /// \tparam indexPhi  index of φ element
 /// \tparam indexM  index of mass element (optional for (pT, η, φ, m) vectors)
 template <std::size_t indexPt = 0, std::size_t indexEta = 1, std::size_t indexPhi = 2, std::size_t indexM = 3>
-struct RecoDecayPtEtaPhiBase
-{
+struct RecoDecayPtEtaPhiBase {
   // Variable-based calculations
 
   /// Sets a vector from pT, η, φ variables
@@ -1220,11 +1218,11 @@ struct RecoDecayPtEtaPhiBase
     printf("e: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::e(vecXYZ, mIn), e(vecPtEtaPhi, mIn), e(vecPtEtaPhiM));
     printf("y: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::y(vecXYZ, mIn), y(vecPtEtaPhi, mIn), y(vecPtEtaPhiM));
     printf("m: In: %g, XYZ(p, E): %g, XYZ(pVec, E): %g, XYZ(arr): %g, PtEtaPhiM: %g\n",
-            mIn,
-            RecoDecay::m(RecoDecay::p(vecXYZ), RecoDecay::e(vecXYZ, mIn)),
-            RecoDecay::m(vecXYZ, RecoDecay::e(vecXYZ, mIn)),
-            RecoDecay::m(std::array{vecXYZ, vecXYZ0}, std::array{mIn, 0.}),
-            vecPtEtaPhiM[indexM]);
+           mIn,
+           RecoDecay::m(RecoDecay::p(vecXYZ), RecoDecay::e(vecXYZ, mIn)),
+           RecoDecay::m(vecXYZ, RecoDecay::e(vecXYZ, mIn)),
+           RecoDecay::m(std::array{vecXYZ, vecXYZ0}, std::array{mIn, 0.}),
+           vecPtEtaPhiM[indexM]);
   }
 };
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -991,6 +991,11 @@ class RecoDecay
 };
 
 /// Calculations using (pT, η, φ) coordinates, aka (transverse momentum, pseudorapidity, azimuth)
+/// \tparam indexPt  index of pT element
+/// \tparam indexEta  index of η element
+/// \tparam indexPhi  index of φ element
+/// \tparam indexM  index of mass element (optional)
+template <size_t indexPt = 0, size_t indexEta = 1, size_t indexPhi = 2, size_t indexM = 3>
 class RecoDecayPtEtaPhi
 {
  public:
@@ -1000,22 +1005,19 @@ class RecoDecayPtEtaPhi
   /// Default destructor
   ~RecoDecayPtEtaPhi() = default;
 
-  /// Sets the convention of ordering pT, η, φ in a vector
-  static constexpr size_t IndexPt = 0;
-  static constexpr size_t IndexEta = 1;
-  static constexpr size_t IndexPhi = 2;
+  // Variable-based calculations
 
-  /// Sets pT, η, φ variables from a vector
-  /// \param vecPtEtaPhi  vector with pT, η, φ elements
-  /// \param ptTo  variable to store pT
-  /// \param etaTo  variable to store η
-  /// \param phiTo  variable to store φ
+  /// Sets a vector from pT, η, φ variables
+  /// \param vecTo  vector to store pT, η, φ elements
+  /// \param ptFrom  variable with pT
+  /// \param etaFrom  variable with η
+  /// \param phiFrom  variable with φ
   template <typename TVec, typename TPt, typename TEta, typename TPhi>
-  static void setPtEtaPhiFromVector(const TVec& vecPtEtaPhi, TPt& ptTo, TEta& etaTo, TPhi& phiTo)
+  static void setVectorFromVariables(TVec& vecTo, TPt ptFrom, TEta etaFrom, TPhi phiFrom)
   {
-    ptTo = vecPtEtaPhi[IndexPt];
-    etaTo = vecPtEtaPhi[IndexEta];
-    phiTo = vecPtEtaPhi[IndexPhi];
+    vecTo[indexPt] = ptFrom;
+    vecTo[indexEta] = etaFrom;
+    vecTo[indexPhi] = phiFrom;
   }
 
   /// px as a function of pT, φ
@@ -1073,6 +1075,96 @@ class RecoDecayPtEtaPhi
   {
     // ln[(E + pz) / √(m^2 + pT^2)]
     return std::log((e(pt, eta, m) + pz(pt, eta)) / RecoDecay::sqrtSumOfSquares(m, pt));
+  }
+
+  // Vector-based calculations
+
+  /// pt
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto pt(const TVec& vec)
+  {
+    return vec[indexPt];
+  }
+
+  /// η
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto eta(const TVec& vec)
+  {
+    return vec[indexEta];
+  }
+
+  /// φ
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto phi(const TVec& vec)
+  {
+    return vec[indexPhi];
+  }
+
+  /// Sets pT, η, φ variables from a vector
+  /// \param vecFrom  vector with pT, η, φ elements
+  /// \param ptTo  variable to store pT
+  /// \param etaTo  variable to store η
+  /// \param phiTo  variable to store φ
+  template <typename TVec, typename TPt, typename TEta, typename TPhi>
+  static void setVariablesFromVector(const TVec& vecFrom, TPt& ptTo, TEta& etaTo, TPhi& phiTo)
+  {
+    ptTo = pt(vecFrom);
+    etaTo = eta(vecFrom);
+    phiTo = phi(vecFrom);
+  }
+
+  /// px as a function of pT, φ
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto px(const TVec& vec)
+  {
+    return px(pt(vec), phi(vec));
+  }
+
+  /// py as a function of pT, φ
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto py(const TVec& vec)
+  {
+    return py(pt(vec), phi(vec));
+  }
+
+  /// pz as a function of pT, η
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto pz(const TVec& vec)
+  {
+    return pz(pt(vec), eta(vec));
+  }
+
+  /// p as a function of pT, η
+  /// \param vec  vector with pT, η, φ elements
+  template <typename TVec>
+  static auto p(const TVec& vec)
+  {
+    return p(pt(vec), eta(vec));
+  }
+
+  /// Energy as a function of pT, η, mass
+  /// \param vec  vector with pT, η, φ elements
+  /// \param m  mass
+  template <typename TVec, typename TM>
+  static auto e(const TVec& vec, TM m)
+  {
+    return RecoDecay::e(p(vec), m);
+  }
+
+  /// Rapidity as a function of pT, η, mass
+  /// \param vec  vector with pT, η, φ elements
+  /// \param m  mass
+  template <typename TVec, typename TM>
+  static auto y(const TVec& vec, TM m)
+  {
+    // ln[(E + pz) / √(m^2 + pT^2)]
+    return std::log((e(vec, m) + pz(vec)) / RecoDecay::sqrtSumOfSquares(m, pt(vec)));
   }
 };
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -1063,6 +1063,17 @@ struct RecoDecayPtEtaPhiBase
     return std::log((e(pt, eta, m) + pz(pt, eta)) / RecoDecay::sqrtSumOfSquares(m, pt));
   }
 
+  /// Momentum vector in (px, py, pz) coordinates from pT, η, φ variables
+  /// \param pt  pT
+  /// \param eta  η
+  /// \param phi  φ
+  /// \return std::array with px, py, pz elements
+  template <typename TPt, typename TEta, typename TPhi>
+  static auto pVector(TPt pt, TEta eta, TPhi phi)
+  {
+    return std::array{px(pt, phi), py(pt, phi), pz(pt, eta)};
+  }
+
   // Vector-based calculations
 
   /// pt
@@ -1152,6 +1163,15 @@ struct RecoDecayPtEtaPhiBase
     return y(pt(vec), eta(vec), m);
   }
 
+  /// Momentum vector in (px, py, pz) coordinates from a (pT, η, φ) vector
+  /// \param vec  vector with pT, η, φ elements
+  /// \return std::array with px, py, pz elements
+  template <typename TVec>
+  static auto pVector(const TVec& vec)
+  {
+    return std::array{px(vec), py(vec), pz(vec)};
+  }
+
   // Calculations for (pT, η, φ, m) vectors
 
   /// Energy as a function of pT, η, mass
@@ -1186,11 +1206,13 @@ struct RecoDecayPtEtaPhiBase
     setVectorFromVariables(vecPtEtaPhi, RecoDecay::pt(vecXYZ), RecoDecay::eta(vecXYZ), RecoDecay::phi(vecXYZ));
     setVectorFromVariables(vecPtEtaPhiM, RecoDecay::pt(vecXYZ), RecoDecay::eta(vecXYZ), RecoDecay::phi(vecXYZ));
     vecPtEtaPhiM[3] = mIn;
+    auto vecXYZFromVec = pVector(vecPtEtaPhi);
+    auto vecXYZFromVars = pVector(pt(vecPtEtaPhi), eta(vecPtEtaPhi), phi(vecPtEtaPhi));
     // Test px, py, pz, pt, p, eta, phi, e, y, m
     printf("RecoDecay test\n");
-    printf("px: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pxIn, vecXYZ[0], px(vecPtEtaPhi), px(vecPtEtaPhiM));
-    printf("py: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pyIn, vecXYZ[1], py(vecPtEtaPhi), py(vecPtEtaPhiM));
-    printf("pz: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pzIn, vecXYZ[2], pz(vecPtEtaPhi), pz(vecPtEtaPhiM));
+    printf("px: In: %g, XYZ: %g, XYZ from vec: %g, XYZ from vars: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pxIn, vecXYZ[0], vecXYZFromVec[0], vecXYZFromVars[0], px(vecPtEtaPhi), px(vecPtEtaPhiM));
+    printf("py: In: %g, XYZ: %g, XYZ from vec: %g, XYZ from vars: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pyIn, vecXYZ[1], vecXYZFromVec[1], vecXYZFromVars[1], py(vecPtEtaPhi), py(vecPtEtaPhiM));
+    printf("pz: In: %g, XYZ: %g, XYZ from vec: %g, XYZ from vars: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pzIn, vecXYZ[2], vecXYZFromVec[2], vecXYZFromVars[2], pz(vecPtEtaPhi), pz(vecPtEtaPhiM));
     printf("pt: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::pt(vecXYZ), pt(vecPtEtaPhi), pt(vecPtEtaPhiM));
     printf("p: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::p(vecXYZ), p(vecPtEtaPhi), p(vecPtEtaPhiM));
     printf("eta: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::eta(vecXYZ), eta(vecPtEtaPhi), eta(vecPtEtaPhiM));

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -1154,7 +1154,7 @@ class RecoDecayPtEtaPhi
   template <typename TVec, typename TM>
   static auto e(const TVec& vec, TM m)
   {
-    return RecoDecay::e(p(vec), m);
+    return e(pt(vec), eta(vec), m);
   }
 
   /// Rapidity as a function of pT, η, mass
@@ -1163,8 +1163,26 @@ class RecoDecayPtEtaPhi
   template <typename TVec, typename TM>
   static auto y(const TVec& vec, TM m)
   {
-    // ln[(E + pz) / √(m^2 + pT^2)]
-    return std::log((e(vec, m) + pz(vec)) / RecoDecay::sqrtSumOfSquares(m, pt(vec)));
+    return y(pt(vec), eta(vec), m);
+  }
+
+  // Calculations for (pT, η, φ, m) vectors
+
+  /// Energy as a function of pT, η, mass
+  /// \param vec  vector with pT, η, φ, m elements
+  template <typename TVec>
+  static auto e(const TVec& vec)
+  {
+    return e(vec, vec[indexM]);
+  }
+
+  /// Rapidity as a function of pT, η, mass
+  /// \param vec  vector with pT, η, φ, m elements
+  /// \param m  mass
+  template <typename TVec>
+  static auto y(const TVec& vec)
+  {
+    return y(vec, vec[indexM]);
   }
 };
 

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -990,4 +990,90 @@ class RecoDecay
   }
 };
 
+/// Calculations using (pT, η, φ) coordinates, aka (transverse momentum, pseudorapidity, azimuth)
+class RecoDecayPtEtaPhi
+{
+ public:
+  /// Default constructor
+  RecoDecayPtEtaPhi() = default;
+
+  /// Default destructor
+  ~RecoDecayPtEtaPhi() = default;
+
+  /// Sets the convention of ordering pT, η, φ in a vector
+  static constexpr size_t IndexPt = 0;
+  static constexpr size_t IndexEta = 1;
+  static constexpr size_t IndexPhi = 2;
+
+  /// Sets pT, η, φ variables from a vector
+  /// \param vecPtEtaPhi  vector with pT, η, φ elements
+  /// \param ptTo  variable to store pT
+  /// \param etaTo  variable to store η
+  /// \param phiTo  variable to store φ
+  template <typename TVec, typename TPt, typename TEta, typename TPhi>
+  static void setPtEtaPhiFromVector(const TVec& vecPtEtaPhi, TPt& ptTo, TEta& etaTo, TPhi& phiTo)
+  {
+    ptTo = vecPtEtaPhi[IndexPt];
+    etaTo = vecPtEtaPhi[IndexEta];
+    phiTo = vecPtEtaPhi[IndexPhi];
+  }
+
+  /// px as a function of pT, φ
+  /// \param pt  pT
+  /// \param phi  φ
+  template <typename TPt, typename TPhi>
+  static auto px(TPt pt, TPhi phi)
+  {
+    return pt * std::cos(phi);
+  }
+
+  /// py as a function of pT, φ
+  /// \param pt  pT
+  /// \param phi  φ
+  template <typename TPt, typename TPhi>
+  static auto py(TPt pt, TPhi phi)
+  {
+    return pt * std::sin(phi);
+  }
+
+  /// pz as a function of pT, η
+  /// \param pt  pT
+  /// \param eta  η
+  template <typename TPt, typename TEta>
+  static auto pz(TPt pt, TEta eta)
+  {
+    return pt * std::sinh(eta);
+  }
+
+  /// p as a function of pT, η
+  /// \param pt  pT
+  /// \param eta  η
+  template <typename TPt, typename TEta>
+  static auto p(TPt pt, TEta eta)
+  {
+    return pt * std::cosh(eta);
+  }
+
+  /// Energy as a function of pT, η, mass
+  /// \param pt  pT
+  /// \param eta  η
+  /// \param m  mass
+  template <typename TPt, typename TEta, typename TM>
+  static auto e(TPt pt, TEta eta, TM m)
+  {
+    return RecoDecay::e(p(pt, eta), m);
+  }
+
+  /// Rapidity as a function of pT, η, mass
+  /// \param pt  pT
+  /// \param eta  η
+  /// \param m  mass
+  template <typename TPt, typename TEta, typename TM>
+  static auto y(TPt pt, TEta eta, TM m)
+  {
+    // ln[(E + pz) / √(m^2 + pT^2)]
+    return std::log((e(pt, eta, m) + pz(pt, eta)) / RecoDecay::sqrtSumOfSquares(m, pt));
+  }
+};
+
 #endif // COMMON_CORE_RECODECAY_H_

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -34,15 +34,8 @@
 /// - calculation of topological properties of secondary vertices
 /// - Monte Carlo matching of decays at track and particle level
 
-class RecoDecay
+struct RecoDecay
 {
- public:
-  /// Default constructor
-  RecoDecay() = default;
-
-  /// Default destructor
-  ~RecoDecay() = default;
-
   // mapping of charm-hadron origin type
   enum OriginType { None = 0,
                     Prompt,

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -994,7 +994,7 @@ class RecoDecay
 /// \tparam indexPt  index of pT element
 /// \tparam indexEta  index of η element
 /// \tparam indexPhi  index of φ element
-/// \tparam indexM  index of mass element (optional)
+/// \tparam indexM  index of mass element (optional for (pT, η, φ, m) vectors)
 template <size_t indexPt = 0, size_t indexEta = 1, size_t indexPhi = 2, size_t indexM = 3>
 class RecoDecayPtEtaPhi
 {

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -996,15 +996,8 @@ class RecoDecay
 /// \tparam indexPhi  index of φ element
 /// \tparam indexM  index of mass element (optional for (pT, η, φ, m) vectors)
 template <size_t indexPt = 0, size_t indexEta = 1, size_t indexPhi = 2, size_t indexM = 3>
-class RecoDecayPtEtaPhi
+struct RecoDecayPtEtaPhi
 {
- public:
-  /// Default constructor
-  RecoDecayPtEtaPhi() = default;
-
-  /// Default destructor
-  ~RecoDecayPtEtaPhi() = default;
-
   // Variable-based calculations
 
   /// Sets a vector from pT, η, φ variables

--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -988,8 +988,8 @@ struct RecoDecay
 /// \tparam indexEta  index of η element
 /// \tparam indexPhi  index of φ element
 /// \tparam indexM  index of mass element (optional for (pT, η, φ, m) vectors)
-template <size_t indexPt = 0, size_t indexEta = 1, size_t indexPhi = 2, size_t indexM = 3>
-struct RecoDecayPtEtaPhi
+template <std::size_t indexPt = 0, std::size_t indexEta = 1, std::size_t indexPhi = 2, std::size_t indexM = 3>
+struct RecoDecayPtEtaPhiBase
 {
   // Variable-based calculations
 
@@ -1170,6 +1170,42 @@ struct RecoDecayPtEtaPhi
   {
     return y(vec, vec[indexM]);
   }
+
+  /// Test consistency of calculations of kinematic quantities
+  /// \param pxIn  px
+  /// \param pyIn  py
+  /// \param pzIn  pz
+  /// \param mIn  mass
+  template <typename T, typename TM>
+  static void test(T pxIn, T pyIn, T pzIn, TM mIn)
+  {
+    std::array<T, 3> vecXYZ{pxIn, pyIn, pzIn};
+    std::array<T, 3> vecXYZ0{0, 0, 0};
+    std::array<T, 3> vecPtEtaPhi;
+    std::array<T, 4> vecPtEtaPhiM;
+    setVectorFromVariables(vecPtEtaPhi, RecoDecay::pt(vecXYZ), RecoDecay::eta(vecXYZ), RecoDecay::phi(vecXYZ));
+    setVectorFromVariables(vecPtEtaPhiM, RecoDecay::pt(vecXYZ), RecoDecay::eta(vecXYZ), RecoDecay::phi(vecXYZ));
+    vecPtEtaPhiM[3] = mIn;
+    // Test px, py, pz, pt, p, eta, phi, e, y, m
+    printf("RecoDecay test\n");
+    printf("px: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pxIn, vecXYZ[0], px(vecPtEtaPhi), px(vecPtEtaPhiM));
+    printf("py: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pyIn, vecXYZ[1], py(vecPtEtaPhi), py(vecPtEtaPhiM));
+    printf("pz: In: %g, XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", pzIn, vecXYZ[2], pz(vecPtEtaPhi), pz(vecPtEtaPhiM));
+    printf("pt: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::pt(vecXYZ), pt(vecPtEtaPhi), pt(vecPtEtaPhiM));
+    printf("p: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::p(vecXYZ), p(vecPtEtaPhi), p(vecPtEtaPhiM));
+    printf("eta: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::eta(vecXYZ), eta(vecPtEtaPhi), eta(vecPtEtaPhiM));
+    printf("phi: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::phi(vecXYZ), phi(vecPtEtaPhi), phi(vecPtEtaPhiM));
+    printf("e: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::e(vecXYZ, mIn), e(vecPtEtaPhi, mIn), e(vecPtEtaPhiM));
+    printf("y: XYZ: %g, PtEtaPhi: %g, PtEtaPhiM: %g\n", RecoDecay::y(vecXYZ, mIn), y(vecPtEtaPhi, mIn), y(vecPtEtaPhiM));
+    printf("m: In: %g, XYZ(p, E): %g, XYZ(pVec, E): %g, XYZ(arr): %g, PtEtaPhiM: %g\n",
+            mIn,
+            RecoDecay::m(RecoDecay::p(vecXYZ), RecoDecay::e(vecXYZ, mIn)),
+            RecoDecay::m(vecXYZ, RecoDecay::e(vecXYZ, mIn)),
+            RecoDecay::m(std::array{vecXYZ, vecXYZ0}, std::array{mIn, 0.}),
+            vecPtEtaPhiM[indexM]);
+  }
 };
+
+using RecoDecayPtEtaPhi = RecoDecayPtEtaPhiBase<>; // alias for instance with default parameters
 
 #endif // COMMON_CORE_RECODECAY_H_


### PR DESCRIPTION
Extends `RecoDecay` with calculations of kinematic quantities using pT, η, φ as input.
- Supported input:
  - pT, η, φ variables,
  - container with pT, η, φ elements (accessible via index),
  - container with pT, η, φ, m elements (accessible via index).
- Quantities: px, py, pz, p, e, y, (pt, eta, phi)
- Utilities:
  - `setVectorFromVariables`, `setVariablesFromVector` (for PtEtaPhi(M) containers),
  - `pVector` returns `std::array` with px, py, pz elements
- Indexing of pT, η, φ, (m) elements in the PtEtaPhi(M) containers is arbitrary and is specified by template arguments.
  - Default instance `RecoDecayPtEtaPhi` uses 0, 1, 2, (3).
- Change `class` to `struct` to remove unnecessary code.