### PR TITLE
PWGHF: Adding correlated bkg information in D+ tree

### DIFF
--- a/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDplusToPiKPi.cxx
@@ -60,6 +60,8 @@ struct HfCandidateSelectorDplusToPiKPi {
   Configurable<std::vector<double>> binsPtTrack{"binsPtTrack", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for DCA pT-dependent cut"};
   // QA switch
   Configurable<bool> activateQA{"activateQA", false, "Flag to enable QA histogram"};
+  // Correlated bakcground from Ds and D+
+  Configurable<bool> storeDsDplusBkg{"storeDsBkg", false, "Flag to store correlated background from misidentified product of Ds and D+ decay"};
   // ML inference
   Configurable<bool> applyMl{"applyMl", false, "Flag to apply ML selections"};
   Configurable<std::vector<double>> binsPtMl{"binsPtMl", std::vector<double>{hf_cuts_ml::vecBinsPt}, "pT bin limits for ML application"};
@@ -223,7 +225,7 @@ struct HfCandidateSelectorDplusToPiKPi {
 
       auto ptCand = candidate.pt();
 
-      if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::DplusToPiKPi)) {
+      if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::DplusToPiKPi) && !(storeDsDplusBkg && TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::DsToKKPi))) { // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
         hfSelDplusToPiKPiCandidate(statusDplusToPiKPi);
         if (applyMl) {
           hfMlDplusToPiKPiCandidate(outputMlNotPreselected);

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -249,7 +249,7 @@ struct HfTreeCreatorDplusToPiKPi {
   Filter filterSelectCandidates = aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
   Filter filterMcGenMatching = nabs(o2::aod::hf_cand_3prong::flagMcMatchGen) == static_cast<int8_t>(BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
 
-  Partition<SelectedCandidatesMc> reconstructedCandSig = nabs(aod::hf_cand_3prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
+  Partition<SelectedCandidatesMc> reconstructedCandSig = nabs(aod::hf_cand_3prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi)) || nabs(aod::hf_cand_3prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_3prong::DecayType::DsToKKPi)); // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
   Partition<SelectedCandidatesMc> reconstructedCandBkg = nabs(aod::hf_cand_3prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_3prong::DecayType::DplusToPiKPi));
 
   void init(InitContext const&)

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -124,7 +124,8 @@ DECLARE_SOA_TABLE(HfCandDpLites, "AOD", "HFCANDDPLITE",
                   full::Phi,
                   full::Y,
                   hf_cand_3prong::FlagMcMatchRec,
-                  hf_cand_3prong::OriginMcRec)
+                  hf_cand_3prong::OriginMcRec,
+                  hf_cand_3prong::FlagMcDecayChanRec)
 
 DECLARE_SOA_TABLE(HfCandDpFulls, "AOD", "HFCANDDPFULL",
                   collision::BCId,
@@ -204,7 +205,8 @@ DECLARE_SOA_TABLE(HfCandDpFulls, "AOD", "HFCANDDPFULL",
                   full::Y,
                   full::E,
                   hf_cand_3prong::FlagMcMatchRec,
-                  hf_cand_3prong::OriginMcRec);
+                  hf_cand_3prong::OriginMcRec,
+                  hf_cand_3prong::FlagMcDecayChanRec);
 
 DECLARE_SOA_TABLE(HfCandDpFullEvs, "AOD", "HFCANDDPFULLEV",
                   collision::BCId,
@@ -274,9 +276,11 @@ struct HfTreeCreatorDplusToPiKPi {
   {
     int8_t flagMc = 0;
     int8_t originMc = 0;
+    int8_t channelMc = 0;
     if constexpr (doMc) {
       flagMc = candidate.flagMcMatchRec();
       originMc = candidate.originMcRec();
+      channelMc = candidate.flagMcDecayChanRec();
     }
 
     auto prong0 = candidate.template prong0_as<TracksWPid>();
@@ -327,7 +331,8 @@ struct HfTreeCreatorDplusToPiKPi {
         candidate.phi(),
         hfHelper.yDplus(candidate),
         flagMc,
-        originMc);
+        originMc,
+        channelMc);
     } else {
       rowCandidateFull(
         candidate.collision().bcId(),
@@ -407,7 +412,8 @@ struct HfTreeCreatorDplusToPiKPi {
         hfHelper.yDplus(candidate),
         hfHelper.eDplus(candidate),
         flagMc,
-        originMc);
+        originMc,
+        channelMc);
     }
   }
 


### PR DESCRIPTION
This PR adds the information of correlated background channels (i.e. D(s)+ --> KKpi with a kaon identified as pi) in the Dplus Tree (@Luca610)