### PR TITLE
PWGHF: add TF and ITSROF borders cut omegac0xic0 creator

### DIFF
--- a/DPG/Tasks/AOTTrack/qaMatchEff.cxx
+++ b/DPG/Tasks/AOTTrack/qaMatchEff.cxx
@@ -75,8 +75,8 @@ struct qaMatchEff {
   Configurable<bool> isUseAnalysisTrackSelections{"isUseAnalysisTrackSelections", false, "Boolean to switch if the analysis track selections are used. If true, all the Explicit track cuts are ignored."};
   // analysis track selections changes
   Configurable<bool> isChangeAnalysisCutEta{"isChangeAnalysisCutEta", false, "Boolean to switch if the analysis eta cut is changed."};
-  Configurable<bool> isChangeAnalysisCutDcaXY{"isChangeAnalysisCutDcaXY", false, "Boolean to switch if the analysis DcaXY cut is changed."};
   Configurable<bool> isChangeAnalysisCutDcaZ{"isChangeAnalysisCutDcaZ", false, "Boolean to switch if the analysis DcaZ cut is changed."};
+  Configurable<bool> isChangeAnalysisCutDcaXY{"isChangeAnalysisCutDcaXY", false, "Boolean to switch if the analysis DcaXY cut is changed."};
   Configurable<bool> isChangeAnalysisCutNClustersTPC{"isChangeAnalysisCutNClustersTPC", false, "Boolean to switch if the analysis NClustersTPC cut is changed."};
   Configurable<bool> isChangeAnalysisITSHitmap{"isChangeAnalysisITSHitmap", false, "Boolean to switch if the analysis ITSHitmap is changed."};
   // kinematics
@@ -106,11 +106,6 @@ struct qaMatchEff {
   Configurable<bool> doDebug{"doDebug", false, "Flag of debug information"};
   // Histogram configuration
   //
-  // histos axes limits
-  Configurable<float> etaMin{"eta-min", -2.0f, "Lower limit in eta"};
-  Configurable<float> etaMax{"eta-max", 2.0f, "Upper limit in eta"};
-  Configurable<float> phiMin{"phi-min", 0.0f, "Lower limit in phi"};
-  Configurable<float> phiMax{"phi-max", 1.0f * TwoPI, "Upper limit in phi"};
   // histos bins
   Configurable<int> etaBins{"eta-bins", 40, "Number of eta bins"};
   Configurable<int> phiBins{"phi-bins", 18, "Number of phi bins"};
@@ -141,9 +136,9 @@ struct qaMatchEff {
   //
   AxisSpec axisQoPt{qoptBins, -20, 20, "#Q/it{p}_{T} (GeV/#it{c})^{-1}"};
   //
-  AxisSpec axisEta{etaBins, etaMin, etaMax, "#eta"};
-  AxisSpec axisPhi{phiBins, phiMin, phiMax, "#it{#varphi} (rad)"};
-  AxisSpec axisDEta{etaBins, etaMin, etaMax, "D#eta"};
+  AxisSpec axisEta{etaBins, -2.f, 2.f, "#eta"};
+  AxisSpec axisPhi{phiBins, 0.f, TwoPI, "#it{#varphi} (rad)"};
+  AxisSpec axisDEta{etaBins, -2.f, 2.f, "D#eta"};
   AxisSpec axisDPh{phiBins, -PI, PI, "D#it{#varphi} (rad)"};
   //
   // pdg codes vector
@@ -155,7 +150,7 @@ struct qaMatchEff {
   ConfigurableAxis thnd0{"thnd0", {150, -3.0f, 3.0f}, "impact parameter in xy [cm]"};
   ConfigurableAxis thndz{"thndz", {150, -10.0f, 10.0f}, "impact parameter in z [cm]"};
   ConfigurableAxis thnPt{"thnPt", {80, 0.0f, 20.0f}, "pt [GeV/c]"};
-  ConfigurableAxis thnPhi{"thnPhi", {180, 0.0f, TMath::TwoPi()}, "phi"};
+  ConfigurableAxis thnPhi{"thnPhi", {180, 0.0f, TwoPI}, "phi"};
   ConfigurableAxis thnEta{"thnEta", {20, -2.0f, 2.0f}, "eta"};
   ConfigurableAxis thnType{"thnType", {3, -0.5f, 2.5f}, "0: primary, 1: physical secondary, 2: sec. from material"};
   ConfigurableAxis thnLabelSign{"thnLabelSign", {3, -1.5f, 1.5f}, "MC -1/+1 antip./particle"};
@@ -260,16 +255,16 @@ struct qaMatchEff {
         cutObject.SetEtaRange(etaMinCut, etaMaxCut);
         LOG(info) << "### Changing analysis eta cut to " << etaMinCut << " - " << etaMaxCut;
       }
+      if (isChangeAnalysisCutDcaZ) {
+        cutObject.SetMaxDcaZ(dcaMaxCut->get("TrVtx", "dcaZ"));
+        LOG(info) << "### Changing analysis DCAZ cut to " << dcaMaxCut->get("TrVtx", "dcaZ");
+      }
       if (isChangeAnalysisCutDcaXY) {
         // clear the pt dependence of DcaXY
         cutObject.SetMaxDcaXYPtDep(nullptr);
         LOG(info) << "### DcaXY cut pt dependence cleared";
         cutObject.SetMaxDcaXY(dcaMaxCut->get("TrVtx", "dcaXY"));
         LOG(info) << "### Changing analysis DcaXY cut to " << dcaMaxCut->get("TrVtx", "dcaXY");
-      }
-      if (isChangeAnalysisCutDcaZ) {
-        cutObject.SetMaxDcaZ(dcaMaxCut->get("TrVtx", "dcaZ"));
-        LOG(info) << "### Changing analysis DCAZ cut to " << dcaMaxCut->get("TrVtx", "dcaZ");
       }
       if (isChangeAnalysisCutNClustersTPC) {
         cutObject.SetMinNClustersTPC(tpcNClusterMin);
@@ -1298,8 +1293,7 @@ struct qaMatchEff {
       return false;
     if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kDCAxy))
       return false;
-    // dcaZ selection to simulate the dca cut in QC ()
-    if (abs(track.dcaZ()) > dcaMaxCut->get("TrVtx", "dcaZ"))
+    if (!cutObject.IsSelected(track, TrackSelection::TrackCuts::kDCAz))
       return false;
     return true;
   }

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -673,6 +673,8 @@ struct HfCandidateCreatorXic0Omegac0Mc {
   Configurable<bool> rejGenTFAndITSROFBorders{"rejGenTFAndITSROFBorders", true, "Reject generated particles coming from bc close to TF and ITSROF borders"};
   float zPvPosMax{1000.f};
 
+  using BCsInfo = soa::Join<aod::BCs, aod::Timestamps, aod::BcSels>;
+
   // inspect for which zPvPosMax cut was set for reconstructed
   void init(InitContext& initContext)
   {
@@ -695,7 +697,8 @@ struct HfCandidateCreatorXic0Omegac0Mc {
                         aod::TracksWMc const&,
                         aod::McParticles const& mcParticles,
                         aod::McCollisions const&,
-                        aod::McCollisionLabels const&)
+                        aod::McCollisionLabels const&,
+                        BCsInfo const&)
   {
     float ptCharmBaryonGen = -999.;
     float etaCharmBaryonGen = -999.;
@@ -896,8 +899,15 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         auto coll = particle.mcCollision_as<aod::McCollisions>();
         auto bc = coll.bc_as<BCsInfo>();
         if (!bc.selection_bit(o2::aod::evsel::kNoITSROFrameBorder) || !bc.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
-          rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
-          ;
+          if constexpr (decayChannel == aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi) {
+            rowMCMatchGenXicToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
+          } else if constexpr (decayChannel == aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToXiPi) {
+            rowMCMatchGenOmegacToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
+          } else if constexpr (decayChannel == aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaPi) {
+            rowMCMatchGenToOmegaPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
+          } else if constexpr (decayChannel == aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaK) {
+            rowMCMatchGenToOmegaK(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
+          }
         }
       }
 
@@ -1057,9 +1067,10 @@ struct HfCandidateCreatorXic0Omegac0Mc {
                           aod::TracksWMc const& tracks,
                           aod::McParticles const& mcParticles,
                           aod::McCollisions const& mcColls,
-                          aod::McCollisionLabels const& mcLabels)
+                          aod::McCollisionLabels const& mcLabels,
+                          BCsInfo const& bcs)
   {
-    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi>(candidates, tracks, mcParticles, mcColls, mcLabels);
+    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi>(candidates, tracks, mcParticles, mcColls, mcLabels, bcs);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcXicToXiPi, "Run Xic0 to xi pi MC process function", false);
 
@@ -1067,9 +1078,10 @@ struct HfCandidateCreatorXic0Omegac0Mc {
                              aod::TracksWMc const& tracks,
                              aod::McParticles const& mcParticles,
                              aod::McCollisions const& mcColls,
-                             aod::McCollisionLabels const& mcLabels)
+                             aod::McCollisionLabels const& mcLabels,
+                             BCsInfo const& bcs)
   {
-    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToXiPi>(candidates, tracks, mcParticles, mcColls, mcLabels);
+    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToXiPi>(candidates, tracks, mcParticles, mcColls, mcLabels, bcs);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcOmegacToXiPi, "Run Omegac0 to xi pi MC process function", false);
 
@@ -1077,9 +1089,10 @@ struct HfCandidateCreatorXic0Omegac0Mc {
                                 aod::TracksWMc const& tracks,
                                 aod::McParticles const& mcParticles,
                                 aod::McCollisions const& mcColls,
-                                aod::McCollisionLabels const& mcLabels)
+                                aod::McCollisionLabels const& mcLabels,
+                                BCsInfo const& bcs)
   {
-    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaPi>(candidates, tracks, mcParticles, mcColls, mcLabels);
+    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaPi>(candidates, tracks, mcParticles, mcColls, mcLabels, bcs);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcOmegacToOmegaPi, "Run Omegac0 to omega pi MC process function", false);
 
@@ -1087,9 +1100,10 @@ struct HfCandidateCreatorXic0Omegac0Mc {
                                aod::TracksWMc const& tracks,
                                aod::McParticles const& mcParticles,
                                aod::McCollisions const& mcColls,
-                               aod::McCollisionLabels const& mcLabels)
+                               aod::McCollisionLabels const& mcLabels,
+                               BCsInfo const& bcs)
   {
-    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaK>(candidates, tracks, mcParticles, mcColls, mcLabels);
+    runXic0Omegac0Mc<aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaK>(candidates, tracks, mcParticles, mcColls, mcLabels, bcs);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcOmegacToOmegaK, "Run Omegac0 to omega K MC process function", false);
 

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -670,6 +670,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
   Produces<aod::HfToOmegaKMCRec> rowMCMatchRecToOmegaK;
   Produces<aod::HfToOmegaKMCGen> rowMCMatchGenToOmegaK;
 
+  Configurable<bool> rejGenTFAndITSROFBorders{"rejGenTFAndITSROFBorders", true, "Reject generated particles coming from bc close to TF and ITSROF borders"};
   float zPvPosMax{1000.f};
 
   // inspect for which zPvPosMax cut was set for reconstructed
@@ -889,6 +890,15 @@ struct HfCandidateCreatorXic0Omegac0Mc {
       debugGenCasc = 0;
       debugGenLambda = 0;
       origin = RecoDecay::OriginType::None;
+
+      // accept only mc particles coming from bc that are far away from TF border and ITSROFrame
+      if (rejGenTFAndITSROFBorders) {
+        auto coll = particle.mcCollision_as<aod::McCollisions>();
+        auto bc = coll.bc_as<BCsInfo>();
+        if (!bc.selection_bit(o2::aod::evsel::kNoITSROFrameBorder) || !bc.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
+          rowMCMatchGen(flag, debugGenCharmBar, debugGenXi, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);;
+        }
+      }
 
       auto mcCollision = particle.mcCollision();
       float zPv = mcCollision.posZ();


### PR DESCRIPTION
In candidateCreator for xic0 and Omegac0, add (optional) selection on generated particles for:
- TF borders
- ITS ROF borders