### PR TITLE
[Infrastructure] Add PR title prefix checker

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,8 @@
 ---
 name: "Pull Request Labeler"
-on:
-  - pull_request_target
+'on':
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
 permissions: read-all
 
 jobs:
@@ -10,8 +11,112 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      labels: ${{ steps.labeler.outputs.all-labels }}
     steps:
-      - uses: actions/labeler@v5
+      - name: Label the PR
+        id: labeler
+        uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+  title-prefix-checker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    needs: labeler
+    steps:
+      - name: Check the PR title prefix
+        id: check-prefix
+        env:
+          title: ${{ github.event.pull_request.title }}
+          labels: ${{ needs.labeler.outputs.labels }}
+        shell: python
+        run: |
+          import os
+          import re
+          import sys
+          title = os.environ['title']
+          labels = os.environ['labels']
+          tags = {
+              "infrastructure": "Infrastructure",
+              "common": "Common",
+              "alice3": "ALICE3",
+              "pwgcf": "PWGCF",
+              "pwgdq": "PWGDQ",
+              "pwgem": "PWGEM",
+              "pwghf": "PWGHF",
+              "pwgje": "PWGJE",
+              "pwglf": "PWGLF",
+              "pwgud": "PWGUD",
+              "dpg": "DPG",
+              "trigger": "Trigger",
+              "tutorial": "Tutorial",
+          }
+          print(f'PR title: "{title}"')
+          print(f'PR labels: "{labels}"')
+          tags_relevant = [tags[label] for label in tags if label in labels.split(",")]
+          print("Relevant title tags:", ",".join(tags_relevant))
+          passed = True
+          prefix_good = ",".join(tags_relevant)
+          prefix_good = f"[{prefix_good}] "
+          print(f"Generated prefix: {prefix_good}")
+          replace_title = 0
+          title_new = title
+          # If there is a prefix which contains a known tag, check it for correct tags, and reformat it if needed.
+          # If there is a prefix which does not contain any known tag, add the tag prefix.
+          # If there is no prefix, add the tag prefix.
+          if match := re.match(r"\[?(\w[\w, /\+-]+)[\]:]+ ", title):
+              prefix_title = match.group(1)
+              words_prefix_title = prefix_title.replace(",", " ").replace("/", " ").split()
+              title_stripped = title[len(match.group()) :]
+              print(f'PR title prefix: "{prefix_title}" -> tags: {words_prefix_title}')
+              print(f'Stripped PR title: "{title_stripped}"')
+              if any(tag in words_prefix_title for tag in tags.values()):
+                  for tag in tags.values():
+                      if tag in tags_relevant and tag not in words_prefix_title:
+                          print(f'::error::Relevant tag "{tag}" not found in the prefix of the PR title.')
+                          passed = False
+                      if tag not in tags_relevant and tag in words_prefix_title:
+                          print(f'::error::Irrelevant tag "{tag}" found in the prefix of the PR title.')
+                          passed = False
+                  # Format a valid prefix.
+                  if passed:
+                      prefix_good = ",".join(w for w in prefix_title.replace(",", " ").split() if w)
+                      prefix_good = f"[{prefix_good}] "
+                      print(f"::notice::Reformatted prefix: {prefix_good}")
+                      if match.group() != prefix_good:
+                          replace_title = 1
+                          title_new = prefix_good + title_stripped
+              else:
+                  print("::warning::No known tags found in the prefix.")
+                  if tags_relevant:
+                      replace_title = 1
+                      title_new = prefix_good + title
+          else:
+              print("::warning::No valid prefix found in the PR title.")
+              if tags_relevant:
+                  replace_title = 1
+                  title_new = prefix_good + title
+          if not passed:
+              print("::error::Problems were found in the PR title prefix.")
+              print('::notice::Use the form "tags: title" or "[tags] title".')
+              sys.exit(1)
+          if replace_title:
+              print("::warning::The PR title prefix with tags needs to be added or adjusted.")
+              print(f'::warning::New title: "{title_new}".')
+          else:
+              print("::notice::The PR title prefix is fine.")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              print(f"replace={replace_title}", file=fh)
+              print(f"title={title_new}", file=fh)
+      - name: Fix the PR title prefix
+        if: ${{ steps.check-prefix.outputs.replace == 1 }}
+        uses: the-wright-jamie/Update-PR-Info-Action@v1.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          base-branch-regex: master
+          error-on-fail: false
+          title-template: "${{ steps.check-prefix.outputs.title }}"
+          title-update-action: replace


### PR DESCRIPTION
This PR extends the PR labeler GitHub action with another CI job which checks whether the PR title has a prefix corresponding to the PR labels, formats it if needed or adds it if it is missing.

The logic of the behaviour is the following:

- Get the list of known tags corresponding to the labels. (Mapping `label:tag` is listed inside the workflow file.)
- Find an existing title prefix. Common recognised formats: `[tags] title`, `tags: title`, `[tags]: title`. Tags can be separated with any combination of `, /`.
- If there is a prefix which contains a known tag:
  - Check it for correct tags and throw an error if extra/missing known tags are found. (Unrecognised tags do not trigger errors.)
  - Reformat a correct prefix if needed. Format: `[tag1,tag2,...] title`.
- If there is a prefix which does not contain any known tag, add the prefix with known tags.
- If there is no prefix, add the prefix with known tags.

The action is triggered when the PR is opened, synchronized, reopened, edited.