### PR TITLE
[PWGUD] Update of global forward tracks in UPCCandidateProducer

### DIFF
--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -1525,7 +1525,7 @@ struct UpcCandProducer {
     std::vector<int> selTrackIdsGlobal{};
 
     // storing n-prong matches
-    int32_t candID = 0; 
+    int32_t candID = 0;
     auto midIt = bcsMatchedTrIdsMID.begin();
     for (auto& pair : bcsMatchedTrIdsGlobal) { // candidates with MFT
       auto globalBC = static_cast<int64_t>(pair.first);
@@ -1534,16 +1534,15 @@ struct UpcCandProducer {
       if (nMFTs > fNFwdProngs) // too many tracks
         continue;
       std::vector<int64_t> trkCandIDs{};
-      auto midBC  = static_cast<int64_t>(midIt->first);
+      auto midBC = static_cast<int64_t>(midIt->first);
       const auto& midTrackIDs = midIt->second;
       if (nMFTs == fNFwdProngs) {
-        for(auto iMft : fwdTrackIDs) {
+        for (auto iMft : fwdTrackIDs) {
           auto trk = fwdTracks.iteratorAt(iMft);
           auto trkEta = trk.eta();
           if (trkEta > fMinEtaMFT && trkEta < fMaxEtaMFT) { // If the track is in the MFT acceptance, store the global track
             trkCandIDs.insert(trkCandIDs.end(), fwdTrackIDs.begin(), fwdTrackIDs.end());
-          }
-          else { // If the track is not in the MFT acceptance, store the MCH-MID track
+          } else { // If the track is not in the MFT acceptance, store the MCH-MID track
             trkCandIDs.insert(trkCandIDs.end(), midTrackIDs.begin(), midTrackIDs.end());
           }
         }

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -12,6 +12,13 @@
 /// \author Diana Krupova, diana.krupova@cern.ch
 /// \since 04.06.2024
 
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <unordered_map>
+#include <algorithm>
+#include <map>
+#include <vector>
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"


### PR DESCRIPTION
Update for the selection of forward tracks in the UPCCandidateProducer: use a global (MFT-MCH-MID) track if the track is within the MFT acceptance; otherwise, use MCH-MID only.