### PR TITLE
PWGEM/Dilepton: bug fix after #8100 and #8146

### DIFF
--- a/PWGEM/Dilepton/Core/DielectronCut.cxx
+++ b/PWGEM/Dilepton/Core/DielectronCut.cxx
@@ -45,23 +45,11 @@ void DielectronCut::SetMeeRange(float min, float max)
   mMaxMee = max;
   LOG(info) << "Dielectron Cut, set mee range: " << mMinMee << " - " << mMaxMee;
 }
-void DielectronCut::SetPairDeltaEta(float minDeltaEta, float maxDeltaEta)
-{
-  mMinDeltaEta = minDeltaEta;
-  mMaxDeltaEta = maxDeltaEta;
-  LOG(info) << "Dielectron Cut, set pair delta eta range: " << mMinDeltaEta << " - " << mMaxDeltaEta;
-}
-void DielectronCut::SetPairDeltaPhi(float minDeltaPhi, float maxDeltaPhi)
-{
-  mMinDeltaPhi = minDeltaPhi;
-  mMaxDeltaPhi = maxDeltaPhi;
-  LOG(info) << "Dielectron Cut, set pair delta phi range: " << mMinDeltaEta << " - " << mMaxDeltaEta;
-}
 void DielectronCut::SetPairOpAng(float minOpAng, float maxOpAng)
 {
   mMinOpAng = minOpAng;
   mMaxOpAng = maxOpAng;
-  LOG(info) << "Dielectron Cut, set pair opening angle range: " << mMinDeltaEta << " - " << mMaxDeltaEta;
+  LOG(info) << "Dielectron Cut, set pair opening angle range: " << mMinOpAng << " - " << mMaxOpAng;
 }
 void DielectronCut::SetMaxPhivPairMeeDep(std::function<float(float)> meeDepCut)
 {

--- a/PWGEM/Dilepton/Core/DielectronCut.h
+++ b/PWGEM/Dilepton/Core/DielectronCut.h
@@ -142,13 +142,6 @@ class DielectronCut : public TNamed
     o2::math_utils::bringToPMPi(dphi);
     if (mApplydEtadPhi && std::pow(deta / mMinDeltaEta, 2) + std::pow(dphi / mMinDeltaPhi, 2) < 1.f) {
       return false;
-    } else {
-      if (deta < mMinDeltaEta || deta > mMaxDeltaEta) {
-        return false;
-      }
-      if (deta < mMinDeltaPhi || deta > mMaxDeltaPhi) {
-        return false;
-      }
     }
 
     return true;
@@ -389,8 +382,6 @@ class DielectronCut : public TNamed
   void SetPairYRange(float minY = -1e10f, float maxY = 1e10f);
   void SetPairDCARange(float min = 0.f, float max = 1e10f); // 3D DCA in sigma
   void SetMeeRange(float min = 0.f, float max = 0.5);
-  void SetPairDeltaEta(float minDeltaEta = 0.f, float maxDeltaEta = 1e10f);
-  void SetPairDeltaPhi(float minDeltaPhi = 0.f, float maxDeltaPhi = 1e10f);
   void SetPairOpAng(float minOpAng = 0.f, float maxOpAng = 1e10f);
   void SetMaxPhivPairMeeDep(std::function<float(float)> meeDepCut);
   void SetPhivPairRange(float min, float max);
@@ -455,8 +446,8 @@ class DielectronCut : public TNamed
   std::function<float(float)> mMaxPhivPairMeeDep{}; // max phiv as a function of mee
   bool mSelectPC{false};                            // flag to select photon conversion used in mMaxPhivPairMeeDep
   bool mApplydEtadPhi{false};                       // flag to apply deta, dphi cut between 2 tracks
-  float mMinDeltaEta{-1e10f}, mMaxDeltaEta{1e10f};
-  float mMinDeltaPhi{-1e10f}, mMaxDeltaPhi{1e10f};
+  float mMinDeltaEta{0.f};
+  float mMinDeltaPhi{0.f};
   float mMinOpAng{0.f}, mMaxOpAng{1e10f};
 
   // kinematic cuts

--- a/PWGEM/Dilepton/Core/Dilepton.h
+++ b/PWGEM/Dilepton/Core/Dilepton.h
@@ -158,10 +158,8 @@ struct Dilepton {
     Configurable<float> cfg_phiv_slope{"cfg_phiv_slope", 0.0185, "slope for m vs. phiv"};
     Configurable<float> cfg_phiv_intercept{"cfg_phiv_intercept", -0.0280, "intercept for m vs. phiv"};
     Configurable<bool> cfg_apply_detadphi{"cfg_apply_detadphi", false, "flag to apply deta-dphi elliptic cut"};
-    Configurable<float> cfg_min_deta{"cfg_min_deta", 0.02, "min deta between 2 electrons (also for elliptic cut)"};
-    Configurable<float> cfg_min_dphi{"cfg_min_dphi", 0.02, "min dphi between 2 electrons (also for elliptic cut)"};
-    Configurable<float> cfg_max_deta{"cfg_max_deta", 3.2, "max deta between 2 electrons"};
-    Configurable<float> cfg_max_dphi{"cfg_max_dphi", 3.2, "max dphi between 2 electrons"};
+    Configurable<float> cfg_min_deta{"cfg_min_deta", 0.02, "min deta between 2 electrons (elliptic cut)"};
+    Configurable<float> cfg_min_dphi{"cfg_min_dphi", 0.2, "min dphi between 2 electrons (elliptic cut)"};
     Configurable<float> cfg_min_opang{"cfg_min_opang", 0.0, "min opening angle"};
     Configurable<float> cfg_max_opang{"cfg_max_opang", 6.4, "max opening angle"};
 
@@ -505,7 +503,7 @@ struct Dilepton {
       fRegistry.add("Pair/same/uls/hDeltaEtaDeltaPhi", "distance between 2 tracks in #eta-#varphi plane;#Delta#varphi (rad.);#Delta#eta", kTH2D, {{200, -0.5, +0.5}, {200, -0.5, 0.5}}, true);
       if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDielectron) {
         fRegistry.add("Pair/same/uls/hMvsPhiV", "m_{ee} vs. #varphi_{V};#varphi_{V} (rad.);m_{ee} (GeV/c^{2})", kTH2D, {{90, 0, M_PI}, {100, 0.0f, 0.1f}}, true); // phiv is only for dielectron
-        fRegistry.add("Pair/same/uls/hMVsOpAng", "m_{ee} vs. angle between 2 tracks;#omega (rad.);m_{ee} (GeV/c^{2})", kTH2D, {{200, 0, 4.0}, {100, 0.0f, 3.2}}, true);
+        fRegistry.add("Pair/same/uls/hMvsOpAng", "m_{ee} vs. angle between 2 tracks;#omega (rad.);m_{ee} (GeV/c^{2})", kTH2D, {{200, 0, 4.0}, {100, 0.0f, 3.2}}, true);
       }
       fRegistry.addClone("Pair/same/uls/", "Pair/same/lspp/");
       fRegistry.addClone("Pair/same/uls/", "Pair/same/lsmm/");
@@ -569,7 +567,7 @@ struct Dilepton {
       fRegistry.addClone("Pair/same/uls/", "Pair/same/lsmm/");
       fRegistry.addClone("Pair/same/", "Pair/mix/");
     } else if (cfgAnalysisType == static_cast<int>(o2::aod::pwgem::dilepton::utils::pairutil::DileptonAnalysisType::kHFll)) {
-      const AxisSpec axis_dphi_ee{36, M_PI / 2., 3. / .2 * M_PI, "#Delta#varphi = #varphi_{l1} - #varphi_{l2} (rad.)"}; // for kHFll
+      const AxisSpec axis_dphi_ee{36, -M_PI / 2., 3. / 2. * M_PI, "#Delta#varphi = #varphi_{l1} - #varphi_{l2} (rad.)"}; // for kHFll
       const AxisSpec axis_deta_ee{40, -2., 2., "#Delta#eta = #eta_{l1} - #eta_{l2}"};
       fRegistry.add("Pair/same/uls/hs", "dilepton", kTHnSparseD, {axis_mass, axis_pt, axis_dca, axis_dphi_ee, axis_deta_ee}, true);
       fRegistry.addClone("Pair/same/uls/", "Pair/same/lspp/");
@@ -623,8 +621,6 @@ struct Dilepton {
     fDielectronCut.ApplyPhiV(dielectroncuts.cfg_apply_phiv);
     fDielectronCut.ApplyPrefilter(dielectroncuts.cfg_apply_pf);
     fDielectronCut.SetMindEtadPhi(dielectroncuts.cfg_apply_detadphi, dielectroncuts.cfg_min_deta, dielectroncuts.cfg_min_dphi);
-    fDielectronCut.SetPairDeltaEta(dielectroncuts.cfg_min_deta, dielectroncuts.cfg_max_deta);
-    fDielectronCut.SetPairDeltaPhi(dielectroncuts.cfg_min_dphi, dielectroncuts.cfg_max_dphi);
     fDielectronCut.SetPairOpAng(dielectroncuts.cfg_min_opang, dielectroncuts.cfg_max_opang);
 
     // for track

--- a/PWGEM/Dilepton/Core/DileptonMC.h
+++ b/PWGEM/Dilepton/Core/DileptonMC.h
@@ -140,7 +140,9 @@ struct DileptonMC {
     Configurable<float> cfg_phiv_intercept{"cfg_phiv_intercept", -0.0280, "intercept for m vs. phiv"};
     Configurable<bool> cfg_apply_detadphi{"cfg_apply_detadphi", false, "flag to apply deta-dphi elliptic cut"};
     Configurable<float> cfg_min_deta{"cfg_min_deta", 0.02, "min deta between 2 electrons (elliptic cut)"};
-    Configurable<float> cfg_min_dphi{"cfg_min_dphi", 0.02, "min dphi between 2 electrons (elliptic cut)"};
+    Configurable<float> cfg_min_dphi{"cfg_min_dphi", 0.2, "min dphi between 2 electrons (elliptic cut)"};
+    Configurable<float> cfg_min_opang{"cfg_min_opang", 0.0, "min opening angle"};
+    Configurable<float> cfg_max_opang{"cfg_max_opang", 6.4, "max opening angle"};
 
     Configurable<float> cfg_min_pt_track{"cfg_min_pt_track", 0.2, "min pT for single track"};
     Configurable<float> cfg_min_eta_track{"cfg_min_eta_track", -0.8, "max eta for single track"};
@@ -284,13 +286,13 @@ struct DileptonMC {
     const AxisSpec axis_pt_meson{ConfPtllBins, "p_{T} (GeV/c)"}; // for omega, phi meson pT spectra
     const AxisSpec axis_y_meson{nbin_y, min_y, max_y, "y"};      // rapidity of meson
 
-    const AxisSpec axis_dphi_ee{36, M_PI / 2., 3. / .2 * M_PI, "#Delta#varphi = #varphi_{l1} - #varphi_{l2} (rad.)"}; // for kHFll
-    const AxisSpec axis_deta_ee{40, -2., 2., "#Delta#eta = #eta_{l1} - #eta_{l2}"};                                 // for kHFll
-    const AxisSpec axis_cos_theta_cs{10, 0.f, 1.f, "|cos(#theta_{CS})|"};                                           // for kPolarization, kUPC
-    const AxisSpec axis_phi_cs{18, 0.f, M_PI, "|#varphi_{CS}| (rad.)"};                                             // for kPolarization
-    const AxisSpec axis_aco{10, 0, 1.f, "#alpha = 1 - #frac{|#varphi_{l^{+}} - #varphi_{l^{-}}|}{#pi}"};            // for kUPC
-    const AxisSpec axis_asym_pt{10, 0, 1.f, "A = #frac{|p_{T,l^{+}} - p_{T,l^{-}}|}{|p_{T,l^{+}} + p_{T,l^{-}}|}"}; // for kUPC
-    const AxisSpec axis_dphi_e_ee{18, 0, M_PI, "#Delta#varphi = #varphi_{l} - #varphi_{ll} (rad.)"};                // for kUPC
+    const AxisSpec axis_dphi_ee{36, -M_PI / 2., 3. / 2. * M_PI, "#Delta#varphi = #varphi_{l1} - #varphi_{l2} (rad.)"}; // for kHFll
+    const AxisSpec axis_deta_ee{40, -2., 2., "#Delta#eta = #eta_{l1} - #eta_{l2}"};                                    // for kHFll
+    const AxisSpec axis_cos_theta_cs{10, 0.f, 1.f, "|cos(#theta_{CS})|"};                                              // for kPolarization, kUPC
+    const AxisSpec axis_phi_cs{18, 0.f, M_PI, "|#varphi_{CS}| (rad.)"};                                                // for kPolarization
+    const AxisSpec axis_aco{10, 0, 1.f, "#alpha = 1 - #frac{|#varphi_{l^{+}} - #varphi_{l^{-}}|}{#pi}"};               // for kUPC
+    const AxisSpec axis_asym_pt{10, 0, 1.f, "A = #frac{|p_{T,l^{+}} - p_{T,l^{-}}|}{|p_{T,l^{+}} + p_{T,l^{-}}|}"};    // for kUPC
+    const AxisSpec axis_dphi_e_ee{18, 0, M_PI, "#Delta#varphi = #varphi_{l} - #varphi_{ll} (rad.)"};                   // for kUPC
 
     // generated info
     fRegistry.add("Generated/sm/Pi0/hs", "gen. dilepton signal", kTHnSparseD, {axis_mass, axis_pt, axis_y, axis_dphi_ee, axis_deta_ee, axis_cos_theta_cs, axis_phi_cs, axis_aco, axis_asym_pt, axis_dphi_e_ee}, true);
@@ -502,6 +504,7 @@ struct DileptonMC {
     fDielectronCut.ApplyPhiV(dielectroncuts.cfg_apply_phiv);
     fDielectronCut.ApplyPrefilter(dielectroncuts.cfg_apply_pf);
     fDielectronCut.SetMindEtadPhi(dielectroncuts.cfg_apply_detadphi, dielectroncuts.cfg_min_deta, dielectroncuts.cfg_min_dphi);
+    fDielectronCut.SetPairOpAng(dielectroncuts.cfg_min_opang, dielectroncuts.cfg_max_opang);
 
     // for track
     fDielectronCut.SetTrackPtRange(dielectroncuts.cfg_min_pt_track, 1e+10f);


### PR DESCRIPTION
PWGEM/Dilepton: bug fix
#8100
sign of M_PI/2. was wrong.
.2 was wrong.

#8146
Histogram name was wrong.
if-else logic was wrong.
The linear cut is part of the elliptic cut. Namely, the linear deta cut is equivalent at the limit of dphi-> infinity.
If one wants to apply linear deta cut, one should set cfg_min_dphi = 1e+10, and vice versa.