### PR TITLE
PWGDQ: Add the electron-muon pair process in filterPPwithAssociation

### DIFF
--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -68,6 +68,7 @@ enum DQTriggers {
   kSingleMuLow,
   kSingleMuHigh,
   kDiMuon,
+//  kElectronMuon, //the ElectronMuon trigger is not available now
   kNTriggersDQ
 };
 } // namespace
@@ -78,6 +79,8 @@ namespace dqppfilter
 DECLARE_SOA_COLUMN(IsDQEventSelected, isDQEventSelected, int);
 DECLARE_SOA_COLUMN(IsDQBarrelSelected, isDQBarrelSelected, uint32_t);
 DECLARE_SOA_COLUMN(IsDQMuonSelected, isDQMuonSelected, uint32_t);
+DECLARE_SOA_COLUMN(IsDQEMuBarrelSelected, isDQEMuBarrelSelected, uint32_t); // for electron-muon pair
+DECLARE_SOA_COLUMN(IsDQEMuMuonSelected, isDQEMuMuonSelected, uint32_t);     // for electron-muon pair
 DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Collision index
 DECLARE_SOA_INDEX_COLUMN(Track, track);         //! Track index
 DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);   //! FwdTrack index
@@ -86,6 +89,8 @@ DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);   //! FwdTrack index
 DECLARE_SOA_TABLE(DQEventCuts, "AOD", "DQEVENTCUTS", dqppfilter::IsDQEventSelected);
 DECLARE_SOA_TABLE(DQBarrelTrackCuts, "AOD", "DQBARRELCUTS", dqppfilter::IsDQBarrelSelected);
 DECLARE_SOA_TABLE(DQMuonsCuts, "AOD", "DQMUONCUTS", dqppfilter::IsDQMuonSelected);
+DECLARE_SOA_TABLE(DQEMuBarrelTrackCuts, "AOD", "DQEMUBARRELCUTS", dqppfilter::IsDQEMuBarrelSelected); //for electron-muon pair
+DECLARE_SOA_TABLE(DQEMuMuonsCuts, "AOD", "DQEMUMUONCUTS", dqppfilter::IsDQEMuMuonSelected);           //for electron-muon pair
 } // namespace o2::aod
 
 using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
@@ -103,10 +108,10 @@ using MyBarrelTracksSelected = soa::Join<aod::Tracks, aod::TracksExtra, aod::Tra
                                          aod::pidTPCFullKa, aod::pidTPCFullPr,
                                          aod::pidTOFFullEl, aod::pidTOFFullPi,
                                          aod::pidTOFFullKa, aod::pidTOFFullPr>;
-using MyBarrelTracksAssocSelected = soa::Join<TrackAssoc, aod::DQBarrelTrackCuts>; // As the kinelatic values must be re-computed for the tracks everytime it is associated to a collision, the selection is done not on the tracks, but on the track-collision association
+using MyBarrelTracksAssocSelected = soa::Join<TrackAssoc, aod::DQBarrelTrackCuts, aod::DQEMuBarrelTrackCuts>; // As the kinelatic values must be re-computed for the tracks everytime it is associated to a collision, the selection is done not on the tracks, but on the track-collision association
 
 using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
-using MyMuonsAssocSelected = soa::Join<FwdTrackAssoc, aod::DQMuonsCuts>; // As the kinelatic values must be re-computed for the muons tracks everytime it is associated to a collision, the selection is done not on the muon, but on the muon-collision association
+using MyMuonsAssocSelected = soa::Join<FwdTrackAssoc, aod::DQMuonsCuts, aod::DQEMuMuonsCuts>; // As the kinelatic values must be re-computed for the muons tracks everytime it is associated to a collision, the selection is done not on the muon, but on the muon-collision association
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackPID;
@@ -185,10 +190,12 @@ struct DQEventSelectionTask {
 
 struct DQBarrelTrackSelection {
   Produces<aod::DQBarrelTrackCuts> trackSel;
+  Produces<aod::DQEMuBarrelTrackCuts> emuSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
   Configurable<std::string> fConfigCuts{"cfgBarrelTrackCuts", "jpsiPID1", "Comma separated list of barrel track cuts"};
+  Configurable<std::string> fConfigCutsForEMu{"cfgBarrelTrackCutsForEMu", "jpsiPID1", "Comma separated list of barrel track cuts"};
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
   Configurable<bool> fPropTrack{"cfgPropTrack", false, "Propgate tracks to associated collision to recalculate DCA and momentum vector"};
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -201,6 +208,7 @@ struct DQBarrelTrackSelection {
   Preslice<aod::TrackAssoc> barrelTrackIndicesPerCollision = aod::track_association::collisionId;
 
   std::vector<AnalysisCompositeCut> fTrackCuts;
+  std::vector<AnalysisCompositeCut> fEMuTrackCuts;
   std::vector<TString> fCutHistNames;
 
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
@@ -208,6 +216,7 @@ struct DQBarrelTrackSelection {
   void init(o2::framework::InitContext&)
   {
     TString cutNamesStr = fConfigCuts.value;
+    TString cutEMuNamesStr = fConfigCutsForEMu.value;
     if (!cutNamesStr.IsNull()) {
       std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
       for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
@@ -216,6 +225,17 @@ struct DQBarrelTrackSelection {
           fTrackCuts.push_back(*cut);
         } else {
           LOGF(fatal, "Invalid barrel track cut provided: %s", objArray->At(icut)->GetName());
+        }
+      }
+    }
+    if (!cutEMuNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray2(cutEMuNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray2->GetEntries(); ++icut) {
+        AnalysisCompositeCut* cut2 = dqcuts::GetCompositeCut(objArray2->At(icut)->GetName());
+        if (cut2) {
+          fEMuTrackCuts.push_back(*cut2);
+        } else {
+          LOGF(fatal, "Invalid e-mu cut provided: %s", objArray2->At(icut)->GetName());
         }
       }
     }
@@ -273,11 +293,14 @@ struct DQBarrelTrackSelection {
     o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
 
     uint32_t filterMap = uint32_t(0);
+    uint32_t filterMapEMu = uint32_t(0);
     trackSel.reserve(tracksBarrel.size());
+    emuSel.reserve(emuBarrel.size());
 
     VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
     for (auto& trackAssoc : trackAssocs) {
       filterMap = uint32_t(0);
+      filterMapEMu = uint32_t(0);
 
       auto track = trackAssoc.template track_as<TTracks>();
 
@@ -298,7 +321,14 @@ struct DQBarrelTrackSelection {
           }
         }
       }
+      int j = 0;
+      for (auto cut = fEMuTrackCuts.begin(); cut != fEMuTrackCuts.end(); ++cut, ++j) {
+          if ((*cut).IsSelected(VarManager::fgValues)) {
+            filterMapEMu |= (uint32_t(1) << j);
+          }
+        }
       trackSel(filterMap);
+      emuSel(filterMapEMu);
     } // end loop over tracks
   }
 
@@ -321,10 +351,12 @@ struct DQBarrelTrackSelection {
 
 struct DQMuonsSelection {
   Produces<aod::DQMuonsCuts> trackSel;
+  Produces<aod::DQEMuMuonsCuts> emuSel;
   OutputObj<THashList> fOutputList{"output"};
   HistogramManager* fHistMan;
 
   Configurable<std::string> fConfigCuts{"cfgMuonsCuts", "muonQualityCuts", "Comma separated list of ADDITIONAL muon track cuts"};
+  Configurable<std::string> fConfigCutsForEMu{"cfgMuonsCutsForEMu", "muonQualityCuts", "Comma separated list of ADDITIONAL muon track cuts"};
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
   Configurable<bool> fPropMuon{"cfgPropMuon", false, "Propgate muon tracks through absorber"};
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -341,6 +373,7 @@ struct DQMuonsSelection {
   // TODO: configure the histogram classes to be filled by QA
 
   std::vector<AnalysisCompositeCut> fTrackCuts;
+  std::vector<AnalysisCompositeCut> fEMuTrackCuts;
   std::vector<TString> fCutHistNames;
 
   void init(o2::framework::InitContext&)
@@ -355,10 +388,17 @@ struct DQMuonsSelection {
     }
 
     TString cutNamesStr = fConfigCuts.value;
+    TString cutEMuNamesStr = fConfigCutsForEMu.value;
     if (!cutNamesStr.IsNull()) {
       std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
       for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
         fTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
+      }
+    }
+    if (!cutEMuNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray2(cutEMuNamesStr.Tokenize(","));
+      for (int icut = 0; icut < objArray2->GetEntries(); ++icut) {
+        fEMuTrackCuts.push_back(*dqcuts::GetCompositeCut(objArray2->At(icut)->GetName()));
       }
     }
     VarManager::SetUseVars(AnalysisCut::fgUsedVars);
@@ -397,12 +437,15 @@ struct DQMuonsSelection {
     }
 
     uint32_t filterMap = uint32_t(0);
+    uint32_t filterMapEMu = uint32_t(0);
     trackSel.reserve(muons.size());
+    emuSel.reserve(muons.size());
 
     VarManager::ResetValues(0, VarManager::kNMuonTrackVariables);
 
     for (auto& muonAssoc : muonAssocs) {
       filterMap = uint32_t(0);
+      filterMapEMu = uint32_t(0);
       auto muon = muonAssoc.template fwdtrack_as<TMuons>();
       VarManager::FillTrack<TMuonFillMap>(muon);
       if (fPropMuon) {
@@ -420,7 +463,14 @@ struct DQMuonsSelection {
           }
         }
       }
+      int j = 0;
+      for (auto cut = fEMuTrackCuts.begin(); cut != fEMuTrackCuts.end(); ++cut, ++j) {
+        if ((*cut).IsSelected(VarManager::fgValues)) {
+          filterMapEMu |= (uint32_t(1) << j);
+        }
+      }
       trackSel(filterMap);
+      emuSel(filterMapEMu);
     } // end loop over muons
   }
 
@@ -510,10 +560,11 @@ struct DQFilterPPTask {
 
   Configurable<std::string> fConfigBarrelSelections{"cfgBarrelSels", "jpsiPID1:pairMassLow:1", "<track-cut>:[<pair-cut>]:<n>,[<track-cut>:[<pair-cut>]:<n>],..."};
   Configurable<std::string> fConfigMuonSelections{"cfgMuonSels", "muonQualityCuts:pairNoCut:1", "<muon-cut>:[<pair-cut>]:<n>"};
+  Configurable<std::string> fConfigElectronMuonSelections{"cfgElectronMuonSels", "jpsiPID1:muonQualityCuts:pairNoCut:1", "<track-cut>:<muon-cut>:[<pair-cut>]:<n>"};
   Configurable<bool> fConfigQA{"cfgWithQA", false, "If true, fill QA histograms"};
   Configurable<std::string> fConfigFilterLsBarrelTracksPairs{"cfgWithBarrelLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) barrel track pairs"};
   Configurable<std::string> fConfigFilterLsMuonsPairs{"cfgWithMuonLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) muon pairs"};
-
+  Configurable<std::string> fConfigFilterLsElectronMuonsPairs{"cfgWithElectronMuonLS", "false", "Comma separated list of booleans for each trigger, If true, also select like sign (--/++) muon pairs"};
   Configurable<bool> fPropMuon{"cfgPropMuon", false, "Propgate muon tracks through absorber"};
   Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
@@ -526,14 +577,20 @@ struct DQFilterPPTask {
 
   int fNBarrelCuts;                                    // number of barrel selections
   int fNMuonCuts;                                      // number of muon selections
+  int fNElectronMuonCuts;                              // number of electron-muon selections
   std::vector<bool> fBarrelRunPairing;                 // bit map on whether the selections require pairing (barrel)
   std::vector<bool> fMuonRunPairing;                   // bit map on whether the selections require pairing (muon)
+  std::vector<bool> fElectronMuonRunPairing;            //bit map on whether the selections require pairing (e-mu)
   std::vector<int> fBarrelNreqObjs;                    // minimal number of tracks/pairs required (barrel)
   std::vector<int> fMuonNreqObjs;                      // minimal number of tracks/pairs required (muon)
+  std::vector<int> fElectronMuonNreqObjs;              //minimal number of electron-muon pairs required
   std::map<int, AnalysisCompositeCut> fBarrelPairCuts; // map of barrel pair cuts
   std::map<int, AnalysisCompositeCut> fMuonPairCuts;   // map of muon pair cuts
+  std::map<int, AnalysisCompositeCut> fElectronMuonPairCuts;   //map of electron-muon pair cuts
   std::map<int, TString> fBarrelPairHistNames;         // map with names of the barrel pairing histogram directories
   std::map<int, TString> fMuonPairHistNames;           // map with names of the muon pairing histogram directories
+  std::map<int, TString> fElectronMuonPairHistNames;   // map with names of the electron-muon pairing histogram directories
+    
 
   std::map<uint64_t, uint64_t> fFiltersMap;           // map of filters for events that passed at least one filter
   std::map<uint64_t, std::vector<bool>> fCEFPfilters; // map of CEFP filters for events that passed at least one filter
@@ -584,10 +641,32 @@ struct DQFilterPPTask {
         }
       }
     }
+    //electron-muon pair
+    TString electronMuonSelsStr = fConfigElectronMuonSelections.value;
+    std::unique_ptr<TObjArray> objArray3(electronMuonSelsStr.Tokenize(","));
+    fNElectronMuonCuts = objArray3->GetEntries();
+    if (fNElectronMuonCuts) {
+      for (int icut = 0; icut < fNElectronMuonCuts; ++icut) {
+        TString selStr = objArray3->At(icut)->GetName();
+        std::unique_ptr<TObjArray> sel(selStr.Tokenize(":"));
+        if (sel->GetEntries() < 3 || sel->GetEntries() > 4) {
+          continue;
+        }
+        if (sel->GetEntries() == 4) {
+          fElectronMuonPairCuts[icut] = (*dqcuts::GetCompositeCut(sel->At(2)->GetName()));
+          fElectronMuonRunPairing.push_back(true);
+          fElectronMuonNreqObjs.push_back(std::atoi(sel->At(3)->GetName()));
+          fElectronMuonPairHistNames[icut] = Form("PairsElectronMuonSEPM_%s_%s_%s", sel->At(0)->GetName(), sel->At(1)->GetName(), sel->At(2)->GetName());
+        } else {
+          fElectronMuonNreqObjs.push_back(std::atoi(sel->At(2)->GetName()));
+          fElectronMuonRunPairing.push_back(false);
+        }
+      }
+    }
     VarManager::SetUseVars(AnalysisCut::fgUsedVars);
 
     // setup the Stats histogram
-    fStats.setObject(new TH1D("Statistics", "Stats for DQ triggers", fNBarrelCuts + fNMuonCuts + 2, -2.5, -0.5 + fNBarrelCuts + fNMuonCuts));
+    fStats.setObject(new TH1D("Statistics", "Stats for DQ triggers", fNBarrelCuts + fNMuonCuts + fNElectronMuonCuts + 2, -2.5, -0.5 + fNBarrelCuts + fNMuonCuts + fNElectronMuonCuts));
     fStats->GetXaxis()->SetBinLabel(1, "Events inspected");
     fStats->GetXaxis()->SetBinLabel(2, "Events selected");
     if (fNBarrelCuts) {
@@ -598,6 +677,11 @@ struct DQFilterPPTask {
     if (fNMuonCuts) {
       for (int ib = 3 + fNBarrelCuts; ib < 3 + fNBarrelCuts + fNMuonCuts; ib++) {
         fStats->GetXaxis()->SetBinLabel(ib, objArray2->At(ib - 3 - fNBarrelCuts)->GetName());
+      }
+    }
+    if (fNElectronMuonCuts) {
+      for (int ib = 3 + fNBarrelCuts + fNMuonCuts; ib < 3 + fNBarrelCuts + fNMuonCuts + fNElectronMuonCuts; ib++) {
+        fStats->GetXaxis()->SetBinLabel(ib, objArray3->At(ib - 3 - fNBarrelCuts - fNMuonCuts)->GetName());
       }
     }
   }
@@ -626,6 +710,10 @@ struct DQFilterPPTask {
         histNames += ";";
       }
       for (const auto& [key, value] : fMuonPairHistNames) {
+        histNames += value;
+        histNames += ";";
+      }
+      for (const auto& [key, value] : fElectronMuonPairHistNames) {
         histNames += value;
         histNames += ";";
       }
@@ -802,6 +890,64 @@ struct DQFilterPPTask {
       }
     }
 
+    //electron-muon pair
+    std::vector<int> objCountersElectronMuon(fNElectronMuonCuts, 0); // init all counters to zero
+    pairingMask = 0; // reset the mask for the e-mu
+    for (auto& [trackAssoc, muon] : combinations(barrelAssocs, muonAssocs)) {
+      for (int i = 0; i < fNElectronMuonCuts; ++i) {
+        if (trackAssoc.isDQEMuBarrelSelected() & muon.isDQEMuMuonSelected() & (uint32_t(1) << i)) {
+          if (fElectronMuonRunPairing[i]) {
+            pairingMask |= (uint32_t(1) << i);
+          }
+        }
+      }
+    }
+    // check which selection should use like sign (LS) (--/++) muon track pairs
+    pairingLS = 0; // reset the decisions for electron-muons
+    TString electronMuonLSstr = fConfigFilterLsElectronMuonsPairs.value;
+    std::unique_ptr<TObjArray> objArrayElectronMuonLS(electronMuonLSstr.Tokenize(","));
+    for (int icut = 0; icut < fNElectronMuonCuts; icut++) {
+      TString objStr = objArrayElectronMuonLS->At(icut)->GetName();
+      if (!objStr.CompareTo("true")) {
+        pairingLS |= (uint32_t(1) << icut);
+      }
+    }
+
+    // run pairing if there is at least one selection that requires it
+    pairFilter = 0;
+    if (pairingMask > 0) {
+      // pairing is done using the collision grouped electron and muon associations
+      for (auto& [a1, a2] : combinations(barrelAssocs, muonAssocs)) {
+        // check the pairing mask and that the tracks share a cut bit
+        pairFilter = pairingMask & a1.isDQEMuBarrelSelected() & a2.isDQEMuMuonSelected();
+        if (pairFilter == 0) {
+          continue;
+        }
+        // get the real electron and muon tracks
+        auto t1 = a1.template track_as<TTracks>();
+        auto t2 = a2.template fwdtrack_as<TMuons>();
+        // construct the pair and apply cuts
+        VarManager::FillPair<VarManager::kElectronMuon, TTrackFillMap>(t1, t2); // compute pair quantities
+        for (int icut = 0; icut < fNElectronMuonCuts; icut++) {
+          // select like-sign pairs if trigger has set boolean true within fConfigFilterLsElectronMuonsPairs
+          if (!(pairingLS & (uint32_t(1) << icut))) {
+            if (t1.sign() * t2.sign() > 0) {
+              continue;
+            }
+          }
+          if (!(pairFilter & (uint32_t(1) << icut))) {
+            continue;
+          }
+          if (!fElectronMuonPairCuts[icut].IsSelected(VarManager::fgValues)) {
+            continue;
+          }
+          objCountersElectronMuon[icut] += 1;
+          if (fConfigQA) {
+            fHistMan->FillHistClass(fElectronMuonPairHistNames[icut].Data(), VarManager::fgValues);
+          }
+        }
+      }
+    }
     // compute the decisions and publish
     uint64_t filter = 0;
     for (int i = 0; i < fNBarrelCuts; i++) {
@@ -812,6 +958,11 @@ struct DQFilterPPTask {
     for (int i = 0; i < fNMuonCuts; i++) {
       if (objCountersMuon[i] >= fMuonNreqObjs[i]) {
         filter |= (uint64_t(1) << (i + fNBarrelCuts));
+      }
+    }
+    for (int i = 0; i < fNElectronMuonCuts; i++) {
+      if (objCountersElectronMuon[i] >= fElectronMuonNreqObjs[i]) {
+        filter |= (uint64_t(1) << (i + fNBarrelCuts + fNMuonCuts));
       }
     }
     return filter;
@@ -839,7 +990,6 @@ struct DQFilterPPTask {
     for (int i = fNBarrelCuts; i < fNBarrelCuts + fNMuonCuts; i++) {
       muonMask |= (uint64_t(1) << i);
     }
-
     // Loop over collisions
     // int event = 0;
     int eventsFired = 0;
@@ -879,7 +1029,14 @@ struct DQFilterPPTask {
           }
         }
       }
-
+      // the ElectronMuon trigger is not available now
+/*      for (int i = fNBarrelCuts + fNMuonCuts; i < fNBarrelCuts + fNMuonCuts + fNElectronMuonCuts; i++) {
+        if (filter & (uint64_t(1) << i)) {
+          if (i < kNTriggersDQ) {
+            decisions[i] = true;
+          }
+        }
+      }*/
       // if this collision fired at least one input, add it to the map, or if it is there already, update the decisions with a logical OR
       // This may happen in the case when some collisions beyond the iterator are added because they contain ambiguous tracks fired on by another collision
       if (fFiltersMap.find(collision.globalIndex()) == fFiltersMap.end()) {
@@ -961,6 +1118,7 @@ struct DQFilterPPTask {
       if (!collision.isDQEventSelected()) {
         eventFilter(0);
         dqtable(false, false, false, false, false, false, false);
+//        dqtable(false, false, false, false, false, false, false, false); //the ElectronMuon trigger is not available now
         continue;
       }
       fStats->Fill(-1.0);
@@ -968,15 +1126,18 @@ struct DQFilterPPTask {
       if (fFiltersMap.find(collision.globalIndex()) == fFiltersMap.end()) {
         eventFilter(0);
         dqtable(false, false, false, false, false, false, false);
+//        dqtable(false, false, false, false, false, false, false, false); //the ElectronMuon trigger is not available now
       } else {
         totalEventsTriggered++;
-        for (int i = 0; i < fNBarrelCuts + fNMuonCuts; i++) {
-          if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i))
-            fStats->Fill(static_cast<float>(i));
-        }
+          for (int i = 0; i < fNBarrelCuts + fNMuonCuts + fNElectronMuonCuts; i++) {
+              if (fFiltersMap[collision.globalIndex()] & (uint32_t(1) << i))
+                  fStats->Fill(static_cast<float>(i));
+              }
+          }
         eventFilter(fFiltersMap[collision.globalIndex()]);
         auto dqDecisions = fCEFPfilters[collision.globalIndex()];
         dqtable(dqDecisions[0], dqDecisions[1], dqDecisions[2], dqDecisions[3], dqDecisions[4], dqDecisions[5], dqDecisions[6]);
+//        dqtable(dqDecisions[0], dqDecisions[1], dqDecisions[2], dqDecisions[3], dqDecisions[4], dqDecisions[5], dqDecisions[6], dqDecisions[7]); //the ElectronMuon trigger is not available now
       }
     }
 
@@ -1021,7 +1182,7 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "its,tpcpid,dca");
     }
 
-    if (classStr.Contains("Muon")) {
+    if (classStr.Contains("Muon") && !classStr.Contains("Electron")) {
       dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "track", "muon");
     }
 
@@ -1031,6 +1192,9 @@ void DefineHistograms(HistogramManager* histMan, TString histClasses)
       }
       if (classStr.Contains("Forward")) {
         dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "dimuon,vertexing-forward");
+      }
+      if (classStr.Contains("ElectronMuon")) {
+        dqhistograms::DefineHistograms(histMan, objArray->At(iclass)->GetName(), "pair", "electronmuon");
       }
     }
   }


### PR DESCRIPTION
1. Add the e-mu pair process in filterPPwithAssociation task
2. The DQ Trigger is also updated but now commented since it requires changes in CEFP and filterTable.h