### PR TITLE
PWGCF: Delete one fillQA_base call in FemtoUniverseParticleHisto.h

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h
@@ -348,7 +348,6 @@ class FemtoUniverseParticleHisto
   template <bool isMC, bool isDebug, typename T, typename H>
   void fillQABase(T const& part, H const& histFolder)
   {
-    fillQA_base<o2::aod::femtouniverseMCparticle::MCType::kRecon>(part, histFolder);
     std::string tempFitVarName;
     if (mHistogramRegistry) {
       fillQA_base<o2::aod::femtouniverseMCparticle::MCType::kRecon>(part, histFolder);


### PR DESCRIPTION
Delete one fillQA_base call in FemtoUniverseParticleHisto.h so it doesn't fill basic histos (pT, eta ...) twice for the same particle.