### PR TITLE
PWGEM/PhotonMeson: Adjust emcalQC task for EM framework changes

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
@@ -32,7 +32,8 @@
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
 #include "PWGEM/PhotonMeson/Core/EMCPhotonCut.h"
 #include "PWGEM/PhotonMeson/Core/CutsLibrary.h"
-#include "PWGEM/PhotonMeson/Core/HistogramsLibrary.h"
+#include "PWGEM/PhotonMeson/Utils/EventHistograms.h"
+#include "PWGEM/PhotonMeson/Utils/ClusterHistograms.h"
 
 using namespace o2;
 using namespace o2::aod;
@@ -40,191 +41,155 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
 using namespace o2::aod::pwgem::photon;
-using std::array;
 
-using MyCollisions = soa::Join<aod::EMEvents, aod::EMEventsMult, aod::EMEventsCent>;
+using MyCollisions = soa::Join<aod::EMEvents, aod::EMEventsMult, aod::EMEventsCent, aod::EMEventsQvec>;
 using MyCollision = MyCollisions::iterator;
+
+using MyEMCClusters = soa::Join<aod::SkimEMCClusters, aod::EMCEMEventIds>;
+using MyEMCCluster = MyEMCClusters::iterator;
 
 struct emcalQC {
 
-  Configurable<bool> requireCaloReadout{"requireCaloReadout", true, "Require calorimeters readout when analyzing EMCal/PHOS"};
-  Configurable<std::string> fConfigEMCCuts{"cfgEMCCuts", "custom,standard,nocut", "Comma separated list of EMCal photon cuts"};
-  Configurable<float> EMC_minTime{"EMC_minTime", -20., "Minimum cluster time for EMCal time cut"};
-  Configurable<float> EMC_maxTime{"EMC_maxTime", +25., "Maximum cluster time for EMCal time cut"};
-  Configurable<float> EMC_minM02{"EMC_minM02", 0.1, "Minimum M02 for EMCal M02 cut"};
-  Configurable<float> EMC_maxM02{"EMC_maxM02", 0.7, "Maximum M02 for EMCal M02 cut"};
-  Configurable<float> EMC_minE{"EMC_minE", 0.7, "Minimum cluster energy for EMCal energy cut"};
-  Configurable<int> EMC_minNCell{"EMC_minNCell", 1, "Minimum number of cells per cluster for EMCal NCell cut"};
-  Configurable<std::vector<float>> EMC_TM_Eta{"EMC_TM_Eta", {0.01f, 4.07f, -2.5f}, "|eta| <= [0]+(pT+[1])^[2] for EMCal track matching"};
-  Configurable<std::vector<float>> EMC_TM_Phi{"EMC_TM_Phi", {0.015f, 3.65f, -2.f}, "|phi| <= [0]+(pT+[1])^[2] for EMCal track matching"};
-  Configurable<float> EMC_Eoverp{"EMC_Eoverp", 1.75, "Minimum cluster energy over track momentum for EMCal track matching"};
-  Configurable<bool> EMC_UseExoticCut{"EMC_UseExoticCut", true, "FLag to use the EMCal exotic cluster cut"};
-  Configurable<bool> fDo2DQC{"Do2DQC", true, "Flag to output 2D QC histograms displaying the energy dependence on the second axis"};
+  Configurable<bool> cfgDo2DQA{"cfgDo2DQA", true, "perform 2 dimensional cluster QA"};
+  ConfigurableAxis ConfVtxBins{"ConfVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
 
-  std::vector<EMCPhotonCut> fEMCCuts;
+  EMEventCut fEMEventCut;
+  struct : ConfigurableGroup {
+    std::string prefix = "eventcut_group";
+    Configurable<float> cfgZvtxMax{"cfgZvtxMax", 10.f, "max. Zvtx"};
+    Configurable<bool> cfgRequireSel8{"cfgRequireSel8", true, "require sel8 in event cut"};
+    Configurable<bool> cfgRequireFT0AND{"cfgRequireFT0AND", true, "require FT0AND in event cut"};
+    Configurable<bool> cfgRequireNoTFB{"cfgRequireNoTFB", false, "require No time frame border in event cut"};
+    Configurable<bool> cfgRequireNoITSROFB{"cfgRequireNoITSROFB", false, "require no ITS readout frame border in event cut"};
+    Configurable<bool> cfgRequireNoSameBunchPileup{"cfgRequireNoSameBunchPileup", false, "require no same bunch pileup in event cut"};
+    Configurable<bool> cfgRequireVertexITSTPC{"cfgRequireVertexITSTPC", false, "require Vertex ITSTPC in event cut"}; // ITS-TPC matched track contributes PV.
+    Configurable<bool> cfgRequireGoodZvtxFT0vsPV{"cfgRequireGoodZvtxFT0vsPV", false, "require good Zvtx between FT0 vs. PV in event cut"};
+    Configurable<int> cfgOccupancyMin{"cfgOccupancyMin", -1, "min. occupancy"};
+    Configurable<int> cfgOccupancyMax{"cfgOccupancyMax", 1000000000, "max. occupancy"};
+  } eventcuts;
 
-  OutputObj<THashList> fOutputEvent{"Event"};
-  OutputObj<THashList> fOutputCluster{"Cluster"};
-  THashList* fMainList = new THashList();
+  EMCPhotonCut fEMCCut;
+  struct : ConfigurableGroup {
+    std::string prefix = "emccut_group";
+    Configurable<bool> requireCaloReadout{"requireCaloReadout", true, "Require calorimeters readout when analyzing EMCal/PHOS"};
+    Configurable<float> minOpenAngle{"minOpenAngle", 0.0202, "apply min opening angle"};
+    Configurable<float> EMC_minTime{"EMC_minTime", -20., "Minimum cluster time for EMCal time cut"};
+    Configurable<float> EMC_maxTime{"EMC_maxTime", +25., "Maximum cluster time for EMCal time cut"};
+    Configurable<float> EMC_minM02{"EMC_minM02", 0.1, "Minimum M02 for EMCal M02 cut"};
+    Configurable<float> EMC_maxM02{"EMC_maxM02", 0.7, "Maximum M02 for EMCal M02 cut"};
+    Configurable<float> EMC_minE{"EMC_minE", 0.7, "Minimum cluster energy for EMCal energy cut"};
+    Configurable<int> EMC_minNCell{"EMC_minNCell", 1, "Minimum number of cells per cluster for EMCal NCell cut"};
+    Configurable<std::vector<float>> EMC_TM_Eta{"EMC_TM_Eta", {0.01f, 4.07f, -2.5f}, "|eta| <= [0]+(pT+[1])^[2] for EMCal track matching"};
+    Configurable<std::vector<float>> EMC_TM_Phi{"EMC_TM_Phi", {0.015f, 3.65f, -2.f}, "|phi| <= [0]+(pT+[1])^[2] for EMCal track matching"};
+    Configurable<float> EMC_Eoverp{"EMC_Eoverp", 1.75, "Minimum cluster energy over track momentum for EMCal track matching"};
+    Configurable<bool> EMC_UseExoticCut{"EMC_UseExoticCut", true, "FLag to use the EMCal exotic cluster cut"};
+  } emccuts;
 
-  void addhistograms()
+  void DefineEMEventCut()
   {
-    fMainList->SetOwner(true);
-    fMainList->SetName("fMainList");
-
-    // create sub lists first.
-    o2::aod::pwgem::photon::histogram::AddHistClass(fMainList, "Event");
-    THashList* list_ev = reinterpret_cast<THashList*>(fMainList->FindObject("Event"));
-    o2::aod::pwgem::photon::histogram::DefineHistograms(list_ev, "Event");
-
-    list_ev->Add(new TH1F("hNEvents", "hNEvents", 6, 0.5f, 6.5f));
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(1, "all cols");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(2, "sel8");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(3, "emc readout");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(4, "1+ Contributor");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(5, "z<10cm");
-    reinterpret_cast<TH2F*>(list_ev->FindObject("hNEvents"))->GetXaxis()->SetBinLabel(6, "unique col");
-
-    o2::aod::pwgem::photon::histogram::AddHistClass(fMainList, "Cluster");
-    THashList* list_cluster = reinterpret_cast<THashList*>(fMainList->FindObject("Cluster"));
-
-    for (const auto& cut : fEMCCuts) {
-      const char* cutname = cut.GetName();
-      o2::aod::pwgem::photon::histogram::AddHistClass(list_cluster, cutname);
-    }
-
-    // for Clusters
-    for (auto& cut : fEMCCuts) {
-      std::string_view cutname = cut.GetName();
-      THashList* list = reinterpret_cast<THashList*>(fMainList->FindObject("Cluster")->FindObject(cutname.data()));
-      o2::aod::pwgem::photon::histogram::DefineHistograms(list, "Cluster", fDo2DQC ? "2D_EMC" : "EMC");
-    }
+    fEMEventCut = EMEventCut("fEMEventCut", "fEMEventCut");
+    fEMEventCut.SetRequireSel8(eventcuts.cfgRequireSel8);
+    fEMEventCut.SetRequireFT0AND(eventcuts.cfgRequireFT0AND);
+    fEMEventCut.SetZvtxRange(-eventcuts.cfgZvtxMax, +eventcuts.cfgZvtxMax);
+    fEMEventCut.SetRequireNoTFB(eventcuts.cfgRequireNoTFB);
+    fEMEventCut.SetRequireNoITSROFB(eventcuts.cfgRequireNoITSROFB);
+    fEMEventCut.SetRequireNoSameBunchPileup(eventcuts.cfgRequireNoSameBunchPileup);
+    fEMEventCut.SetRequireVertexITSTPC(eventcuts.cfgRequireVertexITSTPC);
+    fEMEventCut.SetRequireGoodZvtxFT0vsPV(eventcuts.cfgRequireGoodZvtxFT0vsPV);
+    fEMEventCut.SetOccupancyRange(eventcuts.cfgOccupancyMin, eventcuts.cfgOccupancyMax);
   }
 
-  void DefineCuts()
+  void DefineEMCCut()
   {
-    const float a = EMC_TM_Eta->at(0);
-    const float b = EMC_TM_Eta->at(1);
-    const float c = EMC_TM_Eta->at(2);
+    const float a = emccuts.EMC_TM_Eta->at(0);
+    const float b = emccuts.EMC_TM_Eta->at(1);
+    const float c = emccuts.EMC_TM_Eta->at(2);
 
-    const float d = EMC_TM_Phi->at(0);
-    const float e = EMC_TM_Phi->at(1);
-    const float f = EMC_TM_Phi->at(2);
+    const float d = emccuts.EMC_TM_Phi->at(0);
+    const float e = emccuts.EMC_TM_Phi->at(1);
+    const float f = emccuts.EMC_TM_Phi->at(2);
     LOGF(info, "EMCal track matching parameters : a = %f, b = %f, c = %f, d = %f, e = %f, f = %f", a, b, c, d, e, f);
 
-    TString cutNamesStr = fConfigEMCCuts.value;
-    if (!cutNamesStr.IsNull()) {
-      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
-      for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
-        const char* cutname = objArray->At(icut)->GetName();
-        LOGF(info, "add cut : %s", cutname);
-        if (std::strcmp(cutname, "custom") == 0) {
-          EMCPhotonCut* custom_cut = new EMCPhotonCut(cutname, cutname);
-          custom_cut->SetMinE(EMC_minE);
-          custom_cut->SetMinNCell(EMC_minNCell);
-          custom_cut->SetM02Range(EMC_minM02, EMC_maxM02);
-          custom_cut->SetTimeRange(EMC_minTime, EMC_maxTime);
+    fEMCCut.SetMinE(emccuts.EMC_minE);
+    fEMCCut.SetMinNCell(emccuts.EMC_minNCell);
+    fEMCCut.SetM02Range(emccuts.EMC_minM02, emccuts.EMC_maxM02);
+    fEMCCut.SetTimeRange(emccuts.EMC_minTime, emccuts.EMC_maxTime);
 
-          custom_cut->SetTrackMatchingEta([&a, &b, &c](float pT) {
-            return a + pow(pT + b, c);
-          });
-          custom_cut->SetTrackMatchingPhi([&d, &e, &f](float pT) {
-            return d + pow(pT + e, f);
-          });
+    fEMCCut.SetTrackMatchingEta([&a, &b, &c](float pT) { return a + pow(pT + b, c); });
+    fEMCCut.SetTrackMatchingPhi([&d, &e, &f](float pT) { return d + pow(pT + e, f); });
 
-          custom_cut->SetMinEoverP(EMC_Eoverp);
-          custom_cut->SetUseExoticCut(EMC_UseExoticCut);
-          fEMCCuts.push_back(*custom_cut);
-        } else {
-          fEMCCuts.push_back(*emccuts::GetCut(cutname));
-        }
-      }
-    }
-    LOGF(info, "Number of EMC cuts = %d", fEMCCuts.size());
+    fEMCCut.SetMinEoverP(emccuts.EMC_Eoverp);
+    fEMCCut.SetUseExoticCut(emccuts.EMC_UseExoticCut);
   }
+
+  HistogramRegistry fRegistry{"output", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
+  std::vector<float> zvtx_bin_edges;
 
   void init(InitContext&)
   {
-    DefineCuts();
-    addhistograms(); // please call this after DefinCuts();
+    zvtx_bin_edges = std::vector<float>(ConfVtxBins.value.begin(), ConfVtxBins.value.end());
+    zvtx_bin_edges.erase(zvtx_bin_edges.begin());
 
-    fOutputEvent.setObject(reinterpret_cast<THashList*>(fMainList->FindObject("Event")));
-    fOutputCluster.setObject(reinterpret_cast<THashList*>(fMainList->FindObject("Cluster")));
+    DefineEMCCut();
+    DefineEMEventCut();
+
+    o2::aod::pwgem::photonmeson::utils::eventhistogram::addEventHistograms(&fRegistry, false | false);
+    o2::aod::pwgem::photonmeson::utils::clusterhistogram::addClusterHistograms(&fRegistry, cfgDo2DQA);
   }
 
   Preslice<aod::SkimEMCClusters> perCollision = aod::skimmedcluster::collisionId;
 
   void processQC(MyCollisions const& collisions, aod::SkimEMCClusters const& clusters)
   {
-    THashList* list_ev = static_cast<THashList*>(fMainList->FindObject("Event"));
-    THashList* list_cluster = static_cast<THashList*>(fMainList->FindObject("Cluster"));
-
     for (auto& collision : collisions) {
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(1.0);
-      if (!collision.sel8()) {
-        continue;
-      }
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(2.0);
-      if (collision.alias_bit(triggerAliases::kTVXinEMC) == 0 && requireCaloReadout) {
-        continue;
-      }
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(3.0);
 
-      if (collision.numContrib() < 0.5) {
+      o2::aod::pwgem::photonmeson::utils::eventhistogram::fillEventInfo<0>(&fRegistry, collision, false);
+      if (!fEMEventCut.IsSelected(collision)) {
         continue;
       }
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(4.0);
-
-      if (abs(collision.posZ()) > 10.0) {
+      if (!collision.alias_bit(triggerAliases::kTVXinEMC) && emccuts.requireCaloReadout) {
         continue;
       }
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(5.0);
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hZvtx"))->Fill(collision.posZ());
-
-      if (collision.ncollsPerBC() != 1) { // Check that the collision is unique (the only one in the bc)
-        continue;
-      }
-      reinterpret_cast<TH1F*>(fMainList->FindObject("Event")->FindObject("hNEvents"))->Fill(6.0);
-
-      o2::aod::pwgem::photon::histogram::FillHistClass<EMHistType::kEvent>(list_ev, "", collision); // Fill event histograms
+      o2::aod::pwgem::photonmeson::utils::eventhistogram::fillEventInfo<1>(&fRegistry, collision, false);
+      fRegistry.fill(HIST("Event/before/hCollisionCounter"), 10.0); // accepted
+      fRegistry.fill(HIST("Event/after/hCollisionCounter"), 10.0);  // accepted
 
       auto clusters_per_coll = clusters.sliceBy(perCollision, collision.collisionId());
-      for (const auto& cut : fEMCCuts) {
-        THashList* list_cluster_cut = static_cast<THashList*>(list_cluster->FindObject(cut.GetName()));
-        int ng = 0;
-        for (auto& cluster : clusters_per_coll) {
-          // Fill the cluster properties before applying any cuts
+      fRegistry.fill(HIST("Cluster/before/hNgamma"), clusters_per_coll.size());
+      int ng = 0;
+      for (auto& cluster : clusters_per_coll) {
+        // Fill the cluster properties before applying any cuts
+        o2::aod::pwgem::photonmeson::utils::clusterhistogram::fillClusterHistograms<0>(&fRegistry, cluster, cfgDo2DQA);
 
-          // Apply cuts one by one and fill in hClusterQualityCuts histogram
-          reinterpret_cast<TH2F*>(fMainList->FindObject("Cluster")->FindObject(cut.GetName())->FindObject("hClusterQualityCuts"))->Fill(0., cluster.e());
-          auto track = nullptr;
+        // Apply cuts one by one and fill in hClusterQualityCuts histogram
+        fRegistry.fill(HIST("Cluster/hClusterQualityCuts"), 0., cluster.e());
+        auto track = nullptr;
 
-          // Define two boleans to see, whether the cluster "survives" the EMC cluster cuts to later check, whether the cuts in this task align with the ones in EMCPhotonCut.h:
-          bool survivesIsSelectedEMCalCuts = true;                    // Survives "manual" cuts listed in this task
-          bool survivesIsSelectedCuts = cut.IsSelected<int>(cluster); // Survives the cutlist defines in EMCPhotonCut.h, which is also used in the Pi0Eta task
+        // Define two boleans to see, whether the cluster "survives" the EMC cluster cuts to later check, whether the cuts in this task align with the ones in EMCPhotonCut.h:
+        bool survivesIsSelectedEMCalCuts = true;                        // Survives "manual" cuts listed in this task
+        bool survivesIsSelectedCuts = fEMCCut.IsSelected<int>(cluster); // Survives the cutlist defines in EMCPhotonCut.h, which is also used in the Pi0Eta task
 
-          for (int icut = 0; icut < static_cast<int>(EMCPhotonCut::EMCPhotonCuts::kNCuts); icut++) { // Loop through different cut observables
-            EMCPhotonCut::EMCPhotonCuts specificcut = static_cast<EMCPhotonCut::EMCPhotonCuts>(icut);
-            if (!cut.IsSelectedEMCal(specificcut, cluster, track)) { // Check whether cluster passes this cluster requirement, if not, fill why in the next row
-              reinterpret_cast<TH1F*>(fMainList->FindObject("Cluster")->FindObject(cut.GetName())->FindObject("hClusterQualityCuts"))->Fill(icut + 1, cluster.e());
-              survivesIsSelectedEMCalCuts = false;
-            }
-          }
-
-          if (survivesIsSelectedCuts != survivesIsSelectedEMCalCuts) {
-            LOGF(info, "Cummulative application of IsSelectedEMCal cuts does not equal the IsSelected result");
-          }
-
-          if (survivesIsSelectedCuts) {
-            o2::aod::pwgem::photon::histogram::FillHistClass<EMHistType::kEMCCluster>(list_cluster_cut, fDo2DQC ? "2D" : "1D", cluster);
-            reinterpret_cast<TH2F*>(fMainList->FindObject("Cluster")->FindObject(cut.GetName())->FindObject("hClusterQualityCuts"))->Fill(7., cluster.e());
-            ng++;
+        for (int icut = 0; icut < static_cast<int>(EMCPhotonCut::EMCPhotonCuts::kNCuts); icut++) { // Loop through different cut observables
+          EMCPhotonCut::EMCPhotonCuts specificcut = static_cast<EMCPhotonCut::EMCPhotonCuts>(icut);
+          if (!fEMCCut.IsSelectedEMCal(specificcut, cluster, track)) { // Check whether cluster passes this cluster requirement, if not, fill why in the next row
+            fRegistry.fill(HIST("Cluster/hClusterQualityCuts"), icut + 1, cluster.e());
+            survivesIsSelectedEMCalCuts = false;
           }
         }
-        reinterpret_cast<TH1F*>(fMainList->FindObject("Cluster")->FindObject(cut.GetName())->FindObject("hNgamma"))->Fill(ng);
-      } // end of cut loop
-    }   // end of collision loop
-  }     // end of process
+
+        if (survivesIsSelectedCuts != survivesIsSelectedEMCalCuts) {
+          LOGF(info, "Cummulative application of IsSelectedEMCal cuts does not equal the IsSelected result");
+        }
+
+        if (survivesIsSelectedCuts) {
+          o2::aod::pwgem::photonmeson::utils::clusterhistogram::fillClusterHistograms<1>(&fRegistry, cluster, cfgDo2DQA);
+          fRegistry.fill(HIST("Cluster/hClusterQualityCuts"), 7., cluster.e());
+          ng++;
+        }
+      }
+      fRegistry.fill(HIST("Cluster/after/hNgamma"), ng);
+    } // end of collision loop
+  } // end of process
 
   void processDummy(MyCollisions const&) {}
 

--- a/PWGEM/PhotonMeson/Utils/ClusterHistograms.h
+++ b/PWGEM/PhotonMeson/Utils/ClusterHistograms.h
@@ -1,0 +1,86 @@
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// Header file for histograms used in EMC cluster QA
+/// \author nicolas.strangmann@cern.ch
+
+#ifndef PWGEM_PHOTONMESON_UTILS_CLUSTERHISTOGRAMS_H_
+#define PWGEM_PHOTONMESON_UTILS_CLUSTERHISTOGRAMS_H_
+
+using namespace o2::framework;
+
+namespace o2::aod::pwgem::photonmeson::utils::clusterhistogram
+{
+void addClusterHistograms(HistogramRegistry* fRegistry, bool do2DQA)
+{
+  fRegistry->add("Cluster/before/hE", "E_{cluster};#it{E}_{cluster} (GeV);#it{N}_{cluster}", kTH1F, {{500, 0, 50}}, true);
+  fRegistry->add("Cluster/before/hPt", "Transverse momenta of clusters;#it{p}_{T} (GeV/c);#it{N}_{cluster}", kTH1F, {{1000, 0.0f, 20}}, true);
+  fRegistry->add("Cluster/before/hNgamma", "Number of #gamma candidates per collision;#it{N}_{#gamma} per collision;#it{N}_{collisions}", kTH1F, {{101, -0.5f, 100.5f}}, true);
+  fRegistry->add("Cluster/before/hEtaPhi", "#eta vs #varphi;#eta;#varphi (rad.)", kTH2F, {{200, -1.0f, 1.0f}, {180, 0, 2 * M_PI}}, true);
+  fRegistry->add("Cluster/before/hTrackEtaPhi", "d#eta vs. d#varphi of matched tracks;d#eta;d#varphi (rad.)", kTH2F, {{100, -0.5, 0.5}, {100, -0.5, 0.5}}, true);
+
+  if (do2DQA) { // Check if 2D QA histograms were selected in em-qc task
+    fRegistry->add("Cluster/before/hNCell", "#it{N}_{cells};N_{cells} (GeV);#it{E}_{cluster} (GeV)", kTH2F, {{51, -0.5, 50.5}, {200, 0, 20}}, true);
+    fRegistry->add("Cluster/before/hM02", "Long ellipse axis;#it{M}_{02} (cm);#it{E}_{cluster} (GeV)", kTH2F, {{500, 0, 5}, {200, 0, 20}}, true);
+    fRegistry->add("Cluster/before/hM20", "Short ellipse axis;#it{M}_{20} (cm);#it{E}_{cluster} (GeV)", kTH2F, {{250, 0, 2.5}, {200, 0, 20}}, true);
+    fRegistry->add("Cluster/before/hTime", "Cluster time;#it{t}_{cls} (ns);#it{E}_{cluster} (GeV)", kTH2F, {{100, -250, 250}, {200, 0, 20}}, true);
+    fRegistry->add("Cluster/before/hCellTime", "Cell time;#it{t}_{cell} (ns);#it{E}_{cluster} (GeV)", kTH2F, {{100, -250, 250}, {200, 0, 20}}, true);
+    fRegistry->add("Cluster/before/hDistToBC", "distance to bad channel;#it{d};#it{E}_{cluster} (GeV)", kTH2F, {{100, 0, 1500}, {200, 0, 20}}, true);
+  } else {
+    fRegistry->add("Cluster/before/hNCell", "#it{N}_{cells};N_{cells} (GeV);#it{N}_{cluster}", kTH1F, {{51, -0.5, 50.5}}, true);
+    fRegistry->add("Cluster/before/hM02", "Long ellipse axis;#it{M}_{02} (cm);#it{N}_{cluster}", kTH1F, {{500, 0, 5}}, true);
+    fRegistry->add("Cluster/before/hM20", "Short ellipse axis;#it{M}_{20} (cm);#it{N}_{cluster}", kTH1F, {{250, 0, 2.5}}, true);
+    fRegistry->add("Cluster/before/hTime", "Cluster time;#it{t}_{cls} (ns);#it{N}_{cluster}", kTH1F, {{500, -250, 250}}, true);
+    fRegistry->add("Cluster/before/hCellTime", "Cluster time;#it{t}_{cell} (ns);#it{N}_{cluster}", kTH1F, {{500, -250, 250}}, true);
+    fRegistry->add("Cluster/before/hDistToBC", "distance to bad channel;#it{d};#it{N}_{cluster}", kTH1F, {{100, 0, 1500}}, true);
+  }
+
+  auto hClusterQualityCuts = fRegistry->add<TH2>("Cluster/hClusterQualityCuts", "Energy at which clusters are removed by a given cut;;#it{E} (GeV)", kTH2F, {{8, -0.5, 7.5}, {500, 0, 50}}, true);
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(1, "In");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(2, "Energy");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(3, "NCell");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(4, "M02");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(5, "Timing");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(6, "Track matching");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(7, "Exotic");
+  hClusterQualityCuts->GetXaxis()->SetBinLabel(8, "Out");
+
+  fRegistry->addClone("Cluster/before/", "Cluster/after/");
+}
+
+template <const int cls_id>
+void fillClusterHistograms(HistogramRegistry* fRegistry, SkimEMCCluster cluster, bool do2DQA)
+{
+  static constexpr std::string_view cluster_types[2] = {"before/", "after/"};
+  fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hE"), cluster.pt());
+  fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hPt"), cluster.e());
+  fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hEtaPhi"), cluster.eta(), cluster.phi());
+  for (size_t itrack = 0; itrack < cluster.tracketa().size(); itrack++) { // Fill TrackEtaPhi histogram with delta phi and delta eta of all tracks saved in the vectors in skimmerGammaCalo.cxx
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hTrackEtaPhi"), cluster.tracketa()[itrack] - cluster.eta(), cluster.trackphi()[itrack] - cluster.phi());
+  }
+  if (do2DQA) {
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hNCell"), cluster.nCells(), cluster.e());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hM02"), cluster.m02(), cluster.e());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hM20"), cluster.m20(), cluster.e());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hTime"), cluster.time(), cluster.e());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hDistToBC"), cluster.distanceToBadChannel(), cluster.e());
+  } else {
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hNCell"), cluster.nCells());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hM02"), cluster.m02());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hM20"), cluster.m20());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hTime"), cluster.time());
+    fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hDistToBC"), cluster.distanceToBadChannel());
+  }
+}
+
+} // namespace o2::aod::pwgem::photonmeson::utils::clusterhistogram
+
+#endif // PWGEM_PHOTONMESON_UTILS_CLUSTERHISTOGRAMS_H_

--- a/PWGLF/Tasks/Nuspex/nuclei_in_jets.cxx
+++ b/PWGLF/Tasks/Nuspex/nuclei_in_jets.cxx
@@ -1067,14 +1067,15 @@ struct nuclei_in_jets {
 
       // Reduced Event
       std::vector<int> particle_ID;
-      int leading_ID = 0;
+      int leading_ID(0);
       float pt_max(0);
+      int i = -1;
 
       // Generated Particles
       for (auto& particle : mcParticles_per_coll) {
 
-        // Global Index
-        int i = particle.globalIndex();
+        // Particle Index
+        i++;
 
         // Select Primary Particles
         float deltaX = particle.vx() - mccollision.posX();


### PR DESCRIPTION
- Moved QA histograms from general cut library to ClusterHistograms.h (analogous to GammaGamma task)
- Adjust QC task to only run one cutstring and rather be called via multiple subwagons
- Adjust configurables to be in line with those of the GammaGamma task