### PR TITLE
[PWG-DQ] Small bug fixes

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -2701,7 +2701,14 @@ void VarManager::FillPairVertexing(C const& collision, T const& t1, T const& t2,
                              t2.c1PtX(), t2.c1PtY(), t2.c1PtPhi(), t2.c1PtTgl(), t2.c1Pt21Pt2()};
       SMatrix55 t2covs(v2.begin(), v2.end());
       o2::track::TrackParCovFwd pars2{t2.z(), t2pars, t2covs, chi22};
-      procCode = fgFitterTwoProngFwd.process(pars1, pars2);
+      if (std::abs(t2.cXX()) < 1.0e-6) {
+        // TODO: Some rare fwd-tracks have very small covariances and the DCAFitter throws a fatal!
+        //   This is a protection, but please check for the reason and eventually change the behaviour.
+        //   At the moment, when these tracks are encountered, the vertexing quantities are initialized to default values (-999)
+        procCode = 0;
+      } else {
+        procCode = fgFitterTwoProngFwd.process(pars1, pars2);
+      }
     } else {
       return;
     }

--- a/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
@@ -213,8 +213,8 @@ struct TableMakerMC {
       histClasses += "Event_MCTruth;";
     }
 
-    bool enableBarrelHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processBarrelOnly"));
-    bool enableMuonHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processMuonOnly"));
+    bool enableBarrelHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processPPBarrelOnly") || context.mOptions.get<bool>("processPbPbBarrelOnly"));
+    bool enableMuonHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processPPMuonOnly") || context.mOptions.get<bool>("processPbPbMuonOnly"));
 
     LOG(info) << "enable barrel/muon histograms :: " << enableBarrelHistos << " / " << enableMuonHistos;
 

--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -1438,7 +1438,7 @@ struct AnalysisSameEventPairing {
 
           dielectronList(event.globalIndex(), VarManager::fgValues[VarManager::kMass],
                          VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
-                         t1.sign() + t2.sign(), twoTrackFilter, 0);
+                         t1.sign() + t2.sign(), twoTrackFilter, mcDecision);
 
           if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedTrackCollInfo) > 0) {
             dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
@@ -1479,7 +1479,7 @@ struct AnalysisSameEventPairing {
 
           dimuonList(event.globalIndex(), VarManager::fgValues[VarManager::kMass],
                      VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
-                     t1.sign() + t2.sign(), twoTrackFilter, 0);
+                     t1.sign() + t2.sign(), twoTrackFilter, mcDecision);
           if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedMuonCollInfo) > 0) {
             dileptonInfoList(t1.collisionId(), event.posX(), event.posY(), event.posZ());
           }


### PR DESCRIPTION
1) Fixed a fatal thrown by the DCAFitter due to very small covariances for some rare muon tracks
2) Fixed a run time error in the init() of tableMakeMC_withAssoc appearing due to checking for non-existing process function names
3) Included the mcDecision in the Dielectrons and Dimuons tables in dqEfficiency_withAssoc