### PR TITLE
Update qaEfficiency.cxx

### DIFF
--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -935,11 +935,11 @@ struct QaEfficiency {
       if (!mcParticle.isPhysicalPrimary()) {
         // Check if the particle is produced in a secondary decay
         if (mcParticle.getProcess() == 4) {
-         // Get the mother particle's index and the mother particle itself
-            auto motherParticle = mcParticle.mother0_as<o2::aod::McParticles>();
-         // Check if the mother particle is not primary and produced in a weak decay
-           if (!motherParticle.isPhysicalPrimary() && motherParticle.getProcess() == 4) {
-          return true; // Consider it as a tertiary particle
+          // Get the mother particle's index and the mother particle itself
+          auto motherParticle = mcParticle.mother0_as<o2::aod::McParticles>();
+          // Check if the mother particle is not primary and produced in a weak decay
+          if (!motherParticle.isPhysicalPrimary() && motherParticle.getProcess() == 4) {
+            return true; // Consider it as a tertiary particle
           }
         }
       }

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -935,7 +935,12 @@ struct QaEfficiency {
       if (!mcParticle.isPhysicalPrimary()) {
         // Check if the particle is produced in a secondary decay
         if (mcParticle.getProcess() == 4) {
+         // Get the mother particle's index and the mother particle itself
+            auto motherParticle = mcParticle.mother0_as<o2::aod::McParticles>();
+         // Check if the mother particle is not primary and produced in a weak decay
+           if (!motherParticle.isPhysicalPrimary() && motherParticle.getProcess() == 4) {
           return true; // Consider it as a tertiary particle
+          }
         }
       }
     }

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -937,10 +937,10 @@ struct QaEfficiency {
         if (mcParticle.getProcess() == 4) {
           // Get the mother particle's index and the mother particle itself
           auto mothers = mcParticle.mothers_as<o2::aod::McParticles>();
-           for (const auto& mother : mothers) {
-          // Check if the mother particle is not primary and produced in a weak decay
-          if (!mother.isPhysicalPrimary() && mother.getProcess() == 4) {
-            return true; // Consider it as a tertiary particle
+          for (const auto& mother : mothers) {
+            // Check if the mother particle is not primary and produced in a weak decay
+            if (!mother.isPhysicalPrimary() && mother.getProcess() == 4) {
+              return true; // Consider it as a tertiary particle
             }
           }
         }

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -936,10 +936,12 @@ struct QaEfficiency {
         // Check if the particle is produced in a secondary decay
         if (mcParticle.getProcess() == 4) {
           // Get the mother particle's index and the mother particle itself
-          auto motherParticle = mcParticle.mother0_as<o2::aod::McParticles>();
+          auto mothers = mcParticle.mothers_as<o2::aod::McParticles>();
+           for (const auto& mother : mothers) {
           // Check if the mother particle is not primary and produced in a weak decay
-          if (!motherParticle.isPhysicalPrimary() && motherParticle.getProcess() == 4) {
+          if (!mother.isPhysicalPrimary() && mother.getProcess() == 4) {
             return true; // Consider it as a tertiary particle
+            }
           }
         }
       }


### PR DESCRIPTION
To be ensure that tertiary particle track not belong to physical primary mother but the mother from the weak decay.