### PR TITLE
PWGCF: FemtoUniverse track-V0 task -- to avoid duplication

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -395,69 +395,45 @@ struct femtoUniversePairTaskTrackV0Extended {
       }
     }
 
+    auto f = [&](auto& p1, auto& p2) -> void {
+      // Lambda invariant mass cut for p1
+      if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
+        return;
+      // Lambda invariant mass cut for p2
+      if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
+        return;
+      // track cleaning
+      if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
+        return;
+      }
+      if (ConfIsCPR.value) {
+        if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
+          return;
+        }
+      }
+      const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
+      const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
+      /// Daughters that do not pass this condition are not selected
+      if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
+        return;
+
+      const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
+      /// Daughters that do not pass this condition are not selected
+      if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
+        return;
+
+      sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+    };
     if (ConfV0Type1 == ConfV0Type2) {
       /// Now build the combinations for identical V0s
       for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsTwo, groupPartsTwo))) {
-        // Lambda invariant mass cut for p1
-        if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
-          continue;
-        // Lambda invariant mass cut for p2
-        if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
-          continue;
-        // track cleaning
-        if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
-          continue;
-        }
-        if (ConfIsCPR.value) {
-          if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
-            continue;
-          }
-        }
-        const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
-        const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
-        /// Daughters that do not pass this condition are not selected
-        if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
-          continue;
-
-        const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
-        const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
-        /// Daughters that do not pass this condition are not selected
-        if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
-          continue;
-
-        sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+        f(p1, p2);
       }
     } else {
       /// Now build the combinations for not identical identical V0s
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsTwo, groupPartsTwo))) {
-        // Lambda invariant mass cut for p1
-        if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
-          continue;
-        // Lambda invariant mass cut for p2
-        if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
-          continue;
-        // track cleaning
-        if (!pairCleanerV0.isCleanPair(p1, p2, parts)) {
-          continue;
-        }
-        if (ConfIsCPR.value) {
-          if (pairCloseRejectionV0.isClosePair(p1, p2, parts, magFieldTesla, femtoUniverseContainer::EventType::same)) {
-            continue;
-          }
-        }
-        const auto& posChild1 = parts.iteratorAt(p1.index() - 2);
-        const auto& negChild1 = parts.iteratorAt(p1.index() - 1);
-        /// Daughters that do not pass this condition are not selected
-        if (!IsParticleTPC(posChild1, V0ChildTable[ConfV0Type1][0]) || !IsParticleTPC(negChild1, V0ChildTable[ConfV0Type1][1]))
-          continue;
-
-        const auto& posChild2 = parts.iteratorAt(p2.index() - 2);
-        const auto& negChild2 = parts.iteratorAt(p2.index() - 1);
-        /// Daughters that do not pass this condition are not selected
-        if (!IsParticleTPC(posChild2, V0ChildTable[ConfV0Type2][0]) || !IsParticleTPC(negChild2, V0ChildTable[ConfV0Type2][1]))
-          continue;
-
-        sameEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+        f(p1, p2);
       }
     }
   }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -395,7 +395,7 @@ struct femtoUniversePairTaskTrackV0Extended {
       }
     }
 
-    auto f = [&](auto& p1, auto& p2) -> void {
+    auto pairProcessFunc = [&](auto& p1, auto& p2) -> void {
       // Lambda invariant mass cut for p1
       if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
         return;
@@ -428,12 +428,12 @@ struct femtoUniversePairTaskTrackV0Extended {
     if (ConfV0Type1 == ConfV0Type2) {
       /// Now build the combinations for identical V0s
       for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsTwo, groupPartsTwo))) {
-        f(p1, p2);
+        pairProcessFunc(p1, p2);
       }
     } else {
       /// Now build the combinations for not identical identical V0s
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsTwo, groupPartsTwo))) {
-        f(p1, p2);
+        pairProcessFunc(p1, p2);
       }
     }
   }


### PR DESCRIPTION
- recent commit on fixing V0-V0 Combinations Policy duplicated same block of code twice. I used lambda to avoid that.