### PR TITLE
[PWGLF] Add new occupancy features + change ccdb getters in lambdakzero/cascade pid

### DIFF
--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -151,7 +151,42 @@ DECLARE_SOA_TABLE_VERSIONED(StraEvSels_002, "AOD", "STRAEVSELS", 2,         //! 
                             mult::MultAllTracksITSTPC,                    // ITSTPC track multiplicities, all, no eta cut
                             mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
                             mult::MultZEM2, mult::MultZPA, mult::MultZPC,
-                            evsel::NumTracksInTimeRange,     // add occupancy as extra
+                            evsel::NumTracksInTimeRange,     // add occupancy in specified time interval by a number of tracks from nearby collisions
+                            udcollision::GapSide,            // UPC info: 0 for side A, 1 for side C, 2 for both sides, 3 neither A or C, 4 not enough or too many pv contributors
+                            udcollision::TotalFT0AmplitudeA, // UPC info: re-assigned FT0-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFT0AmplitudeC, // UPC info: re-assigned FT0-C amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFV0AmplitudeA, // UPC info: re-assigned FV0-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFDDAmplitudeA, // UPC info: re-assigned FDD-A amplitude, in case of SG event, from the most active bc
+                            udcollision::TotalFDDAmplitudeC, // UPC info: re-assigned FDD-C amplitude, in case of SG event, from the most active bc
+                            udzdc::EnergyCommonZNA,          // UPC info: re-assigned ZN-A amplitude, in case of SG event, from the most active bc
+                            udzdc::EnergyCommonZNC,          // UPC info: re-assigned ZN-C amplitude, in case of SG event, from the most active bc
+
+                            collision::Flags, // Contains Vertex::Flags, with most notably the UPCMode to know whether the vertex has been found using UPC settings
+
+                            // Dynamic columns for manipulating information
+                            // stracollision::TotalFV0AmplitudeA<mult::MultFV0A>,
+                            // stracollision::TotalFT0AmplitudeA<mult::MultFT0A>,
+                            // stracollision::TotalFT0AmplitudeC<mult::MultFT0C>,
+                            // stracollision::TotalFDDAmplitudeA<mult::MultFDDA>,
+                            // stracollision::TotalFDDAmplitudeC<mult::MultFDDC>,
+                            // stracollision::EnergyCommonZNA<mult::MultZNA>,
+                            // stracollision::EnergyCommonZNC<mult::MultZNC>,
+                            stracollision::IsUPC<udcollision::GapSide>);
+
+DECLARE_SOA_TABLE_VERSIONED(StraEvSels_003, "AOD", "STRAEVSELS", 3,         //! debug information
+                            evsel::Sel8, evsel::Selection,                  //! event selection: sel8
+                            mult::MultFT0A, mult::MultFT0C, mult::MultFV0A, // FIT detectors
+                            mult::MultFDDA, mult::MultFDDC,
+                            mult::MultNTracksPVeta1,                      // track multiplicities with eta cut for INEL>0
+                            mult::MultPVTotalContributors,                // number of PV contribs total
+                            mult::MultNTracksGlobal,                      // global track multiplicities
+                            mult::MultNTracksITSTPC,                      // track multiplicities, PV contribs, no eta cut
+                            mult::MultAllTracksTPCOnly,                   // TPConly track multiplicities, all, no eta cut
+                            mult::MultAllTracksITSTPC,                    // ITSTPC track multiplicities, all, no eta cut
+                            mult::MultZNA, mult::MultZNC, mult::MultZEM1, // ZDC signals
+                            mult::MultZEM2, mult::MultZPA, mult::MultZPC,
+                            evsel::NumTracksInTimeRange,     // add occupancy in specified time interval by a number of tracks from nearby collisions
+                            evsel::SumAmpFT0CInTimeRange,    // add occupancy in specified time interval by a sum of FT0C amplitudes from nearby collisions
                             udcollision::GapSide,            // UPC info: 0 for side A, 1 for side C, 2 for both sides, 3 neither A or C, 4 not enough or too many pv contributors
                             udcollision::TotalFT0AmplitudeA, // UPC info: re-assigned FT0-A amplitude, in case of SG event, from the most active bc
                             udcollision::TotalFT0AmplitudeC, // UPC info: re-assigned FT0-C amplitude, in case of SG event, from the most active bc
@@ -190,7 +225,7 @@ DECLARE_SOA_TABLE(StraStamps, "AOD", "STRASTAMPS", //! information for ID-ing ma
                   bc::RunNumber, timestamp::Timestamp);
 
 using StraRawCents = StraRawCents_004;
-using StraEvSels = StraEvSels_002;
+using StraEvSels = StraEvSels_003;
 using StraCollision = StraCollisions::iterator;
 using StraCent = StraCents::iterator;
 

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(straevselsconverter2rawcents
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(straevselsconverter2rawcents2
+                    SOURCES straevselsconverter2rawcents2.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(v0coresconverter
                     SOURCES v0coresconverter.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore

--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -34,6 +34,11 @@ o2physics_add_dpl_workflow(straevselsconverter2
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(straevselsconverter3
+                    SOURCES straevselsconverter3.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(straevselsconverter2rawcents
                     SOURCES straevselsconverter2rawcents.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
@@ -41,6 +46,11 @@ o2physics_add_dpl_workflow(straevselsconverter2rawcents
 
 o2physics_add_dpl_workflow(straevselsconverter2rawcents2
                     SOURCES straevselsconverter2rawcents2.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(straevselsconverter2rawcents3
+                    SOURCES straevselsconverter2rawcents3.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2rawcents2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2rawcents2.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts V0 version 001 to 002
+struct straevselsconverter2rawcents2 {
+  Produces<aod::StraRawCents_004> straRawCents_004;
+
+  void process(aod::StraEvSels_002 const& straEvSels_002)
+  {
+    for (auto& values : straEvSels_002) {
+      straRawCents_004(values.multFT0A(),
+                       values.multFT0C(),
+                       values.multFT0A(),
+                       values.multNTracksPVeta1(),
+                       values.multPVTotalContributors(),
+                       values.multNTracksGlobal(),
+                       values.multNTracksITSTPC(),
+                       values.multAllTracksTPCOnly(),
+                       values.multAllTracksITSTPC(),
+                       values.multZNA(),
+                       values.multZNC(),
+                       values.multZEM1(),
+                       values.multZEM2(),
+                       values.multZPA(),
+                       values.multZPC(),
+                       values.trackOccupancyInTimeRange());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<straevselsconverter2rawcents2>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2rawcents3.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2rawcents3.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts V0 version 001 to 002
+struct straevselsconverter2rawcents3 {
+  Produces<aod::StraRawCents_004> straRawCents_004;
+
+  void process(aod::StraEvSels_003 const& straEvSels_003)
+  {
+    for (auto& values : straEvSels_003) {
+      straRawCents_004(values.multFT0A(),
+                       values.multFT0C(),
+                       values.multFT0A(),
+                       values.multNTracksPVeta1(),
+                       values.multPVTotalContributors(),
+                       values.multNTracksGlobal(),
+                       values.multNTracksITSTPC(),
+                       values.multAllTracksTPCOnly(),
+                       values.multAllTracksITSTPC(),
+                       values.multZNA(),
+                       values.multZNC(),
+                       values.multZEM1(),
+                       values.multZEM2(),
+                       values.multZPA(),
+                       values.multZPC(),
+                       values.trackOccupancyInTimeRange());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<straevselsconverter2rawcents3>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter3.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter3.cxx
@@ -1,0 +1,65 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "ITStracking/Vertexer.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts Stra Event selections from 000 to 001
+struct straevselsconverter3 {
+  Produces<aod::StraEvSels_003> straEvSels_003;
+
+  void process(aod::StraEvSels_002 const& straEvSels_002)
+  {
+    for (auto& values : straEvSels_002) {
+      straEvSels_003(values.sel8(),
+                     values.selection_raw(),
+                     values.multFT0A(),
+                     values.multFT0C(),
+                     values.multFT0A(),
+                     0 /*dummy FDDA value*/,
+                     0 /*dummy FDDC value*/,
+                     values.multNTracksPVeta1(),
+                     values.multPVTotalContributors(),
+                     values.multNTracksGlobal(),
+                     values.multNTracksITSTPC(),
+                     values.multAllTracksTPCOnly(),
+                     values.multAllTracksITSTPC(),
+                     values.multZNA(),
+                     values.multZNC(),
+                     values.multZEM1(),
+                     values.multZEM2(),
+                     values.multZPA(),
+                     values.multZPC(),
+                     values.trackOccupancyInTimeRange(),
+                     0 /*dummy occupancy value*/,
+                     values.gapSide(),
+                     values.totalFT0AmplitudeA(),
+                     values.totalFT0AmplitudeC(),
+                     values.totalFV0AmplitudeA(),
+                     values.totalFDDAmplitudeA(),
+                     values.totalFDDAmplitudeC(),
+                     values.energyCommonZNA(),
+                     values.energyCommonZNC(),
+                     o2::its::Vertex::FlagsMask /*dummy flag value*/);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<straevselsconverter3>(cfgc)};
+}

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -371,6 +371,7 @@ struct strangederivedbuilder {
                       collision.multZPA() * static_cast<float>(fillTruncationOptions.fillRawZDC),
                       collision.multZPC() * static_cast<float>(fillTruncationOptions.fillRawZDC),
                       collision.trackOccupancyInTimeRange(),
+                      collision.ft0cOccupancyInTimeRange(),
                       // UPC info
                       gapSide,
                       totalFT0AmplitudeA, totalFT0AmplitudeC, totalFV0AmplitudeA,


### PR DESCRIPTION
- change ccdb getters in lambkzero/cascade pid tasks + allow to force specific timestamp/run
- add converter task to go from StraEvSels_002 to StraRawCents_004 (allow to use anterior O2Physics with current derived data)
- change strangeness data model to incorporate new occupancy definition based on the sum of FT0-C amplitudes --> add StraEvSels_003
- add converter tasks to StraEvSels_003 
- Adapt derived table producer task to fill StraEvSels_003 table with the new occupancy definition
- Adapt analysis task to deal with new occupancy event selections and new occupancy definition