### PR TITLE
PWGHF: Derived data for ME in Ds-h correlation analysis

### DIFF
--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DerivedDataCorrelations.h
+/// \brief Tables for producing derived data for correlation analysis
+/// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
+
+#ifndef PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_
+#define PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+namespace hf_collisions_reduced
+{
+DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);                   //! Event multiplicity
+DECLARE_SOA_COLUMN(PosZ, posZ, float);                                   //! Primary vertex z position
+DECLARE_SOA_COLUMN(OriginalCollisionCount, originalCollisionCount, int); //! Size of collision table processed
+} // namespace hf_collisions_reduced
+DECLARE_SOA_TABLE(HfRedCollisions, "AOD", "COLLREDUCED", //! Table with collision info
+                  soa::Index<>,
+                  aod::hf_collisions_reduced::Multiplicity,
+                  aod::hf_collisions_reduced::PosZ);
+
+using HfRedCollision = HfRedCollisions::iterator;
+
+//DECLARE_SOA_TABLE(HfCandColCounts, "AOD", "HFCANDCOLCOUNT", //! Table with number of collisions which contain at least one candidate
+//                  aod::hf_collisions_reduced::OriginalCollisionCount);
+
+namespace hf_candidate_reduced
+{
+DECLARE_SOA_INDEX_COLUMN(HfRedCollision, hfRedCollision); //! ReducedCollision index
+DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(Prong1Id, prong1Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);              //! Original track index
+DECLARE_SOA_COLUMN(PhiCand, phiCand, float);              //! Phi of the candidate
+DECLARE_SOA_COLUMN(EtaCand, etaCand, float);              //! Eta of the candidate
+DECLARE_SOA_COLUMN(PtCand, ptCand, float);                //! Pt of the candidate
+DECLARE_SOA_COLUMN(CosPa, cosPa, float);                  //! Cosine of the pointing angle
+DECLARE_SOA_COLUMN(CosPaXY, cosPaXY, float);              //! Cosine of the pointing angle XY
+DECLARE_SOA_COLUMN(DecayLength, decayLength, float); //! Decay length
+DECLARE_SOA_COLUMN(NormDecayLengthXY, normDecayLengthXY, float); //! Normalised decay length XY
+DECLARE_SOA_COLUMN(ImpactParameterXY, impactParameterXY, float); //! Impact parameter XY
+DECLARE_SOA_COLUMN(DeltaMassPhiDsToKKPi, deltaMassPhiDsToKKPi, float); //! Delta mass Phi for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(DeltaMassPhiDsToPiKK, deltaMassPhiDsToPiKK, float); //! Delta mass Phi for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(Cos3PiKDsToKKPi, cos3PiKDsToKKPi, float); //! Cos3 between the pion and the kaon for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(Cos3PiKDsToPiKK, cos3PiKDsToPiKK, float); //! Cos3 between the pion and the kaon for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(SelFlagDsToKKPi, selFlagDsToKKPi, int); //! Selection flag Ds -> KKPi
+DECLARE_SOA_COLUMN(SelFlagDsToPiKK, selFlagDsToPiKK, int); //! Selection flag Ds -> PiKK
+DECLARE_SOA_COLUMN(BdtScoreClass0DsToKKPi, bdtScoreClass0DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(BdtScoreClass1DsToKKPi, bdtScoreClass1DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(BdtScoreClass2DsToKKPi, bdtScoreClass2DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(BdtScoreClass0DsToPiKK, bdtScoreClass0DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(BdtScoreClass1DsToPiKK, bdtScoreClass1DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(BdtScoreClass2DsToPiKK, bdtScoreClass2DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(InvMassDsToKKPi, invMassDsToKKPi, float); //! Invariant mass of candidate for the Ds -> KKPi  hypothesis
+DECLARE_SOA_COLUMN(InvMassDsToPiKK, invMassDsToPiKK, float); //! Invariant mass of candidate for the Ds -> PiKK  hypothesis
+} // namespace hf_candidate_reduced
+DECLARE_SOA_TABLE(DsCandReduced, "AOD", "DSCANDREDUCED", //! Table with Ds candidate info (rectangular selection)
+                  soa::Index<>,
+                  aod::hf_candidate_reduced::HfRedCollisionId,
+                  aod::hf_candidate_reduced::PhiCand,
+                  aod::hf_candidate_reduced::EtaCand,
+                  aod::hf_candidate_reduced::PtCand);
+
+namespace hf_assoc_track_reduced
+{
+DECLARE_SOA_COLUMN(TrackId, trackId, int);               //! Original track index
+DECLARE_SOA_COLUMN(EtaAssocTrack, etaAssocTrack, float); //! Eta of the track
+DECLARE_SOA_COLUMN(PhiAssocTrack, phiAssocTrack, float); //! Phi of the track
+DECLARE_SOA_COLUMN(PtAssocTrack, ptAssocTrack, float);   //! Pt of the track
+} // namespace hf_assoc_track_reduced
+DECLARE_SOA_TABLE(AssocTrackReduced, "AOD", "TRACKREDUCED", //! Table with associated track info
+                  soa::Index<>,
+                  aod::hf_candidate_reduced::HfRedCollisionId,
+                  aod::hf_assoc_track_reduced::PhiAssocTrack,
+                  aod::hf_assoc_track_reduced::EtaAssocTrack,
+                  aod::hf_assoc_track_reduced::PtAssocTrack)
+} // namespace o2::aod
+
+#endif // PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_

--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -39,38 +39,18 @@ using HfRedCollision = HfRedCollisions::iterator;
 namespace hf_candidate_reduced
 {
 DECLARE_SOA_INDEX_COLUMN(HfRedCollision, hfRedCollision);                  //! ReducedCollision index
-DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                               //! Original track index
-DECLARE_SOA_COLUMN(Prong1Id, prong1Id, int);                               //! Original track index
-DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);                               //! Original track index
 DECLARE_SOA_COLUMN(PhiCand, phiCand, float);                               //! Phi of the candidate
 DECLARE_SOA_COLUMN(EtaCand, etaCand, float);                               //! Eta of the candidate
 DECLARE_SOA_COLUMN(PtCand, ptCand, float);                                 //! Pt of the candidate
-DECLARE_SOA_COLUMN(CosPa, cosPa, float);                                   //! Cosine of the pointing angle
-DECLARE_SOA_COLUMN(CosPaXY, cosPaXY, float);                               //! Cosine of the pointing angle XY
-DECLARE_SOA_COLUMN(DecayLength, decayLength, float);                       //! Decay length
-DECLARE_SOA_COLUMN(NormDecayLengthXY, normDecayLengthXY, float);           //! Normalised decay length XY
-DECLARE_SOA_COLUMN(ImpactParameterXY, impactParameterXY, float);           //! Impact parameter XY
-DECLARE_SOA_COLUMN(DeltaMassPhiDsToKKPi, deltaMassPhiDsToKKPi, float);     //! Delta mass Phi for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(DeltaMassPhiDsToPiKK, deltaMassPhiDsToPiKK, float);     //! Delta mass Phi for the Ds -> PiKK  hypothesis
-DECLARE_SOA_COLUMN(Cos3PiKDsToKKPi, cos3PiKDsToKKPi, float);               //! Cos3 between the pion and the kaon for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(Cos3PiKDsToPiKK, cos3PiKDsToPiKK, float);               //! Cos3 between the pion and the kaon for the Ds -> PiKK  hypothesis
-DECLARE_SOA_COLUMN(SelFlagDsToKKPi, selFlagDsToKKPi, int);                 //! Selection flag Ds -> KKPi
-DECLARE_SOA_COLUMN(SelFlagDsToPiKK, selFlagDsToPiKK, int);                 //! Selection flag Ds -> PiKK
-DECLARE_SOA_COLUMN(BdtScoreClass0DsToKKPi, bdtScoreClass0DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(BdtScoreClass1DsToKKPi, bdtScoreClass1DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(BdtScoreClass2DsToKKPi, bdtScoreClass2DsToKKPi, float); //! Bdt score for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(BdtScoreClass0DsToPiKK, bdtScoreClass0DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
-DECLARE_SOA_COLUMN(BdtScoreClass1DsToPiKK, bdtScoreClass1DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
-DECLARE_SOA_COLUMN(BdtScoreClass2DsToPiKK, bdtScoreClass2DsToPiKK, float); //! Bdt score for the Ds -> PiKK  hypothesis
-DECLARE_SOA_COLUMN(InvMassDsToKKPi, invMassDsToKKPi, float);               //! Invariant mass of candidate for the Ds -> KKPi  hypothesis
-DECLARE_SOA_COLUMN(InvMassDsToPiKK, invMassDsToPiKK, float);               //! Invariant mass of candidate for the Ds -> PiKK  hypothesis
+DECLARE_SOA_COLUMN(InvMassDs, invMassDs, float);                     //! Invariant mass of Ds candidate
 } // namespace hf_candidate_reduced
 DECLARE_SOA_TABLE(DsCandReduced, "AOD", "DSCANDREDUCED", //! Table with Ds candidate info (rectangular selection)
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfRedCollisionId,
                   aod::hf_candidate_reduced::PhiCand,
                   aod::hf_candidate_reduced::EtaCand,
-                  aod::hf_candidate_reduced::PtCand);
+                  aod::hf_candidate_reduced::PtCand,
+                  aod::hf_candidate_reduced::InvMassDs);
 
 namespace hf_assoc_track_reduced
 {

--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -87,4 +87,4 @@ DECLARE_SOA_TABLE(AssocTrackReduced, "AOD", "TRACKREDUCED", //! Table with assoc
                   aod::hf_assoc_track_reduced::PtAssocTrack)
 } // namespace o2::aod
 
-#endif // PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_
+#endif  // PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONTABLES_H_

--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -24,7 +24,7 @@ namespace hf_collisions_reduced
 {
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);                   //! Event multiplicity
 DECLARE_SOA_COLUMN(PosZ, posZ, float);                                   //! Primary vertex z position
-DECLARE_SOA_COLUMN(OriginalCollisionCount, originalCollisionCount, int); //! Size of collision table processed
+
 } // namespace hf_collisions_reduced
 DECLARE_SOA_TABLE(HfRedCollisions, "AOD", "COLLREDUCED", //! Table with collision info
                   soa::Index<>,

--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -13,8 +13,8 @@
 /// \brief Tables for producing derived data for correlation analysis
 /// \author Samuele Cattaruzzi <samuele.cattaruzzi@cern.ch>
 
-#ifndef PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_
-#define PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONS_H_
+#ifndef PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONTABLES_H_
+#define PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONTABLES_H_
 
 #include "Framework/AnalysisDataModel.h"
 

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -698,6 +698,9 @@ struct HfCorrelatorDsHadrons {
     
     // tracks information
     for (const auto& track : tracks) {
+      if (!track.isGlobalTrackWoDCA()) {
+        continue;
+      }
       assocTrackReduced(collReduced.lastIndex(), track.phi(), track.eta(), track.pt());
     }
   }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -693,7 +693,11 @@ struct HfCorrelatorDsHadrons {
     // Ds fill histograms and Ds candidates information stored
     for (const auto& candidate : candidates) {
       // candidate selected
-      candReduced(collReduced.lastIndex(), candidate.phi(), candidate.eta(), candidate.pt());
+      if (candidate.isSelDsToKKPi() >= selectionFlagDs) {
+        candReduced(collReduced.lastIndex(), candidate.phi(), candidate.eta(), candidate.pt(), hfHelper.invMassDsToKKPi(candidate));
+      } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
+        candReduced(collReduced.lastIndex(), candidate.phi(), candidate.eta(), candidate.pt(), hfHelper.invMassDsToPiKK(candidate));
+      }
     }
 
     // tracks information

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -29,6 +29,7 @@
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 #include "PWGHF/HFC/DataModel/CorrelationTables.h"
+#include "PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h"
 
 using namespace o2;
 using namespace o2::analysis;
@@ -135,6 +136,9 @@ struct HfCorrelatorDsHadrons {
   Produces<aod::DsCandRecoInfo> entryDsCandRecoInfo;
   Produces<aod::DsCandGenInfo> entryDsCandGenInfo;
   Produces<aod::TrackRecoInfo> entryTrackRecoInfo;
+  Produces<aod::HfRedCollisions> collReduced;
+  Produces<aod::DsCandReduced> candReduced;
+  Produces<aod::AssocTrackReduced> assocTrackReduced;
 
   Configurable<bool> fillHistoData{"fillHistoData", true, "Flag for filling histograms in data processes"};
   Configurable<bool> fillHistoMcRec{"fillHistoMcRec", true, "Flag for filling histograms in MC Rec processes"};
@@ -679,6 +683,25 @@ struct HfCorrelatorDsHadrons {
     }   // end loop generated collision
   }
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processMcGen, "Process MC Gen mode", false);
+  
+  void processDerivedDataDs(SelCollisionsWithDs::iterator const& collision,
+                            CandDsData const& candidates,
+                            MyTracksData const& tracks)
+  {
+    collReduced(collision.multFV0M(), collision.posZ());
+    // Ds fill histograms and Ds candidates information stored
+    for (const auto& candidate : candidates) {
+          
+      // candidate selected with rectangular selections
+      candReduced(collReduced.lastIndex(), candidate.phi(), candidate.eta(), candidate.pt());
+
+      // tracks information
+      for (const auto& track : tracks) {
+        assocTrackReduced(collReduced.lastIndex(), track.phi(), track.eta(), track.pt());
+      }
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorDsHadrons, processDerivedDataDs, "Process derived data Ds", false);
 
   // Event Mixing
   void processDataME(SelCollisionsWithDs const& collisions,

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -689,16 +689,17 @@ struct HfCorrelatorDsHadrons {
                             MyTracksData const& tracks)
   {
     collReduced(collision.multFV0M(), collision.posZ());
+    
+    int counterDs = 0;
     // Ds fill histograms and Ds candidates information stored
-    for (const auto& candidate : candidates) {
-          
-      // candidate selected with rectangular selections
+    for (const auto& candidate : candidates) {          
+      // candidate selected
       candReduced(collReduced.lastIndex(), candidate.phi(), candidate.eta(), candidate.pt());
-
-      // tracks information
-      for (const auto& track : tracks) {
-        assocTrackReduced(collReduced.lastIndex(), track.phi(), track.eta(), track.pt());
-      }
+    }
+    
+    // tracks information
+    for (const auto& track : tracks) {
+      assocTrackReduced(collReduced.lastIndex(), track.phi(), track.eta(), track.pt());
     }
   }
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processDerivedDataDs, "Process derived data Ds", false);

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -690,7 +690,6 @@ struct HfCorrelatorDsHadrons {
   {
     collReduced(collision.multFV0M(), collision.posZ());
     
-    int counterDs = 0;
     // Ds fill histograms and Ds candidates information stored
     for (const auto& candidate : candidates) {          
       // candidate selected

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -688,7 +688,7 @@ struct HfCorrelatorDsHadrons {
                             CandDsData const& candidates,
                             MyTracksData const& tracks)
   {
-    collReduced(collision.multFV0M(), collision.posZ());
+    collReduced(collision.multFT0M(), collision.posZ());
 
     // Ds fill histograms and Ds candidates information stored
     for (const auto& candidate : candidates) {


### PR DESCRIPTION
Dear all,
I've added 3 new tables in order to store the information on collisions containing a Ds-meson with the idea of using them to save derived data in order to perform the ME offline with the current framework already available in O2Physics.

Let me know for any comment,
Cheers,
Samuele