### PR TITLE
PWGUD: add further info on fwd tracks to UDTables

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -357,12 +357,15 @@ DECLARE_SOA_TABLE(UDFwdTracks, "AOD", "UDFWDTRACK",
 
 // Muon track quality details
 DECLARE_SOA_TABLE(UDFwdTracksExtra, "AOD", "UDFWDTRACKEXTRA",
+                  fwdtrack::TrackType,
                   fwdtrack::NClusters,
                   fwdtrack::PDca,
                   fwdtrack::RAtAbsorberEnd,
                   fwdtrack::Chi2,
                   fwdtrack::Chi2MatchMCHMID,
                   fwdtrack::Chi2MatchMCHMFT,
+                  fwdtrack::MFTTrackkId,
+                  fwdtrack::MCHTrackId,
                   fwdtrack::MCHBitMap,
                   fwdtrack::MIDBitMap,
                   fwdtrack::MIDBoards);

--- a/PWGUD/TableProducer/DGCandProducer.cxx
+++ b/PWGUD/TableProducer/DGCandProducer.cxx
@@ -71,12 +71,15 @@ struct DGCandProducer {
     outputFwdTracks(outputCollisions.lastIndex(),
                     fwdtrack.px(), fwdtrack.py(), fwdtrack.pz(), fwdtrack.sign(),
                     bcnum, fwdtrack.trackTime(), fwdtrack.trackTimeRes());
-    outputFwdTracksExtra(fwdtrack.nClusters(),
+    outputFwdTracksExtra(fwdtrack.trackType(),
+                         fwdtrack.nClusters(),
                          fwdtrack.pDca(),
                          fwdtrack.rAtAbsorberEnd(),
                          fwdtrack.chi2(),
                          fwdtrack.chi2MatchMCHMID(),
                          fwdtrack.chi2MatchMCHMFT(),
+                         fwdtrack.matchMFTTrackId(),
+                         fwdtrack.matchMCHTrackId(),
                          fwdtrack.mchBitMap(),
                          fwdtrack.midBitMap(),
                          fwdtrack.midBoards());

--- a/PWGUD/TableProducer/SGCandProducer.cxx
+++ b/PWGUD/TableProducer/SGCandProducer.cxx
@@ -81,12 +81,15 @@ struct SGCandProducer {
     outputFwdTracks(outputCollisions.lastIndex(),
                     fwdtrack.px(), fwdtrack.py(), fwdtrack.pz(), fwdtrack.sign(),
                     bcnum, fwdtrack.trackTime(), fwdtrack.trackTimeRes());
-    outputFwdTracksExtra(fwdtrack.nClusters(),
+    outputFwdTracksExtra(fwdtrack.trackType(),
+                         fwdtrack.nClusters(),
                          fwdtrack.pDca(),
                          fwdtrack.rAtAbsorberEnd(),
                          fwdtrack.chi2(),
                          fwdtrack.chi2MatchMCHMID(),
                          fwdtrack.chi2MatchMCHMFT(),
+                         fwdtrack.matchMFTTrackId(),
+                         fwdtrack.matchMCHTrackId(),
                          fwdtrack.mchBitMap(),
                          fwdtrack.midBitMap(),
                          fwdtrack.midBoards());

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -368,8 +368,8 @@ struct UpcCandProducer {
       }
       double mchmftChi2 = track.chi2MatchMCHMFT();
       udFwdTracks(candID, track.px(), track.py(), track.pz(), track.sign(), globalBC, trTime, track.trackTimeRes());
-      udFwdTracksExtra(track.nClusters(), track.pDca(), track.rAtAbsorberEnd(), track.chi2(), mchmidChi2, mchmftChi2,
-                       track.mchBitMap(), track.midBitMap(), track.midBoards());
+      udFwdTracksExtra(track.trackType(), track.nClusters(), track.pDca(), track.rAtAbsorberEnd(), track.chi2(), mchmidChi2, mchmftChi2,
+                       track.matchMFTTrackId(), track.matchMCHTrackId(), track.mchBitMap(), track.midBitMap(), track.midBoards());
       // fill MC labels and masks if needed
       if (fDoMC) {
         const auto& label = mcTrackLabels->iteratorAt(trackID);


### PR DESCRIPTION
- store information about fwd track IDs and track types in the UDTables to allow for the detailed studies of forward tracks