### PR TITLE
[PWGEM] add PID scenario: TPC only selection hadron rej, TOF required"

### DIFF
--- a/PWGEM/Dilepton/Core/DielectronCut.h
+++ b/PWGEM/Dilepton/Core/DielectronCut.h
@@ -86,7 +86,8 @@ class DielectronCut : public TNamed
     kTPChadrejORTOFreq = 2,
     kTPConly = 3,
     kTOFif = 4,
-    kPIDML = 5
+    kPIDML = 5,
+    kTPChadrejORTOFreq_woTOFif = 6
   };
 
   template <typename T = int, typename TPair>
@@ -282,6 +283,9 @@ class DielectronCut : public TNamed
       case static_cast<int>(PIDSchemes::kPIDML):
         return true; // don't use kPIDML here.
 
+      case static_cast<int>(PIDSchemes::kTPChadrejORTOFreq_woTOFif):
+        return PassTPConlyhadrej(track) || PassTOFreq(track);
+
       case static_cast<int>(PIDSchemes::kUnDef):
         return true;
 
@@ -316,6 +320,17 @@ class DielectronCut : public TNamed
   {
     bool is_el_included_TPC = mMinTPCNsigmaEl < track.tpcNSigmaEl() && track.tpcNSigmaEl() < mMaxTPCNsigmaEl;
     return is_el_included_TPC;
+  }
+
+  template <typename T>
+  bool PassTPConlyhadrej(T const& track) const
+  {
+    bool is_el_included_TPC = mMinTPCNsigmaEl < track.tpcNSigmaEl() && track.tpcNSigmaEl() < mMaxTPCNsigmaEl;
+    bool is_mu_excluded_TPC = mMuonExclusionTPC ? track.tpcNSigmaMu() < mMinTPCNsigmaMu || mMaxTPCNsigmaMu < track.tpcNSigmaMu() : true;
+    bool is_pi_excluded_TPC = track.tpcInnerParam() < mMaxPinForPionRejectionTPC ? (track.tpcNSigmaPi() < mMinTPCNsigmaPi || mMaxTPCNsigmaPi < track.tpcNSigmaPi()) : true;
+    bool is_ka_excluded_TPC = track.tpcNSigmaKa() < mMinTPCNsigmaKa || mMaxTPCNsigmaKa < track.tpcNSigmaKa();
+    bool is_pr_excluded_TPC = track.tpcNSigmaPr() < mMinTPCNsigmaPr || mMaxTPCNsigmaPr < track.tpcNSigmaPr();
+    return is_el_included_TPC && is_mu_excluded_TPC && is_pi_excluded_TPC && is_ka_excluded_TPC && is_pr_excluded_TPC;
   }
 
   template <typename T>

--- a/PWGEM/Dilepton/Core/Dilepton.h
+++ b/PWGEM/Dilepton/Core/Dilepton.h
@@ -199,7 +199,7 @@ struct Dilepton {
     Configurable<float> cfg_min_rel_diff_pin{"cfg_min_rel_diff_pin", -1e+10, "min rel. diff. between pin and ppv"};
     Configurable<float> cfg_max_rel_diff_pin{"cfg_max_rel_diff_pin", +1e+10, "max rel. diff. between pin and ppv"};
 
-    Configurable<int> cfg_pid_scheme{"cfg_pid_scheme", static_cast<int>(DielectronCut::PIDSchemes::kTPChadrejORTOFreq), "pid scheme [kTOFreq : 0, kTPChadrej : 1, kTPChadrejORTOFreq : 2, kTPConly : 3, kTOFif = 4, kPIDML = 5]"};
+    Configurable<int> cfg_pid_scheme{"cfg_pid_scheme", static_cast<int>(DielectronCut::PIDSchemes::kTPChadrejORTOFreq), "pid scheme [kTOFreq : 0, kTPChadrej : 1, kTPChadrejORTOFreq : 2, kTPConly : 3, kTOFif : 4, kPIDML : 5, kTPChadrejORTOFreq_woTOFif : 6]"};
     Configurable<float> cfg_min_TPCNsigmaEl{"cfg_min_TPCNsigmaEl", -2.0, "min. TPC n sigma for electron inclusion"};
     Configurable<float> cfg_max_TPCNsigmaEl{"cfg_max_TPCNsigmaEl", +3.0, "max. TPC n sigma for electron inclusion"};
     Configurable<float> cfg_min_TPCNsigmaMu{"cfg_min_TPCNsigmaMu", -0.0, "min. TPC n sigma for muon exclusion"};


### PR DESCRIPTION
Adding a PID scenario which doesn't use TOF nSigma for electron selection while applying TPC electron selection.
Used for DQ and EM comparison.