### PR TITLE
[PWGLF] Handle kink decays in association for V0/casc labeler

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -94,32 +94,33 @@ struct cascademcbuilder {
   mcCascinfo thisInfo;
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 
-  // kink handling 
-  template <typename mcpart> 
-  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay){
-    int returnValue = -1; 
+  // kink handling
+  template <typename mcpart>
+  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay)
+  {
+    int returnValue = -1;
     if (part.has_mothers()) {
       auto const& motherList = part.template mothers_as<aod::McParticles>();
-      if (motherList.size()==1){
+      if (motherList.size() == 1) {
         for (const auto& mother : motherList) {
-          if(std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays){
+          if (std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays) {
             // muon decay, de-ref mother twice
             if (mother.has_mothers()) {
               auto grandMotherList = mother.template mothers_as<aod::McParticles>();
-              if (grandMotherList.size()==1){
+              if (grandMotherList.size() == 1) {
                 for (const auto& grandMother : grandMotherList) {
                   returnValue = grandMother.globalIndex();
-                  indexForPositionOfDecay = mother.globalIndex(); //for V0 decay position: grab muon
+                  indexForPositionOfDecay = mother.globalIndex(); // for V0 decay position: grab muon
                 }
               }
             }
-          }else{
+          } else {
             returnValue = mother.globalIndex();
-            indexForPositionOfDecay = part.globalIndex(); 
+            indexForPositionOfDecay = part.globalIndex();
           }
         }
       }
-    } 
+    }
     return returnValue;
   }
 
@@ -179,8 +180,8 @@ struct cascademcbuilder {
         thisInfo.processBachelor = lMCBachTrack.getProcess();
 
         // Step 0: treat pi -> mu + antineutrino
-        // if present, de-reference original V0 correctly and provide label to original object 
-        // NOTA BENE: the prong info will still correspond to a muon, treat carefully! 
+        // if present, de-reference original V0 correctly and provide label to original object
+        // NOTA BENE: the prong info will still correspond to a muon, treat carefully!
         int negOriginating = -1, posOriginating = -1, bachOriginating = -1;
         int particleForLambdaDecayPositionIdx = -1, particleForCascadeDecayPositionIdx = -1;
         negOriginating = getOriginatingParticle(lMCNegTrack, particleForLambdaDecayPositionIdx);
@@ -190,13 +191,13 @@ struct cascademcbuilder {
         if (negOriginating == posOriginating) {
           auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
           auto particleForLambdaDecayPosition = mcParticles.rawIteratorAt(particleForLambdaDecayPositionIdx);
-          
+
           thisInfo.label = originatingV0.globalIndex();
           thisInfo.lxyz[0] = particleForLambdaDecayPosition.vx();
           thisInfo.lxyz[1] = particleForLambdaDecayPosition.vy();
           thisInfo.lxyz[2] = particleForLambdaDecayPosition.vz();
 
-          if(originatingV0.has_mothers()){ 
+          if (originatingV0.has_mothers()) {
             for (auto& lV0Mother : originatingV0.template mothers_as<aod::McParticles>()) {
               if (lV0Mother.globalIndex() == bachOriginating) { // found mother particle
                 thisInfo.label = lV0Mother.globalIndex();
@@ -221,8 +222,8 @@ struct cascademcbuilder {
                 }
               }
             } // end v0 mother loop
-          }   // end has_mothers check for V0
-        }   // end conditional of pos/neg originating being the same
+          } // end has_mothers check for V0
+        } // end conditional of pos/neg originating being the same
       }     // end association check
       // Construct label table (note: this will be joinable with CascDatas)
       casclabels(

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -61,6 +61,8 @@ struct cascademcbuilder {
   Configurable<bool> addGeneratedOmegaMinus{"addGeneratedOmegaMinus", false, "add CascMCCore entry for generated, not-recoed OmegaMinus"};
   Configurable<bool> addGeneratedOmegaPlus{"addGeneratedOmegaPlus", false, "add CascMCCore entry for generated, not-recoed OmegaPlus"};
 
+  Configurable<bool> treatPiToMuDecays{"treatPiToMuDecays", true, "if true, will correctly capture pi -> mu and V0 label will still point to originating V0 decay in those cases. Nota bene: prong info will still be for the muon!"};
+
   Configurable<float> rapidityWindow{"rapidityWindow", 0.5, "rapidity window to save non-recoed candidates"};
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -91,6 +93,35 @@ struct cascademcbuilder {
   };
   mcCascinfo thisInfo;
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
+
+  // kink handling 
+  template <typename mcpart> 
+  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay){
+    int returnValue = -1; 
+    if (part.has_mothers()) {
+      auto const& motherList = part.template mothers_as<aod::McParticles>();
+      if (motherList.size()==1){
+        for (const auto& mother : motherList) {
+          if(std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays){
+            // muon decay, de-ref mother twice
+            if (mother.has_mothers()) {
+              auto grandMotherList = mother.template mothers_as<aod::McParticles>();
+              if (grandMotherList.size()==1){
+                for (const auto& grandMother : grandMotherList) {
+                  returnValue = grandMother.globalIndex();
+                  indexForPositionOfDecay = mother.globalIndex(); //for V0 decay position: grab muon
+                }
+              }
+            }
+          }else{
+            returnValue = mother.globalIndex();
+            indexForPositionOfDecay = part.globalIndex(); 
+          }
+        }
+      }
+    } 
+    return returnValue;
+  }
 
   template <typename TCascadeTable, typename TMCParticleTable>
   void generateCascadeMCinfo(TCascadeTable cascTable, TMCParticleTable mcParticles)
@@ -147,51 +178,51 @@ struct cascademcbuilder {
         thisInfo.processNegative = lMCNegTrack.getProcess();
         thisInfo.processBachelor = lMCBachTrack.getProcess();
 
-        // Step 1: check if the mother is the same, go up a level
-        if (lMCNegTrack.has_mothers() && lMCPosTrack.has_mothers()) {
-          for (auto& lNegMother : lMCNegTrack.template mothers_as<aod::McParticles>()) {
-            for (auto& lPosMother : lMCPosTrack.template mothers_as<aod::McParticles>()) {
-              if (lNegMother == lPosMother) {
-                // acquire information
-                thisInfo.lxyz[0] = lMCPosTrack.vx();
-                thisInfo.lxyz[1] = lMCPosTrack.vy();
-                thisInfo.lxyz[2] = lMCPosTrack.vz();
-                thisInfo.pdgCodeV0 = lNegMother.pdgCode();
+        // Step 0: treat pi -> mu + antineutrino
+        // if present, de-reference original V0 correctly and provide label to original object 
+        // NOTA BENE: the prong info will still correspond to a muon, treat carefully! 
+        int negOriginating = -1, posOriginating = -1, bachOriginating = -1;
+        int particleForLambdaDecayPositionIdx = -1, particleForCascadeDecayPositionIdx = -1;
+        negOriginating = getOriginatingParticle(lMCNegTrack, particleForLambdaDecayPositionIdx);
+        posOriginating = getOriginatingParticle(lMCPosTrack, particleForLambdaDecayPositionIdx);
+        bachOriginating = getOriginatingParticle(lMCBachTrack, particleForCascadeDecayPositionIdx);
 
-                // if we got to this level, it means the mother particle exists and is the same
-                // now we have to go one level up and compare to the bachelor mother too
-                if (lNegMother.has_mothers() && lMCBachTrack.has_mothers()) {
-                  for (auto& lV0Mother : lNegMother.template mothers_as<aod::McParticles>()) {
-                    for (auto& lBachMother : lMCBachTrack.template mothers_as<aod::McParticles>()) {
-                      if (lV0Mother == lBachMother) {
-                        thisInfo.label = lV0Mother.globalIndex();
+        if (negOriginating == posOriginating) {
+          auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
+          auto particleForLambdaDecayPosition = mcParticles.rawIteratorAt(particleForLambdaDecayPositionIdx);
+          
+          thisInfo.label = originatingV0.globalIndex();
+          thisInfo.lxyz[0] = particleForLambdaDecayPosition.vx();
+          thisInfo.lxyz[1] = particleForLambdaDecayPosition.vy();
+          thisInfo.lxyz[2] = particleForLambdaDecayPosition.vz();
 
-                        if (lV0Mother.has_mcCollision()) {
-                          thisInfo.mcCollision = lV0Mother.mcCollisionId(); // save this reference, please
-                        }
+          if(originatingV0.has_mothers()){ 
+            for (auto& lV0Mother : originatingV0.template mothers_as<aod::McParticles>()) {
+              if (lV0Mother.globalIndex() == bachOriginating) { // found mother particle
+                thisInfo.label = lV0Mother.globalIndex();
 
-                        thisInfo.pdgCode = lV0Mother.pdgCode();
-                        thisInfo.isPhysicalPrimary = lV0Mother.isPhysicalPrimary();
-                        thisInfo.xyz[0] = lMCBachTrack.vx();
-                        thisInfo.xyz[1] = lMCBachTrack.vy();
-                        thisInfo.xyz[2] = lMCBachTrack.vz();
-                        thisInfo.momentum[0] = lV0Mother.px();
-                        thisInfo.momentum[1] = lV0Mother.py();
-                        thisInfo.momentum[2] = lV0Mother.pz();
-                        if (lV0Mother.has_mothers()) {
-                          for (auto& lV0GrandMother : lV0Mother.template mothers_as<aod::McParticles>()) {
-                            thisInfo.pdgCodeMother = lV0GrandMother.pdgCode();
-                            thisInfo.motherLabel = lV0GrandMother.globalIndex();
-                          }
-                        }
-                      }
-                    }
-                  } // end conditional V0-bach pair
-                }   // end has mothers
-              }   // end neg = pos mother conditional
-            }
-          } // end loop neg/pos mothers
-        }   // end conditional of mothers existing
+                if (lV0Mother.has_mcCollision()) {
+                  thisInfo.mcCollision = lV0Mother.mcCollisionId(); // save this reference, please
+                }
+
+                thisInfo.pdgCode = lV0Mother.pdgCode();
+                thisInfo.isPhysicalPrimary = lV0Mother.isPhysicalPrimary();
+                thisInfo.xyz[0] = originatingV0.vx();
+                thisInfo.xyz[1] = originatingV0.vy();
+                thisInfo.xyz[2] = originatingV0.vz();
+                thisInfo.momentum[0] = lV0Mother.px();
+                thisInfo.momentum[1] = lV0Mother.py();
+                thisInfo.momentum[2] = lV0Mother.pz();
+                if (lV0Mother.has_mothers()) {
+                  for (auto& lV0GrandMother : lV0Mother.template mothers_as<aod::McParticles>()) {
+                    thisInfo.pdgCodeMother = lV0GrandMother.pdgCode();
+                    thisInfo.motherLabel = lV0GrandMother.globalIndex();
+                  }
+                }
+              }
+            } // end v0 mother loop
+          }   // end has_mothers check for V0
+        }   // end conditional of pos/neg originating being the same
       }     // end association check
       // Construct label table (note: this will be joinable with CascDatas)
       casclabels(

--- a/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcbuilder.cxx
@@ -103,7 +103,7 @@ struct cascademcbuilder {
       auto const& motherList = part.template mothers_as<aod::McParticles>();
       if (motherList.size() == 1) {
         for (const auto& mother : motherList) {
-          if (std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays) {
+          if (std::abs(part.pdgCode()) == 13 && treatPiToMuDecays) {
             // muon decay, de-ref mother twice
             if (mother.has_mothers()) {
               auto grandMotherList = mother.template mothers_as<aod::McParticles>();
@@ -188,7 +188,7 @@ struct cascademcbuilder {
         posOriginating = getOriginatingParticle(lMCPosTrack, particleForLambdaDecayPositionIdx);
         bachOriginating = getOriginatingParticle(lMCBachTrack, particleForCascadeDecayPositionIdx);
 
-        if (negOriginating == posOriginating) {
+        if (negOriginating > -1 && negOriginating == posOriginating) {
           auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
           auto particleForLambdaDecayPosition = mcParticles.rawIteratorAt(particleForLambdaDecayPositionIdx);
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -117,32 +117,33 @@ struct lambdakzeromcbuilder {
   mcV0info thisInfo;
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 
-  // kink handling 
-  template <typename mcpart> 
-  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay){
-    int returnValue = -1; 
+  // kink handling
+  template <typename mcpart>
+  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay)
+  {
+    int returnValue = -1;
     if (part.has_mothers()) {
       auto const& motherList = part.template mothers_as<aod::McParticles>();
-      if (motherList.size()==1){
+      if (motherList.size() == 1) {
         for (const auto& mother : motherList) {
-          if(std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays){
+          if (std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays) {
             // muon decay, de-ref mother twice
             if (mother.has_mothers()) {
               auto grandMotherList = mother.template mothers_as<aod::McParticles>();
-              if (grandMotherList.size()==1){
+              if (grandMotherList.size() == 1) {
                 for (const auto& grandMother : grandMotherList) {
                   returnValue = grandMother.globalIndex();
-                  indexForPositionOfDecay = mother.globalIndex(); //for V0 decay position: grab muon
+                  indexForPositionOfDecay = mother.globalIndex(); // for V0 decay position: grab muon
                 }
               }
             }
-          }else{
+          } else {
             returnValue = mother.globalIndex();
-            indexForPositionOfDecay = part.globalIndex(); 
+            indexForPositionOfDecay = part.globalIndex();
           }
         }
       }
-    } 
+    }
     return returnValue;
   }
 
@@ -186,9 +187,9 @@ struct lambdakzeromcbuilder {
         thisInfo.negP[1] = lMCNegTrack.py();
         thisInfo.negP[2] = lMCNegTrack.pz();
 
-        // check for pi -> mu + antineutrino decay 
-        // if present, de-reference original V0 correctly and provide label to original object 
-        // NOTA BENE: the prong info will still correspond to a muon, treat carefully! 
+        // check for pi -> mu + antineutrino decay
+        // if present, de-reference original V0 correctly and provide label to original object
+        // NOTA BENE: the prong info will still correspond to a muon, treat carefully!
         int negOriginating = -1, posOriginating = -1, particleForDecayPositionIdx = -1;
         negOriginating = getOriginatingParticle(lMCNegTrack, particleForDecayPositionIdx);
         posOriginating = getOriginatingParticle(lMCPosTrack, particleForDecayPositionIdx);
@@ -196,7 +197,7 @@ struct lambdakzeromcbuilder {
         if (negOriginating == posOriginating) {
           auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
           auto particleForDecayPosition = mcParticles.rawIteratorAt(particleForDecayPositionIdx);
-          
+
           thisInfo.label = originatingV0.globalIndex();
           thisInfo.xyz[0] = particleForDecayPosition.vx();
           thisInfo.xyz[1] = particleForDecayPosition.vy();

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -126,7 +126,7 @@ struct lambdakzeromcbuilder {
       auto const& motherList = part.template mothers_as<aod::McParticles>();
       if (motherList.size() == 1) {
         for (const auto& mother : motherList) {
-          if (std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays) {
+          if (std::abs(part.pdgCode()) == 13 && treatPiToMuDecays) {
             // muon decay, de-ref mother twice
             if (mother.has_mothers()) {
               auto grandMotherList = mother.template mothers_as<aod::McParticles>();
@@ -194,7 +194,7 @@ struct lambdakzeromcbuilder {
         negOriginating = getOriginatingParticle(lMCNegTrack, particleForDecayPositionIdx);
         posOriginating = getOriginatingParticle(lMCPosTrack, particleForDecayPositionIdx);
 
-        if (negOriginating == posOriginating) {
+        if (negOriginating > -1 && negOriginating == posOriginating) {
           auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
           auto particleForDecayPosition = mcParticles.rawIteratorAt(particleForDecayPositionIdx);
 

--- a/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdakzeromcbuilder.cxx
@@ -55,6 +55,8 @@ struct lambdakzeromcbuilder {
   Configurable<bool> addGeneratedAntiLambda{"addGeneratedAntiLambda", false, "add V0MCCore entry for generated, not-recoed AntiLambda"};
   Configurable<bool> addGeneratedGamma{"addGeneratedGamma", false, "add V0MCCore entry for generated, not-recoed Gamma"};
 
+  Configurable<bool> treatPiToMuDecays{"treatPiToMuDecays", true, "if true, will correctly capture pi -> mu and V0 label will still point to originating V0 decay in those cases. Nota bene: prong info will still be for the muon!"};
+
   Configurable<float> rapidityWindow{"rapidityWindow", 0.5, "rapidity window to save non-recoed candidates"};
 
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -111,15 +113,37 @@ struct lambdakzeromcbuilder {
     std::array<float, 3> posP;
     std::array<float, 3> negP;
     std::array<float, 3> momentum;
-    uint64_t packedMcParticleIndices;
   };
   mcV0info thisInfo;
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
 
-  // prong index combiner
-  uint64_t combineProngIndices(uint32_t low, uint32_t high)
-  {
-    return (((uint64_t)high) << 32) | ((uint64_t)low);
+  // kink handling 
+  template <typename mcpart> 
+  int getOriginatingParticle(mcpart const& part, int& indexForPositionOfDecay){
+    int returnValue = -1; 
+    if (part.has_mothers()) {
+      auto const& motherList = part.template mothers_as<aod::McParticles>();
+      if (motherList.size()==1){
+        for (const auto& mother : motherList) {
+          if(std::abs(mother.pdgCode()) == 13 && treatPiToMuDecays){
+            // muon decay, de-ref mother twice
+            if (mother.has_mothers()) {
+              auto grandMotherList = mother.template mothers_as<aod::McParticles>();
+              if (grandMotherList.size()==1){
+                for (const auto& grandMother : grandMotherList) {
+                  returnValue = grandMother.globalIndex();
+                  indexForPositionOfDecay = mother.globalIndex(); //for V0 decay position: grab muon
+                }
+              }
+            }
+          }else{
+            returnValue = mother.globalIndex();
+            indexForPositionOfDecay = part.globalIndex(); 
+          }
+        }
+      }
+    } 
+    return returnValue;
   }
 
   //*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*
@@ -131,7 +155,6 @@ struct lambdakzeromcbuilder {
     std::vector<bool> mcParticleIsReco(mcParticles.size(), false); // mc Particle not recoed by V0s
 
     for (auto& v0 : v0table) {
-      thisInfo.packedMcParticleIndices = 0; // not de-referenced properly yet
       thisInfo.label = -1;
       thisInfo.motherLabel = -1;
       thisInfo.pdgCode = 0;
@@ -152,7 +175,6 @@ struct lambdakzeromcbuilder {
         auto lMCNegTrack = lNegTrack.mcParticle_as<aod::McParticles>();
         auto lMCPosTrack = lPosTrack.mcParticle_as<aod::McParticles>();
 
-        thisInfo.packedMcParticleIndices = combineProngIndices(lPosTrack.mcParticleId(), lNegTrack.mcParticleId());
         thisInfo.pdgCodePositive = lMCPosTrack.pdgCode();
         thisInfo.pdgCodeNegative = lMCNegTrack.pdgCode();
         thisInfo.processPositive = lMCPosTrack.getProcess();
@@ -163,65 +185,71 @@ struct lambdakzeromcbuilder {
         thisInfo.negP[0] = lMCNegTrack.px();
         thisInfo.negP[1] = lMCNegTrack.py();
         thisInfo.negP[2] = lMCNegTrack.pz();
-        if (lMCNegTrack.has_mothers() && lMCPosTrack.has_mothers()) {
-          for (auto& lNegMother : lMCNegTrack.mothers_as<aod::McParticles>()) {
-            for (auto& lPosMother : lMCPosTrack.mothers_as<aod::McParticles>()) {
-              if (lNegMother.globalIndex() == lPosMother.globalIndex()) {
-                thisInfo.label = lNegMother.globalIndex();
-                thisInfo.xyz[0] = lMCPosTrack.vx();
-                thisInfo.xyz[1] = lMCPosTrack.vy();
-                thisInfo.xyz[2] = lMCPosTrack.vz();
 
-                // MC pos. and neg. daughters are the same! Looking for replacement...
-                if (lMCPosTrack.globalIndex() == lMCNegTrack.globalIndex()) {
-                  auto const& daughters = lNegMother.daughters_as<aod::McParticles>();
-                  for (auto& ldau : daughters) {
-                    // check if the candidate originate from a decay
-                    // if not, this is not a suitable candidate for one of the decay daughters
-                    if (ldau.getProcess() != 4) // see TMCProcess.h
-                      continue;
+        // check for pi -> mu + antineutrino decay 
+        // if present, de-reference original V0 correctly and provide label to original object 
+        // NOTA BENE: the prong info will still correspond to a muon, treat carefully! 
+        int negOriginating = -1, posOriginating = -1, particleForDecayPositionIdx = -1;
+        negOriginating = getOriginatingParticle(lMCNegTrack, particleForDecayPositionIdx);
+        posOriginating = getOriginatingParticle(lMCPosTrack, particleForDecayPositionIdx);
 
-                    if (lMCPosTrack.pdgCode() < 0 && ldau.pdgCode() > 0) { // the positive track needs to be changed
-                      thisInfo.pdgCodePositive = ldau.pdgCode();
-                      thisInfo.processPositive = ldau.getProcess();
-                      thisInfo.posP[0] = ldau.px();
-                      thisInfo.posP[1] = ldau.py();
-                      thisInfo.posP[2] = ldau.pz();
-                      thisInfo.xyz[0] = ldau.vx();
-                      thisInfo.xyz[1] = ldau.vy();
-                      thisInfo.xyz[2] = ldau.vz();
-                    }
-                    if (lMCNegTrack.pdgCode() > 0 && ldau.pdgCode() < 0) { // the negative track needs to be changed
-                      thisInfo.pdgCodeNegative = ldau.pdgCode();
-                      thisInfo.processNegative = ldau.getProcess();
-                      thisInfo.negP[0] = ldau.px();
-                      thisInfo.negP[1] = ldau.py();
-                      thisInfo.negP[2] = ldau.pz();
-                    }
-                  }
-                }
+        if (negOriginating == posOriginating) {
+          auto originatingV0 = mcParticles.rawIteratorAt(negOriginating);
+          auto particleForDecayPosition = mcParticles.rawIteratorAt(particleForDecayPositionIdx);
+          
+          thisInfo.label = originatingV0.globalIndex();
+          thisInfo.xyz[0] = particleForDecayPosition.vx();
+          thisInfo.xyz[1] = particleForDecayPosition.vy();
+          thisInfo.xyz[2] = particleForDecayPosition.vz();
 
-                if (lNegMother.has_mcCollision()) {
-                  thisInfo.mcCollision = lNegMother.mcCollisionId(); // save this reference, please
-                }
+          // MC pos. and neg. daughters are the same! Looking for replacement...
+          // if (lMCPosTrack.globalIndex() == lMCNegTrack.globalIndex()) {
+          //   auto const& daughters = lNegMother.daughters_as<aod::McParticles>();
+          //   for (auto& ldau : daughters) {
+          //     // check if the candidate originates from a decay
+          //     // if not, this is not a suitable candidate for one of the decay daughters
+          //     if (ldau.getProcess() != 4) // see TMCProcess.h
+          //       continue;
 
-                // acquire information
-                thisInfo.pdgCode = lNegMother.pdgCode();
-                thisInfo.isPhysicalPrimary = lNegMother.isPhysicalPrimary();
-                thisInfo.momentum[0] = lNegMother.px();
-                thisInfo.momentum[1] = lNegMother.py();
-                thisInfo.momentum[2] = lNegMother.pz();
+          //     if (lMCPosTrack.pdgCode() < 0 && ldau.pdgCode() > 0) { // the positive track needs to be changed
+          //       thisInfo.pdgCodePositive = ldau.pdgCode();
+          //       thisInfo.processPositive = ldau.getProcess();
+          //       thisInfo.posP[0] = ldau.px();
+          //       thisInfo.posP[1] = ldau.py();
+          //       thisInfo.posP[2] = ldau.pz();
+          //       thisInfo.xyz[0] = ldau.vx();
+          //       thisInfo.xyz[1] = ldau.vy();
+          //       thisInfo.xyz[2] = ldau.vz();
+          //     }
+          //     if (lMCNegTrack.pdgCode() > 0 && ldau.pdgCode() < 0) { // the negative track needs to be changed
+          //       thisInfo.pdgCodeNegative = ldau.pdgCode();
+          //       thisInfo.processNegative = ldau.getProcess();
+          //       thisInfo.negP[0] = ldau.px();
+          //       thisInfo.negP[1] = ldau.py();
+          //       thisInfo.negP[2] = ldau.pz();
+          //     }
+          //   }
+          // }
 
-                if (lNegMother.has_mothers()) {
-                  for (auto& lNegGrandMother : lNegMother.mothers_as<aod::McParticles>()) {
-                    thisInfo.pdgCodeMother = lNegGrandMother.pdgCode();
-                    thisInfo.motherLabel = lNegGrandMother.globalIndex();
-                  }
-                }
-              }
+          if (originatingV0.has_mcCollision()) {
+            thisInfo.mcCollision = originatingV0.mcCollisionId(); // save this reference, please
+          }
+
+          // acquire information
+          thisInfo.pdgCode = originatingV0.pdgCode();
+          thisInfo.isPhysicalPrimary = originatingV0.isPhysicalPrimary();
+          thisInfo.momentum[0] = originatingV0.px();
+          thisInfo.momentum[1] = originatingV0.py();
+          thisInfo.momentum[2] = originatingV0.pz();
+
+          if (originatingV0.has_mothers()) {
+            for (auto& lV0Mother : originatingV0.mothers_as<aod::McParticles>()) {
+              thisInfo.pdgCodeMother = lV0Mother.pdgCode();
+              thisInfo.motherLabel = lV0Mother.globalIndex();
             }
           }
         }
+
       } // end association check
       // Construct label table (note: this will be joinable with V0Datas!)
       v0labels(
@@ -308,7 +336,6 @@ struct lambdakzeromcbuilder {
     if (populateV0MCCoresAsymmetric) {
       // first step: add any un-recoed v0mmcores that were requested
       for (auto& mcParticle : mcParticles) {
-        thisInfo.packedMcParticleIndices = 0;
         thisInfo.label = -1;
         thisInfo.motherLabel = -1;
         thisInfo.pdgCode = 0;

--- a/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/derivedlambdakzeroanalysis.cxx
@@ -148,6 +148,7 @@ struct derivedlambdakzeroanalysis {
 
   // for MC
   Configurable<bool> doMCAssociation{"doMCAssociation", true, "if MC, do MC association"};
+  Configurable<bool> doTreatPiToMuon{"doTreatPiToMuon", false, "Take pi decay into muon into account in MC"};
   Configurable<bool> doCollisionAssociationQA{"doCollisionAssociationQA", true, "check collision association"};
 
   // Machine learning evaluation for pre-selection and corresponding information generation
@@ -816,19 +817,22 @@ struct derivedlambdakzeroanalysis {
   // precalculate this information so that a check is one mask operation, not many
   {
     uint64_t bitMap = 0;
-    // check for specific particle species
+    bool isPositiveProton = v0.pdgCodePositive() == 2212;
+    bool isPositivePion = v0.pdgCodePositive() == 211 || (doTreatPiToMuon && v0.pdgCodePositive() == -13);
+    bool isNegativeProton = v0.pdgCodeNegative() == -2212;
+    bool isNegativePion = v0.pdgCodeNegative() == -211 || (doTreatPiToMuon && v0.pdgCodeNegative() == 13);
 
-    if (v0.pdgCode() == 310 && v0.pdgCodePositive() == 211 && v0.pdgCodeNegative() == -211) {
+    if (v0.pdgCode() == 310 && isPositivePion && isNegativePion) {
       bitset(bitMap, selConsiderK0Short);
       if (v0.isPhysicalPrimary())
         bitset(bitMap, selPhysPrimK0Short);
     }
-    if (v0.pdgCode() == 3122 && v0.pdgCodePositive() == 2212 && v0.pdgCodeNegative() == -211) {
+    if (v0.pdgCode() == 3122 && isPositiveProton && isNegativePion) {
       bitset(bitMap, selConsiderLambda);
       if (v0.isPhysicalPrimary())
         bitset(bitMap, selPhysPrimLambda);
     }
-    if (v0.pdgCode() == -3122 && v0.pdgCodePositive() == 211 && v0.pdgCodeNegative() == -2212) {
+    if (v0.pdgCode() == -3122 && isPositivePion && isNegativeProton) {
       bitset(bitMap, selConsiderAntiLambda);
       if (v0.isPhysicalPrimary())
         bitset(bitMap, selPhysPrimAntiLambda);


### PR DESCRIPTION
This PR ensures the labeler service provided to help with V0 and cascade analysis still labels V0s/cascades correctly in case a kink decay (pion -> muon + antineutrino) is found in the MC association step. This happens frequently, as the TPC track carries the label and thus a plain de-reference of a V0 that includes a pion that decayed into a muon will have a muon+X in its association. Note that such cases will also be flagged as fake associations by corresponding bits of the track table (if checked).

After this PR is merged, the label will still point to the originating particle regardless, meaning a case in which e.g. Lambda -> p + pi -> p + mu + antineutrino, with the V0 made up of (p+mu), will be correctly labeled with the mcParticle label for the Lambda. For general use, please note that the corresponding prong will still irrevocably carry the muon information, so care must be taken if the prong pdg is checked explicitly in analysis.

Checked to be working perfectly fine, ready to merge. Example plot attached (thanks, @romainschotter!)

![image](https://github.com/user-attachments/assets/d0368d67-73f6-4fa6-a31d-b4b50169f6aa)

Tagging @romainschotter @fgrosa @ChiaraDeMartin95 @ercolessi @Luca610 @nepeivodaRS @GijsvWeelden as people with which this topic has been discussed recently.