### PR TITLE
[PWGLF] Add rapidity cut and trigger selection to cascade correlations task

### DIFF
--- a/PWGLF/Tasks/Strangeness/CMakeLists.txt
+++ b/PWGLF/Tasks/Strangeness/CMakeLists.txt
@@ -41,7 +41,7 @@ o2physics_add_dpl_workflow(v0postprocessing
 
 o2physics_add_dpl_workflow(cascadecorrelations
     SOURCES cascadecorrelations.cxx
-    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(non-prompt-cascade

--- a/PWGLF/Tasks/Strangeness/cascadecorrelations.cxx
+++ b/PWGLF/Tasks/Strangeness/cascadecorrelations.cxx
@@ -386,10 +386,6 @@ struct cascadeCorrelations {
   SliceCache cache;
   ConfigurableAxis axisVtxZ{"axisVtxZ", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "Mixing bins - z-vertex"};
   ConfigurableAxis axisMult{"axisMult", {VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 100, 1000}, "Mixing bins - multiplicity"};
-  using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFT0M<aod::mult::MultFT0A, aod::mult::MultFT0C>>;
-  BinningType colBinning{{axisVtxZ, axisMult}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
-  // Preslice<aod::CascDataExtSelected> collisionSliceCascades = aod::CascDataExtSelected::collisionId;
-  SameKindPair<myCollisions, myCascades, BinningType> pair{colBinning, nMixedEvents, -1, &cache};
 
   void processSameEvent(myCollisions::iterator const& collision, myCascades const& Cascades, aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&)
   {
@@ -597,6 +593,10 @@ struct cascadeCorrelations {
                          aod::V0sLinked const&, aod::V0Datas const&, FullTracksExtIU const&)
   {
     // mixed events
+    using BinningType = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFT0M<aod::mult::MultFT0A, aod::mult::MultFT0C>>;
+    BinningType colBinning{{axisVtxZ, axisMult}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
+    // Preslice<aod::CascDataExtSelected> collisionSliceCascades = aod::CascDataExtSelected::collisionId;
+    SameKindPair<myCollisions, myCascades, BinningType> pair{colBinning, nMixedEvents, -1, &cache};
 
     for (auto& [col1, cascades1, col2, cascades2] : pair) {
       if (!col1.sel8() || !col2.sel8())


### PR DESCRIPTION
This PR adds a rapidity cut and the ability to use the offline trigger selection through zorro.
It also fixes a bug in the ME by initializing the binning policy in the process function of the mixed events, as reported to the O2 analysis mattermost channel