### PR TITLE
[PWGUD] Fix DCA logic for 2 TOF-track topology

### DIFF
--- a/PWGUD/Tasks/exclusiveTwoProtons.cxx
+++ b/PWGUD/Tasks/exclusiveTwoProtons.cxx
@@ -320,10 +320,10 @@ struct ExclusiveTwoProtons {
         }
 
         // DCA checks
-        dcaZ[0] = rawProtonTracks[0].dcaZ();
-        dcaZ[1] = rawProtonTracksTOF[0].dcaZ();
-        dcaXY[0] = rawProtonTracks[0].dcaXY();
-        dcaXY[1] = rawProtonTracksTOF[0].dcaXY();
+        dcaZ[0] = rawProtonTracksTOF[0].dcaZ();
+        dcaZ[1] = rawProtonTracksTOF[1].dcaZ();
+        dcaXY[0] = rawProtonTracksTOF[0].dcaXY();
+        dcaXY[1] = rawProtonTracksTOF[1].dcaXY();
         if (std::abs(dcaZ[0]) < 2. && std::abs(dcaZ[1]) < 2.) {
           dcaZbool = 1;
         } else {

--- a/PWGUD/Tasks/exclusiveTwoProtonsSG.cxx
+++ b/PWGUD/Tasks/exclusiveTwoProtonsSG.cxx
@@ -345,10 +345,10 @@ struct ExclusiveTwoProtonsSG {
         }
 
         // DCA checks
-        dcaZ[0] = rawProtonTracks[0].dcaZ();
-        dcaZ[1] = rawProtonTracksTOF[0].dcaZ();
-        dcaXY[0] = rawProtonTracks[0].dcaXY();
-        dcaXY[1] = rawProtonTracksTOF[0].dcaXY();
+        dcaZ[0] = rawProtonTracksTOF[0].dcaZ();
+        dcaZ[1] = rawProtonTracksTOF[1].dcaZ();
+        dcaXY[0] = rawProtonTracksTOF[0].dcaXY();
+        dcaXY[1] = rawProtonTracksTOF[1].dcaXY();
         if (std::abs(dcaZ[0]) < 2. && std::abs(dcaZ[1]) < 2.) {
           dcaZbool = 1;
         } else {


### PR DESCRIPTION
Found a bug in the way that the DCA logic is treating 2 TOF-track topology for pp events (most of the statistics derives from the 1 TOF+1 TPC topology instead)