### PR TITLE
Use BasicCCDBManger::getRunDuration for better stability

### DIFF
--- a/Common/TableProducer/timestamp.cxx
+++ b/Common/TableProducer/timestamp.cxx
@@ -66,18 +66,9 @@ struct TimestampTask {
       orbitResetTimestamp = mapRunToOrbitReset[runNumber];
     } else { // The run was not requested before: need to acccess CCDB!
       LOGF(debug, "Getting start-of-run and end-of-run timestamps from CCDB");
-      std::map<std::string, std::string> metadata, headers;
-      const std::string run_path = Form("%s/%i", rct_path.value.data(), runNumber);
-      headers = ccdb_api.retrieveHeaders(run_path, metadata, -1);
-      if (headers.count("SOR") == 0) {
-        LOGF(fatal, "Cannot find start-of-run timestamp for run number in path '%s'.", run_path.data());
-      }
-      if (headers.count("EOR") == 0) {
-        LOGF(fatal, "Cannot find end-of-run timestamp for run number in path '%s'.", run_path.data());
-      }
-
-      int64_t sorTimestamp = atol(headers["SOR"].c_str()); // timestamp of the SOR in ms
-      int64_t eorTimestamp = atol(headers["EOR"].c_str()); // timestamp of the EOR in ms
+      auto timestamps = ccdb->getRunDuration(runNumber, true);  /// fatalise if timestamps are not found
+      int64_t sorTimestamp = timestamps.first;  // timestamp of the SOR in ms
+      int64_t eorTimestamp = timestamps.second; // timestamp of the EOR in ms
 
       bool isUnanchoredRun3MC = runNumber >= 300000 && runNumber < 500000;
       if (isRun2MC || isUnanchoredRun3MC) {

--- a/Common/TableProducer/timestamp.cxx
+++ b/Common/TableProducer/timestamp.cxx
@@ -66,9 +66,9 @@ struct TimestampTask {
       orbitResetTimestamp = mapRunToOrbitReset[runNumber];
     } else { // The run was not requested before: need to acccess CCDB!
       LOGF(debug, "Getting start-of-run and end-of-run timestamps from CCDB");
-      auto timestamps = ccdb->getRunDuration(runNumber, true);  /// fatalise if timestamps are not found
-      int64_t sorTimestamp = timestamps.first;  // timestamp of the SOR in ms
-      int64_t eorTimestamp = timestamps.second; // timestamp of the EOR in ms
+      auto timestamps = ccdb->getRunDuration(runNumber, true); /// fatalise if timestamps are not found
+      int64_t sorTimestamp = timestamps.first;                 // timestamp of the SOR in ms
+      int64_t eorTimestamp = timestamps.second;                // timestamp of the EOR in ms
 
       bool isUnanchoredRun3MC = runNumber >= 300000 && runNumber < 500000;
       if (isRun2MC || isUnanchoredRun3MC) {


### PR DESCRIPTION
This avoids issues with runs with missing EOR information, see for instance 551230 (before it gets fixed)