### PR TITLE
[PWGJE] Making the code process events without using weight

### DIFF
--- a/PWGJE/Tasks/bjetTaggingML.cxx
+++ b/PWGJE/Tasks/bjetTaggingML.cxx
@@ -14,6 +14,10 @@
 ///
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, University of Jyväskylä
 
+#include <string>
+#include <algorithm>
+#include <vector>
+
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/ASoA.h"

--- a/PWGJE/Tasks/bjetTaggingML.cxx
+++ b/PWGJE/Tasks/bjetTaggingML.cxx
@@ -84,6 +84,7 @@ struct BJetTaggingML {
   // event level configurables
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
+  Configurable<bool> useEventWeight{"useEventWeight", true, "Flag whether to scale histograms with the event weight"};
 
   Configurable<float> pTHatMaxMCD{"pTHatMaxMCD", 999.0, "maximum fraction of hard scattering for jet acceptance in detector MC"};
   Configurable<float> pTHatMaxMCP{"pTHatMaxMCP", 999.0, "maximum fraction of hard scattering for jet acceptance in particle MC"};
@@ -450,7 +451,7 @@ struct BJetTaggingML {
         continue;
       }
 
-      float eventWeight = analysisJet.eventWeight();
+      float eventWeight = useEventWeight ? analysisJet.eventWeight() : 1.0;
       float pTHat = 10. / (std::pow(eventWeight, 1.0 / pTHatExponent));
       if (analysisJet.pt() > pTHatMaxMCD * pTHat) {
         continue;
@@ -535,7 +536,7 @@ struct BJetTaggingML {
         continue;
       }
 
-      float eventWeight = mcpjet.eventWeight();
+      float eventWeight = useEventWeight ? mcpjet.eventWeight() : 1.0;
       float pTHat = 10. / (std::pow(eventWeight, 1.0 / pTHatExponent));
       if (mcpjet.pt() > pTHatMaxMCP * pTHat) {
         continue;
@@ -582,7 +583,7 @@ struct BJetTaggingML {
         continue;
       }
 
-      float eventWeight = mcpjet.eventWeight();
+      float eventWeight = useEventWeight ? mcpjet.eventWeight() : 1.0;
       float pTHat = 10. / (std::pow(eventWeight, 1.0 / pTHatExponent));
       if (mcpjet.pt() > pTHatMaxMCP * pTHat) {
         continue;


### PR DESCRIPTION
Changing the bjetTraggingML task to process events without using the event weight for normalization.