### PR TITLE
[PWGCF] Updated pair cleaner

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamPairCleaner.h
@@ -70,7 +70,7 @@ class FemtoDreamPairCleaner
       }
       const auto& posChild = particles.iteratorAt(part2.index() - 2);
       const auto& negChild = particles.iteratorAt(part2.index() - 1);
-      if (part1.globalIndex() != posChild.globalIndex() || part1.globalIndex() != negChild.globalIndex()) {
+      if (part1.globalIndex() != posChild.childrenIds()[0] && part1.globalIndex() != negChild.childrenIds()[1]) {
         return true;
       }
       return false;


### PR DESCRIPTION
Fixed the Pair Cleaner, to check if the daughter is really not the same track as primary track in the pairs based on information stored at the producer level