### PR TITLE
PWGCF: Change combinations policy for non identical V0s in V0 task

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h
@@ -38,7 +38,7 @@ class FemtoUniverseEventHisto
     mHistogramRegistry->add("Event/zvtxhist", "; vtx_{z} (cm); Entries", kTH1F, {{300, -12.5, 12.5}});
     mHistogramRegistry->add("Event/MultV0M", "; vMultV0M; Entries", kTH1F, {{16384, 0, 32768}});
     mHistogramRegistry->add("Event/MultNTr", "; vMultNTr; Entries", kTH1F, {{200, 0, 200}});
-    mHistogramRegistry->add("Event/MultNTrVSMultV0M", "; vMultNTr; MultV0M", kTH2F, {{200, 0, 200}, {16384, 0, 32768}});
+    mHistogramRegistry->add("Event/MultNTrVSMultV0M", "; vMultNTr; MultV0M", kTH2F, {{4000, 0, 4000}, {32768, 0, 32768}});
   }
 
   /// Some basic QA of the event

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
@@ -49,8 +49,8 @@ struct femtoUniverseEfficiencyBase {
 
   /// Particle 1
   Configurable<int32_t> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
-  Configurable<uint8_t> ConfParticleTypePartOne{"ConfParticleTypePartOne", aod::femtouniverseparticle::ParticleType::kTrack, "Particle 1 - particle type"};
-  Configurable<bool> ConfNoPDGPartOne{"ConfNoPDGPartOne", false, "0: selecting part one by PDG, 1: no PID selection"};
+  Configurable<uint8_t> ConfParticleTypePartOne{"ConfParticleTypePartOne", aod::femtouniverseparticle::ParticleType::kTrack, "Particle 1 - particle type: 0 - track, 2 - V0, 6 - phi"};
+  Configurable<bool> ConfNoPDGPartOne{"ConfNoPDGPartOne", false, "0: selecting part by PDG, 1: no PID selection"};
   Configurable<float> ConfPtLowPart1{"ConfPtLowPart1", 0.2, "Lower limit for Pt for the first particle"};
   Configurable<float> ConfPtHighPart1{"ConfPtHighPart1", 2.5, "Higher limit for Pt for the first particle"};
   Configurable<int> ConfChargePart1{"ConfChargePart1", 1, "Charge of the first particle"};
@@ -70,7 +70,7 @@ struct femtoUniverseEfficiencyBase {
   /// Particle 2
   Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
   Configurable<int32_t> ConfPDGCodePartTwo{"ConfPDGCodePartTwo", 333, "Particle 2 - PDG code"};
-  Configurable<uint8_t> ConfParticleTypePartTwo{"ConfParticleTypePartTwo", aod::femtouniverseparticle::ParticleType::kTrack, "Particle 2 - particle type"};
+  Configurable<uint8_t> ConfParticleTypePartTwo{"ConfParticleTypePartTwo", aod::femtouniverseparticle::ParticleType::kTrack, "Particle 2 - particle type:  0 - track, 2 - V0, 6 - phi"};
   Configurable<bool> ConfNoPDGPartTwo{"ConfNoPDGPartTwo", false, "0: selecting part two by PDG, 1: no PID selection"};
   Configurable<float> ConfPtLowPart2{"ConfPtLowPart2", 0.2, "Lower limit for Pt for the second particle"};
   Configurable<float> ConfPtHighPart2{"ConfPtHighPart2", 2.5, "Higher limit for Pt for the second particle"};
@@ -333,7 +333,6 @@ struct femtoUniverseEfficiencyBase {
   void doMCRecTrackPhi(PartitionType grouppartsOneMCGen, PartitionType grouppartsTwoGen)
   { // part1 is track and part2 is Phi
 
-    /// Histogramming same event
     for (auto& part : grouppartsOneMCGen) {
       if (part.partType() != ConfParticleTypePartOne || part.sign() != ConfChargePart1 || !IsParticleNSigma(ConfPDGCodePartOne, part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
         continue;

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
@@ -50,7 +50,7 @@ struct femtoUniverseEfficiencyBase {
   /// Particle 1
   Configurable<int32_t> ConfPDGCodePartOne{"ConfPDGCodePartOne", 2212, "Particle 1 - PDG code"};
   Configurable<uint8_t> ConfParticleTypePartOne{"ConfParticleTypePartOne", aod::femtouniverseparticle::ParticleType::kTrack, "Particle 1 - particle type: 0 - track, 2 - V0, 6 - phi"};
-  Configurable<bool> ConfNoPDGPartOne{"ConfNoPDGPartOne", false, "0: selecting part by PDG, 1: no PID selection"};
+  Configurable<bool> ConfNoPDGPartOne{"ConfNoPDGPartOne", false, "0: selecting part one by PDG, 1: no PID selection"};
   Configurable<float> ConfPtLowPart1{"ConfPtLowPart1", 0.2, "Lower limit for Pt for the first particle"};
   Configurable<float> ConfPtHighPart1{"ConfPtHighPart1", 2.5, "Higher limit for Pt for the first particle"};
   Configurable<int> ConfChargePart1{"ConfChargePart1", 1, "Charge of the first particle"};

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -395,36 +395,70 @@ struct femtoUniversePairTaskTrackV0Extended {
       }
     }
 
-    /// Now build the combinations
-    for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsTwo, groupPartsTwo))) {
-      // Lambda invariant mass cut for p1
-      if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
-        continue;
-      // Lambda invariant mass cut for p2
-      if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
-        continue;
-      // track cleaning
-      if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
-        continue;
-      }
-      if (ConfIsCPR.value) {
-        if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
+    if (ConfV0Type1 == ConfV0Type2) {
+      /// Now build the combinations for identical V0s
+      for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsTwo, groupPartsTwo))) {
+        // Lambda invariant mass cut for p1
+        if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
+          continue;
+        // Lambda invariant mass cut for p2
+        if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
+          continue;
+        // track cleaning
+        if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
           continue;
         }
+        if (ConfIsCPR.value) {
+          if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
+            continue;
+          }
+        }
+        const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
+        const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
+        /// Daughters that do not pass this condition are not selected
+        if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
+          continue;
+
+        const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
+        const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
+        /// Daughters that do not pass this condition are not selected
+        if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
+          continue;
+
+        sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
       }
-      const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
-      const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
-      /// Daughters that do not pass this condition are not selected
-      if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
-        continue;
+    } else {
+      /// Now build the combinations for not identical identical V0s
+      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsTwo, groupPartsTwo))) {
+        // Lambda invariant mass cut for p1
+        if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
+          continue;
+        // Lambda invariant mass cut for p2
+        if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
+          continue;
+        // track cleaning
+        if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
+          continue;
+        }
+        if (ConfIsCPR.value) {
+          if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
+            continue;
+          }
+        }
+        const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
+        const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
+        /// Daughters that do not pass this condition are not selected
+        if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
+          continue;
 
-      const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
-      const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
-      /// Daughters that do not pass this condition are not selected
-      if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
-        continue;
+        const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
+        const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
+        /// Daughters that do not pass this condition are not selected
+        if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
+          continue;
 
-      sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+        sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+      }
     }
   }
 


### PR DESCRIPTION
- add a check if V0 are identical and use CombinationsStrictlyUpperIndexPolicy for identical and CombinationsFullIndexPolicy for non identical in femtoUniversePairTaskTrackV0Extended.cxx

Additionally:
- change configurable description in femtoUniverseEfficiencyBase.cxx to simplify setting them,
- change binning of one histogram in FemtoUniverseEventHisto.h to cover larger range