### PR TITLE
Infrastructure: Labeler: Automatically sync labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
Sets `sync-labels: true` for the labeler which allows to update the PR labels when the PR is modified.