### PR TITLE
DPG/AOT: add MC truth and ML application in D-meson tag-and-probe

### DIFF
--- a/DPG/Tasks/AOTTrack/CMakeLists.txt
+++ b/DPG/Tasks/AOTTrack/CMakeLists.txt
@@ -77,6 +77,6 @@ o2physics_add_dpl_workflow(qa-tracksplitting
 
 o2physics_add_dpl_workflow(tag-and-probe-dmesons
     SOURCES tagAndProbeDmesons.cxx
-    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DetectorsVertexing O2Physics::MLCore
     COMPONENT_NAME Analysis)
 

--- a/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
+++ b/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
@@ -86,7 +86,7 @@ constexpr double mlCuts[nBinsPt][3] = {{0.f, 0.f, 0.f},
                                        {0.f, 0.f, 0.f}};
 
 static const std::vector<std::string> labelsEmpty{};
-static const std::vector<std::string> labelsCutVar = {"min mass", "max mass", "min decayLength", "min decayLengthXY", "min normDecayLength", "min normDecayLengthXY", "min impParProd", "min cosPointing", "min cosPointingXY"};
+static const std::vector<std::string> labelsCutVar = {"min mass", "max mass", "min decayLength", "min decayLengthXY", "min normDecayLength", "min normDecayLengthXY", "max impParProd", "min cosPointing", "min cosPointingXY"};
 static const std::vector<std::string> labelsMlScores = {"max bkg score", "min prompt score", "min non-prompt score"};
 
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                   //! Collision index

--- a/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
+++ b/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
@@ -15,19 +15,21 @@
 /// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
 
 #include "CCDB/BasicCCDBManager.h"
-#include "Common/Core/RecoDecay.h"
-#include "Common/Core/trackUtilities.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "CommonConstants/PhysicsConstants.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DCAFitter/DCAFitterN.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/CollisionAssociationTables.h"
-#include "Common/Core/TrackSelection.h"
+#include "PWGHF/Utils/utilsAnalysis.h" 
+#include "Tools/ML/MlResponse.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -62,38 +64,37 @@ enum SignalFlags : uint8_t {
 };
 
 static constexpr int nBinsPt = 7;
-static constexpr int nCutVars = 6;
-static constexpr int nCutVarsDzero = 9;
-constexpr float binsPt[nBinsPt + 1] = {0., 1., 2., 4., 6., 10., 20., 1000.};
-auto vecBinsPt = std::vector<float>{binsPt, binsPt + nBinsPt + 1};
+static constexpr int nCutVars = 9;
+constexpr double binsPt[nBinsPt + 1] = {0., 1., 2., 4., 6., 10., 20., 1000.};
+auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
 
 // default values for the cuts
-constexpr float cuts[nBinsPt][nCutVars] = {{0.1f, 1.5f, 0.01f, 0.01f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.01f, 0.01f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.02f, 0.02f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.02f, 0.02f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.04f, 0.04f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.04f, 0.04f, 2.f, 2.f},
-                                           {0.1f, 1.5f, 0.06f, 0.06f, 2.f, 2.f}};
+constexpr double cuts[nBinsPt][nCutVars] = {{1.815f, 1.915f, 0.01f, 0.01f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
+                                            {1.815f, 1.915f, 0.01f, 0.01f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
+                                            {1.815f, 1.915f, 0.02f, 0.02f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
+                                            {1.815f, 1.915f, 0.02f, 0.02f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
+                                            {1.815f, 1.915f, 0.04f, 0.04f, 2.f, 2.f, 0.f, 0.95f, 0.95f},
+                                            {1.815f, 1.915f, 0.04f, 0.04f, 2.f, 2.f, 0.f, 0.95f, 0.95f},
+                                            {1.815f, 1.915f, 0.06f, 0.06f, 2.f, 2.f, 0.f, 0.95f, 0.95f}};
 
-constexpr float cutsDzero[nBinsPt][nCutVarsDzero] = {{1.815f, 1.915f, 0.01f, 0.01f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
-                                                     {1.815f, 1.915f, 0.01f, 0.01f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
-                                                     {1.815f, 1.915f, 0.02f, 0.02f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
-                                                     {1.815f, 1.915f, 0.02f, 0.02f, 2.f, 2.f, 0.f, 0.90f, 0.90f},
-                                                     {1.815f, 1.915f, 0.04f, 0.04f, 2.f, 2.f, 0.f, 0.95f, 0.95f},
-                                                     {1.815f, 1.915f, 0.04f, 0.04f, 2.f, 2.f, 0.f, 0.95f, 0.95f},
-                                                     {1.815f, 1.915f, 0.06f, 0.06f, 2.f, 2.f, 0.f, 0.95f, 0.95f}};
+constexpr double mlCuts[nBinsPt][3] = {{0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f},
+                                       {0.f, 0.f, 0.f}};
 
-static const std::vector<std::string> labelsPt{};
-static const std::vector<std::string> labelsCutVar = {"minMass", "maxMass", "decayLength", "decayLengthXY", "normDecayLength", "normDecayLengthXY"};
-static const std::vector<std::string> labelsCutVarDzero = {"minMass", "maxMass", "decayLength", "decayLengthXY", "normDecayLength", "normDecayLengthXY", "impParProd", "cosPointing", "cosPointingXY"};
+static const std::vector<std::string> labelsEmpty{};
+static const std::vector<std::string> labelsCutVar = {"min mass", "max mass", "min decayLength", "min decayLengthXY", "min normDecayLength", "min normDecayLengthXY", "min impParProd", "min cosPointing", "min cosPointingXY"};
+static const std::vector<std::string> labelsMlScores = {"max bkg score", "min prompt score", "min non-prompt score"};
 
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                   //! Collision index
 DECLARE_SOA_INDEX_COLUMN_FULL(Track0, track0, int, Tracks, "_0"); //! Index to first track
 DECLARE_SOA_INDEX_COLUMN_FULL(Track1, track1, int, Tracks, "_1"); //! Index to second track
 // Topological variables
 DECLARE_SOA_COLUMN(TagPt, tagPt, float);                                     //! Tag's pT
-DECLARE_SOA_COLUMN(TagInvMass, tagInvMass2, float);                          //! Tag's invMass
+DECLARE_SOA_COLUMN(TagInvMass, tagInvMass, float);                           //! Tag's invMass
 DECLARE_SOA_COLUMN(DecayLength, decayLength, float);                         //! Decay length of the tag (cm)
 DECLARE_SOA_COLUMN(DecayLengthXY, decayLengthXY, float);                     //! Transverse decay length of the tag (cm)
 DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);     //! Normalised decay length of the tag
@@ -103,32 +104,55 @@ DECLARE_SOA_COLUMN(TrackDcaXY1, trackDcaXY1, float);                         //!
 DECLARE_SOA_COLUMN(ProductTrackDcaXY, productTrackDcaXY, float);             //! Product of DCAxy of the two tag tracks
 DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of the tag
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine of the pointing angle in XY of the tag
-DECLARE_SOA_COLUMN(IsSignal, isSignal, uint8_t);                             //! Flag for a signal
 DECLARE_SOA_COLUMN(DecChannel, decChannel, uint8_t);                         //! Flag the selected decay channel
+// MC info
+DECLARE_SOA_COLUMN(IsSignal, isSignal, uint8_t);                             //! Flag for a signal
+DECLARE_SOA_INDEX_COLUMN_FULL(Mother, mother, int, McParticles, "");         //! Index to MC particle mother of the tag tracks
+// ML scores
+DECLARE_SOA_COLUMN(MlScores, mlScores, std::vector<float>);                  //! ML scores (bkg, prompt, non-prompt)
 } // namespace tagandprobe
 
 DECLARE_SOA_TABLE(PiPiFromDpTags, "AOD", "PIPIFROMDPTAG", //! Table for same sign 2-pion vertices used as tags
                   soa::Index<>,
                   aod::tagandprobe::CollisionId,
                   aod::tagandprobe::Track0Id,
-                  aod::tagandprobe::Track1Id);
+                  aod::tagandprobe::Track1Id,
+                  aod::tagandprobe::MlScores);
+DECLARE_SOA_TABLE(PiPiFromDpMcTags, "AOD", "PIPIFROMDPMCTAG", //! Table with MC truth for same sign 2-pion vertices used as tags
+                  aod::tagandprobe::IsSignal,
+                  aod::tagandprobe::MotherId);
 DECLARE_SOA_TABLE(KaKaFromDspTags, "AOD", "KAKAFROMDSPTAG", //! Table for opposite sign 2-kaon vertices used as tags
                   soa::Index<>,
                   aod::tagandprobe::CollisionId,
                   aod::tagandprobe::Track0Id,
                   aod::tagandprobe::Track1Id,
+                  aod::tagandprobe::MlScores,
+                  soa::Marker<1>);
+DECLARE_SOA_TABLE(KaKaFromDsMcTags, "AOD", "KAKAFROMDSMCTAG", //! Table with MC truth for opposite sign 2-kaon vertices used as tags
+                  aod::tagandprobe::IsSignal,
+                  aod::tagandprobe::MotherId,
                   soa::Marker<1>);
 DECLARE_SOA_TABLE(PiKaFromDzTags, "AOD", "PIKAFROMDZTAG", //! Table for opposite sign pion(+)-kaon(-) vertices used as tags
                   soa::Index<>,
                   aod::tagandprobe::CollisionId,
                   aod::tagandprobe::Track0Id,
                   aod::tagandprobe::Track1Id,
+                  aod::tagandprobe::MlScores,
+                  soa::Marker<2>);
+DECLARE_SOA_TABLE(PiKaFromDzMcTags, "AOD", "PIKAFROMDZMCTAG", //! Table with MC truth for opposite sign pion(+)-kaon(-) vertices used as tags
+                  aod::tagandprobe::IsSignal,
+                  aod::tagandprobe::MotherId,
                   soa::Marker<2>);
 DECLARE_SOA_TABLE(KaPiFromDzTags, "AOD", "KAPIFROMDZTAG", //! Table for opposite sign kaon(+)-pion(-) vertices used as tags
                   soa::Index<>,
                   aod::tagandprobe::CollisionId,
                   aod::tagandprobe::Track0Id,
                   aod::tagandprobe::Track1Id,
+                  aod::tagandprobe::MlScores,
+                  soa::Marker<3>);
+DECLARE_SOA_TABLE(KaPiFromDzMcTags, "AOD", "KAPIFROMDZMCTAG", //! Table with MC truth for opposite sign kaon(+)-pion(-) vertices used as tags
+                  aod::tagandprobe::IsSignal,
+                  aod::tagandprobe::MotherId,
                   soa::Marker<3>);
 DECLARE_SOA_TABLE(TagTopoVariables, "AOD", "TAGTOPOVARIABLE", //! Table for the Tags' Topological variables
                   aod::tagandprobe::TagPt,
@@ -153,12 +177,17 @@ DECLARE_SOA_TABLE(TagTopoVariables, "AOD", "TAGTOPOVARIABLE", //! Table for the 
 struct TagTwoProngDisplacedVertices {
 
   Produces<aod::PiPiFromDpTags> tagPiPiTable;
+  Produces<aod::PiPiFromDpMcTags> tagPiPiMcTable;
   Produces<aod::KaKaFromDspTags> tagKaKaTable;
+  Produces<aod::KaKaFromDsMcTags> tagKaKaMcTable;
   Produces<aod::KaPiFromDzTags> tagKaPiTable;
+  Produces<aod::KaPiFromDzMcTags> tagKaPiMcTable;
   Produces<aod::PiKaFromDzTags> tagPiKaTable;
+  Produces<aod::PiKaFromDzMcTags> tagPiKaMcTable;
   Produces<aod::TagTopoVariables> tagVarsTable;
+
   SliceCache cache;
-  Configurable<int> fillTagTable{"fillTagTable", 0, "flag to fill tag table with topological variables (0 -> disabled, 1 -> signal only, 2 -> bkg only, 3 -> both)"};
+  Configurable<int> fillTopoVarsTable{"fillTopoVarsTable", 0, "flag to fill tag table with topological variables (0 -> disabled, 1 -> signal only, 2 -> bkg only, 3 -> both)"};
   Configurable<bool> applyTofPid{"applyTofPid", true, "flag to enable TOF PID selection"};
   Configurable<bool> studyDzeroReflections{"studyDzeroReflections", false, "flag to study Dzero reflections"};
   Configurable<float> trackNumSigmaTof{"trackNumSigmaTof", 3.f, "number of sigma for TOF PID compatibility"};
@@ -166,15 +195,40 @@ struct TagTwoProngDisplacedVertices {
   Configurable<float> trackDcaXyMin{"trackDcaXyMin", 0.002f, "minimum DCAxy for tracks with pT < 2 GeV/c"};
   Configurable<float> trackPtMin{"trackPtMin", 0.4f, "minimum track pT"};
 
-  Configurable<std::vector<float>> binsPtPiPiFromDplus{"binsPtPiPiFromDplus", std::vector<float>{aod::tagandprobe::vecBinsPt}, "pT bin limits for pipi pairs from D+ decays"};
-  Configurable<std::vector<float>> binsKaKaFromDsOrDplus{"binsKaKaFromDsOrDplus", std::vector<float>{aod::tagandprobe::vecBinsPt}, "pT bin limits for KK pairs from Ds or D+ decays"};
-  Configurable<std::vector<float>> binsPtDzeroFromDstar{"binsPtDzeroFromDstar", std::vector<float>{aod::tagandprobe::vecBinsPt}, "pT bin limits for Kpi pairs from D0 <- D*+ decays"};
-  Configurable<std::vector<float>> binsPtDzeroKaKaFromDstar{"binsPtDzeroKaKaFromDstar", std::vector<float>{aod::tagandprobe::vecBinsPt}, "pT bin limits for KK pairs from D0 <- D*+ decays"};
+  Configurable<std::vector<double>> binsPtPiPiFromDplus{"binsPtPiPiFromDplus", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for pipi pairs from D+ decays"};
+  Configurable<std::vector<double>> binsPtKaKaFromDsOrDplus{"binsPtKaKaFromDsOrDplus", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for KK pairs from Ds or D+ decays"};
+  Configurable<std::vector<double>> binsPtDzeroFromDstar{"binsPtDzeroFromDstar", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for Kpi pairs from D0 <- D*+ decays"};
+  Configurable<std::vector<double>> binsPtDzeroKaKaFromDstar{"binsPtDzeroKaKaFromDstar", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for KK pairs from D0 <- D*+ decays"};
 
-  Configurable<LabeledArray<float>> cutsPiPiFromDplus{"cutsPiPiFromDplus", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsPt, aod::tagandprobe::labelsCutVar}, "Selections for pipi pairs from D+ decays"};
-  Configurable<LabeledArray<float>> cutsKaKaFromDsOrDplus{"cutsKaKaFromDsOrDplus", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsPt, aod::tagandprobe::labelsCutVar}, "Selections for KK pairs from Ds or D+ decays"};
-  Configurable<LabeledArray<float>> cutsDzeroFromDstar{"cutsDzeroFromDstar", {aod::tagandprobe::cutsDzero[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVarsDzero, aod::tagandprobe::labelsPt, aod::tagandprobe::labelsCutVarDzero}, "Selections for Kpi pairs from D0 <- D*+ decays"};
-  Configurable<LabeledArray<float>> cutsDzeroKaKaFromDstar{"cutsDzeroKaKaFromDstar", {aod::tagandprobe::cutsDzero[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVarsDzero, aod::tagandprobe::labelsPt, aod::tagandprobe::labelsCutVarDzero}, "Selections for Kpi pairs from D0 <- D*+ decays"};
+  Configurable<LabeledArray<double>> cutsPiPiFromDplus{"cutsPiPiFromDplus", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsCutVar}, "Selections for pipi pairs from D+ decays"};
+  Configurable<LabeledArray<double>> cutsKaKaFromDsOrDplus{"cutsKaKaFromDsOrDplus", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsCutVar}, "Selections for KK pairs from Ds or D+ decays"};
+  Configurable<LabeledArray<double>> cutsDzeroFromDstar{"cutsDzeroFromDstar", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsCutVar}, "Selections for Kpi pairs from D0 <- D*+ decays"};
+  Configurable<LabeledArray<double>> cutsDzeroKaKaFromDstar{"cutsDzeroKaKaFromDstar", {aod::tagandprobe::cuts[0], aod::tagandprobe::nBinsPt, aod::tagandprobe::nCutVars, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsCutVar}, "Selections for KK pairs from D0 <- D*+ decays"};
+
+  // ML models for triggers
+  struct : ConfigurableGroup {
+    std::string prefix = "ML";
+    Configurable<bool> applyMlPiPiFromDplus{"applyMlPiPiFromDplus", false, "Flag to enable ML application for pipi pairs from D+ decays"};
+    Configurable<bool> applyMlKaKaFromDsOrDplus{"applyMlKaKaFromDsOrDplus", false, "Flag to enable ML application for KK pairs from Ds or D+ decays"};
+    Configurable<bool> applyMlDzeroFromDstar{"applyMlDzeroFromDstar", false, "Flag to enable ML application for Kpi pairs from D0 <- D*+ decays"};
+    Configurable<bool> applyMlDzeroKaKaFromDstar{"applyMlDzeroKaKaFromDstar", false, "Flag to enable ML application for KK pairs from D0 <- D*+ decays"};
+    Configurable<int64_t> timestampCcdbForMlModels{"timestampCcdbForMlModels", -1, "timestamp of the ONNX file for ML model used to query in CCDB"};
+    Configurable<bool> loadMlModelsFromCcdb{"loadMlModelsFromCcdb", true, "Flag to enable or disable the loading of ML models from CCDB"};
+    // ML models (one per pT bin)
+    Configurable<std::vector<std::string>> modelPathsCcdbPiPiFromDplus{"modelPathsCcdbPiPiFromDplus", std::vector<std::string>{"/Users/f/fgrosa/TagAndProbe/DplusPt2to3"}, "Paths of models on CCDB for pipi pairs from D+ decays"};
+    Configurable<std::vector<std::string>> modelPathsCcdbKaKaFromDsOrDplus{"modelPathsCcdbKaKaFromDsOrDplus", std::vector<std::string>{"/Users/f/fgrosa/TagAndProbe/DsPt2to3"}, "Paths of models on CCDB for KK pairs from Ds or D+ decays"};
+    Configurable<std::vector<std::string>> modelPathsCcdbDzeroFromDstar{"modelPathsCcdbDzeroFromDstar", std::vector<std::string>{"/Users/f/fgrosa/TagAndProbe/DzeroPt2to3"}, "Paths of models on CCDB for Kpi pairs from D0 <- D*+ decays"};
+    Configurable<std::vector<std::string>> modelPathsCcdbDzeroKaKaFromDstar{"modelPathsCcdbDzeroKaKaFromDstar", std::vector<std::string>{"/Users/f/fgrosa/TagAndProbe/DzeroToKKPt2to3"}, "Paths of models on CCDB for KK pairs from D0 <- D*+ decays"};
+    Configurable<std::vector<std::string>> onnxFileNamesPiPiFromDplus{"onnxFileNamesPiPiFromDplus", std::vector<std::string>{"ModelHandler_onnx_DplusToKPiPi.onnx"}, "ONNX file names for pipi pairs from D+ decays"};
+    Configurable<std::vector<std::string>> onnxFileNamesKaKaFromDsOrDplus{"onnxFileNamesKaKaFromDsOrDplus", std::vector<std::string>{"ModelHandler_onnx_DsToKKPi.onnx"}, "ONNX file names for KK pairs from Ds or D+ decays"};
+    Configurable<std::vector<std::string>> onnxFileNamesDzeroFromDstar{"onnxFileNamesDzeroFromDstar", std::vector<std::string>{"ModelHandler_onnx_DzeroToKPi.onnx"}, "ONNX file names for Kpi pairs from D0 <- D*+ decays"};
+    Configurable<std::vector<std::string>> onnxFileNamesDzeroKaKaFromDstar{"onnxFileNamesDzeroKaKaFromDstar", std::vector<std::string>{"ModelHandler_onnx_DzeroToKK.onnx"}, "ONNX file names for KK pairs from D0 <- D*+ decays"};
+    // ML cuts
+    Configurable<LabeledArray<double>> mlCutsPiPiFromDplus{"mlCutsPiPiFromDplus", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for pipi pairs from D+ decays"};
+    Configurable<LabeledArray<double>> mlCutsKaKaFromDsOrDplus{"mlCutsKaKaFromDsOrDplus", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for KK pairs from Ds or D+ decays"};
+    Configurable<LabeledArray<double>> mlCutsDzeroFromDstar{"mlCutsDzeroFromDstar", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for Kpi pairs from D0 <- D*+ decays"};
+    Configurable<LabeledArray<double>> mlCutsDzeroKaKaFromDstar{"mlCutsDzeroKaKaFromDstar", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for KK pairs from D0 <- D*+ decays"};
+  } mlConfig;
 
   using TracksWithSelAndDca = soa::Join<aod::Tracks, aod::TracksCov, aod::TracksDCA, aod::TracksExtra, aod::TrackSelection, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa>;
   using TracksWithSelAndDcaMc = soa::Join<TracksWithSelAndDca, aod::McTrackLabels>;
@@ -198,6 +252,8 @@ struct TagTwoProngDisplacedVertices {
   Partition<TracksWithSelAndDcaMcFiltered> positiveKaonsMc = aod::track::signed1Pt > 0.f && nabs(aod::pidtpc::tpcNSigmaKa) < trackNumSigmaTpc;
   Partition<TracksWithSelAndDcaMcFiltered> negativeKaonsMc = aod::track::signed1Pt < 0.f && nabs(aod::pidtpc::tpcNSigmaKa) < trackNumSigmaTpc;
 
+  std::array<o2::analysis::MlResponse<float>, aod::tagandprobe::TagChannels::NTagChannels> mlResponse{};
+  std::array<bool, aod::tagandprobe::TagChannels::NTagChannels> applyMl{};
   ccdb::CcdbApi ccdbApi;
   Service<ccdb::BasicCCDBManager> ccdb;
   vertexing::DCAFitterN<2> vertexer;
@@ -209,8 +265,8 @@ struct TagTwoProngDisplacedVertices {
                                                                                            std::array{constants::physics::MassKaonCharged, constants::physics::MassPionCharged},
                                                                                            std::array{constants::physics::MassKaonCharged, constants::physics::MassKaonCharged}};
 
-  std::array<LabeledArray<float>, aod::tagandprobe::TagChannels::NTagChannels> topologicalCuts{};
-  std::array<std::vector<float>, aod::tagandprobe::TagChannels::NTagChannels> ptBinsForTopologicalCuts{};
+  std::array<LabeledArray<double>, aod::tagandprobe::TagChannels::NTagChannels> topologicalCuts{};
+  std::array<std::vector<double>, aod::tagandprobe::TagChannels::NTagChannels> ptBinsForTopologicalCuts{};
 
   HistogramRegistry registry{"registry"};
 
@@ -232,7 +288,7 @@ struct TagTwoProngDisplacedVertices {
     vertexer.setUseAbsDCA(false);
 
     topologicalCuts = {cutsPiPiFromDplus, cutsKaKaFromDsOrDplus, cutsDzeroFromDstar, cutsDzeroFromDstar, cutsDzeroKaKaFromDstar};
-    ptBinsForTopologicalCuts = {binsPtPiPiFromDplus, binsKaKaFromDsOrDplus, binsPtDzeroFromDstar, binsPtDzeroFromDstar, binsPtDzeroKaKaFromDstar};
+    ptBinsForTopologicalCuts = {binsPtPiPiFromDplus, binsPtKaKaFromDsOrDplus, binsPtDzeroFromDstar, binsPtDzeroFromDstar, binsPtDzeroKaKaFromDstar};
 
     const AxisSpec axisPt{250, 0.f, 50.f};
     const AxisSpec axisPtDzeroRefl{{0.f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 2.0f, 2.5f, 3.0f, 3.5f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 10.0f, 12.0f, 14.0f, 16.0f, 18.0f, 20.0f, 24.0f, 30.0f, 40.0f}};
@@ -257,26 +313,28 @@ struct TagTwoProngDisplacedVertices {
     if (doprocessKaKaFromDzero) {
       registry.add<TH2>("hMassDzeroKaKaVsPt", ";#it{p}_{T}(K#pi) (GeV/#it{c}); #it{M}(K#pi) (GeV/#it{c}^{2})", HistType::kTH2D, {axisPt, axisMassKaPi});
     }
-  }
 
-  /// Finds pT bin in an array.
-  /// \param bins  array of pT bins
-  /// \param value  pT
-  /// \return index of the pT bin
-  template <typename T1, typename T2>
-  int findBin(T1 const& binsPt, T2 value)
-  {
-    if (value < binsPt->front()) {
-      return -1;
+    const std::vector<int> cutDirMl = {o2::cuts_ml::CutDirection::CutGreater, o2::cuts_ml::CutDirection::CutSmaller, o2::cuts_ml::CutDirection::CutSmaller};
+    const std::array<LabeledArray<double>, aod::tagandprobe::TagChannels::NTagChannels> mlCuts = {mlConfig.mlCutsPiPiFromDplus, mlConfig.mlCutsKaKaFromDsOrDplus, mlConfig.mlCutsDzeroFromDstar, mlConfig.mlCutsDzeroFromDstar, mlConfig.mlCutsDzeroKaKaFromDstar};
+    const std::array<std::vector<std::string>, aod::tagandprobe::TagChannels::NTagChannels> onnxFileNames = {mlConfig.onnxFileNamesPiPiFromDplus, mlConfig.onnxFileNamesKaKaFromDsOrDplus, mlConfig.onnxFileNamesDzeroFromDstar, mlConfig.onnxFileNamesDzeroFromDstar, mlConfig.onnxFileNamesDzeroKaKaFromDstar};
+    const std::array<std::vector<std::string>, aod::tagandprobe::TagChannels::NTagChannels> modelPathsCcdb = {mlConfig.modelPathsCcdbPiPiFromDplus, mlConfig.modelPathsCcdbKaKaFromDsOrDplus, mlConfig.modelPathsCcdbDzeroFromDstar, mlConfig.modelPathsCcdbDzeroFromDstar, mlConfig.modelPathsCcdbDzeroKaKaFromDstar};
+    applyMl = {mlConfig.applyMlPiPiFromDplus, mlConfig.applyMlKaKaFromDsOrDplus, mlConfig.applyMlDzeroFromDstar, mlConfig.applyMlDzeroFromDstar, mlConfig.applyMlDzeroKaKaFromDstar};
+    for (auto iChannel{0u}; iChannel < aod::tagandprobe::TagChannels::NTagChannels; ++iChannel) {
+      if (applyMl[iChannel]) {
+        mlResponse[iChannel].configure(ptBinsForTopologicalCuts[iChannel], mlCuts[iChannel], cutDirMl, 3);
+        if (mlConfig.loadMlModelsFromCcdb) {
+          mlResponse[iChannel].setModelPathsCCDB(onnxFileNames[iChannel], ccdbApi, modelPathsCcdb[iChannel], mlConfig.timestampCcdbForMlModels);
+        } else {
+          mlResponse[iChannel].setModelPathsLocal(onnxFileNames[iChannel]);
+        }
+        mlResponse[iChannel].init();
+      }
     }
-    if (value >= binsPt->back()) {
-      return -1;
-    }
-    return std::distance(binsPt->begin(), std::upper_bound(binsPt->begin(), binsPt->end(), value)) - 1;
   }
 
   /// Fill a vector with the Mothers pdg codes
-  /// \param pdgMother vector with the pdg codes
+  /// \param pdgDecayMothers vector pdg codes of possible mothers
+  /// \param pdgResonances vector pdg codes of possible resonanced in the decays
   /// \param channel decay channel
   void pdgMothersDecayChannel(std::vector<int>& pdgDecayMothers, std::vector<int>& pdgResonances, const uint8_t channel)
   {
@@ -302,16 +360,20 @@ struct TagTwoProngDisplacedVertices {
   /// Check if the given tag tracks belong to a D meson
   /// \param firstTrack candidate
   /// \param SecondTrack candidate
-  /// \param particlesMc McParticles table
+  /// \param mcParticles McParticles table
   /// \param channel decay channel
+  /// \param pdgDecayMothers vector pdg codes of possible mothers
+  /// \param pdgResonances vector pdg codes of possible resonanced in the decays
+  /// \param motherIdx particle mother index 
   /// \return a flag that contains the information of MC truth (see aod::tagandprobe::SignalFlags)
   template <typename PParticles, typename TTrack>
   uint8_t getTagOrigin(TTrack const& firsTrack,
                        TTrack const& secondTrack,
-                       PParticles const& particlesMc,
+                       PParticles const& mcParticles,
                        const uint8_t channel,
                        std::vector<int>& pdgDecayMothers,
-                       std::vector<int>& pdgResonances)
+                       std::vector<int>& pdgResonances,
+                       int& motherIdx)
   {
     int pdgTagMother{0};
     int pdgProbeParticle{-1};
@@ -333,16 +395,16 @@ struct TagTwoProngDisplacedVertices {
     } else {
       auto firstMcTrack = firsTrack.template mcParticle_as<PParticles>();
       auto secondMcTrack = secondTrack.template mcParticle_as<PParticles>();
-      auto firstTrackMotherId = RecoDecay::getMother(particlesMc, firstMcTrack, pdgTagMother, true);
-      auto secondTrackMotherId = RecoDecay::getMother(particlesMc, secondMcTrack, pdgTagMother, true);
+      auto firstTrackMotherId = RecoDecay::getMother(mcParticles, firstMcTrack, pdgTagMother, true);
+      auto secondTrackMotherId = RecoDecay::getMother(mcParticles, secondMcTrack, pdgTagMother, true);
 
       bool isTaggedAsSignal{false}, isResonant{false};
       if ((firstTrackMotherId == secondTrackMotherId) && (firstTrackMotherId != -1)) {
-        auto particleMother = particlesMc.rawIteratorAt(firstTrackMotherId);
+        auto particleMother = mcParticles.rawIteratorAt(firstTrackMotherId);
 
         /// π±π± for D± → K∓π±π± decays
         if (channel == aod::tagandprobe::TagChannels::DplusToKPiPi) {
-          auto particleMother = particlesMc.rawIteratorAt(firstTrackMotherId);
+          auto particleMother = mcParticles.rawIteratorAt(firstTrackMotherId);
           auto daughters = particleMother.template daughters_as<PParticles>();
 
           // Check if the probe is within the mother's particle daughters
@@ -350,6 +412,7 @@ struct TagTwoProngDisplacedVertices {
             for (auto& daughter : daughters) {
               if (std::abs(daughter.pdgCode()) == pdgProbeParticle) {
                 isTaggedAsSignal = true;
+                motherIdx = firstTrackMotherId;
                 break;
               }
             }
@@ -359,6 +422,7 @@ struct TagTwoProngDisplacedVertices {
               if (std::find(pdgResonances.begin(), pdgResonances.end(), absPdg) != pdgResonances.end()) {
                 isTaggedAsSignal = true;
                 isResonant = true;
+                motherIdx = firstTrackMotherId;
                 break;
               }
             }
@@ -367,15 +431,16 @@ struct TagTwoProngDisplacedVertices {
           ///  K∓K± for φ from Ds± or D± → φπ± decays
           ///  K∓π± for D0 from D±* → D0π± decays
           for (auto pdgGrandMother : pdgDecayMothers) {
-            auto grandMotherId = RecoDecay::getMother(particlesMc, particleMother, pdgGrandMother, true);
+            auto grandMotherId = RecoDecay::getMother(mcParticles, particleMother, pdgGrandMother, true);
             if (grandMotherId != -1) {
-              auto particleGrandMother = particlesMc.rawIteratorAt(grandMotherId);
+              auto particleGrandMother = mcParticles.rawIteratorAt(grandMotherId);
               auto daughters = particleGrandMother.template daughters_as<PParticles>();
               // Check if the probe is within the GrandMother's particle daughters
               if (daughters.size() == 2) { // exclude undesired decays, such as Ds± → φπ±π±π∓
                 for (auto& daughter : daughters) {
                   if (std::abs(daughter.pdgCode()) == pdgProbeParticle) {
                     isTaggedAsSignal = true;
+                    motherIdx = grandMotherId;
                     break;
                   }
                 }
@@ -387,7 +452,7 @@ struct TagTwoProngDisplacedVertices {
 
       // check if it is non-prompt from beauty
       if (isTaggedAsSignal) {
-        if (RecoDecay::getCharmHadronOrigin(particlesMc, particlesMc.rawIteratorAt(firstTrackMotherId)) == RecoDecay::OriginType::NonPrompt) {
+        if (RecoDecay::getCharmHadronOrigin(mcParticles, mcParticles.rawIteratorAt(firstTrackMotherId)) == RecoDecay::OriginType::NonPrompt) {
           SETBIT(signalFlag, aod::tagandprobe::SignalFlags::NonPrompt);
         } else {
           SETBIT(signalFlag, aod::tagandprobe::SignalFlags::Prompt);
@@ -418,61 +483,6 @@ struct TagTwoProngDisplacedVertices {
       return false;
     }
     return true;
-  }
-
-  /// Calculate all the topology variables and store them in the Topology table
-  /// \param doMc 1 for the Mc and 0 for the data
-  /// \param primVtx  primary vertex
-  /// \param secVtx  secondary vertex
-  /// \param trackDcaXy array with the Tags' TrackDCAXY
-  /// \param channel decay channel
-  /// \param firstTrack candidate
-  /// \param SecondTrack candidate
-  /// \param particlesMc McParticle table
-  template <bool doMc, typename PV, typename SV, typename CovMatSV, typename PVec, typename TTrack, typename PParticles>
-  void getTagInfo(const PV& primVtx,
-                  const SV& secVtx,
-                  const CovMatSV& covMatrixSecVtx,
-                  const PVec& pVec,
-                  std::array<float, 2>& trackDcaXy,
-                  const uint8_t channel,
-                  const TTrack& firstTrack,
-                  const TTrack& secondTrack,
-                  float& invMass2,
-                  std::vector<int>& pdgDecayMothers,
-                  std::vector<int>& pdgResonances,
-                  const PParticles& particlesMc)
-  {
-    auto covMatrixPV = primVtx.getCov();
-    float phi, theta;
-    std::array<float, 3> pvCoord = {primVtx.getX(), primVtx.getY(), primVtx.getZ()};
-    getPointDirection(pvCoord, secVtx, phi, theta);
-
-    auto decLen = RecoDecay::distance(pvCoord, secVtx);
-    auto errorDecLen = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixSecVtx, phi, theta));
-    auto errorDecLenXy = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.f) + getRotatedCovMatrixXX(covMatrixSecVtx, phi, 0.f));
-    auto decLenXy = RecoDecay::distanceXY(pvCoord, secVtx);
-    auto cpa = RecoDecay::cpa(pvCoord, secVtx, pVec);
-    auto cpaXy = RecoDecay::cpaXY(pvCoord, secVtx, pVec);
-    auto normDecLen = decLen / errorDecLen;
-    auto normDecLenXy = decLenXy / errorDecLenXy;
-    auto tagsPt = RecoDecay::pt(pVec);
-    auto invMass = std::sqrt(invMass2);
-
-    uint8_t isSignal = 0; // default value for data (no bkg, no signal)
-
-    bool fillTable{true};
-    if constexpr (doMc) {
-      isSignal = getTagOrigin(firstTrack, secondTrack, particlesMc, channel, pdgDecayMothers, pdgResonances);
-      if (fillTagTable == 1 && !(TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Prompt) || TESTBIT(isSignal, aod::tagandprobe::SignalFlags::NonPrompt))) { // only signal
-        fillTable = false;
-      } else if (fillTagTable == 2 && !TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Bkg)) { // only background
-        fillTable = false;
-      }
-    }
-    if (fillTable) {
-      tagVarsTable(tagsPt, invMass, decLen, decLenXy, normDecLen, normDecLenXy, trackDcaXy[0], trackDcaXy[1], trackDcaXy[0] * trackDcaXy[1], cpa, cpaXy, isSignal, channel);
-    }
   }
 
   template <typename TTrack>
@@ -525,13 +535,16 @@ struct TagTwoProngDisplacedVertices {
                           const PVec& pVec,
                           std::array<float, 2>& trackDcaXy,
                           const uint8_t channel,
-                          const int& ptBin)
+                          const int& ptBin,
+                          std::vector<float>& topoVars)
   {
+    topoVars.clear();
     std::array<float, 3> pvCoord = {primVtx.getX(), primVtx.getY(), primVtx.getZ()};
     auto decLen = RecoDecay::distance(pvCoord, secVtx);
     if (decLen < topologicalCuts[channel].get(ptBin, 2u)) {
       return false;
     }
+    topoVars.push_back(decLen);
 
     auto covMatrixPV = primVtx.getCov();
 
@@ -539,6 +552,7 @@ struct TagTwoProngDisplacedVertices {
     if (decLenXy < topologicalCuts[channel].get(ptBin, 3u)) {
       return false;
     }
+    topoVars.push_back(decLenXy);
 
     float phi, theta;
     getPointDirection(pvCoord, secVtx, phi, theta);
@@ -546,26 +560,32 @@ struct TagTwoProngDisplacedVertices {
     if (decLen / errorDecLen < topologicalCuts[channel].get(ptBin, 4u)) {
       return false;
     }
+    topoVars.push_back(decLen / errorDecLen);
 
     auto errorDecLenXy = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.f) + getRotatedCovMatrixXX(covMatrixSecVtx, phi, 0.f));
     if (decLenXy / errorDecLenXy < topologicalCuts[channel].get(ptBin, 5u)) {
       return false;
     }
+    topoVars.push_back(decLenXy / errorDecLenXy);
 
-    // only for D0 meson
-    if (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi || channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi || channel == aod::tagandprobe::TagChannels::DstarToDzeroToKK) {
-      if (trackDcaXy[0] * trackDcaXy[1] > topologicalCuts[channel].get(ptBin, 6u)) {
-        return false;
-      }
-      auto cpa = RecoDecay::cpa(pvCoord, secVtx, pVec);
-      if (cpa < topologicalCuts[channel].get(ptBin, 7u)) {
-        return false;
-      }
-      auto cpaXy = RecoDecay::cpaXY(pvCoord, secVtx, pVec);
-      if (cpaXy < topologicalCuts[channel].get(ptBin, 8u)) {
-        return false;
-      }
+    if (trackDcaXy[0] * trackDcaXy[1] > topologicalCuts[channel].get(ptBin, 6u)) {
+      return false;
     }
+    topoVars.push_back(trackDcaXy[0]);
+    topoVars.push_back(trackDcaXy[1]);
+    topoVars.push_back(trackDcaXy[0] * trackDcaXy[1]);
+
+    auto cpa = RecoDecay::cpa(pvCoord, secVtx, pVec);
+    if (cpa < topologicalCuts[channel].get(ptBin, 7u)) {
+      return false;
+    }
+    topoVars.push_back(cpa);
+
+    auto cpaXy = RecoDecay::cpaXY(pvCoord, secVtx, pVec);
+    if (cpaXy < topologicalCuts[channel].get(ptBin, 8u)) {
+      return false;
+    }
+    topoVars.push_back(cpaXy);
 
     return true;
   }
@@ -577,7 +597,7 @@ struct TagTwoProngDisplacedVertices {
                                       float& /*bz*/,
                                       std::vector<int>& pdgDecayMothers,
                                       std::vector<int>& pdgResonances,
-                                      PParticles const& particlesMc)
+                                      PParticles const& mcParticles)
   {
     for (auto trackFirst = tracks.begin(); trackFirst != tracks.end(); ++trackFirst) {
 
@@ -596,7 +616,8 @@ struct TagTwoProngDisplacedVertices {
         std::array<float, 3> pVecTrackSecond{trackSecond.px(), trackSecond.py(), trackSecond.pz()};
 
         auto pVec = RecoDecay::pVec(pVecTrackFirst, pVecTrackSecond);
-        auto ptBin = findBin(&ptBinsForTopologicalCuts[channel], RecoDecay::pt(pVec));
+        auto ptTag = RecoDecay::pt(pVec);
+        auto ptBin = o2::analysis::findBin(&ptBinsForTopologicalCuts[channel], ptTag);
         if (ptBin == -1) {
           continue;
         }
@@ -623,14 +644,42 @@ struct TagTwoProngDisplacedVertices {
         const auto& secVtx = vertexer.getPCACandidate();
         const auto& covMatrixPCA = vertexer.calcPCACovMatrixFlat();
         std::array<float, 2> trackDcaXy{trackFirst.dcaXY(), trackSecond.dcaXY()};
-        if (fillTagTable) {
-          getTagInfo<doMc>(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, trackFirst, trackSecond, invMass2, pdgDecayMothers, pdgResonances, particlesMc);
-        } else {
-          if (!isSelectedTopology(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, ptBin)) {
+        std::vector<float> topoVars{};
+        if (!isSelectedTopology(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, ptBin, topoVars)) {
+          continue;
+        }
+
+        std::vector<float> mlScoresTag{};
+        if (applyMl[channel]) {
+          if(!mlResponse[channel].isSelectedMl(topoVars, ptTag, mlScoresTag)) { // for the time being all the topological variables used for all channels (decLen, decLenXy, normDecLen, normDecLenXy, cosp, cospXy, dcaXyTrack0, dcaXyTrack1, dcaProd)
             continue;
           }
-          registry.fill(HIST("hMassPiPiVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2)); // only channel with same sign tracks for the moment
-          tagPiPiTable(trackFirst.collisionId(), trackFirst.globalIndex(), trackSecond.globalIndex());
+        }
+
+        float invMass{std::sqrt(invMass2)};
+        registry.fill(HIST("hMassPiPiVsPt"), ptTag, invMass); // only channel with same sign tracks for the moment
+
+        uint8_t isSignal{0u};
+        int motherIdx{-1};
+        if constexpr (doMc) {
+          isSignal = getTagOrigin(trackFirst, trackSecond, mcParticles, channel, pdgDecayMothers, pdgResonances, motherIdx);
+        }
+
+        if (fillTopoVarsTable) {
+          bool fillTable{true};
+          if (fillTopoVarsTable == 1 && !(TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Prompt) || TESTBIT(isSignal, aod::tagandprobe::SignalFlags::NonPrompt))) { // only signal
+            fillTable = false;
+          } else if (fillTopoVarsTable == 2 && !TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Bkg)) { // only background
+            fillTable = false;
+          }
+          if (fillTable) {
+            tagVarsTable(ptTag, invMass, topoVars[0], topoVars[1], topoVars[2], topoVars[3], trackDcaXy[0], trackDcaXy[1], topoVars[6], topoVars[7], topoVars[8], isSignal, channel);
+          }
+        } else {
+          tagPiPiTable(trackFirst.collisionId(), trackFirst.globalIndex(), trackSecond.globalIndex(), mlScoresTag);
+          if constexpr (doMc) {
+            tagPiPiMcTable(isSignal, motherIdx);
+          }
         }
       }
     }
@@ -644,7 +693,7 @@ struct TagTwoProngDisplacedVertices {
                                           float& /*bz*/,
                                           std::vector<int>& pdgDecayMothers,
                                           std::vector<int>& pdgResonances,
-                                          PParticles const& particlesMc)
+                                          PParticles const& mcParticles)
   {
     for (const auto& trackPos : tracksPos) {
 
@@ -663,7 +712,8 @@ struct TagTwoProngDisplacedVertices {
         std::array<float, 3> pVecTrackNeg{trackNeg.px(), trackNeg.py(), trackNeg.pz()};
 
         auto pVec = RecoDecay::pVec(pVecTrackPos, pVecTrackNeg);
-        auto ptBin = findBin(&ptBinsForTopologicalCuts[channel], RecoDecay::pt(pVec));
+        auto ptTag = RecoDecay::pt(pVec);
+        auto ptBin = o2::analysis::findBin(&ptBinsForTopologicalCuts[channel], ptTag);
         if (ptBin == -1) {
           continue;
         }
@@ -690,57 +740,95 @@ struct TagTwoProngDisplacedVertices {
         const auto& secVtx = vertexer.getPCACandidate();
         const auto& covMatrixPCA = vertexer.calcPCACovMatrixFlat();
         std::array<float, 2> trackDcaXy{trackPos.dcaXY(), trackNeg.dcaXY()};
-        if (fillTagTable) {
-          getTagInfo<doMc>(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, trackPos, trackNeg, invMass2, pdgDecayMothers, pdgResonances, particlesMc);
-        } else {
-          if (!isSelectedTopology(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, ptBin)) {
+        std::vector<float> topoVars{};
+        if (!isSelectedTopology(primVtx, secVtx, covMatrixPCA, pVec, trackDcaXy, channel, ptBin, topoVars)) {
+          continue;
+        }
+
+        std::vector<float> mlScoresTag{};
+        if (applyMl[channel]) {
+          if(!mlResponse[channel].isSelectedMl(topoVars, ptTag, mlScoresTag)) { // for the time being all the topological variables used for all channels (decLen, decLenXy, normDecLen, normDecLenXy, cosp, cospXy, dcaXyTrack0, dcaXyTrack1, dcaProd)
             continue;
           }
+        }
+
+        float invMass{std::sqrt(invMass2)};
+        if (channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) {
+          registry.fill(HIST("hMassKaKaVsPt"), ptTag, invMass);
+        } else if (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi) {
+          if (!studyDzeroReflections) {
+            registry.fill(HIST("hMassKaPiVsPt"), ptTag, invMass);
+          } else {
+            float invMassRefl{0.f};
+            int isDzero = 1;
+            if (std::abs(trackPos.tpcNSigmaKa()) < trackNumSigmaTpc && (std::abs(trackNeg.tpcNSigmaPi()) < trackNumSigmaTpc)) {
+              isDzero = 3;
+              if (applyTofPid) {
+                if (!isSelectedPidTof(trackNeg, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) || !isSelectedPidTof(trackPos, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi))
+                  isDzero = 1;
+              }
+            }
+            if (isDzero == 3) {
+              auto arrMomentum = std::array{pVecTrackNeg, pVecTrackPos};
+              invMassRefl = std::sqrt(RecoDecay::m2(arrMomentum, masses[channel]));
+            }
+            registry.fill(HIST("hMassKaPiVsPt"), ptTag, invMass, invMassRefl, isDzero);
+          } 
+        } else if (channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) {
+          if (!studyDzeroReflections) {
+            registry.fill(HIST("hMassKaPiVsPt"), ptTag, invMass);
+          } else {
+            float invMassRefl{0.f};
+            int isDzero = 2;
+            if (std::abs(trackNeg.tpcNSigmaKa()) < trackNumSigmaTpc && (std::abs(trackPos.tpcNSigmaPi()) < trackNumSigmaTpc)) {
+              isDzero = 3;
+              if (applyTofPid) {
+                if (!isSelectedPidTof(trackNeg, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi) || !isSelectedPidTof(trackPos, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi))
+                  isDzero = 2;
+              }
+            }
+            if (isDzero == 3) {
+              auto arrMomentum = std::array{pVecTrackNeg, pVecTrackPos};
+              invMassRefl = std::sqrt(RecoDecay::m2(arrMomentum, masses[channel]));
+            }
+            registry.fill(HIST("hMassKaPiVsPt"), ptTag, invMass, invMassRefl, isDzero);
+          }
+        } else if (channel == aod::tagandprobe::TagChannels::DstarToDzeroToKK) {
+          registry.fill(HIST("hMassDzeroKaKaVsPt"), ptTag, invMass);
+        }
+
+        uint8_t isSignal{0u};
+        int motherIdx{-1};
+        if constexpr (doMc) {
+          isSignal = getTagOrigin(trackPos, trackNeg, mcParticles, channel, pdgDecayMothers, pdgResonances, motherIdx);
+        }
+
+        if (fillTopoVarsTable) {
+          bool fillTable{true};
+          if (fillTopoVarsTable == 1 && !(TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Prompt) || TESTBIT(isSignal, aod::tagandprobe::SignalFlags::NonPrompt))) { // only signal
+            fillTable = false;
+          } else if (fillTopoVarsTable == 2 && !TESTBIT(isSignal, aod::tagandprobe::SignalFlags::Bkg)) { // only background
+            fillTable = false;
+          }
+          if (fillTable) {
+            tagVarsTable(ptTag, invMass, topoVars[0], topoVars[1], topoVars[2], topoVars[3], trackDcaXy[0], trackDcaXy[1], topoVars[6], topoVars[7], topoVars[8], isSignal, channel);
+          }
+        } else {
           if (channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) {
-            registry.fill(HIST("hMassKaKaVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2));
-            tagKaKaTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex());
+            tagKaKaTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex(), mlScoresTag);
+            if constexpr (doMc) {
+              tagKaKaMcTable(isSignal, motherIdx);
+            }
           } else if (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi) {
-            if (!studyDzeroReflections) {
-              registry.fill(HIST("hMassKaPiVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2));
-            } else {
-              float invMassrefl{0.f};
-              int isDzero = 1;
-              if (std::abs(trackPos.tpcNSigmaKa()) < trackNumSigmaTpc && (std::abs(trackNeg.tpcNSigmaPi()) < trackNumSigmaTpc)) {
-                isDzero = 3;
-                if (applyTofPid) {
-                  if (!isSelectedPidTof(trackNeg, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) || !isSelectedPidTof(trackPos, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi))
-                    isDzero = 1;
-                }
-              }
-              if (isDzero == 3) {
-                auto arrMomentum = std::array{pVecTrackNeg, pVecTrackPos};
-                invMassrefl = std::sqrt(RecoDecay::m2(arrMomentum, masses[channel]));
-              }
-              registry.fill(HIST("hMassKaPiVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2), invMassrefl, isDzero);
+            tagPiKaTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex(), mlScoresTag);
+            if constexpr (doMc) {
+              tagPiKaMcTable(isSignal, motherIdx);
             }
-            tagPiKaTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex());
           } else if (channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) {
-            if (!studyDzeroReflections) {
-              registry.fill(HIST("hMassKaPiVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2));
-            } else {
-              float invMassrefl{0.f};
-              int isDzero = 2;
-              if (std::abs(trackNeg.tpcNSigmaKa()) < trackNumSigmaTpc && (std::abs(trackPos.tpcNSigmaPi()) < trackNumSigmaTpc)) {
-                isDzero = 3;
-                if (applyTofPid) {
-                  if (!isSelectedPidTof(trackNeg, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi) || !isSelectedPidTof(trackPos, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi))
-                    isDzero = 2;
-                }
-              }
-              if (isDzero == 3) {
-                auto arrMomentum = std::array{pVecTrackNeg, pVecTrackPos};
-                invMassrefl = std::sqrt(RecoDecay::m2(arrMomentum, masses[channel]));
-              }
-              registry.fill(HIST("hMassKaPiVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2), invMassrefl, isDzero);
+            tagKaPiTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex(), mlScoresTag);
+            if constexpr (doMc) {
+              tagKaPiMcTable(isSignal, motherIdx);
             }
-            tagKaPiTable(trackPos.collisionId(), trackPos.globalIndex(), trackNeg.globalIndex());
-          } else if (channel == aod::tagandprobe::TagChannels::DstarToDzeroToKK) {
-            registry.fill(HIST("hMassDzeroKaKaVsPt"), RecoDecay::pt(pVec), std::sqrt(invMass2));
           }
         }
       }
@@ -750,7 +838,7 @@ struct TagTwoProngDisplacedVertices {
   void processPiPiFromDplusMc(CollisionsFiltered::iterator const& collision,
                               TracksWithSelAndDcaMcFiltered const&,
                               aod::BCsWithTimestamps const&,
-                              aod::McParticles const& particlesMc)
+                              aod::McParticles const& mcParticles)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     float bz{0};
@@ -770,10 +858,10 @@ struct TagTwoProngDisplacedVertices {
     pdgMothersDecayChannel(pdgDecayMothers, pdgResonances, aod::tagandprobe::TagChannels::DplusToKPiPi);
 
     auto groupPositive = positivePionsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    computeCombinatorialSameCharge<true>(collision, groupPositive, aod::tagandprobe::TagChannels::DplusToKPiPi, bz, pdgDecayMothers, pdgResonances, particlesMc);
+    computeCombinatorialSameCharge<true>(collision, groupPositive, aod::tagandprobe::TagChannels::DplusToKPiPi, bz, pdgDecayMothers, pdgResonances, mcParticles);
 
     auto groupNegative = negativePionsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    computeCombinatorialSameCharge<true>(collision, groupNegative, aod::tagandprobe::TagChannels::DplusToKPiPi, bz, pdgDecayMothers, pdgResonances, particlesMc);
+    computeCombinatorialSameCharge<true>(collision, groupNegative, aod::tagandprobe::TagChannels::DplusToKPiPi, bz, pdgDecayMothers, pdgResonances, mcParticles);
   }
   PROCESS_SWITCH(TagTwoProngDisplacedVertices, processPiPiFromDplusMc, "Process pipi combinatorial to tag pion pairs from D+ decays Mc", false);
 
@@ -809,7 +897,7 @@ struct TagTwoProngDisplacedVertices {
   void processKaKaFromDsOrDplusMc(CollisionsFiltered::iterator const& collision,
                                   TracksWithSelAndDcaMcFiltered const&,
                                   aod::BCsWithTimestamps const&,
-                                  aod::McParticles const& particlesMc)
+                                  aod::McParticles const& mcParticles)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     float bz{0};
@@ -830,7 +918,7 @@ struct TagTwoProngDisplacedVertices {
 
     auto groupPositive = positiveKaonsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto groupNegative = negativeKaonsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    computeCombinatorialOppositeCharge<true>(collision, groupPositive, groupNegative, aod::tagandprobe::TagChannels::DsOrDplusToKKPi, bz, pdgDecayMothers, pdgResonances, particlesMc);
+    computeCombinatorialOppositeCharge<true>(collision, groupPositive, groupNegative, aod::tagandprobe::TagChannels::DsOrDplusToKKPi, bz, pdgDecayMothers, pdgResonances, mcParticles);
   }
   PROCESS_SWITCH(TagTwoProngDisplacedVertices, processKaKaFromDsOrDplusMc, "Process KK combinatorial to tag kaon pairs from Ds+/D+ decays Mc", false);
 
@@ -921,7 +1009,7 @@ struct TagTwoProngDisplacedVertices {
   void processKaPiFromDstarMc(CollisionsFiltered::iterator const& collision,
                               TracksWithSelAndDcaMcFiltered const&,
                               aod::BCsWithTimestamps const&,
-                              aod::McParticles const& particlesMc)
+                              aod::McParticles const& mcParticles)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     float bz{0};
@@ -944,8 +1032,8 @@ struct TagTwoProngDisplacedVertices {
     auto groupPionNegative = negativePionsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto groupKaonPositive = positiveKaonsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto groupKaonNegative = negativeKaonsMc->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-    computeCombinatorialOppositeCharge<true>(collision, groupPionPositive, groupKaonNegative, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi, bz, pdgDecayMothers, pdgResonances, particlesMc);
-    computeCombinatorialOppositeCharge<true>(collision, groupKaonPositive, groupPionNegative, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi, bz, pdgDecayMothers, pdgResonances, particlesMc);
+    computeCombinatorialOppositeCharge<true>(collision, groupPionPositive, groupKaonNegative, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi, bz, pdgDecayMothers, pdgResonances, mcParticles);
+    computeCombinatorialOppositeCharge<true>(collision, groupKaonPositive, groupPionNegative, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi, bz, pdgDecayMothers, pdgResonances, mcParticles);
   }
   PROCESS_SWITCH(TagTwoProngDisplacedVertices, processKaPiFromDstarMc, "Process Kpi combinatorial to tag D0 from D*+ decays", false);
 };
@@ -953,12 +1041,39 @@ struct TagTwoProngDisplacedVertices {
 /// Probe third track reconstruction efficiency with different selections
 struct ProbeThirdTrack {
 
+  // ML models for triggers
+  struct : ConfigurableGroup {
+    std::string prefix = "ML";
+    Configurable<bool> applyMlPiPiFromDplus{"applyMlPiPiFromDplus", false, "Flag to enable ML application for pipi pairs from D+ decays"};
+    Configurable<bool> applyMlKaKaFromDsOrDplus{"applyMlKaKaFromDsOrDplus", false, "Flag to enable ML application for KK pairs from Ds or D+ decays"};
+    Configurable<bool> applyMlDzeroFromDstar{"applyMlDzeroFromDstar", false, "Flag to enable ML application for Kpi pairs from D0 <- D*+ decays"};
+    // pt bins
+    Configurable<std::vector<double>> binsPtPiPiFromDplus{"binsPtPiPiFromDplus", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for pipi pairs from D+ decays"};
+    Configurable<std::vector<double>> binsPtKaKaFromDsOrDplus{"binsPtKaKaFromDsOrDplus", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for KK pairs from Ds or D+ decays"};
+    Configurable<std::vector<double>> binsPtDzeroFromDstar{"binsPtDzeroFromDstar", std::vector<double>{aod::tagandprobe::vecBinsPt}, "pT bin limits for Kpi pairs from D0 <- D*+ decays"};
+    // ML cuts
+    Configurable<LabeledArray<double>> mlCutsPiPiFromDplus{"mlCutsPiPiFromDplus", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for pipi pairs from D+ decays"};
+    Configurable<LabeledArray<double>> mlCutsKaKaFromDsOrDplus{"mlCutsKaKaFromDsOrDplus", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for KK pairs from Ds or D+ decays"};
+    Configurable<LabeledArray<double>> mlCutsDzeroFromDstar{"mlCutsDzeroFromDstar", {aod::tagandprobe::mlCuts[0], aod::tagandprobe::nBinsPt, 3, aod::tagandprobe::labelsEmpty, aod::tagandprobe::labelsMlScores}, "ML Selections for Kpi pairs from D0 <- D*+ decays"};
+  } mlConfig;
+
+  Filter tagMcFilter = aod::tagandprobe::isSignal > 0;
+
   using TracksWithDca = soa::Join<aod::Tracks, aod::TracksDCA, aod::TracksExtra>;
+  using TracksWithDcaMc = soa::Join<TracksWithDca, aod::McTrackLabels>;
+  using FilteredPiPiFromDpMcTags = soa::Filtered<soa::Join<aod::PiPiFromDpTags, aod::PiPiFromDpMcTags>>;
+  using FilteredKaKaFromDspMcTags = soa::Filtered<soa::Join<aod::KaKaFromDspTags, aod::KaKaFromDsMcTags>>;
+  using FilteredPiKaFromDzMcTags = soa::Filtered<soa::Join<aod::PiKaFromDzTags, aod::PiKaFromDzMcTags>>;
+  using FilteredKaPiFromDzMcTags = soa::Filtered<soa::Join<aod::KaPiFromDzTags, aod::KaPiFromDzMcTags>>;
 
   Preslice<aod::PiPiFromDpTags> tagsPiPiPerCollision = aod::tagandprobe::collisionId;
   Preslice<aod::KaKaFromDspTags> tagsKaKaPerCollision = aod::tagandprobe::collisionId;
   Preslice<aod::PiKaFromDzTags> tagsPiKaPerCollision = aod::tagandprobe::collisionId;
   Preslice<aod::KaPiFromDzTags> tagsKaPiPerCollision = aod::tagandprobe::collisionId;
+  Preslice<FilteredPiPiFromDpMcTags> tagsPiPiMcPerCollision = aod::tagandprobe::collisionId;
+  Preslice<FilteredKaKaFromDspMcTags> tagsKaKaMcPerCollision = aod::tagandprobe::collisionId;
+  Preslice<FilteredPiKaFromDzMcTags> tagsPiKaMcPerCollision = aod::tagandprobe::collisionId;
+  Preslice<FilteredKaPiFromDzMcTags> tagsKaPiMcPerCollision = aod::tagandprobe::collisionId;
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
 
   std::array<std::array<double, 3>, aod::tagandprobe::TagChannels::NTagChannels> masses = {std::array{constants::physics::MassPionCharged, constants::physics::MassPionCharged, constants::physics::MassKaonCharged},
@@ -968,12 +1083,17 @@ struct ProbeThirdTrack {
                                                                                            std::array{constants::physics::MassKaonCharged, constants::physics::MassKaonCharged, constants::physics::MassPionCharged}};
 
   std::array<TrackSelection, aod::tagandprobe::TrackTypes::NTrackTypes> trackSelector{}; // define the track selectors
+  std::array<bool, aod::tagandprobe::TagChannels::NTagChannels> applyMl{};
 
   std::array<std::array<std::shared_ptr<THnSparse>, aod::tagandprobe::TrackTypes::NTrackTypes>, aod::tagandprobe::TagChannels::NTagChannels> histos{};
   HistogramRegistry registry{"registry"};
 
   void init(InitContext&)
   {
+    if ((doprocessCombinatorialDplusToKaPiPi && doprocessCombinatorialDplusToKaPiPiMc) || (doprocessCombinatorialDsToPhiPi && doprocessCombinatorialDsToPhiPiMc) || (doprocessCombinatorialDstarToDzeroPi && doprocessCombinatorialDstarToDzeroPiMc)) {
+      LOGP(fatal, "The process functions for the same channel with and without MC truth cannot be enabled at the same time! Please check your configuration");
+    }
+
     // ITS-TPC tracks (global tracks)
     trackSelector[aod::tagandprobe::TrackTypes::GlobalWoDca].SetTrackType(o2::aod::track::TrackTypeEnum::Track);
     trackSelector[aod::tagandprobe::TrackTypes::GlobalWoDca].SetPtRange(0.05f, 1e10f);
@@ -1034,6 +1154,8 @@ struct ProbeThirdTrack {
                                                                HistType::kTHnSparseF, {axisPtD, axisPtTag, axisPtProbe, axisPtProbe, axisMass[iChannel], axisMassTag[iChannel], axisEtaProbe, axisNumCrossRowTpc, axisTpcChi2PerClus, axisNumCluIts});
       }
     }
+
+    applyMl = {mlConfig.applyMlPiPiFromDplus, mlConfig.applyMlKaKaFromDsOrDplus, mlConfig.applyMlDzeroFromDstar};
   }
 
   template <typename TTrack>
@@ -1055,22 +1177,52 @@ struct ProbeThirdTrack {
     }
   }
 
-  template <typename TTrackIndices, typename TTrack, typename TTracks>
-  void loopOverThirdTrack(TTrackIndices const& groupedTrackThirdIndices, TTracks const& /*tracks*/, TTrack const& trackFirst, TTrack const& trackSecond, const uint8_t channel)
+  template <uint8_t channel, bool doMc, typename TTrackIndices, typename TTrack, typename TTracks, typename PParticles>
+  void loopOverThirdTrack(TTrackIndices const& groupedTrackThirdIndices, TTracks const& /*tracks*/, TTrack const& trackFirst, TTrack const& trackSecond, PParticles const mcParticles, const int motherIdxTag)
   {
     for (const auto& trackIndex : groupedTrackThirdIndices) {
       auto trackThird = trackIndex.template track_as<TTracks>();
+      if constexpr (doMc) {
+        if (!trackThird.has_mcParticle()) {
+          continue;
+        }
+        int motherIdxProbe{-1};
+        int pdgMotherFirst{0}, pdgMotherSecond{0};
+        if constexpr (channel == aod::tagandprobe::TagChannels::DplusToKPiPi) {
+          pdgMotherFirst = constants::physics::Pdg::kDPlus;
+        } else if constexpr (channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) {
+          pdgMotherFirst = constants::physics::Pdg::kDS;
+          pdgMotherSecond = constants::physics::Pdg::kDPlus;
+        } else if constexpr (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi || channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) {
+          pdgMotherFirst = constants::physics::Pdg::kDStar;
+        }
+        auto particleProbe = trackThird.template mcParticle_as<PParticles>();
+        motherIdxProbe = RecoDecay::getMother(mcParticles, particleProbe, pdgMotherFirst, true);
+        if constexpr (channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) {
+          if (motherIdxProbe < 0) {
+            motherIdxProbe = RecoDecay::getMother(mcParticles, particleProbe, pdgMotherSecond, true);
+          }
+        }
+        if (motherIdxProbe < 0 || motherIdxTag != motherIdxProbe) {
+          continue;
+        }
+      }
+
       if (trackThird.globalIndex() == trackFirst.globalIndex() || trackThird.globalIndex() == trackSecond.globalIndex()) {
         continue;
       }
-      if (channel == aod::tagandprobe::TagChannels::DplusToKPiPi && trackThird.signed1Pt() * trackFirst.signed1Pt() > 0.) { // must be opposite sign
-        continue;
-      }
-      if (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi && trackThird.signed1Pt() < 0.) { // must be positive
-        continue;
-      }
-      if (channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi && trackThird.signed1Pt() > 0.) { // must be negative
-        continue;
+      if constexpr (channel == aod::tagandprobe::TagChannels::DplusToKPiPi) { // must be opposite sign
+        if (trackThird.signed1Pt() * trackFirst.signed1Pt() > 0.) {
+          continue;
+        }
+      } else if constexpr (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi) { // must be positive
+        if (trackThird.signed1Pt() < 0.) {
+          continue;
+        }
+      } else if constexpr (channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) { // must be negative
+        if (trackThird.signed1Pt() > 0.) {
+          continue;
+        }
       }
       auto ptTrackThird = trackThird.pt();
       auto ptTpcInnerTrackThird = trackThird.tpcInnerParam() / std::sqrt(1.f + trackThird.tgl() * trackThird.tgl());
@@ -1080,16 +1232,46 @@ struct ProbeThirdTrack {
       auto numItsCluTrackThird = trackThird.itsNCls();
       float invMass{-1.f}, invMassTag{-1.f}, ptTag{-1.f}, ptD{-1.f};
       computeInvariantMass(trackFirst, trackSecond, trackThird, channel, ptTag, invMassTag, ptD, invMass);
-      if ((channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi || channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) && invMass > 0.17f) {
-        continue;
-      } else if ((channel == aod::tagandprobe::TagChannels::DplusToKPiPi || channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) && (invMass < 1.65f || invMass > 2.10f)) {
-        continue;
+      if constexpr (channel == aod::tagandprobe::TagChannels::DstarPlusToDzeroPi || channel == aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi) {
+        if (invMass > 0.17f) {
+          continue;
+        }
+      } else if constexpr (channel == aod::tagandprobe::TagChannels::DplusToKPiPi || channel == aod::tagandprobe::TagChannels::DsOrDplusToKKPi) {
+        if ((invMass < 1.65f || invMass > 2.10f)) {
+          continue;
+        }
       }
       for (int iTrackType{0}; iTrackType < aod::tagandprobe::TrackTypes::NTrackTypes; ++iTrackType) {
         if (trackSelector[iTrackType].IsSelected(trackThird)) {
           histos[channel][iTrackType]->Fill(ptD, ptTag, ptTrackThird, ptTpcInnerTrackThird, invMass, invMassTag, etaTrackThird, numTpcCrossRowTrackThird, numTpcChi2NumCluTrackThird, numItsCluTrackThird);
         }
       }
+    }
+  }
+
+  template <uint8_t channel, bool doMc, typename TTags, typename TTrackIndices, typename TTracks, typename PParticles>
+  void runCombinatorialThirdTrack(TTags const& groupedTags,
+                                  TTrackIndices const& groupedTrackIndices,
+                                  TTracks const& tracks,
+                                  PParticles const& mcParticles)
+  {
+    for (const auto& tag : groupedTags) {
+      auto trackFirst = tag.template track0_as<TTracks>();
+      auto trackSecond = tag.template track1_as<TTracks>();
+      if (applyMl[channel] && tag.mlScores().size() == 3) {
+        std::array<float, 3> pVecTrackFirst{trackFirst.px(), trackFirst.py(), trackFirst.pz()};
+        std::array<float, 3> pVecTrackSecond{trackSecond.px(), trackSecond.py(), trackSecond.pz()};
+        auto ptTag = RecoDecay::pt(RecoDecay::pVec(pVecTrackFirst, pVecTrackSecond));
+        auto ptBin = o2::analysis::findBin(&mlConfig.binsPtPiPiFromDplus.value, ptTag);
+        if (tag.mlScores()[0] > mlConfig.mlCutsPiPiFromDplus->get(ptBin, 0u) || tag.mlScores()[1] < mlConfig.mlCutsPiPiFromDplus->get(ptBin, 1u) || tag.mlScores()[2] < mlConfig.mlCutsPiPiFromDplus->get(ptBin, 2u)) {
+          continue;
+        }
+      }
+      int motherIdxTag{-1};
+      if constexpr (doMc) {
+        motherIdxTag = tag.motherId();
+      }
+      loopOverThirdTrack<channel, doMc>(groupedTrackIndices, tracks, trackFirst, trackSecond, mcParticles, motherIdxTag);
     }
   }
 
@@ -1103,14 +1285,26 @@ struct ProbeThirdTrack {
       auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
       // D+ -> pi+pi+K- and c.c.
       auto groupedTagsPiPi = tagsPiPi.sliceBy(tagsPiPiPerCollision, thisCollId);
-      for (const auto& tagPiPi : groupedTagsPiPi) {
-        auto trackFirst = tagPiPi.track0_as<TracksWithDca>();
-        auto trackSecond = tagPiPi.track1_as<TracksWithDca>();
-        loopOverThirdTrack(groupedTrackIndices, tracks, trackFirst, trackSecond, aod::tagandprobe::TagChannels::DplusToKPiPi);
-      }
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DplusToKPiPi, false>(groupedTagsPiPi, groupedTrackIndices, tracks, tracks);
     }
   }
   PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDplusToKaPiPi, "Process combinatorial of tagged 2-pion vertices with additional track", true);
+
+  void processCombinatorialDplusToKaPiPiMc(aod::Collisions const& collisions,
+                                           FilteredPiPiFromDpMcTags const& tagsPiPi,
+                                           aod::TrackAssoc const& trackIndices,
+                                           TracksWithDcaMc const& tracks,
+                                           aod::McParticles const& mcParticles)
+  {
+    for (const auto& collision : collisions) {
+      auto thisCollId = collision.globalIndex();
+      auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+      // D+ -> pi+pi+K- and c.c.
+      auto groupedTagsPiPi = tagsPiPi.sliceBy(tagsPiPiMcPerCollision, thisCollId);
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DplusToKPiPi, true>(groupedTagsPiPi, groupedTrackIndices, tracks, mcParticles);
+    }
+  }
+  PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDplusToKaPiPiMc, "Process combinatorial of tagged 2-pion vertices with additional track using MC truth", false);
 
   void processCombinatorialDsToPhiPi(aod::Collisions const& collisions,
                                      aod::KaKaFromDspTags const& tagsKaKa,
@@ -1122,14 +1316,26 @@ struct ProbeThirdTrack {
       auto thisCollId = collision.globalIndex();
       auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
       auto groupedTagsKaKa = tagsKaKa.sliceBy(tagsKaKaPerCollision, thisCollId);
-      for (const auto& tagKaKa : groupedTagsKaKa) {
-        auto trackFirst = tagKaKa.track0_as<TracksWithDca>();
-        auto trackSecond = tagKaKa.track1_as<TracksWithDca>();
-        loopOverThirdTrack(groupedTrackIndices, tracks, trackFirst, trackSecond, aod::tagandprobe::TagChannels::DsOrDplusToKKPi);
-      }
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DsOrDplusToKKPi, false>(groupedTagsKaKa, groupedTrackIndices, tracks, tracks);
     }
   }
   PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDsToPhiPi, "Process combinatorial of tagged 2-kaon (phi) vertices with additional track", true);
+
+  void processCombinatorialDsToPhiPiMc(aod::Collisions const& collisions,
+                                       FilteredKaKaFromDspMcTags const& tagsKaKa,
+                                       aod::TrackAssoc const& trackIndices,
+                                       TracksWithDcaMc const& tracks,
+                                       aod::McParticles const& mcParticles)
+  {
+    for (const auto& collision : collisions) {
+      // Ds+/D+ -> phi(->K+K-)pi+ and c.c.
+      auto thisCollId = collision.globalIndex();
+      auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+      auto groupedTagsKaKa = tagsKaKa.sliceBy(tagsKaKaMcPerCollision, thisCollId);
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DsOrDplusToKKPi, true>(groupedTagsKaKa, groupedTrackIndices, tracks, mcParticles);
+    }
+  }
+  PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDsToPhiPiMc, "Process combinatorial of tagged 2-kaon (phi) vertices with additional track using MC truth", false);
 
   void processCombinatorialDstarToDzeroPi(aod::Collisions const& collisions,
                                           aod::PiKaFromDzTags const& tagsPiKa,
@@ -1142,21 +1348,33 @@ struct ProbeThirdTrack {
       auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
       // D*+ -> D0(->pi+K-)pi+
       auto groupedTagsPiKa = tagsPiKa.sliceBy(tagsPiKaPerCollision, thisCollId);
-      for (const auto& tagPiKa : groupedTagsPiKa) {
-        auto trackFirst = tagPiKa.track0_as<TracksWithDca>();  // positive --> pion
-        auto trackSecond = tagPiKa.track1_as<TracksWithDca>(); // negative --> kaon
-        loopOverThirdTrack(groupedTrackIndices, tracks, trackFirst, trackSecond, aod::tagandprobe::TagChannels::DstarPlusToDzeroPi);
-      }
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DstarPlusToDzeroPi, false>(groupedTagsPiKa, groupedTrackIndices, tracks, tracks);
       // D*- -> D0bar(->K+pi-)pi-
       auto groupedTagsKaPi = tagsKaPi.sliceBy(tagsKaPiPerCollision, thisCollId);
-      for (const auto& tagKaPi : groupedTagsKaPi) {
-        auto trackFirst = tagKaPi.track0_as<TracksWithDca>();  // positive --> kaon
-        auto trackSecond = tagKaPi.track1_as<TracksWithDca>(); // negative --> pion
-        loopOverThirdTrack(groupedTrackIndices, tracks, trackFirst, trackSecond, aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi);
-      }
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi, false>(groupedTagsKaPi, groupedTrackIndices, tracks, tracks);
     }
   }
   PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDstarToDzeroPi, "Process combinatorial of tagged pion-kaon (D0) vertices with additional track", true);
+
+  void processCombinatorialDstarToDzeroPiMc(aod::Collisions const& collisions,
+                                            FilteredPiKaFromDzMcTags const& tagsPiKa,
+                                            FilteredKaPiFromDzMcTags const& tagsKaPi,
+                                            aod::TrackAssoc const& trackIndices,
+                                            TracksWithDcaMc const& tracks,
+                                            aod::McParticles const& mcParticles)
+  {
+    for (const auto& collision : collisions) {
+      auto thisCollId = collision.globalIndex();
+      auto groupedTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+      // D*+ -> D0(->pi+K-)pi+
+      auto groupedTagsPiKa = tagsPiKa.sliceBy(tagsPiKaMcPerCollision, thisCollId);
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DstarPlusToDzeroPi, true>(groupedTagsPiKa, groupedTrackIndices, tracks, mcParticles);
+      // D*- -> D0bar(->K+pi-)pi-
+      auto groupedTagsKaPi = tagsKaPi.sliceBy(tagsKaPiMcPerCollision, thisCollId);
+      runCombinatorialThirdTrack<aod::tagandprobe::TagChannels::DstarMinusToDzeroBarPi, true>(groupedTagsKaPi, groupedTrackIndices, tracks, mcParticles);
+    }
+  }
+  PROCESS_SWITCH(ProbeThirdTrack, processCombinatorialDstarToDzeroPiMc, "Process combinatorial of tagged pion-kaon (D0) vertices with additional track using MC truth", false);
 
   void processDummy(aod::Collisions const&) {}
   PROCESS_SWITCH(ProbeThirdTrack, processDummy, "Dummy process function that does nothing", false);

--- a/PWGLF/Tasks/Nuspex/spectraTOF.cxx
+++ b/PWGLF/Tasks/Nuspex/spectraTOF.cxx
@@ -1610,11 +1610,12 @@ struct tofSpectra {
       return;
     }
 
+    const float multiplicity = getMultiplicityMC(mcCollision);
     if (mcParticle.isPhysicalPrimary()) {
       if (abs(mcCollision.posZ()) < evselOptions.cfgCutVertex) {
-        histos.fill(HIST(hpt_den_prm_mcgoodev[i]), mcParticle.pt());
+        histos.fill(HIST(hpt_den_prm_mcgoodev[i]), mcParticle.pt(), multiplicity);
       } else {
-        histos.fill(HIST(hpt_den_prm_mcbadev[i]), mcParticle.pt());
+        histos.fill(HIST(hpt_den_prm_mcbadev[i]), mcParticle.pt(), multiplicity);
       }
     }
   }


### PR DESCRIPTION
This PR adds 2 features to the D-meson tag-and-probe task:
1) the possibility to select the signal only in MC with MC truth (the MC info of the tag is propagated to the probe workflow via a new table)
2) the possibility to apply ML models to select the tags more efficiently

In addition, it adds the same variables used for the D0 to the other channels.
@arossi81 be careful that after merging this PR, if you synchronise the wagons on hyperloop, they might be reset to the default values. 