### PR TITLE
[DPG] Fix filled efficiency

### DIFF
--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -1301,8 +1301,8 @@ struct QaEfficiency {
     if (!doPtRadius) {
       return;
     }
-    fillEfficiency2D("ITS-TPC_vsPt_vsRadius", hPtRadiusItsTpc[histogramIndex], hPtGenerated[histogramIndex]);
-    fillEfficiency2D("ITS-TPC-TOF_vsPt_vsRadius", hPtRadiusItsTpcTof[histogramIndex], hPtGenerated[histogramIndex]);
+    fillEfficiency2D("ITS-TPC_vsPt_vsRadius", hPtRadiusItsTpc[histogramIndex], hPtRadiusGenerated[histogramIndex]);
+    fillEfficiency2D("ITS-TPC-TOF_vsPt_vsRadius", hPtRadiusItsTpcTof[histogramIndex], hPtRadiusGenerated[histogramIndex]);
   }
   template <bool doFillHistograms, typename CollType>
   bool isCollisionSelected(const CollType& collision)


### PR DESCRIPTION
By Mistake added the` hPtGenerated ` in the efficiency plot for the radius as I've checked it locally so updated it with adding `hPtRadiusGenerated`