### PR TITLE
PWGHF: Exclude PWGHF/ALICE3 from compilation

### DIFF
--- a/PWGHF/CMakeLists.txt
+++ b/PWGHF/CMakeLists.txt
@@ -13,7 +13,7 @@
 # add_subdirectory(DataModel)
 add_subdirectory(TableProducer)
 add_subdirectory(Tasks)
-add_subdirectory(ALICE3)
+# add_subdirectory(ALICE3)
 add_subdirectory(D2H)
 add_subdirectory(HFC)
 add_subdirectory(HFJ)


### PR DESCRIPTION
Saves about 40 minutes of integrated CPU time.