### PR TITLE
[PWGJE] Fixing a small bug with derived data producer

### DIFF
--- a/PWGJE/TableProducer/jetderiveddataproducer.cxx
+++ b/PWGJE/TableProducer/jetderiveddataproducer.cxx
@@ -230,8 +230,8 @@ struct JetDerivedDataProducerTask {
     jTracksTable(track.collisionId(), track.pt(), track.eta(), track.phi(), jetderiveddatautilities::setTrackSelectionBit(track, track.dcaZ(), dcaZMax));
     auto trackParCov = getTrackParCov(track);
     auto xyzTrack = trackParCov.getXYZGlo();
-    float sigmaDCAXYZ;
-    float dcaXYZ = getDcaXYZ(track, &sigmaDCAXYZ);
+    float sigmaDCAXYZ2;
+    float dcaXYZ = getDcaXYZ(track, &sigmaDCAXYZ2);
     float dcaX = -99.0;
     float dcaY = -99.0;
     if (track.collisionId() >= 0) {
@@ -240,7 +240,7 @@ struct JetDerivedDataProducerTask {
       dcaY = xyzTrack.Y() - collision.posY();
     }
 
-    jTracksExtraTable(dcaX, dcaY, track.dcaZ(), track.dcaXY(), dcaXYZ, std::sqrt(track.sigmaDcaZ2()), std::sqrt(track.sigmaDcaXY2()), sigmaDCAXYZ, track.sigma1Pt()); // why is this getSigmaZY
+    jTracksExtraTable(dcaX, dcaY, track.dcaZ(), track.dcaXY(), dcaXYZ, std::sqrt(track.sigmaDcaZ2()), std::sqrt(track.sigmaDcaXY2()), std::sqrt(sigmaDCAXYZ2), track.sigma1Pt()); // why is this getSigmaZY
     jTracksParentIndexTable(track.globalIndex());
     trackCollisionMapping[{track.globalIndex(), track.collisionId()}] = jTracksTable.lastIndex();
   }
@@ -257,9 +257,9 @@ struct JetDerivedDataProducerTask {
           jTracksTable(collision.globalIndex(), track.pt(), track.eta(), track.phi(), jetderiveddatautilities::setTrackSelectionBit(track, track.dcaZ(), dcaZMax));
           jTracksParentIndexTable(track.globalIndex());
           auto xyzTrack = trackParCov.getXYZGlo();
-          float sigmaDCAXYZ;
-          float dcaXYZ = getDcaXYZ(track, &sigmaDCAXYZ);
-          jTracksExtraTable(xyzTrack.X() - collision.posX(), xyzTrack.Y() - collision.posY(), track.dcaZ(), track.dcaXY(), dcaXYZ, std::sqrt(track.sigmaDcaZ2()), std::sqrt(track.sigmaDcaXY2()), sigmaDCAXYZ, track.sigma1Pt()); // why is this getSigmaZY
+          float sigmaDCAXYZ2;
+          float dcaXYZ = getDcaXYZ(track, &sigmaDCAXYZ2);
+          jTracksExtraTable(xyzTrack.X() - collision.posX(), xyzTrack.Y() - collision.posY(), track.dcaZ(), track.dcaXY(), dcaXYZ, std::sqrt(track.sigmaDcaZ2()), std::sqrt(track.sigmaDcaXY2()), std::sqrt(sigmaDCAXYZ2), track.sigma1Pt()); // why is this getSigmaZY
         } else {
           auto bc = collision.bc_as<soa::Join<aod::BCs, aod::Timestamps>>();
           initCCDB(bc, runNumber, ccdb, doprocessCollisionsRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, doprocessCollisionsRun2);

--- a/PWGJE/Tasks/jettaggerhfQA.cxx
+++ b/PWGJE/Tasks/jettaggerhfQA.cxx
@@ -567,11 +567,11 @@ struct JetTaggerHFQA {
       if (fillIPxyz) {
         float varImpXYZ, varSignImpXYZ, varImpXYZSig, varSignImpXYZSig;
         float dcaXYZ = track.dcaXYZ();
-        float sigmadcaXYZ2 = track.sigmadcaXYZ();
+        float sigmadcaXYZ = track.sigmadcaXYZ();
         varImpXYZ = dcaXYZ * jettaggingutilities::cmTomum;
         varSignImpXYZ = geoSign * std::abs(dcaXYZ) * jettaggingutilities::cmTomum;
-        varImpXYZSig = dcaXYZ / std::sqrt(sigmadcaXYZ2);
-        varSignImpXYZSig = geoSign * std::abs(dcaXYZ) / std::sqrt(sigmadcaXYZ2);
+        varImpXYZSig = dcaXYZ / sigmadcaXYZ;
+        varSignImpXYZSig = geoSign * std::abs(dcaXYZ) / sigmadcaXYZ;
         registry.fill(HIST("h3_jet_pt_impact_parameter_xyz_flavour"), mcdjet.pt(), varImpXYZ, jetflavour, eventWeight);
         registry.fill(HIST("h3_jet_pt_sign_impact_parameter_xyz_flavour"), mcdjet.pt(), varSignImpXYZ, jetflavour, eventWeight);
         registry.fill(HIST("h3_jet_pt_impact_parameter_xyz_significance_flavour"), mcdjet.pt(), varImpXYZSig, jetflavour, eventWeight);
@@ -1028,9 +1028,9 @@ struct JetTaggerHFQA {
       varImpZ = jtrack.dcaZ() * jettaggingutilities::cmTomum;
       varImpZSig = jtrack.dcaZ() / jtrack.sigmadcaZ();
       float dcaXYZ = jtrack.dcaXYZ();
-      float sigmadcaXYZ2 = jtrack.sigmadcaXYZ();
+      float sigmadcaXYZ = jtrack.sigmadcaXYZ();
       varImpXYZ = dcaXYZ * jettaggingutilities::cmTomum;
-      varImpXYZSig = dcaXYZ / std::sqrt(sigmadcaXYZ2);
+      varImpXYZSig = dcaXYZ / sigmadcaXYZ;
 
       registry.fill(HIST("h_impact_parameter_xy"), varImpXY);
       registry.fill(HIST("h_impact_parameter_xy_significance"), varImpXYSig);


### PR DESCRIPTION
The `sigmadcaXYZ` taken from `getDcaXYZ` is squared, so a `std::sqrt` was need before writing it in the table.