### PR TITLE
[PWGJE] additional features for GammaJetTrees

### DIFF
--- a/PWGJE/DataModel/GammaJetAnalysisTree.h
+++ b/PWGJE/DataModel/GammaJetAnalysisTree.h
@@ -31,9 +31,10 @@ DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
 DECLARE_SOA_COLUMN(Centrality, centrality, float);
 DECLARE_SOA_COLUMN(Rho, rho, float);
 DECLARE_SOA_COLUMN(EventSel, eventSel, uint8_t);
+DECLARE_SOA_COLUMN(Occupancy, occupancy, float);
 DECLARE_SOA_BITMAP_COLUMN(Alias, alias, 32);
 } // namespace gjevent
-DECLARE_SOA_TABLE(GjEvents, "AOD", "GJEVENT", o2::soa::Index<>, gjevent::Multiplicity, gjevent::Centrality, gjevent::Rho, gjevent::EventSel, gjevent::Alias)
+DECLARE_SOA_TABLE(GjEvents, "AOD", "GJEVENT", o2::soa::Index<>, gjevent::Multiplicity, gjevent::Centrality, gjevent::Rho, gjevent::EventSel, gjevent::Occupancy, gjevent::Alias)
 
 using GjEvent = GjEvents::iterator;
 
@@ -64,12 +65,15 @@ DECLARE_SOA_INDEX_COLUMN(GjEvent, gjevent);
 DECLARE_SOA_COLUMN(Pt, pt, float);
 DECLARE_SOA_COLUMN(Eta, eta, float);
 DECLARE_SOA_COLUMN(Phi, phi, float);
+DECLARE_SOA_COLUMN(Radius, radius, float);
 DECLARE_SOA_COLUMN(Energy, energy, float);
 DECLARE_SOA_COLUMN(Mass, mass, float);
 DECLARE_SOA_COLUMN(Area, area, float);
+DECLARE_SOA_COLUMN(LeadingTrackPt, leadingtrackpt, float);
+DECLARE_SOA_COLUMN(PerpConeRho, perpconerho, float);
 DECLARE_SOA_COLUMN(NConstituents, nConstituents, ushort);
 } // namespace gjchjet
-DECLARE_SOA_TABLE(GjChargedJets, "AOD", "GJCHJET", gjchjet::GjEventId, gjchjet::Pt, gjchjet::Eta, gjchjet::Phi, gjchjet::Energy, gjchjet::Mass, gjchjet::Area, gjchjet::NConstituents)
+DECLARE_SOA_TABLE(GjChargedJets, "AOD", "GJCHJET", gjchjet::GjEventId, gjchjet::Pt, gjchjet::Eta, gjchjet::Phi, gjchjet::Radius, gjchjet::Energy, gjchjet::Mass, gjchjet::Area, gjchjet::LeadingTrackPt,gjchjet::PerpConeRho,gjchjet::NConstituents)
 } // namespace o2::aod
 
 #endif // PWGJE_DATAMODEL_GAMMAJETANALYSISTREE_H_

--- a/PWGJE/DataModel/GammaJetAnalysisTree.h
+++ b/PWGJE/DataModel/GammaJetAnalysisTree.h
@@ -31,7 +31,7 @@ DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
 DECLARE_SOA_COLUMN(Centrality, centrality, float);
 DECLARE_SOA_COLUMN(Rho, rho, float);
 DECLARE_SOA_COLUMN(EventSel, eventSel, uint8_t);
-DECLARE_SOA_COLUMN(Occupancy, occupancy, float);
+DECLARE_SOA_COLUMN(Occupancy, occupancy, int);
 DECLARE_SOA_BITMAP_COLUMN(Alias, alias, 32);
 } // namespace gjevent
 DECLARE_SOA_TABLE(GjEvents, "AOD", "GJEVENT", o2::soa::Index<>, gjevent::Multiplicity, gjevent::Centrality, gjevent::Rho, gjevent::EventSel, gjevent::Occupancy, gjevent::Alias)

--- a/PWGJE/Tasks/gammajettreeproducer.cxx
+++ b/PWGJE/Tasks/gammajettreeproducer.cxx
@@ -102,7 +102,7 @@ struct GammaJetTreeProducer {
     const o2Axis m02Axis{100, 0, 3, "m02"};
     const o2Axis etaAxis{100, -1, 1, "#eta"};
     const o2Axis phiAxis{100, 0 , 2*TMath::Pi(), "#phi"};
-
+    const o2Axis occupancyAxis{300, 0, 30000, "occupancy"};
     mHistograms.add("clusterE", "Energy of cluster", o2HistType::kTH1F, {energyAxis});
     mHistograms.add("trackPt", "pT of track", o2HistType::kTH1F, {ptAxis});
     mHistograms.add("chjetPt", "pT of charged jet", o2HistType::kTH1F, {ptAxis});
@@ -111,6 +111,7 @@ struct GammaJetTreeProducer {
 
     // track QA THnSparse
     mHistograms.add("trackPtEtaPhi", "Track QA", o2HistType::kTHnSparseF, {ptAxis, etaAxis, phiAxis});
+    mHistograms.add("trackPtEtaOccupancy", "Track QA vs occupancy", o2HistType::kTHnSparseF, {ptAxis, etaAxis, occupancyAxis});
   }
 
   // ---------------------
@@ -217,7 +218,7 @@ struct GammaJetTreeProducer {
     collisionMapping[collision.globalIndex()] = eventsTable.lastIndex();
 
     // loop over tracks one time for QA
-    runTrackQA(tracks);
+    runTrackQA(collision, tracks);
 
     // loop over clusters
     for (auto cluster : clusters) {


### PR DESCRIPTION
This PR adds multiple features to the GammaJetTree for prompt photon analyses
- track matching including eta and phi information on emcal surface
- capability to store jets of any given set of radii
- added leading hadron pt to jet information
- added event occupancy information (crucial for Pb-Pb)
- capability to estimate UE in perpendicular cone also perpendicular to jets