### PR TITLE
PWGEM/PhotonMeson: Fix track matching memory bug

### DIFF
--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
@@ -424,8 +424,8 @@ struct Pi0EtaToGammaGamma {
     fEMCCut.SetM02Range(emccuts.EMC_minM02, emccuts.EMC_maxM02);
     fEMCCut.SetTimeRange(emccuts.EMC_minTime, emccuts.EMC_maxTime);
 
-    fEMCCut.SetTrackMatchingEta([&a, &b, &c](float pT) { return a + pow(pT + b, c); });
-    fEMCCut.SetTrackMatchingPhi([&d, &e, &f](float pT) { return d + pow(pT + e, f); });
+    fEMCCut.SetTrackMatchingEta([a, b, c](float pT) { return a + pow(pT + b, c); });
+    fEMCCut.SetTrackMatchingPhi([d, e, f](float pT) { return d + pow(pT + e, f); });
 
     fEMCCut.SetMinEoverP(emccuts.EMC_Eoverp);
     fEMCCut.SetUseExoticCut(emccuts.EMC_UseExoticCut);

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
@@ -391,8 +391,8 @@ struct Pi0EtaToGammaGammaMC {
     fEMCCut.SetM02Range(emccuts.EMC_minM02, emccuts.EMC_maxM02);
     fEMCCut.SetTimeRange(emccuts.EMC_minTime, emccuts.EMC_maxTime);
 
-    fEMCCut.SetTrackMatchingEta([&a, &b, &c](float pT) { return a + pow(pT + b, c); });
-    fEMCCut.SetTrackMatchingPhi([&d, &e, &f](float pT) { return d + pow(pT + e, f); });
+    fEMCCut.SetTrackMatchingEta([a, b, c](float pT) { return a + pow(pT + b, c); });
+    fEMCCut.SetTrackMatchingPhi([d, e, f](float pT) { return d + pow(pT + e, f); });
 
     fEMCCut.SetMinEoverP(emccuts.EMC_Eoverp);
     fEMCCut.SetUseExoticCut(emccuts.EMC_UseExoticCut);

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -152,8 +152,6 @@ struct skimmerGammaCalo {
       return;
     }
     for (const auto& emccluster : emcclusters) {
-      historeg.fill(HIST("hCaloClusterEIn"), emccluster.energy());
-      historeg.fill(HIST("hCaloClusterFilter"), 0);
 
       // Energy cut
       if (emccluster.energy() < minE) {

--- a/PWGEM/PhotonMeson/Tasks/SinglePhoton.cxx
+++ b/PWGEM/PhotonMeson/Tasks/SinglePhoton.cxx
@@ -228,10 +228,10 @@ struct SinglePhoton {
           custom_cut->SetM02Range(EMC_minM02, EMC_maxM02);
           custom_cut->SetTimeRange(EMC_minTime, EMC_maxTime);
 
-          custom_cut->SetTrackMatchingEta([&a, &b, &c](float pT) {
+          custom_cut->SetTrackMatchingEta([a, b, c](float pT) {
             return a + pow(pT + b, c);
           });
-          custom_cut->SetTrackMatchingPhi([&d, &e, &f](float pT) {
+          custom_cut->SetTrackMatchingPhi([d, e, f](float pT) {
             return d + pow(pT + e, f);
           });
 
@@ -331,8 +331,8 @@ struct SinglePhoton {
           reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hY"))->Fill(photon.eta());
           reinterpret_cast<TH1F*>(list_photon_det_cut->FindObject("hPhi"))->Fill(photon.phi());
         } // end of photon loop
-      }   // end of cut loop
-    }     // end of collision loop
+      } // end of cut loop
+    } // end of collision loop
   }
 
   Partition<MyCollisions> grouped_collisions = (cfgCentMin < o2::aod::cent::centFT0M && o2::aod::cent::centFT0M < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0A && o2::aod::cent::centFT0A < cfgCentMax) || (cfgCentMin < o2::aod::cent::centFT0C && o2::aod::cent::centFT0C < cfgCentMax); // this goes to same event.

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0.cxx
@@ -313,10 +313,10 @@ struct TaggingPi0 {
           custom_cut->SetM02Range(EMC_minM02, EMC_maxM02);
           custom_cut->SetTimeRange(EMC_minTime, EMC_maxTime);
 
-          custom_cut->SetTrackMatchingEta([&a, &b, &c](float pT) {
+          custom_cut->SetTrackMatchingEta([a, b, c](float pT) {
             return a + pow(pT + b, c);
           });
-          custom_cut->SetTrackMatchingPhi([&d, &e, &f](float pT) {
+          custom_cut->SetTrackMatchingPhi([d, e, f](float pT) {
             return d + pow(pT + e, f);
           });
 

--- a/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/TaggingPi0MC.cxx
@@ -330,10 +330,10 @@ struct TaggingPi0MC {
           custom_cut->SetM02Range(EMC_minM02, EMC_maxM02);
           custom_cut->SetTimeRange(EMC_minTime, EMC_maxTime);
 
-          custom_cut->SetTrackMatchingEta([&a, &b, &c](float pT) {
+          custom_cut->SetTrackMatchingEta([a, b, c](float pT) {
             return a + pow(pT + b, c);
           });
-          custom_cut->SetTrackMatchingPhi([&d, &e, &f](float pT) {
+          custom_cut->SetTrackMatchingPhi([d, e, f](float pT) {
             return d + pow(pT + e, f);
           });
 

--- a/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
@@ -119,8 +119,8 @@ struct emcalQC {
     fEMCCut.SetM02Range(emccuts.EMC_minM02, emccuts.EMC_maxM02);
     fEMCCut.SetTimeRange(emccuts.EMC_minTime, emccuts.EMC_maxTime);
 
-    fEMCCut.SetTrackMatchingEta([&a, &b, &c](float pT) { return a + pow(pT + b, c); });
-    fEMCCut.SetTrackMatchingPhi([&d, &e, &f](float pT) { return d + pow(pT + e, f); });
+    fEMCCut.SetTrackMatchingEta([a, b, c](float pT) { return a + pow(pT + b, c); });
+    fEMCCut.SetTrackMatchingPhi([d, e, f](float pT) { return d + pow(pT + e, f); });
 
     fEMCCut.SetMinEoverP(emccuts.EMC_Eoverp);
     fEMCCut.SetUseExoticCut(emccuts.EMC_UseExoticCut);


### PR DESCRIPTION
- Change pointer to value in lambda for track matching function, as the values a,b,c,d,e,f were only assigned within the DefineCuts function and therefore did not initialize the cut correctly
- Remove histogram filling in MC part of skimmer task (only to be filled in the common process function)