### PR TITLE
Update the default base CCDB path for Zorro

### DIFF
--- a/EventFiltering/Zorro.h
+++ b/EventFiltering/Zorro.h
@@ -64,7 +64,7 @@ class Zorro
 
   ZorroSummary mZorroSummary{"ZorroSummary", "ZorroSummary"};
 
-  std::string mBaseCCDBPath = "Users/m/mpuccio/EventFiltering/OTS/";
+  std::string mBaseCCDBPath = "Users/m/mpuccio/EventFiltering/OTS/Chunked/";
   int mRunNumber = 0;
   std::pair<int64_t, int64_t> mRunDuration;
   int64_t mOrbitResetTimestamp = 0;


### PR DESCRIPTION
Changes the base CCDB path for the Zorro class from "Users/m/mpuccio/EventFiltering/OTS/" to
"Users/m/mpuccio/EventFiltering/OTS/Chunked/". This is necessary to point to the correct location of the CCDB files for the chunked data.