### PR TITLE
PWGHF: Add quarkonium decay muon histograms in HFL muon source task

### DIFF
--- a/PWGHF/HFL/Tasks/taskSingleMuonReader.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonReader.cxx
@@ -31,6 +31,7 @@ using namespace o2::framework::expressions;
 
 using MyCollisions = soa::Join<aod::ReducedEvents, aod::ReducedEventsExtended>;
 using MyMuons = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
+using MyMcMuons = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsLabels>;
 
 namespace o2::aod
 {
@@ -39,8 +40,9 @@ namespace single_muon
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(DcaXY, dcaXY, float);
 DECLARE_SOA_COLUMN(DeltaPt, deltaPt, float);
+DECLARE_SOA_COLUMN(Chi2, chi2, float);
 } // namespace single_muon
-DECLARE_SOA_TABLE(HfSingleMuon, "AOD", "SINGLEMUON", single_muon::Pt, single_muon::DcaXY, single_muon::DeltaPt);
+DECLARE_SOA_TABLE(HfSingleMuon, "AOD", "SINGLEMUON", single_muon::Pt, single_muon::DcaXY, single_muon::DeltaPt, single_muon::Chi2);
 } // namespace o2::aod
 
 struct HfTaskSingleMuonReader {
@@ -49,10 +51,13 @@ struct HfTaskSingleMuonReader {
   Configurable<int> trkType{"trkType", 0, "Muon track type, valid values are 0, 1, 2, 3 and 4"};
   Configurable<float> etaMin{"etaMin", -3.6, "eta minimum value"};
   Configurable<float> etaMax{"etaMax", -2.5, "eta maximum value"};
+  Configurable<float> pDcaMin{"pDcaMin", 324., "p*DCA maximum value for small Rabs"};
   Configurable<float> pDcaMax{"pDcaMax", 594., "p*DCA maximum value"};
   Configurable<float> rAbsMax{"rAbsMax", 89.5, "R at absorber end maximum value"};
-  Configurable<float> rAbsMin{"rAbsMin", 26.5, "R at absorber end minimum value"};
+  Configurable<float> rAbsMid{"rAbsMid", 26.5, "R at absorber end minimum 2 value"};
+  Configurable<float> rAbsMin{"rAbsMin", 17.6, "R at absorber end minimum value"};
   Configurable<float> zVtx{"zVtx", 10., "Z edge of primary vertex [cm]"};
+  Configurable<bool> fillMcHist{"fillMcHist", false, "fill MC-related histograms"};
 
   o2::framework::HistogramRegistry registry{
     "registry",
@@ -65,20 +70,26 @@ struct HfTaskSingleMuonReader {
   {
     AxisSpec axisPt{200, 0., 100., "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec axisEta{100, -4., -2., "#it{#eta}"};
-    AxisSpec axisDCA{400, 0., 4., "#it{DCA}_{xy} (cm)"};
+    AxisSpec axisDCA{2000, 0., 2., "#it{DCA}_{xy} (cm)"};
     AxisSpec axisChi2MatchMCHMFT{100, 0., 100., "MCH-MFT matching #chi^{2}"};
     AxisSpec axisSign{5, -2.5, 2.5, "Charge"};
+    AxisSpec axisRabs{1000, 0, 100, "R at Absorber End (cm)"};
     AxisSpec axisDeltaPt{10000, -50, 50, "#Delta #it{p}_{T} (GeV/#it{c})"};
     AxisSpec axisVtxZ{80, -20., 20., "#it{z}_{vtx} (cm)"};
 
-    HistogramConfigSpec hTHnMu{HistType::kTHnSparseF, {axisPt, axisEta, axisDCA, axisSign, axisChi2MatchMCHMFT, axisDeltaPt}, 6};
+    HistogramConfigSpec hTHnMu{HistType::kTHnSparseF, {axisPt, axisEta, axisDCA, axisRabs, axisSign, axisChi2MatchMCHMFT, axisDeltaPt}, 7};
     HistogramConfigSpec hVtxZ{HistType::kTH1F, {axisVtxZ}};
 
     registry.add("hMuAfterCuts", "", hTHnMu);
+    if (fillMcHist) {
+      registry.add("hMuAfterCutsTrue", "", hTHnMu);
+      registry.add("hMuAfterCutsFake", "", hTHnMu);
+    }
     registry.add("hVtxZ", "", hVtxZ);
   }
 
-  void process(MyCollisions::iterator const& collision, MyMuons const& muons)
+  template <typename TCollision, typename TMuons>
+  void runMuonSel(TCollision const& collision, TMuons const& muons)
   {
     registry.fill(HIST("hVtxZ"), collision.posZ());
     for (const auto& muon : muons) {
@@ -96,22 +107,78 @@ struct HfTaskSingleMuonReader {
       if ((eta >= etaMax) || (eta < etaMin)) {
         continue;
       }
-      if ((rAbs >= rAbsMax) || (rAbs < rAbsMin)) {
+
+      if ((rAbs < rAbsMid) && (pDca >= pDcaMin)) {
         continue;
       }
-      if (pDca >= pDcaMax) {
+      if ((rAbs >= rAbsMid) && (pDca >= pDcaMax)) {
         continue;
       }
 
       // histograms after acceptance cuts
       if (muon.has_matchMCHTrack()) {
-        auto muonType3 = muon.matchMCHTrack_as<MyMuons>();
+        auto muonType3 = muon.template matchMCHTrack_as<TMuons>();
         auto Dpt = muonType3.pt() - pt;
-        singleMuon(pt, dcaXY, Dpt);
-        registry.fill(HIST("hMuAfterCuts"), pt, eta, dcaXY, charge, chi2, Dpt);
+
+        singleMuon(pt, dcaXY, Dpt, chi2);
+        registry.fill(HIST("hMuAfterCuts"), pt, eta, dcaXY, rAbs, charge, chi2, Dpt);
       }
     }
   }
+  template <typename TCollision, typename TMuons>
+  void runMuonSelMc(TCollision const& collision, TMuons const& muons)
+  {
+    registry.fill(HIST("hVtxZ"), collision.posZ());
+    for (const auto& muon : muons) {
+      if (muon.trackType() != trkType) {
+        continue;
+      }
+
+      const auto eta(muon.eta()), pDca(muon.pDca());
+      const auto rAbs(muon.rAtAbsorberEnd());
+      const auto dcaXY(RecoDecay::sqrtSumOfSquares(muon.fwdDcaX(), muon.fwdDcaY()));
+      const auto pt(muon.pt());
+      const auto charge(muon.sign());
+      const auto chi2(muon.chi2MatchMCHMFT());
+
+      if ((eta >= etaMax) || (eta < etaMin)) {
+        continue;
+      }
+
+      if ((rAbs < rAbsMid) && (pDca >= pDcaMin)) {
+        continue;
+      }
+      if ((rAbs >= rAbsMid) && (pDca >= pDcaMax)) {
+        continue;
+      }
+
+      // histograms after acceptance cuts
+      if (muon.has_matchMCHTrack()) {
+        auto muonType3 = muon.template matchMCHTrack_as<TMuons>();
+        auto Dpt = muonType3.pt() - pt;
+
+        singleMuon(pt, dcaXY, Dpt, chi2);
+        registry.fill(HIST("hMuAfterCuts"), pt, eta, dcaXY, rAbs, charge, chi2, Dpt);
+        if (muon.mcMask() == 0) {
+          registry.fill(HIST("hMuAfterCutsTrue"), pt, eta, dcaXY, rAbs, charge, chi2, Dpt);
+        }
+        if (muon.mcMask() == 128) {
+          registry.fill(HIST("hMuAfterCutsFake"), pt, eta, dcaXY, rAbs, charge, chi2, Dpt);
+        }
+      }
+    }
+  }
+  void processMuon(MyCollisions::iterator const& collision, MyMuons const& muons)
+  {
+    runMuonSel(collision, muons);
+  }
+  void processMuonMc(MyCollisions::iterator const& collision, MyMcMuons const& muons)
+  {
+    runMuonSelMc(collision, muons);
+  }
+
+  PROCESS_SWITCH(HfTaskSingleMuonReader, processMuon, "run muon selection with real data", true);
+  PROCESS_SWITCH(HfTaskSingleMuonReader, processMuonMc, "run muon selection with MC data", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/HFL/Tasks/taskSingleMuonReader.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonReader.cxx
@@ -51,11 +51,9 @@ struct HfTaskSingleMuonReader {
   Configurable<int> trkType{"trkType", 0, "Muon track type, valid values are 0, 1, 2, 3 and 4"};
   Configurable<float> etaMin{"etaMin", -3.6, "eta minimum value"};
   Configurable<float> etaMax{"etaMax", -2.5, "eta maximum value"};
-  Configurable<float> pDcaMin{"pDcaMin", 324., "p*DCA maximum value for small Rabs"};
   Configurable<float> pDcaMax{"pDcaMax", 594., "p*DCA maximum value"};
   Configurable<float> rAbsMax{"rAbsMax", 89.5, "R at absorber end maximum value"};
-  Configurable<float> rAbsMid{"rAbsMid", 26.5, "R at absorber end minimum 2 value"};
-  Configurable<float> rAbsMin{"rAbsMin", 17.6, "R at absorber end minimum value"};
+  Configurable<float> rAbsMin{"rAbsMin", 26.5, "R at absorber end minimum value"};
   Configurable<float> zVtx{"zVtx", 10., "Z edge of primary vertex [cm]"};
   Configurable<bool> fillMcHist{"fillMcHist", false, "fill MC-related histograms"};
 
@@ -108,10 +106,10 @@ struct HfTaskSingleMuonReader {
         continue;
       }
 
-      if ((rAbs < rAbsMid) && (pDca >= pDcaMin)) {
+      if ((rAbs >= rAbsMax) || (rAbs < rAbsMin)) {
         continue;
       }
-      if ((rAbs >= rAbsMid) && (pDca >= pDcaMax)) {
+      if (pDca >= pDcaMax) {
         continue;
       }
 
@@ -145,10 +143,10 @@ struct HfTaskSingleMuonReader {
         continue;
       }
 
-      if ((rAbs < rAbsMid) && (pDca >= pDcaMin)) {
+      if ((rAbs >= rAbsMax) || (rAbs < rAbsMin)) {
         continue;
       }
-      if ((rAbs >= rAbsMid) && (pDca >= pDcaMax)) {
+      if (pDca >= pDcaMax) {
         continue;
       }
 

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -223,7 +223,7 @@ struct HfTaskSingleMuonSource {
   // this muon comes from quarkonium decay
   bool isQuarkoniumDecayMu(const uint8_t& mask)
   {
-    return (isMuon(mask) && TESTBIT(mask, HasQuarkoniumParent) && (!TESTBIT(HasBeautyParent)) && (!TESTBIT(HasCharmParent)));
+    return (isMuon(mask) && TESTBIT(mask, HasQuarkoniumParent) && (!TESTBIT(mask, HasBeautyParent)) && (!TESTBIT(mask, HasCharmParent)));
   }
 
   // this muon comes from transport

--- a/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
+++ b/PWGHF/HFL/Tasks/taskSingleMuonSource.cxx
@@ -88,6 +88,7 @@ struct HfTaskSingleMuonSource {
       "NonpromptCharmMu",
       "PromptCharmMu",
       "LightDecayMu",
+      "QuarkoniumDecayMu",
       "SecondaryMu",
       "Hadron",
       "Unidentified"};
@@ -219,6 +220,12 @@ struct HfTaskSingleMuonSource {
     return (isMuon(mask) && TESTBIT(mask, HasLightParent) && (!TESTBIT(mask, IsSecondary)) && (!TESTBIT(mask, HasQuarkoniumParent)));
   }
 
+  // this muon comes from quarkonium decay
+  bool isQuarkoniumDecayMu(const uint8_t& mask)
+  {
+    return (isMuon(mask) && TESTBIT(mask, HasQuarkoniumParent) && (!TESTBIT(HasBeautyParent)) && (!TESTBIT(HasCharmParent)));
+  }
+
   // this muon comes from transport
   bool isSecondaryMu(const uint8_t& mask)
   {
@@ -269,6 +276,10 @@ struct HfTaskSingleMuonSource {
         registry.fill(HIST("h2LightDecayMuPtDCA"), pt, dca);
         registry.fill(HIST("h2LightDecayMuPtChi2"), pt, chi2);
         registry.fill(HIST("h2LightDecayMuPtDeltaPt"), pt, deltaPt);
+      } else if (isQuarkoniumDecayMu(mask)) {
+        registry.fill(HIST("h2QuarkoniumDecayMuPtDCA"), pt, dca);
+        registry.fill(HIST("h2QuarkoniumDecayMuPtChi2"), pt, chi2);
+        registry.fill(HIST("h2QuarkoniumDecayMuPtDeltaPt"), pt, deltaPt);
       } else if (isSecondaryMu(mask)) {
         registry.fill(HIST("h2SecondaryMuPtDCA"), pt, dca);
         registry.fill(HIST("h2SecondaryMuPtChi2"), pt, chi2);
@@ -291,6 +302,8 @@ struct HfTaskSingleMuonSource {
         registry.fill(HIST("h1PromptCharmMuPt"), pt);
       } else if (isLightDecayMu(mask)) {
         registry.fill(HIST("h1LightDecayMuPt"), pt);
+      } else if (isQuarkoniumDecayMu(mask)) {
+        registry.fill(HIST("h1QuarkoniumDecayMuPt"), pt);
       } else if (isSecondaryMu(mask)) {
         registry.fill(HIST("h1SecondaryMuPt"), pt);
       } else if (isHadron(mask)) {


### PR DESCRIPTION
1. Add the quarkonium decay muon histograms in the muon source task
2. Add the MC-related process in the muon reader task
3. Add back the R_abs histogram in the muon reader task
4. Change the binning of DCA in the muon reader task