### PR TITLE
[PWGHF] XicToXiPiPi: Add chi2topo before applying topological constraints

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1520,7 +1520,9 @@ DECLARE_SOA_COLUMN(DcaPi0Pi1, dcaPi0Pi1, float);
 DECLARE_SOA_COLUMN(DcaPi0Xi, dcaPi0Xi, float);
 DECLARE_SOA_COLUMN(DcaPi1Xi, dcaPi1Xi, float);
 DECLARE_SOA_COLUMN(Chi2TopoXicPlusToPV, chi2TopoXicPlusToPV, float);
+DECLARE_SOA_COLUMN(Chi2TopoXicPlusToPVBeforeConstraint, chi2TopoXicPlusToPVBeforeConstraint, float);
 DECLARE_SOA_COLUMN(Chi2TopoXiToXicPlus, chi2TopoXiToXicPlus, float);
+DECLARE_SOA_COLUMN(Chi2TopoXiToXicPlusBeforeConstraint, chi2TopoXiToXicPlusBeforeConstraint, float);
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
@@ -1591,7 +1593,8 @@ DECLARE_SOA_EXTENDED_TABLE_USER(HfCandXicExt, HfCandXicBase, "HFCANDXICEXT",
 using HfCandXic = HfCandXicExt;
 
 DECLARE_SOA_TABLE(HfCandXicKF, "AOD", "HFCANDXICKF",
-                  cascdata::KFCascadeChi2, cascdata::KFV0Chi2, hf_cand_xic_to_xi_pi_pi::Chi2TopoXicPlusToPV, hf_cand_xic_to_xi_pi_pi::Chi2TopoXiToXicPlus,
+                  cascdata::KFCascadeChi2, cascdata::KFV0Chi2,
+                  hf_cand_xic_to_xi_pi_pi::Chi2TopoXicPlusToPVBeforeConstraint, hf_cand_xic_to_xi_pi_pi::Chi2TopoXicPlusToPV, hf_cand_xic_to_xi_pi_pi::Chi2TopoXiToXicPlusBeforeConstraint, hf_cand_xic_to_xi_pi_pi::Chi2TopoXiToXicPlus,
                   hf_cand_xic_to_xi_pi_pi::DcaXYPi0Pi1, hf_cand_xic_to_xi_pi_pi::DcaXYPi0Xi, hf_cand_xic_to_xi_pi_pi::DcaXYPi1Xi,
                   hf_cand_xic_to_xi_pi_pi::DcaPi0Pi1, hf_cand_xic_to_xi_pi_pi::DcaPi0Xi, hf_cand_xic_to_xi_pi_pi::DcaPi1Xi,
                   cascdata::DCACascDaughters);

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -20,6 +20,10 @@
 #define HomogeneousField
 #endif
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <KFParticleBase.h>
 #include <KFParticle.h>
 #include <KFPTrack.h>
@@ -416,10 +420,10 @@ struct HfCandidateCreatorXicToXiPiPi {
       float chi2GeoXicPlus = kfXicPlus.GetChi2() / kfXicPlus.GetNDF();
 
       // topological constraint of Xic to PV
-      float chi2topoXicPlusPVBeforeConstraint = kfXicPlus.GetDeviationFromVertex(KFPV);
+      float chi2topoXicPlusToPVBeforeConstraint = kfXicPlus.GetDeviationFromVertex(KFPV);
       KFParticle kfXicPlusToPV = kfXicPlus;
       kfXicPlusToPV.SetProductionVertex(KFPV);
-      float chi2topoXicPlusPV = kfXicPlusToPV.GetChi2() / kfXicPlusToPV.GetNDF();
+      float chi2topoXicPlusToPV = kfXicPlusToPV.GetChi2() / kfXicPlusToPV.GetNDF();
       if (constrainXicPlusToPv) {
         kfXicPlus = kfXicPlusToPV;
         kfXicPlus.TransportToDecayVertex();
@@ -553,7 +557,7 @@ struct HfCandidateCreatorXicToXiPiPi {
                        cpaXi, cpaXYXi, cpaLambda, cpaXYLambda,
                        massXiPi0, massXiPi1);
       rowCandidateKF(casc.kfCascadeChi2(), casc.kfV0Chi2(),
-                     chi2topoXicPlusPVBeforeConstraint, chi2topoXicPlusPV, chi2topoXiToXicPlusBeforeConstraint, chi2topoXiToXicPlus,
+                     chi2topoXicPlusToPVBeforeConstraint, chi2topoXicPlusToPV, chi2topoXiToXicPlusBeforeConstraint, chi2topoXiToXicPlus,
                      dcaXYPi0Pi1, dcaXYPi0Xi, dcaXYPi1Xi,
                      dcaPi0Pi1, dcaPi0Xi, dcaPi1Xi,
                      casc.dcacascdaughters());

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -416,7 +416,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       float chi2GeoXicPlus = kfXicPlus.GetChi2() / kfXicPlus.GetNDF();
 
       // topological constraint of Xic to PV
-      float chi2topoXicPlusPVBeforeConstraint =  kfXicPlus.GetDeviationFromVertex(KFPV);
+      float chi2topoXicPlusPVBeforeConstraint = kfXicPlus.GetDeviationFromVertex(KFPV);
       KFParticle kfXicPlusToPV = kfXicPlus;
       kfXicPlusToPV.SetProductionVertex(KFPV);
       float chi2topoXicPlusPV = kfXicPlusToPV.GetChi2() / kfXicPlusToPV.GetNDF();

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -309,12 +309,12 @@ struct HfCandidateCreatorXicToXiPiPi {
       //---------------------------------fill candidate table rows-------------------------------------------------------------------------------------------
       rowCandidateBase(collision.globalIndex(),
                        primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
-                       covMatrixPV[0], covMatrixPV[2], covMatrixPV[5],
+                       std::sqrt(covMatrixPV[0]), std::sqrt(covMatrixPV[2]), std::sqrt(covMatrixPV[5]),
                        /*3-prong specific columns*/
                        rowTrackIndexXicPlus.cascadeId(), rowTrackIndexXicPlus.prong0Id(), rowTrackIndexXicPlus.prong1Id(),
                        casc.bachelorId(), casc.posTrackId(), casc.negTrackId(),
                        secondaryVertex[0], secondaryVertex[1], secondaryVertex[2],
-                       covMatrixSV[0], covMatrixSV[2], covMatrixSV[5],
+                       std::sqrt(covMatrixSV[0]), std::sqrt(covMatrixSV[2]), std::sqrt(covMatrixSV[5]),
                        errorDecayLength, errorDecayLengthXY,
                        chi2SV, massXiPiPi, signXic,
                        pVecXi[0], pVecXi[1], pVecXi[2],
@@ -416,6 +416,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       float chi2GeoXicPlus = kfXicPlus.GetChi2() / kfXicPlus.GetNDF();
 
       // topological constraint of Xic to PV
+      float chi2topoXicPlusPVBeforeConstraint =  kfXicPlus.GetDeviationFromVertex(KFPV);
       KFParticle kfXicPlusToPV = kfXicPlus;
       kfXicPlusToPV.SetProductionVertex(KFPV);
       float chi2topoXicPlusPV = kfXicPlusToPV.GetChi2() / kfXicPlusToPV.GetNDF();
@@ -425,6 +426,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       }
 
       // topological constraint of Xi to XicPlus
+      float chi2topoXiToXicPlusBeforeConstraint = kfXi.GetDeviationFromVertex(kfXicPlus);
       KFParticle kfXiToXicPlus = kfXi;
       kfXiToXicPlus.SetProductionVertex(kfXicPlus);
       float chi2topoXiToXicPlus = kfXiToXicPlus.GetChi2() / kfXiToXicPlus.GetNDF();
@@ -532,7 +534,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       //------------------------------fill candidate table rows--------------------------------------
       rowCandidateBase(collision.globalIndex(),
                        KFPV.GetX(), KFPV.GetY(), KFPV.GetZ(),
-                       covMatrixPV[0], covMatrixPV[2], covMatrixPV[5],
+                       std::sqrt(covMatrixPV[0]), std::sqrt(covMatrixPV[2]), std::sqrt(covMatrixPV[5]),
                        /*3-prong specific columns*/
                        rowTrackIndexXicPlus.cascadeId(), rowTrackIndexXicPlus.prong0Id(), rowTrackIndexXicPlus.prong1Id(),
                        casc.bachelorId(), casc.posTrackId(), casc.negTrackId(),
@@ -550,7 +552,8 @@ struct HfCandidateCreatorXicToXiPiPi {
                        casc.xlambda(), casc.ylambda(), casc.zlambda(),
                        cpaXi, cpaXYXi, cpaLambda, cpaXYLambda,
                        massXiPi0, massXiPi1);
-      rowCandidateKF(casc.kfCascadeChi2(), casc.kfV0Chi2(), chi2topoXicPlusPV, chi2topoXiToXicPlus,
+      rowCandidateKF(casc.kfCascadeChi2(), casc.kfV0Chi2(),
+                     chi2topoXicPlusPVBeforeConstraint, chi2topoXicPlusPV, chi2topoXiToXicPlusBeforeConstraint, chi2topoXiToXicPlus,
                      dcaXYPi0Pi1, dcaXYPi0Xi, dcaXYPi1Xi,
                      dcaPi0Pi1, dcaPi0Xi, dcaPi1Xi,
                      casc.dcacascdaughters());

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -76,7 +76,9 @@ DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);     //!
 DECLARE_SOA_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, float); //! Normalised transverse decay length of candidate
 DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of candidate
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
+DECLARE_SOA_COLUMN(Chi2XicPlusTopoToPVBeforeConstraint, chi2XicPlusTopoToPVBeforeConstraint, float);
 DECLARE_SOA_COLUMN(Chi2XicPlusTopoToPV, chi2XicPlusTopoToPV, float);
+DECLARE_SOA_COLUMN(Chi2XicPlusTopoXiToXicPlusBeforeConstraint, chi2XicPlusTopoXiToXicPlusBeforeConstraint, float);
 DECLARE_SOA_COLUMN(Chi2XicPlusTopoXiToXicPlus, chi2XicPlusTopoXiToXicPlus, float);
 // properties of daughter tracks
 DECLARE_SOA_COLUMN(PtXi, ptXi, float);                                                 //! Transverse momentum of Xi (prong0) (GeV/c)
@@ -191,7 +193,9 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
                   // KF specific columns
                   full::Chi2XiVtx,
                   full::Chi2LamVtx,
+                  full::Chi2XicPlusTopoToPVBeforeConstraint,
                   full::Chi2XicPlusTopoToPV,
+                  full::Chi2XicPlusTopoXiToXicPlusBeforeConstraint,
                   full::Chi2XicPlusTopoXiToXicPlus,
                   full::DcaXYPi0Pi1,
                   full::DcaXYPi0Xi,
@@ -313,7 +317,9 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   // KF-specific columns
                   full::Chi2XiVtx,
                   full::Chi2LamVtx,
+                  full::Chi2XicPlusTopoToPVBeforeConstraint,
                   full::Chi2XicPlusTopoToPV,
+                  full::Chi2XicPlusTopoXiToXicPlusBeforeConstraint,
                   full::Chi2XicPlusTopoXiToXicPlus,
                   full::DcaXYPi0Pi1,
                   full::DcaXYPi0Xi,
@@ -525,7 +531,9 @@ struct HfTreeCreatorXicToXiPiPi {
           // KF-specific columns
           candidate.kfCascadeChi2(),
           candidate.kfV0Chi2(),
+          candidate.chi2TopoXicPlusToPVBeforeConstraint(),
           candidate.chi2TopoXicPlusToPV(),
+          candidate.chi2TopoXiToXicPlusBeforeConstraint(),
           candidate.chi2TopoXiToXicPlus(),
           candidate.dcaXYPi0Pi1(),
           candidate.dcaXYPi0Xi(),
@@ -592,7 +600,9 @@ struct HfTreeCreatorXicToXiPiPi {
           // KF-specific columns
           candidate.kfCascadeChi2(),
           candidate.kfV0Chi2(),
+          candidate.chi2TopoXicPlusToPVBeforeConstraint(),
           candidate.chi2TopoXicPlusToPV(),
+          candidate.chi2TopoXiToXicPlusBeforeConstraint(),
           candidate.chi2TopoXiToXicPlus(),
           candidate.dcaXYPi0Pi1(),
           candidate.dcaXYPi0Xi(),

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -15,6 +15,8 @@
 /// \author Phil Lennart Stahlhut <phil.lennart.stahlhut@cern.ch>, Heidelberg University
 /// \author Carolina Reetz <c.reetz@cern.ch>, Heidelberg University
 
+#include <vector>
+
 #include "CommonConstants/PhysicsConstants.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
@@ -76,10 +78,10 @@ DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);     //!
 DECLARE_SOA_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, float); //! Normalised transverse decay length of candidate
 DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of candidate
 DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
-DECLARE_SOA_COLUMN(Chi2XicPlusTopoToPVBeforeConstraint, chi2XicPlusTopoToPVBeforeConstraint, float);
-DECLARE_SOA_COLUMN(Chi2XicPlusTopoToPV, chi2XicPlusTopoToPV, float);
-DECLARE_SOA_COLUMN(Chi2XicPlusTopoXiToXicPlusBeforeConstraint, chi2XicPlusTopoXiToXicPlusBeforeConstraint, float);
-DECLARE_SOA_COLUMN(Chi2XicPlusTopoXiToXicPlus, chi2XicPlusTopoXiToXicPlus, float);
+DECLARE_SOA_COLUMN(Chi2TopoXicPlusToPVBeforeConstraint, chi2TopoXicPlusToPVBeforeConstraint, float);
+DECLARE_SOA_COLUMN(Chi2TopoXicPlusToPV, chi2TopoXicPlusToPV, float);
+DECLARE_SOA_COLUMN(Chi2TopoXiToXicPlusBeforeConstraint, chi2TopoXiToXicPlusBeforeConstraint, float);
+DECLARE_SOA_COLUMN(Chi2TopoXiToXicPlus, chi2TopoXiToXicPlus, float);
 // properties of daughter tracks
 DECLARE_SOA_COLUMN(PtXi, ptXi, float);                                                 //! Transverse momentum of Xi (prong0) (GeV/c)
 DECLARE_SOA_COLUMN(ImpactParameterXi, impactParameterXi, float);                       //! Impact parameter of Xi (prong0)
@@ -193,10 +195,10 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
                   // KF specific columns
                   full::Chi2XiVtx,
                   full::Chi2LamVtx,
-                  full::Chi2XicPlusTopoToPVBeforeConstraint,
-                  full::Chi2XicPlusTopoToPV,
-                  full::Chi2XicPlusTopoXiToXicPlusBeforeConstraint,
-                  full::Chi2XicPlusTopoXiToXicPlus,
+                  full::Chi2TopoXicPlusToPVBeforeConstraint,
+                  full::Chi2TopoXicPlusToPV,
+                  full::Chi2TopoXiToXicPlusBeforeConstraint,
+                  full::Chi2TopoXiToXicPlus,
                   full::DcaXYPi0Pi1,
                   full::DcaXYPi0Xi,
                   full::DcaXYPi1Xi,
@@ -317,10 +319,10 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   // KF-specific columns
                   full::Chi2XiVtx,
                   full::Chi2LamVtx,
-                  full::Chi2XicPlusTopoToPVBeforeConstraint,
-                  full::Chi2XicPlusTopoToPV,
-                  full::Chi2XicPlusTopoXiToXicPlusBeforeConstraint,
-                  full::Chi2XicPlusTopoXiToXicPlus,
+                  full::Chi2TopoXicPlusToPVBeforeConstraint,
+                  full::Chi2TopoXicPlusToPV,
+                  full::Chi2TopoXiToXicPlusBeforeConstraint,
+                  full::Chi2TopoXiToXicPlus,
                   full::DcaXYPi0Pi1,
                   full::DcaXYPi0Xi,
                   full::DcaXYPi1Xi,
@@ -625,7 +627,7 @@ struct HfTreeCreatorXicToXiPiPi {
     }
     for (const auto& candidate : candidates) {
       if (fillOnlyBackground && downSampleBkgFactor < 1.) {
-        float pseudoRndm = candidate.ptProng1() * 1000. - (int64_t)(candidate.ptProng1() * 1000);
+        float pseudoRndm = candidate.ptProng1() * 1000. - static_cast<int64_t>(candidate.ptProng1() * 1000);
         if (pseudoRndm >= downSampleBkgFactor && candidate.pt() < ptMaxForDownSample) {
           continue;
         }
@@ -645,7 +647,7 @@ struct HfTreeCreatorXicToXiPiPi {
     }
     for (const auto& candidate : candidates) {
       if (fillOnlyBackground && downSampleBkgFactor < 1.) {
-        float pseudoRndm = candidate.ptProng1() * 1000. - (int64_t)(candidate.ptProng1() * 1000);
+        float pseudoRndm = candidate.ptProng1() * 1000. - static_cast<int64_t>(candidate.ptProng1() * 1000);
         if (pseudoRndm >= downSampleBkgFactor && candidate.pt() < ptMaxForDownSample) {
           continue;
         }
@@ -677,7 +679,7 @@ struct HfTreeCreatorXicToXiPiPi {
         rowCandidateFull.reserve(recBg.size());
       }
       for (const auto& candidate : recBg) {
-        float pseudoRndm = candidate.ptProng1() * 1000. - (int64_t)(candidate.ptProng1() * 1000);
+        float pseudoRndm = candidate.ptProng1() * 1000. - static_cast<int64_t>(candidate.ptProng1() * 1000);
         if (candidate.pt() < ptMaxForDownSample && pseudoRndm >= downSampleBkgFactor) {
           continue;
         }
@@ -743,7 +745,7 @@ struct HfTreeCreatorXicToXiPiPi {
         rowCandidateFull.reserve(recBgKf.size());
       }
       for (const auto& candidate : recBgKf) {
-        float pseudoRndm = candidate.ptProng1() * 1000. - (int64_t)(candidate.ptProng1() * 1000);
+        float pseudoRndm = candidate.ptProng1() * 1000. - static_cast<int64_t>(candidate.ptProng1() * 1000);
         if (candidate.pt() < ptMaxForDownSample && pseudoRndm >= downSampleBkgFactor) {
           continue;
         }


### PR DESCRIPTION
@creetz16 @JaeYoonCHO
- Fix bug related to uncertainties of PV/SV in DCAFitter case
- Add topological chi2 before applying the corresponding topological constraints to check for biases