### PR TITLE
PWGHF: add missing line in ML training config file

### DIFF
--- a/PWGHF/D2H/Macros/ML/config_training_DplusToPiKPi.yml
+++ b/PWGHF/D2H/Macros/ML/config_training_DplusToPiKPi.yml
@@ -18,6 +18,8 @@ data_prep:
         dirPath/
       ]
 
+  tree_name: treeMLDplus # null if .parquet input files, not null if .root input files
+
   pt_bins_limits: [1, 24]
   name_pt_var: fPt # name of pT branch in original TTree
   downsample_bkg_factor: 1 # value of downSampleBkgFactor set at TTree creation level

--- a/PWGHF/D2H/Macros/ML/train_models.py
+++ b/PWGHF/D2H/Macros/ML/train_models.py
@@ -37,10 +37,14 @@ try:
     from hipe4ml import plot_utils
     from hipe4ml.model_handler import ModelHandler
     from hipe4ml.tree_handler import TreeHandler
-    from hipe4ml_converter.h4ml_converter import H4MLConverter
     from sklearn.model_selection import train_test_split
 except ModuleNotFoundError:
     print("Module 'hipe4ml' is not installed. Please install it to run this macro")
+
+try:
+    from hipe4ml_converter.h4ml_converter import H4MLConverter
+except ModuleNotFoundError:
+    print("Module 'hipe4ml_converter' is not installed. Please install it to run this macro")
 
 LABEL_BKG = 0
 LABEL_PROMPT = 1

--- a/PWGHF/D2H/Macros/ML/train_models.py
+++ b/PWGHF/D2H/Macros/ML/train_models.py
@@ -31,7 +31,6 @@ try:
     from hipe4ml import plot_utils
     from hipe4ml.model_handler import ModelHandler
     from hipe4ml.tree_handler import TreeHandler
-    from sklearn.model_selection import train_test_split
 except ModuleNotFoundError:
     print("Module 'hipe4ml' is not installed. Please install it to run this macro")
 
@@ -40,6 +39,7 @@ import numpy as np  # pylint: disable=import-error
 import pandas as pd  # pylint: disable=import-error
 import xgboost as xgb  # pylint: disable=import-error
 import yaml  # pylint: disable=import-error
+from sklearn.model_selection import train_test_split  # pylint: disable=import-error
 
 try:
     from hipe4ml_converter.h4ml_converter import H4MLConverter

--- a/PWGHF/D2H/Macros/ML/train_models.py
+++ b/PWGHF/D2H/Macros/ML/train_models.py
@@ -26,12 +26,6 @@ import os
 import pickle
 import sys
 
-import matplotlib.pyplot as plt  # pylint: disable=import-error
-import numpy as np  # pylint: disable=import-error
-import pandas as pd  # pylint: disable=import-error
-import xgboost as xgb  # pylint: disable=import-error
-import yaml  # pylint: disable=import-error
-
 # pylint: disable=import-error
 try:
     from hipe4ml import plot_utils
@@ -40,6 +34,12 @@ try:
     from sklearn.model_selection import train_test_split
 except ModuleNotFoundError:
     print("Module 'hipe4ml' is not installed. Please install it to run this macro")
+
+import matplotlib.pyplot as plt  # pylint: disable=import-error
+import numpy as np  # pylint: disable=import-error
+import pandas as pd  # pylint: disable=import-error
+import xgboost as xgb  # pylint: disable=import-error
+import yaml  # pylint: disable=import-error
 
 try:
     from hipe4ml_converter.h4ml_converter import H4MLConverter


### PR DESCRIPTION
Hi @fcatalan92 !

@VDiBella found a missing line in the ML training config file (the `tree_name` line). I must have accidentally deleted it when I modifed the config file to make it "dummy" for the `D2H/Macros` folder.

I also take the opportunity to add an extra `try... except` safety by defining one dedicated to `hipe4ml_converter` (as it is currently mixed with the `hipe4ml` one).