### PR TITLE
[PWGLF] added e() memeber in reso. initilliser for mc particles and added occupancy cut in lamba1520_pb tasks

### DIFF
--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -339,7 +339,9 @@ DECLARE_SOA_TABLE(ResoMCParents, "AOD", "RESOMCPARENTS",
                   resodaughter::Pz,
                   resodaughter::Eta,
                   resodaughter::Phi,
-                  mcparticle::Y);
+                  mcparticle::Y,
+                  mcparticle::E,
+                  mcparticle::StatusCode);
 using ResoMCParent = ResoMCParents::iterator;
 
 using Reso2TracksExt = soa::Join<aod::FullTracks, aod::TracksDCA>; // without Extra

--- a/PWGLF/DataModel/LFResonanceTablesMergeDF.h
+++ b/PWGLF/DataModel/LFResonanceTablesMergeDF.h
@@ -44,6 +44,7 @@ DECLARE_SOA_COLUMN(BMagField, bMagField, float);   //! Magnetic field
 } // namespace resocollisiondf
 DECLARE_SOA_TABLE(ResoCollisionDFs, "AOD", "RESOCOLLISIONDF",
                   o2::soa::Index<>,
+                  o2::aod::mult::MultNTracksPV,
                   collision::PosX,
                   collision::PosY,
                   collision::PosZ,
@@ -54,7 +55,8 @@ DECLARE_SOA_TABLE(ResoCollisionDFs, "AOD", "RESOCOLLISIONDF",
                   resocollisiondf::EvtPlResAC,
                   resocollisiondf::EvtPlResBC,
                   resocollisiondf::BMagField,
-                  timestamp::Timestamp);
+                  timestamp::Timestamp,
+                  evsel::NumTracksInTimeRange);
 using ResoCollisionDF = ResoCollisionDFs::iterator;
 
 // Resonance Daughters

--- a/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
+++ b/PWGLF/TableProducer/Resonances/LFResonanceInitializer.cxx
@@ -864,7 +864,9 @@ struct reso2initializer {
                      mcPart.pz(),
                      mcPart.eta(),
                      mcPart.phi(),
-                     mcPart.y());
+                     mcPart.y(),
+                     mcPart.e(),
+                     mcPart.statusCode());
       daughterPDGs.clear();
     }
   }

--- a/PWGLF/TableProducer/Resonances/LFResonanceMergeDF.cxx
+++ b/PWGLF/TableProducer/Resonances/LFResonanceMergeDF.cxx
@@ -25,6 +25,7 @@
 /// ///
 /// \author Bong-Hwi Lim <bong-hwi.lim@cern.ch>
 ///    Nasir Mehdi Malik
+#include <vector>
 
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/Core/TrackSelection.h"
@@ -60,7 +61,6 @@ using namespace o2::soa;
 
 struct reso2dfmerged {
   //  SliceCache cache;
-
   Configurable<int> nDF{"nDF", 1, "no of combination of collision"};
   Configurable<bool> cpidCut{"cpidCut", 0, "pid cut"};
   Configurable<bool> crejtpc{"crejtpc", 0, "reject electron pion"};
@@ -184,7 +184,7 @@ struct reso2dfmerged {
       const auto& innerVector = vecOfVecOfTuples[i];
 
       histos.fill(HIST("Event/h1d_ft0_mult_percentile"), std::get<3>(tuple));
-      resoCollisionsdf(std::get<0>(tuple), std::get<1>(tuple), std::get<2>(tuple), std::get<3>(tuple), std::get<4>(tuple), std::get<5>(tuple), 0., 0., 0., 0, 0);
+      resoCollisionsdf(0, std::get<0>(tuple), std::get<1>(tuple), std::get<2>(tuple), std::get<3>(tuple), std::get<4>(tuple), std::get<5>(tuple), 0., 0., 0., 0., 0, collision.trackOccupancyInTimeRange());
       //  LOGF(info, "collisions: Index = %d ) %f - %f - %f %f %d -- %d", std::get<0>(tuple).globalIndex(),std::get<1>(tuple),std::get<2>(tuple), std::get<3>(tuple), std::get<4>(tuple), std::get<5>(tuple).size(),resoCollisionsdf.lastIndex());
 
       for (const auto& tuple : innerVector) {
@@ -239,9 +239,10 @@ struct reso2dfmerged {
 
     if (doprocessTrackDataDF)
       LOG(fatal) << "Disable processTrackDataDF first!";
+
     histos.fill(HIST("Event/h1d_ft0_mult_percentile"), collision.cent());
 
-    resoCollisionsdf(collision.posX(), collision.posY(), collision.posZ(), collision.cent(), collision.spherocity(), collision.evtPl(), 0., 0., 0., 0., 0);
+    resoCollisionsdf(0, collision.posX(), collision.posY(), collision.posZ(), collision.cent(), collision.spherocity(), collision.evtPl(), 0., 0., 0., 0., 0, collision.trackOccupancyInTimeRange());
 
     for (auto& track : tracks) {
       if (isPrimary && !track.isPrimaryTrack())


### PR DESCRIPTION
e() member for MC particles is added in ResoInitiliser table producer tasks, as I need it for my tasks to retrieve the mass of generated MC particles. Additionally, I included occupancy cuts, which I plan to use in my tasks while producing after derived datasets.