### PR TITLE
[PWGCF] Disable IsGlobalTrackSDD for the purposes of checking

### DIFF
--- a/PWGCF/Flow/Tasks/FlowRunbyRun.cxx
+++ b/PWGCF/Flow/Tasks/FlowRunbyRun.cxx
@@ -72,7 +72,7 @@ struct FlowRunbyRun {
   ConfigurableAxis axisIndependent{"axisIndependent", {VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90}, "X axis for histograms"};
 
   Filter collisionFilter = nabs(aod::collision::posZ) < cfgCutVertex;
-  Filter trackFilter = ((requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t) true)) && (nabs(aod::track::eta) < cfgCutEta) && (aod::track::pt > cfgCutPtMin) && (aod::track::pt < cfgCutPtMax) && (aod::track::tpcChi2NCl < cfgCutChi2prTPCcls) && (nabs(aod::track::dcaZ) < cfgCutDCAz);
+  Filter trackFilter = (requireGlobalTrackInFilter()) && (nabs(aod::track::eta) < cfgCutEta) && (aod::track::pt > cfgCutPtMin) && (aod::track::pt < cfgCutPtMax) && (aod::track::tpcChi2NCl < cfgCutChi2prTPCcls) && (nabs(aod::track::dcaZ) < cfgCutDCAz);
 
   // Connect to ccdb
   Service<ccdb::BasicCCDBManager> ccdb;


### PR DESCRIPTION
Disable the track selection `IsGlobalTrackSDD`, to check if it is the cause of the missing statistics in the high multiplicity range of the multiplicity distribution in pp.