### PR TITLE
fixed perpendicular cone calculation

### DIFF
--- a/PWGLF/Tasks/Strangeness/strangeness_in_jets.cxx
+++ b/PWGLF/Tasks/Strangeness/strangeness_in_jets.cxx
@@ -705,15 +705,15 @@ struct strangeness_in_jets {
     return delta_phi;
   }
 
-  void get_perpendicular_cone(TVector3 p, TVector3& u, float sign)
+  void get_perpendicular_axis(TVector3 p, TVector3& u, double sign)
   {
     // Initialization
-    float ux(0), uy(0), uz(0);
+    double ux(0), uy(0), uz(0);
 
     // Components of Vector p
-    float px = p.X();
-    float py = p.Y();
-    float pz = p.Z();
+    double px = p.X();
+    double py = p.Y();
+    double pz = p.Z();
 
     // Protection 1
     if (px == 0 && py != 0) {
@@ -736,10 +736,10 @@ struct strangeness_in_jets {
     }
 
     // Equation Parameters
-    float a = px * px + py * py;
-    float b = 2.0 * px * pz * pz;
-    float c = pz * pz * pz * pz - py * py * py * py - px * px * py * py;
-    float delta = b * b - 4.0 * a * c;
+    double a = px * px + py * py;
+    double b = 2.0 * px * pz * pz;
+    double c = pz * pz * pz * pz - py * py * py * py - px * px * py * py;
+    double delta = b * b - 4.0 * a * c;
 
     // Protection agains delta<0
     if (delta < 0) {
@@ -878,8 +878,8 @@ struct strangeness_in_jets {
     // Perpendicular Cones for UE
     TVector3 ue_axis1(0.0, 0.0, 0.0);
     TVector3 ue_axis2(0.0, 0.0, 0.0);
-    get_perpendicular_cone(jet_axis, ue_axis1, +1.0);
-    get_perpendicular_cone(jet_axis, ue_axis2, -1.0);
+    get_perpendicular_axis(jet_axis, ue_axis1, +1.0);
+    get_perpendicular_axis(jet_axis, ue_axis2, -1.0);
 
     // Protection against delta<0
     if (ue_axis1.X() == 0 && ue_axis1.Y() == 0 && ue_axis1.Z() == 0)
@@ -1404,8 +1404,8 @@ struct strangeness_in_jets {
       // Perpendicular Cones for UE
       TVector3 ue_axis1(0.0, 0.0, 0.0);
       TVector3 ue_axis2(0.0, 0.0, 0.0);
-      get_perpendicular_cone(jet_axis, ue_axis1, +1.0);
-      get_perpendicular_cone(jet_axis, ue_axis2, -1.0);
+      get_perpendicular_axis(jet_axis, ue_axis1, +1.0);
+      get_perpendicular_axis(jet_axis, ue_axis2, -1.0);
 
       // Protection against delta<0
       if (ue_axis1.X() == 0 && ue_axis1.Y() == 0 && ue_axis1.Z() == 0)


### PR DESCRIPTION
I realized that using float for the vector components I had introduced a small quantization error that resulted in a non-zero rapidity shift between the jet axis and UE cone axis. Using double fixes the problem. 
<img width="820" alt="deltaEta" src="https://github.com/AliceO2Group/O2Physics/assets/32872606/cfcbc58d-4f08-465a-85f1-33d3ab8b9610">
<img width="825" alt="deltaEta_fixed" src="https://github.com/AliceO2Group/O2Physics/assets/32872606/0b708811-4d1d-46ef-ba82-f0f44b4d8dff">
