### PR TITLE
PWGLF: Enable another decay mode (rho)

### DIFF
--- a/PWGLF/Tasks/Resonances/k1analysis.cxx
+++ b/PWGLF/Tasks/Resonances/k1analysis.cxx
@@ -27,55 +27,96 @@
 #include "Framework/runDataProcessing.h"
 #include "PWGLF/DataModel/LFResonanceTables.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "CommonConstants/PhysicsConstants.h"
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using namespace o2::constants::physics;
 
 struct k1analysis {
+  enum binAnti : unsigned int {
+    kNormal = 0,
+    kAnti,
+    kNAEnd
+  };
+  enum binType : unsigned int {
+    kK1P = 0,
+    kK1N,
+    kK1P_Mix,
+    kK1N_Mix,
+    kK1P_GenINEL10,
+    kK1N_GenINEL10,
+    kK1P_GenINELgt10,
+    kK1N_GenINELgt10,
+    kK1P_GenTrig10,
+    kK1N_GenTrig10,
+    kK1P_GenEvtSel,
+    kK1N_GenEvtSel,
+    kK1P_Rec,
+    kK1N_Rec,
+    kTYEnd
+  };
   SliceCache cache;
   Preslice<aod::ResoTracks> perRCol = aod::resodaughter::resoCollisionId;
   Preslice<aod::Tracks> perCollision = aod::track::collisionId;
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  using ResoMCCols = soa::Join<aod::ResoCollisions, aod::ResoMCCollisions>;
 
   ///// Configurables
+  Configurable<int> cNbinsDiv{"cNbinsDiv", 1, "Integer to divide the number of bins"};
   /// Event Mixing
   Configurable<int> nEvtMixing{"nEvtMixing", 5, "Number of events to mix"};
   ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
   ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"};
   /// Pre-selection cuts
   Configurable<double> cMinPtcut{"cMinPtcut", 0.15, "Track minium pt cut"};
+
   /// DCA Selections
   // DCAr to PV
   Configurable<double> cMaxDCArToPVcut{"cMaxDCArToPVcut", 0.1, "Track DCAr cut to PV Maximum"};
   // DCAz to PV
   Configurable<double> cMaxDCAzToPVcut{"cMaxDCAzToPVcut", 0.1, "Track DCAz cut to PV Maximum"};
   Configurable<double> cMinDCAzToPVcut{"cMinDCAzToPVcut", 0.0, "Track DCAz cut to PV Minimum"};
+
   /// PID Selections
   Configurable<double> cMaxTPCnSigmaPion{"cMaxTPCnSigmaPion", 3.0, "TPC nSigma cut for Pion"};                // TPC
   Configurable<double> cMaxTOFnSigmaPion{"cMaxTOFnSigmaPion", 3.0, "TOF nSigma cut for Pion"};                // TOF
   Configurable<double> nsigmaCutCombinedPion{"nsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"};  // Combined
+  Configurable<bool> cTOFVeto{"cTOFVeto", true, "TOF Veto, if false, TOF is nessessary for PID selection"};   // TOF Veto
   Configurable<bool> cUseOnlyTOFTrackPi{"cUseOnlyTOFTrackPi", false, "Use only TOF track for PID selection"}; // Use only TOF track for Pion PID selection
-  Configurable<bool> cUseOnlyTOFTrackKa{"cUseOnlyTOFTrackKa", false, "Use only TOF track for PID selection"}; // Use only TOF track for Kaon PID selection
   // Kaon
-  Configurable<double> cMaxTPCnSigmaKaon{"cMaxTPCnSigmaKaon", 3.0, "TPC nSigma cut for Kaon"};               // TPC
-  Configurable<double> cMaxTOFnSigmaKaon{"cMaxTOFnSigmaKaon", 3.0, "TOF nSigma cut for Kaon"};               // TOF
-  Configurable<double> nsigmaCutCombinedKaon{"nsigmaCutCombinedKaon", -999, "Combined nSigma cut for Kaon"}; // Combined
+  Configurable<double> cMaxTPCnSigmaKaon{"cMaxTPCnSigmaKaon", 3.0, "TPC nSigma cut for Kaon"};                // TPC
+  Configurable<double> cMaxTOFnSigmaKaon{"cMaxTOFnSigmaKaon", 3.0, "TOF nSigma cut for Kaon"};                // TOF
+  Configurable<double> nsigmaCutCombinedKaon{"nsigmaCutCombinedKaon", -999, "Combined nSigma cut for Kaon"};  // Combined
+  Configurable<bool> cUseOnlyTOFTrackKa{"cUseOnlyTOFTrackKa", false, "Use only TOF track for PID selection"}; // Use only TOF track for Kaon PID selection
   // Track selections
   Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
   Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
-  Configurable<bool> cfgPVContributor{"cfgPVContributor", true, "PV contributor track selection"};           // PV Contriuibutor
+  Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
+  Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
+  Configurable<bool> additionalQAplots{"additionalQAplots", true, "Additional QA plots"};
+  Configurable<bool> tof_at_high_pt{"tof_at_high_pt", false, "Use TOF at high pT"};
+  Configurable<bool> additionalEvsel{"additionalEvsel", true, "Additional event selcection"};
+  Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
+  Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
+  Configurable<float> cfgRatioTPCRowsOverFindableCls{"cfgRatioTPCRowsOverFindableCls", 0.0f, "TPC Crossed Rows to Findable Clusters"};
+  Configurable<float> cfgITSChi2NCl{"cfgITSChi2NCl", 999.0, "ITS Chi2/NCl"};
+  Configurable<float> cfgTPCChi2NCl{"cfgTPCChi2NCl", 999.0, "TPC Chi2/NCl"};
+  Configurable<bool> cfgUseTPCRefit{"cfgUseTPCRefit", false, "Require TPC Refit"};
+  Configurable<bool> cfgUseITSRefit{"cfgUseITSRefit", false, "Require ITS Refit"};
+  Configurable<bool> cfgHasITS{"cfgHasITS", false, "Require ITS"};
+  Configurable<bool> cfgHasTPC{"cfgHasTPC", false, "Require TPC"};
+  Configurable<bool> cfgHasTOF{"cfgHasTOF", false, "Require TOF"};
 
-  // bachelor pion TOF PID?
-  Configurable<int> cDoTOFPID{"cDoTOFPID", 1, "Do TOF PID"};
-
-  // K(892)0 selection
-  Configurable<double> cK892masswindow{"cK892masswindow", 0.1, "K(892)0 inv mass selection window"};
-  Configurable<double> cPiPiMin{"cPiPiMin", 0, "Pion pair inv mass selection minimum"};
-  Configurable<double> cPiPiMax{"cPiPiMax", 999, "Pion pair inv mass selection maximum"};
-  Configurable<double> cPiKaMin{"cPiKaMin", 0, "bPion-Kaon pair inv mass selection minimum"};
-  Configurable<double> cPiKaMax{"cPiKaMax", 999, "bPion-Kaon pair inv mass selection maximum"};
+  // Secondary selection
+  Configurable<bool> cfgModeK892orRho{"cfgModeK892orRho", true, "Secondary scenario for K892 (true) or Rho (false)"};
+  Configurable<double> cSecondaryMasswindow{"cSecondaryMasswindow", 0.1, "Secondary inv mass selection window"};
+  Configurable<double> cMinAnotherSecondaryMassCut{"cMinAnotherSecondaryMassCut", 0, "Min inv. mass selection of another secondary scenario"};
+  Configurable<double> cMaxAnotherSecondaryMassCut{"cMaxAnotherSecondaryMassCut", 999, "MAx inv. mass selection of another secondary scenario"};
+  Configurable<double> cMinPiKaMassCut{"cMinPiKaMassCut", 0, "bPion-Kaon pair inv mass selection minimum"};
+  Configurable<double> cMaxPiKaMassCut{"cMaxPiKaMassCut", 999, "bPion-Kaon pair inv mass selection maximum"};
   Configurable<double> cMinAngle{"cMinAngle", 0, "Minimum angle between K(892)0 and bachelor pion"};
   Configurable<double> cMaxAngle{"cMaxAngle", 4, "Maximum angle between K(892)0 and bachelor pion"};
   Configurable<double> cMinPairAsym{"cMinPairAsym", -1, "Minimum pair asymmetry"};
@@ -92,108 +133,188 @@ struct k1analysis {
     AxisSpec ptAxis = {150, 0, 15, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec dcaxyAxis = {300, 0, 3, "DCA_{#it{xy}} (cm)"};
     AxisSpec dcazAxis = {500, 0, 5, "DCA_{#it{xy}} (cm)"};
-    AxisSpec invMassAxis = {900, 0.6, 1.5, "Invariant Mass (GeV/#it{c}^2)"};        // K(892)0
-    AxisSpec invMassAxisReso = {1600, 0.9f, 2.5f, "Invariant Mass (GeV/#it{c}^2)"}; // K1
-    AxisSpec invMassAxisScan = {250, 0, 2.5, "Invariant Mass (GeV/#it{c}^2)"};      // For selection
+    AxisSpec invMassAxisK892 = {1400 / cNbinsDiv, 0.6, 2.0, "Invariant Mass (GeV/#it{c}^2)"};   // K(892)0
+    AxisSpec invMassAxisRho = {2000 / cNbinsDiv, 0.0, 2.0, "Invariant Mass (GeV/#it{c}^2)"};    // rho
+    AxisSpec invMassAxisReso = {1600 / cNbinsDiv, 0.9f, 2.5f, "Invariant Mass (GeV/#it{c}^2)"}; // K1
+    AxisSpec invMassAxisScan = {250, 0, 2.5, "Invariant Mass (GeV/#it{c}^2)"};                  // For selection
     AxisSpec pidQAAxis = {130, -6.5, 6.5};
     AxisSpec dataTypeAxis = {9, 0, 9, "Histogram types"};
     AxisSpec mcTypeAxis = {4, 0, 4, "Histogram types"};
 
-    // Mass QA (quick check)
-    histos.add("k892invmass", "Invariant mass of K(892)0", HistType::kTH1F, {invMassAxis});
-    histos.add("k1invmass", "Invariant mass of K1(1270)pm", HistType::kTH1F, {invMassAxisReso});
-    histos.add("k1invmass_LS", "Invariant mass of K1(1270)pm", HistType::kTH1F, {invMassAxisReso});
-    histos.add("k1invmass_Mix", "Invariant mass of K1(1270)pm", HistType::kTH1F, {invMassAxisReso});
-    if (doprocessMC) {
-      histos.add("k1invmass_MC", "Invariant mass of K1(1270)pm", HistType::kTH1F, {invMassAxisReso});
-    }
+    // THnSparse
+    AxisSpec axisAnti = {binAnti::kNAEnd, 0, binAnti::kNAEnd, "Type of bin: Normal or Anti"};
+    AxisSpec axisType = {binType::kTYEnd, 0, binType::kTYEnd, "Type of bin with charge and mix"};
+    AxisSpec mcLabelAxis = {5, -0.5, 4.5, "MC Label"};
+
     // DCA QA
-    histos.add("QA/trkDCAxy_pi", "DCAxy distribution of pion track candidates", HistType::kTH1F, {dcaxyAxis});
-    histos.add("QA/trkDCAxy_ka", "DCAxy distribution of kaon track candidates", HistType::kTH1F, {dcaxyAxis});
-    histos.add("QA/trkDCAxy_pi_bach", "DCAxy distribution of bachelor pion track candidates", HistType::kTH1F, {dcaxyAxis});
-    histos.add("QA/trkDCAz_pi", "DCAz distribution of pion track candidates", HistType::kTH1F, {dcazAxis});
-    histos.add("QA/trkDCAz_ka", "DCAz distribution of kaon track candidates", HistType::kTH1F, {dcazAxis});
-    histos.add("QA/trkDCAz_pi_bach", "DCAz distribution of bachelor pion track candidates", HistType::kTH1F, {dcazAxis});
+    histos.add("QA/trkAllDCAxy", "DCAxy distribution of all track candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkAllDCAz", "DCAz distribution of all track candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkAllEta", "Eta distribution of all track candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of all track candidates"}});
+    histos.add("QA/trkAllpT", "pT distribution of all track candidates", HistType::kTH1F, {ptAxis});
 
-    // pT QA
-    histos.add("QA/trkpT_pi", "pT distribution of pion track candidates", HistType::kTH1F, {ptAxis});
-    histos.add("QA/trkpT_ka", "pT distribution of kaon track candidates", HistType::kTH1F, {ptAxis});
-    histos.add("QA/trkpT_pi_bach", "pT distribution of bachelor pion track candidates", HistType::kTH1F, {ptAxis});
-    // PID QA after cuts
-    histos.add("QA/TOF_TPC_Map_pi", "TOF + TPC Combined PID for Pion;#sigma_{TOF}^{Pion};#sigma_{TPC}^{Pion}", {HistType::kTH2F, {pidQAAxis, pidQAAxis}});
-    histos.add("QA/TOF_Nsigma_pi", "TOF NSigma for Pion;#it{p}_{T} (GeV/#it{c});#sigma_{TOF}^{Pion};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/TPC_Nsigma_pi", "TPC NSigma for Pion;#it{p}_{T} (GeV/#it{c});#sigma_{TPC}^{Pion};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/TOF_TPC_Map_ka", "TOF + TPC Combined PID for Pion;#sigma_{TOF}^{Kaon};#sigma_{TPC}^{Kaon}", {HistType::kTH2F, {pidQAAxis, pidQAAxis}});
-    histos.add("QA/TOF_Nsigma_ka", "TOF NSigma for Pion;#it{p}_{T} (GeV/#it{c});#sigma_{TOF}^{Kaon};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/TPC_Nsigmaka", "TPC NSigma for Kaon;#it{p}_{T} (GeV/#it{c});#sigma_{TPC}^{Kaon};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/TOF_TPC_Map_pi_bach", "TOF + TPC Combined PID for Pion;#sigma_{TOF}^{Pion};#sigma_{TPC}^{Pion}", {HistType::kTH2F, {pidQAAxis, pidQAAxis}});
-    histos.add("QA/TOF_Nsigma_pi_bach", "TOF NSigma for Pion;#it{p}_{T} (GeV/#it{c});#sigma_{TOF}^{Pion};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/TPC_Nsigma_pi_bach", "TPC NSigma for Pion;#it{p}_{T} (GeV/#it{c});#sigma_{TPC}^{Pion};", {HistType::kTH2F, {ptAxis, pidQAAxis}});
-    histos.add("QA/InvMass_piK_pipi", "Invariant mass of pion + kaon and pion+pion;Invariant Mass (GeV/#it{c}^{2});Invariant Mass (GeV/#it{c}^{2});", {HistType::kTH2F, {invMassAxisScan, invMassAxisScan}});
-    histos.add("QA/InvMass_piK_pika", "Invariant mass of pion + kaon and pion+kaon;Invariant Mass (GeV/#it{c}^{2});Invariant Mass (GeV/#it{c}^{2});", {HistType::kTH2F, {invMassAxisScan, invMassAxisScan}});
-    histos.add("QA/K1OA", "Opening angle of K1(1270)pm", HistType::kTH1F, {AxisSpec{100, 0, 3.14, "Opening angle of K1(1270)pm"}});
-    histos.add("QA/K1PairAsymm", "Pair asymmetry of K1(1270)pm", HistType::kTH1F, {AxisSpec{100, -1, 1, "Pair asymmetry of K1(1270)pm"}});
+    // Primary pion
+    histos.add("QA/trkppionDCAxy", "DCAxy distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkppionDCAz", "DCAz distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkppionEta", "Eta distribution of primary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of primary pion candidates"}});
+    histos.add("QA/trkppionpT", "pT distribution of primary pion candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QA/trkppionTPCPID", "TPC PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkppionTOFPID", "TOF PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkppionTPCTOFPID", "TPC-TOF PID map of primary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
 
-    // Invariant mass histograms
-    histos.add("hK892invmass_PP", "Invariant mass of K(892)0 (Matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxis});
-    histos.add("hK892invmass_NP", "Invariant mass of K(892)0 (Matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxis});
-    histos.add("hK892invmass_PN", "Invariant mass of K(892)0 (Anti-matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxis});
-    histos.add("hK892invmass_NN", "Invariant mass of K(892)0 (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxis});
-    histos.add("hK1invmass_NPP", "Invariant mass of K(892)0 + pion (Matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_NPN", "Invariant mass of K(892)0 + pion (Matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_PNP", "Invariant mass of K(892)0 + pion (Anti-matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_PNN", "Invariant mass of K(892)0 + pion (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    // K892-LS bkg
-    histos.add("hK1invmass_PPP", "Invariant mass of K(892)0 + pion (Matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_PPN", "Invariant mass of K(892)0 + pion (Anti-matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_NNP", "Invariant mass of K(892)0 + pion (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_NNN", "Invariant mass of K(892)0 + pion (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    // Mixed event
-    histos.add("hK1invmass_NPP_Mix", "Invariant mass of K(892)0 + pion (Matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_NPN_Mix", "Invariant mass of K(892)0 + pion (Matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_PNP_Mix", "Invariant mass of K(892)0 + pion (Anti-matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-    histos.add("hK1invmass_PNN_Mix", "Invariant mass of K(892)0 + pion (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
+    histos.add("QAcut/trkppionDCAxy", "DCAxy distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkppionDCAz", "DCAz distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkppionEta", "Eta distribution of primary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of primary pion candidates"}});
+    histos.add("QAcut/trkppionpT", "pT distribution of primary pion candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QAcut/trkppionTPCPID", "TPC PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkppionTOFPID", "TOF PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkppionTPCTOFPID", "TPC-TOF PID map of primary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
 
+    // Secondary pion
+    histos.add("QA/trkspionDCAxy", "DCAxy distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkspionDCAz", "DCAz distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkspionEta", "Eta distribution of secondary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of secondary pion candidates"}});
+    histos.add("QA/trkspionpT", "pT distribution of secondary pion candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QA/trkspionTPCPID", "TPC PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkspionTOFPID", "TOF PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkspionTPCTOFPID", "TPC-TOF PID map of secondary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
+
+    histos.add("QAcut/trkspionDCAxy", "DCAxy distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkspionDCAz", "DCAz distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkspionEta", "Eta distribution of secondary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of secondary pion candidates"}});
+    histos.add("QAcut/trkspionpT", "pT distribution of secondary pion candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QAcut/trkspionTPCPID", "TPC PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkspionTOFPID", "TOF PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkspionTPCTOFPID", "TPC-TOF PID map of secondary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
+
+    // Kaon
+    histos.add("QA/trkkaonDCAxy", "DCAxy distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkkaonDCAz", "DCAz distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QA/trkkaonEta", "Eta distribution of kaon candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of kaon candidates"}});
+    histos.add("QA/trkkaonpT", "pT distribution of kaon candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QA/trkkaonTPCPID", "TPC PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkkaonTOFPID", "TOF PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QA/trkkaonTPCTOFPID", "TPC-TOF PID map of kaon candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
+
+    histos.add("QAcut/trkkaonDCAxy", "DCAxy distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkkaonDCAz", "DCAz distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+    histos.add("QAcut/trkkaonEta", "Eta distribution of kaon candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of kaon candidates"}});
+    histos.add("QAcut/trkkaonpT", "pT distribution of kaon candidates", HistType::kTH1F, {ptAxis});
+    histos.add("QAcut/trkkaonTPCPID", "TPC PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkkaonTOFPID", "TOF PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+    histos.add("QAcut/trkkaonTPCTOFPID", "TPC-TOF PID map of kaon candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
+
+    // K1
+    histos.add("QA/K1OA", "Opening angle of K1(1270)", HistType::kTH1F, {AxisSpec{100, 0, 3.14, "Opening angle"}});
+    histos.add("QA/K1PairAssym", "Pair asymmetry of K1(1270)", HistType::kTH1F, {AxisSpec{100, -1, 1, "Pair asymmetry"}});
+    histos.add("QA/hInvmassK892_Rho", "Invariant mass of K(892)0 vs Rho(770)", HistType::kTH2F, {invMassAxisK892, invMassAxisRho});
+    histos.add("QA/hInvmassSecon_PiKa", "Invariant mass of secondary resonance vs pion-kaon", HistType::kTH2F, {invMassAxisK892, invMassAxisK892});
+    histos.add("QA/hInvmassSecon", "Invariant mass of secondary resonance", HistType::kTH1F, {invMassAxisRho});
+    histos.add("QA/hpT_Secondary", "pT distribution of secondary resonance", HistType::kTH1F, {ptAxis});
+
+    histos.add("QAcut/K1OA", "Opening angle of K1(1270)", HistType::kTH1F, {AxisSpec{100, 0, 3.14, "Opening angle"}});
+    histos.add("QAcut/K1PairAssym", "Pair asymmetry of K1(1270)", HistType::kTH1F, {AxisSpec{100, -1, 1, "Pair asymmetry"}});
+    histos.add("QAcut/hInvmassK892_Rho", "Invariant mass of K(892)0 vs Rho(770)", HistType::kTH2F, {invMassAxisK892, invMassAxisRho});
+    histos.add("QAcut/hInvmassSecon_PiKa", "Invariant mass of secondary resonance vs pion-kaon", HistType::kTH2F, {invMassAxisK892, invMassAxisK892});
+    histos.add("QAcut/hInvmassSecon", "Invariant mass of secondary resonance", HistType::kTH1F, {invMassAxisRho});
+    histos.add("QAcut/hpT_Secondary", "pT distribution of secondary resonance", HistType::kTH1F, {ptAxis});
+
+    // Invariant mass
+    histos.add("hInvmass_K1", "Invariant mass of K1(1270)", HistType::kTHnSparseD, {axisAnti, axisType, centAxis, ptAxis, invMassAxisReso});
+    // Mass QA (quick check)
+    histos.add("k1invmass", "Invariant mass of K1(1270)", HistType::kTH1F, {invMassAxisReso});
+    histos.add("k1invmass_Mix", "Invariant mass of K1(1270)", HistType::kTH1F, {invMassAxisReso});
+
+    // MC
     if (doprocessMC) {
-      histos.add("QAMC/InvMass_piK_pipi", "Invariant mass of pion + kaon and pion+pion;Invariant Mass (GeV/#it{c}^{2});Invariant Mass (GeV/#it{c}^{2});", {HistType::kTH2F, {invMassAxisScan, invMassAxisScan}});
-      histos.add("QAMC/InvMass_piK_pika", "Invariant mass of pion + kaon and pion+kaon;Invariant Mass (GeV/#it{c}^{2});Invariant Mass (GeV/#it{c}^{2});", {HistType::kTH2F, {invMassAxisScan, invMassAxisScan}});
-      histos.add("QAMC/K1OA", "Opening angle of K1(1270)pm", HistType::kTH1F, {AxisSpec{100, 0, 3.14, "Opening angle of K1(1270)pm"}});
-      histos.add("QAMC/K1PairAsymm", "Pair asymmetry of K1(1270)pm", HistType::kTH1F, {AxisSpec{100, 0, 1, "Pair asymmetry of K1(1270)pm"}});
+      histos.add("k1invmass_MC", "Invariant mass of K1(1270)", HistType::kTH1F, {invMassAxisReso});
+      histos.add("k1invmass_MC_noK1", "Invariant mass of K1(1270)", HistType::kTH1F, {invMassAxisReso});
 
-      histos.add("hK1invmass_NPP_MC", "Invariant mass of K(892)0 + pion (Matter + Matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
-      histos.add("hK1invmass_PNN_MC", "Invariant mass of K(892)0 + pion (Anti-matter + Anti-matter)", HistType::kTH3F, {centAxis, ptAxis, invMassAxisReso});
+      histos.add("QAMC/trkppionDCAxy", "DCAxy distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkppionDCAz", "DCAz distribution of primary pion candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkppionEta", "Eta distribution of primary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of primary pion candidates"}});
+      histos.add("QAMC/trkppionpT", "pT distribution of primary pion candidates", HistType::kTH1F, {ptAxis});
+      histos.add("QAMC/trkppionTPCPID", "TPC PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkppionTOFPID", "TOF PID of primary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkppionTPCTOFPID", "TPC-TOF PID map of primary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
 
-      histos.add("hReconK892pt", "pT distribution of Reconstructed MC K(892)0", HistType::kTH1F, {ptAxis});
-      histos.add("hTrueK1pt", "pT distribution of True MC K1", HistType::kTH1F, {ptAxis});
-      histos.add("hReconK1pt", "pT distribution of Reconstructed MC K1", HistType::kTH1F, {ptAxis});
+      histos.add("QAMC/trkspionDCAxy", "DCAxy distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkspionDCAz", "DCAz distribution of secondary pion candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkspionEta", "Eta distribution of secondary pion candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of secondary pion candidates"}});
+      histos.add("QAMC/trkspionpT", "pT distribution of secondary pion candidates", HistType::kTH1F, {ptAxis});
+      histos.add("QAMC/trkspionTPCPID", "TPC PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkspionTOFPID", "TOF PID of secondary pion candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkspionTPCTOFPID", "TPC-TOF PID map of secondary pion candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
 
-      histos.add("k1invmass_noK1", "Invariant mass of K1(1270)pm", HistType::kTH1F, {invMassAxisReso});
+      histos.add("QAMC/trkkaonDCAxy", "DCAxy distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkkaonDCAz", "DCAz distribution of kaon candidates", HistType::kTH1F, {dcaxyAxis});
+      histos.add("QAMC/trkkaonEta", "Eta distribution of kaon candidates", HistType::kTH1F, {AxisSpec{20, -1, 1, "Eta distribution of kaon candidates"}});
+      histos.add("QAMC/trkkaonpT", "pT distribution of kaon candidates", HistType::kTH1F, {ptAxis});
+      histos.add("QAMC/trkkaonTPCPID", "TPC PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkkaonTOFPID", "TOF PID of kaon candidates", HistType::kTH2F, {ptAxis, pidQAAxis});
+      histos.add("QAMC/trkkaonTPCTOFPID", "TPC-TOF PID map of kaon candidates", HistType::kTH2F, {pidQAAxis, pidQAAxis});
+
+      histos.add("QAMC/K1OA", "Opening angle of K1(1270)", HistType::kTH1F, {AxisSpec{100, 0, 3.14, "Opening angle"}});
+      histos.add("QAMC/K1PairAssym", "Pair asymmetry of K1(1270)", HistType::kTH1F, {AxisSpec{100, -1, 1, "Pair asymmetry"}});
+      histos.add("QAMC/hInvmassK892_Rho", "Invariant mass of K(892)0 vs Rho(770)", HistType::kTH2F, {invMassAxisK892, invMassAxisRho});
+      histos.add("QAMC/hInvmassSecon_PiKa", "Invariant mass of secondary resonance vs pion-kaon", HistType::kTH2F, {invMassAxisK892, invMassAxisK892});
+      histos.add("QAMC/hInvmassSecon", "Invariant mass of secondary resonance", HistType::kTH1F, {invMassAxisRho});
+      histos.add("QAMC/hpT_Secondary", "pT distribution of secondary resonance", HistType::kTH1F, {ptAxis});
     }
     // Print output histograms statistics
-    LOG(info) << "Size of the histograms in spectraTOF";
+    LOG(info) << "Size of the histograms in K1 Analysis Task";
     histos.print();
   }
 
-  double massKa = TDatabasePDG::Instance()->GetParticle(kKPlus)->Mass();  // FIXME: Get from the common header
-  double massPi = TDatabasePDG::Instance()->GetParticle(kPiPlus)->Mass(); // FIXME: Get from the common header
-  double massK892 = TDatabasePDG::Instance()->GetParticle(313)->Mass();   // FIXME: Get from the common header
+  double massKa = MassKaonCharged;
+  double massPi = MassPionCharged;
+  // double massRho770 = MassRho770;
+  // double massK892 = MassKStar892;
+  double massRho770 = 0.77526;
+  double massK892 = 0.892;
+
+  // PDG code
+  int kPDGRho770 = 113;
+  int kK1Plus = 10323;
 
   template <typename TrackType>
   bool trackCut(const TrackType track)
   {
     // basic track cuts
-    if (track.pt() < cMinPtcut)
+    if (std::abs(track.pt()) < cMinPtcut)
       return false;
-    if (track.dcaXY() > cMaxDCArToPVcut)
+    if (std::abs(track.dcaXY()) > cMaxDCArToPVcut)
       return false;
-    if (track.dcaZ() < cMinDCAzToPVcut || track.dcaZ() > cMaxDCAzToPVcut)
+    if (std::abs(track.dcaZ()) > cMaxDCAzToPVcut)
+      return false;
+    if (track.itsNCls() < cfgITScluster)
+      return false;
+    if (track.tpcNClsFound() < cfgTPCcluster)
+      return false;
+    if (track.tpcCrossedRowsOverFindableCls() < cfgRatioTPCRowsOverFindableCls)
+      return false;
+    if (track.itsChi2NCl() >= cfgITSChi2NCl)
+      return false;
+    if (track.tpcChi2NCl() >= cfgTPCChi2NCl)
+      return false;
+    if (cfgHasITS && !track.hasITS())
+      return false;
+    if (cfgHasTPC && !track.hasTPC())
+      return false;
+    if (cfgHasTOF && !track.hasTOF())
+      return false;
+    if (cfgUseITSRefit && !track.passedITSRefit())
+      return false;
+    if (cfgUseTPCRefit && !track.passedTPCRefit())
+      return false;
+    if (cfgPVContributor && !track.isPVContributor())
       return false;
     if (cfgPrimaryTrack && !track.isPrimaryTrack())
       return false;
     if (cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
       return false;
-    if (cfgPVContributor && !track.isPVContributor())
+    if (cfgGlobalTrack && !track.isGlobalTrack())
       return false;
+
     return true;
   }
 
@@ -204,6 +325,8 @@ struct k1analysis {
     bool tpcPIDPassed{false}, tofPIDPassed{false};
     if (std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion) {
       tpcPIDPassed = true;
+    } else {
+      return false;
     }
     if (candidate.hasTOF()) {
       if (std::abs(candidate.tofNSigmaPi()) < cMaxTOFnSigmaPion) {
@@ -213,6 +336,9 @@ struct k1analysis {
         tofPIDPassed = true;
       }
     } else {
+      if (!cTOFVeto) {
+        return false;
+      }
       tofPIDPassed = true;
     }
     if (tpcPIDPassed && tofPIDPassed) {
@@ -226,6 +352,8 @@ struct k1analysis {
     bool tpcPIDPassed{false}, tofPIDPassed{false};
     if (std::abs(candidate.tpcNSigmaKa()) < cMaxTPCnSigmaKaon) {
       tpcPIDPassed = true;
+    } else {
+      return false;
     }
     if (candidate.hasTOF()) {
       if (std::abs(candidate.tofNSigmaKa()) < cMaxTOFnSigmaKaon) {
@@ -235,6 +363,9 @@ struct k1analysis {
         tofPIDPassed = true;
       }
     } else {
+      if (!cTOFVeto) {
+        return false;
+      }
       tofPIDPassed = true;
     }
     if (tpcPIDPassed && tofPIDPassed) {
@@ -248,21 +379,35 @@ struct k1analysis {
   {
     if (abs(trk1.pdgCode()) != kPiPlus || abs(trk2.pdgCode()) != kKPlus)
       return false;
-    auto mother1 = trk1.motherId();
-    auto mother2 = trk2.motherId();
-    if (mother1 != mother2)
-      return false;
-    if (abs(trk1.motherPDG()) != 313)
-      return false;
     if (abs(bTrack.pdgCode()) != kPiPlus)
       return false;
-    if (abs(bTrack.motherPDG()) != 10323)
-      return false;
-    auto siblings = bTrack.siblingIds();
-    if (siblings[0] != mother1 && siblings[1] != mother1)
-      return false;
-
-    return true;
+    if (cfgModeK892orRho) { // K892 mode
+      auto mother1 = trk1.motherId();
+      auto mother2 = trk2.motherId();
+      if (mother1 != mother2)
+        return false;
+      if (abs(trk1.motherPDG()) != kK0Star892)
+        return false;
+      if (abs(bTrack.motherPDG()) != kK1Plus)
+        return false;
+      auto siblings = bTrack.siblingIds();
+      if (siblings[0] != mother1 && siblings[1] != mother1)
+        return false;
+      return true;
+    } else { // Rho mode
+      auto mother1 = trk1.motherId();
+      auto motherb = bTrack.motherId();
+      if (mother1 != motherb)
+        return false;
+      if (abs(trk1.motherPDG()) != kPDGRho770)
+        return false;
+      if (abs(trk2.motherPDG()) != kK1Plus)
+        return false;
+      auto siblings = trk2.siblingIds();
+      if (siblings[0] != mother1 && siblings[1] != mother1)
+        return false;
+      return true;
+    }
   }
 
   template <typename T>
@@ -274,7 +419,21 @@ struct k1analysis {
     auto mother2 = trk2.motherId();
     if (mother1 != mother2)
       return false;
-    if (abs(trk1.motherPDG()) != 313)
+    if (abs(trk1.motherPDG()) != kK0Star892)
+      return false;
+    return true;
+  }
+
+  template <typename T>
+  bool isTrueRho(const T& trk1, const T& trk2)
+  {
+    if (abs(trk1.pdgCode()) != kPiPlus || abs(trk2.pdgCode()) != kPiPlus)
+      return false;
+    auto mother1 = trk1.motherId();
+    auto mother2 = trk2.motherId();
+    if (mother1 != mother2)
+      return false;
+    if (abs(trk1.motherPDG()) != kPDGRho770)
       return false;
     return true;
   }
@@ -283,7 +442,7 @@ struct k1analysis {
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
     auto multiplicity = collision.cent();
-    TLorentzVector lDecayDaughter1, lDecayDaughter2, lResonanceK892, lDecayDaughter_bach, lResonanceK1;
+    TLorentzVector lDecayDaughter1, lDecayDaughter2, lResonanceSecondary, lDecayDaughter_bach, lResonanceK1;
     for (auto& [trk1, trk2] : combinations(CombinationsFullIndexPolicy(dTracks2, dTracks2))) {
       // Full index policy is needed to consider all possible combinations
       if (trk1.index() == trk2.index())
@@ -295,211 +454,220 @@ struct k1analysis {
 
       auto isTrk1hasTOF = trk1.hasTOF();
       auto isTrk2hasTOF = trk2.hasTOF();
-      auto trk1ptPi = trk1.pt();
+      auto trk1pt = trk1.pt();
       auto trk1NSigmaPiTPC = trk1.tpcNSigmaPi();
       auto trk1NSigmaPiTOF = (isTrk1hasTOF) ? trk1.tofNSigmaPi() : -999.;
-      auto trk2ptKa = trk2.pt();
+      auto trk2pt = trk2.pt();
       auto trk2NSigmaKaTPC = trk2.tpcNSigmaKa();
       auto trk2NSigmaKaTOF = (isTrk2hasTOF) ? trk2.tofNSigmaKa() : -999.;
+      // for rho mode
+      auto trk2NSigmaPiTPC = trk2.tpcNSigmaPi();
+      auto trk2NSigmaPiTOF = (isTrk2hasTOF) ? trk2.tofNSigmaPi() : -999.;
 
       //// PID selections
       if (cUseOnlyTOFTrackPi && !isTrk1hasTOF)
         continue;
       if (cUseOnlyTOFTrackKa && !isTrk2hasTOF)
         continue;
-      if (!selectionPIDPion(trk1) || !selectionPIDKaon(trk2))
-        continue;
+
+      if (cfgModeK892orRho) { // K892 mode
+        if (!selectionPIDPion(trk1) || !selectionPIDKaon(trk2))
+          continue;
+      } else { // Rho mode
+        if (!selectionPIDPion(trk1) || !selectionPIDPion(trk2))
+          continue;
+      }
 
       //// QA plots after the selection
-      //  --- PID QA Pion
       if constexpr (!IsMix) {
-        histos.fill(HIST("QA/TPC_Nsigma_pi"), trk1ptPi, trk1NSigmaPiTPC);
+        //  --- PID QA Pion
+        histos.fill(HIST("QA/trkspionTPCPID"), trk1pt, trk1NSigmaPiTPC);
         if (isTrk1hasTOF) {
-          histos.fill(HIST("QA/TOF_Nsigma_pi"), trk1ptPi, trk1NSigmaPiTOF);
-          histos.fill(HIST("QA/TOF_TPC_Map_pi"), trk1NSigmaPiTOF, trk1NSigmaPiTPC);
+          histos.fill(HIST("QA/trkspionTOFPID"), trk1pt, trk1NSigmaPiTOF);
+          histos.fill(HIST("QA/trkspionTPCTOFPID"), trk1NSigmaPiTPC, trk1NSigmaPiTOF);
         }
-        //  --- PID QA Kaon
-        histos.fill(HIST("QA/TPC_Nsigmaka"), trk2ptKa, trk2NSigmaKaTPC);
-        if (isTrk1hasTOF) {
-          histos.fill(HIST("QA/TOF_Nsigma_ka"), trk2ptKa, trk2NSigmaKaTOF);
-          histos.fill(HIST("QA/TOF_TPC_Map_ka"), trk2NSigmaKaTOF, trk2NSigmaKaTPC);
-        }
-        histos.fill(HIST("QA/trkpT_pi"), trk1ptPi);
-        histos.fill(HIST("QA/trkpT_ka"), trk2ptKa);
+        histos.fill(HIST("QA/trkspionpT"), trk1pt);
+        histos.fill(HIST("QA/trkspionDCAxy"), trk1.dcaXY());
+        histos.fill(HIST("QA/trkspionDCAz"), trk1.dcaZ());
 
-        histos.fill(HIST("QA/trkDCAxy_pi"), trk1.dcaXY());
-        histos.fill(HIST("QA/trkDCAxy_ka"), trk2.dcaXY());
-        histos.fill(HIST("QA/trkDCAz_pi"), trk1.dcaZ());
-        histos.fill(HIST("QA/trkDCAz_ka"), trk2.dcaZ());
+        if (cfgModeK892orRho) { // K892 mode
+          //  --- PID QA Kaon
+          histos.fill(HIST("QA/trkkaonTPCPID"), trk2pt, trk2NSigmaKaTPC);
+          if (isTrk1hasTOF) {
+            histos.fill(HIST("QA/trkkaonTOFPID"), trk2pt, trk2NSigmaKaTOF);
+            histos.fill(HIST("QA/trkkaonTPCTOFPID"), trk2NSigmaKaTPC, trk2NSigmaKaTOF);
+          }
+          histos.fill(HIST("QA/trkkaonpT"), trk2pt);
+          histos.fill(HIST("QA/trkkaonDCAxy"), trk2.dcaXY());
+          histos.fill(HIST("QA/trkkaonDCAz"), trk2.dcaZ());
+        } else { // Rho mode
+          //  --- PID QA Pion
+          histos.fill(HIST("QA/trkppionTPCPID"), trk2pt, trk2NSigmaPiTPC);
+          if (isTrk2hasTOF) {
+            histos.fill(HIST("QA/trkppionTOFPID"), trk2pt, trk2NSigmaPiTOF);
+            histos.fill(HIST("QA/trkppionTPCTOFPID"), trk2NSigmaPiTPC, trk2NSigmaPiTOF);
+          }
+          histos.fill(HIST("QA/trkppionpT"), trk2pt);
+          histos.fill(HIST("QA/trkppionDCAxy"), trk2.dcaXY());
+          histos.fill(HIST("QA/trkppionDCAz"), trk2.dcaZ());
+        }
       }
 
       //// Resonance reconstruction
       lDecayDaughter1.SetXYZM(trk1.px(), trk1.py(), trk1.pz(), massPi);
-      lDecayDaughter2.SetXYZM(trk2.px(), trk2.py(), trk2.pz(), massKa);
-      lResonanceK892 = lDecayDaughter1 + lDecayDaughter2;
+      lDecayDaughter2.SetXYZM(trk2.px(), trk2.py(), trk2.pz(), (cfgModeK892orRho) ? massKa : massPi);
+      lResonanceSecondary = lDecayDaughter1 + lDecayDaughter2;
 
       if constexpr (!IsMix) {
-        histos.fill(HIST("k892invmass"), lResonanceK892.M()); // quick check
-        if (trk1.sign() > 0) {                                // Positive pion
-          if (trk2.sign() > 0)                                // Positive kaon
-            histos.fill(HIST("hK892invmass_PP"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M());
-          else                                                                                           // Negative kaon
-            histos.fill(HIST("hK892invmass_PN"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M()); // Anti-K(892)0
-        } else {                                                                                         // Negative pion
-          if (trk2.sign() > 0)                                                                           // Positive kaon
-            histos.fill(HIST("hK892invmass_NP"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M()); // K(892)0
-          else                                                                                           // Negative kaon
-            histos.fill(HIST("hK892invmass_NN"), multiplicity, lResonanceK892.Pt(), lResonanceK892.M());
-        }
+        histos.fill(HIST("QA/hInvmassSecon"), lResonanceSecondary.M());
       }
-      // Like-sign rejection for K(892)0 - disabled for further LS bkg study
-      // if (trk1.sign() * trk2.sign() > 0)
-      //   continue;
 
-      if constexpr (IsMC) { // MC Check of K(892)0
-        if (isTrueK892(trk1, trk2))
-          histos.fill(HIST("hReconK892pt"), lResonanceK892.Pt());
+      if constexpr (IsMC) { // MC Check
+        if (cfgModeK892orRho) {
+          if (isTrueK892(trk1, trk2))
+            histos.fill(HIST("QAMC/hpT_Secondary"), lResonanceSecondary.Pt());
+        } else {
+          if (isTrueRho(trk1, trk2))
+            histos.fill(HIST("QAMC/hpT_Secondary"), lResonanceSecondary.Pt());
+        }
       }
 
       // Mass window cut
-      if (std::abs(lResonanceK892.M() - massK892) > cK892masswindow)
+      double massCut = cfgModeK892orRho ? massK892 : massRho770;
+      if (std::abs(lResonanceSecondary.M() - massCut) > cSecondaryMasswindow)
         continue;
-      // Add one more track loop for K1 reconstruction
+
+      // bTrack loop for K1 reconstruction
       for (auto bTrack : dTracks1) {
-        // ID cut
         if (bTrack.index() == trk1.index() || bTrack.index() == trk2.index())
           continue;
-        // Track cut
         if (!trackCut(bTrack))
           continue;
 
-        auto bTrkPt = bTrack.pt();
-        auto bTrkTPCnSigmaPi = bTrack.tpcNSigmaPi();
-        auto isbTrkhasTOF = bTrack.hasTOF();
-        auto bTrack_TOFnSigma = (isbTrkhasTOF) ? bTrack.tofNSigmaPi() : -999.;
-
-        // PID selection
-        if (!selectionPIDPion(bTrack))
+        // Kaon or Pion
+        if (cfgModeK892orRho && !selectionPIDPion(bTrack))
           continue;
-
-        if constexpr (!IsMix) {
-          histos.fill(HIST("QA/trkpT_pi_bach"), bTrkPt);
-          //  --- PID QA Pion
-          histos.fill(HIST("QA/TPC_Nsigma_pi_bach"), bTrkPt, bTrkTPCnSigmaPi);
-          if (isbTrkhasTOF) {
-            histos.fill(HIST("QA/TOF_Nsigma_pi_bach"), bTrkPt, bTrack_TOFnSigma);
-            histos.fill(HIST("QA/TOF_TPC_Map_pi_bach"), bTrack_TOFnSigma, bTrkTPCnSigmaPi);
-          }
-          histos.fill(HIST("QA/trkDCAxy_pi_bach"), bTrack.dcaXY());
-          histos.fill(HIST("QA/trkDCAz_pi_bach"), bTrack.dcaZ());
-        }
+        if (!cfgModeK892orRho && !selectionPIDKaon(bTrack))
+          continue;
 
         // K1 reconstruction
-        lDecayDaughter_bach.SetXYZM(bTrack.px(), bTrack.py(), bTrack.pz(), massPi);
-        lResonanceK1 = lResonanceK892 + lDecayDaughter_bach;
+        lDecayDaughter_bach.SetXYZM(bTrack.px(), bTrack.py(), bTrack.pz(), cfgModeK892orRho ? massPi : massKa);
+        lResonanceK1 = lResonanceSecondary + lDecayDaughter_bach;
 
-        // Rapidity cut
+        // Cuts
         if (lResonanceK1.Rapidity() > cK1MaxRap || lResonanceK1.Rapidity() < cK1MinRap)
           continue;
-        // Opening angle cut
-        auto lK1Angle = lResonanceK892.Angle(lDecayDaughter_bach.Vect());
-        // Pair asymmetry cut
-        auto lPairAsym = (lResonanceK892.E() - lDecayDaughter_bach.E()) / (lResonanceK892.E() + lDecayDaughter_bach.E());
-        // PiPi, PiKa mass range cut
-        TLorentzVector tempPiPi = lDecayDaughter1 + lDecayDaughter_bach;
-        TLorentzVector tempPiKa = lDecayDaughter2 + lDecayDaughter_bach;
+
+        auto lK1Angle = lResonanceSecondary.Angle(lDecayDaughter_bach.Vect());
+        auto lPairAsym = (lResonanceSecondary.E() - lDecayDaughter_bach.E()) / (lResonanceSecondary.E() + lDecayDaughter_bach.E());
+
+        TLorentzVector temp13 = lDecayDaughter1 + lDecayDaughter_bach;
+        TLorentzVector temp23 = lDecayDaughter2 + lDecayDaughter_bach;
+
+        // QA histograms
         if constexpr (!IsMix) {
-          histos.fill(HIST("QA/InvMass_piK_pipi"), lResonanceK892.M(), tempPiPi.M());
-          histos.fill(HIST("QA/InvMass_piK_pika"), lResonanceK892.M(), tempPiKa.M());
           histos.fill(HIST("QA/K1OA"), lK1Angle);
-          histos.fill(HIST("QA/K1PairAsymm"), lPairAsym);
+          histos.fill(HIST("QA/K1PairAssym"), lPairAsym);
+          if (cfgModeK892orRho) {
+            histos.fill(HIST("QA/hInvmassK892_Rho"), lResonanceSecondary.M(), temp13.M());
+          } else {
+            histos.fill(HIST("QA/hInvmassK892_Rho"), temp13.M(), lResonanceSecondary.M());
+          }
+          histos.fill(HIST("QA/hInvmassSecon_PiKa"), lResonanceSecondary.M(), temp23.M());
+          histos.fill(HIST("QA/hpT_Secondary"), lResonanceSecondary.Pt());
         }
-        if (tempPiPi.M() < cPiPiMin || tempPiPi.M() > cPiPiMax)
+
+        // Selection cuts
+        if (temp13.M() < cMinAnotherSecondaryMassCut || temp13.M() > cMaxAnotherSecondaryMassCut)
           continue;
-        if (tempPiKa.M() < cPiKaMin || tempPiKa.M() > cPiKaMax)
+        if (temp23.M() < cMinPiKaMassCut || temp23.M() > cMaxPiKaMassCut)
           continue;
         if (lK1Angle < cMinAngle || lK1Angle > cMaxAngle)
           continue;
         if (lPairAsym < cMinPairAsym || lPairAsym > cMaxPairAsym)
           continue;
 
-        if constexpr (!IsMix) {                                   // Same event pair
-          if (trk1.sign() * trk2.sign() < 0) {                    // K892
-            if (bTrack.sign() > 0) {                              // bachelor pi+
-              if (trk2.sign() > 0) {                              // kaon + means K(892)0 is matter.
-                histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            } else {                                                 // bachelor pi-
-              if (trk2.sign() > 0) {                                 // kaon + means K(892)0 is matter.
-                histos.fill(HIST("k1invmass_LS"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("k1invmass"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            }
-          } else {                   // K892-LS (false)
-            if (bTrack.sign() > 0) { // bachelor pi+
-              if (trk2.sign() > 0) { // Kaon+
-                histos.fill(HIST("hK1invmass_PPP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("hK1invmass_PPN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            } else {                 // bachelor pi-
-              if (trk2.sign() > 0) { // Kaon_
-                histos.fill(HIST("hK1invmass_NNN"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("hK1invmass_NNP"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            }
+        // QA histograms after the cuts
+        if constexpr (!IsMix) {
+          histos.fill(HIST("QAcut/K1OA"), lK1Angle);
+          histos.fill(HIST("QAcut/K1PairAssym"), lPairAsym);
+          if (cfgModeK892orRho) {
+            histos.fill(HIST("QAcut/hInvmassK892_Rho"), lResonanceSecondary.M(), temp13.M());
+          } else {
+            histos.fill(HIST("QAcut/hInvmassK892_Rho"), temp13.M(), lResonanceSecondary.M());
           }
+          histos.fill(HIST("QAcut/hInvmassSecon_PiKa"), lResonanceSecondary.M(), temp23.M());
+          histos.fill(HIST("QAcut/hInvmassSecon"), lResonanceSecondary.M());
+          histos.fill(HIST("QAcut/hpT_Secondary"), lResonanceSecondary.Pt());
+        }
+
+        if constexpr (!IsMix) {
+          unsigned int typeK1 = bTrack.sign() > 0 ? binType::kK1P : binType::kK1N;
+          unsigned int typeNormal = cfgModeK892orRho ? (trk1.sign() < 0 ? binAnti::kNormal : binAnti::kAnti) : binAnti::kNormal;
+          histos.fill(HIST("k1invmass"), lResonanceK1.M());
+          histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
 
           if constexpr (IsMC) {
             if (isTrueK1(trk1, trk2, bTrack)) {
-              histos.fill(HIST("hReconK1pt"), lResonanceK1.Pt());
-              histos.fill(HIST("QAMC/InvMass_piK_pipi"), lResonanceK892.M(), tempPiPi.M());
-              histos.fill(HIST("QAMC/InvMass_piK_pika"), lResonanceK892.M(), tempPiKa.M());
-              histos.fill(HIST("QAMC/K1OA"), lK1Angle);
-              histos.fill(HIST("QAMC/K1PairAsymm"), lPairAsym);
-
-              if ((bTrack.sign() > 0) && (trk2.sign() > 0)) { // Matter
-                histos.fill(HIST("hK1invmass_NPP_MC"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-                histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
-              }
-              if ((bTrack.sign() < 0) && (trk2.sign() < 0)) { // Anti-matter
-                histos.fill(HIST("hK1invmass_PNN_MC"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-                histos.fill(HIST("k1invmass_MC"), lResonanceK1.M()); // quick check
-              }
+              typeK1 = bTrack.sign() > 0 ? binType::kK1P_Rec : binType::kK1N_Rec;
+              histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
               histos.fill(HIST("hTrueK1pt"), lResonanceK1.Pt());
+              histos.fill(HIST("k1invmass_MC"), lResonanceK1.M());
+              histos.fill(HIST("QAMC/K1OA"), lK1Angle);
+              histos.fill(HIST("QAMC/K1PairAssym"), lPairAsym);
+              if (cfgModeK892orRho) {
+                histos.fill(HIST("QAMC/hInvmassK892_Rho"), lResonanceSecondary.M(), temp13.M());
+              } else {
+                histos.fill(HIST("QAMC/hInvmassK892_Rho"), temp13.M(), lResonanceSecondary.M());
+              }
+              histos.fill(HIST("QAMC/hInvmassSecon_PiKa"), lResonanceSecondary.M(), temp23.M());
+              histos.fill(HIST("QAMC/hInvmassSecon"), lResonanceSecondary.M());
+              histos.fill(HIST("QAMC/hpT_Secondary"), lResonanceSecondary.Pt());
+
+              //  --- PID QA Pion
+              histos.fill(HIST("QAMC/trkspionTPCPID"), trk1pt, trk1NSigmaPiTPC);
+              if (isTrk1hasTOF) {
+                histos.fill(HIST("QAMC/trkspionTOFPID"), trk1pt, trk1NSigmaPiTOF);
+                histos.fill(HIST("QAMC/trkspionTPCTOFPID"), trk1NSigmaPiTPC, trk1NSigmaPiTOF);
+              }
+              histos.fill(HIST("QAMC/trkspionpT"), trk1pt);
+              histos.fill(HIST("QAMC/trkspionDCAxy"), trk1.dcaXY());
+              histos.fill(HIST("QAMC/trkspionDCAz"), trk1.dcaZ());
+
+              if (cfgModeK892orRho) { // K892 mode
+                //  --- PID QA Kaon
+                histos.fill(HIST("QAMC/trkkaonTPCPID"), trk2pt, trk2NSigmaKaTPC);
+                if (isTrk1hasTOF) {
+                  histos.fill(HIST("QAMC/trkkaonTOFPID"), trk2pt, trk2NSigmaKaTOF);
+                  histos.fill(HIST("QAMC/trkkaonTPCTOFPID"), trk2NSigmaKaTPC, trk2NSigmaKaTOF);
+                }
+                histos.fill(HIST("QAMC/trkkaonpT"), trk2pt);
+                histos.fill(HIST("QAMC/trkkaonDCAxy"), trk2.dcaXY());
+                histos.fill(HIST("QAMC/trkkaonDCAz"), trk2.dcaZ());
+              } else { // Rho mode
+                //  --- PID QA Pion
+                histos.fill(HIST("QAMC/trkppionTPCPID"), trk2pt, trk2NSigmaPiTPC);
+                if (isTrk2hasTOF) {
+                  histos.fill(HIST("QAMC/trkppionTOFPID"), trk2pt, trk2NSigmaPiTOF);
+                  histos.fill(HIST("QAMC/trkppionTPCTOFPID"), trk2NSigmaPiTPC, trk2NSigmaPiTOF);
+                }
+                histos.fill(HIST("QAMC/trkppionpT"), trk2pt);
+                histos.fill(HIST("QAMC/trkppionDCAxy"), trk2.dcaXY());
+                histos.fill(HIST("QAMC/trkppionDCAz"), trk2.dcaZ());
+              }
             } else {
-              if (((bTrack.sign() > 0) && (trk2.sign() > 0)) || ((bTrack.sign() < 0) && (trk2.sign() < 0)))
-                histos.fill(HIST("k1invmass_noK1"), lResonanceK1.M()); // quick check
+              histos.fill(HIST("k1invmass_MC_noK1"), lResonanceK1.M());
             }
-          }
-        } else {                                                      // Mixed event pair
-          if (trk1.sign() * trk2.sign() < 0) {                        // K892
-            if (bTrack.sign() > 0) {                                  // bachelor pi+
-              if (trk2.sign() > 0) {                                  // kaon + means K(892)0 is matter.
-                histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_NPP_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("hK1invmass_PNP_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            } else {                 // bachelor pi-
-              if (trk2.sign() > 0) { // kaon + means K(892)0 is matter.
-                histos.fill(HIST("hK1invmass_NPN_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              } else {
-                histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M()); // quick check
-                histos.fill(HIST("hK1invmass_PNN_Mix"), multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
-              }
-            }
-          }
+          } // MC
+        } // No MIX
+        else
+        { // Mixed event handling
+          unsigned int typeK1 = bTrack.sign() > 0 ? binType::kK1P_Mix : binType::kK1N_Mix;
+          unsigned int typeNormal = cfgModeK892orRho ? (trk1.sign() < 0 ? binAnti::kNormal : binAnti::kAnti) : binAnti::kNormal;
+          histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, lResonanceK1.Pt(), lResonanceK1.M());
+          histos.fill(HIST("k1invmass_Mix"), lResonanceK1.M());
         }
-      }
+      } // bTrack
     }
   }
 
@@ -517,25 +685,57 @@ struct k1analysis {
   }
   PROCESS_SWITCH(k1analysis, processMC, "Process Event for MC", false);
 
-  void processMCTrue(aod::ResoMCParents& resoParents)
+  void processMCTrue(ResoMCCols::iterator const& collision, aod::ResoMCParents& resoParents)
   {
-    for (auto& part : resoParents) {    // loop over all pre-filtered MC particles
-      if (abs(part.pdgCode()) != 10323) // K892(0)
+    auto multiplicity = collision.cent();
+    for (auto& part : resoParents) {      // loop over all pre-filtered MC particles
+      if (abs(part.pdgCode()) != kK1Plus) // K892(0)
         continue;
       if (abs(part.y()) > 0.5) { // rapidity cut
         continue;
       }
       bool pass1 = false;
       bool pass2 = false;
-      if (abs(part.daughterPDG1()) == 313 || abs(part.daughterPDG2()) == 313) { // At least one decay to Kaon
-        pass2 = true;
+      if (cfgModeK892orRho) {
+        if (abs(part.daughterPDG1()) == 313 || abs(part.daughterPDG2()) == 313) { // At least one decay to K892
+          pass2 = true;
+        }
+        if (abs(part.daughterPDG1()) == kPiPlus || abs(part.daughterPDG2()) == kPiPlus) { // At least one decay to Pion
+          pass1 = true;
+        }
+        if (!pass1 || !pass2) // If we have both decay products
+          continue;
+      } else {
+        if (abs(part.daughterPDG1()) == kPDGRho770 || abs(part.daughterPDG2()) == kPDGRho770) { // At least one decay to Rho
+          pass2 = true;
+        }
+        if (abs(part.daughterPDG1()) == kKPlus || abs(part.daughterPDG2()) == kKPlus) { // At least one decay to Kaon
+          pass1 = true;
+        }
+        if (!pass1 || !pass2) // If we have both decay products
+          continue;
       }
-      if (abs(part.daughterPDG1()) == kPiPlus || abs(part.daughterPDG2()) == kPiPlus) { // At least one decay to Pion
-        pass1 = true;
+      auto typeNormal = part.pdgCode() > 0 ? binAnti::kNormal : binAnti::kAnti;
+      if (collision.isVtxIn10()) // INEL10
+      {
+        auto typeK1 = part.pdgCode() > 0 ? binType::kK1P_GenINEL10 : binType::kK1N_GenINEL10;
+        histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, part.pt(), 1);
       }
-      if (!pass1 || !pass2) // If we have both decay products
-        continue;
-      histos.fill(HIST("hTrueK1pt"), part.pt());
+      if (collision.isVtxIn10() && collision.isInSel8()) // INEL>10, vtx10
+      {
+        auto typeK1 = part.pdgCode() > 0 ? binType::kK1P_GenINELgt10 : binType::kK1N_GenINELgt10;
+        histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, part.pt(), 1);
+      }
+      if (collision.isVtxIn10() && collision.isTriggerTVX()) // vtx10, TriggerTVX
+      {
+        auto typeK1 = part.pdgCode() > 0 ? binType::kK1P_GenTrig10 : binType::kK1N_GenTrig10;
+        histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, part.pt(), 1);
+      }
+      if (collision.isInAfterAllCuts()) // after all event selection
+      {
+        auto typeK1 = part.pdgCode() > 0 ? binType::kK1P_GenEvtSel : binType::kK1N_GenEvtSel;
+        histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, part.pt(), 1);
+      }
     }
   }
   PROCESS_SWITCH(k1analysis, processMCTrue, "Process Event for MC", false);

--- a/PWGLF/Tasks/Resonances/k1analysis.cxx
+++ b/PWGLF/Tasks/Resonances/k1analysis.cxx
@@ -659,8 +659,7 @@ struct k1analysis {
               histos.fill(HIST("k1invmass_MC_noK1"), lResonanceK1.M());
             }
           } // MC
-        } // No MIX
-        else { // Mixed event handling
+        } else { // Mixed event handling
           unsigned int typeK1 = bTrack.sign() > 0 ? binType::kK1P_Mix : binType::kK1N_Mix;
           unsigned int typeNormal = cfgModeK892orRho ? (trk1.sign() < 0 ? binAnti::kNormal : binAnti::kAnti) : binAnti::kNormal;
           histos.fill(HIST("hInvmass_K1"), typeNormal, typeK1, multiplicity, lResonanceK1.Pt(), lResonanceK1.M());


### PR DESCRIPTION
K1 analysis task: now it can use the configurable variable `cfgModeK892orRho` that can switch between two different decay mode: K892+pi or Rho770+K.