### PR TITLE
[PWGJE,EMCAL-670] Bugfix in EMCalCorrectionTask for ShaperCorrection

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -280,7 +280,7 @@ struct EmcalCorrectionTask {
       std::vector<int64_t> cellIndicesBC;
       for (const auto& cell : cellsInBC) {
         auto amplitude = cell.amplitude();
-        if (static_cast<bool>(hasShaperCorrection)) {
+        if (static_cast<bool>(hasShaperCorrection) && emcal::intToChannelType(cell.cellType()) == emcal::ChannelType_t::LOW_GAIN) { // Apply shaper correction to LG cells
           amplitude = o2::emcal::NonlinearityHandler::evaluateShaperCorrectionCellEnergy(amplitude);
         }
         if (applyCellAbsScale) {
@@ -402,7 +402,7 @@ struct EmcalCorrectionTask {
           mHistManager.fill(HIST("hMCParticleEnergy"), cellparticle.e());
         }
         auto amplitude = cell.amplitude();
-        if (static_cast<bool>(hasShaperCorrection)) {
+        if (static_cast<bool>(hasShaperCorrection) && emcal::intToChannelType(cell.cellType()) == emcal::ChannelType_t::LOW_GAIN) { // Apply shaper correction to LG cells
           amplitude = o2::emcal::NonlinearityHandler::evaluateShaperCorrectionCellEnergy(amplitude);
         }
         cellsBC.emplace_back(cell.cellNumber(),


### PR DESCRIPTION
- Shaper correction should only be applied for LG cells (oversight in O2Physics implementation), see 
https://github.com/alisw/AliPhysics/blob/master/PWG/EMCAL/EMCALbase/AliEMCALRecoUtils.cxx#L458