### PR TITLE
[PWGHF] Developments for charm resonances workflow

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -786,8 +786,10 @@ DECLARE_SOA_TABLE(HfRed3PrNoTrks, "AOD", "HFRED3PRNOTRK", //! Table with 3 prong
                   hf_track_vars_reduced::EtaProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_track_vars_reduced::EtaProng2<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>,
                   hf_reso_3_prong::InvMassDplus<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>,
-                  hf_reso_3_prong::InvMassDstar<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2, hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
-                  hf_reso_3_prong::InvMassAntiDstar<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2, hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_cand_dstar::InvMassDstar<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2, hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_cand_dstar::InvMassAntiDstar<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2, hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_cand_dstar::InvMassD0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_cand_dstar::InvMassD0Bar<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_reso_3_prong::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PxProng2, hf_cand::PyProng0, hf_cand::PyProng1, hf_cand::PyProng2>);
 
 namespace hf_reso_cand_reduced
@@ -795,6 +797,8 @@ namespace hf_reso_cand_reduced
 DECLARE_SOA_COLUMN(InvMass, invMass, float);                               //! Invariant mass in GeV/c2
 DECLARE_SOA_COLUMN(InvMassProng0, invMassProng0, float);                   //! Invariant Mass of D daughter in GeV/c
 DECLARE_SOA_COLUMN(InvMassProng1, invMassProng1, float);                   //! Invariant Mass of V0 daughter in GeV/c
+DECLARE_SOA_COLUMN(InvMassD0, invMassD0, float);                            //! Invariant Mass of potential D0 daughter
+
 DECLARE_SOA_COLUMN(MlScoreBkgProng0, mlScoreBkgProng0, float);             //! Bkg ML score of the D daughter
 DECLARE_SOA_COLUMN(MlScorePromptProng0, mlScorePromptProng0, float);       //! Prompt ML score of the D daughter
 DECLARE_SOA_COLUMN(MlScoreNonpromptProng0, mlScoreNonpromptProng0, float); //! Nonprompt ML score of the D daughter
@@ -823,10 +827,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStarXiC3055, cosThetaStarXiC3055, //! costhet
 
 DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Resonance candidate information for resonances reduced workflow
                   o2::soa::Index<>,
-                  // Indices
                   hf_track_index_reduced::HfRedCollisionId,
-                  hf_reso_cand_reduced::Prong0Id,
-                  hf_reso_cand_reduced::Prong1Id,
                   // Static
                   hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0,
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
@@ -836,6 +837,7 @@ DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Reso
                   hf_reso_v0::Cpa,
                   hf_reso_v0::Dca,
                   hf_reso_v0::Radius,
+                  hf_reso_cand_reduced::InvMassD0,
                   // Dynamic
                   hf_reso_cand_reduced::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PyProng0, hf_cand::PyProng1>,
                   hf_reso_cand_reduced::PtProng0<hf_cand::PxProng0, hf_cand::PyProng0>,
@@ -845,6 +847,10 @@ DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Reso
                   hf_reso_cand_reduced::CosThetaStarDs1<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_reso_cand_reduced::InvMass>,
                   hf_reso_cand_reduced::CosThetaStarDs2Star<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_reso_cand_reduced::InvMass>,
                   hf_reso_cand_reduced::CosThetaStarXiC3055<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_reso_cand_reduced::InvMass>);
+
+DECLARE_SOA_TABLE(HfResoIndices, "AOD", "HFRESOINDICES", //! Table with Indices of resonance daughters for MC matching
+                  hf_reso_cand_reduced::Prong0Id,
+                  hf_reso_cand_reduced::Prong1Id);
 
 DECLARE_SOA_TABLE(HfCharmResoMLs, "AOD", "HFCHARMRESOML", //! Table with ML scores for the D daughter
                   hf_reso_cand_reduced::MlScoreBkgProng0,

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -676,12 +676,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //!
                            [](float pxProng0, float pxProng1, float pxProng2, float pyProng0, float pyProng1, float pyProng2) -> float { return RecoDecay::pt((1.f * pxProng0 + 1.f * pxProng1 + 1.f * pxProng2), (1.f * pyProng0 + 1.f * pyProng1 + 1.f * pyProng2)); });
 DECLARE_SOA_DYNAMIC_COLUMN(InvMassDplus, invMassDplus,
                            [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2) -> float { return RecoDecay::m(std::array{std::array{px0, py0, pz0}, std::array{px1, py1, pz1}, std::array{px2, py2, pz2}}, std::array{constants::physics::MassPiPlus, constants::physics::MassKPlus, constants::physics::MassPiPlus}); });
-DECLARE_SOA_DYNAMIC_COLUMN(InvMassDstar, invMassDstar,
-                           [](float pxSoftPi, float pySoftPi, float pzSoftPi, float pxProng0, float pyProng0, float pzProng0, float pxProng1, float pyProng1, float pzProng1)
-                             -> float { return RecoDecay::m(std::array{std::array{pxSoftPi, pySoftPi, pzSoftPi}, std::array{pxProng0, pyProng0, pzProng0}, std::array{pxProng1, pyProng1, pzProng1}}, std::array{constants::physics::MassPiPlus, constants::physics::MassPiPlus, constants::physics::MassKPlus}) - RecoDecay::m(std::array{std::array{pxProng0, pyProng0, pzProng0}, std::array{pxProng1, pyProng1, pzProng1}}, std::array{constants::physics::MassPiPlus, constants::physics::MassKPlus}); });
-DECLARE_SOA_DYNAMIC_COLUMN(InvMassAntiDstar, invMassAntiDstar,
-                           [](float pxSoftPi, float pySoftPi, float pzSoftPi, float pxProng0, float pyProng0, float pzProng0, float pxProng1, float pyProng1, float pzProng1)
-                             -> float { return RecoDecay::m(std::array{std::array{pxSoftPi, pySoftPi, pzSoftPi}, std::array{pxProng0, pyProng0, pzProng0}, std::array{pxProng1, pyProng1, pzProng1}}, std::array{constants::physics::MassPiPlus, constants::physics::MassKPlus, constants::physics::MassPiPlus}) - RecoDecay::m(std::array{std::array{pxProng0, pyProng0, pzProng0}, std::array{pxProng1, pyProng1, pzProng1}}, std::array{constants::physics::MassKPlus, constants::physics::MassPiPlus}); });
+DECLARE_SOA_DYNAMIC_COLUMN(PVector, pVector,
+                           [](float px0, float py0, float pz0, float px1, float py1, float pz1, float px2, float py2, float pz2) -> std::array<float, 3> { return std::array{px0 + px1 + px2, py0 + py1 + py2, pz0 + pz1 + pz2}; });
 } // namespace hf_reso_3_prong
 
 namespace hf_reso_v0
@@ -707,6 +703,8 @@ DECLARE_SOA_DYNAMIC_COLUMN(InvMassAntiLambda, invMassAntiLambda, //! mass under 
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton}); });
 DECLARE_SOA_DYNAMIC_COLUMN(InvMassK0s, invMassK0s, //! mass under K0short hypothesis
                            [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float { return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged}); });
+DECLARE_SOA_DYNAMIC_COLUMN(PVector, pVector,
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> std::array<float, 3> { return std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg}; });
 } // namespace hf_reso_v0
 
 DECLARE_SOA_TABLE(HfRedVzeros, "AOD", "HFREDVZERO", //! Table with V0 candidate information for resonances reduced workflow
@@ -735,7 +733,8 @@ DECLARE_SOA_TABLE(HfRedVzeros, "AOD", "HFREDVZERO", //! Table with V0 candidate 
                   hf_reso_v0::V0Radius<hf_cand::XSecondaryVertex, hf_cand::YSecondaryVertex>,
                   hf_reso_v0::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PyProng0, hf_cand::PyProng1>,
                   hf_cand::PVectorProng0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0>,
-                  hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>);
+                  hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_reso_v0::PVector<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>);
 
 DECLARE_SOA_TABLE(HfRedTrkNoParams, "AOD", "HFREDTRKNOPARAM", //! Table with tracks without track parameters for resonances reduced workflow
                   o2::soa::Index<>,
@@ -795,7 +794,8 @@ DECLARE_SOA_TABLE(HfRed3PrNoTrks, "AOD", "HFRED3PRNOTRK", //! Table with 3 prong
                   hf_reso_3_prong::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PxProng2, hf_cand::PyProng0, hf_cand::PyProng1, hf_cand::PyProng2>,
                   hf_cand::PVectorProng0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0>,
                   hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
-                  hf_cand::PVectorProng2<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>);
+                  hf_cand::PVectorProng2<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>,
+                  hf_reso_3_prong::PVector<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>);
 
 namespace hf_reso_cand_reduced
 {
@@ -832,7 +832,6 @@ DECLARE_SOA_DYNAMIC_COLUMN(CosThetaStarXiC3055, cosThetaStarXiC3055, //! costhet
 
 DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Resonance candidate information for resonances reduced workflow
                   o2::soa::Index<>,
-                  hf_track_index_reduced::HfRedCollisionId,
                   // Static
                   hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0,
                   hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1,
@@ -847,6 +846,9 @@ DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Reso
                   hf_reso_cand_reduced::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PyProng0, hf_cand::PyProng1>,
                   hf_reso_cand_reduced::PtProng0<hf_cand::PxProng0, hf_cand::PyProng0>,
                   hf_reso_cand_reduced::PtProng1<hf_cand::PxProng1, hf_cand::PyProng1>,
+                  hf_reso_v0::Px<hf_cand::PxProng0, hf_cand::PxProng1>,
+                  hf_reso_v0::Py<hf_cand::PyProng0, hf_cand::PyProng1>,
+                  hf_reso_v0::Pz<hf_cand::PzProng0, hf_cand::PzProng1>,
                   hf_cand::PVectorProng0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0>,
                   hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_reso_cand_reduced::CosThetaStarDs1<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_reso_cand_reduced::InvMass>,
@@ -854,6 +856,7 @@ DECLARE_SOA_TABLE(HfCandCharmReso, "AOD", "HFCANDCHARMRESO", //! Table with Reso
                   hf_reso_cand_reduced::CosThetaStarXiC3055<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1, hf_reso_cand_reduced::InvMass>);
 
 DECLARE_SOA_TABLE(HfResoIndices, "AOD", "HFRESOINDICES", //! Table with Indices of resonance daughters for MC matching
+                  hf_track_index_reduced::HfRedCollisionId,
                   hf_reso_cand_reduced::Prong0Id,
                   hf_reso_cand_reduced::Prong1Id);
 

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -733,7 +733,9 @@ DECLARE_SOA_TABLE(HfRedVzeros, "AOD", "HFREDVZERO", //! Table with V0 candidate 
                   hf_reso_v0::InvMassLambda<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_reso_v0::InvMassAntiLambda<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_reso_v0::V0Radius<hf_cand::XSecondaryVertex, hf_cand::YSecondaryVertex>,
-                  hf_reso_v0::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PyProng0, hf_cand::PyProng1>);
+                  hf_reso_v0::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PyProng0, hf_cand::PyProng1>,
+                  hf_cand::PVectorProng0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0>,
+                  hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>);
 
 DECLARE_SOA_TABLE(HfRedTrkNoParams, "AOD", "HFREDTRKNOPARAM", //! Table with tracks without track parameters for resonances reduced workflow
                   o2::soa::Index<>,
@@ -790,7 +792,10 @@ DECLARE_SOA_TABLE(HfRed3PrNoTrks, "AOD", "HFRED3PRNOTRK", //! Table with 3 prong
                   hf_cand_dstar::InvMassAntiDstar<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2, hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_cand_dstar::InvMassD0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
                   hf_cand_dstar::InvMassD0Bar<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0, hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
-                  hf_reso_3_prong::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PxProng2, hf_cand::PyProng0, hf_cand::PyProng1, hf_cand::PyProng2>);
+                  hf_reso_3_prong::Pt<hf_cand::PxProng0, hf_cand::PxProng1, hf_cand::PxProng2, hf_cand::PyProng0, hf_cand::PyProng1, hf_cand::PyProng2>,
+                  hf_cand::PVectorProng0<hf_cand::PxProng0, hf_cand::PyProng0, hf_cand::PzProng0>,
+                  hf_cand::PVectorProng1<hf_cand::PxProng1, hf_cand::PyProng1, hf_cand::PzProng1>,
+                  hf_cand::PVectorProng2<hf_cand::PxProng2, hf_cand::PyProng2, hf_cand::PzProng2>);
 
 namespace hf_reso_cand_reduced
 {

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -80,6 +80,8 @@ struct HfCandidateCreatorCharmResoReduced {
   Produces<aod::HfCandChaResTr> rowCandidateResoTrack;
   // Optional daughter ML scores table
   Produces<aod::HfCharmResoMLs> mlScores;
+  // Table with candidate indices for MC matching
+  Produces<aod::HfResoIndices> rowCandidateResoIndices;
 
   // Configurables
   Configurable<bool> rejectDV0PairsWithCommonDaughter{"rejectDV0PairsWithCommonDaughter", true, "flag to reject the pairs that share a daughter track if not done in the derived data creation"};
@@ -91,15 +93,20 @@ struct HfCandidateCreatorCharmResoReduced {
   Configurable<LabeledArray<double>> cutsD{"cutsDdaughter", {hf_cuts_d_daughter::cuts[0], hf_cuts_d_daughter::nBinsPt, hf_cuts_d_daughter::nCutVars, hf_cuts_d_daughter::labelsPt, hf_cuts_d_daughter::labelsCutVar}, "D daughter selections"};
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{hf_cuts_d_daughter::vecBinsPt}, "pT bin limits for D daughter cuts"};
   Configurable<LabeledArray<double>> cutsV0{"cutsV0daughter", {hf_cuts_v0_daughter::cuts[0], hf_cuts_v0_daughter::nBinsPt, hf_cuts_v0_daughter::nCutVars, hf_cuts_v0_daughter::labelsPt, hf_cuts_v0_daughter::labelsCutVar}, "V0 daughter selections"};
-
   Configurable<std::vector<double>> binsPtV0{"binsPtV0", std::vector<double>{hf_cuts_v0_daughter::vecBinsPt}, "pT bin limits for V0 daughter cuts"};
-
+  // Configurables for ME
+  Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "Number of events mixed in ME process"};
+  Configurable<int> numberEventsToSkip{"numberEventsToSkip", -1, "Number of events to Skip in ME process"};
+  ConfigurableAxis multPoolBins{"multPoolBins", {VARIABLE_WIDTH, 0., 45., 60., 75., 95, 250}, "event multiplicity pools (PV contributors for now)"};
+  ConfigurableAxis zPoolBins{"zPoolBins", {VARIABLE_WIDTH, -10.0, -4, -1, 1, 4, 10.0}, "z vertex position pools"};
+  
   using reducedDWithMl = soa::Join<aod::HfRed3PrNoTrks, aod::HfRed3ProngsMl>;
 
   // Partition of V0 candidates based on v0Type
   Partition<aod::HfRedVzeros> candidatesK0s = aod::hf_reso_v0::v0Type == (uint8_t)1 || aod::hf_reso_v0::v0Type == (uint8_t)3 || aod::hf_reso_v0::v0Type == (uint8_t)5;
   Partition<aod::HfRedVzeros> candidatesLambda = aod::hf_reso_v0::v0Type == (uint8_t)2 || aod::hf_reso_v0::v0Type == (uint8_t)4;
 
+  SliceCache cache;
   Preslice<aod::HfRedVzeros> candsV0PerCollision = aod::hf_track_index_reduced::hfRedCollisionId;
   Preslice<aod::HfRedTrkNoParams> candsTrackPerCollision = aod::hf_track_index_reduced::hfRedCollisionId;
   Preslice<aod::HfRed3PrNoTrks> candsDPerCollision = hf_track_index_reduced::hfRedCollisionId;
@@ -117,7 +124,8 @@ struct HfCandidateCreatorCharmResoReduced {
   void init(InitContext const&)
   {
     // check that only one process function is enabled
-    std::array<bool, 10> doprocess{doprocessDs2StarToDplusK0s, doprocessDs2StarToDplusK0sWithMl, doprocessDs1ToDstarK0s, doprocessDs1ToDstarK0sWithMl, doprocessXcToDplusLambda, doprocessXcToDplusLambdaWithMl, doprocessLambdaDminus, doprocessLambdaDminusWithMl, doprocessDstarTrack, doprocessDstarTrackWithMl};
+    std::array<bool, 14> doprocess{doprocessDs2StarToDplusK0s, doprocessDs2StarToDplusK0sWithMl, doprocessDs1ToDstarK0s, doprocessDs1ToDstarK0sWithMl, doprocessDs1ToDstarK0sMixedEvent, doprocessDs1ToDstarK0sMixedEventWithMl, doprocessDs2StarToDplusK0sMixedEventWithMl,
+                                   doprocessXcToDplusLambda, doprocessXcToDplusLambdaWithMl, doprocessLambdaDminus, doprocessLambdaDminusWithMl, doprocessDstarTrack, doprocessDstarTrackWithMl};
     if ((std::accumulate(doprocess.begin(), doprocess.end(), 0)) != 1) {
       LOGP(fatal, "Only one process function should be enabled! Please check your configuration!");
     }
@@ -128,6 +136,10 @@ struct HfCandidateCreatorCharmResoReduced {
     registry.add("hMassXcRes", "XcRes candidates; m_XcRes (GeV/#it{c}^{2}) ;entries", {HistType::kTH2F, {{100, 2.9, 3.3}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hMassLambdaDminus", "LambdaDminus candidates; m_LambdaDminus (GeV/#it{c}^{2}) ;entries", {HistType::kTH2F, {{100, 2.9, 3.3}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hMassDstarTrack", "DstarTrack candidates; m_DstarTrack (GeV/#it{c}^{2}) ;entries", {HistType::kTH2F, {{100, 0.9, 1.4}, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    if (doprocessDs1ToDstarK0sMixedEvent) {
+      registry.add("hNPvContCorr", "Collision number of PV contributors ; N contrib ; N contrib", {HistType::kTH2F, {{100, 0, 250}, {100, 0, 250}}});
+      registry.add("hZvertCorr", "Collision Z Vtx ; z PV [cm] ; z PV [cm]", {HistType::kTH2F, {{120, -12., 12.}, {120, -12., 12.}}});
+    }
 
     if (activateQA) {
       constexpr int kNBinsSelections = Selections::NSelSteps;
@@ -167,9 +179,9 @@ struct HfCandidateCreatorCharmResoReduced {
       invMassD = candD.invMassDplus();
     } else if (channel == DecayChannel::Ds1ToDstarK0s || channel == DecayChannel::DstarTrack) {
       if (candD.dType() > 0)
-        invMassD = candD.invMassDstar();
+        invMassD = candD.invMassDstar() - candD.invMassD0();
       else
-        invMassD = candD.invMassAntiDstar();
+        invMassD = candD.invMassAntiDstar() - candD.invMassD0Bar();
     }
     // invariant mass selection
     if (!keepSideBands) {
@@ -251,15 +263,19 @@ struct HfCandidateCreatorCharmResoReduced {
         registry.fill(HIST("hSelections"), 1 + Selections::DSel);
       }
       float invMassD{0.};
+      float invMassD0{0.};
       if (std::abs(candD.dType()) == 1)
         invMassD = candD.invMassDplus();
-      if (candD.dType() == 2)
+      if (candD.dType() == 2){
         invMassD = candD.invMassDstar();
-      if (candD.dType() == -2)
+        invMassD0 = candD.invMassD0();
+      }     
+      if (candD.dType() == -2){
         invMassD = candD.invMassAntiDstar();
+        invMassD0 = candD.invMassD0Bar();
+      }
       std::array<float, 3> pVecD = {candD.px(), candD.py(), candD.pz()};
       std::array<int, 3> dDaughtersIds = {candD.prong0Id(), candD.prong1Id(), candD.prong2Id()};
-
       // loop on V0 or track candidates
       bool alreadyCounted{false};
       for (const auto& candV0Tr : candsV0Tr) {
@@ -332,11 +348,9 @@ struct HfCandidateCreatorCharmResoReduced {
           rowCandidateResoTrack(pVecD[0], pVecD[1], pVecD[2],
                                 candV0Tr.px(), candV0Tr.py(), candV0Tr.pz(),
                                 invMassReso,
-                                invMassD);
+                                invMassD - invMassD0);
         } else {
           rowCandidateReso(collision.globalIndex(),
-                           candD.globalIndex(),
-                           candV0Tr.globalIndex(),
                            pVecD[0], pVecD[1], pVecD[2],
                            pVecV0Tr[0], pVecV0Tr[1], pVecV0Tr[2],
                            invMassReso,
@@ -344,7 +358,10 @@ struct HfCandidateCreatorCharmResoReduced {
                            invMassV0,
                            candV0Tr.cpa(),
                            candV0Tr.dca(),
-                           candV0Tr.v0Radius());
+                           candV0Tr.v0Radius(),
+                           invMassD0);
+          rowCandidateResoIndices(candD.globalIndex(),
+                                  candV0Tr.globalIndex());
         }
         if constexpr (fillMl) {
           mlScores(candD.mlScoreBkgMassHypo0(), candD.mlScorePromptMassHypo0(), candD.mlScoreNonpromptMassHypo0());
@@ -352,7 +369,100 @@ struct HfCandidateCreatorCharmResoReduced {
       }
     }
   } // main function
+  // Process data with Mixed Event
+  /// \tparam fillMl is a flag to Fill ML scores if present
+  /// \tparam channel is the decay channel of the Resonance
+  /// \param Coll is the reduced collisions table
+  /// \param DRedTable is the D bachelors table
+  /// \param V0TrRedTable is the V0/Track bachelors table
+  template <bool fillMl, DecayChannel channel, typename Coll, typename DRedTable, typename V0TrRedTable>
+  void runCandidateCreationMixedEvent(Coll const& collisions,
+                                      DRedTable const& candsD,
+                                      V0TrRedTable const& candsV0Tr)
+  {
+    using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::collision::NumContrib>;
+    BinningType corrBinning{{zPoolBins, multPoolBins}, true};
+    auto bachTuple = std::make_tuple(candsD,candsV0Tr);
+    Pair<Coll, DRedTable, V0TrRedTable, BinningType> pairs{corrBinning, numberEventsMixed, numberEventsToSkip, collisions, bachTuple, &cache};
+    for (const auto& [collision1, bachDs, collision2, bachV0Trs] : pairs){
+      registry.fill(HIST("hNPvContCorr"), collision1.numContrib(), collision2.numContrib());
+      registry.fill(HIST("hZvertCorr"), collision1.posZ(), collision2.posZ());
+      for (const auto& [bachD, bachV0Tr] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(bachDs, bachV0Trs))){
+        // Apply analysis selections on D and V0 bachelors
+        if (!isDSelected<channel>(bachD) || !isV0Selected<channel>(bachV0Tr, bachD)) {
+          continue;
+        }
+        // Retrieve D and V0 informations
+        float invMassD{0.};
+        float invMassD0{0.};
+        if (std::abs(bachD.dType()) == 1)
+          invMassD = bachD.invMassDplus();
+        if (bachD.dType() == 2){
+          invMassD = bachD.invMassDstar();
+          invMassD0 = bachD.invMassD0();
+        }     
+        if (bachD.dType() == -2){
+          invMassD = bachD.invMassAntiDstar();
+          invMassD0 = bachD.invMassD0Bar();
+        }
+        std::array<float, 3> pVecD = {bachD.px(), bachD.py(), bachD.pz()};
+        float invMassReso{0.};
+        float invMassV0{0.};
+        std::array<float, 3> pVecV0Tr = {bachV0Tr.px(), bachV0Tr.py(), bachV0Tr.pz()};
+        float ptReso = RecoDecay::pt(RecoDecay::sumOfVec(pVecV0Tr, pVecD));
+        switch (channel) {
+          case DecayChannel::Ds1ToDstarK0s:
+            invMassV0 = bachV0Tr.invMassK0s();
+            invMassReso = RecoDecay::m(std::array{pVecD, pVecV0Tr}, std::array{massDstar, massK0});
+            registry.fill(HIST("hMassDs1"), invMassReso, ptReso);
+            break;
+          case DecayChannel::Ds2StarToDplusK0s:
+            invMassV0 = bachV0Tr.invMassK0s();
+            invMassReso = RecoDecay::m(std::array{pVecD, pVecV0Tr}, std::array{massDplus, massK0});
+            registry.fill(HIST("hMassDs2Star"), invMassReso, ptReso);
+            break;
+          case DecayChannel::XcToDplusLambda:
+            if (bachD.dType() > 0) {
+              invMassV0 = bachV0Tr.invMassLambda();
+            } else {
+              invMassV0 = bachV0Tr.invMassAntiLambda();
+            }
+            invMassReso = RecoDecay::m(std::array{pVecD, pVecV0Tr}, std::array{massDplus, massLambda});
+            registry.fill(HIST("hMassXcRes"), invMassReso, ptReso);
+            break;
+          case DecayChannel::LambdaDminus:
+            if (bachD.dType() < 0) {
+              invMassV0 = bachV0Tr.invMassLambda();
+            } else {
+              invMassV0 = bachV0Tr.invMassAntiLambda();
+            }
+            invMassReso = RecoDecay::m(std::array{pVecD, pVecV0Tr}, std::array{massDplus, massLambda});
+            registry.fill(HIST("hMassLambdaDminus"), invMassReso, ptReso);
+            break;
+          default:
+            break;
+        }
+        // Fill output table
+        rowCandidateReso(collision1.globalIndex(),
+                          pVecD[0], pVecD[1], pVecD[2],
+                          pVecV0Tr[0], pVecV0Tr[1], pVecV0Tr[2],
+                          invMassReso,
+                          invMassD,
+                          invMassV0,
+                          bachV0Tr.cpa(),
+                          bachV0Tr.dca(),
+                          bachV0Tr.v0Radius(),
+                          invMassD0);
+        rowCandidateResoIndices(bachD.globalIndex(),
+                                bachV0Tr.globalIndex());
+        if constexpr (fillMl) {
+          mlScores(bachD.mlScoreBkgMassHypo0(), bachD.mlScorePromptMassHypo0(), bachD.mlScoreNonpromptMassHypo0());
+        }
+      }
+    }
+  } // runCandidateCreationMixedEvent
 
+  // List of Process Functions
   void processDs2StarToDplusK0s(aod::HfRedCollisions const& collisions,
                                 aod::HfRed3PrNoTrks const& candsD,
                                 aod::HfRedVzeros const&)
@@ -379,6 +489,22 @@ struct HfCandidateCreatorCharmResoReduced {
   }
   PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs2StarToDplusK0sWithMl, "Process Ds2* candidates with Ml info", false);
 
+  void processDs2StarToDplusK0sMixedEvent(aod::HfRedCollisions const& collisions,
+                                      aod::HfRed3PrNoTrks const& candsD,
+                                      aod::HfRedVzeros const& candsV0)
+  {
+    runCandidateCreationMixedEvent<false, DecayChannel::Ds2StarToDplusK0s>(collisions, candsD, candsV0);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs2StarToDplusK0sMixedEvent, "Process Ds2Star mixed Event without ML", false);
+
+  void processDs2StarToDplusK0sMixedEventWithMl(aod::HfRedCollisions const& collisions,
+                                      reducedDWithMl const& candsD,
+                                      aod::HfRedVzeros const& candsV0)
+  {
+    runCandidateCreationMixedEvent<true, DecayChannel::Ds2StarToDplusK0s>(collisions, candsD, candsV0);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs2StarToDplusK0sMixedEventWithMl, "Process Ds2Star mixed Event with ML", false);
+
   void processDs1ToDstarK0s(aod::HfRedCollisions const& collisions,
                             aod::HfRed3PrNoTrks const& candsD,
                             aod::HfRedVzeros const&)
@@ -404,6 +530,22 @@ struct HfCandidateCreatorCharmResoReduced {
     }
   }
   PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs1ToDstarK0sWithMl, "Process Ds1 candidates with Ml info", false);
+
+  void processDs1ToDstarK0sMixedEvent(aod::HfRedCollisions const& collisions,
+                                      aod::HfRed3PrNoTrks const& candsD,
+                                      aod::HfRedVzeros const& candsV0)
+  {
+    runCandidateCreationMixedEvent<false, DecayChannel::Ds1ToDstarK0s>(collisions, candsD, candsV0);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs1ToDstarK0sMixedEvent, "Process Ds1 mixed Event without ML", false);
+
+  void processDs1ToDstarK0sMixedEventWithMl(aod::HfRedCollisions const& collisions,
+                                      reducedDWithMl const& candsD,
+                                      aod::HfRedVzeros const& candsV0)
+  {
+    runCandidateCreationMixedEvent<true, DecayChannel::Ds1ToDstarK0s>(collisions, candsD, candsV0);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorCharmResoReduced, processDs1ToDstarK0sMixedEventWithMl, "Process Ds1 mixed Event with ML", false);
 
   void processXcToDplusLambda(aod::HfRedCollisions const& collisions,
                               aod::HfRed3PrNoTrks const& candsD,
@@ -488,22 +630,39 @@ struct HfCandidateCreatorCharmResoReducedExpressions {
 
   Produces<aod::HfMcRecRedResos> rowResoMcRec;
 
+  using CandResoWithIndices = soa::Join<aod::HfCandCharmReso, aod::HfResoIndices>;
+
+  // Configurable axis
+  ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0., 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 8.f, 12.f, 24.f, 50.f}, "#it{p}_{T} (GeV/#it{c})"};
+  ConfigurableAxis axisInvMassReso{"axisInvMassReso", {200, 2.5, 2.7}, "inv. mass (DV_{0}) (GeV/#it{c}^{2})"};
+  ConfigurableAxis axisInvMassProng0{"axisInvMassProng0", {200, 0.14, 0.17}, "inv. mass (D) (GeV/#it{c}^{2})"};
+  ConfigurableAxis axisInvMassProng1{"axisInvMassProng1", {200, 0.47, 0.53}, "inv. mass ({V}_{0}) (GeV/#it{c}^{2})"};
+  ConfigurableAxis axisInvMassD0{"axisInvMassD0",  {200, 1.65, 2.05}, "inv. mass ({V}_{0}) (GeV/#it{c}^{2})"};
+  ConfigurableAxis axisDebug{"axisDebug", {16, -0.5, 15.5}, "MC debug flag"};
+  ConfigurableAxis axisOrigin{"axisOrigin", {3, -0.5, 2.5}, "MC origin flag"};
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)
   {
-    const AxisSpec axisPt{(std::vector<double>)vecBinsPt, "#it{p}_{T} (GeV/#it{c})"};
-    registry.add("hMassMcMatched", "Reso MC candidates Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
-    registry.add("hMassMcMatchedIncomplete", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
-    registry.add("hMassMcUnmatched", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
-    registry.add("hMassMcNoEntry", "Reso MC candidates w.o. entry in MC Reco table;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {{200, 2.5, 2.7}, {axisPt}}});
+    registry.add("hMassMcMatched", "Reso MC candidates Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {axisInvMassReso, axisPt}});
+    registry.add("hMassMcMatchedIncomplete", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {axisInvMassReso, axisPt}});
+    registry.add("hMassMcUnmatched", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {axisInvMassReso, axisPt}});
+    registry.add("hMassMcNoEntry", "Reso MC candidates w.o. entry in MC Reco table;m (GeV/#it{c}^{2});entries", {HistType::kTH2F, {axisInvMassReso, axisPt}});
+    registry.add("hMassMcMatchedVsBach0Mass", "Reso MC candidates Matched with generate particle;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassProng0}});
+    registry.add("hMassMcUnmatchedVsBach0Mass", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassProng0}});
+    registry.add("hMassMcMatchedVsBach1Mass", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassProng1}});
+    registry.add("hMassMcUnmatchedVsBach1Mass", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassProng1}});
+    registry.add("hMassMcMatchedVsD0Mass", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassD0}});
+    registry.add("hMassMcUnmatchedVsD0Mass", "Reso MC candidates Matched with generate particle w. Invcomplete decay;m (GeV/#it{c}^{2}); m (GeV/#it{c}^{2})", {HistType::kTH2F, {axisInvMassReso, axisInvMassD0}});
+    registry.add("hMassMcUnmatchedVsDebug", "Reso MC candidates NOT Matched with generate particle;m (GeV/#it{c}^{2});debug flag", {HistType::kTH2F, {axisInvMassReso, axisDebug}});
+    registry.add("hSparseUnmatchedDebug","THn for debug of MC matching and Correlated BKG study", HistType::kTHnSparseF, {axisInvMassReso, axisPt, axisInvMassProng0, axisInvMassProng1, axisInvMassD0, axisDebug, axisOrigin});
   }
 
   /// Fill candidate information at MC reconstruction level
   /// \param rowsDV0McRec MC reco information on DPi pairs
   /// \param candsReso prong global indices of B0 candidates
   template <typename McRec>
-  void fillResoMcRec(McRec const& rowsDV0McRec, aod::HfCandCharmReso const& candsReso)
+  void fillResoMcRec(McRec const& rowsDV0McRec, CandResoWithIndices const& candsReso)
   {
     for (const auto& candReso : candsReso) {
       bool filledMcInfo{false};
@@ -515,22 +674,31 @@ struct HfCandidateCreatorCharmResoReducedExpressions {
         filledMcInfo = true;
         if (TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToD0PiK0s) || TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds2StarToDplusK0sToPiKaPiPiPi)) {
           registry.fill(HIST("hMassMcMatched"), candReso.invMass(), candReso.pt());
+          registry.fill(HIST("hMassMcMatchedVsBach0Mass"), candReso.invMass(), candReso.invMassProng0()-candReso.invMassD0());
+          registry.fill(HIST("hMassMcMatchedVsBach1Mass"), candReso.invMass(), candReso.invMassProng1());
+          registry.fill(HIST("hMassMcMatchedVsD0Mass"), candReso.invMass(), candReso.invMassD0());
+
         } else if (TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToDPlusGammaK0s) || TESTBIT(rowDV0McRec.flagMcMatchRec(), DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s)) {
           registry.fill(HIST("hMassMcMatchedIncomplete"), candReso.invMass(), candReso.pt());
         } else {
           registry.fill(HIST("hMassMcUnmatched"), candReso.invMass(), candReso.pt());
+          registry.fill(HIST("hMassMcUnmatchedVsBach0Mass"), candReso.invMass(), candReso.invMassProng0()-candReso.invMassD0());
+          registry.fill(HIST("hMassMcUnmatchedVsBach1Mass"), candReso.invMass(), candReso.invMassProng1());
+          registry.fill(HIST("hMassMcUnmatchedVsD0Mass"), candReso.invMass(), candReso.invMassD0());
+          registry.fill(HIST("hMassMcUnmatchedVsDebug"), candReso.invMass(), rowDV0McRec.debugMcRec());
+          registry.fill(HIST("hSparseUnmatchedDebug"), candReso.invMass(), candReso.pt(), candReso.invMassProng0()-candReso.invMassD0(), candReso.invMassProng1(), candReso.invMassD0(), rowDV0McRec.debugMcRec(), rowDV0McRec.origin());
         }
 
         break;
       }
       if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D-Pi creator
-        rowResoMcRec(0, -1, -1, -1.f);
+        // rowResoMcRec(0, -1, -1, -1.f);
         registry.fill(HIST("hMassMcNoEntry"), candReso.invMass(), candReso.pt());
       }
     }
   }
 
-  void processMc(aod::HfMcRecRedDV0s const& rowsDV0McRec, aod::HfCandCharmReso const& candsReso)
+  void processMc(aod::HfMcRecRedDV0s const& rowsDV0McRec, CandResoWithIndices const& candsReso)
   {
     fillResoMcRec(rowsDV0McRec, candsReso);
   }

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -13,6 +13,8 @@
 /// \brief Reconstruction of Resonance candidates
 ///
 /// \author Luca Aglietta <luca.aglietta@cern.ch>, Università degli Studi di Torino
+#include <vector>
+#include <string>
 
 #include "CommonConstants/PhysicsConstants.h"
 #include "Framework/AnalysisTask.h"

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -94,6 +94,7 @@ struct HfCandidateCreatorCharmResoReduced {
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{hf_cuts_d_daughter::vecBinsPt}, "pT bin limits for D daughter cuts"};
   Configurable<LabeledArray<double>> cutsV0{"cutsV0daughter", {hf_cuts_v0_daughter::cuts[0], hf_cuts_v0_daughter::nBinsPt, hf_cuts_v0_daughter::nCutVars, hf_cuts_v0_daughter::labelsPt, hf_cuts_v0_daughter::labelsCutVar}, "V0 daughter selections"};
   Configurable<std::vector<double>> binsPtV0{"binsPtV0", std::vector<double>{hf_cuts_v0_daughter::vecBinsPt}, "pT bin limits for V0 daughter cuts"};
+  
   // Configurables for ME
   Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "Number of events mixed in ME process"};
   Configurable<int> numberEventsToSkip{"numberEventsToSkip", -1, "Number of events to Skip in ME process"};
@@ -174,7 +175,6 @@ struct HfCandidateCreatorCharmResoReduced {
     if (ptBin == -1) {
       return false;
     }
-    // slection on D candidate mass
     if (channel == DecayChannel::Ds2StarToDplusK0s || channel == DecayChannel::XcToDplusLambda || channel == DecayChannel::LambdaDminus) {
       invMassD = candD.invMassDplus();
     } else if (channel == DecayChannel::Ds1ToDstarK0s || channel == DecayChannel::DstarTrack) {
@@ -350,8 +350,7 @@ struct HfCandidateCreatorCharmResoReduced {
                                 invMassReso,
                                 invMassD - invMassD0);
         } else {
-          rowCandidateReso(collision.globalIndex(),
-                           pVecD[0], pVecD[1], pVecD[2],
+          rowCandidateReso(pVecD[0], pVecD[1], pVecD[2],
                            pVecV0Tr[0], pVecV0Tr[1], pVecV0Tr[2],
                            invMassReso,
                            invMassD,
@@ -360,7 +359,8 @@ struct HfCandidateCreatorCharmResoReduced {
                            candV0Tr.dca(),
                            candV0Tr.v0Radius(),
                            invMassD0);
-          rowCandidateResoIndices(candD.globalIndex(),
+          rowCandidateResoIndices(collision.globalIndex(),
+                                  candD.globalIndex(),
                                   candV0Tr.globalIndex());
         }
         if constexpr (fillMl) {
@@ -443,8 +443,7 @@ struct HfCandidateCreatorCharmResoReduced {
             break;
         }
         // Fill output table
-        rowCandidateReso(collision1.globalIndex(),
-                          pVecD[0], pVecD[1], pVecD[2],
+        rowCandidateReso( pVecD[0], pVecD[1], pVecD[2],
                           pVecV0Tr[0], pVecV0Tr[1], pVecV0Tr[2],
                           invMassReso,
                           invMassD,
@@ -453,7 +452,8 @@ struct HfCandidateCreatorCharmResoReduced {
                           bachV0Tr.dca(),
                           bachV0Tr.v0Radius(),
                           invMassD0);
-        rowCandidateResoIndices(bachD.globalIndex(),
+        rowCandidateResoIndices(collision1.globalIndex(),
+                                bachD.globalIndex(),
                                 bachV0Tr.globalIndex());
         if constexpr (fillMl) {
           mlScores(bachD.mlScoreBkgMassHypo0(), bachD.mlScorePromptMassHypo0(), bachD.mlScoreNonpromptMassHypo0());

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -245,11 +245,11 @@ struct HfDataCreatorCharmResoReduced {
     registry.add("hMassDstarProton", "D^{*}-proton candidates;m_{D^{*}p} - m_{D^{*}} (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 0.9, 1.4}}});
     registry.add("hDType", "D selection flag", {HistType::kTH1F, {{5, -2.5, 2.5}}});
 
-    registry.add("hMCRecCounter", "Number of Reconstructed MC Matched candidates per channel", {HistType::kTH1F, {{17, -8.5, 8.5}}});
+    registry.add("hMCRecCounter", "Number of Reconstructed MC Matched candidates per channel", {HistType::kTH1F, {{65, -32.5, 32.5}}});
     registry.add("hMCRecDebug", "Debug of MC Reco", {HistType::kTH1F, {{16, -0.5, 15.5}}});
     registry.add("hMCRecOrigin", "Origin of Matched particles", {HistType::kTH1F, {{3, -0.5, 2.5}}});
 
-    registry.add("hMCGenCounter", "Number of Generated particles; Decay Channel Flag; pT [GeV/c]", {HistType::kTH2F, {{17, -8.5, 8.5}, {100, 0, 50}}});
+    registry.add("hMCGenCounter", "Number of Generated particles; Decay Channel Flag; pT [GeV/c]", {HistType::kTH2F, {{65, -32.5, 32.5}, {100, 0, 50}}});
     registry.add("hMCSignCounter", "Sign of Generated particles", {HistType::kTH1F, {{3, -1.5, 1.5}}});
     registry.add("hMCGenOrigin", "Origin of Generated particles", {HistType::kTH1F, {{3, -0.5, 2.5}}});
     registry.add("hMCOriginCounterWrongDecay", "Origin of Generated particles in Wrong decay", {HistType::kTH1F, {{3, -0.5, 2.5}}});
@@ -940,14 +940,18 @@ struct HfDataCreatorCharmResoReduced {
           origin = RecoDecay::getCharmHadronOrigin(particlesMc, particle, false, &idxBhadMothers);
           registry.fill(HIST("hMCGenOrigin"), origin);
           auto candV0MC = particlesMc.rawIteratorAt(particle.daughtersIds().back());
+          auto candDStarMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
           // K0 -> K0s -> π+π-
           if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, candV0MC, kK0, std::array{+kPiPlus, -kPiPlus}, true, &signV0, 2)) {
-            auto candDStarMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
             // D* -> D0 π+ -> K-π+π+
             if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{static_cast<int>(Pdg::kD0), +static_cast<int>(kPiPlus)}, true, &signDStar, 1)) {
               auto candD0MC = particlesMc.rawIteratorAt(candDStarMC.daughtersIds().front());
               if (RecoDecay::isMatchedMCGen(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kPiPlus}, true, &signDStar, 2)) {
                 flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0s);
+                if (RecoDecay::isMatchedMCGen<false, true>(particlesMc, candV0MC, kK0, std::array{+kPiPlus, -kMuonPlus, +kNuMu}, true, &signV0, 3) ||
+                    RecoDecay::isMatchedMCGen<false, true>(particlesMc, candDStarMC, Pdg::kDStar, std::array{-kKPlus, +kPiPlus, +kMuonPlus, -kNuMu}, true, &signDStar, 3)){
+                  flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sOneMu);    
+                }
               } else if (RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, +kPi0}, true, &signDStar, 2) ||
                          RecoDecay::isMatchedMCGen(particlesMc, candD0MC, Pdg::kD0, std::array{-kKPlus, +kPiPlus, +kPiPlus, -kPi0}, true, &signDStar, 2)) {
                 flag = signDStar * BIT(DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart);

--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -19,15 +19,15 @@ o2physics_add_dpl_workflow(task-b0-reduced
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(task-bplus
-                    SOURCES taskBplus.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+# o2physics_add_dpl_workflow(task-bplus
+#                     SOURCES taskBplus.cxx
+#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+#                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(task-bplus-reduced
-                    SOURCES taskBplusReduced.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
-                    COMPONENT_NAME Analysis)
+# o2physics_add_dpl_workflow(task-bplus-reduced
+#                     SOURCES taskBplusReduced.cxx
+#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+#                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(task-bs-reduced
                     SOURCES taskBsReduced.cxx

--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -19,15 +19,15 @@ o2physics_add_dpl_workflow(task-b0-reduced
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-# o2physics_add_dpl_workflow(task-bplus
-#                     SOURCES taskBplus.cxx
-#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
-#                     COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(task-bplus
+                    SOURCES taskBplus.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
 
-# o2physics_add_dpl_workflow(task-bplus-reduced
-#                     SOURCES taskBplusReduced.cxx
-#                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
-#                     COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(task-bplus-reduced
+                    SOURCES taskBplusReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(task-bs-reduced
                     SOURCES taskBsReduced.cxx

--- a/PWGHF/D2H/Tasks/taskCharmResoReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmResoReduced.cxx
@@ -29,6 +29,91 @@ using namespace o2::soa;
 using namespace o2::analysis;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::constants::physics;
+
+enum DecayTypeMc : uint8_t {
+  Ds1ToDStarK0ToD0PiK0s = 0,
+  Ds2StarToDplusK0,
+  Ds1ToDStarK0ToDPlusPi0K0s,
+  Ds1ToDStarK0ToD0PiK0sPart,
+  Ds1ToDStarK0ToD0NoPiK0sPart,
+  Ds1ToDStarK0ToD0PiK0sOneMu
+};
+
+namespace o2::aod
+{
+  namespace hf_cand_reso_lite
+  {
+    DECLARE_SOA_COLUMN(PtBach0, ptBach0, float);                               //! Transverse momentum of bachelor 0 (GeV/c)
+    DECLARE_SOA_COLUMN(PtBach1, ptBach1, float);                               //! Transverse momentum of bachelor 1 (GeV/c)
+    DECLARE_SOA_COLUMN(MBach0, mBach0, float);                                 //! Invariant mass of bachelor 0 (GeV/c)
+    DECLARE_SOA_COLUMN(MBach1, mBach1, float);                                 //! Invariant mass of bachelor 1 (GeV/c)
+    DECLARE_SOA_COLUMN(MBachD0, mBachD0, float);                                 //! Invariant mass of D0 bachelor (of bachelor 0) (GeV/c)
+    DECLARE_SOA_COLUMN(M, m, float);                                             //! Invariant mass of candidate (GeV/c2)
+    DECLARE_SOA_COLUMN(Pt, pt, float);                                           //! Transverse momentum of candidate (GeV/c)
+    DECLARE_SOA_COLUMN(P, p, float);                                             //! Momentum of candidate (GeV/c)
+    DECLARE_SOA_COLUMN(Y, y, float);                                             //! Rapidity of candidate
+    DECLARE_SOA_COLUMN(Eta, eta, float);                                         //! Pseudorapidity of candidate
+    DECLARE_SOA_COLUMN(Phi, phi, float);                                         //! Azimuth angle of candidate
+    DECLARE_SOA_COLUMN(E, e, float);                                             //! Energy of candidate (GeV)
+    DECLARE_SOA_COLUMN(Sign, sign, int8_t);                                       //! Sign of candidate 
+    DECLARE_SOA_COLUMN(CosThetaStar, cosThetaStar, float);                       //! VosThetaStar of candidate (GeV)
+    DECLARE_SOA_COLUMN(MlScoreBkgBach0, mlScoreBkgBach0, float);                 //! ML score for background class of charm daughter
+    DECLARE_SOA_COLUMN(MlScorePromptBach0, mlScorePromptBach0, float);           //! ML score for prompt class of charm daughter
+    DECLARE_SOA_COLUMN(MlScoreNonPromptBach0, mlScoreNonPromptBach0, float);     //! ML score for non-prompt class of charm daughter
+    DECLARE_SOA_COLUMN(ItsNClsProngMinBach0, itsNClsProngMinBach0, int);                       //! minimum value of number of ITS clusters for the decay daughter tracks of bachelor 0
+    DECLARE_SOA_COLUMN(TpcNClsCrossedRowsProngMinBach0, tpcNClsCrossedRowsProngMinBach0, int); //! minimum value of number of TPC crossed rows for the decay daughter tracks of bachelor 0
+    DECLARE_SOA_COLUMN(TpcChi2NClProngMaxBach0, tpcChi2NClProngMaxBach0, float);               //! maximum value of TPC chi2 for the decay daughter tracks of bachelor 0
+    DECLARE_SOA_COLUMN(ItsNClsProngMinBach1, itsNClsProngMinBach1, int);                       //! minimum value of number of ITS clusters for the decay daughter tracks of bachelor 1
+    DECLARE_SOA_COLUMN(TpcNClsCrossedRowsProngMinBach1, tpcNClsCrossedRowsProngMinBach1, int); //! minimum value of number of TPC crossed rows for the decay daughter tracks of bachelor 1
+    DECLARE_SOA_COLUMN(TpcChi2NClProngMaxBach1, tpcChi2NClProngMaxBach1, float);               //! maximum value of TPC chi2 for the decay daughter tracks of bachelor 1
+    DECLARE_SOA_COLUMN(CpaBach1, cpaBach1, float);                                //! Cosine of Pointing Angle of bachelor 1
+    DECLARE_SOA_COLUMN(DcaBach1, dcaBach1, float);                                //! DCA of bachelor 1
+    DECLARE_SOA_COLUMN(RadiusBach1, radiusBach1, float);                          //! Radius of bachelor 1
+    DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t);                   //! flag for decay channel classification reconstruction level
+    DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                           //! debug flag for mis-association at reconstruction level
+    DECLARE_SOA_COLUMN(Origin, origin, int8_t);                                   //! Flag for origin of MC particle 1=promt, 2=FD
+    DECLARE_SOA_COLUMN(PtGen, ptGen, float);                                      //! Transverse momentum of candidate (GeV/c)
+    DECLARE_SOA_COLUMN(SignD0, signD0, float);                                    //! Flag to distinguish D0 and D0Bar
+
+  }// namespace hf_cand_reso_lite
+
+  DECLARE_SOA_TABLE(HfCandResoLites, "AOD", "HFCANDRESOLITE", //! Table with some B0 properties
+                  //Candidate Properties
+                  hf_cand_reso_lite::M,
+                  hf_cand_reso_lite::Pt,
+                  hf_cand_reso_lite::P,
+                  hf_cand_reso_lite::Y,
+                  hf_cand_reso_lite::Eta,
+                  hf_cand_reso_lite::Phi,
+                  hf_cand_reso_lite::E,
+                  hf_cand_reso_lite::CosThetaStar,
+                  hf_cand_reso_lite::Sign,
+                  //Bachelors Properties
+                  hf_cand_reso_lite::MBach0,
+                  hf_cand_reso_lite::PtBach0,
+                  hf_cand_reso_lite::MlScoreBkgBach0,
+                  hf_cand_reso_lite::MlScorePromptBach0,
+                  hf_cand_reso_lite::MlScoreNonPromptBach0,
+                  hf_cand_reso_lite::ItsNClsProngMinBach0,
+                  hf_cand_reso_lite::TpcNClsCrossedRowsProngMinBach0,
+                  hf_cand_reso_lite::TpcChi2NClProngMaxBach0,
+                  hf_cand_reso_lite::MBach1,
+                  hf_cand_reso_lite::PtBach1,
+                  hf_cand_reso_lite::CpaBach1,
+                  hf_cand_reso_lite::DcaBach1,
+                  hf_cand_reso_lite::RadiusBach1,
+                  hf_cand_reso_lite::ItsNClsProngMinBach1,
+                  hf_cand_reso_lite::TpcNClsCrossedRowsProngMinBach1,
+                  hf_cand_reso_lite::TpcChi2NClProngMaxBach1,
+                  //MC
+                  hf_cand_reso_lite::FlagMcMatchRec,
+                  hf_cand_reso_lite::DebugMcRec,
+                  hf_cand_reso_lite::Origin,
+                  hf_cand_reso_lite::PtGen,
+                  hf_cand_reso_lite::SignD0);
+                  
+}// namespace aod 
 
 enum DecayChannel : uint8_t {
   Ds1ToDstarK0s = 0,
@@ -38,7 +123,16 @@ enum DecayChannel : uint8_t {
 };
 
 struct HfTaskCharmResoReduced {
+  Produces<aod::HfCandResoLites> hfCandResoLite;
   Configurable<float> ptMinReso{"ptMinReso", 5, "Discard events with smaller pT"};
+  Configurable<bool> fillTrees{"fillTrees", false, "Fill output Trees"};
+  Configurable<bool> fillSparses{"fillSparses", false, "Fill output Sparses"};
+  Configurable<bool> useDeltaMass{"useDeltaMass", false, "Use Delta Mass for resonance invariant Mass calculation"};
+  Configurable<bool> fillOnlySignal{"fillOnlySignal", false, "Flag to Fill only signal candidates (MC only)"};
+  Configurable<float> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<float> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. track pseudo-rapidity for acceptance calculation"};
+  Configurable<float> ptTrackMin{"ptTrackMin", 0.1, "min. track transverse momentum for acceptance calculation"};
   // Configurables axis for histos
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0., 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 8.f, 12.f, 24.f, 50.f}, "#it{p}_{T} (GeV/#it{c})"};
   ConfigurableAxis axisPtProng0{"axisPtProng0", {VARIABLE_WIDTH, 0., 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 8.f, 12.f, 24.f, 50.f}, "prong0 bach. #it{p}_{T} (GeV/#it{c})"};
@@ -49,11 +143,15 @@ struct HfTaskCharmResoReduced {
   ConfigurableAxis axisCosThetaStar{"axisCosThetaStar", {40, -1, 1}, "cos(#vartheta*)"};
   ConfigurableAxis axisBkgBdtScore{"axisBkgBdtScore", {100, 0, 1}, "bkg BDT Score"};
   ConfigurableAxis axisNonPromptBdtScore{"axisNonPromptBdtScore", {100, 0, 1}, "non-prompt BDT Score"};
+  ConfigurableAxis axisEta{"axisEta", {30, -1.5, 1.5}, "pseudorapidity"};
+  ConfigurableAxis axisOrigin{"axisOrigin", {3, -0.5, 2.5}, "origin"};
+  ConfigurableAxis axisFlag{"axisFlag", {65, -32.5, 32.5}, "mc flag"};
 
-  using ReducedResoWithMl = soa::Join<aod::HfCandCharmReso, aod::HfCharmResoMLs>;
-  SliceCache cache;
-  Preslice<ReducedResoWithMl> resoPerCollision = aod::hf_track_index_reduced::hfRedCollisionId;
-
+  using ReducedReso = soa::Join<aod::HfCandCharmReso, aod::HfResoIndices>;
+  using ReducedResoWithMl = soa::Join<aod::HfCandCharmReso, aod::HfCharmResoMLs, aod::HfResoIndices>;
+  using ReducedResoMc = soa::Join<aod::HfCandCharmReso, aod::HfResoIndices, aod::HfMcRecRedResos>;
+  using ReducedResoWithMlMc = soa::Join<aod::HfCandCharmReso, aod::HfCharmResoMLs, aod::HfResoIndices, aod::HfMcRecRedResos>;
+  using CharmBach = soa::Join<aod::HfRed3PrNoTrks, aod::HfRed3ProngsMl>;
   // Histogram Registry
   HistogramRegistry registry;
 
@@ -70,15 +168,95 @@ struct HfTaskCharmResoReduced {
     registry.add("hZvert", "Collision Z Vtx ; z PV [cm] ; entries", {HistType::kTH1F, {{120, -12., 12.}}});
     registry.add("hBz", "Collision Bz ; Bz [T] ; entries", {HistType::kTH1F, {{20, -10., 10.}}});
     registry.add("hSparse", "THn for production studies with cosThStar and BDT scores", HistType::kTHnSparseF, {axisPt, axisPtProng0, axisPtProng1, axisInvMassReso, axisInvMassProng0, axisInvMassProng1, axisCosThetaStar, axisBkgBdtScore, axisNonPromptBdtScore});
+    
+    if(doprocessDs1Mc || doprocessDs2StarMc){
+      // gen histos
+      registry.add("hYGenPrompt", "Prompt {D_{S}}^j particles (generated);#it{p}_{T}^{gen}({D_{S}}^j) (GeV/#it{c});#it{y}^{gen}({D_{S}}^j);entries", {HistType::kTH2F, {axisPt, axisEta}});
+      registry.add("hYGenPromptWithProngsInAcceptance", "Prompt {D_{S}}^j particles (generated-daughters in acceptance);#it{p}_{T}^{gen}({D_{S}}^j) (GeV/#it{c});#it{y}^{gen}({D_{S}}^j);entries", {HistType::kTH2F, {axisPt, axisEta}});
+      registry.add("hYGenNonPrompt", "NonPrompt {D_{S}}^j particles (generated);#it{p}_{T}^{gen}({D_{S}}^j) (GeV/#it{c});#it{y}^{gen}({D_{S}}^j);entries", {HistType::kTH2F, {axisPt, axisEta}});
+      registry.add("hYGenNonPromptWithProngsInAcceptance", "NonPrompt {D_{S}}^j particles (generated-daughters in acceptance);#it{p}_{T}^{gen}({D_{S}}^j) (GeV/#it{c});#it{y}^{gen}({D_{S}}^j);entries", {HistType::kTH2F, {axisPt, axisEta}});
+      if (fillSparses){
+        registry.add("hPtYGenSig", "{D_{S}}^j particles (generated);#it{p}_{T}({D_{S}}^j) (GeV/#it{c});#it{y}({D_{S}}^j)", {HistType::kTHnSparseF, {axisPt, axisEta, axisOrigin, axisFlag}});
+        registry.add("hPtYWithProngsInAccepanceGenSig", "{D_{S}}^j particles (generated-daughters in acceptance);#it{p}_{T}({D_{S}}^j) (GeV/#it{c});#it{y}({D_{S}}^j)", {HistType::kTHnSparseF, {axisPt, axisEta, axisOrigin, axisFlag}});
+      }
+    }
   }
 
   // Fill histograms
   /// \tparam channel is the decay channel of the Resonance
   /// \param candidate is a candidate
   /// \param coll is a reduced collision
-  template <DecayChannel channel, typename Cand, typename Coll>
-  void fillHisto(const Cand& candidate, const Coll& collision)
-  {
+  /// \param bach0 is a bachelor of the candidate
+  /// \param bach1 is a bachelor of the candidate
+  template <bool doMc, bool withMl, DecayChannel channel, typename Cand, typename Coll,  typename CharmBach, typename V0Bach>
+  void fillCand(const Cand& candidate, const Coll& collision, const CharmBach& bach0, const V0Bach& bach1)
+  { 
+    // Compute quantities to be saved
+    float invMassReso, pdgMassReso, invMassBach0, invMassBach1, pdgMassBach0, pdgMassBach1, sign, invMassD0, cosThetaStar;
+    if (channel == DecayChannel::Ds1ToDstarK0s){
+      pdgMassReso = MassDS1;
+      pdgMassBach0 = MassDStar;
+      pdgMassBach1 = MassK0;
+      invMassBach1 = bach1.invMassK0s();
+      cosThetaStar = candidate.cosThetaStarDs1();
+      if (bach0.dType() > 0){
+        invMassBach0 = bach0.invMassDstar();
+        invMassD0 = bach0.invMassD0();
+        sign = 1;
+        if (useDeltaMass){
+           invMassReso = RecoDecay::m(std::array{bach0.pVectorProng0(), bach0.pVectorProng1(), bach0.pVectorProng2(), bach1.pVector()}, std::array{MassPiPlus, MassKPlus, MassPiPlus, MassK0});
+        }
+      } else{
+        invMassBach0 = bach0.invMassAntiDstar();
+        invMassD0 = bach0.invMassD0Bar();
+        sign = -1;
+        if (useDeltaMass){
+           invMassReso = RecoDecay::m(std::array{bach0.pVectorProng1(), bach0.pVectorProng0(), bach0.pVectorProng2(), bach1.pVector()}, std::array{MassPiPlus, MassKPlus, MassPiPlus, MassK0});
+        }
+      }
+    } else if (channel == DecayChannel::Ds2StarToDplusK0s){
+      pdgMassReso = MassDS2Star;
+      pdgMassBach0 = MassDPlus;
+      pdgMassBach1 = MassK0;
+      invMassBach0 = bach0.invMassDplus();
+      invMassD0 = 0;
+      invMassBach1 = bach1.invMassK0s();
+      cosThetaStar = candidate.cosThetaStarDs2Star();
+      if (useDeltaMass){
+           invMassReso = RecoDecay::m(std::array{bach0.pVectorProng0(), bach0.pVectorProng1(), bach0.pVectorProng2(), bach1.pVector()}, std::array{MassPiPlus, MassKPlus, MassPiPlus, MassK0});
+      }
+      if (bach0.dType() > 0){
+        sign = 1;
+      } else{
+        sign = -1;
+      }
+    } 
+    float y = RecoDecay::y(std::array{candidate.px(),candidate.py(),candidate.pz()}, pdgMassReso);
+    float eta = RecoDecay::eta(std::array{candidate.px(),candidate.py(),candidate.pz()});
+    float phi = RecoDecay::phi(candidate.px(),candidate.py());
+    float p = RecoDecay::p(std::array{candidate.px(),candidate.py(),candidate.pz()});
+    float e = RecoDecay::e(std::array{candidate.px(),candidate.py(),candidate.pz()}, pdgMassReso);
+    if (useDeltaMass){
+      invMassReso = invMassReso - invMassBach0;
+    } else {
+      invMassReso = RecoDecay::m(std::array{bach0.pVector(),bach1.pVector()}, std::array{pdgMassBach0,pdgMassBach1});
+    }
+    invMassBach0 = invMassBach0 - invMassD0;
+    float ptGen{-1.};
+    int8_t origin{-1}, flagMcMatchRec{-1}, debugMcRec{-1}, signD0{0};
+    if constexpr (doMc){
+      ptGen = candidate.ptMother();
+      origin = candidate.origin();
+      flagMcMatchRec = candidate.flagMcMatchRec();
+      debugMcRec = candidate.debugMcRec();
+      // signD0 = candidate.signD0(); 
+    }
+    float mlScoreBkg{-1.}, mlScorePrompt{-1.}, mlScoreNonPrompt{-1.};
+    if constexpr (withMl){
+      mlScoreBkg = bach0.mlScoreBkgMassHypo0();
+      mlScorePrompt = bach0.mlScorePromptMassHypo0();
+      mlScoreNonPrompt = bach0.mlScoreNonpromptMassHypo0();
+    }
     // Collision properties
     registry.fill(HIST("hNPvCont"), collision.numContrib());
     registry.fill(HIST("hZvert"), collision.posZ());
@@ -90,50 +268,186 @@ struct HfTaskCharmResoReduced {
     registry.fill(HIST("hPt"), candidate.pt());
     registry.fill(HIST("hPtProng0"), candidate.ptProng0());
     registry.fill(HIST("hPtProng1"), candidate.ptProng1());
-    float cosThetaStar{0.};
-    switch (channel) {
-      case DecayChannel::Ds1ToDstarK0s:
-        cosThetaStar = candidate.cosThetaStarDs1();
-        break;
-      case DecayChannel::Ds2StarToDplusK0s:
-        cosThetaStar = candidate.cosThetaStarDs2Star();
-        break;
-      default:
-        cosThetaStar = candidate.cosThetaStarXiC3055();
-        break;
+    if (fillSparses){
+      registry.fill(HIST("hSparse"), candidate.pt(), candidate.ptProng0(), candidate.ptProng1(), candidate.invMass(), candidate.invMassProng0(), candidate.invMassProng1(), cosThetaStar, mlScoreBkg, mlScoreNonPrompt);
     }
-    registry.fill(HIST("hSparse"), candidate.pt(), candidate.ptProng0(), candidate.ptProng1(), candidate.invMass(), candidate.invMassProng0(), candidate.invMassProng1(), cosThetaStar, candidate.mlScoreBkgProng0(), candidate.mlScoreNonpromptProng0());
-  } // fillHisto
+    if (doMc && fillOnlySignal){
+      if (channel == DecayChannel::Ds1ToDstarK0s && !(TESTBIT(flagMcMatchRec,DecayTypeMc::Ds1ToDStarK0ToD0PiK0s) || TESTBIT(flagMcMatchRec,DecayTypeMc::Ds1ToDStarK0ToD0PiK0sPart) || TESTBIT(flagMcMatchRec,DecayTypeMc::Ds1ToDStarK0ToD0NoPiK0sPart) || TESTBIT(flagMcMatchRec,DecayTypeMc::Ds1ToDStarK0ToD0PiK0sOneMu))) {
+        return;
+      }
+      if (channel == DecayChannel::Ds2StarToDplusK0s && !(TESTBIT(flagMcMatchRec,DecayTypeMc::Ds2StarToDplusK0) || TESTBIT(flagMcMatchRec,DecayTypeMc::Ds1ToDStarK0ToDPlusPi0K0s))) {
+        return;
+      }
+    }
+    if (fillTrees){
+        hfCandResoLite(
+        invMassReso,
+        candidate.pt(),
+        p,
+        y,
+        eta,
+        phi,
+        e,
+        cosThetaStar,
+        sign,
+        //Bachelors Properties
+        invMassBach0,
+        bach0.pt(),
+        mlScoreBkg,
+        mlScorePrompt,
+        mlScoreNonPrompt,
+        bach0.itsNClsProngMin(),
+        bach0.tpcNClsCrossedRowsProngMin(),
+        bach0.tpcChi2NClProngMax(),
+        invMassBach1,
+        bach1.pt(),
+        bach1.cpa(),
+        bach1.dca(),
+        bach1.v0Radius(),
+        bach1.itsNClsProngMin(),
+        bach1.tpcNClsCrossedRowsProngMin(),
+        bach1.tpcChi2NClProngMax(),
+        //MC
+        flagMcMatchRec,
+        debugMcRec,
+        origin,
+        ptGen,
+        signD0);
+    }
+  } // fillCand
 
   // Process data
   /// \tparam channel is the decay channel of the Resonance
   /// \param Coll is the reduced collisions table
+  /// \param CharmBach is the reduced 3 prong table
+  /// \param V0Bach is the reduced v0 table
   /// \param Cand is the candidates table
-  template <DecayChannel channel, typename Coll, typename Candidates>
+  template <bool doMc, bool withMl, DecayChannel channel, typename Coll, typename Candidates>
   void processData(Coll const&, Candidates const& candidates)
   {
     for (const auto& cand : candidates) {
       if (cand.pt() < ptMinReso) {
         continue;
       }
+      float pdgMassReso{0};
+      if (channel == DecayChannel::Ds1ToDstarK0s){
+        pdgMassReso = MassDS1;
+      } else if(channel == DecayChannel::Ds2StarToDplusK0s){
+        pdgMassReso = MassDS2Star;
+      }
+      if (yCandRecoMax >= 0. && std::abs(RecoDecay::y(std::array{cand.px(),cand.py(),cand.pz()}, pdgMassReso)) > yCandRecoMax ){
+        continue;
+      }
       auto coll = cand.template hfRedCollision_as<Coll>();
-      fillHisto<channel>(cand, coll);
+      auto bach0 = cand.template prong0_as<CharmBach>();
+      auto bach1 = cand.template prong1_as<aod::HfRedVzeros>();
+      fillCand<doMc, withMl, channel>(cand, coll, bach0, bach1);
     }
   }
 
+  /// Selection of resonance daughters in geometrical acceptance
+  /// \param etaProng is the pseudorapidity of Resonance prong
+  /// \param ptProng is the pT of Resonance prong
+  /// \return true if prong is in geometrical acceptance
+  template <typename T = float>
+  bool isProngInAcceptance(const T& etaProng, const T& ptProng)
+  {
+    return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
+  }
+
+
+  /// Fill particle histograms (gen MC truth)
+  template <DecayChannel channel>
+  void fillCandMcGen(aod::HfMcGenRedResos const& mcParticles)
+  {
+    for (const auto& particle : mcParticles){
+      auto ptParticle = particle.ptTrack();
+      auto yParticle = particle.yTrack();
+      auto etaParticle = particle.etaTrack();
+      auto originParticle = particle.origin();
+      auto flag = particle.flagMcMatchGen();
+      if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
+        return;
+      }
+      std::array<float, 2> ptProngs = {particle.ptProng0(), particle.ptProng1()};
+      std::array<float, 2> etaProngs = {particle.etaProng0(), particle.etaProng1()};
+      bool prongsInAcc = isProngInAcceptance(etaProngs[0], ptProngs[0]) && isProngInAcceptance(etaProngs[1], ptProngs[1]);
+      if ((channel == DecayChannel::Ds1ToDstarK0s && TESTBIT(flag, DecayTypeMc::Ds1ToDStarK0ToD0PiK0s)) ||
+          (channel == DecayChannel::Ds2StarToDplusK0s && TESTBIT(flag, DecayTypeMc::Ds2StarToDplusK0))){
+        if (originParticle == 1){ //prompt particles
+          registry.fill(HIST("hYGenPrompt"), ptParticle, yParticle);
+          if (prongsInAcc) {
+            registry.fill(HIST("hYGenPromptWithProngsInAcceptance"), ptParticle, yParticle);
+          }
+        } else if (originParticle == 2){
+          registry.fill(HIST("hYGenNonPrompt"), ptParticle, yParticle);
+          if (prongsInAcc) {
+            registry.fill(HIST("hYGenNonPromptWithProngsInAcceptance"), ptParticle, yParticle);
+          }
+        }
+      }
+      if (fillSparses) {
+        registry.fill(HIST("hPtYGenSig"), ptParticle, yParticle, originParticle, flag);
+        if (prongsInAcc) {
+          registry.fill(HIST("hPtYWithProngsInAccepanceGenSig"), ptParticle, yParticle, originParticle, flag);
+        }
+      }
+    }
+  }// fillCandMcGen
+
   // process functions
 
-  void processDs1Data(aod::HfRedCollisions const& collisions, ReducedResoWithMl const& candidates)
+  void processDs1Data(aod::HfRedCollisions const& collisions, ReducedReso const& candidates)
   {
-    processData<DecayChannel::Ds1ToDstarK0s>(collisions, candidates);
+    processData<false, false, DecayChannel::Ds1ToDstarK0s>(collisions, candidates);
   }
-  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs1Data, "Process data", true);
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs1Data, "Process data for Ds1 analysis without Ml", true);
 
-  void processDs2StarData(aod::HfRedCollisions const& collisions, ReducedResoWithMl const& candidates)
+  void processDs1DataWithMl(aod::HfRedCollisions const& collisions, ReducedResoWithMl const& candidates)
   {
-    processData<DecayChannel::Ds2StarToDplusK0s>(collisions, candidates);
+    processData<false, true, DecayChannel::Ds1ToDstarK0s>(collisions, candidates);
   }
-  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs2StarData, "Process data", false);
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs1DataWithMl, "Process data for Ds1 analysis with Ml", false);
+
+  void processDs2StarData(aod::HfRedCollisions const& collisions, ReducedReso const& candidates)
+  {
+    processData<false, false, DecayChannel::Ds2StarToDplusK0s>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs2StarData, "Process data Ds2Star analysis without Ml", false);
+
+   void processDs2StarDataWithMl(aod::HfRedCollisions const& collisions, ReducedResoWithMl const& candidates)
+  {
+    processData<false, true, DecayChannel::Ds2StarToDplusK0s>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs2StarDataWithMl, "Process data Ds2Star analysis with Ml", false);
+
+  void processDs1Mc(aod::HfRedCollisions const& collisions, ReducedResoMc const& candidates, aod::HfMcGenRedResos const& mcParticles)
+  {
+    processData<true, false, DecayChannel::Ds1ToDstarK0s>(collisions, candidates);
+    fillCandMcGen<DecayChannel::Ds1ToDstarK0s>(mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs1Mc, "Process Mc for Ds1 analysis without Ml", true);
+
+  void processDs1McWithMl(aod::HfRedCollisions const& collisions, ReducedResoWithMlMc const& candidates, aod::HfMcGenRedResos const& mcParticles)
+  {
+    processData<true, true, DecayChannel::Ds1ToDstarK0s>(collisions, candidates);
+    fillCandMcGen<DecayChannel::Ds1ToDstarK0s>(mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs1McWithMl, "Process Mc for Ds1 analysis with Ml", true);
+
+  void processDs2StarMc(aod::HfRedCollisions const& collisions, ReducedResoMc const& candidates, aod::HfMcGenRedResos const& mcParticles)
+  {
+    processData<true, false, DecayChannel::Ds2StarToDplusK0s>(collisions, candidates);
+    fillCandMcGen<DecayChannel::Ds2StarToDplusK0s>(mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs2StarMc, "Process Mc for Ds2Star analysis without Ml", false);
+
+  void processDs2StarMcWithMl(aod::HfRedCollisions const& collisions, ReducedResoWithMlMc const& candidates, aod::HfMcGenRedResos const& mcParticles)
+  {
+    processData<true, true, DecayChannel::Ds2StarToDplusK0s>(collisions, candidates);
+    fillCandMcGen<DecayChannel::Ds2StarToDplusK0s>(mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskCharmResoReduced, processDs2StarMcWithMl, "Process Mc for Ds2Star analysis with Ml", false);
 
 }; // struct HfTaskCharmResoReduced
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
1. dataCreatorCharmResoReduced.cxx:  
- added decay channel of Ds1 with at least one muon in the final state
- changed debug histogram ranges

2. candidateCreatorCharmResoReduced.cxx: 
- Removed indices from output table to avoid unbound indices in slim derived data
- Moved Mixed event here
- Added debug histograms to MC reconstruction analysis

3. taskCharmResoReduced:
- Added output tree for offline analysis
- Added MC process functions