### PR TITLE
PWGHF: Developement of D Resonances MC analysis

### DIFF
--- a/PWGHF/D2H/Core/SelectorCutsRedDataFormat.h
+++ b/PWGHF/D2H/Core/SelectorCutsRedDataFormat.h
@@ -24,69 +24,68 @@
 
 namespace o2::analysis
 {
-  namespace hf_cuts_d_daughter
-  {
-  static constexpr int nBinsPt = 7;
-  static constexpr int nCutVars = 6;
-  constexpr double binsPt[nBinsPt + 1] = {
-    1.,
-    2.,
-    4.,
-    6.,
-    8.,
-    12.,
-    24.,
-    1000.};
-  auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
-  // default values for the cuts
-  constexpr double cuts[nBinsPt][nCutVars] = {{1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 1   < pt < 2 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 2 < pt < 4 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 4   < pt < 6 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 6 < pt < 8 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 8 < pt < 12 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 12   < pt < 24 */
-                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96}}; /* 24   < pt < 1000 */
-  // row labels
-  static const std::vector<std::string> labelsPt{
-    "pT bin 0",
+namespace hf_cuts_d_daughter
+{
+static constexpr int nBinsPt = 7;
+static constexpr int nCutVars = 6;
+constexpr double binsPt[nBinsPt + 1] = {
+  1.,
+  2.,
+  4.,
+  6.,
+  8.,
+  12.,
+  24.,
+  1000.};
+auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
+// default values for the cuts
+constexpr double cuts[nBinsPt][nCutVars] = {{1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 1   < pt < 2 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 2 < pt < 4 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 4   < pt < 6 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 6 < pt < 8 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 8 < pt < 12 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 12   < pt < 24 */
+                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96}}; /* 24   < pt < 1000 */
+// row labels
+static const std::vector<std::string> labelsPt{
+  "pT bin 0",
   "pT bin 1",
   "pT bin 2",
   "pT bin 3",
   "pT bin 4",
   "pT bin 5",
-  "pT bin 6"
-  };
-  // column labels
-  static const std::vector<std::string> labelsCutVar = {"invMassSignalLow", "invMassSignalHigh", "invMassLeftSBLow", "invMassLeftSBHigh", "invMassRightSBLow", "invMassRightSBHigh"};
-  } // namespace hf_cuts_d_daughter
+  "pT bin 6"};
+// column labels
+static const std::vector<std::string> labelsCutVar = {"invMassSignalLow", "invMassSignalHigh", "invMassLeftSBLow", "invMassLeftSBHigh", "invMassRightSBLow", "invMassRightSBHigh"};
+} // namespace hf_cuts_d_daughter
 
-  // namespace with v0 selections for reduced charmed-resonances analysis
-  namespace hf_cuts_v0_daughter
-  {
-  static constexpr int nBinsPt = 7;
-  static constexpr int nCutVars = 5;
-  constexpr double binsPt[nBinsPt + 1] = {
-    0.,
-    1.,
-    2.,
-    4.,
-    8.,
-    12.,
-    24.,
-    1000.};
-  auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
-  // default values for the cuts
-  constexpr double cuts[nBinsPt][nCutVars] = {{0.48, 0.52, 0.99, 1., 0.9},  /* 1   < pt < 2 */
-                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 2 < pt < 4 */
-                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 4   < pt < 6 */
-                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 6 < pt < 8 */
-                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 8 < pt < 12 */
-                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 12   < pt < 24 */
-                                              {0.48, 0.52, 0.99, 1., 0.9}}; /* 24   < pt < 1000 */
-  // row labels
-  static const std::vector<std::string> labelsPt{};
-  // column labels
-  static const std::vector<std::string> labelsCutVar = {"invMassLow", "invMassHigh", "cpaMin", "dcaMax", "radiusMin"};
-  } // namespace hf_cuts_v0_daughter
-} // namespace o2_analysis
+// namespace with v0 selections for reduced charmed-resonances analysis
+namespace hf_cuts_v0_daughter
+{
+static constexpr int nBinsPt = 7;
+static constexpr int nCutVars = 5;
+constexpr double binsPt[nBinsPt + 1] = {
+  0.,
+  1.,
+  2.,
+  4.,
+  8.,
+  12.,
+  24.,
+  1000.};
+auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
+// default values for the cuts
+constexpr double cuts[nBinsPt][nCutVars] = {{0.48, 0.52, 0.99, 1., 0.9},  /* 1   < pt < 2 */
+                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 2 < pt < 4 */
+                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 4   < pt < 6 */
+                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 6 < pt < 8 */
+                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 8 < pt < 12 */
+                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 12   < pt < 24 */
+                                            {0.48, 0.52, 0.99, 1., 0.9}}; /* 24   < pt < 1000 */
+// row labels
+static const std::vector<std::string> labelsPt{};
+// column labels
+static const std::vector<std::string> labelsCutVar = {"invMassLow", "invMassHigh", "cpaMin", "dcaMax", "radiusMin"};
+} // namespace hf_cuts_v0_daughter
+} // namespace o2::analysis
 #endif // PWGHF_D2H_CORE_SELECTORCUTSREDDATAFORMAT_H_

--- a/PWGHF/D2H/Core/SelectorCutsRedDataFormat.h
+++ b/PWGHF/D2H/Core/SelectorCutsRedDataFormat.h
@@ -22,60 +22,71 @@
 #include <string> // std::string
 #include <vector> // std::vector
 
-namespace hf_cuts_d_daughter
+namespace o2::analysis
 {
-const int nBinsPt = 7;
-static constexpr int nCutVars = 6;
-constexpr double binsPt[nBinsPt + 1] = {
-  1.,
-  2.,
-  4.,
-  6.,
-  8.,
-  12.,
-  24.,
-  1000.};
-auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
-// default values for the cuts
-constexpr double cuts[nBinsPt][nCutVars] = {{1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 1   < pt < 2 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 2 < pt < 4 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 4   < pt < 6 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 6 < pt < 8 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 8 < pt < 12 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 12   < pt < 24 */
-                                            {1.84, 1.89, 1.77, 1.81, 1.92, 1.96}}; /* 24   < pt < 1000 */
-// row labels
-static const std::vector<std::string> labelsPt{};
-// column labels
-static const std::vector<std::string> labelsCutVar = {"invMassSignalLow", "invMassSignalHigh", "invMassLeftSBLow", "invMassLeftSBHigh", "invMassRightSBLow", "invMassRightSBHigh"};
-} // namespace hf_cuts_d_daughter
+  namespace hf_cuts_d_daughter
+  {
+  static constexpr int nBinsPt = 7;
+  static constexpr int nCutVars = 6;
+  constexpr double binsPt[nBinsPt + 1] = {
+    1.,
+    2.,
+    4.,
+    6.,
+    8.,
+    12.,
+    24.,
+    1000.};
+  auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
+  // default values for the cuts
+  constexpr double cuts[nBinsPt][nCutVars] = {{1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 1   < pt < 2 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 2 < pt < 4 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 4   < pt < 6 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 6 < pt < 8 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 8 < pt < 12 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96},  /* 12   < pt < 24 */
+                                              {1.84, 1.89, 1.77, 1.81, 1.92, 1.96}}; /* 24   < pt < 1000 */
+  // row labels
+  static const std::vector<std::string> labelsPt{
+    "pT bin 0",
+  "pT bin 1",
+  "pT bin 2",
+  "pT bin 3",
+  "pT bin 4",
+  "pT bin 5",
+  "pT bin 6"
+  };
+  // column labels
+  static const std::vector<std::string> labelsCutVar = {"invMassSignalLow", "invMassSignalHigh", "invMassLeftSBLow", "invMassLeftSBHigh", "invMassRightSBLow", "invMassRightSBHigh"};
+  } // namespace hf_cuts_d_daughter
 
-// namespace with v0 selections for reduced charmed-resonances analysis
-namespace hf_cuts_v0_daughter
-{
-const int nBinsPt = 7;
-static constexpr int nCutVars = 5;
-constexpr double binsPt[nBinsPt + 1] = {
-  0.,
-  1.,
-  2.,
-  4.,
-  8.,
-  12.,
-  24.,
-  1000.};
-auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
-// default values for the cuts
-constexpr double cuts[nBinsPt][nCutVars] = {{0.48, 0.52, 0.99, 1., 0.9},  /* 1   < pt < 2 */
-                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 2 < pt < 4 */
-                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 4   < pt < 6 */
-                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 6 < pt < 8 */
-                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 8 < pt < 12 */
-                                            {0.48, 0.52, 0.99, 1., 0.9},  /* 12   < pt < 24 */
-                                            {0.48, 0.52, 0.99, 1., 0.9}}; /* 24   < pt < 1000 */
-// row labels
-static const std::vector<std::string> labelsPt{};
-// column labels
-static const std::vector<std::string> labelsCutVar = {"invMassLow", "invMassHigh", "cpaMin", "dcaMax", "radiusMin"};
-} // namespace hf_cuts_v0_daughter
+  // namespace with v0 selections for reduced charmed-resonances analysis
+  namespace hf_cuts_v0_daughter
+  {
+  static constexpr int nBinsPt = 7;
+  static constexpr int nCutVars = 5;
+  constexpr double binsPt[nBinsPt + 1] = {
+    0.,
+    1.,
+    2.,
+    4.,
+    8.,
+    12.,
+    24.,
+    1000.};
+  auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
+  // default values for the cuts
+  constexpr double cuts[nBinsPt][nCutVars] = {{0.48, 0.52, 0.99, 1., 0.9},  /* 1   < pt < 2 */
+                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 2 < pt < 4 */
+                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 4   < pt < 6 */
+                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 6 < pt < 8 */
+                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 8 < pt < 12 */
+                                              {0.48, 0.52, 0.99, 1., 0.9},  /* 12   < pt < 24 */
+                                              {0.48, 0.52, 0.99, 1., 0.9}}; /* 24   < pt < 1000 */
+  // row labels
+  static const std::vector<std::string> labelsPt{};
+  // column labels
+  static const std::vector<std::string> labelsCutVar = {"invMassLow", "invMassHigh", "cpaMin", "dcaMax", "radiusMin"};
+  } // namespace hf_cuts_v0_daughter
+} // namespace o2_analysis
 #endif // PWGHF_D2H_CORE_SELECTORCUTSREDDATAFORMAT_H_

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -688,7 +688,7 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedVzeros, "_1");    //! Pr
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);               // flag for decay channel classification reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);               // flag for decay channel classification generator level
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                       // debug flag for mis-association at reconstruction level
-DECLARE_SOA_COLUMN(Origin, origin, int8_t);                          // Flag for origin of MC particle 1=promt, 2=FD 
+DECLARE_SOA_COLUMN(Origin, origin, int8_t);                               // Flag for origin of MC particle 1=promt, 2=FD
 
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //!
                            [](float pxProng0, float pxProng1, float pyProng0, float pyProng1) -> float { return RecoDecay::pt((1.f * pxProng0 + 1.f * pxProng1), (1.f * pyProng0 + 1.f * pyProng1)); });

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -687,7 +687,8 @@ DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3PrNoTrks, "_0"); //! Pr
 DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedVzeros, "_1");    //! Prong1 index (V0 daughter)
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);               // flag for decay channel classification reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t);               // flag for decay channel classification generator level
-DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                       // debug flag for mis-association reconstruction level
+DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                       // debug flag for mis-association at reconstruction level
+DECLARE_SOA_COLUMN(Origin, origin, int8_t);                          // Flag for origin of MC particle 1=promt, 2=FD 
 
 DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //!
                            [](float pxProng0, float pxProng1, float pyProng0, float pyProng1) -> float { return RecoDecay::pt((1.f * pxProng0 + 1.f * pxProng1), (1.f * pyProng0 + 1.f * pyProng1)); });
@@ -741,11 +742,13 @@ DECLARE_SOA_TABLE(HfMcRecRedDV0s, "AOD", "HFMCRECREDDV0", //! Table with reconst
                   hf_reso_cand_reduced::Prong1Id,
                   hf_reso_cand_reduced::FlagMcMatchRec,
                   hf_reso_cand_reduced::DebugMcRec,
+                  hf_reso_cand_reduced::Origin,
                   hf_b0_mc::PtMother,
                   o2::soa::Marker<1>);
 
-DECLARE_SOA_TABLE(HfMcGenRedResos, "AOD", "HFMCGENREDRESO", //! Generation-level MC information on B0 candidates for reduced workflow
+DECLARE_SOA_TABLE(HfMcGenRedResos, "AOD", "HFMCGENREDRESO", //! Generation-level MC information on Ds-Resonances candidates for reduced workflow
                   hf_cand_b0::FlagMcMatchGen,
+                  hf_reso_cand_reduced::Origin,
                   hf_b0_mc::PtTrack,
                   hf_b0_mc::YTrack,
                   hf_b0_mc::EtaTrack,
@@ -765,6 +768,14 @@ DECLARE_SOA_TABLE(HfCandChaResTr, "AOD", "HFCANDCHARESTR", //! Table with Resona
                   hf_reso_cand_reduced::InvMassProng0,
                   // Dynamic
                   hf_reso_cand_reduced::PtProng0<hf_cand::PxProng0, hf_cand::PyProng0>);
+
+// Table with same size as HfCandCharmReso
+DECLARE_SOA_TABLE(HfMcRecRedResos, "AOD", "HFMCRECREDRESO", //! Reconstruction-level MC information on Ds-Resonances candidates for reduced workflow
+                  hf_reso_cand_reduced::FlagMcMatchRec,
+                  hf_reso_cand_reduced::DebugMcRec,
+                  hf_reso_cand_reduced::Origin,
+                  hf_b0_mc::PtMother,
+                  o2::soa::Marker<1>);
 } // namespace aod
 
 namespace soa

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -50,15 +50,15 @@ o2physics_add_dpl_workflow(candidate-selector-bs-to-ds-pi-reduced
 
 # Data creators
 
-o2physics_add_dpl_workflow(data-creator-charm-had-pi-reduced
-                    SOURCES dataCreatorCharmHadPiReduced.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter O2Physics::EventFilteringUtils
-                    COMPONENT_NAME Analysis)
+# o2physics_add_dpl_workflow(data-creator-charm-had-pi-reduced
+#                     SOURCES dataCreatorCharmHadPiReduced.cxx
+#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter O2Physics::EventFilteringUtils
+#                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
-                    SOURCES dataCreatorCharmResoReduced.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
-                    COMPONENT_NAME Analysis)
+# o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
+#                     SOURCES dataCreatorCharmResoReduced.cxx
+#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
+#                     COMPONENT_NAME Analysis)
 
 # Converters
 

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -50,15 +50,15 @@ o2physics_add_dpl_workflow(candidate-selector-bs-to-ds-pi-reduced
 
 # Data creators
 
-# o2physics_add_dpl_workflow(data-creator-charm-had-pi-reduced
-#                     SOURCES dataCreatorCharmHadPiReduced.cxx
-#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter O2Physics::EventFilteringUtils
-#                     COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(data-creator-charm-had-pi-reduced
+                    SOURCES dataCreatorCharmHadPiReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter O2Physics::EventFilteringUtils
+                    COMPONENT_NAME Analysis)
 
-# o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
-#                     SOURCES dataCreatorCharmResoReduced.cxx
-#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
-#                     COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
+                    SOURCES dataCreatorCharmResoReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
+                    COMPONENT_NAME Analysis)
 
 # Converters
 

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -495,7 +495,7 @@ struct HfCandidateCreatorCharmResoReducedExpressions {
   {
     const AxisSpec axisPt{(std::vector<double>)vecBinsPt, "#it{p}_{T} (GeV/#it{c})"};
     registry.add("hMassMcMatched", "Reso MC candidates Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
-    registry.add("hMassMcMatchedIncomplete", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{400, 2.3, 2.7}, {axisPt}}});
+    registry.add("hMassMcMatchedIncomplete", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
     registry.add("hMassMcUnmatched", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
     registry.add("hMassMcNoEntry", "Reso MC candidates w.o. entry in MC Reco table;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
   }

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -91,7 +91,7 @@ struct HfCandidateCreatorCharmResoReduced {
   Configurable<LabeledArray<double>> cutsD{"cutsDdaughter", {hf_cuts_d_daughter::cuts[0], hf_cuts_d_daughter::nBinsPt, hf_cuts_d_daughter::nCutVars, hf_cuts_d_daughter::labelsPt, hf_cuts_d_daughter::labelsCutVar}, "D daughter selections"};
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{hf_cuts_d_daughter::vecBinsPt}, "pT bin limits for D daughter cuts"};
   Configurable<LabeledArray<double>> cutsV0{"cutsV0daughter", {hf_cuts_v0_daughter::cuts[0], hf_cuts_v0_daughter::nBinsPt, hf_cuts_v0_daughter::nCutVars, hf_cuts_v0_daughter::labelsPt, hf_cuts_v0_daughter::labelsCutVar}, "V0 daughter selections"};
-  
+
   Configurable<std::vector<double>> binsPtV0{"binsPtV0", std::vector<double>{hf_cuts_v0_daughter::vecBinsPt}, "pT bin limits for V0 daughter cuts"};
 
   using reducedDWithMl = soa::Join<aod::HfRed3PrNoTrks, aod::HfRed3ProngsMl>;
@@ -485,7 +485,7 @@ struct HfCandidateCreatorCharmResoReduced {
 
 }; // struct HfCandidateCreatorCharmResoReduced
 
-struct HfCandidateCreatorCharmResoReducedExpressions{
+struct HfCandidateCreatorCharmResoReducedExpressions {
 
   Produces<aod::HfMcRecRedResos> rowResoMcRec;
 
@@ -499,7 +499,7 @@ struct HfCandidateCreatorCharmResoReducedExpressions{
     registry.add("hMassMcUnmatched", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
     registry.add("hMassMcNoEntry", "Reso MC candidates w.o. entry in MC Reco table;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
   }
-  
+
   /// Fill candidate information at MC reconstruction level
   /// \param rowsDV0McRec MC reco information on DPi pairs
   /// \param candsReso prong global indices of B0 candidates
@@ -512,9 +512,9 @@ struct HfCandidateCreatorCharmResoReducedExpressions{
         if ((rowDV0McRec.prong0Id() != candReso.prong0Id()) || (rowDV0McRec.prong1Id() != candReso.prong1Id())) {
           continue;
         }
-        rowResoMcRec(rowDV0McRec.flagMcMatchRec(),  rowDV0McRec.debugMcRec(), rowDV0McRec.origin(), rowDV0McRec.ptMother());
+        rowResoMcRec(rowDV0McRec.flagMcMatchRec(), rowDV0McRec.debugMcRec(), rowDV0McRec.origin(), rowDV0McRec.ptMother());
         filledMcInfo = true;
-        if (TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToD0PiK0s) || TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds2StarToDplusK0sToPiKaPiPiPi) ){
+        if (TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToD0PiK0s) || TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds2StarToDplusK0sToPiKaPiPiPi)) {
           registry.fill(HIST("hMassMcMatched"), candReso.invMass(), candReso.pt());
         } else if (TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToDPlusGammaK0s) || TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s)) {
           registry.fill(HIST("hMassMcMatchedIncomplete"), candReso.invMass(), candReso.pt());
@@ -536,7 +536,6 @@ struct HfCandidateCreatorCharmResoReducedExpressions{
     fillResoMcRec(rowsDV0McRec, candsReso);
   }
   PROCESS_SWITCH(HfCandidateCreatorCharmResoReducedExpressions, processMc, "Process MC", false);
-
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -77,7 +77,7 @@ enum DecayTypeMc : uint8_t {
   Ds1ToDStarK0ToD0PiK0s = 0,
   Ds2StarToDplusK0s,
   Ds1ToDStarK0ToDPlusPi0K0s,
-  Ds1ToDStarK0ToDPlusGammaK0s
+  Ds1ToDStarK0ToD0PiK0sPart
 };
 
 /// Creation of D-V0 pairs
@@ -231,12 +231,13 @@ struct HfDataCreatorCharmResoReduced {
     registry.add("hMassDstarProton", "D^{*}-proton candidates;m_{D^{*}p} - m_{D^{*}} (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.9, 1.4}}});
     registry.add("hDType", "D selection flag", {HistType::kTH1F, {{5, -2.5, 2.5}}});
 
-    registry.add("hMCRecCounter", "Number of Reconstructed MC Matched candidates per channel", {HistType::kTH1F, {{11, -5.5, 5.5}}});
+    registry.add("hMCRecCounter", "Number of Reconstructed MC Matched candidates per channel", {HistType::kTH1F, {{17, -8.5, 8.5}}});
     registry.add("hMCRecDebug", "Debug of MC Reco", {HistType::kTH1F, {{5, -0.5, 4.5}}});
+    registry.add("hMCRecOrigin", "Origin of Matched particles", {HistType::kTH1F, {{3, -0.5, 2.5}}});
 
-    registry.add("hMCGenCounter", "Number of Generated particles; Decay Channel Flag; pT [GeV/c]", {HistType::kTH2F, {{11, -5.5, 5.5}, {100, 0, 50}}});
+    registry.add("hMCGenCounter", "Number of Generated particles; Decay Channel Flag; pT [GeV/c]", {HistType::kTH2F, {{17, -8.5, 8.5}, {100, 0, 50}}});
     registry.add("hMCSignCounter", "Sign of Generated particles", {HistType::kTH1F, {{3, -1.5, 1.5}}});
-    registry.add("hMCOriginCounter", "Origin of Generated particles", {HistType::kTH1F, {{3, -0.5, 2.5}}});
+    registry.add("hMCGenOrigin", "Origin of Generated particles", {HistType::kTH1F, {{3, -0.5, 2.5}}});
     registry.add("hMCOriginCounterWrongDecay", "Origin of Generated particles in Wrong decay", {HistType::kTH1F, {{3, -0.5, 2.5}}});
 
     // Configure CCDB access
@@ -501,31 +502,33 @@ struct HfDataCreatorCharmResoReduced {
     int8_t signV0{0};
     int8_t flag{0};
     int8_t debug{0};
+    int8_t origin{0};
+    std::vector<int> idxBhadMothers{};
     float motherPt{-1.f};
     bool fillHisto{false};
 
     if constexpr (decChannel == DecayChannel::DstarV0) {
       // Ds1 → D* K0 → (D0 π+) K0s → ((K-π+) π+)(π+π-)
-      auto indexRec = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS1, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
-      if (indexRec > -1) {
+      auto indexRecReso = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS1, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
+      if (indexRecReso > -1) {
         // D* → π- K+ π-
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2);
+        auto indexRecDstar = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2);
         auto indexRecD0 = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1]}, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &signD0, 1);
         auto indexRecK0 = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[3], vecDaughtersReso[4]}, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2);
-        if (indexRec > -1 && indexRecD0 > -1 && indexRecK0 > -1) {
+        if (indexRecDstar > -1 && indexRecD0 > -1 && indexRecK0 > -1) {
           flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0s);
         } else {
-          if (indexRec <= -1) {
+          if (indexRecDstar <= -1) {
             debug = 1;
-            LOGF(debug, "DS1 decays in the expected final state but Dstar does not!");
+            LOGF(info, "DS1 decays in the expected final state but Dstar does not!");
           }
-          if (indexRec > -1 && indexRecD0 <= -1) {
+          if (indexRecDstar > -1 && indexRecD0 <= -1) {
             debug = 2;
-            LOGF(debug, "DS1 and Dstar decays in the expected final state but D0 does not!");
+            LOGF(info, "DS1 and Dstar decays in the expected final state but D0 does not!");
           }
-          if (indexRec > -1 && indexRecK0 <= -1) {
+          if (indexRecDstar > -1 && indexRecK0 <= -1) {
             debug = 3;
-            LOGF(debug, "DS1 and Dstar decays in the expected final state but K0 does not!");
+            LOGF(info, "DS1 and Dstar decays in the expected final state but K0 does not!");
           }
         }
         auto indexMother = RecoDecay::getMother(particlesMc, vecDaughtersReso.back().template mcParticle_as<PParticles>(), Pdg::kDS1, true);
@@ -534,24 +537,44 @@ struct HfDataCreatorCharmResoReduced {
           motherPt = particleMother.pt();
         }
         fillHisto = true;
+      } else { // Verify partly reconstructed decay Ds1 -> D* K0s -> D+  π0 K0s
+        indexRecReso = RecoDecay::getMatchedMCRec<false, true, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS1, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
+        if (indexRecReso > -1) {
+          auto indexRecDstar = RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2);
+          auto indexRecK0 = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[3], vecDaughtersReso[4]}, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2);
+          if (indexRecDstar > -1 && indexRecK0 > -1) {
+            if ( RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2) > -1){
+              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
+              fillHisto = true;
+            } else if ( RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1]}, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &signD0, 2) > -1){
+              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart);
+              fillHisto = true;
+            } 
+            
+          }
+        }
+      }
+      if (flag != 0) {
+        auto particleReso = particlesMc.iteratorAt(indexRecReso);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMc, particleReso, false, &idxBhadMothers);
       }
     } else if constexpr (decChannel == DecayChannel::DplusV0) {
       // Ds2Star → D+ K0 → (π+K-π+) K0s → (π+K-π+)(π+π-)
-      auto indexRec = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS2Star, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
-      if (indexRec > -1) {
+      auto indexRecReso = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS2Star, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
+      if (indexRecReso > -1) {
         // D+ → π+ K- π+
-        indexRec = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2);
+        auto indexRecDplus = RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2);
         auto indexRecK0 = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[3], vecDaughtersReso[4]}, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2);
-        if (indexRec > -1 && indexRecK0 > -1) {
+        if (indexRecDplus > -1 && indexRecK0 > -1) {
           flag = sign * BIT(DecayTypeMc::Ds2StarToDplusK0s);
         } else {
-          if (indexRec <= -1) {
+          if (indexRecDplus <= -1) {
             debug = 1;
-            LOGF(debug, "DS2Star decays in the expected final state but DPlus does not!");
+            LOGF(info, "DS2Star decays in the expected final state but DPlus does not!");
           }
-          if (indexRec > -1 && indexRecK0 <= -1) {
+          if (indexRecDplus > -1 && indexRecK0 <= -1) {
             debug = 3;
-            LOGF(debug, "DS2Star and DPlus decays in the expected final state but K0 does not!");
+            LOGF(info, "DS2Star and DPlus decays in the expected final state but K0 does not!");
           }
         }
         auto indexMother = RecoDecay::getMother(particlesMc, vecDaughtersReso.back().template mcParticle_as<PParticles>(), Pdg::kDS2Star, true);
@@ -561,8 +584,8 @@ struct HfDataCreatorCharmResoReduced {
         }
         fillHisto = true;
       } else { // Verify partly reconstructed decay Ds1 -> D* K0s -> D+  π0 K0s
-        indexRec = RecoDecay::getMatchedMCRec<false, true, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS1, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
-        if (indexRec > -1) {
+        indexRecReso = RecoDecay::getMatchedMCRec<false, true, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]}, Pdg::kDS1, std::array{+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
+        if (indexRecReso > -1) {
           auto indexRecDstar = RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2);
           auto indexRecK0 = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[3], vecDaughtersReso[4]}, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2);
           if (indexRecDstar > -1 && indexRecK0 > -1) {
@@ -574,12 +597,17 @@ struct HfDataCreatorCharmResoReduced {
           }
         }
       }
+      if (flag != 0) {
+        auto particleReso = particlesMc.iteratorAt(indexRecReso);
+        origin = RecoDecay::getCharmHadronOrigin(particlesMc, particleReso, false, &idxBhadMothers);
+      }
     }
     if (fillHisto) {
       registry.fill(HIST("hMCRecCounter"), flag);
       registry.fill(HIST("hMCRecDebug"), debug);
+      registry.fill (HIST("hMCRecOrigin"), origin);
     }
-    rowHfDV0McRecReduced(indexHfCandCharm, indexCandV0, flag, debug, motherPt);
+    rowHfDV0McRecReduced(indexHfCandCharm, indexCandV0, flag, debug, origin, motherPt);
   }
 
   template <bool withMl, bool doMc, uint8_t DecayChannel, typename Coll, typename CCands, typename Tr, typename PParticles, typename BBach>
@@ -831,15 +859,28 @@ struct HfDataCreatorCharmResoReduced {
         if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, particle, Pdg::kDS1, std::array{static_cast<int>(Pdg::kDStar), +kK0}, true, &sign, 1)) {
           registry.fill(HIST("hMCSignCounter"), sign);
           origin = RecoDecay::getCharmHadronOrigin(particlesMc, particle, false, &idxBhadMothers);
-          registry.fill(HIST("hMCOriginCounter"), origin);
+          registry.fill(HIST("hMCGenOrigin"), origin);
           auto candV0MC = particlesMc.rawIteratorAt(particle.daughtersIds().back());
           // K0 -> K0s -> π+π-
           if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, candV0MC, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2)) {
             auto candDStarMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
             // D* -> D0 π+ -> K-π+π+
-            if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2)) {
-              flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0s);
-            }
+            if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kD0), +static_cast<int>(kPiPlus)}, true, &signDStar, 1)) {
+              auto candD0MC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2)){
+                flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0s);
+              } else if (RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, +kPi0}, true, &signDStar, 2) ||
+                         RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, -kPi0}, true, &signDStar, 2)){
+                flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart);
+                }
+            } else if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kGamma)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kGamma)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDStar, 1)) {
+              auto candDPlusMC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2)) 
+              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
+            } 
           }
         } else {
           if (std::abs(particle.pdgCode()) == Pdg::kDS1) {
@@ -848,7 +889,7 @@ struct HfDataCreatorCharmResoReduced {
           }
         }
         // save information for task
-        if (!TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToD0PiK0s)) {
+        if (!TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToD0PiK0s) && !TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart) && !TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s)) {
           continue;
         }
 
@@ -867,14 +908,14 @@ struct HfDataCreatorCharmResoReduced {
           counter++;
         }
         registry.fill(HIST("hMCGenCounter"), flag, ptParticle);
-        rowHfResoMcGenReduced(flag, ptParticle, yParticle, etaParticle,
+        rowHfResoMcGenReduced(flag, origin, ptParticle, yParticle, etaParticle,
                               ptProngs[0], yProngs[0], etaProngs[0],
                               ptProngs[1], yProngs[1], etaProngs[1]);
       } else if constexpr (decayChannel == DecayChannel::DplusV0) { // Ds2Star → D+ K0
         if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, particle, Pdg::kDS2Star, std::array{static_cast<int>(Pdg::kDPlus), +kK0}, true, &sign, 1)) {
           registry.fill(HIST("hMCSignCounter"), sign);
           origin = RecoDecay::getCharmHadronOrigin(particlesMc, particle, false, &idxBhadMothers);
-          registry.fill(HIST("hMCOriginCounter"), origin);
+          registry.fill(HIST("hMCGenOrigin"), origin);
           auto candV0MC = particlesMc.rawIteratorAt(particle.daughtersIds().back());
           auto candDPlusMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
           // K0 -> K0s -> π+π-
@@ -889,16 +930,15 @@ struct HfDataCreatorCharmResoReduced {
           // K0 -> K0s -> π+π-
           if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, candV0MC, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2)) {
             auto candDStarMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
-            // D* -> D+ γ
-            if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kGamma)}, true, &signDPlus, 1)) {
-              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusGammaK0s);
-            } else if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kGamma)}, true, &signDPlus, 1)) {
-              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusGammaK0s);
-            } else if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDPlus, 1)) {
+            // D* -> D+ π0/γ ->π+K-π+ π0/γ
+            if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kGamma)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kGamma)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDStar, 1) ||
+                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDStar, 1)) {
+              auto candDPlusMC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2)) 
               flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
-            } else if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDPlus, 1)) {
-              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
-            }
+            } 
           }
         } else {
           if (std::abs(particle.pdgCode()) == Pdg::kDS2Star) {
@@ -908,7 +948,7 @@ struct HfDataCreatorCharmResoReduced {
           }
         }
         // save information for task
-        if (!TESTBIT(std::abs(flag), DecayTypeMc::Ds2StarToDplusK0s) && !TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToDPlusGammaK0s) && !TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s)) {
+        if (!TESTBIT(std::abs(flag), DecayTypeMc::Ds2StarToDplusK0s) && !TESTBIT(std::abs(flag), DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s)) {
           continue;
         }
 
@@ -927,7 +967,7 @@ struct HfDataCreatorCharmResoReduced {
           counter++;
         }
         registry.fill(HIST("hMCGenCounter"), flag, ptParticle);
-        rowHfResoMcGenReduced(flag, ptParticle, yParticle, etaParticle,
+        rowHfResoMcGenReduced(flag, origin, ptParticle, yParticle, etaParticle,
                               ptProngs[0], yProngs[0], etaProngs[0],
                               ptProngs[1], yProngs[1], etaProngs[1]);
       } // Dplus V0

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -543,14 +543,13 @@ struct HfDataCreatorCharmResoReduced {
           auto indexRecDstar = RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2);
           auto indexRecK0 = RecoDecay::getMatchedMCRec<false, true>(particlesMc, std::array{vecDaughtersReso[3], vecDaughtersReso[4]}, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2);
           if (indexRecDstar > -1 && indexRecK0 > -1) {
-            if ( RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2) > -1){
+            if (RecoDecay::getMatchedMCRec(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2]}, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2) > -1) {
               flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
               fillHisto = true;
-            } else if ( RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1]}, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &signD0, 2) > -1){
+            } else if (RecoDecay::getMatchedMCRec<false, false, true>(particlesMc, std::array{vecDaughtersReso[0], vecDaughtersReso[1]}, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &signD0, 2) > -1) {
               flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart);
               fillHisto = true;
-            } 
-            
+            }
           }
         }
       }
@@ -605,7 +604,7 @@ struct HfDataCreatorCharmResoReduced {
     if (fillHisto) {
       registry.fill(HIST("hMCRecCounter"), flag);
       registry.fill(HIST("hMCRecDebug"), debug);
-      registry.fill (HIST("hMCRecOrigin"), origin);
+      registry.fill(HIST("hMCRecOrigin"), origin);
     }
     rowHfDV0McRecReduced(indexHfCandCharm, indexCandV0, flag, debug, origin, motherPt);
   }
@@ -867,20 +866,20 @@ struct HfDataCreatorCharmResoReduced {
             // D* -> D0 π+ -> K-π+π+
             if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kD0), +static_cast<int>(kPiPlus)}, true, &signDStar, 1)) {
               auto candD0MC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
-              if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2)){
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2)) {
                 flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0s);
               } else if (RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, +kPi0}, true, &signDStar, 2) ||
-                         RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, -kPi0}, true, &signDStar, 2)){
+                         RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, -kPi0}, true, &signDStar, 2)) {
                 flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart);
-                }
+              }
             } else if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kGamma)}, true, &signDStar, 1) ||
-                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kGamma)}, true, &signDStar, 1) ||
-                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDStar, 1) ||
-                RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDStar, 1)) {
+                       RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kGamma)}, true, &signDStar, 1) ||
+                       RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDStar, 1) ||
+                       RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDStar, 1)) {
               auto candDPlusMC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
-              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2)) 
-              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
-            } 
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2))
+                flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
+            }
           }
         } else {
           if (std::abs(particle.pdgCode()) == Pdg::kDS1) {
@@ -936,9 +935,9 @@ struct HfDataCreatorCharmResoReduced {
                 RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), static_cast<int>(kPi0)}, true, &signDStar, 1) ||
                 RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kDPlus), -static_cast<int>(kPi0)}, true, &signDStar, 1)) {
               auto candDPlusMC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
-              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2)) 
-              flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
-            } 
+              if (RecoDecay::isMatchedMCGen(particlesMc, candDPlusMC, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &signDPlus, 2))
+                flag = sign * BIT(DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s);
+            }
           }
         } else {
           if (std::abs(particle.pdgCode()) == Pdg::kDS2Star) {


### PR DESCRIPTION
This pull request continues the developements of the MC analysis for Charmed resonances:

1) dataCreatorCharmResoReduced:
-added origin information for matched candidates
-added partly-reconstructed decays in decay channel Dstar-V0 for debugging purposes
-fixed partly reconstructed decay D*->D+pi0

2) candidateCreatorCharmResoReduced:
-added MC table 

3) reducedDataFormat:
-modified tables accordingly

4) selectorCutsRedDataFormat:
-added pT Labels  