### PR TITLE
MegaLinter: Checkout the HEAD of the PR

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -23,13 +23,12 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Checkout the HEAD of the PR instead of the merge commit.
-          # This may include unrelated files if the PR branch is not up to date with the upstream.
-          # ref: ${{ github.event.pull_request.head.sha }}
-          # Checkout the merge commit.
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Checkout the merge commit. (If a fixing PR is made, it will include also missing commits from upstream.)
+          # ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 0
           # So we can use secrets.ALIBUILD_GITHUB_TOKEN to push later.
           persist-credentials: false


### PR DESCRIPTION
Getting the list of modified files has been fixed in MegaLinter so we don't need to merge the branch into master anymore to run MegaLinter.
Plus it fixes the current issue, where the formatting PR includes also missing commits from upstream, added by the merge.