### PR TITLE
PWGHF: Fix missing continue statement in Xic0Omegac0

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -913,6 +913,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           } else if constexpr (decayChannel == aod::hf_cand_xic0_omegac0::DecayType::OmegaczeroToOmegaK) {
             rowMCMatchGenToOmegaK(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin);
           }
+          continue;
         }
       }
 


### PR DESCRIPTION
Add missing `continue` statement in xic0-omegac0 candidate creator (fix error)