### PR TITLE
Common: interlink MC extras with reco coll info

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -131,7 +131,7 @@ DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!
                   evsel::Selection);                       // for derived data / QA studies
 using MultExtra = MultsExtra::iterator;
 
-// mc collisions table - indexed to Mult 
+// mc collisions table - indexed to Mult
 DECLARE_SOA_TABLE(MultMCExtras, "AOD", "MULTMCEXTRA", //! Table for the MC information
                   mult::MultMCFT0A,
                   mult::MultMCFT0C,
@@ -145,10 +145,10 @@ DECLARE_SOA_TABLE(MultMCExtras, "AOD", "MULTMCEXTRA", //! Table for the MC infor
 using MultMCExtra = MultMCExtras::iterator;
 using MultsExtraMC = MultMCExtras; // for backwards compatibility with previous naming scheme
 
-// crosslinks 
+// crosslinks
 namespace mult
 {
-DECLARE_SOA_INDEX_COLUMN(MultMCExtra, multMCExtra); 
+DECLARE_SOA_INDEX_COLUMN(MultMCExtra, multMCExtra);
 }
 
 DECLARE_SOA_TABLE(MC2Mults, "AOD", "MC2MULTS", //! Relate BC -> mult

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -130,7 +130,9 @@ DECLARE_SOA_TABLE(MultsGlobal, "AOD", "MULTGLOBAL", //! counters that use Track 
 DECLARE_SOA_TABLE(MultSelections, "AOD", "MULTSELECTIONS", //!
                   evsel::Selection);                       // for derived data / QA studies
 using MultExtra = MultsExtra::iterator;
-DECLARE_SOA_TABLE(MultsExtraMC, "AOD", "MULTEXTRAMC", //! Table for the MC information
+
+// mc collisions table - indexed to Mult 
+DECLARE_SOA_TABLE(MultMCExtras, "AOD", "MULTMCEXTRA", //! Table for the MC information
                   mult::MultMCFT0A,
                   mult::MultMCFT0C,
                   mult::MultMCNParticlesEta05,
@@ -140,7 +142,17 @@ DECLARE_SOA_TABLE(MultsExtraMC, "AOD", "MULTEXTRAMC", //! Table for the MC infor
                   mult::IsInelGt0<mult::MultMCNParticlesEta10>,
                   mult::IsInelGt1<mult::MultMCNParticlesEta10>,
                   o2::soa::Marker<1>);
-using MultExtraMC = MultsExtraMC::iterator;
+using MultMCExtra = MultMCExtras::iterator;
+using MultsExtraMC = MultMCExtras; // for backwards compatibility with previous naming scheme
+
+// crosslinks 
+namespace mult
+{
+DECLARE_SOA_INDEX_COLUMN(MultMCExtra, multMCExtra); 
+}
+
+DECLARE_SOA_TABLE(MC2Mults, "AOD", "MC2MULTS", //! Relate BC -> mult
+                  o2::soa::Index<>, mult::MultMCExtraId);
 
 namespace multZeq
 {

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -43,7 +43,7 @@ static constexpr int kFV0MultZeqs = 9;
 static constexpr int kFT0MultZeqs = 10;
 static constexpr int kFDDMultZeqs = 11;
 static constexpr int kPVMultZeqs = 12;
-static constexpr int kMultsExtraMC = 13;
+static constexpr int kMultMCExtras = 13;
 static constexpr int nTables = 14;
 
 // Checking that the Zeq tables are after the normal ones
@@ -66,7 +66,7 @@ static const std::vector<std::string> tableNames{"FV0Mults",       // 0
                                                  "FT0MultZeqs",    // 10
                                                  "FDDMultZeqs",    // 11
                                                  "PVMultZeqs",     // 12
-                                                 "MultsExtraMC"};  // 13
+                                                 "MultMCExtras"};  // 13
 static const std::vector<std::string> parameterNames{"Enable"};
 static const int defaultParameters[nTables][nParameters]{{-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}};
 
@@ -85,7 +85,8 @@ struct MultiplicityTable {
   Produces<aod::FT0MultZeqs> tableFT0Zeqs;      // 10
   Produces<aod::FDDMultZeqs> tableFDDZeqs;      // 11
   Produces<aod::PVMultZeqs> tablePVZeqs;        // 12
-  Produces<aod::MultsExtraMC> tableExtraMc;     // 13
+  Produces<aod::MultMCExtras> tableExtraMc;     // 13
+  Produces<aod::MC2Mults> tableExtraMc2Mults;
   Produces<aod::MultsGlobal> multsGlobal;       // Not accounted for, produced based on process function processGlobalTrackingCounters
 
   // For vertex-Z corrections in calibration
@@ -163,10 +164,11 @@ struct MultiplicityTable {
       }
     }
     // Handle the custom cases.
-    if (tEnabled[kMultsExtraMC]) {
-      if (enabledTables->get(tableNames[kMultsExtraMC].c_str(), "Enable") == -1) {
+    if (tEnabled[kMultMCExtras]) {
+      if (enabledTables->get(tableNames[kMultMCExtras].c_str(), "Enable") == -1) {
         doprocessMC.value = true;
-        LOG(info) << "Enabling MC processing due to " << tableNames[kMultsExtraMC] << " table being enabled.";
+        doprocessMC2Mults.value = true;
+        LOG(info) << "Enabling MC processing due to " << tableNames[kMultMCExtras] << " table being enabled.";
       }
     }
 
@@ -335,7 +337,7 @@ struct MultiplicityTable {
         case kPVMultZeqs: // Equalized multiplicity for PV
           tablePVZeqs.reserve(collisions.size());
           break;
-        case kMultsExtraMC: // MC extra information (nothing to do in the data)
+        case kMultMCExtras: // MC extra information (nothing to do in the data)
           break;
         default:
           LOG(fatal) << "Unknown table requested: " << i;
@@ -609,7 +611,7 @@ struct MultiplicityTable {
             }
             tablePVZeqs(multZeqNContribs);
           } break;
-          case kMultsExtraMC: // MC only (nothing to do)
+          case kMultMCExtras: // MC only (nothing to do)
           {
           } break;
           default: // Default
@@ -665,6 +667,11 @@ struct MultiplicityTable {
     tableExtraMc(multFT0A, multFT0C, multBarrelEta05, multBarrelEta08, multBarrelEta10, mcCollision.posZ());
   }
 
+  void processMC2Mults(soa::Join<aod::McCollisionLabels, aod::Collisions>::iterator const& collision)
+  {
+    tableExtraMc2Mults(collision.mcCollisionId()); // interlink
+  }
+
   Configurable<float> min_pt_globaltrack{"min_pt_globaltrack", 0.15, "min. pT for global tracks"};
   Configurable<float> max_pt_globaltrack{"max_pt_globaltrack", 1e+10, "max. pT for global tracks"};
   Configurable<int> min_ncluster_its_globaltrack{"min_ncluster_its_globaltrack", 5, "min. number of ITS clusters for global tracks"};
@@ -715,6 +722,7 @@ struct MultiplicityTable {
   PROCESS_SWITCH(MultiplicityTable, processRun3, "Produce Run 3 multiplicity tables", true);
   PROCESS_SWITCH(MultiplicityTable, processGlobalTrackingCounters, "Produce Run 3 global counters", false);
   PROCESS_SWITCH(MultiplicityTable, processMC, "Produce MC multiplicity tables", false);
+  PROCESS_SWITCH(MultiplicityTable, processMC2Mults, "Produce MC -> Mult map", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
It seems this also requires to have an `s` at the end of the table that is being indexed, which is extremely unfortunate - and has required that I change the name of the table as well. `using` has been used to avoid backwards incompatibility. 