### PR TITLE
PWGHF: Ds-h correl, Adding isGlobalTrack requirement

### DIFF
--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -808,6 +808,9 @@ struct HfTaskCorrelationDsHadrons {
 
         // reconstructed track loop
         for (const auto& track : groupedTracks) {
+          if (!track.isGlobalTrackWoDCA()) {
+            continue;
+          }
           if (track.has_mcParticle()) {
             hAssocTracks->Fill(kAssocTrackStepRecoMcMatch, track.eta(), track.pt(), multiplicityReco, posZReco);
             auto mcParticle = track.template mcParticle_as<aod::McParticles>();


### PR DESCRIPTION
Dear all,
Added the requirement of isGlobalTrackWoDCA for track selection in the efficiency process which was missing.

Cheers,
Samuele