### PR TITLE
PWGHF: Add check for wrong collision association for B0 and B+ mesons

### DIFF
--- a/PWGCF/Flow/Tasks/flowGFWOmegaXi.cxx
+++ b/PWGCF/Flow/Tasks/flowGFWOmegaXi.cxx
@@ -384,7 +384,7 @@ struct FlowGFWOmegaXi {
           fGFW->Fill(casc.eta(), fPtAxis->FindBin(casc.pt()) - 1 + ((fOmegaMass->FindBin(casc.mOmega()) - 1) * nPtBins), casc.phi(), wacc * weff, 4);
         }
       }
-      if (TMath::Abs(casc.yXi()) < cfgCasc_rapidity && TMath::Abs(bachelor.tpcNSigmaKa()) < cfgNSigmaCascKaon && TMath::Abs(posdau.tpcNSigmaPr()) < cfgNSigmaCascProton && TMath::Abs(negdau.tpcNSigmaPi()) < cfgNSigmaCascPion) {
+      if (TMath::Abs(casc.yXi()) < cfgCasc_rapidity && TMath::Abs(bachelor.tpcNSigmaPi()) < cfgNSigmaCascPion && TMath::Abs(posdau.tpcNSigmaPr()) < cfgNSigmaCascProton && TMath::Abs(negdau.tpcNSigmaPi()) < cfgNSigmaCascPion) {
         registry.fill(HIST("hEtaPhiPOIXi"), casc.eta(), casc.phi());
         registry.fill(HIST("InvMassXiMinus"), casc.pt(), casc.mXi(), casc.eta(), cent);
         if ((casc.pt() < cfgCutPtPOIMax) && (casc.pt() > cfgCutPtPOIMin) && (casc.mXi() > 1.30) && (casc.mXi() < 1.37)) {

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -295,6 +295,7 @@ DECLARE_SOA_TABLE(HfMcRecRedDpPis, "AOD", "HFMCRECREDDPPI", //! Table with recon
                   hf_cand_b0_reduced::Prong0Id,
                   hf_cand_b0_reduced::Prong1Id,
                   hf_cand_b0::FlagMcMatchRec,
+                  hf_cand_b0::FlagWrongCollision,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
 
@@ -312,6 +313,7 @@ DECLARE_SOA_TABLE(HfMcCheckDpPis, "AOD", "HFMCCHECKDPPI", //! Table with reconst
 // Table with same size as HFCANDB0
 DECLARE_SOA_TABLE(HfMcRecRedB0s, "AOD", "HFMCRECREDB0", //! Reconstruction-level MC information on B0 candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchRec,
+                  hf_cand_b0::FlagWrongCollision,
                   hf_cand_b0::DebugMcRec,
                   hf_b0_mc::PtMother);
 
@@ -374,6 +376,7 @@ DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with recon
                   hf_cand_bplus_reduced::Prong0Id,
                   hf_cand_bplus_reduced::Prong1Id,
                   hf_cand_bplus::FlagMcMatchRec,
+                  hf_cand_bplus::FlagWrongCollision,
                   hf_cand_bplus::DebugMcRec,
                   hf_bplus_mc::PtMother);
 
@@ -388,6 +391,7 @@ DECLARE_SOA_TABLE(HfMcCheckD0Pis, "AOD", "HFMCCHECKD0PI", //! Table with reconst
 // Table with same size as HFCANDBPLUS
 DECLARE_SOA_TABLE(HfMcRecRedBps, "AOD", "HFMCRECREDBP", //! Reconstruction-level MC information on B+ candidates for reduced workflow
                   hf_cand_bplus::FlagMcMatchRec,
+                  hf_cand_bplus::FlagWrongCollision,
                   hf_cand_bplus::DebugMcRec,
                   hf_bplus_mc::PtMother);
 

--- a/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorB0Reduced.cxx
@@ -293,7 +293,7 @@ struct HfCandidateCreatorB0ReducedExpressions {
         if ((rowDPiMcRec.prong0Id() != candB0.prong0Id()) || (rowDPiMcRec.prong1Id() != candB0.prong1Id())) {
           continue;
         }
-        rowB0McRec(rowDPiMcRec.flagMcMatchRec(), rowDPiMcRec.debugMcRec(), rowDPiMcRec.ptMother());
+        rowB0McRec(rowDPiMcRec.flagMcMatchRec(), rowDPiMcRec.flagWrongCollision(), rowDPiMcRec.debugMcRec(), rowDPiMcRec.ptMother());
         filledMcInfo = true;
         if constexpr (checkDecayTypeMc) {
           rowB0McCheck(rowDPiMcRec.pdgCodeBeautyMother(),
@@ -306,7 +306,7 @@ struct HfCandidateCreatorB0ReducedExpressions {
         break;
       }
       if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D-Pi creator
-        rowB0McRec(0, -1, -1.f);
+        rowB0McRec(0, -1, -1, -1.f);
         if constexpr (checkDecayTypeMc) {
           rowB0McCheck(-1, -1, -1, -1, -1, -1);
         }

--- a/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBplusReduced.cxx
@@ -291,7 +291,7 @@ struct HfCandidateCreatorBplusReducedExpressions {
         if ((rowD0PiMcRec.prong0Id() != candBplus.prong0Id()) || (rowD0PiMcRec.prong1Id() != candBplus.prong1Id())) {
           continue;
         }
-        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.debugMcRec(), rowD0PiMcRec.ptMother());
+        rowBplusMcRec(rowD0PiMcRec.flagMcMatchRec(), rowD0PiMcRec.flagWrongCollision(), rowD0PiMcRec.debugMcRec(), rowD0PiMcRec.ptMother());
         filledMcInfo = true;
         if constexpr (checkDecayTypeMc) {
           rowBplusMcCheck(rowD0PiMcRec.pdgCodeBeautyMother(),
@@ -302,7 +302,7 @@ struct HfCandidateCreatorBplusReducedExpressions {
         break;
       }
       if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D0-Pi creator
-        rowBplusMcRec(0, -1, -1.f);
+        rowBplusMcRec(0, -1, -1, -1.f);
         if constexpr (checkDecayTypeMc) {
           rowBplusMcCheck(-1, -1, -1, -1);
         }

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -841,7 +841,7 @@ struct HfDataCreatorCharmHadPiReduced {
                             ptProngs[1], yProngs[1], etaProngs[1]);
       } else if constexpr (decayChannel == DecayChannel::BplusToD0barPi) {
         // B+ → D0bar π+
-        if (RecoDecay::isMatchedMCGen(particlesMc, particle, Pdg::kBPlus, std::array{static_cast<int>(Pdg::kD0), +kPiPlus}, true)) {
+        if (RecoDecay::isMatchedMCGen(particlesMc, particle, Pdg::kBPlus, std::array{-static_cast<int>(Pdg::kD0), +kPiPlus}, true)) {
           // Match D0bar -> π- K+
           auto candD0MC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
           // Printf("Checking D0bar -> π- K+");

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -57,6 +57,11 @@ enum DecayChannel : uint8_t {
   BplusToD0barPi,
 };
 
+enum WrongCollisionType : uint8_t {
+  WrongAssociation = 0,
+  SplitCollision,
+};
+
 /// Creation of CharmHad-Pi pairs for Beauty hadrons
 struct HfDataCreatorCharmHadPiReduced {
   // Produces AOD tables to store track information
@@ -145,6 +150,8 @@ struct HfDataCreatorCharmHadPiReduced {
   using CandsD0Filtered = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0>>;
   using CandsD0FilteredWithMl = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
 
+  using CollisionsWMcLabels = soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels>;
+
   Filter filterSelectDplusCandidates = (aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus);
   Filter filterSelectDzeroCandidates = (aod::hf_sel_candidate_d0::isSelD0 >= selectionFlagD0 || aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlagD0bar);
 
@@ -153,6 +160,7 @@ struct HfDataCreatorCharmHadPiReduced {
   Preslice<CandsD0Filtered> candsD0PerCollision = aod::track_association::collisionId;
   Preslice<CandsD0FilteredWithMl> candsD0PerCollisionWithMl = aod::track_association::collisionId;
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+  PresliceUnsorted<CollisionsWMcLabels> colPerMcCollision = aod::mccollisionlabel::mcCollisionId;
 
   std::shared_ptr<TH1> hCandidatesD0, hCandidatesDPlus;
   HistogramRegistry registry{"registry"};
@@ -295,21 +303,62 @@ struct HfDataCreatorCharmHadPiReduced {
     return true;
   }
 
+
+  ///Calculates the index of the collision with the maximum number of contributions.
+  ///\param collisions are the collisions to search through.
+  ///\return The index of the collision with the maximum number of contributions.
+  template <typename CColl>
+  int64_t getIndexCollisionMaxNumContrib(const CColl& collisions)
+  {
+    unsigned maxNumContrib = 0;
+    int64_t indexCollisionMaxNumContrib = -1;
+    for (const auto& collision : collisions) {
+      if (collision.numContrib() > maxNumContrib) {
+        maxNumContrib = collision.numContrib();
+        indexCollisionMaxNumContrib = collision.globalIndex();
+      }
+    }
+    return indexCollisionMaxNumContrib;
+  }
+
+  /// Checks if the B meson is associated with a different collision than the one it was generated in
+  /// \param particleMother is the mother particle
+  /// \param collision is the reconstructed collision 
+  /// \param indexCollisionMaxNumContrib is the index of the collision associated with a given MC collision with the largest number of contributors.
+  /// \param flagWrongCollision is the flag indicating if whether the associated collision is incorrect.
+  template <typename PParticle, typename CColl>
+  void checkWrongCollision(const PParticle& particleMother,
+                           const CColl& collision,
+                           const int64_t& indexCollisionMaxNumContrib,
+                           int8_t& flagWrongCollision) {
+
+    if (particleMother.mcCollision().globalIndex() != collision.mcCollisionId()) {
+      flagWrongCollision = BIT(WrongCollisionType::WrongAssociation);
+    } else { 
+      if (collision.globalIndex() != indexCollisionMaxNumContrib) {
+        flagWrongCollision = BIT(WrongCollisionType::SplitCollision);
+      }
+    }
+  }
+
   /// Function for filling MC reco information in the tables
   /// \param particlesMc is the table with MC particles
   /// \param vecDaughtersB is the vector with all daughter tracks (bachelor pion in last position)
   /// \param indexHfCandCharm is the index of the charm-hadron candidate
   /// \param selectedTracksPion is the map with the indices of selected bachelor pion tracks
-  template <uint8_t decChannel, typename PParticles, typename TTrack>
-  void fillMcRecoInfo(const PParticles& particlesMc,
+  template <uint8_t decChannel, typename CColl, typename PParticles, typename TTrack>
+  void fillMcRecoInfo(const CColl& collision,
+                      const PParticles& particlesMc,
                       const std::vector<TTrack>& vecDaughtersB,
                       int& indexHfCandCharm,
-                      std::map<int64_t, int64_t> selectedTracksPion)
+                      std::map<int64_t, int64_t> selectedTracksPion,
+                      const int64_t& indexCollisionMaxNumContrib)
   {
 
     // we check the MC matching to be stored
     int8_t sign{0};
     int8_t flag{0};
+    int8_t flagWrongCollision{0};
     int8_t debug{0};
     int pdgCodeBeautyMother{-1};
     int pdgCodeCharmMother{-1};
@@ -337,6 +386,7 @@ struct HfDataCreatorCharmHadPiReduced {
         if (indexMother >= 0) {
           auto particleMother = particlesMc.rawIteratorAt(indexMother);
           motherPt = particleMother.pt();
+          checkWrongCollision(particleMother, collision, indexCollisionMaxNumContrib, flagWrongCollision);
         }
       }
 
@@ -419,7 +469,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         rowHfDPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
       }
-      rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, debug, motherPt);
+      rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
     } else if constexpr (decChannel == DecayChannel::BplusToD0barPi) {
       // B+ → D0(bar) π+ → (K+ π-) π+
       auto indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, Pdg::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
@@ -437,9 +487,10 @@ struct HfDataCreatorCharmHadPiReduced {
         if (indexMother >= 0) {
           auto particleMother = particlesMc.rawIteratorAt(indexMother);
           motherPt = particleMother.pt();
+          checkWrongCollision(particleMother, collision, indexCollisionMaxNumContrib, flagWrongCollision);
         }
       }
-      rowHfD0PiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, debug, motherPt);
+      rowHfD0PiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
 
       // additional checks for correlated backgrounds
       if (checkDecayTypeMc) {
@@ -482,6 +533,7 @@ struct HfDataCreatorCharmHadPiReduced {
                        aod::TrackAssoc const& trackIndices,
                        TTracks const&,
                        PParticles const& particlesMc,
+                       uint64_t const& indexCollisionMaxNumContrib,
                        aod::BCsWithTimestamps const&)
   {
     // helpers for ReducedTables filling
@@ -683,7 +735,7 @@ struct HfDataCreatorCharmHadPiReduced {
             beautyHadDauTracks.push_back(track);
           }
           beautyHadDauTracks.push_back(trackPion);
-          fillMcRecoInfo<decChannel>(particlesMc, beautyHadDauTracks, indexHfCandCharm, selectedTracksPion);
+          fillMcRecoInfo<decChannel>(collision, particlesMc, beautyHadDauTracks, indexHfCandCharm, selectedTracksPion, indexCollisionMaxNumContrib);
         }
         fillHfCandCharm = true;
       }                                                           // pion loop
@@ -850,7 +902,7 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsDplusPerCollision, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<false, false, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, bcs);
+      runDataCreation<false, false, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, -1, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -880,7 +932,7 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsDplusPerCollisionWithMl, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<false, true, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, bcs);
+      runDataCreation<false, true, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, -1, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -910,7 +962,7 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsD0PerCollision, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<false, false, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, bcs);
+      runDataCreation<false, false, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, -1, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -940,7 +992,7 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsD0PerCollisionWithMl, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<false, true, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, bcs);
+      runDataCreation<false, true, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, tracks, -1, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -950,12 +1002,13 @@ struct HfDataCreatorCharmHadPiReduced {
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   // PROCESS FUNCTIONS FOR MC
 
-  void processDplusPiMc(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
+  void processDplusPiMc(CollisionsWMcLabels const& collisions,
                         CandsDplusFiltered const& candsC,
                         aod::TrackAssoc const& trackIndices,
                         TracksPidWithSelAndMc const& tracks,
                         aod::McParticles const& particlesMc,
-                        aod::BCsWithTimestamps const& bcs)
+                        aod::BCsWithTimestamps const& bcs,
+                        McCollisions const&)
   {
     // store configurables needed for B0 workflow
     if (!isHfCandBhadConfigFilled) {
@@ -974,7 +1027,9 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsDplusPerCollision, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<true, false, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, bcs);
+      auto collsSameMcCollision = collisions.sliceBy(colPerMcCollision, collision.mcCollisionId());
+      int64_t indexCollisionMaxNumContrib = getIndexCollisionMaxNumContrib(collsSameMcCollision);
+      runDataCreation<true, false, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, indexCollisionMaxNumContrib, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -982,12 +1037,13 @@ struct HfDataCreatorCharmHadPiReduced {
   }
   PROCESS_SWITCH(HfDataCreatorCharmHadPiReduced, processDplusPiMc, "Process DplusPi with MC info and without ML info", false);
 
-  void processDplusPiMcWithMl(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
+  void processDplusPiMcWithMl(CollisionsWMcLabels const& collisions,
                               CandsDplusFilteredWithMl const& candsC,
                               aod::TrackAssoc const& trackIndices,
                               TracksPidWithSelAndMc const& tracks,
                               aod::McParticles const& particlesMc,
-                              aod::BCsWithTimestamps const& bcs)
+                              aod::BCsWithTimestamps const& bcs,
+                              McCollisions const&)
   {
     // store configurables needed for B0 workflow
     if (!isHfCandBhadConfigFilled) {
@@ -1006,7 +1062,9 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsDplusPerCollisionWithMl, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<true, true, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, bcs);
+      auto collsSameMcCollision = collisions.sliceBy(colPerMcCollision, collision.mcCollisionId());
+      int64_t indexCollisionMaxNumContrib = getIndexCollisionMaxNumContrib(collsSameMcCollision);
+      runDataCreation<true, true, DecayChannel::B0ToDminusPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, indexCollisionMaxNumContrib, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -1014,12 +1072,13 @@ struct HfDataCreatorCharmHadPiReduced {
   }
   PROCESS_SWITCH(HfDataCreatorCharmHadPiReduced, processDplusPiMcWithMl, "Process DplusPi with MC info and with ML info", false);
 
-  void processD0PiMc(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
+  void processD0PiMc(CollisionsWMcLabels const& collisions,
                      CandsD0Filtered const& candsC,
                      aod::TrackAssoc const& trackIndices,
                      TracksPidWithSelAndMc const& tracks,
                      aod::McParticles const& particlesMc,
-                     aod::BCsWithTimestamps const& bcs)
+                     aod::BCsWithTimestamps const& bcs,
+                     McCollisions const&)
   {
     // store configurables needed for B+ workflow
     if (!isHfCandBhadConfigFilled) {
@@ -1038,7 +1097,9 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsD0PerCollision, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<true, false, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, bcs);
+      auto collsSameMcCollision = collisions.sliceBy(colPerMcCollision, collision.mcCollisionId());
+      int64_t indexCollisionMaxNumContrib = getIndexCollisionMaxNumContrib(collsSameMcCollision);
+      runDataCreation<true, false, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, indexCollisionMaxNumContrib, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
@@ -1046,12 +1107,13 @@ struct HfDataCreatorCharmHadPiReduced {
   }
   PROCESS_SWITCH(HfDataCreatorCharmHadPiReduced, processD0PiMc, "Process D0Pi with MC info and without ML info", false);
 
-  void processD0PiMcWithMl(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
+  void processD0PiMcWithMl(CollisionsWMcLabels const& collisions,
                            CandsD0FilteredWithMl const& candsC,
                            aod::TrackAssoc const& trackIndices,
                            TracksPidWithSelAndMc const& tracks,
                            aod::McParticles const& particlesMc,
-                           aod::BCsWithTimestamps const& bcs)
+                           aod::BCsWithTimestamps const& bcs,
+                           McCollisions const&)
   {
     // store configurables needed for B+ workflow
     if (!isHfCandBhadConfigFilled) {
@@ -1070,7 +1132,9 @@ struct HfDataCreatorCharmHadPiReduced {
       auto thisCollId = collision.globalIndex();
       auto candsCThisColl = candsC.sliceBy(candsD0PerCollisionWithMl, thisCollId);
       auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
-      runDataCreation<true, true, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, bcs);
+      auto collsSameMcCollision = collisions.sliceBy(colPerMcCollision, collision.mcCollisionId());
+      int64_t indexCollisionMaxNumContrib = getIndexCollisionMaxNumContrib(collsSameMcCollision);
+      runDataCreation<true, true, DecayChannel::BplusToD0barPi>(collision, candsCThisColl, trackIdsThisCollision, tracks, particlesMc, indexCollisionMaxNumContrib, bcs);
     }
     // handle normalization by the right number of collisions
     hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -58,7 +58,8 @@ enum DecayChannel : uint8_t {
 };
 
 enum WrongCollisionType : uint8_t {
-  WrongAssociation = 0,
+  None = 0,
+  WrongAssociation,
   SplitCollision,
 };
 
@@ -333,10 +334,10 @@ struct HfDataCreatorCharmHadPiReduced {
   {
 
     if (particleMother.mcCollision().globalIndex() != collision.mcCollisionId()) {
-      flagWrongCollision = BIT(WrongCollisionType::WrongAssociation);
+      flagWrongCollision = WrongCollisionType::WrongAssociation;
     } else {
       if (collision.globalIndex() != indexCollisionMaxNumContrib) {
-        flagWrongCollision = BIT(WrongCollisionType::SplitCollision);
+        flagWrongCollision = WrongCollisionType::SplitCollision;
       }
     }
   }
@@ -352,13 +353,13 @@ struct HfDataCreatorCharmHadPiReduced {
                       const std::vector<TTrack>& vecDaughtersB,
                       int& indexHfCandCharm,
                       std::map<int64_t, int64_t> selectedTracksPion,
-                      const int64_t& indexCollisionMaxNumContrib)
+                      const int64_t indexCollisionMaxNumContrib)
   {
 
     // we check the MC matching to be stored
     int8_t sign{0};
     int8_t flag{0};
-    int8_t flagWrongCollision{0};
+    int8_t flagWrongCollision{WrongCollisionType::None};
     int8_t debug{0};
     int pdgCodeBeautyMother{-1};
     int pdgCodeCharmMother{-1};

--- a/PWGHF/D2H/Tasks/taskB0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskB0Reduced.cxx
@@ -58,6 +58,7 @@ DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //!
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
 DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);       //! Maximum normalized difference between measured and expected impact parameter of candidate prongs
 DECLARE_SOA_COLUMN(MlScoreSig, mlScoreSig, float);                           //! ML score for signal class
+DECLARE_SOA_COLUMN(FlagWrongCollision, flagWrongCollision, int8_t);          //! Flag for association with wrong collision
 } // namespace hf_cand_b0_lite
 
 DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with some B0 properties
@@ -89,10 +90,12 @@ DECLARE_SOA_TABLE(HfRedCandB0Lites, "AOD", "HFREDCANDB0LITE", //! Table with som
                   hf_cand_b0_lite::Y,
                   hf_cand_3prong::FlagMcMatchRec,
                   hf_cand_3prong::OriginMcRec,
+                  hf_cand_b0_lite::FlagWrongCollision,
                   hf_cand_b0_lite::PtGen);
 
 DECLARE_SOA_TABLE(HfRedB0McCheck, "AOD", "HFREDB0MCCHECK", //! Table with MC decay type check
                   hf_cand_3prong::FlagMcMatchRec,
+                  hf_cand_b0_lite::FlagWrongCollision,
                   hf_cand_b0_lite::MProng0,
                   hf_cand_b0_lite::PtProng0,
                   hf_cand_b0_lite::M,
@@ -346,9 +349,11 @@ struct HfTaskB0Reduced {
     auto decLenXyD = RecoDecay::distanceXY(posPv, posSvD);
 
     int8_t flagMcMatchRec = 0;
+    int8_t flagWrongCollision = 0;
     bool isSignal = false;
     if constexpr (doMc) {
       flagMcMatchRec = candidate.flagMcMatchRec();
+      flagWrongCollision = candidate.flagWrongCollision();
       isSignal = TESTBIT(std::abs(flagMcMatchRec), hf_cand_b0::DecayTypeMc::B0ToDplusPiToPiKPiPi);
     }
 
@@ -524,6 +529,7 @@ struct HfTaskB0Reduced {
           hfHelper.yB0(candidate),
           flagMcMatchRec,
           isSignal,
+          flagWrongCollision,
           ptMother);
       }
       if constexpr (withDecayTypeCheck) {
@@ -533,6 +539,7 @@ struct HfTaskB0Reduced {
         }
         hfRedB0McCheck(
           flagMcMatchRec,
+          flagWrongCollision,
           invMassD,
           ptD,
           invMassB0,

--- a/PWGHF/D2H/Tasks/taskBplusReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusReduced.cxx
@@ -57,6 +57,7 @@ DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //!
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
 DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);       //! Maximum normalized difference between measured and expected impact parameter of candidate prongs
 DECLARE_SOA_COLUMN(MlScoreSig, mlScoreSig, float);                           //! ML score for signal class
+DECLARE_SOA_COLUMN(FlagWrongCollision, flagWrongCollision, int8_t);          //! Flag for association with wrong collision
 } // namespace hf_cand_bplus_lite
 
 DECLARE_SOA_TABLE(HfRedCandBpLites, "AOD", "HFREDCANDBPLITE", //! Table with some B+ properties
@@ -88,10 +89,12 @@ DECLARE_SOA_TABLE(HfRedCandBpLites, "AOD", "HFREDCANDBPLITE", //! Table with som
                   hf_cand_bplus_lite::Y,
                   hf_cand_2prong::FlagMcMatchRec,
                   hf_cand_2prong::OriginMcRec,
+                  hf_cand_bplus_lite::FlagWrongCollision,
                   hf_cand_bplus_lite::PtGen);
 
 DECLARE_SOA_TABLE(HfRedBpMcCheck, "AOD", "HFREDBPMCCHECK", //! Table with MC decay type check
                   hf_cand_3prong::FlagMcMatchRec,
+                  hf_cand_bplus_lite::FlagWrongCollision,
                   hf_cand_bplus_lite::MProng0,
                   hf_cand_bplus_lite::PtProng0,
                   hf_cand_bplus_lite::M,
@@ -186,10 +189,10 @@ struct HfTaskBplusReduced {
         registry.add("hRapidity", bPlusCandTitle + "candidate #it{y};" + stringPt, {HistType::kTH2F, {axisRapidity, axisPtB}});
         registry.add("hd0d0", bPlusCandTitle + "candidate product of DCAxy to prim. vertex (cm^{2});" + stringPt, {HistType::kTH2F, {axisImpParProd, axisPtB}});
         registry.add("hInvMassD0", bPlusCandTitle + "prong0, D0 inv. mass (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassD0, axisPtD0}});
-        registry.add("hDecLengthD", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate decay length (cm);entries", {HistType::kTH2F, {axisPtD0, axisDecLength}});
-        registry.add("hDecLengthXyD", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});decay length XY (cm);entries", {HistType::kTH2F, {axisPtD0, axisDecLength}});
-        registry.add("hCpaD", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate cos(#vartheta_{P});entries", {HistType::kTH2F, {axisPtD0, axisCpa}});
-        registry.add("hCpaXyD", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate cos(#vartheta_{P}^{XY});entries", {HistType::kTH2F, {axisPtD0, axisCpa}});
+        registry.add("hDecLengthD0", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate decay length (cm);entries", {HistType::kTH2F, {axisPtD0, axisDecLength}});
+        registry.add("hDecLengthXyD0", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});decay length XY (cm);entries", {HistType::kTH2F, {axisPtD0, axisDecLength}});
+        registry.add("hCpaD0", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate cos(#vartheta_{P});entries", {HistType::kTH2F, {axisPtD0, axisCpa}});
+        registry.add("hCpaXyD0", bPlusCandTitle + "#it{p}_{T}(D^{0}) (GeV/#it{c});D^{0} candidate cos(#vartheta_{P}^{XY});entries", {HistType::kTH2F, {axisPtD0, axisCpa}});
 
         // ML scores of D0 daughter
         if (doprocessDataWithDmesMl) {
@@ -340,12 +343,13 @@ struct HfTaskBplusReduced {
   /// \param candidatesD is the table with D0 candidates
   template <bool doMc, bool withDecayTypeCheck, bool withDmesMl, bool withBplusMl, typename Cand>
   void fillCand(Cand const& candidate,
-                aod::HfRed2Prongs const& /*candidatesD*/)
+                aod::HfRed2Prongs const& /*candidatesD*/,
+                TracksPion const&)
   {
     auto ptCandBplus = candidate.pt();
     auto invMassBplus = hfHelper.invMassBplusToD0Pi(candidate);
     auto candD0 = candidate.template prong0_as<aod::HfRed2Prongs>();
-    auto candPi = candidate.template prong1_as<aod::HfRedTracks>();
+    auto candPi = candidate.template prong1_as<TracksPion>();
     auto ptD0 = candidate.ptProng0();
     auto invMassD0 = (candPi.signed1Pt() < 0) ? candD0.invMassD0() : candD0.invMassD0Bar();
     std::array<float, 3> posPv{candidate.posX(), candidate.posY(), candidate.posZ()};
@@ -357,9 +361,11 @@ struct HfTaskBplusReduced {
     auto decLenXyD0 = RecoDecay::distanceXY(posPv, posSvD);
 
     int8_t flagMcMatchRec = 0;
+    int8_t flagWrongCollision = 0;
     bool isSignal = false;
     if constexpr (doMc) {
       flagMcMatchRec = candidate.flagMcMatchRec();
+      flagWrongCollision = candidate.flagWrongCollision();
       isSignal = TESTBIT(std::abs(flagMcMatchRec), hf_cand_bplus::DecayTypeMc::BplusToD0PiToKPiPi);
     }
 
@@ -537,6 +543,7 @@ struct HfTaskBplusReduced {
           hfHelper.yBplus(candidate),
           flagMcMatchRec,
           isSignal,
+          flagWrongCollision,
           ptMother);
       }
       if constexpr (withDecayTypeCheck) {
@@ -546,6 +553,7 @@ struct HfTaskBplusReduced {
         }
         hfRedBpMcCheck(
           flagMcMatchRec,
+          flagWrongCollision,
           invMassD0,
           ptD0,
           invMassBplus,
@@ -600,39 +608,39 @@ struct HfTaskBplusReduced {
   // Process functions
   void processData(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfSelBplusToD0Pi>> const& candidates,
                    aod::HfRed2Prongs const& candidatesD,
-                   TracksPion const&)
+                   TracksPion const& pionTracks)
   {
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, false, false, false>(candidate, candidatesD);
+      fillCand<false, false, false, false>(candidate, candidatesD, pionTracks);
     } // candidate loop
   }   // processData
   PROCESS_SWITCH(HfTaskBplusReduced, processData, "Process data without ML scores for D0 daughter", true);
 
   void processDataWithDmesMl(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfRedBplusD0Mls, aod::HfSelBplusToD0Pi>> const& candidates,
                              aod::HfRed2Prongs const& candidatesD,
-                             TracksPion const&)
+                             TracksPion const& pionTracks)
   {
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, false, true, false>(candidate, candidatesD);
+      fillCand<false, false, true, false>(candidate, candidatesD, pionTracks);
     } // candidate loop
   }   // processDataWithDmesMl
   PROCESS_SWITCH(HfTaskBplusReduced, processDataWithDmesMl, "Process data with ML scores for D0 daughter", false);
 
   void processDataWithBplusMl(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfMlBplusToD0Pi, aod::HfSelBplusToD0Pi>> const& candidates,
                               aod::HfRed2Prongs const& candidatesD,
-                              TracksPion const&)
+                              TracksPion const& pionTracks)
   {
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<false, false, false, true>(candidate, candidatesD);
+      fillCand<false, false, false, true>(candidate, candidatesD, pionTracks);
     } // candidate loop
   }   // processDataWithBplusMl
   PROCESS_SWITCH(HfTaskBplusReduced, processDataWithBplusMl, "Process data with(out) ML scores for B+ (D0 daughter)", false);
@@ -640,14 +648,14 @@ struct HfTaskBplusReduced {
   void processMc(soa::Join<aod::HfRedCandBplus, aod::HfSelBplusToD0Pi, aod::HfMcRecRedBps> const& candidates,
                  aod::HfMcGenRedBps const& mcParticles,
                  aod::HfRed2Prongs const& candidatesD,
-                 TracksPion const&)
+                 TracksPion const& pionTracks)
   {
     // MC rec
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, false, false, false>(candidate, candidatesD);
+      fillCand<true, false, false, false>(candidate, candidatesD, pionTracks);
     } // rec
 
     // MC gen. level
@@ -660,14 +668,14 @@ struct HfTaskBplusReduced {
   void processMcWithDecayTypeCheck(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfSelBplusToD0Pi, aod::HfMcRecRedBps, aod::HfMcCheckBps>> const& candidates,
                                    aod::HfMcGenRedBps const& mcParticles,
                                    aod::HfRed2Prongs const& candidatesD,
-                                   TracksPion const&)
+                                   TracksPion const& pionTracks)
   {
     // MC rec
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, true, false, false>(candidate, candidatesD);
+      fillCand<true, true, false, false>(candidate, candidatesD, pionTracks);
     } // rec
 
     // MC gen. level
@@ -680,14 +688,14 @@ struct HfTaskBplusReduced {
   void processMcWithDmesMl(soa::Join<aod::HfRedCandBplus, aod::HfRedBplusD0Mls, aod::HfSelBplusToD0Pi, aod::HfMcRecRedBps> const& candidates,
                            aod::HfMcGenRedBps const& mcParticles,
                            aod::HfRed2Prongs const& candidatesD,
-                           TracksPion const&)
+                           TracksPion const& pionTracks)
   {
     // MC rec
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, false, true, false>(candidate, candidatesD);
+      fillCand<true, false, true, false>(candidate, candidatesD, pionTracks);
     } // rec
 
     // MC gen. level
@@ -700,14 +708,14 @@ struct HfTaskBplusReduced {
   void processMcWithBplusMl(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfMlBplusToD0Pi, aod::HfSelBplusToD0Pi, aod::HfMcRecRedBps>> const& candidates,
                             aod::HfMcGenRedBps const& mcParticles,
                             aod::HfRed2Prongs const& candidatesD,
-                            TracksPion const&)
+                            TracksPion const& pionTracks)
   {
     // MC rec
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, false, false, true>(candidate, candidatesD);
+      fillCand<true, false, false, true>(candidate, candidatesD, pionTracks);
     } // rec
 
     // MC gen. level
@@ -720,14 +728,14 @@ struct HfTaskBplusReduced {
   void processMcWithBplusMlAndDecayTypeCheck(soa::Filtered<soa::Join<aod::HfRedCandBplus, aod::HfMlBplusToD0Pi, aod::HfSelBplusToD0Pi, aod::HfMcRecRedBps, aod::HfMcCheckBps>> const& candidates,
                                              aod::HfMcGenRedBps const& mcParticles,
                                              aod::HfRed2Prongs const& candidatesD,
-                                             TracksPion const&)
+                                             TracksPion const& pionTracks)
   {
     // MC rec
     for (const auto& candidate : candidates) {
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
         continue;
       }
-      fillCand<true, true, false, true>(candidate, candidatesD);
+      fillCand<true, true, false, true>(candidate, candidatesD, pionTracks);
     } // rec
 
     // MC gen. level

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -757,6 +757,7 @@ namespace hf_cand_bplus
 DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfCand2Prong, "_0"); // D0 index
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
+DECLARE_SOA_COLUMN(FlagWrongCollision, flagWrongCollision, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);       // particle origin, reconstruction level
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);       // particle origin, generator level
@@ -1659,11 +1660,12 @@ namespace hf_cand_b0
 {
 DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfCand3Prong, "_0"); // D index
 // MC matching result:
-DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
-DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
-DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);       // particle origin, reconstruction level
-DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);       // particle origin, generator level
-DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
+DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);         // reconstruction level
+DECLARE_SOA_COLUMN(FlagWrongCollision, flagWrongCollision, int8_t); // reconstruction level
+DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);         // generator level
+DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               // particle origin, reconstruction level
+DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               // particle origin, generator level
+DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                 // debug flag for mis-association reconstruction level
 
 // mapping of decay types
 enum DecayType { B0ToDPi };


### PR DESCRIPTION
This PR adds a flag to the B0 and B+ outputs for tagging B mesons associated with a wrong collision at MC level.
Few minor bugs were also fixed in the B+ reduced task.