### PR TITLE
Fixing issue: Setting collisionId to zero by default

### DIFF
--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -1255,7 +1255,10 @@ struct AnalysisSameEventPairing {
                         VarManager::fgValues[VarManager::kCORR4POI], VarManager::fgValues[VarManager::kCORR2POI], VarManager::fgValues[VarManager::kM01POI], VarManager::fgValues[VarManager::kM0111POI], VarManager::fgValues[VarManager::kMultDimuons],
                         VarManager::fgValues[VarManager::kVertexingPz], VarManager::fgValues[VarManager::kVertexingSV]);
         }
+        auto collId = 0;
         if constexpr ((TTrackFillMap & VarManager::ObjTypes::ReducedMuonCollInfo) > 0) {
+          collId = t1.collisionId();
+        }
           if constexpr (eventHasQvector == true || eventHasQvectorCentr == true) {
             dileptonFlowList(t1.collisionId(), VarManager::fgValues[VarManager::kMass], VarManager::fgValues[VarManager::kCentFT0C],
                              VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], t1.sign() + t2.sign(), isFirst,
@@ -1267,7 +1270,6 @@ struct AnalysisSameEventPairing {
                              VarManager::fgValues[VarManager::kCORR2REF], VarManager::fgValues[VarManager::kCORR4REF], VarManager::fgValues[VarManager::kM11REF], VarManager::fgValues[VarManager::kM1111REF],
                              VarManager::fgValues[VarManager::kMultDimuons], VarManager::fgValues[VarManager::kMultA]);
           }
-        }
         if (t1.sign() != t2.sign()) {
           isFirst = false;
         }


### PR DESCRIPTION
Set collisionId to zero by default to enable the use of processVnDecayToMuMuSkimmedWithWeights.