### PR TITLE
PWGEM: properly add HF Cocktail task

### DIFF
--- a/PWGEM/Dilepton/Tasks/CMakeLists.txt
+++ b/PWGEM/Dilepton/Tasks/CMakeLists.txt
@@ -20,7 +20,7 @@ o2physics_add_executable(lmee-lf-cocktail
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::SimulationDataFormat O2Physics::AnalysisCore
                   COMPONENT_NAME Analysis)
 
-o2physics_add_executable(lmee-hf-cocktail
+o2physics_add_dpl_workflow(lmee-hf-cocktail
                   SOURCES lmeeHFCocktail.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                   COMPONENT_NAME Analysis)


### PR DESCRIPTION
fixing CMake file (lmee-hf-cocktail was not included as dpl_worklfow, so it was not available on Hyperloop)