### PR TITLE
[PWGLF] Remove unnecessary arguments in dyn. col. + fix typo in lambdakzerofinder

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -756,7 +756,7 @@ DECLARE_SOA_TABLE_VERSIONED(V0MCCores_002, "AOD", "V0MCCORE", 2, //! debug infor
                             v0data::RapidityMC<v0data::PxMC, v0data::PyMC, v0data::PzMC>,
                             v0data::NegativePtMC<v0data::PxNegMC, v0data::PyNegMC>,
                             v0data::PositivePtMC<v0data::PxPosMC, v0data::PyPosMC>,
-                            v0data::PtMC<v0data::PxMC, v0data::PyMC, v0data::PzMC>);
+                            v0data::PtMC<v0data::PxMC, v0data::PyMC>);
 
 DECLARE_SOA_TABLE(StoredV0MCCores_000, "AOD", "V0MCCORE", //! MC properties of the V0 for posterior analysis
                   v0data::PDGCode, v0data::PDGCodeMother,

--- a/PWGLF/TableProducer/Strangeness/lambdakzerofinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerofinder.cxx
@@ -270,11 +270,11 @@ struct lambdakzerofinder {
     int collisionIndex = -1;
     //   float getDCAtoPV(float X, float Y, float Z, float Px, float Py, float Pz, float pvX, float pvY, float pvZ){
     for (auto const& collision : collisions) {
-      float thisDCA = TMath::Abs(getDCAtoPV(vtx[0], vtx[1], vtx[2], pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2], collision.posX(), collision.posY(), collision.posY()));
+      float thisDCA = TMath::Abs(getDCAtoPV(vtx[0], vtx[1], vtx[2], pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2], collision.posX(), collision.posY(), collision.posZ()));
       if (thisDCA < smallestDCA) {
         collisionIndex = collision.globalIndex();
         smallestDCA = thisDCA;
-        cosPA = RecoDecay::cpa(std::array{collision.posX(), collision.posY(), collision.posY()}, array{vtx[0], vtx[1], vtx[2]}, array{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]});
+        cosPA = RecoDecay::cpa(std::array{collision.posX(), collision.posY(), collision.posZ()}, array{vtx[0], vtx[1], vtx[2]}, array{pvec0[0] + pvec1[0], pvec0[1] + pvec1[1], pvec0[2] + pvec1[2]});
       }
     }
     if (smallestDCA > maxV0DCAtoPV)


### PR DESCRIPTION
Remove unnecessary Pz argument in dynamic column for pt MC 
Fix typo in lambdakzerofinder about collision.posY() --> collision.posZ()