### PR TITLE
Add nSigmaMC.

### DIFF
--- a/DPG/Tasks/AOTTrack/PID/TPC/qaPIDTPCMC.cxx
+++ b/DPG/Tasks/AOTTrack/PID/TPC/qaPIDTPCMC.cxx
@@ -303,6 +303,7 @@ struct pidTpcQaMc {
     histos.add(hnsigmaMCmat[mcID * Np + massID].data(), Form("True Secondary %s from material", pT[mcID]), HistType::kTH2F, {ptAxis, nSigmaAxis});
 
     if constexpr (mcID == massID) {
+      histos.add(hsignalMC[mcID].data(), Form("%s", pT[mcID]), HistType::kTH2F, {pAxis, signalAxis});
       histos.add(hsignalMCprm[mcID].data(), Form("Primary %s", pT[mcID]), HistType::kTH2F, {pAxis, signalAxis});
       histos.add(hsignalMCstr[mcID].data(), Form("Secondary %s from decay", pT[mcID]), HistType::kTH2F, {pAxis, signalAxis});
       histos.add(hsignalMCmat[mcID].data(), Form("Secondary %s from material", pT[mcID]), HistType::kTH2F, {pAxis, signalAxis});


### PR DESCRIPTION
Adding definition of missing histo.
NB for @njacazio : beware that, as written now, for `nSigmaMC` histogram the code always fills `hnsigma/El/*` histograms. This is because you loop from 0 to 8 here https://github.com/AliceO2Group/O2Physics/blob/master/DPG/Tasks/AOTTrack/PID/TPC/qaPIDTPCMC.cxx#L580-L583 and therefore always these histos are filled: https://github.com/AliceO2Group/O2Physics/blob/master/DPG/Tasks/AOTTrack/PID/TPC/qaPIDTPCMC.cxx#L83-L85

I'm not fixing it, I'd leave it to you to avoid any clash in case somebody is massively using it in your crew.