### PR TITLE
cpplint: Ignore indentation inside namespace.

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-build/c++11,-build/namespaces,-readability/fn_size,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo
+filter=-build/c++11,-build/namespaces,-readability/fn_size,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/indent_namespace,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo


### PR DESCRIPTION
Exception for a false positive. https://github.com/cpplint/cpplint/issues/293