### PR TITLE
Fill event plane in VarManager

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1377,6 +1377,15 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kQ4X0C] = event.q4x0c();
     values[kQ4Y0C] = event.q4y0c();
 
+    EventPlaneHelper epHelper;
+    float Psi2A = epHelper.GetEventPlane(values[kQ2X0A], values[kQ2Y0A], 2);
+    float Psi2B = epHelper.GetEventPlane(values[kQ2X0B], values[kQ2Y0B], 2);
+    float Psi2C = epHelper.GetEventPlane(values[kQ2X0C], values[kQ2Y0C], 2);
+
+    values[VarManager::kPsi2A] = Psi2A;
+    values[VarManager::kPsi2B] = Psi2B;
+    values[VarManager::kPsi2C] = Psi2C;
+
     if constexpr ((fillMap & ReducedEventQvectorExtra) > 0) {
       values[kQ42XA] = event.q42xa();
       values[kQ42YA] = event.q42ya();

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -202,17 +202,6 @@ struct AnalysisEventSelection {
     }
 
     if (fMixHandler != nullptr) {
-      constexpr bool eventHasQvector = ((TEventFillMap & VarManager::ObjTypes::ReducedEventQvector) > 0);
-      if constexpr (eventHasQvector) {
-        EventPlaneHelper epHelper;
-        float Psi2A = epHelper.GetEventPlane(VarManager::fgValues[VarManager::kQ2X0A], VarManager::fgValues[VarManager::kQ2Y0A], 2);
-        float Psi2B = epHelper.GetEventPlane(VarManager::fgValues[VarManager::kQ2X0B], VarManager::fgValues[VarManager::kQ2Y0B], 2);
-        float Psi2C = epHelper.GetEventPlane(VarManager::fgValues[VarManager::kQ2X0C], VarManager::fgValues[VarManager::kQ2Y0C], 2);
-
-        VarManager::fgValues[VarManager::kPsi2A] = Psi2A;
-        VarManager::fgValues[VarManager::kPsi2B] = Psi2B;
-        VarManager::fgValues[VarManager::kPsi2C] = Psi2C;
-      }
       int hh = fMixHandler->FindEventCategory(VarManager::fgValues);
       hash(hh);
     }

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -39,7 +39,6 @@
 #include "TGeoGlobalMagField.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsBase/GeometryManager.h"
-#include "Common/Core/EventPlaneHelper.h"
 
 using std::cout;
 using std::endl;


### PR DESCRIPTION
Move the filling of the event planes in VarManager::FillEvent

@iarsene: please let me know if you find double filling. l 1154 is just the VarManager::FillEvent for me, where I did not find the filling of the event planes.

ps: there is two implementations of the calculations of the event plane. I choose the "Helper" already used in the VarManager, which has nevertheless also his own function.