### PR TITLE
PWGHF: remove pathological non-prompt charm hadrons

### DIFF
--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -680,6 +680,11 @@ struct TaskPolarisationCharmHadrons {
         }
         origin = candidate.originMcRec();
         ptBhadMother = candidate.ptBhadMotherPart();
+        int pdgBhadMother = candidate.pdgBhadMotherPart();
+        // For unknown reasons there are charm hadrons coming directly from beauty diquarks without an intermediate B-hadron which have an unreasonable correlation between the pT of the charm hadron and the beauty mother. We also remove charm hadrons from quarkonia.
+        if (origin == RecoDecay::OriginType::NonPrompt && (pdgBhadMother == 5101 || pdgBhadMother == 5103 || pdgBhadMother == 5201 || pdgBhadMother == 5203 || pdgBhadMother == 5301 || pdgBhadMother == 5303 || pdgBhadMother == 5401 || pdgBhadMother == 5403 || pdgBhadMother == 5503 || pdgBhadMother == 553 || pdgBhadMother == 555 || pdgBhadMother == 553 || pdgBhadMother == 557)) {
+          return isCandidateInSignalRegion;
+        }
       } else if constexpr (channel == charm_polarisation::DecayChannel::LcToPKPi) {
         if (!TESTBIT(std::abs(candidate.flagMcMatchRec()), aod::hf_cand_3prong::DecayType::LcToPKPi)) { // this candidate is not signal, skip
           return isCandidateInSignalRegion;
@@ -913,6 +918,11 @@ struct TaskPolarisationCharmHadrons {
       origin = mcParticle.originMcGen();
       if (origin == RecoDecay::OriginType::NonPrompt) {
         auto bHadMother = mcParticles.rawIteratorAt(mcParticle.idxBhadMotherPart() - mcParticles.offset());
+        int pdgBhadMother = std::abs(bHadMother.pdgCode());
+        // For unknown reasons there are charm hadrons coming directly from beauty diquarks without an intermediate B-hadron which have an unreasonable correlation between the pT of the charm hadron and the beauty mother. We also remove charm hadrons from quarkonia.
+        if (pdgBhadMother == 5101 || pdgBhadMother == 5103 || pdgBhadMother == 5201 || pdgBhadMother == 5203 || pdgBhadMother == 5301 || pdgBhadMother == 5303 || pdgBhadMother == 5401 || pdgBhadMother == 5403 || pdgBhadMother == 5503 || pdgBhadMother == 553 || pdgBhadMother == 555 || pdgBhadMother == 553 || pdgBhadMother == 557) {
+          return;
+        }
         ptBhadMother = bHadMother.pt();
       }
 


### PR DESCRIPTION
This PR excludes non-prompt charm hadrons in the MC that come directly from beauty diquarks. The reason is that they have a strange pT correlation (pT charm hadron > pT beauty mother), which creates issues when reweighting the pT shape to reproduce the one of the B hadron in productions with pT-hard bins (low pTB gets very large weight, but it ends up in creating few charm hadrons with high pT and a very large weight that have very large uncertainties).

![image](https://github.com/AliceO2Group/O2Physics/assets/19532765/f44af2a3-3eae-4b37-b2d6-877224f0a8cd)

![image](https://github.com/AliceO2Group/O2Physics/assets/19532765/e659ce14-eed0-4c14-b34f-805a415e35ee)

A similar issue is observed with bottomonia decaying to a pair of charm hadrons. In this case the decay is genuine, but it produces the same issue in the reweighting, so we remove them as well. 