### PR TITLE
[PWGHF]: Add QA histograms for tracks and charm hadron before pairing

### DIFF
--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -58,12 +58,12 @@ struct HfTaskCharmHadronsFemtoDream {
   ConfigurableAxis bin4DMult{"bin4Dmult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<Confuse4D>> to true in order to use)"};
   ConfigurableAxis bin4DmT{"bin4DmT", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<Confuse4D>> to true in order to use)"};
   ConfigurableAxis bin4DmultPercentile{"bin4DmultPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<Confuse4D>> to true in order to use)"};
-  ConfigurableAxis binInvMass{"binInvMass", {300, 2.15, 2.45}, "InvMass binning"};
+  ConfigurableAxis binInvMass{"binInvMass", {400, 2.10, 2.50}, "InvMass binning"};
+  ConfigurableAxis binpTCharm{"binpTCharm", {360, 0, 36}, "pT binning of charm hadron"};
   ConfigurableAxis binTempFitVarTrack{"binTempFitVarTrack", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Track)"};
   ConfigurableAxis binmT{"binmT", {225, 0., 7.5}, "binning mT"};
   ConfigurableAxis binmultTempFit{"binmultTempFit", {1, 0, 1}, "multiplicity Binning for the TempFitVar plot"};
   ConfigurableAxis binMulPercentile{"binMulPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning"};
-  ConfigurableAxis binpT{"binpT", {20, 0.5, 4.05}, "pT binning"};
   ConfigurableAxis binpTTrack{"binpTTrack", {50, 0.5, 10.05}, "pT binning of the pT vs. TempFitVar plot (Track)"};
   ConfigurableAxis binEta{"binEta", {{200, -1.5, 1.5}}, "eta binning"};
   ConfigurableAxis binPhi{"binPhi", {{200, 0, TMath::TwoPi()}}, "phi binning"};
@@ -167,12 +167,15 @@ struct HfTaskCharmHadronsFemtoDream {
   femtodreamcollision::BitMaskType BitMask = 1 << 0;
 
   /// Histogramming for particle 1
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> allTrackHisto;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 5> selectedTrackHisto;
+
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
   /// Histogram output
   HistogramRegistry registry{"CorrelationsAndQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry registryMixQa{"registryMixQa"};
+  HistogramRegistry registryCharmHadronQa{"registryCharmHadronQa"};
   /// Partition for particle 1
 
   Partition<FilteredFDParticles> partitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) && (ncheckbit(aod::femtodreamparticle::cut, cutBitTrack1)) && ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= pidThresTrack1, ncheckbit(aod::femtodreamparticle::pidcut, tpcBitTrack1), ncheckbit(aod::femtodreamparticle::pidcut, tpcTofBitTrack1));
@@ -201,10 +204,11 @@ struct HfTaskCharmHadronsFemtoDream {
     colBinningMultPercentile = {{mixingBinVztx, mixingBinMultPercentile}, true};
     colBinningMultMultPercentile = {{mixingBinVztx, mixingBinMult, mixingBinMultPercentile}, true};
     eventHisto.init(&registry);
-    trackHistoPartOne.init(&registry, binmultTempFit, binMulPercentile, binpTTrack, binEta, binPhi, binTempFitVarTrack, binNSigmaTPC, binNSigmaTOF, binNSigmaTPCTOF, binTPCClusters, dummy, isMc, pdgCodeTrack1, true);
+    allTrackHisto.init(&registry, binmultTempFit, binMulPercentile, binpTTrack, binEta, binPhi, binTempFitVarTrack, binNSigmaTPC, binNSigmaTOF, binNSigmaTPCTOF, binTPCClusters, dummy, isMc, pdgCodeTrack1, true);
+    selectedTrackHisto.init(&registry, binmultTempFit, binMulPercentile, binpTTrack, binEta, binPhi, binTempFitVarTrack, binNSigmaTPC, binNSigmaTOF, binNSigmaTPCTOF, binTPCClusters, dummy, isMc, pdgCodeTrack1, true);
 
     sameEventCont.init<true>(&registry,
-                             binkstar, binpT, binkT, binmT, mixingBinMult, mixingBinMultPercentile,
+                             binkstar, binpTTrack, binkT, binmT, mixingBinMult, mixingBinMultPercentile,
                              bin4Dkstar, bin4DmT, bin4DMult, bin4DmultPercentile,
                              isMc, use4D, extendedPlots,
                              highkstarCut,
@@ -212,16 +216,18 @@ struct HfTaskCharmHadronsFemtoDream {
 
     sameEventCont.setPDGCodes(pdgCodeTrack1, charmHadPDGCode);
     mixedEventCont.init<true>(&registry,
-                              binkstar, binpT, binkT, binmT, mixingBinMult, mixingBinMultPercentile,
+                              binkstar, binpTTrack, binkT, binmT, mixingBinMult, mixingBinMultPercentile,
                               bin4Dkstar, bin4DmT, bin4DMult, bin4DmultPercentile,
                               isMc, use4D, extendedPlots,
                               highkstarCut,
                               smearingByOrigin, binInvMass);
 
     mixedEventCont.setPDGCodes(pdgCodeTrack1, charmHadPDGCode);
-    registryMixQa.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
-    registryMixQa.add("MixingQA/hSECollisionPool", ";bin;Entries", kTH2F, {{100, -10, 10}, {2000, 0, 200}});
-    registryMixQa.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    registryMixQa.add("MixingQA/hSECollisionBins", "; bin; Entries", kTH1F, {{120, -0.5, 119.5}});
+    registryMixQa.add("MixingQA/hSECollisionPool", "; Vz (cm); Mul", kTH2F, {{100, -10, 10}, {200, 0, 200}});
+    registryMixQa.add("MixingQA/hMECollisionBins", "; bin; Entries", kTH1F, {{120, -0.5, 119.5}});
+    registryCharmHadronQa.add("CharmHadronQA/hPtVsMass", "; #it{p}_{T} (GeV/#it{c}); inv. mass (GeV/#it{c}^{2})", kTH2F, {binpTCharm, binInvMass});
+
     pairCleaner.init(&registry);
     if (useCPR.value) {
       pairCloseRejectionSE.init(&registry, &registry, cprDeltaPhiMax.value, cprDeltaEtaMax.value, cprPlotPerRadii.value, 1);
@@ -243,11 +249,6 @@ struct HfTaskCharmHadronsFemtoDream {
     fillCollision(col);
 
     processType = 1; // for same event
-    /// Histogramming same event
-    for (auto const& part : sliceTrk1) {
-
-      trackHistoPartOne.fillQA<isMc, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-    }
 
     for (auto const& [p1, p2] : combinations(CombinationsFullIndexPolicy(sliceTrk1, sliceCharmHad))) {
 
@@ -304,6 +305,8 @@ struct HfTaskCharmHadronsFemtoDream {
       if (p2.pt() < charmHadMinPt || p2.pt() > charmHadMaxPt) {
         continue;
       }
+      /// Filling QA histograms of the selected tracks
+      selectedTrackHisto.fillQA<isMc, true>(p1, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value), col.multNtr(), col.multV0M());
 
       int charmHadMc = 0;
       int originType = 0;
@@ -427,12 +430,26 @@ struct HfTaskCharmHadronsFemtoDream {
                         FilteredFDParticles const& parts,
                         FilteredCharmCands const&)
   {
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      return;
-    }
     eventHisto.fillQA(col);
     auto sliceTrk1 = partitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto sliceCharmHad = partitionCharmHadron->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    /// Filling QA histograms of the all tracks and all charm hadrons before pairing
+    for (auto const& part : sliceTrk1) {
+      allTrackHisto.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+    }
+    for (auto const& part : sliceCharmHad) {
+      float invMass;
+      if (part.candidateSelFlag() == 1) {
+        invMass = part.m(std::array{o2::constants::physics::MassProton, o2::constants::physics::MassKPlus, o2::constants::physics::MassPiPlus});
+      } else {
+        invMass = part.m(std::array{o2::constants::physics::MassPiPlus, o2::constants::physics::MassKPlus, o2::constants::physics::MassProton});
+      }
+      registryCharmHadronQa.fill(HIST("CharmHadronQA/hPtVsMass"), part.pt(), invMass);
+    }
+
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      return;
+    }
     doSameEvent<false>(sliceTrk1, sliceCharmHad, parts, col);
   }
   PROCESS_SWITCH(HfTaskCharmHadronsFemtoDream, processSameEvent, "Enable processing same event", false);
@@ -467,13 +484,20 @@ struct HfTaskCharmHadronsFemtoDream {
                           o2::aod::FDExtMCParticles const&,
                           FilteredCharmMcCands const&)
   {
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      return;
-    }
+    eventHisto.fillQA(col);
+
     auto sliceMcTrk1 = partitionMcTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto sliceMcCharmHad = partitionMcCharmHadron->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
 
     if (sliceMcTrk1.size() == 0 && sliceMcCharmHad.size() == 0) {
+      return;
+    }
+    /// Filling QA histograms of the all mc tracks before pairing
+    for (auto const& part : sliceMcTrk1) {
+      allTrackHisto.fillQA<true, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+    }
+
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
       return;
     }
     doSameEvent<true>(sliceMcTrk1, sliceMcCharmHad, parts, col);


### PR DESCRIPTION
- To enable more convenient comparison with CF femtoscopy analysis: adding QA histograms for tracks and charm hadrons before pairing.