### PR TITLE
PWGDQ: Removing _Full macro for tables which is not needed

### DIFF
--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -327,24 +327,24 @@ DECLARE_SOA_DYNAMIC_COLUMN(Y, y, //! Particle rapidity
 } // namespace reducedtrackMC
 // NOTE: This table is nearly identical to the one from Framework (except that it points to the event ID, not the BC id)
 //       This table contains all MC truth tracks (both barrel and muon)
-DECLARE_SOA_TABLE_FULL(ReducedMCTracks, "ReducedMCTracks", "AOD", "REDUCEDMCTRACK", //!  MC track information (on disk)
-                       o2::soa::Index<>, reducedtrackMC::ReducedMCEventId,
-                       mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
-                       reducedtrackMC::MothersIds, reducedtrackMC::DaughtersIdSlice,
-                       mcparticle::Weight,
-                       reducedtrackMC::Pt, reducedtrackMC::Eta, reducedtrackMC::Phi, reducedtrackMC::E,
-                       mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
-                       reducedtrackMC::McReducedFlags,
-                       reducedtrackMC::Px<reducedtrackMC::Pt, reducedtrackMC::Phi>,
-                       reducedtrackMC::Py<reducedtrackMC::Pt, reducedtrackMC::Phi>,
-                       reducedtrackMC::Pz<reducedtrackMC::Pt, reducedtrackMC::Eta>,
-                       reducedtrackMC::P<reducedtrackMC::Pt, reducedtrackMC::Eta>,
-                       reducedtrackMC::Y<reducedtrackMC::Pt, reducedtrackMC::Eta, reducedtrackMC::E>,
-                       mcparticle::ProducedByGenerator<mcparticle::Flags>,
-                       mcparticle::FromBackgroundEvent<mcparticle::Flags>,
-                       mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
-                       mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
-                       mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
+DECLARE_SOA_TABLE(ReducedMCTracks, "AOD", "REDUCEDMCTRACK", //!  MC track information (on disk)
+                  o2::soa::Index<>, reducedtrackMC::ReducedMCEventId,
+                  mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
+                  reducedtrackMC::MothersIds, reducedtrackMC::DaughtersIdSlice,
+                  mcparticle::Weight,
+                  reducedtrackMC::Pt, reducedtrackMC::Eta, reducedtrackMC::Phi, reducedtrackMC::E,
+                  mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
+                  reducedtrackMC::McReducedFlags,
+                  reducedtrackMC::Px<reducedtrackMC::Pt, reducedtrackMC::Phi>,
+                  reducedtrackMC::Py<reducedtrackMC::Pt, reducedtrackMC::Phi>,
+                  reducedtrackMC::Pz<reducedtrackMC::Pt, reducedtrackMC::Eta>,
+                  reducedtrackMC::P<reducedtrackMC::Pt, reducedtrackMC::Eta>,
+                  reducedtrackMC::Y<reducedtrackMC::Pt, reducedtrackMC::Eta, reducedtrackMC::E>,
+                  mcparticle::ProducedByGenerator<mcparticle::Flags>,
+                  mcparticle::FromBackgroundEvent<mcparticle::Flags>,
+                  mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
+                  mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
+                  mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
 
 using ReducedMCTrack = ReducedMCTracks::iterator;
 
@@ -378,9 +378,9 @@ DECLARE_SOA_COLUMN(MftNClusters, mftNClusters, int);                            
 } // namespace reducedmft
 
 // MFT track kinematics
-DECLARE_SOA_TABLE_FULL(ReducedMFTs, "ReducedMFTs", "AOD", "REDUCEDMFT", //!
-                       o2::soa::Index<>, reducedmft::ReducedEventId, reducedmft::FilteringFlags,
-                       reducedmft::Pt, reducedmft::Eta, reducedmft::Phi);
+DECLARE_SOA_TABLE(ReducedMFTs, "AOD", "REDUCEDMFT", //!
+                  o2::soa::Index<>, reducedmft::ReducedEventId, reducedmft::FilteringFlags,
+                  reducedmft::Pt, reducedmft::Eta, reducedmft::Phi);
 
 // MFT tracks extra info (cluster size, sign)
 DECLARE_SOA_TABLE(ReducedMFTsExtra, "AOD", "RMFTEXTRA", //!
@@ -426,15 +426,15 @@ DECLARE_SOA_INDEX_COLUMN(ReducedMFT, matchMFTTrack); //!  matching index pointin
 } // namespace reducedmuon
 
 // Muon track kinematics
-DECLARE_SOA_TABLE_FULL(ReducedMuons, "ReducedMuons", "AOD", "REDUCEDMUON", //!
-                       o2::soa::Index<>, reducedmuon::ReducedEventId,
-                       reducedmuon::MatchMCHTrackId, reducedmuon::ReducedMFTId,
-                       reducedmuon::FilteringFlags,
-                       reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign, reducedmuon::IsAmbiguous,
-                       reducedmuon::Px<reducedmuon::Pt, reducedmuon::Phi>,
-                       reducedmuon::Py<reducedmuon::Pt, reducedmuon::Phi>,
-                       reducedmuon::Pz<reducedmuon::Pt, reducedmuon::Eta>,
-                       reducedmuon::P<reducedmuon::Pt, reducedmuon::Eta>);
+DECLARE_SOA_TABLE(ReducedMuons, "AOD", "REDUCEDMUON", //!
+                  o2::soa::Index<>, reducedmuon::ReducedEventId,
+                  reducedmuon::MatchMCHTrackId, reducedmuon::ReducedMFTId,
+                  reducedmuon::FilteringFlags,
+                  reducedmuon::Pt, reducedmuon::Eta, reducedmuon::Phi, reducedmuon::Sign, reducedmuon::IsAmbiguous,
+                  reducedmuon::Px<reducedmuon::Pt, reducedmuon::Phi>,
+                  reducedmuon::Py<reducedmuon::Pt, reducedmuon::Phi>,
+                  reducedmuon::Pz<reducedmuon::Pt, reducedmuon::Eta>,
+                  reducedmuon::P<reducedmuon::Pt, reducedmuon::Eta>);
 
 // Muon track quality details
 DECLARE_SOA_TABLE(ReducedMuonsExtra, "AOD", "RTMUONEXTRA", //!
@@ -676,39 +676,39 @@ DECLARE_SOA_DYNAMIC_COLUMN(Y, y, //!
                            [](float pt, float eta, float m) -> float { return std::log((std::sqrt(m * m + pt * pt * std::cosh(eta) * std::cosh(eta)) + pt * std::sinh(eta)) / std::sqrt(m * m + pt * pt)); });
 } // namespace reducedpair
 
-DECLARE_SOA_TABLE_FULL(Dielectrons, "Dielectrons", "AOD", "RTDIELECTRON", //!
-                       o2::soa::Index<>, reducedpair::ReducedEventId,
-                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                       reducedpair::FilterMap, reducedpair::McDecision,
-                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
+DECLARE_SOA_TABLE(Dielectrons, "AOD", "RTDIELECTRON", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::McDecision,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
 
-DECLARE_SOA_TABLE_FULL(StoredDielectrons, "Dielectrons", "AOD1", "RTDIELECTRON", //!
-                       o2::soa::Index<>, reducedpair::ReducedEventId,
-                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                       reducedpair::FilterMap, reducedpair::McDecision,
-                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
-                       o2::soa::Marker<1>);
+DECLARE_SOA_TABLE(StoredDielectrons, "AOD1", "RTDIELECTRON", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::McDecision,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
+                  o2::soa::Marker<1>);
 
-DECLARE_SOA_TABLE_FULL(Dimuons, "Dimuons", "AOD", "RTDIMUON", //!
-                       o2::soa::Index<>, reducedpair::ReducedEventId,
-                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                       reducedpair::FilterMap, reducedpair::McDecision,
-                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
-                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);
+DECLARE_SOA_TABLE(Dimuons, "AOD", "RTDIMUON", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::McDecision,
+                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>);
 
 DECLARE_SOA_TABLE(DielectronsExtra, "AOD", "RTDIELEEXTRA", //!
                   reducedpair::Index0Id, reducedpair::Index1Id,
@@ -804,16 +804,16 @@ using DielectronAll = DielectronsAll::iterator;
 using DimuonAll = DimuonsAll::iterator;
 
 // Tables for using analysis-dilepton-track with analysis-asymmetric-pairing
-DECLARE_SOA_TABLE_FULL(Ditracks, "Ditracks", "AOD", "RTDITRACK", //!
-                       o2::soa::Index<>, reducedpair::ReducedEventId,
-                       reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                       reducedpair::FilterMap, reducedpair::PairFilterMap,
-                       reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
-                       reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
-                       reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
-                       reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
+DECLARE_SOA_TABLE(Ditracks, "AOD", "RTDITRACK", //!
+                  o2::soa::Index<>, reducedpair::ReducedEventId,
+                  reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
+                  reducedpair::FilterMap, reducedpair::PairFilterMap,
+                  reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
+                  reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Py<reducedpair::Pt, reducedpair::Phi>,
+                  reducedpair::Pz<reducedpair::Pt, reducedpair::Eta>,
+                  reducedpair::P<reducedpair::Pt, reducedpair::Eta>);
 
 DECLARE_SOA_TABLE(DitracksExtra, "AOD", "RTDITRKEXTRA", //!
                   reducedpair::Index0Id, reducedpair::Index1Id,


### PR DESCRIPTION
The DECLARE_SOA_TABLE_FULL macro is not needed in these cases where the first two bindings are the same.
this is how the DECLARE_SOA_TABLE macro is defined:

#define DECLARE_SOA_TABLE(_Name_, _Origin_, _Description_, ...) \
  DECLARE_SOA_TABLE_FULL(_Name_, #_Name_, _Origin_, _Description_, __VA_ARGS__);
  
I propose this change since the _FULL macro definition has some clash with the jet framework

discussed with @aalkin 