### PR TITLE
[PWGDQ] Optimize triplets, add common track cuts for pairs in dilepton-track

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -764,6 +764,18 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     return cut;
   }
 
+  if (!nameStr.compare("posPrimaryTrack_DCAz")) {
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
+    cut->AddCut(GetAnalysisCut("posTrack"));
+    return cut;
+  }
+
+  if (!nameStr.compare("negPrimaryTrack_DCAz")) {
+    cut->AddCut(GetAnalysisCut("PrimaryTrack_DCAz"));
+    cut->AddCut(GetAnalysisCut("negTrack"));
+    return cut;
+  }
+
   if (!nameStr.compare("pionPosPrimaryNoPID")) {
     cut->AddCut(GetAnalysisCut("standardPrimaryTrackDCA"));
     cut->AddCut(GetAnalysisCut("posTrack"));

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -1259,7 +1259,7 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "DeltaEta_DeltaPhi", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhi);
       hm->AddHistogram(histClass, "DeltaEta_DeltaPhiSym", "", false, 20, -2.0, 2.0, VarManager::kDeltaEta, 50, -8.0, 8.0, VarManager::kDeltaPhiSym);
     }
-    if (!groupStr.Contains("dilepton-hadron-array-correlation")) {
+    if (subGroupStr.Contains("dilepton-hadron-array-correlation")) {
       const int kInvMassBins = 500;
       double InvMassBinLims[kInvMassBins + 1];
       for (int i = 0; i <= kInvMassBins; i++)

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -858,7 +858,6 @@ class VarManager : public TObject
     fgFitterThreeProngBarrel.setMinParamChange(minParamChange);
     fgFitterThreeProngBarrel.setMinRelChi2Change(minRelChi2Change);
     fgFitterThreeProngBarrel.setUseAbsDCA(useAbsDCA);
-    cout << "!!! fgFitterThreeProngBarrel bz = " << fgFitterThreeProngBarrel.getBz() << endl;
     fgUsedKF = false;
   }
 

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -628,6 +628,7 @@ DECLARE_SOA_COLUMN(Phi, phi, float);                                     //!
 DECLARE_SOA_COLUMN(Sign, sign, int);                                     //!
 DECLARE_SOA_BITMAP_COLUMN(FilterMap, filterMap, 32);                     //!
 DECLARE_SOA_BITMAP_COLUMN(PairFilterMap, pairFilterMap, 32);             //!
+DECLARE_SOA_BITMAP_COLUMN(CommonFilterMap, commonFilterMap, 32);         //!
 DECLARE_SOA_COLUMN(McDecision, mcDecision, uint32_t);                    //!
 DECLARE_SOA_COLUMN(Tauz, tauz, float);                                   //! Longitudinal pseudo-proper time of lepton pair (in ns)
 DECLARE_SOA_COLUMN(TauzErr, tauzErr, float);                             //! Error on longitudinal pseudo-proper time of lepton pair (in ns)
@@ -823,7 +824,7 @@ using DimuonAll = DimuonsAll::iterator;
 DECLARE_SOA_TABLE(Ditracks, "AOD", "RTDITRACK", //!
                   o2::soa::Index<>, reducedpair::ReducedEventId,
                   reducedpair::Mass, reducedpair::Pt, reducedpair::Eta, reducedpair::Phi, reducedpair::Sign,
-                  reducedpair::FilterMap, reducedpair::PairFilterMap,
+                  reducedpair::FilterMap, reducedpair::PairFilterMap, reducedpair::CommonFilterMap,
                   reducedpair::Rap<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
                   reducedpair::Y<reducedpair::Pt, reducedpair::Eta, reducedpair::Mass>,
                   reducedpair::Px<reducedpair::Pt, reducedpair::Phi>,

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <numeric>
 #include <vector>
@@ -1625,8 +1626,12 @@ struct AnalysisAsymmetricPairing {
 
   // Configurables
   Configurable<string> fConfigLegCuts{"cfgLegCuts", "", "<leg-A-1>:<leg-B-1>[:<leg-C-1>],[<leg-A-2>:<leg-B-2>[:<leg-C-1>],...]"};
+  Configurable<uint32_t> fConfigLegAFilterMask{"cfgLegAFilterMask", 0, "Filter mask corresponding to cuts in event-selection"};
+  Configurable<uint32_t> fConfigLegBFilterMask{"cfgLegBFilterMask", 0, "Filter mask corresponding to cuts in event-selection"};
+  Configurable<uint32_t> fConfigLegCFilterMask{"cfgLegCFilterMask", 0, "Filter mask corresponding to cuts in event-selection"};
   Configurable<string> fConfigCommonTrackCuts{"cfgCommonTrackCuts", "", "Comma separated list of cuts to be applied to all legs"};
   Configurable<string> fConfigPairCuts{"cfgPairCuts", "", "Comma separated list of pair cuts"};
+  Configurable<bool> fConfigSkipAmbiguousIdCombinations{"cfgSkipAmbiguousIdCombinations", true, "Choose whether to skip pairs/triples which pass a stricter combination of cuts, e.g. KKPi triplets for D+ -> KPiPi"};
 
   Configurable<std::string> fConfigHistogramSubgroups{"cfgAsymmetricPairingHistogramsSubgroups", "barrel,vertexing", "Comma separated list of asymmetric-pairing histogram subgroups"};
   Configurable<bool> fConfigSameSignHistograms{"cfgSameSignHistograms", false, "Include same sign pair histograms for 2-prong decays"};
@@ -1666,6 +1671,11 @@ struct AnalysisAsymmetricPairing {
 
   Preslice<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
 
+  // Partitions for triplets and asymmetric pairs
+  Partition<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> legACandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fConfigLegAFilterMask) > uint32_t(0);
+  Partition<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> legBCandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fConfigLegBFilterMask) > uint32_t(0);
+  Partition<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> legCCandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fConfigLegCFilterMask) > uint32_t(0);
+
   void init(o2::framework::InitContext& context)
   {
     bool isDummy = context.mOptions.get<bool>("processDummy");
@@ -1677,6 +1687,10 @@ struct AnalysisAsymmetricPairing {
     TString histNames = "";
     std::vector<TString> names;
 
+    // Get the leg cut filter maps
+    fLegAFilterMask = fConfigLegAFilterMask.value;
+    fLegBFilterMask = fConfigLegBFilterMask.value;
+    fLegCFilterMask = fConfigLegCFilterMask.value;
     // Get the pair cuts
     TString cutNamesStr = fConfigPairCuts.value;
     if (!cutNamesStr.IsNull()) {
@@ -1706,7 +1720,21 @@ struct AnalysisAsymmetricPairing {
         }
       }
     }
+    // Check that the leg cut masks make sense
+    if (int(TMath::Log2(fLegAFilterMask))+1 > objArray->GetEntries()) {
+      LOGF(fatal, "fConfigLegAFilterMask has highest bit at position %d, but track-selection only has %d cuts!", int(TMath::Log2(fLegAFilterMask))+1, objArray->GetEntries());
+    }
+    if (int(TMath::Log2(fLegBFilterMask))+1 > objArray->GetEntries()) {
+      LOGF(fatal, "fConfigLegBFilterMask has highest bit at position %d, but track-selection only has %d cuts!", int(TMath::Log2(fLegBFilterMask))+1, objArray->GetEntries());
+    }
+    if (int(TMath::Log2(fLegCFilterMask))+1 > objArray->GetEntries()) {
+      LOGF(fatal, "fConfigLegCFilterMask has highest bit at position %d, but track-selection only has %d cuts!", int(TMath::Log2(fLegCFilterMask))+1, objArray->GetEntries());
+    }
+    
     // Get the cuts defining the legs
+    uint32_t fConstructedLegAFilterMask = 0;
+    uint32_t fConstructedLegBFilterMask = 0;
+    uint32_t fConstructedLegCFilterMask = 0;
     TString legCutsStr = fConfigLegCuts.value;
     std::unique_ptr<TObjArray> objArrayLegs(legCutsStr.Tokenize(","));
     if (objArrayLegs->GetEntries() == 0) {
@@ -1732,7 +1760,7 @@ struct AnalysisAsymmetricPairing {
       // Find leg cuts in the track selection cuts
       legAIdx = objArray->IndexOf(legs->At(0));
       if (legAIdx >= 0) {
-        fLegAFilterMask |= (uint32_t(1) << legAIdx);
+        fConstructedLegAFilterMask |= (uint32_t(1) << legAIdx);
         fTrackCutFilterMasks[icut] |= uint32_t(1) << legAIdx;
       } else {
         LOGF(fatal, "Leg A cut %s was not calculated upstream. Check the config!", legs->At(0)->GetName());
@@ -1740,7 +1768,7 @@ struct AnalysisAsymmetricPairing {
       }
       legBIdx = objArray->IndexOf(legs->At(1));
       if (legBIdx >= 0) {
-        fLegBFilterMask |= (uint32_t(1) << legBIdx);
+        fConstructedLegBFilterMask |= (uint32_t(1) << legBIdx);
         fTrackCutFilterMasks[icut] |= uint32_t(1) << legBIdx;
       } else {
         LOGF(fatal, "Leg B cut %s was not calculated upstream. Check the config!", legs->At(1)->GetName());
@@ -1749,7 +1777,7 @@ struct AnalysisAsymmetricPairing {
       if (isThreeProng[icut]) {
         legCIdx = objArray->IndexOf(legs->At(2));
         if (legCIdx >= 0) {
-          fLegCFilterMask |= (uint32_t(1) << legCIdx);
+          fConstructedLegCFilterMask |= (uint32_t(1) << legCIdx);
           fTrackCutFilterMasks[icut] |= uint32_t(1) << legCIdx;
         } else {
           LOGF(fatal, "Leg C cut %s was not calculated upstream. Check the config!", legs->At(2)->GetName());
@@ -1844,6 +1872,16 @@ struct AnalysisAsymmetricPairing {
         }   // end if (pair cuts)
       }
     }
+    // Make sure the leg cuts are covered by the configured filter masks
+    if (fLegAFilterMask != fConstructedLegAFilterMask) {
+      LOGF(fatal, "cfgLegAFilterMask (%d) is not equal to the mask constructed by the cuts specified in cfgLegCuts (%d)!", fLegAFilterMask, fConstructedLegAFilterMask);
+    }
+    if (fLegBFilterMask != fConstructedLegBFilterMask) {
+      LOGF(fatal, "cfgLegBFilterMask (%d) is not equal to the mask constructed by the cuts specified in cfgLegCuts (%d)!", fLegBFilterMask, fConstructedLegBFilterMask);
+    }
+    if (fLegCFilterMask != fConstructedLegCFilterMask) {
+      LOGF(fatal, "cfgLegCFilterMask (%d) is not equal to the mask constructed by the cuts specified in cfgLegCuts (%d)!", fLegCFilterMask, fConstructedLegCFilterMask);
+    }
     // Make sure only pairs or only triplets of leg cuts were given
     int tripletCheckSum = std::count(isThreeProng.begin(), isThreeProng.end(), true);
     if (tripletCheckSum != 0 && tripletCheckSum != fNLegCuts) {
@@ -1911,7 +1949,7 @@ struct AnalysisAsymmetricPairing {
 
   // Template function to run same event pairing with asymmetric pairs (e.g. kaon-pion)
   template <bool TTwoProngFitter, int TPairType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTrackAssocs, typename TTracks>
-  void runAsymmetricPairing(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& assocs, TTracks const& /*tracks*/)
+  void runAsymmetricPairing(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& /*tracks*/)
   {
     if (events.size() > 0) { // Additional protection to avoid crashing of events.begin().runNumber()
       if (fCurrentRun != events.begin().runNumber()) {
@@ -1937,145 +1975,147 @@ struct AnalysisAsymmetricPairing {
       VarManager::ResetValues(0, VarManager::kNVars);
       VarManager::FillEvent<TEventFillMap>(event, VarManager::fgValues);
 
-      auto groupedAssocs = assocs.sliceBy(preslice, event.globalIndex());
-      if (groupedAssocs.size() == 0) {
+      auto groupedLegAAssocs = legACandidateAssocs.sliceBy(preslice, event.globalIndex());
+      if (groupedLegAAssocs.size() == 0) {
+        continue;
+      }
+      auto groupedLegBAssocs = legBCandidateAssocs.sliceBy(preslice, event.globalIndex());
+      if (groupedLegBAssocs.size() == 0) {
         continue;
       }
 
       // TODO: Think about double counting
-      for (auto& a1 : groupedAssocs) {
-        // Check if a1 is a leg A candidate
-        uint32_t a1AFilter = a1.isBarrelSelected_raw() & fLegAFilterMask;
-        if (!a1AFilter) {
-          continue;
-        }
-        for (auto& a2 : groupedAssocs) {
-          // Check if a2 is a leg B candidate
-          uint32_t a2BFilter = a2.isBarrelSelected_raw() & fLegBFilterMask;
-          if (!a2BFilter) {
-            continue;
-          }
+      std::set<std::pair<int, int>> globIdxPairs;
+      for (auto& [a1, a2] : combinations(soa::CombinationsFullIndexPolicy(groupedLegAAssocs, groupedLegBAssocs))) {
 
-          uint32_t twoTrackFilter = 0;
-          uint32_t pairFilter = 0;
+        uint32_t twoTrackFilter = 0;
+        uint32_t twoTrackCommonFilter = 0;
+        uint32_t pairFilter = 0;
+        bool isPairIdWrong = false;
+        for (int icut = 0; icut < fNLegCuts; ++icut) {
           // Find leg pair definitions both candidates participate in
-          for (int icut = 0; icut < fNLegCuts; ++icut) {
-            if (((a1AFilter | a2BFilter) & fTrackCutFilterMasks[icut]) == fTrackCutFilterMasks[icut]) {
-              twoTrackFilter |= (uint32_t(1) << icut);
+          if ((((a1.isBarrelSelected_raw() & fLegAFilterMask) | (a2.isBarrelSelected_raw() & fLegBFilterMask)) & fTrackCutFilterMasks[icut]) == fTrackCutFilterMasks[icut]) {
+            twoTrackFilter |= (uint32_t(1) << icut);
+            // If the supposed pion passes a kaon cut, this is a K+K-. Skip it.
+            if (TPairType == VarManager::kDecayToKPi && fConfigSkipAmbiguousIdCombinations.value) {
+              if (a2.isBarrelSelected_raw() & fLegAFilterMask) {
+                isPairIdWrong = true;
+              }
             }
           }
-          // Find common track cuts both candidates pass
-          twoTrackFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & fCommonTrackCutMask;
+        }
 
-          if (!twoTrackFilter) {
-            continue;
-          }
+        if (!twoTrackFilter || isPairIdWrong) {
+          continue;
+        }
 
-          auto t1 = a1.template reducedtrack_as<TTracks>();
-          auto t2 = a2.template reducedtrack_as<TTracks>();
+        // Find common track cuts both candidates pass
+        twoTrackCommonFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & fCommonTrackCutMask;
 
-          // Avoid self-pairs
-          if (t1.globalIndex() == t2.globalIndex()) {
-            continue;
-          }
+        auto t1 = a1.template reducedtrack_as<TTracks>();
+        auto t2 = a2.template reducedtrack_as<TTracks>();
 
-          sign1 = t1.sign();
-          sign2 = t2.sign();
-          // store the ambiguity number of the two dilepton legs in the last 4 digits of the two-track filter
-          if (t1.barrelAmbiguityInBunch() > 1 || t1.barrelAmbiguityOutOfBunch() > 1) {
-            twoTrackFilter |= (uint32_t(1) << 30);
-          }
-          if (t2.barrelAmbiguityInBunch() > 1 || t2.barrelAmbiguityOutOfBunch() > 1) {
-            twoTrackFilter |= (uint32_t(1) << 31);
-          }
+        // Avoid self-pairs
+        if (t1.globalIndex() == t2.globalIndex()) {
+          continue;
+        }
 
-          VarManager::FillPair<TPairType, TTrackFillMap>(t1, t2);
-          if constexpr (TTwoProngFitter) {
-            VarManager::FillPairVertexing<TPairType, TEventFillMap, TTrackFillMap>(event, t1, t2, fConfigPropToPCA);
-          }
+        sign1 = t1.sign();
+        sign2 = t2.sign();
+        // store the ambiguity number of the two dilepton legs in the last 4 digits of the two-track filter
+        if (t1.barrelAmbiguityInBunch() > 1 || t1.barrelAmbiguityOutOfBunch() > 1) {
+          twoTrackFilter |= (uint32_t(1) << 30);
+        }
+        if (t2.barrelAmbiguityInBunch() > 1 || t2.barrelAmbiguityOutOfBunch() > 1) {
+          twoTrackFilter |= (uint32_t(1) << 31);
+        }
 
-          // Fill histograms
-          bool isAmbi = false;
-          for (int icut = 0; icut < fNLegCuts; icut++) {
-            if (twoTrackFilter & (uint32_t(1) << icut)) {
-              isAmbi = (twoTrackFilter & (uint32_t(1) << 30)) || (twoTrackFilter & (uint32_t(1) << 31));
-              if (sign1 * sign2 < 0) {
-                fHistMan->FillHistClass(histNames[icut][0].Data(), VarManager::fgValues);
+        VarManager::FillPair<TPairType, TTrackFillMap>(t1, t2);
+        if constexpr (TTwoProngFitter) {
+          VarManager::FillPairVertexing<TPairType, TEventFillMap, TTrackFillMap>(event, t1, t2, fConfigPropToPCA);
+        }
+
+        // Fill histograms
+        bool isAmbi = false;
+        for (int icut = 0; icut < fNLegCuts; icut++) {
+          if (twoTrackFilter & (uint32_t(1) << icut)) {
+            isAmbi = (twoTrackFilter & (uint32_t(1) << 30)) || (twoTrackFilter & (uint32_t(1) << 31));
+            if (sign1 * sign2 < 0) {
+              fHistMan->FillHistClass(histNames[icut][0].Data(), VarManager::fgValues);
+              if (isAmbi && fConfigAmbiguousHistograms.value) {
+                fHistMan->FillHistClass(histNames[icut][3].Data(), VarManager::fgValues);
+              }
+            } else if (fConfigSameSignHistograms.value) {
+              if (sign1 > 0) {
+                fHistMan->FillHistClass(histNames[icut][1].Data(), VarManager::fgValues);
                 if (isAmbi && fConfigAmbiguousHistograms.value) {
-                  fHistMan->FillHistClass(histNames[icut][3].Data(), VarManager::fgValues);
+                  fHistMan->FillHistClass(histNames[icut][4].Data(), VarManager::fgValues);
                 }
-              } else if (fConfigSameSignHistograms.value) {
-                if (sign1 > 0) {
-                  fHistMan->FillHistClass(histNames[icut][1].Data(), VarManager::fgValues);
-                  if (isAmbi && fConfigAmbiguousHistograms.value) {
-                    fHistMan->FillHistClass(histNames[icut][4].Data(), VarManager::fgValues);
-                  }
-                } else {
-                  fHistMan->FillHistClass(histNames[icut][2].Data(), VarManager::fgValues);
-                  if (isAmbi && fConfigAmbiguousHistograms.value) {
-                    fHistMan->FillHistClass(histNames[icut][5].Data(), VarManager::fgValues);
+              } else {
+                fHistMan->FillHistClass(histNames[icut][2].Data(), VarManager::fgValues);
+                if (isAmbi && fConfigAmbiguousHistograms.value) {
+                  fHistMan->FillHistClass(histNames[icut][5].Data(), VarManager::fgValues);
+                }
+              }
+            }
+            for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
+              if (twoTrackCommonFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
+                if (sign1 * sign2 < 0) {
+                  fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][0].Data(), VarManager::fgValues);
+                } else if (fConfigSameSignHistograms.value) {
+                  if (sign1 > 0) {
+                    fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][1].Data(), VarManager::fgValues);
+                  } else {
+                    fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][2].Data(), VarManager::fgValues);
                   }
                 }
               }
-              for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
-                if (twoTrackFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
+            } // end loop (common cuts)
+            for (unsigned int iPairCut = 0; iPairCut < fPairCuts.size(); iPairCut++) {
+              AnalysisCompositeCut cut = fPairCuts.at(iPairCut);
+              if (!(cut.IsSelected(VarManager::fgValues))) // apply pair cuts
+                continue;
+              pairFilter |= (uint32_t(1) << iPairCut);
+              // Histograms with pair cuts
+              if (sign1 * sign2 < 0) {
+                fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][0].Data(), VarManager::fgValues);
+              } else if (fConfigSameSignHistograms.value) {
+                if (sign1 > 0) {
+                  fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][1].Data(), VarManager::fgValues);
+                } else {
+                  fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][2].Data(), VarManager::fgValues);
+                }
+              }
+              // Histograms with pair cuts and common track cuts
+              for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
+                if (twoTrackCommonFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
                   if (sign1 * sign2 < 0) {
-                    fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][0].Data(), VarManager::fgValues);
+                    fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][0].Data(), VarManager::fgValues);
                   } else if (fConfigSameSignHistograms.value) {
                     if (sign1 > 0) {
-                      fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][1].Data(), VarManager::fgValues);
+                      fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][1].Data(), VarManager::fgValues);
                     } else {
-                      fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][2].Data(), VarManager::fgValues);
+                      fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][2].Data(), VarManager::fgValues);
                     }
                   }
                 }
-              } // end loop (common cuts)
-              for (unsigned int iPairCut = 0; iPairCut < fPairCuts.size(); iPairCut++) {
-                AnalysisCompositeCut cut = fPairCuts.at(iPairCut);
-                if (!(cut.IsSelected(VarManager::fgValues))) // apply pair cuts
-                  continue;
-                pairFilter |= (uint32_t(1) << iPairCut);
-                // Histograms with pair cuts
-                if (sign1 * sign2 < 0) {
-                  fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][0].Data(), VarManager::fgValues);
-                } else if (fConfigSameSignHistograms.value) {
-                  if (sign1 > 0) {
-                    fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][1].Data(), VarManager::fgValues);
-                  } else {
-                    fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][2].Data(), VarManager::fgValues);
-                  }
-                }
-                // Histograms with pair cuts and common track cuts
-                for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
-                  if (twoTrackFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
-                    if (sign1 * sign2 < 0) {
-                      fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][0].Data(), VarManager::fgValues);
-                    } else if (fConfigSameSignHistograms.value) {
-                      if (sign1 > 0) {
-                        fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][1].Data(), VarManager::fgValues);
-                      } else {
-                        fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][2].Data(), VarManager::fgValues);
-                      }
-                    }
-                  }
-                }
-              } // end loop (pair cuts)
-            }
-          } // end loop (cuts)
-          ditrackList(event.globalIndex(), VarManager::fgValues[VarManager::kMass],
-                      VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
-                      t1.sign() + t2.sign(), twoTrackFilter, pairFilter);
-          if constexpr (trackHasCov && TTwoProngFitter) {
-            ditrackExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauzProjected], VarManager::fgValues[VarManager::kVertexingLzProjected], VarManager::fgValues[VarManager::kVertexingLxyProjected]);
+              }
+            } // end loop (pair cuts)
           }
-        } // end inner assoc loop (leg A)
-      }   // end outer assoc loop (leg B)
+        } // end loop (cuts)
+        ditrackList(event.globalIndex(), VarManager::fgValues[VarManager::kMass],
+            VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi],
+            t1.sign() + t2.sign(), twoTrackFilter, pairFilter, twoTrackCommonFilter);
+        if constexpr (trackHasCov && TTwoProngFitter) {
+          ditrackExtraList(t1.globalIndex(), t2.globalIndex(), VarManager::fgValues[VarManager::kVertexingTauzProjected], VarManager::fgValues[VarManager::kVertexingLzProjected], VarManager::fgValues[VarManager::kVertexingLxyProjected]);
+        }
+      } // end inner assoc loop (leg A)
     }     // end event loop
   }
 
   // Template function to run same event triplets (e.g. D+->K-pi+pi+)
   template <bool TThreeProngFitter, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTrackAssocs, typename TTracks>
-  void runThreeProng(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& assocs, TTracks const& tracks, VarManager::PairCandidateType tripletType)
+  void runThreeProng(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& tracks, VarManager::PairCandidateType tripletType)
   {
     if (events.size() > 0) { // Additional protection to avoid crashing of events.begin().runNumber()
       if (fCurrentRun != events.begin().runNumber()) {
@@ -2094,30 +2134,28 @@ struct AnalysisAsymmetricPairing {
       VarManager::ResetValues(0, VarManager::kNVars);
       VarManager::FillEvent<TEventFillMap>(event, VarManager::fgValues);
 
-      auto groupedAssocs = assocs.sliceBy(preslice, event.globalIndex());
-      if (groupedAssocs.size() == 0) {
+      auto groupedLegAAssocs = legACandidateAssocs.sliceBy(preslice, event.globalIndex());
+      if (groupedLegAAssocs.size() == 0) {
+        continue;
+      }
+      auto groupedLegBAssocs = legBCandidateAssocs.sliceBy(preslice, event.globalIndex());
+      if (groupedLegBAssocs.size() == 0) {
+        continue;
+      }
+      auto groupedLegCAssocs = legCCandidateAssocs.sliceBy(preslice, event.globalIndex());
+      if (groupedLegCAssocs.size() == 0) {
         continue;
       }
 
-      // Partitions based on leg selections
-      Partition<TTrackAssocs> legACandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fLegAFilterMask) > uint32_t(0);
-      legACandidateAssocs.bindTable(groupedAssocs);
-      legACandidateAssocs.bindExternalIndices(&tracks);
-      Partition<TTrackAssocs> legBCandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fLegBFilterMask) > uint32_t(0);
-      legBCandidateAssocs.bindTable(groupedAssocs);
-      legBCandidateAssocs.bindExternalIndices(&tracks);
-      Partition<TTrackAssocs> legCCandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fLegCFilterMask) > uint32_t(0);
-      legCCandidateAssocs.bindTable(groupedAssocs);
-      legCCandidateAssocs.bindExternalIndices(&tracks);
-
+      std::set<std::tuple<int64_t, int64_t, int64_t>> globIdxTriplets;
       // Based on triplet type, make suitable combinations of the partitions
       if (tripletType == VarManager::kTripleCandidateToPKPi) {
-        for (auto& [a1, a2, a3] : combinations(soa::CombinationsFullIndexPolicy(legACandidateAssocs, legBCandidateAssocs, legCCandidateAssocs))) {
+        for (auto& [a1, a2, a3] : combinations(soa::CombinationsFullIndexPolicy(groupedLegAAssocs, groupedLegBAssocs, groupedLegCAssocs))) {
           readTriplet<TThreeProngFitter, TEventFillMap, TTrackFillMap>(a1, a2, a3, tracks, event, tripletType, histNames);
         }
       } else if (tripletType == VarManager::kTripleCandidateToKPiPi) {
-        for (auto& a1 : legACandidateAssocs) {
-          for (auto& [a2, a3] : combinations(legBCandidateAssocs, legCCandidateAssocs)) {
+        for (auto& a1 : groupedLegAAssocs) {
+          for (auto& [a2, a3] : combinations(groupedLegBAssocs, groupedLegCAssocs)) {
             readTriplet<TThreeProngFitter, TEventFillMap, TTrackFillMap>(a1, a2, a3, tracks, event, tripletType, histNames);
           }
         }
@@ -2132,18 +2170,35 @@ struct AnalysisAsymmetricPairing {
   void readTriplet(TTrackAssoc const& a1, TTrackAssoc const& a2, TTrackAssoc const& a3, TTracks const& /*tracks*/, TEvent const& event, VarManager::PairCandidateType tripletType, std::map<int, std::vector<TString>> histNames)
   {
     uint32_t threeTrackFilter = 0;
-    // Find out which leg cut combination the triplet passes
+    uint32_t threeTrackCommonFilter = 0;
     for (int icut = 0; icut < fNLegCuts; ++icut) {
+      // Find out which leg cut combination the triplet passes
       if ((((a1.isBarrelSelected_raw() & fLegAFilterMask) | (a2.isBarrelSelected_raw() & fLegBFilterMask) | (a3.isBarrelSelected_raw() & fLegCFilterMask)) & fTrackCutFilterMasks[icut]) == fTrackCutFilterMasks[icut]) {
         threeTrackFilter |= (uint32_t(1) << icut);
+        if (tripletType == VarManager::kTripleCandidateToPKPi && fConfigSkipAmbiguousIdCombinations.value) {
+          // Check if the supposed pion passes as a proton or kaon, if so, skip this triplet. It is pKp or pKK.
+          if ((a3.isBarrelSelected_raw() & fLegAFilterMask) || (a3.isBarrelSelected_raw() & fLegBFilterMask)) {
+            return;
+          }
+          // Check if the supposed kaon passes as a proton, if so, skip this triplet. It is ppPi.
+          if (a2.isBarrelSelected_raw() & fLegAFilterMask) {
+            return;
+          }
+        }
+        if (tripletType == VarManager::kTripleCandidateToKPiPi && fConfigSkipAmbiguousIdCombinations.value) {
+          // Check if one of the supposed pions pass as a kaon, if so, skip this triplet. It is KKPi.
+          if ((a2.isBarrelSelected_raw() & fLegAFilterMask) || (a3.isBarrelSelected_raw() & fLegAFilterMask)) {
+            return;
+          }
+        }
       }
     }
-    // Find common track cuts both candidates pass
-    threeTrackFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a3.isBarrelSelected_raw() & fCommonTrackCutMask;
-
     if (!threeTrackFilter) {
       return;
     }
+
+    // Find common track cuts all candidates pass
+    threeTrackCommonFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a3.isBarrelSelected_raw() & fCommonTrackCutMask;
 
     auto t1 = a1.template reducedtrack_as<TTracks>();
     auto t2 = a2.template reducedtrack_as<TTracks>();
@@ -2178,7 +2233,7 @@ struct AnalysisAsymmetricPairing {
           fHistMan->FillHistClass(histNames[icut][1].Data(), VarManager::fgValues);
         }
         for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
-          if (threeTrackFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
+          if (threeTrackCommonFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
             fHistMan->FillHistClass(histNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut][0].Data(), VarManager::fgValues);
           }
         } // end loop (common cuts)
@@ -2191,7 +2246,7 @@ struct AnalysisAsymmetricPairing {
           fHistMan->FillHistClass(histNames[fNLegCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut][0].Data(), VarManager::fgValues);
           // Histograms with pair cuts and common track cuts
           for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
-            if (threeTrackFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
+            if (threeTrackCommonFilter & fCommonTrackCutFilterMasks[iCommonCut]) {
               fHistMan->FillHistClass(histNames[(fNLegCuts * (fNCommonTrackCuts + 1) + fNLegCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut][0].Data(), VarManager::fgValues);
             }
           }
@@ -2256,6 +2311,8 @@ struct AnalysisDileptonTrack {
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
   int fNCuts;
   int fNPairCuts;
+  int fNCommonTrackCuts;
+  std::map<int, int> fCommonTrackCutMap;
   int fTrackCutBit;
   std::map<int, TString> fHistNamesDileptonTrack;
   std::map<int, TString> fHistNamesDileptons;
@@ -2328,6 +2385,8 @@ struct AnalysisDileptonTrack {
       // get the cuts employed for same-event pairing
       string tempCutsSinglePair;
       string pairCuts;
+      string pairCommonCuts;
+      string tempCutsTrack;
       if (isBarrel) {
         getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgTrackCuts", tempCutsSinglePair, false);
         getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgPairCuts", pairCuts, false);
@@ -2335,8 +2394,27 @@ struct AnalysisDileptonTrack {
         getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgMuonCuts", tempCutsSinglePair, false);
         getTaskOptionValue<string>(context, "analysis-same-event-pairing", "cfgPairCuts", pairCuts, false);
       } else if (isBarrelAsymmetric) {
+        getTaskOptionValue<string>(context, "analysis-track-selection", "cfgTrackCuts", tempCutsTrack, false);
         getTaskOptionValue<string>(context, "analysis-asymmetric-pairing", "cfgLegCuts", tempCutsSinglePair, false);
         getTaskOptionValue<string>(context, "analysis-asymmetric-pairing", "cfgPairCuts", pairCuts, false);
+        getTaskOptionValue<string>(context, "analysis-asymmetric-pairing", "cfgCommonTrackCuts", pairCommonCuts, false);
+      }
+
+      // If asymmetric pair is used, it may have common track cuts
+      TString pairCommonCutsStr = pairCommonCuts;
+      if (!pairCommonCutsStr.IsNull()) { // if common track cuts
+        TString tempCutsTrackStr = tempCutsTrack;
+        std::unique_ptr<TObjArray> objArrayTempTrack(tempCutsTrackStr.Tokenize(","));
+        int fNTempTrackCuts = objArrayTempTrack->GetEntries();
+        std::unique_ptr<TObjArray> objArrayCommon(pairCommonCutsStr.Tokenize(","));
+        fNCommonTrackCuts = objArrayCommon->GetEntries();
+        for (int icut = 0; icut < fNCommonTrackCuts; ++icut) {
+          for (int iicut = 0; iicut < fNTempTrackCuts; ++iicut) {
+            if (std::strcmp(objArrayCommon->At(icut)->GetName(), objArrayTempTrack->At(iicut)->GetName()) == 0) {
+              fCommonTrackCutMap[icut] = iicut;
+            }
+          }
+        }
       }
 
       TString tempCutsSinglePairStr = tempCutsSinglePair;
@@ -2364,14 +2442,35 @@ struct AnalysisDileptonTrack {
             TString pairCutsStr = pairCuts;
             DefineHistograms(fHistMan, fHistNamesDileptonTrack[icut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
             DefineHistograms(fHistMan, fHistNamesDileptons[icut], "barrel,vertexing");                         // define dilepton histograms
+            if (!pairCommonCutsStr.IsNull()) {
+              std::unique_ptr<TObjArray> objArrayCommon(pairCommonCutsStr.Tokenize(","));
+              for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
+                // fTrackHistNames[fNLegCuts + icut * fNCommonTrackCuts + iCommonCut] = names;
+                fHistNamesDileptonTrack[fNCuts + icut * fNCommonTrackCuts + iCommonCut] = Form("DileptonTrack_%s_%s_%s", tempStr.Data(), objArrayCommon->At(iCommonCut)->GetName(), fConfigTrackCut.value.data());
+                fHistNamesDileptons[fNCuts + icut * fNCommonTrackCuts + iCommonCut] = Form("DileptonsSelected_%s_%s", tempStr.Data(), objArrayCommon->At(iCommonCut)->GetName());
+                DefineHistograms(fHistMan, fHistNamesDileptonTrack[fNCuts + icut * fNCommonTrackCuts + iCommonCut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
+                DefineHistograms(fHistMan, fHistNamesDileptons[fNCuts + icut * fNCommonTrackCuts + iCommonCut], "barrel,vertexing");                         // define dilepton histograms
+              }
+            } 
             if (!pairCutsStr.IsNull()) {
               std::unique_ptr<TObjArray> objArrayPairCuts(pairCutsStr.Tokenize(","));
               fNPairCuts = objArrayPairCuts->GetEntries();
               for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) {
-                fHistNamesDileptonTrack[fNCuts + icut * fNPairCuts + iPairCut] = Form("DileptonTrack_%s_%s_%s", tempStr.Data(), objArrayPairCuts->At(iPairCut)->GetName(), fConfigTrackCut.value.data());
-                fHistNamesDileptons[fNCuts + icut * fNPairCuts + iPairCut] = Form("DileptonsSelected_%s_%s", tempStr.Data(), objArrayPairCuts->At(iPairCut)->GetName());
-                DefineHistograms(fHistMan, fHistNamesDileptonTrack[fNCuts + icut * fNPairCuts + iPairCut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
-                DefineHistograms(fHistMan, fHistNamesDileptons[fNCuts + icut * fNPairCuts + iPairCut], "barrel,vertexing");                         // define dilepton histograms
+                fHistNamesDileptonTrack[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut] = Form("DileptonTrack_%s_%s_%s", tempStr.Data(), objArrayPairCuts->At(iPairCut)->GetName(), fConfigTrackCut.value.data());
+                fHistNamesDileptons[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut] = Form("DileptonsSelected_%s_%s", tempStr.Data(), objArrayPairCuts->At(iPairCut)->GetName());
+                DefineHistograms(fHistMan, fHistNamesDileptonTrack[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
+                DefineHistograms(fHistMan, fHistNamesDileptons[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut], "barrel,vertexing");                         // define dilepton histograms
+                if (!pairCommonCutsStr.IsNull()) {
+                  std::unique_ptr<TObjArray> objArrayCommon(pairCommonCutsStr.Tokenize(","));
+                  for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
+                    fHistNamesDileptonTrack[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut]
+                      = Form("DileptonTrack_%s_%s_%s_%s", tempStr.Data(), objArrayCommon->At(iCommonCut)->GetName(), objArrayPairCuts->At(iPairCut)->GetName(), fConfigTrackCut.value.data());
+                    fHistNamesDileptons[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut]
+                      = Form("DileptonsSelected_%s_%s_%s", tempStr.Data(), objArrayCommon->At(iCommonCut)->GetName(), objArrayPairCuts->At(iPairCut)->GetName());
+                    DefineHistograms(fHistMan, fHistNamesDileptonTrack[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
+                    DefineHistograms(fHistMan, fHistNamesDileptons[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut], "barrel,vertexing");                         // define dilepton histograms
+                  }
+                } 
               }
             }
             if (isBarrelME || isMuonME) {
@@ -2448,9 +2547,19 @@ struct AnalysisDileptonTrack {
         if (dilepton.filterMap_bit(icut)) {
           fHistMan->FillHistClass(fHistNamesDileptons[icut].Data(), fValuesDilepton);
           if constexpr (TCandidateType == VarManager::kDstarToD0KPiPi) { // Dielectrons and Dimuons don't have the PairFilterMap column
+            for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
+              if (dilepton.commonFilterMap_bit(fCommonTrackCutMap[iCommonCut])) {
+                fHistMan->FillHistClass(fHistNamesDileptons[fNCuts + icut * fNCommonTrackCuts + iCommonCut].Data(), fValuesDilepton);
+              }
+            }
             for (int iPairCut = 0; iPairCut < fNPairCuts; iPairCut++) {
               if (dilepton.pairFilterMap_bit(iPairCut)) {
-                fHistMan->FillHistClass(fHistNamesDileptons[fNCuts + icut * fNPairCuts + iPairCut].Data(), fValuesDilepton);
+                fHistMan->FillHistClass(fHistNamesDileptons[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut].Data(), fValuesDilepton);
+                for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
+                  if (dilepton.commonFilterMap_bit(fCommonTrackCutMap[iCommonCut])) {
+                    fHistMan->FillHistClass(fHistNamesDileptons[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut].Data(), fValuesDilepton);
+                  }
+                }
               }
             }
           }
@@ -2487,9 +2596,19 @@ struct AnalysisDileptonTrack {
           if (dilepton.filterMap_bit(icut)) {
             fHistMan->FillHistClass(fHistNamesDileptonTrack[icut].Data(), fValuesHadron);
             if constexpr (TCandidateType == VarManager::kDstarToD0KPiPi) { // Dielectrons and Dimuons don't have the PairFilterMap column
+              for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
+                if (dilepton.commonFilterMap_bit(fCommonTrackCutMap[iCommonCut])) {
+                  fHistMan->FillHistClass(fHistNamesDileptonTrack[fNCuts + icut * fNCommonTrackCuts + iCommonCut].Data(), fValuesHadron);
+                }
+              }
               for (int iPairCut = 0; iPairCut < fNPairCuts; iPairCut++) {
                 if (dilepton.pairFilterMap_bit(iPairCut)) {
-                  fHistMan->FillHistClass(fHistNamesDileptonTrack[fNCuts + icut * fNPairCuts + iPairCut].Data(), fValuesHadron);
+                  fHistMan->FillHistClass(fHistNamesDileptonTrack[fNCuts * (fNCommonTrackCuts + 1) + icut * fNPairCuts + iPairCut].Data(), fValuesHadron);
+                  for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; iCommonCut++) {
+                    if (dilepton.commonFilterMap_bit(fCommonTrackCutMap[iCommonCut])) {
+                      fHistMan->FillHistClass(fHistNamesDileptonTrack[(fNCuts * (fNCommonTrackCuts + 1) + fNCuts * fNPairCuts) + icut * (fNPairCuts * fNCommonTrackCuts + 1) + iCommonCut * (1 + fNPairCuts) + iPairCut].Data(), fValuesHadron);
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Add charge-specific DCAz cuts

Move partitioning for asymmetric pairs/triplets outside the process functions

Implement optional double-counting checks for asymmetric pairs/triplets

Implement common track cuts on asymmetric pairs used in dilepton-track