### PR TITLE
PWGHF: factorise 2 and 3 prong configurables, fix bug in D0 <-D*mass cut

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -153,7 +153,7 @@ struct HfCandidateSelectorDplusToPiKPi {
     if (std::abs(hfHelper.invMassDplusToPiKPi(candidate) - o2::constants::physics::MassDPlus) > cuts->get(pTBin, "deltaM")) {
       return false;
     }
-    if (useTriggerMassCut && !isCandidateInMassRange(hfHelper.invMassDplusToPiKPi(candidate), o2::constants::physics::MassDPlus, ptCand, hfTriggerCuts.deltaMassPars3Prong, hfTriggerCuts.sigmaPars3Prong, hfTriggerCuts.ptDeltaMass3ProngMax, hfTriggerCuts.ptMassCut3ProngMax, hfTriggerCuts.nSigma3ProngMax)) {
+    if (useTriggerMassCut && !isCandidateInMassRange(hfHelper.invMassDplusToPiKPi(candidate), o2::constants::physics::MassDPlus, ptCand, hfTriggerCuts)) {
       return false;
     }
     if (candidate.decayLength() < cuts->get(pTBin, "decay length")) {

--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -76,14 +76,14 @@ struct HfCandidateSelectorDplusToPiKPi {
   // Mass Cut for trigger analysis
   Configurable<bool> useTriggerMassCut{"useTriggerMassCut", false, "Flag to enable parametrize pT differential mass cut for triggered data"};
 
-  o2::analysis::HfMlResponseDplusToPiKPi<float> hfMlResponse;
+  HfMlResponseDplusToPiKPi<float> hfMlResponse;
   std::vector<float> outputMlNotPreselected = {};
   std::vector<float> outputMl = {};
   o2::ccdb::CcdbApi ccdbApi;
   TrackSelectorPi selectorPion;
   TrackSelectorKa selectorKaon;
   HfHelper hfHelper;
-  o2::analysis::HfTriggerCuts hfTriggerCuts;
+  HfTrigger3ProngCuts hfTriggerCuts;
 
   using TracksSel = soa::Join<aod::TracksWExtra, aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa>;
 
@@ -153,7 +153,7 @@ struct HfCandidateSelectorDplusToPiKPi {
     if (std::abs(hfHelper.invMassDplusToPiKPi(candidate) - o2::constants::physics::MassDPlus) > cuts->get(pTBin, "deltaM")) {
       return false;
     }
-    if (useTriggerMassCut && !hfTriggerCuts.isCandidateInMassRange<3>(hfHelper.invMassDplusToPiKPi(candidate), o2::constants::physics::MassDPlus, ptCand)) {
+    if (useTriggerMassCut && !isCandidateInMassRange(hfHelper.invMassDplusToPiKPi(candidate), o2::constants::physics::MassDPlus, ptCand, hfTriggerCuts.deltaMassPars3Prong, hfTriggerCuts.sigmaPars3Prong, hfTriggerCuts.ptDeltaMass3ProngMax, hfTriggerCuts.ptMassCut3ProngMax, hfTriggerCuts.nSigma3ProngMax)) {
       return false;
     }
     if (candidate.decayLength() < cuts->get(pTBin, "decay length")) {

--- a/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
@@ -110,7 +110,7 @@ struct HfCandidateSelectorDstarToD0Pi {
   AxisSpec axisSelStatus{2, -0.5f, 1.5f};
   HistogramRegistry registry{"registry"};
 
-  HfTriggerCuts hfTriggerCuts;
+  HfTrigger2ProngCuts hfTriggerCuts;
 
   void init(InitContext&)
   {
@@ -286,7 +286,7 @@ struct HfCandidateSelectorDstarToD0Pi {
       if (std::abs(mInvD0 - massD0) > cutsD0->get(binPt, "m")) {
         return false;
       }
-      if (useTriggerMassCut && !hfTriggerCuts.isCandidateInMassRange<2>(mInvD0, massD0, candidate.pt())) {
+      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0, massD0, candidate.ptD0(), hfTriggerCuts.deltaMassPars2Prong, hfTriggerCuts.sigmaPars2Prong, hfTriggerCuts.ptDeltaMass2ProngMax, hfTriggerCuts.ptMassCut2ProngMax, hfTriggerCuts.nSigma2ProngMax)) {
         return false;
       }
       // cut on daughter pT
@@ -312,6 +312,9 @@ struct HfCandidateSelectorDstarToD0Pi {
       mInvAntiDstar = candidate.invMassAntiDstar();
       mInvD0Bar = candidate.invMassD0Bar();
       if (std::abs(mInvD0Bar - massD0) > cutsD0->get(binPt, "m")) {
+        return false;
+      }
+      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0Bar, massD0, candidate.ptD0(), hfTriggerCuts.deltaMassPars2Prong, hfTriggerCuts.sigmaPars2Prong, hfTriggerCuts.ptDeltaMass2ProngMax, hfTriggerCuts.ptMassCut2ProngMax, hfTriggerCuts.nSigma2ProngMax)) {
         return false;
       }
       // cut on daughter pT

--- a/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
@@ -286,7 +286,7 @@ struct HfCandidateSelectorDstarToD0Pi {
       if (std::abs(mInvD0 - massD0) > cutsD0->get(binPt, "m")) {
         return false;
       }
-      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0, massD0, candidate.ptD0(), hfTriggerCuts.deltaMassPars2Prong, hfTriggerCuts.sigmaPars2Prong, hfTriggerCuts.ptDeltaMass2ProngMax, hfTriggerCuts.ptMassCut2ProngMax, hfTriggerCuts.nSigma2ProngMax)) {
+      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0, massD0, candidate.ptD0(), hfTriggerCuts)) {
         return false;
       }
       // cut on daughter pT
@@ -314,7 +314,7 @@ struct HfCandidateSelectorDstarToD0Pi {
       if (std::abs(mInvD0Bar - massD0) > cutsD0->get(binPt, "m")) {
         return false;
       }
-      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0Bar, massD0, candidate.ptD0(), hfTriggerCuts.deltaMassPars2Prong, hfTriggerCuts.sigmaPars2Prong, hfTriggerCuts.ptDeltaMass2ProngMax, hfTriggerCuts.ptMassCut2ProngMax, hfTriggerCuts.nSigma2ProngMax)) {
+      if (useTriggerMassCut && !isCandidateInMassRange(mInvD0Bar, massD0, candidate.ptD0(), hfTriggerCuts)) {
         return false;
       }
       // cut on daughter pT

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -109,62 +109,52 @@ bool isSelectedTrackTpcQuality(T const& track, const int tpcNClustersFoundMin, c
   return true;
 }
 
-/// Configurable group to apply trigger specific cuts for HF analysis
-struct HfTriggerCuts : o2::framework::ConfigurableGroup {
-  std::string prefix = "hfTriggerCuts"; // JSON group name
+/// Mass selection of 2 or 3 prong canidates in triggered data analysis
+/// \tparam nProngs switch between 2-prong and 3-prong selection
+/// \param invMass is the invariant mass of the candidate
+/// \param pdgMass is the pdg Mass of the candidate particle
+/// \param pt is the pT of the candidate
+/// \param deltaMassPars is the LabelledArray with the parametrisation for the delta mass
+/// \param sigmaPars is the LabelledArray with the parametrisation for the peak width
+/// \param ptDeltaMassMax is the maximum delta mass for the application of the cut
+/// \param ptMassCutMax is the maximum pt for the application of the cut
+/// \param nSigmaMax is the number of sigmas for the pt-differential mass window cut
+/// \return true if candidate passes selection
+template <typename ArrayPars, typename Par>
+bool isCandidateInMassRange(const float& invMass, const double& pdgMass, const float& pt, ArrayPars const& deltaMassPars, ArrayPars const& sigmaPars, Par const& ptDeltaMassMax, Par const& ptMassCutMax, Par const& nSigmaMax)
+{
+  float peakMean = (pt < ptDeltaMassMax.value) ? ((pdgMass + deltaMassPars->get("constant")) + deltaMassPars->get("linear") * pt) : pdgMass;
+  float peakWidth = sigmaPars->get("constant") + sigmaPars->get("linear") * pt;
+
+  return (!(std::abs(invMass - peakMean) > nSigmaMax.value * peakWidth && pt < ptMassCutMax.value));
+}
+
+/// Configurable group to apply trigger specific cuts for 2-prong HF analysis
+struct HfTrigger2ProngCuts : o2::framework::ConfigurableGroup {
+  std::string prefix = "hfTrigger2ProngCuts"; // JSON group name
+
+  static constexpr float defaultDeltaMassPars2Prong[1][2] = {{-0.0025f, 0.0001f}};
+  static constexpr float defaultSigmaPars2Prong[1][2] = {{0.01424f, 0.00178f}};
+  o2::framework::Configurable<float> nSigma2ProngMax{"nSigma2ProngMax", 2, "Maximum number of sigmas for pT-differential mass cut for 2-prong candidates"};
+  o2::framework::Configurable<float> ptDeltaMass2ProngMax{"ptDeltaMass2ProngMax", 10., "Max pT to apply delta mass shift to PDG mass value for 2-prong candidates"};
+  o2::framework::Configurable<float> ptMassCut2ProngMax{"ptMassCut2ProngMax", 9999., "Max pT to apply pT-differential cut for 2-prong candidates"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars2Prong{"deltaMassPars2Prong", {defaultDeltaMassPars2Prong[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 2-prong trigger mass cut"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars2Prong{"sigmaPars2Prong", {defaultSigmaPars2Prong[0], 2, {"constant", "linear"}}, "sigma parameters for HF 2-prong trigger mass cut"};
+};
+
+/// Configurable group to apply trigger specific cuts for 3-prong HF analysis
+struct HfTrigger3ProngCuts : o2::framework::ConfigurableGroup {
+  std::string prefix = "hfTrigger3ProngCuts"; // JSON group name
 
   static constexpr float defaultDeltaMassPars3Prong[1][2] = {{-0.0025f, 0.0001f}};
   static constexpr float defaultSigmaPars3Prong[1][2] = {{0.00796f, 0.00176f}};
-  static constexpr float defaultDeltaMassPars2Prong[1][2] = {{-0.0025f, 0.0001f}};
-  static constexpr float defaultSigmaPars2Prong[1][2] = {{0.01424f, 0.00178f}};
   o2::framework::Configurable<float> nSigma3ProngMax{"nSigma3ProngMax", 2, "Maximum number of sigmas for pT-differential mass cut for 3-prong candidates"};
-  o2::framework::Configurable<float> nSigma2ProngMax{"nSigma2ProngMax", 2, "Maximum number of sigmas for pT-differential mass cut for 2-prong candidates"};
   o2::framework::Configurable<float> ptDeltaMass3ProngMax{"ptDeltaMass3ProngMax", 10., "Max pT to apply delta mass shift to PDG mass value for 3-prong candidates"};
-  o2::framework::Configurable<float> ptDeltaMass2ProngMax{"ptDeltaMass2ProngMax", 10., "Max pT to apply delta mass shift to PDG mass value for 2-prong candidates"};
-  o2::framework::Configurable<float> ptMassCut3ProngMax{"ptMassCut3ProngMax", 8., "Max pT to apply pT-differential cut for 3-prong candidates"};
-  o2::framework::Configurable<float> ptMassCut2ProngMax{"ptMassCut2ProngMax", 8., "Max pT to apply pT-differential cut for 2-prong candidates"};
+  o2::framework::Configurable<float> ptMassCut3ProngMax{"ptMassCut3ProngMax", 9999., "Max pT to apply pT-differential cut for 3-prong candidates"};
   o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars3Prong{"deltaMassPars3Prong", {defaultDeltaMassPars3Prong[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 3-prong trigger mass cut"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars2Prong{"deltaMassPars2Prong", {defaultDeltaMassPars2Prong[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 2-prong trigger mass cut"};
   o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars3Prong{"sigmaPars3Prong", {defaultSigmaPars3Prong[0], 2, {"constant", "linear"}}, "sigma parameters for HF 3-prong trigger mass cut"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars2Prong{"sigmaPars2Prong", {defaultSigmaPars2Prong[0], 2, {"constant", "linear"}}, "sigma parameters for HF 2-prong trigger mass cut"};
-
-  /// Mass selection of 2 or 3 prong canidates in triggered data analysis
-  /// \tparam nProngs switch between 2-prong and 3-prong selection
-  /// \param invMass is the invariant mass of the candidate
-  /// \param pdgMass is the pdg Mass of the candidate particle
-  /// \param pt is the pT of the candidate
-  /// \return true if candidate passes selection
-  template <uint8_t nProngs>
-  bool isCandidateInMassRange(const float& invMass, const double& pdgMass, const float& pt)
-  {
-    float ptMassCutMax{0.};
-    float ptDeltaMassMax{0.};
-    float nSigmaMax{0.};
-    o2::framework::LabeledArray<float> deltaMassPars;
-    o2::framework::LabeledArray<float> sigmaPars;
-
-    if constexpr (nProngs == 2) {
-      deltaMassPars = deltaMassPars2Prong;
-      sigmaPars = sigmaPars2Prong;
-      ptDeltaMassMax = ptDeltaMass2ProngMax;
-      ptMassCutMax = ptMassCut2ProngMax;
-      nSigmaMax = nSigma2ProngMax;
-    } else if constexpr (nProngs == 3) {
-      deltaMassPars = deltaMassPars3Prong;
-      sigmaPars = sigmaPars3Prong;
-      ptDeltaMassMax = ptDeltaMass3ProngMax;
-      ptMassCutMax = ptMassCut3ProngMax;
-      nSigmaMax = nSigma3ProngMax;
-    } else {
-      LOGF(fatal, "nProngs %d not supported!", nProngs);
-    }
-
-    float peakMean = (pt < ptDeltaMassMax) ? ((pdgMass + deltaMassPars.get("constant")) + deltaMassPars.get("linear") * pt) : pdgMass;
-    float peakWidth = sigmaPars.get("constant") + sigmaPars.get("linear") * pt;
-
-    return (!(std::abs(invMass - peakMean) > nSigmaMax * peakWidth && pt < ptMassCutMax));
-  }
 };
+
 } // namespace o2::analysis
 
 #endif // PWGHF_UTILS_UTILSANALYSIS_H_

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -114,45 +114,41 @@ bool isSelectedTrackTpcQuality(T const& track, const int tpcNClustersFoundMin, c
 /// \param invMass is the invariant mass of the candidate
 /// \param pdgMass is the pdg Mass of the candidate particle
 /// \param pt is the pT of the candidate
-/// \param deltaMassPars is the LabelledArray with the parametrisation for the delta mass
-/// \param sigmaPars is the LabelledArray with the parametrisation for the peak width
-/// \param ptDeltaMassMax is the maximum delta mass for the application of the cut
-/// \param ptMassCutMax is the maximum pt for the application of the cut
-/// \param nSigmaMax is the number of sigmas for the pt-differential mass window cut
+/// \param cutConfig is the struct with the pt-dependent mass configurations
 /// \return true if candidate passes selection
-template <typename ArrayPars, typename Par>
-bool isCandidateInMassRange(const float& invMass, const double& pdgMass, const float& pt, ArrayPars const& deltaMassPars, ArrayPars const& sigmaPars, Par const& ptDeltaMassMax, Par const& ptMassCutMax, Par const& nSigmaMax)
+template <typename Config>
+bool isCandidateInMassRange(const float& invMass, const double& pdgMass, const float& pt, Config const& cutConfig)
 {
-  float peakMean = (pt < ptDeltaMassMax.value) ? ((pdgMass + deltaMassPars->get("constant")) + deltaMassPars->get("linear") * pt) : pdgMass;
-  float peakWidth = sigmaPars->get("constant") + sigmaPars->get("linear") * pt;
+  float peakMean = (pt < cutConfig.ptDeltaMassMax.value) ? ((pdgMass + cutConfig.deltaMassPars->get("constant")) + cutConfig.deltaMassPars->get("linear") * pt) : pdgMass;
+  float peakWidth = cutConfig.sigmaPars->get("constant") + cutConfig.sigmaPars->get("linear") * pt;
 
-  return (!(std::abs(invMass - peakMean) > nSigmaMax.value * peakWidth && pt < ptMassCutMax.value));
+  return (!(std::abs(invMass - peakMean) > cutConfig.nSigmaMax.value * peakWidth && pt < cutConfig.ptMassCutMax.value));
 }
 
 /// Configurable group to apply trigger specific cuts for 2-prong HF analysis
 struct HfTrigger2ProngCuts : o2::framework::ConfigurableGroup {
   std::string prefix = "hfTrigger2ProngCuts"; // JSON group name
 
-  static constexpr float defaultDeltaMassPars2Prong[1][2] = {{-0.0025f, 0.0001f}};
-  static constexpr float defaultSigmaPars2Prong[1][2] = {{0.01424f, 0.00178f}};
-  o2::framework::Configurable<float> nSigma2ProngMax{"nSigma2ProngMax", 2, "Maximum number of sigmas for pT-differential mass cut for 2-prong candidates"};
-  o2::framework::Configurable<float> ptDeltaMass2ProngMax{"ptDeltaMass2ProngMax", 10., "Max pT to apply delta mass shift to PDG mass value for 2-prong candidates"};
-  o2::framework::Configurable<float> ptMassCut2ProngMax{"ptMassCut2ProngMax", 9999., "Max pT to apply pT-differential cut for 2-prong candidates"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars2Prong{"deltaMassPars2Prong", {defaultDeltaMassPars2Prong[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 2-prong trigger mass cut"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars2Prong{"sigmaPars2Prong", {defaultSigmaPars2Prong[0], 2, {"constant", "linear"}}, "sigma parameters for HF 2-prong trigger mass cut"};
+  static constexpr float defaultDeltaMassPars[1][2] = {{-0.0025f, 0.0001f}};
+  static constexpr float defaultSigmaPars[1][2] = {{0.01424f, 0.00178f}};
+  o2::framework::Configurable<float> nSigmaMax{"nSigmaMax", 2, "Maximum number of sigmas for pT-differential mass cut for 2-prong candidates"};
+  o2::framework::Configurable<float> ptDeltaMassMax{"ptDeltaMassMax", 10., "Max pT to apply delta mass shift to PDG mass value for 2-prong candidates"};
+  o2::framework::Configurable<float> ptMassCutMax{"ptMassCutMax", 9999., "Max pT to apply pT-differential cut for 2-prong candidates"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars{"deltaMassPars", {defaultDeltaMassPars[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 2-prong trigger mass cut"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars{"sigmaPars", {defaultSigmaPars[0], 2, {"constant", "linear"}}, "sigma parameters for HF 2-prong trigger mass cut"};
 };
 
 /// Configurable group to apply trigger specific cuts for 3-prong HF analysis
 struct HfTrigger3ProngCuts : o2::framework::ConfigurableGroup {
   std::string prefix = "hfTrigger3ProngCuts"; // JSON group name
 
-  static constexpr float defaultDeltaMassPars3Prong[1][2] = {{-0.0025f, 0.0001f}};
-  static constexpr float defaultSigmaPars3Prong[1][2] = {{0.00796f, 0.00176f}};
-  o2::framework::Configurable<float> nSigma3ProngMax{"nSigma3ProngMax", 2, "Maximum number of sigmas for pT-differential mass cut for 3-prong candidates"};
-  o2::framework::Configurable<float> ptDeltaMass3ProngMax{"ptDeltaMass3ProngMax", 10., "Max pT to apply delta mass shift to PDG mass value for 3-prong candidates"};
-  o2::framework::Configurable<float> ptMassCut3ProngMax{"ptMassCut3ProngMax", 9999., "Max pT to apply pT-differential cut for 3-prong candidates"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars3Prong{"deltaMassPars3Prong", {defaultDeltaMassPars3Prong[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 3-prong trigger mass cut"};
-  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars3Prong{"sigmaPars3Prong", {defaultSigmaPars3Prong[0], 2, {"constant", "linear"}}, "sigma parameters for HF 3-prong trigger mass cut"};
+  static constexpr float defaultDeltaMassPars[1][2] = {{-0.0025f, 0.0001f}};
+  static constexpr float defaultSigmaPars[1][2] = {{0.00796f, 0.00176f}};
+  o2::framework::Configurable<float> nSigmaMax{"nSigmaMax", 2, "Maximum number of sigmas for pT-differential mass cut for 3-prong candidates"};
+  o2::framework::Configurable<float> ptDeltaMassMax{"ptDeltaMassMax", 10., "Max pT to apply delta mass shift to PDG mass value for 3-prong candidates"};
+  o2::framework::Configurable<float> ptMassCutMax{"ptMassCutMax", 9999., "Max pT to apply pT-differential cut for 3-prong candidates"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> deltaMassPars{"deltaMassPars", {defaultDeltaMassPars[0], 2, {"constant", "linear"}}, "delta mass parameters for HF 3-prong trigger mass cut"};
+  o2::framework::Configurable<o2::framework::LabeledArray<float>> sigmaPars{"sigmaPars", {defaultSigmaPars[0], 2, {"constant", "linear"}}, "sigma parameters for HF 3-prong trigger mass cut"};
 };
 
 } // namespace o2::analysis


### PR DESCRIPTION
This PR:
- fixes the pt-differential D0 mass cut in the D0 <- D*+ (only applied for D*+ and not D*-, as a function of D* pT instead of D0 pT)
- splits up the configurables for 2-prongs and 3-prongs to avoid the confusion created by configurables that do not have any effect for given selectors 

Auto-approving since needed for HP performance plots.