### PR TITLE
[Common,DPG] Add selection mask for global tracks w/o dcaXY cut.

### DIFF
--- a/Common/DataModel/TrackSelectionTables.h
+++ b/Common/DataModel/TrackSelectionTables.h
@@ -60,6 +60,7 @@ struct TrackSelectionFlags {
   static constexpr flagtype kGlobalTrackWoTPCCluster = kQualityTracksWoTPCCluster | kPrimaryTracks | kInAcceptanceTracks;
   static constexpr flagtype kGlobalTrackWoPtEta = kQualityTracks | kPrimaryTracks;
   static constexpr flagtype kGlobalTrackWoDCA = kQualityTracks | kInAcceptanceTracks;
+  static constexpr flagtype kGlobalTrackWoDCAxy = kQualityTracks | kInAcceptanceTracks | kDCAz;
   static constexpr flagtype kGlobalTrackWoDCATPCCluster = kQualityTracksWoTPCCluster | kInAcceptanceTracks;
 
   /// @brief Function to check flag content

--- a/DPG/Tasks/AOTTrack/qaImpPar.cxx
+++ b/DPG/Tasks/AOTTrack/qaImpPar.cxx
@@ -130,7 +130,8 @@ struct QaImpactPar {
                        ((trackSelection.node() == 2) && requireGlobalTrackWoPtEtaInFilter()) ||
                        ((trackSelection.node() == 3) && requireGlobalTrackWoDCAInFilter()) ||
                        ((trackSelection.node() == 4) && requireQualityTracksInFilter()) ||
-                       ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks));
+                       ((trackSelection.node() == 5) && requireTrackCutInFilter(TrackSelectionFlags::kInAcceptanceTracks)) ||
+                       ((trackSelection.node() == 6) && requireTrackCutInFilter(TrackSelectionFlags::kGlobalTrackWoDCAxy));
   // Pt selection
   Filter ptMinFilter = o2::aod::track::pt > ptMin;
 


### PR DESCRIPTION
@phymanshu this should allow you to do the study on dcaXY by applying the default cut on dcaZ < 2 cm (beware: default cut only, i.e. not changeable at the moment)  