### PR TITLE
PWGHF: add converter for 3-prong ML table in D2H reduced data format

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -224,8 +224,8 @@ DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3pro
 DECLARE_SOA_TABLE(HfRed3ProngsMl_000, "AOD", "HFRED3PRONGML", //! Table with 3prong candidate ML scores
                   hf_charm_cand_reduced::MlScoreBkgMassHypo0,
                   hf_charm_cand_reduced::MlScorePromptMassHypo0,
-                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0
-                    o2::soa::Marker<1>);
+                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0,
+                  o2::soa::Marker<1>);
 
 DECLARE_SOA_TABLE_VERSIONED(HfRed3ProngsMl_001, "AOD", "HFRED3PRONGML", 1, //! Table with 3prong candidate ML scores (format for 2 mass hypotheses needed for Ds and Lc)
                             hf_charm_cand_reduced::MlScoreBkgMassHypo0,

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -221,14 +221,23 @@ DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3pro
                   HFTRACKPARCOV_COLUMNS,
                   o2::soa::Marker<2>);
 
-DECLARE_SOA_TABLE(HfRed3ProngsMl, "AOD", "HFRED3PRONGML", //! Table with 3prong candidate ML scores
+
+DECLARE_SOA_TABLE(HfRed3ProngsMl_000, "AOD", "HFRED3PRONGML", //! Table with 3prong candidate ML scores
                   hf_charm_cand_reduced::MlScoreBkgMassHypo0,
                   hf_charm_cand_reduced::MlScorePromptMassHypo0,
-                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0,
-                  hf_charm_cand_reduced::MlScoreBkgMassHypo1,
-                  hf_charm_cand_reduced::MlScorePromptMassHypo1,
-                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo1,
+                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0
                   o2::soa::Marker<1>);
+
+DECLARE_SOA_TABLE_VERSIONED(HfRed3ProngsMl_001, "AOD", "HFRED3PRONGML", 1, //! Table with 3prong candidate ML scores (format for 2 mass hypotheses needed for Ds and Lc)
+                            hf_charm_cand_reduced::MlScoreBkgMassHypo0,
+                            hf_charm_cand_reduced::MlScorePromptMassHypo0,
+                            hf_charm_cand_reduced::MlScoreNonpromptMassHypo0,
+                            hf_charm_cand_reduced::MlScoreBkgMassHypo1,
+                            hf_charm_cand_reduced::MlScorePromptMassHypo1,
+                            hf_charm_cand_reduced::MlScoreNonpromptMassHypo1,
+                            o2::soa::Marker<1>);
+
+using HfRed3ProngsMl = HfRed3ProngsMl_001;
 
 // Beauty candidates prongs
 namespace hf_cand_b0_reduced

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -224,8 +224,7 @@ DECLARE_SOA_TABLE(HfRed3ProngsCov, "AOD", "HFRED3PRONGSCOV", //! Table with 3pro
 DECLARE_SOA_TABLE(HfRed3ProngsMl_000, "AOD", "HFRED3PRONGML", //! Table with 3prong candidate ML scores
                   hf_charm_cand_reduced::MlScoreBkgMassHypo0,
                   hf_charm_cand_reduced::MlScorePromptMassHypo0,
-                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0,
-                  o2::soa::Marker<1>);
+                  hf_charm_cand_reduced::MlScoreNonpromptMassHypo0);
 
 DECLARE_SOA_TABLE_VERSIONED(HfRed3ProngsMl_001, "AOD", "HFRED3PRONGML", 1, //! Table with 3prong candidate ML scores (format for 2 mass hypotheses needed for Ds and Lc)
                             hf_charm_cand_reduced::MlScoreBkgMassHypo0,

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -50,3 +50,8 @@ o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
                     COMPONENT_NAME Analysis)
 
+# Converters
+o2physics_add_dpl_workflow(converter-reduced-3-prongs-ml
+                    SOURCES converterReduced3ProngsMl.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -51,6 +51,7 @@ o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
                     COMPONENT_NAME Analysis)
 
 # Converters
+
 o2physics_add_dpl_workflow(converter-reduced-3-prongs-ml
                     SOURCES converterReduced3ProngsMl.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -39,4 +39,3 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<ConverterReduced3ProngsMl>(cfgc),
   };
 }
- 

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -27,7 +27,7 @@ using namespace o2::framework;
 struct ConverterReduced3ProngsMl {
   Produces<aod::HfRed3ProngsMl_001> ml3Prongs;
 
-  void process(aod::HfRed3ProngsMl_000 const& mlScoreTable)
+  void process(aod::HfRed3ProngsMl_000::iterator const& mlScoreTable)
   {
     ml3Prongs(mlScoreTable.mlScoreBkgMassHypo0(), mlScoreTable.mlScorePromptMassHypo0(), mlScoreTable.mlScoreNonpromptMassHypo0(), -1.f, -1.f, -1.f);
   }

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -24,7 +24,7 @@ using namespace o2;
 using namespace o2::framework;
 
 // Swaps covariance matrix elements if the data is known to be bogus (collision_000 is bogus)
-struct ConverterReduced3ProngsMl {
+struct HfConverterReduced3ProngsMl {
   Produces<aod::HfRed3ProngsMl_001> ml3Prongs;
 
   void process(aod::HfRed3ProngsMl_000::iterator const& mlScoreTable)

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ConverterReduced3ProngsMl.cxx
+/// \brief Task for conversion of HfRed3ProngsMl to version 001
+///
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+#include "PWGHF/D2H/DataModel/ReducedDataModel.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Swaps covariance matrix elements if the data is known to be bogus (collision_000 is bogus)
+struct ConverterReduced3ProngsMl {
+  Produces<aod::HfRed3ProngsMl_001> ml3Prongs;
+
+  void process(aod::HfRed3ProngsMl_000 const& mlScoreTable)
+  {
+    ml3Prongs(mlScoreTable.mlScoreBkgMassHypo0(), mlScoreTable.mlScorePromptMassHypo0(), mlScoreTable.mlScoreNonpromptMassHypo0(), -1.f, -1.f, -1.f);
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<ConverterReduced3ProngsMl>(cfgc),
+  };
+}

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -36,6 +36,6 @@ struct ConverterReduced3ProngsMl {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ConverterReduced3ProngsMl>(cfgc),
+    adaptAnalysisTask<HfConverterReduced3ProngsMl>(cfgc),
   };
 }

--- a/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
+++ b/PWGHF/D2H/TableProducer/converterReduced3ProngsMl.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file ConverterReduced3ProngsMl.cxx
+/// \file converterReduced3ProngsMl.cxx
 /// \brief Task for conversion of HfRed3ProngsMl to version 001
 ///
 /// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN

--- a/PWGUD/Tasks/upcTauCentralBarrelRL.cxx
+++ b/PWGUD/Tasks/upcTauCentralBarrelRL.cxx
@@ -19,6 +19,7 @@
 // O2 headers
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/HistogramRegistry.h"
 #include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 
@@ -97,6 +98,30 @@ struct UpcTauCentralBarrelRL {
   Configurable<bool> doFourTrackPsi2S{"doFourTrackPsi2S", true, {"Define histos for Psi2S into four charged tracks (pi/mu) and allow to fill them"}};
   Configurable<bool> doSixTracks{"doSixTracks", false, {"Define histos for six tracks and allow to fill them"}};
 
+  ConfigurableAxis axisNtracks{"axisNtracks", {30, -0.5, 29.5}, "Number of tracks in collision"};
+  ConfigurableAxis axisZvtx{"axisZvtx", {40, -20., 20.}, "Z-vertex position (cm)"};
+  ConfigurableAxis axisInvMass{"axisInvMass", {400, 1., 5.}, "Invariant mass (GeV/c^{2})"};
+  ConfigurableAxis axisInvMassWide{"axisInvMassWide", {1000, 0., 10.}, "Invariant mass (GeV/c^{2}), wider range"};
+  ConfigurableAxis axisMom{"axisMom", {400, 0., 2.}, "Momentum (GeV/c)"};
+  ConfigurableAxis axisMomWide{"axisMomWide", {1000, 0., 10.}, "Momentum (GeV/c), wider range"};
+  ConfigurableAxis axisMomSigned{"axisMomSigned", {800, -2., 2.}, "Signed momentum (GeV/c)"};
+  ConfigurableAxis axisPt{"axisPt", {400, 0., 2.}, "Transversal momentum (GeV/c)"};
+  ConfigurableAxis axisPhi{"axisPhi", {64, -2 * o2::constants::math::PI, 2 * o2::constants::math::PI}, "Azimuthal angle (a.y.)"};
+  ConfigurableAxis axisModPhi{"axisModPhi", {400, 0., .4}, "Track fmod(#phi,#pi/9)"};
+  ConfigurableAxis axisEta{"axisEta", {50, -1.2, 1.2}, "Pseudorapidity (a.u.)"};
+  ConfigurableAxis axisRap{"axisRap", {50, -1.2, 1.2}, "Rapidity (a.u.)"};
+  ConfigurableAxis axisAcoplanarity{"axisAcoplanarity", {32, 0.0, o2::constants::math::PI}, "Acoplanarity (rad)"};
+  ConfigurableAxis axisTPCdEdx{"axisTPCdEdx", {2000, 0., 200.}, "TPC dE/dx (a.u.)"};
+  ConfigurableAxis axisTOFsignal{"axisTOFsignal", {2500, -10000., 40000.}, "TOF signal (a.u.)"};
+  ConfigurableAxis axisNsigma{"axisNsigma", {200, -10., 10.}, "n sigma"};
+  ConfigurableAxis axisDCA{"axisDCA", {100, -0.5, 0.5}, "DCA (cm)"};
+  ConfigurableAxis axisAvgITSclsSizes{"axisAvgITSclsSizes", {500, 0., 10.}, "ITS average cluster size"};
+  ConfigurableAxis axisITSnCls{"axisITSnCls", {8, -0.5, 7.5}, "ITS n clusters"};
+  ConfigurableAxis axisITSchi2{"axisITSchi2", {100, 0, 50}, "UTS chi2"};
+  ConfigurableAxis axisTPCnCls{"axisTPCnCls", {165, -0.5, 164.5}, "TPC n clusters"};
+  ConfigurableAxis axisTPCxRwsFrac{"axisTPCxRwsFrac", {200, 0.0, 2.0}, "TPC fraction of crossed raws"};
+  ConfigurableAxis axisTPCchi2{"axisTPCchi2", {100, 0, 10}, "TPC chi2"};
+
   using FullUDTracks = soa::Join<aod::UDTracks, aod::UDTracksExtra, aod::UDTracksDCA, aod::UDTracksPID, aod::UDTracksFlags>;
   using FullUDCollision = soa::Join<aod::UDCollisions, aod::UDCollisionsSels>::iterator;
   using FullSGUDCollision = soa::Join<aod::UDCollisions, aod::UDCollisionsSels, aod::SGCollisions, aod::UDZdcsReduced>::iterator;
@@ -113,30 +138,6 @@ struct UpcTauCentralBarrelRL {
       printLargeMessage("INIT METHOD");
     countCollisions = 0;
     isFirstReconstructedCollisions = true;
-
-    const AxisSpec axisNtracks{30, -0.5, 29.5};
-    const AxisSpec axisZvtx{40, -20., 20.};
-    const AxisSpec axisInvMass{400, 1., 5.};
-    const AxisSpec axisInvMassWide{1000, 0., 10.};
-    const AxisSpec axisMom{400, 0., 2.};
-    const AxisSpec axisMomSigned{800, -2., 2.};
-    const AxisSpec axisMomWide{1000, 0., 10.};
-    const AxisSpec axisPt{400, 0., 2.};
-    const AxisSpec axisPhi{64, -2 * o2::constants::math::PI, 2 * o2::constants::math::PI};
-    const AxisSpec axisModPhi{400, 0., .4};
-    const AxisSpec axisEta{50, -1.2, 1.2};
-    const AxisSpec axisRap{50, -1.2, 1.2};
-    const AxisSpec axisAcoplanarity{32, 0.0, o2::constants::math::PI};
-    const AxisSpec axisDCA{100, -0.5, 0.5};
-    const AxisSpec axisAvgITSclsSizes{500, 0., 10.};
-    const AxisSpec axisTPCdEdx{2000, 0., 200.};
-    const AxisSpec axisTOFsignal{2500, -10000., 40000.};
-    const AxisSpec axisNsigma{200, -10., 10.};
-    const AxisSpec axisITSnCls{8, -0.5, 7.5};
-    const AxisSpec axisITSchi2{100, 0, 50};
-    const AxisSpec axisTPCnCls{165, -0.5, 164.5};
-    const AxisSpec axisTPCxRwsFrac{200, 0.0, 2.0};
-    const AxisSpec axisTPCchi2{100, 0, 10};
 
     histos.add("Events/hCountCollisions", ";;Number of  analysed collision (-)", HistType::kTH1D, {{1, 0.5, 1.5}});
     histos.add("Events/UDtableGapSide", ";GapSide value from UD table (-);Number of events (-)", HistType::kTH1D, {{4, -1.5, 2.5}});


### PR DESCRIPTION
Hi @fcatalan92 yesterday when I asked you to update the data model for the ML scores of the Ds in the Bs decay, I overlooked that it was also used by @Luca610 in the Ds reso code, for which we have derived data produced. So I developed a simple converter for the table, such that we do not have to reproduce the derived data for the Ds resonances.