### PR TITLE
PWGHF: add to Xic0 tree TPC info for systematic

### DIFF
--- a/PWGHF/TableProducer/treeCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorToXiPi.cxx
@@ -116,10 +116,10 @@ DECLARE_SOA_COLUMN(NormImpParPiFromCharmBar, normImpParPiFromCharmBar, double);
 DECLARE_SOA_COLUMN(NormDecayLenCharmBar, normDecayLenCharmBar, double);
 DECLARE_SOA_COLUMN(IsPionGlbTrkWoDca, isPionGlbTrkWoDca, bool);
 DECLARE_SOA_COLUMN(PionItsNCls, pionItsNCls, uint8_t);
-DECLARE_SOA_COLUMN(PionTpcCrRows, pionTpcCrRows, int16_t);
-DECLARE_SOA_COLUMN(PiFromCascTpcCrRows, piFromCascTpcCrRows, int16_t);
-DECLARE_SOA_COLUMN(PosV0DauTpcCrRows, posV0DauTpcCrRows, int16_t);
-DECLARE_SOA_COLUMN(NegV0DauTpcCrRows, negV0DauTpcCrRows, int16_t);
+DECLARE_SOA_COLUMN(NTpcRowsPion, nTpcRowsPion, int16_t);
+DECLARE_SOA_COLUMN(NTpcRowsPiFromCasc, nTpcRowsPiFromCasc, int16_t);
+DECLARE_SOA_COLUMN(NTpcRowsPosV0Dau, nTpcRowsPosV0Dau, int16_t);
+DECLARE_SOA_COLUMN(NTpcRowsNegV0Dau, nTpcRowsNegV0Dau, int16_t);
 // from creator - MC
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
@@ -176,7 +176,7 @@ DECLARE_SOA_TABLE(HfToXiPiFulls, "AOD", "HFTOXIPIFULL",
                   full::DcaCascDau, full::DcaV0Dau, full::DcaCharmBaryonDau,
                   full::DecLenCharmBaryon, full::DecLenCascade, full::DecLenV0, full::ErrorDecayLengthCharmBaryon, full::ErrorDecayLengthXYCharmBaryon,
                   full::NormImpParCascade, full::NormImpParPiFromCharmBar, full::NormDecayLenCharmBar, full::IsPionGlbTrkWoDca, full::PionItsNCls,
-                  full::PionTpcCrRows, full::PiFromCascTpcCrRows, full::PosV0DauTpcCrRows, full::NegV0DauTpcCrRows,
+                  full::NTpcRowsPion, full::NTpcRowsPiFromCasc, full::NTpcRowsPosV0Dau, full::NTpcRowsNegV0Dau,
                   full::StatusPidLambda, full::StatusPidCascade, full::StatusPidCharmBaryon,
                   full::StatusInvMassLambda, full::StatusInvMassCascade, full::StatusInvMassCharmBaryon, full::ResultSelections, full::PidTpcInfoStored, full::PidTofInfoStored,
                   full::TpcNSigmaPiFromCharmBaryon, full::TpcNSigmaPiFromCasc, full::TpcNSigmaPiFromLambda, full::TpcNSigmaPrFromLambda,
@@ -202,7 +202,7 @@ DECLARE_SOA_TABLE(HfToXiPiLites, "AOD", "HFTOXIPILITE",
                   full::DcaCascDau, full::DcaV0Dau, full::DcaCharmBaryonDau,
                   full::ErrorDecayLengthCharmBaryon, full::NormImpParCascade, full::NormImpParPiFromCharmBar,
                   full::IsPionGlbTrkWoDca, full::PionItsNCls,
-                  full::PionTpcCrRows, full::PiFromCascTpcCrRows, full::PosV0DauTpcCrRows, full::NegV0DauTpcCrRows,
+                  full::NTpcRowsPion, full::NTpcRowsPiFromCasc, full::NTpcRowsPosV0Dau, full::NTpcRowsNegV0Dau,
                   full::PidTpcInfoStored, full::PidTofInfoStored,
                   full::TpcNSigmaPiFromCharmBaryon, full::TpcNSigmaPiFromCasc, full::TpcNSigmaPiFromLambda, full::TpcNSigmaPrFromLambda,
                   full::TofNSigmaPiFromCharmBaryon, full::TofNSigmaPiFromCasc, full::TofNSigmaPiFromLambda, full::TofNSigmaPrFromLambda,

--- a/PWGHF/TableProducer/treeCreatorToXiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorToXiPi.cxx
@@ -116,6 +116,10 @@ DECLARE_SOA_COLUMN(NormImpParPiFromCharmBar, normImpParPiFromCharmBar, double);
 DECLARE_SOA_COLUMN(NormDecayLenCharmBar, normDecayLenCharmBar, double);
 DECLARE_SOA_COLUMN(IsPionGlbTrkWoDca, isPionGlbTrkWoDca, bool);
 DECLARE_SOA_COLUMN(PionItsNCls, pionItsNCls, uint8_t);
+DECLARE_SOA_COLUMN(PionTpcCrRows, pionTpcCrRows, int16_t);
+DECLARE_SOA_COLUMN(PiFromCascTpcCrRows, piFromCascTpcCrRows, int16_t);
+DECLARE_SOA_COLUMN(PosV0DauTpcCrRows, posV0DauTpcCrRows, int16_t);
+DECLARE_SOA_COLUMN(NegV0DauTpcCrRows, negV0DauTpcCrRows, int16_t);
 // from creator - MC
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
@@ -172,6 +176,7 @@ DECLARE_SOA_TABLE(HfToXiPiFulls, "AOD", "HFTOXIPIFULL",
                   full::DcaCascDau, full::DcaV0Dau, full::DcaCharmBaryonDau,
                   full::DecLenCharmBaryon, full::DecLenCascade, full::DecLenV0, full::ErrorDecayLengthCharmBaryon, full::ErrorDecayLengthXYCharmBaryon,
                   full::NormImpParCascade, full::NormImpParPiFromCharmBar, full::NormDecayLenCharmBar, full::IsPionGlbTrkWoDca, full::PionItsNCls,
+                  full::PionTpcCrRows, full::PiFromCascTpcCrRows, full::PosV0DauTpcCrRows, full::NegV0DauTpcCrRows,
                   full::StatusPidLambda, full::StatusPidCascade, full::StatusPidCharmBaryon,
                   full::StatusInvMassLambda, full::StatusInvMassCascade, full::StatusInvMassCharmBaryon, full::ResultSelections, full::PidTpcInfoStored, full::PidTofInfoStored,
                   full::TpcNSigmaPiFromCharmBaryon, full::TpcNSigmaPiFromCasc, full::TpcNSigmaPiFromLambda, full::TpcNSigmaPrFromLambda,
@@ -197,6 +202,7 @@ DECLARE_SOA_TABLE(HfToXiPiLites, "AOD", "HFTOXIPILITE",
                   full::DcaCascDau, full::DcaV0Dau, full::DcaCharmBaryonDau,
                   full::ErrorDecayLengthCharmBaryon, full::NormImpParCascade, full::NormImpParPiFromCharmBar,
                   full::IsPionGlbTrkWoDca, full::PionItsNCls,
+                  full::PionTpcCrRows, full::PiFromCascTpcCrRows, full::PosV0DauTpcCrRows, full::NegV0DauTpcCrRows,
                   full::PidTpcInfoStored, full::PidTofInfoStored,
                   full::TpcNSigmaPiFromCharmBaryon, full::TpcNSigmaPiFromCasc, full::TpcNSigmaPiFromLambda, full::TpcNSigmaPrFromLambda,
                   full::TofNSigmaPiFromCharmBaryon, full::TofNSigmaPiFromCasc, full::TofNSigmaPiFromLambda, full::TofNSigmaPrFromLambda,
@@ -317,6 +323,10 @@ struct HfTreeCreatorToXiPi {
       candidate.decLenCharmBaryon() / candidate.errorDecayLengthCharmBaryon(),
       candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().isGlobalTrackWoDCA(),
       candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().itsNCls(),
+      candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().tpcNClsCrossedRows(),
+      candidate.template bachelor_as<MyTrackTable>().tpcNClsCrossedRows(),
+      candidate.template posTrack_as<MyTrackTable>().tpcNClsCrossedRows(),
+      candidate.template negTrack_as<MyTrackTable>().tpcNClsCrossedRows(),
       candidate.statusPidLambda(),
       candidate.statusPidCascade(),
       candidate.statusPidCharmBaryon(),
@@ -398,6 +408,10 @@ struct HfTreeCreatorToXiPi {
         candidate.impactParBachFromCharmBaryonXY() / candidate.errImpactParBachFromCharmBaryonXY(),
         candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().isGlobalTrackWoDCA(),
         candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().itsNCls(),
+        candidate.template bachelorFromCharmBaryon_as<MyTrackTable>().tpcNClsCrossedRows(),
+        candidate.template bachelor_as<MyTrackTable>().tpcNClsCrossedRows(),
+        candidate.template posTrack_as<MyTrackTable>().tpcNClsCrossedRows(),
+        candidate.template negTrack_as<MyTrackTable>().tpcNClsCrossedRows(),
         candidate.pidTpcInfoStored(),
         candidate.pidTofInfoStored(),
         candidate.tpcNSigmaPiFromCharmBaryon(),


### PR DESCRIPTION
Add TPC crossed rows information to Xic0 tree for offline systematic uncertainty calculations 