### PR TITLE
PWGUD: add index of fwd tracks to UDTables (fix)

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -342,8 +342,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });
 
-DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);              //! FwdTrack index
-DECLARE_SOA_INDEX_COLUMN(MFTTrack, mfttrack);              //! MFTTrack index
+DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack); //! FwdTrack index
+DECLARE_SOA_INDEX_COLUMN(MFTTrack, mfttrack); //! MFTTrack index
 } // namespace udfwdtrack
 
 // Muon track kinematics

--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -341,6 +341,9 @@ DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 16) & 0xFF); });
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });
+
+DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);              //! FwdTrack index
+DECLARE_SOA_INDEX_COLUMN(MFTTrack, mfttrack);              //! MFTTrack index
 } // namespace udfwdtrack
 
 // Muon track kinematics


### PR DESCRIPTION
To fix the previous [version](https://github.com/AliceO2Group/O2Physics/pull/6647/files) where information about fwd tracks indices was added (causing unbound indices `ERROR: Index on O2fwdtrack but no tree found` and `ERROR: Index on O2mfttrack but no tree found` when tested on hyperloop) 