### PR TITLE
ALICE 3 core: add sanity check in smearing function

### DIFF
--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -192,7 +192,10 @@ bool TrackSmearer::smearTrack(O2Track& o2track, lutEntry_t* lutEntry, float inte
     double val = 0.;
     for (int j = 0; j < 5; ++j)
       val += lutEntry->eigvec[j][i] * o2track.getParam(j);
-    params_[i] = gRandom->Gaus(val, sqrt(lutEntry->eigval[i]));
+    double eigValToUse = 0.0f;
+    if(lutEntry->eigval[i]>0.0f) 
+      eigValToUse = lutEntry->eigval[i];
+    params_[i] = gRandom->Gaus(val, eigValToUse);
   }
   // transform back params vector
   for (int i = 0; i < 5; ++i) {

--- a/ALICE3/Core/DelphesO2TrackSmearer.cxx
+++ b/ALICE3/Core/DelphesO2TrackSmearer.cxx
@@ -193,7 +193,7 @@ bool TrackSmearer::smearTrack(O2Track& o2track, lutEntry_t* lutEntry, float inte
     for (int j = 0; j < 5; ++j)
       val += lutEntry->eigvec[j][i] * o2track.getParam(j);
     double eigValToUse = 0.0f;
-    if(lutEntry->eigval[i]>0.0f) 
+    if (lutEntry->eigval[i] > 0.0f)
       eigValToUse = lutEntry->eigval[i];
     params_[i] = gRandom->Gaus(val, eigValToUse);
   }


### PR DESCRIPTION
This change takes into account that the stored value inside LUTs for eigval could be very slightly negative in some cases, ie `-1e-7`, and an attempt to take a sqrt of that small value leads to a NaN. This is something that I did "experimentally" based on exploring some issues I see: I would like to have confirmation from people more experienced with LUTs that this is an acceptable change. @shahor02 @njacazio @jesgum @altsybee 

(it would also be good if we had some reference document that explains the calculations being done by the LUT-based smearing - I am not sure I have seen such a thing myself and would love to have that...) 