### PR TITLE
[PWGDQ] Fix uint8_t configurables

### DIFF
--- a/PWGDQ/Tasks/dqCorrelation.cxx
+++ b/PWGDQ/Tasks/dqCorrelation.cxx
@@ -116,7 +116,7 @@ struct DqCumulantFlow {
   ConfigurableAxis axisEta{"axisEta", {40, -6.0, 1.5}, "eta axis for histograms"};
   ConfigurableAxis axisPt{"axisPt", {100, 0, 20}, "pt axis for histograms"};
   ConfigurableAxis axisMass{"axisMass", {40, 2, 4}, "mass axis for histograms"};
-  Configurable<uint8_t> fConfigNPow{"cfgNPow", 0, "Power of weights for Q vector"};
+  Configurable<uint> fConfigNPow{"cfgNPow", 0, "Power of weights for Q vector"};
   // Configurables for the reference flow
   Configurable<string> fConfigTrackCuts{"cfgLeptonCuts", "jpsiO2MCdebugCuts2", "Comma separated list of barrel track cuts"};
   Configurable<float> fConfigCutPtMin{"cfgCutPtMin", 1.0f, "Minimal pT for tracks"};

--- a/PWGDQ/Tasks/dqFlow.cxx
+++ b/PWGDQ/Tasks/dqFlow.cxx
@@ -117,7 +117,7 @@ struct DQEventQvector {
   Configurable<int> fConfigCutTPCNClMin{"cfgCutTPCNclMin", 0, "Min requirement for number of TPC clusters"};
   Configurable<float> fConfigEtaLimitMin{"cfgEtaLimitMin", -0.4f, "Eta gap min separation, only if using subEvents"};
   Configurable<float> fConfigEtaLimitMax{"cfgEtaLimitMax", 0.4f, "Eta gap max separation, only if using subEvents"};
-  // Configurable<uint8_t> fConfigNPow{"cfgNPow", 0, "Power of weights for Q vector"};
+  // Configurable<uint> fConfigNPow{"cfgNPow", 0, "Power of weights for Q vector"};
   // Configurable<GFWBinningCuts> cfgGFWBinning{"cfgGFWBinning", {40, 16, 72, 300, 0, 3000, 0.2, 10.0, 0.2, 3.0, {0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2, 2.2, 2.4, 2.6, 2.8, 3, 3.5, 4, 5, 6, 8, 10}, {0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90}}, "Configuration for binning"};
 
   // Access to the efficiencies and acceptances from CCDB


### PR DESCRIPTION
Default values of configurables of type int8_t are not correctly read from the JSON because they are interpreted as literal char values and the character code is used instead. It is therefore better to avoid them completely and use int instead.