### PR TITLE
[PWGCF] Change mixing to use centrality when needed in V0 task

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -152,6 +152,8 @@ struct femtoUniversePairTaskTrackV0Extended {
   HistogramRegistry registryMCtruth{"MCtruthHistos", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
   HistogramRegistry registryMCreco{"MCrecoHistos", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
 
+  HistogramRegistry MixQaRegistry{"MixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
   std::unique_ptr<TFile> plocalEffFile;
   std::unique_ptr<TH1> plocalEffp1;
   std::unique_ptr<TH1> plocalEffp2;
@@ -219,6 +221,8 @@ struct femtoUniversePairTaskTrackV0Extended {
     trackHistoV0Type2.init(&qaRegistry, ConfV0TempFitVarpTBins, ConfV0TempFitVarBins, ConfIsMC, ConfV0PDGCodePartTwo, true, "V0Type2");
     posChildV0Type2.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, 0, true, "posChildV0Type2");
     negChildV0Type2.init(&qaRegistry, ConfChildTempFitVarpTBins, ConfChildTempFitVarBins, false, 0, true, "negChildV0Type2");
+
+    MixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
     // MC truth
     registryMCtruth.add("plus/MCtruthLambda", "MC truth Lambdas;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
@@ -555,10 +559,10 @@ struct femtoUniversePairTaskTrackV0Extended {
   template <typename PartType, typename PartitionType, typename MCParticles = std::nullptr_t>
   void doMixedEvent(FilteredFDCollisions& cols, PartType& parts, PartitionType& partitionOne, PartitionType& partitionTwo, [[maybe_unused]] MCParticles mcParts = nullptr)
   {
-    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinningMult{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultV0M> colBinningCent{{ConfVtxBins, ConfMultBins}, true};
 
-    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
-
+    auto mixedCollProcessFunc = [&](auto& collision1, auto& collision2) -> void {
       const int multCol = ConfUseCent ? collision1.multV0M() : collision1.multNtr();
 
       auto groupPartsOne = partitionOne->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
@@ -568,7 +572,7 @@ struct femtoUniversePairTaskTrackV0Extended {
       const auto& magFieldTesla2 = collision2.magField();
 
       if (magFieldTesla1 != magFieldTesla2) {
-        continue;
+        return;
       }
 
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
@@ -603,6 +607,18 @@ struct femtoUniversePairTaskTrackV0Extended {
         else
           mixedEventCont.setPair<false>(p1, p2, multCol, ConfUse3D, weight);
       }
+    };
+
+    if (ConfUseCent) {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningCent, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningCent.getBin({collision1.posZ(), collision1.multV0M()}));
+      }
+    } else {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningMult, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), collision1.multNtr()}));
+      }
     }
   }
 
@@ -621,10 +637,10 @@ struct femtoUniversePairTaskTrackV0Extended {
   /// This function processes the mixed event for V0 - V0
   void processMixedEventV0(FilteredFDCollisions& cols, FemtoFullParticles& parts)
   {
-    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinningMult{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultV0M> colBinningCent{{ConfVtxBins, ConfMultBins}, true};
 
-    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
-
+    auto mixedCollProcessFunc = [&](auto& collision1, auto& collision2) -> void {
       const int multCol = ConfUseCent ? collision1.multV0M() : collision1.multNtr();
 
       auto groupPartsOne = partsTwo->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
@@ -634,16 +650,18 @@ struct femtoUniversePairTaskTrackV0Extended {
       const auto& magFieldTesla2 = collision2.magField();
 
       if (magFieldTesla1 != magFieldTesla2) {
-        continue;
+        return;
       }
 
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
         // Lambda invariant mass cut for p1
-        if (!invMLambda(p1.mLambda(), p1.mAntiLambda()))
+        if (!invMLambda(p1.mLambda(), p1.mAntiLambda())) {
           continue;
+        }
         // Lambda invariant mass cut for p2
-        if (!invMLambda(p2.mLambda(), p2.mAntiLambda()))
+        if (!invMLambda(p2.mLambda(), p2.mAntiLambda())) {
           continue;
+        }
 
         const auto& posChild1 = parts.iteratorAt(p1.globalIndex() - 2);
         const auto& negChild1 = parts.iteratorAt(p1.globalIndex() - 1);
@@ -668,6 +686,18 @@ struct femtoUniversePairTaskTrackV0Extended {
         }
         mixedEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
       }
+    };
+
+    if (ConfUseCent) {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningCent, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningCent.getBin({collision1.posZ(), collision1.multV0M()}));
+      }
+    } else {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningMult, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), collision1.multNtr()}));
+      }
     }
   }
   PROCESS_SWITCH(femtoUniversePairTaskTrackV0Extended, processMixedEventV0, "Enable processing mixed events for V0 - V0", false);
@@ -675,10 +705,10 @@ struct femtoUniversePairTaskTrackV0Extended {
   /// This function processes MC mixed events for Track - V0
   void processMCMixedEvent(FilteredFDCollisions& cols, FemtoFullParticles& parts)
   {
-    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinningMult{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultV0M> colBinningCent{{ConfVtxBins, ConfMultBins}, true};
 
-    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
-
+    auto mixedCollProcessFunc = [&](auto& collision1, auto& collision2) -> void {
       const int multCol = ConfUseCent ? collision1.multV0M() : collision1.multNtr();
 
       auto groupPartsOne = partsOneMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
@@ -688,7 +718,7 @@ struct femtoUniversePairTaskTrackV0Extended {
       const auto& magFieldTesla2 = collision2.magField();
 
       if (magFieldTesla1 != magFieldTesla2) {
-        continue;
+        return;
       }
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
         if (static_cast<int>(p1.pidcut()) != ConfTrkPDGCodePartOne)
@@ -703,6 +733,18 @@ struct femtoUniversePairTaskTrackV0Extended {
         }
         mixedEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
       }
+    };
+
+    if (ConfUseCent) {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningCent, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningCent.getBin({collision1.posZ(), collision1.multV0M()}));
+      }
+    } else {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningMult, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), collision1.multNtr()}));
+      }
     }
   }
 
@@ -711,10 +753,10 @@ struct femtoUniversePairTaskTrackV0Extended {
   /// This function processes MC mixed events for V0 - V0
   void processMCMixedEventV0(FilteredFDCollisions& cols, FemtoFullParticles& parts)
   {
-    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinning{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultNtr> colBinningMult{{ConfVtxBins, ConfMultBins}, true};
+    ColumnBinningPolicy<aod::collision::PosZ, aod::femtouniversecollision::MultV0M> colBinningCent{{ConfVtxBins, ConfMultBins}, true};
 
-    for (auto& [collision1, collision2] : soa::selfCombinations(colBinning, 5, -1, cols, cols)) {
-
+    auto mixedCollProcessFunc = [&](auto& collision1, auto& collision2) -> void {
       const int multCol = ConfUseCent ? collision1.multV0M() : collision1.multNtr();
 
       auto groupPartsOne = partsTwoMC->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
@@ -728,6 +770,18 @@ struct femtoUniversePairTaskTrackV0Extended {
         if ((ConfV0Type2 == 0 && pdgCode2 != 3122) || (ConfV0Type2 == 1 && pdgCode2 != -3122))
           continue;
         mixedEventCont.setPair<false>(p1, p2, multCol, ConfUse3D);
+      }
+    };
+
+    if (ConfUseCent) {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningCent, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningCent.getBin({collision1.posZ(), collision1.multV0M()}));
+      }
+    } else {
+      for (auto& [collision1, collision2] : soa::selfCombinations(colBinningMult, 5, -1, cols, cols)) {
+        mixedCollProcessFunc(collision1, collision2);
+        MixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinningMult.getBin({collision1.posZ(), collision1.multNtr()}));
       }
     }
   }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -31,6 +31,8 @@
 #include "Framework/O2DatabasePDGPlugin.h"
 #include <TFile.h>
 #include <TH1.h>
+#include <string>
+#include <memory>
 
 using namespace o2;
 using namespace o2::soa;

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -15,6 +15,8 @@
 /// \author Shirajum Monira, WUT Warsaw, shirajum.monira.dokt@pw.edu.pl
 
 #include <vector>
+#include <string>
+#include <memory>
 #include "Framework/AnalysisTask.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/HistogramRegistry.h"
@@ -31,8 +33,6 @@
 #include "Framework/O2DatabasePDGPlugin.h"
 #include <TFile.h>
 #include <TH1.h>
-#include <string>
-#include <memory>
 
 using namespace o2;
 using namespace o2::soa;


### PR DESCRIPTION
When using centrality (ConfUseCent) replace MutlNtr with MultV0M in binning policy.
Add mixing QA histogram.