### PR TITLE
PWGHF: Add the QA plots for the mixed-event and Change the strategy of mixed event

### DIFF
--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -434,7 +434,7 @@ struct HfFemtoDreamProducer {
       bitCand |= 1 << 0;
     }
 
-    Masks(static_cast<aod::femtodreamcollision::BitMaskType>(bitTrack),
+    rowMasks(static_cast<aod::femtodreamcollision::BitMaskType>(bitTrack),
           static_cast<aod::femtodreamcollision::BitMaskType>(bitCand),
           0);
   }

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -412,8 +412,7 @@ struct HfFemtoDreamProducer {
                 if constexpr (isMc) {
                   rowCandMcCharmHad(
                     candidate.flagMcMatchRec(),
-                    candidate.originMcRec());
-                }           
+                    candidate.originMcRec());}
       } };
 
       fillTable(0, candidate.isSelLcToPKPi(), outputMlPKPi.at(0), outputMlPKPi.at(1), outputMlPKPi.at(2));

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -46,7 +46,7 @@ using namespace o2::analysis::femtoDream;
 struct HfFemtoDreamProducer {
 
   Produces<aod::FDCollisions> outputCollision;
-  Produces<aod::FDColMasks> Masks;
+  Produces<aod::FDColMasks> rowMasks;
   Produces<aod::FDHfCand> rowCandCharmHad;
   Produces<aod::FDHfCandMC> rowCandMcCharmHad;
   Produces<aod::FDHfCandMCGen> rowCandCharmHadGen;

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -388,7 +388,6 @@ struct HfFemtoDreamProducer {
                            float BDTScorePrompt,
                            float BDTScoreFD) {
         if (FunctionSelection >= 1){
-    
                 rowCandCharmHad(
                     outputCollision.lastIndex(),
                     trackPos1.sign() + trackNeg.sign() + trackPos2.sign(),
@@ -414,8 +413,7 @@ struct HfFemtoDreamProducer {
                   rowCandMcCharmHad(
                     candidate.flagMcMatchRec(),
                     candidate.originMcRec());
-                }
-           
+                }           
       } };
 
       fillTable(0, candidate.isSelLcToPKPi(), outputMlPKPi.at(0), outputMlPKPi.at(1), outputMlPKPi.at(2));

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -299,7 +299,7 @@ struct HfFemtoDreamProducer {
       outputPartsIndex(track.globalIndex());
       // now the table is filled
 
-      outputParts(outputCollision.lastIndex() + 1,
+      outputParts(outputCollision.lastIndex(),
                   track.pt(),
                   track.eta(),
                   track.phi(),

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -217,7 +217,7 @@ struct HfTaskCharmHadronsFemtoDream {
   }
 
   template <typename CollisionType>
-  void fillCollision(CollisionType col)
+  void fillCollision(CollisionType const& col)
   {
     MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinningMult.getBin({col.posZ(), col.multNtr()}));
     MixQaRegistry.fill(HIST("MixingQA/hSECollisionPool"), col.posZ(), col.multNtr());

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -163,7 +163,7 @@ struct HfTaskCharmHadronsFemtoDream {
   FemtoDreamEventHisto eventHisto;
   /// Histogram output
   HistogramRegistry registry{"CorrelationsAndQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry registryMixQa{"registryMixQa"};
   /// Partition for particle 1
 
   Partition<FilteredFDParticles> partitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack));

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -227,11 +227,6 @@ struct HfTaskCharmHadronsFemtoDream {
   template <bool isMc, typename PartitionType, typename CandType, typename TableTracks, typename Collision>
   void doSameEvent(PartitionType& sliceTrk1, CandType& sliceCharmHad, TableTracks const& parts, Collision const& col)
   {
-
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      return;
-    }
-
     fillCollision(col);
 
     processType = 1; // for same event
@@ -420,6 +415,9 @@ struct HfTaskCharmHadronsFemtoDream {
                         FilteredFDParticles const& parts,
                         FilteredCharmCands const&)
   {
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      return;
+    }
     eventHisto.fillQA(col);
     auto sliceTrk1 = partitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto sliceCharmHad = partitionCharmHadron->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
@@ -456,6 +454,9 @@ struct HfTaskCharmHadronsFemtoDream {
                           o2::aod::FDMCParticles const&,
                           FilteredCharmMcCands const&)
   {
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      return;
+    }
     auto sliceMcTrk1 = partitionMcTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto sliceMcCharmHad = partitionMcCharmHadron->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
 

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -12,7 +12,7 @@
 /// \file taskCharmHadronsFemtoDream.cxx.cxx
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
 /// \author Ravindra SIngh, GSI, ravindra.singh@cern.ch
-/// \author Biao Zhang, Heidelburg University, biao.zhang@cern.ch
+/// \author Biao Zhang, Heidelberg University, biao.zhang@cern.ch
 
 #include <vector>
 

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -229,7 +229,7 @@ struct HfTaskCharmHadronsFemtoDream {
   {
 
     if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      continue;
+      return;
     }
 
     fillCollision(col);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -206,9 +206,9 @@ struct HfTaskCharmHadronsFemtoDream {
                               smearingByOrigin, binInvMass);
 
     mixedEventCont.setPDGCodes(pdgCodeTrack1, charmHadPDGCode);
-    MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
-    MixQaRegistry.add("MixingQA/hSECollisionPool", ";bin;Entries", kTH2F, {{100, -10, 10}, {2000, 0, 200}});
-    MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    registryMixQa.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    registryMixQa.add("MixingQA/hSECollisionPool", ";bin;Entries", kTH2F, {{100, -10, 10}, {2000, 0, 200}});
+    registryMixQa.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     pairCleaner.init(&registry);
     if (useCPR.value) {
       pairCloseRejectionSE.init(&registry, &registry, cprDeltaPhiMax.value, cprDeltaEtaMax.value, cprPlotPerRadii.value, 1);
@@ -219,8 +219,8 @@ struct HfTaskCharmHadronsFemtoDream {
   template <typename CollisionType>
   void fillCollision(CollisionType const& col)
   {
-    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinningMult.getBin({col.posZ(), col.multNtr()}));
-    MixQaRegistry.fill(HIST("MixingQA/hSECollisionPool"), col.posZ(), col.multNtr());
+    registryMixQa.fill(HIST("MixingQA/hSECollisionBins"), colBinningMult.getBin({col.posZ(), col.multNtr()}));
+    registryMixQa.fill(HIST("MixingQA/hSECollisionPool"), col.posZ(), col.multNtr());
   }
 
   /// This function processes the same event and takes care of all the histogramming
@@ -341,7 +341,7 @@ struct HfTaskCharmHadronsFemtoDream {
 
       const int multiplicityCol = collision1.multNtr();
 
-      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), multiplicityCol}));
+      registryMixQa.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), multiplicityCol}));
 
       auto sliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
       auto sliceCharmHad = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -12,6 +12,7 @@
 /// \file taskCharmHadronsFemtoDream.cxx.cxx
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
 /// \author Ravindra SIngh, GSI, ravindra.singh@cern.ch
+/// \author Biao Zhang, Heidelburg University, biao.zhang@cern.ch
 
 #include <vector>
 
@@ -92,11 +93,11 @@ struct HfTaskCharmHadronsFemtoDream {
   ConfigurableAxis dummy{"dummy", {1, 0, 1}, "dummy axis"};
 
   // Mixing configurables
-  ConfigurableAxis mixingBinMult{"mixingBinMult", {VARIABLE_WIDTH, 0.0f, 200.0f}, "Mixing bins - multiplicity"};
+  ConfigurableAxis mixingBinMult{"mixingBinMult", {VARIABLE_WIDTH, 0.0f, 20.0f, 60.0f, 200.0f}, "Mixing bins - multiplicity"};
   ConfigurableAxis mixingBinMultPercentile{"mixingBinMultPercentile", {VARIABLE_WIDTH, 0.0f, 100.f}, "Mixing bins - multiplicity percentile"};
   ConfigurableAxis mixingBinVztx{"mixingBinVztx", {VARIABLE_WIDTH, -10.0f, -4.f, 0.f, 4.f, 10.f}, "Mixing bins - z-vertex"};
   Configurable<int> mixingDepth{"mixingDepth", 5, "Number of events for mixing"};
-  Configurable<int> mixingPolicy{"mixingBinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
+  Configurable<int> mixingBinPolicy{"mixingBinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
 
   /// Event selection
   struct : ConfigurableGroup {
@@ -142,10 +143,10 @@ struct HfTaskCharmHadronsFemtoDream {
   using FilteredCharmMcCands = soa::Filtered<soa::Join<aod::FDHfCand, aod::FDHfCandMC>>;
   using FilteredCharmMcCand = FilteredCharmMcCands::iterator;
 
-  using FilteredColisions = FDCollisions;
+  using FilteredColisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks>>;
   using FilteredColision = FilteredColisions::iterator;
 
-  using FilteredMcColisions = soa::Filtered<soa::Join<aod::FDCollisions, aod::FDMCCollLabels>>;
+  using FilteredMcColisions = soa::Filtered<soa::Join<aod::FDCollisions, FDColMasks, aod::FDMCCollLabels>>;
   using FilteredMcColision = FilteredMcColisions::iterator;
 
   using FilteredFDMcParts = soa::Filtered<soa::Join<aod::FDParticles, aod::FDParticlesIndex, aod::FDMCLabels>>;
@@ -154,13 +155,15 @@ struct HfTaskCharmHadronsFemtoDream {
   using FilteredFDParticles = soa::Filtered<soa::Join<aod::FDParticles, aod::FDParticlesIndex>>;
   using FilteredFDParticle = FilteredFDParticles::iterator;
 
+  femtodreamcollision::BitMaskType BitMask = 1 << 0;
+
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
   /// Histogram output
   HistogramRegistry registry{"CorrelationsAndQA", {}, OutputObjHandlingPolicy::AnalysisObject};
-
+  HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
   /// Partition for particle 1
 
   Partition<FilteredFDParticles> partitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack));
@@ -203,6 +206,9 @@ struct HfTaskCharmHadronsFemtoDream {
                               smearingByOrigin, binInvMass);
 
     mixedEventCont.setPDGCodes(pdgCodeTrack1, charmHadPDGCode);
+    MixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    MixQaRegistry.add("MixingQA/hSECollisionPool", ";bin;Entries", kTH2F, {{100, -10, 10}, {2000, 0, 200}});
+    MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     pairCleaner.init(&registry);
     if (useCPR.value) {
       pairCloseRejectionSE.init(&registry, &registry, cprDeltaPhiMax.value, cprDeltaEtaMax.value, cprPlotPerRadii.value, 1);
@@ -210,10 +216,24 @@ struct HfTaskCharmHadronsFemtoDream {
     }
   }
 
+  template <typename CollisionType>
+  void fillCollision(CollisionType col)
+  {
+    MixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinningMult.getBin({col.posZ(), col.multNtr()}));
+    MixQaRegistry.fill(HIST("MixingQA/hSECollisionPool"), col.posZ(), col.multNtr());
+  }
+
   /// This function processes the same event and takes care of all the histogramming
   template <bool isMc, typename PartitionType, typename CandType, typename TableTracks, typename Collision>
   void doSameEvent(PartitionType& sliceTrk1, CandType& sliceCharmHad, TableTracks const& parts, Collision const& col)
   {
+
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      continue;
+    }
+
+    fillCollision(col);
+
     processType = 1; // for same event
     /// Histogramming same event
     for (auto const& part : sliceTrk1) {
@@ -222,6 +242,9 @@ struct HfTaskCharmHadronsFemtoDream {
     }
 
     for (auto const& [p1, p2] : combinations(CombinationsFullIndexPolicy(sliceTrk1, sliceCharmHad))) {
+
+      if (p1.trackId() == p2.prong0Id() || p1.trackId() == p2.prong1Id() || p1.trackId() == p2.prong2Id())
+        continue;
 
       if (useCPR.value) {
         if (pairCloseRejectionSE.isClosePair(p1, p2, parts, col.magField())) {
@@ -309,11 +332,22 @@ struct HfTaskCharmHadronsFemtoDream {
     // Mixed events that contain the pair of interest
     processType = 2; // for mixed event
 
-    for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockFullSameIndexPolicy(policy, mixingDepth.value, -1, cols, cols))) {
+    Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask;
+    PartitionMaskedCol1.bindTable(cols);
+
+    Partition<CollisionType> PartitionMaskedCol2 = (aod::femtodreamcollision::bitmaskTrackTwo & BitMask) == BitMask;
+    PartitionMaskedCol2.bindTable(cols);
+
+    for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockFullIndexPolicy(policy, mixingDepth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
       // make sure that tracks in the same events are not mixed
       if (collision1.globalIndex() == collision2.globalIndex()) {
         continue;
       }
+
+      const int multiplicityCol = collision1.multNtr();
+
+      MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), multiplicityCol}));
+
       auto sliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
       auto sliceCharmHad = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(sliceTrk1, sliceCharmHad))) {
@@ -345,7 +379,6 @@ struct HfTaskCharmHadronsFemtoDream {
         if (kstar > highkstarCut) {
           continue;
         }
-
         float invMass;
         if (p2.candidateSelFlag() == 1) {
           invMass = p2.m(std::array{o2::constants::physics::MassProton, o2::constants::physics::MassKPlus, o2::constants::physics::MassPiPlus});
@@ -398,7 +431,7 @@ struct HfTaskCharmHadronsFemtoDream {
                          FilteredFDParticles const& parts,
                          FilteredCharmCands const&)
   {
-    switch (mixingPolicy.value) {
+    switch (mixingBinPolicy.value) {
       case femtodreamcollision::kMult:
         doMixedEvent<false>(cols, parts, partitionTrk1, partitionCharmHadron, colBinningMult);
         break;
@@ -442,7 +475,7 @@ struct HfTaskCharmHadronsFemtoDream {
                            o2::aod::FDMCParticles const&,
                            FilteredCharmMcCands const&)
   {
-    switch (mixingPolicy.value) {
+    switch (mixingBinPolicy.value) {
       case femtodreamcollision::kMult:
         doMixedEvent<true>(cols, parts, partitionMcTrk1, partitionMcCharmHadron, colBinningMult);
         break;


### PR DESCRIPTION
Hi @1994ra and @fgrosa, The commit I implemented last week is still not satisfactory, since the number of events that contain lc (with selection) in one DF are few. The mixed event flow can only process in one DF for the current O2. so I made further modifications. Now, the producer no longer stores only the Lc-proton pair for collisions. Instead, I’ve set a mask to tag the collisions that contain at least one Lc or at least one selected track. Let me know if you have any questions or comments. Thanks!