### PR TITLE
feat: Add collision labels to non-prompt cascade task

### DIFF
--- a/PWGLF/Tasks/Strangeness/nonPromptCascade.cxx
+++ b/PWGLF/Tasks/Strangeness/nonPromptCascade.cxx
@@ -362,7 +362,7 @@ struct NonPromptCascadeTask {
   }
 
   void processTrackedCascadesMC(CollisionsCandidatesRun3 const& /*collisions*/,
-                                aod::AssignedTrackedCascades const& trackedCascades, aod::Cascades const& /*cascades*/,
+                                aod::AssignedTrackedCascades const& trackedCascades, aod::McCollisionLabels const& collisionLabels, aod::Cascades const& /*cascades*/,
                                 aod::V0s const& /*v0s*/, TracksExtMC const& /*tracks*/,
                                 aod::McParticles const& mcParticles, aod::McCollisions const&, aod::BCsWithTimestamps const&)
   {
@@ -598,6 +598,7 @@ struct NonPromptCascadeTask {
       auto particle = mcParticles.iteratorAt(mcParticleId[i]);
       auto& c = candidates[i];
       auto mcCollision = particle.mcCollision_as<aod::McCollisions>();
+      auto label = collisionLabels.iteratorAt(c.collisionID);
 
       NPCTableMC(c.matchingChi2, c.itsClusSize, c.isGoodMatch, c.isGoodCascade, c.pdgCodePrimary,
                  c.pvX, c.pvY, c.pvZ,
@@ -611,7 +612,7 @@ struct NonPromptCascadeTask {
                  c.protonTPCNSigma, c.pionTPCNSigma, c.bachKaonTPCNSigma, c.bachPionTPCNSigma,
                  c.protonHasTOF, c.pionHasTOF, c.bachKaonHasTOF, c.bachPionHasTOF,
                  c.protonTOFNSigma, c.pionTOFNSigma, c.bachKaonTOFNSigma, c.bachPionTOFNSigma,
-                 particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(), mcCollision.posX() - particle.vx(), mcCollision.posY() - particle.vy(), mcCollision.posZ() - particle.vz(), mcCollision.globalIndex() == c.collisionID);
+                 particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(), mcCollision.posX() - particle.vx(), mcCollision.posY() - particle.vy(), mcCollision.posZ() - particle.vz(), mcCollision.globalIndex() == label.mcCollisionId());
     }
   }
   PROCESS_SWITCH(NonPromptCascadeTask, processTrackedCascadesMC, "process cascades from strangeness tracking: MC analysis", true);


### PR DESCRIPTION
This commit adds the usage of collision labels to the non-prompt cascade
task in the ALICE PWGLF analysis. The changes ensure that the correct
collision information is used when processing the Monte Carlo
information, improving the accuracy of the analysis.

The key changes include:

- Accessing the collision label information from the `aod::McCollisionLabels`
  table and associating it with the cascade candidates.
- Updating the `NPCTableMC` function to use the collision label information
  instead of the `collisionID` field.
- Modifying the `processTrackedCascadesMC` function to include the
  `aod::McCollisionLabels` table as an input.

These changes help to enhance the reliability and correctness of the
non-prompt cascade analysis in the ALICE PWGLF framework.