### PR TITLE
PWGDQ: Add bit for ITSUPCMode to event filter

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -3465,6 +3465,26 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cutAorC;
   }
 
+  if (!nameStr.compare("eventUPCMode")) {
+    cut->AddCut(VarManager::kIsITSUPCMode, 0.5, 1.5);
+    return cut;
+  }
+
+  if (!nameStr.compare("eventSingleGapACZDC_UPCMode")) {
+    AnalysisCompositeCut* cutA = new AnalysisCompositeCut("singleGapAZDC", "singleGapAZDC", kTRUE);
+    cutA->AddCut(GetAnalysisCut("eventSingleGapAZDC"));
+    cutA->AddCut(GetAnalysisCut("eventUPCMode"));
+
+    AnalysisCompositeCut* cutC = new AnalysisCompositeCut("singleGapCZDC", "singleGapCZDC", kTRUE);
+    cutC->AddCut(GetAnalysisCut("eventSingleGapCZDC"));
+    cutC->AddCut(GetAnalysisCut("eventUPCMode"));
+
+    AnalysisCompositeCut* cutAorC = new AnalysisCompositeCut("singleGapACZDC", "singleGapACZDC", kFALSE);
+    cutAorC->AddCut(cutA);
+    cutAorC->AddCut(cutC);
+    return cutAorC;
+  }
+
   // Event cuts based on centrality
   if (!nameStr.compare("eventStandardNoINT7Cent090")) {
     cut->AddCut(VarManager::kVtxZ, -10.0, 10.0);

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -301,6 +301,8 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
       hm->AddHistogram(histClass, "IsDoubleGap", "Is double gap", false, 2, -0.5, 1.5, VarManager::kIsDoubleGap);
       hm->AddHistogram(histClass, "IsSingleGapA", "Is single gap on side A", false, 2, -0.5, 1.5, VarManager::kIsSingleGapA);
       hm->AddHistogram(histClass, "IsSingleGapC", "Is single gap on side C", false, 2, -0.5, 1.5, VarManager::kIsSingleGapC);
+      hm->AddHistogram(histClass, "IsITSUPCMode", "UPC settings used", false, 2, -0.5, 1.5, VarManager::kIsITSUPCMode);
+      hm->AddHistogram(histClass, "IsITSUPCMode_IsSingleGap", "UPC settings used vs Is single gap", false, 2, -0.5, 1.5, VarManager::kIsITSUPCMode, 2, -0.5, 1.5, VarManager::kIsSingleGap);
     }
     if (subGroupStr.Contains("zdc")) {
       hm->AddHistogram(histClass, "energyCommonZNA_energyCommonZNC", "Common ZNA energy vs common ZNC energy", false, 1050, -10.0, 200.0, VarManager::kEnergyCommonZNA, 1050, -10.0, 200.0, VarManager::kEnergyCommonZNC);

--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -895,6 +895,10 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kIsSingleGapA] = "";
   fgVariableNames[kIsSingleGapC] = "is single gap event side C";
   fgVariableUnits[kIsSingleGapC] = "";
+  fgVariableNames[kIsSingleGap] = "is single gap event";
+  fgVariableUnits[kIsSingleGap] = "";
+  fgVariableNames[kIsITSUPCMode] = "UPC settings used";
+  fgVariableUnits[kIsITSUPCMode] = "";
   fgVariableNames[kQuadMass] = "mass quadruplet";
   fgVariableUnits[kQuadMass] = "GeV/c2";
   fgVariableNames[kQuadPt] = "p_{T}";

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -334,6 +334,7 @@ class VarManager : public TObject
     kIsSingleGapA, // Rapidity gap on side A
     kIsSingleGapC, // Rapidity gap on side C
     kIsSingleGap,  // Rapidity gap on either side
+    kIsITSUPCMode, // UPC mode used for event
     kTwoEvPosZ1,   // vtx-z for collision 1 in two events correlations
     kTwoEvPosZ2,   // vtx-z for collision 2 in two events correlations
     kTwoEvPosR1,   // vtx-R for collision 1 in two events correlations
@@ -718,7 +719,8 @@ class VarManager : public TObject
   enum EventFilters {
     kDoubleGap = 0,
     kSingleGapA,
-    kSingleGapC
+    kSingleGapC,
+    kITSUPCMode
   };
 
   enum MuonExtrapolation {
@@ -1465,6 +1467,9 @@ void VarManager::FillEvent(T const& event, float* values)
       values[kIsSingleGapC] = (event.tag_bit(56 + kSingleGapC) > 0);
       values[kIsSingleGap] = values[kIsSingleGapA] || values[kIsSingleGapC];
     }
+    if (fgUsedVars[kIsITSUPCMode]) {
+      values[kIsITSUPCMode] = (event.tag_bit(56 + kITSUPCMode) > 0);
+    }
     values[kCollisionTime] = event.collisionTime();
     values[kCollisionTimeRes] = event.collisionTimeRes();
   }
@@ -1667,6 +1672,7 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kIsSingleGapA] = (event.eventFilter() & (uint64_t(1) << kSingleGapA)) > 0;
     values[kIsSingleGapC] = (event.eventFilter() & (uint64_t(1) << kSingleGapC)) > 0;
     values[kIsSingleGap] = values[kIsSingleGapA] || values[kIsSingleGapC];
+    values[kIsITSUPCMode] = (event.eventFilter() & (uint64_t(1) << kITSUPCMode)) > 0;
   }
 
   if constexpr ((fillMap & ReducedZdc) > 0) {

--- a/PWGDQ/Tasks/filterPbPb.cxx
+++ b/PWGDQ/Tasks/filterPbPb.cxx
@@ -17,6 +17,7 @@
 #include "PWGDQ/DataModel/ReducedInfoTables.h"
 #include "PWGDQ/Core/VarManager.h"
 #include "CommonConstants/LHCConstants.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 using namespace std;
 
@@ -58,7 +59,7 @@ struct DQFilterPbPbTask {
     fStats->GetXaxis()->SetBinLabel(1, "Events inspected");
     fStats->GetXaxis()->SetBinLabel(2, "Events selected");
     // setup the FilterOutcome histogram
-    fFilterOutcome.setObject(new TH1D("Filter outcome", "Filter outcome", 8, 0.5, 8.5));
+    fFilterOutcome.setObject(new TH1D("Filter outcome", "Filter outcome", 9, 0.5, 9.5));
     fFilterOutcome->GetXaxis()->SetBinLabel(1, "Events inspected");
     fFilterOutcome->GetXaxis()->SetBinLabel(2, "Events selected");
     fFilterOutcome->GetXaxis()->SetBinLabel(3, "!A && !C");
@@ -67,6 +68,7 @@ struct DQFilterPbPbTask {
     fFilterOutcome->GetXaxis()->SetBinLabel(6, "A && C");
     fFilterOutcome->GetXaxis()->SetBinLabel(7, Form("numContrib not in [%d, %d]", fConfigMinNPVCs.value, fConfigMaxNPVCs.value));
     fFilterOutcome->GetXaxis()->SetBinLabel(8, "BC not found");
+    fFilterOutcome->GetXaxis()->SetBinLabel(9, "ITS UPC settings used");
 
     TString eventTypesString = fConfigEventTypes.value;
     for (std::vector<std::string>::size_type i = 0; i < eventTypeOptions.size(); i++) {
@@ -264,6 +266,12 @@ struct DQFilterPbPbTask {
 
     bool isSelected = filter;
     fStats->Fill(-1.0, isSelected);
+
+    // Record whether UPC settings were used for this event
+    if (collision.flags() & dataformats::Vertex<o2::dataformats::TimeStamp<int>>::Flags::UPCMode) {
+      filter |= (uint64_t(1) << VarManager::kITSUPCMode);
+      fFilterOutcome->Fill(9, 1);
+    }
 
     eventFilter(filter);
   }


### PR DESCRIPTION
* Save info on whether UPC settings were used to reconstruct an event in the event filter.
* Add corresponding variable, cuts, and histograms.