### PR TITLE
PWGCF: Fix in FemtoDream

### DIFF
--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -49,30 +49,32 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// General options
   struct : ConfigurableGroup {
-    Configurable<bool> IsMC{"Option.IsMC", false, "Enable additional Histogramms in the case of runninger over Monte Carlo"};
-    Configurable<bool> Use4D{"Option.Use4D", false, "Enable four dimensional histogramms (to be used only for analysis with high statistics): k* vs multiplicity vs multiplicity percentil vs mT"};
-    Configurable<bool> ExtendedPlots{"Option.ExtendedPlots", false, "Enable additional three dimensional histogramms. High memory consumption. Use for debugging"};
-    Configurable<float> HighkstarCut{"Option.HighkstarCut", -1., "Set a cut for high k*, above which the pairs are rejected. Set it to -1 to deactivate it"};
-    Configurable<bool> SameSpecies{"Option.SameSpecies", false, "Set to true if particle 1 and particle 2 are the same species"};
-    Configurable<bool> MixEventWithPairs{"Option.MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
-    Configurable<bool> RandomizePair{"Option.RandomizePair", true, "Randomly mix particle 1 and particle 2 in case both are identical"};
-    Configurable<bool> CPROn{"Option.CPROn", true, "Close Pair Rejection"};
-    Configurable<bool> CPROld{"Option.CPROld", false, "Set to FALSE to use fixed version of CPR (for testing now, will be default soon)"};
-    Configurable<bool> CPRSepMeSe{"Option.CPRSepMESE", true, "Use seperated plots for same and mixed event for CPR plots"};
-    Configurable<bool> CPRPlotPerRadii{"Option.CPRPlotPerRadii", false, "Plot CPR per radii"};
-    Configurable<float> CPRdeltaPhiMax{"Option.CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
-    Configurable<float> CPRdeltaEtaMax{"Option.CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
-    Configurable<bool> DCACutPtDep{"Option.DCACutPtDep", false, "Use pt dependent dca cut"};
-    ConfigurableAxis Dummy{"Option.Dummy", {1, 0, 1}, "Dummy axis"};
-    Configurable<bool> SmearingByOrigin{"Option.SmearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption"};
+    std::string prefix = std::string("Option");
+    Configurable<bool> IsMC{"IsMC", false, "Enable additional Histogramms in the case of runninger over Monte Carlo"};
+    Configurable<bool> Use4D{"Use4D", false, "Enable four dimensional histogramms (to be used only for analysis with high statistics): k* vs multiplicity vs multiplicity percentil vs mT"};
+    Configurable<bool> ExtendedPlots{"ExtendedPlots", false, "Enable additional three dimensional histogramms. High memory consumption. Use for debugging"};
+    Configurable<float> HighkstarCut{"HighkstarCut", -1., "Set a cut for high k*, above which the pairs are rejected. Set it to -1 to deactivate it"};
+    Configurable<bool> SameSpecies{"SameSpecies", false, "Set to true if particle 1 and particle 2 are the same species"};
+    Configurable<bool> MixEventWithPairs{"MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
+    Configurable<bool> RandomizePair{"RandomizePair", true, "Randomly mix particle 1 and particle 2 in case both are identical"};
+    Configurable<bool> CPROn{"CPROn", true, "Close Pair Rejection"};
+    Configurable<bool> CPROld{"CPROld", false, "Set to FALSE to use fixed version of CPR (for testing now, will be default soon)"};
+    Configurable<bool> CPRSepMeSe{"CPRSepMESE", true, "Use seperated plots for same and mixed event for CPR plots"};
+    Configurable<bool> CPRPlotPerRadii{"CPRPlotPerRadii", false, "Plot CPR per radii"};
+    Configurable<float> CPRdeltaPhiMax{"CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+    Configurable<float> CPRdeltaEtaMax{"CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+    Configurable<bool> DCACutPtDep{"DCACutPtDep", false, "Use pt dependent dca cut"};
+    Configurable<bool> SmearingByOrigin{"SmearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption"};
+    ConfigurableAxis Dummy{"Dummy", {1, 0, 1}, "Dummy axis"};
   } Option;
 
   /// Event selection
   struct : ConfigurableGroup {
-    Configurable<int> MultMin{"EventSel.MultMin", 0, "Minimum Multiplicity (MultNtr)"};
-    Configurable<int> MultMax{"EventSel.MultMax", 99999, "Maximum Multiplicity (MultNtr)"};
-    Configurable<float> MultPercentileMin{"EventSel.MultPercentileMin", 0, "Maximum Multiplicity Percentile"};
-    Configurable<float> MultPercentileMax{"EventSel.MultPercentileMax", 100, "Minimum Multiplicity Percentile"};
+    std::string prefix = std::string("EventSel");
+    Configurable<int> MultMin{"MultMin", 0, "Minimum Multiplicity (MultNtr)"};
+    Configurable<int> MultMax{"MultMax", 99999, "Maximum Multiplicity (MultNtr)"};
+    Configurable<float> MultPercentileMin{"MultPercentileMin", 0, "Maximum Multiplicity Percentile"};
+    Configurable<float> MultPercentileMax{"MultPercentileMax", 100, "Minimum Multiplicity Percentile"};
   } EventSel;
 
   Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
@@ -92,18 +94,19 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// Track 1
   struct : ConfigurableGroup {
-    Configurable<int> PDGCode{"Track1.PDGCode", 2212, "PDG code of particle 1 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"Track1.CutBit", 3191978, "Selection bit from cutCulator for particle 1 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit{"Track1.TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"Track1.TPCBit_Reject", 0, "PID TPC bit from cutCulator to reject a particle hypothesis for particle 1 (set to 0 to ignore)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"Track1.TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
-    Configurable<float> PIDThres{"Track1.PIDThres", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
-    Configurable<float> PtMin{"Track1.PtMin", 0., "Minimum pT of partricle 1 (Track)"};
-    Configurable<float> PtMax{"Track1.PtMax", 999., "Maximum pT of partricle 1 (Track)"};
-    Configurable<float> EtaMin{"Track1.EtaMin", -10., "Minimum eta of partricle 1 (Track)"};
-    Configurable<float> EtaMax{"Track1.EtaMax", 10., "Maximum eta of partricle 1 (Track)"};
-    Configurable<float> TempFitVarMin{"Track1.TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
-    Configurable<float> TempFitVarMax{"Track1.TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
+    std::string prefix = std::string("Track1");
+    Configurable<int> PDGCode{"PDGCode", 2212, "PDG code of particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 3191978, "Selection bit from cutCulator for particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit{"TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"TPCBit_Reject", 0, "PID TPC bit from cutCulator to reject a particle hypothesis for particle 1 (set to 0 to ignore)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
+    Configurable<float> PIDThres{"PIDThres", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of partricle 1 (Track)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of partricle 1 (Track)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of partricle 1 (Track)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMin{"TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMax{"TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
   } Track1;
 
   /// Partition for particle 1
@@ -136,18 +139,19 @@ struct femtoDreamPairTaskTrackTrack {
 
   /// Track 2
   struct : ConfigurableGroup {
-    Configurable<int> PDGCode{"Track2.PDGCode", 2212, "PDG code of particle 2 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"Track2.CutBit", 3191978, "Selection bit from cutCulator for particle 2 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit{"Track2.TPCBit", 4, "PID TPC bit from cutCulator for particle 2 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"Track2.TPCBit_Reject", 0, "PID TPC bit from cutCulator to reject a particle hypothesis for particle 2 (set to 0 to ignore)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"Track2.TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 2 (Track)"};
-    Configurable<float> PIDThres{"Track2.PIDThres", 0.75, "Momentum threshold for PID selection for particle 2 (Track)"};
-    Configurable<float> PtMin{"Track2.PtMin", 0., "Minimum pT of particle 2 (Track)"};
-    Configurable<float> PtMax{"Track2.PtMax", 999., "Maximum pT of particle 2 (Track)"};
-    Configurable<float> EtaMin{"Track2.EtaMin", -10., "Minimum eta of particle 2 (Track)"};
-    Configurable<float> EtaMax{"Track2.EtaMax", 10., "Maximum eta of particle 2 (Track)"};
-    Configurable<float> TempFitVarMin{"Track2.TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
-    Configurable<float> TempFitVarMax{"Track2.TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
+    std::string prefix = std::string("Track2");
+    Configurable<int> PDGCode{"PDGCode", 2212, "PDG code of particle 2 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 3191978, "Selection bit from cutCulator for particle 2 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit{"TPCBit", 4, "PID TPC bit from cutCulator for particle 2 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"TPCBit_Reject", 0, "PID TPC bit from cutCulator to reject a particle hypothesis for particle 2 (set to 0 to ignore)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 2 (Track)"};
+    Configurable<float> PIDThres{"PIDThres", 0.75, "Momentum threshold for PID selection for particle 2 (Track)"};
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of particle 2 (Track)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of particle 2 (Track)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of particle 2 (Track)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of particle 2 (Track)"};
+    Configurable<float> TempFitVarMin{"TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMax{"TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
   } Track2;
 
   /// Partition for track 2
@@ -221,8 +225,7 @@ struct femtoDreamPairTaskTrackTrack {
   FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kTrack> pairCloseRejectionSE;
   FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kTrack> pairCloseRejectionME;
   /// Histogram output
-  HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry Registry{"Output", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   TRandom3* random;
 
@@ -231,19 +234,19 @@ struct femtoDreamPairTaskTrackTrack {
     if (Option.RandomizePair.value) {
       random = new TRandom3(0);
     }
-    eventHisto.init(&qaRegistry, Option.IsMC);
-    trackHistoPartOne.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
+    eventHisto.init(&Registry, Option.IsMC);
+    trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
     if (!Option.SameSpecies) {
-      trackHistoPartTwo.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track2.PDGCode);
+      trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.TrackpT, Option.Dummy, Option.Dummy, Binning.TempFitVar, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track2.PDGCode);
     }
 
-    sameEventCont.init(&resultRegistry,
+    sameEventCont.init(&Registry,
                        Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.MultMixBins, Mixing.MultPercentileMixBins,
                        Binning4D.kstar, Binning4D.mT, Binning4D.mult, Binning4D.multPercentile,
                        Option.IsMC, Option.Use4D, Option.ExtendedPlots,
                        Option.HighkstarCut,
                        Option.SmearingByOrigin);
-    mixedEventCont.init(&resultRegistry,
+    mixedEventCont.init(&Registry,
                         Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.MultMixBins, Mixing.MultPercentileMixBins,
                         Binning4D.kstar, Binning4D.mT, Binning4D.mult, Binning4D.multPercentile,
                         Option.IsMC, Option.Use4D, Option.ExtendedPlots,
@@ -251,10 +254,10 @@ struct femtoDreamPairTaskTrackTrack {
                         Option.SmearingByOrigin);
     sameEventCont.setPDGCodes(Track1.PDGCode, Track2.PDGCode);
     mixedEventCont.setPDGCodes(Track1.PDGCode, Track2.PDGCode);
-    pairCleaner.init(&qaRegistry);
+    pairCleaner.init(&Registry);
     if (Option.CPROn.value) {
-      pairCloseRejectionSE.init(&resultRegistry, &qaRegistry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
-      pairCloseRejectionME.init(&resultRegistry, &qaRegistry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value);
+      pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
+      pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value);
     }
 
     // get bit for the collision mask

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -22,7 +22,6 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/Expressions.h"
-#include "Framework/StepTHn.h"
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h"
@@ -45,152 +44,172 @@ struct femtoDreamPairTaskTrackV0 {
 
   /// General options
   struct : ConfigurableGroup {
-    Configurable<bool> IsMC{"Option.IsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
-    Configurable<bool> Use4D{"Option.Use4D", false, "Enable four dimensional histogramms (to be used only for analysis with high statistics): k* vs multiplicity vs multiplicity percentil vs mT"};
-    Configurable<bool> ExtendedPlots{"Option.ExtendedPlots", false, "Enable additional three dimensional histogramms. High memory consumption. Use for debugging"};
-    Configurable<float> HighkstarCut{"Option.HighkstarCut", -1., "Set a cut for high k*, above which the pairs are rejected. Set it to -1 to deactivate it"};
-    Configurable<bool> CPROn{"Option.CPROn", true, "Close Pair Rejection"};
-    Configurable<bool> CPROld{"Option.CPROld", false, "Set to FALSE to use fixed version of CPR (for testing now, will be default soon)"};
-    Configurable<bool> CPRPlotPerRadii{"Option.CPRPlotPerRadii", false, "Plot CPR per radii"};
-    Configurable<float> CPRdeltaPhiMax{"Option.CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
-    Configurable<float> CPRdeltaEtaMax{"Option.CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
-    Configurable<bool> DCACutPtDep{"Option.DCACutPtDep", false, "Use pt dependent dca cut"};
-    Configurable<bool> MixEventWithPairs{"Option.MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
-    Configurable<bool> smearingByOrigin{"Option.smearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption. Use with care!"};
-    ConfigurableAxis Dummy{"Option.Dummy", {1, 0, 1}, "Dummy axis"};
+    std::string prefix = std::string("Option");
+    Configurable<bool> IsMC{"IsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+    Configurable<bool> Use4D{"Use4D", false, "Enable four dimensional histogramms (to be used only for analysis with high statistics): k* vs multiplicity vs multiplicity percentil vs mT"};
+    Configurable<bool> ExtendedPlots{"ExtendedPlots", false, "Enable additional three dimensional histogramms. High memory consumption. Use for debugging"};
+    Configurable<float> HighkstarCut{"HighkstarCut", -1., "Set a cut for high k*, above which the pairs are rejected. Set it to -1 to deactivate it"};
+    Configurable<bool> CPROn{"CPROn", true, "Close Pair Rejection"};
+    Configurable<bool> CPROld{"CPROld", false, "Set to FALSE to use fixed version of CPR (for testing now, will be default soon)"};
+    Configurable<bool> CPRPlotPerRadii{"CPRPlotPerRadii", false, "Plot CPR per radii"};
+    Configurable<float> CPRdeltaPhiMax{"CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+    Configurable<float> CPRdeltaEtaMax{"CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+    Configurable<bool> DCACutPtDep{"DCACutPtDep", false, "Use pt dependent dca cut"};
+    Configurable<bool> MixEventWithPairs{"MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
+    Configurable<bool> smearingByOrigin{"smearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption. Use with care!"};
+    ConfigurableAxis Dummy{"Dummy", {1, 0, 1}, "Dummy axis"};
   } Option;
 
   /// Event selection
   struct : ConfigurableGroup {
-    Configurable<int> MultMin{"EventSel.MultMin", 0, "Minimum Multiplicity (MultNtr)"};
-    Configurable<int> MultMax{"EventSel.MultMax", 99999, "Maximum Multiplicity (MultNtr)"};
-    Configurable<float> MultPercentileMin{"EventSel.MultPercentileMin", 0, "Minimum Multiplicity Percentile"};
-    Configurable<float> MultPercentileMax{"EventSel.MultPercentileMax", 100, "Maximum Multiplicity Percentile"};
+    std::string prefix = std::string("EventSel");
+    Configurable<int> MultMin{"MultMin", 0, "Minimum Multiplicity (MultNtr)"};
+    Configurable<int> MultMax{"MultMax", 99999, "Maximum Multiplicity (MultNtr)"};
+    Configurable<float> MultPercentileMin{"MultPercentileMin", 0, "Minimum Multiplicity Percentile"};
+    Configurable<float> MultPercentileMax{"MultPercentileMax", 100, "Maximum Multiplicity Percentile"};
   } EventSel;
 
   Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
   Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
+
+  /// Histogramming for Event
+  FemtoDreamEventHisto eventHisto;
 
   using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
   using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
   using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
   using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
 
+  using FDMCParts = soa::Join<aod::FDParticles, aod::FDMCLabels>;
+  using FDMCPart = FDMCParts::iterator;
+
   femtodreamcollision::BitMaskType BitMask = 1;
 
   /// Particle 1 (track)
   struct : ConfigurableGroup {
-    Configurable<int> PDGCode{"Track1.PDGCode", 2212, "PDG code of Particle 1 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"Track1.CutBit", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit{"Track1.TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
-    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"Track1.TPCBit_Reject", 0, "Reject PID TPC bit from cutCulator for particle 1 (Track). Set to 0 to turn off"};
-    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"Track1.TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
-    Configurable<float> PIDThres{"Track1.PIDThres", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
-    Configurable<float> PtMin{"Track1.PtMin", 0., "Minimum pT of partricle 1 (Track)"};
-    Configurable<float> PtMax{"Track1.PtMax", 999., "Maximum pT of partricle 1 (Track)"};
-    Configurable<float> EtaMin{"Track1.EtaMin", -10., "Minimum eta of partricle 1 (Track)"};
-    Configurable<float> EtaMax{"Track1.EtaMax", 10., "Maximum eta of partricle 1 (Track)"};
-    Configurable<float> TempFitVarMin{"Track1.TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
-    Configurable<float> TempFitVarMax{"Track1.TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
+    std::string prefix = std::string("Track1");
+    Configurable<int> PDGCode{"PDGCode", 2212, "PDG code of Particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit{"TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"TPCBit_Reject", 0, "Reject PID TPC bit from cutCulator for particle 1 (Track). Set to 0 to turn off"};
+    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
+    Configurable<float> PIDThres{"PIDThres", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of partricle 1 (Track)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of partricle 1 (Track)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of partricle 1 (Track)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMin{"TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMax{"TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
   } Track1;
 
-  Filter trackPtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt > Track1.PtMin, true);
-  Filter trackPtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::pt < Track1.PtMax, true);
-  Filter trackEtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta > Track1.EtaMin, true);
-  Filter trackEtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::eta < Track1.EtaMax, true);
-  Filter trackTempFitVarFilterUp = !Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar > Track1.TempFitVarMin, true);
-  Filter trackTempFitVarFilterLow = !Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), aod::femtodreamparticle::tempFitVar < Track1.TempFitVarMax, true);
-  Filter trackTempFitVarFilterPtDep = Option.DCACutPtDep && ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack), nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f)), true);
+  /// Partition for particle 1
+  Partition<FDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                         (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+                                         ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+                                         (aod::femtodreamparticle::pt > Track1.PtMin) &&
+                                         (aod::femtodreamparticle::pt < Track1.PtMax) &&
+                                         (aod::femtodreamparticle::eta > Track1.EtaMin) &&
+                                         (aod::femtodreamparticle::eta < Track1.EtaMax) &&
+                                         ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+                                                ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+                                                 (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
+
+  Partition<FDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                         (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+                                         ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+                                         (aod::femtodreamparticle::pt > Track1.PtMin) &&
+                                         (aod::femtodreamparticle::pt < Track1.PtMax) &&
+                                         (aod::femtodreamparticle::eta > Track1.EtaMin) &&
+                                         (aod::femtodreamparticle::eta < Track1.EtaMax) &&
+                                         ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+                                                ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+                                                 (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
 
   /// Particle 2 (V0)
   struct : ConfigurableGroup {
-    Configurable<int> PDGCode{"V02.PDGCode", 3122, "PDG code of particle 2 (V0)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"V02.CutBit", 338, "Selection bit for particle 2 (V0)"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"V02.ChildPos_CutBit", 149, "Selection bit for positive child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"V02.ChildPos_TPCBit", 2, "PID TPC bit for positive child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"V02.ChildNeg_CutBit", 149, "Selection bit for negative child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"V02.ChildNeg_TPCBit", 2, "PID TPC bit for negative child of V0"};
+    std::string prefix = std::string("V02");
+    Configurable<int> PDGCode{"PDGCode", 3122, "PDG code of particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 338, "Selection bit for particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 149, "Selection bit for positive child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 2, "PID TPC bit for positive child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 149, "Selection bit for negative child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 2, "PID TPC bit for negative child of V0"};
 
-    Configurable<float> InvMassMin{"V02.InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
-    Configurable<float> InvMassMax{"V02.InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
-    Configurable<float> InvMassAntiMin{"V02.InvMassAntiMin", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
-    Configurable<float> InvMassAntiMax{"V02.InvMassAntiMax", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
+    Configurable<float> InvMassMin{"InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
+    Configurable<float> InvMassMax{"InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
+    Configurable<float> InvMassAntiMin{"InvMassAntiMin", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
+    Configurable<float> InvMassAntiMax{"InvMassAntiMax", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
 
-    Configurable<float> PtMin{"V02.PtMin", 0., "Minimum pT of Partricle 2 (V0)"};
-    Configurable<float> PtMax{"V02.PtMax", 999., "Maximum pT of Partricle 2 (V0)"};
-    Configurable<float> EtaMin{"V02.EtaMin", -10., "Minimum eta of Partricle 2 (V0)"};
-    Configurable<float> EtaMax{"V02.EtaMax", 10., "Maximum eta of Partricle 2 (V0)"};
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of Partricle 2 (V0)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of Partricle 2 (V0)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of Partricle 2 (V0)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of Partricle 2 (V0)"};
   } V02;
 
-  Filter v0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda > V02.InvMassMin, true);
-  Filter v0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mLambda < V02.InvMassMax, true);
-  Filter antiv0MassFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin, true);
-  Filter antiv0MassFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax, true);
+  /// Partition for particle 2
+  Partition<FDParticles> PartitionV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
+                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
+                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
+                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
+                                        (aod::femtodreamparticle::eta > V02.EtaMin) &&
+                                        (aod::femtodreamparticle::eta < V02.EtaMax) &&
+                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
+                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
+                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
+                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
 
-  Filter v0PtFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt > V02.PtMin, true);
-  Filter v0PtFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::pt < V02.PtMax, true);
-  Filter v0EtaFilterUp = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta > V02.EtaMin, true);
-  Filter v0EtaFilterLow = ifnode(aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0), aod::femtodreamparticle::eta < V02.EtaMax, true);
+  Partition<FDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
+                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
+                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
+                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
+                                        (aod::femtodreamparticle::eta > V02.EtaMax) &&
+                                        (aod::femtodreamparticle::eta < V02.EtaMin) &&
+                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
+                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
+                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
+                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
 
   /// Histogramming for particle 2
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
 
-  using FilteredFDParticles = soa::Filtered<aod::FDParticles>;
-  using FilteredFDParticle = FilteredFDParticles::iterator;
-
-  using FilteredFDMCParts = soa::Filtered<soa::Join<aod::FDParticles, aod::FDMCLabels>>;
-  using FilteredFDMCPart = FilteredFDMCParts::iterator;
-
-  /// Partition for particle 1
-  Partition<FilteredFDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                 (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
-                                                 ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit));
-  Partition<FilteredFDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                                 (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
-                                                 ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit));
-
-  /// Partition for particle 2
-  Partition<FilteredFDParticles> PartitionV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit);
-  Partition<FilteredFDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) && ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit);
-
-  /// Histogramming for Event
-  FemtoDreamEventHisto eventHisto;
-
   /// Binning configurables
   struct : ConfigurableGroup {
-    ConfigurableAxis TempFitVarTrack{"Binning.TempFitVarTrack", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Track)"};
-    ConfigurableAxis TempFitVarV0{"Binning.TempFitVarV0", {300, 0.9, 1}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0)"};
-    ConfigurableAxis TempFitVarV0Child{"Binning.TempFitVarV0Child", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0 child)"};
-    ConfigurableAxis InvMass{"Binning.InvMass", {200, 1, 1.2}, "InvMass binning"};
-    ConfigurableAxis pTTrack{"Binning.pTTrack", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Track)"};
-    ConfigurableAxis pTV0{"Binning.pTV0", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
-    ConfigurableAxis pTV0Child{"Binning.pTV0Child", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
-    ConfigurableAxis pT{"Binning.pT", {20, 0.5, 4.05}, "pT binning"};
-    ConfigurableAxis kstar{"Binning.kstar", {1500, 0., 6.}, "binning kstar"};
-    ConfigurableAxis kT{"Binning.kT", {150, 0., 9.}, "binning kT"};
-    ConfigurableAxis mT{"Binning.mT", {225, 0., 7.5}, "binning mT"};
-    ConfigurableAxis multTempFit{"Binning.multTempFit", {1, 0, 1}, "multiplicity Binning for the TempFitVar plot"};
+    std::string prefix = std::string("Binning");
+    ConfigurableAxis TempFitVarTrack{"TempFitVarTrack", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Track)"};
+    ConfigurableAxis TempFitVarV0{"TempFitVarV0", {300, 0.9, 1}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis TempFitVarV0Child{"TempFitVarV0Child", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0 child)"};
+    ConfigurableAxis InvMass{"InvMass", {200, 1, 1.2}, "InvMass binning"};
+    ConfigurableAxis pTTrack{"pTTrack", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Track)"};
+    ConfigurableAxis pTV0{"pTV0", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis pTV0Child{"pTV0Child", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis pT{"pT", {20, 0.5, 4.05}, "pT binning"};
+    ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar"};
+    ConfigurableAxis kT{"kT", {150, 0., 9.}, "binning kT"};
+    ConfigurableAxis mT{"mT", {225, 0., 7.5}, "binning mT"};
+    ConfigurableAxis multTempFit{"multTempFit", {1, 0, 1}, "multiplicity for the TempFitVar plot"};
   } Binning;
 
   struct : ConfigurableGroup {
-    ConfigurableAxis kstar{"Binning4D.kstar", {1500, 0., 6.}, "binning kstar for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
-    ConfigurableAxis mT{"Binning4D.mT", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
-    ConfigurableAxis Mult{"Binning4D.mult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
-    ConfigurableAxis multPercentile{"Binning4D.multPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    std::string prefix = std::string("Binning4D");
+    ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis mT{"mT", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis Mult{"mult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis multPercentile{"multPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
   } Binning4D;
 
   // Mixing configurables
   struct : ConfigurableGroup {
-    ConfigurableAxis BinMult{"Mixing.BinMult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "Mixing bins - multiplicity"};
-    ConfigurableAxis BinMultPercentile{"Mixing.BinMultPercentile", {VARIABLE_WIDTH, 0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.f}, "Mixing bins - multiplicity percentile"};
-    ConfigurableAxis BinVztx{"Mixing.BinVztx", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
-    Configurable<int> Depth{"Mixing.Depth", 5, "Number of events for mixing"};
-    Configurable<int> Policy{"Mixing.BinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
+    std::string prefix = std::string("Mixing");
+    ConfigurableAxis BinMult{"BinMult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "bins - multiplicity"};
+    ConfigurableAxis BinMultPercentile{"BinMultPercentile", {VARIABLE_WIDTH, 0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.f}, "bins - multiplicity percentile"};
+    ConfigurableAxis BinVztx{"BinVztx", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "bins - z-vertex"};
+    Configurable<int> Depth{"Depth", 5, "Number of events for mixing"};
+    Configurable<int> Policy{"BinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
   } Mixing;
 
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinningMult{{Mixing.BinVztx, Mixing.BinMult}, true};
@@ -204,21 +223,17 @@ struct femtoDreamPairTaskTrackV0 {
   FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCloseRejectionME;
 
   /// Histogram output
-  HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry Registry{"Output", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext& context)
   {
-    eventHisto.init(&qaRegistry, Option.IsMC);
-    // void init(HistogramRegistry* registry,
-    //    T& MomentumBins, T& tempFitVarBins, T& NsigmaTPCBins, T& NsigmaTOFBins, T& NsigmaTPCTOFBins, T& InvMassBins,
-    //    bool isMC, int pdgCode, bool isDebug = false)
-    trackHistoPartOne.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
-    trackHistoPartTwo.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, V02.PDGCode);
-    posChildHistos.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
-    negChildHistos.init(&qaRegistry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    eventHisto.init(&Registry, Option.IsMC);
+    trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
+    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, V02.PDGCode);
+    posChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    negChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
 
-    sameEventCont.init(&resultRegistry,
+    sameEventCont.init(&Registry,
                        Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                        Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
                        Option.IsMC, Option.Use4D, Option.ExtendedPlots,
@@ -226,7 +241,7 @@ struct femtoDreamPairTaskTrackV0 {
                        Option.smearingByOrigin);
 
     sameEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
-    mixedEventCont.init(&resultRegistry,
+    mixedEventCont.init(&Registry,
                         Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                         Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
                         Option.IsMC, Option.Use4D, Option.ExtendedPlots,
@@ -234,10 +249,10 @@ struct femtoDreamPairTaskTrackV0 {
                         Option.smearingByOrigin);
 
     mixedEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
-    pairCleaner.init(&qaRegistry);
+    pairCleaner.init(&Registry);
     if (Option.CPROn.value) {
-      pairCloseRejectionSE.init(&resultRegistry, &qaRegistry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
-      pairCloseRejectionME.init(&resultRegistry, &qaRegistry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 8, true);
+      pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
+      pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 99, true);
     }
 
     // get bit for the collision mask
@@ -331,7 +346,7 @@ struct femtoDreamPairTaskTrackV0 {
     }
   }
 
-  void processSameEventMasked(FilteredMaskedCollision const& col, FilteredFDParticles const& parts)
+  void processSameEventMasked(FilteredMaskedCollision const& col, FDParticles const& parts)
   {
     if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
@@ -343,7 +358,7 @@ struct femtoDreamPairTaskTrackV0 {
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", true);
 
-  void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
+  void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
   {
     if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
@@ -433,7 +448,7 @@ struct femtoDreamPairTaskTrackV0 {
     }
   }
 
-  void processMixedEventMasked(FilteredMaskedCollisions const& cols, FilteredFDParticles const& parts)
+  void processMixedEventMasked(FilteredMaskedCollisions const& cols, FDParticles const& parts)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:
@@ -451,7 +466,7 @@ struct femtoDreamPairTaskTrackV0 {
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMasked, "Enable processing mixed events with masks", true);
 
-  void processMixedEventMCMasked(FilteredMaskedMCCollisions const& cols, o2::aod::FDMCCollisions&, FilteredFDMCParts const& parts, o2::aod::FDMCParticles const&)
+  void processMixedEventMCMasked(FilteredMaskedMCCollisions const& cols, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:


### PR DESCRIPTION
This PR addresses two fixes
- Remove filters used in pair-track-V0 task. When using filters, we encountered problems with applying deta-dphi cut. Applying selections of V0 and tracks separately with partitions has fixed the issue. 
- Use the new feature of configurable groups by declaring the prefix only once (in track-track and track-v0 task)