### PR TITLE
Common: ESE splines for FT0-A and FV0-A

### DIFF
--- a/Common/Core/FFitWeights.cxx
+++ b/Common/Core/FFitWeights.cxx
@@ -10,42 +10,37 @@
 // or submit itself to any jurisdiction.
 
 /// \file FFitWeights.cxx
-/// \brief Implementation file for FFitWeights.h, see the header fore more information
+/// \brief Implementation file for FFitWeights.h, see the header for more information
 ///
-/// \author Joachim C. K. B. Hansen, Lund University
+/// \author Joachim C. K. B. Hansen
 
 #include "FFitWeights.h"
 
-// using std::complex;
-// using std::pair;
-// using std::string;
-// using std::vector;
+#include <TSpline.h>
 
 ClassImp(FFitWeights)
 
   FFitWeights::FFitWeights() : TNamed("", ""),
                                fW_data{nullptr},
-                               vGain{0},
                                CentBin{100},
-                               ChIDBin{220},
-                               sAmpl{nullptr},
-                               sqVec{nullptr},
-                               sqCorVec{nullptr}
+                               qAxis{nullptr},
+                               nResolution{3000},
+                               qnTYPE{0}
 {
 }
 
 FFitWeights::FFitWeights(const char* name) : TNamed(name, name),
                                              fW_data{nullptr},
-                                             vGain{0},
                                              CentBin{100},
-                                             ChIDBin{220},
-                                             sAmpl{nullptr},
-                                             sqVec{nullptr},
-                                             sqCorVec{nullptr} {}
+                                             qAxis{nullptr},
+                                             nResolution{3000},
+                                             qnTYPE{0} {}
 
 FFitWeights::~FFitWeights()
 {
   delete fW_data;
+  if (qAxis)
+    delete qAxis;
 };
 
 void FFitWeights::Init()
@@ -54,31 +49,14 @@ void FFitWeights::Init()
   fW_data->SetName("FFitWeights_Data");
   fW_data->SetOwner(kTRUE);
 
-  this->SetBinAxis(1000, 0, 5000, 0);
-  this->SetBinAxis(250, -3500, 3500, 1);
-  this->SetBinAxis(250, -250, 250, 2);
-
-  const char* tnd = "FT0Ampl";
-  fW_data->Add(new TH2F(tnd, ";channel;amplitude", ChIDBin, 0, ChIDBin, sAmpl->GetNbins(), sAmpl->GetXmin(), sAmpl->GetXmax()));
-  fW_data->Add(new TH2F(Form("%sCorr", tnd), ";channel;amplitude", ChIDBin, 0, ChIDBin, sAmpl->GetNbins(), sAmpl->GetXmin(), sAmpl->GetXmax()));
-
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C", "x", 2), ";Centrality;Qx_{2}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C", "y", 2), ";Centrality;Qy_{2}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C", "x", 3), ";Centrality;Qx_{3}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C", "y", 3), ";Centrality;Qy_{3}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_Rec", "x", 2), ";Centrality;Qx_{2}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_Rec", "y", 2), ";Centrality;Qy_{2}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_Rec", "x", 3), ";Centrality;Qx_{3}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_Rec", "y", 3), ";Centrality;Qy_{3}", CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_RecTot", "x", 2), ";Centrality;Qx_{2}", CentBin, 0, CentBin, sqCorVec->GetNbins(), sqCorVec->GetXmin(), sqCorVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_RecTot", "y", 2), ";Centrality;Qy_{2}", CentBin, 0, CentBin, sqCorVec->GetNbins(), sqCorVec->GetXmin(), sqCorVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_RecTot", "x", 3), ";Centrality;Qx_{3}", CentBin, 0, CentBin, sqCorVec->GetNbins(), sqCorVec->GetXmin(), sqCorVec->GetXmax()));
-  fW_data->Add(new TH2F(Form("hQ%s%i_FT0C_RecTot", "y", 3), ";Centrality;Qy_{3}", CentBin, 0, CentBin, sqCorVec->GetNbins(), sqCorVec->GetXmin(), sqCorVec->GetXmax()));
+  if (!qAxis)
+    this->SetBinAxis(500, 0, 25);
+  for (const auto& qn : qnTYPE) {
+    fW_data->Add(new TH2D(this->GetQName(qn.first, qn.second.c_str()), this->GetAxisName(qn.first, qn.second.c_str()), CentBin, 0, CentBin, qAxis->GetNbins(), qAxis->GetXmin(), qAxis->GetXmax()));
+  }
 };
 
-void FFitWeights::FillFT0(std::size_t iCh, float amplitude, float GainCst)
+void FFitWeights::Fill(float centrality, float qn, int nh, const char* pf)
 {
   TObjArray* tar{nullptr};
 
@@ -86,209 +64,108 @@ void FFitWeights::FillFT0(std::size_t iCh, float amplitude, float GainCst)
   if (!tar)
     return;
 
-  TH2F* th2 = reinterpret_cast<TH2F*>(tar->FindObject("FT0Ampl"));
+  TH2D* th2 = reinterpret_cast<TH2D*>(tar->FindObject(this->GetQName(nh, pf)));
   if (!th2) {
-    tar->Add(new TH2F("FT0Ampl", ";channel;amplitude", ChIDBin, 0, ChIDBin, sAmpl->GetNbins(), sAmpl->GetXmin(), sAmpl->GetXmax()));
-    th2 = reinterpret_cast<TH2F*>(tar->At(tar->GetEntries() - 1));
+    tar->Add(new TH2D(this->GetQName(nh, pf), this->GetAxisName(nh, pf), CentBin, 0, CentBin, qAxis->GetNbins(), qAxis->GetXmin(), qAxis->GetXmax()));
+    th2 = reinterpret_cast<TH2D*>(tar->At(tar->GetEntries() - 1));
   }
-  th2->Fill(iCh, amplitude);
-
-  TH2F* th2Cor = reinterpret_cast<TH2F*>(tar->FindObject("FT0AmplCorr"));
-  if (!th2Cor) {
-    tar->Add(new TH2F("FT0AmplCorr", ";channel;amplitude", ChIDBin, 0, ChIDBin, sAmpl->GetNbins(), sAmpl->GetXmin(), sAmpl->GetXmax()));
-    th2Cor = reinterpret_cast<TH2F*>(tar->At(tar->GetEntries() - 1));
-  }
-  th2Cor->Fill(iCh, amplitude / GainCst);
+  th2->Fill(centrality, qn);
 };
 
-void FFitWeights::FillQ(float mult, float vec, int nHarm, const char* coord, const char* qType)
-{
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return;
-
-  TH2F* th2 = reinterpret_cast<TH2F*>(tar->FindObject(Form("hQ%s%i_FT0C%s", coord, nHarm, qType)));
-  if (!th2) {
-    tar->Add(new TH2F(Form("hQ%s%i_FT0C%s", coord, nHarm, qType), Form(";Centrality;Q%s_{%i}", coord, nHarm), CentBin, 0, CentBin, sqVec->GetNbins(), sqVec->GetXmin(), sqVec->GetXmax()));
-    th2 = reinterpret_cast<TH2F*>(tar->At(tar->GetEntries() - 1));
-  }
-  th2->Fill(mult, vec);
-};
-
-void FFitWeights::CreateGain()
-{
-  vGain.clear();
-
-  TH1D* h1;
-  if (fW_data->GetEntries() < 1)
-    return;
-
-  TH2F* hGain = reinterpret_cast<TH2F*>(fW_data->At(0)->Clone("FT0Ampl"));
-  double vMean{0}; // = hGain->GetMean(2);
-  // c-side first bin ich: 97 (last 208)'
-  // gain split for c-side 144
-  hGain->GetXaxis()->SetRangeUser(96, 144);
-  float vMeanC_inner = hGain->GetMean(2);
-
-  hGain->GetXaxis()->SetRangeUser(144, 208);
-  float vMeanC_outer = hGain->GetMean(2);
-
-  hGain->GetXaxis()->SetRangeUser(0, -1);
-
-  for (int iCh{0}; iCh < hGain->GetNbinsX(); iCh++) {
-    h1 = static_cast<TH1D*>(hGain->ProjectionY(Form("proj%i", iCh), iCh, iCh));
-    double mean = h1->GetMean();
-    double meanErr = h1->GetMeanError();
-
-    if (iCh > 95 && iCh < 144)
-      vMean = vMeanC_inner;
-    else if (iCh > 144)
-      vMean = vMeanC_outer;
-    double fWeight = mean / vMean;
-
-    if (fWeight > 0) {
-      vGain.push_back(fWeight);
-    } else {
-      vGain.push_back(1.0);
-    }
-
-    TObjArray* tar = fW_data;
-    if (!tar)
-      return;
-
-    fW_data->Add(new TH1F("FT0MultCorr", ";channel", ChIDBin, 0, ChIDBin));
-    TH1F* htmp = reinterpret_cast<TH1F*>(tar->FindObject("FT0MultCorr"));
-    if (!htmp)
-      return;
-
-    htmp->SetBinContent(iCh, mean);
-    htmp->SetBinError(iCh, meanErr);
-  }
-
-  // note to self if FT0A is implemented this has to be done differently
-};
-
-std::vector<float> FFitWeights::GetGain()
-{
-  return vGain;
-};
-
-void FFitWeights::CreateRecenter(const char* xy)
-{
-  if (fW_data->GetEntries() < 1)
-    return;
-
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return;
-
-  for (int nHarm{2}; nHarm <= 3; nHarm++) {
-    fW_data->Add(new TH1F(Form("havgQ%s%i_FT0C", xy, nHarm), "", CentBin, 0, CentBin));
-    TH1F* hRec = reinterpret_cast<TH1F*>(tar->FindObject(Form("havgQ%s%i_FT0C", xy, nHarm)));
-    if (!hRec)
-      return;
-
-    TH2F* hQ = reinterpret_cast<TH2F*>(fW_data->At(0)->Clone(Form("hQ%s%i_FT0C", xy, nHarm)));
-    TH1D* h1;
-
-    for (int i{1}; i < hQ->GetXaxis()->GetNbins() + 1; i++) {
-      h1 = static_cast<TH1D*>(hQ->ProjectionY(Form("proj%i_Q%s%is", i, xy, nHarm), i, i));
-
-      double mean = h1->GetMean();
-      double meanErr = h1->GetMeanError();
-      int binc = hRec->GetXaxis()->GetBinCenter(i);
-
-      hRec->SetBinContent(binc, mean);
-      hRec->SetBinError(binc, meanErr);
-    }
-  }
-};
-
-void FFitWeights::CreateRMS(const char* xy)
-{
-  if (fW_data->GetEntries() < 1)
-    return;
-
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return;
-
-  for (int nHarm{2}; nHarm <= 3; nHarm++) {
-    fW_data->Add(new TH1F(Form("hrmsQ%s%i_FT0C", xy, nHarm), "", CentBin, 0, CentBin));
-    TH1F* hRec = reinterpret_cast<TH1F*>(tar->FindObject(Form("hrmsQ%s%i_FT0C", xy, nHarm)));
-    if (!hRec)
-      return;
-
-    TH2F* hQ = reinterpret_cast<TH2F*>(fW_data->At(0)->Clone(Form("hQ%s%i_FT0C", xy, nHarm)));
-    TH1D* h1;
-
-    for (int i{1}; i < hQ->GetXaxis()->GetNbins() + 1; i++) {
-      h1 = static_cast<TH1D*>(hQ->ProjectionY(Form("proj%i_Q%s%is", i, xy, nHarm), i, i));
-
-      double mean = h1->GetRMS();
-      double meanErr = h1->GetRMSError();
-      int binc = hRec->GetXaxis()->GetBinCenter(i);
-
-      hRec->SetBinContent(binc, mean);
-      hRec->SetBinError(binc, meanErr);
-    }
-  }
-};
-
-float FFitWeights::GetRecVal(int cent, const char* xy, const int nHarm)
-{
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return -999;
-
-  TH1F* htmp = reinterpret_cast<TH1F*>(tar->FindObject(Form("havgQ%s%i_FT0C", xy, nHarm)));
-
-  return htmp->GetBinContent(cent);
-};
-
-float FFitWeights::GetRMSVal(int cent, const char* xy, const int nHarm)
-{
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return -999;
-
-  TH1F* htmp = reinterpret_cast<TH1F*>(tar->FindObject(Form("hrmsQ%s%i_FT0C", xy, nHarm)));
-
-  return htmp->GetBinContent(cent);
-};
-
-TH1F* FFitWeights::GetRecHist(const char* xy, const int nHarm)
-{
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return nullptr;
-
-  return reinterpret_cast<TH1F*>(tar->FindObject(Form("havgQ%s%i_FT0C", xy, nHarm)));
-};
-
-TH1F* FFitWeights::GetRmsHist(const char* xy, const int nHarm)
-{
-  TObjArray* tar{nullptr};
-
-  tar = fW_data;
-  if (!tar)
-    return nullptr;
-
-  return reinterpret_cast<TH1F*>(tar->FindObject(Form("hrmsQ%s%i_FT0C", xy, nHarm)));
-};
-
-// float FFitWeights::EventPlane(const float& x, const float& y, const float& nHarm) {
-//   return 1/nHarm * TMath::ATan2(y, x);
+// Long64_t FFitWeights::Merge(TCollection* collist)
+// {
+//   Long64_t nmerged = 0;
+//   if (!fW_data) {
+//     fW_data = new TObjArray();
+//     fW_data->SetName("FFitWeights_Data");
+//     fW_data->SetOwner(kTRUE);
+//   }
+//   FFitWeights* l_w = 0;
+//   TIter all_w(collist);
+//   while ((l_w = (reinterpret_cast<FFitWeights*>(all_w())))) {
+//     AddArray(fW_data, l_w->GetDataArray());
+//     nmerged++;
+//   }
+//   return nmerged;
 // };
+void FFitWeights::AddArray(TObjArray* targ, TObjArray* sour)
+{
+  if (!sour) {
+    printf("Source array does not exist!\n");
+    return;
+  }
+  for (int i = 0; i < sour->GetEntries(); i++) {
+    TH2D* sourh = reinterpret_cast<TH2D*>(sour->At(i));
+    TH2D* targh = reinterpret_cast<TH2D*>(targ->FindObject(sourh->GetName()));
+    if (!targh) {
+      targh = reinterpret_cast<TH2D*>(sourh->Clone(sourh->GetName()));
+      targh->SetDirectory(0);
+      targ->Add(targh);
+    } else {
+      targh->Add(sourh);
+    }
+  }
+};
+
+void FFitWeights::qSelectionSpline(std::vector<int> nhv, std::vector<std::string> stv) /* only execute OFFLINE */
+{
+  TObjArray* tar{nullptr};
+
+  tar = fW_data;
+  if (!tar)
+    return;
+
+  for (const auto& pf : stv) {
+    for (const auto& nh : nhv) {
+      TH2D* th2 = reinterpret_cast<TH2D*>(tar->FindObject(this->GetQName(nh, pf.c_str())));
+      if (!th2) {
+        printf("qh not found!\n");
+        return;
+      }
+
+      TH1D* tmp = nullptr;
+      TGraph* tmpgr = nullptr;
+      TSpline3* spline = nullptr;
+      for (int iSP{0}; iSP < 90; iSP++) {
+        tmp = th2->ProjectionY(Form("q%i_%i_%i", nh, iSP, iSP + 1), iSP + 1, iSP + 1);
+        double xq[nResolution];
+        double yq[nResolution];
+        for (int i{0}; i < nResolution; i++)
+          xq[i] = double(i + 1) / nResolution;
+        tmp->GetQuantiles(nResolution, yq, xq);
+        tmpgr = new TGraph(nResolution, yq, xq);
+        spline = new TSpline3(Form("sp_q%i%s_%i", nh, pf.c_str(), iSP), tmpgr);
+        spline->SetName(Form("sp_q%i%s_%i", nh, pf.c_str(), iSP));
+        fW_data->Add(spline);
+      }
+    }
+  }
+};
+
+float FFitWeights::EvalSplines(float centr, const float& dqn, const int nh, const char* pf)
+{
+  TObjArray* tar{nullptr};
+
+  tar = fW_data;
+  if (!tar)
+    return -1;
+
+  int isp = static_cast<int>(centr);
+  if (isp < 0 || isp > 90) {
+    return -1;
+  }
+
+  TSpline3* spline = nullptr;
+  spline = reinterpret_cast<TSpline3*>(tar->FindObject(Form("sp_q%i%s_%i", nh, pf, isp)));
+  if (!spline) {
+    printf("Spline not found!\n");
+    return -1;
+  }
+
+  float qn_val = 100. * spline->Eval(dqn);
+  if (qn_val < 0) {
+    return -1;
+  }
+
+  return qn_val;
+};

--- a/Common/Core/FFitWeights.cxx
+++ b/Common/Core/FFitWeights.cxx
@@ -128,12 +128,12 @@ void FFitWeights::qSelectionSpline(std::vector<int> nhv, std::vector<std::string
       TSpline3* spline = nullptr;
       for (int iSP{0}; iSP < 90; iSP++) {
         tmp = th2->ProjectionY(Form("q%i_%i_%i", nh, iSP, iSP + 1), iSP + 1, iSP + 1);
-        double xq[nResolution];
-        double yq[nResolution];
+        std::vector<double> xq(nResolution);
+        std::vector<double> yq(nResolution);
         for (int i{0}; i < nResolution; i++)
-          xq[i] = double(i + 1) / nResolution;
-        tmp->GetQuantiles(nResolution, yq, xq);
-        tmpgr = new TGraph(nResolution, yq, xq);
+          xq[i] = static_cast<double>(i + 1) / static_cast<double>(nResolution);
+        tmp->GetQuantiles(nResolution, yq.data(), xq.data());
+        tmpgr = new TGraph(nResolution, yq.data(), xq.data());
         spline = new TSpline3(Form("sp_q%i%s_%i", nh, pf.c_str(), iSP), tmpgr);
         spline->SetName(Form("sp_q%i%s_%i", nh, pf.c_str(), iSP));
         fW_data->Add(spline);

--- a/Common/Core/FFitWeights.cxx
+++ b/Common/Core/FFitWeights.cxx
@@ -72,22 +72,22 @@ void FFitWeights::Fill(float centrality, float qn, int nh, const char* pf)
   th2->Fill(centrality, qn);
 };
 
-// Long64_t FFitWeights::Merge(TCollection* collist)
-// {
-//   Long64_t nmerged = 0;
-//   if (!fW_data) {
-//     fW_data = new TObjArray();
-//     fW_data->SetName("FFitWeights_Data");
-//     fW_data->SetOwner(kTRUE);
-//   }
-//   FFitWeights* l_w = 0;
-//   TIter all_w(collist);
-//   while ((l_w = (reinterpret_cast<FFitWeights*>(all_w())))) {
-//     AddArray(fW_data, l_w->GetDataArray());
-//     nmerged++;
-//   }
-//   return nmerged;
-// };
+Long64_t FFitWeights::Merge(TCollection* collist)
+{
+  Long64_t nmerged = 0;
+  if (!fW_data) {
+    fW_data = new TObjArray();
+    fW_data->SetName("FFitWeights_Data");
+    fW_data->SetOwner(kTRUE);
+  }
+  FFitWeights* l_w = 0;
+  TIter all_w(collist);
+  while ((l_w = (reinterpret_cast<FFitWeights*>(all_w())))) {
+    AddArray(fW_data, l_w->GetDataArray());
+    nmerged++;
+  }
+  return nmerged;
+};
 void FFitWeights::AddArray(TObjArray* targ, TObjArray* sour)
 {
   if (!sour) {
@@ -158,7 +158,6 @@ float FFitWeights::EvalSplines(float centr, const float& dqn, const int nh, cons
   TSpline3* spline = nullptr;
   spline = reinterpret_cast<TSpline3*>(tar->FindObject(Form("sp_q%i%s_%i", nh, pf, isp)));
   if (!spline) {
-    printf("Spline not found!\n");
     return -1;
   }
 

--- a/Common/Core/FFitWeights.h
+++ b/Common/Core/FFitWeights.h
@@ -10,9 +10,9 @@
 // or submit itself to any jurisdiction.
 
 /// \file FFitWeights.h
-/// \brief Class for handling fit weights. Right now holds FT0, will hold methods for loading and calculating all ESE splines in the future.
+/// \brief Class for handling fit weights for ESE framework. Hold methods for loading and calculating all ESE splines. Supports FT0C, in the future it will support FT0A, FV0A and TPC.
 ///
-/// \author Joachim C. K. B. Hansen, Lund University
+/// \author Joachim C. K. B. Hansen
 
 #ifndef COMMON_CORE_FFITWEIGHTS_H_
 #define COMMON_CORE_FFITWEIGHTS_H_
@@ -42,59 +42,41 @@ class FFitWeights : public TNamed
   ~FFitWeights();
 
   void Init();
-  void FillFT0(std::size_t iCh, float amplitude, float GainCst);
-  void FillQ(float mult, float vec, int nHarm, const char* coord, const char* qType);
+  void Fill(float centrality, float qn, int nh, const char* pf = "");
   TObjArray* GetDataArray() { return fW_data; }
-  // double GetGain(double phi, double eta, double vz);
-  void CreateGain();
-  std::vector<float> GetGain();
-  void SetChIdBin(int bin) { ChIDBin = bin; }
+
   void SetCentBin(int bin) { CentBin = bin; }
-
-  void SetBinAxis(int bin, float min, float max, int axisLevel)
+  void SetBinAxis(int bin, float min, float max)
   {
-    if (axisLevel == 0)
-      sAmpl = std::shared_ptr<TAxis>(new TAxis(bin, min, max));
-    else if (axisLevel == 1)
-      sqVec = std::shared_ptr<TAxis>(new TAxis(bin, min, max));
-    else if (axisLevel == 2)
-      sqCorVec = std::shared_ptr<TAxis>(new TAxis(bin, min, max));
-    else
-      printf("something went wrong assigning axes");
+    qAxis = new TAxis(bin, min, max);
   }
-  std::shared_ptr<TAxis> GetAmplAx() { return sAmpl; }
-  std::shared_ptr<TAxis> GetqVecAx() { return sqVec; }
-  std::shared_ptr<TAxis> GetqCorVecAx() { return sqCorVec; }
+  TAxis* GetqVecAx() { return qAxis; }
 
-  void CreateRecenter(const char* xy);
-  float GetRecVal(int cent, const char* xy, const int nHarm);
-  TH1F* GetRecHist(const char* xy, const int nHarm);
-  void CreateRMS(const char* xy);
-  float GetRMSVal(int cent, const char* xy, const int nHarm);
-  TH1F* GetRmsHist(const char* xy, const int nHarm);
-
-  template <typename CollType>
-  static float EventPlane(const CollType& coll, float nHarm)
-  {
-    auto x = coll.qFT0CRe();
-    auto y = coll.qFT0CIm();
-    return 1 / nHarm * TMath::ATan2(y[nHarm - 2], x[nHarm - 2]);
-  }
-  // static float EventPlane(const float& x, const float& y, const float& nHarm);
+  // Long64_t Merge(TCollection* collist);
+  void qSelectionSpline(std::vector<int> nhv, std::vector<std::string> stv);
+  float EvalSplines(float centr, const float& dqn, const int nh, const char* pf = "");
+  void SetResolution(int res) { nResolution = res; }
+  void SetQnType(std::vector<std::pair<int, std::string>> qninp) { qnTYPE = qninp; }
 
  private:
   TObjArray* fW_data;
-  std::vector<float> vGain;
 
   int CentBin;
-  int ChIDBin;
+  TAxis* qAxis; //!
+  int nResolution;
 
-  std::shared_ptr<TAxis> sAmpl;    //!
-  std::shared_ptr<TAxis> sqVec;    //!
-  std::shared_ptr<TAxis> sqCorVec; //!
+  std::vector<std::pair<int, std::string>> qnTYPE; 
 
-  // TH2F *FT0Ampl;
+  const char* GetQName(const int nh, const char* pf = "")
+  {
+    return Form("q%i%s", nh, pf);
+  };
+  const char* GetAxisName(const int nh, const char* pf = "")
+  {
+    return Form(";Centrality;q_{%i}^{%s}", nh, pf);
+  };
+  void AddArray(TObjArray* targ, TObjArray* sour);
 
-  ClassDef(FFitWeights, 2); // calibration class
+  ClassDef(FFitWeights, 1); // calibration class
 };
 #endif // COMMON_CORE_FFITWEIGHTS_H_

--- a/Common/Core/FFitWeights.h
+++ b/Common/Core/FFitWeights.h
@@ -52,7 +52,7 @@ class FFitWeights : public TNamed
   }
   TAxis* GetqVecAx() { return qAxis; }
 
-  // Long64_t Merge(TCollection* collist);
+  Long64_t Merge(TCollection* collist);
   void qSelectionSpline(std::vector<int> nhv, std::vector<std::string> stv);
   float EvalSplines(float centr, const float& dqn, const int nh, const char* pf = "");
   void SetResolution(int res) { nResolution = res; }
@@ -65,7 +65,7 @@ class FFitWeights : public TNamed
   TAxis* qAxis; //!
   int nResolution;
 
-  std::vector<std::pair<int, std::string>> qnTYPE; 
+  std::vector<std::pair<int, std::string>> qnTYPE;
 
   const char* GetQName(const int nh, const char* pf = "")
   {

--- a/Common/DataModel/EseTable.h
+++ b/Common/DataModel/EseTable.h
@@ -26,20 +26,22 @@ namespace o2::aod
 {
 namespace q_vector
 {
-DECLARE_SOA_COLUMN(QFV0ARe, qFV0ARe, float);
-DECLARE_SOA_COLUMN(QFV0AIm, qFV0AIm, float);
-DECLARE_SOA_COLUMN(QFT0CRe, qFT0CRe, std::vector<float>);
-DECLARE_SOA_COLUMN(QFT0CIm, qFT0CIm, std::vector<float>);
 DECLARE_SOA_COLUMN(QPERCFT0C, qPERCFT0C, std::vector<float>);
+DECLARE_SOA_COLUMN(qPERCFT0A, qPERCFT0A, std::vector<float>);
+DECLARE_SOA_COLUMN(qPERCFV0, qPERCFV0, std::vector<float>);
+DECLARE_SOA_COLUMN(qPERCTPC, qPERCTPC, std::vector<float>);
 DECLARE_SOA_COLUMN(FESECOL, fESECOL, std::vector<int>);
 } // namespace q_vector
-DECLARE_SOA_TABLE(QVecFV0As, "AOD", "QVECFV0A", q_vector::QFV0ARe, q_vector::QFV0AIm);
-DECLARE_SOA_TABLE(QVecFT0Cs, "AOD", "QVECFT0C", q_vector::QFT0CRe, q_vector::QFT0CIm);
 DECLARE_SOA_TABLE(QPercentileFT0Cs, "AOD", "QPERCENTILEFT0C", q_vector::QPERCFT0C);
+DECLARE_SOA_TABLE(QPercentileFT0As, "AOD", "QPERCENTILEFT0A", q_vector::QPERCFT0A);
+DECLARE_SOA_TABLE(QPercentileFV0s, "AOD", "QPERCENTILEFV0", q_vector::QPERCFV0);
+DECLARE_SOA_TABLE(QPercentileTPCs, "AOD", "QPERCENTILETPC", q_vector::QPERCTPC);
 DECLARE_SOA_TABLE(FEseCols, "AOD", "FEVENTSHAPE", q_vector::FESECOL);
-using QVecFV0A = QVecFV0As::iterator;
-using QVecFT0C = QVecFT0Cs::iterator;
+
 using QPercentileFT0C = QPercentileFT0Cs::iterator;
+using QPercentileFT0A = QPercentileFT0As::iterator;
+using QPercentileFV0 = QPercentileFV0s::iterator;
+using QPercentileTPC = QPercentileTPCs::iterator;
 using FEseCol = FEseCols::iterator;
 
 } // namespace o2::aod

--- a/Common/DataModel/EseTable.h
+++ b/Common/DataModel/EseTable.h
@@ -27,20 +27,20 @@ namespace o2::aod
 namespace q_vector
 {
 DECLARE_SOA_COLUMN(QPERCFT0C, qPERCFT0C, std::vector<float>);
-DECLARE_SOA_COLUMN(qPERCFT0A, qPERCFT0A, std::vector<float>);
-DECLARE_SOA_COLUMN(qPERCFV0, qPERCFV0, std::vector<float>);
-DECLARE_SOA_COLUMN(qPERCTPC, qPERCTPC, std::vector<float>);
+DECLARE_SOA_COLUMN(QPERCFT0A, qPERCFT0A, std::vector<float>);
+DECLARE_SOA_COLUMN(QPERCFV0A, qPERCFV0A, std::vector<float>);
+DECLARE_SOA_COLUMN(QPERCTPC, qPERCTPC, std::vector<float>);
 DECLARE_SOA_COLUMN(FESECOL, fESECOL, std::vector<int>);
 } // namespace q_vector
 DECLARE_SOA_TABLE(QPercentileFT0Cs, "AOD", "QPERCENTILEFT0C", q_vector::QPERCFT0C);
 DECLARE_SOA_TABLE(QPercentileFT0As, "AOD", "QPERCENTILEFT0A", q_vector::QPERCFT0A);
-DECLARE_SOA_TABLE(QPercentileFV0s, "AOD", "QPERCENTILEFV0", q_vector::QPERCFV0);
+DECLARE_SOA_TABLE(QPercentileFV0As, "AOD", "QPERCENTILEFV0A", q_vector::QPERCFV0A);
 DECLARE_SOA_TABLE(QPercentileTPCs, "AOD", "QPERCENTILETPC", q_vector::QPERCTPC);
 DECLARE_SOA_TABLE(FEseCols, "AOD", "FEVENTSHAPE", q_vector::FESECOL);
 
 using QPercentileFT0C = QPercentileFT0Cs::iterator;
 using QPercentileFT0A = QPercentileFT0As::iterator;
-using QPercentileFV0 = QPercentileFV0s::iterator;
+using QPercentileFV0A = QPercentileFV0As::iterator;
 using QPercentileTPC = QPercentileTPCs::iterator;
 using FEseCol = FEseCols::iterator;
 

--- a/Common/TableProducer/eseTableProducer.cxx
+++ b/Common/TableProducer/eseTableProducer.cxx
@@ -9,17 +9,15 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// q vector framework with ESE (20/08/2024)
-//
-/// \author Joachim Hansen <joachim.hansen@cern.ch>
-//
+/// \file eseTableProducer.cxx
+/// \brief Producer for the ESE table
+///
+/// \author Joachim C. K. B. Hansen
+
 #include <CCDB/BasicCCDBManager.h>
-#include <DataFormatsParameters/GRPObject.h>
-#include <DataFormatsParameters/GRPMagField.h>
 
 #include <chrono>
 #include <string>
-#include <TComplex.h>
 #include <algorithm>
 #include <numeric>
 #include <vector>
@@ -27,70 +25,42 @@
 #include "Framework/ASoA.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
 #include "Framework/ASoAHelpers.h"
-#include "Framework/RunningWorkflowInfo.h"
 #include "Framework/HistogramRegistry.h"
 
 #include "Common/DataModel/EventSelection.h"
 #include "Common/Core/TrackSelection.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/FT0Corrected.h"
-#include "DetectorsCommonDataFormats/AlignParam.h"
-#include "FT0Base/Geometry.h"
 
 #include "Common/DataModel/EseTable.h"
+#include "Common/DataModel/Qvectors.h"
 #include "FFitWeights.h"
-
-#include <TSpline.h>
 
 using namespace o2;
 using namespace o2::framework;
-// using namespace o2::framework::expressions;
 
-// using CollWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As>;
-using CollWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
+using CollWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::QvectorFT0CVecs>;
 
 struct EseTableProducer {
-  Produces<o2::aod::QVecFV0As> qVectorFV0A;
-  Produces<o2::aod::QVecFT0Cs> qVectorFT0C;
-  Produces<o2::aod::QPercentileFT0Cs> qPercs;
+  Produces<o2::aod::QPercentileFT0Cs> qPercsFT0C;
   Produces<o2::aod::FEseCols> fEseCol;
 
   OutputObj<FFitWeights> FFitObj{FFitWeights("weights")};
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
 
-  Configurable<int> cfgCorrLevel{"cfgCorrLevel", 2, "calibration step: 0 = no corr, 1 = gain corr, 2 = rectr, 3 = 1/sigma, 4 = full"};
-  Configurable<bool> cfgESE{"cfgESE", 1, "ese actovation step: false = no ese, true = evaluate splines and fill table"};
-
-  Configurable<std::string> cfgCalibrationPath{"cfgCalibrationPath", "Users/j/joachiha/Calibration/local/LHC23zzh", "CCDB path for gain equalization constants"};
+  Configurable<bool> cfgESE{"cfgESE", 1, "ese activation step: false = no ese, true = evaluate splines and fill table"};
   Configurable<std::string> cfgEsePath{"cfgEsePath", "Users/j/joachiha/ESE/local/splines", "CCDB path for ese splines"};
+  Configurable<bool> cfgFT0C{"cfgFT0C", 1, "FT0C flag"};
+  Configurable<std::vector<int>> cfgLoopHarmonics{"cfgLoopHarmonics", {2, 3}, "Harmonics to loop over when filling and evaluating splines"};
+  Configurable<std::vector<std::string>> vecStr{"vecStr", {"FT0C"}, "Qn type"};
 
-  ConfigurableAxis cfgaxisFITamp{"cfgaxisFITamp", {1000, 0, 5000}, "Fit amplitude range"};
-  ConfigurableAxis cfgaxisq2FT0C{"cfgaxisq2FT0C", {200, 0, 25}, "q2 amplitude range"};
-  ConfigurableAxis cfgaxisQFT0C{"cfgaxisQFT0C", {250, -3500, 3500}, "q2 amplitude range"};
+  Configurable<std::vector<float>> cfgaxisqnFT0C{"cfgaxisqnFT0C", {500, 0, 25}, "q_n amplitude range"};
+  Configurable<int> cfgnResolution{"cfgnResolution", 3000, "resolution of splines"};
 
-  AxisSpec axisFITamp{cfgaxisFITamp, "FIT amp"};
-  AxisSpec axisq2FT0C{cfgaxisq2FT0C, "q2 FIT amp"};
-  AxisSpec axisQFT0C{cfgaxisQFT0C, "Q xy Range"};
-
-  AxisSpec axisCentralityR = {100, 0, 100};
-  AxisSpec axisChID = {220, 0, 220};
-  std::vector<float> FV0RelGainConst{};
-  std::vector<float> FT0RelGainConst{};
   int runNumber{-1};
 
-  o2::ft0::Geometry ft0geom;
-  double mOffsetFT0AX = 0.; // X-coordinate of the offset of FT0-A.
-  double mOffsetFT0AY = 0.; // Y-coordinate of the offset of FT0-A.
-  double mOffsetFT0CX = 0.; // X-coordinate of the offset of FT0-C.
-  double mOffsetFT0CY = 0.; // Y-coordinate of the offset of FT0-C.
-
-  FFitWeights* weights{nullptr};
-  TList* eselist{nullptr};
-  std::vector<std::vector<TSpline3*>> spl{2, std::vector<TSpline3*>(90)}; // 90x2
+  FFitWeights* splines{nullptr};
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
@@ -99,23 +69,8 @@ struct EseTableProducer {
 
     LOGF(info, "ESETable::init()");
 
-    registry.add("h_collisions", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
-
-    registry.add("h_qx2VecFT0C", "qxVecFT0C;qxVecFT0C;entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-    registry.add("h_qy2VecFT0C", "qyVecFT0C;qyVecFT0C;entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-    registry.add("h_qx3VecFT0C", "qxVecFT0C;qxVecFT0C;entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-    registry.add("h_qy3VecFT0C", "qyVecFT0C;qyVecFT0C;entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-
-    registry.add("h_Q2XvsQ2YFT0C", "Q_{2,y}^{FT0C};Q_{2,x}^{FT0C};", {HistType::kTH2F, {{350, -3500, 3500}, {350, -3500, 3500}}});
-    registry.add("h_Q2XvsQ2YFT0C_Rec", "Q_{2,y}^{FT0C};Q_{2,x}^{FT0C};", {HistType::kTH2F, {{350, -350, 350}, {350, -350, 350}}});
-
-    registry.add("h_Cent_q2FT0C", "q^{FT0C}_{2};Centrality (FT0A);", {HistType::kTH2F, {axisCentralityR, axisq2FT0C}});
-    registry.add("h_Cent_q3FT0C", "q^{FT0C}_{3};Centrality (FT0A);", {HistType::kTH2F, {axisCentralityR, axisq2FT0C}});
-
-    registry.add("h_Psi2", "#Psi_{2}^{FT0C};Centrality;", {HistType::kTH2F, {axisCentralityR, {100, -5, 5}}});
-    registry.add("h_Psi3", "#Psi_{3}^{FT0C};Centrality;", {HistType::kTH2F, {axisCentralityR, {100, -5, 5}}});
-
-    registry.add("h_ESE_status", "ese status;ese status;entries", {HistType::kTH1F, {{2, 0.0, 2.0}}});
+    registry.add("hEventCounter", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
+    registry.add("hESEstat", "ese status;ese status;entries", {HistType::kTH1F, {{2, 0.0, 2.0}}});
 
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
@@ -124,103 +79,31 @@ struct EseTableProducer {
     int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
 
+    std::vector<std::pair<int, std::string>> veccfg;
+    for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) 
+    {
+      for (std::size_t j{0}; j < vecStr->size(); j++) 
+      {
+        veccfg.push_back({cfgLoopHarmonics->at(i), vecStr->at(j)});
+      }
+    }
+    FFitObj->SetBinAxis(cfgaxisqnFT0C->at(0), cfgaxisqnFT0C->at(1), cfgaxisqnFT0C->at(2));
+    FFitObj->SetResolution(cfgnResolution);
+    FFitObj->SetQnType(veccfg);
     FFitObj->Init();
   }
 
   void initCCDB(aod::BCsWithTimestamps::iterator const& bc)
   {
-    FV0RelGainConst.clear();
-    FT0RelGainConst.clear();
-    FV0RelGainConst = {};
-    FT0RelGainConst = {};
 
     auto timestamp = bc.timestamp();
 
-    // auto offsetFT0 = ccdb->getForTimeStamp<std::vector<o2::detectors::AlignParam>>("FT0/Calib/Align", timestamp);
-    // auto offsetFV0 = ccdb->getForTimeStamp<std::vector<o2::detectors::AlignParam>>("FV0/Calib/Align", timestamp);
-
-    // if (!objfv0Gain || cfgCorrLevel == 0) {
-    //   for (auto i{0u}; i < 48; i++) {
-    //     FV0RelGainConst.push_back(1.);
-    //   }
-    // } else {
-    //   FV0RelGainConst = *(objfv0Gain);
-    // }
-    for (auto i{0u}; i < 48; i++) {
-      FV0RelGainConst.push_back(1.);
-    }
-
-    std::string fullPath = cfgCalibrationPath;
-
-    weights = ccdb->getForTimeStamp<FFitWeights>(fullPath, timestamp);
-    if (!weights || cfgCorrLevel == 0) {
-      for (auto i{0u}; i < 208; i++) {
-        FT0RelGainConst.push_back(1.);
-      }
-    } else {
-      weights->CreateGain();
-      FT0RelGainConst = weights->GetGain();
-    }
-    if (cfgCorrLevel > 1) {
-      weights->CreateRecenter("x");
-      weights->CreateRMS("x");
-      weights->CreateRecenter("y");
-      weights->CreateRMS("y");
-    }
-
     if (cfgESE) {
-      eselist = ccdb->getForTimeStamp<TList>(cfgEsePath, timestamp);
-      if (!LoadSplines())
+      splines = ccdb->getForTimeStamp<FFitWeights>(cfgEsePath, timestamp);
+      if (!splines)
         LOGF(fatal, "failed loading splines with ese flag");
       LOGF(info, "successfully loaded splines");
     }
-  }
-
-  // void processQVecFV0 (CollWithFV0 const& collision, aod::BCsWithTimestamps const&) {
-  // template <typename CollType>
-  // void QVecFV0 (CollType const& collision) {
-  //   TComplex Qvec(0);
-  //   float qVecFV0A[2] = {0.};
-  //   float sumAmplFV0A{0.0f};
-
-  //   if (collision.has_foundFV0()){
-  //     auto fv0 = collision.foundFV0();
-
-  //     for (std::size_t iCh = 0; iCh < fv0.channel().size(); iCh++) {
-  //       float ampl = fv0.amplitude()[iCh];
-  //       int FV0AchId = fv0.channel()[iCh];
-  //       registry.fill(HIST("FV0Amplitude"), ampl, FV0AchId);
-  //       registry.fill(HIST("FV0AmplitudeCorr"), ampl / FV0RelGainConst[FV0AchId], FV0AchId);
-
-  //       // helperEP.SumQvectors(1, FV0AchId, ampl / FV0RelGainConst[FV0AchId], nmode, QvecDet, sumAmplFV0A, ft0geom, fv0geom);
-  //     }
-
-  //     if (sumAmplFV0A > 1e-8) {
-  //       Qvec /= sumAmplFV0A;
-  //       qVecFV0A[0] = Qvec.Re();
-  //       qVecFV0A[1] = Qvec.Im();
-  //     } else {
-  //       qVecFV0A[0] = 999.;
-  //       qVecFV0A[1] = 999.;
-  //     }
-  //   }
-  //   else {
-  //     qVecFV0A[0] = -999.;
-  //     qVecFV0A[1] = -999.;
-  //   }
-
-  //   //// qVector(Qvec.Re(),Qvec.Im());
-  //   registry.fill(HIST("h_collisions"), 1.5);
-  //   qVectorFV0A(1,-2);
-  // }
-  bool LoadSplines()
-  {
-    for (int i{0}; i < 90; i++) {
-      for (int j{0}; j < 2; j++) {
-        spl[j][i] = static_cast<TSpline3*>(eselist->FindObject(Form("sp_q%iFT0C_%i", j + 2, i)));
-      }
-    }
-    return true;
   }
 
   float Calcqn(const float& Qx, const float& Qy, const float& Mult)
@@ -233,161 +116,60 @@ struct EseTableProducer {
     return qn;
   }
 
-  double GetPhiFT0(const int& chno, o2::ft0::Geometry ft0geom)
+  bool validQvec(const float& qVec)
   {
-    /* Calculate the azimuthal angle in FT0 for the channel number 'chno'. The offset
-      of FT0-A is taken into account if chno is between 0 and 95. */
-
-    float offsetX = 0.;
-    float offsetY = 0.; // No offset for FT0-C (default case).
-
-    if (chno < 96) { // Channel in FT0-A, non-zero offset must be applied. // LOKI: make general.
-      offsetX = mOffsetFT0AX;
-      offsetY = mOffsetFT0AY;
+    if (qVec == 999. || qVec == -999) {
+      return false;
+    } else {
+      return true;
     }
+  };
 
-    ft0geom.calculateChannelCenter();
-    auto chPos = ft0geom.getChannelCenter(chno);
-    /// printf("Channel id: %d X: %.3f Y: %.3f\n", chno, chPos.X(), chPos.Y());
-
-    return TMath::ATan2(chPos.Y() + offsetY, chPos.X() + offsetX);
-  }
-
-  float EventPlane(const float& x, const float& y, const float& nHarm)
+  template <typename T>
+  void calculateESE(T const& collision, std::vector<float>& qnpFT0C, std::vector<int>& fIsEseAvailable)
   {
-    return 1 / nHarm * TMath::ATan2(y, x);
-  }
 
-  void SumQvectors(const int& chno, const float& ampl, const int& nHarm, TComplex& Qvec, float& sum, o2::ft0::Geometry ft0geom)
-  {
-    /* Calculate the complex Q-vector for the provided detector and channel number,
-      before adding it to the total Q-vector given as argument. */
-    double phi = -999.;
-
-    phi = GetPhiFT0(chno, ft0geom); // already be given in the right range.
-
-    if (phi < -900) {
-      printf("Error on phi. Skip\n");
-      return;
-    }
-    Qvec += TComplex(ampl * TMath::Cos(phi * nHarm), ampl * TMath::Sin(phi * nHarm));
-    sum += ampl;
-  }
-
-  template <typename CollType>
-  void QVecFT0C(CollType const& collision, const int& nHarm, std::vector<float>& qx, std::vector<float>& qy, std::vector<float>& qnP, std::vector<int>& fIsEseAvailable)
-  {
-    TComplex Qvec(0);
-    float qVecFT0C[2] = {0.};
-    float sumAmplFT0C{0.0f};
-    float qn{0.0f};
-    bool fCalc{0};
-
-    if (collision.has_foundFT0()) {
-      const auto& ft0 = collision.foundFT0();
-      // auto ft0 = collision.foundFT0();
-      for (std::size_t iChC = 0; iChC < ft0.channelC().size(); iChC++) {
-        float ampl = ft0.amplitudeC()[iChC];
-        int FT0CchId = ft0.channelC()[iChC] + 96;
-
-        // registry.fill(HIST("FT0Amplitude"), FT0CchId, ampl);
-        // registry.fill(HIST("FT0AmplitudeCorr"), FT0CchId, ampl / FT0RelGainConst[FT0CchId]);
-        if (nHarm == 2)
-          FFitObj->FillFT0(FT0CchId, ampl, FT0RelGainConst[FT0CchId]);
-
-        SumQvectors(FT0CchId, ampl / FT0RelGainConst[FT0CchId], nHarm, Qvec, sumAmplFT0C, ft0geom);
-      }
-
-      if (sumAmplFT0C > 1e-8) {
-        // Qvec /= sumAmplFT0C;
-        qVecFT0C[0] = Qvec.Re();
-        qVecFT0C[1] = Qvec.Im();
-        fCalc = true;
-      } else {
-        qVecFT0C[0] = 9999.;
-        qVecFT0C[1] = 9999.;
-        fCalc = false;
+    if (cfgFT0C) {
+      const auto QxFT0C_Qvec = collision.qvecFT0CReVec();
+      const auto QyFT0C_Qvec = collision.qvecFT0CImVec();
+      const auto SumAmplFT0C = collision.sumAmplFT0C();
+      for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
+        int nHarm = cfgLoopHarmonics->at(i);
+        std::cout<< "nharm " << nHarm << std::endl;
+        if (validQvec(QxFT0C_Qvec[nHarm - 2]) && validQvec(QyFT0C_Qvec[nHarm - 2]) && SumAmplFT0C > 1e-8) {
+          float qnval = Calcqn(QxFT0C_Qvec[nHarm - 2]*SumAmplFT0C, QyFT0C_Qvec[nHarm - 2]*SumAmplFT0C, SumAmplFT0C);
+          FFitObj->Fill(collision.centFT0C(), qnval, nHarm, "FT0C");
+          if (cfgESE) {
+            float qnCent{splines->EvalSplines(collision.centFT0C(), qnval, nHarm, "FT0C")};
+            qnpFT0C.push_back(qnCent);
+            fIsEseAvailable.push_back(1);
+            registry.fill(HIST("hESEstat"), 1.5);
+          } else {
+            qnpFT0C.push_back(-1);
+            fIsEseAvailable.push_back(0);
+            registry.fill(HIST("hESEstat"), .5);
+          }
+        } else {
+          qnpFT0C.push_back(-1);
+          fIsEseAvailable.push_back(0);
+          registry.fill(HIST("hESEstat"), .5);
+        }
       }
     } else {
-      qVecFT0C[0] = 9999.;
-      qVecFT0C[1] = 9999.;
-    }
-
-    if (fCalc) {
-      if (cfgCorrLevel == 0) {
-        qn = Calcqn(qVecFT0C[0], qVecFT0C[1], sumAmplFT0C);
-      }
-
-      FFitObj->FillQ(collision.centFT0C(), qVecFT0C[0], nHarm, "x", "");
-      FFitObj->FillQ(collision.centFT0C(), qVecFT0C[1], nHarm, "y", "");
-
-      if (cfgCorrLevel > 1) {
-        int centr = static_cast<int>(collision.centFT0C());
-
-        registry.fill(HIST("h_Q2XvsQ2YFT0C"), qVecFT0C[0], qVecFT0C[1]);
-        qVecFT0C[0] = qVecFT0C[0] - weights->GetRecVal(centr, "x", nHarm);
-        qVecFT0C[1] = qVecFT0C[1] - weights->GetRecVal(centr, "y", nHarm);
-        FFitObj->FillQ(collision.centFT0C(), qVecFT0C[0], nHarm, "x", "_Rec");
-        FFitObj->FillQ(collision.centFT0C(), qVecFT0C[1], nHarm, "y", "_Rec");
-        if (centr < 89) {
-          registry.fill(HIST("h_Q2XvsQ2YFT0C_Rec"), qVecFT0C[0], qVecFT0C[1]);
-        }
-
-        qn = Calcqn(qVecFT0C[0], qVecFT0C[1], sumAmplFT0C);
-
-        if (cfgCorrLevel > 2) {
-          qVecFT0C[0] = qVecFT0C[0] / weights->GetRMSVal(centr, "x", nHarm);
-          qVecFT0C[1] = qVecFT0C[1] / weights->GetRMSVal(centr, "y", nHarm);
-          FFitObj->FillQ(collision.centFT0C(), qVecFT0C[0], nHarm, "x", "_RecTot");
-          FFitObj->FillQ(collision.centFT0C(), qVecFT0C[1], nHarm, "y", "_RecTot");
-        }
-      }
-      float Psi = EventPlane(qVecFT0C[0], qVecFT0C[1], nHarm);
-
-      if (nHarm == 2) {
-        registry.fill(HIST("h_qx2VecFT0C"), qVecFT0C[0]);
-        registry.fill(HIST("h_qy2VecFT0C"), qVecFT0C[1]);
-        registry.fill(HIST("h_Cent_q2FT0C"), collision.centFT0C(), qn);
-        registry.fill(HIST("h_Psi2"), collision.centFT0C(), Psi);
-      } else if (nHarm == 3) {
-        registry.fill(HIST("h_qx3VecFT0C"), qVecFT0C[0]);
-        registry.fill(HIST("h_qy3VecFT0C"), qVecFT0C[1]);
-        registry.fill(HIST("h_Cent_q3FT0C"), collision.centFT0C(), qn);
-        registry.fill(HIST("h_Psi3"), collision.centFT0C(), Psi);
-      }
-
-      if (cfgESE) {
-        int qSpCent = static_cast<int>(collision.centFT0C());
-        float qnCent{-1};
-        if (qSpCent > 0 && qSpCent < 90)
-          qnCent = 100. * spl[nHarm - 2][qSpCent]->Eval(qn);
-
-        qnP.push_back(qnCent);
-        fIsEseAvailable.push_back(1);
-        registry.fill(HIST("h_ESE_status"), 1.5);
-      } else {
-        qnP.push_back(-1);
+      for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
+        qnpFT0C.push_back(-1);
         fIsEseAvailable.push_back(0);
-        registry.fill(HIST("h_ESE_status"), .5);
+        registry.fill(HIST("hESEstat"), .5);
       }
-    } else {
-      qn = 0;
-      qnP.push_back(qn);
-      fIsEseAvailable.push_back(0);
-      registry.fill(HIST("h_ESE_status"), .5);
     }
+  };
 
-    qx.push_back(qVecFT0C[0]);
-    qy.push_back(qVecFT0C[1]);
-    registry.fill(HIST("h_collisions"), 1.5);
-  }
-
-  void processQVecs(CollWithMults::iterator const& collision, aod::BCsWithTimestamps const&, aod::FV0As const&, aod::FT0s const&)
+  void processESE(CollWithMults::iterator const& collision, aod::BCsWithTimestamps const&, aod::FV0As const&, aod::FT0s const&)
   {
+    float counter{0.5};
+    registry.fill(HIST("hEventCounter"), counter++);
 
-    std::vector<float> qvecRe{};
-    std::vector<float> qvecIm{};
-    std::vector<float> qnp{};
+    std::vector<float> qnpFT0C{};
     std::vector<int> fIsEseAvailable{};
 
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
@@ -396,16 +178,13 @@ struct EseTableProducer {
       runNumber = currentRun;
       initCCDB(bc);
     }
-    registry.fill(HIST("h_collisions"), 0.5);
+    registry.fill(HIST("hEventCounter"), counter++);
+    calculateESE(collision, qnpFT0C, fIsEseAvailable);
 
-    // QVecFV0(collision);
-    QVecFT0C(collision, 2, qvecRe, qvecIm, qnp, fIsEseAvailable);
-    QVecFT0C(collision, 3, qvecRe, qvecIm, qnp, fIsEseAvailable);
-
-    qVectorFT0C(qvecRe, qvecIm);
-    qPercs(qnp);
+    qPercsFT0C(qnpFT0C);
     fEseCol(fIsEseAvailable);
+    registry.fill(HIST("hEventCounter"), counter++);
   }
-  PROCESS_SWITCH(EseTableProducer, processQVecs, "procc q vectors ", true);
+  PROCESS_SWITCH(EseTableProducer, processESE, "proccess q vectors to calculate reduced q-vector", true);
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc) { return WorkflowSpec{adaptAnalysisTask<EseTableProducer>(cfgc)}; }

--- a/Common/TableProducer/eseTableProducer.cxx
+++ b/Common/TableProducer/eseTableProducer.cxx
@@ -40,22 +40,28 @@
 using namespace o2;
 using namespace o2::framework;
 
-using CollWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::QvectorFT0CVecs>;
+using CollWithMults = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::QvectorFT0CVecs, aod::QvectorFT0AVecs, aod::QvectorFV0AVecs>;
 
 struct EseTableProducer {
   Produces<o2::aod::QPercentileFT0Cs> qPercsFT0C;
+  Produces<o2::aod::QPercentileFT0As> qPercsFT0A;
+  Produces<o2::aod::QPercentileFV0As> qPercsFV0A;
+  Produces<o2::aod::QPercentileTPCs> qPercsTPC;
   Produces<o2::aod::FEseCols> fEseCol;
 
   OutputObj<FFitWeights> FFitObj{FFitWeights("weights")};
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
 
   Configurable<bool> cfgESE{"cfgESE", 1, "ese activation step: false = no ese, true = evaluate splines and fill table"};
-  Configurable<std::string> cfgEsePath{"cfgEsePath", "Users/j/joachiha/ESE/local/splines", "CCDB path for ese splines"};
+  Configurable<std::string> cfgEsePath{"cfgEsePath", "Users/j/joachiha/ESE/local/ffitsplines", "CCDB path for ese splines"};
   Configurable<bool> cfgFT0C{"cfgFT0C", 1, "FT0C flag"};
+  Configurable<bool> cfgFT0A{"cfgFT0A", 0, "FT0A flag"};
+  Configurable<bool> cfgFV0A{"cfgFV0A", 0, "FV0A flag"};
+  Configurable<bool> cfgTPC{"cfgTPC", 0, "TPC flag"};
   Configurable<std::vector<int>> cfgLoopHarmonics{"cfgLoopHarmonics", {2, 3}, "Harmonics to loop over when filling and evaluating splines"};
-  Configurable<std::vector<std::string>> vecStr{"vecStr", {"FT0C"}, "Qn type"};
+  Configurable<std::string> cfgCentEst{"cfgCentEst", "FT0C", "centrality estimator"};
 
-  Configurable<std::vector<float>> cfgaxisqnFT0C{"cfgaxisqnFT0C", {500, 0, 25}, "q_n amplitude range"};
+  Configurable<std::vector<float>> cfgaxisqn{"cfgaxisqn", {500, 0, 25}, "q_n amplitude range"};
   Configurable<int> cfgnResolution{"cfgnResolution", 3000, "resolution of splines"};
 
   int runNumber{-1};
@@ -70,7 +76,7 @@ struct EseTableProducer {
     LOGF(info, "ESETable::init()");
 
     registry.add("hEventCounter", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
-    registry.add("hESEstat", "ese status;ese status;entries", {HistType::kTH1F, {{2, 0.0, 2.0}}});
+    registry.add("hESEstat", "ese status;ese status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
 
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
@@ -79,15 +85,23 @@ struct EseTableProducer {
     int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     ccdb->setCreatedNotAfter(now);
 
+    std::vector<std::string> vecStr{};
+    if (cfgFT0C)
+      vecStr.push_back("FT0C");
+    if (cfgFT0A)
+      vecStr.push_back("FT0A");
+    if (cfgFV0A)
+      vecStr.push_back("FV0A");
+    if (cfgTPC)
+      vecStr.push_back("TPC");
+
     std::vector<std::pair<int, std::string>> veccfg;
-    for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) 
-    {
-      for (std::size_t j{0}; j < vecStr->size(); j++) 
-      {
-        veccfg.push_back({cfgLoopHarmonics->at(i), vecStr->at(j)});
+    for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
+      for (const auto& j : vecStr) {
+        veccfg.push_back({cfgLoopHarmonics->at(i), j});
       }
     }
-    FFitObj->SetBinAxis(cfgaxisqnFT0C->at(0), cfgaxisqnFT0C->at(1), cfgaxisqnFT0C->at(2));
+    FFitObj->SetBinAxis(cfgaxisqn->at(0), cfgaxisqn->at(1), cfgaxisqn->at(2));
     FFitObj->SetResolution(cfgnResolution);
     FFitObj->SetQnType(veccfg);
     FFitObj->Init();
@@ -125,42 +139,67 @@ struct EseTableProducer {
     }
   };
 
+  void doSpline(float& splineVal, int& eseval, const float& centr, const float& nHarm, const char* pf, const auto& QX, const auto& QY, const auto& Ampl)
+  {
+    if (validQvec(QX[nHarm - 2]) && validQvec(QY[nHarm - 2]) && Ampl > 1e-8) {
+      float qnval = Calcqn(QX[nHarm - 2] * Ampl, QY[nHarm - 2] * Ampl, Ampl);
+      FFitObj->Fill(centr, qnval, nHarm, pf);
+      if (cfgESE) {
+        splineVal = splines->EvalSplines(centr, qnval, nHarm, pf);
+        eseval = cfgFT0C ? 1 : 0;
+      }
+    }
+  }
+
   template <typename T>
-  void calculateESE(T const& collision, std::vector<float>& qnpFT0C, std::vector<int>& fIsEseAvailable)
+  void calculateESE(T const& collision,
+                    std::vector<float>& qnpFT0C,
+                    std::vector<float>& qnpFT0A,
+                    std::vector<float>& qnpFV0A,
+                    std::vector<float>& qnpTPC,
+                    std::vector<int>& fIsEseAvailable)
   {
 
-    if (cfgFT0C) {
-      const auto QxFT0C_Qvec = collision.qvecFT0CReVec();
-      const auto QyFT0C_Qvec = collision.qvecFT0CImVec();
-      const auto SumAmplFT0C = collision.sumAmplFT0C();
-      for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
-        int nHarm = cfgLoopHarmonics->at(i);
-        std::cout<< "nharm " << nHarm << std::endl;
-        if (validQvec(QxFT0C_Qvec[nHarm - 2]) && validQvec(QyFT0C_Qvec[nHarm - 2]) && SumAmplFT0C > 1e-8) {
-          float qnval = Calcqn(QxFT0C_Qvec[nHarm - 2]*SumAmplFT0C, QyFT0C_Qvec[nHarm - 2]*SumAmplFT0C, SumAmplFT0C);
-          FFitObj->Fill(collision.centFT0C(), qnval, nHarm, "FT0C");
-          if (cfgESE) {
-            float qnCent{splines->EvalSplines(collision.centFT0C(), qnval, nHarm, "FT0C")};
-            qnpFT0C.push_back(qnCent);
-            fIsEseAvailable.push_back(1);
-            registry.fill(HIST("hESEstat"), 1.5);
-          } else {
-            qnpFT0C.push_back(-1);
-            fIsEseAvailable.push_back(0);
-            registry.fill(HIST("hESEstat"), .5);
-          }
-        } else {
-          qnpFT0C.push_back(-1);
-          fIsEseAvailable.push_back(0);
-          registry.fill(HIST("hESEstat"), .5);
-        }
+    const float centrality = collision.centFT0C();
+    registry.fill(HIST("hESEstat"), 0.5);
+    for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
+      float splineValFT0C{-1.0};
+      float splineValFT0A{-1.0};
+      float splineValFV0A{-1.0};
+      qnpTPC.push_back(-1.0); /* not implemented yet */
+      int eseAvailable{0};
+
+      int nHarm = cfgLoopHarmonics->at(i);
+      if (cfgFT0C) {
+        const auto QxFT0C_Qvec = collision.qvecFT0CReVec();
+        const auto QyFT0C_Qvec = collision.qvecFT0CImVec();
+        const auto SumAmplFT0C = collision.sumAmplFT0C();
+        doSpline(splineValFT0C, eseAvailable, centrality, nHarm, "FT0C", QxFT0C_Qvec, QyFT0C_Qvec, SumAmplFT0C);
+        if (i == 0)
+          registry.fill(HIST("hESEstat"), 1.5);
       }
-    } else {
-      for (std::size_t i{0}; i < cfgLoopHarmonics->size(); i++) {
-        qnpFT0C.push_back(-1);
-        fIsEseAvailable.push_back(0);
-        registry.fill(HIST("hESEstat"), .5);
+      qnpFT0C.push_back(splineValFT0C);
+      fIsEseAvailable.push_back(eseAvailable);
+
+      if (cfgFT0A) {
+        const auto QxFT0A_Qvec = collision.qvecFT0AReVec();
+        const auto QyFT0A_Qvec = collision.qvecFT0AImVec();
+        const auto SumAmplFT0A = collision.sumAmplFT0A();
+        doSpline(splineValFT0A, eseAvailable, centrality, nHarm, "FT0A", QxFT0A_Qvec, QyFT0A_Qvec, SumAmplFT0A);
+        if (i == 0)
+          registry.fill(HIST("hESEstat"), 2.5);
       }
+      qnpFT0A.push_back(splineValFT0A);
+
+      if (cfgFV0A) {
+        const auto QxFV0A_Qvec = collision.qvecFV0AReVec();
+        const auto QyFV0A_Qvec = collision.qvecFV0AImVec();
+        const auto SumAmplFV0A = collision.sumAmplFV0A();
+        doSpline(splineValFV0A, eseAvailable, centrality, nHarm, "FV0A", QxFV0A_Qvec, QyFV0A_Qvec, SumAmplFV0A);
+        if (i == 0)
+          registry.fill(HIST("hESEstat"), 3.5);
+      }
+      qnpFV0A.push_back(splineValFV0A);
     }
   };
 
@@ -170,6 +209,10 @@ struct EseTableProducer {
     registry.fill(HIST("hEventCounter"), counter++);
 
     std::vector<float> qnpFT0C{};
+    std::vector<float> qnpFT0A{};
+    std::vector<float> qnpFV0A{};
+    std::vector<float> qnpTPC{};
+
     std::vector<int> fIsEseAvailable{};
 
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
@@ -179,9 +222,12 @@ struct EseTableProducer {
       initCCDB(bc);
     }
     registry.fill(HIST("hEventCounter"), counter++);
-    calculateESE(collision, qnpFT0C, fIsEseAvailable);
+    calculateESE(collision, qnpFT0C, qnpFT0A, qnpFV0A, qnpTPC, fIsEseAvailable);
 
     qPercsFT0C(qnpFT0C);
+    qPercsFT0A(qnpFT0A);
+    qPercsFV0A(qnpFV0A);
+    qPercsTPC(qnpTPC);
     fEseCol(fIsEseAvailable);
     registry.fill(HIST("hEventCounter"), counter++);
   }


### PR DESCRIPTION
Added existing Q-vector framework. FFitWeights now holds the spline functionality of the event shape engineering procedure. Table columns for FT0-A and FV0-A added.