### PR TITLE
PWGLF:To add charged Kstar in pp using THnsparse

### DIFF
--- a/PWGLF/Tasks/Resonances/chargedkstaranalysis.cxx
+++ b/PWGLF/Tasks/Resonances/chargedkstaranalysis.cxx
@@ -48,9 +48,13 @@
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "ReconstructionDataFormats/Track.h"
 
+// For charged kstarpp analysis
+#include "PWGLF/DataModel/LFResonanceTables.h"
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::soa;
 using std::array;
 
 struct chargedkstaranalysis {
@@ -68,6 +72,15 @@ struct chargedkstaranalysis {
 
   SliceCache cache;
 
+  // For charged Kstarpp analysis use Resonance Initalizer and THnSparse
+  ConfigurableAxis binsCent{"binsCent", {VARIABLE_WIDTH, 0., 1., 5., 10., 30., 50., 70., 100., 110.}, "Binning of the centrality axis"};
+  ConfigurableAxis binsPt{"binsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
+  ConfigurableAxis Etabins{"Etabins", {VARIABLE_WIDTH, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0}, "Eta Binning"};
+  Configurable<int> cDCABinsQA{"cDCABinsQA", 150, "DCA binning"};
+  ConfigurableAxis binsPtQA{"binsPtQA", {VARIABLE_WIDTH, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 7.2, 7.4, 7.6, 7.8, 8.0, 8.2, 8.4, 8.6, 8.8, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0}, "Binning of the pT axis"};
+
+  HistogramRegistry histos1{"histos1", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+
   // Histograms are defined with HistogramRegistry
   HistogramRegistry rEventSelection{"eventSelection",
                                     {},
@@ -83,6 +96,34 @@ struct chargedkstaranalysis {
 
   HistogramRegistry rGenParticles{"genParticles", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry rRecParticles{"recParticles", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+
+  // Pre-selection cuts
+  Configurable<double> cMinPtcut{"cMinPtcut", 0.15, "Track minimum pt cut"};
+  /// PID Selections
+  Configurable<double> nsigmaCutCombinedPion{"nsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"}; // Combined
+
+  // DCAr to PV
+  Configurable<double> cMaxDCArToPVcut{"cMaxDCArToPVcut", 0.5, "Track DCAr cut to PV Maximum"};
+  // DCAz to PV
+  Configurable<double> cMaxDCAzToPVcut{"cMaxDCAzToPVcut", 2.0, "Track DCAz cut to PV Maximum"};
+  // Track selections
+  Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
+  Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
+  Configurable<bool> cfgPVContributor{"cfgPVContributor", true, "PV contributor track selection"};           // PV Contributor
+  // V0 selections
+  Configurable<double> cV0MinCosPA{"cV0MinCosPA", 0.97, "V0 minimum pointing angle cosine"};
+  Configurable<double> cV0MaxDaughDCA{"cV0MaxDaughDCA", 1.0, "V0 daughter DCA Maximum"};
+  // Competing V0 rejection
+  Configurable<double> cV0MassWindow{"cV0MassWindow", 0.0043, "Mass window for competing Lambda0 rejection"};
+  Configurable<float> cInvMassStart{"cInvMassStart", 0.6, "Invariant mass start"};
+  Configurable<float> cInvMassEnd{"cInvMassEnd", 1.5, "Invariant mass end"};
+  Configurable<int> cInvMassBins{"cInvMassBins", 900, "Invariant mass binning"};
+
+  // Event mixing
+  Configurable<int> nEvtMixing{"nEvtMixing", 5, "Number of events to mix"};
+  ConfigurableAxis CfgVtxBins{"CfgVtxBins", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
+  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0., 1., 5., 10., 30., 50., 70., 100., 110.}, "Mixing bins - multiplicity"};
+  Configurable<int> cTpcNsigmaPionBinsQA{"cTpcNsigmaPionBinsQA", 140, "tpcNSigmaPi binning"};
 
   // Configurable for histograms
   Configurable<int> nBins{"nBins", 100, "N bins in all histos"};
@@ -158,11 +199,57 @@ struct chargedkstaranalysis {
 
   void init(InitContext const&)
   {
+    AxisSpec dcaxyAxisQA = {cDCABinsQA, 0.0, 3.0, "DCA_{#it{xy}} (cm)"};
+    AxisSpec dcazAxisQA = {cDCABinsQA, 0.0, 3.0, "DCA_{#it{xy}} (cm)"};
+    AxisSpec ptAxisQA = {binsPtQA, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec tpcNSigmaPiAxisQA = {cTpcNsigmaPionBinsQA, -7.0, 7.0, "N#sigma_{TPC}"};
+
+    AxisSpec centAxis = {binsCent, "V0M (%)"};
+    AxisSpec ptAxis = {binsPt, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec invMassAxis = {cInvMassBins, cInvMassStart, cInvMassEnd, "Invariant Mass (GeV/#it{c}^2)"};
+    AxisSpec etaAxis = {Etabins, "#eta"};
+    AxisSpec goodTrackCountAxis = {3, 0., 3., "Passed track = 1, Passed V0 = 2, Passed track and V0 = 3"};
+    // register histograms
+    histos1.add("hVertexZ", "hVertexZ", HistType::kTH1F, {{nBins, -15., 15.}});
+    histos1.add("hEta", "Eta distribution", kTH1F, {{200, -1.0f, 1.0f}});
+    // Multiplicity and accepted events QA
+    histos1.add("QAbefore/collMult", "Collision multiplicity", HistType::kTH1F, {centAxis});
+    // QA before
+    histos1.add("QAbefore/pi_Eta", "Primary pion track eta", kTH1F, {etaAxis});
+    histos1.add("QAbefore/k0s_Eta", "K0short track eta", kTH1F, {etaAxis});
+    histos1.add("QAbefore/chargedkstarpmRapidity", "Reconstructed K*^{#pm} rapidity", kTH1F, {etaAxis});
+
+    histos1.add("QAbefore/DCAxy_pi", "DCAxy distribution of pion track candidates", HistType::kTH1F, {dcaxyAxisQA});
+    histos1.add("QAbefore/DCAz_pi", "DCAz distribution of pion track candidates", HistType::kTH1F, {dcazAxisQA});
+    histos1.add("QAbefore/pT_pi", "pT distribution of pion track candidates", kTH1F, {ptAxisQA});
+    histos1.add("QAbefore/tpcNsigmaPionQA", "NsigmaTPC distribution of primary pion candidates", kTH2F, {ptAxisQA, tpcNSigmaPiAxisQA});
+
+    // QA after
+    histos1.add("QAAfter/DCAxy_pi", "DCAxy distribution of pion track candidates", HistType::kTH1F, {dcaxyAxisQA});
+    histos1.add("QAAfter/DCAz_pi", "DCAz distribution of pion track candidates", HistType::kTH1F, {dcazAxisQA});
+    histos1.add("QAAfter/pT_pi", "pT distribution of pion track candidates", kTH1F, {ptAxisQA});
+    histos1.add("QAAfter/tpcNsigmaPionQA", "NsigmaTPC distribution of primary pion candidates", kTH2F, {ptAxisQA, tpcNSigmaPiAxisQA});
+    histos1.add("QAAfter/pi_Eta", "Primary pion track eta", kTH1F, {etaAxis});
+
+    // Good tracks and V0 counts QA
+    histos1.add("QAafter/hGoodTracksV0s", "Number of good track and V0 passed", kTH1F, {goodTrackCountAxis});
+    histos1.add("chargedkstarinvmassUlikeSign", "Invariant mass of charged K*(892)", kTH1F, {invMassAxis});
+    histos1.add("chargedkstarinvmassMixedEvent", "Invariant mass of charged K*(892)", kTH1F, {invMassAxis});
+
+    // Mass vs Pt vs Multiplicity 3-dimensional histogram
+    //    histos1.add("chargekstarMassPtMult", "Charged K*(892) mass vs pT vs V0 multiplicity distribution", kTH3F, {invMassAxis, ptAxis, centAxis});
+
+    histos1.add("chargekstarMassPtMultPtUnlikeSign",
+                "Invariant mass of CKS meson Unlike Sign", kTHnSparseF,
+                {invMassAxis, ptAxis, centAxis}, true);
+    histos1.add("chargekstarMassPtMultPtMixedEvent",
+                "Invariant mass of CKS meson MixedEvent Sign", kTHnSparseF,
+                {invMassAxis, ptAxis, centAxis}, true);
+
     // Axes
     AxisSpec K0ShortMassAxis = {200, 0.45f, 0.55f,
                                 "#it{M}_{inv} [GeV/#it{c}^{2}]"};
     AxisSpec vertexZAxis = {nBins, -10., 10., "vrtx_{Z} [cm]"};
-    AxisSpec ptAxis = {200, 0.0f, 20.0f, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec multAxis = {100, 0.0f, 100.0f, "Multiplicity"};
 
     // Histograms
@@ -459,6 +546,161 @@ struct chargedkstaranalysis {
     return true;
   }
 
+  double massK0 = o2::constants::physics::MassK0Short;
+  double massPicharged = o2::constants::physics::MassPionCharged;
+  double massLambda0 = o2::constants::physics::MassLambda;
+  double massAntiLambda0 = o2::constants::physics::MassLambda0Bar;
+  // Fill histograms (main function)
+  template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType, typename V0sType>
+  void fillHistograms(const CollisionType& collision, const TracksType& dTracks, const V0sType& dV0s)
+  {
+    // auto multiplicity = collision.cent();
+    auto multiplicity = collision.cent();
+    histos1.fill(HIST("QAbefore/collMult"), multiplicity);
+    TLorentzVector lDecayDaughter, lDecayV0, lResonance;
+
+    for (auto track : dTracks) { // loop over all dTracks1
+      // if (!trackCut(track1))
+      // continue; // track selection and PID selection
+      // trying to see the information without applying any cut yet //Let's I am trying to reconstruct the charged kstar it is V0s + pion
+      histos1.fill(HIST("hEta"), track.eta());
+
+      auto trackId = track.index();
+      auto trackptPi = track.pt();
+      auto tracketaPi = track.eta();
+
+      histos1.fill(HIST("QAbefore/pi_Eta"), tracketaPi);
+
+      if (!IsMix) {
+        // DCA QA (before cuts)
+        histos1.fill(HIST("QAbefore/DCAxy_pi"), track.dcaXY());
+        histos1.fill(HIST("QAbefore/DCAz_pi"), track.dcaZ());
+        // Pseudo-rapidity QA (before cuts)
+        histos1.fill(HIST("QAbefore/pi_Eta"), tracketaPi);
+        // pT QA (before cuts)
+        histos1.fill(HIST("QAbefore/pT_pi"), trackptPi);
+        // TPC PID (before cuts)
+        histos1.fill(HIST("QAbefore/tpcNsigmaPionQA"), trackptPi, track.tpcNSigmaPi());
+      }
+
+      // apply the track cut
+      if (!trackCutpp(track) || !selectionPIDpp(track))
+        continue;
+
+      histos1.fill(HIST("QAafter/hGoodTracksV0s"), 0.5);
+
+      if (!IsMix) {
+        // DCA QA (before cuts)
+        histos1.fill(HIST("QAAfter/DCAxy_pi"), track.dcaXY());
+        histos1.fill(HIST("QAAfter/DCAz_pi"), track.dcaZ());
+        // Pseudo-rapidity QA (before cuts)
+        histos1.fill(HIST("QAAfter/pi_Eta"), tracketaPi);
+        // pT QA (before cuts)
+        histos1.fill(HIST("QAAfter/pT_pi"), trackptPi);
+        // TPC PID (before cuts)
+        histos1.fill(HIST("QAAfter/tpcNsigmaPionQA"), trackptPi, track.tpcNSigmaPi());
+      }
+
+      for (auto& v0 : dV0s) {
+
+        // Full index policy is needed to consider all possible combinations
+        if (v0.indices()[0] == trackId || v0.indices()[1] == trackId)
+          continue; // To avoid combining secondary and primary pions
+                    //// Initialize variables
+        // trk: Pion, v0: K0s
+        // apply the track cut
+        if (!V0Cut(v0))
+          continue;
+        histos1.fill(HIST("QAafter/hGoodTracksV0s"), 1.5);
+
+        lDecayDaughter.SetXYZM(track.px(), track.py(), track.pz(), massPi);
+        lDecayV0.SetXYZM(v0.px(), v0.py(), v0.pz(), massK0);
+        lResonance = lDecayDaughter + lDecayV0;
+        // Counting how many resonances passed
+        histos1.fill(HIST("QAafter/hGoodTracksV0s"), 2.5);
+
+        // Checking whether the mid-rapidity condition is met
+        if (abs(lResonance.Rapidity()) > 0.5)
+          continue;
+        if constexpr (!IsMix) {
+          histos1.fill(HIST("chargedkstarinvmassUlikeSign"), lResonance.M());
+          // Reconstructed K*(892)pm 3d mass, pt, multiplicity histogram
+          histos1.fill(HIST("chargekstarMassPtMultPtUnlikeSign"), lResonance.M(), lResonance.Pt(), multiplicity);
+
+        } else {
+          histos1.fill(HIST("chargedkstarinvmassMixedEvent"), lResonance.M());
+          // Reconstructed K*(892)pm 3d mass, pt, multiplicity histogram
+          histos1.fill(HIST("chargekstarMassPtMultPtMixedEvent"), lResonance.M(), lResonance.Pt(), multiplicity);
+        }
+      }
+    }
+  }
+
+  template <typename T>
+  bool selectionPIDpp(const T& candidate)
+  {
+    bool tpcPIDPassed{false}, tofPIDPassed{false};
+    if (std::abs(candidate.tpcNSigmaPi()) < nsigmaCutTPC) {
+      tpcPIDPassed = true;
+    }
+    if (candidate.hasTOF()) {
+      if (std::abs(candidate.tofNSigmaPi()) < nsigmaCutTOF) {
+        tofPIDPassed = true;
+      }
+      if ((nsigmaCutCombinedPion > 0) && (candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi() + candidate.tofNSigmaPi() * candidate.tofNSigmaPi() < nsigmaCutCombinedPion * nsigmaCutCombinedPion)) {
+        tofPIDPassed = true;
+      }
+    } else {
+      tofPIDPassed = true;
+    }
+    if (tpcPIDPassed && tofPIDPassed) {
+      return true;
+    }
+    return false;
+  }
+
+  template <typename TrackType>
+  bool trackCutpp(const TrackType track)
+  {
+    // basic track cuts
+    if (std::abs(track.pt()) < cMinPtcut)
+      return false;
+    if (std::abs(track.eta()) > ConfDaughEta)
+      return false;
+    if (std::abs(track.dcaXY()) > cMaxDCArToPVcut)
+      return false;
+    if (std::abs(track.dcaZ()) > cMaxDCAzToPVcut)
+      return false;
+    if (cfgPrimaryTrack && !track.isPrimaryTrack())
+      return false;
+    if (cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
+      return false;
+    if (cfgPVContributor && !track.isPVContributor())
+      return false;
+
+    return true;
+  }
+  template <typename V0Type>
+  bool V0Cut(const V0Type v0)
+  {
+    // V0 track cuts
+    if (std::abs(v0.eta()) > ConfDaughEta)
+      return false;
+    if (v0.v0CosPA() < cV0MinCosPA)
+      return false;
+    if (v0.daughDCA() > cV0MaxDaughDCA)
+      return false;
+
+    // apply the competing V0 rejection cut (excluding Lambda0 candidates, massLambdaPDG = 1115.683 MeV/c2)
+
+    if (std::abs(v0.mLambda() - massLambda0) < cV0MassWindow)
+      return false;
+    if (std::abs(v0.mAntiLambda() - massAntiLambda0) < cV0MassWindow)
+      return false;
+
+    return true;
+  }
+
   // Defining filters for events (event selection)
   // Processed events will be already fulfilling the event selection
   // requirements
@@ -698,7 +940,7 @@ struct chargedkstaranalysis {
     }
   }
 
-  PROCESS_SWITCH(chargedkstaranalysis, processSE, "Process Same event", true);
+  PROCESS_SWITCH(chargedkstaranalysis, processSE, "Process Same event", false);
 
   void processME(EventCandidates const& /*collisions*/,
                  TrackCandidates const& /*tracks*/, V0TrackCandidate const& /*V0s*/)
@@ -803,7 +1045,7 @@ struct chargedkstaranalysis {
     }
   }
 
-  PROCESS_SWITCH(chargedkstaranalysis, processME, "Process Mixed event", true);
+  PROCESS_SWITCH(chargedkstaranalysis, processME, "Process Mixed event", false);
 
   void processGenMC(aod::McCollision const& mcCollision, aod::McParticles& mcParticles, const soa::SmallGroups<EventCandidatesMC>& collisions)
   {
@@ -1045,8 +1287,29 @@ struct chargedkstaranalysis {
     } // track loop ends
   }
 
-  PROCESS_SWITCH(chargedkstaranalysis, processGenMC, "Process Gen event", true);
-  PROCESS_SWITCH(chargedkstaranalysis, processRecMC, "Process Rec event", true);
+  PROCESS_SWITCH(chargedkstaranalysis, processGenMC, "Process Gen event", false);
+  PROCESS_SWITCH(chargedkstaranalysis, processRecMC, "Process Rec event", false);
+
+  void processSEnew(aod::ResoCollision& collision, aod::ResoTracks const& resotracks, aod::ResoV0s const& resov0s)
+  {
+    // Fill the event counter
+    histos1.fill(HIST("hVertexZ"), collision.posZ());
+    fillHistograms<false, false>(collision, resotracks, resov0s); // Fill histograms, no MC, no mixing
+  }
+  PROCESS_SWITCH(chargedkstaranalysis, processSEnew, "Process Same event new", true);
+
+  using BinningTypeVtxZT0M = ColumnBinningPolicy<aod::collision::PosZ, aod::resocollision::Cent>;
+  void processMEnew(aod::ResoCollisions& collisions, aod::ResoTracks const& resotracks, aod::ResoV0s const& resov0s)
+  {
+    auto tracksV0sTuple = std::make_tuple(resotracks, resov0s);
+    auto V0sTuple = std::make_tuple(resov0s);
+    BinningTypeVtxZT0M colBinning{{CfgVtxBins, CfgMultBins}, true};
+    Pair<aod::ResoCollisions, aod::ResoTracks, aod::ResoV0s, BinningTypeVtxZT0M> pairs{colBinning, nEvtMixing, -1, collisions, tracksV0sTuple, &cache}; // -1 is the number of the bin to skip
+    for (auto& [c1, restrk1, c2, resov0s2] : pairs) {
+      fillHistograms<false, true>(c1, restrk1, resov0s2);
+    }
+  }
+  PROCESS_SWITCH(chargedkstaranalysis, processMEnew, "Process Mixed events new", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
Dear Experts,

I have started working on the charged K* analysis in pp collisions. For this, I made some changes to the chargedkstaranalysis.cxx file, ensuring that it doesn't affect the study of the previous analyzer. I used the re-initializer table for reconstruction and also utilized THnSparse to fill the reconstructed mass, multiplicity, and p_{T} distributions.

Please review the code and let me know your suggestions.

Thanks,
With Regards,
Navneet Kumar