### PR TITLE
PWGUD: store fwd matching indices in a separate table

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -340,10 +340,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh2, midBoardCh2, //!
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 16) & 0xFF); });
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
-                           [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });
-
-DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack); //! FwdTrack index
-DECLARE_SOA_INDEX_COLUMN(MFTTrack, mfttrack); //! MFTTrack index
+                           [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });                    
 } // namespace udfwdtrack
 
 // Muon track kinematics
@@ -367,8 +364,6 @@ DECLARE_SOA_TABLE(UDFwdTracksExtra, "AOD", "UDFWDTRACKEXTRA",
                   fwdtrack::Chi2,
                   fwdtrack::Chi2MatchMCHMID,
                   fwdtrack::Chi2MatchMCHMFT,
-                  fwdtrack::MFTTrackId,
-                  fwdtrack::MCHTrackId,
                   fwdtrack::MCHBitMap,
                   fwdtrack::MIDBitMap,
                   fwdtrack::MIDBoards);

--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -340,7 +340,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh2, midBoardCh2, //!
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
                            [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 16) & 0xFF); });
 DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
-                           [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });                    
+                           [](uint32_t midBoards) -> int { return static_cast<int>((midBoards >> 24) & 0xFF); });
 } // namespace udfwdtrack
 
 // Muon track kinematics
@@ -354,6 +354,22 @@ DECLARE_SOA_TABLE(UDFwdTracks, "AOD", "UDFWDTRACK",
                   udfwdtrack::GlobalBC,
                   udfwdtrack::TrackTime,
                   udfwdtrack::TrackTimeRes);
+
+namespace udfwdmatchindex
+{
+DECLARE_SOA_INDEX_COLUMN(UDCollision, udCollision);    //!
+DECLARE_SOA_COLUMN(GlobalIndex, globalIndex, int64_t); //! Index of the track in the global track table
+DECLARE_SOA_COLUMN(MCHTrackId, mchTrackId, int64_t);   //! Id of original MCH track used for matching
+DECLARE_SOA_COLUMN(MFTTrackId, mftTrackId, int64_t);   //! Id of original MFT track used for matching
+} // namespace udfwdmatchindex
+
+// Details about FWD indices
+DECLARE_SOA_TABLE(UDFwdIndices, "AOD", "UDFWDINDEX",
+                  o2::soa::Index<>,
+                  udfwdmatchindex::UDCollisionId,
+                  udfwdmatchindex::GlobalIndex,
+                  udfwdmatchindex::MCHTrackId,
+                  udfwdmatchindex::MFTTrackId);
 
 // Muon track quality details
 DECLARE_SOA_TABLE(UDFwdTracksExtra, "AOD", "UDFWDTRACKEXTRA",
@@ -369,6 +385,7 @@ DECLARE_SOA_TABLE(UDFwdTracksExtra, "AOD", "UDFWDTRACKEXTRA",
                   fwdtrack::MIDBoards);
 
 using UDFwdTrack = UDFwdTracks::iterator;
+using UDFwdIndex = UDFwdIndices::iterator;
 using UDFwdTrackExtra = UDFwdTracksExtra::iterator;
 
 DECLARE_SOA_TABLE(UDFwdTracksProp, "AOD", "UDFWDTRACKPROP",

--- a/PWGUD/TableProducer/DGCandProducer.cxx
+++ b/PWGUD/TableProducer/DGCandProducer.cxx
@@ -78,8 +78,6 @@ struct DGCandProducer {
                          fwdtrack.chi2(),
                          fwdtrack.chi2MatchMCHMID(),
                          fwdtrack.chi2MatchMCHMFT(),
-                         fwdtrack.matchMFTTrackId(),
-                         fwdtrack.matchMCHTrackId(),
                          fwdtrack.mchBitMap(),
                          fwdtrack.midBitMap(),
                          fwdtrack.midBoards());

--- a/PWGUD/TableProducer/SGCandProducer.cxx
+++ b/PWGUD/TableProducer/SGCandProducer.cxx
@@ -88,8 +88,6 @@ struct SGCandProducer {
                          fwdtrack.chi2(),
                          fwdtrack.chi2MatchMCHMID(),
                          fwdtrack.chi2MatchMCHMFT(),
-                         fwdtrack.matchMFTTrackId(),
-                         fwdtrack.matchMCHTrackId(),
                          fwdtrack.mchBitMap(),
                          fwdtrack.midBitMap(),
                          fwdtrack.midBoards());

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -37,6 +37,7 @@ struct UpcCandProducer {
 
   Produces<o2::aod::UDFwdTracks> udFwdTracks;
   Produces<o2::aod::UDFwdTracksExtra> udFwdTracksExtra;
+  Produces<o2::aod::UDFwdIndices> udFwdIndices;
   Produces<o2::aod::UDFwdTracksCls> udFwdTrkClusters;
   Produces<o2::aod::UDMcFwdTrackLabels> udFwdTrackLabels;
 
@@ -367,9 +368,13 @@ struct UpcCandProducer {
         mchmidChi2 = -999.;                                                                                                     // no MID match
       }
       double mchmftChi2 = track.chi2MatchMCHMFT();
+      int64_t globalIndex = track.globalIndex();
+      int64_t mchIndex = track.matchMCHTrackId();
+      int64_t mftIndex = track.matchMFTTrackId();
       udFwdTracks(candID, track.px(), track.py(), track.pz(), track.sign(), globalBC, trTime, track.trackTimeRes());
       udFwdTracksExtra(track.trackType(), track.nClusters(), track.pDca(), track.rAtAbsorberEnd(), track.chi2(), mchmidChi2, mchmftChi2,
                        track.mchBitMap(), track.midBitMap(), track.midBoards());
+      udFwdIndices(candID, globalIndex, mchIndex, mftIndex);
       // fill MC labels and masks if needed
       if (fDoMC) {
         const auto& label = mcTrackLabels->iteratorAt(trackID);

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -369,7 +369,7 @@ struct UpcCandProducer {
       double mchmftChi2 = track.chi2MatchMCHMFT();
       udFwdTracks(candID, track.px(), track.py(), track.pz(), track.sign(), globalBC, trTime, track.trackTimeRes());
       udFwdTracksExtra(track.trackType(), track.nClusters(), track.pDca(), track.rAtAbsorberEnd(), track.chi2(), mchmidChi2, mchmftChi2,
-                       track.matchMFTTrackId(), track.matchMCHTrackId(), track.mchBitMap(), track.midBitMap(), track.midBoards());
+                       track.mchBitMap(), track.midBitMap(), track.midBoards());
       // fill MC labels and masks if needed
       if (fDoMC) {
         const auto& label = mcTrackLabels->iteratorAt(trackID);


### PR DESCRIPTION
- changes in #6712 reverted  (not necessary)
- information about indices used for forward matching is now stored in a separate table instead of UDFwdTracksExtra  (which was initially introduced in #6647)