### PR TITLE
PWGJE : addition of prompt/non-prompt data column to MC process function

### DIFF
--- a/PWGJE/Tasks/hffragmentationfunction.cxx
+++ b/PWGJE/Tasks/hffragmentationfunction.cxx
@@ -74,7 +74,7 @@ DECLARE_SOA_COLUMN(HfPhi, hfphi, float);
 DECLARE_SOA_COLUMN(HfMass, hfmass, float);
 DECLARE_SOA_COLUMN(HfY, hfy, float);
 DECLARE_SOA_COLUMN(HfMatch, hfmatch, bool);
-DECLARE_SOA_COLUMN(HfPrompt, hfprompt, bool);
+DECLARE_SOA_COLUMN(HfPrompt, hfPrompt, bool);
 } // namespace jet_distance
 DECLARE_SOA_TABLE(JetDistanceTable, "AOD", "JETDISTTABLE",
                   jet_distance::JetHfDist,
@@ -223,8 +223,8 @@ struct HfFragmentationFunctionTask {
 
           // store data in MC detector level table
           mcddistJetTable(axisDistance,
-                          mcdjet.pt(), mcdjet.eta(), mcdjet.phi(),                                                                                                                   // detector level jet
-                          mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), (mcdd0cand.originMcRec() == RecoDecay::OriginType::Prompt) ? true : false, // detector level D0 candidate
+                          mcdjet.pt(), mcdjet.eta(), mcdjet.phi(),                                                                                                    // detector level jet
+                          mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), (mcdd0cand.originMcRec() == RecoDecay::OriginType::Prompt), // detector level D0 candidate
                           mcdjet.has_matchedJetCand());
         }
       }
@@ -241,8 +241,8 @@ struct HfFragmentationFunctionTask {
 
         // store data in MC detector level table
         mcpdistJetTable(axisDistance,
-                        mcpjet.pt(), mcpjet.eta(), mcpjet.phi(),                                                                                                    // particle level jet
-                        mcpd0cand.pt(), mcpd0cand.eta(), mcpd0cand.phi(), mcpd0cand.y(), (mcpd0cand.originMcGen() == RecoDecay::OriginType::Prompt) ? true : false, // particle level D0
+                        mcpjet.pt(), mcpjet.eta(), mcpjet.phi(),                                                                                     // particle level jet
+                        mcpd0cand.pt(), mcpd0cand.eta(), mcpd0cand.phi(), mcpd0cand.y(), (mcpd0cand.originMcGen() == RecoDecay::OriginType::Prompt), // particle level D0
                         mcpjet.has_matchedJetCand());
       }
     }

--- a/PWGJE/Tasks/hffragmentationfunction.cxx
+++ b/PWGJE/Tasks/hffragmentationfunction.cxx
@@ -74,6 +74,7 @@ DECLARE_SOA_COLUMN(HfPhi, hfphi, float);
 DECLARE_SOA_COLUMN(HfMass, hfmass, float);
 DECLARE_SOA_COLUMN(HfY, hfy, float);
 DECLARE_SOA_COLUMN(HfMatch, hfmatch, bool);
+DECLARE_SOA_COLUMN(HfPrompt, hfprompt, bool);
 } // namespace jet_distance
 DECLARE_SOA_TABLE(JetDistanceTable, "AOD", "JETDISTTABLE",
                   jet_distance::JetHfDist,
@@ -94,6 +95,7 @@ DECLARE_SOA_TABLE(MCPJetDistanceTable, "AOD", "MCPJETDISTTABLE",
                   jet_distance::HfEta,
                   jet_distance::HfPhi,
                   jet_distance::HfY,
+                  jet_distance::HfPrompt,
                   jet_distance::HfMatch);
 DECLARE_SOA_TABLE(MCDJetDistanceTable, "AOD", "MCDJETDISTTABLE",
                   jet_distance::JetHfDist,
@@ -105,6 +107,7 @@ DECLARE_SOA_TABLE(MCDJetDistanceTable, "AOD", "MCDJETDISTTABLE",
                   jet_distance::HfPhi,
                   jet_distance::HfMass,
                   jet_distance::HfY,
+                  jet_distance::HfPrompt,
                   jet_distance::HfMatch);
 } // namespace o2::aod
 
@@ -219,7 +222,10 @@ struct HfFragmentationFunctionTask {
           axisDistance = RecoDecay::sqrtSumOfSquares(mcdjet.eta() - mcdd0cand.eta(), deltaPhi(mcdjet.phi(), mcdd0cand.phi()));
 
           // store data in MC detector level table
-          mcddistJetTable(axisDistance, mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), mcdjet.has_matchedJetCand());
+          mcddistJetTable(axisDistance, 
+                          mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), // detector level jet
+                          mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), (mcdd0cand.originMcRec() == RecoDecay::OriginType::Prompt) ? true : false, // detector level D0 candidate
+                          mcdjet.has_matchedJetCand());
         }
       }
 
@@ -234,7 +240,10 @@ struct HfFragmentationFunctionTask {
         axisDistance = RecoDecay::sqrtSumOfSquares(mcpjet.eta() - mcpd0cand.eta(), deltaPhi(mcpjet.phi(), mcpd0cand.phi()));
 
         // store data in MC detector level table
-        mcpdistJetTable(axisDistance, mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpd0cand.pt(), mcpd0cand.eta(), mcpd0cand.phi(), mcpd0cand.y(), mcpjet.has_matchedJetCand());
+        mcpdistJetTable(axisDistance, 
+                        mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), // particle level jet
+                        mcpd0cand.pt(), mcpd0cand.eta(), mcpd0cand.phi(), mcpd0cand.y(), (mcpd0cand.originMcGen() == RecoDecay::OriginType::Prompt) ? true : false, // particle level D0
+                        mcpjet.has_matchedJetCand());
       }
     }
   }

--- a/PWGJE/Tasks/hffragmentationfunction.cxx
+++ b/PWGJE/Tasks/hffragmentationfunction.cxx
@@ -222,8 +222,8 @@ struct HfFragmentationFunctionTask {
           axisDistance = RecoDecay::sqrtSumOfSquares(mcdjet.eta() - mcdd0cand.eta(), deltaPhi(mcdjet.phi(), mcdd0cand.phi()));
 
           // store data in MC detector level table
-          mcddistJetTable(axisDistance, 
-                          mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), // detector level jet
+          mcddistJetTable(axisDistance,
+                          mcdjet.pt(), mcdjet.eta(), mcdjet.phi(),                                                                                                                   // detector level jet
                           mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), (mcdd0cand.originMcRec() == RecoDecay::OriginType::Prompt) ? true : false, // detector level D0 candidate
                           mcdjet.has_matchedJetCand());
         }
@@ -240,8 +240,8 @@ struct HfFragmentationFunctionTask {
         axisDistance = RecoDecay::sqrtSumOfSquares(mcpjet.eta() - mcpd0cand.eta(), deltaPhi(mcpjet.phi(), mcpd0cand.phi()));
 
         // store data in MC detector level table
-        mcpdistJetTable(axisDistance, 
-                        mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), // particle level jet
+        mcpdistJetTable(axisDistance,
+                        mcpjet.pt(), mcpjet.eta(), mcpjet.phi(),                                                                                                    // particle level jet
                         mcpd0cand.pt(), mcpd0cand.eta(), mcpd0cand.phi(), mcpd0cand.y(), (mcpd0cand.originMcGen() == RecoDecay::OriginType::Prompt) ? true : false, // particle level D0
                         mcpjet.has_matchedJetCand());
       }


### PR DESCRIPTION
PWGJE: prompt/non-prompt D0 data column was added to MC tables.
If the candidate/particle is prompt a boolean `true` value is stored and `false` otherwise
Prompt/non-prompt information will be used for efficiency estimation and feed-down subtraction.