### PR TITLE
[PWGLF] feat: Add new features to the NonPromptCascadeTask

### DIFF
--- a/PWGLF/DataModel/LFNonPromptCascadeTables.h
+++ b/PWGLF/DataModel/LFNonPromptCascadeTables.h
@@ -25,7 +25,9 @@ namespace o2::aod
 namespace NPCascadeTable
 {
 DECLARE_SOA_COLUMN(MatchingChi2, matchingChi2, float);
+DECLARE_SOA_COLUMN(DeltaPtITSCascade, deltaPtITSCascade, float);
 DECLARE_SOA_COLUMN(ITSClusSize, itsClusSize, float);
+DECLARE_SOA_COLUMN(HasReassociatedCluster, hasReassociatedCluster, bool);
 DECLARE_SOA_COLUMN(IsGoodMatch, isGoodMatch, bool);
 DECLARE_SOA_COLUMN(IsGoodCascade, isGoodCascade, bool);
 DECLARE_SOA_COLUMN(PdgCodeMom, pdgCodeMom, int);
@@ -108,7 +110,9 @@ DECLARE_SOA_COLUMN(MCcollisionMatch, mcCollisionMatch, bool);
 } // namespace NPCascadeTable
 DECLARE_SOA_TABLE(NPCascTable, "AOD", "NPCASCTABLE",
                   NPCascadeTable::MatchingChi2,
+                  NPCascadeTable::DeltaPtITSCascade,
                   NPCascadeTable::ITSClusSize,
+                  NPCascadeTable::HasReassociatedCluster,
                   NPCascadeTable::PvX,
                   NPCascadeTable::PvY,
                   NPCascadeTable::PvZ,
@@ -162,7 +166,9 @@ DECLARE_SOA_TABLE(NPCascTable, "AOD", "NPCASCTABLE",
 
 DECLARE_SOA_TABLE(NPCascTableMC, "AOD", "NPCASCTABLEMC",
                   NPCascadeTable::MatchingChi2,
+                  NPCascadeTable::DeltaPtITSCascade,
                   NPCascadeTable::ITSClusSize,
+                  NPCascadeTable::HasReassociatedCluster,
                   NPCascadeTable::IsGoodMatch,
                   NPCascadeTable::IsGoodCascade,
                   NPCascadeTable::PdgCodeMom,

--- a/PWGLF/Tasks/Strangeness/nonPromptCascade.cxx
+++ b/PWGLF/Tasks/Strangeness/nonPromptCascade.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -47,7 +48,9 @@ struct NPCascCandidate {
   int64_t trackITSID;
   int64_t collisionID;
   float matchingChi2;
+  float deltaPt;
   float itsClusSize;
+  bool hasReassociatedCluster;
   bool isGoodMatch;
   bool isGoodCascade;
   int pdgCodeMom;
@@ -292,7 +295,7 @@ struct NonPromptCascadeTask {
     if (o2::base::Propagator::Instance()->propagateToDCA(primaryVertex, trackCovTrk, bz, 2.f, matCorr, &impactParameterTrk)) {
       if (protonTrack.hasTPC() && pionTrack.hasTPC()) {
         if (isOmega) {
-          registry.fill(HIST("h_dca_Omega"), TMath::Sqrt(impactParameterTrk.getR2()));
+          registry.fill(HIST("h_dca_Omega"), std::sqrt(impactParameterTrk.getR2()));
           registry.fill(HIST("h_dcaxy_Omega"), impactParameterTrk.getY());
           registry.fill(HIST("h_dcaz_Omega"), impactParameterTrk.getZ());
           registry.fill(HIST("h_dcavspt_Omega"), impactParameterTrk.getY(), track.pt());
@@ -301,7 +304,7 @@ struct NonPromptCascadeTask {
       }
 
       if (protonTrack.hasTPC() && pionTrack.hasTPC()) {
-        registry.fill(HIST("h_dca_Xi"), TMath::Sqrt(impactParameterTrk.getR2()));
+        registry.fill(HIST("h_dca_Xi"), std::sqrt(impactParameterTrk.getR2()));
         registry.fill(HIST("h_dcaxy_Xi"), impactParameterTrk.getY());
         registry.fill(HIST("h_dcaz_Xi"), impactParameterTrk.getZ());
         registry.fill(HIST("h_dcavspt_Xi"), impactParameterTrk.getY(), track.pt());
@@ -432,6 +435,7 @@ struct NonPromptCascadeTask {
       o2::track::TrackParCov trackParCovV0;
       o2::track::TrackPar trackParV0;
       o2::track::TrackPar trackParBachelor;
+      std::array<float, 3> cascadeMomentum;
 
       float cascCpa = -1;
       float v0Cpa = -1;
@@ -446,10 +450,9 @@ struct NonPromptCascadeTask {
           trackParBachelor = df2.getTrackParamAtPCA(1);
           trackParV0.getPxPyPzGlo(momenta[0]);       // getting the V0 momentum
           trackParBachelor.getPxPyPzGlo(momenta[1]); // getting the bachelor momentum
-          std::array<float, 3> pVec;
-          df2.createParentTrackParCov().getPxPyPzGlo(pVec);
+          df2.createParentTrackParCov().getPxPyPzGlo(cascadeMomentum);
           std::array<float, 3> pvPos = {primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()};
-          cascCpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), pVec);
+          cascCpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), cascadeMomentum);
           v0Cpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), momenta[0]);
         } else {
           continue;
@@ -599,8 +602,9 @@ struct NonPromptCascadeTask {
         pdgCodeMom = track.mcParticle().has_mothers() ? track.mcParticle().mothers_as<aod::McParticles>()[0].pdgCode() : 0;
       }
       int itsTrackPDG = ITStrack.has_mcParticle() ? ITStrack.mcParticle().pdgCode() : 0;
-
-      candidates.emplace_back(NPCascCandidate{track.globalIndex(), ITStrack.globalIndex(), trackedCascade.collisionId(), trackedCascade.matchingChi2(), trackedCascade.itsClsSize(), isGoodMatch, isGoodCascade, pdgCodeMom, itsTrackPDG, std::get<0>(fromHF), std::get<1>(fromHF),
+      float deltaPtITSCascade = std::hypot(cascadeMomentum[0], cascadeMomentum[1]) - ITStrack.pt();
+      bool hasReassociatedClusters = (track.itsNCls() != ITStrack.itsNCls());
+      candidates.emplace_back(NPCascCandidate{track.globalIndex(), ITStrack.globalIndex(), trackedCascade.collisionId(), trackedCascade.matchingChi2(), deltaPtITSCascade, trackedCascade.itsClsSize(), hasReassociatedClusters, isGoodMatch, isGoodCascade, pdgCodeMom, itsTrackPDG, std::get<0>(fromHF), std::get<1>(fromHF),
                                               primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                                               track.pt(), track.eta(), track.phi(),
                                               protonTrack.pt(), protonTrack.eta(), pionTrack.pt(), pionTrack.eta(), bachelor.pt(), bachelor.eta(),
@@ -629,7 +633,7 @@ struct NonPromptCascadeTask {
       auto mcCollision = particle.mcCollision_as<aod::McCollisions>();
       auto label = collisions.iteratorAt(c.collisionID);
 
-      NPCTableMC(c.matchingChi2, c.itsClusSize, c.isGoodMatch, c.isGoodCascade, c.pdgCodeMom, c.pdgCodeITStrack, c.isFromBeauty, c.isFromCharm,
+      NPCTableMC(c.matchingChi2, c.deltaPt, c.itsClusSize, c.hasReassociatedCluster, c.isGoodMatch, c.isGoodCascade, c.pdgCodeMom, c.pdgCodeITStrack, c.isFromBeauty, c.isFromCharm,
                  c.pvX, c.pvY, c.pvZ,
                  c.cascPt, c.cascEta, c.cascPhi,
                  c.protonPt, c.protonEta, c.pionPt, c.pionEta, c.bachPt, c.bachEta,
@@ -691,6 +695,7 @@ struct NonPromptCascadeTask {
       const auto& ntrack = v0.negTrack_as<TracksExtData>();
       const auto& protonTrack = bachelor.sign() > 0 ? ntrack : ptrack;
       const auto& pionTrack = bachelor.sign() > 0 ? ptrack : ntrack;
+      bool hasReassociatedClusters = (track.itsNCls() != ITStrack.itsNCls());
 
       std::array<std::array<float, 3>, 2> momenta;
       std::array<double, 2> masses;
@@ -699,6 +704,7 @@ struct NonPromptCascadeTask {
       o2::track::TrackParCov trackParCovV0;
       o2::track::TrackPar trackParV0;
       o2::track::TrackPar trackParBachelor;
+      std::array<float, 3> cascadeMomentum;
 
       float cascCpa = -1;
       float v0Cpa = -1;
@@ -713,10 +719,9 @@ struct NonPromptCascadeTask {
           trackParBachelor = df2.getTrackParamAtPCA(1);
           trackParV0.getPxPyPzGlo(momenta[0]);       // getting the V0 momentum
           trackParBachelor.getPxPyPzGlo(momenta[1]); // getting the bachelor momentum
-          std::array<float, 3> pVec;
-          df2.createParentTrackParCov().getPxPyPzGlo(pVec);
+          df2.createParentTrackParCov().getPxPyPzGlo(cascadeMomentum);
           std::array<float, 3> pvPos = {primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()};
-          cascCpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), pVec);
+          cascCpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), cascadeMomentum);
           v0Cpa = RecoDecay::cpa(pvPos, df2.getPCACandidate(), momenta[0]);
         } else {
           continue;
@@ -724,6 +729,7 @@ struct NonPromptCascadeTask {
       } else {
         continue;
       }
+      float deltaPtITSCascade = std::hypot(cascadeMomentum[0], cascadeMomentum[1]) - ITStrack.pt();
 
       // PV
       registry.fill(HIST("h_PV_x"), primaryVertex.getX());
@@ -745,7 +751,7 @@ struct NonPromptCascadeTask {
       const auto v0mass = RecoDecay::m(momenta, masses);
 
       ////Omega hypohesis -> rejecting Xi
-      if (TMath::Abs(massXi - constants::physics::MassXiMinus) > 0.005) {
+      if (std::abs(massXi - constants::physics::MassXiMinus) > 0.005) {
         isOmega = true;
         invMassBCOmega->Fill(massOmega);
       }
@@ -849,7 +855,7 @@ struct NonPromptCascadeTask {
       daughtersDCA dDCA;
       fillDauDCA(trackedCascade, bachelor, protonTrack, pionTrack, primaryVertex, isOmega, dDCA);
 
-      candidates.emplace_back(NPCascCandidate{track.globalIndex(), ITStrack.globalIndex(), trackedCascade.collisionId(), trackedCascade.matchingChi2(), trackedCascade.itsClsSize(), 0, 0, 0, 0, 0, 0,
+      candidates.emplace_back(NPCascCandidate{track.globalIndex(), ITStrack.globalIndex(), trackedCascade.collisionId(), trackedCascade.matchingChi2(), deltaPtITSCascade, trackedCascade.itsClsSize(), hasReassociatedClusters, 0, 0, 0, 0, 0, 0,
                                               primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ(),
                                               track.pt(), track.eta(), track.phi(),
                                               protonTrack.pt(), protonTrack.eta(), pionTrack.pt(), pionTrack.eta(), bachelor.pt(), bachelor.eta(),
@@ -865,7 +871,7 @@ struct NonPromptCascadeTask {
 
     for (auto& c : candidates) {
 
-      NPCTable(c.matchingChi2, c.itsClusSize,
+      NPCTable(c.matchingChi2, c.deltaPt, c.itsClusSize, c.hasReassociatedCluster,
                c.pvX, c.pvY, c.pvZ,
                c.cascPt, c.cascEta, c.cascPhi,
                c.protonPt, c.protonEta, c.pionPt, c.pionEta, c.bachPt, c.bachEta,


### PR DESCRIPTION
This commit introduces several new features to the NonPromptCascadeTask:

1. Calculates the delta PT between the cascade and the ITS track, and stores it in the `DeltaPtITSCascade` column of the `NPCascTable`.
2. Adds a new column `HasReassociatedCluster` to the `NPCascTable` to indicate if the ITS track has reassociated clusters.
3. Modifies the `cpa` calculation to use the cascade momentum instead of a separate array.
4. Adds the `deltaPt` and `hasReassociatedCluster` fields to the `NPCascCandidate` struct and the corresponding `emplace_back` calls.

These changes aim to provide more detailed information about the non-prompt cascade candidates, which can be useful for further analysis and selection.