### PR TITLE
[PWGJE] Adding a try catch to the SV reconstruction task

### DIFF
--- a/PWGJE/TableProducer/secondaryVertexReconstruction.cxx
+++ b/PWGJE/TableProducer/secondaryVertexReconstruction.cxx
@@ -163,7 +163,12 @@ struct SecondaryVertexReconstruction {
 
       // Reconstruct the secondary vertex
       int processResult = 0;
-      std::apply([&df, &processResult](const auto&... elems) { processResult = df.process(elems...); }, trackParVars);
+      try {
+        std::apply([&df, &processResult](const auto&... elems) { processResult = df.process(elems...); }, trackParVars);
+      } catch (const std::runtime_error& error) {
+        LOG(info) << "Run time error found: " << error.what() << ". DCAFitterN cannot work, skipping the candidate.";
+        return;
+      }
       if (processResult == 0) {
         return;
       }


### PR DESCRIPTION
The track tuner is causing some the covariant matrix to be a bit messed up leading the DCAFitter to crash. I added a try catch block in order to catch the error thrown by the DCAFitter.