### PR TITLE
Common: add MC Collision converter

### DIFF
--- a/Common/TableProducer/Converters/CMakeLists.txt
+++ b/Common/TableProducer/Converters/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(collision-converter
                     PUBLIC_LINK_LIBRARIES
                 COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(mccollision-converter
+                SOURCES mcCollisionConverter.cxx
+                PUBLIC_LINK_LIBRARIES
+            COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(bc-converter
                     SOURCES bcConverter.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework

--- a/Common/TableProducer/Converters/mcCollisionConverter.cxx
+++ b/Common/TableProducer/Converters/mcCollisionConverter.cxx
@@ -29,8 +29,7 @@ struct mcCollisionConverter {
         mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
         mcCollision.t(), mcCollision.weight(),
         mcCollision.impactParameter(),
-        0.0f // dummy event plane, not available in _000
-      );
+        0.0f); // dummy event plane, not available in _000
     }
   }
 };

--- a/Common/TableProducer/Converters/mcCollisionConverter.cxx
+++ b/Common/TableProducer/Converters/mcCollisionConverter.cxx
@@ -26,9 +26,9 @@ struct mcCollisionConverter {
       mcCollisions_001(
         mcCollision.bcId(),
         mcCollision.generatorsID(),
-        mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(), 
-        mcCollision.t(), mcCollision.weight(), 
-        mcCollision.impactParameter(), 
+        mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
+        mcCollision.t(), mcCollision.weight(),
+        mcCollision.impactParameter(),
         0.0f // dummy event plane, not available in _000
       );
     }

--- a/Common/TableProducer/Converters/mcCollisionConverter.cxx
+++ b/Common/TableProducer/Converters/mcCollisionConverter.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+struct mcCollisionConverter {
+  Produces<aod::McCollisions_001> mcCollisions_001;
+
+  void process(aod::McCollisions_000 const& mcCollisionTable)
+  {
+    for (auto& mcCollision : mcCollisionTable) {
+
+      // Repopulate new table
+      mcCollisions_001(
+        mcCollision.bcId(),
+        mcCollision.generatorsID(),
+        mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(), 
+        mcCollision.t(), mcCollision.weight(), 
+        mcCollision.impactParameter(), 
+        0.0f // dummy event plane, not available in _000
+      );
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<mcCollisionConverter>(cfgc),
+  };
+}


### PR DESCRIPTION
This change follows O2 [#13287](https://github.com/AliceO2Group/AliceO2/pull/13287) and adds a MC collision converter that fills a dummy EP angle for MC collisions. Created as draft for now. 