### PR TITLE
checkov: Add configuration file with exceptions.

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,6 @@
+---
+# You can see all available properties here: https://github.com/bridgecrewio/checkov#configuration-using-a-config-file
+quiet: true
+skip-check:
+  - CKV_DOCKER_2
+  - CKV_GHA_7


### PR DESCRIPTION
Exclude CKV_GHA_7 to tolerate workflow_dispatch inputs in https://github.com/AliceO2Group/O2Physics/pull/8199
See details in https://github.com/bridgecrewio/checkov/issues/3839