### PR TITLE
[PWGUD] Fixing UPCCandProducer problem after upcflag introduction + personal task modification

### DIFF
--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -467,10 +467,11 @@ struct UpcCandProducer {
     return hasNoFT0;
   }
 
+  template <typename TBCs>
   void processFITInfo(upchelpers::FITInfo& fitInfo,
                       uint64_t midbc,
                       std::vector<std::pair<uint64_t, int64_t>>& v,
-                      BCsWithBcSels const& bcs,
+                      TBCs const& bcs,
                       o2::aod::FT0s const& /*ft0s*/,
                       o2::aod::FDDs const& /*fdds*/,
                       o2::aod::FV0As const& /*fv0as*/)
@@ -721,9 +722,10 @@ struct UpcCandProducer {
     return 0; // found exactly tracksToFind tracks in [midbc - range, midbc + range]
   }
 
+  template <typename TBCs>
   void createCandidatesCentral(BarrelTracks const& barrelTracks,
                                o2::aod::AmbiguousTracks const& ambBarrelTracks,
-                               BCsWithBcSels const& bcs,
+                               TBCs const& bcs,
                                o2::aod::Collisions const& collisions,
                                o2::aod::FT0s const& ft0s,
                                o2::aod::FDDs const& /*fdds*/,
@@ -738,7 +740,7 @@ struct UpcCandProducer {
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambBarrelTrBCs;
     if (upcCuts.getAmbigSwitch() != 1)
-      collectAmbTrackBCs<0, o2::aod::BCs>(ambBarrelTrBCs, ambBarrelTracks);
+      collectAmbTrackBCs<0, BCsWithBcSels>(ambBarrelTrBCs, ambBarrelTracks);
 
     collectBarrelTracks(bcsMatchedTrIdsTOF,
                         0,
@@ -759,7 +761,7 @@ struct UpcCandProducer {
     std::map<uint64_t, int32_t> mapGlobalBcWithTVX{};
     std::map<uint64_t, int32_t> mapGlobalBcWithTSC{};
     for (const auto& ft0 : ft0s) {
-      uint64_t globalBC = ft0.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = ft0.bc_as<TBCs>().globalBC();
       int32_t globalIndex = ft0.globalIndex();
       if (!(std::abs(ft0.timeA()) > 2.f && std::abs(ft0.timeC()) > 2.f))
         mapGlobalBcWithTOR[globalBC] = globalIndex;
@@ -780,7 +782,7 @@ struct UpcCandProducer {
     for (const auto& fv0a : fv0as) {
       if (std::abs(fv0a.time()) > 15.f)
         continue;
-      uint64_t globalBC = fv0a.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = fv0a.bc_as<TBCs>().globalBC();
       mapGlobalBcWithV0A[globalBC] = fv0a.globalIndex();
     }
 
@@ -792,7 +794,7 @@ struct UpcCandProducer {
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNA", 1);
       if (!(std::abs(zdc.timeZNC()) > 2.f))
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNC", 1);
-      auto globalBC = zdc.bc_as<o2::aod::BCs>().globalBC();
+      auto globalBC = zdc.bc_as<TBCs>().globalBC();
       mapGlobalBcWithZdc[globalBC] = zdc.globalIndex();
     }
 
@@ -1011,12 +1013,13 @@ struct UpcCandProducer {
     bcsMatchedTrIdsTOF.clear();
   }
 
+  template <typename TBCs>
   void createCandidatesSemiFwd(BarrelTracks const& barrelTracks,
                                o2::aod::AmbiguousTracks const& ambBarrelTracks,
                                ForwardTracks const& fwdTracks,
                                o2::aod::FwdTrkCls const& /*fwdTrkClusters*/,
                                o2::aod::AmbiguousFwdTracks const& ambFwdTracks,
-                               BCsWithBcSels const& bcs,
+                               TBCs const& bcs,
                                o2::aod::Collisions const& collisions,
                                o2::aod::FT0s const& ft0s,
                                o2::aod::FDDs const& fdds,
@@ -1220,10 +1223,11 @@ struct UpcCandProducer {
     }
   }
 
+  template <typename TBCs>
   void createCandidatesFwd(ForwardTracks const& fwdTracks,
                            o2::aod::FwdTrkCls const& fwdTrkClusters,
                            o2::aod::AmbiguousFwdTracks const& ambFwdTracks,
-                           BCsWithBcSels const& bcs,
+                           TBCs const& bcs,
                            o2::aod::Collisions const& collisions,
                            o2::aod::FT0s const& ft0s,
                            o2::aod::FDDs const& /*fdds*/,
@@ -1237,7 +1241,7 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, o2::aod::BCs>(ambFwdTrBCs, ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,
@@ -1264,7 +1268,7 @@ struct UpcCandProducer {
       }
       if (std::abs(ft0.timeA()) > 2.f)
         continue;
-      uint64_t globalBC = ft0.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = ft0.bc_as<TBCs>().globalBC();
       mapGlobalBcWithT0A[globalBC] = ft0.globalIndex();
     }
 
@@ -1274,7 +1278,7 @@ struct UpcCandProducer {
         continue;
       if (std::abs(fv0a.time()) > 15.f)
         continue;
-      uint64_t globalBC = fv0a.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = fv0a.bc_as<TBCs>().globalBC();
       mapGlobalBcWithV0A[globalBC] = fv0a.globalIndex();
     }
 
@@ -1286,7 +1290,7 @@ struct UpcCandProducer {
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNA", 1);
       if (!(std::abs(zdc.timeZNC()) > 2.f))
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNC", 1);
-      auto globalBC = zdc.bc_as<o2::aod::BCs>().globalBC();
+      auto globalBC = zdc.bc_as<TBCs>().globalBC();
       mapGlobalBcWithZdc[globalBC] = zdc.globalIndex();
     }
 
@@ -1423,10 +1427,11 @@ struct UpcCandProducer {
     mapGlobalBcWithV0A.clear();
   }
 
+  template <typename TBCs>
   void createCandidatesFwdGlobal(ForwardTracks const& fwdTracks,
                                  o2::aod::FwdTrkCls const& /*fwdTrkClusters*/,
                                  o2::aod::AmbiguousFwdTracks const& ambFwdTracks,
-                                 BCsWithBcSels const& bcs,
+                                 TBCs const& bcs,
                                  o2::aod::Collisions const& collisions,
                                  o2::aod::FT0s const& ft0s,
                                  o2::aod::FDDs const& /*fdds*/,
@@ -1441,7 +1446,7 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, o2::aod::BCs>(ambFwdTrBCs, ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,
@@ -1476,7 +1481,7 @@ struct UpcCandProducer {
       }
       if (std::abs(ft0.timeA()) > 2.f)
         continue;
-      uint64_t globalBC = ft0.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = ft0.bc_as<TBCs>().globalBC();
       mapGlobalBcWithT0A[globalBC] = ft0.globalIndex();
     }
 
@@ -1486,7 +1491,7 @@ struct UpcCandProducer {
         continue;
       if (std::abs(fv0a.time()) > 15.f)
         continue;
-      uint64_t globalBC = fv0a.bc_as<o2::aod::BCs>().globalBC();
+      uint64_t globalBC = fv0a.bc_as<TBCs>().globalBC();
       mapGlobalBcWithV0A[globalBC] = fv0a.globalIndex();
     }
 
@@ -1498,7 +1503,7 @@ struct UpcCandProducer {
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNA", 1);
       if (!(std::abs(zdc.timeZNC()) > 2.f))
         histRegistry.get<TH1>(HIST("hCountersTrg"))->Fill("ZNC", 1);
-      auto globalBC = zdc.bc_as<o2::aod::BCs>().globalBC();
+      auto globalBC = zdc.bc_as<TBCs>().globalBC();
       mapGlobalBcWithZdc[globalBC] = zdc.globalIndex();
     }
 

--- a/PWGUD/Tasks/upcTauCentralBarrelRL.cxx
+++ b/PWGUD/Tasks/upcTauCentralBarrelRL.cxx
@@ -88,6 +88,7 @@ struct UpcTauCentralBarrelRL {
   Configurable<int> cutMyGTtpcNClsCrossedRowsMin{"cutMyGTtpcNClsCrossedRowsMin", 70, {"MyGlobalTrack cut"}};
   Configurable<float> cutMyGTtpcNClsCrossedRowsOverNClsMin{"cutMyGTtpcNClsCrossedRowsOverNClsMin", 0.8f, {"MyGlobalTrack cut"}};
   Configurable<float> cutMyGTtpcChi2NclMax{"cutMyGTtpcChi2NclMax", 4.f, {"MyGlobalTrack cut"}};
+  Configurable<bool> applyTauEventSelection{"applyTauEventSelection", true, {"Select event"}};
   Configurable<bool> doMainHistos{"doMainHistos", true, {"Fill main histos"}};
   Configurable<bool> doPIDhistos{"doPIDhistos", true, {"Fill PID histos"}};
   Configurable<bool> doTwoTracks{"doTwoTracks", true, {"Define histos for two tracks and allow to fill them"}};
@@ -446,6 +447,7 @@ struct UpcTauCentralBarrelRL {
       histos.add("EventTwoTracks/ElectronMuPi/hMotherPhi", ";Mother #phi (rad);Number of events (-)", HistType::kTH1D, {axisPhi});
       histos.add("EventTwoTracks/ElectronMuPi/hMotherRapidity", ";Mother #it{y} (-);Number of events (-)", HistType::kTH1D, {axisRap});
       histos.add("EventTwoTracks/ElectronMuPi/hMotherMassVsPt", ";Invariant mass (GeV/c^{2});Mother #it{p_{T}} (GeV/c)", HistType::kTH2D, {axisInvMassWide, axisPt});
+      histos.add("EventTwoTracks/ElectronMuPi/hElectronPt", ";Electron #it{p_{T}} (GeV/c);Number of events (-)", HistType::kTH1D, {axisPt});
       histos.add("EventTwoTracks/ElectronMuPi/hElectronPtWide", ";Electron #it{p_{T}} (GeV/c);Number of events (-)", HistType::kTH1D, {axisMomWide});
       histos.add("EventTwoTracks/ElectronMuPi/hDaughtersP", ";Daughter 1 #it{p} (GeV/c);Daughter 2 #it{p} (GeV/c)", HistType::kTH2D, {axisMom, axisMom});
       histos.add("EventTwoTracks/ElectronMuPi/hDaughtersPwide", ";Daughter 1 #it{p} (GeV/c);Daughter 2 #it{p} (GeV/c)", HistType::kTH2D, {axisMomWide, axisMomWide});
@@ -482,6 +484,7 @@ struct UpcTauCentralBarrelRL {
       histos.add("EventTwoTracks/ElectronOther/hMotherPhi", ";Mother #phi (rad);Number of events (-)", HistType::kTH1D, {axisPhi});
       histos.add("EventTwoTracks/ElectronOther/hMotherRapidity", ";Mother #it{y} (-);Number of events (-)", HistType::kTH1D, {axisRap});
       histos.add("EventTwoTracks/ElectronOther/hMotherMassVsPt", ";Invariant mass (GeV/c^{2});Mother #it{p_{T}} (GeV/c)", HistType::kTH2D, {axisInvMassWide, axisPt});
+      histos.add("EventTwoTracks/ElectronOther/hElectronPt", ";Electron #it{p_{T}} (GeV/c);Number of events (-)", HistType::kTH1D, {axisPt});
       histos.add("EventTwoTracks/ElectronOther/hElectronPtWide", ";Electron #it{p_{T}} (GeV/c);Number of events (-)", HistType::kTH1D, {axisMomWide});
       histos.add("EventTwoTracks/ElectronOther/hDaughtersP", ";Daughter 1 #it{p} (GeV/c);Daughter 2 #it{p} (GeV/c)", HistType::kTH2D, {axisMom, axisMom});
       histos.add("EventTwoTracks/ElectronOther/hDaughtersPwide", ";Daughter 1 #it{p} (GeV/c);Daughter 2 #it{p} (GeV/c)", HistType::kTH2D, {axisMomWide, axisMomWide});
@@ -1172,6 +1175,13 @@ struct UpcTauCentralBarrelRL {
       auto acoplanarity = calculateAcoplanarity(daug[0].Phi(), daug[1].Phi());
       auto sign = trkDaug1.sign() * trkDaug2.sign();
       bool passAvgITSclsSizesCut = passITSAvgClsSizesLowMomCut(trkDaug1, cutAvgITSclusterSize, cutPtAvgITSclusterSize) && passITSAvgClsSizesLowMomCut(trkDaug2, cutAvgITSclusterSize, cutPtAvgITSclusterSize);
+      if (applyTauEventSelection){
+        if (sign > 0) return;
+        if (acoplanarity > 4 * o2::constants::math::PI / 5) return; // max opening angle 144 degrees (I hope, check)
+//        if (daug[0].Pt() < 0.2 || daug[1].Pt() < 0.2) return;
+//        if (motherOfPions.M() > 0.55 || motherOfPions.M() < 1.05) return;
+//        if (!trkDaug1.hasTOF() || !trkDaug2.hasTOF()) return;
+      }
 
       histos.get<TH1>(HIST("EventTwoTracks/hInvariantMass"))->Fill(mother.M());
       histos.get<TH1>(HIST("EventTwoTracks/hInvariantMassWide"))->Fill(mother.M());
@@ -1377,6 +1387,7 @@ struct UpcTauCentralBarrelRL {
         histos.get<TH1>(HIST("EventTwoTracks/ElectronMuPi/hMotherPhi"))->Fill(mother.Phi());
         histos.get<TH1>(HIST("EventTwoTracks/ElectronMuPi/hMotherRapidity"))->Fill(mother.Rapidity());
         histos.get<TH2>(HIST("EventTwoTracks/ElectronMuPi/hMotherMassVsPt"))->Fill(mother.M(), mother.Pt());
+        histos.get<TH1>(HIST("EventTwoTracks/ElectronMuPi/hElectronPt"))->Fill(electronPt);
         histos.get<TH1>(HIST("EventTwoTracks/ElectronMuPi/hElectronPtWide"))->Fill(electronPt);
         histos.get<TH2>(HIST("EventTwoTracks/ElectronMuPi/hDaughtersP"))->Fill(daug[0].P(), daug[1].P());
         histos.get<TH2>(HIST("EventTwoTracks/ElectronMuPi/hDaughtersPwide"))->Fill(daug[0].P(), daug[1].P());
@@ -1427,6 +1438,7 @@ struct UpcTauCentralBarrelRL {
         histos.get<TH1>(HIST("EventTwoTracks/ElectronOther/hMotherPhi"))->Fill(mother.Phi());
         histos.get<TH1>(HIST("EventTwoTracks/ElectronOther/hMotherRapidity"))->Fill(mother.Rapidity());
         histos.get<TH2>(HIST("EventTwoTracks/ElectronOther/hMotherMassVsPt"))->Fill(mother.M(), mother.Pt());
+        histos.get<TH1>(HIST("EventTwoTracks/ElectronOther/hElectronPt"))->Fill(electronPt);
         histos.get<TH1>(HIST("EventTwoTracks/ElectronOther/hElectronPtWide"))->Fill(electronPt);
         histos.get<TH2>(HIST("EventTwoTracks/ElectronOther/hDaughtersP"))->Fill(daug[0].P(), daug[1].P());
         histos.get<TH2>(HIST("EventTwoTracks/ElectronOther/hDaughtersPwide"))->Fill(daug[0].P(), daug[1].P());


### PR DESCRIPTION
After [this PR](https://github.com/AliceO2Group/O2Physics/commit/d71cfadb5bec112a65ee917a6648d224ef94b642#diff-3a6ed49cd6043ddee2f1608ae04181cd1ba9f0fcc9ae1a59104f7aa698688370L96) UPCCandProducer stopped working and was returning 
`[ERROR] SEVERE: Device upc-cand-producer (85030) had at least one message above severity 5: Unhandled o2::framework::runtime_error reached the top of main of o2-analysis-ud-upccand-producer, device shutting down. Reason: Trying to dereference index with a wrong type in _as<>. Note that if you have several compatible index targets in your process() signature, the last one will be the one actually bound to the getter.` 
This PR should fix it.

In addition, personal task modification are pushed to master.