### PR TITLE
Common/TableProducer/qVectorTable.cxx: bug fix to support vector of Qvector

### DIFF
--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -156,7 +156,8 @@ struct qVectorsTable {
           goto allDetectorsInUse; // Added to break from nested loop if all detectors are in use.
         }
         for (auto det : useDetector) {
-          if (input.matcher.binding == det.first) {
+          std::string table_name_with_vector = det.first; // for replacing s with Vecs at the end.
+          if (input.matcher.binding == det.first || input.matcher.binding == table_name_with_vector.replace(table_name_with_vector.size() - 1, 1, "Vecs")) {
             useDetector[det.first.data()] = true;
             LOGF(info, Form("Using detector: %s.", det.first.data()));
           }
@@ -219,7 +220,7 @@ struct qVectorsTable {
     }
 
     objQvec.clear();
-    for (auto i = 0; i < cfgnMods->size(); i++) {
+    for (std::size_t i = 0; i < cfgnMods->size(); i++) {
       int ind = cfgnMods->at(i);
       fullPath = cfgQvecCalibPath;
       fullPath += "/v";
@@ -522,7 +523,7 @@ struct qVectorsTable {
       cent = 110.;
       IsCalibrated = false;
     }
-    for (auto id = 0; id < cfgnMods->size(); id++) {
+    for (std::size_t id = 0; id < cfgnMods->size(); id++) {
       int ind = cfgnMods->at(id);
       CalQvec(ind, coll, tracks, qvecRe, qvecIm, qvecAmp, TrkBPosLabel, TrkBNegLabel, TrkBTotLabel);
       if (cent < 80) {


### PR DESCRIPTION
This PR is to support vector of Qvector (https://github.com/AliceO2Group/O2Physics/pull/6577). In the previous version, only aod::QvectorXXXXs (FT0C, etc) or aod::Qvectors were accepted by comparing string. But, aod::QvectorXXXXVecs were not supported, and q vectors were -999.
In addition, suppress warning about comparison between int and size_t.