### PR TITLE
GH Actions: Bypass PEP 668 in runners

### DIFF
--- a/.github/workflows/codeowner-self-approval.yml
+++ b/.github/workflows/codeowner-self-approval.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: pip install codeowners PyGithub
+        run: pip install --break-system-packages codeowners PyGithub
 
       # Approve the PR, if the author is only editing files owned by themselves.
       - name: Auto-approve PR if permitted


### PR DESCRIPTION
This is needed in order to install pip packages globally in the new Ubuntu images, the other choice would be to create a venv and install the deps there instead

https://peps.python.org/pep-0668/

https://mattermost.web.cern.ch/alice/pl/f75f33zosf8rbd9dnagywfinac

CC: @mpuccio @vkucera @ktf 
