### PR TITLE
Add automatic pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+---
+alice3:
+  - changed-files:
+      - any-glob-to-any-file: ['ALICE3/**']
+
+common:
+  - changed-files:
+      - any-glob-to-any-file: ['Common/**']
+
+infrastructure:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**', 'cmake/**', 'dependencies/**', 'packaging/**']
+
+dpg:
+  - changed-files:
+      - any-glob-to-any-file: ['DPG/**']
+
+pwgcf:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGCF/**', '*/PWGCF/**']
+
+pwgdq:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGDQ/**', '*/PWGDQ/**']
+
+pwgem:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGEM/**', '*/PWGEM/**']
+
+pwghf:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGHF/**', '*/PWGHF/**']
+
+pwgje:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGJE/**', '*/PWGJE/**']
+
+pwglf:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGLF/**', '*/PWGLF/**', 'PWGMM/**', '*/PWGMM/**']
+
+pwgud:
+  - changed-files:
+      - any-glob-to-any-file: ['PWGUD/**', '*/PWGUD/**']
+
+tutorial:
+  - changed-files:
+      - any-glob-to-any-file: ['Tutorials/**']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+---
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+permissions: read-all
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automatically label
pull requests based on the files changed. The workflow uses the
`actions/labeler` action to apply labels to the pull request based on
the configuration defined in the `.github/labeler.yml` file.

The labels are defined for the following areas:

- `alice3`: Changes to the ALICE3 project
- `common`: Changes to the COMMON project
- `infrastructure`: Changes to the project infrastructure (e.g., CI/CD,
  dependencies, packaging)
- `dpg`: Changes to the DPG
- `pwgcf`: Changes to the PWGCF
- `pwgdq`: Changes to the PWGDQ
- `pwgem`: Changes to the PWGEM
- `pwghf`: Changes to the PWGHF
- `pwgje`: Changes to the PWGJE
- `pwglf`: Changes to the PWGLF and PWGMM projects
- `pwgud`: Changes to the PWGUD project