### PR TITLE
PWGHF: Ds-h correlation: Solving a bug with Ds daughters removal

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -602,6 +602,7 @@ struct HfCorrelatorDsHadrons {
         std::array<int, 3> prongsId;
         listDaughters.clear();
         RecoDecay::getDaughters(particle, &listDaughters, arrDaughDsPDG, 2);
+        int counterDaughters = 0;
         if (listDaughters.size() == 3) {
           for (const auto& dauIdx : listDaughters) {
             auto daughI = mcParticles.rawIteratorAt(dauIdx - mcParticles.offset());

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -603,9 +603,10 @@ struct HfCorrelatorDsHadrons {
         listDaughters.clear();
         RecoDecay::getDaughters(particle, &listDaughters, arrDaughDsPDG, 2);
         if (listDaughters.size() == 3) {
-          for (auto iProng = 0; iProng < listDaughters.size(); ++iProng) {
-            auto daughI = mcParticles.rawIteratorAt(listDaughters[iProng]);
-            prongsId[iProng] = daughI.globalIndex();
+          for (const auto& dauIdx : listDaughters) {
+            auto daughI = mcParticles.rawIteratorAt(dauIdx - mcParticles.offset());
+            counterDaughters += 1;
+            prongsId[counterDaughters - 1] = daughI.globalIndex();
           }
         }
         // Ds Hadron correlation dedicated section


### PR DESCRIPTION
Dear all,
I have noticed a problem in the removal of the Ds daughters from the correlation analysis at the kinematic level.
Previous version of the code:

        RecoDecay::getDaughters(particle, &listDaughters, arrDaughDsPDG, 2);
        if (listDaughters.size() == 3) {
          for (auto iProng = 0; iProng < listDaughters.size(); ++iProng) {
            auto daughI = mcParticles.rawIteratorAt(listDaughters[iProng]);
            prongsId[iProng] = daughI.globalIndex();
          }
        }
        // Ds Hadron correlation dedicated section
        for (const auto& particleAssoc : mcParticles) {
          if (particleAssoc.globalIndex() == prongsId[0] || particleAssoc.globalIndex() == prongsId[1] || particleAssoc.globalIndex() == prongsId[2]) {
            continue;
          }

Now:

        RecoDecay::getDaughters(particle, &listDaughters, arrDaughDsPDG, 2);
        int counterDaughters = 0;
        if (listDaughters.size() == 3) {
          for (const auto& dauIdx : listDaughters) {
            auto daughI = mcParticles.rawIteratorAt(dauIdx - mcParticles.offset());
            counterDaughters += 1;
            prongsId[counterDaughters - 1] = daughI.globalIndex();
          }
        }
        // Ds Hadron correlation dedicated section
        for (const auto& particleAssoc : mcParticles) {
          if (particleAssoc.globalIndex() == prongsId[0] || particleAssoc.globalIndex() == prongsId[1] || particleAssoc.globalIndex() == prongsId[2]) {
            continue;
          }

Doing in the previous mode no particle is removed looking at the globalIndex whereas with the new implementation I've checked and the daughters are correctly removed. Just to add that in this process i passed as input the iterator over the McCollisions. Sorry for the naive question but should it be the reason why the daughters are not removed? as far as I know passing as input an iterator over the collision table all other tables with an index that points to the collision table are automatically sliced in order to take only those rows which refer to the collision considered in the loop.

Thanks a lot in advance,
Cheers,
Samuele