### PR TITLE
PWGHF: candidateSelectorLc: templatize process to remove Bayes PID table, if not used.

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -97,9 +97,7 @@ struct HfCandidateSelectorLc {
 
   using TracksSel = soa::Join<aod::TracksWExtra,
                               aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr>;
-  using TracksSelBayesPid = soa::Join<aod::TracksWExtra,
-                                      aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr,
-                                      aod::pidBayesPi, aod::pidBayesKa, aod::pidBayesPr, aod::pidBayes>;
+  using TracksSelBayesPid = soa::Join<TracksSel, aod::pidBayesPi, aod::pidBayesKa, aod::pidBayesPr, aod::pidBayes>;
 
   HistogramRegistry registry{"registry"};
 
@@ -266,11 +264,11 @@ struct HfCandidateSelectorLc {
     return true;
   }
 
-  /// @brief process function w/o Bayes PID
+  /// \brief process function w/o Bayes PID
   /// \param candidates Lc candidate table
   /// \param tracks track table
-  template <bool useBayesPid = false, typename T>
-  void runSelectLc(aod::HfCand3Prong const& candidates, T const&)
+  template <bool useBayesPid = false, typename TTracks>
+  void runSelectLc(aod::HfCand3Prong const& candidates, TTracks const&)
   {
     // looping over 3-prong candidates
     for (const auto& candidate : candidates) {
@@ -299,9 +297,9 @@ struct HfCandidateSelectorLc {
         registry.fill(HIST("hSelections"), 2 + aod::SelectionStep::RecoSkims, ptCand);
       }
 
-      auto trackPos1 = candidate.template prong0_as<T>(); // positive daughter (negative for the antiparticles)
-      auto trackNeg = candidate.template prong1_as<T>();  // negative daughter (positive for the antiparticles)
-      auto trackPos2 = candidate.template prong2_as<T>(); // positive daughter (negative for the antiparticles)
+      auto trackPos1 = candidate.template prong0_as<TTracks>(); // positive daughter (negative for the antiparticles)
+      auto trackNeg = candidate.template prong1_as<TTracks>();  // negative daughter (positive for the antiparticles)
+      auto trackPos2 = candidate.template prong2_as<TTracks>(); // positive daughter (negative for the antiparticles)
 
       // implement filter bit 4 cut - should be done before this task at the track selection level
 
@@ -442,7 +440,7 @@ struct HfCandidateSelectorLc {
     }
   }
 
-  /// @brief process function w/o Bayes PID
+  /// \brief process function w/o Bayes PID
   /// \param candidates Lc candidate table
   /// \param tracks track table
   void processNoBayesPid(aod::HfCand3Prong const& candidates,
@@ -452,7 +450,7 @@ struct HfCandidateSelectorLc {
   }
   PROCESS_SWITCH(HfCandidateSelectorLc, processNoBayesPid, "Process Lc selection w/o Bayes PID", true);
 
-  /// @brief process function with Bayes PID
+  /// \brief process function with Bayes PID
   /// \param candidates Lc candidate table
   /// \param tracks track table with Bayes PID information
   void processBayesPid(aod::HfCand3Prong const& candidates,

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -264,7 +264,7 @@ struct HfCandidateSelectorLc {
     return true;
   }
 
-  /// \brief process function w/o Bayes PID
+  /// \brief function to apply Lc selections
   /// \param candidates Lc candidate table
   /// \param tracks track table
   template <bool useBayesPid = false, typename TTracks>

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -52,7 +52,6 @@ struct HfCandidateSelectorLc {
   Configurable<double> nSigmaTofMax{"nSigmaTofMax", 3., "Nsigma cut on TOF only"};
   Configurable<double> nSigmaTofCombinedMax{"nSigmaTofCombinedMax", 5., "Nsigma cut on TOF combined with TPC"};
   // Bayesian PID
-  Configurable<bool> usePidBayes{"usePidBayes", true, "Bool to use or not the PID based on Bayesian probability cut at filtering level"};
   Configurable<double> ptPidBayesMin{"ptPidBayesMin", 0., "Lower bound of track pT for Bayesian PID"};
   Configurable<double> ptPidBayesMax{"ptPidBayesMax", 100, "Upper bound of track pT for Bayesian PID"};
   // Combined PID options
@@ -97,13 +96,20 @@ struct HfCandidateSelectorLc {
   TrackSelectorPr selectorProton;
 
   using TracksSel = soa::Join<aod::TracksWExtra,
-                              aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr,
-                              aod::pidBayesPi, aod::pidBayesKa, aod::pidBayesPr, aod::pidBayes>;
+                              aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr>;
+  using TracksSelBayesPid = soa::Join<aod::TracksWExtra,
+                                      aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr,
+                                      aod::pidBayesPi, aod::pidBayesKa, aod::pidBayesPr, aod::pidBayes>;
 
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
   {
+    std::array<bool, 2> processes = {doprocessNoBayesPid, doprocessBayesPid};
+    if (std::accumulate(processes.begin(), processes.end(), 0) != 1) {
+      LOGP(fatal, "One and only one process function must be enabled at a time.");
+    }
+
     selectorPion.setRangePtTpc(ptPidTpcMin, ptPidTpcMax);
     selectorPion.setRangeNSigmaTpc(-nSigmaTpcMax, nSigmaTpcMax);
     selectorPion.setRangeNSigmaTpcCondTof(-nSigmaTpcCombinedMax, nSigmaTpcCombinedMax);
@@ -260,8 +266,11 @@ struct HfCandidateSelectorLc {
     return true;
   }
 
-  void process(aod::HfCand3Prong const& candidates,
-               TracksSel const&)
+  /// @brief process function w/o Bayes PID
+  /// \param candidates Lc candidate table
+  /// \param tracks track table
+  template <bool useBayesPid = false, typename T>
+  void runSelectLc(aod::HfCand3Prong const& candidates, T const&)
   {
     // looping over 3-prong candidates
     for (const auto& candidate : candidates) {
@@ -290,9 +299,9 @@ struct HfCandidateSelectorLc {
         registry.fill(HIST("hSelections"), 2 + aod::SelectionStep::RecoSkims, ptCand);
       }
 
-      auto trackPos1 = candidate.prong0_as<TracksSel>(); // positive daughter (negative for the antiparticles)
-      auto trackNeg = candidate.prong1_as<TracksSel>();  // negative daughter (positive for the antiparticles)
-      auto trackPos2 = candidate.prong2_as<TracksSel>(); // positive daughter (negative for the antiparticles)
+      auto trackPos1 = candidate.template prong0_as<T>(); // positive daughter (negative for the antiparticles)
+      auto trackNeg = candidate.template prong1_as<T>();  // negative daughter (positive for the antiparticles)
+      auto trackPos2 = candidate.template prong2_as<T>(); // positive daughter (negative for the antiparticles)
 
       // implement filter bit 4 cut - should be done before this task at the track selection level
 
@@ -366,7 +375,7 @@ struct HfCandidateSelectorLc {
         }
       }
 
-      if (usePidBayes) {
+      if constexpr (useBayesPid) {
         TrackSelectorPID::Status pidBayesTrackPos1Proton = selectorProton.statusBayes(trackPos1);
         TrackSelectorPID::Status pidBayesTrackPos2Proton = selectorProton.statusBayes(trackPos2);
         TrackSelectorPID::Status pidBayesTrackPos1Pion = selectorPion.statusBayes(trackPos1);
@@ -432,6 +441,26 @@ struct HfCandidateSelectorLc {
       hfSelLcCandidate(statusLcToPKPi, statusLcToPiKP);
     }
   }
+
+  /// @brief process function w/o Bayes PID
+  /// \param candidates Lc candidate table
+  /// \param tracks track table
+  void processNoBayesPid(aod::HfCand3Prong const& candidates,
+                         TracksSel const& tracks)
+  {
+    runSelectLc<false>(candidates, tracks);
+  }
+  PROCESS_SWITCH(HfCandidateSelectorLc, processNoBayesPid, "Process Lc selection w/o Bayes PID", true);
+
+  /// @brief process function with Bayes PID
+  /// \param candidates Lc candidate table
+  /// \param tracks track table with Bayes PID information
+  void processBayesPid(aod::HfCand3Prong const& candidates,
+                       TracksSelBayesPid const& tracks)
+  {
+    runSelectLc<true>(candidates, tracks);
+  }
+  PROCESS_SWITCH(HfCandidateSelectorLc, processBayesPid, "Process Lc selection with Bayes PID", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
Tagging @DelloStritto @gluparel @strogolo @saganatt @zhangbiao-phy @1994ra for their info.
With this, the Bayes PID dependency can be removed, if not used. Beware of the new `processNoBayesPid` (`true` by default) and `processBayesPid`