### PR TITLE
[PWGLF] Fix derived data production + adapt analysis task

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -693,7 +693,7 @@ DECLARE_SOA_TABLE_VERSIONED(V0MCCores_002, "AOD", "V0MCCORE", 2, //! debug infor
                             v0data::IsPhysicalPrimary, v0data::XMC, v0data::YMC, v0data::ZMC,
                             v0data::PxPosMC, v0data::PyPosMC, v0data::PzPosMC,
                             v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC,
-                            v0data::PxMC, v0data::PyMC, v0data::PzMC, 
+                            v0data::PxMC, v0data::PyMC, v0data::PzMC,
                             v0data::RapidityMC<v0data::PxMC, v0data::PyMC, v0data::PzMC>,
                             v0data::NegativePtMC<v0data::PxNegMC, v0data::PyNegMC>,
                             v0data::PositivePtMC<v0data::PxPosMC, v0data::PyPosMC>,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -100,8 +100,6 @@ DECLARE_SOA_TABLE(StraMCCollisions, "AOD", "STRAMCCOLLISION", //! MC collision p
                   mccollision::ImpactParameter);
 DECLARE_SOA_TABLE(StraMCCollMults, "AOD", "STRAMCCOLLMULTS", //! MC collision multiplicities
                   mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<2>);
-DECLARE_SOA_TABLE(StraMCCollCents, "AOD", "STRAMCCOLLCENTS", //! MC collision centrality
-                  mccollisionprop::BestCollisionCentFT0C);
 
 using StraMCCollision = StraMCCollisions::iterator;
 
@@ -711,6 +709,7 @@ using V0fCDatas = soa::Join<V0fCIndices, V0fCTrackXs, V0fCCores>;
 using V0fCData = V0fCDatas::iterator;
 using V0MCDatas = soa::Join<V0MCCores, V0MCMothers>;
 using V0MCData = V0MCDatas::iterator;
+using V0MCCore = V0MCCores::iterator;
 
 // definitions of indices for interlink tables
 namespace v0data

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -295,6 +295,9 @@ DECLARE_SOA_COLUMN(PzPosMC, pzPosMC, float);                    //! V0 positive 
 DECLARE_SOA_COLUMN(PxNegMC, pxNegMC, float);                    //! V0 positive daughter px (GeV/c)
 DECLARE_SOA_COLUMN(PyNegMC, pyNegMC, float);                    //! V0 positive daughter py (GeV/c)
 DECLARE_SOA_COLUMN(PzNegMC, pzNegMC, float);                    //! V0 positive daughter pz (GeV/c)
+DECLARE_SOA_COLUMN(PxMC, pxMC, float);                          //! V0 px (GeV/c)
+DECLARE_SOA_COLUMN(PyMC, pyMC, float);                          //! V0 py (GeV/c)
+DECLARE_SOA_COLUMN(PzMC, pzMC, float);                          //! V0 pz (GeV/c)
 
 //______________________________________________________
 // Binned content for generated particles: derived data
@@ -465,6 +468,22 @@ DECLARE_SOA_DYNAMIC_COLUMN(IsPhotonTPConly, isPhotonTPConly, //! is tpc-only pho
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 1); });
 DECLARE_SOA_DYNAMIC_COLUMN(IsCollinear, isCollinear, //! is collinear V0
                            [](uint8_t V0Type) -> bool { return V0Type & (1 << 2); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(RapidityMC, rapidityMC, //! rapidity (0:K0, 1:L, 2:Lbar)
+                           [](float PxMC, float PyMC, float PzMC, int value) -> float {
+                             if (value == 0)
+                               return RecoDecay::y(std::array{PxMC, PyMC, PzMC}, o2::constants::physics::MassKaonNeutral);
+                             if (value == 1 || value == 2)
+                               return RecoDecay::y(std::array{PxMC, PyMC, PzMC}, o2::constants::physics::MassLambda);
+                             return 0.0f;
+                           });
+
+DECLARE_SOA_DYNAMIC_COLUMN(NegativePtMC, negativeptMC, //! negative daughter pT
+                           [](float pxnegMC, float pynegMC) -> float { return RecoDecay::sqrtSumOfSquares(pxnegMC, pynegMC); });
+DECLARE_SOA_DYNAMIC_COLUMN(PositivePtMC, positiveptMC, //! positive daughter pT
+                           [](float pxposMC, float pyposMC) -> float { return RecoDecay::sqrtSumOfSquares(pxposMC, pyposMC); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtMC, ptMC, //! V0 pT
+                           [](float pxMC, float pyMC) -> float { return RecoDecay::sqrtSumOfSquares(pxMC, pyMC); });
 } // namespace v0data
 
 DECLARE_SOA_TABLE(V0Indices, "AOD", "V0INDEX", //! index table when using AO2Ds
@@ -667,6 +686,19 @@ DECLARE_SOA_TABLE_VERSIONED(V0MCCores_001, "AOD", "V0MCCORE", 1, //! debug infor
                             v0data::PxPosMC, v0data::PyPosMC, v0data::PzPosMC,
                             v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC);
 
+DECLARE_SOA_TABLE_VERSIONED(V0MCCores_002, "AOD", "V0MCCORE", 2, //! debug information
+                            v0data::ParticleIdMC,                //! MC properties of the V0 for posterior analysis
+                            v0data::PDGCode, v0data::PDGCodeMother,
+                            v0data::PDGCodePositive, v0data::PDGCodeNegative,
+                            v0data::IsPhysicalPrimary, v0data::XMC, v0data::YMC, v0data::ZMC,
+                            v0data::PxPosMC, v0data::PyPosMC, v0data::PzPosMC,
+                            v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC,
+                            v0data::PxMC, v0data::PyMC, v0data::PzMC, 
+                            v0data::RapidityMC<v0data::PxMC, v0data::PyMC, v0data::PzMC>,
+                            v0data::NegativePtMC<v0data::PxNegMC, v0data::PyNegMC>,
+                            v0data::PositivePtMC<v0data::PxPosMC, v0data::PyPosMC>,
+                            v0data::PtMC<v0data::PxMC, v0data::PyMC, v0data::PzMC>);
+
 DECLARE_SOA_TABLE(StoredV0MCCores_000, "AOD", "V0MCCORE", //! MC properties of the V0 for posterior analysis
                   v0data::PDGCode, v0data::PDGCodeMother,
                   v0data::PDGCodePositive, v0data::PDGCodeNegative,
@@ -684,6 +716,16 @@ DECLARE_SOA_TABLE_VERSIONED(StoredV0MCCores_001, "AOD", "V0MCCORE", 1, //! debug
                             v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC,
                             o2::soa::Marker<1>);
 
+DECLARE_SOA_TABLE_VERSIONED(StoredV0MCCores_002, "AOD", "V0MCCORE", 2, //! debug information
+                            v0data::ParticleIdMC,                      //! MC properties of the V0 for posterior analysis
+                            v0data::PDGCode, v0data::PDGCodeMother,
+                            v0data::PDGCodePositive, v0data::PDGCodeNegative,
+                            v0data::IsPhysicalPrimary, v0data::XMC, v0data::YMC, v0data::ZMC,
+                            v0data::PxPosMC, v0data::PyPosMC, v0data::PzPosMC,
+                            v0data::PxNegMC, v0data::PyNegMC, v0data::PzNegMC,
+                            v0data::PxMC, v0data::PyMC, v0data::PzMC,
+                            o2::soa::Marker<1>);
+
 DECLARE_SOA_TABLE(V0MCCollRefs, "AOD", "V0MCCOLLREF", //! refers MC candidate back to proper MC Collision
                   o2::soa::Index<>, v0data::StraMCCollisionId, o2::soa::Marker<2>);
 
@@ -697,8 +739,8 @@ DECLARE_SOA_TABLE(V0MCMothers, "AOD", "V0MCMOTHER", //! optional table for MC mo
 DECLARE_SOA_TABLE(StoredV0MCMothers, "AOD1", "V0MCMOTHER", //! optional table for MC mothers
                   o2::soa::Index<>, v0data::MotherMCPartId, o2::soa::Marker<1>);
 
-using V0MCCores = V0MCCores_001;
-using StoredV0MCCores = StoredV0MCCores_001;
+using V0MCCores = V0MCCores_002;
+using StoredV0MCCores = StoredV0MCCores_002;
 
 using V0Index = V0Indices::iterator;
 using V0Core = V0Cores::iterator;
@@ -999,6 +1041,24 @@ DECLARE_SOA_DYNAMIC_COLUMN(BachelorEta, bacheloreta, //! bachelor daughter eta
                            [](float PxPos, float PyPos, float PzPos) -> float { return RecoDecay::eta(std::array{PxPos, PyPos, PzPos}); });
 DECLARE_SOA_DYNAMIC_COLUMN(BachelorPhi, bachelorphi, //! bachelor daughter phi
                            [](float PxPos, float PyPos) -> float { return RecoDecay::phi(PxPos, PyPos); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(RapidityMC, rapidityMC, //! rapidity (0, 1: Xi; 2, 3: Omega)
+                           [](float PxMC, float PyMC, float PzMC, int value) -> float {
+                             if (value == 0 || value == 1)
+                               return RecoDecay::y(std::array{PxMC, PyMC, PzMC}, o2::constants::physics::MassXiMinus);
+                             if (value == 2 || value == 3)
+                               return RecoDecay::y(std::array{PxMC, PyMC, PzMC}, o2::constants::physics::MassOmegaMinus);
+                             return 0.0f;
+                           });
+
+DECLARE_SOA_DYNAMIC_COLUMN(NegativePtMC, negativeptMC, //! negative daughter pT
+                           [](float pxNegMC, float pyNegMC) -> float { return RecoDecay::sqrtSumOfSquares(pxNegMC, pyNegMC); });
+DECLARE_SOA_DYNAMIC_COLUMN(PositivePtMC, positiveptMC, //! positive daughter pT
+                           [](float pxPosMC, float pyPosMC) -> float { return RecoDecay::sqrtSumOfSquares(pxPosMC, pyPosMC); });
+DECLARE_SOA_DYNAMIC_COLUMN(BachelorPtMC, bachelorptMC, //! bachelor daughter pT
+                           [](float pxBachMC, float pyBachMC) -> float { return RecoDecay::sqrtSumOfSquares(pxBachMC, pyBachMC); });
+DECLARE_SOA_DYNAMIC_COLUMN(PtMC, ptMC, //! cascade pT
+                           [](float pxMC, float pyMC) -> float { return RecoDecay::sqrtSumOfSquares(pxMC, pyMC); });
 } // namespace cascdata
 
 //______________________________________________________
@@ -1192,7 +1252,12 @@ DECLARE_SOA_TABLE(CascMCCores, "AOD", "CASCMCCORE", //! bachelor-baryon correlat
                   cascdata::PxPosMC, cascdata::PyPosMC, cascdata::PzPosMC,
                   cascdata::PxNegMC, cascdata::PyNegMC, cascdata::PzNegMC,
                   cascdata::PxBachMC, cascdata::PyBachMC, cascdata::PzBachMC,
-                  cascdata::PxMC, cascdata::PyMC, cascdata::PzMC);
+                  cascdata::PxMC, cascdata::PyMC, cascdata::PzMC,
+                  cascdata::RapidityMC<cascdata::PxMC, cascdata::PyMC, cascdata::PzMC>,
+                  cascdata::NegativePtMC<cascdata::PxNegMC, cascdata::PyNegMC>,
+                  cascdata::PositivePtMC<cascdata::PxPosMC, cascdata::PyPosMC>,
+                  cascdata::BachelorPtMC<cascdata::PxBachMC, cascdata::PyBachMC>,
+                  cascdata::PtMC<cascdata::PxMC, cascdata::PyMC>);
 
 namespace cascdata
 {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -20,6 +20,7 @@
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Qvectors.h"
+#include "Common/DataModel/McCollisionExtra.h"
 #include "PWGLF/DataModel/EPCalibrationTables.h"
 
 namespace o2::aod
@@ -99,6 +100,8 @@ DECLARE_SOA_TABLE(StraMCCollisions, "AOD", "STRAMCCOLLISION", //! MC collision p
                   mccollision::ImpactParameter);
 DECLARE_SOA_TABLE(StraMCCollMults, "AOD", "STRAMCCOLLMULTS", //! MC collision multiplicities
                   mult::MultMCFT0A, mult::MultMCFT0C, mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10, o2::soa::Marker<2>);
+DECLARE_SOA_TABLE(StraMCCollCents, "AOD", "STRAMCCOLLCENTS", //! MC collision centrality
+                  mccollisionprop::BestCollisionCentFT0C);
 
 using StraMCCollision = StraMCCollisions::iterator;
 

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -28,3 +28,8 @@ o2physics_add_dpl_workflow(v0coresconverter
                     SOURCES v0coresconverter.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(v0coresconverter2
+                    SOURCES v0coresconverter2.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)                    

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -32,4 +32,4 @@ o2physics_add_dpl_workflow(v0coresconverter
 o2physics_add_dpl_workflow(v0coresconverter2
                     SOURCES v0coresconverter2.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)                    
+                    COMPONENT_NAME Analysis)

--- a/PWGLF/TableProducer/Strangeness/Converters/v0coresconverter2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/v0coresconverter2.cxx
@@ -38,9 +38,9 @@ struct v0coresconverter2 {
                     values.pxNegMC(),
                     values.pyNegMC(),
                     values.pzNegMC(),
-                    values.pxPosMC()+values.pxNegMC(),
-                    values.pyPosMC()+values.pyNegMC(),
-                    values.pzPosMC()+values.pzNegMC());
+                    values.pxPosMC() + values.pxNegMC(),
+                    values.pyPosMC() + values.pyNegMC(),
+                    values.pzPosMC() + values.pzNegMC());
     }
   }
 };

--- a/PWGLF/TableProducer/Strangeness/Converters/v0coresconverter2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/v0coresconverter2.cxx
@@ -1,0 +1,52 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts V0 version 001 to 002
+struct v0coresconverter2 {
+  Produces<aod::V0MCCores_002> v0MCCores_002;
+
+  void process(aod::V0MCCores_001 const& v0MCCores_001)
+  {
+    for (auto& values : v0MCCores_001) {
+      v0MCCores_002(0,
+                    values.pdgCode(),
+                    values.pdgCodeMother(),
+                    values.pdgCodePositive(),
+                    values.pdgCodeNegative(),
+                    values.isPhysicalPrimary(),
+                    values.xMC(),
+                    values.yMC(),
+                    values.zMC(),
+                    values.pxPosMC(),
+                    values.pyPosMC(),
+                    values.pzPosMC(),
+                    values.pxNegMC(),
+                    values.pyNegMC(),
+                    values.pzNegMC(),
+                    values.pxPosMC()+values.pxNegMC(),
+                    values.pyPosMC()+values.pyNegMC(),
+                    values.pzPosMC()+values.pzNegMC());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<v0coresconverter2>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -197,7 +197,6 @@ struct cascadeBuilder {
   // for using cascade momentum at prim. vtx
   Configurable<bool> useCascadeMomentumAtPrimVtx{"useCascadeMomentumAtPrimVtx", false, "if enabled, store cascade momentum at prim. vtx instead of decay point (= default)"};
 
-
   // for topo var QA
   struct : ConfigurableGroup {
     ConfigurableAxis axisTopoVarPointingAngle{"axisConfigurations.axisTopoVarPointingAngle", {50, 0.0, 1.0}, "pointing angle"};

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -196,7 +196,7 @@ struct cascadeBuilder {
 
   // for using cascade momentum at prim. vtx
   Configurable<bool> useCascadeMomentumAtPrimVtx{"useCascadeMomentumAtPrimVtx", false, "if enabled, store cascade momentum at prim. vtx instead of decay point (= default)"};
-  
+
 
   // for topo var QA
   struct : ConfigurableGroup {
@@ -1103,7 +1103,7 @@ struct cascadeBuilder {
       cascadecandidate.cascademom[1] = cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1];
       cascadecandidate.cascademom[2] = cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2];
     }
-    
+
     // Calculate masses a priori
     cascadecandidate.mXi = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassLambda});
     cascadecandidate.mOmega = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassKaonCharged, o2::constants::physics::MassLambda});

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -194,6 +194,10 @@ struct cascadeBuilder {
   Configurable<bool> kfDoDCAFitterPreMinimV0{"kfDoDCAFitterPreMinimV0", true, "KF: do DCAFitter pre-optimization before KF fit to include material corrections for V0"};
   Configurable<bool> kfDoDCAFitterPreMinimCasc{"kfDoDCAFitterPreMinimCasc", true, "KF: do DCAFitter pre-optimization before KF fit to include material corrections for Xi"};
 
+  // for using cascade momentum at prim. vtx
+  Configurable<bool> useCascadeMomentumAtPrimVtx{"useCascadeMomentumAtPrimVtx", false, "if enabled, store cascade momentum at prim. vtx instead of decay point (= default)"};
+  
+
   // for topo var QA
   struct : ConfigurableGroup {
     ConfigurableAxis axisTopoVarPointingAngle{"axisConfigurations.axisTopoVarPointingAngle", {50, 0.0, 1.0}, "pointing angle"};
@@ -1090,7 +1094,16 @@ struct cascadeBuilder {
     o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, lCascadeTrack, 2.f, matCorrCascade, &dcaInfo);
     cascadecandidate.cascDCAxy = dcaInfo[0];
     cascadecandidate.cascDCAz = dcaInfo[1];
-
+    if (useCascadeMomentumAtPrimVtx) {
+      lCascadeTrack.getPxPyPzGlo(cascadecandidate.cascademom);
+    }
+    else
+    {
+      cascadecandidate.cascademom[0] = cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0];
+      cascadecandidate.cascademom[1] = cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1];
+      cascadecandidate.cascademom[2] = cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2];
+    }
+    
     // Calculate masses a priori
     cascadecandidate.mXi = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassLambda});
     cascadecandidate.mOmega = RecoDecay::m(array{array{cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2]}, array{v0.pxpos() + v0.pxneg(), v0.pypos() + v0.pyneg(), v0.pzpos() + v0.pzneg()}}, array{o2::constants::physics::MassKaonCharged, o2::constants::physics::MassLambda});
@@ -1555,9 +1568,7 @@ struct cascadeBuilder {
              cascadecandidate.v0mompos[0], cascadecandidate.v0mompos[1], cascadecandidate.v0mompos[2],
              cascadecandidate.v0momneg[0], cascadecandidate.v0momneg[1], cascadecandidate.v0momneg[2],
              cascadecandidate.bachP[0], cascadecandidate.bachP[1], cascadecandidate.bachP[2],
-             cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0], // <--- redundant but ok
-             cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1], // <--- redundant but ok
-             cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2], // <--- redundant but ok
+             cascadecandidate.cascademom[0], cascadecandidate.cascademom[1], cascadecandidate.cascademom[2],
              cascadecandidate.v0dcadau, cascadecandidate.dcacascdau,
              cascadecandidate.v0dcapostopv, cascadecandidate.v0dcanegtopv,
              cascadecandidate.bachDCAxy, cascadecandidate.cascDCAxy, cascadecandidate.cascDCAz); // <--- no corresponding stratrack information available

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -1096,9 +1096,7 @@ struct cascadeBuilder {
     cascadecandidate.cascDCAz = dcaInfo[1];
     if (useCascadeMomentumAtPrimVtx) {
       lCascadeTrack.getPxPyPzGlo(cascadecandidate.cascademom);
-    }
-    else
-    {
+    } else {
       cascadecandidate.cascademom[0] = cascadecandidate.bachP[0] + cascadecandidate.v0mompos[0] + cascadecandidate.v0momneg[0];
       cascadecandidate.cascademom[1] = cascadecandidate.bachP[1] + cascadecandidate.v0mompos[1] + cascadecandidate.v0momneg[1];
       cascadecandidate.cascademom[2] = cascadecandidate.bachP[2] + cascadecandidate.v0mompos[2] + cascadecandidate.v0momneg[2];

--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -196,7 +196,6 @@ struct cascadeBuilder {
 
   // for using cascade momentum at prim. vtx
   Configurable<bool> useCascadeMomentumAtPrimVtx{"useCascadeMomentumAtPrimVtx", false, "if enabled, store cascade momentum at prim. vtx instead of decay point (= default)"};
-
   // for topo var QA
   struct : ConfigurableGroup {
     ConfigurableAxis axisTopoVarPointingAngle{"axisConfigurations.axisTopoVarPointingAngle", {50, 0.0, 1.0}, "pointing angle"};

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -291,14 +291,14 @@ struct cascademcbuilder {
                 thisInfo.xyz[2] = dau.vz();
                 thisInfo.mcParticleBachelor = dau.globalIndex();
               }
-              if (TMath::Abs(dau.pdgCode()) == 2212) {              
+              if (TMath::Abs(dau.pdgCode()) == 2212) {
                 thisInfo.pdgCodeV0 = dau.pdgCode();
 
                 for (auto& v0Dau : dau.template daughters_as<aod::McParticles>()) {
                   if (v0Dau.getProcess() != 4 )
                     continue;
 
-                  if (v0Dau.pdgCode() > 0) { 
+                  if (v0Dau.pdgCode() > 0) {
                     thisInfo.pdgCodePositive = v0Dau.pdgCode();
                     thisInfo.processPositive = v0Dau.getProcess();
                     thisInfo.posP[0] = v0Dau.px();
@@ -318,7 +318,7 @@ struct cascademcbuilder {
                     thisInfo.mcParticleNegative = v0Dau.globalIndex();
                   }
                 }
-              }    
+              }
             }
           }
 

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -194,8 +194,8 @@ struct cascademcbuilder {
         thisInfo.label, thisInfo.motherLabel);
 
       // Mark mcParticle as recoed (no searching necessary afterwards)
-      if (thisInfo.motherLabel > -1) {
-        mcParticleIsReco[thisInfo.motherLabel] = true;
+      if (thisInfo.label > -1) {
+        mcParticleIsReco[thisInfo.label] = true;
       }
 
       if (populateCascMCCoresSymmetric) {
@@ -216,10 +216,7 @@ struct cascademcbuilder {
         // step 1: check if this element is already provided in the table
         //         using the packedIndices variable calculated above
         for (uint32_t ii = 0; ii < mcCascinfos.size(); ii++) {
-          if (
-            thisInfo.mcParticlePositive == mcCascinfos[ii].mcParticlePositive && mcCascinfos[ii].mcParticlePositive > 0 &&
-            thisInfo.mcParticleNegative == mcCascinfos[ii].mcParticleNegative && mcCascinfos[ii].mcParticleNegative > 0 &&
-            thisInfo.mcParticleBachelor == mcCascinfos[ii].mcParticleBachelor && mcCascinfos[ii].mcParticleBachelor > 0) {
+          if (thisInfo.label == mcCascinfos[ii].label && mcCascinfos[ii].label > -1) {
             thisCascMCCoreIndex = ii;
             break; // this exists already in list
           }

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -278,7 +278,7 @@ struct cascademcbuilder {
           if (mcParticle.has_daughters()) {
             auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
             for (auto& dau : daughters) {
-              if (dau.getProcess() != 4 ) // check whether the daughter comes from a decay
+              if (dau.getProcess() != 4) // check whether the daughter comes from a decay
                 continue;
 
               if (TMath::Abs(dau.pdgCode()) == 211 || TMath::Abs(dau.pdgCode()) == 321) {
@@ -295,7 +295,7 @@ struct cascademcbuilder {
                 thisInfo.pdgCodeV0 = dau.pdgCode();
 
                 for (auto& v0Dau : dau.template daughters_as<aod::McParticles>()) {
-                  if (v0Dau.getProcess() != 4 )
+                  if (v0Dau.getProcess() != 4)
                     continue;
 
                   if (v0Dau.pdgCode() > 0) {

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -181,7 +181,7 @@ struct lambdakzeromcbuilder {
                     // if not, this is not a suitable candidate for one of the decay daughters
                     if (ldau.getProcess() != 4) // see TMCProcess.h
                       continue;
-                    
+
                     if (lMCPosTrack.pdgCode() < 0 && ldau.pdgCode() > 0) { // the positive track needs to be changed
                       thisInfo.pdgCodePositive = ldau.pdgCode();
                       thisInfo.processPositive = ldau.getProcess();
@@ -360,7 +360,7 @@ struct lambdakzeromcbuilder {
               if (dau.getProcess() != 4 )
                 continue;
 
-              if (dau.pdgCode() > 0) { 
+              if (dau.pdgCode() > 0) {
                 thisInfo.pdgCodePositive = dau.pdgCode();
                 thisInfo.processPositive = dau.getProcess();
                 thisInfo.posP[0] = dau.px();

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -102,7 +102,7 @@ struct lambdakzeromcbuilder {
     int pdgCode = 0;
     int pdgCodeMother = 0;
     int pdgCodePositive = 0;
-    int pdgCodeNegative = 0 ;
+    int pdgCodeNegative = 0;
     int mcCollision = -1;
     bool isPhysicalPrimary = false;
     int processPositive = -1;
@@ -173,8 +173,7 @@ struct lambdakzeromcbuilder {
                 thisInfo.xyz[2] = lMCPosTrack.vz();
 
                 // MC pos. and neg. daughters are the same! Looking for replacement...
-                if (lMCPosTrack.globalIndex() == lMCNegTrack.globalIndex())
-                {
+                if (lMCPosTrack.globalIndex() == lMCNegTrack.globalIndex()) {
                   auto const& daughters = lNegMother.daughters_as<aod::McParticles>();
                   for (auto& ldau : daughters) {
                     // check if the candidate originate from a decay
@@ -353,11 +352,9 @@ struct lambdakzeromcbuilder {
           }
           if (mcParticle.has_daughters()) {
             auto const& daughters = mcParticle.daughters_as<aod::McParticles>();
-            // if(daughters.size() > 2)
-              // LOGF(info, Form("V0 candidate with %d daughters!", daughters.size()));
 
             for (auto& dau : daughters) {
-              if (dau.getProcess() != 4 )
+              if (dau.getProcess() != 4)
                 continue;
 
               if (dau.pdgCode() > 0) {

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -470,7 +470,7 @@ struct strangederivedbuilder {
     // Figure out the numbering of the new tracks table
     // assume filling per order
     int nTracks = 0;
-    for (int i = 0; i < trackMap.size(); i++) {
+    for (int i = 0; i < int(trackMap.size()); i++) {
       if (trackMap[i] >= 0) {
         trackMap[i] = nTracks++;
       }
@@ -545,7 +545,7 @@ struct strangederivedbuilder {
     // Figure out the numbering of the new tracks table
     // assume filling per order
     int nTracks = 0;
-    for (int i = 0; i < trackMap.size(); i++) {
+    for (int i = 0; i < int(trackMap.size()); i++) {
       if (trackMap[i] >= 0) {
         trackMap[i] = nTracks++;
       }
@@ -637,7 +637,7 @@ struct strangederivedbuilder {
     // Figure out the numbering of the new mcMother table
     // assume filling per order
     int nParticles = 0;
-    for (int i = 0; i < motherReference.size(); i++) {
+    for (int i = 0; i < int(motherReference.size()); i++) {
       if (motherReference[i] >= 0) {
         motherReference[i] = nParticles++; // count particles of interest
       }

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -72,7 +72,6 @@ struct strangederivedbuilder {
   Produces<aod::StraCollLabels> strangeCollLabels; // characterises collisions
   Produces<aod::StraMCCollisions> strangeMCColl;   // characterises collisions / MC
   Produces<aod::StraMCCollMults> strangeMCMults;   // characterises collisions / MC mults
-  Produces<aod::StraMCCollCents> strangeMCCents;   // characterises collisions / MC centrality
   Produces<aod::StraCents> strangeCents;           // characterises collisions / centrality
   Produces<aod::StraRawCents> strangeRawCents;     // characterises collisions / centrality
   Produces<aod::StraEvSels> strangeEvSels;         // characterises collisions / sel8 selection
@@ -383,7 +382,6 @@ struct strangederivedbuilder {
                      mccollision.multMCNParticlesEta05(),
                      mccollision.multMCNParticlesEta08(),
                      mccollision.multMCNParticlesEta10());
-      strangeMCCents(mccollision.bestCollisionCentFT0C());
     }
 
     // ______________________________________________

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -364,7 +364,7 @@ struct strangederivedbuilder {
       tracasccollref(TraCascadeCollIndices[casc.globalIndex()]);
   }
 
-  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels, aod::MultsExtra, aod::MultsGlobal> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::McCollsExtra, aod::MultsExtraMC> const& mcCollisions, aod::McParticles const&)
+  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels, aod::MultsExtra, aod::MultsGlobal> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& /*V0MCCores*/, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::McCollsExtra, aod::MultsExtraMC> const& mcCollisions, aod::McParticles const&)
   {
     // create collision indices beforehand
     std::vector<int> V0CollIndices(V0s.size(), -1);                 // index -1: no collision

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -72,6 +72,7 @@ struct strangederivedbuilder {
   Produces<aod::StraCollLabels> strangeCollLabels; // characterises collisions
   Produces<aod::StraMCCollisions> strangeMCColl;   // characterises collisions / MC
   Produces<aod::StraMCCollMults> strangeMCMults;   // characterises collisions / MC mults
+  Produces<aod::StraMCCollCents> strangeMCCents;   // characterises collisions / MC centrality
   Produces<aod::StraCents> strangeCents;           // characterises collisions / centrality
   Produces<aod::StraRawCents> strangeRawCents;     // characterises collisions / centrality
   Produces<aod::StraEvSels> strangeEvSels;         // characterises collisions / sel8 selection
@@ -211,8 +212,8 @@ struct strangederivedbuilder {
 
     // Creation of histograms: MC generated
     for (Int_t i = 0; i < nSpecies; i++) {
-      histos.add(Form("hGen%s", particleNames[i].data()), Form("hGen%s", particleNames[i].data()), kTH1D, {axisPt});
-      histos.add(Form("h2dGen%s", particleNames[i].data()), Form("h2dGen%s", particleNames[i].data()), kTH2D, {axisCentrality, axisPt});
+      histos.add(Form("hGenerated%s", particleNames[i].data()), Form("hGenerated%s", particleNames[i].data()), kTH1D, {axisPt});
+      histos.add(Form("h2dGenerated%s", particleNames[i].data()), Form("h2dGenerated%s", particleNames[i].data()), kTH2D, {axisCentrality, axisPt});
     }
 
     histos.add("h2dNVerticesVsCentrality", "h2dNVerticesVsCentrality", kTH2D, {axisCentrality, axisNVertices});
@@ -237,7 +238,7 @@ struct strangederivedbuilder {
 
     if (doprocessBinnedGenerated) {
       // reserve space for generated vectors if that process enabled
-      auto hBinFinder = histos.get<TH2>(HIST("h2dGenK0Short"));
+      auto hBinFinder = histos.get<TH2>(HIST("h2dGeneratedK0Short"));
       LOGF(info, "Binned generated processing enabled. Initialising with %i elements...", hBinFinder->GetNcells());
       genK0Short.resize(hBinFinder->GetNcells(), 0);
       genLambda.resize(hBinFinder->GetNcells(), 0);
@@ -364,7 +365,7 @@ struct strangederivedbuilder {
       tracasccollref(TraCascadeCollIndices[casc.globalIndex()]);
   }
 
-  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels, aod::MultsExtra, aod::MultsGlobal> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::V0MCCores, aod::McV0Labels> const& /*V0MCCores*/, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::MultsExtraMC> const& mcCollisions, aod::McParticles const&)
+  void processCollisionsMC(soa::Join<aod::Collisions, aod::FT0Mults, aod::FV0Mults, aod::PVMults, aod::ZDCMults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::EvSels, aod::McCollisionLabels, aod::MultsExtra, aod::MultsGlobal> const& collisions, soa::Join<aod::V0Datas, aod::McV0Labels> const& V0s, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::CascDatas, aod::McCascLabels> const& Cascades, aod::KFCascDatas const& KFCascades, aod::TraCascDatas const& TraCascades, aod::BCsWithTimestamps const&, soa::Join<aod::McCollisions, aod::McCollsExtra, aod::MultsExtraMC> const& mcCollisions, aod::McParticles const&)
   {
     // create collision indices beforehand
     std::vector<int> V0CollIndices(V0s.size(), -1);                 // index -1: no collision
@@ -382,6 +383,7 @@ struct strangederivedbuilder {
                      mccollision.multMCNParticlesEta05(),
                      mccollision.multMCNParticlesEta08(),
                      mccollision.multMCNParticlesEta10());
+      strangeMCCents(mccollision.bestCollisionCentFT0C());
     }
 
     // ______________________________________________
@@ -710,7 +712,7 @@ struct strangederivedbuilder {
         static_for<0, nSpecies - 1>([&](auto i) {
           constexpr int index = i.value;
           if (mcp.pdgCode() == particlePDGCodes[index] && bitcheck(enabledBits, index)) {
-            histos.fill(HIST("hGen") + HIST(particleNamesConstExpr[index]), mcp.pt());
+            histos.fill(HIST("hGenerated") + HIST(particleNamesConstExpr[index]), mcp.pt());
           }
         });
       }
@@ -740,7 +742,7 @@ struct strangederivedbuilder {
         static_for<0, nSpecies - 1>([&](auto i) {
           constexpr int index = i.value;
           if (mcp.pdgCode() == particlePDGCodes[index] && bitcheck(enabledBits, index)) {
-            histos.fill(HIST("h2dGen") + HIST(particleNamesConstExpr[index]), bestCentrality, mcp.pt());
+            histos.fill(HIST("h2dGenerated") + HIST(particleNamesConstExpr[index]), bestCentrality, mcp.pt());
           }
         });
       }
@@ -763,7 +765,7 @@ struct strangederivedbuilder {
       const uint64_t mcCollIndex = mcCollision.globalIndex();
 
       // use one of the generated histograms as the bin finder
-      auto hBinFinder = histos.get<TH2>(HIST("h2dGenK0Short"));
+      auto hBinFinder = histos.get<TH2>(HIST("h2dGeneratedK0Short"));
 
       auto mcParticles = mcParticlesEntireTable.sliceBy(mcParticlePerMcCollision, mcCollIndex);
       for (auto& mcp : mcParticles) {

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -444,7 +444,9 @@ struct strangederivedbuilder {
     // populate references, including those that might not be assigned
     for (const auto& v0 : V0s) {
       v0collref(V0CollIndices[v0.globalIndex()]);
+      printf("%d ", V0CollIndices[v0.globalIndex()]);
     }
+    printf("\n");
     for (const auto& casc : Cascades) {
       casccollref(CascadeCollIndices[casc.globalIndex()]);
     }

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -444,9 +444,7 @@ struct strangederivedbuilder {
     // populate references, including those that might not be assigned
     for (const auto& v0 : V0s) {
       v0collref(V0CollIndices[v0.globalIndex()]);
-      printf("%d ", V0CollIndices[v0.globalIndex()]);
     }
-    printf("\n");
     for (const auto& casc : Cascades) {
       casccollref(CascadeCollIndices[casc.globalIndex()]);
     }

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -1497,51 +1497,51 @@ struct derivedlambdakzeroanalysis {
     auto hOmegaMinus = histos.get<TH2>(HIST("h2dGeneratedOmegaMinus"));
     auto hOmegaPlus = histos.get<TH2>(HIST("h2dGeneratedOmegaPlus"));
     for (auto& gVec : geK0Short) {
-      if (gVec.generatedK0Short().size() != hK0Short->GetNcells())
+      if (int(gVec.generatedK0Short().size()) != hK0Short->GetNcells())
         LOGF(fatal, "K0Short: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedK0Short().size(), hK0Short->GetNcells());
-      for (uint64_t iv = 0; iv < hK0Short->GetNcells(); iv++) {
+      for (int iv = 0; iv < hK0Short->GetNcells(); iv++) {
         hK0Short->SetBinContent(iv, hK0Short->GetBinContent(iv) + gVec.generatedK0Short()[iv]);
       }
     }
     for (auto& gVec : geLambda) {
-      if (gVec.generatedLambda().size() != hLambda->GetNcells())
+      if (int(gVec.generatedLambda().size()) != hLambda->GetNcells())
         LOGF(fatal, "Lambda: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedLambda().size(), hLambda->GetNcells());
-      for (uint64_t iv = 0; iv < hLambda->GetNcells(); iv++) {
+      for (int iv = 0; iv < hLambda->GetNcells(); iv++) {
         hLambda->SetBinContent(iv, hLambda->GetBinContent(iv) + gVec.generatedLambda()[iv]);
       }
     }
     for (auto& gVec : geAntiLambda) {
-      if (gVec.generatedAntiLambda().size() != hAntiLambda->GetNcells())
+      if (int(gVec.generatedAntiLambda().size()) != hAntiLambda->GetNcells())
         LOGF(fatal, "AntiLambda: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedAntiLambda().size(), hAntiLambda->GetNcells());
-      for (uint64_t iv = 0; iv < hAntiLambda->GetNcells(); iv++) {
+      for (int iv = 0; iv < hAntiLambda->GetNcells(); iv++) {
         hAntiLambda->SetBinContent(iv, hAntiLambda->GetBinContent(iv) + gVec.generatedAntiLambda()[iv]);
       }
     }
     for (auto& gVec : geXiMinus) {
-      if (gVec.generatedXiMinus().size() != hXiMinus->GetNcells())
+      if (int(gVec.generatedXiMinus().size()) != hXiMinus->GetNcells())
         LOGF(fatal, "XiMinus: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedXiMinus().size(), hXiMinus->GetNcells());
-      for (uint64_t iv = 0; iv < hXiMinus->GetNcells(); iv++) {
+      for (int iv = 0; iv < hXiMinus->GetNcells(); iv++) {
         hXiMinus->SetBinContent(iv, hXiMinus->GetBinContent(iv) + gVec.generatedXiMinus()[iv]);
       }
     }
     for (auto& gVec : geXiPlus) {
-      if (gVec.generatedXiPlus().size() != hXiPlus->GetNcells())
+      if (int(gVec.generatedXiPlus().size()) != hXiPlus->GetNcells())
         LOGF(fatal, "XiPlus: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedXiPlus().size(), hXiPlus->GetNcells());
-      for (uint64_t iv = 0; iv < hXiPlus->GetNcells(); iv++) {
+      for (int iv = 0; iv < hXiPlus->GetNcells(); iv++) {
         hXiPlus->SetBinContent(iv, hXiPlus->GetBinContent(iv) + gVec.generatedXiPlus()[iv]);
       }
     }
     for (auto& gVec : geOmegaMinus) {
-      if (gVec.generatedOmegaMinus().size() != hOmegaMinus->GetNcells())
+      if (int(gVec.generatedOmegaMinus().size()) != hOmegaMinus->GetNcells())
         LOGF(fatal, "OmegaMinus: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedOmegaMinus().size(), hOmegaMinus->GetNcells());
-      for (uint64_t iv = 0; iv < hOmegaMinus->GetNcells(); iv++) {
+      for (int iv = 0; iv < hOmegaMinus->GetNcells(); iv++) {
         hOmegaMinus->SetBinContent(iv, hOmegaMinus->GetBinContent(iv) + gVec.generatedOmegaMinus()[iv]);
       }
     }
     for (auto& gVec : geOmegaPlus) {
-      if (gVec.generatedOmegaPlus().size() != hOmegaPlus->GetNcells())
+      if (int(gVec.generatedOmegaPlus().size()) != hOmegaPlus->GetNcells())
         LOGF(fatal, "OmegaPlus: Number of elements in generated array and number of cells in receiving histogram differ: %i vs %i!", gVec.generatedOmegaPlus().size(), hOmegaPlus->GetNcells());
-      for (uint64_t iv = 0; iv < hOmegaPlus->GetNcells(); iv++) {
+      for (int iv = 0; iv < hOmegaPlus->GetNcells(); iv++) {
         hOmegaPlus->SetBinContent(iv, hOmegaPlus->GetBinContent(iv) + gVec.generatedOmegaPlus()[iv]);
       }
     }

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -1445,7 +1445,8 @@ struct derivedlambdakzeroanalysis {
   }
 
   // ______________________________________________________
-  // Simulated processing (subscribes to MC information too)
+  // Simulated processing
+  // Fill event information (for event loss estimation) and return the index to the recoed collision associated to a given MC collision.
   std::vector<int> fillGenEventHist(soa::Join<aod::StraMCCollisions,aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
   {
     std::vector<int> listBestCollisionIdx(mcCollisions.size());
@@ -1461,33 +1462,33 @@ struct derivedlambdakzeroanalysis {
       float centrality = 100.5f;
       int nCollisions = 0;
       for (auto const& collision : groupedCollisions) {
-        // if (!collision.sel8()) {
-        //   continue;
-        // }
-        // if (std::abs(collision.posZ()) > 10.f) {
-        //   continue;
-        // }
-        // if (rejectITSROFBorder && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
-        //   continue;
-        // }
-        // if (rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
-        //   continue;
-        // }
-        // if (requireIsVertexITSTPC && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
-        //   continue;
-        // }
-        // if (requireIsGoodZvtxFT0VsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
-        //   continue;
-        // }
+        if (!collision.sel8()) {
+          continue;
+        }
+        if (std::abs(collision.posZ()) > 10.f) {
+          continue;
+        }
+        if (rejectITSROFBorder && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
+          continue;
+        }
+        if (rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
+          continue;
+        }
+        if (requireIsVertexITSTPC && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
+          continue;
+        }
+        if (requireIsGoodZvtxFT0VsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
+          continue;
+        }
         if (requireIsVertexTOFmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTOFmatched)) {
           continue;
         }
         if (requireIsVertexTRDmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTRDmatched)) {
           continue;
         }
-        // if (rejectSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          // continue;
-        // }
+        if (rejectSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
+          continue;
+        }
         if (requireNoHighOccupancyAgressive && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyAgressive)) {
           continue;
         }

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -1269,7 +1269,7 @@ struct derivedlambdakzeroanalysis {
 
       if (!v0.has_v0MCCore())
         continue;
-        
+
       auto v0MC = v0.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
 
       // fill AP plot for all V0s
@@ -1408,7 +1408,7 @@ struct derivedlambdakzeroanalysis {
       histos.fill(HIST("hGenEvents"), mcCollision.multMCNParticlesEta05(), 0 /* all gen. events*/);
 
       auto groupedCollisions = collisions.sliceBy(perMcCollision, mcCollision.globalIndex());
-      // Check if there is at least one of the reconstructed collisions associated to this MC collision 
+      // Check if there is at least one of the reconstructed collisions associated to this MC collision
       // If so, we consider it
       bool atLeastOne = false;
       int biggestNContribs = -1;
@@ -1467,16 +1467,16 @@ struct derivedlambdakzeroanalysis {
         atLeastOne = true;
       }
       listBestCollisionIdx[mcCollision.globalIndex()] = bestCollisionIndex;
-      
+
       histos.fill(HIST("hCentralityVsNcoll_beforeEvSel"), centrality, groupedCollisions.size());
       histos.fill(HIST("hCentralityVsNcoll_afterEvSel"), centrality, nCollisions);
-      
+
       histos.fill(HIST("hCentralityVsMultMC"), centrality, mcCollision.multMCNParticlesEta05());
 
       if (atLeastOne) {
         histos.fill(HIST("hGenEvents"), mcCollision.multMCNParticlesEta05(), 1 /* at least 1 rec. event*/);
 
-        histos.fill(HIST("hGenEventCentrality"), centrality);        
+        histos.fill(HIST("hGenEventCentrality"), centrality);
       }
     }
     return listBestCollisionIdx;

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -81,11 +81,6 @@ struct derivedlambdakzeroanalysis {
   Configurable<bool> requireIsVertexTOFmatched{"requireIsVertexTOFmatched", false, "require events with at least one of vertex contributors matched to TOF"};
   Configurable<bool> requireIsVertexTRDmatched{"requireIsVertexTRDmatched", false, "require events with at least one of vertex contributors matched to TRD"};
   Configurable<bool> rejectSameBunchPileup{"rejectSameBunchPileup", true, "reject collisions in case of pileup with another collision in the same foundBC"};
-  Configurable<bool> requireNoHighOccupancyAgressive{"requireNoHighOccupancyAgressive", false, "reject collisions with high occupancies according to the aggressive cuts"};
-  Configurable<bool> requireNoHighOccupancyStrict{"requireNoHighOccupancyStrict", false, "reject collisions with high occupancies according to the strict cuts"};
-  Configurable<bool> requireNoHighOccupancyMedium{"requireNoHighOccupancyMedium", false, "reject collisions with high occupancies according to the medium cuts"};
-  Configurable<bool> requireNoHighOccupancyRelaxed{"requireNoHighOccupancyRelaxed", false, "reject collisions with high occupancies according to the relaxed cuts"};
-  Configurable<bool> requireNoHighOccupancyGentle{"requireNoHighOccupancyGentle", false, "reject collisions with high occupancies according to the gentle cuts"};
   Configurable<bool> requireNoCollInTimeRangeStd{"requireNoCollInTimeRangeStd", true, "reject collisions corrupted by the cannibalism, with other collisions within +/- 10 microseconds"};
   Configurable<bool> requireNoCollInTimeRangeNarrow{"requireNoCollInTimeRangeNarrow", false, "reject collisions corrupted by the cannibalism, with other collisions within +/- 10 microseconds"};
 
@@ -327,15 +322,10 @@ struct derivedlambdakzeroanalysis {
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(8, "kIsVertexTOFmatched");
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(9, "kIsVertexTRDmatched");
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(10, "kNoSameBunchPileup");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(11, "kNoHighOccupancyAgressive");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(12, "kNoHighOccupancyStrict");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(13, "kNoHighOccupancyMedium");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(14, "kNoHighOccupancyRelaxed");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(15, "kNoHighOccupancyGentle");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(16, "kNoCollInTimeRangeStd");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(17, "kNoCollInTimeRangeNarrow");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(18, "Below min occup.");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(19, "Above max occup.");
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(11, "kNoCollInTimeRangeStd");
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(12, "kNoCollInTimeRangeNarrow");
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(13, "Below min occup.");
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(14, "Above max occup.");
 
     histos.add("hEventCentrality", "hEventCentrality", kTH1F, {{100, 0.0f, +100.0f}});
     histos.add("hCentralityVsNch", "hCentralityVsNch", kTH2F, {axisCentrality, axisNch});
@@ -1135,49 +1125,24 @@ struct derivedlambdakzeroanalysis {
     }
     histos.fill(HIST("hEventSelection"), 9 /* Not at same bunch pile-up */);
 
-    if (requireNoHighOccupancyAgressive && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyAgressive)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 10 /* No occupancy according to the aggressive cuts */);
-
-    if (requireNoHighOccupancyStrict && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyStrict)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 11 /* No occupancy according to the strict cuts */);
-
-    if (requireNoHighOccupancyMedium && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyMedium)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 12 /* No occupancy according to the medium cuts */);
-
-    if (requireNoHighOccupancyRelaxed && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyRelaxed)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 13 /* No occupancy according to the relaxed cuts */);
-
-    if (requireNoHighOccupancyGentle && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyGentle)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 14 /* No occupancy according to the gentle cuts */);
-
     if (requireNoCollInTimeRangeStd && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 15 /* No other collision within +/- 10 microseconds */);
+    histos.fill(HIST("hEventSelection"), 10 /* No other collision within +/- 10 microseconds */);
 
     if (requireNoCollInTimeRangeNarrow && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeNarrow)) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 16 /* No other collision within +/- 4 microseconds */);
+    histos.fill(HIST("hEventSelection"), 11 /* No other collision within +/- 4 microseconds */);
 
     if (minOccupancy > 0 && collision.trackOccupancyInTimeRange() < minOccupancy) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 17 /* Below min occupancy */);
+    histos.fill(HIST("hEventSelection"), 12 /* Below min occupancy */);
     if (maxOccupancy > 0 && collision.trackOccupancyInTimeRange() > maxOccupancy) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 18 /* Above max occupancy */);
+    histos.fill(HIST("hEventSelection"), 13 /* Above max occupancy */);
 
     float centrality = collision.centFT0C();
     if (qaCentrality) {
@@ -1264,49 +1229,24 @@ struct derivedlambdakzeroanalysis {
     }
     histos.fill(HIST("hEventSelection"), 9 /* Not at same bunch pile-up */);
 
-    if (requireNoHighOccupancyAgressive && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyAgressive)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 10 /* No occupancy according to the aggressive cuts */);
-
-    if (requireNoHighOccupancyStrict && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyStrict)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 11 /* No occupancy according to the strict cuts */);
-
-    if (requireNoHighOccupancyMedium && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyMedium)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 12 /* No occupancy according to the medium cuts */);
-
-    if (requireNoHighOccupancyRelaxed && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyRelaxed)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 13 /* No occupancy according to the relaxed cuts */);
-
-    if (requireNoHighOccupancyGentle && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyGentle)) {
-      return;
-    }
-    histos.fill(HIST("hEventSelection"), 14 /* No occupancy according to the gentle cuts */);
-
     if (requireNoCollInTimeRangeStd && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 15 /* No other collision within +/- 10 microseconds */);
+    histos.fill(HIST("hEventSelection"), 10 /* No other collision within +/- 10 microseconds */);
 
     if (requireNoCollInTimeRangeNarrow && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeNarrow)) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 16 /* No other collision within +/- 4 microseconds */);
+    histos.fill(HIST("hEventSelection"), 11 /* No other collision within +/- 4 microseconds */);
 
     if (minOccupancy > 0 && collision.trackOccupancyInTimeRange() < minOccupancy) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 17 /* Below min occupancy */);
+    histos.fill(HIST("hEventSelection"), 12 /* Below min occupancy */);
     if (maxOccupancy > 0 && collision.trackOccupancyInTimeRange() > maxOccupancy) {
       return;
     }
-    histos.fill(HIST("hEventSelection"), 18 /* Above max occupancy */);
+    histos.fill(HIST("hEventSelection"), 13 /* Above max occupancy */);
 
     float centrality = collision.centFT0C();
     if (qaCentrality) {
@@ -1501,21 +1441,6 @@ struct derivedlambdakzeroanalysis {
           continue;
         }
         if (rejectSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-          continue;
-        }
-        if (requireNoHighOccupancyAgressive && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyAgressive)) {
-          continue;
-        }
-        if (requireNoHighOccupancyStrict && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyStrict)) {
-          continue;
-        }
-        if (requireNoHighOccupancyMedium && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyMedium)) {
-          continue;
-        }
-        if (requireNoHighOccupancyRelaxed && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyRelaxed)) {
-          continue;
-        }
-        if (requireNoHighOccupancyGentle && !collision.selection_bit(o2::aod::evsel::kNoHighOccupancyGentle)) {
           continue;
         }
         if (requireNoCollInTimeRangeStd && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -1314,7 +1314,7 @@ struct derivedlambdakzeroanalysis {
 
   // ______________________________________________________
   // Simulated processing (subscribes to MC information too)
-  void processGenerated(soa::Join<aod::StraMCCollisions,aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::CascMCCores, aod::CascMCCollRefs> const& CascMCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
+  void processGenerated(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::CascMCCores, aod::CascMCCollRefs> const& CascMCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
   {
     std::vector<int> listBestCollisionIdx = fillGenEventHist(mcCollisions, collisions);
     for (auto const& v0MC : V0MCCores) {
@@ -1334,7 +1334,7 @@ struct derivedlambdakzeroanalysis {
       if (TMath::Abs(ymc) > rapidityCut)
         continue;
 
-      auto mcCollision = v0MC.straMCCollision_as<soa::Join<aod::StraMCCollisions,aod::StraMCCollMults>>();
+      auto mcCollision = v0MC.straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
       float centrality = 100.5f;
       if (listBestCollisionIdx[mcCollision.globalIndex()] > -1) {
         auto collision = collisions.iteratorAt(listBestCollisionIdx[mcCollision.globalIndex()]);
@@ -1372,7 +1372,7 @@ struct derivedlambdakzeroanalysis {
       if (TMath::Abs(ymc) > rapidityCut)
         continue;
 
-      auto mcCollision = cascMC.straMCCollision_as<soa::Join<aod::StraMCCollisions,aod::StraMCCollMults>>();
+      auto mcCollision = cascMC.straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
       float centrality = 100.5f;
       if (listBestCollisionIdx[mcCollision.globalIndex()] > -1) {
         auto collision = collisions.iteratorAt(listBestCollisionIdx[mcCollision.globalIndex()]);
@@ -1401,7 +1401,7 @@ struct derivedlambdakzeroanalysis {
   // ______________________________________________________
   // Simulated processing
   // Fill event information (for event loss estimation) and return the index to the recoed collision associated to a given MC collision.
-  std::vector<int> fillGenEventHist(soa::Join<aod::StraMCCollisions,aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
+  std::vector<int> fillGenEventHist(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
   {
     std::vector<int> listBestCollisionIdx(mcCollisions.size());
     for (auto const& mcCollision : mcCollisions) {

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -548,10 +548,10 @@ struct derivedlambdakzeroanalysis {
 
     // Creation of histograms: MC generated
     if (doprocessGenerated) {
-      histos.add("hGenEvents", "hGenEvents", kTH1F, {{2, -0.5f, +1.5f}});
-      histos.get<TH1>(HIST("hGenEvents"))->GetXaxis()->SetBinLabel(1, "All gen. events");
-      histos.get<TH1>(HIST("hGenEvents"))->GetXaxis()->SetBinLabel(2, "Gen. with at least 1 rec. events");
-      histos.add("hGenEventCentrality", "hGenEventCentrality", kTH1F, {axisCentrality});
+      histos.add("hGenEvents", "hGenEvents", kTH2F, {{axisNch}, {2, -0.5f, +1.5f}});
+      histos.get<TH2>(HIST("hGenEvents"))->GetYaxis()->SetBinLabel(1, "All gen. events");
+      histos.get<TH2>(HIST("hGenEvents"))->GetYaxis()->SetBinLabel(2, "Gen. with at least 1 rec. events");
+      histos.add("hGenEventCentrality", "hGenEventCentrality", kTH1F, {{100, 0.0f, +100.0f}});
 
       histos.add("hCentralityVsNcoll_beforeEvSel", "hCentralityVsNcoll_beforeEvSel", kTH2F, {axisCentrality, {50, -0.5f, 49.5f}});
       histos.add("hCentralityVsNcoll_afterEvSel", "hCentralityVsNcoll_afterEvSel", kTH2F, {axisCentrality, {50, -0.5f, 49.5f}});
@@ -565,6 +565,14 @@ struct derivedlambdakzeroanalysis {
       histos.add("h2dGenXiPlus", "h2dGenXiPlus", kTH2D, {axisCentrality, axisPt});
       histos.add("h2dGenOmegaMinus", "h2dGenOmegaMinus", kTH2D, {axisCentrality, axisPt});
       histos.add("h2dGenOmegaPlus", "h2dGenOmegaPlus", kTH2D, {axisCentrality, axisPt});
+
+      histos.add("h2dGenK0ShortVsMultMC", "h2dGenK0ShortVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenLambdaVsMultMC", "h2dGenLambdaVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenAntiLambdaVsMultMC", "h2dGenAntiLambdaVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenXiMinusVsMultMC", "h2dGenXiMinusVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenXiPlusVsMultMC", "h2dGenXiPlusVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenOmegaMinusVsMultMC", "h2dGenOmegaMinusVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("h2dGenOmegaPlusVsMultMC", "h2dGenOmegaPlusVsMultMC", kTH2D, {axisNch, axisPt});
     }
     if (doprocessBinnedGenerated) {
       histos.add("h2dGeneratedK0Short", "h2dGeneratedK0Short", kTH2D, {axisCentrality, axisPt});
@@ -1369,7 +1377,6 @@ struct derivedlambdakzeroanalysis {
   void processGenerated(soa::Join<aod::StraMCCollisions,aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::CascMCCores, aod::CascMCCollRefs> const& CascMCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraRawCents, aod::StraEvSels, aod::StraCollLabels> const& collisions)
   {
     std::vector<int> listBestCollisionIdx = fillGenEventHist(mcCollisions, collisions);
-
     for (auto const& v0MC : V0MCCores) {
       if (!v0MC.has_straMCCollision())
         continue;
@@ -1396,12 +1403,15 @@ struct derivedlambdakzeroanalysis {
 
       if (v0MC.pdgCode() == 310) {
         histos.fill(HIST("h2dGenK0Short"), centrality, ptmc);
+        histos.fill(HIST("h2dGenK0ShortVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
       if (v0MC.pdgCode() == 3122) {
         histos.fill(HIST("h2dGenLambda"), centrality, ptmc);
+        histos.fill(HIST("h2dGenLambdaVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
       if (v0MC.pdgCode() == -3122) {
         histos.fill(HIST("h2dGenAntiLambda"), centrality, ptmc);
+        histos.fill(HIST("h2dGenAntiLambdaVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
     }
 
@@ -1431,15 +1441,19 @@ struct derivedlambdakzeroanalysis {
 
       if (cascMC.pdgCode() == 3312) {
         histos.fill(HIST("h2dGenXiMinus"), centrality, ptmc);
+        histos.fill(HIST("h2dGenXiMinusVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
       if (cascMC.pdgCode() == -3312) {
         histos.fill(HIST("h2dGenXiPlus"), centrality, ptmc);
+        histos.fill(HIST("h2dGenXiPlusVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
       if (cascMC.pdgCode() == 3334) {
         histos.fill(HIST("h2dGenOmegaMinus"), centrality, ptmc);
+        histos.fill(HIST("h2dGenOmegaMinusVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
       if (cascMC.pdgCode() == -3334) {
         histos.fill(HIST("h2dGenOmegaPlus"), centrality, ptmc);
+        histos.fill(HIST("h2dGenOmegaPlusVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
       }
     }
   }
@@ -1451,7 +1465,7 @@ struct derivedlambdakzeroanalysis {
   {
     std::vector<int> listBestCollisionIdx(mcCollisions.size());
     for (auto const& mcCollision : mcCollisions) {
-      histos.fill(HIST("hGenEvents"), 0 /* all gen. events*/);
+      histos.fill(HIST("hGenEvents"), mcCollision.multMCNParticlesEta05(), 0 /* all gen. events*/);
 
       auto groupedCollisions = collisions.sliceBy(perMcCollision, mcCollision.globalIndex());
       // Check if there is at least one of the reconstructed collisions associated to this MC collision 
@@ -1535,7 +1549,7 @@ struct derivedlambdakzeroanalysis {
       histos.fill(HIST("hCentralityVsMultMC"), centrality, mcCollision.multMCNParticlesEta05());
 
       if (atLeastOne) {
-        histos.fill(HIST("hGenEvents"), 1 /* at least 1 rec. event*/);
+        histos.fill(HIST("hGenEvents"), mcCollision.multMCNParticlesEta05(), 1 /* at least 1 rec. event*/);
 
         histos.fill(HIST("hGenEventCentrality"), centrality);        
       }


### PR DESCRIPTION
- Fix derived data production to deal with the decoupling between V0Cores and V0MCCores + adapt analysis task 
- Enable all event selections in MC 
- Add histograms to estimate event splitting, event loss and signal loss
- Add option to access casc. mom. info at prim. vtx (@ddobrigk)
- Remove obsolete event selections related to occupancy 