### PR TITLE
[PWGCF] singletrackselector: Add TPC nsigma electron and Zorro utils

### DIFF
--- a/PWGCF/Femto3D/DataModel/singletrackselector.h
+++ b/PWGCF/Femto3D/DataModel/singletrackselector.h
@@ -483,7 +483,7 @@ DECLARE_SOA_TABLE(SingleTrkExtras, "AOD", "SINGLETRKEXTRA",
                   singletrackselector::TPCSignal,
                   singletrackselector::Beta);
 
-DECLARE_SOA_TABLE(SinglePIDExtras, "AOD", "SINGLEPIDEXTRA",
+DECLARE_SOA_TABLE(SinglePIDEls, "AOD", "SINGLEPIDEL",
                   singletrackselector::StoredTPCNSigmaEl,
                   singletrackselector::TPCNSigmaEl<singletrackselector::StoredTPCNSigmaEl>);
 

--- a/PWGCF/Femto3D/DataModel/singletrackselector.h
+++ b/PWGCF/Femto3D/DataModel/singletrackselector.h
@@ -302,6 +302,10 @@ DECLARE_SOA_COLUMN(TPCInnerParam, tpcInnerParam, float); // Momentum at inner wa
 DECLARE_SOA_COLUMN(TPCSignal, tpcSignal, float);         // dE/dx TPC
 DECLARE_SOA_COLUMN(Beta, beta, float);                   // TOF beta
 
+DECLARE_SOA_COLUMN(StoredTPCNSigmaEl, storedTpcNSigmaEl, binning::nsigma::binned_t);
+DECLARE_SOA_DYNAMIC_COLUMN(TPCNSigmaEl, tpcNSigmaEl,
+                           [](binning::nsigma_v1::binned_t nsigma_binned) -> float { return singletrackselector::unPackSymmetric<binning::nsigma_v1>(nsigma_binned); });
+
 DECLARE_SOA_DYNAMIC_COLUMN(Rapidity, rapidity, //! Track rapidity, computed under the mass assumption given as input
                            [](float p, float eta, float mass) -> float {
                              const auto pz = p * std::tanh(eta);
@@ -478,6 +482,10 @@ DECLARE_SOA_TABLE(SingleTrkExtras, "AOD", "SINGLETRKEXTRA",
                   singletrackselector::TPCInnerParam,
                   singletrackselector::TPCSignal,
                   singletrackselector::Beta);
+
+DECLARE_SOA_TABLE(SinglePIDExtras, "AOD", "SINGLEPIDEXTRA",
+                  singletrackselector::StoredTPCNSigmaEl,
+                  singletrackselector::TPCNSigmaEl<singletrackselector::StoredTPCNSigmaEl>);
 
 namespace singletrackselector
 {

--- a/PWGCF/Femto3D/TableProducer/CMakeLists.txt
+++ b/PWGCF/Femto3D/TableProducer/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(Converters)
 
 o2physics_add_dpl_workflow(single-track-selector
     SOURCES singleTrackSelector.cxx
-    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::AnalysisCCDB
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2Physics::EventFilteringUtils
     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(single-track-selector-extra

--- a/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
+++ b/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
@@ -18,6 +18,9 @@
 
 #include <vector>
 
+#include "EventFiltering/Zorro.h"
+#include "EventFiltering/ZorroSummary.h"
+
 #include "PWGCF/Femto3D/DataModel/singletrackselector.h"
 
 #include "Framework/AnalysisTask.h"
@@ -44,9 +47,14 @@ using namespace o2::aod;
 struct singleTrackSelector {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
+  Zorro zorro;
+  OutputObj<ZorroSummary> zorroSummary{"zorroSummary"};
+
   Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> grpPath{"grpPath", "GLO/GRP/GRP", "Path of the grp file"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<bool> applySkimming{"applySkimming", false, "Skimmed dataset processing"};
+  Configurable<std::string> cfgSkimming{"cfgSkimming", "fPD", "Configurable for skimming"};
 
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply rapidity cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   // Configurable<int> trackSelection{"trackSelection", 1, "Track selection: 0 -> No Cut, 1 -> kGlobalTrack, 2 -> kGlobalTrackWoPtEta, 3 -> kGlobalTrackWoDCA, 4 -> kQualityTracks, 5 -> kInAcceptanceTracks"};
@@ -89,6 +97,7 @@ struct singleTrackSelector {
   Produces<o2::aod::SingleCollExtras> tableRowCollExtra;
   Produces<o2::aod::SingleTrackSels> tableRow;
   Produces<o2::aod::SingleTrkExtras> tableRowExtra;
+  Produces<o2::aod::SinglePIDExtras> tableRowPIDExtra;
   Produces<o2::aod::SingleTrkMCs> tableRowMC;
 
   Filter eventFilter = (applyEvSel.node() == 0) ||
@@ -110,7 +119,7 @@ struct singleTrackSelector {
   std::vector<int> particlesToKeep;
   std::vector<int> particlesToReject;
 
-  HistogramRegistry registry{"registry"};
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
   SliceCache cache;
 
   void init(InitContext&)
@@ -119,10 +128,19 @@ struct singleTrackSelector {
     particlesToKeep = _particlesToKeep;
     particlesToReject = _particlesToReject;
 
+    if (applySkimming) {
+      zorroSummary.setObject(zorro.getZorroSummary());
+    }
     ccdb->setURL(ccdburl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     ccdb->setFatalWhenNull(false);
+
+    if (applySkimming) {
+      registry.add("hNEvents", "hNEvents", {HistType::kTH1D, {{2, 0.f, 2.f}}});
+      registry.get<TH1>(HIST("hNEvents"))->GetXaxis()->SetBinLabel(1, "All");
+      registry.get<TH1>(HIST("hNEvents"))->GetXaxis()->SetBinLabel(2, "Skimmed");
+    }
 
     if (enable_gen_info) {
       registry.add("hNEvents_MCGen", "hNEvents_MCGen", {HistType::kTH1F, {{1, 0.f, 1.f}}});
@@ -141,6 +159,11 @@ struct singleTrackSelector {
       return;
     }
     d_bz = 0.f;
+
+    if (applySkimming) {
+      zorro.initCCDB(ccdb.service, bc.runNumber(), bc.timestamp(), cfgSkimming.value);
+      zorro.populateHistRegistry(registry, bc.runNumber());
+    }
 
     auto run3grp_timestamp = bc.timestamp();
     o2::parameters::GRPObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPObject>(grpPath, run3grp_timestamp);
@@ -224,6 +247,8 @@ struct singleTrackSelector {
                         track.tpcSignal(),
                         track.beta());
 
+          tableRowPIDExtra(singletrackselector::packSymmetric<singletrackselector::binning::nsigma>(track.tpcNSigmaEl()));
+
           if constexpr (isMC) {
             int origin = -1;
             if (track.mcParticle().isPhysicalPrimary()) {
@@ -288,6 +313,16 @@ struct singleTrackSelector {
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     initCCDB(bc);
+
+    if (applySkimming) {
+      registry.fill(HIST("hNEvents"), 0.5);
+      bool zorroSelected = zorro.isSelected(bc.globalBC());
+      if (!zorroSelected) {
+        return;
+      }
+      registry.fill(HIST("hNEvents"), 1.5);
+    }
+
     double hadronicRate = 0.;
     if (fetchRate) {
       hadronicRate = mRateFetcher.fetch(ccdb.service, bc.timestamp(), mRunNumber, "ZNC hadronic") * 1.e-3; // fetch IR

--- a/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
+++ b/PWGCF/Femto3D/TableProducer/singleTrackSelector.cxx
@@ -97,7 +97,7 @@ struct singleTrackSelector {
   Produces<o2::aod::SingleCollExtras> tableRowCollExtra;
   Produces<o2::aod::SingleTrackSels> tableRow;
   Produces<o2::aod::SingleTrkExtras> tableRowExtra;
-  Produces<o2::aod::SinglePIDExtras> tableRowPIDExtra;
+  Produces<o2::aod::SinglePIDEls> tableRowPIDEl;
   Produces<o2::aod::SingleTrkMCs> tableRowMC;
 
   Filter eventFilter = (applyEvSel.node() == 0) ||
@@ -247,7 +247,7 @@ struct singleTrackSelector {
                         track.tpcSignal(),
                         track.beta());
 
-          tableRowPIDExtra(singletrackselector::packSymmetric<singletrackselector::binning::nsigma>(track.tpcNSigmaEl()));
+          tableRowPIDEl(singletrackselector::packSymmetric<singletrackselector::binning::nsigma>(track.tpcNSigmaEl()));
 
           if constexpr (isMC) {
             int origin = -1;


### PR DESCRIPTION
This PR is to include the TPC nsigma electron and the possibility to use a trigger mask on the skimmed datasets.