### PR TITLE
Add collision flags to StraEvSels derived table

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -130,6 +130,40 @@ DECLARE_SOA_TABLE_VERSIONED(StraEvSels_001, "AOD", "STRAEVSELS", 1,         //! 
                             // stracollision::EnergyCommonZNC<mult::MultZNC>,
                             stracollision::IsUPC<udcollision::GapSide>);
 
+DECLARE_SOA_TABLE_VERSIONED(StraEvSels_002, "AOD", "STRAEVSELS", 2,         //! debug information
+                            evsel::Sel8, evsel::Selection,                  //! event selection: sel8
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors
+                            mult::MultFDDA, mult::MultFDDC,
+                            mult::MultNTracksPVeta1,                      // track multiplicities with eta cut for INEL>0
+                            mult::MultPVTotalContributors,                // number of PV contribs total
+                            mult::MultNTracksGlobal,                      // global track multiplicities
+                            mult::MultNTracksITSTPC,                      // track multiplicities, PV contribs, no eta cut
+                            mult::MultAllTracksTPCOnly,                   // TPConly track multiplicities, all, no eta cut
+                            mult::MultAllTracksITSTPC,                    // ITSTPC track multiplicities, all, no eta cut
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+                            mult::MultZEM2, mult::MultZPA, mult::MultZPC,
+                            evsel::NumTracksInTimeRange,     // add occupancy as extra
+                            udcollision::GapSide,            // UPC info: 0 for side A, 1 for side C, 2 for both sides, 3 neither A or C, 4 not enough or too many pv contributors
+                            udcollision::TotalFT0AmplitudeA, // UPC info: re-assigned FT0-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFT0AmplitudeC, // UPC info: re-assigned FT0-C amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFV0AmplitudeA, // UPC info: re-assigned FV0-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFDDAmplitudeA, // UPC info: re-assigned FDD-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFDDAmplitudeC, // UPC info: re-assigned FDD-C amplitude, in case of SG event, from the most active bc
+                            udzdc::EnergyCommonZNA,          // UPC info: re-assigned ZN-A amplitude, in case of SG event, from the most active bc
+                            udzdc::EnergyCommonZNC,          // UPC info: re-assigned ZN-C amplitude, in case of SG event, from the most active bc
+
+                            collision::Flags, // Contains Vertex::Flags, with most notably the UPCMode to know whether the vertex has been found using UPC settings
+
+                            // Dynamic columns for manipulating information
+                            // stracollision::TotalFV0AmplitudeA<mult::MultFV0A>,
+                            // stracollision::TotalFT0AmplitudeA<mult::MultFT0A>,
+                            // stracollision::TotalFT0AmplitudeC<mult::MultFT0C>,
+                            // stracollision::TotalFDDAmplitudeA<mult::MultFDDA>,
+                            // stracollision::TotalFDDAmplitudeC<mult::MultFDDC>,
+                            // stracollision::EnergyCommonZNA<mult::MultZNA>,
+                            // stracollision::EnergyCommonZNC<mult::MultZNC>,
+                            stracollision::IsUPC<udcollision::GapSide>);
+
 DECLARE_SOA_TABLE(StraFT0AQVs, "AOD", "STRAFT0AQVS", //! t0a Qvec
                   qvec::QvecFT0ARe, qvec::QvecFT0AIm, qvec::SumAmplFT0A);
 DECLARE_SOA_TABLE(StraFT0CQVs, "AOD", "STRAFT0CQVS", //! t0c Qvec
@@ -147,7 +181,7 @@ DECLARE_SOA_TABLE(StraStamps, "AOD", "STRASTAMPS", //! information for ID-ing ma
                   bc::RunNumber, timestamp::Timestamp);
 
 using StraRawCents = StraRawCents_004;
-using StraEvSels = StraEvSels_001;
+using StraEvSels = StraEvSels_002;
 using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
 

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -29,6 +29,11 @@ o2physics_add_dpl_workflow(straevselsconverter
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(straevselsconverter2
+                    SOURCES straevselsconverter2.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(straevselsconverter2rawcents
                     SOURCES straevselsconverter2rawcents.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
@@ -41,5 +46,10 @@ o2physics_add_dpl_workflow(v0coresconverter
 
 o2physics_add_dpl_workflow(v0coresconverter2
                     SOURCES v0coresconverter2.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(v0mlscoresconverter
+                    SOURCES v0mlscoresconverter.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -31,7 +31,7 @@ o2physics_add_dpl_workflow(straevselsconverter
 
 o2physics_add_dpl_workflow(straevselsconverter2
                     SOURCES straevselsconverter2.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(straevselsconverter2rawcents

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "ReconstructionDataFormats/Vertex.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts Stra Event selections from 000 to 001
+struct straevselsconverter2 {
+  Produces<aod::StraEvSels_001> straEvSels_001;
+
+  void process(aod::StraEvSels_001 const& straEvSels_001)
+  {
+    for (auto& values : straEvSels_001) {
+      straEvSels_002(values.sel8(),
+                     values.selection_raw(),
+                     values.multFT0A(),
+                     values.multFT0C(),
+                     values.multFT0A(),
+                     0 /*dummy FDDA value*/,
+                     0 /*dummy FDDC value*/,
+                     values.multNTracksPVeta1(),
+                     values.multPVTotalContributors(),
+                     values.multNTracksGlobal(),
+                     values.multNTracksITSTPC(),
+                     values.multAllTracksTPCOnly(),
+                     values.multAllTracksITSTPC(),
+                     values.multZNA(),
+                     values.multZNC(),
+                     values.multZEM1(),
+                     values.multZEM2(),
+                     values.multZPA(),
+                     values.multZPC(),
+                     values.trackOccupancyInTimeRange(),
+                     -1 /*dummy gap side value*/,
+                     -999. /*dummy FT0-A value*/,
+                     -999. /*dummy FT0-C value*/,
+                     -999. /*dummy FV0-A value*/,
+                     -999. /*dummy FDD-A value*/,
+                     -999. /*dummy FDD-C value*/,
+                     -999. /*dummy ZN-A value*/,
+                     -999. /*dummy ZN-C value*/,
+                     Vertex::FlagsMask /*dummy flag value*/);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<straevselsconverter2>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
@@ -11,7 +11,7 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
-#include "ReconstructionDataFormats/Vertex.h"
+#include "ITStracking/Vertexer.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 
 using namespace o2;
@@ -19,7 +19,7 @@ using namespace o2::framework;
 
 // Converts Stra Event selections from 000 to 001
 struct straevselsconverter2 {
-  Produces<aod::StraEvSels_001> straEvSels_001;
+  Produces<aod::StraEvSels_002> straEvSels_002;
 
   void process(aod::StraEvSels_001 const& straEvSels_001)
   {
@@ -52,7 +52,7 @@ struct straevselsconverter2 {
                      -999. /*dummy FDD-C value*/,
                      -999. /*dummy ZN-A value*/,
                      -999. /*dummy ZN-C value*/,
-                     Vertex::FlagsMask /*dummy flag value*/);
+                     o2::its::Vertex::FlagsMask /*dummy flag value*/);
     }
   }
 };

--- a/PWGLF/TableProducer/Strangeness/Converters/v0mlscoresconverter.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/v0mlscoresconverter.cxx
@@ -30,7 +30,7 @@ struct v0mlscoresconverter {
       gammaMLSelections(-1);
       lambdaMLSelections(-1);
       antiLambdaMLSelections(-1);
-      k0ShortMLSelections(-1);  
+      k0ShortMLSelections(-1);
     }
   }
 };

--- a/PWGLF/TableProducer/Strangeness/Converters/v0mlscoresconverter.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/v0mlscoresconverter.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "PWGLF/DataModel/LFStrangenessMLTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts V0 version 001 to 002
+struct v0mlscoresconverter {
+  Produces<aod::V0GammaMLScores> gammaMLSelections;           // gamma scores
+  Produces<aod::V0LambdaMLScores> lambdaMLSelections;         // lambda scores
+  Produces<aod::V0AntiLambdaMLScores> antiLambdaMLSelections; // AntiLambda scores
+  Produces<aod::V0K0ShortMLScores> k0ShortMLSelections;       // K0Short scores
+
+  void process(aod::V0Cores const& v0cores)
+  {
+    for (auto& values : v0cores) {
+      gammaMLSelections(-1);
+      lambdaMLSelections(-1);
+      antiLambdaMLSelections(-1);
+      k0ShortMLSelections(-1);  
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<v0mlscoresconverter>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -369,7 +369,9 @@ struct strangederivedbuilder {
                       gapSide,
                       totalFT0AmplitudeA, totalFT0AmplitudeC, totalFV0AmplitudeA,
                       totalFDDAmplitudeA, totalFDDAmplitudeC,
-                      energyCommonZNA, energyCommonZNC);
+                      energyCommonZNA, energyCommonZNC,
+                      // Collision flags
+                      collision.flags());
         strangeStamps(bc.runNumber(), bc.timestamp());
       }
       for (const auto& v0 : V0Table_thisColl)


### PR DESCRIPTION
Add collision flags to the StraEvSels derived table in order to allow the separation between events with and without UPC mode