### PR TITLE
[PWGHF] Add pt and inv.mass cuts also in mixed event

### DIFF
--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -396,6 +396,14 @@ struct HfTaskCharmHadronsFemtoDream {
           invMass = p2.m(std::array{o2::constants::physics::MassPiPlus, o2::constants::physics::MassKPlus, o2::constants::physics::MassProton});
         }
 
+        if (invMass < charmHadMinInvMass || invMass > charmHadMaxInvMass) {
+          continue;
+        }
+
+        if (p2.pt() < charmHadMinPt || p2.pt() > charmHadMaxPt) {
+          continue;
+        }
+
         int charmHadMc = 0;
         int originType = 0;
         if constexpr (isMc) {


### PR DESCRIPTION
It can be done offline for mix-event tree, but do it online can help reduce the tree size