### PR TITLE
PWGHF: fix L(1520) PDG code.

### DIFF
--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -529,7 +529,7 @@ struct HfCandidateCreator3ProngExpressions {
     std::array<int, 2> arrPDGDaugh;
     std::array<int, 2> arrPDGResonant1 = {kProton, 313};      // Λc± → p± K*
     std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};      // Λc± → Δ(1232)±± K∓
-    std::array<int, 2> arrPDGResonant3 = {3124, kPiPlus};     // Λc± → Λ(1520) π±
+    std::array<int, 2> arrPDGResonant3 = {102134, kPiPlus};     // Λc± → Λ(1520) π±
     std::array<int, 2> arrPDGResonantDPhiPi = {333, kPiPlus}; // Ds± → Phi π± and D± → Phi π±
     std::array<int, 2> arrPDGResonantDKstarK = {313, kKPlus}; // Ds± → K*(892)0bar K± and D± → K*(892)0bar K±
 

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -529,7 +529,7 @@ struct HfCandidateCreator3ProngExpressions {
     std::array<int, 2> arrPDGDaugh;
     std::array<int, 2> arrPDGResonant1 = {kProton, 313};      // Λc± → p± K*
     std::array<int, 2> arrPDGResonant2 = {2224, kKPlus};      // Λc± → Δ(1232)±± K∓
-    std::array<int, 2> arrPDGResonant3 = {102134, kPiPlus};     // Λc± → Λ(1520) π±
+    std::array<int, 2> arrPDGResonant3 = {102134, kPiPlus};   // Λc± → Λ(1520) π±
     std::array<int, 2> arrPDGResonantDPhiPi = {333, kPiPlus}; // Ds± → Phi π± and D± → Phi π±
     std::array<int, 2> arrPDGResonantDKstarK = {313, kKPlus}; // Ds± → K*(892)0bar K± and D± → K*(892)0bar K±
 


### PR DESCRIPTION
Fixing Lambda(1520) PDG code in candidateCreator3Prong.cxx, aligning it to the expected value, as done in O2DPG here: [PR #1673](https://github.com/AliceO2Group/O2DPG/pull/1673).

Tested on 1 file of `HF_LHC24g5_All` MC production (see bin centered at 3 below):

![image](https://github.com/user-attachments/assets/76d9caf5-8d00-4f55-b8fb-69ecdc7f01ab)

