### PR TITLE
[PWGCF] Add some selections to pt-effeciency code

### DIFF
--- a/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
+++ b/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
@@ -102,8 +102,7 @@ struct flowPtEfficiency {
     }
     if (cfgCutDCAxyppPass3Enabled) {
       myTrackSel.SetMaxDcaXYPtDep([](float pt) { return 0.004f + 0.013f / pt; });
-    }
-    else {
+    } else {
       myTrackSel.SetMaxDcaXY(cfgCutDCAxy);
     }
     myTrackSel.SetMinNClustersTPC(cfgCutTPCclu);

--- a/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
+++ b/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
@@ -17,8 +17,11 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/EventSelection.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/HistogramRegistry.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/TrackSelectionDefaults.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -32,17 +35,37 @@ struct flowPtEfficiency {
   O2_DEFINE_CONFIGURABLE(cfgCutPtMin, float, 0.2f, "Minimal pT for tracks")
   O2_DEFINE_CONFIGURABLE(cfgCutPtMax, float, 3.0f, "Maximal pT for tracks")
   O2_DEFINE_CONFIGURABLE(cfgCutEta, float, 0.8f, "Eta range for tracks")
+  O2_DEFINE_CONFIGURABLE(cfgTrkSelRun3ITSMatch, bool, false, "GlobalTrackRun3ITSMatching::Run3ITSall7Layers selection")
+  O2_DEFINE_CONFIGURABLE(cfgCutChi2prTPCcls, float, 2.5f, "max chi2 per TPC clusters")
+  O2_DEFINE_CONFIGURABLE(cfgCutTPCclu, float, 70.0f, "minimum TPC clusters")
+  O2_DEFINE_CONFIGURABLE(cfgCutTPCcrossedrows, float, 70.0f, "minimum TPC crossed rows")
   O2_DEFINE_CONFIGURABLE(cfgCutDCAxy, float, 0.2f, "DCAxy cut for tracks")
+  O2_DEFINE_CONFIGURABLE(cfgCutDCAz, float, 2.0f, "DCAz cut for tracks")
+  O2_DEFINE_CONFIGURABLE(cfgCutDCAxyppPass3Enabled, bool, false, "switch of ppPass3 DCAxy pt dependent cut")
+  O2_DEFINE_CONFIGURABLE(cfgCutDCAzPtDepEnabled, bool, false, "switch of DCAz pt dependent cut")
+  O2_DEFINE_CONFIGURABLE(cfgSelRunNumberEnabled, bool, false, "switch of run number selection")
+  Configurable<std::vector<int>> cfgRunNumberList{"cfgRunNumberList", std::vector<int>{-1}, "runnumber list in consideration for analysis"};
 
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.2, 0.25, 0.30, 0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00, 1.10, 1.20, 1.30, 1.40, 1.50, 1.60, 1.70, 1.80, 1.90, 2.00, 2.20, 2.40, 2.60, 2.80, 3.00}, "pt axis for histograms"};
 
   // Filter the tracks
-  Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::pt > cfgCutPtMin) && (aod::track::pt < cfgCutPtMax) && (nabs(aod::track::dcaXY) < cfgCutDCAxy);
+  Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::pt > cfgCutPtMin) && (aod::track::pt < cfgCutPtMax) && (aod::track::tpcChi2NCl < cfgCutChi2prTPCcls);
   using myTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::McTrackLabels>>;
+
+  // Filter for collisions
+  Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
+  using myCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::EvSels>>;
 
   // Filter for MCParticle
   Filter particleFilter = (nabs(aod::mcparticle::eta) < cfgCutEta) && (aod::mcparticle::pt > cfgCutPtMin) && (aod::mcparticle::pt < cfgCutPtMax);
   using myMcParticles = soa::Filtered<aod::McParticles>;
+
+  // Filter for MCcollisions
+  Filter mccollisionFilter = nabs(aod::mccollision::posZ) < cfgCutVertex;
+  using myMcCollisions = soa::Filtered<aod::McCollisions>;
+
+  // Additional filters for tracks
+  TrackSelection myTrackSel;
 
   // Define the output
   HistogramRegistry registry{"registry"};
@@ -71,13 +94,47 @@ struct flowPtEfficiency {
 
     registry.add("mcEventCounter", "Monte Carlo Truth EventCounter", kTH1F, {axisCounter});
     registry.add("hPtMCGen", "Monte Carlo Truth", {HistType::kTH1D, {axisPt}});
+
+    if (cfgTrkSelRun3ITSMatch) {
+      myTrackSel = getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSall7Layers, TrackSelection::GlobalTrackRun3DCAxyCut::Default);
+    } else {
+      myTrackSel = getGlobalTrackSelectionRun3ITSMatch(TrackSelection::GlobalTrackRun3ITSMatching::Run3ITSibAny, TrackSelection::GlobalTrackRun3DCAxyCut::Default);
+    }
+    if (cfgCutDCAxyppPass3Enabled) {
+      myTrackSel.SetMaxDcaXYPtDep([](float pt) { return 0.004f + 0.013f / pt; });
+    }
+    else {
+      myTrackSel.SetMaxDcaXY(cfgCutDCAxy);
+    }
+    myTrackSel.SetMinNClustersTPC(cfgCutTPCclu);
+    myTrackSel.SetMinNCrossedRowsTPC(cfgCutTPCcrossedrows);
+    if (!cfgCutDCAzPtDepEnabled)
+      myTrackSel.SetMaxDcaZ(cfgCutDCAz);
   }
 
-  void processReco(o2::aod::Collision const&, myTracks const& tracks, aod::McParticles const&)
+  template <typename TTrack>
+  bool trackSelected(TTrack track)
+  {
+    if (cfgCutDCAzPtDepEnabled && (track.dcaZ() > (0.004f + 0.013f / track.pt())))
+      return false;
+    return myTrackSel.IsSelected(track);
+  }
+
+  void processReco(myCollisions::iterator const& collision, aod::BCsWithTimestamps const&, myTracks const& tracks, aod::McParticles const&)
   {
     registry.fill(HIST("eventCounter"), 0.5);
+    if (!collision.sel8())
+      return;
+    if (tracks.size() < 1)
+      return;
+    if (cfgSelRunNumberEnabled) {
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      int RunNumber = bc.runNumber();
+      if (!std::count(cfgRunNumberList.value.begin(), cfgRunNumberList.value.end(), RunNumber))
+        return;
+    }
     for (const auto& track : tracks) {
-      if (track.tpcNClsCrossedRows() < 70)
+      if (!trackSelected(track))
         continue;
       if (track.has_mcParticle()) {
         auto mcParticle = track.mcParticle();
@@ -89,8 +146,14 @@ struct flowPtEfficiency {
   }
   PROCESS_SWITCH(flowPtEfficiency, processReco, "process reconstructed information", true);
 
-  void processSim(aod::McCollision const&, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions, myMcParticles const& mcParticles)
+  void processSim(myMcCollisions::iterator const& collision, aod::BCsWithTimestamps const&, soa::SmallGroups<soa::Join<aod::McCollisionLabels, aod::Collisions>> const& collisions, myMcParticles const& mcParticles)
   {
+    if (cfgSelRunNumberEnabled) {
+      auto bc = collision.bc_as<aod::BCsWithTimestamps>();
+      int RunNumber = bc.runNumber();
+      if (!std::count(cfgRunNumberList.value.begin(), cfgRunNumberList.value.end(), RunNumber))
+        return;
+    }
     if (collisions.size() > -1) {
       registry.fill(HIST("mcEventCounter"), 0.5);
       for (const auto& mcParticle : mcParticles) {

--- a/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
+++ b/PWGCF/Flow/Tasks/flowPtEfficiency.cxx
@@ -14,6 +14,7 @@
 /// \author everyone
 
 #include <iostream>
+#include <vector>
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Common/DataModel/TrackSelectionTables.h"


### PR DESCRIPTION
Summary of Changes:

- Added additional track selection criteria, including:

  - Chi2 per TPC clusters
  - TPC crossed rows
  - Pt-dependent cuts for DCAxy and DCAz, tailored for Run 3 pp
  - `GlobalTrackRun3ITSMatching::Run3ITSall7Layers` selection

- Implemented selection criteria for vertex z.

- Enabled processing for specific runs of interest only.