### PR TITLE
[PWGHF] add converter for table with Dstar indices

### DIFF
--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -285,3 +285,10 @@ o2physics_add_dpl_workflow(derived-data-creator-lc-to-p-k-pi
                     SOURCES derivedDataCreatorLcToPKPi.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+# Converters
+
+o2physics_add_dpl_workflow(converter-dstar-indices
+                           SOURCES converterDstarIndices.cxx
+                           PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                           COMPONENT_NAME Analysis)

--- a/PWGHF/TableProducer/converterDstarIndices.cxx
+++ b/PWGHF/TableProducer/converterDstarIndices.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file converterDstarIndices.cxx
+/// \brief Task for conversion of HfDstars to version 001, using the collision index from the D0 daughter
+///
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+struct HfConverterDstarIndices {
+  Produces<aod::HfDstars_001> dstarIndices;
+
+  void process(aod::HfDstars_000::iterator const& candDstar,
+               aod::Hf2Prongs const&)
+  {
+    auto candDzero = candDstar.prongD0_as<aod::Hf2Prongs>();
+    dstarIndices(candDzero.collisionId(), candDstar.prong0Id(), candDstar.prongD0Id());
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HfConverterDstarIndices>(cfgc),
+  };
+}


### PR DESCRIPTION
This PR adds a converter to allow the analyses of HF derived data for D* after the fix in https://github.com/AliceO2Group/O2Physics/pull/8322