### PR TITLE
[PWGEM/PhotonMeson] Fix Cluster-Collision assignment in emcQC task

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
@@ -152,9 +152,9 @@ struct emcalQC {
     o2::aod::pwgem::photonmeson::utils::clusterhistogram::addClusterHistograms(&fRegistry, cfgDo2DQA);
   }
 
-  Preslice<aod::SkimEMCClusters> perCollision = aod::skimmedcluster::collisionId;
+  Preslice<MyEMCClusters> perCollision = aod::emccluster::emeventId;
 
-  void processQC(MyCollisions const& collisions, aod::SkimEMCClusters const& clusters)
+  void processQC(MyCollisions const& collisions, MyEMCClusters const& clusters)
   {
     for (auto& collision : collisions) {
 

--- a/PWGEM/PhotonMeson/Utils/ClusterHistograms.h
+++ b/PWGEM/PhotonMeson/Utils/ClusterHistograms.h
@@ -55,8 +55,8 @@ void addClusterHistograms(HistogramRegistry* fRegistry, bool do2DQA)
   fRegistry->addClone("Cluster/before/", "Cluster/after/");
 }
 
-template <const int cls_id>
-void fillClusterHistograms(HistogramRegistry* fRegistry, SkimEMCCluster cluster, bool do2DQA, float weight = 1.f)
+template <const int cls_id, typename TCluster>
+void fillClusterHistograms(HistogramRegistry* fRegistry, TCluster cluster, bool do2DQA, float weight = 1.f)
 {
   static constexpr std::string_view cluster_types[2] = {"before/", "after/"};
   fRegistry->fill(HIST("Cluster/") + HIST(cluster_types[cls_id]) + HIST("hE"), cluster.e(), weight);


### PR DESCRIPTION
- In EMCalQC task: Change SkimEMCCluster to MyEMCCluster, containing the EMEventId
- Template "fillClusterHistograms" function to allow for this different cluster class