### PR TITLE
PWGEM: fix seg fault in MomentumSmearer

### DIFF
--- a/PWGEM/Dilepton/Utils/MomentumSmearer.h
+++ b/PWGEM/Dilepton/Utils/MomentumSmearer.h
@@ -154,7 +154,9 @@ class MomentumSmearer
         LOGP(fatal, "Could not open {} from file {}", fResPhiNegHistName.Data(), fResFileName.Data());
       }
     }
-    delete listRes;
+
+    if (!fFromCcdb)
+      delete listRes;
 
     LOGP(info, "Set efficiency histos");
     TList* listEff = new TList();
@@ -207,7 +209,9 @@ class MomentumSmearer
         LOGP(fatal, "Could not identify type of histogram {}", fEffHistName.Data());
       }
     }
-    delete listEff;
+
+    if (!fFromCcdb)
+      delete listEff;
 
     fInitialized = true;
   }


### PR DESCRIPTION
The smearing task was crashing with a seg fault when reading the files from ccdb. Should be ok now for both options (local file and from ccdb).