### PR TITLE
(QVecDev) Added tables with new labeling

### DIFF
--- a/Common/DataModel/Qvectors.h
+++ b/Common/DataModel/Qvectors.h
@@ -50,7 +50,6 @@ DECLARE_SOA_COLUMN(QvecTPCnegImVec, qvecTPCnegImVec, std::vector<float>);
 DECLARE_SOA_COLUMN(QvecTPCallReVec, qvecTPCallReVec, std::vector<float>);
 DECLARE_SOA_COLUMN(QvecTPCallImVec, qvecTPCallImVec, std::vector<float>);
 
-
 DECLARE_SOA_COLUMN(QvecFT0CRe, qvecFT0CRe, float);
 DECLARE_SOA_COLUMN(QvecFT0CIm, qvecFT0CIm, float);
 DECLARE_SOA_COLUMN(QvecFT0ARe, qvecFT0ARe, float);

--- a/Common/DataModel/Qvectors.h
+++ b/Common/DataModel/Qvectors.h
@@ -43,12 +43,13 @@ DECLARE_SOA_COLUMN(QvecFT0MReVec, qvecFT0MReVec, std::vector<float>);
 DECLARE_SOA_COLUMN(QvecFT0MImVec, qvecFT0MImVec, std::vector<float>);
 DECLARE_SOA_COLUMN(QvecFV0AReVec, qvecFV0AReVec, std::vector<float>);
 DECLARE_SOA_COLUMN(QvecFV0AImVec, qvecFV0AImVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBPosReVec, qvecBPosReVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBPosImVec, qvecBPosImVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBNegReVec, qvecBNegReVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBNegImVec, qvecBNegImVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBTotReVec, qvecBTotReVec, std::vector<float>);
-DECLARE_SOA_COLUMN(QvecBTotImVec, qvecBTotImVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCposReVec, qvecTPCposReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCposImVec, qvecTPCposImVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCnegReVec, qvecTPCnegReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCnegImVec, qvecTPCnegImVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCallReVec, qvecTPCallReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecTPCallImVec, qvecTPCallImVec, std::vector<float>);
+
 
 DECLARE_SOA_COLUMN(QvecFT0CRe, qvecFT0CRe, float);
 DECLARE_SOA_COLUMN(QvecFT0CIm, qvecFT0CIm, float);
@@ -58,6 +59,32 @@ DECLARE_SOA_COLUMN(QvecFT0MRe, qvecFT0MRe, float);
 DECLARE_SOA_COLUMN(QvecFT0MIm, qvecFT0MIm, float);
 DECLARE_SOA_COLUMN(QvecFV0ARe, qvecFV0ARe, float);
 DECLARE_SOA_COLUMN(QvecFV0AIm, qvecFV0AIm, float);
+DECLARE_SOA_COLUMN(QvecTPCposRe, qvecTPCposRe, float);
+DECLARE_SOA_COLUMN(QvecTPCposIm, qvecTPCposIm, float);
+DECLARE_SOA_COLUMN(QvecTPCnegRe, qvecTPCnegRe, float);
+DECLARE_SOA_COLUMN(QvecTPCnegIm, qvecTPCnegIm, float);
+DECLARE_SOA_COLUMN(QvecTPCallRe, qvecTPCallRe, float);
+DECLARE_SOA_COLUMN(QvecTPCallIm, qvecTPCallIm, float);
+
+DECLARE_SOA_COLUMN(SumAmplFT0C, sumAmplFT0C, float);
+DECLARE_SOA_COLUMN(SumAmplFT0A, sumAmplFT0A, float);
+DECLARE_SOA_COLUMN(SumAmplFT0M, sumAmplFT0M, float);
+DECLARE_SOA_COLUMN(SumAmplFV0A, sumAmplFV0A, float);
+DECLARE_SOA_COLUMN(NTrkTPCpos, nTrkTPCpos, int);
+DECLARE_SOA_COLUMN(NTrkTPCneg, nTrkTPCneg, int);
+DECLARE_SOA_COLUMN(NTrkTPCall, nTrkTPCall, int);
+DECLARE_SOA_COLUMN(LabelsTPCpos, labelsTPCpos, std::vector<int>);
+DECLARE_SOA_COLUMN(LabelsTPCneg, labelsTPCneg, std::vector<int>);
+DECLARE_SOA_COLUMN(LabelsTPCall, labelsTPCall, std::vector<int>);
+
+// Deprecated, will be removed in future after transition time //
+DECLARE_SOA_COLUMN(QvecBPosReVec, qvecBPosReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecBPosImVec, qvecBPosImVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecBNegReVec, qvecBNegReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecBNegImVec, qvecBNegImVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecBTotReVec, qvecBTotReVec, std::vector<float>);
+DECLARE_SOA_COLUMN(QvecBTotImVec, qvecBTotImVec, std::vector<float>);
+
 DECLARE_SOA_COLUMN(QvecBPosRe, qvecBPosRe, float);
 DECLARE_SOA_COLUMN(QvecBPosIm, qvecBPosIm, float);
 DECLARE_SOA_COLUMN(QvecBNegRe, qvecBNegRe, float);
@@ -65,16 +92,13 @@ DECLARE_SOA_COLUMN(QvecBNegIm, qvecBNegIm, float);
 DECLARE_SOA_COLUMN(QvecBTotRe, qvecBTotRe, float);
 DECLARE_SOA_COLUMN(QvecBTotIm, qvecBTotIm, float);
 
-DECLARE_SOA_COLUMN(SumAmplFT0C, sumAmplFT0C, float);
-DECLARE_SOA_COLUMN(SumAmplFT0A, sumAmplFT0A, float);
-DECLARE_SOA_COLUMN(SumAmplFT0M, sumAmplFT0M, float);
-DECLARE_SOA_COLUMN(SumAmplFV0A, sumAmplFV0A, float);
 DECLARE_SOA_COLUMN(NTrkBPos, nTrkBPos, int);
 DECLARE_SOA_COLUMN(NTrkBNeg, nTrkBNeg, int);
 DECLARE_SOA_COLUMN(NTrkBTot, nTrkBTot, int);
 DECLARE_SOA_COLUMN(LabelsBPos, labelsBPos, std::vector<int>);
 DECLARE_SOA_COLUMN(LabelsBNeg, labelsBNeg, std::vector<int>);
 DECLARE_SOA_COLUMN(LabelsBTot, labelsBTot, std::vector<int>);
+/////////////////////////////////////////////////////////////////
 } // namespace qvec
 
 DECLARE_SOA_TABLE(Qvectors, "AOD", "QVECTORDEVS", //! Table with all Qvectors.
@@ -85,33 +109,51 @@ DECLARE_SOA_TABLE(QvectorFT0Cs, "AOD", "QVECTORSFT0C", qvec::IsCalibrated, qvec:
 DECLARE_SOA_TABLE(QvectorFT0As, "AOD", "QVECTORSFT0A", qvec::IsCalibrated, qvec::QvecFT0ARe, qvec::QvecFT0AIm, qvec::SumAmplFT0A);
 DECLARE_SOA_TABLE(QvectorFT0Ms, "AOD", "QVECTORSFT0M", qvec::IsCalibrated, qvec::QvecFT0MRe, qvec::QvecFT0MIm, qvec::SumAmplFT0M);
 DECLARE_SOA_TABLE(QvectorFV0As, "AOD", "QVECTORSFV0A", qvec::IsCalibrated, qvec::QvecFV0ARe, qvec::QvecFV0AIm, qvec::SumAmplFV0A);
-DECLARE_SOA_TABLE(QvectorBPoss, "AOD", "QVECTORSBPOS", qvec::IsCalibrated, qvec::QvecBPosRe, qvec::QvecBPosIm, qvec::NTrkBPos, qvec::LabelsBPos);
-DECLARE_SOA_TABLE(QvectorBNegs, "AOD", "QVECTORSBNEG", qvec::IsCalibrated, qvec::QvecBNegRe, qvec::QvecBNegIm, qvec::NTrkBNeg, qvec::LabelsBNeg);
-DECLARE_SOA_TABLE(QvectorBTots, "AOD", "QVECTORSBTOT", qvec::IsCalibrated, qvec::QvecBTotRe, qvec::QvecBTotIm, qvec::NTrkBTot, qvec::LabelsBTot);
+DECLARE_SOA_TABLE(QvectorTPCposs, "AOD", "QVECTORSTPCPOS", qvec::IsCalibrated, qvec::QvecTPCposRe, qvec::QvecTPCposIm, qvec::NTrkTPCpos, qvec::LabelsTPCpos);
+DECLARE_SOA_TABLE(QvectorTPCnegs, "AOD", "QVECTORSTPCNEG", qvec::IsCalibrated, qvec::QvecTPCnegRe, qvec::QvecTPCnegIm, qvec::NTrkTPCneg, qvec::LabelsTPCneg);
+DECLARE_SOA_TABLE(QvectorTPCalls, "AOD", "QVECTORSTPCALL", qvec::IsCalibrated, qvec::QvecTPCallRe, qvec::QvecTPCallIm, qvec::NTrkTPCall, qvec::LabelsTPCall);
 
 DECLARE_SOA_TABLE(QvectorFT0CVecs, "AOD", "QVECTORSFT0CVEC", qvec::IsCalibrated, qvec::QvecFT0CReVec, qvec::QvecFT0CImVec, qvec::SumAmplFT0C);
 DECLARE_SOA_TABLE(QvectorFT0AVecs, "AOD", "QVECTORSFT0AVEC", qvec::IsCalibrated, qvec::QvecFT0AReVec, qvec::QvecFT0AImVec, qvec::SumAmplFT0A);
 DECLARE_SOA_TABLE(QvectorFT0MVecs, "AOD", "QVECTORSFT0MVEC", qvec::IsCalibrated, qvec::QvecFT0MReVec, qvec::QvecFT0MImVec, qvec::SumAmplFT0M);
 DECLARE_SOA_TABLE(QvectorFV0AVecs, "AOD", "QVECTORSFV0AVEC", qvec::IsCalibrated, qvec::QvecFV0AReVec, qvec::QvecFV0AImVec, qvec::SumAmplFV0A);
-DECLARE_SOA_TABLE(QvectorBPosVecs, "AOD", "QVECTORSBPOSVEC", qvec::IsCalibrated, qvec::QvecBPosReVec, qvec::QvecBPosImVec, qvec::NTrkBPos, qvec::LabelsBPos);
-DECLARE_SOA_TABLE(QvectorBNegVecs, "AOD", "QVECTORSBNEGVEC", qvec::IsCalibrated, qvec::QvecBNegReVec, qvec::QvecBNegImVec, qvec::NTrkBNeg, qvec::LabelsBNeg);
-DECLARE_SOA_TABLE(QvectorBTotVecs, "AOD", "QVECTORSBTOTVEC", qvec::IsCalibrated, qvec::QvecBTotReVec, qvec::QvecBTotImVec, qvec::NTrkBTot, qvec::LabelsBTot);
+DECLARE_SOA_TABLE(QvectorTPCposVecs, "AOD", "QVECTORSTPCPVEC", qvec::IsCalibrated, qvec::QvecTPCposReVec, qvec::QvecTPCposImVec, qvec::NTrkTPCpos, qvec::LabelsTPCpos);
+DECLARE_SOA_TABLE(QvectorTPCnegVecs, "AOD", "QVECTORSTPCNVEC", qvec::IsCalibrated, qvec::QvecTPCnegReVec, qvec::QvecTPCnegImVec, qvec::NTrkTPCneg, qvec::LabelsTPCneg);
+DECLARE_SOA_TABLE(QvectorTPCallVecs, "AOD", "QVECTORSTPCAVEC", qvec::IsCalibrated, qvec::QvecTPCallReVec, qvec::QvecTPCallImVec, qvec::NTrkTPCall, qvec::LabelsTPCall);
 
 using QvectorFT0C = QvectorFT0Cs::iterator;
 using QvectorFT0A = QvectorFT0As::iterator;
 using QvectorFT0M = QvectorFT0Ms::iterator;
 using QvectorFV0A = QvectorFV0As::iterator;
-using QvectorBPos = QvectorBPoss::iterator;
-using QvectorBNeg = QvectorBNegs::iterator;
-using QvectorBTot = QvectorBTots::iterator;
+using QvectorTPCpos = QvectorTPCposs::iterator;
+using QvectorTPCneg = QvectorTPCnegs::iterator;
+using QvectorTPCall = QvectorTPCalls::iterator;
 
 using QvectorFT0CVec = QvectorFT0CVecs::iterator;
 using QvectorFT0AVec = QvectorFT0AVecs::iterator;
 using QvectorFT0MVec = QvectorFT0MVecs::iterator;
 using QvectorFV0AVec = QvectorFV0AVecs::iterator;
+using QvectorTPCposVec = QvectorTPCposVecs::iterator;
+using QvectorTPCnegVec = QvectorTPCnegVecs::iterator;
+using QvectorTPCallVec = QvectorTPCallVecs::iterator;
+
+// Deprecated, will be removed in future after transition time //
+DECLARE_SOA_TABLE(QvectorBPoss, "AOD", "QVECTORSBPOS", qvec::IsCalibrated, qvec::QvecBPosRe, qvec::QvecBPosIm, qvec::NTrkBPos, qvec::LabelsBPos);
+DECLARE_SOA_TABLE(QvectorBNegs, "AOD", "QVECTORSBNEG", qvec::IsCalibrated, qvec::QvecBNegRe, qvec::QvecBNegIm, qvec::NTrkBNeg, qvec::LabelsBNeg);
+DECLARE_SOA_TABLE(QvectorBTots, "AOD", "QVECTORSBTOT", qvec::IsCalibrated, qvec::QvecBTotRe, qvec::QvecBTotIm, qvec::NTrkBTot, qvec::LabelsBTot);
+
+DECLARE_SOA_TABLE(QvectorBPosVecs, "AOD", "QVECTORSBPOSVEC", qvec::IsCalibrated, qvec::QvecBPosReVec, qvec::QvecBPosImVec, qvec::NTrkBPos, qvec::LabelsBPos);
+DECLARE_SOA_TABLE(QvectorBNegVecs, "AOD", "QVECTORSBNEGVEC", qvec::IsCalibrated, qvec::QvecBNegReVec, qvec::QvecBNegImVec, qvec::NTrkBNeg, qvec::LabelsBNeg);
+DECLARE_SOA_TABLE(QvectorBTotVecs, "AOD", "QVECTORSBTOTVEC", qvec::IsCalibrated, qvec::QvecBTotReVec, qvec::QvecBTotImVec, qvec::NTrkBTot, qvec::LabelsBTot);
+
+using QvectorBPos = QvectorBPoss::iterator;
+using QvectorBNeg = QvectorBNegs::iterator;
+using QvectorBTot = QvectorBTots::iterator;
+
 using QvectorBPosVec = QvectorBPosVecs::iterator;
 using QvectorBNegVec = QvectorBNegVecs::iterator;
 using QvectorBTotVec = QvectorBTotVecs::iterator;
+/////////////////////////////////////////////////////////////////
 
 } // namespace o2::aod
 

--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -59,9 +59,9 @@ struct qVectorsTable {
     kFT0A = 1,
     kFT0M,
     kFV0A,
-    kBPos,
-    kBNeg,
-    kBTot
+    kTPCpos,
+    kTPCneg,
+    kTPCall
   };
 
   // Configurables.
@@ -91,9 +91,9 @@ struct qVectorsTable {
   Configurable<bool> cfgUseFT0A{"cfgUseFT0A", false, "Initial value for using FT0A. By default obtained from DataModel."};
   Configurable<bool> cfgUseFT0M{"cfgUseFT0M", false, "Initial value for using FT0M. By default obtained from DataModel."};
   Configurable<bool> cfgUseFV0A{"cfgUseFV0A", false, "Initial value for using FV0A. By default obtained from DataModel."};
-  Configurable<bool> cfgUseBPos{"cfgUseBPos", false, "Initial value for using BPos. By default obtained from DataModel."};
-  Configurable<bool> cfgUseBNeg{"cfgUseBNeg", false, "Initial value for using BNeg. By default obtained from DataModel."};
-  Configurable<bool> cfgUseBTot{"cfgUseBTot", false, "Initial value for using BTot. By default obtained from DataModel."};
+  Configurable<bool> cfgUseTPCpos{"cfgUseTPCpos", false, "Initial value for using TPCpos. By default obtained from DataModel."};
+  Configurable<bool> cfgUseTPCneg{"cfgUseTPCneg", false, "Initial value for using TPCneg. By default obtained from DataModel."};
+  Configurable<bool> cfgUseTPCall{"cfgUseTPCall", false, "Initial value for using TPCall. By default obtained from DataModel."};
 
   // Table.
   Produces<aod::Qvectors> qVector;
@@ -101,17 +101,17 @@ struct qVectorsTable {
   Produces<aod::QvectorFT0As> qVectorFT0A;
   Produces<aod::QvectorFT0Ms> qVectorFT0M;
   Produces<aod::QvectorFV0As> qVectorFV0A;
-  Produces<aod::QvectorBPoss> qVectorBPos;
-  Produces<aod::QvectorBNegs> qVectorBNeg;
-  Produces<aod::QvectorBTots> qVectorBTot;
+  Produces<aod::QvectorTPCposs> qVectorTPCpos;
+  Produces<aod::QvectorTPCnegs> qVectorTPCneg;
+  Produces<aod::QvectorTPCalls> qVectorTPCall;
 
   Produces<aod::QvectorFT0CVecs> qVectorFT0CVec;
   Produces<aod::QvectorFT0AVecs> qVectorFT0AVec;
   Produces<aod::QvectorFT0MVecs> qVectorFT0MVec;
   Produces<aod::QvectorFV0AVecs> qVectorFV0AVec;
-  Produces<aod::QvectorBPosVecs> qVectorBPosVec;
-  Produces<aod::QvectorBNegVecs> qVectorBNegVec;
-  Produces<aod::QvectorBTotVecs> qVectorBTotVec;
+  Produces<aod::QvectorTPCposVecs> qVectorTPCposVec;
+  Produces<aod::QvectorTPCnegVecs> qVectorTPCnegVec;
+  Produces<aod::QvectorTPCallVecs> qVectorTPCallVec;
 
   std::vector<float> FT0RelGainConst{};
   std::vector<float> FV0RelGainConst{};
@@ -134,10 +134,25 @@ struct qVectorsTable {
 
   std::vector<TH3F*> objQvec{};
 
+
+  // Deprecated, will be removed in future after transition time //
+  Configurable<bool> cfgUseBPos{"cfgUseBPos", false, "Initial value for using BPos. By default obtained from DataModel."};
+  Configurable<bool> cfgUseBNeg{"cfgUseBNeg", false, "Initial value for using BNeg. By default obtained from DataModel."};
+  Configurable<bool> cfgUseBTot{"cfgUseBTot", false, "Initial value for using BTot. By default obtained from DataModel."};
+
+  Produces<aod::QvectorBPoss> qVectorBPos;
+  Produces<aod::QvectorBNegs> qVectorBNeg;
+  Produces<aod::QvectorBTots> qVectorBTot;
+
+  Produces<aod::QvectorBPosVecs> qVectorBPosVec;
+  Produces<aod::QvectorBNegVecs> qVectorBNegVec;
+  Produces<aod::QvectorBTotVecs> qVectorBTotVec;
+  /////////////////////////////////////////////////////////////////
+
   std::unordered_map<string, bool> useDetector = {
-    {"QvectorBTots", cfgUseBTot},
-    {"QvectorBNegs", cfgUseBNeg},
-    {"QvectorBPoss", cfgUseBPos},
+    {"QvectorTPCalls", cfgUseTPCall || cfgUseBTot},
+    {"QvectorTPCnegs", cfgUseTPCneg || cfgUseBNeg},
+    {"QvectorTPCposs", cfgUseTPCpos || cfgUseBPos},
     {"QvectorFV0As", cfgUseFV0A},
     {"QvectorFT0Ms", cfgUseFT0M},
     {"QvectorFT0As", cfgUseFT0A},
@@ -283,15 +298,15 @@ struct qVectorsTable {
   }
 
   template <typename Nmode, typename CollType, typename TrackType>
-  void CalQvec(const Nmode nmode, const CollType& coll, const TrackType& track, std::vector<float>& QvecRe, std::vector<float>& QvecIm, std::vector<float>& QvecAmp, std::vector<int>& TrkBPosLabel, std::vector<int>& TrkBNegLabel, std::vector<int>& TrkBTotLabel)
+  void CalQvec(const Nmode nmode, const CollType& coll, const TrackType& track, std::vector<float>& QvecRe, std::vector<float>& QvecIm, std::vector<float>& QvecAmp, std::vector<int>& TrkTPCposLabel, std::vector<int>& TrkTPCnegLabel, std::vector<int>& TrkTPCallLabel)
   {
     float qVectFT0A[2] = {0.};
     float qVectFT0C[2] = {0.};
     float qVectFT0M[2] = {0.};
     float qVectFV0A[2] = {0.};
-    float qVectBPos[2] = {0.};
-    float qVectBNeg[2] = {0.};
-    float qVectBTot[2] = {0.};
+    float qVectTPCpos[2] = {0.};
+    float qVectTPCneg[2] = {0.};
+    float qVectTPCall[2] = {0.};
 
     TComplex QvecDet(0);
     TComplex QvecFT0M(0);
@@ -394,9 +409,9 @@ struct qVectorsTable {
       qVectFV0A[1] = -999.;
     }
 
-    int nTrkBPos = 0;
-    int nTrkBNeg = 0;
-    int nTrkBTot = 0;
+    int nTrkTPCpos = 0;
+    int nTrkTPCneg = 0;
+    int nTrkTPCall = 0;
 
     for (auto& trk : track) {
       if (!SelTrack(trk)) {
@@ -406,47 +421,47 @@ struct qVectorsTable {
       if (std::abs(trk.eta()) > 0.8) {
         continue;
       }
-      qVectBTot[0] += trk.pt() * std::cos(trk.phi() * nmode);
-      qVectBTot[1] += trk.pt() * std::sin(trk.phi() * nmode);
-      TrkBTotLabel.push_back(trk.globalIndex());
-      nTrkBTot++;
+      qVectTPCall[0] += trk.pt() * std::cos(trk.phi() * nmode);
+      qVectTPCall[1] += trk.pt() * std::sin(trk.phi() * nmode);
+      TrkTPCallLabel.push_back(trk.globalIndex());
+      nTrkTPCall++;
       if (std::abs(trk.eta()) < 0.1) {
         continue;
       }
-      if (trk.eta() > 0 && useDetector["QvectorBPoss"]) {
-        qVectBPos[0] += trk.pt() * std::cos(trk.phi() * nmode);
-        qVectBPos[1] += trk.pt() * std::sin(trk.phi() * nmode);
-        TrkBPosLabel.push_back(trk.globalIndex());
-        nTrkBPos++;
-      } else if (trk.eta() < 0 && useDetector["QvectorBNegs"]) {
-        qVectBNeg[0] += trk.pt() * std::cos(trk.phi() * nmode);
-        qVectBNeg[1] += trk.pt() * std::sin(trk.phi() * nmode);
-        TrkBNegLabel.push_back(trk.globalIndex());
-        nTrkBNeg++;
+      if (trk.eta() > 0 && useDetector["QvectorTPCposs"]) {
+        qVectTPCpos[0] += trk.pt() * std::cos(trk.phi() * nmode);
+        qVectTPCpos[1] += trk.pt() * std::sin(trk.phi() * nmode);
+        TrkTPCposLabel.push_back(trk.globalIndex());
+        nTrkTPCpos++;
+      } else if (trk.eta() < 0 && useDetector["QvectorTPCnegs"]) {
+        qVectTPCneg[0] += trk.pt() * std::cos(trk.phi() * nmode);
+        qVectTPCneg[1] += trk.pt() * std::sin(trk.phi() * nmode);
+        TrkTPCnegLabel.push_back(trk.globalIndex());
+        nTrkTPCneg++;
       }
     }
-    if (nTrkBPos > 0) {
-      qVectBPos[0] /= nTrkBPos;
-      qVectBPos[1] /= nTrkBPos;
+    if (nTrkTPCpos > 0) {
+      qVectTPCpos[0] /= nTrkTPCpos;
+      qVectTPCpos[1] /= nTrkTPCpos;
     } else {
-      qVectBPos[0] = 999.;
-      qVectBPos[1] = 999.;
+      qVectTPCpos[0] = 999.;
+      qVectTPCpos[1] = 999.;
     }
 
-    if (nTrkBNeg > 0) {
-      qVectBNeg[0] /= nTrkBNeg;
-      qVectBNeg[1] /= nTrkBNeg;
+    if (nTrkTPCneg > 0) {
+      qVectTPCneg[0] /= nTrkTPCneg;
+      qVectTPCneg[1] /= nTrkTPCneg;
     } else {
-      qVectBNeg[0] = 999.;
-      qVectBNeg[1] = 999.;
+      qVectTPCneg[0] = 999.;
+      qVectTPCneg[1] = 999.;
     }
 
-    if (nTrkBTot > 0) {
-      qVectBTot[0] /= nTrkBTot;
-      qVectBTot[1] /= nTrkBTot;
+    if (nTrkTPCall > 0) {
+      qVectTPCall[0] /= nTrkTPCall;
+      qVectTPCall[1] /= nTrkTPCall;
     } else {
-      qVectBTot[0] = 999.;
-      qVectBTot[1] = 999.;
+      qVectTPCall[0] = 999.;
+      qVectTPCall[1] = 999.;
     }
 
     for (auto i{0u}; i < 4; i++) {
@@ -466,32 +481,32 @@ struct qVectorsTable {
       QvecIm.push_back(qVectFV0A[1]);
     }
     for (auto i{0u}; i < 4; i++) {
-      QvecRe.push_back(qVectBPos[0]);
-      QvecIm.push_back(qVectBPos[1]);
+      QvecRe.push_back(qVectTPCpos[0]);
+      QvecIm.push_back(qVectTPCpos[1]);
     }
     for (auto i{0u}; i < 4; i++) {
-      QvecRe.push_back(qVectBNeg[0]);
-      QvecIm.push_back(qVectBNeg[1]);
+      QvecRe.push_back(qVectTPCneg[0]);
+      QvecIm.push_back(qVectTPCneg[1]);
     }
     for (auto i{0u}; i < 4; i++) {
-      QvecRe.push_back(qVectBTot[0]);
-      QvecIm.push_back(qVectBTot[1]);
+      QvecRe.push_back(qVectTPCall[0]);
+      QvecIm.push_back(qVectTPCall[1]);
     }
 
     QvecAmp.push_back(sumAmplFT0C);
     QvecAmp.push_back(sumAmplFT0A);
     QvecAmp.push_back(sumAmplFT0M);
     QvecAmp.push_back(sumAmplFV0A);
-    QvecAmp.push_back(static_cast<float>(nTrkBPos));
-    QvecAmp.push_back(static_cast<float>(nTrkBNeg));
-    QvecAmp.push_back(static_cast<float>(nTrkBTot));
+    QvecAmp.push_back(static_cast<float>(nTrkTPCpos));
+    QvecAmp.push_back(static_cast<float>(nTrkTPCneg));
+    QvecAmp.push_back(static_cast<float>(nTrkTPCall));
   }
 
   void process(MyCollisions::iterator const& coll, aod::BCsWithTimestamps const&, aod::FT0s const&, aod::FV0As const&, MyTracks const& tracks)
   {
-    std::vector<int> TrkBPosLabel{};
-    std::vector<int> TrkBNegLabel{};
-    std::vector<int> TrkBTotLabel{};
+    std::vector<int> TrkTPCposLabel{};
+    std::vector<int> TrkTPCnegLabel{};
+    std::vector<int> TrkTPCallLabel{};
     std::vector<float> qvecRe{};
     std::vector<float> qvecIm{};
     std::vector<float> qvecAmp{};
@@ -504,12 +519,12 @@ struct qVectorsTable {
     std::vector<float> qvecImFT0M{};
     std::vector<float> qvecReFV0A{};
     std::vector<float> qvecImFV0A{};
-    std::vector<float> qvecReBPos{};
-    std::vector<float> qvecImBPos{};
-    std::vector<float> qvecReBNeg{};
-    std::vector<float> qvecImBNeg{};
-    std::vector<float> qvecReBTot{};
-    std::vector<float> qvecImBTot{};
+    std::vector<float> qvecReTPCpos{};
+    std::vector<float> qvecImTPCpos{};
+    std::vector<float> qvecReTPCneg{};
+    std::vector<float> qvecImTPCneg{};
+    std::vector<float> qvecReTPCall{};
+    std::vector<float> qvecImTPCall{};
 
     auto bc = coll.bc_as<aod::BCsWithTimestamps>();
     int currentRun = bc.runNumber();
@@ -529,40 +544,40 @@ struct qVectorsTable {
     }
     for (std::size_t id = 0; id < cfgnMods->size(); id++) {
       int ind = cfgnMods->at(id);
-      CalQvec(ind, coll, tracks, qvecRe, qvecIm, qvecAmp, TrkBPosLabel, TrkBNegLabel, TrkBTotLabel);
+      CalQvec(ind, coll, tracks, qvecRe, qvecIm, qvecAmp, TrkTPCposLabel, TrkTPCnegLabel, TrkTPCallLabel);
       if (cent < cfgMaxCentrality) {
-        for (auto i{0u}; i < kBTot + 1; i++) {
-          helperEP.DoRecenter(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 1], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 1],
+        for (auto i{0u}; i < kTPCall + 1; i++) {
+          helperEP.DoRecenter(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 1], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 1],
                               objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 1, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 2, i + 1));
 
-          helperEP.DoRecenter(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 2], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 2],
+          helperEP.DoRecenter(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 2], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 2],
                               objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 1, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 2, i + 1));
-          helperEP.DoTwist(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 2], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 2],
+          helperEP.DoTwist(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 2], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 2],
                            objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 3, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 4, i + 1));
 
-          helperEP.DoRecenter(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 3], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 3],
+          helperEP.DoRecenter(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 3], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 3],
                               objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 1, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 2, i + 1));
-          helperEP.DoTwist(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 3], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 3],
+          helperEP.DoTwist(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 3], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 3],
                            objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 3, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 4, i + 1));
-          helperEP.DoRescale(qvecRe[(kBTot + 1) * 4 * id + i * 4 + 3], qvecIm[(kBTot + 1) * 4 * id + i * 4 + 3],
+          helperEP.DoRescale(qvecRe[(kTPCall + 1) * 4 * id + i * 4 + 3], qvecIm[(kTPCall + 1) * 4 * id + i * 4 + 3],
                              objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 5, i + 1), objQvec.at(id)->GetBinContent(static_cast<int>(cent) + 1, 6, i + 1));
         }
       }
       int CorrLevel = cfgCorrLevel == 0 ? 0 : cfgCorrLevel - 1;
-      qvecReFT0C.push_back(qvecRe[(kBTot + 1) * 4 * id + kFT0C * 4 + CorrLevel]);
-      qvecImFT0C.push_back(qvecIm[(kBTot + 1) * 4 * id + kFT0C * 4 + CorrLevel]);
-      qvecReFT0A.push_back(qvecRe[(kBTot + 1) * 4 * id + kFT0A * 4 + CorrLevel]);
-      qvecImFT0A.push_back(qvecIm[(kBTot + 1) * 4 * id + kFT0A * 4 + CorrLevel]);
-      qvecReFT0M.push_back(qvecRe[(kBTot + 1) * 4 * id + kFT0M * 4 + CorrLevel]);
-      qvecImFT0M.push_back(qvecIm[(kBTot + 1) * 4 * id + kFT0M * 4 + CorrLevel]);
-      qvecReFV0A.push_back(qvecRe[(kBTot + 1) * 4 * id + kFV0A * 4 + CorrLevel]);
-      qvecImFV0A.push_back(qvecIm[(kBTot + 1) * 4 * id + kFV0A * 4 + CorrLevel]);
-      qvecReBPos.push_back(qvecRe[(kBTot + 1) * 4 * id + kBPos * 4 + CorrLevel]);
-      qvecImBPos.push_back(qvecIm[(kBTot + 1) * 4 * id + kBPos * 4 + CorrLevel]);
-      qvecReBNeg.push_back(qvecRe[(kBTot + 1) * 4 * id + kBNeg * 4 + CorrLevel]);
-      qvecImBNeg.push_back(qvecIm[(kBTot + 1) * 4 * id + kBNeg * 4 + CorrLevel]);
-      qvecReBTot.push_back(qvecRe[(kBTot + 1) * 4 * id + kBTot * 4 + CorrLevel]);
-      qvecImBTot.push_back(qvecIm[(kBTot + 1) * 4 * id + kBTot * 4 + CorrLevel]);
+      qvecReFT0C.push_back(qvecRe[(kTPCall + 1) * 4 * id + kFT0C * 4 + CorrLevel]);
+      qvecImFT0C.push_back(qvecIm[(kTPCall + 1) * 4 * id + kFT0C * 4 + CorrLevel]);
+      qvecReFT0A.push_back(qvecRe[(kTPCall + 1) * 4 * id + kFT0A * 4 + CorrLevel]);
+      qvecImFT0A.push_back(qvecIm[(kTPCall + 1) * 4 * id + kFT0A * 4 + CorrLevel]);
+      qvecReFT0M.push_back(qvecRe[(kTPCall + 1) * 4 * id + kFT0M * 4 + CorrLevel]);
+      qvecImFT0M.push_back(qvecIm[(kTPCall + 1) * 4 * id + kFT0M * 4 + CorrLevel]);
+      qvecReFV0A.push_back(qvecRe[(kTPCall + 1) * 4 * id + kFV0A * 4 + CorrLevel]);
+      qvecImFV0A.push_back(qvecIm[(kTPCall + 1) * 4 * id + kFV0A * 4 + CorrLevel]);
+      qvecReTPCpos.push_back(qvecRe[(kTPCall + 1) * 4 * id + kTPCpos * 4 + CorrLevel]);
+      qvecImTPCpos.push_back(qvecIm[(kTPCall + 1) * 4 * id + kTPCpos * 4 + CorrLevel]);
+      qvecReTPCneg.push_back(qvecRe[(kTPCall + 1) * 4 * id + kTPCneg * 4 + CorrLevel]);
+      qvecImTPCneg.push_back(qvecIm[(kTPCall + 1) * 4 * id + kTPCneg * 4 + CorrLevel]);
+      qvecReTPCall.push_back(qvecRe[(kTPCall + 1) * 4 * id + kTPCall * 4 + CorrLevel]);
+      qvecImTPCall.push_back(qvecIm[(kTPCall + 1) * 4 * id + kTPCall * 4 + CorrLevel]);
     }
 
     // Fill the columns of the Qvectors table.
@@ -575,20 +590,34 @@ struct qVectorsTable {
       qVectorFT0M(IsCalibrated, qvecReFT0M.at(0), qvecImFT0M.at(0), qvecAmp[kFT0M]);
     if (useDetector["QvectorFV0As"])
       qVectorFV0A(IsCalibrated, qvecReFV0A.at(0), qvecImFV0A.at(0), qvecAmp[kFV0A]);
-    if (useDetector["QvectorBPoss"])
-      qVectorBPos(IsCalibrated, qvecReBPos.at(0), qvecImBPos.at(0), qvecAmp[kBPos], TrkBPosLabel);
-    if (useDetector["QvectorBNegs"])
-      qVectorBNeg(IsCalibrated, qvecReBNeg.at(0), qvecImBNeg.at(0), qvecAmp[kBNeg], TrkBNegLabel);
-    if (useDetector["QvectorBTots"])
-      qVectorBTot(IsCalibrated, qvecReBTot.at(0), qvecImBTot.at(0), qvecAmp[kBTot], TrkBTotLabel);
+    if (useDetector["QvectorTPCposs"])
+      qVectorTPCpos(IsCalibrated, qvecReTPCpos.at(0), qvecImTPCpos.at(0), qvecAmp[kTPCpos], TrkTPCposLabel);
+    if (useDetector["QvectorTPCnegs"])
+      qVectorTPCneg(IsCalibrated, qvecReTPCneg.at(0), qvecImTPCneg.at(0), qvecAmp[kTPCneg], TrkTPCnegLabel);
+    if (useDetector["QvectorTPCalls"])
+      qVectorTPCall(IsCalibrated, qvecReTPCall.at(0), qvecImTPCall.at(0), qvecAmp[kTPCall], TrkTPCallLabel);
 
     qVectorFT0CVec(IsCalibrated, qvecReFT0C, qvecImFT0C, qvecAmp[kFT0C]);
     qVectorFT0AVec(IsCalibrated, qvecReFT0A, qvecImFT0A, qvecAmp[kFT0A]);
     qVectorFT0MVec(IsCalibrated, qvecReFT0M, qvecImFT0M, qvecAmp[kFT0M]);
     qVectorFV0AVec(IsCalibrated, qvecReFV0A, qvecImFV0A, qvecAmp[kFV0A]);
-    qVectorBPosVec(IsCalibrated, qvecReBPos, qvecImBPos, qvecAmp[kBPos], TrkBPosLabel);
-    qVectorBNegVec(IsCalibrated, qvecReBNeg, qvecImBNeg, qvecAmp[kBNeg], TrkBNegLabel);
-    qVectorBTotVec(IsCalibrated, qvecReBTot, qvecImBTot, qvecAmp[kBTot], TrkBTotLabel);
+    qVectorTPCposVec(IsCalibrated, qvecReTPCpos, qvecImTPCpos, qvecAmp[kTPCpos], TrkTPCposLabel);
+    qVectorTPCnegVec(IsCalibrated, qvecReTPCneg, qvecImTPCneg, qvecAmp[kTPCneg], TrkTPCnegLabel);
+    qVectorTPCallVec(IsCalibrated, qvecReTPCall, qvecImTPCall, qvecAmp[kTPCall], TrkTPCallLabel);
+
+    // Deprecated, will be removed in future after transition time //
+    if (useDetector["QvectorTPCposs"])
+      qVectorBPos(IsCalibrated, qvecReTPCpos.at(0), qvecImTPCpos.at(0), qvecAmp[kTPCpos], TrkTPCposLabel);
+    if (useDetector["QvectorTPCnegs"])
+      qVectorBNeg(IsCalibrated, qvecReTPCneg.at(0), qvecImTPCneg.at(0), qvecAmp[kTPCneg], TrkTPCnegLabel);
+    if (useDetector["QvectorTPCalls"])
+      qVectorBTot(IsCalibrated, qvecReTPCall.at(0), qvecImTPCall.at(0), qvecAmp[kTPCall], TrkTPCallLabel);
+
+    qVectorBPosVec(IsCalibrated, qvecReTPCpos, qvecImTPCpos, qvecAmp[kTPCpos], TrkTPCposLabel);
+    qVectorBNegVec(IsCalibrated, qvecReTPCneg, qvecImTPCneg, qvecAmp[kTPCneg], TrkTPCnegLabel);
+    qVectorBTotVec(IsCalibrated, qvecReTPCall, qvecImTPCall, qvecAmp[kTPCall], TrkTPCallLabel);
+    /////////////////////////////////////////////////////////////////
+
   } // End process.
 };
 

--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -134,7 +134,6 @@ struct qVectorsTable {
 
   std::vector<TH3F*> objQvec{};
 
-
   // Deprecated, will be removed in future after transition time //
   Configurable<bool> cfgUseBPos{"cfgUseBPos", false, "Initial value for using BPos. By default obtained from DataModel."};
   Configurable<bool> cfgUseBNeg{"cfgUseBNeg", false, "Initial value for using BNeg. By default obtained from DataModel."};

--- a/Common/Tasks/qVectorsCorrection.cxx
+++ b/Common/Tasks/qVectorsCorrection.cxx
@@ -58,8 +58,8 @@ struct qVectorsCorrection {
   Configurable<std::vector<int>> cfgnMods{"cfgnMods", {2, 3}, "Modulation of interest"};
 
   Configurable<std::string> cfgDetName{"cfgDetName", "FT0C", "The name of detector to be analyzed"};
-  Configurable<std::string> cfgRefAName{"cfgRefAName", "BPos", "The name of detector for reference A"};
-  Configurable<std::string> cfgRefBName{"cfgRefBName", "BNeg", "The name of detector for reference B"};
+  Configurable<std::string> cfgRefAName{"cfgRefAName", "TPCpos", "The name of detector for reference A"};
+  Configurable<std::string> cfgRefBName{"cfgRefBName", "TPCneg", "The name of detector for reference B"};
   Configurable<bool> cfgAddEvtSel{"cfgAddEvtSel", true, "event selection"};
 
   Configurable<int> cfgnTotalSystem{"cfgnTotalSystem", 7, "total qvector number"};
@@ -81,6 +81,9 @@ struct qVectorsCorrection {
   template <typename T>
   int GetDetId(const T& name)
   {
+    if (name.value == "BPos" || name.value == "BNeg" || name.value == "BTot") {
+      LOGF(warning, "Using deprecated label: %s. Please use TPCpos, TPCneg, TPCall instead.", name.value);
+    }
     if (name.value == "FT0C") {
       return 0;
     } else if (name.value == "FT0A") {
@@ -89,11 +92,11 @@ struct qVectorsCorrection {
       return 2;
     } else if (name.value == "FV0A") {
       return 3;
-    } else if (name.value == "BPos") {
+    } else if (name.value == "TPCpos" || name.value == "BPos") {
       return 4;
-    } else if (name.value == "BNeg") {
+    } else if (name.value == "TPCneg" || name.value == "BNeg") {
       return 5;
-    } else if (name.value == "BTot") {
+    } else if (name.value == "TPCall" || name.value == "BTot") {
       return 6;
     } else {
       return 0;
@@ -107,7 +110,7 @@ struct qVectorsCorrection {
     RefBId = GetDetId(cfgRefBName);
 
     if (DetId == RefAId || DetId == RefBId || RefAId == RefBId) {
-      LOGF(info, "Wrong detector configuration \n The FT0C will be used to get Q-Vector \n The BPos and BNeg will be used as reference systems");
+      LOGF(info, "Wrong detector configuration \n The FT0C will be used to get Q-Vector \n The TPCpos and TPCneg will be used as reference systems");
       DetId = 0;
       RefAId = 4;
       RefBId = 5;
@@ -122,7 +125,7 @@ struct qVectorsCorrection {
     histosQA.add("histCentFull", "Centrality distribution for valid events",
                  HistType::kTH1F, {axisCent});
 
-    for (auto i = 0; i < cfgnMods->size(); i++) {
+    for (uint i = 0; i < cfgnMods->size(); i++) {
       histosQA.add(Form("histQvecUncorV%d", cfgnMods->at(i)), "", {HistType::kTH3F, {axisQvecF, axisQvecF, axisCent}});
       histosQA.add(Form("histQvecRefAUncorV%d", cfgnMods->at(i)), "", {HistType::kTH3F, {axisQvecF, axisQvecF, axisCent}});
       histosQA.add(Form("histQvecRefBUncorV%d", cfgnMods->at(i)), "", {HistType::kTH3F, {axisQvecF, axisQvecF, axisCent}});
@@ -337,7 +340,7 @@ struct qVectorsCorrection {
                          !qVec.selection_bit(aod::evsel::kNoSameBunchPileup))) {
       return;
     }
-    for (auto i = 0; i < cfgnMods->size(); i++) {
+    for (uint i = 0; i < cfgnMods->size(); i++) {
       fillHistosQvec(qVec, cfgnMods->at(i));
     }
   } // End void process(...)


### PR DESCRIPTION
New labeling added for the Q-vector tables, with backwards compatibility with the old labeling convetion.
Internal variables have been changed directly.