### PR TITLE
Common: move mult/cent table producers to getForRun CCDB queries

### DIFF
--- a/Common/TableProducer/centralityTable.cxx
+++ b/Common/TableProducer/centralityTable.cxx
@@ -249,6 +249,7 @@ struct CentralityTable {
     /* check the previous run number */
     auto bc = collision.bc_as<BCsWithTimestampsAndRun2Infos>();
     if (bc.runNumber() != mRunNumber) {
+      mRunNumber = bc.runNumber(); // mark that this run has been attempted already regardless of outcome
       LOGF(debug, "timestamp=%llu", bc.timestamp());
       TList* callst = nullptr;
       if (ccdbConfig.reconstructionPass.value == "") {
@@ -256,10 +257,12 @@ struct CentralityTable {
       } else if (ccdbConfig.reconstructionPass.value == "metadata") {
         std::map<std::string, std::string> metadata;
         metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
+        LOGF(info, "Loading CCDB for reconstruction pass (from metadata): %s", metadataInfo.get("RecoPassName"));
         callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
       } else {
         std::map<std::string, std::string> metadata;
         metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
+        LOGF(info, "Loading CCDB for reconstruction pass (from provided argument): %s", ccdbConfig.reconstructionPass.value);
         callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
       }
 
@@ -350,15 +353,11 @@ struct CentralityTable {
             LOGF(fatal, "Calibration information from CL1 multiplicity for run %d corrupted", bc.runNumber());
           }
         }
-        if (Run2V0MInfo.mCalibrationStored || Run2V0AInfo.mCalibrationStored || Run2SPDTksInfo.mCalibrationStored || Run2SPDClsInfo.mCalibrationStored || Run2CL0Info.mCalibrationStored || Run2CL1Info.mCalibrationStored) {
-          mRunNumber = bc.runNumber();
-        }
       } else {
         if (!ccdbConfig.doNotCrashOnNull) { // default behaviour: crash
           LOGF(fatal, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
         } else { // only if asked: continue filling with non-valid values (105)
           LOGF(info, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu, will fill tables with dummy values", bc.runNumber(), bc.timestamp());
-          mRunNumber = bc.runNumber();
         }
       }
     }
@@ -473,6 +472,7 @@ struct CentralityTable {
       /* check the previous run number */
       auto bc = collision.template bc_as<BCsWithTimestamps>();
       if (bc.runNumber() != mRunNumber) {
+        mRunNumber = bc.runNumber(); // mark that this run has been attempted already regardless of outcome
         LOGF(info, "timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
         TList* callst = nullptr;
         // Check if the ccdb path is a root file
@@ -489,10 +489,12 @@ struct CentralityTable {
           } else if (ccdbConfig.reconstructionPass.value == "metadata") {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
+            LOGF(info, "Loading CCDB for reconstruction pass (from metadata): %s", metadataInfo.get("RecoPassName"));
             callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
           } else {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
+            LOGF(info, "Loading CCDB for reconstruction pass (from provided argument): %s", ccdbConfig.reconstructionPass.value);
             callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
           }
         }
@@ -555,13 +557,11 @@ struct CentralityTable {
                 break;
             }
           }
-          mRunNumber = bc.runNumber();
         } else {
           if (!ccdbConfig.doNotCrashOnNull) { // default behaviour: crash
             LOGF(fatal, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
           } else { // only if asked: continue filling with non-valid values (105)
             LOGF(info, "Centrality calibration is not available in CCDB for run=%d at timestamp=%llu, will fill tables with dummy values", bc.runNumber(), bc.timestamp());
-            mRunNumber = bc.runNumber();
           }
         }
       }

--- a/Common/TableProducer/centralityTable.cxx
+++ b/Common/TableProducer/centralityTable.cxx
@@ -252,15 +252,15 @@ struct CentralityTable {
       LOGF(debug, "timestamp=%llu", bc.timestamp());
       TList* callst = nullptr;
       if (ccdbConfig.reconstructionPass.value == "") {
-        callst = ccdb->getForTimeStamp<TList>(ccdbConfig.ccdbPath, bc.timestamp());
+        callst = ccdb->getForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber());
       } else if (ccdbConfig.reconstructionPass.value == "metadata") {
         std::map<std::string, std::string> metadata;
         metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
-        callst = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+        callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
       } else {
         std::map<std::string, std::string> metadata;
         metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
-        callst = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+        callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
       }
 
       Run2V0MInfo.mCalibrationStored = false;
@@ -485,15 +485,15 @@ struct CentralityTable {
           }
         } else {
           if (ccdbConfig.reconstructionPass.value == "") {
-            callst = ccdb->getForTimeStamp<TList>(ccdbConfig.ccdbPath, bc.timestamp());
+            callst = ccdb->getForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber());
           } else if (ccdbConfig.reconstructionPass.value == "metadata") {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
-            callst = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+            callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
           } else {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
-            callst = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+            callst = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, bc.runNumber(), metadata);
           }
         }
 

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -379,15 +379,15 @@ struct MultiplicityTable {
         if (bc.runNumber() != mRunNumber) {
           mRunNumber = bc.runNumber(); // mark this run as at least tried
           if (ccdbConfig.reconstructionPass.value == "") {
-            lCalibObjects = ccdb->getForTimeStamp<TList>(ccdbConfig.ccdbPath, bc.timestamp());
+            lCalibObjects = ccdb->getForRun<TList>(ccdbConfig.ccdbPath, mRunNumber);
           } else if (ccdbConfig.reconstructionPass.value == "metadata") {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
-            lCalibObjects = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+            lCalibObjects = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, mRunNumber, metadata);
           } else {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
-            lCalibObjects = ccdb->getSpecific<TList>(ccdbConfig.ccdbPath, bc.timestamp(), metadata);
+            lCalibObjects = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, mRunNumber, metadata);
           }
 
           if (lCalibObjects) {

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -383,10 +383,12 @@ struct MultiplicityTable {
           } else if (ccdbConfig.reconstructionPass.value == "metadata") {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = metadataInfo.get("RecoPassName");
+            LOGF(info, "Loading CCDB for reconstruction pass (from metadata): %s", metadataInfo.get("RecoPassName"));
             lCalibObjects = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, mRunNumber, metadata);
           } else {
             std::map<std::string, std::string> metadata;
             metadata["RecoPassName"] = ccdbConfig.reconstructionPass.value;
+            LOGF(info, "Loading CCDB for reconstruction pass (from provided argument): %s", ccdbConfig.reconstructionPass.value);
             lCalibObjects = ccdb->getSpecificForRun<TList>(ccdbConfig.ccdbPath, mRunNumber, metadata);
           }
 


### PR DESCRIPTION
* changes CCDB queries in mult and cent tasks to `getForRun` (without metadata) and `getSpecificForRun` (with metadata information) 
* Adds a healthy printout explaining which object is being loaded in case of metadata use with reconstruction pass
* Rearranges the `mRunNumber = bc.runNumber();` call such that operation without crash over uncalibrated data doesn't result in unnecessary CCDB queries: attempt CCDB load only once when run number changes and switch run number regardless of outcome. 