### PR TITLE
[Infrastructure] Add O2 linter

### DIFF
--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -1,5 +1,5 @@
 ---
-# Find code issues in modified text files
+# Find issues in O2 code
 name: O2 linter
 
 'on': [pull_request, push]
@@ -23,6 +23,7 @@ jobs:
       - name: Run tests
         run: |
           # Diff against the common ancestor of the source branch and the target branch.
-          files=$(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
+          readarray -t files < <(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
           [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
-          python Scripts/o2_linter.py $options $files
+          # shellcheck disable=SC2086 # Ignore unquoted options.
+          python Scripts/o2_linter.py $options "${files[@]}"

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   o2-linter:
-    name: Lint O2 code
+    name: O2 linter
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # needed to get the full history
       - name: Run tests
         run: |
-          # Diff against the common ancestor of the source branch and the target branch.
+          # Diff against the common ancestor of the source branch and the main branch.
           readarray -t files < <(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
           [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
           # shellcheck disable=SC2086 # Ignore unquoted options.

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -31,5 +31,6 @@ jobs:
         run: |
           # Diff against the common ancestor of the source branch and the target branch.
           files=$(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
-          python Scripts/o2_linter.py -g $files
+          [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
+          python Scripts/o2_linter.py $options $files
           done

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -20,17 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # needed to get the full history
-      - name: Fetch upstream
-        run: |
-          # Fetch the main upstream branch to find the common ancestor
-          # git config --global user.name "Nemo" # required on some servers
-          # git remote add upstream https://github.com/AliceO2Group/Run3Analysisvalidation.git || exit 1
-          # git fetch upstream ${{ env.MAIN_BRANCH }} || exit 1
-          # git fetch origin ${{ env.MAIN_BRANCH }} || exit 1
       - name: Run tests
         run: |
           # Diff against the common ancestor of the source branch and the target branch.
           files=$(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
           [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
           python Scripts/o2_linter.py $options $files
-          done

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   o2-linter:
     name: O2 linter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -26,4 +26,5 @@ jobs:
           readarray -t files < <(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
           [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
           # shellcheck disable=SC2086 # Ignore unquoted options.
-          python Scripts/o2_linter.py $options "${files[@]}"
+          python3 Scripts/o2_linter.py $options "${files[@]}"
+          echo "Tip: If you allow actions in your fork repository, O2 linter will run when you push commits."

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -12,7 +12,7 @@
 # or submit itself to any jurisdiction.
 
 """!
-@brief  O2 linter (Find issues in O2 code)
+@brief  O2 linter (Find O2-specific issues in O2 code)
 @author Vít Kučera <vit.kucera@cern.ch>, Inha University
 @date   2024-07-14
 """

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -114,34 +114,34 @@ def remove_comment_cpp(line: str) -> str:
     return line.strip()
 
 
-def block_ranges(line: str, c_open: str, c_close: str) -> "list[list[int]]":
-    """Get list of index ranges of longest blocks opened with str_open and closed with str_close."""
-    # print(f"Looking for {c_open}{c_close} blocks in \"{line}\".")
+def block_ranges(line: str, char_open: str, char_close: str) -> "list[list[int]]":
+    """Get list of index ranges of longest blocks opened with char_open and closed with char_close."""
+    # print(f"Looking for {char_open}{char_close} blocks in \"{line}\".")
     # print(line)
-    list_ranges = []
-    if not all((line, len(c_open) == 1, len(c_close) == 1)):
+    list_ranges: list[list[int]] = []
+    if not all((line, len(char_open) == 1, len(char_close) == 1)):
         return list_ranges
-    def direction(c:str) -> int:
-        if c == c_open:
+    def direction(char:str) -> int:
+        if char == char_open:
             return 1
-        if c == c_close:
+        if char == char_close:
             return -1
         return 0
     list_levels = [] # list of block levels (net number of opened blocks)
-    level = 0 # current block level (sum or previous directions)
-    for c in line:
-        list_levels.append(level := level + direction(c))
-    level_min = min(list_levels) # minimum level (!= 0 if there are opened blocks)
+    level_sum = 0 # current block level (sum of previous directions)
+    for char in line:
+        list_levels.append(level_sum := level_sum + direction(char))
+    level_min = min(list_levels) # minimum level (!= 0 if line has opened blocks)
     # Look for openings (level_min + 1) and closings (level_min).
     index_start = -1
     is_opened = False
     # print(list_levels)
-    for i, l in enumerate(list_levels):
-        if not is_opened and l > level_min:
+    for i, level in enumerate(list_levels):
+        if not is_opened and level > level_min:
             is_opened = True
             index_start = i
             # print(f"Opening at {i}")
-        elif is_opened and (l == level_min or i == len(list_levels) -1):
+        elif is_opened and (level == level_min or i == len(list_levels) - 1):
             is_opened = False
             list_ranges.append([index_start, i])
             # print(f"Closing at {i}")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -300,7 +300,7 @@ class TestConstRefInForLoop(TestSpec):
         if not line.startswith("for (") or " : " not in line:
             return True
         line = line[:line.index(" : ")] # keep only the iterator part
-        return True if re.search(r"\([\w]* ?const ?[\w]*&", line) else False
+        return re.search(r"(\w const|const \w+)& ", line) is not None
 
 
 class TestConstRefInSubscription(TestSpec):

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -75,7 +75,7 @@ def remove_comment_cpp(line: str) -> str:
     """Remove C++ comments from the end of a line."""
     for keyword in ("//", "/*"):
         if keyword in line:
-            line = line[:line.find(keyword)]
+            line = line[:line.index(keyword)]
     return line
 
 
@@ -96,7 +96,7 @@ class TestSpec(ABC):
         for prefix in [prefix_comment, prefix_disable]:
             if not prefix in line:
                 return False
-            line = line[(line.find(prefix) + len(prefix)):] # Strip away part before prefix.
+            line = line[(line.index(prefix) + len(prefix)):] # Strip away part before prefix.
         if self.name in line:
             return True
         return False
@@ -345,11 +345,11 @@ class TestConstRefInSubscription(TestSpec):
             if self.is_disabled(line):
                 continue
             if "//" in line: # Remove comment. (Ignore /* to avoid truncating at /*parameter*/.)
-                line = line[:line.find("//")]
+                line = line[:line.index("//")]
             if re.search(r"^void process[\w]*\(", line):
                 line_process = (i + 1)
                 i_closing = line.rfind(")")
-                i_start = line.find("(") + 1
+                i_start = line.index("(") + 1
                 i_end = i_closing if i_closing != -1 else len(line)
                 arguments = line[i_start:i_end] # get arguments between parentheses
                 n_parens_opened = line.count("(") - line.count(")")
@@ -444,7 +444,7 @@ class TestNameFunctionVariable(TestSpec):
         # For functions, stripping after "(" is enough but this way we also identify many declarations of variables.
         for keyword in ("(", "{", ";", " = ", "//", "/*"):
             if keyword in line:
-                line = line[:line.find(keyword)]
+                line = line[:line.index(keyword)]
 
         # Check the words.
         words = line.split()
@@ -480,7 +480,7 @@ class TestNameFunctionVariable(TestSpec):
 
         # Extract function/variable name.
         if "[" in funval_name: # Remove brackets for arrays.
-            funval_name = funval_name[:funval_name.find("[")]
+            funval_name = funval_name[:funval_name.index("[")]
         if "::" in funval_name: # Remove the class prefix for methods.
             funval_name = funval_name.split("::")[-1]
 
@@ -537,7 +537,7 @@ class TestNameConstant(TestSpec):
             opens_brackets = ["[" in w for w in words]
             constant_name = words[opens_brackets.index(True)] # the name is in the first element with "["
         if "[" in constant_name: # Remove brackets for arrays.
-            constant_name = constant_name[:constant_name.find("[")]
+            constant_name = constant_name[:constant_name.index("[")]
         if "::" in constant_name: # Remove the class prefix for methods.
             constant_name = constant_name.split("::")[-1]
         # The actual test comes here.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -501,7 +501,7 @@ class TestNameFunctionVariable(TestSpec):
 class TestNameMacro(TestSpec):
     """Test macro names."""
     name = "name/macro"
-    message = "Use SCREAMING_SNAKE_CASE for macro names."
+    message = "Use SCREAMING_SNAKE_CASE for names of macros."
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -520,7 +520,7 @@ class TestNameMacro(TestSpec):
 class TestNameConstant(TestSpec):
     """Test constexpr constant names."""
     name = "name/constexpr-constant"
-    message = "Use UpperCamelCase for constexpr constant names. Names of special constants may be prefixed with \"k\"."
+    message = "Use UpperCamelCase for names of constexpr constants. Names of special constants may be prefixed with \"k\"."
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -676,7 +676,7 @@ class TestNameWorkflow(TestSpec):
             # Compare the actual and expected file names.
             if expected_workflow_file_name != workflow_file_name:
                 passed = False
-                print_error(path, i + 1, self.name, f"Workflow name {workflow_name} does not match the workflow file name {workflow_file_name} (expected {expected_workflow_file_name}).")
+                print_error(path, i + 1, self.name, f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. (Matches {expected_workflow_file_name}.)")
         return passed
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -345,8 +345,10 @@ class TestTwoPiAddSubtract(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def test_line(self, line: str) -> bool:
-        pattern_two_pi = r"(2(\.0*f?)? \* (M_PI|TMath::Pi\(\)|(((o2::)?constants::)?math::)?PI)|" \
+        pattern_two_pi = (
+            r"(2(\.0*f?)? \* (M_PI|TMath::Pi\(\)|(((o2::)?constants::)?math::)?PI)|"
             r"(((o2::)?constants::)?math::)?TwoPI|TMath::TwoPi\(\))"
+        )
         pattern = rf"[\+-]=? {pattern_two_pi}"
         if is_comment_cpp(line):
             return True
@@ -376,8 +378,10 @@ class TestPdgDatabase(TestSpec):
     """Detect use of TDatabasePDG."""
 
     name = "pdg/database"
-    message = "Direct use of TDatabasePDG is not allowed. " \
+    message = (
+        "Direct use of TDatabasePDG is not allowed. "
         "Use o2::constants::physics::Mass... or Service<o2::framework::O2DatabasePDG>."
+    )
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
@@ -524,8 +528,10 @@ class TestWorkflowOptions(TestSpec):
     """Detect usage of workflow options in defineDataProcessing. (Not supported on AliHyperloop.)"""
 
     name = "o2-workflow-options"
-    message = "Do not use workflow options to customise workflow topology composition in defineDataProcessing. " \
+    message = (
+        "Do not use workflow options to customise workflow topology composition in defineDataProcessing. "
         "Use process function switches or metadata instead."
+    )
     suffixes = [".cxx"]
     per_line = False
 
@@ -960,8 +966,8 @@ class TestNameWorkflow(TestSpec):
                     path,
                     i + 1,
                     self.name,
-                    f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. " \
-                        f"(Matches {expected_workflow_file_name}.)",
+                    f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. "
+                    f"(Matches {expected_workflow_file_name}.)",
                 )
         return passed
 
@@ -1051,8 +1057,8 @@ class TestNameTask(TestSpec):
                         path,
                         i + 1,
                         self.name,
-                        f"Specified task name {task_name} and the struct name {struct_name} produce " \
-                            f"the same device name {device_name_from_struct_name}. TaskName is redundant.",
+                        f"Specified task name {task_name} and the struct name {struct_name} produce "
+                        f"the same device name {device_name_from_struct_name}. TaskName is redundant.",
                     )
                     passed = False
                 elif device_name_from_struct_name.replace("-", "") == device_name_from_task_name.replace("-", ""):
@@ -1063,7 +1069,10 @@ class TestNameTask(TestSpec):
                         path,
                         i + 1,
                         self.name,
-                        f"Device names {device_name_from_task_name} and {device_name_from_struct_name} generated from the specified task name {task_name} and from the struct name {struct_name}, respectively, differ in hyphenation. Consider fixing capitalisation of the struct name to {struct_name_from_device_name} and removing TaskName.",
+                        f"Device names {device_name_from_task_name} and {device_name_from_struct_name} generated "
+                        f"from the specified task name {task_name} and from the struct name {struct_name}, "
+                        f"respectively, differ in hyphenation. Consider fixing capitalisation of the struct name "
+                        f"to {struct_name_from_device_name} and removing TaskName.",
                     )
                     passed = False
                 elif device_name_from_task_name.startswith(device_name_from_struct_name):
@@ -1075,10 +1084,10 @@ class TestNameTask(TestSpec):
                             path,
                             i + 1,
                             self.name,
-                            f"Device name {device_name_from_task_name} from the specified task name " \
-                                f"{task_name} is an extension of the device name {device_name_from_struct_name} " \
-                                    f"from the struct name {struct_name} but the struct is not templated. " \
-                                        "Is it adapted multiple times?",
+                            f"Device name {device_name_from_task_name} from the specified task name "
+                            f"{task_name} is an extension of the device name {device_name_from_struct_name} "
+                            f"from the struct name {struct_name} but the struct is not templated. "
+                            "Is it adapted multiple times?",
                         )
                         passed = False
                     # else:
@@ -1092,9 +1101,9 @@ class TestNameTask(TestSpec):
                         path,
                         i + 1,
                         self.name,
-                        f"Specified task name {task_name} produces device name {device_name_from_task_name} " \
-                            f"which does not match the device name {device_name_from_struct_name} from " \
-                                f"the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})",
+                        f"Specified task name {task_name} produces device name {device_name_from_task_name} "
+                        f"which does not match the device name {device_name_from_struct_name} from "
+                        f"the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})",
                     )
                     passed = False
         return passed
@@ -1215,8 +1224,8 @@ class TestHfStructMembers(TestSpec):
                         path,
                         first_line,
                         self.name,
-                        f"{struct_name}: {member.strip()} appears too early " \
-                            f"(before end of {self.member_order[index_last_member].strip()}).",
+                        f"{struct_name}: {member.strip()} appears too early "
+                        f"(before end of {self.member_order[index_last_member].strip()}).",
                     )
                 last_line_last_member = last_line
                 index_last_member = i_m
@@ -1227,8 +1236,10 @@ class TestHfNameFileWorkflow(TestSpec):
     """PWGHF: Test names of workflow files."""
 
     name = "pwghf/name/workflow-file"
-    message = "Name of a workflow file must match the name of the main task in it. " \
+    message = (
+        "Name of a workflow file must match the name of the main task in it. "
         "See the PWGHF O2 naming conventions for details."
+    )
     suffixes = [".cxx"]
     per_line = False
 
@@ -1262,8 +1273,10 @@ class TestHfNameConfigurable(TestSpec):
     """PWGHF: Test names of configurables."""
 
     name = "pwghf/name/configurable"
-    message = "Use lowerCamelCase for names of configurables and use the same name " \
+    message = (
+        "Use lowerCamelCase for names of configurables and use the same name "
         "for the struct member as for the JSON string."
+    )
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -345,7 +345,8 @@ class TestTwoPiAddSubtract(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def test_line(self, line: str) -> bool:
-        pattern_two_pi = r"(2(\.0*f?)? \* (M_PI|TMath::Pi\(\)|(((o2::)?constants::)?math::)?PI)|(((o2::)?constants::)?math::)?TwoPI|TMath::TwoPi\(\))"
+        pattern_two_pi = r"(2(\.0*f?)? \* (M_PI|TMath::Pi\(\)|(((o2::)?constants::)?math::)?PI)|" \
+            r"(((o2::)?constants::)?math::)?TwoPI|TMath::TwoPi\(\))"
         pattern = rf"[\+-]=? {pattern_two_pi}"
         if is_comment_cpp(line):
             return True
@@ -375,7 +376,8 @@ class TestPdgDatabase(TestSpec):
     """Detect use of TDatabasePDG."""
 
     name = "pdg/database"
-    message = "Direct use of TDatabasePDG is not allowed. Use o2::constants::physics::Mass... or Service<o2::framework::O2DatabasePDG>."
+    message = "Direct use of TDatabasePDG is not allowed. " \
+        "Use o2::constants::physics::Mass... or Service<o2::framework::O2DatabasePDG>."
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
@@ -522,7 +524,8 @@ class TestWorkflowOptions(TestSpec):
     """Detect usage of workflow options in defineDataProcessing. (Not supported on AliHyperloop.)"""
 
     name = "o2-workflow-options"
-    message = "Do not use workflow options to customise workflow topology composition in defineDataProcessing. Use process function switches or metadata instead."
+    message = "Do not use workflow options to customise workflow topology composition in defineDataProcessing. " \
+        "Use process function switches or metadata instead."
     suffixes = [".cxx"]
     per_line = False
 
@@ -957,7 +960,8 @@ class TestNameWorkflow(TestSpec):
                     path,
                     i + 1,
                     self.name,
-                    f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. (Matches {expected_workflow_file_name}.)",
+                    f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. " \
+                        f"(Matches {expected_workflow_file_name}.)",
                 )
         return passed
 
@@ -1041,16 +1045,20 @@ class TestNameTask(TestSpec):
                     device_name_from_task_name
                 )  # struct name matching the TaskName
                 if device_name_from_struct_name == device_name_from_task_name:
-                    # If the task name results in the same device name as the struct name would, TaskName is redundant and should be removed.
+                    # If the task name results in the same device name as the struct name would,
+                    # TaskName is redundant and should be removed.
                     print_error(
                         path,
                         i + 1,
                         self.name,
-                        f"Specified task name {task_name} and the struct name {struct_name} produce the same device name {device_name_from_struct_name}. TaskName is redundant.",
+                        f"Specified task name {task_name} and the struct name {struct_name} produce " \
+                            f"the same device name {device_name_from_struct_name}. TaskName is redundant.",
                     )
                     passed = False
                 elif device_name_from_struct_name.replace("-", "") == device_name_from_task_name.replace("-", ""):
-                    # If the device names generated from the task name and from the struct name differ in hyphenation, capitalisation of the struct name should be fixed and TaskName should be removed. (special cases: alice3-, -2prong)
+                    # If the device names generated from the task name and from the struct name differ in hyphenation,
+                    # capitalisation of the struct name should be fixed and TaskName should be removed.
+                    # (special cases: alice3-, -2prong)
                     print_error(
                         path,
                         i + 1,
@@ -1059,24 +1067,34 @@ class TestNameTask(TestSpec):
                     )
                     passed = False
                 elif device_name_from_task_name.startswith(device_name_from_struct_name):
-                    # If the device name generated from the task name is an extension of the device name generated from the struct name, accept it if the struct is templated. If the struct is not templated, extension is acceptable if adaptAnalysisTask is called multiple times for the same struct.
+                    # If the device name generated from the task name is an extension of the device name generated
+                    # from the struct name, accept it if the struct is templated. If the struct is not templated,
+                    # extension is acceptable if adaptAnalysisTask is called multiple times for the same struct.
                     if not struct_templated:
                         print_error(
                             path,
                             i + 1,
                             self.name,
-                            f"Device name {device_name_from_task_name} from the specified task name {task_name} is an extension of the device name {device_name_from_struct_name} from the struct name {struct_name} but the struct is not templated. Is it adapted multiple times?",
+                            f"Device name {device_name_from_task_name} from the specified task name " \
+                                f"{task_name} is an extension of the device name {device_name_from_struct_name} " \
+                                    f"from the struct name {struct_name} but the struct is not templated. " \
+                                        "Is it adapted multiple times?",
                         )
                         passed = False
                     # else:
-                    #     print_error(path, i + 1, self.name, f"Device name {device_name_from_task_name} from the specified task name {task_name} is an extension of the device name {device_name_from_struct_name} from the struct name {struct_name} and the struct is templated. All good")
+                    #     print_error(path, i + 1, self.name, f"Device name {device_name_from_task_name} from
+                    # the specified task name {task_name} is an extension of the device name
+                    # {device_name_from_struct_name} from the struct name {struct_name} and the struct is templated.
+                    # All good")
                 else:
                     # Other cases should be rejected.
                     print_error(
                         path,
                         i + 1,
                         self.name,
-                        f"Specified task name {task_name} produces device name {device_name_from_task_name} which does not match the device name {device_name_from_struct_name} from the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})",
+                        f"Specified task name {task_name} produces device name {device_name_from_task_name} " \
+                            f"which does not match the device name {device_name_from_struct_name} from " \
+                                f"the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})",
                     )
                     passed = False
         return passed
@@ -1197,7 +1215,8 @@ class TestHfStructMembers(TestSpec):
                         path,
                         first_line,
                         self.name,
-                        f"{struct_name}: {member.strip()} appears too early (before end of {self.member_order[index_last_member].strip()}).",
+                        f"{struct_name}: {member.strip()} appears too early " \
+                            f"(before end of {self.member_order[index_last_member].strip()}).",
                     )
                 last_line_last_member = last_line
                 index_last_member = i_m
@@ -1208,7 +1227,8 @@ class TestHfNameFileWorkflow(TestSpec):
     """PWGHF: Test names of workflow files."""
 
     name = "pwghf/name/workflow-file"
-    message = "Name of a workflow file must match the name of the main task in it. See the PWGHF O2 naming conventions for details."
+    message = "Name of a workflow file must match the name of the main task in it. " \
+        "See the PWGHF O2 naming conventions for details."
     suffixes = [".cxx"]
     per_line = False
 
@@ -1242,7 +1262,8 @@ class TestHfNameConfigurable(TestSpec):
     """PWGHF: Test names of configurables."""
 
     name = "pwghf/name/configurable"
-    message = "Use lowerCamelCase for names of configurables and use the same name for the struct member as for the JSON string."
+    message = "Use lowerCamelCase for names of configurables and use the same name " \
+        "for the struct member as for the JSON string."
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1441,8 +1441,10 @@ def main():
             print(f"{title_result}: {msg_result}")
     else:
         msg_result = "Issues have been found."
-        msg_disable = f"You can disable a test for a line by adding a comment with \"{prefix_disable}\"" \
+        msg_disable = (
+            f'You can disable a test for a line by adding a comment with "{prefix_disable}"'
             " followed by the name of the test."
+        )
         if github_mode:
             print(f"::error title={title_result}::{msg_result}")
             print(f"::notice::{msg_disable}")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1263,7 +1263,7 @@ class TestHfNameFileTask(TestSpec):
     """PWGHF: Test names of task workflow files."""
 
     name = "pwghf/name/task-file"
-    message = ('Name of a PWGHF task workflow file must start with "task".')
+    message = 'Name of a PWGHF task workflow file must start with "task".'
     suffixes = [".cxx"]
     per_line = False
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -713,7 +713,7 @@ class TestNameMacro(TestSpec):
     """Test macro names."""
 
     name = "name/macro"
-    message = "Use SCREAMING_SNAKE_CASE for names of macros."
+    message = "Use SCREAMING_SNAKE_CASE for names of macros. Leading and double underscores are not allowed."
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -726,6 +726,10 @@ class TestNameMacro(TestSpec):
         if "(" in macro_name:
             macro_name = macro_name.split("(")[0]
         # The actual test comes here.
+        if macro_name.startswith("_"):
+            return False
+        if "__" in macro_name:
+            return False
         return is_screaming_snake_case(macro_name)
 
 
@@ -828,7 +832,7 @@ class TestNameNamespace(TestSpec):
     """Test names of namespaces."""
 
     name = "name/namespace"
-    message = "Use snake_case for names of namespaces."
+    message = "Use snake_case for names of namespaces. Double underscores are not allowed."
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -841,6 +845,8 @@ class TestNameNamespace(TestSpec):
         if namespace_name == "{":  # ignore anonymous namespaces
             return True
         # The actual test comes here.
+        if "__" in namespace_name:
+            return False
         return is_snake_case(namespace_name)
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -68,7 +68,7 @@ def print_error(path: str, line: int, title: str, message: str) -> str:
 
 def is_comment_cpp(line: str) -> bool:
     """Test whether a line is a C++ comment."""
-    return line.startswith(("//", "/*"))
+    return line.strip().startswith(("//", "/*"))
 
 
 class TestSpec(ABC):

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -547,7 +547,7 @@ class TestWorkflowOptions(TestSpec):
             line = remove_comment_cpp(line)
             # Wait for defineDataProcessing.
             if not is_inside_define:
-                if not re.match(r"(o2::)?(framework::)?WorkflowSpec defineDataProcessing\(", line):
+                if not re.match(r"((o2::)?framework::)?WorkflowSpec defineDataProcessing\(", line):
                     continue
                 # print(f"{i + 1}: Entering define.")
                 is_inside_define = True
@@ -844,6 +844,24 @@ class TestNameNamespace(TestSpec):
         return is_snake_case(namespace_name)
 
 
+class TestNameType(TestSpec):
+    """Test names of defined types."""
+
+    name = "name/type"
+    message = "Use UpperCamelCase for names of defined types."
+    suffixes = [".h", ".cxx", ".C"]
+
+    def test_line(self, line: str) -> bool:
+        if is_comment_cpp(line):
+            return True
+        if not (match := re.match(r"using (\w+) = ", line)):
+            return True
+        # Extract type name.
+        type_name = match.group(1)
+        # The actual test comes here.
+        return is_upper_camel_case(type_name)
+
+
 class TestNameUpperCamelCase(TestSpec):
     """Base class for a test of UpperCamelCase names."""
 
@@ -998,7 +1016,7 @@ class TestNameTask(TestSpec):
             line = remove_comment_cpp(line)
             # Wait for defineDataProcessing.
             if not is_inside_define:
-                if not re.match(r"(o2::)?(framework::)?WorkflowSpec defineDataProcessing\(", line):
+                if not re.match(r"((o2::)?framework::)?WorkflowSpec defineDataProcessing\(", line):
                     continue
                 # print(f"{i + 1}: Entering define.")
                 is_inside_define = True
@@ -1365,6 +1383,7 @@ def main():
         tests.append(TestNameColumn())
         tests.append(TestNameTable())
         tests.append(TestNameNamespace())
+        tests.append(TestNameType())
         tests.append(TestNameEnum())
         tests.append(TestNameClass())
         tests.append(TestNameStruct())

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -95,7 +95,7 @@ def camel_case_to_kebab_case(line: str) -> str:
 
 def print_error(path: str, line: Union[int, None], title: str, message: str):
     """Format and print error message."""
-    # return # Use to suppress error message when counting speed.
+    # return # Use to suppress error messages.
     str_line = "" if line is None else f"{line}:"
     print(f"{path}:{str_line} {message} [{title}]")  # terminal format
     if github_mode:
@@ -1206,6 +1206,7 @@ class TestHfStructMembers(TestSpec):
         "using ",
         "Filter ",
         "Preslice<",
+        "PresliceUnsorted<",
         "Partition<",
         "ConfigurableAxis ",
         "AxisSpec ",

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -345,7 +345,7 @@ class TestConstRefInSubscription(TestSpec):
                 words = arguments.split(", ")
                 # test
                 for arg in words:
-                    if not re.search(r"[\w<>:]* ?const ?[\w<>:]*&", arg):
+                    if not re.search(r"([\w>] const|const [\w<>:]+)&", arg):
                         passed = False
                         print_error(path, i + 1, self.name, f"Argument {arg} is not const&.")
                 line_process = 0

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -29,7 +29,7 @@ github_mode = False  # GitHub mode
 
 def is_camel_case(name: str) -> bool:
     """forExample or ForExample"""
-    return not "_" in name and not "-" in name and not " " in name
+    return "_" not in name and "-" not in name and " " not in name
 
 
 def is_upper_camel_case(name: str) -> bool:
@@ -50,21 +50,21 @@ def is_kebab_case(name: str) -> bool:
     """for-example"""
     if not name:
         return False
-    return name.islower() and not "_" in name and not " " in name
+    return name.islower() and "_" not in name and " " not in name
 
 
 def is_snake_case(name: str) -> bool:
     """for_example"""
     if not name:
         return False
-    return name.islower() and not "-" in name and not " " in name
+    return name.islower() and "-" not in name and " " not in name
 
 
 def is_screaming_snake_case(name: str) -> bool:
     """FOR_EXAMPLE"""
     if not name:
         return False
-    return name.isupper() and not "-" in name and not " " in name
+    return name.isupper() and "-" not in name and " " not in name
 
 
 def kebab_case_to_camel_case_u(line: str) -> str:
@@ -170,7 +170,7 @@ class TestSpec(ABC):
         """Detect whether the test is explicitly disabled."""
         prefix_disable = "o2-linter: disable="
         for prefix in [prefix_comment, prefix_disable]:
-            if not prefix in line:
+            if prefix not in line:
                 return False
             line = line[(line.index(prefix) + len(prefix)) :]  # Strip away part before prefix.
         if self.name in line:
@@ -289,7 +289,7 @@ class TestStdPrefix(TestSpec):
             matches = [(it.start(), it.group()) for it in iterators]
             if not matches:
                 continue
-            if not '"' in line:  # Found a match which cannot be inside a string.
+            if '"' not in line:  # Found a match which cannot be inside a string.
                 return False
             # Ignore matches inside strings.
             for match in matches:
@@ -309,7 +309,7 @@ class TestROOT(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = r"TMath|(U?(Int|Char|Short)|Double(32)?|Float(16)?|U?Long(64)?|Bool)_t"
@@ -327,7 +327,7 @@ class TestPi(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = r"M_PI|TMath::(Two)?Pi"
@@ -379,13 +379,13 @@ class TestPdgDatabase(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
-        return not "TDatabasePDG" in line
+        return "TDatabasePDG" not in line
 
 
 class TestPdgCode(TestSpec):
@@ -438,7 +438,7 @@ class TestLogging(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = r"^([Pp]rintf\(|(std::)?cout <)"
@@ -734,7 +734,7 @@ class TestNameConstant(TestSpec):
             return True
         line = remove_comment_cpp(line)
         words = line.split()
-        if not "constexpr" in words or not "=" in words:
+        if "constexpr" not in words or "=" not in words:
             return True
         # Extract constant name.
         words = words[: words.index("=")]  # keep only words before "="
@@ -863,24 +863,24 @@ class TestNameEnum(TestNameUpperCamelCase):
     """Test names of enumerators."""
 
     keyword = "enum"
-    name = f"name/enum"
-    message = f"Use UpperCamelCase for names of enumerators and their values."
+    name = "name/enum"
+    message = "Use UpperCamelCase for names of enumerators and their values."
 
 
 class TestNameClass(TestNameUpperCamelCase):
     """Test names of classes."""
 
     keyword = "class"
-    name = f"name/class"
-    message = f"Use UpperCamelCase for names of classes."
+    name = "name/class"
+    message = "Use UpperCamelCase for names of classes."
 
 
 class TestNameStruct(TestNameUpperCamelCase):
     """Test names of structs."""
 
     keyword = "struct"
-    name = f"name/struct"
-    message = f"Use UpperCamelCase for names of structs."
+    name = "name/struct"
+    message = "Use UpperCamelCase for names of structs."
 
 
 class TestNameFileCpp(TestSpec):
@@ -1021,7 +1021,7 @@ class TestNameTask(TestSpec):
                     # print(f"{i + 1}: Exiting adapt.")
                     is_inside_adapt = False
                 # Find explicit task name.
-                if not "TaskName{" in line:
+                if "TaskName{" not in line:
                     continue
                 passed = False
                 # Extract explicit task name.
@@ -1099,7 +1099,7 @@ class TestHfConstAuto(TestSpec):
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
-        return not "auto const" in line
+        return "auto const" not in line
 
 
 class TestHfNameStructClass(TestSpec):
@@ -1213,7 +1213,7 @@ class TestHfNameFileWorkflow(TestSpec):
     per_line = False
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path).rstrip(".cxx")
@@ -1246,7 +1246,7 @@ class TestHfNameConfigurable(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path and not "Macros/" in path
+        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -17,14 +17,15 @@
 @date   2024-07-14
 """
 
-from abc import ABC
 import argparse
 import os
 import re
 import sys
+from abc import ABC
 from typing import Union
 
-github_mode = False # GitHub mode
+github_mode = False  # GitHub mode
+
 
 def is_camel_case(name: str) -> bool:
     """forExample or ForExample"""
@@ -74,7 +75,7 @@ def kebab_case_to_camel_case_u(line: str) -> str:
 def kebab_case_to_camel_case_l(line: str) -> str:
     """Convert kebab-case string to lowerCamelCase string."""
     new_line = kebab_case_to_camel_case_u(line)
-    return f"{new_line[0].lower()}{new_line[1:]}" # start with lowercase letter
+    return f"{new_line[0].lower()}{new_line[1:]}"  # start with lowercase letter
 
 
 def camel_case_to_kebab_case(line: str) -> str:
@@ -95,10 +96,10 @@ def print_error(path: str, line: Union[int, None], title: str, message: str):
     """Format and print error message."""
     # return # Use to suppress error message when counting speed.
     str_line = "" if line is None else f"{line}:"
-    print(f"{path}:{str_line} {message} [{title}]") # terminal format
+    print(f"{path}:{str_line} {message} [{title}]")  # terminal format
     if github_mode:
         str_line = "" if line is None else f",line={line}"
-        print(f"::error file={path}{str_line},title=[{title}]::{message}") # GitHub annotation format
+        print(f"::error file={path}{str_line},title=[{title}]::{message}")  # GitHub annotation format
 
 
 def is_comment_cpp(line: str) -> bool:
@@ -110,7 +111,7 @@ def remove_comment_cpp(line: str) -> str:
     """Remove C++ comments from the end of a line."""
     for keyword in ("//", "/*"):
         if keyword in line:
-            line = line[:line.index(keyword)]
+            line = line[: line.index(keyword)]
     return line.strip()
 
 
@@ -121,17 +122,19 @@ def block_ranges(line: str, char_open: str, char_close: str) -> "list[list[int]]
     list_ranges: list[list[int]] = []
     if not all((line, len(char_open) == 1, len(char_close) == 1)):
         return list_ranges
-    def direction(char:str) -> int:
+
+    def direction(char: str) -> int:
         if char == char_open:
             return 1
         if char == char_close:
             return -1
         return 0
-    list_levels = [] # list of block levels (net number of opened blocks)
-    level_sum = 0 # current block level (sum of previous directions)
+
+    list_levels = []  # list of block levels (net number of opened blocks)
+    level_sum = 0  # current block level (sum of previous directions)
     for char in line:
         list_levels.append(level_sum := level_sum + direction(char))
-    level_min = min(list_levels) # minimum level (!= 0 if line has opened blocks)
+    level_min = min(list_levels)  # minimum level (!= 0 if line has opened blocks)
     # Look for openings (level_min + 1) and closings (level_min).
     index_start = -1
     is_opened = False
@@ -153,10 +156,11 @@ def block_ranges(line: str, char_open: str, char_close: str) -> "list[list[int]]
 
 class TestSpec(ABC):
     """Prototype of a test class"""
-    name = "test-template" # short name of the test
-    message = "Test failed" # error message
-    suffixes: "list[str]" = [] # suffixes of files to test
-    per_line = True # Test lines separately one by one.
+
+    name = "test-template"  # short name of the test
+    message = "Test failed"  # error message
+    suffixes: "list[str]" = []  # suffixes of files to test
+    per_line = True  # Test lines separately one by one.
 
     def file_matches(self, path: str) -> bool:
         """Test whether the path matches the pattern for files to test."""
@@ -168,7 +172,7 @@ class TestSpec(ABC):
         for prefix in [prefix_comment, prefix_disable]:
             if not prefix in line:
                 return False
-            line = line[(line.index(prefix) + len(prefix)):] # Strip away part before prefix.
+            line = line[(line.index(prefix) + len(prefix)) :]  # Strip away part before prefix.
         if self.name in line:
             return True
         return False
@@ -177,11 +181,11 @@ class TestSpec(ABC):
         """Test a line."""
         raise NotImplementedError()
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         """Test a file in a way that cannot be done line by line."""
         raise NotImplementedError()
 
-    def run(self, path : str, content) -> bool:
+    def run(self, path: str, content) -> bool:
         """Run the test."""
         # print(content)
         passed = True
@@ -212,8 +216,10 @@ class TestSpec(ABC):
 
 # Bad practice
 
+
 class TestIOStream(TestSpec):
     """Detect included iostream."""
+
     name = "include-iostream"
     message = "Including iostream is discouraged. Use O2 logging instead."
     suffixes = [".h", ".cxx"]
@@ -226,6 +232,7 @@ class TestIOStream(TestSpec):
 
 class TestUsingStd(TestSpec):
     """Detect importing names from the std namespace."""
+
     name = "import-std-name"
     message = "Importing names from the std namespace is not allowed in headers."
     suffixes = [".h"]
@@ -238,6 +245,7 @@ class TestUsingStd(TestSpec):
 
 class TestUsingDirectives(TestSpec):
     """Detect using directives in headers."""
+
     name = "using-directive"
     message = "Using directives are not allowed in headers."
     suffixes = [".h"]
@@ -250,27 +258,43 @@ class TestUsingDirectives(TestSpec):
 
 class TestStdPrefix(TestSpec):
     """Detect missing std:: prefix for common names from the std namespace."""
+
     name = "std-prefix"
     message = "Use std:: prefix for names from the std namespace."
     suffixes = [".h", ".cxx", ".C"]
     prefix_bad = r"[^\w:\.\"]"
-    patterns = [r"vector<", r"array[<\{\(]", r"f?abs\(", r"sqrt\(", r"pow\(", r"min\(", r"max\(", r"log\(", r"exp\(", r"sin\(", r"cos\(", r"tan\(", r"atan\(", r"atan2\("]
+    patterns = [
+        r"vector<",
+        r"array[<\{\(]",
+        r"f?abs\(",
+        r"sqrt\(",
+        r"pow\(",
+        r"min\(",
+        r"max\(",
+        r"log\(",
+        r"exp\(",
+        r"sin\(",
+        r"cos\(",
+        r"tan\(",
+        r"atan\(",
+        r"atan2\(",
+    ]
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
         for pattern in self.patterns:
-            iterators = re.finditer(fr"{self.prefix_bad}{pattern}", line)
+            iterators = re.finditer(rf"{self.prefix_bad}{pattern}", line)
             matches = [(it.start(), it.group()) for it in iterators]
             if not matches:
                 continue
-            if not "\"" in line: # Found a match which cannot be inside a string.
+            if not '"' in line:  # Found a match which cannot be inside a string.
                 return False
             # Ignore matches inside strings.
             for match in matches:
-                n_quotes_before = line.count("\"", 0, match[0]) # Count quotation marks before the match.
-                if n_quotes_before % 2: # If odd, we are inside a string and we should ignore this match.
+                n_quotes_before = line.count('"', 0, match[0])  # Count quotation marks before the match.
+                if n_quotes_before % 2:  # If odd, we are inside a string and we should ignore this match.
                     continue
                 # We are not inside a string and this match is valid.
                 return False
@@ -279,6 +303,7 @@ class TestStdPrefix(TestSpec):
 
 class TestROOT(TestSpec):
     """Detect use of unnecessary ROOT entities."""
+
     name = "root-entity"
     message = "Consider replacing ROOT entities with STD C++ or O2 entities."
     suffixes = [".h", ".cxx"]
@@ -296,6 +321,7 @@ class TestROOT(TestSpec):
 
 class TestPi(TestSpec):
     """Detect use of external pi."""
+
     name = "external-pi"
     message = "Consider using the PI constant (and its multiples and fractions) defined in o2::constants::math."
     suffixes = [".h", ".cxx"]
@@ -313,13 +339,14 @@ class TestPi(TestSpec):
 
 class TestTwoPiAddSubtract(TestSpec):
     """Detect adding/subtracting of 2 pi."""
+
     name = "two-pi-add-subtract"
     message = "Consider using RecoDecay::constrainAngle to restrict angle to a given range."
     suffixes = [".h", ".cxx"]
 
     def test_line(self, line: str) -> bool:
         pattern_two_pi = r"(2(\.0*f?)? \* (M_PI|TMath::Pi\(\)|(((o2::)?constants::)?math::)?PI)|(((o2::)?constants::)?math::)?TwoPI|TMath::TwoPi\(\))"
-        pattern = fr"[\+-]=? {pattern_two_pi}"
+        pattern = rf"[\+-]=? {pattern_two_pi}"
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
@@ -328,15 +355,16 @@ class TestTwoPiAddSubtract(TestSpec):
 
 class TestPiMultipleFraction(TestSpec):
     """Detect multiplying/dividing of pi for existing equivalent constants."""
+
     name = "pi-multiple-fraction"
     message = "Consider using multiples/fractions of PI defined in o2::constants::math."
     suffixes = [".h", ".cxx"]
 
     def test_line(self, line: str) -> bool:
         pattern_pi = r"(M_PI|TMath::(Two)?Pi\(\)|(((o2::)?constants::)?math::)?(Two)?PI)"
-        pattern_multiple = r"(2(\.0*f?)?|0\.2?5f?) \* " # * 2, 0.25, 0.5
-        pattern_fraction = r" / ((2|3|4)([ ,;\)]|\.0*f?))" # / 2, 3, 4
-        pattern = fr"{pattern_multiple}{pattern_pi}|{pattern_pi}{pattern_fraction}"
+        pattern_multiple = r"(2(\.0*f?)?|0\.2?5f?) \* "  # * 2, 0.25, 0.5
+        pattern_fraction = r" / ((2|3|4)([ ,;\)]|\.0*f?))"  # / 2, 3, 4
+        pattern = rf"{pattern_multiple}{pattern_pi}|{pattern_pi}{pattern_fraction}"
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
@@ -345,6 +373,7 @@ class TestPiMultipleFraction(TestSpec):
 
 class TestPdgDatabase(TestSpec):
     """Detect use of TDatabasePDG."""
+
     name = "pdg/database"
     message = "Direct use of TDatabasePDG is not allowed. Use o2::constants::physics::Mass... or Service<o2::framework::O2DatabasePDG>."
     suffixes = [".h", ".cxx"]
@@ -361,6 +390,7 @@ class TestPdgDatabase(TestSpec):
 
 class TestPdgCode(TestSpec):
     """Detect use of hard-coded PDG codes."""
+
     name = "pdg/explicit-code"
     message = "Avoid using hard-coded PDG codes. Use named values from PDG_t or o2::constants::physics::Pdg instead."
     suffixes = [".h", ".cxx", ".C"]
@@ -381,8 +411,11 @@ class TestPdgCode(TestSpec):
 
 class TestPdgMass(TestSpec):
     """Detect unnecessary call of Mass() for a known PDG code."""
+
     name = "pdg/known-mass"
-    message = "Consider using o2::constants::physics::Mass... instead of calling a database method for a known PDG code."
+    message = (
+        "Consider using o2::constants::physics::Mass... instead of calling a database method for a known PDG code."
+    )
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -390,15 +423,16 @@ class TestPdgMass(TestSpec):
             return True
         line = remove_comment_cpp(line)
         pattern_pdg_code = r"[+-]?(k[A-Z][a-zA-Z0-9]*|[0-9]+)"
-        if re.search(fr"->GetParticle\({pattern_pdg_code}\)->Mass\(\)", line):
+        if re.search(rf"->GetParticle\({pattern_pdg_code}\)->Mass\(\)", line):
             return False
-        if re.search(fr"->Mass\({pattern_pdg_code}\)", line):
+        if re.search(rf"->Mass\({pattern_pdg_code}\)", line):
             return False
         return True
 
 
 class TestLogging(TestSpec):
     """Detect non-O2 logging."""
+
     name = "logging"
     message = "Consider using O2 logging (LOG, LOGF, LOGP)."
     suffixes = [".h", ".cxx"]
@@ -416,6 +450,7 @@ class TestLogging(TestSpec):
 
 class TestConstRefInForLoop(TestSpec):
     """Test const refs in range-based for loops."""
+
     name = "const-ref-in-for-loop"
     message = "Use constant references for non-modified iterators in range-based for loops."
     suffixes = [".h", ".cxx", ".C"]
@@ -426,48 +461,49 @@ class TestConstRefInForLoop(TestSpec):
         line = remove_comment_cpp(line)
         if not re.match(r"for \(.* :", line):
             return True
-        line = line[:line.index(" :")] # keep only the iterator part
+        line = line[: line.index(" :")]  # keep only the iterator part
         return re.search(r"(\w const|const \w+)& ", line) is not None
 
 
 class TestConstRefInSubscription(TestSpec):
     """Test const refs in process function subscriptions."""
+
     name = "const-ref-in-process"
     message = "Use constant references for table subscriptions in process functions."
     suffixes = [".cxx"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         passed = True
-        n_parens_opened = 0 # number of opened parentheses
-        arguments = "" # process function arguments
-        line_process = 0 # line number of the process function
+        n_parens_opened = 0  # number of opened parentheses
+        arguments = ""  # process function arguments
+        line_process = 0  # line number of the process function
         for i, line in enumerate(content):
             line = line.strip()
             if is_comment_cpp(line):
                 continue
             if self.is_disabled(line):
                 continue
-            if "//" in line: # Remove comment. (Ignore /* to avoid truncating at /*parameter*/.)
-                line = line[:line.index("//")]
+            if "//" in line:  # Remove comment. (Ignore /* to avoid truncating at /*parameter*/.)
+                line = line[: line.index("//")]
             if re.search(r"^void process[\w]*\(", line):
                 line_process = i + 1
                 i_closing = line.rfind(")")
                 i_start = line.index("(") + 1
                 i_end = i_closing if i_closing != -1 else len(line)
-                arguments = line[i_start:i_end] # get arguments between parentheses
+                arguments = line[i_start:i_end]  # get arguments between parentheses
                 n_parens_opened = line.count("(") - line.count(")")
             elif n_parens_opened > 0:
                 i_closing = line.rfind(")")
                 i_start = 0
                 i_end = i_closing if i_closing != -1 else len(line)
-                arguments += " " + line[i_start:i_end] # get arguments between parentheses
+                arguments += " " + line[i_start:i_end]  # get arguments between parentheses
                 n_parens_opened += line.count("(") - line.count(")")
             if line_process > 0 and n_parens_opened == 0:
                 # Process arguments.
                 # Sanitise arguments with spaces between <>.
                 for start, end in block_ranges(arguments, "<", ">"):
-                    arg = arguments[start:(end + 1)]
+                    arg = arguments[start : (end + 1)]
                     # print(f"Found argument \"{arg}\" in [{start}, {end}]")
                     if ", " in arg:
                         arguments = arguments.replace(arg, arg.replace(", ", "__"))
@@ -484,13 +520,14 @@ class TestConstRefInSubscription(TestSpec):
 
 class TestWorkflowOptions(TestSpec):
     """Detect usage of workflow options in defineDataProcessing. (Not supported on AliHyperloop.)"""
+
     name = "o2-workflow-options"
     message = "Do not use workflow options to customise workflow topology composition in defineDataProcessing. Use process function switches or metadata instead."
     suffixes = [".cxx"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
-        is_inside_define = False # Are we inside defineDataProcessing?
+    def test_file(self, path: str, content) -> bool:
+        is_inside_define = False  # Are we inside defineDataProcessing?
         for i, line in enumerate(content):
             if not line.strip():
                 continue
@@ -521,40 +558,46 @@ class TestWorkflowOptions(TestSpec):
 
 class TestDocumentationFile(TestSpec):
     """Test mandatory documentation of C++ files."""
+
     name = "doc/file"
     message = "Provide mandatory file documentation."
     suffixes = [".h", ".cxx", ".C"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         passed = False
         doc_items = []
-        doc_items.append({"keyword": "file", "pattern": fr"{os.path.basename(path)}$", "found": False})
-        doc_items.append({"keyword": "brief", "pattern": r"\w.* \w", "found": False}) # at least two words
+        doc_items.append({"keyword": "file", "pattern": rf"{os.path.basename(path)}$", "found": False})
+        doc_items.append({"keyword": "brief", "pattern": r"\w.* \w", "found": False})  # at least two words
         doc_items.append({"keyword": "author", "pattern": r"[\w]+", "found": False})
         doc_prefix = "///"
         n_lines_copyright = 11
         last_doc_line = n_lines_copyright
 
         for i, line in enumerate(content):
-            if i < n_lines_copyright: # Skip copyright lines.
+            if i < n_lines_copyright:  # Skip copyright lines.
                 continue
-            if line.strip() and not line.startswith(doc_prefix): # Stop at the first non-empty non-doc line.
+            if line.strip() and not line.startswith(doc_prefix):  # Stop at the first non-empty non-doc line.
                 break
             if line.startswith(doc_prefix):
-                last_doc_line = (i + 1)
+                last_doc_line = i + 1
             for item in doc_items:
-                if re.search(fr"^{doc_prefix} [\\@]{item['keyword']} +{item['pattern']}", line):
+                if re.search(rf"^{doc_prefix} [\\@]{item['keyword']} +{item['pattern']}", line):
                     item["found"] = True
                     # print_error(path, i + 1, self.name, f"Found \{item['keyword']}.")
                     break
-            if all(item["found"] for item in doc_items): # All items have been found.
+            if all(item["found"] for item in doc_items):  # All items have been found.
                 passed = True
                 break
         if not passed:
             for item in doc_items:
                 if not item["found"]:
-                    print_error(path, last_doc_line, self.name, f"Documentation for \\{item['keyword']} is missing, incorrect or misplaced.")
+                    print_error(
+                        path,
+                        last_doc_line,
+                        self.name,
+                        f"Documentation for \\{item['keyword']} is missing, incorrect or misplaced.",
+                    )
         return passed
 
 
@@ -570,6 +613,7 @@ class TestNameFunctionVariable(TestSpec):
     Does not detect multi-line declarations.
     Does not check capitalisation for constexpr because of special rules for constants. See TestNameConstant.
     """
+
     name = "name/function-variable"
     message = "Use lowerCamelCase for names of functions and variables."
     suffixes = [".h", ".cxx", ".C"]
@@ -583,7 +627,7 @@ class TestNameFunctionVariable(TestSpec):
         # For functions, stripping after "(" is enough but this way we also identify many declarations of variables.
         for keyword in ("(", "{", ";", " = ", "//", "/*"):
             if keyword in line:
-                line = line[:line.index(keyword)]
+                line = line[: line.index(keyword)]
 
         # Check the words.
         words = line.split()
@@ -597,21 +641,38 @@ class TestNameFunctionVariable(TestSpec):
             return True
 
         # Reject false positives with same structure.
-        if words[0] in ("return", "if", "else", "new", "delete", "delete[]", "case", "typename", "using", "typedef", "enum", "namespace", "struct", "class"):
+        if words[0] in (
+            "return",
+            "if",
+            "else",
+            "new",
+            "delete",
+            "delete[]",
+            "case",
+            "typename",
+            "using",
+            "typedef",
+            "enum",
+            "namespace",
+            "struct",
+            "class",
+        ):
             return True
         if len(words) > 2 and words[1] in ("typename", "class", "struct"):
             return True
 
         # Identify the position of the name for cases "name[n + m]".
-        funval_name = words[-1] # expecting the name in the last word
-        if funval_name.endswith("]") and "[" not in funval_name: # it's an array and we do not have the name before "[" here
+        funval_name = words[-1]  # expecting the name in the last word
+        if (
+            funval_name.endswith("]") and "[" not in funval_name
+        ):  # it's an array and we do not have the name before "[" here
             opens_brackets = ["[" in w for w in words]
-            if not any(opens_brackets): # The opening "[" is not on this line. We have to give up.
+            if not any(opens_brackets):  # The opening "[" is not on this line. We have to give up.
                 return True
-            index_name = opens_brackets.index(True) # the name is in the first element with "["
+            index_name = opens_brackets.index(True)  # the name is in the first element with "["
             funval_name = words[index_name]
-            words = words[:(index_name + 1)] # Strip away words after the name.
-            if len(words) < 2: # Check the adjusted number of words.
+            words = words[: (index_name + 1)]  # Strip away words after the name.
+            if len(words) < 2:  # Check the adjusted number of words.
                 return True
 
         # All words before the name start with an alphanumeric character (underscores not allowed).
@@ -620,15 +681,15 @@ class TestNameFunctionVariable(TestSpec):
             return True
 
         # Extract function/variable name.
-        if "[" in funval_name: # Remove brackets for arrays.
-            funval_name = funval_name[:funval_name.index("[")]
-        if "::" in funval_name: # Remove the class prefix for methods.
+        if "[" in funval_name:  # Remove brackets for arrays.
+            funval_name = funval_name[: funval_name.index("[")]
+        if "::" in funval_name:  # Remove the class prefix for methods.
             funval_name = funval_name.split("::")[-1]
 
         # Check the name candidate.
 
         # Names of variables and functions are identifiers.
-        if not funval_name.isidentifier(): # should be same as ^[\w]+$
+        if not funval_name.isidentifier():  # should be same as ^[\w]+$
             return True
 
         # print(f"{line} -> {funval_name}")
@@ -641,6 +702,7 @@ class TestNameFunctionVariable(TestSpec):
 
 class TestNameMacro(TestSpec):
     """Test macro names."""
+
     name = "name/macro"
     message = "Use SCREAMING_SNAKE_CASE for names of macros."
     suffixes = [".h", ".cxx", ".C"]
@@ -660,8 +722,11 @@ class TestNameMacro(TestSpec):
 
 class TestNameConstant(TestSpec):
     """Test constexpr constant names."""
+
     name = "name/constexpr-constant"
-    message = "Use UpperCamelCase for names of constexpr constants. Names of special constants may be prefixed with \"k\"."
+    message = (
+        'Use UpperCamelCase for names of constexpr constants. Names of special constants may be prefixed with "k".'
+    )
     suffixes = [".h", ".cxx", ".C"]
 
     def test_line(self, line: str) -> bool:
@@ -672,25 +737,28 @@ class TestNameConstant(TestSpec):
         if not "constexpr" in words or not "=" in words:
             return True
         # Extract constant name.
-        words = words[:words.index("=")] # keep only words before "="
-        constant_name = words[-1] # last word before "="
-        if constant_name.endswith("]") and "[" not in constant_name: # it's an array and we do not have the name before "[" here
+        words = words[: words.index("=")]  # keep only words before "="
+        constant_name = words[-1]  # last word before "="
+        if (
+            constant_name.endswith("]") and "[" not in constant_name
+        ):  # it's an array and we do not have the name before "[" here
             opens_brackets = ["[" in w for w in words]
-            if not any(opens_brackets): # The opening "[" is not on this line. We have to give up.
+            if not any(opens_brackets):  # The opening "[" is not on this line. We have to give up.
                 return True
-            constant_name = words[opens_brackets.index(True)] # the name is in the first element with "["
-        if "[" in constant_name: # Remove brackets for arrays.
-            constant_name = constant_name[:constant_name.index("[")]
-        if "::" in constant_name: # Remove the class prefix for methods.
+            constant_name = words[opens_brackets.index(True)]  # the name is in the first element with "["
+        if "[" in constant_name:  # Remove brackets for arrays.
+            constant_name = constant_name[: constant_name.index("[")]
+        if "::" in constant_name:  # Remove the class prefix for methods.
             constant_name = constant_name.split("::")[-1]
         # The actual test comes here.
-        if constant_name.startswith("k") and len(constant_name) > 1: # exception for special constants
-            constant_name = constant_name[1:] # test the name without "k"
+        if constant_name.startswith("k") and len(constant_name) > 1:  # exception for special constants
+            constant_name = constant_name[1:]  # test the name without "k"
         return is_upper_camel_case(constant_name)
 
 
 class TestNameColumn(TestSpec):
     """Test names of O2 columns."""
+
     name = "name/o2-column"
     message = "Use UpperCamelCase for names of O2 columns and matching lowerCamelCase names for their getters."
     suffixes = [".h", ".cxx"]
@@ -702,15 +770,15 @@ class TestNameColumn(TestSpec):
             return True
         # Extract names of the column type and getter.
         line = remove_comment_cpp(line)
-        line = line[len(match.group()):].strip() # Extract part after "(".
+        line = line[len(match.group()) :].strip()  # Extract part after "(".
         if not (match := re.match(r"([^,]+), ([^,\) ]+)", line)):
-            print(f"Failed to extract column type and getter from \"{line}\".")
+            print(f'Failed to extract column type and getter from "{line}".')
             return False
         column_type_name = match.group(1)
         column_getter_name = match.group(2)
         # print(f"Got \"{column_type_name}\" \"{column_getter_name}\"")
         # return True
-        if column_type_name[0] == "_": # probably a macro variable
+        if column_type_name[0] == "_":  # probably a macro variable
             return True
         # The actual test comes here.
         if not is_upper_camel_case(column_type_name):
@@ -722,6 +790,7 @@ class TestNameColumn(TestSpec):
 
 class TestNameTable(TestSpec):
     """Test names of O2 tables."""
+
     name = "name/o2-table"
     message = "Use UpperCamelCase for names of O2 tables."
     suffixes = [".h", ".cxx"]
@@ -733,14 +802,14 @@ class TestNameTable(TestSpec):
             return True
         # Extract names of the column type and getter.
         line = remove_comment_cpp(line)
-        line = line[len(match.group()):].strip() # Extract part after "(".
+        line = line[len(match.group()) :].strip()  # Extract part after "(".
         if not (match := re.match(r"([^,\) ]+)", line)):
-            print(f"Failed to extract table type from \"{line}\".")
+            print(f'Failed to extract table type from "{line}".')
             return False
         table_type_name = match.group(1)
         # print(f"Got \"{table_type_name}\"")
         # return True
-        if table_type_name[0] == "_": # probably a macro variable
+        if table_type_name[0] == "_":  # probably a macro variable
             return True
         # The actual test comes here.
         return is_upper_camel_case(table_type_name)
@@ -748,6 +817,7 @@ class TestNameTable(TestSpec):
 
 class TestNameNamespace(TestSpec):
     """Test names of namespaces."""
+
     name = "name/namespace"
     message = "Use snake_case for names of namespaces."
     suffixes = [".h", ".cxx", ".C"]
@@ -759,7 +829,7 @@ class TestNameNamespace(TestSpec):
             return True
         # Extract namespace name.
         namespace_name = line.split()[1]
-        if namespace_name == "{": # ignore anonymous namespaces
+        if namespace_name == "{":  # ignore anonymous namespaces
             return True
         # The actual test comes here.
         return is_snake_case(namespace_name)
@@ -767,6 +837,7 @@ class TestNameNamespace(TestSpec):
 
 class TestNameUpperCamelCase(TestSpec):
     """Base class for a test of UpperCamelCase names."""
+
     keyword = "key"
     name = f"name/{keyword}"
     message = f"Use UpperCamelCase for names of {keyword}."
@@ -779,10 +850,10 @@ class TestNameUpperCamelCase(TestSpec):
             return True
         # Extract object name.
         words = line.split()
-        if not words[1].isalnum(): # "struct : ...", "enum { ..."
+        if not words[1].isalnum():  # "struct : ...", "enum { ..."
             return True
         object_name = words[1]
-        if object_name in ("class", "struct") and len(words) > 2: # enum class ... or enum struct
+        if object_name in ("class", "struct") and len(words) > 2:  # enum class ... or enum struct
             object_name = words[2]
         # The actual test comes here.
         return is_upper_camel_case(object_name)
@@ -790,6 +861,7 @@ class TestNameUpperCamelCase(TestSpec):
 
 class TestNameEnum(TestNameUpperCamelCase):
     """Test names of enumerators."""
+
     keyword = "enum"
     name = f"name/enum"
     message = f"Use UpperCamelCase for names of enumerators and their values."
@@ -797,6 +869,7 @@ class TestNameEnum(TestNameUpperCamelCase):
 
 class TestNameClass(TestNameUpperCamelCase):
     """Test names of classes."""
+
     keyword = "class"
     name = f"name/class"
     message = f"Use UpperCamelCase for names of classes."
@@ -804,6 +877,7 @@ class TestNameClass(TestNameUpperCamelCase):
 
 class TestNameStruct(TestNameUpperCamelCase):
     """Test names of structs."""
+
     keyword = "struct"
     name = f"name/struct"
     message = f"Use UpperCamelCase for names of structs."
@@ -811,12 +885,13 @@ class TestNameStruct(TestNameUpperCamelCase):
 
 class TestNameFileCpp(TestSpec):
     """Test names of C++ files."""
+
     name = "name/file-cpp"
     message = "Use lowerCamelCase or UpperCamelCase for names of C++ files. See the O2 naming conventions for details."
     suffixes = [".h", ".cxx", ".C"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path)
         # workflow file
         if re.search(r"(TableProducer|Tasks)/.*\.cxx", path):
@@ -832,24 +907,26 @@ class TestNameFileCpp(TestSpec):
 
 class TestNameFilePython(TestSpec):
     """Test names of Python files."""
+
     name = "name/file-python"
     message = "Use snake_case for names of Python files."
     suffixes = [".py", ".ipynb"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path)
         return is_snake_case(file_name)
 
 
 class TestNameWorkflow(TestSpec):
     """Test names of O2 workflows."""
+
     name = "name/o2-workflow"
     message = "Use kebab-case for names of workflows and match the name of the workflow file."
     suffixes = ["CMakeLists.txt"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         passed = True
         workflow_name = ""
         for i, line in enumerate(content):
@@ -870,30 +947,36 @@ class TestNameWorkflow(TestSpec):
                 passed = False
                 print_error(path, i + 2, self.name, f"Did not find sources for workflow: {workflow_name}.")
                 continue
-            workflow_file_name = os.path.basename(words[1]) # the actual file name
+            workflow_file_name = os.path.basename(words[1])  # the actual file name
             # Generate the file name matching the workflow name.
             expected_workflow_file_name = kebab_case_to_camel_case_l(workflow_name) + ".cxx"
             # Compare the actual and expected file names.
             if expected_workflow_file_name != workflow_file_name:
                 passed = False
-                print_error(path, i + 1, self.name, f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. (Matches {expected_workflow_file_name}.)")
+                print_error(
+                    path,
+                    i + 1,
+                    self.name,
+                    f"Workflow name {workflow_name} does not match its file name {workflow_file_name}. (Matches {expected_workflow_file_name}.)",
+                )
         return passed
 
 
 class TestNameTask(TestSpec):
     """Test explicit task names.
     Detect usage of TaskName, check whether it is needed and whether the task name matches the struct name."""
+
     name = "name/o2-task"
     message = "Specify task name only when it cannot be derived from the struct name. Only append to the default name."
     suffixes = [".cxx"]
     per_line = False
 
-    def test_file(self, path : str, content) -> bool:
-        is_inside_define = False # Are we inside defineDataProcessing?
-        is_inside_adapt = False # Are we inside adaptAnalysisTask?
+    def test_file(self, path: str, content) -> bool:
+        is_inside_define = False  # Are we inside defineDataProcessing?
+        is_inside_adapt = False  # Are we inside adaptAnalysisTask?
         struct_name = ""
-        struct_templated = False # Is the struct templated?
-        n_parens_opened = 0 # number of opened parentheses
+        struct_templated = False  # Is the struct templated?
+        n_parens_opened = 0  # number of opened parentheses
         passed = True
         for i, line in enumerate(content):
             if not line.strip():
@@ -919,10 +1002,10 @@ class TestNameTask(TestSpec):
                     continue
                 # print(f"{i + 1}: Entering adapt.")
                 is_inside_adapt = True
-                line = line[(index + len("adaptAnalysisTask<")):]
+                line = line[(index + len("adaptAnalysisTask<")) :]
                 # Extract struct name.
                 if not (match := re.match(r"([^>]+)", line)):
-                    print_error(path, i + 1, self.name, f"Failed to extract struct name from \"{line}\".")
+                    print_error(path, i + 1, self.name, f'Failed to extract struct name from "{line}".')
                     return False
                 struct_name = match.group(1)
                 if (index := struct_name.find("<")) > -1:
@@ -930,7 +1013,7 @@ class TestNameTask(TestSpec):
                     # print(f"{i + 1}: Got templated struct name {struct_name}")
                     struct_name = struct_name[:index]
                 # print(f"{i + 1}: Got struct name {struct_name}")
-                line = line[(line.index(struct_name) + len(struct_name)):]
+                line = line[(line.index(struct_name) + len(struct_name)) :]
             if is_inside_adapt:
                 n_parens_opened += line.count("(") - line.count(")")
                 # print(f"{i + 1}: {n_parens_opened} opened parens")
@@ -943,32 +1026,58 @@ class TestNameTask(TestSpec):
                 passed = False
                 # Extract explicit task name.
                 if not (match := re.search(r"TaskName\{\"([^\}]+)\"\}", line)):
-                    print_error(path, i + 1, self.name, f"Failed to extract explicit task name from \"{line}\".")
+                    print_error(path, i + 1, self.name, f'Failed to extract explicit task name from "{line}".')
                     return False
                 task_name = match.group(1)
                 # print(f"{i + 1}: Got struct \"{struct_name}\" with task name \"{task_name}\".")
                 # Test explicit task name.
-                device_name_from_struct_name = camel_case_to_kebab_case(struct_name) # default device name, in absence of TaskName
-                device_name_from_task_name = camel_case_to_kebab_case(task_name) # actual device name, generated from TaskName
-                struct_name_from_device_name = kebab_case_to_camel_case_u(device_name_from_task_name) # struct name matching the TaskName
+                device_name_from_struct_name = camel_case_to_kebab_case(
+                    struct_name
+                )  # default device name, in absence of TaskName
+                device_name_from_task_name = camel_case_to_kebab_case(
+                    task_name
+                )  # actual device name, generated from TaskName
+                struct_name_from_device_name = kebab_case_to_camel_case_u(
+                    device_name_from_task_name
+                )  # struct name matching the TaskName
                 if device_name_from_struct_name == device_name_from_task_name:
                     # If the task name results in the same device name as the struct name would, TaskName is redundant and should be removed.
-                    print_error(path, i + 1, self.name, f"Specified task name {task_name} and the struct name {struct_name} produce the same device name {device_name_from_struct_name}. TaskName is redundant.")
+                    print_error(
+                        path,
+                        i + 1,
+                        self.name,
+                        f"Specified task name {task_name} and the struct name {struct_name} produce the same device name {device_name_from_struct_name}. TaskName is redundant.",
+                    )
                     passed = False
                 elif device_name_from_struct_name.replace("-", "") == device_name_from_task_name.replace("-", ""):
                     # If the device names generated from the task name and from the struct name differ in hyphenation, capitalisation of the struct name should be fixed and TaskName should be removed. (special cases: alice3-, -2prong)
-                    print_error(path, i + 1, self.name, f"Device names {device_name_from_task_name} and {device_name_from_struct_name} generated from the specified task name {task_name} and from the struct name {struct_name}, respectively, differ in hyphenation. Consider fixing capitalisation of the struct name to {struct_name_from_device_name} and removing TaskName.")
+                    print_error(
+                        path,
+                        i + 1,
+                        self.name,
+                        f"Device names {device_name_from_task_name} and {device_name_from_struct_name} generated from the specified task name {task_name} and from the struct name {struct_name}, respectively, differ in hyphenation. Consider fixing capitalisation of the struct name to {struct_name_from_device_name} and removing TaskName.",
+                    )
                     passed = False
                 elif device_name_from_task_name.startswith(device_name_from_struct_name):
                     # If the device name generated from the task name is an extension of the device name generated from the struct name, accept it if the struct is templated. If the struct is not templated, extension is acceptable if adaptAnalysisTask is called multiple times for the same struct.
                     if not struct_templated:
-                        print_error(path, i + 1, self.name, f"Device name {device_name_from_task_name} from the specified task name {task_name} is an extension of the device name {device_name_from_struct_name} from the struct name {struct_name} but the struct is not templated. Is it adapted multiple times?")
+                        print_error(
+                            path,
+                            i + 1,
+                            self.name,
+                            f"Device name {device_name_from_task_name} from the specified task name {task_name} is an extension of the device name {device_name_from_struct_name} from the struct name {struct_name} but the struct is not templated. Is it adapted multiple times?",
+                        )
                         passed = False
                     # else:
                     #     print_error(path, i + 1, self.name, f"Device name {device_name_from_task_name} from the specified task name {task_name} is an extension of the device name {device_name_from_struct_name} from the struct name {struct_name} and the struct is templated. All good")
                 else:
                     # Other cases should be rejected.
-                    print_error(path, i + 1, self.name, f"Specified task name {task_name} produces device name {device_name_from_task_name} which does not match the device name {device_name_from_struct_name} from the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})")
+                    print_error(
+                        path,
+                        i + 1,
+                        self.name,
+                        f"Specified task name {task_name} produces device name {device_name_from_task_name} which does not match the device name {device_name_from_struct_name} from the struct name {struct_name}. (Matching struct name {struct_name_from_device_name})",
+                    )
                     passed = False
         return passed
 
@@ -978,8 +1087,9 @@ class TestNameTask(TestSpec):
 
 class TestHfConstAuto(TestSpec):
     """PWGHF: Detect swapped const auto."""
+
     name = "pwghf/const-auto"
-    message = "Use \"const auto\" instead of \"auto const\"."
+    message = 'Use "const auto" instead of "auto const".'
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
@@ -994,8 +1104,9 @@ class TestHfConstAuto(TestSpec):
 
 class TestHfNameStructClass(TestSpec):
     """PWGHF: Test names of structs and classes."""
+
     name = "pwghf/name/struct-class"
-    message = "Names of PWGHF structs and classes must start with \"Hf\"."
+    message = 'Names of PWGHF structs and classes must start with "Hf".'
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
@@ -1009,7 +1120,7 @@ class TestHfNameStructClass(TestSpec):
         line = remove_comment_cpp(line)
         # Extract struct/class name.
         words = line.split()
-        if not words[1].isalnum(): # "struct : ..."
+        if not words[1].isalnum():  # "struct : ..."
             return True
         struct_name = words[1]
         # The actual test comes here.
@@ -1019,23 +1130,42 @@ class TestHfNameStructClass(TestSpec):
 class TestHfStructMembers(TestSpec):
     """PWGHF: Test order of struct members.
     Caveat: Does not see Configurables in ConfigurableGroup."""
+
     name = "pwghf/struct-member-order"
     message = "Declare struct members in the conventional order. See the PWGHF coding guidelines."
     suffixes = [".cxx"]
     per_line = False
-    member_order = ["Spawns<", "Builds<", "Produces<", "Configurable<", "HfHelper ", "SliceCache ", "Service<", "using ", "Filter ", "Preslice<", "Partition<", "ConfigurableAxis ", "AxisSpec ", "HistogramRegistry ", "OutputObj<", "void init(", "void process"]
+    member_order = [
+        "Spawns<",
+        "Builds<",
+        "Produces<",
+        "Configurable<",
+        "HfHelper ",
+        "SliceCache ",
+        "Service<",
+        "using ",
+        "Filter ",
+        "Preslice<",
+        "Partition<",
+        "ConfigurableAxis ",
+        "AxisSpec ",
+        "HistogramRegistry ",
+        "OutputObj<",
+        "void init(",
+        "void process",
+    ]
 
     def file_matches(self, path: str) -> bool:
         return TestSpec.file_matches(self, path) and "PWGHF/" in path
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         passed = True
-        dic_struct:dict[str, dict] = {}
+        dic_struct: dict[str, dict] = {}
         struct_name = ""
         for i, line in enumerate(content):
             if is_comment_cpp(line):
                 continue
-            if line.startswith("struct "): # expecting no indentation
+            if line.startswith("struct "):  # expecting no indentation
                 line = remove_comment_cpp(line)
                 struct_name = line.strip().split()[1]
                 dic_struct[struct_name] = {}
@@ -1044,24 +1174,31 @@ class TestHfStructMembers(TestSpec):
                 continue
             # Save line numbers of members of the current struct for each category.
             for member in self.member_order:
-                if line.startswith(f"  {member}"): # expecting single-level indentation for direct members
+                if line.startswith(f"  {member}"):  # expecting single-level indentation for direct members
                     if member not in dic_struct[struct_name]:
                         dic_struct[struct_name][member] = []
-                    dic_struct[struct_name][member].append(i + 1) # save line number
+                    dic_struct[struct_name][member].append(i + 1)  # save line number
                     break
         # print(dic_struct)
         # Detect members declared in a wrong order.
-        last_line_last_member = 0 # line number of the last member of the previous member category
-        index_last_member = 0 # index of the previous member category in the member_order list
+        last_line_last_member = 0  # line number of the last member of the previous member category
+        index_last_member = 0  # index of the previous member category in the member_order list
         for struct_name in dic_struct:
             for i_m, member in enumerate(self.member_order):
                 if member not in dic_struct[struct_name]:
                     continue
-                first_line = min(dic_struct[struct_name][member]) # line number of the first member of this category
-                last_line = max(dic_struct[struct_name][member]) # line number of the last member of this category
-                if first_line < last_line_last_member: # The current category starts before the end of the previous category.
+                first_line = min(dic_struct[struct_name][member])  # line number of the first member of this category
+                last_line = max(dic_struct[struct_name][member])  # line number of the last member of this category
+                if (
+                    first_line < last_line_last_member
+                ):  # The current category starts before the end of the previous category.
                     passed = False
-                    print_error(path, first_line, self.name, f"{struct_name}: {member.strip()} appears too early (before end of {self.member_order[index_last_member].strip()}).")
+                    print_error(
+                        path,
+                        first_line,
+                        self.name,
+                        f"{struct_name}: {member.strip()} appears too early (before end of {self.member_order[index_last_member].strip()}).",
+                    )
                 last_line_last_member = last_line
                 index_last_member = i_m
         return passed
@@ -1069,6 +1206,7 @@ class TestHfStructMembers(TestSpec):
 
 class TestHfNameFileWorkflow(TestSpec):
     """PWGHF: Test names of workflow files."""
+
     name = "pwghf/name/workflow-file"
     message = "Name of a workflow file must match the name of the main task in it. See the PWGHF O2 naming conventions for details."
     suffixes = [".cxx"]
@@ -1077,19 +1215,19 @@ class TestHfNameFileWorkflow(TestSpec):
     def file_matches(self, path: str) -> bool:
         return TestSpec.file_matches(self, path) and "PWGHF/" in path and not "Macros/" in path
 
-    def test_file(self, path : str, content) -> bool:
+    def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path).rstrip(".cxx")
         if file_name[0].isupper():
             return False
-        base_struct_name = f"Hf{file_name[0].upper()}{file_name[1:]}" # expected base of struct names
+        base_struct_name = f"Hf{file_name[0].upper()}{file_name[1:]}"  # expected base of struct names
         # print(f"For file {file_name} expecting to find {base_struct_name}.")
-        struct_names = [] # actual struct names in the file
+        struct_names = []  # actual struct names in the file
         for line in content:
             if not line.startswith("struct "):
                 continue
             # Extract struct name.
             words = line.split()
-            if not words[1].isalnum(): # "struct : ..."
+            if not words[1].isalnum():  # "struct : ..."
                 continue
             struct_name = words[1]
             struct_names.append(struct_name)
@@ -1102,6 +1240,7 @@ class TestHfNameFileWorkflow(TestSpec):
 
 class TestHfNameConfigurable(TestSpec):
     """PWGHF: Test names of configurables."""
+
     name = "pwghf/name/configurable"
     message = "Use lowerCamelCase for names of configurables and use the same name for the struct member as for the JSON string."
     suffixes = [".h", ".cxx"]
@@ -1116,16 +1255,16 @@ class TestHfNameConfigurable(TestSpec):
             return True
         # Extract Configurable name.
         words = line.split()
-        if words[2] == "=": # expecting Configurable... nameCpp = {"nameJson",
-            name_cpp = words[1] # nameCpp
-            name_json = words[3][1:] # expecting "nameJson",
+        if words[2] == "=":  # expecting Configurable... nameCpp = {"nameJson",
+            name_cpp = words[1]  # nameCpp
+            name_json = words[3][1:]  # expecting "nameJson",
         else:
-            names = words[1].split("{") # expecting Configurable... nameCpp{"nameJson",
-            name_cpp = names[0] # nameCpp
-            name_json = names[1] # expecting "nameJson",
-        if name_json[0] != "\"": # JSON name is not a literal string.
+            names = words[1].split("{")  # expecting Configurable... nameCpp{"nameJson",
+            name_cpp = names[0]  # nameCpp
+            name_json = names[1]  # expecting "nameJson",
+        if name_json[0] != '"':  # JSON name is not a literal string.
             return True
-        name_json = name_json.strip("\",") # expecting nameJson
+        name_json = name_json.strip('",')  # expecting nameJson
         # The actual test comes here.
         return is_lower_camel_case(name_cpp) and name_cpp == name_json
 
@@ -1135,9 +1274,7 @@ class TestHfNameConfigurable(TestSpec):
 
 def main():
     """Main function"""
-    parser = argparse.ArgumentParser(
-        description="Run tests on files to find code issues."
-    )
+    parser = argparse.ArgumentParser(description="Run tests on files to find code issues.")
     parser.add_argument("paths", type=str, nargs="+", help="File path(s)")
     parser.add_argument(
         "-g",
@@ -1150,7 +1287,7 @@ def main():
         global github_mode
         github_mode = True
 
-    tests = [] # list of activated tests
+    tests = []  # list of activated tests
 
     # Bad practice
     enable_bad_practice = True
@@ -1202,9 +1339,9 @@ def main():
         tests.append(TestHfNameFileWorkflow())
         tests.append(TestHfNameConfigurable())
 
-    test_names = [t.name for t in tests] # short names of activated tests
-    suffixes = tuple(set([s for test in tests for s in test.suffixes])) # all suffixes from all enabled tests
-    passed = True # global result of all tests
+    test_names = [t.name for t in tests]  # short names of activated tests
+    suffixes = tuple(set([s for test in tests for s in test.suffixes]))  # all suffixes from all enabled tests
+    passed = True  # global result of all tests
 
     # Report overview before running.
     print(f"Testing {len(args.paths)} files.")
@@ -1229,7 +1366,7 @@ def main():
                         passed = False
                     # print(f"File \"{path}\" {'passed' if result else 'failed'} the test {test.name}.")
         except IOError:
-            print(f"Failed to open file \"{path}\".")
+            print(f'Failed to open file "{path}".')
             sys.exit(1)
 
     # Report global result.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -25,6 +25,7 @@ from abc import ABC
 from typing import Union
 
 github_mode = False  # GitHub mode
+prefix_disable = "o2-linter: disable="
 
 
 def is_camel_case(name: str) -> bool:
@@ -168,7 +169,6 @@ class TestSpec(ABC):
 
     def is_disabled(self, line: str, prefix_comment="//") -> bool:
         """Detect whether the test is explicitly disabled."""
-        prefix_disable = "o2-linter: disable="
         for prefix in [prefix_comment, prefix_disable]:
             if prefix not in line:
                 return False
@@ -1404,10 +1404,23 @@ def main():
             sys.exit(1)
 
     # Report global result.
+    title_result = "O2 linter result"
     if passed:
-        print("All tests passed.")
+        msg_result = "All tests passed."
+        if github_mode:
+            print(f"::notice title={title_result}::{msg_result}")
+        else:
+            print(f"{title_result}: {msg_result}")
     else:
-        print("Issues have been found.")
+        msg_result = "Issues have been found."
+        msg_disable = f"You can disable a test for a line by adding a comment with \"{prefix_disable}\"" \
+            " followed by the name of the test."
+        if github_mode:
+            print(f"::error title={title_result}::{msg_result}")
+            print(f"::notice::{msg_disable}")
+        else:
+            print(f"{title_result}: {msg_result}")
+            print(msg_disable)
         sys.exit(1)
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -28,7 +28,7 @@ github_mode = False # GitHub mode
 
 def is_camel_case(name: str) -> bool:
     """forExample or ForExample"""
-    return not "_" in name and not "-" in name
+    return not "_" in name and not "-" in name and not " " in name
 
 
 def is_upper_camel_case(name: str) -> bool:
@@ -43,17 +43,17 @@ def is_lower_camel_case(name: str) -> bool:
 
 def is_kebab_case(name: str) -> bool:
     """for-example"""
-    return name.islower() and not "_" in name
+    return name.islower() and not "_" in name and not " " in name
 
 
 def is_snake_case(name: str) -> bool:
     """for_example"""
-    return name.islower() and not "-" in name
+    return name.islower() and not "-" in name and not " " in name
 
 
 def is_screaming_snake_case(name: str) -> bool:
     """FOR_EXAMPLE"""
-    return name.isupper() and not "-" in name
+    return name.isupper() and not "-" in name and not " " in name
 
 
 def print_error(path: str, line: int, title: str, message: str) -> str:
@@ -628,7 +628,7 @@ class TestNameWorkflow(TestSpec):
             if self.is_disabled(line, "#"):
                 continue
             # Extract workflow name.
-            workflow_name = line.strip().split("(")[1]
+            workflow_name = line.strip().split("(")[1].split()[0]
             if not is_kebab_case(workflow_name):
                 passed = False
                 print_error(path, i + 1, self.name, f"Invalid workflow name: {workflow_name}.")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -503,8 +503,12 @@ class TestConstRefInSubscription(TestSpec):
             words = line.split()
             if len(words) < 2:
                 passed = False
-                print_error(path, i + 1, self.name,
-                            "Failed to get the process function name. Keep it on the same line as the switch.")
+                print_error(
+                    path,
+                    i + 1,
+                    self.name,
+                    "Failed to get the process function name. Keep it on the same line as the switch.",
+                )
                 continue
             names_functions.append(words[1][:-1])
             # print_error(path, i + 1, self.name, f"Got process function name {words[1][:-1]}.")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -392,7 +392,7 @@ class TestDocumentationFile(TestSpec):
         passed = False
         doc_items = []
         doc_items.append({"keyword": "file", "pattern": fr"{os.path.basename(path)}$", "found": False})
-        doc_items.append({"keyword": "brief", "pattern": r"\w.* \w", "found": False})
+        doc_items.append({"keyword": "brief", "pattern": r"\w.* \w", "found": False}) # at least two words
         doc_items.append({"keyword": "author", "pattern": r"[\w]+", "found": False})
         doc_prefix = "///"
         n_lines_copyright = 11
@@ -617,6 +617,15 @@ class TestNameFileCpp(TestSpec):
 
     def test_file(self, path : str, content) -> bool:
         file_name = os.path.basename(path)
+        # workflow file
+        if re.search("(TableProducer|Tasks)/.*\.cxx", path):
+            return is_lower_camel_case(file_name)
+         # data model file
+        if "DataModel/" in path:
+            return is_upper_camel_case(file_name)
+         # utility file
+        if re.search("[Uu]til(ity|ities|s)?", file_name):
+            return is_lower_camel_case(file_name)
         return is_camel_case(file_name)
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1050,7 +1050,16 @@ class TestNameTask(TestSpec):
                 struct_name_from_device_name = kebab_case_to_camel_case_u(
                     device_name_from_task_name
                 )  # struct name matching the TaskName
-                if device_name_from_struct_name == device_name_from_task_name:
+                if not is_kebab_case(device_name_from_task_name):
+                    print_error(
+                        path,
+                        i + 1,
+                        self.name,
+                        f"Specified task name {task_name} produces an invalid device name "
+                        f"{device_name_from_task_name}.",
+                    )
+                    passed = False
+                elif device_name_from_struct_name == device_name_from_task_name:
                     # If the task name results in the same device name as the struct name would,
                     # TaskName is redundant and should be removed.
                     print_error(

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1308,7 +1308,7 @@ class TestHfNameConfigurable(TestSpec):
 
 def main():
     """Main function"""
-    parser = argparse.ArgumentParser(description="Run tests on files to find code issues.")
+    parser = argparse.ArgumentParser(description="O2 linter (Find O2-specific issues in O2 code)")
     parser.add_argument("paths", type=str, nargs="+", help="File path(s)")
     parser.add_argument(
         "-g",

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -123,7 +123,7 @@ class TestSpec(ABC):
 
 class TestIOStream(TestSpec):
     """Detect included iostream."""
-    name = "include iostream"
+    name = "include-iostream"
     message = "Including iostream is discouraged. Use O2 logging instead."
     suffixes = [".h", ".cxx"]
 
@@ -135,7 +135,7 @@ class TestIOStream(TestSpec):
 
 class TestUsingStd(TestSpec):
     """Detect importing names from the std namespace."""
-    name = "import std names"
+    name = "import-std-name"
     message = "Importing names from the std namespace is not allowed in headers."
     suffixes = [".h"]
 
@@ -147,7 +147,7 @@ class TestUsingStd(TestSpec):
 
 class TestUsingDirectives(TestSpec):
     """Detect using directives in headers."""
-    name = "using directives"
+    name = "using-directive"
     message = "Using directives are not allowed in headers."
     suffixes = [".h"]
 
@@ -159,7 +159,7 @@ class TestUsingDirectives(TestSpec):
 
 class TestStdPrefix(TestSpec):
     """Detect missing std:: prefix for common names from the std namespace."""
-    name = "std prefix"
+    name = "std-prefix"
     message = "Use std:: prefix for names from the std namespace."
     suffixes = [".h", ".cxx", ".C"]
     prefix_bad = "[^\w:.]"
@@ -180,7 +180,7 @@ class TestStdPrefix(TestSpec):
 
 class TestROOT(TestSpec):
     """Detect use of unnecessary ROOT entities."""
-    name = "ROOT entities"
+    name = "root-entity"
     message = "Consider replacing ROOT entities with STD C++ or O2 entities."
     suffixes = [".h", ".cxx"]
     keywords = ["TMath", "Double_t", "Float_t", "Int_t", "Bool_t"]
@@ -199,7 +199,7 @@ class TestROOT(TestSpec):
 
 class TestPI(TestSpec):
     """Detect use of external PI."""
-    name = "external PI"
+    name = "external-pi"
     message = "Consider using the PI constant (and its multiples) defined in o2::constants::math."
     suffixes = [".h", ".cxx"]
     keywords = ["M_PI", "TMath::Pi", "TMath::TwoPi"]
@@ -218,7 +218,7 @@ class TestPI(TestSpec):
 
 class TestPdgDatabase(TestSpec):
     """Detect use of TDatabasePDG."""
-    name = "pdg database"
+    name = "pdg/database"
     message = "Direct use of TDatabasePDG is not allowed. Use o2::constants::physics::Mass... or Service<o2::framework::O2DatabasePDG>."
     suffixes = [".h", ".cxx"]
 
@@ -235,7 +235,7 @@ class TestPdgDatabase(TestSpec):
 
 class TestPdgCode(TestSpec):
     """Detect use of hard-coded PDG codes."""
-    name = "explicit pdg code"
+    name = "pdg/explicit-code"
     message = "Avoid using hard-coded PDG codes. Use named values from PDG_t or o2::constants::physics::Pdg instead."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -254,7 +254,7 @@ class TestPdgCode(TestSpec):
 
 class TestPdgMass(TestSpec):
     """Detect unnecessary call of Mass() for a known PDG code."""
-    name = "known pdg mass"
+    name = "pdg/known-mass"
     message = "Consider using o2::constants::physics::Mass... instead of calling a database method for a known PDG code."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -290,7 +290,7 @@ class TestLogging(TestSpec):
 
 class TestConstRefInForLoop(TestSpec):
     """Test const refs in range-based for loops."""
-    name = "const ref in for loop"
+    name = "const-ref-in-for-loop"
     message = "Use constant references for non-modified iterators in range-based for loops."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -305,7 +305,7 @@ class TestConstRefInForLoop(TestSpec):
 
 class TestConstRefInSubscription(TestSpec):
     """Test const refs in process function subscriptions."""
-    name = "const ref in process"
+    name = "const-ref-in-process"
     message = "Use constant references for table subscriptions in process functions."
     suffixes = [".cxx"]
     # suffixes = [".h"]
@@ -357,7 +357,7 @@ class TestConstRefInSubscription(TestSpec):
 
 class TestDocumentationFile(TestSpec):
     """Test mandatory documentation of C++ files."""
-    name = "file documentation"
+    name = "doc/file"
     message = "Provide mandatory file documentation."
     suffixes = [".h", ".cxx", ".C"]
     per_line = False
@@ -405,7 +405,7 @@ class TestNameFunctionVariable(TestSpec):
     Does not detect function arguments on the same line as the function declaration.
     Does not check capitalisation for constexpr because of special rules for constants. See TestNameConstant.
     """
-    name = "function/variable names"
+    name = "name/function-variable"
     message = "Use lowerCamelCase for names of functions and variables."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -474,7 +474,7 @@ class TestNameFunctionVariable(TestSpec):
 
 class TestNameMacro(TestSpec):
     """Test macro names."""
-    name = "macro names"
+    name = "name/macro"
     message = "Use SCREAMING_SNAKE_CASE for macro names."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -493,7 +493,7 @@ class TestNameMacro(TestSpec):
 
 class TestNameConstant(TestSpec):
     """Test constexpr constant names."""
-    name = "constexpr constant names"
+    name = "name/constexpr-constant"
     message = "Use UpperCamelCase for constexpr constant names. Names of special constants may be prefixed with \"k\"."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -517,7 +517,7 @@ class TestNameConstant(TestSpec):
 
 class TestNameNamespace(TestSpec):
     """Test names of namespaces."""
-    name = "namespace names"
+    name = "name/namespace"
     message = "Use snake_case for names of namespaces."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -535,7 +535,7 @@ class TestNameNamespace(TestSpec):
 class TestNameUpperCamelCase(TestSpec):
     """Base class for a test of UpperCamelCase names."""
     keyword = "key"
-    name = f"{keyword} UpperCamelCase"
+    name = f"name/{keyword}"
     message = f"Use UpperCamelCase for names of {keyword}."
     suffixes = [".h", ".cxx", ".C"]
 
@@ -558,27 +558,27 @@ class TestNameUpperCamelCase(TestSpec):
 class TestNameEnum(TestNameUpperCamelCase):
     """Test names of enumerators."""
     keyword = "enum"
-    name = f"{keyword} names"
+    name = f"name/enum"
     message = f"Use UpperCamelCase for names of enumerators and their values."
 
 
 class TestNameClass(TestNameUpperCamelCase):
     """Test names of classes."""
     keyword = "class"
-    name = f"{keyword} names"
+    name = f"name/class"
     message = f"Use UpperCamelCase for names of classes."
 
 
 class TestNameStruct(TestNameUpperCamelCase):
     """Test names of structs."""
     keyword = "struct"
-    name = f"{keyword} names"
+    name = f"name/struct"
     message = f"Use UpperCamelCase for names of structs."
 
 
 class TestNameFileCpp(TestSpec):
     """Test names of C++ files."""
-    name = "C++ file names"
+    name = "name/file-cpp"
     message = "Use lowerCamelCase or UpperCamelCase for names of C++ files. See the O2 naming conventions for details."
     suffixes = [".h", ".cxx", ".C"]
     per_line = False
@@ -590,7 +590,7 @@ class TestNameFileCpp(TestSpec):
 
 class TestNameFilePython(TestSpec):
     """Test names of Python files."""
-    name = "Python file names"
+    name = "name/file-python"
     message = "Use snake_case for names of Python files."
     suffixes = [".py", ".ipynb"]
     per_line = False
@@ -602,7 +602,7 @@ class TestNameFilePython(TestSpec):
 
 class TestNameWorkflow(TestSpec):
     """Test names of O2 workflows."""
-    name = "O2 workflow names"
+    name = "name/o2-workflow"
     message = "Use kebab-case for names of workflows and match the name of the workflow file."
     suffixes = ["CMakeLists.txt"]
     per_line = False
@@ -637,12 +637,12 @@ class TestNameWorkflow(TestSpec):
         return passed
 
 
-# PWG-specific
+# PWG-HF
 
 
 class TestHfConstAuto(TestSpec):
     """PWGHF: Detect swapped const auto."""
-    name = "PWGHF: const auto"
+    name = "pwghf/const-auto"
     message = "Use \"const auto\" instead of \"auto const\"."
     suffixes = [".h", ".cxx"]
 
@@ -657,7 +657,7 @@ class TestHfConstAuto(TestSpec):
 
 class TestHfNameStructClass(TestSpec):
     """PWGHF: Test names of structs and classes."""
-    name = "PWGHF: struct/class names"
+    name = "pwghf/name/struct-class"
     message = "Names of PWGHF structs and classes must start with \"Hf\"."
     suffixes = [".h", ".cxx"]
 
@@ -681,7 +681,7 @@ class TestHfNameStructClass(TestSpec):
 class TestHfStructMembers(TestSpec):
     """PWGHF: Test order of struct members.
     Caveat: Does not see Configurables in ConfigurableGroup."""
-    name = "PWGHF: struct member order"
+    name = "pwghf/struct member order"
     message = "Declare struct members in the conventional order. See the PWGHF coding guidelines."
     suffixes = [".cxx"]
     per_line = False
@@ -730,7 +730,7 @@ class TestHfStructMembers(TestSpec):
 
 class TestHfNameFileWorkflow(TestSpec):
     """PWGHF: Test names of workflow files."""
-    name = "PWGHF: workflow file names"
+    name = "pwghf/name/workflow-file"
     message = "Name of a workflow file must match the name of the main task in it. See the PWGHF O2 naming conventions for details."
     suffixes = [".cxx"]
     per_line = False
@@ -763,7 +763,7 @@ class TestHfNameFileWorkflow(TestSpec):
 
 class TestHfNameConfigurable(TestSpec):
     """PWGHF: Test names of configurables."""
-    name = "PWGHF: Configurable names"
+    name = "pwghf/name/configurable"
     message = "Use lowerCamelCase for Configurable names and use the same name for the struct member as for the JSON string."
     suffixes = [".h", ".cxx"]
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -320,9 +320,9 @@ class TestConstRefInForLoop(TestSpec):
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)
-        if not line.startswith("for (") or " : " not in line:
+        if not re.match("for \(.* :", line):
             return True
-        line = line[:line.index(" : ")] # keep only the iterator part
+        line = line[:line.index(" :")] # keep only the iterator part
         return re.search(r"(\w const|const \w+)& ", line) is not None
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -25,7 +25,7 @@ from abc import ABC
 from typing import Union
 
 github_mode = False  # GitHub mode
-prefix_disable = "o2-linter: disable="
+prefix_disable = "o2-linter: disable="  # prefix for disabling tests
 
 
 def is_camel_case(name: str) -> bool:
@@ -120,7 +120,7 @@ def block_ranges(line: str, char_open: str, char_close: str) -> "list[list[int]]
     """Get list of index ranges of longest blocks opened with char_open and closed with char_close."""
     # print(f"Looking for {char_open}{char_close} blocks in \"{line}\".")
     # print(line)
-    list_ranges: list[list[int]] = []
+    list_ranges: "list[list[int]]" = []
     if not all((line, len(char_open) == 1, len(char_close) == 1)):
         return list_ranges
 
@@ -537,7 +537,7 @@ class TestWorkflowOptions(TestSpec):
 
     def test_file(self, path: str, content) -> bool:
         is_inside_define = False  # Are we inside defineDataProcessing?
-        for i, line in enumerate(content):
+        for i, line in enumerate(content):  # pylint: disable=unused-variable
             if not line.strip():
                 continue
             if self.is_disabled(line):
@@ -1170,7 +1170,7 @@ class TestHfNameStructClass(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path
+        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
@@ -1284,6 +1284,8 @@ class TestHfNameFileWorkflow(TestSpec):
         file_name = os.path.basename(path).rstrip(".cxx")
         if file_name[0].isupper():
             return False
+        if "/Tasks/" in path and not file_name.startswith("task"):
+            return False
         base_struct_name = f"Hf{file_name[0].upper()}{file_name[1:]}"  # expected base of struct names
         # print(f"For file {file_name} expecting to find {base_struct_name}.")
         struct_names = []  # actual struct names in the file
@@ -1352,7 +1354,7 @@ def main():
     )
     args = parser.parse_args()
     if args.github:
-        global github_mode
+        global github_mode  # pylint: disable=global-statement
         github_mode = True
 
     tests = []  # list of activated tests
@@ -1427,7 +1429,7 @@ def main():
             # print(f"Skipping path \"{path}\".")
             continue
         try:
-            with open(path, "r") as file:
+            with open(path, "r", encoding="utf-8") as file:
                 content = file.readlines()
                 for test in tests:
                     result = test.run(path, content)

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -247,7 +247,7 @@ class TestPdgCode(TestSpec):
             return True
         if re.search(r"->(GetParticle|Mass)\([+-]?[0-9]+\)", line):
             return False
-        match = re.search(r"[Pp][Dd][Gg][\w]* = [+-]?([0-9]+);", line)
+        match = re.search(r"[Pp][Dd][Gg][\w]* ={1,2} [+-]?([0-9]+);", line)
         if match:
             code = match.group(1)
             if code not in ("0", "1", "999"):
@@ -366,9 +366,9 @@ class TestDocumentationFile(TestSpec):
     def test_file(self, path : str, content) -> bool:
         passed = False
         doc_items = []
-        doc_items.append({"keyword": "file", "pattern": f"{os.path.basename(path)}$", "found": False})
-        doc_items.append({"keyword": "brief", "pattern": "[\w]+", "found": False})
-        doc_items.append({"keyword": "author", "pattern": "[\w]+", "found": False})
+        doc_items.append({"keyword": "file", "pattern": fr"{os.path.basename(path)}$", "found": False})
+        doc_items.append({"keyword": "brief", "pattern": r"\w.* \w", "found": False})
+        doc_items.append({"keyword": "author", "pattern": r"[\w]+", "found": False})
         doc_prefix = "///"
         n_lines_copyright = 11
         last_doc_line = n_lines_copyright
@@ -510,6 +510,10 @@ class TestNameConstant(TestSpec):
         if constant_name.endswith("]") and "[" not in constant_name: # it's an array and we do not have the name before "[" here
             opens_brackets = ["[" in w for w in words]
             constant_name = words[opens_brackets.index(True)] # the name is in the first element with "["
+        if "[" in constant_name: # Remove brackets for arrays.
+            constant_name = constant_name[:constant_name.find("[")]
+        if "::" in constant_name: # Remove the class prefix for methods.
+            constant_name = constant_name.split("::")[-1]
         # The actual test comes here.
         if constant_name.startswith("k"): # exception for special constants
             constant_name = constant_name[1:] # test the name without "k"

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1411,7 +1411,7 @@ def main():
         tests.append(TestHfNameConfigurable())
 
     test_names = [t.name for t in tests]  # short names of activated tests
-    suffixes = tuple(set([s for test in tests for s in test.suffixes]))  # all suffixes from all enabled tests
+    suffixes = tuple({s for test in tests for s in test.suffixes})  # all suffixes from all enabled tests
     passed = True  # global result of all tests
 
     # Report overview before running.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -302,7 +302,7 @@ class TestStdPrefix(TestSpec):
 
 
 class TestROOT(TestSpec):
-    """Detect use of unnecessary ROOT entities."""
+    """Detect unnecessary use of ROOT entities."""
 
     name = "root-entity"
     message = "Consider replacing ROOT entities with STD C++ or O2 entities."
@@ -357,7 +357,7 @@ class TestTwoPiAddSubtract(TestSpec):
 
 
 class TestPiMultipleFraction(TestSpec):
-    """Detect multiplying/dividing of pi for existing equivalent constants."""
+    """Detect multiples/fractions of pi for existing equivalent constants."""
 
     name = "pi-multiple-fraction"
     message = "Consider using multiples/fractions of PI defined in o2::constants::math."

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1318,18 +1318,18 @@ class TestNameFileWorkflow(TestSpec):
         return False
 
 
-class TestHfNameConfigurable(TestSpec):
-    """PWGHF: Test names of configurables."""
+class TestNameConfigurable(TestSpec):
+    """Test names of configurables."""
 
-    name = "pwghf/name/configurable"
+    name = "name/configurable"
     message = (
         "Use lowerCamelCase for names of configurables and use the same name "
-        "for the struct member as for the JSON string."
+        "for the struct member as for the JSON string. (Declare the type and names on the same line.)"
     )
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
+        return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
@@ -1338,13 +1338,19 @@ class TestHfNameConfigurable(TestSpec):
             return True
         # Extract Configurable name.
         words = line.split()
-        if words[2] == "=":  # expecting Configurable... nameCpp = {"nameJson",
+        if len(words) < 2:
+            return False
+        if len(words) > 2 and words[2] == "=":  # expecting Configurable... nameCpp = {"nameJson",
             name_cpp = words[1]  # nameCpp
             name_json = words[3][1:]  # expecting "nameJson",
         else:
             names = words[1].split("{")  # expecting Configurable... nameCpp{"nameJson",
+            if len(names) < 2:
+                return False
             name_cpp = names[0]  # nameCpp
             name_json = names[1]  # expecting "nameJson",
+            if not name_json:
+                return False
         if name_json[0] != '"':  # JSON name is not a literal string.
             return True
         name_json = name_json.strip('",')  # expecting nameJson
@@ -1421,7 +1427,7 @@ def main():
         tests.append(TestHfStructMembers())
         tests.append(TestHfNameFileTask())
         tests.append(TestNameFileWorkflow())
-        tests.append(TestHfNameConfigurable())
+        tests.append(TestNameConfigurable())
 
     test_names = [t.name for t in tests]  # short names of activated tests
     suffixes = tuple({s for test in tests for s in test.suffixes})  # all suffixes from all enabled tests

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1458,6 +1458,9 @@ def main():
         else:
             print(f"\n{title_result}: {msg_result}")
             print(msg_disable)
+    # Print tips.
+    print("\nTip: You can run the O2 linter locally with: python3 Scripts/o2_linter.py <files>")
+    if not passed:
         sys.exit(1)
 
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1153,23 +1153,6 @@ class TestNameTask(TestSpec):
 # PWG-HF
 
 
-class TestHfConstAuto(TestSpec):
-    """PWGHF: Detect swapped const auto."""
-
-    name = "pwghf/const-auto"
-    message = 'Use "const auto" instead of "auto const".'
-    suffixes = [".h", ".cxx"]
-
-    def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path
-
-    def test_line(self, line: str) -> bool:
-        if is_comment_cpp(line):
-            return True
-        line = remove_comment_cpp(line)
-        return "auto const" not in line
-
-
 class TestHfNameStructClass(TestSpec):
     """PWGHF: Test names of structs and classes."""
 
@@ -1412,7 +1395,6 @@ def main():
     # PWG-HF
     enable_pwghf = True
     if enable_pwghf:
-        tests.append(TestHfConstAuto())
         tests.append(TestHfNameStructClass())
         tests.append(TestHfStructMembers())
         tests.append(TestHfNameFileWorkflow())

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1257,13 +1257,12 @@ class TestHfStructMembers(TestSpec):
         return passed
 
 
-class TestHfNameFileWorkflow(TestSpec):
-    """PWGHF: Test names of workflow files."""
+class TestHfNameFileWorkflowTask(TestSpec):
+    """PWGHF: Test names of task workflow files."""
 
-    name = "pwghf/name/workflow-file"
+    name = "pwghf/name/workflow-file-task"
     message = (
-        "Name of a workflow file must match the name of the main task in it. "
-        "See the PWGHF O2 naming conventions for details."
+        'Name of a PWGHF task workflow file must start with "task". '
     )
     suffixes = [".cxx"]
     per_line = False
@@ -1272,12 +1271,31 @@ class TestHfNameFileWorkflow(TestSpec):
         return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_file(self, path: str, content) -> bool:
-        file_name = os.path.basename(path).rstrip(".cxx")
-        if file_name[0].isupper():
-            return False
+        file_name = os.path.basename(path)
         if "/Tasks/" in path and not file_name.startswith("task"):
             return False
-        base_struct_name = f"Hf{file_name[0].upper()}{file_name[1:]}"  # expected base of struct names
+        return True
+
+
+class TestNameFileWorkflow(TestSpec):
+    """Test names of workflow files."""
+
+    name = "name/workflow-file"
+    message = (
+        "Name of a workflow file must match the name of the main task in it (without the PWG prefix). "
+        '(Class implementation files should be in "Core" directories.)'
+    )
+    suffixes = [".cxx"]
+    per_line = False
+
+    def file_matches(self, path: str) -> bool:
+        return TestSpec.file_matches(self, path) and "/Core/" not in path
+
+    def test_file(self, path: str, content) -> bool:
+        file_name = os.path.basename(path).rstrip(".cxx")
+        base_struct_name = f"{file_name[0].upper()}{file_name[1:]}"  # expected base of struct names
+        if "PWGHF/" in path:
+            base_struct_name = "Hf" + base_struct_name
         # print(f"For file {file_name} expecting to find {base_struct_name}.")
         struct_names = []  # actual struct names in the file
         for line in content:
@@ -1397,7 +1415,8 @@ def main():
     if enable_pwghf:
         tests.append(TestHfNameStructClass())
         tests.append(TestHfStructMembers())
-        tests.append(TestHfNameFileWorkflow())
+        tests.append(TestHfNameFileWorkflowTask())
+        tests.append(TestNameFileWorkflow())
         tests.append(TestHfNameConfigurable())
 
     test_names = [t.name for t in tests]  # short names of activated tests

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1434,9 +1434,10 @@ def main():
 
     # Report results per test.
     print("\nResults per test")
-    print("test\tissues\tbad files")
+    len_max = max(len(name) for name in test_names)
+    print(f"test{' ' * (len_max - len('test'))}\tissues\tbad files")
     for test in tests:
-        print(f"{test.name}\t{test.n_issues}\t{n_files_bad[test.name]}")
+        print(f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{n_files_bad[test.name]}")
 
     # Report global result.
     title_result = "O2 linter result"

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1259,10 +1259,10 @@ class TestHfStructMembers(TestSpec):
         return passed
 
 
-class TestHfNameFileWorkflowTask(TestSpec):
+class TestHfNameFileTask(TestSpec):
     """PWGHF: Test names of task workflow files."""
 
-    name = "pwghf/name/workflow-file-task"
+    name = "pwghf/name/task-file"
     message = (
         'Name of a PWGHF task workflow file must start with "task".'
     )
@@ -1419,7 +1419,7 @@ def main():
     if enable_pwghf:
         tests.append(TestHfNameStructClass())
         tests.append(TestHfStructMembers())
-        tests.append(TestHfNameFileWorkflowTask())
+        tests.append(TestHfNameFileTask())
         tests.append(TestNameFileWorkflow())
         tests.append(TestHfNameConfigurable())
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -492,8 +492,8 @@ class TestConstRefInSubscription(TestSpec):
         n_parens_opened = 0  # number of opened parentheses
         arguments = ""  # process function arguments
         line_process = 0  # line number of the process function
-        # Find names of all top-level process functions with switches.
-        names_functions = ["process"]
+        # Find names of all top-level process functions.
+        names_functions = ["process"]  # names of allowed process functions to test
         for i, line in enumerate(content):
             line = line.strip()
             if is_comment_cpp(line):
@@ -510,7 +510,7 @@ class TestConstRefInSubscription(TestSpec):
                     "Failed to get the process function name. Keep it on the same line as the switch.",
                 )
                 continue
-            names_functions.append(words[1][:-1])
+            names_functions.append(words[1][:-1])  # Remove the trailing comma.
             # print_error(path, i + 1, self.name, f"Got process function name {words[1][:-1]}.")
         # Test process functions.
         for i, line in enumerate(content):

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1403,29 +1403,29 @@ def main():
     # Bad practice
     enable_bad_practice = True
     if enable_bad_practice:
-        # tests.append(TestIOStream())
-        # tests.append(TestUsingStd())
-        # tests.append(TestUsingDirectives())
-        # tests.append(TestStdPrefix())
-        # tests.append(TestROOT())
-        # tests.append(TestPi())
-        # tests.append(TestTwoPiAddSubtract())
-        # tests.append(TestPiMultipleFraction())
-        # tests.append(TestPdgDatabase())
-        # tests.append(TestPdgCode())
-        # tests.append(TestPdgMass())
-        # tests.append(TestLogging())
-        # tests.append(TestConstRefInForLoop())
+        tests.append(TestIOStream())
+        tests.append(TestUsingStd())
+        tests.append(TestUsingDirectives())
+        tests.append(TestStdPrefix())
+        tests.append(TestROOT())
+        tests.append(TestPi())
+        tests.append(TestTwoPiAddSubtract())
+        tests.append(TestPiMultipleFraction())
+        tests.append(TestPdgDatabase())
+        tests.append(TestPdgCode())
+        tests.append(TestPdgMass())
+        tests.append(TestLogging())
+        tests.append(TestConstRefInForLoop())
         tests.append(TestConstRefInSubscription())
-        # tests.append(TestWorkflowOptions())
+        tests.append(TestWorkflowOptions())
 
     # Documentation
-    enable_documentation = False
+    enable_documentation = True
     if enable_documentation:
         tests.append(TestDocumentationFile())
 
     # Naming conventions
-    enable_naming = False
+    enable_naming = True
     if enable_naming:
         tests.append(TestNameFunctionVariable())
         tests.append(TestNameMacro())
@@ -1445,7 +1445,7 @@ def main():
         tests.append(TestNameConfigurable())
 
     # PWG-HF
-    enable_pwghf = False
+    enable_pwghf = True
     if enable_pwghf:
         tests.append(TestHfNameStructClass())
         tests.append(TestHfNameFileTask())

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1263,9 +1263,7 @@ class TestHfNameFileTask(TestSpec):
     """PWGHF: Test names of task workflow files."""
 
     name = "pwghf/name/task-file"
-    message = (
-        'Name of a PWGHF task workflow file must start with "task".'
-    )
+    message = ('Name of a PWGHF task workflow file must start with "task".')
     suffixes = [".cxx"]
     per_line = False
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -816,7 +816,7 @@ class TestNameTable(TestSpec):
             return True
         if not (match := re.match(r"DECLARE(_[A-Z]+)*_TABLES?(_[A-Z]+)*\(", line)):
             return True
-        # Extract names of the column type and getter.
+        # Extract names of the table type.
         line = remove_comment_cpp(line)
         line = line[len(match.group()) :].strip()  # Extract part after "(".
         if not (match := re.match(r"([^,\) ]+)", line)):
@@ -825,6 +825,11 @@ class TestNameTable(TestSpec):
         table_type_name = match.group(1)
         # print(f"Got \"{table_type_name}\"")
         # return True
+        # Check for a version suffix.
+        if match := re.match(r"(.*)_([0-9]{3})", line):
+            table_type_name = match.group(1)
+            # table_version = match.group(2)
+            # print(f"Got versioned table \"{table_type_name}\", version {table_version}")
         if table_type_name[0] == "_":  # probably a macro variable
             return True
         # The actual test comes here.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1212,7 +1212,7 @@ class TestHfStructMembers(TestSpec):
 
     def test_file(self, path: str, content) -> bool:
         passed = True
-        dic_struct: dict[str, dict] = {}
+        dic_structs: dict[str, dict] = {}
         struct_name = ""
         for i, line in enumerate(content):
             if is_comment_cpp(line):
@@ -1220,27 +1220,27 @@ class TestHfStructMembers(TestSpec):
             if line.startswith("struct "):  # expecting no indentation
                 line = remove_comment_cpp(line)
                 struct_name = line.strip().split()[1]
-                dic_struct[struct_name] = {}
+                dic_structs[struct_name] = {}
                 continue
             if not struct_name:
                 continue
             # Save line numbers of members of the current struct for each category.
             for member in self.member_order:
                 if line.startswith(f"  {member}"):  # expecting single-level indentation for direct members
-                    if member not in dic_struct[struct_name]:
-                        dic_struct[struct_name][member] = []
-                    dic_struct[struct_name][member].append(i + 1)  # save line number
+                    if member not in dic_structs[struct_name]:
+                        dic_structs[struct_name][member] = []
+                    dic_structs[struct_name][member].append(i + 1)  # save line number
                     break
         # print(dic_struct)
         # Detect members declared in a wrong order.
         last_line_last_member = 0  # line number of the last member of the previous member category
         index_last_member = 0  # index of the previous member category in the member_order list
-        for struct_name in dic_struct:
+        for struct_name, dic_struct in dic_structs.items():
             for i_m, member in enumerate(self.member_order):
-                if member not in dic_struct[struct_name]:
+                if member not in dic_struct:
                     continue
-                first_line = min(dic_struct[struct_name][member])  # line number of the first member of this category
-                last_line = max(dic_struct[struct_name][member])  # line number of the last member of this category
+                first_line = min(dic_struct[member])  # line number of the first member of this category
+                last_line = max(dic_struct[member])  # line number of the last member of this category
                 if (
                     first_line < last_line_last_member
                 ):  # The current category starts before the end of the previous category.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -311,7 +311,7 @@ class TestROOT(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "Macros/" not in path
+        return super().file_matches(path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = (
@@ -332,7 +332,7 @@ class TestPi(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "Macros/" not in path
+        return super().file_matches(path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = r"M_PI|TMath::(Two)?Pi"
@@ -390,7 +390,7 @@ class TestPdgDatabase(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "Macros/" not in path
+        return super().file_matches(path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
@@ -449,7 +449,7 @@ class TestLogging(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "Macros/" not in path
+        return super().file_matches(path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         pattern = r"^([Pp]rintf\(|(std::)?cout <)"
@@ -1164,7 +1164,7 @@ class TestNameFileWorkflow(TestSpec):
     per_line = False
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "/Core/" not in path
+        return super().file_matches(path) and "/Core/" not in path
 
     def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path).rstrip(".cxx")
@@ -1202,7 +1202,7 @@ class TestNameConfigurable(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "Macros/" not in path
+        return super().file_matches(path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
@@ -1242,7 +1242,7 @@ class TestHfNameStructClass(TestSpec):
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
+        return super().file_matches(path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
         if is_comment_cpp(line):
@@ -1270,7 +1270,7 @@ class TestHfNameFileTask(TestSpec):
     per_line = False
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path and "Macros/" not in path
+        return super().file_matches(path) and "PWGHF/" in path and "Macros/" not in path
 
     def test_file(self, path: str, content) -> bool:
         file_name = os.path.basename(path)
@@ -1309,7 +1309,7 @@ class TestHfStructMembers(TestSpec):
     ]
 
     def file_matches(self, path: str) -> bool:
-        return TestSpec.file_matches(self, path) and "PWGHF/" in path
+        return super().file_matches(path) and "PWGHF/" in path
 
     def test_file(self, path: str, content) -> bool:
         passed = True

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1428,7 +1428,7 @@ def main():
     print(f"Testing {len(args.paths)} files.")
     # print(args.paths)
     print("Enabled tests:", test_names)
-    print("Suffixes of tested files:", suffixes)
+    print("Suffixes of tested files:", sorted(suffixes))
     # print(f"Github annotations: {github_mode}.")
 
     # Test files.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -274,13 +274,12 @@ class TestStdPrefix(TestSpec):
         r"pow\(",
         r"min\(",
         r"max\(",
-        r"log\(",
+        r"log(2|10)?\(",
         r"exp\(",
-        r"sin\(",
-        r"cos\(",
-        r"tan\(",
-        r"atan\(",
+        r"a?(sin|cos|tan)h?\(",
         r"atan2\(",
+        r"erfc?\(",
+        r"hypot\(",
     ]
 
     def test_line(self, line: str) -> bool:

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1282,7 +1282,7 @@ class TestNameFileWorkflow(TestSpec):
 
     name = "name/workflow-file"
     message = (
-        "Name of a workflow file must match the name of the main task in it (without the PWG prefix). "
+        "Name of a workflow file must match the name of the main struct in it (without the PWG prefix). "
         '(Class implementation files should be in "Core" directories.)'
     )
     suffixes = [".cxx"]

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1264,7 +1264,7 @@ class TestHfNameFileWorkflowTask(TestSpec):
 
     name = "pwghf/name/workflow-file-task"
     message = (
-        'Name of a PWGHF task workflow file must start with "task". '
+        'Name of a PWGHF task workflow file must start with "task".'
     )
     suffixes = [".cxx"]
     per_line = False
@@ -1301,6 +1301,8 @@ class TestNameFileWorkflow(TestSpec):
         # print(f"For file {file_name} expecting to find {base_struct_name}.")
         struct_names = []  # actual struct names in the file
         for line in content:
+            if self.is_disabled(line):
+                return True
             if not line.startswith("struct "):
                 continue
             # Extract struct name.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -195,7 +195,8 @@ class TestSpec(ABC):
         # print(f"Running test {self.name} for {path} with {len(content)} lines")
         if self.per_line:
             for i, line in enumerate(content):
-                line = line.strip()
+                if not isinstance(self, TestUsingDirectives):  # Keep the indentation if needed.
+                    line = line.strip()
                 if not line:
                     continue
                 # print(i + 1, line)

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -308,14 +308,17 @@ class TestROOT(TestSpec):
     """Detect unnecessary use of ROOT entities."""
 
     name = "root-entity"
-    message = "Consider replacing ROOT entities with STD C++ or O2 entities."
+    message = "Consider replacing ROOT entities with equivalents from standard C++ or from O2."
     suffixes = [".h", ".cxx"]
 
     def file_matches(self, path: str) -> bool:
         return TestSpec.file_matches(self, path) and "Macros/" not in path
 
     def test_line(self, line: str) -> bool:
-        pattern = r"TMath|(U?(Int|Char|Short)|Double(32)?|Float(16)?|U?Long(64)?|Bool)_t"
+        pattern = (
+            r"TMath::(Abs|Sqrt|Power|Min|Max|Log(2|10)?|Exp|A?(Sin|Cos|Tan)H?|ATan2|Erfc?|Hypot)\(|"
+            r"(U?(Int|Char|Short)|Double(32)?|Float(16)?|U?Long(64)?|Bool)_t"
+        )
         if is_comment_cpp(line):
             return True
         line = remove_comment_cpp(line)

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -100,7 +100,7 @@ def print_error(path: str, line: Union[int, None], title: str, message: str):
     print(f"{path}:{str_line} {message} [{title}]")  # terminal format
     if github_mode:
         str_line = "" if line is None else f",line={line}"
-        print(f"::error file={path}{str_line},title=[{title}]::{message}")  # GitHub annotation format
+        print(f"::warning file={path}{str_line},title=[{title}]::{message}")  # GitHub annotation format
 
 
 def is_comment_cpp(line: str) -> bool:


### PR DESCRIPTION
Adds a GitHub action that runs a script that checks for O2-specific issues in the code.
The script can run standalone, taking paths of files as arguments.
When running in the GitHub action on the pull_request event, the script tests files modified by the PR and generates error messages as GitHub annotations which appear as comments on the relevant lines or at the top of the file in case of per-file tests.
When running in the GitHub action on the push event, the script tests files modified in the branch w.r.t. the main branch and does not produce annotations.
False positives should be rare but, if any, they can be silenced per line for most of the tests by adding a comment in a given format.

Implements the following tests.

Bad practice:

- included `iostream`
- importing names from the `std` namespace
- using directives in headers
- missing `std::` prefix for common names from the `std` namespace
- unnecessary use of ROOT entities
- use of external pi
- adding/subtracting of 2 pi
- multiples/fractions of pi for existing equivalent constants
- use of `TDatabasePDG`
- use of hard-coded PDG codes
- unnecessary call of `Mass()` for a known PDG code
- non-O2 logging
- not using const refs in range-based `for` loops
- not using const refs in `process` function subscriptions
- usage of workflow options in `defineDataProcessing`

Documentation:

- mandatory documentation of C++ files

Naming conventions:

- functions
- variables
- macros
- `constexpr` constants
- namespaces
- defined types
- enumerators
- classes
- structs
- O2 columns
- O2 tables
- O2 workflows
- explicit task names
- workflow files
- configurables
- C++ files
- Python files

PWG-HF specific conventions:

- PWGHF: names of structs and classes
- PWGHF: names of task files
- PWGHF: order of struct members
