### PR TITLE
[Common,PWGLF] feat(nucleiSpectra): Add matching study histograms

### DIFF
--- a/Common/DataModel/PIDResponseITS.h
+++ b/Common/DataModel/PIDResponseITS.h
@@ -81,6 +81,12 @@ struct ITSResponse {
     return (average * coslInv - exp) / resolution;
   };
 
+  template <o2::track::PID::ID id, typename T>
+  static float nSigmaITS(const T& track)
+  {
+    return nSigmaITS<id>(track.itsClusterSizes(), track.p(), track.eta());
+  }
+
   static void setParameters(float p0, float p1, float p2, float p0_Z2, float p1_Z2, float p2_Z2, float p0_res, float p1_res, float p2_res)
   {
     if (mIsInitialized) {


### PR DESCRIPTION
This commit adds new histograms to study the matching between ITS, TPC, and TOF
for nuclei candidates. The new histograms are added to the `hMatchingStudy`
array and are filled with the following information:

- Transverse momentum (`p_T`)
- Azimuthal angle (`phi`)
- Pseudorapidity (`eta`)
- ITS n-sigma for Helium-3
- TPC n-sigma
- TOF beta

The matching study is controlled by the `doprocessMatching` flag, which is set
to `false` by default. When enabled, the new histograms will be filled for both
matter and antimatter candidates.