### PR TITLE
PWGLF: adapt V0 TOF PID to be used also for coll-unassoc V0s

### DIFF
--- a/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
@@ -49,6 +49,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
 #include "CommonConstants/PhysicsConstants.h"
 #include "Common/TableProducer/PID/pidTOFBase.h"
 #include "Common/DataModel/PIDResponse.h"
@@ -75,6 +76,9 @@ struct lambdakzeropid {
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
+  // mean vertex position to be used if no collision associated
+  o2::dataformats::MeanVertexObject* mVtx = nullptr;
+
   // For manual sliceBy
   Preslice<V0OriginalDatas> perCollisionOriginal = o2::aod::v0data::collisionId;
   ;
@@ -100,6 +104,11 @@ struct lambdakzeropid {
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
   Configurable<std::string> nSigmaPath{"nSigmaPath", "Users/d/ddobrigk/stratof", "Path of information for n-sigma calculation"};
+  Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
+
+  // manual 
+  Configurable<int> manualRunNumber{"manualRunNumber", 544122, "manual run number if no collisions saved"};
+  Configurable<uint64_t> manualTimeStamp{"manualTimeStamp", 1696549226920, "manual time stamp if no collisions saved"};
 
   ConfigurableAxis axisEta{"axisEta", {20, -1.0f, +1.0f}, "#eta"};
   ConfigurableAxis axisDeltaTime{"axisDeltaTime", {2000, -1000.0f, +1000.0f}, "delta-time (ps)"};
@@ -318,10 +327,9 @@ struct lambdakzeropid {
     }
   }
 
-  template <typename TInformationClass>
-  void initCCDB(TInformationClass const& infoObject)
+  void initCCDB(int runNumber, uint64_t timeStamp)
   {
-    if (mRunNumber == infoObject.runNumber()) {
+    if (mRunNumber == runNumber) {
       return;
     }
 
@@ -333,11 +341,12 @@ struct lambdakzeropid {
         grpmag.setL3Current(30000.f / (d_bz / 5.0f));
       }
       o2::base::Propagator::initFieldFromGRP(&grpmag);
-      mRunNumber = infoObject.runNumber();
+      mVtx = ccdb->getForTimeStamp<o2::dataformats::MeanVertexObject>(mVtxPath, timeStamp);
+      mRunNumber = runNumber;
       return;
     }
 
-    auto run3grp_timestamp = infoObject.timestamp();
+    auto run3grp_timestamp = timeStamp;
     o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
     o2::parameters::GRPMagField* grpmag = 0x0;
     if (grpo) {
@@ -353,12 +362,13 @@ struct lambdakzeropid {
       o2::base::Propagator::initFieldFromGRP(grpmag);
       // Fetch magnetic field from ccdb for current collision
       d_bz = std::lround(5.f * grpmag->getL3Current() / 30000.f);
+      mVtx = ccdb->getForTimeStamp<o2::dataformats::MeanVertexObject>(mVtxPath, timeStamp);
       LOG(info) << "Retrieved GRP for timestamp " << run3grp_timestamp << " with magnetic field of " << d_bz << " kZG";
     }
 
     // if TOF Nsigma desired
     if (doNSigmas) {
-      nSigmaCalibObjects = ccdb->getForTimeStamp<TList>(nSigmaPath, infoObject.timestamp());
+      nSigmaCalibObjects = ccdb->getForTimeStamp<TList>(nSigmaPath, timeStamp);
       if (nSigmaCalibObjects) {
         LOGF(info, "loaded TList with this many objects: %i", nSigmaCalibObjects->GetEntries());
 
@@ -393,7 +403,7 @@ struct lambdakzeropid {
         }
       }
     }
-    mRunNumber = infoObject.runNumber();
+    mRunNumber = runNumber;
   }
 
   float velocity(float lMomentum, float lMass)
@@ -409,7 +419,7 @@ struct lambdakzeropid {
   void processV0Candidate(TCollision const& collision, TV0 const& v0, TTrack const& pTra, TTrack const& nTra)
   {
     // time of V0 segment
-    float lengthV0 = std::hypot(v0.x() - collision.posX(), v0.y() - collision.posY(), v0.z() - collision.posZ());
+    float lengthV0 = std::hypot(v0.x() - collision.getX(), v0.y() - collision.getY(), v0.z() - collision.getZ());
     float velocityK0Short = velocity(v0.p(), o2::constants::physics::MassKaonNeutral);
     float velocityLambda = velocity(v0.p(), o2::constants::physics::MassLambda);
     float timeK0Short = lengthV0 / velocityK0Short; // in picoseconds
@@ -582,43 +592,57 @@ struct lambdakzeropid {
 
   void processStandardData(aod::Collisions const& collisions, V0OriginalDatas const& V0s, TracksWithAllExtras const&, aod::BCsWithTimestamps const& /*bcs*/)
   {
-    auto collision = collisions.begin();
-    auto bc = collision.bc_as<aod::BCsWithTimestamps>();
-    // Fire up CCDB - based on standard collisions
-    initCCDB(bc);
-    for (const auto& collision : collisions) {
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = collision.globalIndex();
-      auto V0Table_thisCollision = V0s.sliceBy(perCollisionOriginal, collIdx);
-      histos.fill(HIST("hCandidateCounter"), V0Table_thisCollision.size());
-      // V0 table sliced
-      for (auto const& v0 : V0Table_thisCollision) {
-        // de-reference interlinks by hand for derived data
-        auto pTra = v0.posTrack_as<TracksWithAllExtras>();
-        auto nTra = v0.negTrack_as<TracksWithAllExtras>();
+    // Fire up CCDB with first collision in record. If no collisions, bypass
+    if(collisions.size()>0){
+      auto collision = collisions.begin();
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      initCCDB(bc.runNumber(), bc.timestamp());
+    }else{
+      initCCDB(manualRunNumber, manualTimeStamp);
+    }
 
-        processV0Candidate(collision, v0, pTra, nTra);
+    for (const auto& V0 : V0s) {
+      // for storing whatever is the relevant quantity for the PV
+      o2::dataformats::VertexBase primaryVertex;
+      if (V0.has_collision()) {
+        auto const& collision = V0.collision();
+        primaryVertex.setPos({collision.posX(), collision.posY(), collision.posZ()});
+        primaryVertex.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
+      } else {
+        primaryVertex.setPos({mVtx->getX(), mVtx->getY(), mVtx->getZ()});
       }
+
+      auto pTra = V0.posTrack_as<TracksWithAllExtras>();
+      auto nTra = V0.negTrack_as<TracksWithAllExtras>();
+      processV0Candidate(primaryVertex, V0, pTra, nTra);
     }
   }
 
   void processDerivedData(soa::Join<aod::StraCollisions, aod::StraStamps> const& collisions, V0DerivedDatas const& V0s, dauTracks const&)
   {
-    for (const auto& collision : collisions) {
-      // Fire up CCDB - based on StraCollisions for derived analysis
-      initCCDB(collision);
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = collision.globalIndex();
-      auto V0Table_thisCollision = V0s.sliceBy(perCollisionDerived, collIdx);
-      histos.fill(HIST("hCandidateCounter"), V0Table_thisCollision.size());
-      // V0 table sliced
-      for (auto const& v0 : V0Table_thisCollision) {
-        // de-reference interlinks by hand for derived data
-        auto pTra = v0.posTrackExtra_as<dauTracks>();
-        auto nTra = v0.negTrackExtra_as<dauTracks>();
+    // Fire up CCDB with first collision in record. If no collisions, bypass
+    if(collisions.size()>0){
+      auto collision = collisions.begin();
+      initCCDB(collision.runNumber(), collision.timestamp());
+    }else{
+      initCCDB(manualRunNumber, manualTimeStamp);
+    }
 
-        processV0Candidate(collision, v0, pTra, nTra);
+    for (const auto& V0 : V0s) {
+      // for storing whatever is the relevant quantity for the PV
+      o2::dataformats::VertexBase primaryVertex;
+      if (V0.has_straCollision()) {
+        auto const& collision = V0.straCollision();
+        primaryVertex.setPos({collision.posX(), collision.posY(), collision.posZ()});
+        // cov: won't be used anyways, all fine
+        primaryVertex.setCov(1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6);
+      } else {
+        primaryVertex.setPos({mVtx->getX(), mVtx->getY(), mVtx->getZ()});
       }
+
+      auto pTra = V0.posTrackExtra_as<dauTracks>();
+      auto nTra = V0.negTrackExtra_as<dauTracks>();
+      processV0Candidate(primaryVertex, V0, pTra, nTra);
     }
   }
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
@@ -106,7 +106,7 @@ struct lambdakzeropid {
   Configurable<std::string> nSigmaPath{"nSigmaPath", "Users/d/ddobrigk/stratof", "Path of information for n-sigma calculation"};
   Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
 
-  // manual 
+  // manual
   Configurable<int> manualRunNumber{"manualRunNumber", 544122, "manual run number if no collisions saved"};
   Configurable<uint64_t> manualTimeStamp{"manualTimeStamp", 1696549226920, "manual time stamp if no collisions saved"};
 
@@ -593,11 +593,11 @@ struct lambdakzeropid {
   void processStandardData(aod::Collisions const& collisions, V0OriginalDatas const& V0s, TracksWithAllExtras const&, aod::BCsWithTimestamps const& /*bcs*/)
   {
     // Fire up CCDB with first collision in record. If no collisions, bypass
-    if(collisions.size()>0){
+    if (collisions.size() > 0) {
       auto collision = collisions.begin();
       auto bc = collision.bc_as<aod::BCsWithTimestamps>();
       initCCDB(bc.runNumber(), bc.timestamp());
-    }else{
+    } else {
       initCCDB(manualRunNumber, manualTimeStamp);
     }
 
@@ -621,10 +621,10 @@ struct lambdakzeropid {
   void processDerivedData(soa::Join<aod::StraCollisions, aod::StraStamps> const& collisions, V0DerivedDatas const& V0s, dauTracks const&)
   {
     // Fire up CCDB with first collision in record. If no collisions, bypass
-    if(collisions.size()>0){
+    if (collisions.size() > 0) {
       auto collision = collisions.begin();
       initCCDB(collision.runNumber(), collision.timestamp());
-    }else{
+    } else {
       initCCDB(manualRunNumber, manualTimeStamp);
     }
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
@@ -470,14 +470,14 @@ struct lambdakzeropid {
       // calculate and pack properties for QA purposes
       int posProperties = 0;
       if (lengthPositive > 0)
-        posProperties = posProperties | (int(1) << kLength);
+        posProperties = posProperties | (static_cast<int>(1) << kLength);
       if (pTra.hasTOF())
-        posProperties = posProperties | (int(1) << kHasTOF);
+        posProperties = posProperties | (static_cast<int>(1) << kHasTOF);
       int negProperties = 0;
       if (lengthNegative > 0)
-        negProperties = negProperties | (int(1) << kLength);
+        negProperties = negProperties | (static_cast<int>(1) << kLength);
       if (nTra.hasTOF())
-        negProperties = negProperties | (int(1) << kHasTOF);
+        negProperties = negProperties | (static_cast<int>(1) << kHasTOF);
 
       histos.fill(HIST("h2dPositiveTOFProperties"), v0.pt(), posProperties);
       histos.fill(HIST("h2dNegativeTOFProperties"), v0.pt(), negProperties);

--- a/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
@@ -632,7 +632,7 @@ struct lambdakzeropid {
       // for storing whatever is the relevant quantity for the PV
       o2::dataformats::VertexBase primaryVertex;
       if (V0.has_straCollision()) {
-        auto const& collision = V0.straCollision();
+        auto const& collision = V0.straCollision_as<soa::Join<aod::StraCollisions, aod::StraStamps>();
         primaryVertex.setPos({collision.posX(), collision.posY(), collision.posZ()});
         // cov: won't be used anyways, all fine
         primaryVertex.setCov(1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6);

--- a/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeropid.cxx
@@ -632,7 +632,7 @@ struct lambdakzeropid {
       // for storing whatever is the relevant quantity for the PV
       o2::dataformats::VertexBase primaryVertex;
       if (V0.has_straCollision()) {
-        auto const& collision = V0.straCollision_as<soa::Join<aod::StraCollisions, aod::StraStamps>();
+        auto const& collision = V0.straCollision_as<soa::Join<aod::StraCollisions, aod::StraStamps>>();
         primaryVertex.setPos({collision.posX(), collision.posY(), collision.posZ()});
         // cov: won't be used anyways, all fine
         primaryVertex.setCov(1e-6, 1e-6, 1e-6, 1e-6, 1e-6, 1e-6);

--- a/PWGLF/Tasks/QC/findableStudy.cxx
+++ b/PWGLF/Tasks/QC/findableStudy.cxx
@@ -61,7 +61,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
 
-using recoStraCollisions = soa::Join<aod::StraCollisions, aod::StraEvSels, aod::StraCents, aod::StraRawCents_003, aod::StraCollLabels>;
+using recoStraCollisions = soa::Join<aod::StraCollisions, aod::StraEvSels, aod::StraCents, aod::StraRawCents, aod::StraCollLabels>;
 using reconstructedV0s = soa::Join<aod::V0CoreMCLabels, aod::V0Cores, aod::V0FoundTags, aod::V0MCCollRefs, aod::V0CollRefs, aod::V0Extras, aod::V0TOFPIDs, aod::V0TOFNSigmas>;
 using reconstructedV0sNoMC = soa::Join<aod::V0Cores, aod::V0Extras>;
 
@@ -280,161 +280,166 @@ struct findableStudy {
       // Detailed analysis level
       bool topoV0RadiusOK = false, topoV0RadiusMaxOK = false, topoV0CosPAOK = false, topoDcaPosToPVOK = false, topoDcaNegToPVOK = false, topoDcaV0DauOK = false;
 
-      auto coll = recv0.straCollision_as<recoStraCollisions>();
-      int mcCollID_fromCollision = coll.straMCCollisionId();
-      int mcCollID_fromV0 = recv0.straMCCollisionId();
-      if (mcCollID_fromCollision != mcCollID_fromV0) {
-        hasWrongCollision = true;
-      } else {
-        // if this is a correctly collision-associated V0, take centrality from here
-        // N.B.: this could still be an issue if collision <-> mc collision is imperfect
-        centrality = coll.centFT0C();
-      }
-
-      if (recv0.isFound()) {
-        hasBeenFoundAny = true; // includes also ITS-only, checked before skipITSonly check
-      }
-
-      if (
-        (pTrack.hasTPC() && pTrack.hasITS()) ||     // full global track
-        (pTrack.hasTPC() && pTrack.hasTOF()) ||     // TPC + TOF is accepted
-        (pTrack.hasTPC() && pTrack.hasTRD()) ||     // TPC + TRD is accepted
-        (!pTrack.hasTPC() && pTrack.itsNCls() >= 6) // long ITS-only
-      ) {
-        pTrackOK = true; // for this V0 only
-      }
-      if (
-        (nTrack.hasTPC() && nTrack.hasITS()) ||
-        (nTrack.hasTPC() && nTrack.hasTOF()) || // TPC + TOF is accepted
-        (nTrack.hasTPC() && nTrack.hasTRD()) || // TPC + TRD is accepted
-        (!nTrack.hasTPC() && nTrack.itsNCls() >= 6)) {
-        nTrackOK = true; // for this V0 only
-      }
-
-      if (pTrackOK && nTrackOK)
-        hasBeenAcceptablyTracked = true;
-
-      // cross-check correctness of new getter
-      if (pTrack.hasITSTracker() && (pTrack.hasITS() && pTrack.itsChi2PerNcl() < -1e-3)) {
-        LOGF(fatal, "Positive track: inconsistent outcome of ITS tracker getter and explicit check!");
-      }
-      if (nTrack.hasITSTracker() && (pTrack.hasITS() && nTrack.itsChi2PerNcl() < -1e-3)) {
-        LOGF(fatal, "Negative track: inconsistent outcome of ITS tracker getter and explicit check!");
-      }
-      if (pTrack.hasITSAfterburner() && (pTrack.hasITS() && pTrack.itsChi2PerNcl() > -1e-3)) {
-        LOGF(fatal, "Positive track: inconsistent outcome of ITS tracker getter and explicit check!");
-      }
-      if (nTrack.hasITSAfterburner() && (pTrack.hasITS() && nTrack.itsChi2PerNcl() > -1e-3)) {
-        LOGF(fatal, "Negative track: inconsistent outcome of ITS tracker getter and explicit check!");
-      }
-
-      // Cross-checking consistency: found should be a subset of nTrack, pTrack OK
-      histos.fill(HIST("hFoundVsTracksOK"), nTrackOK && pTrackOK, recv0.isFound());
-
-      // encode conditions of tracks
-      uint8_t positiveTrackCode = ((uint8_t(pTrack.hasTPC()) << hasTPC) |
-                                   (uint8_t(pTrack.hasITSTracker()) << hasITSTracker) |
-                                   (uint8_t(pTrack.hasITSAfterburner()) << hasITSAfterburner) |
-                                   (uint8_t(pTrack.hasTRD()) << hasTRD) |
-                                   (uint8_t(pTrack.hasTOF()) << hasTOF));
-
-      uint8_t negativeTrackCode = ((uint8_t(nTrack.hasTPC()) << hasTPC) |
-                                   (uint8_t(nTrack.hasITSTracker()) << hasITSTracker) |
-                                   (uint8_t(nTrack.hasITSAfterburner()) << hasITSAfterburner) |
-                                   (uint8_t(nTrack.hasTRD()) << hasTRD) |
-                                   (uint8_t(nTrack.hasTOF()) << hasTOF));
-
-      if (pTrackOK && nTrackOK && ptmc > 1.0 && ptmc < 1.1) {
-        // this particular V0 reco entry has been acceptably tracked. Do bookkeeping
-        histos.fill(HIST("h2dTrackPropAcceptablyTracked"), positiveTrackCode, negativeTrackCode, centrality);
-      }
-
-      // determine if this V0 would go to analysis or not
-      if (recv0.isFound() && pTrackOK && nTrackOK) { // hack to avoid type check; only interested in found type 1
-        // at this stage, this should be REALLY mostly unique (unless you switch skipITSonly to false or so)
-        // ... but we will cross-check this assumption (hNRecoV0sWithTPC, h2dPtVsCentrality_FoundInLoop)
-        if (pTrack.hasTPC() && !pTrack.hasITS() && !pTrack.hasTRD() && !pTrack.hasTOF()) {
-          LOGF(info, "Positive track is TPC only and this is a found V0. Puzzling!");
-        }
-        if (nTrack.hasTPC() && !nTrack.hasITS() && !nTrack.hasTRD() && !nTrack.hasTOF()) {
-          LOGF(info, "Negative track is TPC only and this is a found V0. Puzzling!");
+      if (recv0.has_straCollision()) {
+        auto coll = recv0.straCollision_as<recoStraCollisions>();
+        int mcCollID_fromCollision = coll.straMCCollisionId();
+        int mcCollID_fromV0 = recv0.straMCCollisionId();
+        if (mcCollID_fromCollision != mcCollID_fromV0) {
+          hasWrongCollision = true;
+        } else {
+          // if this is a correctly collision-associated V0, take centrality from here
+          // N.B.: this could still be an issue if collision <-> mc collision is imperfect
+          centrality = coll.centFT0C();
         }
 
-        nCandidatesWithTPC++;
-        hasBeenFound = true;
-        histos.fill(HIST("h2dPtVsCentrality_FoundInLoop"), centrality, ptmc);
-        if (ptmc > 1.0 && ptmc < 1.1) {
-          histos.fill(HIST("h2dTrackPropFound"), positiveTrackCode, negativeTrackCode, centrality);
+        if (recv0.isFound()) {
+          hasBeenFoundAny = true; // includes also ITS-only, checked before skipITSonly check
         }
 
-        uint64_t selMap = v0data::computeReconstructionBitmap(recv0, pTrack, nTrack, coll, recv0.yLambda(), recv0.yK0Short(), v0Selections);
+        if (
+          (pTrack.hasTPC() && pTrack.hasITS()) ||     // full global track
+          (pTrack.hasTPC() && pTrack.hasTOF()) ||     // TPC + TOF is accepted
+          (pTrack.hasTPC() && pTrack.hasTRD()) ||     // TPC + TRD is accepted
+          (!pTrack.hasTPC() && pTrack.itsNCls() >= 6) // long ITS-only
+        ) {
+          pTrackOK = true; // for this V0 only
+        }
+        if (
+          (nTrack.hasTPC() && nTrack.hasITS()) ||
+          (nTrack.hasTPC() && nTrack.hasTOF()) || // TPC + TOF is accepted
+          (nTrack.hasTPC() && nTrack.hasTRD()) || // TPC + TRD is accepted
+          (!nTrack.hasTPC() && nTrack.itsNCls() >= 6)) {
+          nTrackOK = true; // for this V0 only
+        }
 
-        // Consider in all cases
-        selMap = selMap | (uint64_t(1) << v0data::selConsiderK0Short) | (uint64_t(1) << v0data::selConsiderLambda) | (uint64_t(1) << v0data::selConsiderAntiLambda);
+        if (pTrackOK && nTrackOK)
+          hasBeenAcceptablyTracked = true;
 
-        // selection checker: ensure this works on subset of actual svertexer-findable
-        bool validTrackProperties = v0Selections->verifyMask(selMap, maskTrackProperties) && pTrackOK && nTrackOK;
-        bool validTopology = v0Selections->verifyMask(selMap, maskTopological);
+        // cross-check correctness of new getter
+        if (pTrack.hasITSTracker() && (pTrack.hasITS() && pTrack.itsChi2PerNcl() < -1e-3)) {
+          LOGF(fatal, "Positive track: inconsistent outcome of ITS tracker getter and explicit check!");
+        }
+        if (nTrack.hasITSTracker() && (pTrack.hasITS() && nTrack.itsChi2PerNcl() < -1e-3)) {
+          LOGF(fatal, "Negative track: inconsistent outcome of ITS tracker getter and explicit check!");
+        }
+        if (pTrack.hasITSAfterburner() && (pTrack.hasITS() && pTrack.itsChi2PerNcl() > -1e-3)) {
+          LOGF(fatal, "Positive track: inconsistent outcome of ITS tracker getter and explicit check!");
+        }
+        if (nTrack.hasITSAfterburner() && (pTrack.hasITS() && nTrack.itsChi2PerNcl() > -1e-3)) {
+          LOGF(fatal, "Negative track: inconsistent outcome of ITS tracker getter and explicit check!");
+        }
 
-        uint64_t thisSpeciesMask = maskK0ShortSpecific;
-        if (pdgCode == 3122)
-          thisSpeciesMask = maskLambdaSpecific;
-        if (pdgCode == -3122)
-          thisSpeciesMask = maskAntiLambdaSpecific;
-        // add other species masks as necessary
+        // Cross-checking consistency: found should be a subset of nTrack, pTrack OK
+        histos.fill(HIST("hFoundVsTracksOK"), nTrackOK && pTrackOK, recv0.isFound());
 
-        bool validThisSpecies = v0Selections->verifyMask(selMap, thisSpeciesMask);
+        // encode conditions of tracks
+        uint8_t positiveTrackCode = ((uint8_t(pTrack.hasTPC()) << hasTPC) |
+                                    (uint8_t(pTrack.hasITSTracker()) << hasITSTracker) |
+                                    (uint8_t(pTrack.hasITSAfterburner()) << hasITSAfterburner) |
+                                    (uint8_t(pTrack.hasTRD()) << hasTRD) |
+                                    (uint8_t(pTrack.hasTOF()) << hasTOF));
 
-        // specific selection (not cumulative)
-        topoV0RadiusOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selRadius);
-        topoV0RadiusMaxOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selRadiusMax);
-        topoV0CosPAOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selCosPA);
-        topoDcaPosToPVOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCAPosToPV);
-        topoDcaNegToPVOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCANegToPV);
-        topoDcaV0DauOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCAV0Dau);
-        // trackTPCRowsOK = v0Selections->verifyMask(selMap, (uint64_t(1) << v0data::selPosGoodTPCTrack) | (uint64_t(1) << v0data::selNegGoodTPCTrack) );
+        uint8_t negativeTrackCode = ((uint8_t(nTrack.hasTPC()) << hasTPC) |
+                                    (uint8_t(nTrack.hasITSTracker()) << hasITSTracker) |
+                                    (uint8_t(nTrack.hasITSAfterburner()) << hasITSAfterburner) |
+                                    (uint8_t(nTrack.hasTRD()) << hasTRD) |
+                                    (uint8_t(nTrack.hasTOF()) << hasTOF));
 
-        // uint64_t tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositivePion) | (uint64_t(1) << v0data::selTPCPIDNegativePion);
-        // if(pdgCode==3122)
-        //   tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositiveProton) | (uint64_t(1) << v0data::selTPCPIDNegativePion);
-        // if(pdgCode==-3122)
-        //   tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositivePion) | (uint64_t(1) << v0data::selTPCPIDNegativeProton);
+        if (pTrackOK && nTrackOK && ptmc > 1.0 && ptmc < 1.1) {
+          // this particular V0 reco entry has been acceptably tracked. Do bookkeeping
+          histos.fill(HIST("h2dTrackPropAcceptablyTracked"), positiveTrackCode, negativeTrackCode, centrality);
+        }
 
-        // trackTPCPIDOK = v0Selections->verifyMask(selMap, tpcPidMask);
-
-        // Broad level
-        if (validTrackProperties) {
-          histos.fill(HIST("h2dPtVsCentrality_PassesTrackQuality"), centrality, ptmc);
-          if (ptmc > 1.0 && ptmc < 1.1) {
-            histos.fill(HIST("h2dTrackPropAnalysisTracks"), positiveTrackCode, negativeTrackCode, centrality);
+        // determine if this V0 would go to analysis or not
+        if (recv0.isFound() && pTrackOK && nTrackOK) { // hack to avoid type check; only interested in found type 1
+          // at this stage, this should be REALLY mostly unique (unless you switch skipITSonly to false or so)
+          // ... but we will cross-check this assumption (hNRecoV0sWithTPC, h2dPtVsCentrality_FoundInLoop)
+          if (pTrack.hasTPC() && !pTrack.hasITS() && !pTrack.hasTRD() && !pTrack.hasTOF()) {
+            LOGF(info, "Positive track is TPC only and this is a found V0. Puzzling!");
           }
-        }
-        if (validTrackProperties && validTopology) {
-          histos.fill(HIST("h2dPtVsCentrality_PassesTopological"), centrality, ptmc);
-          if (ptmc > 1.0 && ptmc < 1.1) {
-            histos.fill(HIST("h2dTrackPropAnalysisTopo"), positiveTrackCode, negativeTrackCode, centrality);
+          if (nTrack.hasTPC() && !nTrack.hasITS() && !nTrack.hasTRD() && !nTrack.hasTOF()) {
+            LOGF(info, "Negative track is TPC only and this is a found V0. Puzzling!");
           }
-        }
-        if (validTrackProperties && validTopology && validThisSpecies) {
-          histos.fill(HIST("h2dPtVsCentrality_PassesThisSpecies"), centrality, ptmc);
-          if (ptmc > 1.0 && ptmc < 1.1) {
-            histos.fill(HIST("h2dTrackPropAnalysisSpecies"), positiveTrackCode, negativeTrackCode, centrality);
-          }
-        }
 
-        // topological
-        if (validTrackProperties && validThisSpecies && topoV0RadiusOK)
-          histos.fill(HIST("h2dPtVsCentrality_V0Radius"), centrality, ptmc);
-        if (validTrackProperties && validThisSpecies && topoV0RadiusMaxOK)
-          histos.fill(HIST("h2dPtVsCentrality_V0RadiusMax"), centrality, ptmc);
-        if (validTrackProperties && validThisSpecies && topoV0CosPAOK)
-          histos.fill(HIST("h2dPtVsCentrality_V0CosPA"), centrality, ptmc);
-        if (validTrackProperties && validThisSpecies && topoDcaPosToPVOK)
-          histos.fill(HIST("h2dPtVsCentrality_DcaPosToPV"), centrality, ptmc);
-        if (validTrackProperties && validThisSpecies && topoDcaNegToPVOK)
-          histos.fill(HIST("h2dPtVsCentrality_DcaNegToPV"), centrality, ptmc);
-        if (validTrackProperties && validThisSpecies && topoDcaV0DauOK)
-          histos.fill(HIST("h2dPtVsCentrality_DcaV0Dau"), centrality, ptmc);
+          nCandidatesWithTPC++;
+          hasBeenFound = true;
+          histos.fill(HIST("h2dPtVsCentrality_FoundInLoop"), centrality, ptmc);
+          if (ptmc > 1.0 && ptmc < 1.1) {
+            histos.fill(HIST("h2dTrackPropFound"), positiveTrackCode, negativeTrackCode, centrality);
+          }
+
+          uint64_t selMap = v0data::computeReconstructionBitmap(recv0, pTrack, nTrack, coll, recv0.yLambda(), recv0.yK0Short(), v0Selections);
+
+          // Consider in all cases
+          selMap = selMap | (uint64_t(1) << v0data::selConsiderK0Short) | (uint64_t(1) << v0data::selConsiderLambda) | (uint64_t(1) << v0data::selConsiderAntiLambda);
+
+          // selection checker: ensure this works on subset of actual svertexer-findable
+          bool validTrackProperties = v0Selections->verifyMask(selMap, maskTrackProperties) && pTrackOK && nTrackOK;
+          bool validTopology = v0Selections->verifyMask(selMap, maskTopological);
+
+          uint64_t thisSpeciesMask = maskK0ShortSpecific;
+          if (pdgCode == 3122)
+            thisSpeciesMask = maskLambdaSpecific;
+          if (pdgCode == -3122)
+            thisSpeciesMask = maskAntiLambdaSpecific;
+          // add other species masks as necessary
+
+          bool validThisSpecies = v0Selections->verifyMask(selMap, thisSpeciesMask);
+
+          // specific selection (not cumulative)
+          topoV0RadiusOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selRadius);
+          topoV0RadiusMaxOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selRadiusMax);
+          topoV0CosPAOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selCosPA);
+          topoDcaPosToPVOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCAPosToPV);
+          topoDcaNegToPVOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCANegToPV);
+          topoDcaV0DauOK = v0Selections->verifyMask(selMap, uint64_t(1) << v0data::selDCAV0Dau);
+          // trackTPCRowsOK = v0Selections->verifyMask(selMap, (uint64_t(1) << v0data::selPosGoodTPCTrack) | (uint64_t(1) << v0data::selNegGoodTPCTrack) );
+
+          // uint64_t tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositivePion) | (uint64_t(1) << v0data::selTPCPIDNegativePion);
+          // if(pdgCode==3122)
+          //   tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositiveProton) | (uint64_t(1) << v0data::selTPCPIDNegativePion);
+          // if(pdgCode==-3122)
+          //   tpcPidMask = (uint64_t(1) << v0data::selTPCPIDPositivePion) | (uint64_t(1) << v0data::selTPCPIDNegativeProton);
+
+          // trackTPCPIDOK = v0Selections->verifyMask(selMap, tpcPidMask);
+
+          // Broad level
+          if (validTrackProperties) {
+            histos.fill(HIST("h2dPtVsCentrality_PassesTrackQuality"), centrality, ptmc);
+            if (ptmc > 1.0 && ptmc < 1.1) {
+              histos.fill(HIST("h2dTrackPropAnalysisTracks"), positiveTrackCode, negativeTrackCode, centrality);
+            }
+          }
+          if (validTrackProperties && validTopology) {
+            histos.fill(HIST("h2dPtVsCentrality_PassesTopological"), centrality, ptmc);
+            if (ptmc > 1.0 && ptmc < 1.1) {
+              histos.fill(HIST("h2dTrackPropAnalysisTopo"), positiveTrackCode, negativeTrackCode, centrality);
+            }
+          }
+          if (validTrackProperties && validTopology && validThisSpecies) {
+            histos.fill(HIST("h2dPtVsCentrality_PassesThisSpecies"), centrality, ptmc);
+            if (ptmc > 1.0 && ptmc < 1.1) {
+              histos.fill(HIST("h2dTrackPropAnalysisSpecies"), positiveTrackCode, negativeTrackCode, centrality);
+            }
+          }
+
+          // topological
+          if (validTrackProperties && validThisSpecies && topoV0RadiusOK)
+            histos.fill(HIST("h2dPtVsCentrality_V0Radius"), centrality, ptmc);
+          if (validTrackProperties && validThisSpecies && topoV0RadiusMaxOK)
+            histos.fill(HIST("h2dPtVsCentrality_V0RadiusMax"), centrality, ptmc);
+          if (validTrackProperties && validThisSpecies && topoV0CosPAOK)
+            histos.fill(HIST("h2dPtVsCentrality_V0CosPA"), centrality, ptmc);
+          if (validTrackProperties && validThisSpecies && topoDcaPosToPVOK)
+            histos.fill(HIST("h2dPtVsCentrality_DcaPosToPV"), centrality, ptmc);
+          if (validTrackProperties && validThisSpecies && topoDcaNegToPVOK)
+            histos.fill(HIST("h2dPtVsCentrality_DcaNegToPV"), centrality, ptmc);
+          if (validTrackProperties && validThisSpecies && topoDcaV0DauOK)
+            histos.fill(HIST("h2dPtVsCentrality_DcaV0Dau"), centrality, ptmc);
+        }
+      }
+      else{
+        continue;
       }
     }
     histos.fill(HIST("hNRecoV0sWithTPC"), nCandidatesWithTPC);

--- a/PWGLF/Tasks/QC/findableStudy.cxx
+++ b/PWGLF/Tasks/QC/findableStudy.cxx
@@ -334,16 +334,16 @@ struct findableStudy {
 
         // encode conditions of tracks
         uint8_t positiveTrackCode = ((uint8_t(pTrack.hasTPC()) << hasTPC) |
-                                    (uint8_t(pTrack.hasITSTracker()) << hasITSTracker) |
-                                    (uint8_t(pTrack.hasITSAfterburner()) << hasITSAfterburner) |
-                                    (uint8_t(pTrack.hasTRD()) << hasTRD) |
-                                    (uint8_t(pTrack.hasTOF()) << hasTOF));
+                                     (uint8_t(pTrack.hasITSTracker()) << hasITSTracker) |
+                                     (uint8_t(pTrack.hasITSAfterburner()) << hasITSAfterburner) |
+                                     (uint8_t(pTrack.hasTRD()) << hasTRD) |
+                                     (uint8_t(pTrack.hasTOF()) << hasTOF));
 
         uint8_t negativeTrackCode = ((uint8_t(nTrack.hasTPC()) << hasTPC) |
-                                    (uint8_t(nTrack.hasITSTracker()) << hasITSTracker) |
-                                    (uint8_t(nTrack.hasITSAfterburner()) << hasITSAfterburner) |
-                                    (uint8_t(nTrack.hasTRD()) << hasTRD) |
-                                    (uint8_t(nTrack.hasTOF()) << hasTOF));
+                                     (uint8_t(nTrack.hasITSTracker()) << hasITSTracker) |
+                                     (uint8_t(nTrack.hasITSAfterburner()) << hasITSAfterburner) |
+                                     (uint8_t(nTrack.hasTRD()) << hasTRD) |
+                                     (uint8_t(nTrack.hasTOF()) << hasTOF));
 
         if (pTrackOK && nTrackOK && ptmc > 1.0 && ptmc < 1.1) {
           // this particular V0 reco entry has been acceptably tracked. Do bookkeeping
@@ -437,8 +437,7 @@ struct findableStudy {
           if (validTrackProperties && validThisSpecies && topoDcaV0DauOK)
             histos.fill(HIST("h2dPtVsCentrality_DcaV0Dau"), centrality, ptmc);
         }
-      }
-      else{
+      } else {
         continue;
       }
     }


### PR DESCRIPTION
@gianniliveraro this should fix the issues in the findable test you are doing. Can you rebase and try this out? 

@pbuehler @rolavick this should allow for the calculation of TOF delta-times between daughter prongs also for unassociated V0s using the existing `lambdakzeropid.cxx` task - to be checked. These delta-times should be close to zero and don't require a collision PV to be reco'ed. 