### PR TITLE
[Tutorial] Fix int8_t configurables

### DIFF
--- a/Tutorials/ML/applyMlSelection.cxx
+++ b/Tutorials/ML/applyMlSelection.cxx
@@ -39,7 +39,7 @@ struct applyMlSelection {
   Configurable<std::vector<double>> binsPtMl{"binsPtMl", std::vector<double>{1., 36.}, "pT bin limits for ML application"};
   Configurable<std::vector<int>> cutDirMl{"cutDirMl", std::vector<int>{cuts_ml::CutSmaller, cuts_ml::CutNot, cuts_ml::CutNot}, "Whether to reject score values greater or smaller than the threshold"};
   Configurable<LabeledArray<double>> cutsMl{"cutsMl", {defaultCutsMl[0], 1, 3, {"pT bin 0"}, {"score prompt", "score non-prompt", "score bkg"}}, "ML selections per pT bin"};
-  Configurable<int8_t> nClassesMl{"nClassesMl", (int8_t)3, "Number of classes in ML model"};
+  Configurable<int> nClassesMl{"nClassesMl", 3, "Number of classes in ML model"};
   // Model file names
   Configurable<std::vector<std::string>> onnxFileNames{"onnxFileNames", std::vector<std::string>{"model_onnx.onnx"}, "ONNX file names for each pT bin (if not from CCDB full path)"};
   // Bonus: CCDB configuration (needed for ML application on the GRID)


### PR DESCRIPTION
Default values of configurables of type int8_t are not correctly read from the JSON because they are interpreted as literal char values and the character code is used instead. It is therefore better to avoid them completely and use int instead.