### PR TITLE
fixing abs rounding with fabs

### DIFF
--- a/PWGCF/Femto3D/Core/femto3dPairTask.h
+++ b/PWGCF/Femto3D/Core/femto3dPairTask.h
@@ -109,14 +109,14 @@ float GetKstarFrom4vectors(TLorentzVector& first4momentum, TLorentzVector& secon
 {
   if (isIdentical) {
     TLorentzVector fourmomentadiff = first4momentum - second4momentum;
-    return 0.5 * abs(fourmomentadiff.Mag());
+    return 0.5 * fabs(fourmomentadiff.Mag());
   } else {
     TLorentzVector fourmomentasum = first4momentum + second4momentum;
     TLorentzVector fourmomentadif = first4momentum - second4momentum;
 
     fourmomentadif.Boost((-1) * fourmomentasum.BoostVector());
 
-    return 0.5 * abs(fourmomentadif.Vect().Mag());
+    return 0.5 * fabs(fourmomentadif.Vect().Mag());
   }
 }
 
@@ -252,9 +252,9 @@ bool FemtoPair<TrackType>::IsClosePair(const float& deta, const float& dphi, con
     return true;
   if (_magfield1 * _magfield2 == 0)
     return true;
-  if (std::pow(abs(GetEtaDiff()) / deta, 2) + std::pow(abs(GetPhiStarDiff(radius)) / dphi, 2) < 1.0f)
+  if (std::pow(fabs(GetEtaDiff()) / deta, 2) + std::pow(fabs(GetPhiStarDiff(radius)) / dphi, 2) < 1.0f)
     return true;
-  // if (abs(GetEtaDiff()) < deta && abs(GetPhiStarDiff(radius)) < dphi)
+  // if (fabs(GetEtaDiff()) < deta && fabs(GetPhiStarDiff(radius)) < dphi)
   //   return true;
 
   return false;

--- a/PWGCF/Femto3D/Core/femto3dPairTask.h
+++ b/PWGCF/Femto3D/Core/femto3dPairTask.h
@@ -109,14 +109,14 @@ float GetKstarFrom4vectors(TLorentzVector& first4momentum, TLorentzVector& secon
 {
   if (isIdentical) {
     TLorentzVector fourmomentadiff = first4momentum - second4momentum;
-    return 0.5 * fabs(fourmomentadiff.Mag());
+    return 0.5 * std::fabs(fourmomentadiff.Mag());
   } else {
     TLorentzVector fourmomentasum = first4momentum + second4momentum;
     TLorentzVector fourmomentadif = first4momentum - second4momentum;
 
     fourmomentadif.Boost((-1) * fourmomentasum.BoostVector());
 
-    return 0.5 * fabs(fourmomentadif.Vect().Mag());
+    return 0.5 * std::fabs(fourmomentadif.Vect().Mag());
   }
 }
 
@@ -252,9 +252,9 @@ bool FemtoPair<TrackType>::IsClosePair(const float& deta, const float& dphi, con
     return true;
   if (_magfield1 * _magfield2 == 0)
     return true;
-  if (std::pow(fabs(GetEtaDiff()) / deta, 2) + std::pow(fabs(GetPhiStarDiff(radius)) / dphi, 2) < 1.0f)
+  if (std::pow(std::fabs(GetEtaDiff()) / deta, 2) + std::pow(std::fabs(GetPhiStarDiff(radius)) / dphi, 2) < 1.0f)
     return true;
-  // if (fabs(GetEtaDiff()) < deta && fabs(GetPhiStarDiff(radius)) < dphi)
+  // if (std::fabs(GetEtaDiff()) < deta && std::fabs(GetPhiStarDiff(radius)) < dphi)
   //   return true;
 
   return false;

--- a/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
+++ b/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
@@ -492,7 +492,7 @@ struct singleTrackSelector {
       return;
     }
 
-    if (abs(mcCollision.posZ()) > _vertexZ) {
+    if (fabs(mcCollision.posZ()) > _vertexZ) {
       return;
     }
 

--- a/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
+++ b/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
@@ -492,7 +492,7 @@ struct singleTrackSelector {
       return;
     }
 
-    if (fabs(mcCollision.posZ()) > _vertexZ) {
+    if (std::fabs(mcCollision.posZ()) > _vertexZ) {
       return;
     }
 

--- a/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
@@ -380,7 +380,7 @@ struct FemtoCorrelations {
       LOGF(fatal, "One of passed PDG is 0!!!");
 
     for (auto track : tracks) {
-      if (abs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
+      if (fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
         continue;
       if (_removeSameBunchPileup && !track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().isNoSameBunchPileup())
         continue;
@@ -400,7 +400,7 @@ struct FemtoCorrelations {
         continue;
       if (track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().occupancy() < _OccupancyCut.value.first || track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().occupancy() >= _OccupancyCut.value.second)
         continue;
-      if (abs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || abs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+      if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
         continue;
 
       if (track.sign() == _sign_1 && (track.p() < _PIDtrshld_1 ? o2::aod::singletrackselector::TPCselection(track, TPCcuts_1) : o2::aod::singletrackselector::TOFselection(track, TOFcuts_1, _tpcNSigmaResidual_1.value))) { // filling the map: eventID <-> selected particles1

--- a/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTask.cxx
@@ -380,7 +380,7 @@ struct FemtoCorrelations {
       LOGF(fatal, "One of passed PDG is 0!!!");
 
     for (auto track : tracks) {
-      if (fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
+      if (std::fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
         continue;
       if (_removeSameBunchPileup && !track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().isNoSameBunchPileup())
         continue;
@@ -400,7 +400,7 @@ struct FemtoCorrelations {
         continue;
       if (track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().occupancy() < _OccupancyCut.value.first || track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().occupancy() >= _OccupancyCut.value.second)
         continue;
-      if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+      if (std::fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || std::fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
         continue;
 
       if (track.sign() == _sign_1 && (track.p() < _PIDtrshld_1 ? o2::aod::singletrackselector::TPCselection(track, TPCcuts_1) : o2::aod::singletrackselector::TOFselection(track, TOFcuts_1, _tpcNSigmaResidual_1.value))) { // filling the map: eventID <-> selected particles1

--- a/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
@@ -321,7 +321,7 @@ struct FemtoCorrelationsMC {
     int trackPDG, trackOrigin;
 
     for (auto track : tracks) {
-      if (fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
+      if (std::fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
         continue;
       if (track.tpcFractionSharedCls() > _tpcFractionSharedCls || track.itsNCls() < _itsNCls)
         continue;
@@ -351,7 +351,7 @@ struct FemtoCorrelationsMC {
         if (trackOrigin > -1 && trackOrigin < 3)
           DCA_histos_1[centBin][track.origin()]->Fill(track.pt(), track.dcaXY(), track.dcaZ());
 
-        if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+        if (std::fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || std::fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
           continue;
 
         trackPDG = abs(track.pdgCode());
@@ -372,7 +372,7 @@ struct FemtoCorrelationsMC {
         if (trackOrigin > -1 && trackOrigin < 3)
           DCA_histos_2[centBin][track.origin()]->Fill(track.pt(), track.dcaXY(), track.dcaZ());
 
-        if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+        if (std::fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || std::fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
           continue;
 
         trackPDG = abs(track.pdgCode());

--- a/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dPairTaskMC.cxx
@@ -321,7 +321,7 @@ struct FemtoCorrelationsMC {
     int trackPDG, trackOrigin;
 
     for (auto track : tracks) {
-      if (abs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
+      if (fabs(track.template singleCollSel_as<soa::Filtered<FilteredCollisions>>().posZ()) > _vertexZ)
         continue;
       if (track.tpcFractionSharedCls() > _tpcFractionSharedCls || track.itsNCls() < _itsNCls)
         continue;
@@ -351,7 +351,7 @@ struct FemtoCorrelationsMC {
         if (trackOrigin > -1 && trackOrigin < 3)
           DCA_histos_1[centBin][track.origin()]->Fill(track.pt(), track.dcaXY(), track.dcaZ());
 
-        if (abs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || abs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+        if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
           continue;
 
         trackPDG = abs(track.pdgCode());
@@ -372,7 +372,7 @@ struct FemtoCorrelationsMC {
         if (trackOrigin > -1 && trackOrigin < 3)
           DCA_histos_2[centBin][track.origin()]->Fill(track.pt(), track.dcaXY(), track.dcaZ());
 
-        if (abs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || abs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+        if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
           continue;
 
         trackPDG = abs(track.pdgCode());

--- a/PWGCF/Femto3D/Tasks/femto3dQA.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dQA.cxx
@@ -186,7 +186,7 @@ struct QAHistograms {
       if (_requestNoCollInTimeRangeStandard && !track.template singleCollSel_as<ColsType>().noCollInTimeRangeStandard())
         continue;
 
-      if (fabs(track.template singleCollSel_as<ColsType>().posZ()) > _vertexZ)
+      if (std::fabs(track.template singleCollSel_as<ColsType>().posZ()) > _vertexZ)
         continue;
       if (track.template singleCollSel_as<ColsType>().multPerc() < _centCut.value.first || track.template singleCollSel_as<ColsType>().multPerc() >= _centCut.value.second)
         continue;
@@ -196,7 +196,7 @@ struct QAHistograms {
         continue;
       if ((track.tpcFractionSharedCls()) > _tpcFractionSharedCls || (track.itsNCls()) < _itsNCls)
         continue;
-      if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+      if (std::fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || std::fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
         continue;
 
       if constexpr (FillExtra) {

--- a/PWGCF/Femto3D/Tasks/femto3dQA.cxx
+++ b/PWGCF/Femto3D/Tasks/femto3dQA.cxx
@@ -186,7 +186,7 @@ struct QAHistograms {
       if (_requestNoCollInTimeRangeStandard && !track.template singleCollSel_as<ColsType>().noCollInTimeRangeStandard())
         continue;
 
-      if (abs(track.template singleCollSel_as<ColsType>().posZ()) > _vertexZ)
+      if (fabs(track.template singleCollSel_as<ColsType>().posZ()) > _vertexZ)
         continue;
       if (track.template singleCollSel_as<ColsType>().multPerc() < _centCut.value.first || track.template singleCollSel_as<ColsType>().multPerc() >= _centCut.value.second)
         continue;
@@ -196,7 +196,7 @@ struct QAHistograms {
         continue;
       if ((track.tpcFractionSharedCls()) > _tpcFractionSharedCls || (track.itsNCls()) < _itsNCls)
         continue;
-      if (abs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || abs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
+      if (fabs(track.dcaXY()) > _dcaXY.value[0] + _dcaXY.value[1] * std::pow(track.pt(), _dcaXY.value[2]) || fabs(track.dcaZ()) > _dcaZ.value[0] + _dcaZ.value[1] * std::pow(track.pt(), _dcaZ.value[2]))
         continue;
 
       if constexpr (FillExtra) {


### PR DESCRIPTION
Dear @victor-gonzalez 

in this commit we're attempting to fix a bug I spotted recently: O2Physics tags after 15 Aug in the HL were producing strange distributions on k*  -- discrete values like the values that are supposed to be float were rounded to int. I didn't manage to reproduce the issue on my machine but I assume that might be due to the usage of abs() function that might return "int" or "float" depending on if it was overloaded, compiler settings etc. Maybe in the middle of August the building settings for O2 were changed and this caused the bug. Maybe in that case it can also be helpful to notify other analysers.

So, I changed it everywhere where floats needed to fabs(). On my local machine it doesn't make any difference (I used today's build of O2 on a Mac), but hopefully it'll solve the issue in the HL.

Sincerely yours, Gleb.

@njacazio @ercolessi 