### PR TITLE
Revert "GH Actions: Bypass PEP 668 in runners (#8020)"

### DIFF
--- a/.github/workflows/codeowner-self-approval.yml
+++ b/.github/workflows/codeowner-self-approval.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   approve:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only run if the PR author enabled auto-merge, not someone else.
     # Also run if a new approval was created, as this affects whether we can
     # auto-approve. There is a risk of infinite loops here, though -- when we

--- a/.github/workflows/codeowner-self-approval.yml
+++ b/.github/workflows/codeowner-self-approval.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: pip install --break-system-packages codeowners PyGithub
+        run: pip install codeowners PyGithub
 
       # Approve the PR, if the author is only editing files owned by themselves.
       - name: Auto-approve PR if permitted


### PR DESCRIPTION
This reverts commit 4bb538f.

Ubuntu latest is now back to 22.04, so our workaround is broken as the pip version there is too old. I'm also pinning to 22.04 instead, seeing that the latest tag is not very stable...

https://github.com/actions/runner-images/issues/10636#issuecomment-2417303444


CC @ktf @vkucera

- **Revert "GH Actions: Bypass PEP 668 in runners (#8020)"**
- **Pin action to Ubuntu 22.04**
