### PR TITLE
[PWGHF] Adjust the structure of the Lc to pkpi task

### DIFF
--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -40,7 +40,7 @@ struct HfTaskLc {
   Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lc_to_p_k_pi::vecBinsPt}, "pT bin limits"};
   // ThnSparse for ML outputScores and Vars
-  Configurable<bool> enableTHn{"enableTHn", false, "enable THn for Lc"};
+  Configurable<bool> fillTHn{"fillTHn", false, "enable THn for Lc"};
   ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {72, 0, 36}, ""};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {300, 1.98, 2.58}, ""};
   ConfigurableAxis thnConfigAxisPtProng{"thnConfigAxisPtProng", {100, 0, 20}, ""};
@@ -271,7 +271,7 @@ struct HfTaskLc {
     registry.add("MC/reconstructed/prompt/hDecLenErrSigPrompt", "3-prong candidates (matched, prompt);decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("MC/reconstructed/nonprompt/hDecLenErrSigNonPrompt", "3-prong candidates (matched, non-prompt);decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
-    if (enableTHn) {
+    if (fillTHn) {
       const AxisSpec thnAxisMass{thnConfigAxisMass, "inv. mass (p K #pi) (GeV/#it{c}^{2})"};
       const AxisSpec thnAxisPt{thnConfigAxisPt, "#it{p}_{T}(#Lambda_{c}^{+}) (GeV/#it{c})"};
       const AxisSpec thnAxisPtProng0{thnConfigAxisPtProng, "#it{p}_{T}(prong0) (GeV/#it{c})"};
@@ -462,7 +462,7 @@ struct HfTaskLc {
           registry.fill(HIST("MC/reconstructed/nonprompt/hImpParErrProng2SigNonPrompt"), candidate.errorImpactParameter2(), pt);
           registry.fill(HIST("MC/reconstructed/nonprompt/hDecLenErrSigNonPrompt"), candidate.errorDecayLength(), pt);
         }
-        if (enableTHn) {
+        if (fillTHn) {
           float cent = evaluateCentralityColl(collision);
           double massLc(-1);
           double outputBkg(-1), outputPrompt(-1), outputFD(-1);
@@ -681,7 +681,7 @@ struct HfTaskLc {
                       LcCandidates const& selectedLcCandidates,
                       aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStd, "Process Data with the standard method", true);
 
@@ -689,7 +689,7 @@ struct HfTaskLc {
                          LcCandidatesMl const& selectedLcCandidatesMl,
                          aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process real data with the ML method and without centrality", false);
 
@@ -697,7 +697,7 @@ struct HfTaskLc {
                               LcCandidates const& selectedLcCandidates,
                               aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0C, "Process Data with the standard method", false);
 
@@ -705,7 +705,7 @@ struct HfTaskLc {
                                  LcCandidatesMl const& selectedLcCandidatesMl,
                                  aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0C, "Process real data with the ML method and with FT0C centrality", false);
 
@@ -713,7 +713,7 @@ struct HfTaskLc {
                               LcCandidates const& selectedLcCandidates,
                               aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0M, "Process real data with the standard method and with FT0M centrality", false);
 
@@ -721,7 +721,7 @@ struct HfTaskLc {
                                  LcCandidatesMl const& selectedLcCandidatesMl,
                                  aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process real data with the ML method and with FT0M centrality", false);
 
@@ -735,8 +735,8 @@ struct HfTaskLc {
       // MC Rec.
       fillMcRecHistosAndSparse<fillMl>(collision, candidates, mcParticles);
       // MC gen.
-      auto mcParticlesPerColl = mcParticles.sliceBy(perMCCollision, collision.globalIndex());
-      fillMcGenHistos(mcParticlesPerColl);
+      auto mcParticlesPerColl = mcParticles.sliceBy(perMcCollision, collision.globalIndex());
+      fillHistosMcGen(mcParticlesPerColl);
     }
   }
   void processMcStd(CollisionsMc const& collisions,
@@ -757,7 +757,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method and without centrality", false);
 
   void processMcStdWithFT0C(CollisionsMcWithFT0C const& collisions,
                             LcCandidatesMc const& selectedLcCandidatesMc,
@@ -767,7 +767,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionMc<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0C, "Process MC with the standard method", false);
+  PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0C, "Process MC with the standard method with FT0C centrality", false);
 
   void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collisions,
                                LcCandidatesMlMc const& selectedLcCandidatesMlMc,
@@ -777,7 +777,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0C, "Process Mc with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0C, "Process Mc with the ML method with FT0C centrality", false);
 
   void processMcStdWithFT0M(CollisionsMcWithFT0M const& collisions,
                             LcCandidatesMc const& selectedLcCandidatesMc,
@@ -787,7 +787,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionMc<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0M, "Process MC with the standard method", false);
+  PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0M, "Process MC with the standard method with FT0M centrality", false);
 
   void processMcWithMlWithFT0M(CollisionsMcWithFT0M const& collisions,
                                LcCandidatesMlMc const& selectedLcCandidatesMlMc,
@@ -797,7 +797,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0M, "Process Mc with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0M, "Process Mc with the ML method with FT0M centrality", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -500,10 +500,11 @@ struct HfTaskLc {
       }
     }
   }
+
   /// Fill MC histograms at genernated level
   /// \param mcParticles are particles in MC
   template <typename CandLcMcGen>
-  void fillMcGenHistos(CandLcMcGen const& mcParticles)
+  void fillHistosMcGen(CandLcMcGen const& mcParticles)
   {
     // MC gen.
     for (const auto& particle : mcParticles) {
@@ -626,7 +627,7 @@ struct HfTaskLc {
       registry.fill(HIST("Data/hImpParErrProng2"), candidate.errorImpactParameter2(), pt);
       registry.fill(HIST("Data/hDecLenErr"), candidate.errorDecayLength(), pt);
 
-      if (enableTHn) {
+      if (fillTHn) {
         float cent = evaluateCentralityColl(collision);
         double massLc(-1);
         double outputBkg(-1), outputPrompt(-1), outputFD(-1);
@@ -734,8 +735,8 @@ struct HfTaskLc {
       // MC Rec.
       fillMcRecHistosAndSparse<fillMl>(collision, candidates, mcParticles);
       // MC gen.
-      auto mcParticles_per_coll = mcParticles.sliceBy(perMCCollision, collision.globalIndex());
-      fillMcGenHistos(mcParticles_per_coll);
+      auto mcParticlesPerColl = mcParticles.sliceBy(perMCCollision, collision.globalIndex());
+      fillMcGenHistos(mcParticlesPerColl);
     }
   }
   void processMcStd(CollisionsMc const& collisions,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -723,7 +723,7 @@ struct HfTaskLc {
   {
     runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
   }
-  PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0M, "Process Data with the standard method", false);
+  PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0M, "Process real data with the standard method and with FT0M centrality", false);
 
   void processDataWithMlWithFT0M(CollisionsWithFT0M const& collisions,
                                  LcCandidatesMl const& selectedLcCandidatesMl,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -547,8 +547,8 @@ struct HfTaskLc {
   /// Fill MC histograms at reconstruction level
   /// \param collision is collision
   /// \param candidates is candidates
-  template <bool fillMl, typename CollType, typename CandType, typename TrackType>
-  void fillDataHistosAndSparse(CollType const& collision, CandType const& candidates, TrackType const& tracks)
+  template <bool fillMl, typename CollType, typename CandType>
+  void fillDataHistosAndSparse(CollType const& collision, CandType const& candidates)
   {
     auto thisCollId = collision.globalIndex();
     auto groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);
@@ -656,61 +656,54 @@ struct HfTaskLc {
 
   template <bool fillMl, typename CollType, typename CandType>
   void runAnalysisPerCollisionData(CollType const& collisions,
-                                   CandType const& candidates,
-                                   aod::TracksWDca const& tracks)
+                                   CandType const& candidates)
   {
 
     for (const auto& collision : collisions) {
 
-      fillDataHistosAndSparse<fillMl>(collision, candidates, tracks);
+      fillDataHistosAndSparse<fillMl>(collision, candidates);
     }
   }
 
   void processDataStd(Collisions const& collisions,
-                      LcCandidates const& selectedLcCandidates,
-                      aod::TracksWDca const& tracks)
+                      LcCandidates const& selectedLcCandidates)
   {
-    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStd, "Process Data with the standard method", true);
 
   void processDataWithMl(Collisions const& collisions,
-                         LcCandidatesMl const& selectedLcCandidatesMl,
-                         aod::TracksWDca const& tracks)
+                         LcCandidatesMl const& selectedLcCandidatesMl)
   {
-    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process real data with the ML method and without centrality", false);
 
   void processDataStdWithFT0C(CollisionsWithFT0C const& collisions,
-                              LcCandidates const& selectedLcCandidates,
-                              aod::TracksWDca const& tracks)
+                              LcCandidates const& selectedLcCandidates)
   {
-    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0C, "Process Data with the standard method", false);
 
   void processDataWithMlWithFT0C(CollisionsWithFT0C const& collisions,
-                                 LcCandidatesMl const& selectedLcCandidatesMl,
-                                 aod::TracksWDca const& tracks)
+                                 LcCandidatesMl const& selectedLcCandidatesMl)
   {
-    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0C, "Process real data with the ML method and with FT0C centrality", false);
 
   void processDataStdWithFT0M(CollisionsWithFT0M const& collisions,
-                              LcCandidates const& selectedLcCandidates,
-                              aod::TracksWDca const& tracks)
+                              LcCandidates const& selectedLcCandidates)
   {
-    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates, tracks);
+    runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0M, "Process real data with the standard method and with FT0M centrality", false);
 
   void processDataWithMlWithFT0M(CollisionsWithFT0M const& collisions,
-                                 LcCandidatesMl const& selectedLcCandidatesMl,
-                                 aod::TracksWDca const& tracks)
+                                 LcCandidatesMl const& selectedLcCandidatesMl)
   {
-    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl, tracks);
+    runAnalysisPerCollisionData<true>(collisions, selectedLcCandidatesMl);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process real data with the ML method and with FT0M centrality", false);
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -779,7 +779,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method", false);
 
-  void processMcStdWithFT0C(CollisionsMcWithFT0C const& collision,
+  void processMcStdWithFT0C(CollisionsMcWithFT0C const& collisions,
                             LcCandidatesMc const& selectedLcCandidatesMc,
                             McParticles3ProngMatched const& mcParticles,
                             aod::McCollisions const&,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -68,7 +68,7 @@ struct HfTaskLc {
   using LcCandidatesMlMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfMlLcToPKPi, aod::HfCand3ProngMcRec>>;
   using McParticles3ProngMatched = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
   Filter filterSelectCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
-  Preslice<aod::McParticles> perMCCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
   Preslice<aod::HfCand3Prong> candLcPerCollision = aod::hf_cand::collisionId;
   SliceCache cache;
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -759,7 +759,7 @@ struct HfTaskLc {
       fillMcGenHistos(mcParticles_per_coll);
     }
   }
-  void processMcStd(CollisionsMc const& collision,
+  void processMcStd(CollisionsMc const& collisions,
                     LcCandidatesMc const& selectedLcCandidatesMc,
                     McParticles3ProngMatched const& mcParticles,
                     aod::McCollisions const&,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -665,7 +665,7 @@ struct HfTaskLc {
   }
 
   template <bool fillMl, typename CollType, typename CandType>
-  void runDataAnalysisPerCollision(CollType const& collisions,
+  void runAnalysisPerCollisionData(CollType const& collisions,
                                    CandType const& candidates,
                                    aod::TracksWDca const& tracks)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -40,7 +40,7 @@ struct HfTaskLc {
   Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lc_to_p_k_pi::vecBinsPt}, "pT bin limits"};
   // ThnSparse for ML outputScores and Vars
-  Configurable<bool> fillTHn{"fillTHn", false, "enable THn for Lc"};
+  Configurable<bool> fillTHn{"fillTHn", false, "fill THn"};
   ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {72, 0, 36}, ""};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {300, 1.98, 2.58}, ""};
   ConfigurableAxis thnConfigAxisPtProng{"thnConfigAxisPtProng", {100, 0, 20}, ""};

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -100,7 +100,7 @@ struct HfTaskLc {
      {"MC/reconstructed/signal/hPtRecProng2Sig", "3-prong candidates (matched);prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},
      {"MC/reconstructed/prompt/hPtRecProng2SigPrompt", "3-prong candidates (matched, prompt);prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},
      {"MC/reconstructed/nonprompt/hPtRecProng2SigNonPrompt", "3-prong candidates (matched, non-prompt);prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}}},
-     {"Data/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
+     {"Data/hNPvContrib", "number of prim. vertex contributor;number of prim. vertex contributor;entries", {HistType::kTH1F, {{10000, 0., 10000.}}}},
      /// DCAxy to prim. vertex prongs
      {"Data/hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}}},
      {"MC/reconstructed/signal/hd0RecProng0Sig", "3-prong candidates (matched);prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}}},
@@ -553,19 +553,8 @@ struct HfTaskLc {
     auto thisCollId = collision.globalIndex();
     auto groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);
 
-    int nTracks = 0;
-    if (collision.numContrib() > 1) {
-      for (const auto& track : tracks) {
-        if (std::abs(track.eta()) > 4.0) {
-          continue;
-        }
-        if (std::abs(track.dcaXY()) > 0.0025 || std::abs(track.dcaZ()) > 0.0025) {
-          continue;
-        }
-        nTracks++;
-      }
-    }
-    registry.fill(HIST("Data/hMultiplicity"), nTracks);
+    int numPvContributors = collision.numContrib();
+    registry.fill(HIST("Data/hNPvContrib"), numPvContributors);
 
     for (const auto& candidate : groupedLcCandidates) {
       if (!(candidate.hfflag() & 1 << aod::hf_cand_3prong::DecayType::LcToPKPi)) {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -686,51 +686,51 @@ struct HfTaskLc {
     }
   }
 
-  void processDataStd(Collisions const& collision,
+  void processDataStd(Collisions const& collisions,
                       LcCandidates const& selectedLcCandidates,
                       aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collision, selectedLcCandidates, tracks);
+    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStd, "Process Data with the standard method", true);
 
-  void processDataWithMl(Collisions const& collision,
+  void processDataWithMl(Collisions const& collisions,
                          LcCandidatesMl const& selectedLcCandidatesMl,
                          aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collision, selectedLcCandidatesMl, tracks);
+    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process Data with the ML method", false);
 
-  void processDataStdWithFT0C(CollisionsWithFT0C const& collision,
+  void processDataStdWithFT0C(CollisionsWithFT0C const& collisions,
                               LcCandidates const& selectedLcCandidates,
                               aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collision, selectedLcCandidates, tracks);
+    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0C, "Process Data with the standard method", false);
 
-  void processDataWithMlWithFT0C(CollisionsWithFT0C const& collision,
+  void processDataWithMlWithFT0C(CollisionsWithFT0C const& collisions,
                                  LcCandidatesMl const& selectedLcCandidatesMl,
                                  aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collision, selectedLcCandidatesMl, tracks);
+    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0C, "Process Data with the ML method", false);
 
-  void processDataStdWithFT0M(CollisionsWithFT0M const& collision,
+  void processDataStdWithFT0M(CollisionsWithFT0M const& collisions,
                               LcCandidates const& selectedLcCandidates,
                               aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<false>(collision, selectedLcCandidates, tracks);
+    runDataAnalysisPerCollision<false>(collisions, selectedLcCandidates, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0M, "Process Data with the standard method", false);
 
-  void processDataWithMlWithFT0M(CollisionsWithFT0M const& collision,
+  void processDataWithMlWithFT0M(CollisionsWithFT0M const& collisions,
                                  LcCandidatesMl const& selectedLcCandidatesMl,
                                  aod::TracksWDca const& tracks)
   {
-    runDataAnalysisPerCollision<true>(collision, selectedLcCandidatesMl, tracks);
+    runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process Data with the ML method", false);
 
@@ -754,7 +754,7 @@ struct HfTaskLc {
                     aod::McCollisions const&,
                     aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collision, selectedLcCandidatesMc, mcParticles);
+    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStd, "Process MC with the standard method", false);
 
@@ -764,7 +764,7 @@ struct HfTaskLc {
                        aod::McCollisions const&,
                        aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collision, selectedLcCandidatesMlMc, mcParticles);
+    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method", false);
 
@@ -774,17 +774,17 @@ struct HfTaskLc {
                             aod::McCollisions const&,
                             aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collision, selectedLcCandidatesMc, mcParticles);
+    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0C, "Process MC with the standard method", false);
 
-  void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collision,
+  void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collisions,
                                LcCandidatesMlMc const& selectedLcCandidatesMlMc,
                                McParticles3ProngMatched const& mcParticles,
                                aod::McCollisions const&,
                                aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collision, selectedLcCandidatesMlMc, mcParticles);
+    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0C, "Process Mc with the ML method", false);
 
@@ -794,7 +794,7 @@ struct HfTaskLc {
                             aod::McCollisions const&,
                             aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collision, selectedLcCandidatesMc, mcParticles);
+    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0M, "Process MC with the standard method", false);
 
@@ -804,7 +804,7 @@ struct HfTaskLc {
                                aod::McCollisions const&,
                                aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collision, selectedLcCandidatesMlMc, mcParticles);
+    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0M, "Process Mc with the ML method", false);
 };

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -69,7 +69,7 @@ struct HfTaskLc {
   using LcCandidatesMlMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfMlLcToPKPi, aod::HfCand3ProngMcRec>>;
   using McParticles3ProngMatched = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
 
-  PresliceUnsorted<aod::McParticles> perMCCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::McParticles> perMCCollision = aod::mcparticle::mcCollisionId;
   Preslice<aod::HfCand3Prong> candLcPerCollision = aod::hf_cand::collisionId;
   SliceCache cache;
 
@@ -303,14 +303,6 @@ struct HfTaskLc {
   {
     return o2::hf_centrality::getCentralityColl<Coll>(collision);
   }
-  /// Evaluate centrality/multiplicity percentile
-  /// \param candidate is candidate
-  /// \return centrality/multiplicity percentile of the collision associated to the candidate
-  template <typename Coll, typename T1>
-  float evaluateCentralityCand(const T1& candidate)
-  {
-    return evaluateCentralityColl(candidate.template collision_as<Coll>());
-  }
 
   /// Fill MC histograms at reconstruction level
   /// \param collision is collision
@@ -471,7 +463,6 @@ struct HfTaskLc {
           registry.fill(HIST("MC/reconstructed/nonprompt/hImpParErrProng2SigNonPrompt"), candidate.errorImpactParameter2(), pt);
           registry.fill(HIST("MC/reconstructed/nonprompt/hDecLenErrSigNonPrompt"), candidate.errorDecayLength(), pt);
         }
-
         if (enableTHn) {
           float cent = evaluateCentralityColl(collision);
           double massLc(-1);
@@ -520,14 +511,12 @@ struct HfTaskLc {
   void fillMcGenHistos(CandLcMcGen const& mcParticles)
   {
     // MC gen.
-
     for (const auto& particle : mcParticles) {
       if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_3prong::DecayType::LcToPKPi) {
         auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }
-
         auto ptGen = particle.pt();
         registry.fill(HIST("MC/generated/signal/hPtGen"), ptGen);
         registry.fill(HIST("MC/generated/signal/hEtaGen"), particle.eta());

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -809,7 +809,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0M, "Process MC with the standard method", false);
 
-  void processMcWithMlWithFT0M(CollisionsMcWithFT0M const& collision,
+  void processMcWithMlWithFT0M(CollisionsMcWithFT0M const& collisions,
                                LcCandidatesMlMc const& selectedLcCandidatesMlMc,
                                McParticles3ProngMatched const& mcParticles,
                                aod::McCollisions const&,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -18,6 +18,8 @@
 /// \author Annalena Kalteyer <annalena.sophie.kalteyer@cern.ch>, GSI Darmstadt
 /// \author Biao Zhang <biao.zhang@cern.ch>, Heidelberg University
 
+#include <vector>    // std::vector
+
 #include "CommonConstants/PhysicsConstants.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -715,7 +715,7 @@ struct HfTaskLc {
   {
     runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
-  PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0C, "Process Data with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0C, "Process real data with the ML method and with FT0C centrality", false);
 
   void processDataStdWithFT0M(CollisionsWithFT0M const& collisions,
                               LcCandidates const& selectedLcCandidates,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -547,7 +547,7 @@ struct HfTaskLc {
   /// \param collision is collision
   /// \param candidates is candidates
   template <bool fillMl, typename CollType, typename CandType, typename TrackType>
-  void fillDataHistosAndSparse(CollType collision, CandType const& candidates, TrackType const& tracks)
+  void fillDataHistosAndSparse(CollType const& collision, CandType const& candidates, TrackType const& tracks)
   {
     auto thisCollId = collision.globalIndex();
     auto groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -735,7 +735,7 @@ struct HfTaskLc {
 
   /// Fills MC histograms.
   template <bool fillMl, typename CollType, typename CandType, typename CandLcMcGen>
-  void runMcAnalysisPerCollision(CollType const& collisions,
+  void runAnalysisPerCollisionMc(CollType const& collisions,
                                  CandType const& candidates,
                                  CandLcMcGen const& mcParticles)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -307,7 +307,7 @@ struct HfTaskLc {
   /// \param collision is collision
   /// \param candidates is candidates
   template <bool fillMl, typename CollType, typename CandLcMcRec, typename CandLcMcGen>
-  void fillMcRecHistosAndSparse(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
+  void fillHistosMcRec(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
   {
 
     auto thisCollId = collision.globalIndex();
@@ -548,7 +548,7 @@ struct HfTaskLc {
   /// \param collision is collision
   /// \param candidates is candidates
   template <bool fillMl, typename CollType, typename CandType>
-  void fillDataHistosAndSparse(CollType const& collision, CandType const& candidates)
+  void fillHistosData(CollType const& collision, CandType const& candidates)
   {
     auto thisCollId = collision.globalIndex();
     auto groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);
@@ -653,7 +653,7 @@ struct HfTaskLc {
       }
     }
   }
-
+  /// Fills Data histograms.
   template <bool fillMl, typename CollType, typename CandType>
   void runAnalysisPerCollisionData(CollType const& collisions,
                                    CandType const& candidates)
@@ -661,7 +661,22 @@ struct HfTaskLc {
 
     for (const auto& collision : collisions) {
 
-      fillDataHistosAndSparse<fillMl>(collision, candidates);
+      fillHistosData<fillMl>(collision, candidates);
+    }
+  }
+
+  /// Fills Mc histograms.
+  template <bool fillMl, typename CollType, typename CandType, typename CandLcMcGen>
+  void runAnalysisPerCollisionMc(CollType const& collisions,
+                                 CandType const& candidates,
+                                 CandLcMcGen const& mcParticles)
+  {
+    for (const auto& collision : collisions) {
+      // MC Rec.
+      fillHistosMcRec<fillMl>(collision, candidates, mcParticles);
+      // MC gen.
+      auto mcParticlesPerColl = mcParticles.sliceBy(perMcCollision, collision.globalIndex());
+      fillHistosMcGen(mcParticlesPerColl);
     }
   }
 
@@ -707,20 +722,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process real data with the ML method and with FT0M centrality", false);
 
-  /// Fills MC histograms.
-  template <bool fillMl, typename CollType, typename CandType, typename CandLcMcGen>
-  void runAnalysisPerCollisionMc(CollType const& collisions,
-                                 CandType const& candidates,
-                                 CandLcMcGen const& mcParticles)
-  {
-    for (const auto& collision : collisions) {
-      // MC Rec.
-      fillMcRecHistosAndSparse<fillMl>(collision, candidates, mcParticles);
-      // MC gen.
-      auto mcParticlesPerColl = mcParticles.sliceBy(perMcCollision, collision.globalIndex());
-      fillHistosMcGen(mcParticlesPerColl);
-    }
-  }
+
   void processMcStd(CollisionsMc const& collisions,
                     LcCandidatesMc const& selectedLcCandidatesMc,
                     McParticles3ProngMatched const& mcParticles,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -731,7 +731,7 @@ struct HfTaskLc {
   {
     runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
-  PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process Data with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processDataWithMlWithFT0M, "Process real data with the ML method and with FT0M centrality", false);
 
   /// Fills MC histograms.
   template <bool fillMl, typename CollType, typename CandType, typename CandLcMcGen>

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -304,9 +304,7 @@ struct HfTaskLc {
   }
 
   /// Fill MC histograms at reconstruction level
-  /// \param collision is collision
-  /// \param candidates is candidates
-  /// \param mcParticles is mcParticles
+  /// \tparam fillMl switch to fill ML histograms
   template <bool fillMl, typename CollType, typename CandLcMcRec, typename CandLcMcGen>
   void fillHistosMcRec(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
   {
@@ -502,8 +500,8 @@ struct HfTaskLc {
     }
   }
 
-  /// Fill MC histograms at genernated level
-  /// \param mcParticles are particles in MC
+  /// Fill MC histograms at generated level
+  /// \tparam fillMl switch to fill ML histograms
   template <typename CandLcMcGen>
   void fillHistosMcGen(CandLcMcGen const& mcParticles)
   {
@@ -666,7 +664,9 @@ struct HfTaskLc {
       }
     }
   }
-  /// Fills Data histograms.
+
+  /// Run the analysis on real data
+  /// \tparam fillMl switch to fill ML histograms
   template <bool fillMl, typename CollType, typename CandType>
   void runAnalysisPerCollisionData(CollType const& collisions,
                                    CandType const& candidates,
@@ -674,12 +674,12 @@ struct HfTaskLc {
   {
 
     for (const auto& collision : collisions) {
-
       fillHistosData<fillMl>(collision, candidates, tracks);
     }
   }
 
-  /// Fills Mc histograms.
+  /// Run the analysis on MC data
+  /// \tparam fillMl switch to fill ML histograms
   template <bool fillMl, typename CollType, typename CandType, typename CandLcMcGen>
   void runAnalysisPerCollisionMc(CollType const& collisions,
                                  CandType const& candidates,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -554,7 +554,6 @@ struct HfTaskLc {
   template <bool fillMl, typename CollType, typename CandType, typename TrackType>
   void fillDataHistosAndSparse(CollType collision, CandType const& candidates, TrackType const& tracks)
   {
-
     auto thisCollId = collision.globalIndex();
     auto groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -699,7 +699,7 @@ struct HfTaskLc {
   {
     runDataAnalysisPerCollision<true>(collisions, selectedLcCandidatesMl, tracks);
   }
-  PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process Data with the ML method", false);
+  PROCESS_SWITCH(HfTaskLc, processDataWithMl, "Process real data with the ML method and without centrality", false);
 
   void processDataStdWithFT0C(CollisionsWithFT0C const& collisions,
                               LcCandidates const& selectedLcCandidates,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -769,7 +769,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processMcStd, "Process MC with the standard method", false);
 
-  void processMcWithMl(CollisionsMc const& collision,
+  void processMcWithMl(CollisionsMc const& collisions,
                        LcCandidatesMlMc const& selectedLcCandidatesMlMc,
                        McParticles3ProngMatched const& mcParticles,
                        aod::McCollisions const&,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -684,7 +684,7 @@ struct HfTaskLc {
   {
     runAnalysisPerCollisionData<false>(collisions, selectedLcCandidates);
   }
-  PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0C, "Process Data with the standard method", false);
+  PROCESS_SWITCH(HfTaskLc, processDataStdWithFT0C, "Process real data with the standard method and with FT0C centrality", false);
 
   void processDataWithMlWithFT0C(CollisionsWithFT0C const& collisions,
                                  LcCandidatesMl const& selectedLcCandidatesMl)

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -306,6 +306,7 @@ struct HfTaskLc {
   /// Fill MC histograms at reconstruction level
   /// \param collision is collision
   /// \param candidates is candidates
+  /// \param mcParticles is mcParticles                                    
   template <bool fillMl, typename CollType, typename CandLcMcRec, typename CandLcMcGen>
   void fillHistosMcRec(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
   {
@@ -547,6 +548,7 @@ struct HfTaskLc {
   /// Fill MC histograms at reconstruction level
   /// \param collision is collision
   /// \param candidates is candidates
+  /// \param tracks is tracks        
   template <bool fillMl, typename CollType, typename CandType, typename TrackType>
   void fillHistosData(CollType const& collision, CandType const& candidates, TrackType const& tracks)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -545,10 +545,8 @@ struct HfTaskLc {
     }
   }
 
-  /// Fill MC histograms at reconstruction level
-  /// \param collision is collision
-  /// \param candidates is candidates
-  /// \param tracks is tracks
+  /// Fill histograms for real data
+  /// \tparam fillMl switch to fill ML histograms
   template <bool fillMl, typename CollType, typename CandType, typename TrackType>
   void fillHistosData(CollType const& collision, CandType const& candidates, TrackType const& tracks)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -53,7 +53,6 @@ struct HfTaskLc {
   ConfigurableAxis thnConfigAxisCanType{"thnConfigAxisCanType", {5, 0., 5.}, ""};
 
   HfHelper hfHelper;
-  Filter filterSelectCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
 
   using Collisions = soa::Join<aod::Collisions, aod::EvSels>;
   using CollisionsMc = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels>;
@@ -68,7 +67,7 @@ struct HfTaskLc {
   using LcCandidatesMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfCand3ProngMcRec>>;
   using LcCandidatesMlMc = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfMlLcToPKPi, aod::HfCand3ProngMcRec>>;
   using McParticles3ProngMatched = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
-
+  Filter filterSelectCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLc || aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLc;
   Preslice<aod::McParticles> perMCCollision = aod::mcparticle::mcCollisionId;
   Preslice<aod::HfCand3Prong> candLcPerCollision = aod::hf_cand::collisionId;
   SliceCache cache;
@@ -471,9 +470,7 @@ struct HfTaskLc {
             massLc = hfHelper.invMassLcToPKPi(candidate);
 
             if constexpr (fillMl) {
-
               if (candidate.mlProbLcToPKPi().size() == 3) {
-
                 outputBkg = candidate.mlProbLcToPKPi()[0];    /// bkg score
                 outputPrompt = candidate.mlProbLcToPKPi()[1]; /// prompt score
                 outputFD = candidate.mlProbLcToPKPi()[2];     /// non-prompt score
@@ -488,9 +485,7 @@ struct HfTaskLc {
             massLc = hfHelper.invMassLcToPiKP(candidate);
 
             if constexpr (fillMl) {
-
               if (candidate.mlProbLcToPiKP().size() == 3) {
-
                 outputBkg = candidate.mlProbLcToPiKP()[0];    /// bkg score
                 outputPrompt = candidate.mlProbLcToPiKP()[1]; /// prompt score
                 outputFD = candidate.mlProbLcToPiKP()[2];     /// non-prompt score
@@ -639,9 +634,7 @@ struct HfTaskLc {
           massLc = hfHelper.invMassLcToPKPi(candidate);
 
           if constexpr (fillMl) {
-
             if (candidate.mlProbLcToPKPi().size() == 3) {
-
               outputBkg = candidate.mlProbLcToPKPi()[0];    /// bkg score
               outputPrompt = candidate.mlProbLcToPKPi()[1]; /// prompt score
               outputFD = candidate.mlProbLcToPKPi()[2];     /// non-prompt score
@@ -656,9 +649,7 @@ struct HfTaskLc {
           massLc = hfHelper.invMassLcToPiKP(candidate);
 
           if constexpr (fillMl) {
-
             if (candidate.mlProbLcToPiKP().size() == 3) {
-
               outputBkg = candidate.mlProbLcToPiKP()[0];    /// bkg score
               outputPrompt = candidate.mlProbLcToPiKP()[1]; /// prompt score
               outputFD = candidate.mlProbLcToPiKP()[2];     /// non-prompt score
@@ -753,7 +744,7 @@ struct HfTaskLc {
                     aod::McCollisions const&,
                     aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
+    runAnalysisPerCollisionMc<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStd, "Process MC with the standard method", false);
 
@@ -763,7 +754,7 @@ struct HfTaskLc {
                        aod::McCollisions const&,
                        aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
+    runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMl, "Process Mc with the ML method", false);
 
@@ -773,7 +764,7 @@ struct HfTaskLc {
                             aod::McCollisions const&,
                             aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
+    runAnalysisPerCollisionMc<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0C, "Process MC with the standard method", false);
 
@@ -783,7 +774,7 @@ struct HfTaskLc {
                                aod::McCollisions const&,
                                aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
+    runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0C, "Process Mc with the ML method", false);
 
@@ -793,7 +784,7 @@ struct HfTaskLc {
                             aod::McCollisions const&,
                             aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<false>(collisions, selectedLcCandidatesMc, mcParticles);
+    runAnalysisPerCollisionMc<false>(collisions, selectedLcCandidatesMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcStdWithFT0M, "Process MC with the standard method", false);
 
@@ -803,7 +794,7 @@ struct HfTaskLc {
                                aod::McCollisions const&,
                                aod::TracksWMc const&)
   {
-    runMcAnalysisPerCollision<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
+    runAnalysisPerCollisionMc<true>(collisions, selectedLcCandidatesMlMc, mcParticles);
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0M, "Process Mc with the ML method", false);
 };

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -799,7 +799,7 @@ struct HfTaskLc {
   }
   PROCESS_SWITCH(HfTaskLc, processMcWithMlWithFT0C, "Process Mc with the ML method", false);
 
-  void processMcStdWithFT0M(CollisionsMcWithFT0M const& collision,
+  void processMcStdWithFT0M(CollisionsMcWithFT0M const& collisions,
                             LcCandidatesMc const& selectedLcCandidatesMc,
                             McParticles3ProngMatched const& mcParticles,
                             aod::McCollisions const&,

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -308,7 +308,7 @@ struct HfTaskLc {
   /// \param collision is collision
   /// \param candidates is candidates
   template <bool fillMl, typename CollType, typename CandLcMcRec, typename CandLcMcGen>
-  void fillMcRecHistosAndSparse(CollType collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
+  void fillMcRecHistosAndSparse(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
   {
 
     auto thisCollId = collision.globalIndex();

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -575,12 +575,12 @@ struct HfTaskLc {
 
       if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
         registry.fill(HIST("Data/hMass"), hfHelper.invMassLcToPKPi(candidate));
-        registry.fill(HIST("Data/hMassVsPtVsMult"), hfHelper.invMassLcToPKPi(candidate), pt, nTracks);
+        registry.fill(HIST("Data/hMassVsPtVsMult"), hfHelper.invMassLcToPKPi(candidate), pt, numPvContributors);
         registry.fill(HIST("Data/hMassVsPt"), hfHelper.invMassLcToPKPi(candidate), pt);
       }
       if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
         registry.fill(HIST("Data/hMass"), hfHelper.invMassLcToPiKP(candidate));
-        registry.fill(HIST("Data/hMassVsPtVsMult"), hfHelper.invMassLcToPiKP(candidate), pt, nTracks);
+        registry.fill(HIST("Data/hMassVsPtVsMult"), hfHelper.invMassLcToPiKP(candidate), pt, numPvContributors);
         registry.fill(HIST("Data/hMassVsPt"), hfHelper.invMassLcToPiKP(candidate), pt);
       }
       registry.fill(HIST("Data/hPt"), pt);


### PR DESCRIPTION
- Fixed the default setting for the processes (there are 3 process functions be enabled simultaneously before)
- Adjust the structure to analyze data and mc per collision, reference as taskDs.cxx
- Add helper functions to make the structure clean (`fillHistosMcGen`, `fillHistosMcRec`, `fillHistosData` for the histogram and THnSparse filling)