### PR TITLE
PWGCF: Update lambdaR2Correlation.cxx

### DIFF
--- a/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
@@ -440,7 +440,7 @@ struct lambdaCorrTableProducer {
     }
 
     if (v0part == kAntiLambda) {
-      histos.fill(HIST("QA_Checks/h1d_lambda_mass"), v0track.mLambda());
+      histos.fill(HIST("QA_Checks/h1d_lambda_mass"), v0track.mAntiLambda());
     }
 
     // apply further mass window selection [central, left, right]

--- a/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
@@ -13,8 +13,7 @@
 /// \brief R2 correlation of Lambda baryons.
 /// \author Yash Patley <yash.patley@cern.ch>
 
-#include <TLorentzVector.h>
-#include <TRandom.h>
+#include <TMath.h>
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
@@ -49,30 +48,30 @@ namespace lambdatrack
 {
 DECLARE_SOA_INDEX_COLUMN(LambdaCollision, lambdaCollision);
 DECLARE_SOA_COLUMN(Pt, pt, float);
-DECLARE_SOA_COLUMN(Y, y, float);
-DECLARE_SOA_COLUMN(Eta, eta, float);
+DECLARE_SOA_COLUMN(Rap, rap, float);
 DECLARE_SOA_COLUMN(Phi, phi, float);
 DECLARE_SOA_COLUMN(Mass, mass, float);
 DECLARE_SOA_COLUMN(PosTrackId, postrackid, int64_t);
 DECLARE_SOA_COLUMN(NegTrackId, negtrackid, int64_t);
-DECLARE_SOA_COLUMN(Flag, flag, bool);
+DECLARE_SOA_COLUMN(V0Type, v0type, int8_t);
+DECLARE_SOA_COLUMN(MassWindow, masswindow, int8_t);
 } // namespace lambdatrack
 DECLARE_SOA_TABLE(LambdaTracks, "AOD", "LAMBDATRACKS", o2::soa::Index<>,
                   lambdatrack::LambdaCollisionId,
                   lambdatrack::Pt,
-                  lambdatrack::Y,
-                  lambdatrack::Eta,
+                  lambdatrack::Rap,
                   lambdatrack::Phi,
                   lambdatrack::Mass,
                   lambdatrack::PosTrackId,
                   lambdatrack::NegTrackId,
-                  lambdatrack::Flag);
+                  lambdatrack::V0Type,
+                  lambdatrack::MassWindow);
 using LambdaTrack = LambdaTracks::iterator;
 } // namespace o2::aod
 
-enum MinMax {
-  kMin = 0,
-  kMax
+enum PidType {
+  kPion = 0,
+  kProton
 };
 
 enum ParticleType {
@@ -80,7 +79,7 @@ enum ParticleType {
   kAntiLambda
 };
 
-enum ParticlePair {
+enum ParticlePairType {
   kLambdaAntiLambda = 0,
   kLambdaLambda,
   kAntiLambdaAntiLambda
@@ -89,8 +88,7 @@ enum ParticlePair {
 enum MassWindowType {
   kCentralWindow = 0,
   kLeftWindow,
-  kRightWindow,
-  kNoOfMassWindows
+  kRightWindow
 };
 
 struct lambdaCorrTableProducer {
@@ -109,10 +107,12 @@ struct lambdaCorrTableProducer {
   Configurable<bool> cfg_zvtx_time_diff{"cfg_zvtx_time_diff", false, "z-vtx time diff selection"};
 
   // Tracks
-  Configurable<float> cfg_Eta_Cut{"cfg_Eta_Cut", 0.8, "Pseudorapidity cut"};
+  Configurable<float> cfg_eta_cut{"cfg_eta_cut", 0.8, "Pseudorapidity cut"};
+  Configurable<int> cfg_min_crossed_rows{"cfg_min_crossed_rows", 70, "min crossed rows"};
+  Configurable<double> cfg_tpc_nsigma{"cfg_tpc_nsigma", 3.0, "TPC NSigma Selection Cut"};
+  Configurable<double> cfg_tof_nsigma{"cfg_tof_nsigma", 3.0, "TOF NSigma Selection Cut"};
 
   // V0s
-  Configurable<int> cfg_min_crossed_rows{"cfg_min_crossed_rows", 70, "min crossed rows"};
   Configurable<double> cfg_min_dca_V0_daughters{"cfg_min_dca_V0_daughters", 1.0, "min DCA between V0 daughters"};
   Configurable<double> cfg_min_dca_pos_to_PV{"cfg_min_dca_pos_to_PV", 0.1, "Minimum V0 Positive Track DCAr cut to PV"};
   Configurable<double> cfg_min_dca_neg_to_PV{"cfg_min_dca_neg_to_PV", 0.1, "Minimum V0 Negative Track DCAr cut to PV"};
@@ -124,42 +124,73 @@ struct lambdaCorrTableProducer {
   Configurable<double> cfg_min_V0_cosPA{"cfg_min_V0_cosPA", 0.995, "Minimum V0 CosPA to PV"};
   Configurable<double> cfg_lambda_mass_window{"cfg_lambda_mass_window", 0.01, "Mass Window to select Lambda"};
   Configurable<double> cfg_kshort_rej{"cfg_kshort_rej", 0.005, "Reject K0Short Candidates"};
-  Configurable<double> cfg_tpc_nsigma{"cfg_tpc_nsigma", 3.0, "TPC NSigma Selection Cut"};
-  Configurable<double> cfg_tof_nsigma{"cfg_tof_nsigma", 3.0, "TOF NSigma Selection Cut"};
+
+  // V0s kinmatic acceptance
+  Configurable<float> cfg_v0_pt_min{"cfg_v0_pt_min", 0.5, "Minimum V0 pT"};
+  Configurable<float> cfg_v0_pt_max{"cfg_v0_pt_max", 2.5, "Minimum V0 pT"};
+  Configurable<float> cfg_v0_rap_max{"cfg_v0_rap_max", 0.8, "|rap| cut"};
+
+  // bool eta/rapidity
+  Configurable<bool> cfg_do_eta_analysis{"cfg_do_eta_analysis", false, "Eta Analysis"};
+
+  // lambda mass windows
+  Configurable<float> cfg_lambda_mass_min{"cfg_lambda_mass_min", 1.11, "Minimum Central Window"};
+  Configurable<float> cfg_lambda_mass_max{"cfg_lambda_mass_max", 1.12, "Maximum Central Window"};
+  Configurable<float> cfg_lambda_left_min{"cfg_lambda_left_min", 1.08, "Minimum Left Window"};
+  Configurable<float> cfg_lambda_left_max{"cfg_lambda_left_max", 1.10, "Maximum Left Window"};
+  Configurable<float> cfg_lambda_right_min{"cfg_lambda_right_min", 1.13, "Minimum Right Window"};
+  Configurable<float> cfg_lambda_right_max{"cfg_lambda_right_max", 1.15, "Maximum Right Window"};
+
+  // global variable declaration
+  std::map<MassWindowType, float> mass_map_min;
+  std::map<MassWindowType, float> mass_map_max;
 
   // Histogram Registry.
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext const&)
   {
+    // global variable
+    mass_map_min = {{kCentralWindow, cfg_lambda_mass_min}, {kLeftWindow, cfg_lambda_left_min}, {kRightWindow, cfg_lambda_right_min}};
+    mass_map_max = {{kCentralWindow, cfg_lambda_mass_max}, {kLeftWindow, cfg_lambda_left_max}, {kRightWindow, cfg_lambda_right_max}};
 
     const AxisSpec axisCent(105, 0, 105, "FT0M (%)");
     const AxisSpec axisMult(10, 0, 10, "N_{#Lambda}");
 
+    const AxisSpec axisV0Mass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
+    const AxisSpec axisV0Pt(200, 0., 5., "p_{T} (GeV/#it{c})");
+    const AxisSpec axisV0Rap(16, -cfg_v0_rap_max, cfg_v0_rap_max, "rap");
+    const AxisSpec axisV0Phi(36, 0., 2 * TMath::Pi(), "#phi (rad)");
+
     const AxisSpec axisRadius(500, 0, 100, "r(cm)");
-    const AxisSpec axisCosPA(120, 0.97, 1.0, "cos(#theta_{PA})(rad)");
+    const AxisSpec axisCosPA(120, 0.97, 1.0, "cos(#theta_{PA})");
     const AxisSpec axisDcaV0PV(200, 0, 2., "dca (cm)");
     const AxisSpec axisDcaProngPV(200, 0, 20., "dca (cm)");
     const AxisSpec axisDcaDau(75, 0., 1.5, "Daug DCA (cm^{2})");
     const AxisSpec axisCTau(500, 0, 100, "c#tau (cm/#it{c})");
-    const AxisSpec axisLambdaMass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
-    const AxisSpec axisLambdaPt(120, 0., 3., "p_{T} (GeV/#it{c})");
 
     const AxisSpec axisMomPID(80, 0, 4, "p (GeV/#it{c})");
     const AxisSpec axisNsigma(401, -10.025, 10.025, {"n#sigma"});
     const AxisSpec axisdEdx(360, 20, 200, "#frac{dE}{dx}");
 
     // Create Histograms.
+    // QA
+    histos.add("QA_Checks/h1d_lambda_mass", "M_{#Lambda}", kTH1F, {axisV0Mass});
+
     // QA Lambda
+    histos.add("QA_Sel_Lambda/h1d_V0_inv_mass", "V_{0} mass", kTH1F, {axisV0Mass});
+    histos.add("QA_Sel_Lambda/h1d_V0_pt", "V_{0} p_{T}", kTH1F, {axisV0Pt});
+    histos.add("QA_Sel_Lambda/h1d_V0_eta", "#eta-distribution", kTH1F, {axisV0Rap});
+    histos.add("QA_Sel_Lambda/h1d_V0_rap", "y-distribution", kTH1F, {axisV0Rap});
+    histos.add("QA_Sel_Lambda/h1d_V0_phi", "#phi-distribution", kTH1F, {axisV0Phi});
+
     histos.add("QA_Sel_Lambda/h1d_dca_V0_daughters", "DCA between V0 daughters", kTH1F, {axisDcaDau});
     histos.add("QA_Sel_Lambda/h1d_dca_pos_to_PV", "DCA positive prong to PV", kTH1F, {axisDcaProngPV});
     histos.add("QA_Sel_Lambda/h1d_dca_neg_to_PV", "DCA negative prong to PV", kTH1F, {axisDcaProngPV});
     histos.add("QA_Sel_Lambda/h1d_dca_V0_to_PV", "DCA V0 to PV", kTH1F, {axisDcaV0PV});
-    histos.add("QA_Sel_Lambda/h1d_v0_cospa", "cos(#theta_{PA})", kTH1F, {axisCosPA});
-    histos.add("QA_Sel_Lambda/h1d_v0_radius", "V_{0} Decay Radius in XY plane", kTH1F, {axisRadius});
-    histos.add("QA_Sel_Lambda/h1d_v0_ctau", "V_{0} c#tau", kTH1F, {axisCTau});
-    histos.add("QA_Sel_Lambda/h1d_inv_mass", "V_{0} mass", kTH1F, {axisLambdaMass});
-    histos.add("QA_Sel_Lambda/h1d_pt", "V_{0} p_{T}", kTH1F, {axisLambdaPt});
+    histos.add("QA_Sel_Lambda/h1d_V0_cospa", "cos(#theta_{PA})", kTH1F, {axisCosPA});
+    histos.add("QA_Sel_Lambda/h1d_V0_radius", "V_{0} Decay Radius in XY plane", kTH1F, {axisRadius});
+    histos.add("QA_Sel_Lambda/h1d_V0_ctau", "V_{0} c#tau", kTH1F, {axisCTau});
 
     histos.add("QA_Sel_Lambda/h2d_pr_dEdx_vs_p", "TPC Signal Proton", kTH2F, {axisMomPID, axisdEdx});
     histos.add("QA_Sel_Lambda/h2d_pi_dEdx_vs_p", "TPC Signal Pion", kTH2F, {axisMomPID, axisdEdx});
@@ -218,11 +249,11 @@ struct lambdaCorrTableProducer {
     auto postrack = v0.template posTrack_as<T>();
     auto negtrack = v0.template negTrack_as<T>();
 
-    if (fabs(postrack.eta()) > cfg_Eta_Cut) {
+    if (fabs(postrack.eta()) > cfg_eta_cut) {
       return false;
     }
 
-    if (fabs(negtrack.eta()) > cfg_Eta_Cut) {
+    if (fabs(negtrack.eta()) > cfg_eta_cut) {
       return false;
     }
 
@@ -261,27 +292,52 @@ struct lambdaCorrTableProducer {
     return true;
   }
 
-  template <typename T>
-  bool selPIDTrack(T const& track, float tpcNsigma, float tofNsigma)
+  template <PidType pid, typename T>
+  bool selPIDTrack(T const& track)
   {
 
-    bool selTPCFlag = false, selTOFFlag = false;
+    bool selTPCv0type = false, selTOFv0type = false;
 
-    if (track.hasTOF()) {
-      if (fabs(tofNsigma) < cfg_tof_nsigma) {
-        selTOFFlag = true;
-      }
-      if (fabs(tpcNsigma) < cfg_tpc_nsigma) {
-        selTPCFlag = true;
-      }
-    } else {
-      selTOFFlag = true;
-      if (fabs(tpcNsigma) < cfg_tpc_nsigma) {
-        selTPCFlag = true;
-      }
+    switch (pid) {
+
+      case kPion:
+        if (track.hasTOF()) {
+          if (fabs(track.tofNSigmaPi()) < cfg_tof_nsigma) {
+            selTOFv0type = true;
+          }
+          if (fabs(track.tpcNSigmaPi()) < cfg_tpc_nsigma) {
+            selTPCv0type = true;
+          }
+        } else {
+          selTOFv0type = true;
+          if (fabs(track.tpcNSigmaPi()) < cfg_tpc_nsigma) {
+            selTPCv0type = true;
+          }
+        }
+        break;
+
+      case kProton:
+        if (track.hasTOF()) {
+          if (fabs(track.tofNSigmaPr()) < cfg_tof_nsigma) {
+            selTOFv0type = true;
+          }
+          if (fabs(track.tpcNSigmaPr()) < cfg_tpc_nsigma) {
+            selTPCv0type = true;
+          }
+        } else {
+          selTOFv0type = true;
+          if (fabs(track.tpcNSigmaPr()) < cfg_tpc_nsigma) {
+            selTPCv0type = true;
+          }
+        }
+        break;
+
+      default:
+        LOGF(error, "NO Particle Selected for PID");
+        break;
     }
 
-    if (selTPCFlag && selTOFFlag) {
+    if (selTPCv0type && selTOFv0type) {
       return true;
     }
 
@@ -305,12 +361,15 @@ struct lambdaCorrTableProducer {
     histos.fill(HIST(sub_dir[part]) + HIST("h1d_dca_pos_to_PV"), fabs(v0.dcapostopv()));
     histos.fill(HIST(sub_dir[part]) + HIST("h1d_dca_neg_to_PV"), fabs(v0.dcanegtopv()));
     histos.fill(HIST(sub_dir[part]) + HIST("h1d_dca_V0_to_PV"), fabs(v0.dcav0topv()));
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_v0_cospa"), v0.v0cosPA());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_v0_radius"), v0.v0radius());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_v0_ctau"), ctau);
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_pt"), v0.pt());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_cospa"), v0.v0cosPA());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_radius"), v0.v0radius());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_ctau"), ctau);
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_pt"), v0.pt());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_eta"), v0.eta());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_rap"), v0.yLambda());
+    histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_phi"), v0.phi());
     if constexpr (part == kLambda) {
-      histos.fill(HIST(sub_dir[part]) + HIST("h1d_inv_mass"), v0.mLambda());
+      histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_inv_mass"), v0.mLambda());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pr_dEdx_vs_p"), postrack.tpcInnerParam(), postrack.tpcSignal());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pi_dEdx_vs_p"), negtrack.tpcInnerParam(), negtrack.tpcSignal());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pr_nsigma_tpc"), postrack.tpcInnerParam(), postrack.tpcNSigmaPr());
@@ -322,7 +381,7 @@ struct lambdaCorrTableProducer {
         histos.fill(HIST(sub_dir[part]) + HIST("h2d_pi_nsigma_tof"), negtrack.tofExpMom(), negtrack.tofNSigmaPi());
       }
     } else {
-      histos.fill(HIST(sub_dir[part]) + HIST("h1d_inv_mass"), v0.mAntiLambda());
+      histos.fill(HIST(sub_dir[part]) + HIST("h1d_V0_inv_mass"), v0.mAntiLambda());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pi_dEdx_vs_p"), postrack.tpcInnerParam(), postrack.tpcSignal());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pr_dEdx_vs_p"), negtrack.tpcInnerParam(), negtrack.tpcSignal());
       histos.fill(HIST(sub_dir[part]) + HIST("h2d_pi_nsigma_tpc"), postrack.tpcInnerParam(), postrack.tpcNSigmaPi());
@@ -333,6 +392,63 @@ struct lambdaCorrTableProducer {
       if (negtrack.hasTOF()) {
         histos.fill(HIST(sub_dir[part]) + HIST("h2d_pr_nsigma_tof"), negtrack.tofExpMom(), negtrack.tofNSigmaPr());
       }
+    }
+  }
+
+  template <ParticleType v0part, PidType pos_prong, PidType neg_prong, MassWindowType masswin, typename C, typename V, typename P, typename T>
+  void selV0Particle(C const& collision, V const& v0track, P const& postrack, P const& negtrack, T const& tracks)
+  {
+
+    // initialize variables
+    float mass = 0., rap = 0.;
+    if (v0part == kLambda) {
+      mass = v0track.mLambda();
+    }
+    if (v0part == kAntiLambda) {
+      mass = v0track.mAntiLambda();
+    }
+
+    if (cfg_do_eta_analysis) {
+      rap = v0track.eta();
+    } else {
+      rap = v0track.yLambda();
+    }
+
+    // apply mass window selection [global]
+    if ((fabs(mass - MassLambda0) >= cfg_lambda_mass_window) || (fabs(v0track.mK0Short() - MassK0Short) <= cfg_kshort_rej)) {
+      return;
+    }
+
+    // apply daughter particle id
+    if (!selPIDTrack<pos_prong>(postrack) || !selPIDTrack<neg_prong>(negtrack)) {
+      return;
+    }
+
+    // apply kinematic acceptance
+    if (v0track.pt() <= cfg_v0_pt_min || v0track.pt() >= cfg_v0_pt_max) {
+      return;
+    }
+
+    if (cfg_do_eta_analysis && (fabs(v0track.eta()) >= cfg_v0_rap_max)) {
+      return;
+    } else if (fabs(v0track.yLambda()) >= cfg_v0_rap_max) {
+      return;
+    }
+
+    if (v0part == kLambda) {
+      histos.fill(HIST("QA_Checks/h1d_lambda_mass"), v0track.mLambda());
+    }
+
+    if (v0part == kAntiLambda) {
+      histos.fill(HIST("QA_Checks/h1d_lambda_mass"), v0track.mLambda());
+    }
+
+    // apply further mass window selection [central, left, right]
+    if (mass > mass_map_min[masswin] && mass < mass_map_max[masswin]) {
+      if (masswin == kCentralWindow) {
+        fillQALambda<v0part>(collision, v0track, tracks);
+      }
+      lambdaTrackTable(lambdaCollisionTable.lastIndex(), v0track.pt(), rap, v0track.phi(), mass, postrack.index(), negtrack.index(), v0part, masswin);
     }
   }
 
@@ -359,45 +475,25 @@ struct lambdaCorrTableProducer {
       auto postrack = v0.template posTrack_as<Tracks>();
       auto negtrack = v0.template negTrack_as<Tracks>();
 
-      // get lambda
-      if ((fabs(v0.mLambda() - MassLambda0) < cfg_lambda_mass_window) && (fabs(v0.mK0Short() - MassK0Short) > cfg_kshort_rej) && (selPIDTrack(postrack, postrack.tpcNSigmaPr(), postrack.tofNSigmaPr())) && (selPIDTrack(negtrack, negtrack.tpcNSigmaPi(), negtrack.tofNSigmaPi()))) {
-        fillQALambda<kLambda>(collision, v0, tracks);
-        lambdaTrackTable(lambdaCollisionTable.lastIndex(), v0.pt(), v0.yLambda(), v0.eta(), v0.phi(), v0.mLambda(), postrack.index(), negtrack.index(), true);
-      }
-
-      // get anti-lambda
-      if ((fabs(v0.mAntiLambda() - MassLambda0) < cfg_lambda_mass_window) && (fabs(v0.mK0Short() - MassK0Short) > cfg_kshort_rej) && (selPIDTrack(negtrack, negtrack.tpcNSigmaPr(), negtrack.tofNSigmaPr())) && (selPIDTrack(postrack, postrack.tpcNSigmaPi(), postrack.tofNSigmaPi()))) {
-        fillQALambda<kAntiLambda>(collision, v0, tracks);
-        lambdaTrackTable(lambdaCollisionTable.lastIndex(), v0.pt(), v0.yLambda(), v0.eta(), v0.phi(), v0.mAntiLambda(), postrack.index(), negtrack.index(), false);
-      }
+      selV0Particle<kLambda, kProton, kPion, kCentralWindow>(collision, v0, postrack, negtrack, tracks);
+      selV0Particle<kLambda, kProton, kPion, kLeftWindow>(collision, v0, postrack, negtrack, tracks);
+      selV0Particle<kLambda, kProton, kPion, kRightWindow>(collision, v0, postrack, negtrack, tracks);
+      selV0Particle<kAntiLambda, kPion, kProton, kCentralWindow>(collision, v0, postrack, negtrack, tracks);
+      selV0Particle<kAntiLambda, kPion, kProton, kLeftWindow>(collision, v0, postrack, negtrack, tracks);
+      selV0Particle<kAntiLambda, kPion, kProton, kRightWindow>(collision, v0, postrack, negtrack, tracks);
     }
   }
 };
 
 struct lambdaCorrelationAnalysis {
 
-  // tracks
-  Configurable<float> cfg_Lambda_Pt_Min{"cfg_Lambda_Pt_Min", 0.5, "Minimum Track pT"};
-  Configurable<float> cfg_Lambda_Pt_Max{"cfg_Lambda_Pt_Max", 2.5, "Maximum Track pT"};
-
-  // global variables
+  // Global Configurables
   Configurable<int> cfg_nRapBins{"cfg_nRapBins", 16, "N Rapidity Bins"};
   Configurable<float> cfg_Rap_Min{"cfg_Rap_Min", -0.8, "Minimum Rapidity"};
   Configurable<float> cfg_Rap_Max{"cfg_Rap_Max", 0.8, "Maximum Rapidity"};
   Configurable<int> cfg_nPhiBins{"cfg_nPhiBins", 64, "N Phi Bins"};
   Configurable<float> cfg_Phi_Min{"cfg_Phi_Min", 0, "Minimum Phi"};
   Configurable<float> cfg_Phi_Max{"cfg_Phi_Max", 2 * TMath::Pi(), "Maximum Phi"};
-
-  // lambda mass windows
-  Configurable<float> cfg_lambda_mass_min{"cfg_lambda_mass_min", 1.11, "Minimum Central Window"};
-  Configurable<float> cfg_lambda_mass_max{"cfg_lambda_mass_max", 1.12, "Maximum Central Window"};
-  Configurable<float> cfg_lambda_left_min{"cfg_lambda_left_min", 1.08, "Minimum Left Window"};
-  Configurable<float> cfg_lambda_left_max{"cfg_lambda_left_max", 1.10, "Maximum Left Window"};
-  Configurable<float> cfg_lambda_right_min{"cfg_lambda_right_min", 1.13, "Minimum Right Window"};
-  Configurable<float> cfg_lambda_right_max{"cfg_lambda_right_max", 1.15, "Maximum Right Window"};
-
-  // bool eta/rapidity
-  Configurable<bool> cfg_do_eta_analysis{"cfg_do_eta_analysis", false, "Eta Analysis"};
 
   // Histogram Registry.
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -431,11 +527,7 @@ struct lambdaCorrelationAnalysis {
     const AxisSpec axisPosZ(220, -11, 11, "V_{z} (cm)");
     const AxisSpec axisCent(105, 0, 105, "FT0M (%)");
     const AxisSpec axisMult(10, 0, 10, "N_{#Lambda}");
-
-    const AxisSpec axisPt(120, 0., 3., "p_{T} (GeV/#it{c})");
-    const AxisSpec axisEta(40, -1., 1., "#eta");
     const AxisSpec axisMass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
-
     const AxisSpec axisRap(cfg_nRapBins, cfg_Rap_Min, cfg_Rap_Max, "rap");
     const AxisSpec axisPhi(cfg_nPhiBins, cfg_Phi_Min, cfg_Phi_Max, "#phi (rad)");
     const AxisSpec axisRapPhi(knrapphibins, kminrapphi, kmaxrapphi, "rap #phi");
@@ -449,10 +541,6 @@ struct lambdaCorrelationAnalysis {
     histos.add("Event/h1d_antilambda_multiplicity", "#bar{#Lambda} - Multiplicity", kTH1I, {axisMult});
 
     // Lambda
-    histos.add("Lambda/h1d_pt", "p_{T}-distribution", kTH1F, {axisPt});
-    histos.add("Lambda/h1d_eta", "#eta-distribution", kTH1F, {axisEta});
-    histos.add("Lambda/h1d_y", "Rapidity", kTH1F, {axisRap});
-    histos.add("Lambda/h1d_phi", "#phi-distribution", kTH1F, {axisPhi});
     histos.add("Lambda/h1d_inv_mass", "M_{p#pi}", kTH1F, {axisMass});
 
     // Anti-Lambda
@@ -469,49 +557,15 @@ struct lambdaCorrelationAnalysis {
     histos.addClone("Lambda_Mass/", "Lambda_Left/");
   }
 
-  template <ParticleType part, typename V>
-  void fillHistos(V const& v)
-  {
-
-    static constexpr std::string_view sub_dir[] = {"Lambda/", "AntiLambda/"};
-
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_pt"), v.pt());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_eta"), v.eta());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_y"), v.y());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_phi"), v.phi());
-    histos.fill(HIST(sub_dir[part]) + HIST("h1d_inv_mass"), v.mass());
-  }
-
-  template <ParticleType part, MassWindowType mass_win, typename V>
-  void partSingle(V& p)
-  {
-
-    static constexpr std::string_view sub_dir_hist[] = {"h2d_n1_LaP", "h2d_n1_LaM"};
-    static constexpr std::string_view sub_dir_type[] = {"Lambda_Mass/", "Lambda_Left/", "Lambda_Right/"};
-
-    if (cfg_do_eta_analysis) {
-      histos.fill(HIST(sub_dir_type[mass_win]) + HIST(sub_dir_hist[part]), p.eta(), p.phi());
-    } else {
-      histos.fill(HIST(sub_dir_type[mass_win]) + HIST(sub_dir_hist[part]), p.y(), p.phi());
-    }
-  }
-
-  template <ParticlePair part_pair, MassWindowType mass_win, typename U>
-  void partPair(U& p1, U& p2)
+  template <ParticlePairType part_pair, MassWindowType mass_win, typename U>
+  void fillPairHistos(U& p1, U& p2)
   {
 
     static constexpr std::string_view sub_dir_type[] = {"Lambda_Mass/", "Lambda_Left/", "Lambda_Right/"};
     static constexpr std::string_view sub_dir_hist[] = {"h2d_n2_LaP_LaM", "h2d_n2_LaP_LaP", "h2d_n2_LaM_LaM"};
 
-    int rapbin1 = 0, rapbin2 = 0;
-
-    if (cfg_do_eta_analysis) {
-      rapbin1 = static_cast<int>((p1.eta() - kminrap) / rapbinwidth);
-      rapbin2 = static_cast<int>((p2.eta() - kminrap) / rapbinwidth);
-    } else {
-      rapbin1 = static_cast<int>((p1.y() - kminrap) / rapbinwidth);
-      rapbin2 = static_cast<int>((p2.y() - kminrap) / rapbinwidth);
-    }
+    int rapbin1 = static_cast<int>((p1.rap() - kminrap) / rapbinwidth);
+    int rapbin2 = static_cast<int>((p2.rap() - kminrap) / rapbinwidth);
 
     int phibin1 = static_cast<int>(p1.phi() / phibinwidth);
     int phibin2 = static_cast<int>(p2.phi() / phibinwidth);
@@ -525,112 +579,82 @@ struct lambdaCorrelationAnalysis {
     }
   }
 
-  template <ParticleType part, MassWindowType mass_window, typename T>
-  void analyseSingles(T const& track, std::vector<std::vector<float>> v_mass_win)
+  template <ParticleType part, MassWindowType masswin, typename T>
+  void analyzeSingles(T const& tracks)
   {
 
-    // apply rapidity cut
-    if (cfg_do_eta_analysis) {
-      if (std::abs(track.eta()) > cfg_Rap_Max) {
-        return;
-      }
-    } else {
-      if (std::abs(track.y()) > cfg_Rap_Max) {
-        return;
-      }
-    }
+    static constexpr std::string_view sub_dir_part[] = {"Lambda/", "AntiLambda/"};
+    static constexpr std::string_view sub_dir_mass_win[] = {"Lambda_Mass/", "Lambda_Left/", "Lambda_Right/"};
+    static constexpr std::string_view sub_dir_hist[] = {"h2d_n1_LaP", "h2d_n1_LaM"};
 
-    // apply mass window acceptance
-    if (track.mass() <= v_mass_win[mass_window][kMin] || track.mass() >= v_mass_win[mass_window][kMax]) {
-      return;
+    for (auto const& track : tracks) {
+      histos.fill(HIST(sub_dir_part[part]) + HIST("h1d_inv_mass"), track.mass());
+      histos.fill(HIST(sub_dir_mass_win[masswin]) + HIST(sub_dir_hist[part]), track.rap(), track.phi());
     }
-
-    fillHistos<part>(track);
-    partSingle<part, mass_window>(track);
   }
 
-  template <ParticlePair part_pair, MassWindowType mass_window, bool same, typename T>
-  void analysePairs(T const& trk_1, T const& trk_2, std::vector<std::vector<float>> v_mass_win)
+  template <ParticlePairType partpair, MassWindowType masswin, bool samelambda, typename T>
+  void analyzePairs(T const& trks_1, T const& trks_2)
   {
 
-    // apply rapidity cut
-    if (cfg_do_eta_analysis) {
-      if (std::abs(trk_1.eta()) > cfg_Rap_Max || std::abs(trk_2.eta()) > cfg_Rap_Max) {
-        return;
-      }
-    } else {
-      if (std::abs(trk_1.y()) > cfg_Rap_Max || std::abs(trk_2.y()) > cfg_Rap_Max) {
-        return;
-      }
-    }
-
-    // apply mass window acceptance
-    if (trk_1.mass() <= v_mass_win[mass_window][kMin] || trk_1.mass() >= v_mass_win[mass_window][kMax]) {
-      return;
-    }
-
-    if (trk_2.mass() <= v_mass_win[mass_window][kMin] || trk_2.mass() >= v_mass_win[mass_window][kMax]) {
-      return;
-    }
-
-    if constexpr (!same) {
-      partPair<part_pair, mass_window>(trk_1, trk_2);
-    } else {
-      if (trk_1.index() != trk_2.index() && trk_1.postrackid() != trk_2.postrackid() && trk_1.negtrackid() != trk_2.negtrackid()) {
-        partPair<part_pair, mass_window>(trk_1, trk_2);
+    for (auto const& trk_1 : trks_1) {
+      for (auto const& trk_2 : trks_2) {
+        if (samelambda && (trk_1.index() == trk_2.index()) && (trk_1.postrackid() == trk_2.postrackid()) && (trk_1.negtrackid() == trk_2.negtrackid())) {
+          continue;
+        }
+        fillPairHistos<partpair, masswin>(trk_1, trk_2);
       }
     }
   }
 
   using Lambda_Collisions = aod::LambdaCollisions;
-  using Lambda_Tracks = soa::Filtered<aod::LambdaTracks>;
-
-  Filter trkPt = (aod::lambdatrack::pt > cfg_Lambda_Pt_Min) && (aod::lambdatrack::pt < cfg_Lambda_Pt_Max);
+  using Lambda_Tracks = aod::LambdaTracks;
 
   SliceCache cache;
 
-  Partition<Lambda_Tracks> part_lambda_tracks = aod::lambdatrack::flag == true;
-  Partition<Lambda_Tracks> part_anti_lambda_tracks = aod::lambdatrack::flag == false;
+  Partition<Lambda_Tracks> part_lambda_tracks = (aod::lambdatrack::v0type == (int8_t)kLambda && aod::lambdatrack::masswindow == (int8_t)kCentralWindow);
+  Partition<Lambda_Tracks> part_anti_lambda_tracks = (aod::lambdatrack::v0type == (int8_t)kAntiLambda && aod::lambdatrack::masswindow == (int8_t)kCentralWindow);
 
-  void process(Lambda_Collisions::iterator const& collision, Lambda_Tracks const& /*lambdas*/)
+  Partition<Lambda_Tracks> part_lambda_tracks_left_masswin = (aod::lambdatrack::v0type == (int8_t)kLambda && aod::lambdatrack::masswindow == (int8_t)kLeftWindow);
+  Partition<Lambda_Tracks> part_anti_lambda_tracks_left_masswin = (aod::lambdatrack::v0type == (int8_t)kAntiLambda && aod::lambdatrack::masswindow == (int8_t)kLeftWindow);
+
+  Partition<Lambda_Tracks> part_lambda_tracks_right_masswin = (aod::lambdatrack::v0type == (int8_t)kLambda && aod::lambdatrack::masswindow == (int8_t)kRightWindow);
+  Partition<Lambda_Tracks> part_anti_lambda_tracks_right_masswin = (aod::lambdatrack::v0type == (int8_t)kAntiLambda && aod::lambdatrack::masswindow == (int8_t)kRightWindow);
+
+  void process(Lambda_Collisions::iterator const& collision, Lambda_Tracks const& lambdas)
   {
 
     histos.fill(HIST("Event/h1d_posz"), collision.posZ());
     histos.fill(HIST("Event/h1d_ft0m_mult_percentile"), collision.cent());
 
-    std::vector<std::vector<float>> v_mass_win = {{cfg_lambda_mass_min, cfg_lambda_mass_max}, {cfg_lambda_left_min, cfg_lambda_left_max}, {cfg_lambda_right_min, cfg_lambda_right_max}};
-
     auto lambda_tracks = part_lambda_tracks->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
     auto anti_lambda_tracks = part_anti_lambda_tracks->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
 
-    for (auto const& lambda_1 : lambda_tracks) {
-      analyseSingles<kLambda, kCentralWindow>(lambda_1, v_mass_win);
-      analyseSingles<kLambda, kLeftWindow>(lambda_1, v_mass_win);
-      analyseSingles<kLambda, kRightWindow>(lambda_1, v_mass_win);
-      for (auto const& antilambda_2 : anti_lambda_tracks) {
-        analysePairs<kLambdaAntiLambda, kCentralWindow, false>(lambda_1, antilambda_2, v_mass_win);
-        analysePairs<kLambdaAntiLambda, kLeftWindow, false>(lambda_1, antilambda_2, v_mass_win);
-        analysePairs<kLambdaAntiLambda, kRightWindow, false>(lambda_1, antilambda_2, v_mass_win);
-      }
+    auto lambda_tracks_left = part_lambda_tracks_left_masswin->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
+    auto anti_lambda_tracks_left = part_anti_lambda_tracks_left_masswin->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
 
-      for (auto const& lambda_2 : lambda_tracks) {
-        analysePairs<kLambdaLambda, kCentralWindow, true>(lambda_1, lambda_2, v_mass_win);
-        analysePairs<kLambdaLambda, kLeftWindow, true>(lambda_1, lambda_2, v_mass_win);
-        analysePairs<kLambdaLambda, kRightWindow, true>(lambda_1, lambda_2, v_mass_win);
-      }
-    }
+    auto lambda_tracks_right = part_lambda_tracks_right_masswin->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
+    auto anti_lambda_tracks_right = part_anti_lambda_tracks_right_masswin->sliceByCached(aod::lambdatrack::lambdaCollisionId, collision.globalIndex(), cache);
 
-    for (auto const& antilambda_1 : anti_lambda_tracks) {
-      analyseSingles<kAntiLambda, kCentralWindow>(antilambda_1, v_mass_win);
-      analyseSingles<kAntiLambda, kLeftWindow>(antilambda_1, v_mass_win);
-      analyseSingles<kAntiLambda, kRightWindow>(antilambda_1, v_mass_win);
+    analyzeSingles<kLambda, kCentralWindow>(lambda_tracks);
+    analyzeSingles<kLambda, kLeftWindow>(lambda_tracks_left);
+    analyzeSingles<kLambda, kRightWindow>(lambda_tracks_right);
 
-      for (auto const& antilambda_2 : anti_lambda_tracks) {
-        analysePairs<kAntiLambdaAntiLambda, kCentralWindow, true>(antilambda_1, antilambda_2, v_mass_win);
-        analysePairs<kAntiLambdaAntiLambda, kLeftWindow, true>(antilambda_1, antilambda_2, v_mass_win);
-        analysePairs<kAntiLambdaAntiLambda, kRightWindow, true>(antilambda_1, antilambda_2, v_mass_win);
-      }
-    }
+    analyzeSingles<kAntiLambda, kCentralWindow>(anti_lambda_tracks);
+    analyzeSingles<kAntiLambda, kLeftWindow>(anti_lambda_tracks_left);
+    analyzeSingles<kAntiLambda, kRightWindow>(anti_lambda_tracks_right);
+
+    analyzePairs<kLambdaAntiLambda, kCentralWindow, false>(lambda_tracks, anti_lambda_tracks);
+    analyzePairs<kLambdaAntiLambda, kLeftWindow, false>(lambda_tracks_left, anti_lambda_tracks_left);
+    analyzePairs<kLambdaAntiLambda, kRightWindow, false>(lambda_tracks_right, anti_lambda_tracks_right);
+
+    analyzePairs<kLambdaLambda, kCentralWindow, true>(lambda_tracks, lambda_tracks);
+    analyzePairs<kLambdaLambda, kLeftWindow, true>(lambda_tracks_left, lambda_tracks_left);
+    analyzePairs<kLambdaLambda, kRightWindow, true>(lambda_tracks_right, lambda_tracks_right);
+
+    analyzePairs<kAntiLambdaAntiLambda, kCentralWindow, true>(anti_lambda_tracks, anti_lambda_tracks);
+    analyzePairs<kAntiLambdaAntiLambda, kLeftWindow, true>(anti_lambda_tracks_left, anti_lambda_tracks_left);
+    analyzePairs<kAntiLambdaAntiLambda, kRightWindow, true>(anti_lambda_tracks_right, anti_lambda_tracks_right);
   }
 };
 

--- a/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
@@ -159,7 +159,7 @@ struct lambdaCorrTableProducer {
 
     const AxisSpec axisV0Mass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
     const AxisSpec axisV0Pt(200, 0., 5., "p_{T} (GeV/#it{c})");
-    const AxisSpec axisV0Rap(16, -cfg_v0_rap_max, cfg_v0_rap_max, "rap");
+    const AxisSpec axisV0Rap(20, -1., 1., "rap");
     const AxisSpec axisV0Phi(36, 0., 2 * TMath::Pi(), "#phi (rad)");
 
     const AxisSpec axisRadius(500, 0, 100, "r(cm)");


### PR DESCRIPTION
Some major changes made in this PR are as follows, 
1. Replaced the pseudo-rapidity and rapidity column in table producer task with only one variable based on type of analysis.
2. Added the lambda selection in the table producer task itself.
3. Added analyzeSingles and analyzePairs method in the correlation task.

Rest of the changes can be inferred from the code itself.