### PR TITLE
PWGCF: FemtoUniverse - Adding FDCascParticles table to FemtoDerived

### DIFF
--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -126,6 +126,24 @@ DECLARE_SOA_COLUMN(DecayVtxZ, decayVtxZ, float);     //! Z position of the decay
 DECLARE_SOA_COLUMN(MKaon, mKaon, float);             //! The invariant mass of V0 candidate, assuming kaon
 
 } // namespace femtouniverseparticle
+
+/// FemtoUniverseCascadeTrack
+namespace femtouniversecascparticle
+{
+
+DECLARE_SOA_COLUMN(DcaV0daughters, dcaV0daughters, float);     //! DCA between V0 daughters
+DECLARE_SOA_COLUMN(Cpav0, cpav0, float);                       //! V0 cos of pointing angle
+DECLARE_SOA_COLUMN(V0radius, v0radius, float);                 //! V0 transverse radius
+DECLARE_SOA_COLUMN(CpaCasc, cpaCasc, float);                   //! cascade cosinus of pointing angle
+DECLARE_SOA_COLUMN(Dcacascdaughters, dcacascdaughters, float); //! DCA between cascade daughters
+DECLARE_SOA_COLUMN(Cascradius, cascradius, float);             //! cascade transverse radius
+DECLARE_SOA_COLUMN(Dcapostopv, dcapostopv, float);             //! DCA of positive daughter to PV
+DECLARE_SOA_COLUMN(Dcanegtopv, dcanegtopv, float);             //! DCA of negative daughter to PV
+DECLARE_SOA_COLUMN(Dcabachtopv, dcabachtopv, float);           //! DCA of bachelor track to PV
+DECLARE_SOA_COLUMN(Dcav0topv, dcav0topv, float);               //! DCA of V0 to PV
+
+} // namespace femtouniversecascparticle
+
 DECLARE_SOA_TABLE(FDParticles, "AOD", "FDPARTICLE",
                   o2::soa::Index<>,
                   femtouniverseparticle::FDCollisionId,
@@ -186,6 +204,36 @@ DECLARE_SOA_TABLE(FDExtParticles, "AOD", "FDEXTPARTICLE",
                   pidtof_tiny::TOFNSigmaPr<pidtof_tiny::TOFNSigmaStorePr>,
                   pidtof_tiny::TOFNSigmaDe<pidtof_tiny::TOFNSigmaStoreDe>);
 using FDFullParticle = FDExtParticles::iterator;
+
+DECLARE_SOA_TABLE(FDCascParticles, "AOD", "FDCASCPARTICLE",
+                  o2::soa::Index<>,
+                  femtouniverseparticle::FDCollisionId,
+                  femtouniverseparticle::Pt,
+                  femtouniverseparticle::Eta,
+                  femtouniverseparticle::Phi,
+                  femtouniverseparticle::PartType,
+                  femtouniverseparticle::Cut,
+                  femtouniverseparticle::PIDCut,
+                  femtouniverseparticle::TempFitVar,
+                  femtouniverseparticle::ChildrenIds,
+                  femtouniverseparticle::MLambda,
+                  femtouniverseparticle::MAntiLambda,
+                  femtouniverseparticle::Theta<femtouniverseparticle::Eta>,
+                  femtouniverseparticle::Px<femtouniverseparticle::Pt, femtouniverseparticle::Phi>,
+                  femtouniverseparticle::Py<femtouniverseparticle::Pt, femtouniverseparticle::Phi>,
+                  femtouniverseparticle::Pz<femtouniverseparticle::Pt, femtouniverseparticle::Eta>,
+                  femtouniverseparticle::P<femtouniverseparticle::Pt, femtouniverseparticle::Eta>,
+                  femtouniversecascparticle::DcaV0daughters,
+                  femtouniversecascparticle::Cpav0,
+                  femtouniversecascparticle::V0radius,
+                  femtouniversecascparticle::CpaCasc,
+                  femtouniversecascparticle::Dcacascdaughters,
+                  femtouniversecascparticle::Cascradius,
+                  femtouniversecascparticle::Dcapostopv,
+                  femtouniversecascparticle::Dcanegtopv,
+                  femtouniversecascparticle::Dcabachtopv,
+                  femtouniversecascparticle::Dcav0topv);
+using FDCascParticle = FDCascParticles::iterator;
 
 /// FemtoUniverseTrackMC
 namespace femtouniverseMCparticle

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -102,6 +102,7 @@ struct femtoUniverseProducerTask {
   Produces<aod::FDExtParticles> outputDebugParts;
   Produces<aod::FDMCLabels> outputPartsMCLabels;
   Produces<aod::FDExtMCParticles> outputDebugPartsMC;
+  Produces<aod::FDCascParticles> outputCascParts;
 
   Configurable<bool> ConfIsDebug{"ConfIsDebug", true, "Enable Debug tables"};
   // Choose if filtering or skimming version is run
@@ -123,7 +124,7 @@ struct femtoUniverseProducerTask {
   Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", false, "Evt sel: check for offline selection"};
   Configurable<bool> ConfIsActivateV0{"ConfIsActivateV0", false, "Activate filling of V0 into femtouniverse tables"};
   Configurable<bool> ConfActivateSecondaries{"ConfActivateSecondaries", false, "Fill secondary MC gen particles that were reconstructed"};
-  Configurable<bool> ConfIsActivateCascade{"ConfIsActivateCascade", true, "Activate filling of Cascade into femtouniverse tables"};
+  Configurable<bool> ConfIsActivateCascade{"ConfIsActivateCascade", false, "Activate filling of Cascade into femtouniverse tables"};
   Configurable<bool> ConfIsActivatePhi{"ConfIsActivatePhi", false, "Activate filling of Phi into femtouniverse tables"};
   Configurable<bool> ConfMCTruthAnalysisWithPID{"ConfMCTruthAnalysisWithPID", true, "1: take only particles with specified PDG, 0: all particles (for MC Truth)"};
   Configurable<std::vector<int>> ConfMCTruthPDGCodes{"ConfMCTruthPDGCodes", std::vector<int>{211, -211, 2212, -2212, 333}, "PDG of particles to be stored"};
@@ -907,13 +908,23 @@ struct femtoUniverseProducerTask {
       auto cutContainer = trackCuts.getCutContainer<aod::femtouniverseparticle::cutContainerType>(track);
 
       // now the table is filled
-      outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),
-                  track.phi(), aod::femtouniverseparticle::ParticleType::kTrack,
-                  cutContainer.at(
-                    femtoUniverseTrackSelection::TrackContainerPosition::kCuts),
-                  cutContainer.at(
-                    femtoUniverseTrackSelection::TrackContainerPosition::kPID),
-                  track.dcaXY(), childIDs, 0, 0);
+      if (!ConfIsActivateCascade) {
+        outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),
+                    track.phi(), aod::femtouniverseparticle::ParticleType::kTrack,
+                    cutContainer.at(
+                      femtoUniverseTrackSelection::TrackContainerPosition::kCuts),
+                    cutContainer.at(
+                      femtoUniverseTrackSelection::TrackContainerPosition::kPID),
+                    track.dcaXY(), childIDs, 0, 0);
+      } else {
+        outputCascParts(outputCollision.lastIndex(), track.pt(), track.eta(),
+                        track.phi(), aod::femtouniverseparticle::ParticleType::kTrack,
+                        cutContainer.at(
+                          femtoUniverseTrackSelection::TrackContainerPosition::kCuts),
+                        cutContainer.at(
+                          femtoUniverseTrackSelection::TrackContainerPosition::kPID),
+                        track.dcaXY(), childIDs, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      }
       tmpIDtrack.push_back(track.globalIndex());
       if (ConfIsDebug) {
         fillDebugParticle<true, false, false>(track);
@@ -1040,18 +1051,28 @@ struct femtoUniverseProducerTask {
       childIDs[0] = rowInPrimaryTrackTablePos; // pos
       childIDs[1] = 0;                         // neg
       childIDs[2] = 0;                         // bachelor
-      outputParts(outputCollision.lastIndex(),
-                  casc.positivept(),
-                  casc.positiveeta(),
-                  casc.positivephi(),
-                  aod::femtouniverseparticle::ParticleType::kV0Child,
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
-                  0.,
-                  childIDs,
-                  0,
-                  0);
-      const int rowOfPosTrack = outputParts.lastIndex();
+      outputCascParts(outputCollision.lastIndex(),
+                      casc.positivept(),
+                      casc.positiveeta(),
+                      casc.positivephi(),
+                      aod::femtouniverseparticle::ParticleType::kV0Child,
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosCuts),
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kPosPID),
+                      0.,
+                      childIDs,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0);
+      const int rowOfPosTrack = outputCascParts.lastIndex();
       // if constexpr (isMC) {
       //   fillMCParticle(postrack, o2::aod::femtouniverseparticle::ParticleType::kV0Child);
       // }
@@ -1061,18 +1082,28 @@ struct femtoUniverseProducerTask {
       childIDs[0] = 0;                         // pos
       childIDs[1] = rowInPrimaryTrackTableNeg; // neg
       childIDs[2] = 0;                         // bachelor
-      outputParts(outputCollision.lastIndex(),
-                  casc.negativept(),
-                  casc.negativeeta(),
-                  casc.negativephi(),
-                  aod::femtouniverseparticle::ParticleType::kV0Child,
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
-                  0.,
-                  childIDs,
-                  0,
-                  0);
-      const int rowOfNegTrack = outputParts.lastIndex();
+      outputCascParts(outputCollision.lastIndex(),
+                      casc.negativept(),
+                      casc.negativeeta(),
+                      casc.negativephi(),
+                      aod::femtouniverseparticle::ParticleType::kV0Child,
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
+                      0.,
+                      childIDs,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0);
+      const int rowOfNegTrack = outputCascParts.lastIndex();
       // if constexpr (isMC) {
       //   fillMCParticle(negtrack, o2::aod::femtouniverseparticle::ParticleType::kV0Child);
       // }
@@ -1083,31 +1114,51 @@ struct femtoUniverseProducerTask {
       childIDs[0] = 0;                          // pos
       childIDs[1] = 0;                          // neg
       childIDs[2] = rowInPrimaryTrackTableBach; // bachelor
-      outputParts(outputCollision.lastIndex(),
-                  casc.bachelorpt(),
-                  casc.bacheloreta(),
-                  casc.bachelorphi(),
-                  aod::femtouniverseparticle::ParticleType::kCascadeBachelor,
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
-                  0.,
-                  childIDs,
-                  0,
-                  0);
-      const int rowOfBachTrack = outputParts.lastIndex();
+      outputCascParts(outputCollision.lastIndex(),
+                      casc.bachelorpt(),
+                      casc.bacheloreta(),
+                      casc.bachelorphi(),
+                      aod::femtouniverseparticle::ParticleType::kCascadeBachelor,
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegCuts),
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kNegPID),
+                      0.,
+                      childIDs,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0);
+      const int rowOfBachTrack = outputCascParts.lastIndex();
       // cascade
       std::vector<int> indexCascChildID = {rowOfPosTrack, rowOfNegTrack, rowOfBachTrack};
-      outputParts(outputCollision.lastIndex(),
-                  casc.pt(),
-                  casc.eta(),
-                  casc.phi(),
-                  aod::femtouniverseparticle::ParticleType::kCascade,
-                  0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kV0), // zmienic
-                  0,
-                  casc.casccosPA(col.posX(), col.posY(), col.posZ()),
-                  indexCascChildID,
-                  casc.mXi(),
-                  casc.mXi());
+      outputCascParts(outputCollision.lastIndex(),
+                      casc.pt(),
+                      casc.eta(),
+                      casc.phi(),
+                      aod::femtouniverseparticle::ParticleType::kCascade,
+                      0, // cutContainerV0.at(femtoUniverseV0Selection::V0ContainerPosition::kV0),
+                      0,
+                      0,
+                      indexCascChildID,
+                      casc.mXi(),
+                      casc.mXi(),
+                      casc.dcaV0daughters(),
+                      casc.v0cosPA(col.posX(), col.posY(), col.posZ()),
+                      casc.v0radius(),
+                      casc.casccosPA(col.posX(), col.posY(), col.posZ()),
+                      casc.dcacascdaughters(),
+                      casc.cascradius(),
+                      casc.dcapostopv(),
+                      casc.dcanegtopv(),
+                      casc.dcabachtopv(),
+                      casc.dcav0topv(col.posX(), col.posY(), col.posZ()));
       if (ConfIsDebug) {
         fillDebugParticle<true, false, false>(posTrackCasc);  // QA for positive daughter
         fillDebugParticle<true, false, false>(negTrackCasc);  // QA for negative daughter

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackCascadeExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackCascadeExtended.cxx
@@ -37,7 +37,7 @@ using namespace o2::aod::pidutils;
 struct femtoUniversePairTaskTrackCascadeExtended {
 
   SliceCache cache;
-  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
+  using FemtoFullParticles = soa::Join<aod::FDCascParticles, aod::FDExtParticles>;
   Preslice<FemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
 
   Configurable<float> ConfZVertexCut{"ConfZVertexCut", 10.f, "Event sel: Maximum z-Vertex (cm)"};
@@ -80,17 +80,27 @@ struct femtoUniversePairTaskTrackCascadeExtended {
     AxisSpec ptAxis = {100, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec etaAxis = {100, -2.0f, 2.0f, "#it{#eta}"};
     AxisSpec phiAxis = {100, 0.0f, 6.0f, "#it{#phi}"};
+    AxisSpec DCADaughAxis = {1000, 0.0f, 2.0f, "DCA (cm)"};
+    AxisSpec CPAAxis = {1000, 0.95f, 1.0f, "#it{cos #theta_{p}}"};
+    AxisSpec tranRadAxis = {1000, 0.0f, 100.0f, "#it{r}_{xy} (cm)"};
+    AxisSpec DCAToPVAxis = {1000, -10.0f, 10.0f, "DCA to PV (cm)"};
 
     // Histograms
-    rXiQA.add("hMassXiMinus", "hMassXiMinus", {HistType::kTH1F, {XiMassAxis}});
-    rXiQA.add("hMassXiPlus", "hMassXiPlus", {HistType::kTH1F, {XiMassAxis}});
-    rXiQA.add("hMassXiMinusSelected", "hMassXiSelected", {HistType::kTH1F, {XiMassAxis}});
-    rXiQA.add("hMassXiPlusSelected", "hMassXiSelected", {HistType::kTH1F, {XiMassAxis}});
+    rXiQA.add("hMassXi", "hMassXi", {HistType::kTH1F, {XiMassAxis}});
+    rXiQA.add("hMassXiSelected", "hMassXiSelected", {HistType::kTH1F, {XiMassAxis}});
     rXiQA.add("hPtXi", "hPtXi", {HistType::kTH1F, {{ptAxis}}});
     rXiQA.add("hEtaXi", "hEtaXi", {HistType::kTH1F, {{etaAxis}}});
     rXiQA.add("hPhiXi", "hPhiXi", {HistType::kTH1F, {{phiAxis}}});
-    rXiQA.add("hCascCosPA", "hCascCosPA", {HistType::kTH1F, {{100, 0.9f, 1.f}}});
-    // rXiQA.add("hCascDCAV0Daughters", "hCascDCAV0Daughters", {HistType::kTH1F, {{55, 0.0f, 2.2f}}});
+    rXiQA.add("hDCAV0Daughters", "hDCAV0Daughters", {HistType::kTH1F, {DCADaughAxis}});
+    rXiQA.add("hV0CosPA", "hV0CosPA", {HistType::kTH1F, {CPAAxis}});
+    rXiQA.add("hV0TranRad", "hV0TranRad", {HistType::kTH1F, {tranRadAxis}});
+    rXiQA.add("hDCACascDaughters", "hDCACascDaughters", {HistType::kTH1F, {DCADaughAxis}});
+    rXiQA.add("hCascCosPA", "hCascCosPA", {HistType::kTH1F, {CPAAxis}});
+    rXiQA.add("hCascTranRad", "hCascTranRad", {HistType::kTH1F, {tranRadAxis}});
+    rXiQA.add("hDcaPostoPV", "hDcaPostoPV", {HistType::kTH1F, {DCAToPVAxis}});
+    rXiQA.add("hDcaNegtoPV", "hDcaNegtoPV", {HistType::kTH1F, {DCAToPVAxis}});
+    rXiQA.add("hDcaBachtoPV", "hDcaBachtoPV", {HistType::kTH1F, {DCAToPVAxis}});
+    rXiQA.add("hDcaV0toPV", "hDcaV0toPV", {HistType::kTH1F, {DCAToPVAxis}});
 
     posChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, 0, true);
     negChildHistos.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, 0, true);
@@ -103,8 +113,7 @@ struct femtoUniversePairTaskTrackCascadeExtended {
     // const int multCol = col.multNtr();
 
     for (auto& casc : groupCascs) {
-      rXiQA.fill(HIST("hMassXiMinus"), casc.mLambda());
-      rXiQA.fill(HIST("hMassXiPlus"), casc.mAntiLambda());
+      rXiQA.fill(HIST("hMassXi"), casc.mLambda());
 
       // if (!invMCascade(casc.mLambda(), casc.mAntiLambda()))
       //   continue;
@@ -141,10 +150,17 @@ struct femtoUniversePairTaskTrackCascadeExtended {
       rXiQA.fill(HIST("hPtXi"), casc.pt());
       rXiQA.fill(HIST("hEtaXi"), casc.eta());
       rXiQA.fill(HIST("hPhiXi"), casc.phi());
-      rXiQA.fill(HIST("hMassXiMinusSelected"), casc.mLambda());
-      rXiQA.fill(HIST("hMassXiPlusSelected"), casc.mAntiLambda());
-      rXiQA.fill(HIST("hCascCosPA"), casc.tempFitVar());
-      // rXiQA.fill(HIST("hCascDCAV0Daughters"), casc.dcaV0daughters()); // nie ma miejsca na to w FemtoDerived
+      rXiQA.fill(HIST("hMassXiSelected"), casc.mLambda());
+      rXiQA.fill(HIST("hDCAV0Daughters"), casc.dcaV0daughters());
+      rXiQA.fill(HIST("hV0CosPA"), casc.cpav0());
+      rXiQA.fill(HIST("hV0TranRad"), casc.v0radius());
+      rXiQA.fill(HIST("hCascCosPA"), casc.cpaCasc());
+      rXiQA.fill(HIST("hDCACascDaughters"), casc.dcacascdaughters());
+      rXiQA.fill(HIST("hCascTranRad"), casc.cascradius());
+      rXiQA.fill(HIST("hDcaPostoPV"), casc.dcapostopv());
+      rXiQA.fill(HIST("hDcaNegtoPV"), casc.dcanegtopv());
+      rXiQA.fill(HIST("hDcaBachtoPV"), casc.dcabachtopv());
+      rXiQA.fill(HIST("hDcaV0toPV"), casc.dcav0topv());
 
       posChildHistos.fillQA<false, true>(posChild);
       negChildHistos.fillQA<false, true>(negChild);


### PR DESCRIPTION
Adding a table for cascade analysis to FemtoDerived data model (it is created only when analyzing cascades). Changing the table used for cascades in Producer and TrackCascadeExtended task. Adding histograms for new saved variables to Cascade task.