### PR TITLE
PWGJE: restrict true jets to evnet selected level as well as reco jets

### DIFF
--- a/PWGJE/Tasks/jetfinderQA.cxx
+++ b/PWGJE/Tasks/jetfinderQA.cxx
@@ -736,7 +736,7 @@ struct JetFinderQATask {
     }
     if (checkMcCollisionIsMatched) {
       auto collisionspermcpjet = collisions.sliceBy(CollisionsPerMCPCollision, jet.mcCollisionId());
-      if (collisionspermcpjet.size() == 1 && jetderiveddatautilities::selectCollision(collisionspermcpjet.begin(), eventSelection)) {
+      if (collisionspermcpjet.size() >= 1 && jetderiveddatautilities::selectCollision(collisionspermcpjet.begin(), eventSelection)) {
         fillMCPHistograms(jet);
       }
     } else {

--- a/PWGJE/Tasks/jetfinderQA.cxx
+++ b/PWGJE/Tasks/jetfinderQA.cxx
@@ -736,7 +736,7 @@ struct JetFinderQATask {
     }
     if (checkMcCollisionIsMatched) {
       auto collisionspermcpjet = collisions.sliceBy(CollisionsPerMCPCollision, jet.mcCollisionId());
-      if (collisionspermcpjet.size() >= 1) {
+      if (collisionspermcpjet.size() == 1 && jetderiveddatautilities::selectCollision(collisionspermcpjet.begin(), eventSelection)) {
         fillMCPHistograms(jet);
       }
     } else {


### PR DESCRIPTION
Due to the difference between event selections in Data and MC currently, only TVX-selected true jets seem to make the difference when unfolding Data and MC (response matrix: selMC -> kIsTVXtriggered != sel8 -> kIsTVXtriggered).