### PR TITLE
Common/Core: add check in getCharmHadronOrigin to reject in case of first mother parton

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -935,6 +935,16 @@ struct RecoDecay {
       for (auto& iPart : arrayIds[-stage]) { // check all the particles that were the mothers at the previous stage
         auto particleMother = particlesMC.rawIteratorAt(iPart - particlesMC.offset());
         if (particleMother.has_mothers()) {
+
+          // we exit immediately if searchUpToQuark is false and the first mother is a parton (an hadron should never be the mother of a parton)
+          if (!searchUpToQuark) {
+            auto mother = particlesMC.rawIteratorAt(particleMother.mothersIds().front() - particlesMC.offset());
+            auto PDGParticleIMother = std::abs(mother.pdgCode()); // PDG code of the mother
+            if (PDGParticleIMother < 9 || (PDGParticleIMother > 20 && PDGParticleIMother < 38)) {
+              return OriginType::Prompt;
+            }
+          }
+
           for (auto iMother = particleMother.mothersIds().front(); iMother <= particleMother.mothersIds().back(); ++iMother) { // loop over the mother particles of the analysed particle
             if (std::find(arrayIdsStage.begin(), arrayIdsStage.end(), iMother) != arrayIdsStage.end()) {                       // if a mother is still present in the vector, do not check it again
               continue;


### PR DESCRIPTION
This PR adds a check in `RecoDecay::getCharmHadronOrigin` that returns immediately if a parton is found as first mother in case of `searchUpToQuark == false`. In fact, no beauty hadron can decay to a parton, so if a parton is found as mother it means that the charm hadron doesn't come from a beauty-hadron decay. If it comes from a beauty-hadron decays in fact, the function will return before finding the first parton mother.

This is very important for the analysis of Pb-Pb MCs, since the analysis code is very slow otherwise.