### PR TITLE
[PWGLF] Add MotherPDG and flag for ambiguous tracks

### DIFF
--- a/PWGLF/DataModel/LFSlimNucleiTables.h
+++ b/PWGLF/DataModel/LFSlimNucleiTables.h
@@ -48,6 +48,7 @@ DECLARE_SOA_COLUMN(gPt, genPt, float);
 DECLARE_SOA_COLUMN(gEta, genEta, float);
 DECLARE_SOA_COLUMN(gPhi, genPhi, float);
 DECLARE_SOA_COLUMN(PDGcode, pdgCode, int);
+DECLARE_SOA_COLUMN(MotherPDGcode, MotherpdgCode, int);
 DECLARE_SOA_COLUMN(SurvivedEventSelection, survivedEventSelection, bool);
 DECLARE_SOA_COLUMN(AbsoDecL, absoDecL, float);
 
@@ -127,6 +128,7 @@ DECLARE_SOA_TABLE(NucleiTableMC, "AOD", "NUCLEITABLEMC",
                   NucleiTableNS::gEta,
                   NucleiTableNS::gPhi,
                   NucleiTableNS::PDGcode,
+                  NucleiTableNS::MotherPDGcode,
                   NucleiTableNS::SurvivedEventSelection,
                   NucleiTableNS::AbsoDecL);
 

--- a/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
@@ -831,12 +831,16 @@ struct nucleiSpectra {
           if (particle.mcCollisionId() == collMCGlobId) {
             c.correctPV = true;
           }
+          if(!c.correctPV){
+            c.flags |= kIsAmbiguous;
+          }
           if (!particle.isPhysicalPrimary()) {
             c.isSecondary = true;
             if (particle.getProcess() == 4) {
               c.fromWeakDecay = true;
             }
           }
+          
           if (c.fillDCAHist && cfgDCAHists->get(iS, c.pt < 0)) {
             nuclei::hDCAHists[c.pt < 0][iS]->Fill(std::abs(c.pt), c.DCAxy, c.DCAz, c.nSigmaTPC[iS], c.tofMasses[iS], c.ITSnCls, c.TPCnCls, c.correctPV, c.isSecondary, c.fromWeakDecay);
           }
@@ -845,16 +849,20 @@ struct nucleiSpectra {
       if (!storeIt) {
         continue;
       }
+      int MotherpdgCode=0;
       isReconstructed[particle.globalIndex()] = true;
       if (particle.isPhysicalPrimary()) {
         c.flags |= kIsPhysicalPrimary;
       } else if (particle.has_mothers()) {
         c.flags |= kIsSecondaryFromWeakDecay;
+        for (auto& motherparticle : particle.mothers_as<aod::McParticles>()) {
+          MotherpdgCode=motherparticle.pdgCode();
+        }
       } else {
         c.flags |= kIsSecondaryFromMaterial;
       }
       float absoDecL = computeAbsoDecL(particle);
-      nucleiTableMC(c.pt, c.eta, c.phi, c.tpcInnerParam, c.beta, c.zVertex, c.DCAxy, c.DCAz, c.TPCsignal, c.ITSchi2, c.TPCchi2, c.TOFchi2, c.flags, c.TPCfindableCls, c.TPCcrossedRows, c.ITSclsMap, c.TPCnCls, c.TPCnClsShared, c.clusterSizesITS, particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(), goodCollisions[particle.mcCollisionId()], absoDecL);
+      nucleiTableMC(c.pt, c.eta, c.phi, c.tpcInnerParam, c.beta, c.zVertex, c.DCAxy, c.DCAz, c.TPCsignal, c.ITSchi2, c.TPCchi2, c.TOFchi2, c.flags, c.TPCfindableCls, c.TPCcrossedRows, c.ITSclsMap, c.TPCnCls, c.TPCnClsShared, c.clusterSizesITS, particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(),MotherpdgCode, goodCollisions[particle.mcCollisionId()], absoDecL);
     }
 
     int index{0};
@@ -875,7 +883,7 @@ struct nucleiSpectra {
 
         if (!isReconstructed[index] && (cfgTreeConfig->get(iS, 0u) || cfgTreeConfig->get(iS, 1u))) {
           float absDecL = computeAbsoDecL(particle);
-          nucleiTableMC(999., 999., 999., 0., 0., 999., 999., 999., -1, -1, -1, -1, flags, 0, 0, 0, 0, 0, 0, particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(), goodCollisions[particle.mcCollisionId()], absDecL);
+          nucleiTableMC(999., 999., 999., 0., 0., 999., 999., 999., -1, -1, -1, -1, flags, 0, 0, 0, 0, 0, 0, particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(),0, goodCollisions[particle.mcCollisionId()], absDecL);
         }
         break;
       }


### PR DESCRIPTION
In this PR I add to the table the PDGcode of mother od secondary particles. I also use the bit(7) of flags to check if track is matched with correct collision