### PR TITLE
feat(EventFiltering/Zorro): Add getTriggerOfInterestResults method

### DIFF
--- a/EventFiltering/Zorro.cxx
+++ b/EventFiltering/Zorro.cxx
@@ -187,3 +187,16 @@ bool Zorro::isSelected(uint64_t bcGlobalId, uint64_t tolerance)
   }
   return false;
 }
+
+std::vector<bool> Zorro::getTriggerOfInterestResults() const
+{
+  std::vector<bool> results(mTOIidx.size(), false);
+  for (size_t i{0}; i < mTOIidx.size(); ++i) {
+    if (mTOIidx[i] < 0) {
+      continue;
+    } else if (mLastResult.test(mTOIidx[i])) {
+      results[i] = true;
+    }
+  }
+  return results;
+}

--- a/EventFiltering/Zorro.h
+++ b/EventFiltering/Zorro.h
@@ -47,6 +47,7 @@ class Zorro
   TH1D* getInspectedTVX() const { return mInspectedTVX; }
   std::bitset<128> getLastResult() const { return mLastResult; }
   std::vector<int> getTOIcounters() const { return mTOIcounts; }
+  std::vector<bool> getTriggerOfInterestResults() const;
 
   void setCCDBpath(std::string path) { mBaseCCDBPath = path; }
   void setBaseCCDBPath(std::string path) { mBaseCCDBPath = path; }


### PR DESCRIPTION
The changes add a new method `getTriggerOfInterestResults` to the `Zorro` class. This method returns a vector of boolean values indicating which Triggers of Interest (TOIs) were selected in the last run of the `isSelected` method. This functionality is useful for providing the results of the TOI selection to the users.