### PR TITLE
PWGLF: Adding TPC PID + Mass pre-selection for photons

### DIFF
--- a/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
@@ -263,6 +263,7 @@ struct lambdakzeroBuilder {
   static constexpr float defaultLambdaWindowParameters[1][4] = {{1.17518e-03, 1.24099e-04, 5.47937e-03, 3.08009e-01}};
   Configurable<LabeledArray<float>> massCutK0{"massCutK0", {defaultK0MassWindowParameters[0], 4, {"constant", "linear", "expoConstant", "expoRelax"}}, "mass parameters for K0"};
   Configurable<LabeledArray<float>> massCutLambda{"massCutLambda", {defaultLambdaWindowParameters[0], 4, {"constant", "linear", "expoConstant", "expoRelax"}}, "mass parameters for Lambda"};
+  Configurable<float> massCutPhoton{"massCutPhoton", 0.5, "Photon max mass"};
   Configurable<float> massWindownumberOfSigmas{"massWindownumberOfSigmas", 5e+6, "number of sigmas around mass peaks to keep"};
   Configurable<bool> massWindowWithTPCPID{"massWindowWithTPCPID", false, "when checking mass windows, correlate with TPC dE/dx"};
   Configurable<float> massWindowSafetyMargin{"massWindowSafetyMargin", 0.001, "Extra mass window safety margin"};
@@ -977,15 +978,18 @@ struct lambdakzeroBuilder {
     bool desiredMassK0Short = false;
     bool desiredMassLambda = false;
     bool desiredMassAntiLambda = false;
+    bool desiredMassGamma = false;
 
     if (massWindownumberOfSigmas > 1e+3) {
       desiredMassK0Short = true;    // safety fallback
       desiredMassLambda = true;     // safety fallback
       desiredMassAntiLambda = true; // safety fallback
+      desiredMassGamma = true; // safety fallback
     } else {
       desiredMassK0Short = TMath::Abs(v0candidate.k0ShortMass - o2::constants::physics::MassKaonNeutral) < massWindownumberOfSigmas * getMassSigmaK0Short(lPt) + massWindowSafetyMargin;
       desiredMassLambda = TMath::Abs(v0candidate.lambdaMass - o2::constants::physics::MassLambda) < massWindownumberOfSigmas * getMassSigmaLambda(lPt) + massWindowSafetyMargin;
       desiredMassAntiLambda = TMath::Abs(v0candidate.antiLambdaMass - o2::constants::physics::MassLambda) < massWindownumberOfSigmas * getMassSigmaLambda(lPt) + massWindowSafetyMargin;
+      desiredMassGamma = TMath::Abs(lGammaMass) < massCutPhoton;
     }
 
     // check if user requested to correlate mass requirement with TPC PID
@@ -993,6 +997,7 @@ struct lambdakzeroBuilder {
     bool dEdxK0Short = V0.isdEdxK0Short() || !massWindowWithTPCPID;
     bool dEdxLambda = V0.isdEdxLambda() || !massWindowWithTPCPID;
     bool dEdxAntiLambda = V0.isdEdxAntiLambda() || !massWindowWithTPCPID;
+    bool dEdxGamma = V0.isdEdxGamma() || !massWindowWithTPCPID;
 
     // check proper lifetime if asked for
     bool passML2P_K0Short = lML2P_K0Short < lifetimecut->get("lifetimecutK0S") || lifetimecut->get("lifetimecutK0S") > 1000;
@@ -1003,6 +1008,8 @@ struct lambdakzeroBuilder {
     if (passML2P_Lambda && dEdxLambda && desiredMassLambda)
       keepCandidate = true;
     if (passML2P_Lambda && dEdxAntiLambda && desiredMassAntiLambda)
+      keepCandidate = true;
+    if (dEdxGamma && desiredMassGamma)
       keepCandidate = true;
 
     if (!keepCandidate)

--- a/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzerobuilder.cxx
@@ -263,7 +263,7 @@ struct lambdakzeroBuilder {
   static constexpr float defaultLambdaWindowParameters[1][4] = {{1.17518e-03, 1.24099e-04, 5.47937e-03, 3.08009e-01}};
   Configurable<LabeledArray<float>> massCutK0{"massCutK0", {defaultK0MassWindowParameters[0], 4, {"constant", "linear", "expoConstant", "expoRelax"}}, "mass parameters for K0"};
   Configurable<LabeledArray<float>> massCutLambda{"massCutLambda", {defaultLambdaWindowParameters[0], 4, {"constant", "linear", "expoConstant", "expoRelax"}}, "mass parameters for Lambda"};
-  Configurable<float> massCutPhoton{"massCutPhoton", 0.5, "Photon max mass"};
+  Configurable<float> massCutPhoton{"massCutPhoton", 0.2, "Photon max mass"};
   Configurable<float> massWindownumberOfSigmas{"massWindownumberOfSigmas", 5e+6, "number of sigmas around mass peaks to keep"};
   Configurable<bool> massWindowWithTPCPID{"massWindowWithTPCPID", false, "when checking mass windows, correlate with TPC dE/dx"};
   Configurable<float> massWindowSafetyMargin{"massWindowSafetyMargin", 0.001, "Extra mass window safety margin"};

--- a/PWGLF/Tasks/Strangeness/lambdapolsp.cxx
+++ b/PWGLF/Tasks/Strangeness/lambdapolsp.cxx
@@ -152,24 +152,19 @@ struct lambdapolsp {
       histos.add("hpuyQypvseta", "hpuyQypvseta", kTProfile, {etaAxis});
       histos.add("hpuxQxtvseta", "hpuxQxtvseta", kTProfile, {etaAxis});
       histos.add("hpuyQytvseta", "hpuyQytvseta", kTProfile, {etaAxis});
-      histos.add("hpQxtQxpvseta", "hpQxtQxpvseta", kTProfile, {etaAxis});
-      histos.add("hpQytQypvseta", "hpQytQypvseta", kTProfile, {etaAxis});
       histos.add("hpuxyQxytvscent", "hpuxyQxytvscent", kTProfile, {centAxis});
       histos.add("hpuxyQxypvscent", "hpuxyQxypvscent", kTProfile, {centAxis});
       histos.add("hpQxytpvscent", "hpQxytpvscent", kTProfile, {centAxis});
+      histos.add("hpQxpQxpvscent", "hpQxpQxpvscent", kTProfile, {centAxis});
+      histos.add("hpQypQypvscent", "hpQypQypvscent", kTProfile, {centAxis});
+      histos.add("hpQxtQxtvscent", "hpQxtQxtvscent", kTProfile, {centAxis});
+      histos.add("hpQytQytvscent", "hpQytQytvscent", kTProfile, {centAxis});
       histos.add("hppuxyQxytvscenteta", "hppuxyQxytvscenteta", kTProfile2D, {centAxis, etaAxis});
       histos.add("hppuxyQxypvscenteta", "hppuxyQxypvscenteta", kTProfile2D, {centAxis, etaAxis});
-      histos.add("hppQxytpvscenteta", "hppQxytpvscenteta", kTProfile2D, {centAxis, etaAxis});
+      // histos.add("hppQxytpvscenteta", "hppQxytpvscenteta", kTProfile2D, {centAxis, etaAxis});
 
       histos.add("hpv1Avscent", "hpv1Avscent", kTProfile, {centAxis});
       histos.add("hpv1Cvscent", "hpv1Cvscent", kTProfile, {centAxis});
-
-      histos.add("hpposuxyQxytvseta", "hpposuxyQxytvseta", kTProfile, {etaAxis});
-      histos.add("hpposuxyQxypvseta", "hpposuxyQxypvseta", kTProfile, {etaAxis});
-      histos.add("hpposQxytpvseta", "hpposQxytpvseta", kTProfile, {etaAxis});
-      histos.add("hpneguxyQxytvseta", "hpneguxyQxytvseta", kTProfile, {etaAxis});
-      histos.add("hpneguxyQxypvseta", "hpneguxyQxypvseta", kTProfile, {etaAxis});
-      histos.add("hpnegQxytpvseta", "hpnegQxytpvseta", kTProfile, {etaAxis});
     }
 
     histos.add("hCentrality", "Centrality distribution", kTH1F, {{centAxis}});
@@ -392,6 +387,22 @@ struct lambdapolsp {
     ///////////checking v1 and v2////////////////////////////////
     if (checkwithpub) {
 
+      auto QxtQxp = qxZDCA * qxZDCC;
+      auto QytQyp = qyZDCA * qyZDCC;
+      auto Qxytp = QxtQxp + QytQyp;
+      auto QxpQxp = qxZDCA * qxZDCA;
+      auto QxtQxt = qxZDCC * qxZDCC;
+      auto QypQyp = qyZDCA * qyZDCA;
+      auto QytQyt = qyZDCC * qyZDCC;
+
+      histos.fill(HIST("hpQxtQxpvscent"), centrality, QxtQxp);
+      histos.fill(HIST("hpQytQypvscent"), centrality, QytQyp);
+      histos.fill(HIST("hpQxytpvscent"), centrality, Qxytp);
+      histos.fill(HIST("hpQxpQxpvscent"), centrality, QxpQxp);
+      histos.fill(HIST("hpQxtQxtvscent"), centrality, QxtQxt);
+      histos.fill(HIST("hpQypQypvscent"), centrality, QypQyp);
+      histos.fill(HIST("hpQytQytvscent"), centrality, QytQyt);
+
       for (auto track : tracks) {
         if (!selectionTrack(track)) {
           continue;
@@ -420,31 +431,22 @@ struct lambdapolsp {
         auto uyQyt = uy * qyZDCC;
         auto uxyQxyt = uxQxt + uyQyt;
 
-        auto QxtQxp = qxZDCA * qxZDCC;
-        auto QytQyp = qyZDCA * qyZDCC;
-        auto Qxytp = QxtQxp + QytQyp;
-
         histos.fill(HIST("hpuxQxpvscent"), centrality, uxQxp);
         histos.fill(HIST("hpuyQypvscent"), centrality, uyQyp);
         histos.fill(HIST("hpuxQxtvscent"), centrality, uxQxt);
         histos.fill(HIST("hpuyQytvscent"), centrality, uyQyt);
-        histos.fill(HIST("hpQxtQxpvscent"), centrality, QxtQxp);
-        histos.fill(HIST("hpQytQypvscent"), centrality, QytQyp);
 
         histos.fill(HIST("hpuxyQxytvscent"), centrality, uxyQxyt);
         histos.fill(HIST("hpuxyQxypvscent"), centrality, uxyQxyp);
-        histos.fill(HIST("hpQxytpvscent"), centrality, Qxytp);
         histos.fill(HIST("hppuxyQxytvscenteta"), centrality, track.eta(), uxyQxyt);
         histos.fill(HIST("hppuxyQxypvscenteta"), centrality, track.eta(), uxyQxyp);
-        histos.fill(HIST("hppQxytpvscenteta"), centrality, track.eta(), Qxytp);
+        // histos.fill(HIST("hppQxytpvscenteta"), centrality, track.eta(), Qxytp);
 
         if (centrality > 30.0 && centrality < 40.0) {
           histos.fill(HIST("hpuxQxpvseta"), track.eta(), uxQxp);
           histos.fill(HIST("hpuyQypvseta"), track.eta(), uyQyp);
           histos.fill(HIST("hpuxQxtvseta"), track.eta(), uxQxt);
           histos.fill(HIST("hpuyQytvseta"), track.eta(), uyQyt);
-          histos.fill(HIST("hpQxtQxpvseta"), track.eta(), QxtQxp);
-          histos.fill(HIST("hpQytQypvseta"), track.eta(), QytQyp);
         }
 
         histos.fill(HIST("hpv1Avscent"), centrality, v1ZDCA);


### PR DESCRIPTION
* This PR adds a specific TPC PID + MassWindow selection for photons in lambdakzerobuilder. 
 