### PR TITLE
PWGHF: fix vector access if searchUpToQuark=true

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -760,7 +760,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           auto particle = mcParticles.rawIteratorAt(indexRecCharmBaryon);
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           auto bHadMother = mcParticles.rawIteratorAt(idxBhadMothers[0]);
           rowMCMatchRecXicToXiPi(flag, debug, origin, collisionMatched, bHadMother.pt(), bHadMother.pdgCode());
         } else {
@@ -799,7 +799,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           auto particle = mcParticles.rawIteratorAt(indexRecCharmBaryon);
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           auto bHadMother = mcParticles.rawIteratorAt(idxBhadMothers[0]);
           rowMCMatchRecOmegacToXiPi(flag, debug, origin, collisionMatched, bHadMother.pt(), bHadMother.pdgCode());
         } else {
@@ -838,7 +838,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           auto particle = mcParticles.rawIteratorAt(indexRecCharmBaryon);
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           auto bHadMother = mcParticles.rawIteratorAt(idxBhadMothers[0]);
           rowMCMatchRecToOmegaPi(flag, debug, origin, collisionMatched, bHadMother.pt(), bHadMother.pdgCode());
         } else {
@@ -877,7 +877,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           auto particle = mcParticles.rawIteratorAt(indexRecCharmBaryon);
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           auto bHadMother = mcParticles.rawIteratorAt(idxBhadMothers[0]);
           rowMCMatchRecToOmegaK(flag, debug, origin, collisionMatched, bHadMother.pt(), bHadMother.pdgCode());
         } else {
@@ -948,7 +948,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         if (flag != 0) {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0){
           rowMCMatchGenXicToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, idxBhadMothers[0]);
         } else {
           rowMCMatchGenXicToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, -1);
@@ -984,7 +984,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         if (flag != 0) {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           rowMCMatchGenOmegacToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, idxBhadMothers[0]);
         } else {
           rowMCMatchGenOmegacToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, -1);
@@ -1020,7 +1020,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         if (flag != 0) {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           rowMCMatchGenToOmegaPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, idxBhadMothers[0]);
         } else {
           rowMCMatchGenToOmegaPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, -1);
@@ -1056,7 +1056,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         if (flag != 0) {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt) {
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           rowMCMatchGenToOmegaK(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, idxBhadMothers[0]);
         } else {
           rowMCMatchGenToOmegaK(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, -1);

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -948,7 +948,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
         if (flag != 0) {
           origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, true, &idxBhadMothers);
         }
-        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0){
+        if (origin == RecoDecay::OriginType::NonPrompt && idxBhadMothers.size() > 0) {
           rowMCMatchGenXicToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, idxBhadMothers[0]);
         } else {
           rowMCMatchGenXicToXiPi(flag, debugGenCharmBar, debugGenCasc, debugGenLambda, ptCharmBaryonGen, etaCharmBaryonGen, origin, -1);


### PR DESCRIPTION
If `searchUpToQuark` is `true` in `getCharmHadronOrigin`, the vector with the indexes of B mothers could be empty