### PR TITLE
[PWGUD] Fill FDD tables using UPCCandidateProducer

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -86,16 +86,21 @@ DECLARE_SOA_COLUMN(TotalFT0AmplitudeC, totalFT0AmplitudeC, float); //! sum of am
 DECLARE_SOA_COLUMN(TimeFT0A, timeFT0A, float);                     //! FT0A average time
 DECLARE_SOA_COLUMN(TimeFT0C, timeFT0C, float);                     //! FT0C average time
 DECLARE_SOA_COLUMN(TriggerMaskFT0, triggerMaskFT0, uint8_t);       //! FT0 trigger mask
+DECLARE_SOA_COLUMN(ChFT0A, chFT0A, uint8_t);                       //! number of FT0A active channels
+DECLARE_SOA_COLUMN(ChFT0C, chFT0C, uint8_t);                       //! number of FT0C active channels
 // FDD information
 DECLARE_SOA_COLUMN(TotalFDDAmplitudeA, totalFDDAmplitudeA, float); //! sum of amplitudes on A side of FDD
 DECLARE_SOA_COLUMN(TotalFDDAmplitudeC, totalFDDAmplitudeC, float); //! sum of amplitudes on C side of FDD
 DECLARE_SOA_COLUMN(TimeFDDA, timeFDDA, float);                     //! FDDA average time
 DECLARE_SOA_COLUMN(TimeFDDC, timeFDDC, float);                     //! FDDC average time
 DECLARE_SOA_COLUMN(TriggerMaskFDD, triggerMaskFDD, uint8_t);       //! FDD trigger mask
+DECLARE_SOA_COLUMN(ChFDDA, chFDDA, uint8_t);                       //! number of FDDA active channels
+DECLARE_SOA_COLUMN(ChFDDC, chFDDC, uint8_t);                       //! number of FDDC active channels
 // FV0A information
 DECLARE_SOA_COLUMN(TotalFV0AmplitudeA, totalFV0AmplitudeA, float); //! sum of amplitudes on A side of FDD
 DECLARE_SOA_COLUMN(TimeFV0A, timeFV0A, float);                     //! FV0A average time
 DECLARE_SOA_COLUMN(TriggerMaskFV0A, triggerMaskFV0A, uint8_t);     //! FV0 trigger mask
+DECLARE_SOA_COLUMN(ChFV0A, chFV0A, uint8_t);                       //! number of FV0A active channels
 // Gap Side Information
 DECLARE_SOA_COLUMN(GapSide, gapSide, uint8_t); // 0 for side A, 1 for side C, 2 for both sides (or use an enum for better readability)
 // FIT selection flags
@@ -198,6 +203,13 @@ DECLARE_SOA_TABLE(UDCollisionsSels, "AOD", "UDCOLLISIONSEL",
                   udcollision::BBFV0A<udcollision::BBFV0APF>, udcollision::BGFV0A<udcollision::BGFV0APF>,
                   udcollision::BBFDDA<udcollision::BBFDDAPF>, udcollision::BBFDDC<udcollision::BBFDDCPF>, udcollision::BGFDDA<udcollision::BGFDDAPF>, udcollision::BGFDDC<udcollision::BGFDDCPF>);
 
+DECLARE_SOA_TABLE(UDCollisionSelExtras, "AOD", "UDCOLSELEXTRA",
+                  udcollision::ChFT0A,  //! number of active channels in FT0A
+                  udcollision::ChFT0C,  //! number of active channels in FT0C
+                  udcollision::ChFDDA,  //! number of active channels in FDDA
+                  udcollision::ChFDDC,  //! number of active channels in FDDC
+                  udcollision::ChFV0A); //! number of active channels in FV0A
+
 // central barrel-specific selections
 DECLARE_SOA_TABLE(UDCollisionsSelsCent, "AOD", "UDCOLSELCNT",
                   udcollision::DBcTOR,
@@ -227,6 +239,7 @@ using SGCollision = SGCollisions::iterator;
 using UDCollisionsSel = UDCollisionsSels::iterator;
 using UDCollisionsSelCent = UDCollisionsSelsCent::iterator;
 using UDCollisionsSelFwd = UDCollisionsSelsFwd::iterator;
+using UDCollisionSelExtra = UDCollisionSelExtras::iterator;
 using UDCollsLabel = UDCollsLabels::iterator;
 using UDMcCollsLabel = UDMcCollsLabels::iterator;
 

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -60,6 +60,7 @@ struct UpcCandProducer {
   Produces<o2::aod::UDCollisionsSels> eventCandidatesSels;
   Produces<o2::aod::UDCollisionsSelsCent> eventCandidatesSelsCent;
   Produces<o2::aod::UDCollisionsSelsFwd> eventCandidatesSelsFwd;
+  Produces<o2::aod::UDCollisionSelExtras> eventCandidatesSelExtras;
 
   Produces<o2::aod::UDZdcsReduced> udZdcsReduced;
 
@@ -1240,7 +1241,7 @@ struct UpcCandProducer {
                            TBCs const& bcs,
                            o2::aod::Collisions const& collisions,
                            o2::aod::FT0s const& ft0s,
-                           o2::aod::FDDs const& /*fdds*/,
+                           o2::aod::FDDs const& fdds,
                            o2::aod::FV0As const& fv0as,
                            o2::aod::Zdcs const& zdcs,
                            const o2::aod::McFwdTrackLabels* mcFwdTrackLabels)
@@ -1304,10 +1305,29 @@ struct UpcCandProducer {
       mapGlobalBcWithZdc[globalBC] = zdc.globalIndex();
     }
 
+    std::map<uint64_t, int32_t> mapGlobalBcWithFDD{};
+    uint8_t twoLayersA = 0;
+    uint8_t twoLayersC = 0;
+    for (const auto& fdd : fdds) {
+      // get signal coincidence
+      for (int i = 0; i < 4; i++) {
+        if (fdd.chargeA()[i + 4] > 0 && fdd.chargeA()[i] > 0)
+          twoLayersA++;
+        if (fdd.chargeC()[i + 4] > 0 && fdd.chargeC()[i] > 0)
+          twoLayersC++;
+      }
+      // if no signal, continue
+      if ((twoLayersA == 0) && (twoLayersC == 0))
+        continue;
+      uint64_t globalBC = fdd.bc_as<TBCs>().globalBC();
+      mapGlobalBcWithFDD[globalBC] = fdd.globalIndex();
+    }
+
     auto nFT0s = mapGlobalBcWithT0A.size();
     auto nFV0As = mapGlobalBcWithV0A.size();
     auto nZdcs = mapGlobalBcWithZdc.size();
     auto nBcsWithMCH = bcsMatchedTrIdsMCH.size();
+    auto nFDDs = mapGlobalBcWithFDD.size();
 
     // todo: calculate position of UD collision?
     float dummyX = 0.;
@@ -1356,6 +1376,8 @@ struct UpcCandProducer {
       std::vector<float> amplitudesV0A{};
       std::vector<int8_t> relBCsT0A{};
       std::vector<int8_t> relBCsV0A{};
+      uint8_t chFT0A = 0;
+      uint8_t chFT0C = 0;
       if (nFT0s > 0) {
         uint64_t closestBcT0A = findClosestBC(globalBC, mapGlobalBcWithT0A);
         int64_t distClosestBcT0A = globalBC - static_cast<int64_t>(closestBcT0A);
@@ -1370,8 +1392,11 @@ struct UpcCandProducer {
         const auto& t0AmpsC = ft0.amplitudeC();
         fitInfo.ampFT0A = std::accumulate(t0AmpsA.begin(), t0AmpsA.end(), 0.f);
         fitInfo.ampFT0C = std::accumulate(t0AmpsC.begin(), t0AmpsC.end(), 0.f);
+        chFT0A = ft0.amplitudeA().size();
+        chFT0C = ft0.amplitudeC().size();
         fillAmplitudes(ft0s, mapGlobalBcWithT0A, amplitudesT0A, relBCsT0A, globalBC);
       }
+      uint8_t chFV0A = 0;
       if (nFV0As > 0) {
         uint64_t closestBcV0A = findClosestBC(globalBC, mapGlobalBcWithV0A);
         int64_t distClosestBcV0A = globalBC - static_cast<int64_t>(closestBcV0A);
@@ -1383,7 +1408,31 @@ struct UpcCandProducer {
         fitInfo.timeFV0A = fv0a.time();
         const auto& v0Amps = fv0a.amplitude();
         fitInfo.ampFV0A = std::accumulate(v0Amps.begin(), v0Amps.end(), 0.f);
+        chFV0A = fv0a.amplitude().size();
         fillAmplitudes(fv0as, mapGlobalBcWithV0A, amplitudesV0A, relBCsV0A, globalBC);
+      }
+      uint8_t chFDDA = 0;
+      uint8_t chFDDC = 0;
+      if (nFDDs > 0) {
+        uint64_t closestBcFDD = findClosestBC(globalBC, mapGlobalBcWithFDD);
+        auto fddId = mapGlobalBcWithFDD.at(closestBcFDD);
+        auto fdd = fdds.iteratorAt(fddId);
+        fitInfo.timeFDDA = fdd.timeA();
+        fitInfo.timeFDDC = fdd.timeC();
+        fitInfo.ampFDDA = 0;
+        for (int i = 0; i < 8; i++)
+          fitInfo.ampFDDA += fdd.chargeA()[i];
+        fitInfo.ampFDDC = 0;
+        for (int i = 0; i < 8; i++)
+          fitInfo.ampFDDC += fdd.chargeC()[i];
+        fitInfo.triggerMaskFDD = fdd.triggerMask();
+        // get signal coincidence
+        for (int i = 0; i < 4; i++) {
+          if (fdd.chargeA()[i + 4] > 0 && fdd.chargeA()[i] > 0)
+            chFDDA++;
+          if (fdd.chargeC()[i + 4] > 0 && fdd.chargeC()[i] > 0)
+            chFDDC++;
+        }
       }
       if (nZdcs > 0) {
         auto itZDC = mapGlobalBcWithZdc.find(globalBC);
@@ -1417,6 +1466,7 @@ struct UpcCandProducer {
                           fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                           fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                           fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
+      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A);
       eventCandidatesSelsFwd(fitInfo.distClosestBcV0A,
                              fitInfo.distClosestBcT0A,
                              amplitudesT0A,
@@ -1435,6 +1485,7 @@ struct UpcCandProducer {
     bcsMatchedTrIdsMCH.clear();
     mapGlobalBcWithT0A.clear();
     mapGlobalBcWithV0A.clear();
+    mapGlobalBcWithFDD.clear();
   }
 
   template <typename TBCs>
@@ -1444,7 +1495,7 @@ struct UpcCandProducer {
                                  TBCs const& bcs,
                                  o2::aod::Collisions const& collisions,
                                  o2::aod::FT0s const& ft0s,
-                                 o2::aod::FDDs const& /*fdds*/,
+                                 o2::aod::FDDs const& fdds,
                                  o2::aod::FV0As const& fv0as,
                                  o2::aod::Zdcs const& zdcs,
                                  const o2::aod::McFwdTrackLabels* mcFwdTrackLabels)
@@ -1517,10 +1568,29 @@ struct UpcCandProducer {
       mapGlobalBcWithZdc[globalBC] = zdc.globalIndex();
     }
 
+    std::map<uint64_t, int32_t> mapGlobalBcWithFDD{};
+    uint8_t twoLayersA = 0;
+    uint8_t twoLayersC = 0;
+    for (const auto& fdd : fdds) {
+      // get signal coincidence
+      for (int i = 0; i < 4; i++) {
+        if (fdd.chargeA()[i + 4] > 0 && fdd.chargeA()[i] > 0)
+          twoLayersA++;
+        if (fdd.chargeC()[i + 4] > 0 && fdd.chargeC()[i] > 0)
+          twoLayersC++;
+      }
+      // if no signal, continue
+      if ((twoLayersA == 0) && (twoLayersC == 0))
+        continue;
+      uint64_t globalBC = fdd.bc_as<TBCs>().globalBC();
+      mapGlobalBcWithFDD[globalBC] = fdd.globalIndex();
+    }
+
     auto nFT0s = mapGlobalBcWithT0A.size();
     auto nFV0As = mapGlobalBcWithV0A.size();
     auto nZdcs = mapGlobalBcWithZdc.size();
     auto nBcsWithMID = bcsMatchedTrIdsMID.size();
+    auto nFDDs = mapGlobalBcWithFDD.size();
 
     // todo: calculate position of UD collision?
     float dummyX = 0.;
@@ -1566,6 +1636,8 @@ struct UpcCandProducer {
       std::vector<float> amplitudesV0A{};
       std::vector<int8_t> relBCsT0A{};
       std::vector<int8_t> relBCsV0A{};
+      uint8_t chFT0A = 0;
+      uint8_t chFT0C = 0;
       if (nFT0s > 0) {
         uint64_t closestBcT0A = findClosestBC(globalBC, mapGlobalBcWithT0A);
         int64_t distClosestBcT0A = globalBC - static_cast<int64_t>(closestBcT0A);
@@ -1580,8 +1652,11 @@ struct UpcCandProducer {
         const auto& t0AmpsC = ft0.amplitudeC();
         fitInfo.ampFT0A = std::accumulate(t0AmpsA.begin(), t0AmpsA.end(), 0.f);
         fitInfo.ampFT0C = std::accumulate(t0AmpsC.begin(), t0AmpsC.end(), 0.f);
+        chFT0A = ft0.amplitudeA().size();
+        chFT0C = ft0.amplitudeC().size();
         fillAmplitudes(ft0s, mapGlobalBcWithT0A, amplitudesT0A, relBCsT0A, globalBC);
       }
+      uint8_t chFV0A = 0;
       if (nFV0As > 0) {
         uint64_t closestBcV0A = findClosestBC(globalBC, mapGlobalBcWithV0A);
         int64_t distClosestBcV0A = globalBC - static_cast<int64_t>(closestBcV0A);
@@ -1593,7 +1668,31 @@ struct UpcCandProducer {
         fitInfo.timeFV0A = fv0a.time();
         const auto& v0Amps = fv0a.amplitude();
         fitInfo.ampFV0A = std::accumulate(v0Amps.begin(), v0Amps.end(), 0.f);
+        chFV0A = fv0a.amplitude().size();
         fillAmplitudes(fv0as, mapGlobalBcWithV0A, amplitudesV0A, relBCsV0A, globalBC);
+      }
+      uint8_t chFDDA = 0;
+      uint8_t chFDDC = 0;
+      if (nFDDs > 0) {
+        uint64_t closestBcFDD = findClosestBC(globalBC, mapGlobalBcWithFDD);
+        auto fddId = mapGlobalBcWithFDD.at(closestBcFDD);
+        auto fdd = fdds.iteratorAt(fddId);
+        fitInfo.timeFDDA = fdd.timeA();
+        fitInfo.timeFDDC = fdd.timeC();
+        fitInfo.ampFDDA = 0;
+        for (int i = 0; i < 8; i++)
+          fitInfo.ampFDDA += fdd.chargeA()[i];
+        fitInfo.ampFDDC = 0;
+        for (int i = 0; i < 8; i++)
+          fitInfo.ampFDDC += fdd.chargeC()[i];
+        fitInfo.triggerMaskFDD = fdd.triggerMask();
+        // get signal coincidence
+        for (int i = 0; i < 4; i++) {
+          if (fdd.chargeA()[i + 4] > 0 && fdd.chargeA()[i] > 0)
+            chFDDA++;
+          if (fdd.chargeC()[i + 4] > 0 && fdd.chargeC()[i] > 0)
+            chFDDC++;
+        }
       }
       if (nZdcs > 0) {
         auto itZDC = mapGlobalBcWithZdc.find(globalBC);
@@ -1627,6 +1726,7 @@ struct UpcCandProducer {
                           fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                           fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                           fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
+      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A);
       eventCandidatesSelsFwd(fitInfo.distClosestBcV0A,
                              fitInfo.distClosestBcT0A,
                              amplitudesT0A,
@@ -1645,6 +1745,7 @@ struct UpcCandProducer {
     bcsMatchedTrIdsGlobal.clear();
     mapGlobalBcWithT0A.clear();
     mapGlobalBcWithV0A.clear();
+    mapGlobalBcWithFDD.clear();
   }
 
   // data processors


### PR DESCRIPTION
- a new table `UDCollisionSelExtras` was defined that stores information about the number of active channels in all FIT detectors (FT0A, FT0C, FDDA, FDDC, FV0A). 
- FDD information (time, amplitude) is now correctly filled in both forward processes
- signal coincidence is used to get the number of active channels in FDD