### PR TITLE
[PWGLF] Fix KF cascade daughter DCA calculation in cascadebuilder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascadebuilder.cxx
@@ -1412,12 +1412,8 @@ struct cascadeBuilder {
     KFXi.TransportToDecayVertex();
     KFOmega.TransportToDecayVertex();
 
-    // get DCA of updated daughters at vertex
-    KFParticle kfpBachPionUpd = kfpBachPion;
-    KFParticle kfpV0Upd = kfpV0;
-    kfpBachPionUpd.SetProductionVertex(KFXi);
-    kfpV0Upd.SetProductionVertex(KFXi);
-    cascadecandidate.dcacascdau = kfpBachPionUpd.GetDistanceFromParticle(kfpV0Upd);
+    // get DCA of daughters at vertex
+    cascadecandidate.dcacascdau = kfpBachPion.GetDistanceFromParticle(kfpV0);
     if (cascadecandidate.dcacascdau > dcacascdau)
       return false;
 


### PR DESCRIPTION
Hi @ddobrigk 
You probably remember that I added this part some time ago. After another detailed discussion with the KF authors it turned out that we should not use the SetProductionVertex in this case. I changed the code accordingly. 
Let me know if you have any comments on this. :)
Cheers
Carolina