### PR TITLE
make the V0 selector cofigrable

### DIFF
--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -91,7 +91,7 @@ struct v0selector {
     Configurable<float> cutAPL1{"cutAPL1", 0.107, "cutAPL1"};
     Configurable<float> cutAPL2{"cutAPL2", -0.69, "cutAPL2"};
     Configurable<float> cutAPL3{"cutAPL3", 0.5, "cutAPL3"};
-  
+
     // // Gamma cuts
     // const float cutAlphaG = 0.4;
     // const float cutQTG = 0.03;

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -74,20 +74,39 @@ struct v0selector {
     // float qt = qtarmv0(ppos, pneg);
 
     // Gamma cuts
-    const float cutAlphaG = 0.4;
-    const float cutQTG = 0.03;
-    const float cutAlphaG2[2] = {0.4, 0.8};
-    const float cutQTG2 = 0.02;
-
+    Configurable<float> cutAlphaG{"cutAlphaG", 0.4, "cutAlphaG"};
+    Configurable<float> cutQTG{"cutQTG", 0.03, "cutQTG"};
+    Configurable<float> cutAlphaGLow{"cutAlphaGLow", 0.4, "cutAlphaGLow"};
+    Configurable<float> cutAlphaGHigh{"cutAlphaGHigh", 0.8, "cutAlphaGHigh"};
+    Configurable<float> cutQTG2{"cutQTG2", 0.02, "cutQTG2"};
     // K0S cuts
-    const float cutQTK0S[2] = {0.1075, 0.215};
-    const float cutAPK0S[2] = {0.199, 0.8}; // parameters for curved QT cut
-
+    Configurable<float> cutQTK0SLow{"cutQTK0SLow", 0.1075, "cutQTK0SLow"};
+    Configurable<float> cutQTK0SHigh{"cutQTK0SHigh", 0.215, "cutQTK0SHigh"};
+    Configurable<float> cutAPK0SLow{"cutAPK0SLow", 0.199, "cutAPK0SLow"};
+    Configurable<float> cutAPK0SHigh{"cutAPK0SHigh", 0.8, "cutAPK0SHigh"};
     // Lambda & A-Lambda cuts
-    const float cutQTL = 0.03;
-    const float cutAlphaL[2] = {0.35, 0.7};
-    const float cutAlphaAL[2] = {-0.7, -0.35};
-    const float cutAPL[3] = {0.107, -0.69, 0.5}; // parameters for curved QT cut
+    Configurable<float> cutQTL{"cutQTL", 0.03, "cutQTL"};
+    Configurable<float> cutAlphaLLow{"cutAlphaLLow", 0.35, "cutAlphaLLow"};
+    Configurable<float> cutAlphaLHigh{"cutAlphaLHigh", 0.7, "cutAlphaLHigh"};
+    Configurable<float> cutAPL1{"cutAPL1", 0.107, "cutAPL1"};
+    Configurable<float> cutAPL2{"cutAPL2", -0.69, "cutAPL2"};
+    Configurable<float> cutAPL3{"cutAPL3", 0.5, "cutAPL3"};
+  
+    // // Gamma cuts
+    // const float cutAlphaG = 0.4;
+    // const float cutQTG = 0.03;
+    // const float cutAlphaG2[2] = {0.4, 0.8};
+    // const float cutQTG2 = 0.02;
+
+    // // K0S cuts
+    // const float cutQTK0S[2] = {0.1075, 0.215};
+    // const float cutAPK0S[2] = {0.199, 0.8}; // parameters for curved QT cut
+
+    // // Lambda & A-Lambda cuts
+    // const float cutQTL = 0.03;
+    // const float cutAlphaL[2] = {0.35, 0.7};
+    // const float cutAlphaAL[2] = {-0.7, -0.35};
+    // const float cutAPL[3] = {0.107, -0.69, 0.5}; // parameters for curved QT cut
 
     // Check for Gamma candidates
     if (qt < cutQTG) {
@@ -97,26 +116,26 @@ struct v0selector {
     }
     if (qt < cutQTG2) {
       // additional region - should help high pT gammas
-      if ((TMath::Abs(alpha) > cutAlphaG2[0]) && (TMath::Abs(alpha) < cutAlphaG2[1])) {
+      if ((TMath::Abs(alpha) > cutAlphaGLow) && (TMath::Abs(alpha) < cutAlphaGHigh)) {
         return kGamma;
       }
     }
 
     // Check for K0S candidates
-    float q = cutAPK0S[0] * TMath::Sqrt(TMath::Abs(1 - alpha * alpha / (cutAPK0S[1] * cutAPK0S[1])));
-    if ((qt > cutQTK0S[0]) && (qt < cutQTK0S[1]) && (qt > q)) {
+    float q = cutAPK0SLow * TMath::Sqrt(TMath::Abs(1 - alpha * alpha / (cutAPK0SHigh * cutAPK0SHigh)));
+    if ((qt > cutQTK0SLow) && (qt < cutQTK0SHigh) && (qt > q)) {
       return kK0S;
     }
 
     // Check for Lambda candidates
-    q = cutAPL[0] * TMath::Sqrt(TMath::Abs(1 - ((alpha + cutAPL[1]) * (alpha + cutAPL[1])) / (cutAPL[2] * cutAPL[2])));
-    if ((alpha > cutAlphaL[0]) && (alpha < cutAlphaL[1]) && (qt > cutQTL) && (qt < q)) {
+    q = cutAPL1 * TMath::Sqrt(TMath::Abs(1 - ((alpha + cutAPL2) * (alpha + cutAPL2)) / (cutAPL3 * cutAPL3)));
+    if ((alpha > cutAlphaLLow) && (alpha < cutAlphaLHigh) && (qt > cutQTL) && (qt < q)) {
       return kLambda;
     }
 
     // Check for AntiLambda candidates
-    q = cutAPL[0] * TMath::Sqrt(TMath::Abs(1 - ((alpha - cutAPL[1]) * (alpha - cutAPL[1])) / (cutAPL[2] * cutAPL[2])));
-    if ((alpha > cutAlphaAL[0]) && (alpha < cutAlphaAL[1]) && (qt > cutQTL) && (qt < q)) {
+    q = cutAPL1 * TMath::Sqrt(TMath::Abs(1 - ((alpha - cutAPL2) * (alpha - cutAPL2)) / (cutAPL3 * cutAPL3)));
+    if ((alpha > cutAlphaLLow) && (alpha < cutAlphaLHigh) && (qt > cutQTL) && (qt < q)) {
       return kAntiLambda;
     }
 


### PR DESCRIPTION
HI Ionut and HI Daiki

I made some small modifications to the V0 selectors and made the selection cut configurable.     This is the suggestion from the TPC PID group since the selection purity from PbPb is quite low. we want to optimise the cuts.

Cheers
Xiaozhi    