### PR TITLE
[PWGLF] Adding cut for selecting antitriton for tree saving

### DIFF
--- a/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
@@ -702,7 +702,7 @@ struct nucleiSpectra {
         if (fillTree) {
           if (flag & BIT(2)) {
             if (track.pt() < cfgCutPtMinTree || track.pt() > cfgCutPtMaxTree || track.sign() > 0)
-            continue;
+              continue;
           }
         }
         nuclei::candidates.emplace_back(NucleusCandidate{

--- a/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
@@ -700,8 +700,10 @@ struct nucleiSpectra {
             collision.multTPC()});
         }
         if (fillTree) {
-          if (track.pt() < cfgCutPtMinTree || track.pt() > cfgCutPtMaxTree)
+          if (flag & BIT(2)) { 
+            if (track.pt() < cfgCutPtMinTree || track.pt() > cfgCutPtMaxTree || track.sign() > 0)
             continue;
+          }
         }
         nuclei::candidates.emplace_back(NucleusCandidate{
           static_cast<int>(track.globalIndex()), static_cast<int>(track.collisionId()), (1 - 2 * iC) * mTrackParCov.getPt(), mTrackParCov.getEta(), mTrackParCov.getPhi(),

--- a/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
@@ -700,7 +700,7 @@ struct nucleiSpectra {
             collision.multTPC()});
         }
         if (fillTree) {
-          if (flag & BIT(2)) { 
+          if (flag & BIT(2)) {
             if (track.pt() < cfgCutPtMinTree || track.pt() > cfgCutPtMaxTree || track.sign() > 0)
             continue;
           }


### PR DESCRIPTION
Adding selection on antimatter for triton measurement in order to reduce the output of derived data, storing only antimatter candidates. 