### PR TITLE
PWGCF:FemtoUniverse - MCTruth update

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerMCTruthTask.cxx
@@ -170,6 +170,8 @@ struct femtoUniverseProducerMCTruthTask {
         for (uint32_t pdg : tmpPDGCodes) {
           if (pdgCode == 333) {
             pass = true;
+          } else if (pdgCode == 421) {
+            pass = true;
           } else if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
             if (particle.isPhysicalPrimary())
               pass = true;

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -556,7 +556,7 @@ struct femtoUniversePairTaskTrackD0 {
           }
         }
       } // It is the end of the for loop over D0bar mesons
-    }   // It is the end of the for loop over all candidates
+    } // It is the end of the for loop over all candidates
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackD0, processSideBand, "Enable processing side-band methode", false);
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -483,9 +483,9 @@ struct femtoUniversePairTaskTrackD0 {
       }
       // filling QA plots for D0 mesons' negative daughters (pi-)
       if (daughD0D0bar.mLambda() == -1 && daughD0D0bar.mAntiLambda() == 1) {
-        qaRegistry.fill(HIST("D0_pos_daugh/pt"), daughD0D0bar.pt());
-        qaRegistry.fill(HIST("D0_pos_daugh/eta"), daughD0D0bar.eta());
-        qaRegistry.fill(HIST("D0_pos_daugh/phi"), daughD0D0bar.phi());
+        qaRegistry.fill(HIST("D0_neg_daugh/pt"), daughD0D0bar.pt());
+        qaRegistry.fill(HIST("D0_neg_daugh/eta"), daughD0D0bar.eta());
+        qaRegistry.fill(HIST("D0_neg_daugh/phi"), daughD0D0bar.phi());
       }
       // filling QA plots for D0bar mesons' positive daughters (pi+)
       if (daughD0D0bar.mLambda() == 1 && daughD0D0bar.mAntiLambda() == -1) {
@@ -578,6 +578,7 @@ struct femtoUniversePairTaskTrackD0 {
     for (auto& d0candidate : groupPartsD0) {
       trackHistoPartD0D0bar.fillQA<isMC, false>(d0candidate);
     }
+
     float tpcNSigmaPr, tofNSigmaPr, tpcNSigmaPi, tofNSigmaPi, tpcNSigmaKa, tofNSigmaKa;
 
     if (!ConfTrack.ConfIsSame) {

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
@@ -57,7 +57,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
 
   /// Partition for particle 1
   Partition<aod::FDParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) &&
-                                         aod::femtouniverseparticle::pt < ConfPtHighPart1 && aod::femtouniverseparticle::pt > ConfPtLowPart1&& nabs(aod::femtouniverseparticle::eta) < ConfEtaMax;
+                                         (aod::femtouniverseparticle::pt < ConfPtHighPart1) && (aod::femtouniverseparticle::pt > ConfPtLowPart1) && (nabs(aod::femtouniverseparticle::eta) < ConfEtaMax);
 
   /// Histogramming for particle 1
   FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, 1> trackHistoPartOne;
@@ -71,7 +71,7 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
 
   /// Partition for particle 2
   Partition<aod::FDParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) &&
-                                         aod::femtouniverseparticle::pt < ConfPtHighPart2 && aod::femtouniverseparticle::pt > ConfPtLowPart2&& nabs(aod::femtouniverseparticle::eta) < ConfEtaMax;
+                                         (aod::femtouniverseparticle::pt < ConfPtHighPart2) && (aod::femtouniverseparticle::pt > ConfPtLowPart2) && (nabs(aod::femtouniverseparticle::eta) < ConfEtaMax);
 
   /// Histogramming for particle 2
   FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, 2> trackHistoPartTwo;
@@ -176,23 +176,43 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
       }
     }
     /// Now build the combinations
-    for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
-      // track cleaning
-      if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-        continue;
-      }
-      if ((!ConfNoPDGPartOne && p2.pidcut() != ConfPDGCodePartOne) || (!ConfNoPDGPartTwo && p1.pidcut() != ConfPDGCodePartTwo)) {
-        continue;
-      }
-      if (swpart)
-        sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
-      else
-        sameEventCont.setPair<isMC>(p2, p1, multCol, ConfUse3D);
+    if (!ConfIsSame) {
+      // Build the combinations for pairs of non-identical particles
+      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
+        // track cleaning
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          continue;
+        }
+        if ((!ConfNoPDGPartOne && p2.pidcut() != ConfPDGCodePartOne) || (!ConfNoPDGPartTwo && p1.pidcut() != ConfPDGCodePartTwo)) {
+          continue;
+        }
+        if (swpart)
+          sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+        else
+          sameEventCont.setPair<isMC>(p2, p1, multCol, ConfUse3D);
 
-      swpart = !swpart;
+        swpart = !swpart;
+      }
+    } else {
+        // Build the combinations for pairs of identical pairs
+        for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
+          // track cleaning
+          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+            continue;
+          }
+          if ((!ConfNoPDGPartOne && p2.pidcut() != ConfPDGCodePartOne) || (!ConfNoPDGPartTwo && p1.pidcut() != ConfPDGCodePartTwo)) {
+            continue;
+          }
+          if (swpart)
+            sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+          else
+            sameEventCont.setPair<isMC>(p2, p1, multCol, ConfUse3D);
+
+          swpart = !swpart;
+        }
+      }
     }
-  }
-
+    
   /// process function for to call doSameEvent with Data
   /// \param col subscribe to the collision table (Data)
   /// \param parts subscribe to the femtoUniverseParticleTable

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMcTruth.cxx
@@ -194,25 +194,24 @@ struct femtoUniversePairTaskTrackTrackMcTruth {
         swpart = !swpart;
       }
     } else {
-        // Build the combinations for pairs of identical pairs
-        for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
-          // track cleaning
-          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-            continue;
-          }
-          if ((!ConfNoPDGPartOne && p2.pidcut() != ConfPDGCodePartOne) || (!ConfNoPDGPartTwo && p1.pidcut() != ConfPDGCodePartTwo)) {
-            continue;
-          }
-          if (swpart)
-            sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
-          else
-            sameEventCont.setPair<isMC>(p2, p1, multCol, ConfUse3D);
-
-          swpart = !swpart;
+      // Build the combinations for pairs of identical pairs
+      for (auto& [p1, p2] : combinations(CombinationsStrictlyUpperIndexPolicy(groupPartsOne, groupPartsTwo))) {
+        // track cleaning
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          continue;
         }
+        if ((!ConfNoPDGPartOne && p2.pidcut() != ConfPDGCodePartOne) || (!ConfNoPDGPartTwo && p1.pidcut() != ConfPDGCodePartTwo)) {
+          continue;
+        }
+        if (swpart)
+          sameEventCont.setPair<isMC>(p1, p2, multCol, ConfUse3D);
+        else
+          sameEventCont.setPair<isMC>(p2, p1, multCol, ConfUse3D);
+
+        swpart = !swpart;
       }
     }
-    
+  }
   /// process function for to call doSameEvent with Data
   /// \param col subscribe to the collision table (Data)
   /// \param parts subscribe to the femtoUniverseParticleTable


### PR DESCRIPTION
I change the producer and the task for MCTruth. In the producer I excluded checking isPhysicalPrimary() for D0s. In the MCTruth task I change the mixing policy for same event. Now the StrictlyUpperPolicy is set for identical particle pairs and FullIndexPolicy for non-identical particle pairs.