### PR TITLE
[Common] PID: Add AO2D metadata handling for pass name in TPC CCDB calls

### DIFF
--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -301,7 +301,7 @@ struct tpcPid {
         response = ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata);
         headers = ccdbApi.retrieveHeaders(ccdbPath.value, metadata, bc.timestamp());
         if (!response) {
-          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", recoPass.value);
+          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", metadata["RecoPassName"]);
           headers = ccdbApi.retrieveHeaders(ccdbPath.value, nullmetadata, bc.timestamp());
           response = ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp());
           if (!response) {
@@ -503,7 +503,7 @@ struct tpcPid {
         response = ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata);
         headers = ccdbApi.retrieveHeaders(ccdbPath.value, metadata, bc.timestamp());
         if (!response) {
-          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", recoPass.value);
+          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", metadata["RecoPassName"]);
           response = ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp());
           headers = ccdbApi.retrieveHeaders(ccdbPath.value, nullmetadata, bc.timestamp());
           if (!response) {
@@ -594,7 +594,7 @@ struct tpcPid {
         }
         response = ccdb->getSpecific<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp(), metadata);
         if (!response) {
-          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", recoPass.value);
+          LOGP(warning, "!! Could not find a valid TPC response object for specific pass name {}! Falling back to latest uploaded object.", metadata["RecoPassName"]);
           response = ccdb->getForTimeStamp<o2::pid::tpc::Response>(ccdbPath.value, bc.timestamp());
           if (!response) {
             LOGP(fatal, "Could not find ANY TPC response object for the timestamp {}!", bc.timestamp());

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -261,7 +261,7 @@ struct tpcPid {
             network.evalModel(dummyInput); /// Init the model evaluations
             LOGP(info, "Retrieved NN corrections for production tag {}, pass number {}", headers["LPMProductionTag"], headers["RecoPassName"]);
           } else {
-            LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
+            LOG(fatal) << "No valid NN object found matching retrieved Bethe-Bloch parametrisation for pass " << metadata["RecoPassName"] << ". Please ensure that the requested pass has dedicated NN corrections available";
           }
         } else {
           /// Taking the network from local file
@@ -323,7 +323,7 @@ struct tpcPid {
           network.evalModel(dummyInput);
           LOGP(info, "Retrieved NN corrections for production tag {}, pass number {}", headers["LPMProductionTag"], headers["RecoPassName"]);
         } else {
-          LOG(fatal) << "Error encountered while fetching/loading the network from CCDB! Maybe the network doesn't exist yet for this runnumber/timestamp?";
+          LOG(fatal) << "No valid NN object found matching retrieved Bethe-Bloch parametrisation for pass " << metadata["RecoPassName"] << ". Please ensure that the requested pass has dedicated NN corrections available";
         }
       }
     }

--- a/Common/TableProducer/PID/pidTPC.cxx
+++ b/Common/TableProducer/PID/pidTPC.cxx
@@ -153,8 +153,6 @@ struct tpcPid {
       LOG(fatal) << "pid-tpc must have only one of the options 'processStandard' OR 'processMcTuneOnData' enabled. Please check your configuration.";
     }
 
-
-
     response = new o2::pid::tpc::Response();
     // Checking the tables are requested in the workflow and enabling them
     auto enableFlag = [&](const std::string particle, Configurable<int>& flag) {
@@ -194,12 +192,11 @@ struct tpcPid {
     speciesNetworkFlags[7] = useNetworkHe;
     speciesNetworkFlags[8] = useNetworkAl;
 
-    
     // Initialise metadata object for CCDB calls from AO2D metadata
     if (recoPass.value == "") {
-      if(metadataInfo.isFullyDefined()) {
-      metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
-      LOGP(info, "Automatically setting reco pass for TPC Response to {} from AO2D",metadata["RecoPassName"]);
+      if (metadataInfo.isFullyDefined()) {
+        metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
+        LOGP(info, "Automatically setting reco pass for TPC Response to {} from AO2D", metadata["RecoPassName"]);
       }
     } else {
       LOGP(info, "Setting reco pass for TPC response to user-defined name {}", recoPass.value);
@@ -665,7 +662,8 @@ struct tpcPid {
   PROCESS_SWITCH(tpcPid, processMcTuneOnData, "Creating PID tables with MC TuneOnData", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc) {
-   metadataInfo.initMetadata(cfgc); // Parse AO2D metadata
-   return WorkflowSpec{adaptAnalysisTask<tpcPid>(cfgc)};
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  metadataInfo.initMetadata(cfgc); // Parse AO2D metadata
+  return WorkflowSpec{adaptAnalysisTask<tpcPid>(cfgc)};
 }


### PR DESCRIPTION
* Adds lookup from AO2D metadata for pass name when retrieving 
* Add report in log for metadata from retrieved objects (LPMProductionTag and RecoPassName)
* Force neural network CCDB lookup to use same pass name as retrieved Bethe-Bloch parametrisation