### PR TITLE
PWGCF: FemtoUniverse -- Changes in the two track cuts for the h-Phi analysis

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -140,45 +140,6 @@ class FemtoUniverseDetaDphiStar
     }
   }
 
-  bool IsKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
-  {
-    if (mom < 0.3) { // 0.0-0.3
-      if (TMath::Abs(nsigmaTPCK) < 3.0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < 0.45) { // 0.30 - 0.45
-      if (TMath::Abs(nsigmaTPCK) < 2.0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < 0.55) { // 0.45-0.55
-      if (TMath::Abs(nsigmaTPCK) < 1.0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < 1.5) { // 0.55-1.5 (now we use TPC and TOF)
-      if ((TMath::Abs(nsigmaTOFK) < 3.0) && (TMath::Abs(nsigmaTPCK) < 3.0)) {
-        {
-          return true;
-        }
-      } else {
-        return false;
-      }
-    } else if (mom > 1.5) { // 1.5 -
-      if ((TMath::Abs(nsigmaTOFK) < 2.0) && (TMath::Abs(nsigmaTPCK) < 3.0)) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
-
   ///  Check if pair is close or not
   template <typename Part, typename Parts>
   bool isClosePair(Part const& part1, Part const& part2, Parts const& particles, float lmagfield, uint8_t ChosenEventType)
@@ -363,21 +324,18 @@ class FemtoUniverseDetaDphiStar
           LOG(fatal) << "FemtoUniverseDetaDphiStar: passed arguments don't agree with FemtoUniverseDetaDphiStar's type of events! Please provide same or mixed.";
         }
 
-        // if proton is kaon reject the ring
-        if (IsKaonNSigma(daughter.pt(), trackCuts.getNsigmaTPC(daughter, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(daughter, o2::track::PID::Kaon))) {
-          // REMOVING THE "RING" -- CALCULATING THE INVARIANT MASS
-          TLorentzVector part1Vec;
-          TLorentzVector part2Vec;
-          float mMassOne = TDatabasePDG::Instance()->GetParticle(321)->Mass();
-          float mMassTwo = TDatabasePDG::Instance()->GetParticle(321)->Mass();
-          part1Vec.SetPtEtaPhiM(part1.pt(), part1.eta(), part1.phi(), mMassOne);
-          part2Vec.SetPtEtaPhiM(daughter.pt(), daughter.eta(), daughter.phi(), mMassTwo);
-          TLorentzVector sumVec(part1Vec);
-          sumVec += part2Vec;
-          float phiM = sumVec.M();
-          if ((phiM > CutPhiInvMassLow) && (phiM < CutPhiInvMassHigh)) {
-            pass = true; // pair comes from Phi meson decay
-          }
+        // REMOVING THE "RING" -- CALCULATING THE INVARIANT MASS
+        TLorentzVector part1Vec;
+        TLorentzVector part2Vec;
+        float mMassOne = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+        float mMassTwo = TDatabasePDG::Instance()->GetParticle(321)->Mass();
+        part1Vec.SetPtEtaPhiM(part1.pt(), part1.eta(), part1.phi(), mMassOne);
+        part2Vec.SetPtEtaPhiM(daughter.pt(), daughter.eta(), daughter.phi(), mMassTwo);
+        TLorentzVector sumVec(part1Vec);
+        sumVec += part2Vec;
+        float phiM = sumVec.M();
+        if ((phiM > CutPhiInvMassLow) && (phiM < CutPhiInvMassHigh)) {
+          pass = true; // pair comes from Phi meson decay
         }
 
         // APPLYING THE CUTS


### PR DESCRIPTION
Removing the kaon PID check for the hadron (mostly proton) in the two track cut section of the code
