### PR TITLE
PWGHF: update sparse axes in taskCorrelationDMesonPairs.cxx

### DIFF
--- a/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
@@ -53,14 +53,10 @@ enum D0Type {
 
 struct HfTaskCorrelationDMesonPairs {
   // Configurables to set sparse axes
-  ConfigurableAxis thnConfigAxisInvMassCand1{"thnConfigAxisInvMassCand1", {200, 1.6, 2.1}, "Cand. 1 Inv-mass bins"};
-  ConfigurableAxis thnConfigAxisInvMassCand2{"thnConfigAxisInvMassCand2", {200, 1.6, 2.1}, "Cand. 2 Inv-mass bins"};
-  ConfigurableAxis thnConfigAxisPtCand1{"thnConfigAxisPtCand1", {25, 0., 24.}, "Cand. 1 pT bins"};
-  ConfigurableAxis thnConfigAxisPtCand2{"thnConfigAxisPtCand2", {25, 0., 24.}, "Cand. 2 pT bins"};
-  ConfigurableAxis thnConfigAxisYCand1{"thnConfigAxisYCand1", {10, -1, 1}, "Cand. 1 rapidity bins"};
-  ConfigurableAxis thnConfigAxisYCand2{"thnConfigAxisYCand2", {10, -1, 1}, "Cand. 2 rapidity bins"};
-  ConfigurableAxis thnConfigAxisCandType1{"thnConfigAxisCandType1", {4, -0.5, 3.5}, "Cand. 1 Type"};
-  ConfigurableAxis thnConfigAxisCandType2{"thnConfigAxisCandType2", {4, -0.5, 3.5}, "Cand. 2 Type"};
+  ConfigurableAxis thnConfigAxisInvMass{"thnConfigAxisInvMassCand1", {200, 1.6, 2.1}, "Inv-mass bins"};
+  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPtCand1", {25, 0., 24.}, "pT bins"};
+  ConfigurableAxis thnConfigAxisY{"thnConfigAxisYCand1", {10, -1, 1}, "Rapidity bins"};
+  ConfigurableAxis thnConfigAxisCandType{"thnConfigAxisCandType1", {4, -0.5, 3.5}, "Candidate Type"};
 
   HistogramRegistry registry{
     "registry",
@@ -68,14 +64,14 @@ struct HfTaskCorrelationDMesonPairs {
 
   void init(InitContext&)
   {
-    const AxisSpec thnAxisInvMassCand1{thnConfigAxisInvMassCand1, "inv. mass D_{1} (GeV/#it{c}^{2})"};
-    const AxisSpec thnAxisInvMassCand2{thnConfigAxisInvMassCand2, "inv. mass D_{2} (GeV/#it{c}^{2})"};
-    const AxisSpec thnAxisPtCand1{thnConfigAxisPtCand1, "#it{p}_{T}^{D_{1}} (GeV/#it{c})"};
-    const AxisSpec thnAxisPtCand2{thnConfigAxisPtCand2, "#it{p}_{T}^{D_{2}} (GeV/#it{c})"};
-    const AxisSpec thnAxisYCand1{thnConfigAxisYCand1, "#it{y} D_{1}"};
-    const AxisSpec thnAxisYCand2{thnConfigAxisYCand2, "#it{y} D_{2}"};
-    const AxisSpec thnAxisCandType1{thnConfigAxisCandType1, "Type D_{1}"};
-    const AxisSpec thnAxisCandType2{thnConfigAxisCandType2, "Type D_{2}"};
+    const AxisSpec thnAxisInvMassCand1{thnConfigAxisInvMass, "inv. mass D_{1} (GeV/#it{c}^{2})"};
+    const AxisSpec thnAxisInvMassCand2{thnConfigAxisInvMass, "inv. mass D_{2} (GeV/#it{c}^{2})"};
+    const AxisSpec thnAxisPtCand1{thnConfigAxisPt, "#it{p}_{T}^{D_{1}} (GeV/#it{c})"};
+    const AxisSpec thnAxisPtCand2{thnConfigAxisPt, "#it{p}_{T}^{D_{2}} (GeV/#it{c})"};
+    const AxisSpec thnAxisYCand1{thnConfigAxisY, "#it{y} D_{1}"};
+    const AxisSpec thnAxisYCand2{thnConfigAxisY, "#it{y} D_{2}"};
+    const AxisSpec thnAxisCandType1{thnConfigAxisCandType, "Type D_{1}"};
+    const AxisSpec thnAxisCandType2{thnConfigAxisCandType, "Type D_{2}"};
 
     registry.add("hMass2DCorrelationPairsLS", "hMass2DCorrelationPairsLS", HistType::kTHnSparseD, {thnAxisInvMassCand1, thnAxisInvMassCand2, thnAxisPtCand1, thnAxisPtCand2, thnAxisYCand1, thnAxisYCand2, thnAxisCandType1, thnAxisCandType2});
     registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLS"))->Sumw2();

--- a/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
@@ -51,60 +51,41 @@ enum D0Type {
 };
 } // namespace
 
-// string definitions, used for histogram axis labels
-const char stringCorrelationPairs[193] = "D meson pair candidates 2D;inv. mass D_{1} (GeV/#it{c}^{2});inv. mass D_{2} (GeV/#it{c}^{2});#it{p}_{T}^{D_{1}} (GeV/#it{c});#it{p}_{T}^{D_{2}} (GeV/#it{c});#eta D_{1};#eta D_{2};type1;type2;";
-const char stringCorrelationPairsFinerBinning[207] = "D meson pair candidates 2D Finer Binning;inv. mass D_{1} (GeV/#it{c}^{2});inv. mass D_{2} (GeV/#it{c}^{2});#it{p}_{T}^{D_{1}} (GeV/#it{c});#it{p}_{T}^{D_{2}} (GeV/#it{c});#eta D_{1};#eta D_{2};type1;type2;";
-
-// definition of vectors for standard ptbin and invariant mass configurables
-const int nPtBinsCorrelations = 8;
-const double ptBinsCorrelations[nPtBinsCorrelations + 1] = {0., 2., 4., 6., 8., 12., 16., 24., 99.};
-auto vecPtBinsCorrelations = std::vector<double>{ptBinsCorrelations, ptBinsCorrelations + nPtBinsCorrelations + 1};
-
 struct HfTaskCorrelationDMesonPairs {
-  // Enable histograms with finer pT and y binning
-  Configurable<bool> enableFinerBinning{"enableFinerBinning", false, "Enable histograms with finer pT and y binning"};
-  Configurable<std::vector<double>> binsPtCorrelations{"binsPtCorrelations", std::vector<double>{vecPtBinsCorrelations}, "pT bin limits for correlation plots"};
-
-  // HistoTypes
-  HistogramConfigSpec hTHnMass2DCorrPairs{HistType::kTHnSparseD, {{200, 1.6, 2.1}, {200, 1.6, 2.1}, {10, 0., 10.}, {10, 0., 10.}, {10, -1, 1}, {10, -1, 1}, {4, -0.5, 3.5}, {4, -0.5, 3.5}}}; // note: axes 3 and 4 (the pT) are updated in the init();
-  HistogramConfigSpec hTHnMass2DCorrPairsFinerBinning{HistType::kTHnSparseD, {{200, 1.6, 2.1}, {200, 1.6, 2.1}, {60, 1., 6.}, {60, 1., 6.}, {160, -0.8, 0.8}, {160, -0.8, 0.8}, {4, -0.5, 3.5}, {4, -0.5, 3.5}}};
+  // Configurables to set sparse axes
+  ConfigurableAxis thnConfigAxisInvMassCand1{"thnConfigAxisInvMassCand1", {200, 1.6, 2.1}, "Cand. 1 Inv-mass bins"};
+  ConfigurableAxis thnConfigAxisInvMassCand2{"thnConfigAxisInvMassCand2", {200, 1.6, 2.1}, "Cand. 2 Inv-mass bins"};
+  ConfigurableAxis thnConfigAxisPtCand1{"thnConfigAxisPtCand1", {25, 0., 24.}, "Cand. 1 pT bins"};
+  ConfigurableAxis thnConfigAxisPtCand2{"thnConfigAxisPtCand2", {25, 0., 24.}, "Cand. 2 pT bins"};
+  ConfigurableAxis thnConfigAxisYCand1{"thnConfigAxisYCand1", {10, -1, 1}, "Cand. 1 rapidity bins"};
+  ConfigurableAxis thnConfigAxisYCand2{"thnConfigAxisYCand2", {10, -1, 1}, "Cand. 2 rapidity bins"};
+  ConfigurableAxis thnConfigAxisCandType1{"thnConfigAxisCandType1", {4, -0.5, 3.5}, "Cand. 1 Type"};
+  ConfigurableAxis thnConfigAxisCandType2{"thnConfigAxisCandType2", {4, -0.5, 3.5}, "Cand. 2 Type"};
 
   HistogramRegistry registry{
-    "registry",
-    {{"hMass2DCorrelationPairsLS", stringCorrelationPairs, hTHnMass2DCorrPairs},
-     {"hMass2DCorrelationPairsOS", stringCorrelationPairs, hTHnMass2DCorrPairs},
-     {"hMass2DCorrelationPairsLSMcGen", stringCorrelationPairs, hTHnMass2DCorrPairs},
-     {"hMass2DCorrelationPairsOSMcGen", stringCorrelationPairs, hTHnMass2DCorrPairs}}};
+    "registry", {}
+  };
 
   void init(InitContext&)
   {
-    // redefinition of pT axes for THnSparse holding correlation entries
-    int nBinspTaxis = binsPtCorrelations->size() - 1;
-    const double* valuespTaxis = binsPtCorrelations->data();
+    const AxisSpec thnAxisInvMassCand1{thnConfigAxisInvMassCand1, "inv. mass D_{1} (GeV/#it{c}^{2})"};
+    const AxisSpec thnAxisInvMassCand2{thnConfigAxisInvMassCand2, "inv. mass D_{2} (GeV/#it{c}^{2})"};
+    const AxisSpec thnAxisPtCand1{thnConfigAxisPtCand1, "#it{p}_{T}^{D_{1}} (GeV/#it{c})"};
+    const AxisSpec thnAxisPtCand2{thnConfigAxisPtCand2, "#it{p}_{T}^{D_{2}} (GeV/#it{c})"};
+    const AxisSpec thnAxisYCand1{thnConfigAxisYCand1, "#it{y} D_{1}"};
+    const AxisSpec thnAxisYCand2{thnConfigAxisYCand2, "#it{y} D_{2}"};
+    const AxisSpec thnAxisCandType1{thnConfigAxisCandType1, "Type D_{1}"};
+    const AxisSpec thnAxisCandType2{thnConfigAxisCandType2, "Type D_{2}"};
 
-    if (enableFinerBinning) {
-      registry.add("hMass2DCorrelationPairsLSFinerBinning", stringCorrelationPairsFinerBinning, hTHnMass2DCorrPairsFinerBinning);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLSFinerBinning"))->Sumw2();
-      registry.add("hMass2DCorrelationPairsOSFinerBinning", stringCorrelationPairsFinerBinning, hTHnMass2DCorrPairsFinerBinning);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOSFinerBinning"))->Sumw2();
+    registry.add("hMass2DCorrelationPairsLS", "hMass2DCorrelationPairsLS", HistType::kTHnSparseD, {thnAxisInvMassCand1, thnAxisInvMassCand2, thnAxisPtCand1, thnAxisPtCand2, thnAxisYCand1, thnAxisYCand2, thnAxisCandType1, thnAxisCandType2});
+    registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLS"))->Sumw2();
+    registry.add("hMass2DCorrelationPairsOS", "hMass2DCorrelationPairsOS", HistType::kTHnSparseD, {thnAxisInvMassCand1, thnAxisInvMassCand2, thnAxisPtCand1, thnAxisPtCand2, thnAxisYCand1, thnAxisYCand2, thnAxisCandType1, thnAxisCandType2});
+    registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOS"))->Sumw2();
 
-      registry.add("hMass2DCorrelationPairsLSMcGenFinerBinning", stringCorrelationPairsFinerBinning, hTHnMass2DCorrPairsFinerBinning);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLSMcGenFinerBinning"))->Sumw2();
-      registry.add("hMass2DCorrelationPairsOSMcGenFinerBinning", stringCorrelationPairsFinerBinning, hTHnMass2DCorrPairsFinerBinning);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOSMcGenFinerBinning"))->Sumw2();
-    }
-
-    for (int i = 2; i <= 3; i++) {
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLS"))->GetAxis(i)->Set(nBinspTaxis, valuespTaxis);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLS"))->Sumw2();
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOS"))->GetAxis(i)->Set(nBinspTaxis, valuespTaxis);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOS"))->Sumw2();
-
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLSMcGen"))->GetAxis(i)->Set(nBinspTaxis, valuespTaxis);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLSMcGen"))->Sumw2();
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOSMcGen"))->GetAxis(i)->Set(nBinspTaxis, valuespTaxis);
-      registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOSMcGen"))->Sumw2();
-    }
+    registry.add("hMass2DCorrelationPairsLSMcGen", "hMass2DCorrelationPairsLSMcGen", HistType::kTHnSparseD, {thnAxisInvMassCand1, thnAxisInvMassCand2, thnAxisPtCand1, thnAxisPtCand2, thnAxisYCand1, thnAxisYCand2, thnAxisCandType1, thnAxisCandType2});
+    registry.get<THnSparse>(HIST("hMass2DCorrelationPairsLSMcGen"))->Sumw2();
+    registry.add("hMass2DCorrelationPairsOSMcGen", "hMass2DCorrelationPairsOSMcGen", HistType::kTHnSparseD, {thnAxisInvMassCand1, thnAxisInvMassCand2, thnAxisPtCand1, thnAxisPtCand2, thnAxisYCand1, thnAxisYCand2, thnAxisCandType1, thnAxisCandType2});
+    registry.get<THnSparse>(HIST("hMass2DCorrelationPairsOSMcGen"))->Sumw2();
   }
 
   uint getD0Type(uint const& candidateType)
@@ -139,28 +120,16 @@ struct HfTaskCorrelationDMesonPairs {
 
       if (TESTBIT(pairType, DD)) {
         registry.fill(HIST("hMass2DCorrelationPairsLS"), massDCand1, massDCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsLSFinerBinning"), massDCand1, massDCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        }
       }
       if (TESTBIT(pairType, DbarDbar)) {
         registry.fill(HIST("hMass2DCorrelationPairsLS"), massDbarCand1, massDbarCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsLSFinerBinning"), massDbarCand1, massDbarCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        }
       }
 
       if (TESTBIT(pairType, DDbar)) {
         registry.fill(HIST("hMass2DCorrelationPairsOS"), massDCand1, massDbarCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsOSFinerBinning"), massDCand1, massDbarCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        }
       }
       if (TESTBIT(pairType, DbarD)) {
         registry.fill(HIST("hMass2DCorrelationPairsOS"), massDbarCand1, massDCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsOSFinerBinning"), massDbarCand1, massDCand2, ptCand1, ptCand2, yCand1, yCand2, d0Type1, d0Type2);
-        }
       }
     }
   }
@@ -184,27 +153,15 @@ struct HfTaskCorrelationDMesonPairs {
 
       if (TESTBIT(pairType, DD)) {
         registry.fill(HIST("hMass2DCorrelationPairsLSMcGen"), massDParticle1, massDParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsLSMcGenFinerBinning"), massDParticle1, massDParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        }
       }
       if (TESTBIT(pairType, DbarDbar)) {
         registry.fill(HIST("hMass2DCorrelationPairsLSMcGen"), massDbarParticle1, massDbarParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsLSMcGenFinerBinning"), massDbarParticle1, massDbarParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        }
       }
       if (TESTBIT(pairType, DDbar)) {
         registry.fill(HIST("hMass2DCorrelationPairsOSMcGen"), massDParticle1, massDbarParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsOSMcGenFinerBinning"), massDParticle1, massDbarParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        }
       }
       if (TESTBIT(pairType, DbarD)) {
         registry.fill(HIST("hMass2DCorrelationPairsOSMcGen"), massDbarParticle1, massDParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        if (enableFinerBinning) {
-          registry.fill(HIST("hMass2DCorrelationPairsOSMcGenFinerBinning"), massDbarParticle1, massDParticle2, ptParticle1, ptParticle2, yParticle1, yParticle2, d0Type1, d0Type2);
-        }
       }
     }
   }

--- a/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDMesonPairs.cxx
@@ -53,10 +53,10 @@ enum D0Type {
 
 struct HfTaskCorrelationDMesonPairs {
   // Configurables to set sparse axes
-  ConfigurableAxis thnConfigAxisInvMass{"thnConfigAxisInvMassCand1", {200, 1.6, 2.1}, "Inv-mass bins"};
-  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPtCand1", {25, 0., 24.}, "pT bins"};
-  ConfigurableAxis thnConfigAxisY{"thnConfigAxisYCand1", {10, -1, 1}, "Rapidity bins"};
-  ConfigurableAxis thnConfigAxisCandType{"thnConfigAxisCandType1", {4, -0.5, 3.5}, "Candidate Type"};
+  ConfigurableAxis thnConfigAxisInvMass{"thnConfigAxisInvMass", {200, 1.6, 2.1}, "Inv-mass bins"};
+  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {25, 0., 24.}, "pT bins"};
+  ConfigurableAxis thnConfigAxisY{"thnConfigAxisY", {10, -1, 1}, "Rapidity bins"};
+  ConfigurableAxis thnConfigAxisCandType{"thnConfigAxisCandType", {4, -0.5, 3.5}, "Candidate Type"};
 
   HistogramRegistry registry{
     "registry",

--- a/PWGLF/Tasks/Nuspex/LFNucleiBATask.cxx
+++ b/PWGLF/Tasks/Nuspex/LFNucleiBATask.cxx
@@ -350,7 +350,7 @@ struct LFNucleiBATask {
     // tracks
     // DCAxy,z
     if (makeDCABeforeCutPlots) {
-      histos.add<TH3>("tracks/dca/before/hDCAxyVsDCAzVsPt", "DCAxy vs DCAz vs Pt/z; DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
+      histos.add<TH3>("tracks/dca/before/hDCAxyVsDCAzVsPt", "DCAxy vs DCAz vs Pt/z; DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
       histos.add<TH2>("tracks/dca/before/hDCAxyVsDCAz", "DCAxy vs DCAz (before cuts)", HistType::kTH2F, {{1100, -1.1, 1.1}, {1100, -1.1, 1.1}});
       histos.add<TH1>("tracks/dca/before/hDCAxy", "DCAxy", HistType::kTH1F, {dcaxyAxis});
       histos.add<TH1>("tracks/dca/before/hDCAz", "DCAz", HistType::kTH1F, {dcazAxis});
@@ -358,16 +358,16 @@ struct LFNucleiBATask {
       histos.add<TH2>("tracks/dca/before/hDCAzVsPt", "DCAz vs Pt", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
 
       if (enablePr) {
-        // histos.add<TH3>("tracks/proton/dca/before/hDCAxyVsDCAzVsPtProton", "DCAxy vs DCAz vs Pt/z (p)", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
-        // histos.add<TH3>("tracks/proton/dca/before/hDCAxyVsDCAzVsPtantiProton", "DCAxy vs DCAz vs Pt/z (#bar{p})", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/proton/dca/before/hDCAxyVsDCAzVsPtProton", "DCAxy vs DCAz vs Pt/z (p)", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/proton/dca/before/hDCAxyVsDCAzVsPtantiProton", "DCAxy vs DCAz vs Pt/z (#bar{p})", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
         histos.add<TH2>("tracks/proton/dca/before/hDCAxyVsPtProton", "DCAxy vs Pt (p)", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/proton/dca/before/hDCAxyVsPtantiProton", "DCAxy vs Pt (#bar{p})", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/proton/dca/before/hDCAzVsPtProton", "DCAz vs Pt (p)", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
         histos.add<TH2>("tracks/proton/dca/before/hDCAzVsPtantiProton", "DCAz vs Pt (#bar{p})", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
       }
       if (enableDe) {
-        // histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsDCAzVsPtDeuteron", "DCAxy vs DCAz vs Pt/z (d)", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
-        // histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsDCAzVsPtantiDeuteron", "DCAxy vs DCAz vs Pt/z (#bar{d})", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsDCAzVsPtDeuteron", "DCAxy vs DCAz vs Pt/z (d)", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsDCAzVsPtantiDeuteron", "DCAxy vs DCAz vs Pt/z (#bar{d})", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
         if (enableCentrality) {
           histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsPtDeuteronVsMult", "DCAxy vs Pt (d)", HistType::kTH3F, {{ptAxis}, {dcaxyAxis}, {binsPercentile}});
           histos.add<TH3>("tracks/deuteron/dca/before/hDCAxyVsPtantiDeuteronVsMult", "DCAxy vs Pt (#bar{d})", HistType::kTH3F, {{ptAxis}, {dcaxyAxis}, {binsPercentile}});
@@ -384,16 +384,16 @@ struct LFNucleiBATask {
         histos.add<TH2>("tracks/deuteron/dca/before/hDCAzVsPtantiDeuteronNoTOF", "DCAz vs Pt (#bar{d})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
       }
       if (enableTr) {
-        // histos.add<TH3>("tracks/triton/dca/before/hDCAxyVsDCAzVsPtTriton", "DCAxy vs DCAz vs Pt/z (t)", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
-        // histos.add<TH3>("tracks/triton/dca/before/hDCAxyVsDCAzVsPtantiTriton", "DCAxy vs DCAz vs Pt/z (#bar{t})", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/triton/dca/before/hDCAxyVsDCAzVsPtTriton", "DCAxy vs DCAz vs Pt/z (t)", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
+        // histos.add<TH3>("tracks/triton/dca/before/hDCAxyVsDCAzVsPtantiTriton", "DCAxy vs DCAz vs Pt/z (#bar{t})", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtHe}});
         histos.add<TH2>("tracks/triton/dca/before/hDCAxyVsPtTriton", "DCAxy vs Pt (t)", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/triton/dca/before/hDCAxyVsPtantiTriton", "DCAxy vs Pt (#bar{t})", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/triton/dca/before/hDCAzVsPtTriton", "DCAz vs Pt (t)", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
         histos.add<TH2>("tracks/triton/dca/before/hDCAzVsPtantiTriton", "DCAz vs Pt (#bar{t})", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
       }
       if (enableHe) {
-        histos.add<TH3>("tracks/helium/dca/before/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
-        histos.add<TH3>("tracks/helium/dca/before/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
+        histos.add<TH3>("tracks/helium/dca/before/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
+        histos.add<TH3>("tracks/helium/dca/before/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
         histos.add<TH2>("tracks/helium/dca/before/hDCAxyVsPtHelium", "DCAxy vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
         histos.add<TH2>("tracks/helium/dca/before/hDCAxyVsPtantiHelium", "DCAxy vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
         histos.add<TH2>("tracks/helium/dca/before/hDCAzVsPtHelium", "DCAz vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
@@ -405,8 +405,8 @@ struct LFNucleiBATask {
         histos.add<TH2>("tracks/helium/dca/before/hDCAzVsPtantiHeliumNoTOF", "DCAz vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
 
         if (doTOFplots) {
-          histos.add<TH3>("tracks/helium/dca/before/TOF/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He) (w/TOF); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
-          histos.add<TH3>("tracks/helium/dca/before/TOF/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}) (w/TOF); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
+          histos.add<TH3>("tracks/helium/dca/before/TOF/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He) (w/TOF); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
+          histos.add<TH3>("tracks/helium/dca/before/TOF/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}) (w/TOF); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
           histos.add<TH2>("tracks/helium/dca/before/TOF/hDCAxyVsPtHelium", "DCAxy vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
           histos.add<TH2>("tracks/helium/dca/before/TOF/hDCAxyVsPtantiHelium", "DCAxy vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
           histos.add<TH2>("tracks/helium/dca/before/TOF/hDCAzVsPtHelium", "DCAz vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
@@ -414,8 +414,8 @@ struct LFNucleiBATask {
         }
       }
       if (enableAl) {
-        // histos.add<TH3>("tracks/alpha/dca/before/hDCAxyVsDCAzVsPtAlpha", "DCAxy vs DCAz vs Pt/z (#alpha)", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
-        // histos.add<TH3>("tracks/alpha/dca/before/hDCAxyVsDCAzVsPtantiAlpha", "DCAxy vs DCAz vs Pt/z (#bar{#alpha})", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
+        // histos.add<TH3>("tracks/alpha/dca/before/hDCAxyVsDCAzVsPtAlpha", "DCAxy vs DCAz vs Pt/z (#alpha)", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
+        // histos.add<TH3>("tracks/alpha/dca/before/hDCAxyVsDCAzVsPtantiAlpha", "DCAxy vs DCAz vs Pt/z (#bar{#alpha})", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
         histos.add<TH2>("tracks/alpha/dca/before/hDCAxyVsPtAlpha", "DCAxy vs Pt (#alpha)", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/alpha/dca/before/hDCAxyVsPtantiAlpha", "DCAxy vs Pt (#bar{#alpha})", HistType::kTH2F, {{ptAxis}, {dcaxyAxis}});
         histos.add<TH2>("tracks/alpha/dca/before/hDCAzVsPtAlpha", "DCAz vs Pt (#alpha)", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
@@ -448,16 +448,16 @@ struct LFNucleiBATask {
       histos.add<TH2>("tracks/triton/dca/after/hDCAzVsPtantiTriton", "DCAz vs Pt (#bar{t})", HistType::kTH2F, {{ptAxis}, {dcazAxis}});
     }
     if (enableHe && makeDCAAfterCutPlots) {
-      histos.add<TH3>("tracks/helium/dca/after/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
-      histos.add<TH3>("tracks/helium/dca/after/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
+      histos.add<TH3>("tracks/helium/dca/after/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
+      histos.add<TH3>("tracks/helium/dca/after/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
       histos.add<TH2>("tracks/helium/dca/after/hDCAxyVsPtHelium", "DCAxy vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
       histos.add<TH2>("tracks/helium/dca/after/hDCAxyVsPtantiHelium", "DCAxy vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
       histos.add<TH2>("tracks/helium/dca/after/hDCAzVsPtHelium", "DCAz vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
       histos.add<TH2>("tracks/helium/dca/after/hDCAzVsPtantiHelium", "DCAz vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});
 
       if (doTOFplots) {
-        histos.add<TH3>("tracks/helium/dca/after/TOF/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
-        histos.add<TH3>("tracks/helium/dca/after/TOF/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, -0.6f}, {320, -0.8f, -0.8f}, {binsPtZHe}});
+        histos.add<TH3>("tracks/helium/dca/after/TOF/hDCAxyVsDCAzVsPtHelium", "DCAxy vs DCAz vs Pt/z (He); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
+        histos.add<TH3>("tracks/helium/dca/after/TOF/hDCAxyVsDCAzVsPtantiHelium", "DCAxy vs DCAz vs Pt/z (#bar{He}); DCAxy; DCAz", HistType::kTH3F, {{240, -0.6f, 0.6f}, {320, -0.8f, 0.8f}, {binsPtZHe}});
         histos.add<TH2>("tracks/helium/dca/after/TOF/hDCAxyVsPtHelium", "DCAxy vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
         histos.add<TH2>("tracks/helium/dca/after/TOF/hDCAxyVsPtantiHelium", "DCAxy vs Pt (#bar{He})", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcaxyAxis}});
         histos.add<TH2>("tracks/helium/dca/after/TOF/hDCAzVsPtHelium", "DCAz vs Pt (He)", HistType::kTH2F, {{900, 0.5f, 5.f}, {dcazAxis}});


### PR DESCRIPTION
This PR aims to update the way sparse axes are configured in taskCorrelationDMesonPairs.cxx so that they can be modified directly on Hyperloop