### PR TITLE
clang-format: Insert a newline at end of file if missing.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,7 @@ ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
 IndentFunctionDeclarationAfterType: true
 IndentWidth:     2
+InsertNewlineAtEOF: true
 # It is broken on windows. Breaks all #include "header.h"
 ---
 Language:        Cpp


### PR DESCRIPTION
New option which fixes the missing end of line, which is reported as error by `cpplint`.