### PR TITLE
[PWGDQ] Fixing table-maker + adding zorro tag to skimmed data

### DIFF
--- a/PWGDQ/TableProducer/CMakeLists.txt
+++ b/PWGDQ/TableProducer/CMakeLists.txt
@@ -11,12 +11,12 @@
 
 o2physics_add_dpl_workflow(table-maker
                     SOURCES tableMaker.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore O2Physics::EventFilteringUtils
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(table-maker-with-assoc
                     SOURCES tableMaker_withAssoc.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore O2Physics::EventFilteringUtils
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(table-maker-mc

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -67,13 +67,13 @@ using namespace o2::aod;
 
 // DQ triggers
 enum DQTriggers {
-  kSingleE      = 1 << 0, // 0000001
-  kLMeeIMR      = 1 << 1, // 0000010
-  kLMeeHMR      = 1 << 2, // 0000100
-  kDiElectron   = 1 << 3, // 0001000
-  kSingleMuLow  = 1 << 4, // 0010000
+  kSingleE = 1 << 0,      // 0000001
+  kLMeeIMR = 1 << 1,      // 0000010
+  kLMeeHMR = 1 << 2,      // 0000100
+  kDiElectron = 1 << 3,   // 0001000
+  kSingleMuLow = 1 << 4,  // 0010000
   kSingleMuHigh = 1 << 5, // 0100000
-  kDiMuon       = 1 << 6, // 1000000
+  kDiMuon = 1 << 6,       // 1000000
   kNTriggersDQ
 };
 
@@ -1688,13 +1688,13 @@ struct TableMaker {
   PROCESS_SWITCH(TableMaker, processMuonsAndMFTWithFilter, "Build MFT and muons DQ skimmed data model, w/ event filter", false);
 
   // List of process functions removed because they are not using cov matrix
-  //PROCESS_SWITCH(TableMaker, processMuonOnlyWithCent, "Build muon-only DQ skimmed data model, w/ centrality", false);
-  //PROCESS_SWITCH(TableMaker, processMuonOnlyWithMults, "Build muon-only DQ skimmed data model, w/ multiplicity", false);
-  //PROCESS_SWITCH(TableMaker, processMuonOnlyWithMultsAndEventFilter, "Build muon-only DQ skimmed data model, w/ multiplicity, w/ event filter", false);
-  //PROCESS_SWITCH(TableMaker, processMuonOnlyWithCentAndMults, "Build muon-only DQ skimmed data model, w/ centrality and multiplicities", false);
-  //PROCESS_SWITCH(TableMaker, processMuonOnly, "Build muon-only DQ skimmed data model", false);
-  //PROCESS_SWITCH(TableMaker, processMuonOnlyWithEventFilter, "Build muon-only DQ skimmed data model, w/ event filter", false);
-  //PROCESS_SWITCH(TableMaker, processAssociatedMuonOnly, "Build muon-only DQ skimmed data model using track-collision association tables", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnlyWithCent, "Build muon-only DQ skimmed data model, w/ centrality", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnlyWithMults, "Build muon-only DQ skimmed data model, w/ multiplicity", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnlyWithMultsAndEventFilter, "Build muon-only DQ skimmed data model, w/ multiplicity, w/ event filter", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnlyWithCentAndMults, "Build muon-only DQ skimmed data model, w/ centrality and multiplicities", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnly, "Build muon-only DQ skimmed data model", false);
+  // PROCESS_SWITCH(TableMaker, processMuonOnlyWithEventFilter, "Build muon-only DQ skimmed data model, w/ event filter", false);
+  // PROCESS_SWITCH(TableMaker, processAssociatedMuonOnly, "Build muon-only DQ skimmed data model using track-collision association tables", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -63,13 +63,13 @@ using namespace o2::aod;
 
 // DQ triggers
 enum DQTriggers {
-  kSingleE      = 1 << 0, // 0000001
-  kLMeeIMR      = 1 << 1, // 0000010
-  kLMeeHMR      = 1 << 2, // 0000100
-  kDiElectron   = 1 << 3, // 0001000
-  kSingleMuLow  = 1 << 4, // 0010000
+  kSingleE = 1 << 0,      // 0000001
+  kLMeeIMR = 1 << 1,      // 0000010
+  kLMeeHMR = 1 << 2,      // 0000100
+  kDiElectron = 1 << 3,   // 0001000
+  kSingleMuLow = 1 << 4,  // 0010000
   kSingleMuHigh = 1 << 5, // 0100000
-  kDiMuon       = 1 << 6, // 1000000
+  kDiMuon = 1 << 6,       // 1000000
   kNTriggersDQ
 };
 


### PR DESCRIPTION
- Removal of all the process function for muons not using convariance matrix (the implementation is still kept commented in the code). This is done becasue we reached the limit of process functions and output tables produced and this prevent the running of the table-maker
- Addition of a flag to run the event selection for events triggered by the CEFP (zorro). This functionality is still under development and needs to be tested once the trigger mask info is loaded to the ccdb for all the periods.