### PR TITLE
Fix int8_t configurables

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -109,7 +109,7 @@ struct femtoUniversePairTaskTrackD0 {
     Configurable<bool> ConfIsSame{"ConfIsSame", false, "Pairs of the same particle"};
     Configurable<int> ConfPDGCodeTrack{"ConfPDGCodeTrack", 2212, "Particle 2 - PDG code"};
     Configurable<int> ConfPIDTrack{"ConfPIDTrack", 2, "Particle 2 - Read from cutCulator"}; // we also need the possibility to specify whether the bit is true/false ->std>>vector<std::pair<int, int>>
-    Configurable<int8_t> ConfTrackSign{"ConfTrackSign", 1, "Track sign"};
+    Configurable<int> ConfTrackSign{"ConfTrackSign", 1, "Track sign"};
     Configurable<bool> ConfIsTrackIdentified{"ConfIsTrackIdentified", true, "Enable PID for the track"};
   } ConfTrack;
 

--- a/PWGCF/TwoParticleCorrelations/Tasks/r2p2-4-id.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/r2p2-4-id.cxx
@@ -258,8 +258,8 @@ struct r2p24id {
   Configurable<float> maxpT{"maxpT", 2.0, "Maximum pT"};
   Configurable<float> trackpartition{"trackpartition", 1.0, "where(in pT) to partition"};
 
-  Configurable<int8_t> pid_particle1{"pid_particle1", 1, "Define particle1 type"}; // 1->Pion, 2->Kaon, 3->Proton
-  Configurable<int8_t> pid_particle2{"pid_particle2", 1, "Define particle2 type"};
+  Configurable<int> pid_particle1{"pid_particle1", 1, "Define particle1 type"}; // 1->Pion, 2->Kaon, 3->Proton
+  Configurable<int> pid_particle2{"pid_particle2", 1, "Define particle2 type"};
 
   Configurable<bool> iftrackpartition{"iftrackpartition", false, "If track partition is needed"};
   Configurable<bool> ifpid{"ifpid", false, "If PID is needed"};


### PR DESCRIPTION
Default values of configurables of type int8_t are not correctly read from the JSON because they are interpreted as literal char values and the character code is used instead. It is therefore better to avoid them completely and use int instead.