### PR TITLE
[PWGHF] taskFlow.cxx: adding Lc-h correlations for TPC-TPC and TPC-MFT cases. Adding cuts on MFT tracks.

### DIFF
--- a/PWGHF/HFC/Tasks/taskFlow.cxx
+++ b/PWGHF/HFC/Tasks/taskFlow.cxx
@@ -13,6 +13,9 @@
 /// \author Katarina Krizkova Gajdosova <katarina.gajdosova@cern.ch>, CERN
 /// \author Maja Kabus <maja.kabus@cern.ch>, CERN
 
+#include <string>
+#include <vector>
+
 #include <TDirectory.h>
 #include <TH1F.h>
 #include <THn.h>

--- a/PWGHF/HFC/Tasks/taskFlow.cxx
+++ b/PWGHF/HFC/Tasks/taskFlow.cxx
@@ -23,6 +23,7 @@
 #include "Framework/AnalysisTask.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
+#include "Framework/Logger.h"
 #include "Framework/O2DatabasePDGPlugin.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/RunningWorkflowInfo.h"
@@ -50,7 +51,6 @@ using namespace o2::framework::expressions;
 struct HfTaskFlow {
 
   //  configurables for processing options
-  Configurable<bool> do3Prong{"do3Prong", false, "Flag to know if the HF candidate is 3Prong or not"};
   Configurable<bool> doReferenceFlow{"doReferenceFlow", false, "Flag to know if reference flow should be done"};
   Configurable<bool> processRun2{"processRun2", false, "Flag to run on Run 2 data"};
   Configurable<bool> processRun3{"processRun3", true, "Flag to run on Run 3 data"};
@@ -64,9 +64,14 @@ struct HfTaskFlow {
   //  configurables for HF candidates
   Configurable<int> selectionFlagD0{"selectionFlagD0", 1, "Selection Flag for D0"};
   Configurable<int> selectionFlagD0bar{"selectionFlagD0bar", 1, "Selection Flag for D0bar"};
-  Configurable<int> selectionFlagLc{"selectionFlagLc", 1, "Selection Flag for LambdaC"};
+  Configurable<int> selectionFlagLcToPKPi{"selectionFlagLcToPKPi", 1, "Selection Flag for LambdaC"};
+  Configurable<int> selectionFlagLcToPiKP{"selectionFlagLcToPiKP", 1, "Selection Flag for LambdaC bar"};
   Configurable<double> yCandMax{"yCandMax", -1., "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
+  //  configurables for MFT tracks
+  Configurable<double> etaMftTrackMax{"etaMftTrackMax", 0, "Maximum value for the eta of MFT tracks"};
+  Configurable<double> etaMftTrackMin{"etaMftTrackMin", -5, "Minimum value for the eta of MFT tracks"};
+  Configurable<int> nClustersMftTrack{"nClustersMftTrack", 5, "Minimum number of clusters for the reconstruction of MFT tracks"};
 
   Service<o2::framework::O2DatabasePDG> pdg;
   HfHelper hfHelper;
@@ -103,8 +108,12 @@ struct HfTaskFlow {
 
   //  HF candidate filter
   //  TODO: use Partition instead of filter
-  Filter candidateFilter = aod::hf_sel_candidate_d0::isSelD0 >= selectionFlagD0 ||
+  Filter candidateFilterD0 = aod::hf_sel_candidate_d0::isSelD0 >= selectionFlagD0 ||
                            aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlagD0bar;
+
+                           
+  Filter candidateFilterLc = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlagLcToPKPi ||
+                           aod::hf_sel_candidate_lc::isSelLcToPiKP >= selectionFlagLcToPiKP;
 
   //  Collision filters
   //  FIXME: The filter is applied also on the candidates! Beware!
@@ -113,12 +122,6 @@ struct HfTaskFlow {
   Filter trackFilter = (nabs(aod::track::eta) < etaTrackAssocMax) &&
                        (aod::track::pt > ptTrackAssocMin) &&
                        requireGlobalTrackWoPtEtaInFilter();
-
-  // Katarina had this in her code :
-  // Charged track filters
-  // Filter trackFilter = (nabs(aod::track::eta) < etaTrackAssocMax) &&
-  //                      (aod::track::pt > ptTrackAssocMin) &&
-  //                      requireGlobalTrackWoPtEtaInFilter();
 
   // =========================
   //      Filters & partitions : MC
@@ -232,7 +235,7 @@ struct HfTaskFlow {
     registry.add("Data/TpcTpc/HadronHadron/MixedEvent/hPhiMixing", "phi", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
 
     //  =========================
-    //      DATA : histograms for TPC-TPC HF-h case
+    //      DATA : histograms for TPC-TPC HF-h case for 2PRONG
     //  =========================
 
     // DATA : event histograms for TPC-TPC HF-h same event
@@ -243,29 +246,71 @@ struct HfTaskFlow {
 
     // DATA : trigger particles (candidates) histograms for TPC-TPC h-h same event
     auto vbins = (std::vector<double>)binsPt;
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hPtCandidate", "2-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hPtProng0", "2-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hPtProng1", "2-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hMass", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hDecLength", "2-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hDecLengthXY", "2-prong candidates;decay length xy (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hd0Prong0", "2-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hd0Prong1", "2-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hd0d0", "2-prong candidates;product of DCAxy to prim. vertex (cm^{2});entries", {HistType::kTH2F, {{500, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hCTS", "2-prong candidates;cos #it{#theta}* (D^{0});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hCt", "2-prong candidates;proper lifetime (D^{0}) * #it{c} (cm);entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hCPA", "2-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hEtaCandVsPt", "2-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hSelectionStatus", "2-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hImpParErr", "2-prong candidates;impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcTpc/HfHadron/SameEvent/hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtCandidate", "2-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtProng0", "2-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtProng1", "2-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMass", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLength", "2-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLengthXY", "2-prong candidates;decay length xy (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0Prong0", "2-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0Prong1", "2-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0d0", "2-prong candidates;product of DCAxy to prim. vertex (cm^{2});entries", {HistType::kTH2F, {{500, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCTS", "2-prong candidates;cos #it{#theta}* (D^{0});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCt", "2-prong candidates;proper lifetime (D^{0}) * #it{c} (cm);entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCPA", "2-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hEtaCandVsPt", "2-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hSelectionStatus", "2-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hImpParErr", "2-prong candidates;impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
     // DATA : trigger particles (candidates) histograms for TPC-TPC h-h mixed event
     registry.add("Data/TpcTpc/HfHadron/MixedEvent/hPtHFMixing", "pT", {HistType::kTH1F, {{100, 0, 10, "p_{T}"}}});
     registry.add("Data/TpcTpc/HfHadron/MixedEvent/hEtaHFMixing", "eta", {HistType::kTH1F, {{100, -4, 4, "#eta"}}});
     registry.add("Data/TpcTpc/HfHadron/MixedEvent/hPhiHFMixing", "phi", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
+
+    //  =========================
+    //      DATA : histograms for TPC-TPC HF-h case for 3PRONG
+    //  ===================
+    
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPt", "3-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMass", "3-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPtVsMult", "3-prong candidates;inv. mass (p K #pi) (GeV/#it{c}^{2}); p_{T}; multiplicity", {HistType::kTH3F, {{600, 1.98, 2.58}, {vbins, "#it{p}_{T} (GeV/#it{c})"}, {5000, 0., 10000.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPt", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng0", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng1", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng2", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLength", "3-prong candidates;decay length (cm);entries", {HistType::kTH1F, {{400, 0., 1.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthxy", "3-prong candidates;decay length xy (cm);entries", {HistType::kTH1F, {{400, 0., 1.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCt", "3-prong candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPA", "3-prong candidates;cosine of pointing angle;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAxy", "3-prong candidates;cosine of pointing angle xy;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDca2", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);entries", {HistType::kTH1F, {{400, 0., 20.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hEta", "3-prong candidates;#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPhi", "3-prong candidates;#it{#Phi};entries", {HistType::kTH1F, {{100, 0., 6.3}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthVsPt", "3-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{400, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthxyVsPt", "3-prong candidates;decay length xy(cm);entries", {HistType::kTH2F, {{400, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCtVsPt", "3-prong candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH2F, {{100, 0., 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAVsPt", "3-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAxyVsPt", "3-prong candidates;cosine of pointing angle xy;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDca2VsPt", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);entries", {HistType::kTH2F, {{400, 0., 20.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hEtaVsPt", "3-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPhiVsPt", "3-prong candidates;candidate #it{#Phi};entries", {HistType::kTH2F, {{100, 0., 6.3}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hSelectionStatus", "3-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng0", "3-prong candidates;prong 0 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng1", "3-prong candidates;prong 1 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng2", "3-prong candidates;prong 2 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLenErr", "3-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    
+
 
     //  =========================
     //      DATA : histograms for TPC-MFT h-h case
@@ -277,7 +322,7 @@ struct HfTaskFlow {
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hPhiTPC", "phiTPC", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hPtTPC", "pT", {HistType::kTH1F, {{100, 0, 10, "p_{T}"}}});
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hYieldsTPC", "multiplicity vs pT vs eta", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
-    registry.add("Data/TpcTpc/HadronHadron/SameEvent/hNtracksTPC", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
+    registry.add("Data/TpcMft/HadronHadron/SameEvent/hNtracksTPC", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
 
     // DATA : associated particles (MFT tracks) histograms for TPC-MFT h-h same event
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hEtaPhiMFT", "multiplicity vs eta vs phi in MFT", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {100, -2, 2, "#eta"}, {200, 0, TwoPI, "#varphi"}}});
@@ -285,7 +330,7 @@ struct HfTaskFlow {
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hPhiMFT", "phiMFT", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hPtMFT", "pT", {HistType::kTH1F, {{100, 0, 10, "p_{T}"}}});
     registry.add("Data/TpcMft/HadronHadron/SameEvent/hYieldsMFT", "multiplicity vs pT vs eta", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
-    registry.add("Data/TpcTpc/HadronHadron/SameEvent/hNtracksMFT", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
+    registry.add("Data/TpcMft/HadronHadron/SameEvent/hNtracksMFT", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
 
     // DATA : histograms for TPC-MFT h-h event mixing for TPC tracks
     registry.add("Data/TpcMft/HadronHadron/MixedEvent/hMultiplicityMixingTPC", "hMultiplicityMixing", {HistType::kTH1F, {{500, 0, 500}}});
@@ -307,35 +352,35 @@ struct HfTaskFlow {
     registry.add("Data/TpcMft/HadronHadron/MixedEvent/hEventCountMixing", "bin", {HistType::kTH1F, {{nBinsMix + 2, -2.5, -0.5 + nBinsMix, "bin"}}});
 
     //  =========================
-    //      DATA : histograms for TPC-MFT HF-h case
+    //      DATA : histograms for TPC-MFT HF-h case FOR 2PRONG
     //  =========================
 
     // DATA : trigger particles (candidates) histograms for TPC-MFT HF-h same event
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hEtaPhiCandidate", "multiplicity vs eta vs phi in TPC", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {100, -2, 2, "#eta"}, {200, 0, TwoPI, "#varphi"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hEtaCandidate", "etaTPC", {HistType::kTH1F, {{100, -4, 4, "#eta"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hPhiCandidate", "phiTPC", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hYieldsCandidate", "multiplicity vs pT vs eta", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hNtracksCandidate", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaPhiCandidate", "multiplicity vs eta vs phi in TPC", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {100, -2, 2, "#eta"}, {200, 0, TwoPI, "#varphi"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaCandidate", "etaTPC", {HistType::kTH1F, {{100, -4, 4, "#eta"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hPhiCandidate", "phiTPC", {HistType::kTH1F, {{100, 0, TwoPI, "#varphi"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hYieldsCandidate", "multiplicity vs pT vs eta", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hNtracksCandidate", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
 
     // DATA : trigger particles (candidates) histograms for TPC-MFT HF-h same event
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hPtCandidate", "2-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hPtProng0", "2-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hPtProng1", "2-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hMass", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hDecLength", "2-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hDecLengthXY", "2-prong candidates;decay length xy (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hd0Prong0", "2-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hd0Prong1", "2-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hd0d0", "2-prong candidates;product of DCAxy to prim. vertex (cm^{2});entries", {HistType::kTH2F, {{500, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hCTS", "2-prong candidates;cos #it{#theta}* (D^{0});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hCt", "2-prong candidates;proper lifetime (D^{0}) * #it{c} (cm);entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hCPA", "2-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hEtaCandVsPt", "2-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hSelectionStatus", "2-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hImpParErr", "2-prong candidates;impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("Data/TpcMft/HfHadron/SameEvent/hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtCandidate", "2-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtProng0", "2-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtProng1", "2-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{100, 0, 10.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hMass", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLength", "2-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLengthXY", "2-prong candidates;decay length xy (cm);entries", {HistType::kTH2F, {{200, 0., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0Prong0", "2-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0Prong1", "2-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0d0", "2-prong candidates;product of DCAxy to prim. vertex (cm^{2});entries", {HistType::kTH2F, {{500, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hCTS", "2-prong candidates;cos #it{#theta}* (D^{0});entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hCt", "2-prong candidates;proper lifetime (D^{0}) * #it{c} (cm);entries", {HistType::kTH2F, {{120, -20., 100.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hCPA", "2-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaCandVsPt", "2-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hSelectionStatus", "2-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hImpParErr", "2-prong candidates;impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLenErr", "2-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLenXYErr", "2-prong candidates;decay length xy error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
 
     // DATA : associated particles (MFT tracks) histograms for TPC-MFT h-h same event
     registry.add("Data/TpcMft/HfHadron/SameEvent/hEtaPhiMFT", "multiplicity vs eta vs phi in MFT", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {100, -2, 2, "#eta"}, {200, 0, TwoPI, "#varphi"}}});
@@ -365,7 +410,53 @@ struct HfTaskFlow {
     registry.add("Data/TpcMft/HfHadron/MixedEvent/hEventCountMixing", "bin", {HistType::kTH1F, {{nBinsMix + 2, -2.5, -0.5 + nBinsMix, "bin"}}});
 
     //  =========================
-    //      MC : histograms for TPC-MFT h-h case
+    //      DATA : histograms for TPC-MFT HF-h case FOR 3PRONG
+    //  =========================
+
+    
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hYieldsCandidate", "multiplicity vs pT vs eta", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hNtracksCandidate", "hNtracks", {HistType::kTH1F, {{500, 0, 500}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hEtaPhiCandidate", "multiplicity vs eta vs phi in TPC", {HistType::kTH3F, {{200, 0, 200, "multiplicity"}, {100, -2, 2, "#eta"}, {200, 0, TwoPI, "#varphi"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPt", "3-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{500, 0., 5.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hMass", "3-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPtVsMult", "3-prong candidates;inv. mass (p K #pi) (GeV/#it{c}^{2}); p_{T}; multiplicity", {HistType::kTH3F, {{600, 1.98, 2.58}, {vbins, "#it{p}_{T} (GeV/#it{c})"}, {5000, 0., 10000.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH2F, {{600, -0.4, 0.4}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hMultiplicity", "multiplicity;multiplicity;entries", {HistType::kTH1F, {{10000, 0., 10000.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPt", "3-prong candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng0", "3-prong candidates;prong 0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng1", "3-prong candidates;prong 1 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng2", "3-prong candidates;prong 2 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {{360, 0., 36.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong0", "3-prong candidates;prong 0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong1", "3-prong candidates;prong 1 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong2", "3-prong candidates;prong 2 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {{600, -0.4, 0.4}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLength", "3-prong candidates;decay length (cm);entries", {HistType::kTH1F, {{400, 0., 1.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthxy", "3-prong candidates;decay length xy (cm);entries", {HistType::kTH1F, {{400, 0., 1.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCt", "3-prong candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPA", "3-prong candidates;cosine of pointing angle;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAxy", "3-prong candidates;cosine of pointing angle xy;entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDca2", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);entries", {HistType::kTH1F, {{400, 0., 20.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hEta", "3-prong candidates;#it{#eta};entries", {HistType::kTH1F, {{100, -2., 2.}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPhi", "3-prong candidates;#it{#Phi};entries", {HistType::kTH1F, {{100, 0., 6.3}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthVsPt", "3-prong candidates;decay length (cm);entries", {HistType::kTH2F, {{400, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthxyVsPt", "3-prong candidates;decay length xy(cm);entries", {HistType::kTH2F, {{400, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCtVsPt", "3-prong candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH2F, {{100, 0., 0.2}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAVsPt", "3-prong candidates;cosine of pointing angle;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAxyVsPt", "3-prong candidates;cosine of pointing angle xy;entries", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDca2VsPt", "3-prong candidates;prong Chi2PCA to sec. vertex (cm);entries", {HistType::kTH2F, {{400, 0., 20.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hEtaVsPt", "3-prong candidates;candidate #it{#eta};entries", {HistType::kTH2F, {{100, -2., 2.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hPhiVsPt", "3-prong candidates;candidate #it{#Phi};entries", {HistType::kTH2F, {{100, 0., 6.3}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hSelectionStatus", "3-prong candidates;selection status;entries", {HistType::kTH2F, {{5, -0.5, 4.5}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng0", "3-prong candidates;prong 0 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng1", "3-prong candidates;prong 1 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng2", "3-prong candidates;prong 2 impact parameter error (cm);entries", {HistType::kTH2F, {{100, -1., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLenErr", "3-prong candidates;decay length error (cm);entries", {HistType::kTH2F, {{100, 0., 1.}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    
+
+
+    //  =========================
+    //      MC : histograms for TPC-TPC h-h case
     //  =========================
 
     // MC reconstructed
@@ -576,11 +667,19 @@ struct HfTaskFlow {
   template <typename TTracks>
   void fillTpcTpcHfChMixedEventQa(float multiplicity, float vz, TTracks const& tracks)
   {
+    // This function is only called with HF candidates
+
     registry.fill(HIST("Data/TpcTpc/HfHadron/MixedEvent/hMultiplicityHFMixing"), multiplicity);
     registry.fill(HIST("Data/TpcTpc/HfHadron/MixedEvent/hVtxZHFMixing"), vz);
 
     int nTracks = tracks.size();
     for (const auto& track1 : tracks) {
+      
+      // apply candidate cuts
+      if (!isAcceptedCandidate(track1)) {
+        continue;
+      }
+
       registry.fill(HIST("Data/TpcTpc/HfHadron/MixedEvent/hPtHFMixing"), track1.pt());
       registry.fill(HIST("Data/TpcTpc/HfHadron/MixedEvent/hEtaHFMixing"), track1.eta());
       registry.fill(HIST("Data/TpcTpc/HfHadron/MixedEvent/hPhiHFMixing"), track1.phi());
@@ -596,15 +695,22 @@ struct HfTaskFlow {
     bool isMFT = false;
     for (const auto& track1 : tracks) {
       if constexpr (std::is_same_v<aod::MFTTracks, TTracks>) { // if MFT tracks
+
+        // apply cuts for MFT tracks
+        if (!isAcceptedMftTrack(track1)) {
+          continue;
+        }
+
         isMFT = true;
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hEtaMFT"), track1.eta());
         float phi = track1.phi();
         o2::math_utils::bringTo02Pi(phi);
+
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hPhiMFT"), phi);
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hEtaPhiMFT"), multiplicity, track1.eta(), phi);
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hPtMFT"), track1.pt());
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hYieldsMFT"), multiplicity, track1.pt(), track1.eta());
-      } else { // if TPC tracks
+      } else {                                                // if TPC tracks
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hEtaTPC"), track1.eta());
         float phi = track1.phi();
         o2::math_utils::bringTo02Pi(phi);
@@ -614,9 +720,9 @@ struct HfTaskFlow {
         registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hYieldsTPC"), multiplicity, track1.pt(), track1.eta());
       }
       if (isMFT) {
-        registry.fill(HIST("Data/TpcTpc/HadronHadron/SameEvent/hNtracksMFT"), nTracks);
+        registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hNtracksMFT"), nTracks);
       } else {
-        registry.fill(HIST("Data/TpcTpc/HadronHadron/SameEvent/hNtracksTPC"), nTracks);
+        registry.fill(HIST("Data/TpcMft/HadronHadron/SameEvent/hNtracksTPC"), nTracks);
       }
     }
   }
@@ -629,9 +735,16 @@ struct HfTaskFlow {
     int nTracks = tracks.size();
     for (const auto& track1 : tracks) {
       if constexpr (std::is_same_v<aod::MFTTracks, TTracks>) { // if MFT tracks
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaMFT"), track1.eta());
+
+        // apply cuts for MFT tracks
+        if (!isAcceptedMftTrack(track1)) {
+          continue;
+        }
+
         float phi = track1.phi();
         o2::math_utils::bringTo02Pi(phi);
+
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaMFT"), track1.eta());
         registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPhiMFT"), phi);
         registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaPhiMFT"), multiplicity, track1.eta(), phi);
         registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPtMFT"), track1.pt());
@@ -646,22 +759,32 @@ struct HfTaskFlow {
   void fillTpcMftChChMixedEventQa(float multiplicity, float vz, TTracks const& tracks)
   {
     if constexpr (std::is_same_v<aod::MFTTracks, TTracks>) { // if MFT tracks
+      int nTracks = tracks.size();
+
       registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hMultiplicityMixingMFT"), multiplicity);
       registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hVtxZMixingMFT"), vz);
 
-      int nTracks = tracks.size();
       for (const auto& track1 : tracks) {
+        
+        // apply cuts for MFT tracks
+        if (!isAcceptedMftTrack(track1)) {
+          continue;
+        }
+
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hPtMixingMFT"), track1.pt());
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hEtaMixingMFT"), track1.eta());
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hPhiMixingMFT"), track1.phi());
       }
       registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hNtracksMixingMFT"), nTracks);
     } else { // if TPC tracks
+
+      int nTracks = tracks.size();
+
       registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hMultiplicityMixingTPC"), multiplicity);
       registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hVtxZMixingTPC"), vz);
 
-      int nTracks = tracks.size();
       for (const auto& track1 : tracks) {
+
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hPtMixingTPC"), track1.pt());
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hEtaMixingTPC"), track1.eta());
         registry.fill(HIST("Data/TpcMft/HadronHadron/MixedEvent/hPhiMixingTPC"), track1.phi());
@@ -680,6 +803,12 @@ struct HfTaskFlow {
 
       int nTracks = tracks.size();
       for (const auto& track1 : tracks) {
+
+        // apply cuts for MFT tracks
+        if (!isAcceptedMftTrack(track1)) {
+          continue;
+        }
+
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hPtMixingMFT"), track1.pt());
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hEtaMixingMFT"), track1.eta());
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hPhiMixingMFT"), track1.phi());
@@ -691,6 +820,12 @@ struct HfTaskFlow {
 
       int nTracks = tracks.size();
       for (const auto& track1 : tracks) {
+
+        // apply candidate cuts
+        if (!isAcceptedCandidate(track1)) {
+        continue;
+        }
+
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hPtMixingCandidate"), track1.pt());
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hEtaMixingCandidate"), track1.eta());
         registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hPhiMixingCandidate"), track1.phi());
@@ -698,12 +833,13 @@ struct HfTaskFlow {
       registry.fill(HIST("Data/TpcMft/HfHadron/MixedEvent/hNtracksMixingCandidate"), nTracks);
     }
   }
-
+  
   //  TODO: Check how to put this into a Filter
   template <typename TTrack>
   bool isAcceptedCandidate(TTrack const& candidate)
   {
-    if (do3Prong) { // For now, that means we do LambdaC
+
+    if constexpr (std::is_same_v<HfCandidatesSelLc, TTrack>) { // For now, that means we do LambdaC
       if (!(candidate.hfflag() & 1 << aod::hf_cand_3prong::DecayType::LcToPKPi)) {
         return false;
       }
@@ -711,7 +847,7 @@ struct HfTaskFlow {
         return false;
       }
       return true;
-    } else {  // For now, that means we do D0
+    } else { // For now, that means we do D0
       if (!(candidate.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
         return false;
       }
@@ -720,6 +856,25 @@ struct HfTaskFlow {
       }
       return true;
     }
+  }
+
+  //  TODO: Check how to put this into a Filter 
+  // I tried to put it as a filter, but filters for normal TPC tracks also apply to MFT tracks I think
+  // and it seems that they are not compatible
+  template <typename TTrack>
+  bool isAcceptedMftTrack(TTrack const& mftTrack)
+  {
+    // cut on the eta of MFT tracks
+    if (mftTrack.eta() > etaMftTrackMax || mftTrack.eta() < etaMftTrackMin) {
+      return false;
+    }
+
+    // cut on the number of clusters of the reconstructed MFT track
+    if (mftTrack.nClusters() < nClustersMftTrack) {
+      return false;
+    }
+
+    return true;
   }
 
   // I am not sure if to template McParticles is useful, I'll address this when doing the MC Gen case of HF-h correlations
@@ -752,31 +907,31 @@ struct HfTaskFlow {
       }
 
       if (candidate.isSelD0() >= selectionFlagD0) {
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassD0ToPiK(candidate), candidate.pt());
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMass"), hfHelper.invMassD0ToPiK(candidate));
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMassVsPt"), hfHelper.invMassD0ToPiK(candidate), candidate.pt());
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMass"), hfHelper.invMassD0ToPiK(candidate));
       }
       if (candidate.isSelD0bar() >= selectionFlagD0bar) {
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassD0barToKPi(candidate), candidate.pt());
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMass"), hfHelper.invMassD0barToKPi(candidate));
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMassVsPt"), hfHelper.invMassD0barToKPi(candidate), candidate.pt());
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hMass"), hfHelper.invMassD0barToKPi(candidate));
       }
 
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtCandidate"), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtProng0"), candidate.ptProng0());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtProng1"), candidate.ptProng1());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLength"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0Prong0"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0Prong1"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0d0"), candidate.impactParameterProduct(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCTS"), hfHelper.cosThetaStarD0(candidate), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCt"), hfHelper.ctD0(candidate), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCPA"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hEtaCandVsPt"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hSelectionStatus"), candidate.isSelD0() + (candidate.isSelD0bar() * 2), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtCandidate"), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtProng0"), candidate.ptProng0());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hPtProng1"), candidate.ptProng1());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLength"), candidate.decayLength(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0Prong0"), candidate.impactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0Prong1"), candidate.impactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hd0d0"), candidate.impactParameterProduct(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCTS"), hfHelper.cosThetaStarD0(candidate), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCt"), hfHelper.ctD0(candidate), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hCPA"), candidate.cpa(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hEtaCandVsPt"), candidate.eta(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hSelectionStatus"), candidate.isSelD0() + (candidate.isSelD0bar() * 2), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/2Prong/hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
     }
   }
 
@@ -785,6 +940,7 @@ struct HfTaskFlow {
   template <typename TTracks>
   void fillTpcTpcLcCandidateQa(TTracks const& candidates)
   {
+    int nTracks = candidates.size();
     for (const auto& candidate : candidates) {
       if (!isAcceptedCandidate(candidate)) {
         continue;
@@ -800,52 +956,50 @@ struct HfTaskFlow {
       auto cpa = candidate.cpa();
       auto cpaXY = candidate.cpaXY();
 
-      if (candidate.isSelLcToPKPi() >= selectionFlagLc) {
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMass"), hfHelper.invMassLcToPKPi(candidate));
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPtVsMult"), hfHelper.invMassLcToPKPi(candidate), pt, nTracks);
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassLcToPKPi(candidate), pt);
+      if (candidate.isSelLcToPKPi() >= selectionFlagLcToPKPi) {
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMass"), hfHelper.invMassLcToPKPi(candidate));
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPtVsMult"), hfHelper.invMassLcToPKPi(candidate), pt, nTracks);
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPt"), hfHelper.invMassLcToPKPi(candidate), pt);
       }
-      if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMass"), hfHelper.invMassLcToPiKP(candidate));
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPtVsMult"), hfHelper.invMassLcToPiKP(candidate), pt, nTracks);
-        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassLcToPiKP(candidate), pt);
+      if (candidate.isSelLcToPiKP() >= selectionFlagLcToPiKP) {
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMass"), hfHelper.invMassLcToPiKP(candidate));
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPtVsMult"), hfHelper.invMassLcToPiKP(candidate), pt, nTracks);
+        registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMassVsPt"), hfHelper.invMassLcToPiKP(candidate), pt);
       }
-
       
-      //registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hMultiplicity"), nTracks);
-
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPt"), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtProng0"), ptProng0);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtProng1"), ptProng1);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPtProng2"), ptProng2);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0Prong0"), candidate.impactParameter0());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0Prong1"), candidate.impactParameter1());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0Prong2"), candidate.impactParameter2());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0VsPtProng0"), candidate.impactParameter0(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0VsPtProng1"), candidate.impactParameter1(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hd0VsPtProng2"), candidate.impactParameter2(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLength"), decayLength);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLengthVsPt"), decayLength, pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLengthxy"), decayLengthXY);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLengthxyVsPt"), decayLengthXY, pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCt"), hfHelper.ctLc(candidate));
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCtVsPt"), hfHelper.ctLc(candidate), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCPA"), cpa);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCPAVsPt"), cpa, pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCPAxy"), cpaXY);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hCPAxyVsPt"), cpaXY, pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDca2"), chi2PCA);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDca2VsPt"), chi2PCA, pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hEta"), candidate.eta());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hEtaVsPt"), candidate.eta(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPhi"), candidate.phi());
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hPhiVsPt"), candidate.phi(), pt);
-      //registry.fill(HIST("hSelectionStatus"), candidate.isSelLcToPKPi(), pt);
-      //registry.fill(HIST("hSelectionStatus"), candidate.isSelLcToPiKP(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hImpParErrProng0"), candidate.errorImpactParameter0(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hImpParErrProng1"), candidate.errorImpactParameter1(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hImpParErrProng2"), candidate.errorImpactParameter2(), pt);
-      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/hDecLenErr"), candidate.errorDecayLength(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hMultiplicity"), nTracks);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPt"), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng0"), ptProng0);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng1"), ptProng1);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPtProng2"), ptProng2);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong0"), candidate.impactParameter0());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong1"), candidate.impactParameter1());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0Prong2"), candidate.impactParameter2());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng0"), candidate.impactParameter0(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng1"), candidate.impactParameter1(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hd0VsPtProng2"), candidate.impactParameter2(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLength"), decayLength);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthVsPt"), decayLength, pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthxy"), decayLengthXY);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLengthxyVsPt"), decayLengthXY, pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCt"), hfHelper.ctLc(candidate));
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCtVsPt"), hfHelper.ctLc(candidate), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPA"), cpa);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAVsPt"), cpa, pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAxy"), cpaXY);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hCPAxyVsPt"), cpaXY, pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDca2"), chi2PCA);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDca2VsPt"), chi2PCA, pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hEta"), candidate.eta());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hEtaVsPt"), candidate.eta(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPhi"), candidate.phi());
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hPhiVsPt"), candidate.phi(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hSelectionStatus"), candidate.isSelLcToPKPi(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hSelectionStatus"), candidate.isSelLcToPiKP(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng0"), candidate.errorImpactParameter0(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng1"), candidate.errorImpactParameter1(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hImpParErrProng2"), candidate.errorImpactParameter2(), pt);
+      registry.fill(HIST("Data/TpcTpc/HfHadron/SameEvent/3Prong/hDecLenErr"), candidate.errorDecayLength(), pt);
     }
   }
   
@@ -862,37 +1016,37 @@ struct HfTaskFlow {
       }
 
       if (candidate.isSelD0() >= selectionFlagD0) {
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassD0ToPiK(candidate), candidate.pt());
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMass"), hfHelper.invMassD0ToPiK(candidate));
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hMassVsPt"), hfHelper.invMassD0ToPiK(candidate), candidate.pt());
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hMass"), hfHelper.invMassD0ToPiK(candidate));
       }
       if (candidate.isSelD0bar() >= selectionFlagD0bar) {
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassD0barToKPi(candidate), candidate.pt());
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMass"), hfHelper.invMassD0barToKPi(candidate));
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hMassVsPt"), hfHelper.invMassD0barToKPi(candidate), candidate.pt());
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hMass"), hfHelper.invMassD0barToKPi(candidate));
       }
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaCandidate"), candidate.eta());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaCandidate"), candidate.eta());
       float phi = candidate.phi();
       o2::math_utils::bringTo02Pi(phi);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPhiCandidate"), phi);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaPhiCandidate"), multiplicity, candidate.eta(), phi);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hYieldsCandidate"), multiplicity, candidate.pt(), candidate.eta());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hNtracksCandidate"), nTracks);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPtCandidate"), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPtProng0"), candidate.ptProng0());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hPtProng1"), candidate.ptProng1());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hDecLength"), candidate.decayLength(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hd0Prong0"), candidate.impactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hd0Prong1"), candidate.impactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hd0d0"), candidate.impactParameterProduct(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hCTS"), hfHelper.cosThetaStarD0(candidate), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hCt"), hfHelper.ctD0(candidate), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hCPA"), candidate.cpa(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaCandVsPt"), candidate.eta(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hSelectionStatus"), candidate.isSelD0() + (candidate.isSelD0bar() * 2), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hPhiCandidate"), phi);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaPhiCandidate"), multiplicity, candidate.eta(), phi);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hYieldsCandidate"), multiplicity, candidate.pt(), candidate.eta());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hNtracksCandidate"), nTracks);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtCandidate"), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtProng0"), candidate.ptProng0());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hPtProng1"), candidate.ptProng1());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLength"), candidate.decayLength(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLengthXY"), candidate.decayLengthXY(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0Prong0"), candidate.impactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0Prong1"), candidate.impactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hd0d0"), candidate.impactParameterProduct(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hCTS"), hfHelper.cosThetaStarD0(candidate), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hCt"), hfHelper.ctD0(candidate), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hCPA"), candidate.cpa(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hEtaCandVsPt"), candidate.eta(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hSelectionStatus"), candidate.isSelD0() + (candidate.isSelD0bar() * 2), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hImpParErr"), candidate.errorImpactParameter0(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hImpParErr"), candidate.errorImpactParameter1(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLenErr"), candidate.errorDecayLength(), candidate.pt());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/2Prong/hDecLenXYErr"), candidate.errorDecayLengthXY(), candidate.pt());
     }
   }
 
@@ -901,30 +1055,71 @@ struct HfTaskFlow {
   template <typename TTracks>
   void fillTpcMftLcCandidateQa(TTracks const& candidates, float multiplicity)
   {
-    int nTracks = candidates.size(); // This is probably the same as the multiplicity that we have as parameter of the function
     for (const auto& candidate : candidates) {
       if (!isAcceptedCandidate(candidate)) {
         continue;
       }
 
-      if (candidate.isSelLcToPiKP() >= selectionFlagLc) {
-        // TO BE ADAPTED TO LC
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassLcToPiKP(candidate), candidate.pt());
-        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMass"), hfHelper.invMassLcToPiKP(candidate));
-      } 
-      //if (candidate.isSelD0bar() >= selectionFlagD0bar) { // DO WE CARE ABOUT ANTI LC ?
-      //  // TO BE ADAPTED TO LC
-      //  registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMassVsPt"), hfHelper.invMassD0barToKPi(candidate), candidate.pt());
-      //  registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hMass"), hfHelper.invMassD0barToKPi(candidate));
-      //}
-      // PLOTS
-      // FOR
-      // LC
-      // ADDING THAT SO IT COMPILES FOR NOW
+      auto pt = candidate.pt();
+      auto ptProng0 = candidate.ptProng0();
+      auto ptProng1 = candidate.ptProng1();
+      auto ptProng2 = candidate.ptProng2();
+      auto decayLength = candidate.decayLength();
+      auto decayLengthXY = candidate.decayLengthXY();
+      auto chi2PCA = candidate.chi2PCA();
+      auto cpa = candidate.cpa();
+      auto cpaXY = candidate.cpaXY();
       float phi = candidate.phi();
       o2::math_utils::bringTo02Pi(phi);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hEtaPhiCandidate"), multiplicity, candidate.eta(), phi);
-      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/hNtracksCandidate"), nTracks);
+
+      
+      if (candidate.isSelLcToPKPi() >= selectionFlagLcToPKPi) {
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMass"), hfHelper.invMassLcToPKPi(candidate));
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPtVsMult"), hfHelper.invMassLcToPKPi(candidate), pt, multiplicity);
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPt"), hfHelper.invMassLcToPKPi(candidate), pt);
+      }
+      if (candidate.isSelLcToPiKP() >= selectionFlagLcToPiKP) {
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMass"), hfHelper.invMassLcToPiKP(candidate));
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPtVsMult"), hfHelper.invMassLcToPiKP(candidate), pt, multiplicity);
+        registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hMassVsPt"), hfHelper.invMassLcToPiKP(candidate), pt);
+      }
+      
+      
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hYieldsCandidate"), multiplicity, candidate.pt(), candidate.eta());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hEtaPhiCandidate"), multiplicity, candidate.eta(), phi);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hNtracksCandidate"), multiplicity);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPt"), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng0"), ptProng0);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng1"), ptProng1);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPtProng2"), ptProng2);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong0"), candidate.impactParameter0());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong1"), candidate.impactParameter1());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0Prong2"), candidate.impactParameter2());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng0"), candidate.impactParameter0(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng1"), candidate.impactParameter1(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hd0VsPtProng2"), candidate.impactParameter2(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLength"), decayLength);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthVsPt"), decayLength, pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthxy"), decayLengthXY);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLengthxyVsPt"), decayLengthXY, pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCt"), hfHelper.ctLc(candidate));
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCtVsPt"), hfHelper.ctLc(candidate), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPA"), cpa);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAVsPt"), cpa, pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAxy"), cpaXY);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hCPAxyVsPt"), cpaXY, pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDca2"), chi2PCA);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDca2VsPt"), chi2PCA, pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hEta"), candidate.eta());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hEtaVsPt"), candidate.eta(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPhi"), candidate.phi());
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hPhiVsPt"), candidate.phi(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hSelectionStatus"), candidate.isSelLcToPKPi(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hSelectionStatus"), candidate.isSelLcToPiKP(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng0"), candidate.errorImpactParameter0(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng1"), candidate.errorImpactParameter1(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hImpParErrProng2"), candidate.errorImpactParameter2(), pt);
+      registry.fill(HIST("Data/TpcMft/HfHadron/SameEvent/3Prong/hDecLenErr"), candidate.errorDecayLength(), pt);
     }
   }
 
@@ -958,7 +1153,13 @@ struct HfTaskFlow {
           continue;
         }
         fillingHFcontainer = true;
-        invmass = hfHelper.invMassD0ToPiK(track1);
+        if constexpr (std::is_same_v<HfCandidatesSelD0, TTracksTrig>) { // If D0
+          invmass = hfHelper.invMassD0ToPiK(track1);
+          // Should add D0 bar ?
+        } else { // If Lc
+          invmass = hfHelper.invMassLcToPKPi(track1);
+          // Should add Lc bar ? (maybe not its the same mass right ?)
+        }
       }
 
       // From Katarina's code
@@ -981,6 +1182,13 @@ struct HfTaskFlow {
 
       for (const auto& track2 : tracks2) {
 
+        // apply cuts for MFT tracks
+        if constexpr (std::is_same_v<aod::MFTTracks, TTracksAssoc>) {
+          if (!isAcceptedMftTrack(track2)) {
+            continue;
+          }
+        }
+
         //  case of h-h correlations where the two types of tracks are the same
         //  this avoids autocorrelations and double counting of particle pairs
         if constexpr (std::is_same_v<TTracksAssoc, TTracksTrig>) {
@@ -992,8 +1200,13 @@ struct HfTaskFlow {
         //  in case of HF-h correlations, remove candidate daughters from the pool of associated hadrons
         //  with which the candidate is being correlated (will not have to do it for TPC-MFT case)
         if constexpr (!std::is_same_v<aod::MFTTracks, TTracksAssoc>) { // if NOT TPC-MFT case -> TPC-TPC case
-          if constexpr (std::is_same_v<HfCandidatesSelD0, TTracksTrig> || std::is_same_v<HfCandidatesSelLc, TTracksTrig>) {
+          if constexpr (std::is_same_v<HfCandidatesSelD0, TTracksTrig>) { // Remove the 2 prong daughters
             if ((track1.prong0Id() == track2.globalIndex()) || (track1.prong1Id() == track2.globalIndex())) {
+              continue;
+            }
+          }
+          if constexpr (std::is_same_v<HfCandidatesSelLc, TTracksTrig>) { // Remove the 3 prong daughters
+            if ((track1.prong0Id() == track2.globalIndex()) || (track1.prong1Id() == track2.globalIndex()) || (track1.prong2Id() == track2.globalIndex())) {
               continue;
             }
           }
@@ -1100,7 +1313,7 @@ struct HfTaskFlow {
       }
 
       corrContainer->fillEvent(multiplicityTracks2, CorrelationContainer::kCFStepReconstructed);
-      fillCorrelations<CorrelationContainer::kCFStepReconstructed>(corrContainer, tracks1, tracks2, multiplicityTracks1, collision1.posZ());
+      fillCorrelations<CorrelationContainer::kCFStepReconstructed>(corrContainer, tracks1, tracks2, multiplicityTracks2, collision1.posZ());
     }
   }
 
@@ -1357,7 +1570,7 @@ struct HfTaskFlow {
     //}
 
     // if (!collision.has_mcCollision()) {
-    //   LOGF(warning, "No MC collision for this collision, skip...");
+    //   LOGF(info, "No MC collision for this collision, skip...");
     //   return;
     // }
 
@@ -1491,6 +1704,7 @@ struct HfTaskFlow {
                               HfCandidatesSelLc const& candidates,
                               aod::MFTTracks const& mftTracks)
   {
+
     //  we want to group collisions based on charged-track multiplicity
     auto getTracksSize = [&candidates, this](FilteredCollisionsWSelMult::iterator const& col) {
       // Still o2::aod::track::collisionId with HF ??? -> I don't think so

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -111,7 +111,7 @@ struct HfTaskMcValidationGen {
   AxisSpec axisResiduals{100, -0.01, 0.01};
   AxisSpec axisPt{100, 0., 50.};
   AxisSpec axisY{100, -5., 5.};
-  AxisSpec axisCent{100, 0., 100.};
+  AxisSpec axisCent{110, 0., 110.};
   AxisSpec axisMesonSpecies{nMesonChannels, -0.5, static_cast<float>(nMesonChannels) - 0.5};
   AxisSpec axisBaryonSpecies{nChannels - nMesonChannels, -0.5, static_cast<float>(nChannels - nMesonChannels) - 0.5};
   AxisSpec axisDecLen{100, 0., 10000.};
@@ -132,19 +132,19 @@ struct HfTaskMcValidationGen {
      {"Quarks/hPtVsYCharmQuark", "Y vs. Pt - charm quarks ; #it{p}_{T}^{gen} (GeV/#it{c}); #it{y}^{gen}", {HistType::kTH2F, {axisPt, axisY}}},
      {"Quarks/hPtVsYBeautyQuark", "Y vs. Pt - beauty quarks ; #it{p}_{T}^{gen} (GeV/#it{c}); #it{y}^{gen}", {HistType::kTH2F, {axisPt, axisY}}},
      {"PromptCharmMesons/hPromptMesonsPtDistr", "Pt distribution vs prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c})", {HistType::kTH2F, {axisMesonSpecies, axisPt}}},
-     {"PromptCharmMesons/hPromptMesonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%);", {HistType::kTH3F, {axisMesonSpecies, axisPt, axisCent}}},
+     {"PromptCharmMesons/hPromptMesonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%)", {HistType::kTH3F, {axisMesonSpecies, axisPt, axisCent}}},
      {"PromptCharmMesons/hPromptMesonsYDistr", "Y distribution vs prompt charm meson; ; #it{y}^{gen}", {HistType::kTH2F, {axisMesonSpecies, axisY}}},
      {"PromptCharmMesons/hPromptMesonsDecLenDistr", "Decay length distribution vs prompt charm meson; ; decay length (#mum)", {HistType::kTH2F, {axisMesonSpecies, axisDecLen}}},
      {"NonPromptCharmMesons/hNonPromptMesonsPtDistr", "Pt distribution vs non-prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c})", {HistType::kTH2F, {axisMesonSpecies, axisPt}}},
-     {"NonPromptCharmMesons/hNonPromptMesonsPtCentDistr", "Pt vs Cent vs distribution vs non-prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%);", {HistType::kTH3F, {axisMesonSpecies, axisPt, axisCent}}},
+     {"NonPromptCharmMesons/hNonPromptMesonsPtCentDistr", "Pt vs Cent vs distribution vs non-prompt charm meson in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%)", {HistType::kTH3F, {axisMesonSpecies, axisPt, axisCent}}},
      {"NonPromptCharmMesons/hNonPromptMesonsYDistr", "Y distribution vs non-prompt charm meson; ; #it{y}^{gen}", {HistType::kTH2F, {axisMesonSpecies, axisY}}},
      {"NonPromptCharmMesons/hNonPromptMesonsDecLenDistr", "Decay length distribution vs non-prompt charm meson; ; decay length (#mum)", {HistType::kTH2F, {axisMesonSpecies, axisDecLen}}},
      {"PromptCharmBaryons/hPromptBaryonsPtDistr", "Pt distribution vs prompt charm baryon in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c})", {HistType::kTH2F, {axisBaryonSpecies, axisPt}}},
-     {"PromptCharmBaryons/hPromptBaryonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm baryons in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%);", {HistType::kTH3F, {axisBaryonSpecies, axisPt, axisCent}}},
+     {"PromptCharmBaryons/hPromptBaryonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm baryons in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%)", {HistType::kTH3F, {axisBaryonSpecies, axisPt, axisCent}}},
      {"PromptCharmBaryons/hPromptBaryonsYDistr", "Y distribution vs prompt charm baryon; ; #it{y}^{gen}", {HistType::kTH2F, {axisBaryonSpecies, axisY}}},
      {"PromptCharmBaryons/hPromptBaryonsDecLenDistr", "Decay length distribution vs prompt charm baryon; ; decay length (#mum)", {HistType::kTH2F, {axisBaryonSpecies, axisDecLen}}},
      {"NonPromptCharmBaryons/hNonPromptBaryonsPtDistr", "Pt distribution vs non-prompt charm baryon in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c})", {HistType::kTH2F, {axisBaryonSpecies, axisPt}}},
-     {"NonPromptCharmBaryons/hNonPromptBaryonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm baryons in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%);", {HistType::kTH3F, {axisBaryonSpecies, axisPt, axisCent}}},
+     {"NonPromptCharmBaryons/hNonPromptBaryonsPtCentDistr", "Pt vs Cent vs distribution vs prompt charm baryons in |#it{y}^{gen}|<0.5; ; #it{p}_{T}^{gen} (GeV/#it{c}); Centrality (%)", {HistType::kTH3F, {axisBaryonSpecies, axisPt, axisCent}}},
      {"NonPromptCharmBaryons/hNonPromptBaryonsYDistr", "Y distribution vs non-prompt charm baryon; ; #it{y}^{gen}", {HistType::kTH2F, {axisBaryonSpecies, axisY}}},
      {"NonPromptCharmBaryons/hNonPromptBaryonsDecLenDistr", "Decay length distribution vs non-prompt charm baryon; ; decay length (#mum)", {HistType::kTH2F, {axisBaryonSpecies, axisDecLen}}}}};
 
@@ -210,7 +210,7 @@ struct HfTaskMcValidationGen {
     registry.fill(HIST("hNevGen"), 1);
 
     // Slice the collisions table to get the collision info for the current MC collision
-    float centrality{-1.f};
+    float centrality{105.f};
     uint16_t rejectionMask{0};
     if constexpr (centEstimator == CentralityEstimator::FT0C) {
       rejectionMask = hfEvSelMc.getHfMcCollisionRejectionMask<BCsInfo, centEstimator>(mcCollision, recoCollisions, centrality);
@@ -540,7 +540,7 @@ struct HfTaskMcValidationRec {
   AxisSpec axisEta{40, -1., 1.};
   AxisSpec axisPt{50, 0., 10.};
   AxisSpec axisPtD{100, 0., 50.};
-  AxisSpec axisCent{100, 0., 100.};
+  AxisSpec axisCent{110, 0., 110.};
   AxisSpec axisDeltaVtx{200, -1, 1.};
   AxisSpec axisDecision{2, -0.5, 1.5};
   AxisSpec axisITShits{8, -0.5, 7.5};
@@ -936,7 +936,7 @@ struct HfTaskMcValidationRec {
     // loop over collisions
     for (const auto& collision : collisions) {
       // apply event selection
-      float centrality{-1.f};
+      float centrality{105.f};
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, centEstimator, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry); // only needed to update centrality, no bitmask selection applied
       if (!collision.has_mcCollision()) {
         return;


### PR DESCRIPTION
In this PR, I added : 
- Lc-h correlations for TPC-TPC case
- Lc-h correlations for TPC-MFT case
- QA plots associated with the respective cases
- Eta cut on MFT tracks (configurable, min and max)
- Cut on the number of clusters of the reconstructed track (configurable, min) 

Concerning Lc-h correlations, it is basically a copy/paste of D0-h correlations. 