### PR TITLE
adding variable bin widths for DCA histos; plus some minor adjustments

### DIFF
--- a/PWGCF/Femto3D/Core/femto3dPairTask.h
+++ b/PWGCF/Femto3D/Core/femto3dPairTask.h
@@ -37,6 +37,45 @@ double particle_mass(int PDGcode)
     return TDatabasePDG::Instance()->GetParticle(PDGcode)->Mass();
 }
 
+// for the variable binning in 3D DCA histos in the PairMC task
+inline std::unique_ptr<double[]> calc_const_bins(const int& N, const float& xmin, const float& xmax) // needed only to calculate bins along X axis for DCA histos (even if the bin width is constant have to use an array since want to have variable bins in Y and Z)
+{
+  auto bins = std::make_unique<double[]>(N + 1);
+
+  float wbin = (xmax - xmin) / N;
+  bins[0] = xmin;
+
+  for (int i = 1; i < N + 1; i++) {
+    bins[i] = bins[i - 1] + wbin;
+  }
+
+  return bins;
+}
+
+// for the variable binning in 3D DCA histos in the PairMC task
+inline std::unique_ptr<double[]> calc_var_bins(const int& N, const float& xmax, const int& scale)
+{
+  auto bins = std::make_unique<double[]>(N);
+
+  float q = std::pow(scale, 1.0 / (0.5 * N)); // q -- common ratio of the geometric progression, estimated through the requested scaling of w_bin
+
+  float winit = xmax * (1 - q) / (1 - scale); // initial w_bin is estimated through sum of the bin width (sum of N elements in geometric progression) that must be equal to xmax
+
+  float bin_edge = 0.5 * winit;
+  bins[0.5 * N - 1] = -bin_edge; // first bin edge left to the center (i.e. 0)
+  bins[0.5 * N] = bin_edge;      // first bin edge right to the center (i.e. 0)
+  bins[0] = -xmax;
+  bins[N - 1] = xmax;
+
+  for (int i = 1; i < 0.5 * N - 1; i++) {
+    bin_edge += winit * pow(q, i);
+    bins[0.5 * N - 1 - i] = -bin_edge;
+    bins[0.5 * N + i] = bin_edge;
+  }
+
+  return bins;
+}
+
 namespace o2::aod::singletrackselector
 {
 template <typename Type>

--- a/PWGCF/Femto3D/Core/femto3dPairTask.h
+++ b/PWGCF/Femto3D/Core/femto3dPairTask.h
@@ -24,6 +24,7 @@
 // #include "Common/DataModel/Multiplicity.h"
 
 #include <vector>
+#include <memory>
 #include "TLorentzVector.h"
 #include "TVector3.h"
 #include "TDatabasePDG.h"

--- a/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
@@ -228,8 +228,8 @@ struct FemtoCorrelations {
             continue;
 
           for (unsigned int j = 0; j < _kTbins.value.size() - 1; j++) {
-            auto hDblTrk_SE = registry.add<TH2>(Form("Cent%i/DoubleTrackEffects/SE_cent%i_kT%i", i, i, j) + suffix[f], Form("DoubleTrackEffects_deta(dphi*)_SE_cent%i_kT%i", i, j) + suffix[f], kTH2F, {{628, -M_PI / 2.0, M_PI / 2.0, "dphi*"}, {200, -0.5, 0.5, "deta"}});
-            auto hDblTrk_ME = registry.add<TH2>(Form("Cent%i/DoubleTrackEffects/ME_cent%i_kT%i", i, i, j) + suffix[f], Form("DoubleTrackEffects_deta(dphi*)_ME_cent%i_kT%i", i, j) + suffix[f], kTH2F, {{628, -M_PI / 2.0, M_PI / 2.0, "dphi*"}, {200, -0.5, 0.5, "deta"}});
+            auto hDblTrk_SE = registry.add<TH2>(Form("Cent%i/DoubleTrackEffects/SE_cent%i_kT%i", i, i, j) + suffix[f], Form("DoubleTrackEffects_deta(dphi*)_SE_cent%i_kT%i", i, j) + suffix[f], kTH2F, {{101, -0.2, 0.2, "dphi*"}, {101, -0.2, 0.2, "deta"}});
+            auto hDblTrk_ME = registry.add<TH2>(Form("Cent%i/DoubleTrackEffects/ME_cent%i_kT%i", i, i, j) + suffix[f], Form("DoubleTrackEffects_deta(dphi*)_ME_cent%i_kT%i", i, j) + suffix[f], kTH2F, {{101, -0.2, 0.2, "dphi*"}, {101, -0.2, 0.2, "deta"}});
 
             DoubleTrack_SE_histos_perMult.push_back(std::move(hDblTrk_SE));
             DoubleTrack_ME_histos_perMult.push_back(std::move(hDblTrk_ME));

--- a/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
@@ -146,7 +146,7 @@ struct FemtoCorrelationsMC {
     int N = _dcaBinning.value[0]; // number of bins -- must be odd otherwise will be increased by 1
     if (N % 2 != 1)
       N += 1;
-    auto var_bins = calc_var_bins(N + 1, _dcaBinning.value[1], (int)_dcaBinning.value[2]);
+    auto var_bins = calc_var_bins(N + 1, _dcaBinning.value[1], static_cast<int>(_dcaBinning.value[2]));
     auto const_bins = calc_const_bins(100, 0., 5.0);
 
     for (unsigned int i = 0; i < _centBins.value.size() - 1; i++) {

--- a/PWGCF/Femto3D/Tasks/femto3dQA.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dQA.cxx
@@ -100,10 +100,10 @@ struct QAHistograms {
     registry.add("p", "p", kTH1F, {{100, 0., 5., "p"}});
     registry.add("pt", "pt", kTH1F, {{100, 0., 5., "pt"}});
     registry.add("sign", "sign", kTH1F, {{3, -1.5, 1.5, "sign"}});
-    registry.add("dcaxy_to_p", "dcaxy_to_p", kTH2F, {{100, 0., 5.0, "p"}, {500, -0.5, 0.5, "dcaxy"}});
-    registry.add("dcaxy_to_pt", "dcaxy_to_pt", kTH2F, {{100, 0., 5., "pt"}, {500, -0.5, 0.5, "dcaxy"}});
-    registry.add("dcaz_to_p", "dcaz_to_p", kTH2F, {{100, 0., 5., "p"}, {500, -0.5, 0.5, "dcaz"}});
-    registry.add("dcaz_to_pt", "dcaz_to_pt", kTH2F, {{100, 0., 5., "pt"}, {500, -0.5, 0.5, "dcaz"}});
+    registry.add("dcaxy_to_p", "dcaxy_to_p", kTH2F, {{100, 0., 5.0, "p"}, {501, -0.5, 0.5, "dcaxy"}});
+    registry.add("dcaxy_to_pt", "dcaxy_to_pt", kTH2F, {{100, 0., 5., "pt"}, {501, -0.5, 0.5, "dcaxy"}});
+    registry.add("dcaz_to_p", "dcaz_to_p", kTH2F, {{100, 0., 5., "p"}, {501, -0.5, 0.5, "dcaz"}});
+    registry.add("dcaz_to_pt", "dcaz_to_pt", kTH2F, {{100, 0., 5., "pt"}, {501, -0.5, 0.5, "dcaz"}});
     registry.add("TPCClusters", "TPCClusters", kTH1F, {{163, -0.5, 162.5, "NTPCClust"}});
     registry.add("TPCCrossedRowsOverFindableCls", "TPCCrossedRowsOverFindableCls", kTH1F, {{100, 0.0, 10.0, "NcrossedRowsOverFindable"}});
     registry.add("TPCFractionSharedCls", "TPCFractionSharedCls", kTH1F, {{100, 0.0, 1.0, "TPCsharedFraction"}});


### PR DESCRIPTION
Dear @victor-gonzalez ,

in this commit we're adding a possibility to use variable bin widths in 3D DCA histograms (finer binning is not needed at the edges of the dist-s) in the MC pair task in order to reduce output size;
plus some other minor adjustments.
Could you please approve it. Thank you.

Sincerely yours, Gleb.