### PR TITLE
[PWGDQ] Set negative ZDC energies to -1. Add cuts for Lambdac including DCAz.

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -12,6 +12,8 @@
 // Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
 //
 #include "PWGDQ/Core/CutsLibrary.h"
+#include <TF1.h>
+#include "VarManager.h"
 
 AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
 {
@@ -2816,6 +2818,11 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("pairLxyProjected3sigmaLambdacCand")) {
+    cut->AddCut(GetAnalysisCut("pairLxyProjected3sigmaLambdacCand"));
+    return cut;
+  }
+
   // -------------------------------------------------------------------------------------------------
   //
   // Below are a list of single electron single muon and in order or optimize the trigger
@@ -5027,6 +5034,13 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
 
   if (!nameStr.compare("pairTauxyzProjected1sigma")) {
     cut->AddCut(VarManager::kVertexingTauxyzProjected, 0.003, 10.);
+    return cut;
+  }
+
+  if (!nameStr.compare("pairLxyProjected3sigmaLambdacCand")) {
+    TF1* f1minLxyProjected = new TF1("f1minLxyProjected", "[0]+[1]*x", 0., 20.);
+    f1minLxyProjected->SetParameters(0.0065, -0.0023);
+    cut->AddCut(VarManager::kVertexingLxyProjected, f1minLxyProjected, 1., false, VarManager::kPt, 0., 20.);
     return cut;
   }
 

--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -570,6 +570,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("kaonPosPID4DCAz")) {
+    cut->AddCut(GetAnalysisCut("kaonPID_TPCnTOF"));
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
+    return cut;
+  }
+
   if (!nameStr.compare("kaonPosPID5")) {
     cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
     cut->AddCut(GetAnalysisCut("posTrack"));
@@ -633,6 +640,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   if (!nameStr.compare("pionNegPID")) {
     cut->AddCut(GetAnalysisCut("pionPID_TPCnTOF"));
     cut->AddCut(GetAnalysisCut("negTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pionNegPIDDCAz")) {
+    cut->AddCut(GetAnalysisCut("pionPID_TPCnTOF"));
+    cut->AddCut(GetAnalysisCut("negTrack"));
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
     return cut;
   }
 

--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -5039,7 +5039,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
 
   if (!nameStr.compare("pairLxyProjected3sigmaLambdacCand")) {
     TF1* f1minLxyProjected = new TF1("f1minLxyProjected", "[0]+[1]*x", 0., 20.);
-    f1minLxyProjected->SetParameters(0.0065, -0.0023);
+    f1minLxyProjected->SetParameters(0.0065, -0.00023);
     cut->AddCut(VarManager::kVertexingLxyProjected, f1minLxyProjected, 1., false, VarManager::kPt, 0., 20.);
     return cut;
   }

--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -582,6 +582,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("kaonNegPID4DCAz")) {
+    cut->AddCut(GetAnalysisCut("kaonPID_TPCnTOF"));
+    cut->AddCut(GetAnalysisCut("negTrack"));
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
+    return cut;
+  }
+
   if (!nameStr.compare("kaonNegPID5")) {
     cut->AddCut(GetAnalysisCut("kaonPIDnsigma"));
     cut->AddCut(GetAnalysisCut("negTrack"));
@@ -607,6 +614,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   if (!nameStr.compare("pionPosPID")) {
     cut->AddCut(GetAnalysisCut("pionPID_TPCnTOF"));
     cut->AddCut(GetAnalysisCut("posTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pionPosPIDDCAz")) {
+    cut->AddCut(GetAnalysisCut("pionPID_TPCnTOF"));
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
     return cut;
   }
 
@@ -637,6 +651,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
   if (!nameStr.compare("protonPosPID")) {
     cut->AddCut(GetAnalysisCut("protonPID_TPCnTOF"));
     cut->AddCut(GetAnalysisCut("posTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("protonPosPIDDCAz")) {
+    cut->AddCut(GetAnalysisCut("protonPID_TPCnTOF"));
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
     return cut;
   }
 

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -758,6 +758,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
         hm->AddHistogram(histClass, "TauzProj", "", false, 1000, -0.03, 0.03, VarManager::kVertexingTauzProjected);
         hm->AddHistogram(histClass, "TauxyProj", "", false, 1000, -0.03, 0.03, VarManager::kVertexingTauxyProjected);
         hm->AddHistogram(histClass, "TauxyzProj", "", false, 1000, -0.03, 0.03, VarManager::kVertexingTauxyzProjected);
+        hm->AddHistogram(histClass, "LxyProj_Pt", "", false, 10, 0.0, 20.0, VarManager::kPt, 1000, -1.0, 1.0, VarManager::kVertexingLxyProjected);
         hm->AddHistogram(histClass, "LxyProj_Mass_Pt", "", false, 50, 2.0, 4.0, VarManager::kMass, 10, 0.0, 20.0, VarManager::kPt, 1000, -1.0, 1.0, VarManager::kVertexingLxyProjected);
         hm->AddHistogram(histClass, "LzProj_Mass_Pt", "", false, 50, 2.0, 4.0, VarManager::kMass, 10, 0.0, 20.0, VarManager::kPt, 1000, -1.0, 1.0, VarManager::kVertexingLzProjected);
       }

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -3536,10 +3536,10 @@ void VarManager::FillZDC(T const& zdc, float* values)
     values = fgValues;
   }
 
-  values[kEnergyCommonZNA] = zdc.energyCommonZNA();
-  values[kEnergyCommonZNC] = zdc.energyCommonZNC();
-  values[kEnergyCommonZPA] = zdc.energyCommonZPA();
-  values[kEnergyCommonZPC] = zdc.energyCommonZPC();
+  values[kEnergyCommonZNA] = (zdc.energyCommonZNA() > 0) ? zdc.energyCommonZNA() : -1.;
+  values[kEnergyCommonZNC] = (zdc.energyCommonZNC() > 0) ? zdc.energyCommonZNC() : -1.;
+  values[kEnergyCommonZPA] = (zdc.energyCommonZPA() > 0) ? zdc.energyCommonZPA() : -1.;
+  values[kEnergyCommonZPC] = (zdc.energyCommonZPC() > 0) ? zdc.energyCommonZPC() : -1.;
   values[kTimeZNA] = zdc.timeZNA();
   values[kTimeZNC] = zdc.timeZNC();
   values[kTimeZPA] = zdc.timeZPA();


### PR DESCRIPTION
The fill function for ZDC now sets the energy values to -1 if they are negative, for more straight-forward cutting and histogramming. The original values are still in the table itself.