### PR TITLE
Common: Event selection: Fix compilation warning

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -819,8 +819,12 @@ struct EventSelectionTask {
       bool decisions[4];
       for (int iCut = 0; iCut < 4; iCut++) {
         decisions[iCut] = true;
-        for (int iTime = 0; iTime < nTimeIntervals; iTime++)
-          decisions[iCut] *= (nITS567tracksInTimeBins[iTime] < coeffOccupInTimeBins[iCut] * confReferenceOccupanciesInTimeBins->at(iTime));
+        for (int iTime = 0; iTime < nTimeIntervals; iTime++) {
+          if (nITS567tracksInTimeBins[iTime] >= coeffOccupInTimeBins[iCut] * confReferenceOccupanciesInTimeBins->at(iTime)) {
+            decisions[iCut] = false;
+            break;
+          }
+        }
       }
       vNoOccupStrictCuts[colIndex] = decisions[0];
       vNoOccupMediumCuts[colIndex] = decisions[1];


### PR DESCRIPTION
@altsybee This fixes the `int-in-bool-context` warning introduced in https://github.com/AliceO2Group/O2Physics/pull/6548 and also fixes the unnecessary evaluation of the condition and assignment when the result is already known.
Please check carefully that the logic has been preserved.