### PR TITLE
[PWGJE,EMCAL-670] EMCal Clusterizer - add different MinMax time setting

### DIFF
--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -35,6 +35,9 @@ const EMCALClusterDefinition kV3Default(ClusterAlgorithm_t::kV3, 10, 1, "kV3Defa
 const EMCALClusterDefinition kV3MostSplit(ClusterAlgorithm_t::kV3, 11, 1, "kV3MostSplit", 0.5, 0.1, -10000, 10000, true, 0.);
 const EMCALClusterDefinition kV3LowSeed(ClusterAlgorithm_t::kV3, 12, 1, "kV3LowSeed", 0.3, 0.1, -10000, 10000, true, 0.03);
 const EMCALClusterDefinition kV3MostSplitLowSeed(ClusterAlgorithm_t::kV3, 13, 1, "kV3MostSplitLowSeed", 0.3, 0.1, -10000, 10000, true, 0.);
+const EMCALClusterDefinition kV3StrictTime(ClusterAlgorithm_t::kV3, 20, 1, "kV3StrictTime", 0.5, 0.1, -500, 500, true, 0.03);
+const EMCALClusterDefinition kV3StricterTime(ClusterAlgorithm_t::kV3, 21, 1, "kV3StricterTime", 0.5, 0.1, -100, 100, true, 0.03);
+const EMCALClusterDefinition kV3MostStrictTime(ClusterAlgorithm_t::kV3, 22, 1, "kV3MostStrictTime", 0.5, 0.1, -50, 50, true, 0.03);
 
 /// \brief function returns EMCALClusterDefinition for the given name
 /// \param name name of the cluster definition
@@ -55,6 +58,12 @@ const EMCALClusterDefinition getClusterDefinitionFromString(const std::string& c
     return kV3LowSeed;
   } else if (clusterDefinitionName == "kV3MostSplitLowSeed") {
     return kV3MostSplitLowSeed;
+  } else if (clusterDefinitionName == "kV3StrictTime") {
+    return kV3StrictTime;
+  } else if (clusterDefinitionName == "kV3StricterTime") {
+    return kV3StricterTime;
+  } else if (clusterDefinitionName == "kV3MostStrictTime") {
+    return kV3MostStrictTime;
   } else {
     throw std::invalid_argument("Cluster definition name not recognized");
   }

--- a/PWGJE/Tasks/emcclustermonitor.cxx
+++ b/PWGJE/Tasks/emcclustermonitor.cxx
@@ -76,6 +76,7 @@ struct ClusterMonitor {
 
   std::vector<int> mVetoBCIDs;
   std::vector<int> mSelectBCIDs;
+  std::vector<float> mCellTime;
 
   /// \brief Create output histograms and initialize geometry
   void init(InitContext const&)
@@ -243,20 +244,20 @@ struct ClusterMonitor {
       auto cellsofcluster = emccluscells.sliceBy(perCluster, cluster.globalIndex());
       double maxamp = 0;
       double ampfraction = 0;
-      std::vector<float> vCellTime;
-      vCellTime.reserve(cellsofcluster.size());
+      mCellTime.clear();
+      mCellTime.reserve(cellsofcluster.size());
       for (const auto& cell : cellsofcluster) {
         // example how to get any information of the cell associated with cluster
         LOG(debug) << "Cell ID:" << cell.calo().amplitude() << " Time " << cell.calo().time();
         if (cell.calo().amplitude() > maxamp) {
           maxamp = cell.calo().amplitude();
         }
-        vCellTime.push_back(cell.calo().time());
+        mCellTime.push_back(cell.calo().time());
       } // end of loop over cells
-      mHistManager.fill(HIST("clusterCellTimeMean"), std::accumulate(vCellTime.begin(), vCellTime.end(), 0.0f) / vCellTime.size());
-      for (int iCell1 = 0; iCell1 < vCellTime.size() - 1; iCell1++) {
-        for (int iCell2 = iCell1 + 1; iCell2 < vCellTime.size(); iCell2++) {
-          mHistManager.fill(HIST("clusterCellTimeDiff"), vCellTime[iCell1] - vCellTime[iCell2]);
+      mHistManager.fill(HIST("clusterCellTimeMean"), std::accumulate(mCellTime.begin(), mCellTime.end(), 0.0f) / mCellTime.size());
+      for (int iCell1 = 0; iCell1 < mCellTime.size() - 1; iCell1++) {
+        for (int iCell2 = iCell1 + 1; iCell2 < mCellTime.size(); iCell2++) {
+          mHistManager.fill(HIST("clusterCellTimeDiff"), mCellTime[iCell1] - mCellTime[iCell2]);
         }
       }
       ampfraction = maxamp / cluster.energy();

--- a/PWGJE/Tasks/emcclustermonitor.cxx
+++ b/PWGJE/Tasks/emcclustermonitor.cxx
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <numeric>
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -94,6 +95,8 @@ struct ClusterMonitor {
     const o2Axis supermoduleAxis{20, -0.5, 19.5, "Supermodule ID"};
     o2Axis timeAxis{mClusterTimeBinning, "t_{cl} (ns)"};
     o2Axis numberClustersAxis{mNumberClusterBinning, "Number of clusters / event"};
+    const AxisSpec thAxisCellTimeDiff{3000, -1500, 1500, "#Delta#it{t}_{cell} (ns)"};
+    const AxisSpec thAxisCellTimeMean{1500, -600, 900, "#LT#it{t}_{cell}#GT (ns)"};
 
     // event properties
     mHistManager.add("eventsAll", "Number of events", o2HistType::kTH1F, {{1, 0.5, 1.5}});
@@ -121,6 +124,8 @@ struct ClusterMonitor {
     mHistManager.add("clusterDistanceToBadChannel", "Distance to bad channel", o2HistType::kTH1F, {{100, 0, 100}});
     mHistManager.add("clusterTimeVsE", "Cluster time vs energy", o2HistType::kTH2F, {timeAxis, energyAxis});
     mHistManager.add("clusterAmpFractionLeadingCell", "Fraction of energy in leading cell", o2HistType::kTH1F, {{100, 0, 1}});
+    mHistManager.add("clusterCellTimeDiff", "Cell time difference in clusters", o2HistType::kTH1D, {thAxisCellTimeDiff});
+    mHistManager.add("clusterCellTimeMean", "Mean cell time per cluster", o2HistType::kTH1D, {thAxisCellTimeMean});
 
     // add histograms per supermodule
     for (int ism = 0; ism < 20; ++ism) {
@@ -238,11 +243,20 @@ struct ClusterMonitor {
       auto cellsofcluster = emccluscells.sliceBy(perCluster, cluster.globalIndex());
       double maxamp = 0;
       double ampfraction = 0;
+      std::vector<float> vCellTime;
+      vCellTime.reserve(cellsofcluster.size());
       for (const auto& cell : cellsofcluster) {
         // example how to get any information of the cell associated with cluster
         LOG(debug) << "Cell ID:" << cell.calo().amplitude() << " Time " << cell.calo().time();
         if (cell.calo().amplitude() > maxamp) {
           maxamp = cell.calo().amplitude();
+        }
+        vCellTime.push_back(cell.calo().time());
+      } // end of loop over cells
+      mHistManager.fill(HIST("clusterCellTimeMean"), std::accumulate(vCellTime.begin(), vCellTime.end(), 0.0f) / vCellTime.size());
+      for (int iCell1 = 0; iCell1 < vCellTime.size() - 1; iCell1++) {
+        for (int iCell2 = iCell1 + 1; iCell2 < vCellTime.size(); iCell2++) {
+          mHistManager.fill(HIST("clusterCellTimeDiff"), vCellTime[iCell1] - vCellTime[iCell2]);
         }
       }
       ampfraction = maxamp / cluster.energy();


### PR DESCRIPTION
- Add three new clusterizer settings:
  - `kV3StrictTime` with a cell time window of +- 500 ns
  - `kV3StricterTime` with a cell time window of +- 100 ns
  - `kV3MostStrictTime` with a cell time window of +- 50 ns
  
These setting can be used to test the effect of different cell time windows on Pi0 analysis. The clustermonitor task also got two new histograms to monitor this:
  - `clusterCellTimeMean` which stores the mean cell time per cluster
  - `clusterCellTimeDiff` which stores the difference of each cell times for each cluster. This is done FOR EACH cell pair in a cluster, not just cell_i to leading cell!