### PR TITLE
(EPDev): new selection criteria added

### DIFF
--- a/Common/Tasks/qVectorsCorrection.cxx
+++ b/Common/Tasks/qVectorsCorrection.cxx
@@ -202,10 +202,8 @@ struct qVectorsCorrection {
   {
     histosQA.fill(HIST("histCentFull"), qVec.cent());
     if (cfgAddEvtSel && (!qVec.sel8() ||
-                         !qVec.selection_bit(aod::evsel::kNoTimeFrameBorder) ||
-                         !qVec.selection_bit(aod::evsel::kNoTimeFrameBorder) ||
-                         !qVec.selection_bit(aod::evsel::kNoITSROFrameBorder) ||
-                         !qVec.selection_bit(aod::evsel::kNoITSROFrameBorder))) {
+                         !qVec.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) ||
+                         !qVec.selection_bit(aod::evsel::kNoSameBunchPileup))) {
       return;
     }
     fillHistosQvec(qVec);


### PR DESCRIPTION
New event selection criteria were added by AOT convener's suggestion.
Obsolete selections were removed ("kNoTimeFrameBorder" and "kNoITSROFrameBorder" are already included in "sel8").