### PR TITLE
PWGLF: Remove V0Datas tables from cascadePreselector processes in the cascadebuilder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -1628,6 +1628,7 @@ struct cascadeBuilder {
   template <class TTrackTo, typename TCascTable>
   void buildKFStrangenessTables(TCascTable const& cascades)
   {
+    statisticsRegistry.eventCounter++;
     for (auto& cascade : cascades) {
       bool validCascadeCandidateKF = buildCascadeCandidateWithKF<TTrackTo>(cascade);
       if (!validCascadeCandidateKF)
@@ -1672,6 +1673,9 @@ struct cascadeBuilder {
         kfcasccovs(trackCovariance, trackCovarianceV0, trackCovariancePos, trackCovarianceNeg);
       }
     }
+    // En masse filling at end of process call
+    fillHistos();
+    resetHistos();
   }
 
   template <class TTrackTo, typename TCascTable, typename TStraTrack>
@@ -2235,7 +2239,7 @@ struct cascadePreselector {
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all cascades are built. It will simply tag everything as true.
-  void processBuildAll(aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, aod::TracksExtra const&)
+  void processBuildAll(aod::Cascades const& cascades, aod::V0s const&, aod::TracksExtra const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -2246,7 +2250,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildMCAssociated(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const& /*v0table*/, LabeledTracksExtra const&, aod::McParticles const&)
+  void processBuildMCAssociated(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, LabeledTracksExtra const&, aod::McParticles const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -2258,7 +2262,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildValiddEdx(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, TracksExtraWithPID const&)
+  void processBuildValiddEdx(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, TracksExtraWithPID const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -2270,7 +2274,7 @@ struct cascadePreselector {
       checkAndFinalize();
   }
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
-  void processBuildValiddEdxMCAssociated(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, aod::V0Datas const&, TracksExtraWithPIDandLabels const&, aod::McParticles const&)
+  void processBuildValiddEdxMCAssociated(aod::Collisions const& /*collisions*/, aod::Cascades const& cascades, aod::V0s const&, TracksExtraWithPIDandLabels const&, aod::McParticles const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {
@@ -2285,7 +2289,7 @@ struct cascadePreselector {
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
   /// This process function ensures that all findable cascades are built.
   /// Not to be used with processSkip.
-  void processBuildFindable(aod::FindableCascades const& cascades, aod::FindableV0s const&, aod::V0Datas const&, aod::TracksExtra const&)
+  void processBuildFindable(aod::FindableCascades const& cascades, aod::FindableV0s const&, aod::TracksExtra const&)
   {
     initializeMasks(cascades.size());
     for (auto& casc : cascades) {


### PR DESCRIPTION
Hi @ddobrigk :)
Would it be possible to add these changes to the cascadebuilder? They would allow to run the cascadebuilder with the KF without having to run the lambdakzerobuilder to produce the V0Datas tables. 
As far as I see, the aod::V0Datas subscriptions in the cascadePreselector processes are not necessary. I ran some tests locally to make sure and everything looks fine so far. Am I overlooking something or could we indeed remove those subscriptions?