### PR TITLE
[PWGDQ] [PWGDQ-120] debugging of undefined histogram in AnalysisDileptonTrack (dqEfficiency_withAssoc.cxx)

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -1954,6 +1954,12 @@ struct AnalysisDileptonTrack {
       if (objArraySingleCuts->FindObject(fConfigTrackCut.value.data()) == nullptr) {
         LOG(fatal) << " Track cut chosen for the correlation task was not computed in the single-track task! Check it out!";
       }
+      for (int icut = 0; icut < objArraySingleCuts->GetEntries(); ++icut) {
+        TString tempStr = objArraySingleCuts->At(icut)->GetName();
+        if (tempStr.CompareTo(fConfigTrackCut.value.data()) == 0) {
+          fTrackCutBit = icut; // the bit corresponding to the track to be combined with dileptons
+        }
+      }
       // get the cuts employed for same-event pairing
       string tempCutsPair;
       if (isBarrel) {
@@ -1965,22 +1971,20 @@ struct AnalysisDileptonTrack {
       if (!tempCutsSingleStr.IsNull() && !tempCutsPairStr.IsNull()) {
         std::unique_ptr<TObjArray> objArray(tempCutsPairStr.Tokenize(","));
         fNCuts = objArray->GetEntries();
-        for (int icut = 0; icut < objArraySingleCuts->GetEntries(); ++icut) {
-          TString tempStr = objArraySingleCuts->At(icut)->GetName();
+        for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
+          TString tempStr = objArray->At(icut)->GetName();
           if (objArray->FindObject(tempStr.Data()) != nullptr) {
             fHistNamesDileptonTrack[icut] = Form("DileptonTrack_%s_%s", tempStr.Data(), fConfigTrackCut.value.data());
             fHistNamesDileptons[icut] = Form("DileptonsSelected_%s", tempStr.Data());
             DefineHistograms(fHistMan, fHistNamesDileptonTrack[icut], fConfigHistogramSubgroups.value.data()); // define dilepton-track histograms
             DefineHistograms(fHistMan, fHistNamesDileptons[icut], "barrel,vertexing");                         // define dilepton histograms
             std::vector<TString> mcHistNames;
+            int isig = 0;
             for (auto& sig : fRecMCSignals) {
               mcHistNames.push_back(Form("DileptonTrackMCMatched_%s_%s_%s", tempStr.Data(), fConfigTrackCut.value.data(), sig.GetName()));
-              DefineHistograms(fHistMan, mcHistNames[mcHistNames.size() - 1], "");
+              DefineHistograms(fHistMan, mcHistNames[mcHistNames.size() - 1], fConfigHistogramSubgroups.value.data());
             }
             fHistNamesDileptonTrackMCmatched[icut] = mcHistNames;
-          }
-          if (tempStr.CompareTo(fConfigTrackCut.value.data()) == 0) {
-            fTrackCutBit = icut; // the bit corresponding to the track to be combined with dileptons
           }
         }
       }


### PR DESCRIPTION
There are is an undefined histogram that are filled in AnalysisDileptonTrack

1. When defining the histogram, subgroups must be given. Therefore `DefineHistograms(fHistMan, fHistNamesDileptonTrack[icut], "")`, the latter agument was set to` fConfigHistogramSubgroups.value.data()`
2. The histograms should be defined in a loop over the cuts on the electron legs `objArray`, not the cuts on the associated ytrack `objArraySingleCuts`. Therefore `objArraySingleCuts -> objArray`
3. However `fTrackCutBit`should be initialized with a the cuts on the associated track. Therefore this part of the for-loop was moved out. 