### PR TITLE
[PWGDQ] Fixed typo in efficiency task -> not urgent

### DIFF
--- a/PWGDQ/Tasks/MIDefficiency.cxx
+++ b/PWGDQ/Tasks/MIDefficiency.cxx
@@ -260,7 +260,7 @@ struct midEfficiency {
           if (isPbPb)
             histos.fill(HIST("hSparseCentFiredBothperRPC"), deId, cent, pt, eta, phi);
           else
-            histos.fill(HIST("hSparseCentFiredNBPperRPC"), deId, pt, eta, phi);
+            histos.fill(HIST("hSparseCentFiredBothperRPC"), deId, pt, eta, phi);
         }
 
         if (effFlag < 3) {


### PR DESCRIPTION
Fixed typo in efficiency task -> commit is not urgent since the affected part of the code is not used for the moment but I fixed it now since I noticed it