### PR TITLE
PWGEM/PhotonMeson: add occupancy in data model

### DIFF
--- a/PWGEM/Dilepton/Utils/MCUtilities.h
+++ b/PWGEM/Dilepton/Utils/MCUtilities.h
@@ -180,7 +180,8 @@ int IsHF(TMCParticle1 const& p1, TMCParticle2 const& p2, TMCParticles const& mcp
           if (mid1 == mid2) {
             auto common_mp = mcparticles.iteratorAt(mid1);
             int mp_pdg = common_mp.pdgCode();
-            if (abs(mp_pdg) < 1e+9 && (std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 3] == '5' || std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 4] == '5')) {
+            bool is_mp_diquark = (1100 < abs(mp_pdg) && abs(mp_pdg) < 5600) && std::to_string(mp_pdg)[std::to_string(mp_pdg).length() - 2] == '0';
+            if (!is_mp_diquark && abs(mp_pdg) < 1e+9 && (std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 3] == '5' || std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 4] == '5')) {
               mothers_id1.clear();
               mothers_pdg1.clear();
               mothers_id2.clear();
@@ -201,7 +202,8 @@ int IsHF(TMCParticle1 const& p1, TMCParticle2 const& p2, TMCParticles const& mcp
           if (mid1 == mid2) {
             auto common_mp = mcparticles.iteratorAt(mid1);
             int mp_pdg = common_mp.pdgCode();
-            if (abs(mp_pdg) < 1e+9 && (std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 3] == '5' || std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 4] == '5')) {
+            bool is_mp_diquark = (1100 < abs(mp_pdg) && abs(mp_pdg) < 5600) && std::to_string(mp_pdg)[std::to_string(mp_pdg).length() - 2] == '0';
+            if (!is_mp_diquark && abs(mp_pdg) < 1e+9 && (std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 3] == '5' || std::to_string(abs(mp_pdg))[std::to_string(abs(mp_pdg)).length() - 4] == '5')) {
               is_same_mother_found = true;
             }
           }
@@ -329,6 +331,46 @@ bool checkFromSameQuarkPair(T& p1, T& p2, U& mcParticles, int pdg)
   int id1 = findHFOrigin(p1, mcParticles, pdg);
   int id2 = findHFOrigin(p2, mcParticles, pdg);
   return id1 == id2 && id1 > -1 && id2 > -1;
+}
+//_______________________________________________________________________
+template <typename T>
+bool isCharmMeson(T const& track)
+{
+  if (400 < abs(track.pdgCode()) && abs(track.pdgCode()) < 500) {
+    return true;
+  } else {
+    return false;
+  }
+}
+//_______________________________________________________________________
+template <typename T>
+bool isCharmBaryon(T const& track)
+{
+  if (4000 < abs(track.pdgCode()) && abs(track.pdgCode()) < 5000) {
+    return true;
+  } else {
+    return false;
+  }
+}
+//_______________________________________________________________________
+template <typename T>
+bool isBeautyMeson(T const& track)
+{
+  if (500 < abs(track.pdgCode()) && abs(track.pdgCode()) < 600) {
+    return true;
+  } else {
+    return false;
+  }
+}
+//_______________________________________________________________________
+template <typename T>
+bool isBeautyBaryon(T const& track)
+{
+  if (5000 < abs(track.pdgCode()) && abs(track.pdgCode()) < 6000) {
+    return true;
+  } else {
+    return false;
+  }
 }
 //_______________________________________________________________________
 //_______________________________________________________________________

--- a/PWGEM/PhotonMeson/Core/EMEventCut.cxx
+++ b/PWGEM/PhotonMeson/Core/EMEventCut.cxx
@@ -39,6 +39,13 @@ void EMEventCut::SetZvtxRange(float min, float max)
   LOG(info) << "EM Event Cut, set z vtx range: " << mMinZvtx << " - " << mMaxZvtx;
 }
 
+void EMEventCut::SetOccupancyRange(int min, int max)
+{
+  mMinOccupancy = min;
+  mMaxOccupancy = max;
+  LOG(info) << "EM Event Cut, set occupancy range: " << mMinOccupancy << " - " << mMaxOccupancy;
+}
+
 void EMEventCut::SetRequireNoTFB(bool flag)
 {
   mRequireNoTFB = flag;

--- a/PWGEM/PhotonMeson/Core/EMEventCut.h
+++ b/PWGEM/PhotonMeson/Core/EMEventCut.h
@@ -37,6 +37,7 @@ class EMEventCut : public TNamed
     kNoSameBunchPileup,
     kIsVertexITSTPC,
     kIsGoodZvtxFT0vsPV,
+    kOccupancy,
     kNCuts
   };
 
@@ -67,6 +68,9 @@ class EMEventCut : public TNamed
       return false;
     }
     if (mRequireGoodZvtxFT0vsPV && !IsSelected(collision, EMEventCuts::kIsGoodZvtxFT0vsPV)) {
+      return false;
+    }
+    if (!IsSelected(collision, EMEventCuts::kOccupancy)) {
       return false;
     }
     return true;
@@ -100,8 +104,15 @@ class EMEventCut : public TNamed
       case EMEventCuts::kIsGoodZvtxFT0vsPV:
         return collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV);
 
+      case EMEventCuts::kOccupancy: {
+        if (mMinOccupancy < 0) {
+          return true;
+        } else {
+          return mMinOccupancy <= collision.trackOccupancyInTimeRange() && collision.trackOccupancyInTimeRange() < mMaxOccupancy;
+        }
+      }
       default:
-        return false;
+        return true;
     }
   }
 
@@ -109,6 +120,7 @@ class EMEventCut : public TNamed
   void SetRequireSel8(bool flag);
   void SetRequireFT0AND(bool flag);
   void SetZvtxRange(float min, float max);
+  void SetOccupancyRange(int min, int max);
   void SetRequireNoTFB(bool flag);
   void SetRequireNoITSROFB(bool flag);
   void SetRequireNoSameBunchPileup(bool flag);
@@ -122,6 +134,7 @@ class EMEventCut : public TNamed
   bool mRequireSel8{true};
   bool mRequireFT0AND{true};
   float mMinZvtx{-10.f}, mMaxZvtx{+10.f};
+  int mMinOccupancy{static_cast<int>(-1e+9)}, mMaxOccupancy{static_cast<int>(+1e+9)};
   bool mRequireNoTFB{true};
   bool mRequireNoITSROFB{true};
   bool mRequireNoSameBunchPileup{false};

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
@@ -465,10 +465,8 @@ struct Pi0EtaToGammaGamma {
 
   o2::aod::pwgem::photonmeson::utils::EventMixingHandler<std::tuple<int, int, int>, std::pair<int, int64_t>, EMTrack>* emh1 = nullptr;
   o2::aod::pwgem::photonmeson::utils::EventMixingHandler<std::tuple<int, int, int>, std::pair<int, int64_t>, EMTrack>* emh2 = nullptr;
-  std::map<std::tuple<int, int, int>, std::vector<std::pair<int, int64_t>>> map_mix_bins; // zvtx, centrality, event plane bins -> pair<df index, vector of collisionId>
-  std::map<std::pair<int, int64_t>, std::vector<EMTrack>> map_photons_to_collision;       // pair<df index, collisionId> -> vector of track
-  std::vector<std::pair<int, int>> used_photonIds;                                        // <ndf, trackId>
-  std::vector<std::tuple<int, int, int>> used_dileptonIds;                                // <ndf, trackId>
+  std::vector<std::pair<int, int>> used_photonIds;              // <ndf, trackId>
+  std::vector<std::tuple<int, int, int, int>> used_dileptonIds; // <ndf, trackId>
 
   template <typename TCollisions, typename TPhotons1, typename TPhotons2, typename TSubInfos1, typename TSubInfos2, typename TPreslice1, typename TPreslice2, typename TCut1, typename TCut2, typename TTracksMatchedWithEMC, typename TTracksMatchedWithPHOS>
   void runPairing(TCollisions const& collisions,
@@ -523,7 +521,7 @@ struct Pi0EtaToGammaGamma {
         epbin = static_cast<int>(ep_bin_edges.size()) - 2;
       }
 
-      std::tuple<int, int, int64_t> key_bin = std::make_tuple(zbin, centbin, epbin);
+      std::tuple<int, int, int> key_bin = std::make_tuple(zbin, centbin, epbin);
       std::pair<int, int64_t> key_df_collision = std::make_pair(ndf, collision.globalIndex());
 
       if constexpr (pairtype == PairType::kPCMPCM || pairtype == PairType::kPHOSPHOS || pairtype == PairType::kEMCEMC) { // same kinds pairing
@@ -609,7 +607,7 @@ struct Pi0EtaToGammaGamma {
             float dca_ee_3d = std::sqrt((dca_pos_3d * dca_pos_3d + dca_ele_3d * dca_ele_3d) / 2.);
 
             std::pair<int, int> pair_tmp_id1 = std::make_pair(ndf, g1.globalIndex());
-            std::tuple<int, int, int> tuple_tmp_id2 = std::make_tuple(ndf, pos2.trackId(), ele2.trackId());
+            std::tuple<int, int, int, int> tuple_tmp_id2 = std::make_tuple(ndf, collision.globalIndex(), pos2.trackId(), ele2.trackId());
             if (std::find(used_photonIds.begin(), used_photonIds.end(), pair_tmp_id1) == used_photonIds.end()) {
               emh1->AddTrackToEventPool(key_df_collision, EMTrack(collision.globalIndex(), g1.globalIndex(), g1.pt(), g1.eta(), g1.phi(), 0, 0, 0));
               used_photonIds.emplace_back(pair_tmp_id1);
@@ -670,7 +668,7 @@ struct Pi0EtaToGammaGamma {
             float dca_ee_3d = std::sqrt((dca_pos_3d * dca_pos_3d + dca_ele_3d * dca_ele_3d) / 2.);
 
             std::pair<int, int> pair_tmp_id1 = std::make_pair(ndf, g1.globalIndex());
-            std::tuple<int, int, int> tuple_tmp_id2 = std::make_tuple(ndf, muplus.trackId(), muminus.trackId());
+            std::tuple<int, int, int, int> tuple_tmp_id2 = std::make_tuple(ndf, collision.globalIndex(), muplus.trackId(), muminus.trackId());
             if (std::find(used_photonIds.begin(), used_photonIds.end(), pair_tmp_id1) == used_photonIds.end()) {
               emh1->AddTrackToEventPool(key_df_collision, EMTrack(collision.globalIndex(), g1.globalIndex(), g1.pt(), g1.eta(), g1.phi(), 0, 0, 0));
               used_photonIds.emplace_back(pair_tmp_id1);

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
@@ -109,6 +109,8 @@ struct Pi0EtaToGammaGamma {
     Configurable<bool> cfgRequireNoSameBunchPileup{"cfgRequireNoSameBunchPileup", false, "require no same bunch pileup in event cut"};
     Configurable<bool> cfgRequireVertexITSTPC{"cfgRequireVertexITSTPC", false, "require Vertex ITSTPC in event cut"}; // ITS-TPC matched track contributes PV.
     Configurable<bool> cfgRequireGoodZvtxFT0vsPV{"cfgRequireGoodZvtxFT0vsPV", false, "require good Zvtx between FT0 vs. PV in event cut"};
+    Configurable<int> cfgOccupancyMin{"cfgOccupancyMin", -1, "min. occupancy"};
+    Configurable<int> cfgOccupancyMax{"cfgOccupancyMax", 1000000000, "max. occupancy"};
   } eventcuts;
 
   V0PhotonCut fV0PhotonCut;
@@ -272,6 +274,7 @@ struct Pi0EtaToGammaGamma {
     fEMEventCut.SetRequireNoSameBunchPileup(eventcuts.cfgRequireNoSameBunchPileup);
     fEMEventCut.SetRequireVertexITSTPC(eventcuts.cfgRequireVertexITSTPC);
     fEMEventCut.SetRequireGoodZvtxFT0vsPV(eventcuts.cfgRequireGoodZvtxFT0vsPV);
+    fEMEventCut.SetOccupancyRange(eventcuts.cfgOccupancyMin, eventcuts.cfgOccupancyMax);
   }
 
   void DefinePCMCut()

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
@@ -199,12 +199,7 @@ struct Pi0EtaToGammaGammaMC {
     Configurable<bool> EMC_UseExoticCut{"EMC_UseExoticCut", true, "FLag to use the EMCal exotic cluster cut"};
   } emccuts;
 
-  struct : ConfigurableGroup {
-    Configurable<float> maxY{"maxY", 0.9, "maximum rapidity for generated particles"};                 // for PCM and dielectron
-    Configurable<float> minPhi{"minPhi", 0, "minimum azimuthal angle for generated particles"};        // for PCM and dielectron
-    Configurable<float> maxPhi{"maxPhi", 2 * M_PI, "maximum azimuthal angle for generated particles"}; // for PCM and dielectron
-  } mctrackcuts;
-
+  Configurable<float> maxY_gen{"maxY_gen", 0.9, "maximum rapidity for generated particles"}; // for PCM and dielectron
   Configurable<float> maxRgen{"maxRgen", 90.f, "maximum radius for generated particles"};
   Configurable<float> margin_z_mc{"margin_z_mc", 7.0, "margin for z cut in cm for MC"};
 
@@ -477,7 +472,7 @@ struct Pi0EtaToGammaGammaMC {
           auto g2mc = mcparticles.iteratorAt(photonid2);
 
           if constexpr (pairtype == PairType::kPCMPCM) {
-            if (!IsConversionPointInAcceptance(g1mc, maxRgen, mctrackcuts.maxY, margin_z_mc, mcparticles) || !IsConversionPointInAcceptance(g2mc, maxRgen, mctrackcuts.maxY, margin_z_mc, mcparticles)) {
+            if (!IsConversionPointInAcceptance(g1mc, maxRgen, maxY_gen, margin_z_mc, mcparticles) || !IsConversionPointInAcceptance(g2mc, maxRgen, maxY_gen, margin_z_mc, mcparticles)) {
               continue;
             }
           }
@@ -522,7 +517,7 @@ struct Pi0EtaToGammaGammaMC {
             continue;
           }
           auto g1mc = mcparticles.iteratorAt(photonid1);
-          if (!IsConversionPointInAcceptance(g1mc, maxRgen, mctrackcuts.maxY, margin_z_mc, mcparticles)) {
+          if (!IsConversionPointInAcceptance(g1mc, maxRgen, maxY_gen, margin_z_mc, mcparticles)) {
             continue;
           }
           ROOT::Math::PtEtaPhiMVector v_gamma(g1.pt(), g1.eta(), g1.phi(), 0.f);
@@ -589,7 +584,7 @@ struct Pi0EtaToGammaGammaMC {
             continue;
           }
           auto g1mc = mcparticles.iteratorAt(photonid1);
-          if (!IsConversionPointInAcceptance(g1mc, maxRgen, mctrackcuts.maxY, margin_z_mc, mcparticles)) {
+          if (!IsConversionPointInAcceptance(g1mc, maxRgen, maxY_gen, margin_z_mc, mcparticles)) {
             continue;
           }
           ROOT::Math::PtEtaPhiMVector v_gamma(g1.pt(), g1.eta(), g1.phi(), 0.f);
@@ -670,7 +665,7 @@ struct Pi0EtaToGammaGammaMC {
       hPtY->GetBinXYZ(ibin, xbin, ybin, zbin);
       float pt = hPtY->GetXaxis()->GetBinCenter(xbin);
       float y = hPtY->GetYaxis()->GetBinCenter(ybin);
-      if (y > mctrackcuts.maxY) {
+      if (y > maxY_gen) {
         continue;
       }
 

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <vector>
 
+#include "TF1.h"
 #include "TString.h"
 #include "Math/Vector4D.h"
 #include "Framework/runDataProcessing.h"
@@ -93,6 +94,7 @@ struct Pi0EtaToGammaGammaMC {
   ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
   ConfigurableAxis ConfCentBins{"ConfCentBins", {VARIABLE_WIDTH, 0.0f, 5.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.f, 999.f}, "Mixing bins - centrality"};
   ConfigurableAxis ConfEPBins{"ConfEPBins", {VARIABLE_WIDTH, -M_PI / 2, -M_PI / 4, 0.0f, +M_PI / 4, +M_PI / 2}, "Mixing bins - event plane angle"};
+  Configurable<std::string> fd_k0s_to_pi0{"fd_k0s_pi0", "1.0", "feed down correction to pi0"};
 
   EMEventCut fEMEventCut;
   struct : ConfigurableGroup {
@@ -213,6 +215,7 @@ struct Pi0EtaToGammaGammaMC {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   Configurable<std::string> ccdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
 
+  TF1* f1fd_k0s_to_pi0;
   HistogramRegistry fRegistry{"output", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
   static constexpr std::string_view event_types[2] = {"before/", "after/"};
   static constexpr std::string_view event_pair_types[2] = {"same/", "mix/"};
@@ -235,10 +238,16 @@ struct Pi0EtaToGammaGammaMC {
     DefineEMCCut();
     DefinePHOSCut();
 
+    f1fd_k0s_to_pi0 = new TF1("f1fd_k0s_to_pi0", TString(fd_k0s_to_pi0), 0.f, 100.f);
+
     fRegistry.add("Event/hNrecPerMCCollision", "Nrec per mc collision;N_{rec} collisions per MC collision", kTH1F, {{21, -0.5f, 20.5f}}, false);
   }
 
-  ~Pi0EtaToGammaGammaMC() {}
+  ~Pi0EtaToGammaGammaMC()
+  {
+    delete f1fd_k0s_to_pi0;
+    f1fd_k0s_to_pi0 = 0x0;
+  }
 
   void DefineEMEventCut()
   {
@@ -493,10 +502,10 @@ struct Pi0EtaToGammaGammaMC {
 
           if (pi0id > 0) {
             auto pi0mc = mcparticles.iteratorAt(pi0id);
-            o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, v12, pi0mc, mcparticles, mccollisions);
+            o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, v12, pi0mc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
           } else if (etaid > 0) {
             auto etamc = mcparticles.iteratorAt(etaid);
-            o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, v12, etamc, mcparticles, mccollisions);
+            o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, v12, etamc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
           }
         } // end of pairing loop
       } else if constexpr (pairtype == PairType::kPCMDalitzEE) {
@@ -559,10 +568,10 @@ struct Pi0EtaToGammaGammaMC {
             }
             if (pi0id > 0) {
               auto pi0mc = mcparticles.iteratorAt(pi0id);
-              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, pi0mc, mcparticles, mccollisions);
+              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, pi0mc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
             } else if (etaid > 0) {
               auto etamc = mcparticles.iteratorAt(etaid);
-              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, etamc, mcparticles, mccollisions);
+              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, etamc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
             }
           } // end of dielectron loop
         }   // end of pcm loop
@@ -626,10 +635,10 @@ struct Pi0EtaToGammaGammaMC {
             }
             if (pi0id > 0) {
               auto pi0mc = mcparticles.iteratorAt(pi0id);
-              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, pi0mc, mcparticles, mccollisions);
+              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, pi0mc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
             } else if (etaid > 0) {
               auto etamc = mcparticles.iteratorAt(etaid);
-              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, etamc, mcparticles, mccollisions);
+              o2::aod::pwgem::photonmeson::utils::nmhistogram::fillTruePairInfo(&fRegistry, veeg, etamc, mcparticles, mccollisions, f1fd_k0s_to_pi0);
             }
           }    // end of dielectron loop
         }      // end of pcm loop

--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -75,10 +75,17 @@ DECLARE_SOA_DYNAMIC_COLUMN(EP2FV0A, ep2fv0a, [](float q2x, float q2y) -> float {
 DECLARE_SOA_DYNAMIC_COLUMN(EP2BPos, ep2bpos, [](float q2x, float q2y) -> float { return std::atan2(q2y, q2x) / 2.0; });
 DECLARE_SOA_DYNAMIC_COLUMN(EP2BNeg, ep2bneg, [](float q2x, float q2y) -> float { return std::atan2(q2y, q2x) / 2.0; });
 } // namespace emevent
-DECLARE_SOA_TABLE(EMEvents, "AOD", "EMEVENT", //!   Main event information table
+DECLARE_SOA_TABLE(EMEvents_000, "AOD", "EMEVENT", //!   Main event information table
                   o2::soa::Index<>, emevent::CollisionId, bc::GlobalBC, bc::RunNumber, evsel::Sel8, evsel::Alias, evsel::Selection, emevent::NcollsPerBC,
                   collision::PosX, collision::PosY, collision::PosZ,
                   collision::NumContrib, collision::CollisionTime, collision::CollisionTimeRes, emevent::Bz);
+
+DECLARE_SOA_TABLE_VERSIONED(EMEvents_001, "AOD", "EMEVENT", 1, //!   Main event information table
+                            o2::soa::Index<>, emevent::CollisionId, bc::GlobalBC, bc::RunNumber, evsel::Sel8, evsel::Alias, evsel::Selection, emevent::NcollsPerBC,
+                            collision::PosX, collision::PosY, collision::PosZ,
+                            collision::NumContrib, collision::CollisionTime, collision::CollisionTimeRes, emevent::Bz, evsel::NumTracksInTimeRange);
+
+using EMEvents = EMEvents_001;
 using EMEvent = EMEvents::iterator;
 
 DECLARE_SOA_TABLE(EMEventsBz, "AOD", "EMEVENTBZ", emevent::Bz); // joinable to EMEvents

--- a/PWGEM/PhotonMeson/DataModel/gammaTables.h
+++ b/PWGEM/PhotonMeson/DataModel/gammaTables.h
@@ -135,7 +135,7 @@ using EMEventNmumu = EMEventsNmumu::iterator;
 namespace emmcevent
 {
 DECLARE_SOA_COLUMN(McCollisionId, mcCollisionId, int);
-}
+} // namespace emmcevent
 
 DECLARE_SOA_TABLE(EMMCEvents, "AOD", "EMMCEVENT", //!   MC event information table
                   o2::soa::Index<>, emmcevent::McCollisionId, mccollision::GeneratorsID,
@@ -198,6 +198,51 @@ DECLARE_SOA_TABLE_FULL(EMMCParticles, "EMMCParticles", "AOD", "EMMCPARTICLE", //
                        mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
 
 using EMMCParticle = EMMCParticles::iterator;
+
+namespace emmcbinnedgen
+{
+DECLARE_SOA_COLUMN(GeneratedGamma, generatedGamma, std::vector<uint16_t>);             //! gamma binned generated data
+DECLARE_SOA_COLUMN(GeneratedPi0, generatedPi0, std::vector<uint16_t>);                 //! pi0 binned generated data
+DECLARE_SOA_COLUMN(GeneratedEta, generatedEta, std::vector<uint16_t>);                 //! eta binned generated data
+DECLARE_SOA_COLUMN(GeneratedOmega, generatedOmega, std::vector<uint16_t>);             //! omega(782) binned generated data
+DECLARE_SOA_COLUMN(GeneratedPhi, generatedPhi, std::vector<uint16_t>);                 //! phi(1020) binned generated data
+DECLARE_SOA_COLUMN(GeneratedChargedPion, generatedChargedPion, std::vector<uint16_t>); //! charged pion binned generated data
+DECLARE_SOA_COLUMN(GeneratedChargedKaon, generatedChargedKaon, std::vector<uint16_t>); //! charged kaon binned generated data
+DECLARE_SOA_COLUMN(GeneratedK0S, generatedK0S, std::vector<uint16_t>);                 //! K0S binned generated data
+DECLARE_SOA_COLUMN(GeneratedLambda, generatedLambda, std::vector<uint16_t>);           //! Lambda binned generated data
+
+DECLARE_SOA_COLUMN(GeneratedPi0_Acc_gg, generatedPi0_acc_gg, std::vector<uint16_t>);       //! pi0 -> gg binned generated data
+DECLARE_SOA_COLUMN(GeneratedPi0_Acc_eeg, generatedPi0_acc_eeg, std::vector<uint16_t>);     //! pi0 -> eeg binned generated data
+DECLARE_SOA_COLUMN(GeneratedEta_Acc_gg, generatedEta_acc_gg, std::vector<uint16_t>);       //! eta -> gg binned generated data
+DECLARE_SOA_COLUMN(GeneratedEta_Acc_eeg, generatedEta_acc_eeg, std::vector<uint16_t>);     //! eta -> eeg binned generated data
+DECLARE_SOA_COLUMN(GeneratedEta_Acc_mumug, generatedEta_acc_mumug, std::vector<uint16_t>); //! eta -> mumug binned generated data
+DECLARE_SOA_COLUMN(GeneratedEta_Acc_pipig, generatedEta_acc_pipig, std::vector<uint16_t>); //! eta -> pipig binned generated data
+DECLARE_SOA_COLUMN(GeneratedOmega_Acc_ee, generatedOmega_acc_ee, std::vector<uint16_t>);   //! omega(782) -> ee binned generated data
+DECLARE_SOA_COLUMN(GeneratedPhi_Acc_ee, generatedPhi_acc_ee, std::vector<uint16_t>);       //! phi(1020) -> ee binned generated data
+} // namespace emmcbinnedgen
+
+DECLARE_SOA_TABLE(BinnedGenPts, "AOD", "BINNEDGENPT", // To be joined with EMMCEvents table at analysis level.
+                  emmcbinnedgen::GeneratedGamma,
+                  emmcbinnedgen::GeneratedPi0,
+                  emmcbinnedgen::GeneratedEta,
+                  emmcbinnedgen::GeneratedOmega,
+                  emmcbinnedgen::GeneratedPhi,
+                  emmcbinnedgen::GeneratedChargedPion,
+                  emmcbinnedgen::GeneratedChargedKaon,
+                  emmcbinnedgen::GeneratedK0S,
+                  emmcbinnedgen::GeneratedLambda);
+using BinnedGenPt = BinnedGenPts::iterator;
+
+DECLARE_SOA_TABLE(BinnedGenPtAccs, "AOD", "BINNEDGENPTACC", // To be joined with EMMCEvents table at analysis level.
+                  emmcbinnedgen::GeneratedPi0_Acc_gg,
+                  emmcbinnedgen::GeneratedPi0_Acc_eeg,
+                  emmcbinnedgen::GeneratedEta_Acc_gg,
+                  emmcbinnedgen::GeneratedEta_Acc_eeg,
+                  emmcbinnedgen::GeneratedEta_Acc_mumug,
+                  emmcbinnedgen::GeneratedEta_Acc_pipig,
+                  emmcbinnedgen::GeneratedOmega_Acc_ee,
+                  emmcbinnedgen::GeneratedPhi_Acc_ee);
+using BinnedGenPtAcc = BinnedGenPtAccs::iterator;
 
 namespace v0legmclabel
 {

--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+add_subdirectory(converters)
+
 o2physics_add_dpl_workflow(skimmer-gamma-conversion
                     SOURCES skimmerGammaConversion.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2Physics::AnalysisCore KFParticle::KFParticle

--- a/PWGEM/PhotonMeson/TableProducer/associateMCinfo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/associateMCinfo.cxx
@@ -49,8 +49,12 @@ struct AssociateMCInfo {
   Produces<o2::aod::EMPrimaryMuonMCLabels> emprimarymuonmclabels;
   Produces<o2::aod::EMEMCClusterMCLabels> ememcclustermclabels;
 
+  Produces<o2::aod::BinnedGenPts> binned_gen_pt;
+  // Produces<o2::aod::BinnedGenPtAccs> binned_gen_pt_acc;
+
   Configurable<float> max_rxy_gen{"max_rxy_gen", 100, "max rxy to store generated information"};
-  Configurable<float> max_Y_gen{"max_Y_gen", 0.9, "max rapidity Y to store generated information"};
+  Configurable<float> max_Y_gen_primary{"max_Y_gen_primary", 1.2, "max rapidity Y to store generated information"}; // smearing might be applied at analysis stage. set wider value.
+  Configurable<float> max_Y_gen_secondary{"max_Y_gen_secondary", 0.9, "max rapidity Y to store generated information"};
   Configurable<float> margin_z_gen{"margin_z_gen", 15.f, "margin for Z of true photon conversion point to store generated information"};
 
   HistogramRegistry registry{"EMMCEvent"};
@@ -60,14 +64,92 @@ struct AssociateMCInfo {
     auto hEventCounter = registry.add<TH1>("hEventCounter", "hEventCounter", kTH1I, {{6, 0.5f, 6.5f}});
     hEventCounter->GetXaxis()->SetBinLabel(1, "all");
     hEventCounter->GetXaxis()->SetBinLabel(2, "has mc collision");
-    registry.add<TH2>("PCM/hXY", "hRxy;X (cm);Y (cm)", kTH2F, {{400, -100, +100}, {400, -100, +100}});
-    registry.add<TH2>("PCM/hRZ", "hRxy;R (cm);Z (cm)", kTH2F, {{400, -100, +100}, {200, 0, +100}});
-    registry.add<TH1>("Generated/hPt_Pi0", "pT distribution of #pi^{0};p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
-    registry.add<TH1>("Generated/hPt_Eta", "pT distribution of #eta;p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
-    registry.add<TH1>("Generated/hPt_ChargedPion", "pT distribution of #pi^{#pm};p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
-    registry.add<TH1>("Generated/hPt_ChargedKaon", "pT distribution of K^{#pm};p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
-    registry.add<TH1>("Generated/hPt_K0S", "pT distribution of K0S;p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
-    registry.add<TH1>("Generated/hPt_Lambda", "pT distribution of #Lambda(#bar{#Lambda});p_{T} (GeV/c)", kTH1F, {{200, 0, 20}});
+    registry.add<TH2>("PCM/hXY", "hRxy;X (cm);Y (cm)", kTH2F, {{1000, -100, +100}, {1000, -100, +100}});
+    registry.add<TH2>("PCM/hRZ", "hRxy;R (cm);Z (cm)", kTH2F, {{1000, -100, +100}, {1000, 0, +100}});
+
+    // !!Don't change pt,eta,y binning. These binnings have to be consistent with binned data at analysis.!!
+    std::vector<double> ptbins;
+    for (int i = 0; i < 2; i++) {
+      ptbins.emplace_back(0.05 * (i - 0) + 0.0); // from 0 to 0.1 GeV/c, every 0.05 GeV/c
+    }
+    for (int i = 2; i < 52; i++) {
+      ptbins.emplace_back(0.1 * (i - 2) + 0.1); // from 0.1 to 5 GeV/c, every 0.1 GeV/c
+    }
+    for (int i = 52; i < 62; i++) {
+      ptbins.emplace_back(0.5 * (i - 52) + 5.0); // from 5 to 10 GeV/c, evety 0.5 GeV/c
+    }
+    for (int i = 62; i < 73; i++) {
+      ptbins.emplace_back(1.0 * (i - 62) + 10.0); // from 10 to 20 GeV/c, evety 1 GeV/c
+    }
+    const AxisSpec axis_pt{ptbins, "p_{T} (GeV/c)"};
+    const AxisSpec axis_rapidity{{0.0, +0.8, +0.9}, "rapidity |y|"};
+
+    static constexpr std::string_view parnames[9] = {
+      "Gamma", "Pi0", "Eta", "Omega", "Phi",
+      "ChargedPion", "ChargedKaon", "K0S", "Lambda"};
+
+    for (int i = 0; i < 9; i++) {
+      registry.add<TH2>(Form("Generated/h2PtY_%s", parnames[i].data()), Form("Generated %s", parnames[i].data()), kTH2F, {axis_pt, axis_rapidity}, true);
+    }
+
+    // reserve space for generated vectors if that process enabled
+    auto hBinFinder = registry.get<TH2>(HIST("Generated/h2PtY_Pi0"));
+    LOGF(info, "Binned generated processing enabled. Initialising with %i elements...", hBinFinder->GetNcells());
+    genGamma.resize(hBinFinder->GetNcells(), 0);
+    genPi0.resize(hBinFinder->GetNcells(), 0);
+    genEta.resize(hBinFinder->GetNcells(), 0);
+    genOmega.resize(hBinFinder->GetNcells(), 0);
+    genPhi.resize(hBinFinder->GetNcells(), 0);
+    genChargedPion.resize(hBinFinder->GetNcells(), 0);
+    genChargedKaon.resize(hBinFinder->GetNcells(), 0);
+    genK0S.resize(hBinFinder->GetNcells(), 0);
+    genLambda.resize(hBinFinder->GetNcells(), 0);
+
+    static constexpr std::string_view parnames_acc[8] = {
+      "Pi0_acc_gg", "Pi0_acc_eeg",
+      "Eta_acc_gg", "Eta_acc_eeg", "Eta_acc_mumug", "Eta_acc_pipig",
+      "Omega_acc_ee",
+      "Phi_acc_ee"};
+    const AxisSpec axis_eta{{0.0, +0.8, +0.9}, "pseudo-rapidity |#eta|"};
+
+    for (int i = 0; i < 8; i++) {
+      registry.add<THnSparse>(Form("Generated/hs_%s", parnames_acc[i].data()), Form("Generated %s", parnames_acc[i].data()), kTHnSparseF, {axis_pt, axis_rapidity, axis_eta, axis_eta, axis_eta}, true);
+    }
+    auto hBinFinder_acc = registry.get<THnSparse>(HIST("Generated/hs_Pi0_acc_gg"));
+    int nbins_acc = 1;
+    for (int idim = 0; idim < hBinFinder_acc->GetNdimensions(); idim++) {
+      nbins_acc *= hBinFinder_acc->GetAxis(idim)->GetNbins(); // without over/underflow
+    }
+
+    LOGF(info, "Binned generated processing enabled. Initialising with %i elements... for particles in acceptance", nbins_acc);
+    genPi0_acc_gg.resize(nbins_acc, 0);
+    genPi0_acc_eeg.resize(nbins_acc, 0);
+    genEta_acc_gg.resize(nbins_acc, 0);
+    genEta_acc_eeg.resize(nbins_acc, 0);
+    genEta_acc_mumug.resize(nbins_acc, 0);
+    genEta_acc_pipig.resize(nbins_acc, 0);
+    genOmega_acc_ee.resize(nbins_acc, 0);
+    genPhi_acc_ee.resize(nbins_acc, 0);
+  }
+
+  template <typename TMCParticle>
+  bool isBeam(TMCParticle const& p)
+  {
+    if ((abs(p.pdgCode()) == 2212 || abs(p.pdgCode()) > 1e+9) && p.pt() < 1e-4 && p.pz() > 440.f && p.globalIndex() < 2 && !p.has_mothers()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  template <typename TMCParticle>
+  bool isQuarkOrGluon(TMCParticle const& p)
+  {
+    if ((1 <= abs(p.pdgCode()) && abs(p.pdgCode()) <= 6) || p.pdgCode() == 21) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
@@ -76,6 +158,24 @@ struct AssociateMCInfo {
   Preslice<aod::EMPrimaryMuons> perCollision_mu = aod::emprimarymuon::collisionId;
   Preslice<aod::PHOSClusters> perCollision_phos = aod::skimmedcluster::collisionId;
   Preslice<MyEMCClusters> perCollision_emc = aod::skimmedcluster::collisionId;
+
+  std::vector<uint16_t> genGamma;         // primary, pt, y
+  std::vector<uint16_t> genPi0;           // primary, pt, y
+  std::vector<uint16_t> genPi0_acc_gg;    // primary, pt, y
+  std::vector<uint16_t> genPi0_acc_eeg;   // primary, pt, y
+  std::vector<uint16_t> genEta;           // primary, pt, y
+  std::vector<uint16_t> genEta_acc_gg;    // primary, pt, y
+  std::vector<uint16_t> genEta_acc_eeg;   // primary, pt, y
+  std::vector<uint16_t> genEta_acc_mumug; // primary, pt, y
+  std::vector<uint16_t> genEta_acc_pipig; // primary, pt, y
+  std::vector<uint16_t> genOmega;         // primary, pt, y
+  std::vector<uint16_t> genOmega_acc_ee;  // primary, pt, y
+  std::vector<uint16_t> genPhi;           // primary, pt, y
+  std::vector<uint16_t> genPhi_acc_ee;    // primary, pt, y
+  std::vector<uint16_t> genChargedPion;   // primary, pt, y
+  std::vector<uint16_t> genChargedKaon;   // primary, pt, y
+  std::vector<uint16_t> genK0S;           // primary, pt, y
+  std::vector<uint16_t> genLambda;        // primary, pt, y
 
   template <uint8_t system, typename TTracks, typename TPCMs, typename TPCMLegs, typename TPHOSs, typename TEMCs, typename TEMPrimaryElectrons, typename TEMPrimaryMuons>
   void skimmingMC(MyCollisionsMC const& collisions, aod::BCs const&, aod::McCollisions const&, aod::McParticles const& mcTracks, TTracks const& o2tracks, TPCMs const& v0photons, TPCMLegs const& /*v0legs*/, TPHOSs const& /*phosclusters*/, TEMCs const& emcclusters, TEMPrimaryElectrons const& emprimaryelectrons, TEMPrimaryMuons const& emprimarymuons)
@@ -87,6 +187,7 @@ struct AssociateMCInfo {
     std::map<uint64_t, int> fEventIdx;
     std::map<uint64_t, int> fEventLabels;
     int fCounters[2] = {0, 0}; //! [0] - particle counter, [1] - event counter
+    auto hBinFinder = registry.get<TH2>(HIST("Generated/h2PtY_Gamma"));
 
     for (auto& collision : collisions) {
       registry.fill(HIST("hEventCounter"), 1);
@@ -97,19 +198,137 @@ struct AssociateMCInfo {
       }
       registry.fill(HIST("hEventCounter"), 2);
 
+      std::fill(genGamma.begin(), genGamma.end(), 0);
+      std::fill(genPi0.begin(), genPi0.end(), 0);
+      std::fill(genEta.begin(), genEta.end(), 0);
+      std::fill(genOmega.begin(), genOmega.end(), 0);
+      std::fill(genPhi.begin(), genPhi.end(), 0);
+      std::fill(genChargedPion.begin(), genChargedPion.end(), 0);
+      std::fill(genChargedKaon.begin(), genChargedKaon.end(), 0);
+      std::fill(genK0S.begin(), genK0S.end(), 0);
+      std::fill(genLambda.begin(), genLambda.end(), 0);
+
+      std::fill(genPi0_acc_gg.begin(), genPi0_acc_gg.end(), 0);
+      std::fill(genPi0_acc_eeg.begin(), genPi0_acc_eeg.end(), 0);
+      std::fill(genEta_acc_gg.begin(), genEta_acc_gg.end(), 0);
+      std::fill(genEta_acc_eeg.begin(), genEta_acc_eeg.end(), 0);
+      std::fill(genEta_acc_mumug.begin(), genEta_acc_mumug.end(), 0);
+      std::fill(genEta_acc_pipig.begin(), genEta_acc_pipig.end(), 0);
+      std::fill(genOmega_acc_ee.begin(), genOmega_acc_ee.end(), 0);
+      std::fill(genPhi_acc_ee.begin(), genPhi_acc_ee.end(), 0);
+
       auto mcCollision = collision.mcCollision();
+      // store mc particles
+      auto groupedMcTracks = mcTracks.sliceBy(perMcCollision, mcCollision.globalIndex());
+
+      for (auto& mctrack : groupedMcTracks) { // store necessary information for denominator of efficiency
+        if ((mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) && abs(mctrack.y()) < 0.9f && mctrack.pt() < 20.f) {
+          auto binNumber = hBinFinder->FindBin(mctrack.pt(), mctrack.y()); // caution: pack
+          switch (abs(mctrack.pdgCode())) {
+            case 22:
+              registry.fill(HIST("Generated/h2PtY_Gamma"), mctrack.pt(), mctrack.y());
+              genGamma[binNumber]++;
+              break;
+            case 111:
+              registry.fill(HIST("Generated/h2PtY_Pi0"), mctrack.pt(), mctrack.y());
+              genPi0[binNumber]++;
+              if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{22, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genPi0_acc_gg[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                registry.fill(HIST("Generated/hs_Pi0_acc_gg"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), 0.0);
+              } else if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-11, 11, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genPi0_acc_eeg[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                auto dau3 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 2);
+                registry.fill(HIST("Generated/hs_Pi0_acc_eeg"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), abs(dau3.eta()));
+              }
+              break;
+            case 221:
+              registry.fill(HIST("Generated/h2PtY_Eta"), mctrack.pt(), mctrack.y());
+              genEta[binNumber]++;
+              if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{22, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genEta_acc_gg[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                registry.fill(HIST("Generated/hs_Eta_acc_gg"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), 0.0);
+              } else if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-11, 11, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genEta_acc_eeg[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                auto dau3 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 2);
+                registry.fill(HIST("Generated/hs_Eta_acc_eeg"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), abs(dau3.eta()));
+              } else if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-13, 13, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genEta_acc_mumug[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                auto dau3 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 2);
+                registry.fill(HIST("Generated/hs_Eta_acc_mumug"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), abs(dau3.eta()));
+              } else if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-211, 211, 22}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genEta_acc_pipig[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                auto dau3 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 2);
+                registry.fill(HIST("Generated/hs_Eta_acc_pipig"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), abs(dau3.eta()));
+              }
+              break;
+            case 223:
+              registry.fill(HIST("Generated/h2PtY_Omega"), mctrack.pt(), mctrack.y());
+              genOmega[binNumber]++;
+              if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-11, 11}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genOmega_acc_ee[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                registry.fill(HIST("Generated/hs_Omega_acc_ee"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), 0.f);
+              }
+              break;
+            case 333:
+              registry.fill(HIST("Generated/h2PtY_Phi"), mctrack.pt(), mctrack.y());
+              genPhi[binNumber]++;
+              if (o2::aod::pwgem::mcutil::IsInAcceptanceNonDerived(mctrack, mcTracks, std::vector<int>{-11, 11}, -0.9, +0.9, 0, 2 * M_PI)) {
+                genPhi_acc_ee[binNumber]++;
+                auto dau1 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 0);
+                auto dau2 = mcTracks.iteratorAt(mctrack.daughtersIds()[0] + 1);
+                registry.fill(HIST("Generated/hs_Phi_acc_ee"), mctrack.pt(), abs(mctrack.y()), abs(dau1.eta()), abs(dau2.eta()), 0.f);
+              }
+              break;
+            case 211:
+              registry.fill(HIST("Generated/h2PtY_ChargedPion"), mctrack.pt(), mctrack.y());
+              genChargedPion[binNumber]++;
+              break;
+            case 321:
+              registry.fill(HIST("Generated/h2PtY_ChargedKaon"), mctrack.pt(), mctrack.y());
+              genChargedKaon[binNumber]++;
+              break;
+            case 310:
+              registry.fill(HIST("Generated/h2PtY_K0S"), mctrack.pt(), mctrack.y());
+              genK0S[binNumber]++;
+              break;
+            case 3122:
+              registry.fill(HIST("Generated/h2PtY_Lambda"), mctrack.pt(), mctrack.y());
+              genLambda[binNumber]++;
+              break;
+            default:
+              break;
+          }
+        }
+      } // end of mc track loop
 
       // make an entry for this MC event only if it was not already added to the table
       if (!(fEventLabels.find(mcCollision.globalIndex()) != fEventLabels.end())) {
         mcevents(mcCollision.globalIndex(), mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(), mcCollision.t(), mcCollision.impactParameter());
         fEventLabels[mcCollision.globalIndex()] = fCounters[1];
         fCounters[1]++;
+        binned_gen_pt(genGamma, genPi0, genEta, genOmega, genPhi, genChargedPion, genChargedKaon, genK0S, genLambda);
+        // binned_gen_pt_acc(
+        //   genPi0_acc_gg, genPi0_acc_eeg,
+        //   genEta_acc_gg, genEta_acc_eeg, genEta_acc_mumug, genEta_acc_pipig,
+        //   genOmega_acc_ee,
+        //   genPhi_acc_ee);
       }
 
       mceventlabels(fEventLabels.find(mcCollision.globalIndex())->second, collision.mcMask());
-
-      // store mc particles
-      auto groupedMcTracks = mcTracks.sliceBy(perMcCollision, mcCollision.globalIndex());
 
       for (auto& mctrack : groupedMcTracks) { // store necessary information for denominator of efficiency
         if (mctrack.pt() < 1e-3 || abs(mctrack.vz()) > 250 || sqrt(pow(mctrack.vx(), 2) + pow(mctrack.vy(), 2)) > max_rxy_gen) {
@@ -120,149 +339,84 @@ struct AssociateMCInfo {
           continue;
         }
 
-        // fill basic histograms
-        if ((mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) && abs(mctrack.y()) < 0.5) {
-          switch (abs(pdg)) {
-            case 111:
-              registry.fill(HIST("Generated/hPt_Pi0"), mctrack.pt());
-              break;
-            case 211:
-              registry.fill(HIST("Generated/hPt_ChargedPion"), mctrack.pt());
-              break;
-            case 221:
-              registry.fill(HIST("Generated/hPt_Eta"), mctrack.pt());
-              break;
-            case 310:
-              registry.fill(HIST("Generated/hPt_K0S"), mctrack.pt());
-              break;
-            case 321:
-              registry.fill(HIST("Generated/hPt_ChargedKaon"), mctrack.pt());
-              break;
-            case 3122:
-              registry.fill(HIST("Generated/hPt_Lambda"), mctrack.pt());
-              break;
-            default:
-              break;
-          }
-        }
-
         // Note that pi0 from weak decay gives producedByGenerator() = false
         if (
           abs(pdg) != 11      // electron
           && (abs(pdg) != 13) // muon
-          && (abs(pdg) != 22) // photon
-          // light mesons
-          && (abs(pdg) != 111) // pi0
-          && (abs(pdg) != 113) // rho(770)
-          // && (abs(pdg) != 211) // changed pion
-          && (abs(pdg) != 221) // eta
-          && (abs(pdg) != 223) // omega(782)
-          && (abs(pdg) != 331) // eta'(958)
-          && (abs(pdg) != 333) // phi(1020)
-          // charmonia
-          && (abs(pdg) != 443)    // J/psi
-          && (abs(pdg) != 100443) // psi(2S)
-          // bottomonia
-          && (abs(pdg) != 553)    // Upsilon(1S)
-          && (abs(pdg) != 100553) // Upsilon(2S)
-          && (abs(pdg) != 200553) // Upsilon(3S)
-
-          // heavy flavor hadrons
-          && (std::to_string(abs(pdg))[std::to_string(abs(pdg)).length() - 3] != '4') // charmed mesons
-          && (std::to_string(abs(pdg))[std::to_string(abs(pdg)).length() - 3] != '5') // beauty mesons
-          && (std::to_string(abs(pdg))[std::to_string(abs(pdg)).length() - 4] != '4') // charmed baryons
-          && (std::to_string(abs(pdg))[std::to_string(abs(pdg)).length() - 4] != '5') // beauty baryons
-
-          // strange hadrons
-          // && (abs(pdg) != 310)  // K0S
-          // && (abs(pdg) != 130)  // K0L
-          // && (abs(pdg) != 3122) // Lambda
         ) {
           continue;
         }
         // LOGF(info,"index = %d , mc track pdg = %d , producedByGenerator =  %d , isPhysicalPrimary = %d", mctrack.index(), mctrack.pdgCode(), mctrack.producedByGenerator(), mctrack.isPhysicalPrimary());
-
-        if (!(mctrack.isPhysicalPrimary() || mctrack.producedByGenerator())) { // neither physical primary nor producedByGenerator
-          if (abs(pdg) == 11) {                                                // one more check for secondary electrons. i.e. gamma->ee
-
-            if (sqrt(pow(mctrack.vx(), 2) + pow(mctrack.vy(), 2)) < abs(mctrack.vz()) * std::tan(2 * std::atan(std::exp(-max_Y_gen))) - margin_z_gen) {
-              continue;
-            }
-
-            if (mctrack.has_mothers()) {
-              auto mp = mctrack.template mothers_first_as<aod::McParticles>(); // mother particle of electron
-              int pdg_mother = mp.pdgCode();
-              if (pdg_mother != 22 || !(mp.isPhysicalPrimary() || mp.producedByGenerator())) { // mother of electron is not photon, or not physical primary, or not producedByGenerator
-                continue;
-              }
-            }
-          } else { // not physical primary, not producedByGenerator, not electrons
-            continue;
-          }
-        } else if (abs(mctrack.y()) > max_Y_gen) { // physical primary or producedByGenerator, but outside of acceptance.
-          continue;
-        }
 
         if (abs(pdg) == 11 && !(mctrack.isPhysicalPrimary() || mctrack.producedByGenerator())) { // only for quick check, only secondary electrons should appear.
           registry.fill(HIST("PCM/hXY"), mctrack.vx(), mctrack.vy());
           registry.fill(HIST("PCM/hRZ"), mctrack.vz(), sqrt(pow(mctrack.vx(), 2) + pow(mctrack.vy(), 2)));
         }
 
-        // these are used as denominator for efficiency. (i.e. generated information)
-        if (!(fNewLabels.find(mctrack.globalIndex()) != fNewLabels.end())) {
-          fNewLabels[mctrack.globalIndex()] = fCounters[0];
-          fNewLabelsReversed[fCounters[0]] = mctrack.globalIndex();
-          // fMCFlags[mctrack.globalIndex()] = mcflags;
-          fEventIdx[mctrack.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
-          fCounters[0]++;
-        }
+        if (mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) { // primary leptons
+          if (abs(mctrack.y()) < max_Y_gen_primary) {                       // primary leptons
+            if (!(fNewLabels.find(mctrack.globalIndex()) != fNewLabels.end())) {
+              fNewLabels[mctrack.globalIndex()] = fCounters[0];
+              fNewLabelsReversed[fCounters[0]] = mctrack.globalIndex();
+              // fMCFlags[mctrack.globalIndex()] = mcflags;
+              fEventIdx[mctrack.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
+              fCounters[0]++;
+            }
 
-        bool is_used_for_gen = false;
-        if ((mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) && (abs(pdg) == 11 || abs(pdg) == 13) && mctrack.has_mothers()) {
-          auto mp = mctrack.template mothers_first_as<aod::McParticles>(); // mother particle of electron
-          int pdg_mother = abs(mp.pdgCode());
+            int motherid = -999; // first mother index
+            if (mctrack.has_mothers()) {
+              motherid = mctrack.mothersIds()[0]; // first mother index
+            }
+            while (motherid > -1) {
+              if (motherid < mcTracks.size()) { // protect against bad mother indices. why is this needed?
+                auto mp = mcTracks.iteratorAt(motherid);
 
-          bool is_from_sm = pdg_mother == 111 || pdg_mother == 221 || pdg_mother == 331 || pdg_mother == 113 || pdg_mother == 223 || pdg_mother == 333 || pdg_mother == 443 || pdg_mother == 100443 || pdg_mother == 553 || pdg_mother == 100553 || pdg_mother == 200553;
-          bool is_from_c_hadron = std::to_string(pdg_mother)[std::to_string(pdg_mother).length() - 3] == '4' || std::to_string(pdg_mother)[std::to_string(pdg_mother).length() - 4] == '4';
-          bool is_from_b_hadron = std::to_string(pdg_mother)[std::to_string(pdg_mother).length() - 3] == '5' || std::to_string(pdg_mother)[std::to_string(pdg_mother).length() - 4] == '5';
+                // if the MC truth particle corresponding to this reconstructed track which is not already written, add it to the skimmed MC stack
+                if (!(fNewLabels.find(mp.globalIndex()) != fNewLabels.end())) {
+                  fNewLabels[mp.globalIndex()] = fCounters[0];
+                  fNewLabelsReversed[fCounters[0]] = mp.globalIndex();
+                  // fMCFlags[mp.globalIndex()] = mcflags;
+                  fEventIdx[mp.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
+                  fCounters[0]++;
+                }
 
-          if ((is_from_sm || is_from_c_hadron || is_from_b_hadron)) {
-            is_used_for_gen = true;
-          }
-        }
-
-        if (is_used_for_gen) {
-          // Next, store mother-chain for only HF->l, because HF->ll analysis requires correlation between HF hadrons or quarks. PLEASE DON'T do this for other partices.
-          int motherid = -999; // first mother index
-          if (mctrack.has_mothers()) {
-            motherid = mctrack.mothersIds()[0]; // first mother index
-          }
-          while (motherid > -1) {
-            if (motherid < mcTracks.size()) { // protect against bad mother indices. why is this needed?
-              auto mp = mcTracks.iteratorAt(motherid);
-
-              if (abs(mp.pdgCode()) < 100) { // don't store quark/gluon informaiton, because data size explodes.
-                break;
-              }
-
-              // if the MC truth particle corresponding to this reconstructed track which is not already written, add it to the skimmed MC stack
-              if (!(fNewLabels.find(mp.globalIndex()) != fNewLabels.end())) {
-                fNewLabels[mp.globalIndex()] = fCounters[0];
-                fNewLabelsReversed[fCounters[0]] = mp.globalIndex();
-                // fMCFlags[mp.globalIndex()] = mcflags;
-                fEventIdx[mp.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
-                fCounters[0]++;
-              }
-
-              if (mp.has_mothers()) {
-                motherid = mp.mothersIds()[0]; // first mother index
+                if (mp.has_mothers()) {
+                  motherid = mp.mothersIds()[0]; // first mother index
+                } else {
+                  motherid = -999;
+                }
               } else {
                 motherid = -999;
               }
-            } else {
-              motherid = -999;
+            } // end of mother chain loop
+          }
+        } else if (abs(pdg) == 11 && mctrack.has_mothers()) { // secondary electrons. i.e. ele/pos from photon conversions.
+          int motherid = mctrack.mothersIds()[0];             // first mother index
+          auto mp = mcTracks.iteratorAt(motherid);
+
+          if (sqrt(pow(mctrack.vx(), 2) + pow(mctrack.vy(), 2)) < abs(mctrack.vz()) * std::tan(2 * std::atan(std::exp(-max_Y_gen_secondary))) - margin_z_gen) {
+            continue;
+          }
+
+          if (mp.pdgCode() == 22 && (mp.isPhysicalPrimary() || mp.producedByGenerator()) && abs(mp.y()) < max_Y_gen_secondary) {
+            // if the MC truth particle corresponding to this reconstructed track which is not already written, add it to the skimmed MC stack
+            if (!(fNewLabels.find(mctrack.globalIndex()) != fNewLabels.end())) { // store electron information. !!Not photon!!
+              fNewLabels[mctrack.globalIndex()] = fCounters[0];
+              fNewLabelsReversed[fCounters[0]] = mctrack.globalIndex();
+              // fMCFlags[mctrack.globalIndex()] = mcflags;
+              fEventIdx[mctrack.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
+              fCounters[0]++;
             }
-          } // end of mother chain loop
+
+            // if the MC truth particle corresponding to this reconstructed track which is not already written, add it to the skimmed MC stack
+            if (!(fNewLabels.find(mp.globalIndex()) != fNewLabels.end())) { // store conversion photon
+              fNewLabels[mp.globalIndex()] = fCounters[0];
+              fNewLabelsReversed[fCounters[0]] = mp.globalIndex();
+              // fMCFlags[mp.globalIndex()] = mcflags;
+              fEventIdx[mp.globalIndex()] = fEventLabels.find(mcCollision.globalIndex())->second;
+              fCounters[0]++;
+            }
+          }
         }
       } // end of mc track loop
 

--- a/PWGEM/PhotonMeson/TableProducer/converters/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/converters/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2physics_add_dpl_workflow(emevents-converter
+                    SOURCES emeventsconverter.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+

--- a/PWGEM/PhotonMeson/TableProducer/converters/emeventsconverter.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/converters/emeventsconverter.cxx
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts EMEvents version 000 to 001
+struct emeventsconverter {
+  Produces<aod::EMEvents_001> events_001;
+
+  void process(aod::EMEvents_000 const& events)
+  {
+    for (auto& event : events) {
+      events_001(
+        event.collisionId(),
+        event.globalBC(),
+        event.runNumber(),
+        event.sel8(),
+        event.alias_raw(),
+        event.selection_raw(),
+        event.ncollsPerBC(),
+        event.posX(),
+        event.posY(),
+        event.posZ(),
+        event.numContrib(),
+        event.collisionTime(),
+        event.collisionTimeRes(),
+        event.bz(),
+        0 /*dummy occupancy value*/);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<emeventsconverter>(cfgc, TaskName{"emevents-converter"})};
+}

--- a/PWGEM/PhotonMeson/TableProducer/createEMEvent.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createEMEvent.cxx
@@ -146,7 +146,7 @@ struct CreateEMEvent {
       // uint64_t tag = collision.selection_raw();
       event(collision.globalIndex(), bc.globalBC(), bc.runNumber(), collision.sel8(), collision.alias_raw(), collision.selection_raw(), map_ncolls_per_bc[bc.globalIndex()],
             collision.posX(), collision.posY(), collision.posZ(),
-            collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes(), d_bz);
+            collision.numContrib(), collision.collisionTime(), collision.collisionTimeRes(), d_bz, collision.trackOccupancyInTimeRange());
 
       event_mult(collision.multFV0A(), collision.multFV0C(), collision.multFT0A(), collision.multFT0C(), collision.multFDDA(), collision.multFDDC(),
                  collision.multZNA(), collision.multZNC(),

--- a/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
@@ -34,6 +34,16 @@ o2physics_add_dpl_workflow(pcm-qc-mc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(dielectron-qc
+                    SOURCES dielectronQC.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(dielectron-qc-mc
+                    SOURCES dielectronQCMC.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(dalitz-ee-qc
                     SOURCES dalitzEEQC.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore

--- a/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
@@ -85,14 +85,23 @@ o2physics_add_dpl_workflow(pi0eta-to-gammagamma-pcmdalitzee
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(pi0eta-to-gammagamma-emcemc
-                    SOURCES Pi0EtaToGammaGammaPCMPCM.cxx
+                    SOURCES Pi0EtaToGammaGammaEMCEMC.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(pi0eta-to-gammagamma-mc-pcmpcm
+                    SOURCES Pi0EtaToGammaGammaMCPCMPCM.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(pi0eta-to-gammagamma-mc
-                    SOURCES Pi0EtaToGammaGammaMC.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore
+o2physics_add_dpl_workflow(pi0eta-to-gammagamma-mc-pcmdalitzee
+                    SOURCES Pi0EtaToGammaGammaMCPCMDalitzEE.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(pi0eta-to-gammagamma-mc-emcemc
+                    SOURCES Pi0EtaToGammaGammaMCEMCEMC.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(tagging-pi0

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCEMCEMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCEMCEMC.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// ========================
+//
+// This code loops over photons and makes pairs for neutral mesons analyses.
+//    Please write to: daiki.sekihata@cern.ch
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+
+#include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+#include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
+#include "PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h"
+
+using namespace o2;
+using namespace o2::aod;
+
+using MyEMCClusters = soa::Join<aod::SkimEMCClusters, aod::EMEMCClusterMCLabels, aod::EMCEMEventIds>;
+using MyEMCCluster = MyEMCClusters::iterator;
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<Pi0EtaToGammaGammaMC<PairType::kEMCEMC, MyEMCClusters, aod::SkimEMCMTs>>(cfgc, TaskName{"pi0eta-to-gammagamma-mc-emcemc"}),
+  };
+}

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCPCMDalitzEE.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCPCMDalitzEE.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// ========================
+//
+// This code loops over photons and makes pairs for neutral mesons analyses.
+//    Please write to: daiki.sekihata@cern.ch
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+
+#include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+#include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
+#include "PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h"
+
+using namespace o2;
+using namespace o2::aod;
+
+using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0KFEMEventIds>;
+using MyV0Photon = MyV0Photons::iterator;
+
+using MyMCV0Legs = soa::Join<aod::V0Legs, aod::V0LegMCLabels>;
+using MyMCV0Leg = MyMCV0Legs::iterator;
+
+using MyMCElectrons = soa::Join<aod::EMPrimaryElectrons, aod::EMPrimaryElectronEMEventIds, aod::EMPrimaryElectronsPrefilterBit, aod::EMPrimaryElectronMCLabels>;
+using MyMCElectron = MyMCElectrons::iterator;
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<Pi0EtaToGammaGammaMC<PairType::kPCMDalitzEE, MyV0Photons, MyMCV0Legs, MyMCElectrons>>(cfgc, TaskName{"pi0eta-to-gammagamma-mc-pcmdalitzee"}),
+  };
+}

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCPCMPCM.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCPCMPCM.cxx
@@ -1,0 +1,40 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// ========================
+//
+// This code loops over photons and makes pairs for neutral mesons analyses.
+//    Please write to: daiki.sekihata@cern.ch
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoAHelpers.h"
+
+#include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+#include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
+#include "PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h"
+
+using namespace o2;
+using namespace o2::aod;
+
+using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0KFEMEventIds>;
+using MyV0Photon = MyV0Photons::iterator;
+
+using MyMCV0Legs = soa::Join<aod::V0Legs, aod::V0LegMCLabels>;
+using MyMCV0Leg = MyMCV0Legs::iterator;
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<Pi0EtaToGammaGammaMC<PairType::kPCMPCM, MyV0Photons, MyMCV0Legs>>(cfgc, TaskName{"pi0eta-to-gammagamma-mc-pcmpcm"}),
+  };
+}

--- a/PWGEM/PhotonMeson/Tasks/SinglePhotonMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/SinglePhotonMC.cxx
@@ -338,7 +338,7 @@ struct SinglePhotonMC {
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hPt_Photon_Primary"))->Fill(photon.pt());
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hY_Photon_Primary"))->Fill(photon.eta());
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hPhi_Photon_Primary"))->Fill(photon.phi());
-          } else if (IsFromWD(mcphoton.emmcevent(), mcphoton, mcparticles)) {
+          } else if (IsFromWD(mcphoton.emmcevent(), mcphoton, mcparticles) > 0) {
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hPt_Photon_FromWD"))->Fill(photon.pt());
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hY_Photon_FromWD"))->Fill(photon.eta());
             reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hPhi_Photon_FromWD"))->Fill(photon.phi());

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
@@ -380,7 +380,7 @@ struct TaggingPi0MC {
               continue;
             }
             reinterpret_cast<TH1F*>(list_pcm->FindObject(cut1.GetName())->FindObject("hPt_v0photon_Pi0_Primary"))->Fill(g1.pt());
-          } else if (IsFromWD(mcpi01.emmcevent(), mcpi01, mcparticles)) {
+          } else if (IsFromWD(mcpi01.emmcevent(), mcpi01, mcparticles) > 0) {
             reinterpret_cast<TH1F*>(list_pcm->FindObject(cut1.GetName())->FindObject("hPt_v0photon_Pi0_FromWD"))->Fill(g1.pt());
           } else {
             reinterpret_cast<TH1F*>(list_pcm->FindObject(cut1.GetName())->FindObject("hPt_v0photon_Pi0_hs"))->Fill(g1.pt());

--- a/PWGEM/PhotonMeson/Tasks/dielectronQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/dielectronQC.cxx
@@ -383,7 +383,6 @@ struct dielectronQC {
         epbin = static_cast<int>(ep_bin_edges.size()) - 2;
       }
 
-      std::tuple<int, int, int> key_bin = std::make_tuple(zbin, centbin, epbin);
       std::pair<int, int64_t> key_df_collision = std::make_pair(ndf, collision.globalIndex());
 
       std::tuple<int, int, int> tuple_tmp_id1 = std::make_tuple(ndf, collision.globalIndex(), t1.trackId());

--- a/PWGEM/PhotonMeson/Tasks/dielectronQCMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/dielectronQCMC.cxx
@@ -47,7 +47,7 @@ using MyCollision = MyCollisions::iterator;
 using MyMCTracks = soa::Join<aod::EMPrimaryElectrons, aod::EMPrimaryElectronEMEventIds, aod::EMPrimaryElectronsPrefilterBit, aod::EMPrimaryElectronMCLabels>;
 using MyMCTrack = MyMCTracks::iterator;
 
-struct DalitzEEQCMC {
+struct dielectronQCMC {
   Configurable<int> cfgCentEstimator{"cfgCentEstimator", 2, "FT0M:0, FT0A:1, FT0C:2"};
   Configurable<float> cfgCentMin{"cfgCentMin", 0, "min. centrality"};
   Configurable<float> cfgCentMax{"cfgCentMax", 999.f, "max. centrality"};
@@ -128,7 +128,7 @@ struct DalitzEEQCMC {
   HistogramRegistry fRegistry{"output", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
   static constexpr std::string_view event_cut_types[2] = {"before/", "after/"};
 
-  ~DalitzEEQCMC() {}
+  ~dielectronQCMC() {}
 
   void addhistograms()
   {
@@ -137,9 +137,19 @@ struct DalitzEEQCMC {
 
     std::vector<double> ptbins;
     std::vector<double> massbins;
+    std::vector<double> dcabins;
 
     for (int i = 0; i < 110; i++) {
       massbins.emplace_back(0.01 * (i - 0) + 0.0); // every 0.01 GeV/c2 from 0.0 to 1.1 GeV/c2
+    }
+    for (int i = 110; i < 126; i++) {
+      massbins.emplace_back(0.1 * (i - 110) + 1.1); // every 0.1 GeV/c2 from 1.1 to 2.7 GeV/c2
+    }
+    for (int i = 126; i < 136; i++) {
+      massbins.emplace_back(0.05 * (i - 126) + 2.7); // every 0.05 GeV/c2 from 2.7 to 3.2 GeV/c2
+    }
+    for (int i = 136; i < 145; i++) {
+      massbins.emplace_back(0.1 * (i - 136) + 3.2); // every 0.1 GeV/c2 from 3.2 to 4.0 GeV/c2
     }
     const AxisSpec axis_mass{massbins, "m_{ee} (GeV/c^{2})"};
 
@@ -154,6 +164,17 @@ struct DalitzEEQCMC {
     }
     const AxisSpec axis_pt{ptbins, "p_{T,ee} (GeV/c)"};
 
+    for (int i = 0; i < 20; i++) {
+      dcabins.emplace_back(0.1 * i); // every 0.1 sigma from 0.0 to 2.0 sigma
+    }
+    for (int i = 20; i < 27; i++) {
+      dcabins.emplace_back(0.5 * (i - 20) + 2.0); // every 0.5 sigma from 2.0 to 5.0 sigma
+    }
+    for (int i = 27; i < 33; i++) {
+      dcabins.emplace_back(1.0 * (i - 27) + 5.0); // every 1.0 sigma from 5.0 to 10.0 sigma
+    }
+    const AxisSpec axis_dca{dcabins, "DCA_{ee}^{3D} (#sigma)"};
+
     // generated info
     fRegistry.add("Generated/sm/Pi0/hMvsPt", "m_{ee} vs. p_{T,ee} ULS", kTH2F, {axis_mass, axis_pt}, true);
     fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/Eta/");
@@ -161,9 +182,22 @@ struct DalitzEEQCMC {
     fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/Rho/");
     fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/Omega/");
     fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/Phi/");
+    fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/PromptJPsi/");
+    fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/NonPromptJPsi/");
+    fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/PromptPsi2S/");
+    fRegistry.addClone("Generated/sm/Pi0/", "Generated/sm/NonPromptPsi2S/");
+
+    fRegistry.add("Generated/ccbar/c2e_c2e/hadron_hadron/hMvsPt", "m_{ee} vs. p_{T,ee}", kTH2F, {axis_mass, axis_pt}, true);
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/hadron_hadron/", "Generated/ccbar/c2e_c2e/meson_meson/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/hadron_hadron/", "Generated/ccbar/c2e_c2e/baryon_baryon/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/hadron_hadron/", "Generated/ccbar/c2e_c2e/meson_baryon/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/", "Generated/bbbar/b2e_b2e/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/", "Generated/bbbar/b2c2e_b2c2e/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/", "Generated/bbbar/b2c2e_b2e_sameb/");
+    fRegistry.addClone("Generated/ccbar/c2e_c2e/", "Generated/bbbar/b2c2e_b2e_diffb/"); // LS
 
     // reconstructed pair info
-    fRegistry.add("Pair/sm/Photon/hMvsPt", "m_{ee} vs. p_{T,ee} ULS", kTH2F, {axis_mass, axis_pt}, true);
+    fRegistry.add("Pair/sm/Photon/hs", "hs pair", kTHnSparseF, {axis_mass, axis_pt, axis_dca}, true);
     fRegistry.add("Pair/sm/Photon/hMvsPhiV", "m_{ee} vs. #varphi_{V};#varphi (rad.);m_{ee} (GeV/c^{2})", kTH2F, {{90, 0, M_PI}, {100, 0.0f, 0.1f}}, false);
     fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/Pi0/");
     fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/Eta/");
@@ -171,6 +205,19 @@ struct DalitzEEQCMC {
     fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/Rho/");
     fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/Omega/");
     fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/Phi/");
+    fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/PromptJPsi/");
+    fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/NonPromptJPsi/");
+    fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/PromptPsi2S/");
+    fRegistry.addClone("Pair/sm/Photon/", "Pair/sm/NonPromptPsi2S/");
+
+    fRegistry.add("Pair/ccbar/c2e_c2e/hadron_hadron/hs", "hs pair", kTHnSparseF, {axis_mass, axis_pt, axis_dca}, true);
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/hadron_hadron/", "Pair/ccbar/c2e_c2e/meson_meson/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/hadron_hadron/", "Pair/ccbar/c2e_c2e/baryon_baryon/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/hadron_hadron/", "Pair/ccbar/c2e_c2e/meson_baryon/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/", "Pair/bbbar/b2e_b2e/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/", "Pair/bbbar/b2c2e_b2c2e/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/", "Pair/bbbar/b2c2e_b2e_sameb/");
+    fRegistry.addClone("Pair/ccbar/c2e_c2e/", "Pair/bbbar/b2c2e_b2e_diffb/"); // LS
 
     // track info
     fRegistry.add("Track/hPt", "pT;p_{T} (GeV/c)", kTH1F, {{1000, 0.0f, 10}}, false);
@@ -346,36 +393,56 @@ struct DalitzEEQCMC {
         if ((t1mc.isPhysicalPrimary() || t1mc.producedByGenerator()) && (t2mc.isPhysicalPrimary() || t2mc.producedByGenerator())) {
           switch (abs(mcmother.pdgCode())) {
             case 111:
-              fRegistry.fill(HIST("Pair/sm/Pi0/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/Pi0/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Pi0/hMvsPhiV"), phiv, v12.M());
               break;
             case 221:
-              fRegistry.fill(HIST("Pair/sm/Eta/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/Eta/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Eta/hMvsPhiV"), phiv, v12.M());
               break;
             case 331:
-              fRegistry.fill(HIST("Pair/sm/EtaPrime/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/EtaPrime/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/EtaPrime/hMvsPhiV"), phiv, v12.M());
               break;
             case 113:
-              fRegistry.fill(HIST("Pair/sm/Rho/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/Rho/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Rho/hMvsPhiV"), phiv, v12.M());
               break;
             case 223:
-              fRegistry.fill(HIST("Pair/sm/Omega/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/Omega/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Omega/hMvsPhiV"), phiv, v12.M());
               break;
             case 333:
-              fRegistry.fill(HIST("Pair/sm/Phi/hMvsPt"), v12.M(), v12.Pt());
+              fRegistry.fill(HIST("Pair/sm/Phi/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Phi/hMvsPhiV"), phiv, v12.M());
               break;
+            case 443: {
+              if (IsFromBeauty(mcmother, mcparticles) > 0) {
+                fRegistry.fill(HIST("Pair/sm/NonPromptJPsi/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+                fRegistry.fill(HIST("Pair/sm/NonPromptJPsi/hMvsPhiV"), phiv, v12.M());
+              } else {
+                fRegistry.fill(HIST("Pair/sm/PromptJPsi/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+                fRegistry.fill(HIST("Pair/sm/PromptJPsi/hMvsPhiV"), phiv, v12.M());
+              }
+              break;
+            }
+            case 100443: {
+              if (IsFromBeauty(mcmother, mcparticles) > 0) {
+                fRegistry.fill(HIST("Pair/sm/NonPromptPsi2S/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+                fRegistry.fill(HIST("Pair/sm/NonPromptPsi2S/hMvsPhiV"), phiv, v12.M());
+              } else {
+                fRegistry.fill(HIST("Pair/sm/PromptPsi2S/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+                fRegistry.fill(HIST("Pair/sm/PromptPsi2S/hMvsPhiV"), phiv, v12.M());
+              }
+              break;
+            }
             default:
               break;
           }
         } else if (!(t1mc.isPhysicalPrimary() || t1mc.producedByGenerator()) && !(t2mc.isPhysicalPrimary() || t2mc.producedByGenerator())) {
           switch (abs(mcmother.pdgCode())) {
             case 22:
-              fRegistry.fill(HIST("Pair/sm/Photon/hMvsPt"), v12.M(), v12.Pt(), dca_ee_3d);
+              fRegistry.fill(HIST("Pair/sm/Photon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
               fRegistry.fill(HIST("Pair/sm/Photon/hMvsPhiV"), phiv, v12.M());
               break;
             default:
@@ -383,7 +450,93 @@ struct DalitzEEQCMC {
           }
         } // end of primary/secondary selection
       }   // end of primary selection for same mother
-    }
+    } else if (hfee_type > -1) {
+      if ((t1mc.isPhysicalPrimary() || t1mc.producedByGenerator()) && (t2mc.isPhysicalPrimary() || t2mc.producedByGenerator())) {
+        auto mp1 = mcparticles.iteratorAt(t1mc.mothersIds()[0]);
+        auto mp2 = mcparticles.iteratorAt(t2mc.mothersIds()[0]);
+        if (t1mc.pdgCode() * t2mc.pdgCode() < 0) { // ULS
+          switch (hfee_type) {
+            case static_cast<int>(EM_HFeeType::kCe_Ce): {
+              fRegistry.fill(HIST("Pair/ccbar/c2e_c2e/hadron_hadron/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              if (isCharmMeson(mp1) && isCharmMeson(mp2)) {
+                fRegistry.fill(HIST("Pair/ccbar/c2e_c2e/meson_meson/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else if (isCharmBaryon(mp1) && isCharmBaryon(mp2)) {
+                fRegistry.fill(HIST("Pair/ccbar/c2e_c2e/baryon_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else {
+                fRegistry.fill(HIST("Pair/ccbar/c2e_c2e/meson_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBe_Be): {
+              fRegistry.fill(HIST("Pair/bbbar/b2e_b2e/hadron_hadron/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              if (isBeautyMeson(mp1) && isBeautyMeson(mp2)) {
+                fRegistry.fill(HIST("Pair/bbbar/b2e_b2e/meson_meson/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else if (isBeautyBaryon(mp1) && isBeautyBaryon(mp2)) {
+                fRegistry.fill(HIST("Pair/bbbar/b2e_b2e/baryon_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else {
+                fRegistry.fill(HIST("Pair/bbbar/b2e_b2e/meson_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_BCe): {
+              fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2c2e/hadron_hadron/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              if (isCharmMeson(mp1) && isCharmMeson(mp2)) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2c2e/meson_meson/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else if (isCharmBaryon(mp1) && isCharmBaryon(mp2)) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2c2e/baryon_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2c2e/meson_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_Be_SameB): { // ULS
+              fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_sameb/hadron_hadron/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              if ((isCharmMeson(mp1) && isBeautyMeson(mp2)) || (isCharmMeson(mp2) && isBeautyMeson(mp1))) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_sameb/meson_meson/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else if ((isCharmBaryon(mp1) && isBeautyBaryon(mp2)) || (isCharmBaryon(mp2) && isBeautyBaryon(mp1))) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_sameb/baryon_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_sameb/meson_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_Be_DiffB): // LS
+              LOGF(info, "You should not see kBCe_Be_DiffB in ULS. Good luck.");
+              break;
+            default:
+              break;
+          }
+        } else { // LS
+          switch (hfee_type) {
+            case static_cast<int>(EM_HFeeType::kCe_Ce):
+              LOGF(info, "You should not see kCe_Ce in LS. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBe_Be):
+              LOGF(info, "You should not see kBe_Be in LS. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_BCe):
+              LOGF(info, "You should not see kBCe_BCe in LS. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_SameB): // ULS
+              LOGF(info, "You should not see kBCe_Be_SameB in LS. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_DiffB): { // LS
+              fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_diffb/hadron_hadron/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              if ((isCharmMeson(mp1) && isBeautyMeson(mp2)) || (isCharmMeson(mp2) && isBeautyMeson(mp1))) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_diffb/meson_meson/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else if ((isCharmBaryon(mp1) && isBeautyBaryon(mp2)) || (isCharmBaryon(mp2) && isBeautyBaryon(mp1))) {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_diffb/baryon_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              } else {
+                fRegistry.fill(HIST("Pair/bbbar/b2c2e_b2e_diffb/meson_baryon/hs"), v12.M(), v12.Pt(), dca_ee_3d);
+              }
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      }
+    } // end of HF evaluation
 
     // fill track info that belong to true pairs.
     if (t1.sign() > 0) {
@@ -483,12 +636,21 @@ struct DalitzEEQCMC {
         fillTruePairInfo(collision, pos, ele, mcparticles);
       } // end of ULS pair loop
 
+      for (auto& [pos1, pos2] : combinations(CombinationsStrictlyUpperIndexPolicy(posTracks_per_coll, posTracks_per_coll))) { // LS++
+        fillTruePairInfo(collision, pos1, pos2, mcparticles);
+      } // end of ULS pair loop
+
+      for (auto& [ele1, ele2] : combinations(CombinationsStrictlyUpperIndexPolicy(negTracks_per_coll, negTracks_per_coll))) { // LS__
+        fillTruePairInfo(collision, ele1, ele2, mcparticles);
+      } // end of ULS pair loop
+
     } // end of collision loop
 
     used_trackIds.clear();
     used_trackIds.shrink_to_fit();
+
   } // end of process
-  PROCESS_SWITCH(DalitzEEQCMC, processQCMC, "run Dalitz QC", true);
+  PROCESS_SWITCH(dielectronQCMC, processQCMC, "run Dalitz QC", true);
 
   Partition<aod::EMMCParticles> posTracksMC = o2::aod::mcparticle::pdgCode == -11; // e+
   Partition<aod::EMMCParticles> negTracksMC = o2::aod::mcparticle::pdgCode == +11; // e-
@@ -558,22 +720,201 @@ struct DalitzEEQCMC {
               case 333:
                 fRegistry.fill(HIST("Generated/sm/Phi/hMvsPt"), v12.M(), v12.Pt());
                 break;
+              case 443: {
+                if (IsFromBeauty(mcmother, mcparticles) > 0) {
+                  fRegistry.fill(HIST("Generated/sm/NonPromptJPsi/hMvsPt"), v12.M(), v12.Pt());
+                } else {
+                  fRegistry.fill(HIST("Generated/sm/PromptJPsi/hMvsPt"), v12.M(), v12.Pt());
+                }
+                break;
+              }
+              case 100443: {
+                if (IsFromBeauty(mcmother, mcparticles) > 0) {
+                  fRegistry.fill(HIST("Generated/sm/NonPromptPsi2S/hMvsPt"), v12.M(), v12.Pt());
+                } else {
+                  fRegistry.fill(HIST("Generated/sm/PromptPsi2S/hMvsPt"), v12.M(), v12.Pt());
+                }
+                break;
+              }
               default:
                 break;
             }
           }
+        } else if (hfee_type > -1) {
+          auto mp1 = mcparticles.iteratorAt(t1.mothersIds()[0]);
+          auto mp2 = mcparticles.iteratorAt(t2.mothersIds()[0]);
+          switch (hfee_type) {
+            case static_cast<int>(EM_HFeeType::kCe_Ce): {
+              fRegistry.fill(HIST("Generated/ccbar/c2e_c2e/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if (isCharmMeson(mp1) && isCharmMeson(mp2)) {
+                fRegistry.fill(HIST("Generated/ccbar/c2e_c2e/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if (isCharmBaryon(mp1) && isCharmBaryon(mp2)) {
+                fRegistry.fill(HIST("Generated/ccbar/c2e_c2e/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/ccbar/c2e_c2e/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBe_Be): {
+              fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if (isBeautyMeson(mp1) && isBeautyMeson(mp2)) {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if (isBeautyBaryon(mp1) && isBeautyBaryon(mp2)) {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_BCe): {
+              fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2c2e/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if (isCharmMeson(mp1) && isCharmMeson(mp2)) {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if (isCharmBaryon(mp1) && isCharmBaryon(mp2)) {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/bbbar/b2e_b2e/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_Be_SameB): { // ULS
+              fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_sameb/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if ((isCharmMeson(mp1) && isBeautyMeson(mp2)) || (isCharmMeson(mp2) && isBeautyMeson(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_sameb/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if ((isCharmBaryon(mp1) && isBeautyBaryon(mp2)) || (isCharmBaryon(mp2) && isBeautyBaryon(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_sameb/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_sameb/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            case static_cast<int>(EM_HFeeType::kBCe_Be_DiffB): // LS
+              LOGF(info, "You should not see kBCe_Be_DiffB in ULS. Good luck.");
+              break;
+            default:
+              break;
+          }
+        } // end of HF evaluation
+      }   // end of true ULS pair loop
+
+      for (auto& [t1, t2] : combinations(CombinationsStrictlyUpperIndexPolicy(posTracks_per_coll, posTracks_per_coll))) {
+        // LOGF(info, "pdg1 = %d, pdg2 = %d", t1.pdgCode(), t2.pdgCode());
+
+        if (!isInAcceptance(t1) || !isInAcceptance(t2)) {
+          continue;
         }
-      } // end of true ULS pair loop
-    }   // end of collision loop
+
+        if (!t1.isPhysicalPrimary() && !t1.producedByGenerator()) {
+          continue;
+        }
+        if (!t2.isPhysicalPrimary() && !t2.producedByGenerator()) {
+          continue;
+        }
+
+        int hfee_type = IsHF(t1, t2, mcparticles);
+        if (hfee_type < 0) {
+          continue;
+        }
+        ROOT::Math::PtEtaPhiMVector v1(t1.pt(), t1.eta(), t1.phi(), o2::constants::physics::MassElectron);
+        ROOT::Math::PtEtaPhiMVector v2(t2.pt(), t2.eta(), t2.phi(), o2::constants::physics::MassElectron);
+        ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;
+        if (hfee_type > -1) {
+          auto mp1 = mcparticles.iteratorAt(t1.mothersIds()[0]);
+          auto mp2 = mcparticles.iteratorAt(t2.mothersIds()[0]);
+          switch (hfee_type) {
+            case static_cast<int>(EM_HFeeType::kCe_Ce):
+              LOGF(info, "You should not see kCe_Ce in LS++. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBe_Be):
+              LOGF(info, "You should not see kBe_Be in LS++. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_BCe):
+              LOGF(info, "You should not see kBCe_BCe in LS++. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_SameB): // ULS
+              LOGF(info, "You should not see kBCe_Be_SameB in LS++. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_DiffB): { // LS
+              fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if ((isCharmMeson(mp1) && isBeautyMeson(mp2)) || (isCharmMeson(mp2) && isBeautyMeson(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if ((isCharmBaryon(mp1) && isBeautyBaryon(mp2)) || (isCharmBaryon(mp2) && isBeautyBaryon(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      } // end of true LS++ pair loop
+
+      for (auto& [t1, t2] : combinations(CombinationsStrictlyUpperIndexPolicy(negTracks_per_coll, negTracks_per_coll))) {
+        // LOGF(info, "pdg1 = %d, pdg2 = %d", t1.pdgCode(), t2.pdgCode());
+
+        if (!isInAcceptance(t1) || !isInAcceptance(t2)) {
+          continue;
+        }
+
+        if (!t1.isPhysicalPrimary() && !t1.producedByGenerator()) {
+          continue;
+        }
+        if (!t2.isPhysicalPrimary() && !t2.producedByGenerator()) {
+          continue;
+        }
+
+        int hfee_type = IsHF(t1, t2, mcparticles);
+        if (hfee_type < 0) {
+          continue;
+        }
+        ROOT::Math::PtEtaPhiMVector v1(t1.pt(), t1.eta(), t1.phi(), o2::constants::physics::MassElectron);
+        ROOT::Math::PtEtaPhiMVector v2(t2.pt(), t2.eta(), t2.phi(), o2::constants::physics::MassElectron);
+        ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;
+        if (hfee_type > -1) {
+          auto mp1 = mcparticles.iteratorAt(t1.mothersIds()[0]);
+          auto mp2 = mcparticles.iteratorAt(t2.mothersIds()[0]);
+          switch (hfee_type) {
+            case static_cast<int>(EM_HFeeType::kCe_Ce):
+              LOGF(info, "You should not see kCe_Ce in LS--. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBe_Be):
+              LOGF(info, "You should not see kBe_Be in LS--. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_BCe):
+              LOGF(info, "You should not see kBCe_BCe in LS--. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_SameB): // ULS
+              LOGF(info, "You should not see kBCe_Be_SameB in LS--. Good luck.");
+              break;
+            case static_cast<int>(EM_HFeeType::kBCe_Be_DiffB): { // LS
+              fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/hadron_hadron/hMvsPt"), v12.M(), v12.Pt());
+              if ((isCharmMeson(mp1) && isBeautyMeson(mp2)) || (isCharmMeson(mp2) && isBeautyMeson(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/meson_meson/hMvsPt"), v12.M(), v12.Pt());
+              } else if ((isCharmBaryon(mp1) && isBeautyBaryon(mp2)) || (isCharmBaryon(mp2) && isBeautyBaryon(mp1))) {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/baryon_baryon/hMvsPt"), v12.M(), v12.Pt());
+              } else {
+                fRegistry.fill(HIST("Generated/bbbar/b2c2e_b2e_diffb/meson_baryon/hMvsPt"), v12.M(), v12.Pt());
+              }
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      } // end of true LS++ pair loop
+
+    } // end of collision loop
   }
-  PROCESS_SWITCH(DalitzEEQCMC, processGen, "run genrated info", true);
+  PROCESS_SWITCH(dielectronQCMC, processGen, "run genrated info", true);
 
   void processDummy(MyCollisions const&) {}
-  PROCESS_SWITCH(DalitzEEQCMC, processDummy, "Dummy function", false);
+  PROCESS_SWITCH(dielectronQCMC, processDummy, "Dummy function", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<DalitzEEQCMC>(cfgc, TaskName{"dalitz-ee-qc-mc"})};
+    adaptAnalysisTask<dielectronQCMC>(cfgc, TaskName{"dielectron-qc-mc"})};
 }

--- a/PWGEM/PhotonMeson/Tasks/pcmQCMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/pcmQCMC.cxx
@@ -14,25 +14,24 @@
 // This code runs loop over v0 photons for PCM QC.
 //    Please write to: daiki.sekihata@cern.ch
 
-#include <array>
+// #include <array>
 #include "TString.h"
 #include "THashList.h"
-#include "Math/Vector4D.h"
-#include "Math/Vector3D.h"
-#include "Math/LorentzRotation.h"
-#include "Math/Rotation3D.h"
-#include "Math/AxisAngle.h"
+// #include "Math/Vector4D.h"
+// #include "Math/Vector3D.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/ASoAHelpers.h"
-#include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/trackUtilities.h"
-#include "Common/Core/TrackSelection.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/PIDResponse.h"
+
+// #include "ReconstructionDataFormats/Track.h"
+// #include "Common/Core/trackUtilities.h"
+// #include "Common/Core/TrackSelection.h"
+// #include "Common/DataModel/TrackSelectionTables.h"
+// #include "Common/DataModel/EventSelection.h"
+// #include "Common/DataModel/Centrality.h"
+// #include "Common/DataModel/PIDResponse.h"
+
 #include "Common/Core/RecoDecay.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
 #include "PWGEM/PhotonMeson/Utils/PCMUtilities.h"
@@ -48,10 +47,13 @@ using namespace o2::framework::expressions;
 using namespace o2::soa;
 using namespace o2::aod::pwgem::mcutil;
 using namespace o2::aod::pwgem::photon;
-using std::array;
+// using std::array;
 
 using MyCollisions = soa::Join<aod::EMEvents, aod::EMEventsMult, aod::EMEventsCent, aod::EMMCEventLabels>;
 using MyCollision = MyCollisions::iterator;
+
+using MyMCCollisions = soa::Join<aod::EMMCEvents, aod::BinnedGenPts>;
+using MyMCCollision = MyMCCollisions::iterator;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0KFEMEventIds>;
 using MyV0Photon = MyV0Photons::iterator;
@@ -73,6 +75,8 @@ struct PCMQCMC {
   Configurable<std::string> fConfigEMEventCut{"cfgEMEventCut", "minbias", "em event cut"}; // only 1 event cut per wagon
   EMEventCut fEMEventCut;
   static constexpr std::string_view event_types[2] = {"before", "after"};
+
+  HistogramRegistry fRegistry{"output", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
 
   OutputObj<THashList> fOutputEvent{"Event"};
   OutputObj<THashList> fOutputV0Leg{"V0Leg"};
@@ -122,6 +126,24 @@ struct PCMQCMC {
       THashList* list = reinterpret_cast<THashList*>(fMainList->FindObject("V0")->FindObject(cutname.data()));
       o2::aod::pwgem::photon::histogram::DefineHistograms(list, "V0", "mc");
     }
+
+    std::vector<double> ptbins;
+    for (int i = 0; i < 2; i++) {
+      ptbins.emplace_back(0.05 * (i - 0) + 0.0); // from 0 to 0.1 GeV/c, every 0.05 GeV/c
+    }
+    for (int i = 2; i < 52; i++) {
+      ptbins.emplace_back(0.1 * (i - 2) + 0.1); // from 0.1 to 5 GeV/c, every 0.1 GeV/c
+    }
+    for (int i = 52; i < 62; i++) {
+      ptbins.emplace_back(0.5 * (i - 52) + 5.0); // from 5 to 10 GeV/c, evety 0.5 GeV/c
+    }
+    for (int i = 62; i < 73; i++) {
+      ptbins.emplace_back(1.0 * (i - 62) + 10.0); // from 10 to 20 GeV/c, evety 1 GeV/c
+    }
+    const AxisSpec axis_pt{ptbins, "p_{T} (GeV/c)"};
+    const AxisSpec axis_rapidity{{0.0, +0.8, +0.9}, "rapidity |y|"};
+    fRegistry.add("Generated_dir/Photon/hPt", "pT;p_{T} (GeV/c)", kTH1F, {axis_pt}, true);
+    fRegistry.add("Generated_dir/Photon/hPtY", "Generated info", kTH2F, {axis_pt, axis_rapidity}, true);
   }
 
   void DefineCuts()
@@ -151,17 +173,18 @@ struct PCMQCMC {
     fOutputGen.setObject(reinterpret_cast<THashList*>(fMainList->FindObject("Generated")));
   }
 
-  Partition<MyCollisions> grouped_collisions = (cfgCentMin < o2::aod::cent::centFT0M && o2::aod::cent::centFT0M < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0A && o2::aod::cent::centFT0A < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0C && o2::aod::cent::centFT0C < cfgCentMax); // this goes to same event.
+  Filter collisionFilter_centrality = (cfgCentMin < o2::aod::cent::centFT0M && o2::aod::cent::centFT0M < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0A && o2::aod::cent::centFT0A < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0C && o2::aod::cent::centFT0C < cfgCentMax);
+  using FilteredMyCollisions = soa::Filtered<MyCollisions>;
 
   Preslice<MyV0Photons> perCollision = aod::v0photonkf::emeventId;
-  void processQCMC(MyCollisions const&, MyV0Photons const& v0photons, MyMCV0Legs const&, aod::EMMCParticles const& mcparticles, aod::EMMCEvents const&)
+  void processQCMC(FilteredMyCollisions const& collisions, MyV0Photons const& v0photons, MyMCV0Legs const&, aod::EMMCParticles const& mcparticles, MyMCCollisions const&)
   {
     THashList* list_ev_before = static_cast<THashList*>(fMainList->FindObject("Event")->FindObject(event_types[0].data()));
     THashList* list_ev_after = static_cast<THashList*>(fMainList->FindObject("Event")->FindObject(event_types[1].data()));
     THashList* list_v0 = static_cast<THashList*>(fMainList->FindObject("V0"));
     THashList* list_v0leg = static_cast<THashList*>(fMainList->FindObject("V0Leg"));
 
-    for (auto& collision : grouped_collisions) {
+    for (auto& collision : collisions) {
       const float centralities[3] = {collision.centFT0M(), collision.centFT0A(), collision.centFT0C()};
       if (centralities[cfgCentEstimator] < cfgCentMin || cfgCentMax < centralities[cfgCentEstimator]) {
         continue;
@@ -233,7 +256,7 @@ struct PCMQCMC {
                 }
               }
 
-            } else if (IsFromWD(mcphoton.emmcevent(), mcphoton, mcparticles)) {
+            } else if (IsFromWD(mcphoton.template emmcevent_as<MyMCCollisions>(), mcphoton, mcparticles)) {
               reinterpret_cast<TH1F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hPt_Photon_FromWD"))->Fill(v0.pt());
               reinterpret_cast<TH2F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hEtaPhi_Photon_FromWD"))->Fill(v0.phi(), v0.eta());
               reinterpret_cast<TH2F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hCosPA_Rxy_Photon_FromWD"))->Fill(v0.v0radius(), v0.cospa());
@@ -263,23 +286,49 @@ struct PCMQCMC {
     }   // end of collision loop
   }     // end of process
 
+  template <typename TBinnedData>
+  void fillBinnedData(TBinnedData const& binned_data, const float weight = 1.f)
+  {
+    int xbin = 0, ybin = 0, zbin = 0;
+    auto hPtY = fRegistry.get<TH2>(HIST("Generated_dir/Photon/hPtY")); // 2D
+    auto hPt = fRegistry.get<TH1>(HIST("Generated_dir/Photon/hPt"));   // 1D
+
+    for (int ibin = 0; ibin < hPtY->GetNcells(); ibin++) {
+      int nentry = binned_data[ibin];
+      hPtY->GetBinXYZ(ibin, xbin, ybin, zbin);
+      float pt = hPtY->GetXaxis()->GetBinCenter(xbin);
+      float y = hPtY->GetYaxis()->GetBinCenter(ybin);
+      if (y > maxY) {
+        continue;
+      }
+
+      for (int j = 0; j < nentry; j++) {
+        hPtY->Fill(pt, y, weight);
+        hPt->Fill(pt, weight);
+      }
+    }
+  }
+
   PresliceUnsorted<aod::EMMCParticles> perMcCollision = aod::emmcparticle::emmceventId;
-  void processGen(MyCollisions const&, aod::EMMCEvents const&, aod::EMMCParticles const& mcparticles)
+  void processGen(FilteredMyCollisions const& collisions, MyMCCollisions const&, aod::EMMCParticles const& mcparticles)
   {
     // loop over mc stack and fill histograms for pure MC truth signals
     // all MC tracks which belong to the MC event corresponding to the current reconstructed event
 
-    for (auto& collision : grouped_collisions) {
+    for (auto& collision : collisions) {
       const float centralities[3] = {collision.centFT0M(), collision.centFT0A(), collision.centFT0C()};
       if (centralities[cfgCentEstimator] < cfgCentMin || cfgCentMax < centralities[cfgCentEstimator]) {
         continue;
       }
-      auto mccollision = collision.emmcevent();
-      // LOGF(info, "mccollision.globalIndex() = %d", mccollision.globalIndex());
 
       if (!fEMEventCut.IsSelected(collision)) {
         continue;
       }
+
+      auto mccollision = collision.template emmcevent_as<MyMCCollisions>();
+      auto binned_data_gamma_gen = mccollision.generatedGamma();
+      fillBinnedData(binned_data_gamma_gen, 1.f);
+      // LOGF(info, "mccollision.globalIndex() = %d", mccollision.globalIndex());
 
       auto mctracks_coll = mcparticles.sliceBy(perMcCollision, mccollision.globalIndex());
       for (auto& mctrack : mctracks_coll) {
@@ -288,10 +337,6 @@ struct PCMQCMC {
         }
 
         if (abs(mctrack.pdgCode()) == 22 && (mctrack.isPhysicalPrimary() || mctrack.producedByGenerator())) {
-          reinterpret_cast<TH1F*>(fMainList->FindObject("Generated")->FindObject("hPt_Photon"))->Fill(mctrack.pt());
-          reinterpret_cast<TH1F*>(fMainList->FindObject("Generated")->FindObject("hY_Photon"))->Fill(mctrack.y());
-          reinterpret_cast<TH1F*>(fMainList->FindObject("Generated")->FindObject("hPhi_Photon"))->Fill(mctrack.phi());
-
           bool is_ele_fromPC = false;
           bool is_pos_fromPC = false;
           auto daughtersIds = mctrack.daughtersIds();
@@ -331,10 +376,7 @@ struct PCMQCMC {
     }   // end of collision loop
   }
 
-  void processDummy(MyCollisions const&)
-  {
-    // do nothing
-  }
+  void processDummy(MyCollisions const&) {}
 
   PROCESS_SWITCH(PCMQCMC, processQCMC, "run PCM QC in MC", false);
   PROCESS_SWITCH(PCMQCMC, processGen, "run generated information", false);

--- a/PWGEM/PhotonMeson/Tasks/pcmQCMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/pcmQCMC.cxx
@@ -256,7 +256,7 @@ struct PCMQCMC {
                 }
               }
 
-            } else if (IsFromWD(mcphoton.template emmcevent_as<MyMCCollisions>(), mcphoton, mcparticles)) {
+            } else if (IsFromWD(mcphoton.template emmcevent_as<MyMCCollisions>(), mcphoton, mcparticles) > 0) {
               reinterpret_cast<TH1F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hPt_Photon_FromWD"))->Fill(v0.pt());
               reinterpret_cast<TH2F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hEtaPhi_Photon_FromWD"))->Fill(v0.phi(), v0.eta());
               reinterpret_cast<TH2F*>(fMainList->FindObject("V0")->FindObject(cut.GetName())->FindObject("hCosPA_Rxy_Photon_FromWD"))->Fill(v0.v0radius(), v0.cospa());

--- a/PWGEM/PhotonMeson/Utils/EventHistograms.h
+++ b/PWGEM/PhotonMeson/Utils/EventHistograms.h
@@ -36,12 +36,13 @@ void addEventHistograms(HistogramRegistry* fRegistry, bool doFlow)
   fRegistry->add("Event/before/hZvtx", "vertex z; Z_{vtx} (cm)", kTH1F, {{100, -50, +50}}, false);
   fRegistry->add("Event/before/hMultNTracksPV", "hMultNTracksPV; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
   fRegistry->add("Event/before/hMultNTracksPVeta1", "hMultNTracksPVeta1; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
-  fRegistry->add("Event/before/hMultFT0", "hMultFT0;mult. FT0A;mult. FT0C", kTH2F, {{300, 0, 6000}, {300, 0, 6000}}, false);
+  fRegistry->add("Event/before/hMultFT0", "hMultFT0;mult. FT0A;mult. FT0C", kTH2F, {{200, 0, 200000}, {60, 0, 60000}}, false);
   fRegistry->add("Event/before/hCentFT0A", "hCentFT0A;centrality FT0A (%)", kTH1F, {{110, 0, 110}}, false);
   fRegistry->add("Event/before/hCentFT0C", "hCentFT0C;centrality FT0C (%)", kTH1F, {{110, 0, 110}}, false);
   fRegistry->add("Event/before/hCentFT0M", "hCentFT0M;centrality FT0M (%)", kTH1F, {{110, 0, 110}}, false);
-  fRegistry->add("Event/before/hCentFT0MvsMultNTracksPV", "hCentFT0MvsMultNTracksPV;centrality FT0M (%);N_{track} to PV", kTH2F, {{110, 0, 110}, {600, 0, 6000}}, false);
-  fRegistry->add("Event/before/hMultFT0MvsMultNTracksPV", "hMultFT0MvsMultNTracksPV;mult. FT0M;N_{track} to PV", kTH2F, {{600, 0, 6000}, {600, 0, 6000}}, false);
+  fRegistry->add("Event/before/hCentFT0CvsMultNTracksPV", "hCentFT0CvsMultNTracksPV;centrality FT0C (%);N_{track} to PV", kTH2F, {{110, 0, 110}, {500, 0, 5000}}, false);
+  fRegistry->add("Event/before/hMultFT0CvsMultNTracksPV", "hMultFT0CvsMultNTracksPV;mult. FT0C;N_{track} to PV", kTH2F, {{60, 0, 60000}, {500, 0, 5000}}, false);
+  fRegistry->add("Event/before/hMultFT0CvsOccupancy", "hMultFT0CvsOccupancy;mult. FT0C;N_{track} in time range", kTH2F, {{60, 0, 60000}, {2000, 0, 20000}}, false);
 
   if (doFlow) {
     fRegistry->add("Event/before/hQ2xFT0M_CentFT0C", "hQ2xFT0M_CentFT0C;centrality FT0C (%);Q_{2,x}^{FT0M}", kTH2F, {{110, 0, 110}, {200, -10, +10}}, false);
@@ -117,8 +118,9 @@ void fillEventInfo(HistogramRegistry* fRegistry, TCollision const& collision, co
   fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCentFT0A"), collision.centFT0A());
   fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCentFT0C"), collision.centFT0C());
   fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCentFT0M"), collision.centFT0M());
-  fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCentFT0MvsMultNTracksPV"), collision.centFT0M(), collision.multNTracksPV());
-  fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hMultFT0MvsMultNTracksPV"), collision.multFT0A() + collision.multFT0C(), collision.multNTracksPV());
+  fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCentFT0CvsMultNTracksPV"), collision.centFT0C(), collision.multNTracksPV());
+  fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hMultFT0CvsMultNTracksPV"), collision.multFT0C(), collision.multNTracksPV());
+  fRegistry->fill(HIST("Event/") + HIST(event_types[ev_id]) + HIST("hMultFT0CvsOccupancy"), collision.multFT0C(), collision.trackOccupancyInTimeRange());
 
   if (doFlow) {
     std::array<float, 2> q2ft0m = {collision.q2xft0m(), collision.q2yft0m()};

--- a/PWGEM/PhotonMeson/Utils/MCUtilities.h
+++ b/PWGEM/PhotonMeson/Utils/MCUtilities.h
@@ -34,11 +34,11 @@ bool IsPhysicalPrimary(TTrack const& mctrack)
 }
 //_______________________________________________________________________
 template <typename TCollision, typename T, typename TMCs>
-bool IsFromWD(TCollision const&, T const& mctrack, TMCs const& mcTracks)
+int IsFromWD(TCollision const&, T const& mctrack, TMCs const& mcTracks)
 {
   // is this particle from weak decay?
   if (mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) {
-    return false;
+    return -1;
   }
 
   if (mctrack.has_mothers()) {
@@ -50,7 +50,7 @@ bool IsFromWD(TCollision const&, T const& mctrack, TMCs const& mcTracks)
         int pdg_mother = mp.pdgCode();
         if (abs(pdg_mother) == 310 || abs(pdg_mother) == 130 || abs(pdg_mother) == 3122) {
           // LOGF(info, "mctrack.globalIndex() = %d, mp.globalIndex() = %d , pdg_mother = %d", mctrack.globalIndex(), mp.globalIndex(), pdg_mother);
-          return true;
+          return motherid;
         }
         if (mp.has_mothers()) {
           motherid = mp.mothersIds()[0]; // first mother index
@@ -60,9 +60,9 @@ bool IsFromWD(TCollision const&, T const& mctrack, TMCs const& mcTracks)
       }
     }
   } else {
-    return false;
+    return -1;
   }
-  return false;
+  return -1;
 }
 //_______________________________________________________________________
 template <typename T, typename TMCs>

--- a/PWGEM/PhotonMeson/Utils/MCUtilities.h
+++ b/PWGEM/PhotonMeson/Utils/MCUtilities.h
@@ -218,7 +218,58 @@ int FindCommonMotherFrom3Prongs(TMCParticle1 const& p1, TMCParticle2 const& p2, 
 }
 //_______________________________________________________________________
 template <typename TMCParticle, typename TMCParticles, typename TTargetPDGs>
-bool IsInAcceptance(TMCParticle const& mcparticle, TMCParticles const& mcparticles, TTargetPDGs const& target_pdgs, const float ymin, const float ymax, const float phimin, const float phimax)
+bool IsInAcceptanceNonDerived(TMCParticle const& mcparticle, TMCParticles const& mcparticles, TTargetPDGs target_pdgs, const float ymin, const float ymax, const float phimin, const float phimax)
+{
+  // contents in vector of daughter ID is different.
+
+  if (mcparticle.y() < ymin || ymax < mcparticle.y()) {
+    return false; // mother rapidity is out of acceptance
+  }
+  if (mcparticle.phi() < phimin || phimax < mcparticle.phi()) {
+    return false; // mother rapidity is out of acceptance
+  }
+  // auto daughtersIds = mcparticle.daughtersIds(); // always size = 2. first and last index. one should run loop from the first index to the last index.
+  int ndau = mcparticle.daughtersIds()[1] - mcparticle.daughtersIds()[0] + 1;
+
+  if (ndau != static_cast<int>(target_pdgs.size())) {
+    return false;
+  }
+  std::vector<int> pdgs;
+  pdgs.reserve(target_pdgs.size());
+  for (int daughterId = mcparticle.daughtersIds()[0]; daughterId <= mcparticle.daughtersIds()[1]; ++daughterId) {
+    if (daughterId < 0) {
+      pdgs.clear();
+      pdgs.shrink_to_fit();
+      return false;
+    }
+    auto daughter = mcparticles.iteratorAt(daughterId);
+    pdgs.emplace_back(daughter.pdgCode());
+
+    if (daughter.eta() < ymin || ymax < daughter.eta()) {
+      pdgs.clear();
+      pdgs.shrink_to_fit();
+      return false;
+    }
+    if (daughter.phi() < phimin || phimax < daughter.phi()) {
+      pdgs.clear();
+      pdgs.shrink_to_fit();
+      return false;
+    }
+  } // end of daughter loop
+
+  sort(target_pdgs.begin(), target_pdgs.end());
+  sort(pdgs.begin(), pdgs.end());
+  bool is_equal = std::equal(pdgs.cbegin(), pdgs.cend(), target_pdgs.cbegin());
+  pdgs.clear();
+  pdgs.shrink_to_fit();
+  if (!is_equal) {
+    return false; // garantee daughter is in acceptance.
+  }
+  return true;
+}
+//_______________________________________________________________________
+template <typename TMCParticle, typename TMCParticles, typename TTargetPDGs>
+bool IsInAcceptance(TMCParticle const& mcparticle, TMCParticles const& mcparticles, TTargetPDGs target_pdgs, const float ymin, const float ymax, const float phimin, const float phimax)
 {
   if (mcparticle.y() < ymin || ymax < mcparticle.y()) {
     return false; // mother rapidity is out of acceptance
@@ -226,9 +277,8 @@ bool IsInAcceptance(TMCParticle const& mcparticle, TMCParticles const& mcparticl
   if (mcparticle.phi() < phimin || phimax < mcparticle.phi()) {
     return false; // mother rapidity is out of acceptance
   }
-  auto daughtersIds = mcparticle.daughtersIds(); // always size = 2. first and last index. one should run loop from the first index to the last index.
+  auto daughtersIds = mcparticle.daughtersIds();
 
-  // if (daughtersIds.size() != static_cast<int>(target_pdgs.size())) {
   if (daughtersIds.size() != target_pdgs.size()) {
     return false;
   }
@@ -255,6 +305,7 @@ bool IsInAcceptance(TMCParticle const& mcparticle, TMCParticles const& mcparticl
     }
   } // end of daughter loop
 
+  sort(target_pdgs.begin(), target_pdgs.end());
   sort(pdgs.begin(), pdgs.end());
   bool is_equal = std::equal(pdgs.cbegin(), pdgs.cend(), target_pdgs.cbegin());
   pdgs.clear();


### PR DESCRIPTION
This PR contains following commits:
PWGEM/PhotonMeson: add occupancy in data model
PWGEM/PhotonMeson: reduce derived MC data size
In order to reduce derived data size of MC, the generated meson pT spectra (pi0, eta) are stored as binned data. Further more, acceptance information is not stored in the derived data, as this requires mother-daughter relation, which is heavy. Instead, acceptance information (i.e. pT histogram for each decay channel) for |y| < 0.8 or 0.9 is stored in AnalysisResults.root, when the skimming task runs. By doing these things, finally, the data compression factor is 60 in EM. The requirement is 60.