### PR TITLE
Fix unexpected behavior in DCA cuts due to `abs` returning an integer

### DIFF
--- a/Common/Core/TrackSelection.h
+++ b/Common/Core/TrackSelection.h
@@ -195,10 +195,10 @@ class TrackSelection
         return (isRun2 && mRequireGoldenChi2) ? (track.flags() & o2::aod::track::GoldenChi2) : true;
 
       case TrackCuts::kDCAxy:
-        return abs(track.dcaXY()) <= ((mMaxDcaXYPtDep) ? mMaxDcaXYPtDep(track.pt()) : mMaxDcaXY);
+        return std::fabs(track.dcaXY()) <= ((mMaxDcaXYPtDep) ? mMaxDcaXYPtDep(track.pt()) : mMaxDcaXY);
 
       case TrackCuts::kDCAz:
-        return abs(track.dcaZ()) <= mMaxDcaZ;
+        return std::fabs(track.dcaZ()) <= mMaxDcaZ;
 
       default:
         return false;

--- a/PWGCF/TableProducer/dptdptfilter.h
+++ b/PWGCF/TableProducer/dptdptfilter.h
@@ -840,7 +840,7 @@ inline bool matchTrackType(TrackObject const& track)
           }
         };
         auto checkDcaZcut = [&](auto const& track) {
-          return ((maxDcaZPtDep) ? abs(track.dcaZ()) <= maxDcaZPtDep(track.pt()) : true);
+          return ((maxDcaZPtDep) ? std::fabs(track.dcaZ()) <= maxDcaZPtDep(track.pt()) : true);
         };
 
         /* tight pT dependent DCAz cut */


### PR DESCRIPTION
See also https://github.com/AliceO2Group/O2Physics/pull/7634