### PR TITLE
MegaLinter: Add missing step for artifact upload

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -47,6 +47,16 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Upload MegaLinter artifacts
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: MegaLinter reports
+          path: |
+            megalinter-reports
+            mega-linter.log
+
       # Create or delete the cleanup branch
       - name: Update cleanup branch
         if: ${{ github.event.repository.owner.login == 'AliceO2Group' }}


### PR DESCRIPTION
MegaLinter does not create an automatic formatting PR if linters have found errors. The reported error messages are referring to lines in formatted files which can make it difficult to locate the corresponding lines in the committed files. See https://github.com/oxsecurity/megalinter/issues/3399 Formatted files can be uploaded in artifacts, which gives the PR author the possibility to see which lines the linters complain about.