### PR TITLE
[PWGDQ] add option to exclude MC signal which share common ancestor

### DIFF
--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -146,7 +146,11 @@ void MCProng::Print() const
   for (int i = 0; i < fNGenerations; i++) {
     std::cout << "Generation #" << i << " PDGcode(" << fPDGcodes[i] << ") CheckBothCharges(" << fCheckBothCharges[i]
               << ") ExcludePDG(" << fExcludePDG[i] << ")  SourceBits(" << fSourceBits[i] << ") ExcludeSource(" << fExcludeSource[i]
-              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ") CheckGenerationsInTime(" << fCheckGenerationsInTime << ") PDGInHistory(" << fPDGInHistory[i] << ") ExcludePDGInHistory(" << fExcludePDGInHistory[i] << ")" << std::endl;
+              << ") UseANDonSource(" << fUseANDonSourceBitMap[i] << ") CheckGenerationsInTime(" << fCheckGenerationsInTime << ")";
+    for (int j = 0; j < fPDGInHistory.size(); j++) {
+      std::cout << " #" << j << " PDGInHistory(" << fPDGInHistory[j] << ") ExcludePDGInHistory(" << fExcludePDGInHistory[j] << ")";
+    }
+    std::cout << std::endl;
   }
 }
 

--- a/PWGDQ/Core/MCSignal.cxx
+++ b/PWGDQ/Core/MCSignal.cxx
@@ -21,6 +21,7 @@ MCSignal::MCSignal() : TNamed("", ""),
                        fProngs({}),
                        fNProngs(0),
                        fCommonAncestorIdxs({}),
+                       fExcludeCommonAncestor(false),
                        fTempAncestorLabel(-1)
 {
 }
@@ -30,17 +31,19 @@ MCSignal::MCSignal(int nProngs, const char* name /*= ""*/, const char* title /*=
                                                                                          fProngs({}),
                                                                                          fNProngs(nProngs),
                                                                                          fCommonAncestorIdxs({}),
+                                                                                         fExcludeCommonAncestor(false),
                                                                                          fTempAncestorLabel(-1)
 {
   fProngs.reserve(nProngs);
 }
 
 //________________________________________________________________________________________________
-MCSignal::MCSignal(const char* name, const char* title, std::vector<MCProng> prongs, std::vector<short> commonAncestors) : TNamed(name, title),
-                                                                                                                           fProngs(prongs),
-                                                                                                                           fNProngs(prongs.size()),
-                                                                                                                           fCommonAncestorIdxs(commonAncestors),
-                                                                                                                           fTempAncestorLabel(-1)
+MCSignal::MCSignal(const char* name, const char* title, std::vector<MCProng> prongs, std::vector<short> commonAncestors, bool excludeCommonAncestor) : TNamed(name, title),
+                                                                                                                                                       fProngs(prongs),
+                                                                                                                                                       fNProngs(prongs.size()),
+                                                                                                                                                       fCommonAncestorIdxs(commonAncestors),
+                                                                                                                                                       fExcludeCommonAncestor(excludeCommonAncestor),
+                                                                                                                                                       fTempAncestorLabel(-1)
 {
 }
 
@@ -67,10 +70,11 @@ void MCSignal::AddProng(MCProng prong, short commonAncestor)
 void MCSignal::PrintConfig()
 {
   cout << "Name/Title: " << fName << " / " << fTitle << endl;
+  cout << "Exclude common ancestor combinations: " << fExcludeCommonAncestor << endl;
   cout << "Printing " << fNProngs << "/" << fProngs.size() << " prongs:" << endl;
   int i = 0;
   for (auto& pr : fProngs) {
-    cout << "Prong #" << i << "  commonAncestor" << fCommonAncestorIdxs[i] << " ================ " << endl;
+    cout << "Prong #" << i << "  commonAncestor: " << fCommonAncestorIdxs[i] << " ================ " << endl;
     i++;
     pr.Print();
   }

--- a/PWGDQ/Core/MCSignalLibrary.cxx
+++ b/PWGDQ/Core/MCSignalLibrary.cxx
@@ -911,23 +911,89 @@ MCSignal* o2::aod::dqmcsignals::GetMCSignal(const char* name)
     return signal;
   }
 
-  // Any b->e and Any b->c->e
-  if (!nameStr.compare("eeFromBandBtoC")) {
-    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}); // check if mother pdg code is in history
+  // Any b->e and Any b->X->c->e
+  // Looking at such decays: B -> (e) D -> (e)e and bar{B} -> e
+  // Signal allows combinations of ee from the same B meson
+  // + the combination of e fom B and e from bar{B}
+  if (!nameStr.compare("eeFromBandAnyBtoC")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
     MCProng prongBtoC(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
     prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
-    signal = new MCSignal(name, "ee pairs from b->e and b->c->e", {prongB, prongBtoC}, {-1, -1}); // signal at pair level
+    signal = new MCSignal(name, "ee pairs from b->e and b->X->c->e", {prongB, prongBtoC}, {-1, -1}); // signal at pair level
+    return signal;
+  }
+
+  // Any b->e and Any b->X->c->e
+  if (!nameStr.compare("eeFromBandAnyBtoCBis")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "ee pairs from b->X->c->e and b->e", {prongBtoC, prongB}, {-1, -1}); // signal at pair level
+    return signal;
+  }
+
+  if (!nameStr.compare("eeFromBandBtoC")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "direkt ee pairs from b->e and b->c->e", {prongB, prongBtoC}, {-1, -1}); // signal at pair level
     return signal;
   }
 
   // Any b->e and Any b->c->e
   if (!nameStr.compare("eeFromBandBtoCBis")) {
-    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}); // check if mother pdg code is in history
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
     prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
-    MCProng prongBtoC(2, {11, 402}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false}, false, {502}, {false}); // check if mother pdg code is in history
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
     prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
     signal = new MCSignal(name, "ee pairs from b->c->e and b->e", {prongBtoC, prongB}, {-1, -1}); // signal at pair level
+    return signal;
+  }
+
+  // Any b->e and Any b->c->e (same mother/grandmother)
+  // require that the mother is the grandmother of the other electron
+  if (!nameStr.compare("eeFromBandBtoCsameGM")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "ee pairs from b->e and b->c->e, mother = grandmother", {prongB, prongBtoC}, {1, 2}, false); // signal at pair level, accept commonAncestor Pairs
+    return signal;
+  }
+
+  // Any b->e and Any b->c->e (same mother/grandmother)
+  // require that the mother is the grandmother of the other electron
+  if (!nameStr.compare("eeFromBandBtoCsameGMBis")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "ee pairs from b->c->e and b->e, mother = grandmother", {prongBtoC, prongB}, {2, 1}, false); // signal at pair level, accept commonAncestor Pairs
+    return signal;
+  }
+
+  // Any b->e and Any b->c->e (different mother/grandmother)
+  // require that the mother is not the grandmother of the other electron
+  if (!nameStr.compare("eeFromBandBtoCdiffGM")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "ee pairs from b->e and b->c->e, mother != grandmother", {prongB, prongBtoC}, {1, 2}, true); // signal at pair level, exclude commonAncestor Pairs
+    return signal;
+  }
+
+  // Any b->e and Any b->c->e (different mother/grandmother)
+  // require that the mother is not the grandmother of the other electron
+  if (!nameStr.compare("eeFromBandBtoCdiffGMBis")) {
+    MCProng prongB(2, {11, 502}, {true, true}, {false, false}, {0, 0}, {0, 0}, {false, false});
+    prongB.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    MCProng prongBtoC(3, {11, 402, 502}, {true, true, true}, {false, false, false}, {0, 0, 0}, {0, 0, 0}, {false, false, false}, false); // check if mother pdg code is in history
+    prongBtoC.SetSourceBit(0, MCProng::kPhysicalPrimary);
+    signal = new MCSignal(name, "ee pairs from b->c->e and b->e, mother != grandmother", {prongBtoC, prongB}, {2, 1}, true); // signal at pair level, exclude commonAncestor Pairs
     return signal;
   }
 

--- a/PWGEM/Dilepton/Tasks/emEfficiencyEE.cxx
+++ b/PWGEM/Dilepton/Tasks/emEfficiencyEE.cxx
@@ -171,7 +171,7 @@ struct AnalysisEventSelection {
         subGeneratorID = event.mcCollision().getSubGeneratorId();
       }
     }
-
+    
     registry.fill(HIST("Generator/SubGenerator_BeforeCuts"), subGeneratorID);
 
     // check if SubGeneratorID is part of list:

--- a/PWGEM/Dilepton/Tasks/emEfficiencyEE.cxx
+++ b/PWGEM/Dilepton/Tasks/emEfficiencyEE.cxx
@@ -171,7 +171,7 @@ struct AnalysisEventSelection {
         subGeneratorID = event.mcCollision().getSubGeneratorId();
       }
     }
-    
+
     registry.fill(HIST("Generator/SubGenerator_BeforeCuts"), subGeneratorID);
 
     // check if SubGeneratorID is part of list:


### PR DESCRIPTION
These are some changes to add the option excluding signals that share a common ancestor.
This is needed to differ between electron pairs coming from same ancestor (e.g. B->De->ee, same Mother and Grandmother)
and pair which have not the same ancestor relation (pair from B->D->e and bar{B}->e)

If the extra boolean `fExcludeCommonAncestor`  is true it rejects the MC signal if the ancestors are equal and accepts them if the boolean is false.

Since this is a change concerning more analysers I would like to ask @iarsene to have a look.
Those changes are required for the HP conference and thus merging this in the next days would be very nice.