### PR TITLE
PWGEM/PhotonMeson: Fix rapidity bug of generated particles

### DIFF
--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
@@ -38,6 +38,7 @@
 #include "Framework/ASoAHelpers.h"
 
 #include "DetectorsBase/GeometryManager.h"
+#include "EMCALBase/Geometry.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "CCDB/BasicCCDBManager.h"
@@ -243,6 +244,7 @@ struct Pi0EtaToGammaGamma {
 
     if constexpr (pairtype == kEMCEMC) {
       fRegistry.addClone("Pair/same/", "Pair/rotation/");
+      o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
     }
 
     mRunNumber = 0;
@@ -462,10 +464,24 @@ struct Pi0EtaToGammaGamma {
       float openingAngle1 = std::acos(photon1.Vect().Dot(photon3.Vect()) / (photon1.P() * photon3.P()));
       float openingAngle2 = std::acos(photon2.Vect().Dot(photon3.Vect()) / (photon2.P() * photon3.P()));
 
-      if (openingAngle1 > emccuts.minOpenAngle && abs(mother1.Rapidity()) < maxY) {
+      int iCellID_photon1 = 0;
+      int iCellID_photon2 = 0;
+
+      try {
+        iCellID_photon1 = o2::emcal::Geometry::GetInstance()->GetAbsCellIdFromEtaPhi(photon1.Eta(), photon1.Phi());
+      } catch (o2::emcal::InvalidPositionException& e) {
+        iCellID_photon1 = -1;
+      }
+      try {
+        iCellID_photon2 = o2::emcal::Geometry::GetInstance()->GetAbsCellIdFromEtaPhi(photon2.Eta(), photon2.Phi());
+      } catch (o2::emcal::InvalidPositionException& e) {
+        iCellID_photon2 = -1;
+      }
+
+      if (openingAngle1 > emccuts.minOpenAngle && abs(mother1.Rapidity()) < maxY && iCellID_photon1 > 0) {
         fRegistry.fill(HIST("Pair/rotation/hs"), mother1.M(), mother1.Pt());
       }
-      if (openingAngle2 > emccuts.minOpenAngle && abs(mother2.Rapidity()) < maxY) {
+      if (openingAngle2 > emccuts.minOpenAngle && abs(mother2.Rapidity()) < maxY && iCellID_photon2 > 0) {
         fRegistry.fill(HIST("Pair/rotation/hs"), mother2.M(), mother2.Pt());
       }
     }

--- a/PWGEM/PhotonMeson/TableProducer/associateMCinfoPhoton.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/associateMCinfoPhoton.cxx
@@ -142,18 +142,18 @@ struct AssociateMCInfoPhoton {
 
       for (auto& mctrack : groupedMcTracks) { // store necessary information for denominator of efficiency
         if ((mctrack.isPhysicalPrimary() || mctrack.producedByGenerator()) && abs(mctrack.y()) < 0.9f && mctrack.pt() < 20.f) {
-          auto binNumber = hBinFinder->FindBin(mctrack.pt(), mctrack.y()); // caution: pack
+          auto binNumber = hBinFinder->FindBin(mctrack.pt(), abs(mctrack.y())); // caution: pack
           switch (abs(mctrack.pdgCode())) {
             case 22:
-              registry.fill(HIST("Generated/h2PtY_Gamma"), mctrack.pt(), mctrack.y());
+              registry.fill(HIST("Generated/h2PtY_Gamma"), mctrack.pt(), abs(mctrack.y()));
               genGamma[binNumber]++;
               break;
             case 111:
-              registry.fill(HIST("Generated/h2PtY_Pi0"), mctrack.pt(), mctrack.y());
+              registry.fill(HIST("Generated/h2PtY_Pi0"), mctrack.pt(), abs(mctrack.y()));
               genPi0[binNumber]++;
               break;
             case 221:
-              registry.fill(HIST("Generated/h2PtY_Eta"), mctrack.pt(), mctrack.y());
+              registry.fill(HIST("Generated/h2PtY_Eta"), mctrack.pt(), abs(mctrack.y()));
               genEta[binNumber]++;
               break;
             default:
@@ -276,8 +276,8 @@ struct AssociateMCInfoPhoton {
               motherid = -999;
             }
           } // end of mother chain loop
-        }   // end of leg loop
-      }     // end of v0 loop
+        } // end of leg loop
+      } // end of v0 loop
     }
 
     if constexpr (static_cast<bool>(system & kElectron)) {


### PR DESCRIPTION
- Ask for absolute value of rapidity when filling generated histogram
- Lost half of generated particles before