### PR TITLE
PWGLF: Fix a bug of TPC nclusters cut and change the order of cuts on tracks for analysis of hypertriton 3body decay

### DIFF
--- a/PWGLF/TableProducer/Nuspex/decay3bodybuilder.cxx
+++ b/PWGLF/TableProducer/Nuspex/decay3bodybuilder.cxx
@@ -523,7 +523,7 @@ struct decay3bodyBuilder {
       auto t1 = vtx3body.template track1_as<TTrackClass>();
       auto t2 = vtx3body.template track2_as<TTrackClass>();
 
-      if (t0.tpcNClsFound() < mintpcNCls && t1.tpcNClsFound() < mintpcNCls && t2.tpcNClsFound() < mintpcNCls) {
+      if (t0.tpcNClsFound() < mintpcNCls || t1.tpcNClsFound() < mintpcNCls || t2.tpcNClsFound() < mintpcNCls) {
         continue;
       }
       registry.fill(HIST("hVtx3BodyCounter"), kVtxTPCNcls);

--- a/PWGLF/TableProducer/Nuspex/threebodyRecoTask.cxx
+++ b/PWGLF/TableProducer/Nuspex/threebodyRecoTask.cxx
@@ -150,9 +150,9 @@ struct threebodyRecoTask {
                  kCandRapidity,
                  kCandct,
                  kCandDcaDau,
-                 kCandTOFPID,
-                 kCandTPCPID,
                  kCandTPCNcls,
+                 kCandTPCPID,
+                 kCandTOFPID,
                  kCandDauPt,
                  kCandDcaToPV,
                  kCandInvMass,
@@ -281,23 +281,37 @@ struct threebodyRecoTask {
       return;
     }
     FillCandCounter(kCandCosPA, isTrueCand);
+
     if (std::abs(trackProton.eta()) > etacut || std::abs(trackPion.eta()) > etacut || std::abs(trackDeuteron.eta()) > etacut) {
       return;
     }
     FillCandCounter(kCandDauEta, isTrueCand);
+
     if (std::abs(candData.yHypertriton()) > rapiditycut) {
       return;
     }
     FillCandCounter(kCandRapidity, isTrueCand);
+
     double ct = candData.distovertotmom(dCollision.posX(), dCollision.posY(), dCollision.posZ()) * o2::constants::physics::MassHyperTriton;
     if (ct > lifetimecut) {
       return;
     }
     FillCandCounter(kCandct, isTrueCand);
+
     if (candData.dcaVtxdaughters() > dcavtxdau) {
       return;
     }
     FillCandCounter(kCandDcaDau, isTrueCand);
+
+    if (trackProton.tpcNClsFound() < mintpcNClsproton || trackPion.tpcNClsFound() < mintpcNClspion || trackDeuteron.tpcNClsFound() < mintpcNClsdeuteron) {
+      return;
+    }
+    FillCandCounter(kCandTPCNcls, isTrueCand);
+
+    if (std::abs(trackProton.tpcNSigmaPr()) > TpcPidNsigmaCut || std::abs(trackPion.tpcNSigmaPi()) > TpcPidNsigmaCut || std::abs(trackDeuteron.tpcNSigmaDe()) > TpcPidNsigmaCut) {
+      return;
+    }
+    FillCandCounter(kCandTPCPID, isTrueCand);
 
     registry.fill(HIST("hDeuteronTOFVsPBeforeTOFCut"), trackDeuteron.sign() * trackDeuteron.p(), candData.tofNSigmaBachDe());
     if ((candData.tofNSigmaBachDe() < TofPidNsigmaMin || candData.tofNSigmaBachDe() > TofPidNsigmaMax) && trackDeuteron.p() > minDeuteronPUseTOF) {
@@ -305,16 +319,6 @@ struct threebodyRecoTask {
     }
     FillCandCounter(kCandTOFPID, isTrueCand);
     registry.fill(HIST("hDeuteronTOFVsPAtferTOFCut"), trackDeuteron.sign() * trackDeuteron.p(), candData.tofNSigmaBachDe());
-
-    if (std::abs(trackProton.tpcNSigmaPr()) > TpcPidNsigmaCut || std::abs(trackPion.tpcNSigmaPi()) > TpcPidNsigmaCut || std::abs(trackDeuteron.tpcNSigmaDe()) > TpcPidNsigmaCut) {
-      return;
-    }
-    FillCandCounter(kCandTPCPID, isTrueCand);
-
-    if (trackProton.tpcNClsFound() < mintpcNClsproton || trackPion.tpcNClsFound() < mintpcNClspion || trackDeuteron.tpcNClsFound() < mintpcNClsdeuteron) {
-      return;
-    }
-    FillCandCounter(kCandTPCNcls, isTrueCand);
 
     if (trackProton.pt() < minProtonPt || trackProton.pt() > maxProtonPt || trackPion.pt() < minPionPt || trackPion.pt() > maxPionPt || trackDeuteron.pt() < minDeuteronPt || trackDeuteron.pt() > maxDeuteronPt) {
       return;

--- a/PWGLF/Tasks/Nuspex/hypertriton3bodyanalysis.cxx
+++ b/PWGLF/Tasks/Nuspex/hypertriton3bodyanalysis.cxx
@@ -236,9 +236,9 @@ struct hypertriton3bodyAnalysis {
                  kCandRapidity,
                  kCandct,
                  kCandDcaDau,
-                 kCandTOFPID,
-                 kCandTPCPID,
                  kCandTPCNcls,
+                 kCandTPCPID,
+                 kCandTOFPID,
                  kCandDauPt,
                  kCandDcaToPV,
                  kCandInvMass,
@@ -329,23 +329,37 @@ struct hypertriton3bodyAnalysis {
       return;
     }
     FillCandCounter(kCandCosPA, isTrueCand);
-    if (TMath::Abs(trackProton.eta()) > etacut || TMath::Abs(trackPion.eta()) > etacut || TMath::Abs(trackDeuteron.eta()) > etacut) {
+
+    if (std::abs(trackProton.eta()) > etacut || std::abs(trackPion.eta()) > etacut || std::abs(trackDeuteron.eta()) > etacut) {
       return;
     }
     FillCandCounter(kCandDauEta, isTrueCand);
-    if (TMath::Abs(candData.yHypertriton()) > rapiditycut) {
+
+    if (std::abs(candData.yHypertriton()) > rapiditycut) {
       return;
     }
     FillCandCounter(kCandRapidity, isTrueCand);
+
     double ct = candData.distovertotmom(dCollision.posX(), dCollision.posY(), dCollision.posZ()) * o2::constants::physics::MassHyperTriton;
     if (ct > lifetimecut) {
       return;
     }
     FillCandCounter(kCandct, isTrueCand);
+
     if (candData.dcaVtxdaughters() > dcavtxdau) {
       return;
     }
     FillCandCounter(kCandDcaDau, isTrueCand);
+
+    if (trackProton.tpcNClsFound() < mintpcNClsproton || trackPion.tpcNClsFound() < mintpcNClspion || trackDeuteron.tpcNClsFound() < mintpcNClsdeuteron) {
+      return;
+    }
+    FillCandCounter(kCandTPCNcls, isTrueCand);
+
+    if (TMath::Abs(trackProton.tpcNSigmaPr()) > TpcPidNsigmaCut || TMath::Abs(trackPion.tpcNSigmaPi()) > TpcPidNsigmaCut || TMath::Abs(trackDeuteron.tpcNSigmaDe()) > TpcPidNsigmaCut) {
+      return;
+    }
+    FillCandCounter(kCandTPCPID, isTrueCand);
 
     // registry.fill(HIST("hDeuteronDefaultTOFVsPBeforeTOFCut"), trackDeuteron.sign() * trackDeuteron.p(), trackDeuteron.tofNSigmaDe());
     registry.fill(HIST("hDeuteronTOFVsPBeforeTOFCut"), trackDeuteron.sign() * trackDeuteron.p(), candData.tofNSigmaBachDe());
@@ -363,16 +377,6 @@ struct hypertriton3bodyAnalysis {
       // registry.fill(HIST("hDeuteronDefaultTOFVsPAfterTOFCutSig"), trackDeuteron.sign() * trackDeuteron.p(), trackDeuteron.tofNSigmaDe());
       registry.fill(HIST("hDeuteronTOFVsPAfterTOFCutSig"), trackDeuteron.sign() * trackDeuteron.p(), candData.tofNSigmaBachDe());
     }
-
-    if (TMath::Abs(trackProton.tpcNSigmaPr()) > TpcPidNsigmaCut || TMath::Abs(trackPion.tpcNSigmaPi()) > TpcPidNsigmaCut || TMath::Abs(trackDeuteron.tpcNSigmaDe()) > TpcPidNsigmaCut) {
-      return;
-    }
-    FillCandCounter(kCandTPCPID, isTrueCand);
-
-    if (trackProton.tpcNClsFound() < mintpcNClsproton || trackPion.tpcNClsFound() < mintpcNClspion || trackDeuteron.tpcNClsFound() < mintpcNClsdeuteron) {
-      return;
-    }
-    FillCandCounter(kCandTPCNcls, isTrueCand);
 
     if (trackProton.pt() < minProtonPt || trackProton.pt() > maxProtonPt || trackPion.pt() < minPionPt || trackPion.pt() > maxPionPt || trackDeuteron.pt() < minDeuteronPt || trackDeuteron.pt() > maxDeuteronPt) {
       return;


### PR DESCRIPTION
Fix a bug in pre-selection (which is applied with a tighter cut in final selection later) of decay3bodybuilder
Change the order of cuts