### PR TITLE
PWGJE: Custom DCA cuts for quality tracks

### DIFF
--- a/PWGJE/Tasks/ChJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/ChJetTriggerQATask.cxx
@@ -49,6 +49,10 @@ using filteredJTracks = soa::Filtered<soa::Join<aod::JTracks, aod::JTrackPIs, ao
 using filteredJets = soa::Filtered<soa::Join<aod::ChargedJets, aod::ChargedJetConstituents>>;
 using joinedTracks = soa::Join<aod::Tracks, aod::TracksExtra>;
 
+float DcaXYPtCut(float tracPt){
+  return 0.0105f + 0.0350f / pow(tracPt, 1.1f);
+}
+
 // What this task should do
 // Event by event fill
 // 1) pT spectrum of tracks in TPC volume
@@ -78,9 +82,11 @@ struct ChJetTriggerQATask {
   Configurable<bool> bAddSupplementHistosToOutput{"bAddAdditionalHistosToOutput", false, "add supplementary histos to the output"};
 
   Configurable<float> phiAngleRestriction{"phiAngleRestriction", 0.3, "angle to restrict track phi for plotting tpc momentum"};
+  Configurable<float> dcaXY_multFact{"dcaXY_multFact", 3., "mult factor to relax pT dependent dcaXY cut for quality tracks"};
+  Configurable<float> dcaZ_cut{"dcaZ_cut", 3., "cut on dcaZ for quality tracks"};
 
   ConfigurableAxis dcaXY_Binning{"dcaXY_Binning", {100, -5., 5.}, ""};
-  ConfigurableAxis dcaZ_Binning{"dcaZ_Binning", {100, -5., 5.}, ""};
+  ConfigurableAxis dcaZ_Binning{"dcaZ_Binning", {100, -3., 3.}, ""};
 
   float fiducialVolume; // 0.9 - jetR
 
@@ -116,10 +122,9 @@ struct ChJetTriggerQATask {
     spectra.add("globalP_tpcglobalPDiff_phirestrict", "difference of global and TPC inner momentum vs global momentum with selection applied restricted phi", {HistType::kTH2F, {{100, 0., +100.}, {200, -100., +100.}}});
     spectra.add("global1overP_tpcglobalPDiff_phirestrict", "difference of 1/p global and TPC inner momentum vs global momentum with selection applied restricted phi", {HistType::kTH2F, {{100, 0., +100.}, {500, -8., +8.}}});
 
-    spectra.add("DCAx_track_Phi_pT", "track DCAx vs phi & pT of global tracks w. nITSClusters #ge 4", kTH3F, {dcaXY_Binning, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
-    spectra.add("DCAy_track_Phi_pT", "track DCAy vs phi & pT of global tracks w. nITSClusters #ge 4", kTH3F, {dcaXY_Binning, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
-    spectra.add("DCAz_track_Phi_pT", "track DCAz vs phi & pT of global tracks w. nITSClusters #ge 4", kTH3F, {dcaZ_Binning, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
-    spectra.add("nITSClusters_TrackPt", "Number of ITS hits vs phi & pT of global tracks", kTH3F, {{7, 1., 8.}, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
+    spectra.add("DCAxy_track_Phi_pT", "track DCAxy vs phi & pT of tracks w. nITSClusters #geq 4", kTH3F, {dcaXY_Binning, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
+    spectra.add("DCAz_track_Phi_pT", "track DCAz vs phi & pT of tracks w. nITSClusters #geq 4", kTH3F, {dcaZ_Binning, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
+    spectra.add("nITSClusters_TrackPt", "Number of ITS hits vs phi & pT of tracks", kTH3F, {{7, 1., 8.}, {60, 0., TMath::TwoPi()}, {100, 0., 100.}});
 
     // Supplementary plots
     if (bAddSupplementHistosToOutput) {
@@ -196,9 +201,9 @@ struct ChJetTriggerQATask {
           continue;
         }
 
-        if (originalTrack.itsNCls() >= 4) { // correspond to number of track hits in ITS layers
-          spectra.fill(HIST("DCAx_track_Phi_pT"), track.dcaX(), track.phi(), track.pt());
-          spectra.fill(HIST("DCAy_track_Phi_pT"), track.dcaY(), track.phi(), track.pt());
+        bool bDcaCondition = (nabs(track.dcaZ()) < dcaZ_cut) && (nabs(track.dcaXY()) < dcaXY_multFact*DcaXYPtCut(track.pt()));
+        if (originalTrack.itsNCls() >= 4 && bDcaCondition) { // correspond to number of track hits in ITS layers
+          spectra.fill(HIST("DCAxy_track_Phi_pT"), track.dcaXY(), track.phi(), track.pt());
           spectra.fill(HIST("DCAz_track_Phi_pT"), track.dcaZ(), track.phi(), track.pt());
         }
 

--- a/PWGJE/Tasks/ChJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/ChJetTriggerQATask.cxx
@@ -202,7 +202,7 @@ struct ChJetTriggerQATask {
           continue;
         }
 
-        bool bDcaCondition = (nabs(track.dcaZ()) < dcaZ_cut) && (nabs(track.dcaXY()) < dcaXY_multFact * DcaXYPtCut(track.pt()));
+        bool bDcaCondition = (abs(track.dcaZ()) < dcaZ_cut) && (abs(track.dcaXY()) < dcaXY_multFact * DcaXYPtCut(track.pt()));
         if (originalTrack.itsNCls() >= 4 && bDcaCondition) { // correspond to number of track hits in ITS layers
           spectra.fill(HIST("DCAxy_track_Phi_pT"), track.dcaXY(), track.phi(), track.pt());
           spectra.fill(HIST("DCAz_track_Phi_pT"), track.dcaZ(), track.phi(), track.pt());

--- a/PWGJE/Tasks/ChJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/ChJetTriggerQATask.cxx
@@ -49,7 +49,8 @@ using filteredJTracks = soa::Filtered<soa::Join<aod::JTracks, aod::JTrackPIs, ao
 using filteredJets = soa::Filtered<soa::Join<aod::ChargedJets, aod::ChargedJetConstituents>>;
 using joinedTracks = soa::Join<aod::Tracks, aod::TracksExtra>;
 
-float DcaXYPtCut(float tracPt){
+float DcaXYPtCut(float tracPt)
+{
   return 0.0105f + 0.0350f / pow(tracPt, 1.1f);
 }
 
@@ -201,7 +202,7 @@ struct ChJetTriggerQATask {
           continue;
         }
 
-        bool bDcaCondition = (nabs(track.dcaZ()) < dcaZ_cut) && (nabs(track.dcaXY()) < dcaXY_multFact*DcaXYPtCut(track.pt()));
+        bool bDcaCondition = (nabs(track.dcaZ()) < dcaZ_cut) && (nabs(track.dcaXY()) < dcaXY_multFact * DcaXYPtCut(track.pt()));
         if (originalTrack.itsNCls() >= 4 && bDcaCondition) { // correspond to number of track hits in ITS layers
           spectra.fill(HIST("DCAxy_track_Phi_pT"), track.dcaXY(), track.phi(), track.pt());
           spectra.fill(HIST("DCAz_track_Phi_pT"), track.dcaZ(), track.phi(), track.pt());


### PR DESCRIPTION
Due to an issue with the phi distribution of high pT tacks, it was proposed to study tracks with relaxed conditions on the DCA. 
The updated code implements functionality to adjust DCA cuts for the quality tracks:
1) DcaZ cut is const and it can be tuned in JSON file
2) DcaXY cut has pT dependence of a track (taking here: https://github.com/AliceO2Group/O2Physics/blob/master/Common/Core/TrackSelectionDefaults.cxx#L37); Additional multiplication factor is introduced to relax this condition 