### PR TITLE
[PWGCF]: Fix bug in event mixing

### DIFF
--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -231,6 +231,12 @@ struct femtoDreamPairTaskTrackTrack {
 
   void init(InitContext& context)
   {
+
+    // setup columnpolicy for binning
+    colBinningMult = {{Mixing.VztxMixBins, Mixing.MultMixBins}, true};
+    colBinningMultPercentile = {{Mixing.VztxMixBins, Mixing.MultPercentileMixBins}, true};
+    colBinningMultMultPercentile = {{Mixing.VztxMixBins, Mixing.MultMixBins, Mixing.MultPercentileMixBins}, true};
+
     if (Option.RandomizePair.value) {
       random = new TRandom3(0);
     }

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackV0.cxx
@@ -227,6 +227,11 @@ struct femtoDreamPairTaskTrackV0 {
 
   void init(InitContext& context)
   {
+    // setup binnnig policy for mixing
+    colBinningMult = {{Mixing.BinVztx, Mixing.BinMult}, true};
+    colBinningMultPercentile = {{Mixing.BinVztx, Mixing.BinMultPercentile}, true};
+    colBinningMultMultPercentile = {{Mixing.BinVztx, Mixing.BinMult, Mixing.BinMultPercentile}, true};
+
     eventHisto.init(&Registry, Option.IsMC);
     trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
     trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, V02.PDGCode);


### PR DESCRIPTION
Initialization of the column mixing policy has to be done in the init function. Otherwise, the mixing bins set in the hyperloop interface are not applied, and always the default values are used.