### PR TITLE
[PWGDQ] Improve three-prong vertexing. Add cut for open charm analysis

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -732,6 +732,28 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("pionPosPrimaryNoPID")) {
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrackDCA"));
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("pionNegPrimaryNoPID")) {
+    cut->AddCut(GetAnalysisCut("standardPrimaryTrackDCA"));
+    cut->AddCut(GetAnalysisCut("negTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("posTrack")) {
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("negTrack")) {
+    cut->AddCut(GetAnalysisCut("negTrack"));
+    return cut;
+  }
+
   // NOTE Below there are several TPC pid cuts used for studies of the Run3 TPC post PID calib.
   if (!nameStr.compare("Jpsi_TPCPost_calib_debug1")) {
     cut->AddCut(GetAnalysisCut("jpsi_trackCut_debug"));

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -798,8 +798,15 @@ class VarManager : public TObject
   }
 
   // Setup the 3 prong DCAFitterN
-  static void SetupThreeProngDCAFitter()
+  static void SetupThreeProngDCAFitter(float magField, bool propagateToPCA, float maxR, float maxDZIni, float minParamChange, float minRelChi2Change, bool useAbsDCA)
   {
+    fgFitterThreeProngBarrel.setBz(magField);
+    fgFitterThreeProngBarrel.setPropagateToPCA(propagateToPCA);
+    fgFitterThreeProngBarrel.setMaxR(maxR);
+    fgFitterThreeProngBarrel.setMinParamChange(minParamChange);
+    fgFitterThreeProngBarrel.setMinRelChi2Change(minRelChi2Change);
+    fgFitterThreeProngBarrel.setUseAbsDCA(useAbsDCA);
+    cout << "!!! fgFitterThreeProngBarrel bz = " << fgFitterThreeProngBarrel.getBz() << endl;
     fgUsedKF = false;
   }
 
@@ -2356,8 +2363,8 @@ void VarManager::FillTriple(T1 const& t1, T2 const& t2, T3 const& t3, float* val
   }
 
   if (pairType == kTripleCandidateToKPiPi) {
-    float m1 = o2::constants::physics::MassKMinus;
-    float m2 = o2::constants::physics::MassPiPlus;
+    float m1 = o2::constants::physics::MassKaonCharged;
+    float m2 = o2::constants::physics::MassPionCharged;
 
     ROOT::Math::PtEtaPhiMVector v1(t1.pt(), t1.eta(), t1.phi(), m1);
     ROOT::Math::PtEtaPhiMVector v2(t2.pt(), t2.eta(), t2.phi(), m2);
@@ -2372,8 +2379,8 @@ void VarManager::FillTriple(T1 const& t1, T2 const& t2, T3 const& t3, float* val
 
   if (pairType == kTripleCandidateToPKPi) {
     float m1 = o2::constants::physics::MassProton;
-    float m2 = o2::constants::physics::MassKMinus;
-    float m3 = o2::constants::physics::MassPiPlus;
+    float m2 = o2::constants::physics::MassKaonCharged;
+    float m3 = o2::constants::physics::MassPionCharged;
 
     ROOT::Math::PtEtaPhiMVector v1(t1.pt(), t1.eta(), t1.phi(), m1);
     ROOT::Math::PtEtaPhiMVector v2(t2.pt(), t2.eta(), t2.phi(), m2);
@@ -2695,6 +2702,16 @@ void VarManager::FillPairVertexing(C const& collision, T const& t1, T const& t2,
       trk0KF = KFParticle(kfpTrack0, -13 * t1.sign());
       KFPTrack kfpTrack1 = createKFPFwdTrackFromFwdTrack(t2);
       trk1KF = KFParticle(kfpTrack1, -13 * t2.sign());
+
+      KFGeoTwoProng.SetConstructMethod(2);
+      KFGeoTwoProng.AddDaughter(trk0KF);
+      KFGeoTwoProng.AddDaughter(trk1KF);
+
+    } else if constexpr ((pairType == kDecayToKPi) && trackHasCov) {
+      KFPTrack kfpTrack0 = createKFPTrackFromTrack(t1);
+      trk0KF = KFParticle(kfpTrack0, 321 * t1.sign());
+      KFPTrack kfpTrack1 = createKFPTrackFromTrack(t2);
+      trk1KF = KFParticle(kfpTrack1, 211 * t2.sign());
 
       KFGeoTwoProng.SetConstructMethod(2);
       KFGeoTwoProng.AddDaughter(trk0KF);

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -1612,13 +1612,13 @@ struct AnalysisDileptonHadron {
         if (fConfigUseKFVertexing) {
           VarManager::SetupThreeProngKFParticle(mMagField);
         } else {
-          VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+          VarManager::SetupThreeProngDCAFitter(mMagField, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, false); // TODO: get these parameters from Configurables
         }
       } else {
         if (fConfigUseKFVertexing) {
           VarManager::SetupThreeProngKFParticle(fConfigMagField.value);
         } else {
-          VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+          VarManager::SetupThreeProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, false); // TODO: get these parameters from Configurables
         }
       }
       fCurrentRun = event.runNumber();

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1760,7 +1760,7 @@ struct AnalysisAsymmetricPairing {
         if (fConfigUseKFVertexing.value) {
           VarManager::SetupThreeProngKFParticle(magField);
         } else {
-          VarManager::SetupThreeProngDCAFitter();
+          VarManager::SetupThreeProngDCAFitter(magField, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value);
         }
       } else {
         if (fConfigUseKFVertexing.value) {
@@ -1774,7 +1774,7 @@ struct AnalysisAsymmetricPairing {
         if (fConfigUseKFVertexing.value) {
           VarManager::SetupThreeProngKFParticle(fConfigMagField.value);
         } else {
-          VarManager::SetupThreeProngDCAFitter();
+          VarManager::SetupThreeProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, fConfigUseAbsDCA.value);
         }
       } else {
         if (fConfigUseKFVertexing.value) {
@@ -2287,13 +2287,13 @@ struct AnalysisDileptonTrack {
       if (fConfigUseKFVertexing.value) {
         VarManager::SetupThreeProngKFParticle(magField);
       } else {
-        VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+        VarManager::SetupThreeProngDCAFitter(magField, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, false); // TODO: get these parameters from Configurables
       }
     } else {
       if (fConfigUseKFVertexing.value) {
         VarManager::SetupThreeProngKFParticle(fConfigMagField.value);
       } else {
-        VarManager::SetupThreeProngDCAFitter(); // TODO: get these parameters from Configurables
+        VarManager::SetupThreeProngDCAFitter(fConfigMagField.value, true, 200.0f, 4.0f, 1.0e-3f, 0.9f, false); // TODO: get these parameters from Configurables
       }
     }
   }


### PR DESCRIPTION
Vertexing: Properly set up DCA fitter for three-prong decays. Implement KF vertexing for D0.
Cuts: Add track cuts to be used for pions in open-charm UPC analyses.