### PR TITLE
[PWGDQ] Fix vector type

### DIFF
--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -542,7 +542,7 @@ struct TableMaker {
     fOccup.oContribShortC.clear();
 
     std::map<int32_t, int64_t> oBC;                      // key: collision index; value: global BC
-    std::map<int64_t, std::vector<int32_t>> oBCreversed; // key: global BC, value: list of collisions attached to this BC
+    std::map<int64_t, std::vector<int64_t>> oBCreversed; // key: global BC, value: list of collisions attached to this BC
     std::map<int32_t, float> oVtxZ;                      // key: collision index; value: vtx-z position
     std::map<int32_t, int32_t> collMultPos;              // key: collision index; value: tpc multiplicity on the A side
     std::map<int32_t, int32_t> collMultNeg;              // key: collision index; value: tpc multiplicity on the C side
@@ -564,7 +564,7 @@ struct TableMaker {
 
       // if more than one collision per bunch, add that collision to the list for that bunch
       if (oBCreversed.find(bc) == oBCreversed.end()) {
-        std::vector<int32_t> evs = {collision.globalIndex()};
+        std::vector<int64_t> evs = {collision.globalIndex()};
         oBCreversed[bc] = evs;
       } else {
         auto& evs = oBCreversed[bc];


### PR DESCRIPTION
Attempting to fix CI regression

Bisect df9d954090

```
/System/Volumes/Data/build/alice-ci-workdir/o2physics/sw/SOURCES/O2Physics/8807/0/PWGDQ/TableProducer/tableMaker_withAssoc.cxx:567:37: error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]
        std::vector<int32_t> evs = {collision.globalIndex()};
```