### PR TITLE
DPL Analysis: rename `aod::Hashes` for upcoming O2 update

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -451,8 +451,8 @@ namespace hash
 {
 DECLARE_SOA_COLUMN(Bin, bin, int); //! Hash for the event mixing
 } // namespace hash
-DECLARE_SOA_TABLE(Hashes, "AOD", "HASH", hash::Bin);
-using Hash = Hashes::iterator;
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "HASH", hash::Bin);
+using MixingHash = MixingHashes::iterator;
 
 } // namespace o2::aod
 

--- a/PWGCF/FemtoDream/Tasks/femtoDreamHashTask.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamHashTask.cxx
@@ -31,7 +31,7 @@ struct femtoDreamPairHashTask {
 
   std::vector<float> CastCfgVtxBins, CastCfgMultBins;
 
-  Produces<aod::Hashes> hashes;
+  Produces<aod::MixingHashes> hashes;
 
   void init(InitContext&)
   {

--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -301,8 +301,8 @@ namespace hash
 {
 DECLARE_SOA_COLUMN(Bin, bin, int); //! Hash for the event mixing
 } // namespace hash
-DECLARE_SOA_TABLE(Hashes, "AOD", "HASH", hash::Bin);
-using Hash = Hashes::iterator;
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "HASH", hash::Bin);
+using MixingHash = MixingHashes::iterator;
 
 } // namespace o2::aod
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniverseHashTask.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniverseHashTask.cxx
@@ -32,7 +32,7 @@ struct femtoUniversePairHashTask {
 
   std::vector<float> CastCfgVtxBins, CastCfgMultBins;
 
-  Produces<aod::Hashes> hashes;
+  Produces<aod::MixingHashes> hashes;
 
   void init(InitContext&)
   {

--- a/PWGCF/FemtoWorld/Tasks/femtoWorldHashTask.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoWorldHashTask.cxx
@@ -33,7 +33,7 @@ struct femtoWorldPairHashTask {
 
   std::vector<float> CastCfgVtxBins, CastCfgMultBins;
 
-  Produces<aod::Hashes> hashes;
+  Produces<aod::MixingHashes> hashes;
 
   void init(InitContext&)
   {

--- a/Tutorials/src/eventMixing.cxx
+++ b/Tutorials/src/eventMixing.cxx
@@ -31,7 +31,7 @@ namespace hash
 {
 DECLARE_SOA_COLUMN(Bin, bin, int);
 } // namespace hash
-DECLARE_SOA_TABLE(Hashes, "AOD", "HASH", hash::Bin);
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "HASH", hash::Bin);
 
 } // namespace o2::aod
 
@@ -304,7 +304,7 @@ struct MixedEventsTripleVariousKinds {
 struct HashTask {
   std::vector<float> xBins{-0.064f, -0.062f, -0.060f, 0.066f, 0.068f, 0.070f, 0.072};
   std::vector<float> yBins{-0.320f, -0.301f, -0.300f, 0.330f, 0.340f, 0.350f, 0.360};
-  Produces<aod::Hashes> hashes;
+  Produces<aod::MixingHashes> hashes;
 
   // Calculate hash for an element based on 2 properties and their bins.
   int getHash(const std::vector<float>& xBins, const std::vector<float>& yBins, float colX, float colY)
@@ -341,7 +341,7 @@ struct HashTask {
 
 struct MixedEventsWithHashTask {
   SliceCache cache;
-  using myCollisions = soa::Join<aod::Hashes, aod::Collisions>;
+  using myCollisions = soa::Join<aod::MixingHashes, aod::Collisions>;
   NoBinningPolicy<aod::hash::Bin> hashBin;
   SameKindPair<myCollisions, aod::Tracks, NoBinningPolicy<aod::hash::Bin>> pair{hashBin, 5, -1, &cache}; // indicates that 5 events should be mixed and under/overflow (-1) to be ignored
 

--- a/Tutorials/src/tracksCombinations.cxx
+++ b/Tutorials/src/tracksCombinations.cxx
@@ -30,7 +30,7 @@ namespace hash
 {
 DECLARE_SOA_COLUMN(Bin, bin, int);
 } // namespace hash
-DECLARE_SOA_TABLE(Hashes, "AOD", "HASH", hash::Bin);
+DECLARE_SOA_TABLE(MixingHashes, "AOD", "HASH", hash::Bin);
 
 } // namespace o2::aod
 
@@ -116,7 +116,7 @@ struct BinnedTrackPartitionsCombinations {
 struct HashTask {
   std::vector<float> xBins{-0.064f, -0.062f, -0.060f, 0.066f, 0.068f, 0.070f, 0.072};
   std::vector<float> yBins{-0.320f, -0.301f, -0.300f, 0.330f, 0.340f, 0.350f, 0.360};
-  Produces<aod::Hashes> hashes;
+  Produces<aod::MixingHashes> hashes;
 
   // Calculate hash for an element based on 2 properties and their bins.
   int getHash(const std::vector<float>& xBins, const std::vector<float>& yBins, float colX, float colY)
@@ -154,7 +154,7 @@ struct HashTask {
 struct BinnedTrackCombinationsWithHashTable {
   NoBinningPolicy<aod::hash::Bin> hashBin;
 
-  void process(soa::Join<aod::Hashes, aod::Tracks> const& hashedTracks)
+  void process(soa::Join<aod::MixingHashes, aod::Tracks> const& hashedTracks)
   {
     int count = 0;
     // Strictly upper categorised tracks


### PR DESCRIPTION
Hello!

Upcoming O2 update will introduce `aod::Hash` template used in the core of refactored table types and providing mapping between string hash and the string. Unfortunately, it would clash with the aliases already defined in O2Physics. To ensure that O2 update would be seamless and do not require any interventions, I've took the liberty of renaming the `aod::Hashes` tables into `aod::MixingHashes` and the clashing alias to `using MixingHash = aod::MixingHashes::iterator;`. 