### PR TITLE
[PWGLF] Fix int8_t configurables

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascadeflow.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadeflow.cxx
@@ -165,7 +165,7 @@ struct cascadeFlow {
   Configurable<std::vector<double>> binsPtMl{"binsPtMl", std::vector<double>{cascade_flow_cuts_ml::vecBinsPt}, "pT bin limits for ML application"};
   Configurable<std::vector<int>> cutDirMl{"cutDirMl", std::vector<int>{cascade_flow_cuts_ml::vecCutDir}, "Whether to reject score values greater or smaller than the threshold"};
   Configurable<LabeledArray<double>> cutsMl{"cutsMl", {cascade_flow_cuts_ml::cuts[0], cascade_flow_cuts_ml::nBinsPt, cascade_flow_cuts_ml::nCutScores, cascade_flow_cuts_ml::labelsPt, cascade_flow_cuts_ml::labelsCutScore}, "ML selections per pT bin"};
-  Configurable<int8_t> nClassesMl{"nClassesMl", (int8_t)cascade_flow_cuts_ml::nCutScores, "Number of classes in ML model"};
+  Configurable<int> nClassesMl{"nClassesMl", static_cast<int>(cascade_flow_cuts_ml::nCutScores), "Number of classes in ML model"};
 
   o2::ccdb::CcdbApi ccdbApi;
 


### PR DESCRIPTION
Default values of configurables of type int8_t are not correctly read from the JSON because they are interpreted as literal char values and the character code is used instead. It is therefore better to avoid them completely and use int instead.