### PR TITLE
[PWGUD] Fix angle selection for exclusive phi->ee

### DIFF
--- a/PWGUD/Tasks/exclusivePentaquark.cxx
+++ b/PWGUD/Tasks/exclusivePentaquark.cxx
@@ -140,7 +140,7 @@ struct ExclusivePentaquark {
       if (trk.itsNCls() < 7) {
         continue;
       }
-      if (trk.pt() < 0.3) {
+      if (trk.pt() < 0.1) {
         continue;
       }
       if (!(std::abs(trk.dcaZ()) < 2.)) {
@@ -201,7 +201,7 @@ struct ExclusivePentaquark {
         registry.fill(HIST("hClusterSizeProtonsTPC"), averageClusterSize);
       }
 
-      if (trk.hasTOF() && (fabs(nSigmaElTOF) < 2. || fabs(nSigmaMuTOF) < 2.)) {
+      if (trk.hasTOF() && (fabs(nSigmaElTOF) < 2. || fabs(nSigmaMuTOF) < 2.) && trk.pt() > 0.5) {
         if (fabs(trk.tpcNSigmaEl()) < fabs(trk.tpcNSigmaMu())) {
           onlyLeptonTracks.push_back(electron);
         } else {
@@ -232,7 +232,7 @@ struct ExclusivePentaquark {
       pentaquark += resonance;
       if (onlyProtonTracksTOF.size() == 1) {
         pentaquark += onlyProtonTracksTOF[0];
-        if (resonance.M() > 2.9 && resonance.M() < 3.2) {
+        if (resonance.M() > 3. && resonance.M() < 3.13) {
           registry.fill(HIST("PP/hMassPtUnlikeSignProton"), pentaquark.M(), pentaquark.Pt());
           registry.fill(HIST("hSelectionCounter"), 8);
           registry.fill(HIST("PP/hUnlikePt"), pentaquark.Pt());

--- a/PWGUD/Tasks/exclusivePhiLeptons.cxx
+++ b/PWGUD/Tasks/exclusivePhiLeptons.cxx
@@ -81,8 +81,24 @@ struct ExclusivePhiLeptons {
     registry.add("PP/hMassUnlike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{1000, 0., 10.}});
     registry.add("PP/hUnlikePt", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
     registry.add("PP/hUnlikePt2", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PP/hUnlikePt3", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PP/hUnlikePt4", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
+    registry.add("PP/hUnlikePt5", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
     registry.add("PP/hCoherentMass", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hCoherentMass2", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hCoherentMass3", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hCoherentMass4", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hCoherentMass5", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hIncoherentMass", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hIncoherentMass2", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hIncoherentMass3", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hIncoherentMass4", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
+    registry.add("PP/hIncoherentMass5", "Raw Inv.M;#it{m_{pp}}, GeV/c^{2};", kTH1F, {{1000, 0., 10.}});
     registry.add("PP/hAngle", "Angular distrib helicity frame;#theta;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PP/hAngle2", "Angular distrib helicity frame;#theta;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PP/hAngle3", "Angular distrib helicity frame;#theta;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PP/hAngle4", "Angular distrib helicity frame;#theta;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
+    registry.add("PP/hAngle5", "Angular distrib helicity frame;#theta;", kTH1F, {{100, 0. * TMath::Pi(), 2. * TMath::Pi()}});
   }
 
   using udtracks = soa::Join<aod::UDTracks, aod::UDTracksExtra, aod::UDTracksPID>;
@@ -203,6 +219,7 @@ struct ExclusivePhiLeptons {
       int signSum = -999.;
       double sigmaTotal = -999.;
       TVector3 momentum[2];
+      int restrictedMomenta = -1;
       if (onlyElectronTracksTOF.size() == 1) {
 
         if (!(fabs(onlyElectronTracks[0].Eta()) < 0.8 && fabs(onlyElectronTracksTOF[0].Eta()) < 0.8)) {
@@ -210,6 +227,9 @@ struct ExclusivePhiLeptons {
         }
         if (!(onlyElectronTracks[0].P() < 0.8 && onlyElectronTracks[0].P() > 0.3 && onlyElectronTracksTOF[0].P() < 0.8 && onlyElectronTracksTOF[0].P() > 0.3)) {
           return;
+        }
+        if (!(onlyElectronTracks[0].P() < 0.6 && onlyElectronTracks[0].P() > 0.4 && onlyElectronTracksTOF[0].P() < 0.6 && onlyElectronTracksTOF[0].P() > 0.4)) {
+          restrictedMomenta = 1;
         }
         momentum[0] = onlyElectronTracks[0].Vect();
         momentum[1] = onlyElectronTracksTOF[0].Vect();
@@ -233,6 +253,9 @@ struct ExclusivePhiLeptons {
         }
         if (!(onlyElectronTracksTOF[0].P() < 0.8 && onlyElectronTracksTOF[0].P() > 0.3 && onlyElectronTracksTOF[1].P() < 0.8 && onlyElectronTracksTOF[1].P() > 0.3)) {
           return;
+        }
+        if (!(onlyElectronTracksTOF[0].P() < 0.6 && onlyElectronTracksTOF[0].P() > 0.4 && onlyElectronTracksTOF[1].P() < 0.6 && onlyElectronTracksTOF[1].P() > 0.4)) {
+          restrictedMomenta = 1;
         }
         momentum[0] = onlyElectronTracksTOF[0].Vect();
         momentum[1] = onlyElectronTracksTOF[1].Vect();
@@ -264,9 +287,9 @@ struct ExclusivePhiLeptons {
         registry.fill(HIST("PP/hAngle"), angleBetweenMomenta);
       }
 
-      if (fabs(angleBetweenMomenta - TMath::Pi()) > TMath::Pi() / 18.) {
-        return;
-      }
+      // if (fabs(angleBetweenMomenta - TMath::Pi()) > TMath::Pi() / 18.) {
+      //   return;
+      // }
 
       if (signSum != 0) {
         registry.fill(HIST("hMassPtLikeSignElectron"), resonance.M(), resonance.Pt());
@@ -276,12 +299,63 @@ struct ExclusivePhiLeptons {
       } else {
         registry.fill(HIST("PP/hMassPtUnlikeSignElectron"), resonance.M(), resonance.Pt());
         registry.fill(HIST("hSelectionCounter"), 8);
-        registry.fill(HIST("PP/hUnlikePt"), resonance.Pt());
-        registry.fill(HIST("PP/hMassUnlike"), resonance.M());
-        registry.fill(HIST("PP/hRapidity"), resonance.Rapidity());
-        // if (resonance.Pt() < 0.15) {
-        if (resonance.Pt() > 0.075) {
-          registry.fill(HIST("PP/hCoherentMass"), resonance.M());
+        if (fabs(angleBetweenMomenta - TMath::Pi()) < TMath::Pi() / 18.) {
+          registry.fill(HIST("PP/hAngle2"), angleBetweenMomenta);
+          registry.fill(HIST("PP/hUnlikePt"), resonance.Pt());
+          registry.fill(HIST("PP/hMassUnlike"), resonance.M());
+          registry.fill(HIST("PP/hRapidity"), resonance.Rapidity());
+          if (resonance.Pt() > 0.1) {
+            registry.fill(HIST("PP/hIncoherentMass"), resonance.M());
+          } else {
+            registry.fill(HIST("PP/hCoherentMass"), resonance.M());
+          }
+        }
+        if (fabs(angleBetweenMomenta - TMath::Pi()) < TMath::Pi() / 90.) {
+          // two degs
+          registry.fill(HIST("PP/hAngle3"), angleBetweenMomenta);
+          if (resonance.M() > 1. && resonance.M() < 1.05) {
+            registry.fill(HIST("PP/hUnlikePt3"), resonance.Pt());
+          }
+          if (resonance.Pt() > 0.1) {
+            registry.fill(HIST("PP/hIncoherentMass3"), resonance.M());
+          } else {
+            registry.fill(HIST("PP/hCoherentMass3"), resonance.M());
+          }
+        }
+        if (fabs(angleBetweenMomenta - TMath::Pi()) < TMath::Pi() / 180.) {
+          // one deg
+          registry.fill(HIST("PP/hAngle4"), angleBetweenMomenta);
+          if (resonance.M() > 1. && resonance.M() < 1.05) {
+            registry.fill(HIST("PP/hUnlikePt4"), resonance.Pt());
+          }
+          if (resonance.Pt() > 0.1) {
+            registry.fill(HIST("PP/hIncoherentMass4"), resonance.M());
+          } else {
+            registry.fill(HIST("PP/hCoherentMass4"), resonance.M());
+          }
+        }
+        if (fabs(angleBetweenMomenta - TMath::Pi()) < TMath::Pi() / 180.) {
+          // one deg
+          if (resonance.M() > 1. && resonance.M() < 1.05) {
+            registry.fill(HIST("PP/hUnlikePt4"), resonance.Pt());
+          }
+          if (resonance.Pt() > 0.1) {
+            registry.fill(HIST("PP/hIncoherentMass4"), resonance.M());
+          } else {
+            registry.fill(HIST("PP/hCoherentMass4"), resonance.M());
+          }
+        }
+        if (fabs(angleBetweenMomenta - TMath::Pi()) < TMath::Pi() / 18. && restrictedMomenta == 1) {
+          // two degs
+          registry.fill(HIST("PP/hAngle5"), angleBetweenMomenta);
+          if (resonance.M() > 1. && resonance.M() < 1.05) {
+            registry.fill(HIST("PP/hUnlikePt5"), resonance.Pt());
+          }
+          if (resonance.Pt() > 0.1) {
+            registry.fill(HIST("PP/hIncoherentMass5"), resonance.M());
+          } else {
+            registry.fill(HIST("PP/hCoherentMass5"), resonance.M());
+          }
         }
         if (resonance.M() > 1. && resonance.M() < 1.05) {
           registry.fill(HIST("PP/hUnlikePt2"), resonance.Pt());

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -693,7 +693,6 @@ struct sgExclusivePhi {
             registry.fill(HIST("hClusterSizeOnlyITS3"), averageClusterSize);
           }
 
-
           int clusterSizeKaonBand[7];
           double averageClusterSizeKaonBand = 0.;
           for (int i = 0; i < 7; i++) { // info stored in 4 bits
@@ -729,7 +728,6 @@ struct sgExclusivePhi {
               registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon3"), reallyPhi.M());
             }
           }
-
         }
       } // Kaon Band
     }   // double gap

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -144,7 +144,10 @@ struct sgExclusivePhi {
     registry.add("hClusterSizeAllTracks", "ClusterSizeAllTracks;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
     registry.add("hClusterSizeMomentumCut", "ClusterSizeMomentumCut;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
     registry.add("hClusterSizeOnlyIdentifiedKaons", "ClusterSizeOnlyIdentifiedKaons;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeOnlyIdentifiedKaons2", "ClusterSizeOnlyIdentifiedKaons;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
     registry.add("hClusterSizeOnlyITS", "ClusterSizeOnlyITS;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeOnlyITS2", "ClusterSizeOnlyITS;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
+    registry.add("hClusterSizeOnlyITS3", "ClusterSizeOnlyITS;Average cls size in the ITS layers;", kTH1F, {{1000, 0., 100.}});
     registry.add("hEta1", "#eta_{#ka};#it{#eta_{trk}}, GeV/c;", kTH1F, {{100, -2., 2.}});
     registry.add("hEta2", "#eta_{#ka};#it{#eta_{trk}}, GeV/c;", kTH1F, {{100, -2., 2.}});
     registry.add("hPtPhi", "Pt;#it{p_{t}}, GeV/c;", kTH1F, {{500, 0., 5.}});
@@ -181,8 +184,14 @@ struct sgExclusivePhi {
     registry.add("KaonBandPHI/hMassPhiIdentifiedKaons", "Raw Inv.M;#it{M_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
     registry.add("KaonBandPHI/hPtPhiIdentifiedKaons", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
     registry.add("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon2", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon3", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});Pt;#it{p_{t}}, GeV/c;", kTH2F, {{400, 0., 4.}, {400, 0., 4.}});
     registry.add("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon2", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon3", "Raw Inv.M;#it{m_{KK}} (GeV/c^{2});", kTH1F, {{400, 0., 4.}});
     registry.add("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon2", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
+    registry.add("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon3", "Pt;#it{p_{t}} (GeV/c);", kTH1F, {{400, 0., 4.}});
 
     registry.add("PHI/hMassLike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
     registry.add("PHI/hMassUnlike", "m_{#pi#pi} [GeV/#it{c}^{2}]", kTH1F, {{400, 0., 4.}});
@@ -381,6 +390,8 @@ struct sgExclusivePhi {
       std::vector<TLorentzVector> allTracksAreKaonsWrongMomentum;
       std::vector<TLorentzVector> allTracksAreKaonsBandPID;
       std::vector<TLorentzVector> allTracksAreITSonlyAndFourITSclusters;
+      std::vector<int> booleanAvgClusterSizePerTrackKaonBand;
+      std::vector<int> booleanAvgClusterSizePerTrackITSonly;
 
       int counter = 0;
       for (auto t : tracks) {
@@ -464,6 +475,11 @@ struct sgExclusivePhi {
           onlyKaonBandPID.push_back(t);
           registry.fill(HIST("hdEdxKaon7"), t.tpcInnerParam() / t.sign(), dEdx);
           registry.fill(HIST("hClusterSizeOnlyIdentifiedKaons"), averageClusterSize);
+          if (averageClusterSize > 5.5) {
+            booleanAvgClusterSizePerTrackKaonBand.push_back(1);
+          } else {
+            booleanAvgClusterSizePerTrackKaonBand.push_back(2);
+          }
         }
 
         if (NFindable < 1 && t.itsNCls() < 7) {
@@ -472,6 +488,12 @@ struct sgExclusivePhi {
           onlyITS.push_back(t);
           registry.fill(HIST("hdEdxKaon8"), t.tpcInnerParam() / t.sign(), dEdx);
           registry.fill(HIST("hSelectionCounter2"), 6);
+          registry.fill(HIST("hClusterSizeOnlyITS2"), averageClusterSize);
+          if (averageClusterSize > 5.5) {
+            booleanAvgClusterSizePerTrackITSonly.push_back(1);
+          } else {
+            booleanAvgClusterSizePerTrackITSonly.push_back(2);
+          }
         }
 
       } // track loop
@@ -480,7 +502,8 @@ struct sgExclusivePhi {
       // Creating phis and saving all the information
       // in the case that there are ONLY 2 PV
 
-      if ((collision.posZ() < -10) || (collision.posZ() > 10)) {
+      // if ((collision.posZ() < -10) || (collision.posZ() > 10)) {
+      if (fabs(collision.posZ()) < 10.) {
         if (allTracksAreKaons.size() == 2) {
           registry.fill(HIST("hSelectionCounter2"), 7);
           for (auto kaon : allTracksAreKaons) {
@@ -526,11 +549,11 @@ struct sgExclusivePhi {
               registry.fill(HIST("PHI/hCostheta_Phi"), phiPhi, costhetaPhi);
               registry.fill(HIST("PHI/hUnlikePt"), phiWithoutPID.Pt());
               registry.fill(HIST("PHI/hMassUnlike"), phiWithoutPID.M());
-              if (phiWithoutPID.Pt() < 0.2) {
+              if (phiWithoutPID.Pt() < 0.1) {
                 registry.fill(HIST("hSelectionCounter2"), 9);
                 registry.fill(HIST("PHI/hCoherentPhiWithoutPID"), phiWithoutPID.M());
               }
-              if (phiWithoutPID.Pt() > 0.2) {
+              if (phiWithoutPID.Pt() > 0.1) {
                 registry.fill(HIST("hSelectionCounter2"), 10);
                 registry.fill(HIST("PHI/hInCoherentPhiWithoutPID"), phiWithoutPID.M());
               }
@@ -666,6 +689,21 @@ struct sgExclusivePhi {
           }
           averageClusterSize /= 7.;
           registry.fill(HIST("hClusterSizeOnlyITS"), averageClusterSize);
+          if (booleanAvgClusterSizePerTrackITSonly.size() == 1 && booleanAvgClusterSizePerTrackITSonly[0] == 1) {
+            registry.fill(HIST("hClusterSizeOnlyITS3"), averageClusterSize);
+          }
+
+
+          int clusterSizeKaonBand[7];
+          double averageClusterSizeKaonBand = 0.;
+          for (int i = 0; i < 7; i++) { // info stored in 4 bits
+            clusterSizeKaonBand[i] = (((1 << 4) - 1) & (onlyKaonBandPID[0].itsClusterSizes() >> 4 * i));
+            averageClusterSizeKaonBand += static_cast<double>(clusterSizeKaonBand[i]);
+          }
+          averageClusterSizeKaonBand /= 7.;
+          if (booleanAvgClusterSizePerTrackKaonBand.size() == 1 && booleanAvgClusterSizePerTrackKaonBand[0] == 1) {
+            registry.fill(HIST("hClusterSizeOnlyIdentifiedKaons2"), averageClusterSizeKaonBand);
+          }
 
           TLorentzVector reallyPhi;
           reallyPhi += allTracksAreKaonsBandPID[0];
@@ -675,6 +713,23 @@ struct sgExclusivePhi {
           if (reallyPhi.Pt() < 0.2) {
             registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon"), reallyPhi.M());
           }
+
+          if (booleanAvgClusterSizePerTrackKaonBand.size() == 1 && booleanAvgClusterSizePerTrackKaonBand[0] == 1) {
+            registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon2"), reallyPhi.M(), reallyPhi.Pt());
+            registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon2"), reallyPhi.Pt());
+            if (reallyPhi.Pt() < 0.2) {
+              registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon2"), reallyPhi.M());
+            }
+          }
+
+          if (booleanAvgClusterSizePerTrackKaonBand.size() == 1 && booleanAvgClusterSizePerTrackITSonly.size() == 1 && booleanAvgClusterSizePerTrackKaonBand[0] == 1 && booleanAvgClusterSizePerTrackITSonly[0] == 1) {
+            registry.fill(HIST("KaonBandPHI/hMassPtPhiIdentifiedKaonAndITSkaon3"), reallyPhi.M(), reallyPhi.Pt());
+            registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaonAndITSkaon3"), reallyPhi.Pt());
+            if (reallyPhi.Pt() < 0.2) {
+              registry.fill(HIST("KaonBandPHI/hMassPhiIdentifiedKaonAndITSkaon3"), reallyPhi.M());
+            }
+          }
+
         }
       } // Kaon Band
     }   // double gap


### PR DESCRIPTION
Exclusive phi->KK:
- adding selections on the average cluster sizes in ITS 
- misidentified electrons are already relativistic -> small cluster size

Exclusive phi->ee:
- identified bug in the selection for the angles of the pair
- added study on the aperture of the angle of the pair (names could be improved though)

Pentaquark searches:
- relaxed global pT requirement on the tracks
- tightened a lot the pT requirement on the lepton tracks
- tightened the aperture of the Jpsi mass window to look for pentaquarks

