### PR TITLE
feat: add method to get trigger of interest results

### DIFF
--- a/EventFiltering/Zorro.cxx
+++ b/EventFiltering/Zorro.cxx
@@ -188,6 +188,12 @@ bool Zorro::isSelected(uint64_t bcGlobalId, uint64_t tolerance)
   return false;
 }
 
+std::vector<bool> Zorro::getTriggerOfInterestResults(uint64_t bcGlobalId, uint64_t tolerance)
+{
+  fetch(bcGlobalId, tolerance);
+  return getTriggerOfInterestResults();
+}
+
 std::vector<bool> Zorro::getTriggerOfInterestResults() const
 {
   std::vector<bool> results(mTOIidx.size(), false);
@@ -199,4 +205,10 @@ std::vector<bool> Zorro::getTriggerOfInterestResults() const
     }
   }
   return results;
+}
+
+bool Zorro::isNotSelectedByAny(uint64_t bcGlobalId, uint64_t tolerance)
+{
+  fetch(bcGlobalId, tolerance);
+  return mLastResult.none();
 }

--- a/EventFiltering/Zorro.h
+++ b/EventFiltering/Zorro.h
@@ -39,6 +39,7 @@ class Zorro
   std::vector<int> initCCDB(o2::ccdb::BasicCCDBManager* ccdb, int runNumber, uint64_t timestamp, std::string tois, int bcTolerance = 500);
   std::bitset<128> fetch(uint64_t bcGlobalId, uint64_t tolerance = 100);
   bool isSelected(uint64_t bcGlobalId, uint64_t tolerance = 100);
+  bool isNotSelectedByAny(uint64_t bcGlobalId, uint64_t tolerance = 100);
 
   void populateHistRegistry(o2::framework::HistogramRegistry& histRegistry, int runNumber, std::string folderName = "Zorro");
 
@@ -47,6 +48,7 @@ class Zorro
   TH1D* getInspectedTVX() const { return mInspectedTVX; }
   std::bitset<128> getLastResult() const { return mLastResult; }
   std::vector<int> getTOIcounters() const { return mTOIcounts; }
+  std::vector<bool> getTriggerOfInterestResults(uint64_t bcGlobalId, uint64_t tolerance = 100);
   std::vector<bool> getTriggerOfInterestResults() const;
 
   void setCCDBpath(std::string path) { mBaseCCDBPath = path; }


### PR DESCRIPTION
Add a new method `getTriggerOfInterestResults` that fetches the data for a given
bunch crossing global ID and tolerance, and returns the vector of boolean
results indicating whether each trigger of interest is satisfied. This is a
convenience method that combines the existing `fetch` and
`getTriggerOfInterestResults` methods.

Also add a new method `isNotSelectedByAny` that returns whether within a given tolerance a bunch
crossing global ID was not selected by any trigger.
This is a useful utility method for selecting parasitic MB events