### PR TITLE
[PWGHF] Fixing the decay length calculation using the KFParticle in the Omegac0 reconstruction.

### DIFF
--- a/Common/Tasks/centralityStudy.cxx
+++ b/Common/Tasks/centralityStudy.cxx
@@ -61,11 +61,16 @@ struct centralityStudy {
   Configurable<float> minTimeDelta{"minTimeDelta", -1.0f, "reject collision if another collision is this close or less in time"};
   Configurable<float> minFT0CforVertexZ{"minFT0CforVertexZ", 250, "minimum FT0C for vertex-Z profile calculation"};
 
+  Configurable<bool> sumFT0AC{"sumFT0AC", false, "sum FT0A and FT0C"};
+  Configurable<float> scaleSignalFT0C{"scaleSignalFT0C", 1.00f, "scale FT0C/A+C signal for convenience"};
+  Configurable<float> scaleSignalFV0A{"scaleSignalFV0A", 1.00f, "scale FV0A signal for convenience"};
+
   // Configurable Axes
   ConfigurableAxis axisMultFT0C{"axisMultFT0C", {2000, 0, 100000}, "FT0C amplitude"};
   ConfigurableAxis axisMultPVContributors{"axisMultPVContributors", {200, 0, 6000}, "Number of PV Contributors"};
 
   // For one-dimensional plots, where binning is no issue
+  ConfigurableAxis axisMultUltraFineFV0A{"axisMultUltraFineFV0A", {60000, 0, 60000}, "FV0A amplitude"};
   ConfigurableAxis axisMultUltraFineFT0C{"axisMultUltraFineFT0C", {60000, 0, 60000}, "FT0C amplitude"};
   ConfigurableAxis axisMultUltraFinePVContributors{"axisMultUltraFinePVContributors", {10000, 0, 10000}, "Number of PV Contributors"};
 
@@ -100,6 +105,7 @@ struct centralityStudy {
       histos.get<TH1>(HIST("hCollisionSelection"))->GetXaxis()->SetBinLabel(13, "no ITS in-ROF pileup (strict)");
 
       histos.add("hFT0C_Collisions", "hFT0C_Collisions", kTH1D, {axisMultUltraFineFT0C});
+      histos.add("hFV0A_Collisions", "hFV0A_Collisions", kTH1D, {axisMultUltraFineFV0A});
       histos.add("hNPVContributors", "hNPVContributors", kTH1D, {axisMultUltraFinePVContributors});
 
       histos.add("hFT0CvsPVz_Collisions_All", "hFT0CvsPVz_Collisions_All", kTProfile, {axisPVz});
@@ -109,6 +115,7 @@ struct centralityStudy {
     if (doprocessBCs) {
       histos.add("hBCSelection", "hBCSelection", kTH1D, {{20, -0.5, 19.5f}});
       histos.add("hFT0C_BCs", "hFT0C_BCs", kTH1D, {axisMultUltraFineFT0C});
+      histos.add("hFV0A_BCs", "hFV0A_BCs", kTH1D, {axisMultUltraFineFV0A});
 
       histos.add("hFT0CvsPVz_BCs_All", "hFT0CvsPVz_BCs_All", kTProfile, {axisPVz});
       histos.add("hFT0CvsPVz_BCs", "hFT0CvsPVz_BCs", kTProfile, {axisPVz});
@@ -182,6 +189,12 @@ struct centralityStudy {
     }
     histos.fill(HIST("hCollisionSelection"), 9 /* Not at same bunch pile-up */);
 
+    float multFT0_touse = collision.multFT0C();
+    if (sumFT0AC) {
+      multFT0_touse += collision.multFT0A();
+    }
+    multFT0_touse *= scaleSignalFT0C;
+
     // do this only if information is available
     if constexpr (requires { collision.timeToNext(); }) {
       float timeToNeighbour = TMath::Min(
@@ -216,13 +229,14 @@ struct centralityStudy {
 
     // if we got here, we also finally fill the FT0C histogram, please
     histos.fill(HIST("hNPVContributors"), collision.multPVTotalContributors());
-    histos.fill(HIST("hFT0C_Collisions"), collision.multFT0C());
-    histos.fill(HIST("hFT0CvsPVz_Collisions_All"), collision.multPVz(), collision.multFT0C());
+    histos.fill(HIST("hFT0C_Collisions"), multFT0_touse);
+    histos.fill(HIST("hFV0A_Collisions"), collision.multFV0A() * scaleSignalFV0A);
+    histos.fill(HIST("hFT0CvsPVz_Collisions_All"), collision.multPVz(), multFT0_touse);
     if (collision.multFT0C() > minFT0CforVertexZ) {
-      histos.fill(HIST("hFT0CvsPVz_Collisions"), collision.multPVz(), collision.multFT0C());
+      histos.fill(HIST("hFT0CvsPVz_Collisions"), collision.multPVz(), multFT0_touse);
     }
     if (do2DPlots) {
-      histos.fill(HIST("hFT0CvsNContribs"), collision.multNTracksPV(), collision.multFT0C());
+      histos.fill(HIST("hFT0CvsNContribs"), collision.multNTracksPV(), multFT0_touse);
       histos.fill(HIST("hMatchedVsITSOnly"), collision.multNTracksITSOnly(), collision.multNTracksITSTPC());
     }
 
@@ -274,12 +288,19 @@ struct centralityStudy {
     }
     histos.fill(HIST("hBCSelection"), 4); // FV0OrA
 
+    float multFT0_touse = multbc.multBCFT0C();
+    if (sumFT0AC) {
+      multFT0_touse += multbc.multBCFT0A();
+    }
+    multFT0_touse *= scaleSignalFT0C;
+
     // if we got here, we also finally fill the FT0C histogram, please
-    histos.fill(HIST("hFT0C_BCs"), multbc.multBCFT0C());
+    histos.fill(HIST("hFT0C_BCs"), multFT0_touse);
+    histos.fill(HIST("hFV0A_BCs"), multbc.multBCFV0A() * scaleSignalFV0A);
     if (multbc.multBCFT0PosZValid()) {
-      histos.fill(HIST("hFT0CvsPVz_BCs_All"), multbc.multBCFT0PosZ(), multbc.multBCFT0C());
+      histos.fill(HIST("hFT0CvsPVz_BCs_All"), multbc.multBCFT0PosZ(), multFT0_touse);
       if (multbc.multBCFT0C() > minFT0CforVertexZ) {
-        histos.fill(HIST("hFT0CvsPVz_BCs"), multbc.multBCFT0PosZ(), multbc.multBCFT0C());
+        histos.fill(HIST("hFT0CvsPVz_BCs"), multbc.multBCFT0PosZ(), multFT0_touse);
       }
     }
 

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -938,15 +938,15 @@ struct HfCandidateCreatorXic0Omegac0 {
 
       // KF decay length
       float DecayLxy_Lam, err_DecayLxy_Lam;
-      kfV0.GetDecayLengthXY(DecayLxy_Lam, err_DecayLxy_Lam);
+      kfV0ToCasc.GetDecayLengthXY(DecayLxy_Lam, err_DecayLxy_Lam);
       kfOmegac0Candidate.decayLenXYLambda = DecayLxy_Lam;
 
       float DecayLxy_Casc, err_DecayLxy_Casc;
-      kfOmega.GetDecayLengthXY(DecayLxy_Casc, err_DecayLxy_Casc);
+      kfOmegaToOmegaC.GetDecayLengthXY(DecayLxy_Casc, err_DecayLxy_Casc); 
       kfOmegac0Candidate.decayLenXYCasc = DecayLxy_Casc;
 
       float DecayLxy_Omegac0, err_DecayLxy_Omegac0;
-      kfOmegaC0.GetDecayLengthXY(DecayLxy_Omegac0, err_DecayLxy_Omegac0);
+      kfOmegac0ToPv.GetDecayLengthXY(DecayLxy_Omegac0, err_DecayLxy_Omegac0);
       kfOmegac0Candidate.decayLenXYOmegac = DecayLxy_Omegac0;
 
       // KF cosPA


### PR DESCRIPTION
using the particles constrained to the production vertex to calculate the decay length.