### PR TITLE
Check the source of the signal for skimming

### DIFF
--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -470,9 +470,9 @@ struct TableMakerMC {
           bool checked = false;
           if constexpr (soa::is_soa_filtered_v<aod::McParticles_001>) {
             auto mctrack_raw = groupedMcTracks.rawIteratorAt(mctrack.globalIndex());
-            checked = sig.CheckSignal(false, mctrack_raw);
+            checked = sig.CheckSignal(true, mctrack_raw);
           } else {
-            checked = sig.CheckSignal(false, mctrack);
+            checked = sig.CheckSignal(true, mctrack);
           }
           if (checked) {
             mcflags |= (uint16_t(1) << i);
@@ -1015,9 +1015,9 @@ struct TableMakerMC {
           bool checked = false;
           if constexpr (soa::is_soa_filtered_v<aod::McParticles_001>) {
             auto mctrack_raw = groupedMcTracks.rawIteratorAt(mctrack.globalIndex());
-            checked = sig.CheckSignal(false, mctrack_raw);
+            checked = sig.CheckSignal(true, mctrack_raw);
           } else {
-            checked = sig.CheckSignal(false, mctrack);
+            checked = sig.CheckSignal(true, mctrack);
           }
           if (checked) {
             mcflags |= (uint16_t(1) << i);


### PR DESCRIPTION
The two reasons are:
a. Otherwise it is not possible to skimm with primary electrons for example. The rejection factor is much too small including secondary electrons from conversion happening far away (TRD...)
b. Otherwise there is an inconsistency between the signals defined at the reconstruction level (no source checked) and for reconstructed tracks in the histograms..
